### PR TITLE
Bound idle embedding residency

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import queue
+import re
 import shutil
 import stat
 import subprocess
@@ -149,7 +150,16 @@ def find_value(value: object, key: str) -> object | None:
     return None
 
 
-def engine_identity(status: dict, expected_policy: str | None, expected_backend: str | None) -> dict:
+def engine_identity(
+    status: dict,
+    expected_policy: str | None,
+    expected_backend: str | None,
+    *,
+    expected_load_count: int = 1,
+    expected_load_generation: int = 1,
+    expected_residency: str = "resident",
+    expected_load_error: bool = False,
+) -> dict:
     fields = {
         key: find_value(status, key)
         for key in (
@@ -159,6 +169,9 @@ def engine_identity(status: dict, expected_policy: str | None, expected_backend:
             "embedding_adapter",
             "embedding_policy",
             "embedding_engine_instance_id",
+            "embedding_engine_residency",
+            "embedding_engine_load_generation",
+            "embedding_engine_load_error",
             "embedding_model_load_count",
             "embedding_smoke_ms",
             "embedding_initialization_ms",
@@ -178,7 +191,13 @@ def engine_identity(status: dict, expected_policy: str | None, expected_backend:
     require(not any(token in adapter.lower() for token in SOFTWARE_ADAPTERS), f"software adapter is not allowed: {adapter}")
     require(fields["embedding_policy"] in {"accelerated", "cpu_explicit"}, "status lacks an explicit embedding policy")
     require(bool(fields["embedding_engine_instance_id"]), "status lacks the process engine identity")
-    require(fields["embedding_model_load_count"] == 1, "the process must load one shared embedding model")
+    require(fields["embedding_engine_residency"] == expected_residency, f"engine residency is {fields['embedding_engine_residency']!r}, expected {expected_residency!r}")
+    require(fields["embedding_model_load_count"] == expected_load_count, f"engine load count is {fields['embedding_model_load_count']!r}, expected {expected_load_count}")
+    require(fields["embedding_engine_load_generation"] == expected_load_generation, f"engine load generation is {fields['embedding_engine_load_generation']!r}, expected {expected_load_generation}")
+    if expected_load_error:
+        require(bool(fields["embedding_engine_load_error"]), "failed reload did not retain its load error")
+    else:
+        require(fields["embedding_engine_load_error"] is None, f"engine retained an unexpected load error: {fields['embedding_engine_load_error']}")
     require(isinstance(fields["embedding_smoke_ms"], (int, float)) and fields["embedding_smoke_ms"] >= 0, "status lacks the timed live embedding smoke")
     require(isinstance(fields["embedding_initialization_ms"], (int, float)) and fields["embedding_initialization_ms"] >= 0, "status lacks initialization timing")
     if expected_policy:
@@ -197,6 +216,52 @@ def engine_identity(status: dict, expected_policy: str | None, expected_backend:
     return fields
 
 
+def parse_byte_quantity(value: str) -> int:
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([KMG])?", value.strip())
+    require(match is not None, f"invalid memory quantity: {value!r}")
+    scale = {None: 1, "K": 1024, "M": 1024**2, "G": 1024**3}[match.group(2)]
+    return round(float(match.group(1)) * scale)
+
+
+def process_resident_memory(pid: int) -> tuple[int, str]:
+    if os.name == "nt":
+        command = [
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            f"(Get-Process -Id {pid} -ErrorAction Stop).WorkingSet64",
+        ]
+        scale = 1
+        metric = "windows_working_set"
+    elif sys.platform == "darwin":
+        completed = subprocess.run(
+            ["vmmap", "-summary", str(pid)],
+            text=True,
+            capture_output=True,
+            timeout=20,
+        )
+        require(completed.returncode == 0, f"could not read physical footprint for process {pid}: {completed.stderr.strip()}")
+        match = re.search(r"^Physical footprint:\s+([^\s]+)", completed.stdout, re.MULTILINE)
+        require(match is not None, f"vmmap omitted the physical footprint for process {pid}")
+        return parse_byte_quantity(match.group(1)), "macos_physical_footprint"
+    else:
+        command = ["ps", "-o", "rss=", "-p", str(pid)]
+        scale = 1024
+        metric = "rss"
+    completed = subprocess.run(command, text=True, capture_output=True, timeout=10)
+    require(completed.returncode == 0, f"could not read RSS for process {pid}: {completed.stderr.strip()}")
+    try:
+        return int(completed.stdout.strip()) * scale, metric
+    except ValueError as exc:
+        raise ProofFailure(f"invalid RSS for process {pid}: {completed.stdout!r}") from exc
+
+
+def engine_process_id(identity: dict) -> int:
+    parts = str(identity.get("embedding_engine_instance_id") or "").split(":")
+    require(len(parts) >= 3 and parts[0] == "inprocess" and parts[1].isdigit(), "invalid process engine identity")
+    return int(parts[1])
+
+
 def assert_public_status(status: dict) -> None:
     require(find_value(status, "retrieval_mode") == "full", "public status does not report full retrieval")
     maintainer_only = (
@@ -208,6 +273,9 @@ def assert_public_status(status: dict) -> None:
         "embedding_adapter",
         "embedding_policy",
         "embedding_engine_instance_id",
+        "embedding_engine_residency",
+        "embedding_engine_load_generation",
+        "embedding_engine_load_error",
         "embedding_materialized_path",
         "embedding_detected_provider",
         "embedding_detected_gpu",
@@ -382,6 +450,185 @@ def create_second_repository(root: Path) -> Path:
     return repo
 
 
+def native_cli_pid(mcp: McpProcess, plugin_handoff: bool) -> int:
+    if not plugin_handoff:
+        return mcp.process.pid
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if os.name == "nt":
+            command = [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                f"Get-CimInstance Win32_Process -Filter \"ParentProcessId = {mcp.process.pid}\" | Select-Object -ExpandProperty ProcessId",
+            ]
+            completed = subprocess.run(command, text=True, capture_output=True, timeout=10)
+            candidates = [line.strip() for line in completed.stdout.splitlines()]
+        else:
+            completed = subprocess.run(
+                ["ps", "-axo", "pid=,ppid="],
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+            candidates = []
+            for line in completed.stdout.splitlines():
+                fields = line.split()
+                if len(fields) == 2 and fields[1] == str(mcp.process.pid):
+                    candidates.append(fields[0])
+        numeric = [int(value) for value in candidates if value.isdigit()]
+        if len(numeric) == 1:
+            return numeric[0]
+        time.sleep(0.1)
+    raise ProofFailure("plugin launcher did not expose exactly one native CLI child")
+
+
+def create_residency_projects(root: Path) -> list[tuple[Path, str]]:
+    projects = []
+    for name, symbol in (("idle fixture alpha", "AlphaResidency"), ("idle fixture ü", "BetaResidency")):
+        project = root / name
+        source = project / "src"
+        source.mkdir(parents=True, exist_ok=True)
+        (project / "Cargo.toml").write_text(
+            f'[package]\nname = "{name.replace(" ", "-").replace("ü", "u")}"\nversion = "0.1.0"\nedition = "2024"\n',
+            encoding="utf-8",
+        )
+        (source / "lib.rs").write_text(
+            f"pub struct {symbol};\nimpl {symbol} {{ pub fn ready(&self) -> bool {{ true }} }}\n",
+            encoding="utf-8",
+        )
+        projects.append((project, symbol))
+    return projects
+
+
+def prove_idle_residency(
+    args: argparse.Namespace,
+    command: list[str],
+    env: dict[str, str],
+    out_dir: Path,
+) -> dict:
+    projects = create_residency_projects(out_dir / "idle-fixtures")
+    project, query = projects[0]
+    additional_projects = projects[1:]
+    mcp = McpProcess(command, env=env, cwd=project, timeout=args.timeout_secs)
+    try:
+        mcp.initialize()
+        mcp.status(project, "idle-baseline-status")
+        for index, (additional_project, _) in enumerate(additional_projects, start=1):
+            mcp.status(additional_project, f"idle-baseline-additional-{index}")
+        cli_pid = native_cli_pid(mcp, args.plugin_handoff)
+        baseline_memory, memory_metric = process_resident_memory(cli_pid)
+
+        mcp.tool_until_ready(
+            "search",
+            {"project": str(project), "query": query, "why": True},
+            "idle-load-search",
+        )
+        first_identity = engine_identity(
+            mcp.engine_diagnostics(project, "idle-load-diagnostics"),
+            args.engine_policy,
+            args.expected_backend,
+        )
+        require(engine_process_id(first_identity) == cli_pid, "diagnostics identified a different CLI process")
+        require(first_identity["embedding_materialized_reused"] is True, "measured process did not reuse the materialized model")
+        for index, (additional_project, query) in enumerate(additional_projects, start=1):
+            mcp.tool_until_ready(
+                "search",
+                {"project": str(additional_project), "query": query, "why": True},
+                f"idle-load-additional-{index}",
+            )
+            additional_identity = engine_identity(
+                mcp.engine_diagnostics(additional_project, f"idle-load-additional-diagnostics-{index}"),
+                args.engine_policy,
+                args.expected_backend,
+            )
+            require(additional_identity["embedding_engine_instance_id"] == first_identity["embedding_engine_instance_id"], "measured repositories did not share one owner")
+        loaded_memory, loaded_metric = process_resident_memory(cli_pid)
+        require(loaded_metric == memory_metric, "process memory metric changed during the proof")
+
+        time.sleep(30)
+        warm_identity = engine_identity(
+            mcp.engine_diagnostics(project, "idle-still-warm-diagnostics"),
+            args.engine_policy,
+            args.expected_backend,
+        )
+        require(warm_identity["embedding_engine_instance_id"] == first_identity["embedding_engine_instance_id"], "recently active engine changed owner")
+        time.sleep(35)
+        sleeping_identity = engine_identity(
+            mcp.engine_diagnostics(project, "idle-sleeping-diagnostics"),
+            args.engine_policy,
+            args.expected_backend,
+            expected_residency="sleeping",
+        )
+        sleeping_memory, sleeping_metric = process_resident_memory(cli_pid)
+        require(sleeping_metric == memory_metric, "process memory metric changed during the proof")
+        loaded_increment = max(0, loaded_memory - baseline_memory)
+        idle_allowance = max(50 * 1024 * 1024, loaded_increment // 4)
+        require(
+            sleeping_memory <= baseline_memory + idle_allowance,
+            "idle process memory did not return near its pre-engine baseline: "
+            f"metric={memory_metric} baseline={baseline_memory} loaded={loaded_memory} "
+            f"sleeping={sleeping_memory} allowance={idle_allowance}",
+        )
+        assert_public_status(mcp.status(project, "idle-sleeping-status"))
+
+        materialized = Path(str(first_identity["embedding_materialized_path"]))
+        backup = materialized.with_name(materialized.name + ".proof-backup")
+        materialized.rename(backup)
+        materialized.mkdir()
+        try:
+            failed_wake = mcp.tool(
+                "search",
+                {"project": str(project), "query": query, "why": True},
+                "idle-failed-wake",
+            )
+            require(failed_wake.get("result", {}).get("isError") is True, "blocked model path did not fail the activating wake")
+            failed_identity = engine_identity(
+                mcp.engine_diagnostics(project, "idle-failed-wake-diagnostics"),
+                args.engine_policy,
+                args.expected_backend,
+                expected_residency="sleeping",
+                expected_load_error=True,
+            )
+        finally:
+            materialized.rmdir()
+            backup.rename(materialized)
+
+        mcp.tool_until_ready(
+            "search",
+            {"project": str(project), "query": query, "why": True},
+            "idle-wake-search",
+        )
+        wake_identity = engine_identity(
+            mcp.engine_diagnostics(project, "idle-wake-diagnostics"),
+            args.engine_policy,
+            args.expected_backend,
+            expected_load_count=2,
+            expected_load_generation=2,
+        )
+        require(wake_identity["embedding_engine_instance_id"] == first_identity["embedding_engine_instance_id"], "idle wake replaced the engine owner")
+        require(wake_identity["embedding_materialized_path"] == first_identity["embedding_materialized_path"], "idle wake selected a different model path")
+        require(wake_identity["embedding_materialized_reused"] is True, "idle wake rewrote the content-addressed model")
+        result = {
+            "memory_metric": memory_metric,
+            "baseline_memory_bytes": baseline_memory,
+            "loaded_memory_bytes": loaded_memory,
+            "sleeping_memory_bytes": sleeping_memory,
+            "idle_allowance_bytes": idle_allowance,
+            "warm_identity": warm_identity,
+            "sleeping_identity": sleeping_identity,
+            "failed_identity": failed_identity,
+            "wake_identity": wake_identity,
+            "wake_memory_bytes": process_resident_memory(cli_pid)[0],
+        }
+        transcript = mcp.transcript
+    finally:
+        mcp.close()
+    write_json(out_dir / "idle-residency-mcp.json", transcript)
+    write_json(out_dir / "idle-residency.json", result)
+    return result
+
+
 def prove_runtime(args: argparse.Namespace, cli: Path, env: dict[str, str], root: Path, out_dir: Path) -> dict:
     project = args.project.resolve()
     if args.additional_project:
@@ -464,6 +711,15 @@ def prove_runtime(args: argparse.Namespace, cli: Path, env: dict[str, str], root
     require(cold_materialization["sha256"] == identity["embedding_model_sha256"], "first-use model digest does not match engine identity")
     before_mtime = materialized.stat().st_mtime_ns
 
+    idle_residency = None
+    if args.idle_residency_proof:
+        idle_residency = prove_idle_residency(
+            args,
+            command,
+            env,
+            out_dir,
+        )
+
     restart = McpProcess([str(cli), "serve", "--stdio", "--multi-project", "--refresh", "none"], env=env, cwd=project, timeout=args.timeout_secs)
     try:
         restart.initialize()
@@ -479,11 +735,13 @@ def prove_runtime(args: argparse.Namespace, cli: Path, env: dict[str, str], root
     return {
         "cold_materialization": cold_materialization,
         "identity": identity,
+        "idle_residency": idle_residency,
         "restart_identity": restart_identity,
     }
 
 
 def self_test() -> None:
+    require(parse_byte_quantity("24.1M") == 25_270_682, "memory quantity parser failed")
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw)
         payload = root / "artifact.zip"
@@ -511,6 +769,8 @@ def self_test() -> None:
             "embedding_adapter": "Apple GPU",
             "embedding_policy": "accelerated",
             "embedding_engine_instance_id": "engine-1",
+            "embedding_engine_residency": "resident",
+            "embedding_engine_load_generation": 1,
             "embedding_model_load_count": 1,
             "embedding_smoke_ms": 1.0,
             "embedding_initialization_ms": 2.0,
@@ -547,6 +807,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--engine-policy", choices=("accelerated", "cpu_explicit"))
     parser.add_argument("--expected-backend")
     parser.add_argument("--offline", action="store_true")
+    parser.add_argument("--idle-residency-proof", action="store_true")
     parser.add_argument("--self-test", action="store_true")
     return parser.parse_args()
 

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -128,6 +128,7 @@ jobs:
             --engine-policy accelerated \
             --expected-backend Metal \
             --offline \
+            --idle-residency-proof \
             --timeout-secs 1800 \
             --out-dir target/macos-metal-proof/packaged-agent
 

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -105,6 +105,7 @@ jobs:
             --engine-policy accelerated `
             --expected-backend Vulkan `
             --offline `
+            --idle-residency-proof `
             --timeout-secs 1800 `
             --out-dir target/windows-vulkan-proof/packaged-agent
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - One warm embedding engine can serve several open repositories while every
   repository keeps its own cache, publication, and readiness state. Switching
   projects no longer means loading the model again.
+- Inactive coding tasks no longer keep the model and GPU allocation forever.
+  After a short quiet period CodeStory releases that memory, then restores the
+  same packaged engine automatically when the task needs search again.
 - Apple Silicon uses Metal. Windows and supported Linux hardware use Vulkan.
   Production never silently falls back to CPU; hosted CI can opt into the
   clearly labelled CPU path without making an acceleration claim.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -22,5 +22,8 @@ llama-cpp-2 = { workspace = true, features = ["metal"] }
 [target.'cfg(any(target_os = "windows", target_os = "linux"))'.dependencies]
 llama-cpp-2 = { workspace = true, features = ["vulkan"] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_System_Threading"] }
+
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))'.dependencies]
 llama-cpp-2 = { workspace = true }

--- a/crates/codestory-llama-sys/src/lib.rs
+++ b/crates/codestory-llama-sys/src/lib.rs
@@ -1,6 +1,6 @@
 //! CodeStory-owned boundary around the statically linked llama.cpp runtime.
 
-use crossbeam_channel::{Receiver, Sender, bounded, select_biased, unbounded};
+use crossbeam_channel::{Receiver, Sender, after, bounded, select_biased, unbounded};
 use fs4::fs_std::FileExt;
 use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::context::params::{LlamaAttentionType, LlamaContextParams, LlamaPoolingType};
@@ -31,6 +31,7 @@ const MODEL_CONTEXT_TOKENS: usize = 512;
 const LOGICAL_BATCH_TOKENS: usize = 1024;
 const MAX_BATCH_SEQUENCES: usize = 6;
 const REQUEST_QUEUE_CAPACITY: usize = 64;
+const ENGINE_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -97,6 +98,31 @@ pub struct EngineIdentity {
     pub accelerator_execution_verified: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EngineResidency {
+    Resident,
+    Sleeping,
+}
+
+impl EngineResidency {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Resident => "resident",
+            Self::Sleeping => "sleeping",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EngineLifecycleSnapshot {
+    pub identity: EngineIdentity,
+    pub residency: EngineResidency,
+    pub load_generation: u64,
+    pub model_load_count: u64,
+    pub worker_alive: bool,
+    pub load_error: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct MaterializedModel {
     pub path: PathBuf,
@@ -108,11 +134,37 @@ pub struct EmbeddingEngine {
     shared: Arc<EngineShared>,
 }
 
+pub struct EmbeddingResidencyLease {
+    shared: Arc<EngineShared>,
+    snapshot: EngineLifecycleSnapshot,
+}
+
+impl std::fmt::Debug for EmbeddingResidencyLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EmbeddingResidencyLease")
+            .field("load_generation", &self.snapshot.load_generation)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EmbeddingResidencyLease {
+    pub fn snapshot(&self) -> &EngineLifecycleSnapshot {
+        &self.snapshot
+    }
+}
+
+impl Drop for EmbeddingResidencyLease {
+    fn drop(&mut self) {
+        let _ = self.shared.control_sender.send(Control::ReleaseLease);
+    }
+}
+
 impl std::fmt::Debug for EmbeddingEngine {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("EmbeddingEngine")
-            .field("identity", &self.shared.identity)
+            .field("snapshot", &self.snapshot().ok())
             .finish_non_exhaustive()
     }
 }
@@ -121,7 +173,7 @@ struct EngineShared {
     query_sender: Sender<EmbeddingRequest>,
     bulk_sender: Sender<EmbeddingRequest>,
     control_sender: Sender<Control>,
-    identity: EngineIdentity,
+    lifecycle: Arc<Mutex<Option<EngineLifecycleSnapshot>>>,
     worker: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -151,6 +203,13 @@ struct EmbeddingRequest {
 
 enum Control {
     Shutdown,
+    EnsureResident {
+        response: Sender<Result<EngineLifecycleSnapshot, EngineError>>,
+    },
+    AcquireLease {
+        response: Sender<Result<EngineLifecycleSnapshot, EngineError>>,
+    },
+    ReleaseLease,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -165,6 +224,8 @@ impl EmbeddingEngine {
         let (bulk_sender, bulk_receiver) = bounded(REQUEST_QUEUE_CAPACITY);
         let (control_sender, control_receiver) = unbounded();
         let (startup_sender, startup_receiver) = bounded(1);
+        let lifecycle = Arc::new(Mutex::new(None));
+        let worker_lifecycle = lifecycle.clone();
         let cache_root = cache_root.to_path_buf();
         let worker = thread::Builder::new()
             .name("codestory-embedding-engine".into())
@@ -176,13 +237,14 @@ impl EmbeddingEngine {
                     &query_receiver,
                     &bulk_receiver,
                     &control_receiver,
+                    &worker_lifecycle,
                 ) {
                     let _ = startup_sender.try_send(Err(error));
                 }
             })
             .map_err(|error| EngineError::WorkerUnavailable(error.to_string()))?;
-        let identity = match startup_receiver.recv() {
-            Ok(Ok(identity)) => identity,
+        match startup_receiver.recv() {
+            Ok(Ok(_)) => {}
             Ok(Err(error)) => {
                 let _ = worker.join();
                 return Err(error);
@@ -191,20 +253,62 @@ impl EmbeddingEngine {
                 let _ = worker.join();
                 return Err(EngineError::WorkerUnavailable(error.to_string()));
             }
-        };
+        }
         Ok(Self {
             shared: Arc::new(EngineShared {
                 query_sender,
                 bulk_sender,
                 control_sender,
-                identity,
+                lifecycle,
                 worker: Mutex::new(Some(worker)),
             }),
         })
     }
 
-    pub fn identity(&self) -> &EngineIdentity {
-        &self.shared.identity
+    pub fn snapshot(&self) -> Result<EngineLifecycleSnapshot, EngineError> {
+        let mut snapshot = self
+            .shared
+            .lifecycle
+            .lock()
+            .map_err(|_| EngineError::WorkerUnavailable("lifecycle mutex was poisoned".into()))?
+            .clone()
+            .ok_or_else(|| {
+                EngineError::WorkerUnavailable("lifecycle snapshot is unavailable".into())
+            })?;
+        snapshot.worker_alive = self
+            .shared
+            .worker
+            .lock()
+            .map_err(|_| EngineError::WorkerUnavailable("worker mutex was poisoned".into()))?
+            .as_ref()
+            .is_some_and(|worker| !worker.is_finished());
+        Ok(snapshot)
+    }
+
+    pub fn ensure_resident(&self) -> Result<EngineLifecycleSnapshot, EngineError> {
+        let (response, result) = bounded(1);
+        self.shared
+            .control_sender
+            .send(Control::EnsureResident { response })
+            .map_err(|error| EngineError::WorkerUnavailable(error.to_string()))?;
+        result
+            .recv()
+            .map_err(|error| EngineError::WorkerUnavailable(error.to_string()))?
+    }
+
+    pub fn acquire_residency_lease(&self) -> Result<EmbeddingResidencyLease, EngineError> {
+        let (response, result) = bounded(1);
+        self.shared
+            .control_sender
+            .send(Control::AcquireLease { response })
+            .map_err(|error| EngineError::WorkerUnavailable(error.to_string()))?;
+        let snapshot = result
+            .recv()
+            .map_err(|error| EngineError::WorkerUnavailable(error.to_string()))??;
+        Ok(EmbeddingResidencyLease {
+            shared: self.shared.clone(),
+            snapshot,
+        })
     }
 
     pub fn embed_query_prepared(&self, input: String) -> Result<Vec<f32>, EngineError> {
@@ -251,143 +355,429 @@ impl EmbeddingEngine {
 fn run_engine_owner(
     cache_root: &Path,
     allow_cpu: bool,
-    startup: &Sender<Result<EngineIdentity, EngineError>>,
+    startup: &Sender<Result<EngineLifecycleSnapshot, EngineError>>,
     query_receiver: &Receiver<EmbeddingRequest>,
     bulk_receiver: &Receiver<EmbeddingRequest>,
     control_receiver: &Receiver<Control>,
+    lifecycle: &Arc<Mutex<Option<EngineLifecycleSnapshot>>>,
 ) -> Result<(), EngineError> {
-    let started = Instant::now();
-    let materialized = materialize_embedded_model(cache_root)?;
-    send_logs_to_tracing(LogOptions::default().with_logs_enabled(false));
-    let backend = LlamaBackend::init().map_err(llama_error)?;
-    let devices = list_llama_ggml_backend_devices();
-    let (device, policy) = select_device(&devices, allow_cpu)?;
-    let free_before = device.memory_free;
+    let mut wake = WakeReason::Startup;
+    let mut load_generation = 0;
+    let mut last_snapshot: Option<EngineLifecycleSnapshot> = None;
+    loop {
+        let result = run_resident_generation(
+            cache_root,
+            allow_cpu,
+            wake,
+            load_generation + 1,
+            startup,
+            query_receiver,
+            bulk_receiver,
+            control_receiver,
+            lifecycle,
+        );
+        trim_unloaded_engine_working_set();
+        match result {
+            ResidentRunResult::Sleeping(mut snapshot) => {
+                load_generation = snapshot.load_generation;
+                snapshot.residency = EngineResidency::Sleeping;
+                publish_lifecycle(lifecycle, snapshot.clone())?;
+                last_snapshot = Some(snapshot);
+            }
+            ResidentRunResult::Shutdown(mut snapshot) => {
+                snapshot.worker_alive = false;
+                publish_lifecycle(lifecycle, snapshot)?;
+                return Ok(());
+            }
+            ResidentRunResult::LoadFailed { wake, error } => {
+                if let Some(snapshot) = last_snapshot.as_mut() {
+                    snapshot.residency = EngineResidency::Sleeping;
+                    snapshot.load_error = Some(error.to_string());
+                    publish_lifecycle(lifecycle, snapshot.clone())?;
+                }
+                if fail_wake(wake, startup, error) {
+                    return Ok(());
+                }
+            }
+        }
 
-    let mut model_params = LlamaModelParams::default().with_use_mmap(true);
-    if policy == ExecutionPolicy::Accelerated {
-        model_params = model_params
-            .with_devices(&[device.index])
-            .map_err(llama_error)?
-            .with_n_gpu_layers(u32::MAX);
-    } else {
-        model_params = model_params.with_n_gpu_layers(0);
+        let Some(next_wake) = wait_for_wake(query_receiver, bulk_receiver, control_receiver) else {
+            if let Some(mut snapshot) = last_snapshot {
+                snapshot.worker_alive = false;
+                publish_lifecycle(lifecycle, snapshot)?;
+            }
+            return Ok(());
+        };
+        wake = next_wake;
     }
-    let model = LlamaModel::load_from_file(&backend, &materialized.path, &model_params)
-        .map_err(llama_error)?;
-    if model.n_embd() as usize != EMBEDDING_DIM {
-        return Err(EngineError::Dimension {
-            expected: EMBEDDING_DIM,
-            actual: model.n_embd() as usize,
-        });
-    }
-    let model_layer_count = model.n_layer() + 1;
+}
 
-    let context_params = LlamaContextParams::default()
-        .with_n_ctx(NonZeroU32::new(4096))
-        .with_n_batch(LOGICAL_BATCH_TOKENS as u32)
-        .with_n_ubatch(LOGICAL_BATCH_TOKENS as u32)
-        .with_n_seq_max(MAX_BATCH_SEQUENCES as u32)
-        .with_attention_type(LlamaAttentionType::NonCausal)
-        .with_pooling_type(LlamaPoolingType::Cls)
-        .with_embeddings(true);
-    let mut context = model
-        .new_context(&backend, context_params)
-        .map_err(llama_error)?;
-    let free_after = list_llama_ggml_backend_devices()
-        .into_iter()
-        .find(|candidate| candidate.index == device.index)
-        .map_or(device.memory_free, |candidate| candidate.memory_free);
-    // llama.cpp receives one explicit physical device and n_gpu_layers=u32::MAX.
-    // A successful load with a real allocation on that device proves the full
-    // layer request was realized; llama.cpp does not silently lower this value.
-    let accelerator_execution_verified =
-        policy == ExecutionPolicy::Accelerated && free_before > free_after && free_after > 0;
-    if policy == ExecutionPolicy::Accelerated && !accelerator_execution_verified {
-        return Err(EngineError::AcceleratorExecutionUnverified(format!(
-            "{} ({})",
-            device.name, device.description
-        )));
-    }
-    let offloaded_layer_count = if accelerator_execution_verified {
-        model_layer_count
-    } else {
-        0
-    };
+#[cfg(target_os = "windows")]
+fn trim_unloaded_engine_working_set() {
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, SetProcessWorkingSetSize};
 
-    let smoke_started = Instant::now();
-    let smoke = embed_inputs(
-        &model,
-        &mut context,
-        &[
-            "Represent this query for searching relevant code: codestory embedding smoke"
-                .to_string(),
-        ],
-        RequestPriority::Query,
-        query_receiver,
-    )?;
-    if smoke
-        .first()
-        .is_none_or(|vector| vector.len() != EMBEDDING_DIM)
-    {
-        return Err(EngineError::Dimension {
-            expected: EMBEDDING_DIM,
-            actual: smoke.first().map_or(0, Vec::len),
-        });
+    // SAFETY: GetCurrentProcess returns a valid pseudo-handle for the calling process. Passing
+    // usize::MAX for both limits asks Windows to evict unused pages after the llama objects drop.
+    let _ = unsafe { SetProcessWorkingSetSize(GetCurrentProcess(), usize::MAX, usize::MAX) };
+}
+
+#[cfg(not(target_os = "windows"))]
+fn trim_unloaded_engine_working_set() {}
+
+enum WakeReason {
+    Startup,
+    Query(EmbeddingRequest),
+    Bulk(EmbeddingRequest),
+    EnsureResident(Sender<Result<EngineLifecycleSnapshot, EngineError>>),
+    AcquireLease(Sender<Result<EngineLifecycleSnapshot, EngineError>>),
+}
+
+enum ResidentRunResult {
+    Sleeping(EngineLifecycleSnapshot),
+    Shutdown(EngineLifecycleSnapshot),
+    LoadFailed {
+        wake: WakeReason,
+        error: EngineError,
+    },
+}
+
+#[derive(Debug)]
+struct ResidencyTracker {
+    idle_timeout: Duration,
+    last_activity: Instant,
+    leases: usize,
+}
+
+impl ResidencyTracker {
+    fn new(idle_timeout: Duration, now: Instant) -> Self {
+        Self {
+            idle_timeout,
+            last_activity: now,
+            leases: 0,
+        }
     }
-    let identity = EngineIdentity {
-        model_digest: MODEL_SHA256,
-        ggml_build_identity: GGML_BUILD_IDENTITY,
-        backend: device.backend.clone(),
-        adapter_name: device.name.clone(),
-        adapter_description: device.description.clone(),
-        policy,
-        embedded_model: EMBEDDED_MODEL_COMPILED,
-        materialized_path: materialized.path,
-        materialized_reused: materialized.reused,
-        initialization_duration: started.elapsed(),
-        smoke_duration: smoke_started.elapsed(),
-        adapter_memory_total: device.memory_total,
-        adapter_memory_free_before_load: free_before,
-        adapter_memory_free_after_load: free_after,
-        execution_device_names: if accelerator_execution_verified {
-            vec![device.name.clone()]
+
+    fn complete_activity(&mut self, now: Instant) {
+        self.last_activity = now;
+    }
+
+    fn acquire_lease(&mut self) {
+        self.leases += 1;
+    }
+
+    fn release_lease(&mut self, now: Instant) {
+        self.leases = self.leases.saturating_sub(1);
+        self.last_activity = now;
+    }
+
+    fn remaining(&self, now: Instant) -> Duration {
+        if self.leases > 0 {
+            return self.idle_timeout;
+        }
+        self.idle_timeout
+            .saturating_sub(now.saturating_duration_since(self.last_activity))
+    }
+
+    fn should_sleep(&self, now: Instant) -> bool {
+        self.leases == 0 && now.saturating_duration_since(self.last_activity) >= self.idle_timeout
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_resident_generation(
+    cache_root: &Path,
+    allow_cpu: bool,
+    wake: WakeReason,
+    load_generation: u64,
+    startup: &Sender<Result<EngineLifecycleSnapshot, EngineError>>,
+    query_receiver: &Receiver<EmbeddingRequest>,
+    bulk_receiver: &Receiver<EmbeddingRequest>,
+    control_receiver: &Receiver<Control>,
+    lifecycle: &Arc<Mutex<Option<EngineLifecycleSnapshot>>>,
+) -> ResidentRunResult {
+    let mut pending_wake = Some(wake);
+    let result = (|| -> Result<ResidentRunResult, EngineError> {
+        let started = Instant::now();
+        let materialized = materialize_embedded_model(cache_root)?;
+        send_logs_to_tracing(LogOptions::default().with_logs_enabled(false));
+        let backend = LlamaBackend::init().map_err(llama_error)?;
+        let devices = list_llama_ggml_backend_devices();
+        let (device, policy) = select_device(&devices, allow_cpu)?;
+        let free_before = device.memory_free;
+
+        let mut model_params = LlamaModelParams::default().with_use_mmap(true);
+        if policy == ExecutionPolicy::Accelerated {
+            model_params = model_params
+                .with_devices(&[device.index])
+                .map_err(llama_error)?
+                .with_n_gpu_layers(u32::MAX);
         } else {
-            Vec::new()
+            model_params = model_params.with_n_gpu_layers(0);
+        }
+        let model = LlamaModel::load_from_file(&backend, &materialized.path, &model_params)
+            .map_err(llama_error)?;
+        if model.n_embd() as usize != EMBEDDING_DIM {
+            return Err(EngineError::Dimension {
+                expected: EMBEDDING_DIM,
+                actual: model.n_embd() as usize,
+            });
+        }
+        let model_layer_count = model.n_layer() + 1;
+
+        let context_params = LlamaContextParams::default()
+            .with_n_ctx(NonZeroU32::new(4096))
+            .with_n_batch(LOGICAL_BATCH_TOKENS as u32)
+            .with_n_ubatch(LOGICAL_BATCH_TOKENS as u32)
+            .with_n_seq_max(MAX_BATCH_SEQUENCES as u32)
+            .with_attention_type(LlamaAttentionType::NonCausal)
+            .with_pooling_type(LlamaPoolingType::Cls)
+            .with_embeddings(true);
+        let mut context = model
+            .new_context(&backend, context_params)
+            .map_err(llama_error)?;
+        let free_after = list_llama_ggml_backend_devices()
+            .into_iter()
+            .find(|candidate| candidate.index == device.index)
+            .map_or(device.memory_free, |candidate| candidate.memory_free);
+        let accelerator_execution_verified =
+            policy == ExecutionPolicy::Accelerated && free_before > free_after && free_after > 0;
+        if policy == ExecutionPolicy::Accelerated && !accelerator_execution_verified {
+            return Err(EngineError::AcceleratorExecutionUnverified(format!(
+                "{} ({})",
+                device.name, device.description
+            )));
+        }
+        let offloaded_layer_count = if accelerator_execution_verified {
+            model_layer_count
+        } else {
+            0
+        };
+
+        let smoke_started = Instant::now();
+        let smoke = embed_inputs(
+            &model,
+            &mut context,
+            &[
+                "Represent this query for searching relevant code: codestory embedding smoke"
+                    .to_string(),
+            ],
+            RequestPriority::Query,
+            query_receiver,
+        )?;
+        if smoke
+            .first()
+            .is_none_or(|vector| vector.len() != EMBEDDING_DIM)
+        {
+            return Err(EngineError::Dimension {
+                expected: EMBEDDING_DIM,
+                actual: smoke.first().map_or(0, Vec::len),
+            });
+        }
+        let identity = EngineIdentity {
+            model_digest: MODEL_SHA256,
+            ggml_build_identity: GGML_BUILD_IDENTITY,
+            backend: device.backend.clone(),
+            adapter_name: device.name.clone(),
+            adapter_description: device.description.clone(),
+            policy,
+            embedded_model: EMBEDDED_MODEL_COMPILED,
+            materialized_path: materialized.path,
+            materialized_reused: materialized.reused,
+            initialization_duration: started.elapsed(),
+            smoke_duration: smoke_started.elapsed(),
+            adapter_memory_total: device.memory_total,
+            adapter_memory_free_before_load: free_before,
+            adapter_memory_free_after_load: free_after,
+            execution_device_names: if accelerator_execution_verified {
+                vec![device.name.clone()]
+            } else {
+                Vec::new()
+            },
+            model_layer_count,
+            offloaded_layer_count,
+            accelerator_execution_verified,
+        };
+        let snapshot = EngineLifecycleSnapshot {
+            identity,
+            residency: EngineResidency::Resident,
+            load_generation,
+            model_load_count: load_generation,
+            worker_alive: true,
+            load_error: None,
+        };
+        publish_lifecycle(lifecycle, snapshot.clone())?;
+
+        let channels = ResidentChannels {
+            startup,
+            query: query_receiver,
+            bulk: bulk_receiver,
+            control: control_receiver,
+        };
+        Ok(serve_resident_generation(
+            pending_wake
+                .take()
+                .expect("resident generation must have one wake reason"),
+            &snapshot,
+            &channels,
+            ENGINE_IDLE_TIMEOUT,
+            |request, priority| {
+                handle_request(request, priority, &model, &mut context, query_receiver);
+            },
+        ))
+    })();
+
+    match result {
+        Ok(result) => result,
+        Err(error) => ResidentRunResult::LoadFailed {
+            wake: pending_wake
+                .take()
+                .expect("load failure must retain its wake reason"),
+            error,
         },
-        model_layer_count,
-        offloaded_layer_count,
-        accelerator_execution_verified,
-    };
-    startup
-        .send(Ok(identity))
-        .map_err(|error| EngineError::WorkerUnavailable(error.to_string()))?;
+    }
+}
+
+struct ResidentChannels<'a> {
+    startup: &'a Sender<Result<EngineLifecycleSnapshot, EngineError>>,
+    query: &'a Receiver<EmbeddingRequest>,
+    bulk: &'a Receiver<EmbeddingRequest>,
+    control: &'a Receiver<Control>,
+}
+
+fn serve_resident_generation(
+    wake: WakeReason,
+    snapshot: &EngineLifecycleSnapshot,
+    channels: &ResidentChannels<'_>,
+    idle_timeout: Duration,
+    mut handle: impl FnMut(EmbeddingRequest, RequestPriority),
+) -> ResidentRunResult {
+    let mut tracker = ResidencyTracker::new(idle_timeout, Instant::now());
+    match wake {
+        WakeReason::Startup => {
+            let _ = channels.startup.send(Ok(snapshot.clone()));
+        }
+        WakeReason::Query(request) => {
+            handle(request, RequestPriority::Query);
+            tracker.complete_activity(Instant::now());
+        }
+        WakeReason::Bulk(request) => {
+            handle(request, RequestPriority::Bulk);
+            tracker.complete_activity(Instant::now());
+        }
+        WakeReason::EnsureResident(response) => {
+            tracker.complete_activity(Instant::now());
+            let _ = response.send(Ok(snapshot.clone()));
+        }
+        WakeReason::AcquireLease(response) => {
+            grant_residency_lease(response, snapshot, &mut tracker);
+        }
+    }
 
     loop {
+        let idle = after(tracker.remaining(Instant::now()));
         select_biased! {
-            recv(control_receiver) -> _ => break,
-            recv(query_receiver) -> request => match request {
-                Ok(request) => handle_request(
-                    request,
-                    RequestPriority::Query,
-                    &model,
-                    &mut context,
-                    query_receiver,
-                ),
-                Err(_) => break,
+            recv(channels.control) -> control => match control {
+                Ok(Control::Shutdown) | Err(_) => {
+                    return ResidentRunResult::Shutdown(snapshot.clone());
+                }
+                Ok(Control::EnsureResident { response }) => {
+                    tracker.complete_activity(Instant::now());
+                    let _ = response.send(Ok(snapshot.clone()));
+                }
+                Ok(Control::AcquireLease { response }) => {
+                    grant_residency_lease(response, snapshot, &mut tracker);
+                }
+                Ok(Control::ReleaseLease) => tracker.release_lease(Instant::now()),
             },
-            recv(bulk_receiver) -> request => match request {
-                Ok(request) => handle_request(
-                    request,
-                    RequestPriority::Bulk,
-                    &model,
-                    &mut context,
-                    query_receiver,
-                ),
-                Err(_) => break,
+            recv(channels.query) -> request => match request {
+                Ok(request) => {
+                    handle(request, RequestPriority::Query);
+                    tracker.complete_activity(Instant::now());
+                }
+                Err(_) => return ResidentRunResult::Shutdown(snapshot.clone()),
+            },
+            recv(channels.bulk) -> request => match request {
+                Ok(request) => {
+                    handle(request, RequestPriority::Bulk);
+                    tracker.complete_activity(Instant::now());
+                }
+                Err(_) => return ResidentRunResult::Shutdown(snapshot.clone()),
+            },
+            recv(idle) -> _ => {
+                if tracker.should_sleep(Instant::now()) {
+                    return ResidentRunResult::Sleeping(snapshot.clone());
+                }
             },
         }
     }
+}
+
+fn grant_residency_lease(
+    response: Sender<Result<EngineLifecycleSnapshot, EngineError>>,
+    snapshot: &EngineLifecycleSnapshot,
+    tracker: &mut ResidencyTracker,
+) {
+    if response.send(Ok(snapshot.clone())).is_ok() {
+        tracker.acquire_lease();
+    }
+}
+
+fn fail_wake(
+    wake: WakeReason,
+    startup: &Sender<Result<EngineLifecycleSnapshot, EngineError>>,
+    error: EngineError,
+) -> bool {
+    match wake {
+        WakeReason::Startup => {
+            let _ = startup.send(Err(error));
+            true
+        }
+        WakeReason::Query(request) | WakeReason::Bulk(request) => {
+            let _ = request.response.send(Err(error));
+            false
+        }
+        WakeReason::EnsureResident(response) | WakeReason::AcquireLease(response) => {
+            let _ = response.send(Err(error));
+            false
+        }
+    }
+}
+
+fn wait_for_wake(
+    query_receiver: &Receiver<EmbeddingRequest>,
+    bulk_receiver: &Receiver<EmbeddingRequest>,
+    control_receiver: &Receiver<Control>,
+) -> Option<WakeReason> {
+    loop {
+        select_biased! {
+            recv(control_receiver) -> control => match control {
+                Ok(Control::Shutdown) | Err(_) => return None,
+                Ok(Control::EnsureResident { response }) => {
+                    return Some(WakeReason::EnsureResident(response));
+                }
+                Ok(Control::AcquireLease { response }) => {
+                    return Some(WakeReason::AcquireLease(response));
+                }
+                Ok(Control::ReleaseLease) => {}
+            },
+            recv(query_receiver) -> request => {
+                return request.ok().map(WakeReason::Query);
+            },
+            recv(bulk_receiver) -> request => {
+                return request.ok().map(WakeReason::Bulk);
+            },
+        }
+    }
+}
+
+fn publish_lifecycle(
+    lifecycle: &Arc<Mutex<Option<EngineLifecycleSnapshot>>>,
+    snapshot: EngineLifecycleSnapshot,
+) -> Result<(), EngineError> {
+    *lifecycle
+        .lock()
+        .map_err(|_| EngineError::WorkerUnavailable("lifecycle mutex was poisoned".into()))? =
+        Some(snapshot);
     Ok(())
 }
 
@@ -751,6 +1141,143 @@ mod tests {
                 device_type: LlamaBackendDeviceType::Gpu,
             };
             assert!(is_software_adapter(&device));
+        }
+    }
+
+    #[test]
+    fn residency_tracker_sleeps_only_after_the_idle_window() {
+        let started = Instant::now();
+        let timeout = Duration::from_secs(60);
+        let tracker = ResidencyTracker::new(timeout, started);
+
+        assert_eq!(tracker.remaining(started), timeout);
+        assert!(!tracker.should_sleep(started + timeout - Duration::from_millis(1)));
+        assert!(tracker.should_sleep(started + timeout));
+    }
+
+    #[test]
+    fn residency_lease_pins_the_load_and_release_starts_a_fresh_window() {
+        let started = Instant::now();
+        let timeout = Duration::from_secs(60);
+        let mut tracker = ResidencyTracker::new(timeout, started);
+        tracker.acquire_lease();
+
+        assert!(!tracker.should_sleep(started + timeout * 2));
+
+        let released = started + timeout * 2;
+        tracker.release_lease(released);
+        assert!(!tracker.should_sleep(released + timeout - Duration::from_millis(1)));
+        assert!(tracker.should_sleep(released + timeout));
+    }
+
+    #[test]
+    fn abandoned_lease_handoff_does_not_pin_residency() {
+        let started = Instant::now();
+        let timeout = Duration::from_secs(60);
+        let mut tracker = ResidencyTracker::new(timeout, started);
+        let snapshot = test_lifecycle_snapshot();
+        let (sender, receiver) = bounded(1);
+        drop(receiver);
+
+        grant_residency_lease(sender, &snapshot, &mut tracker);
+
+        assert!(tracker.should_sleep(started + timeout));
+    }
+
+    #[test]
+    fn owner_loop_honors_injected_timeout_and_all_live_leases() {
+        let (startup_sender, _startup_receiver) = bounded(1);
+        let (_query_sender, query_receiver) = bounded(1);
+        let (_bulk_sender, bulk_receiver) = bounded(1);
+        let (control_sender, control_receiver) = unbounded();
+        let (first_lease_sender, first_lease_receiver) = bounded(1);
+        let (done_sender, done_receiver) = bounded(1);
+        let snapshot = test_lifecycle_snapshot();
+
+        let worker = thread::spawn(move || {
+            let channels = ResidentChannels {
+                startup: &startup_sender,
+                query: &query_receiver,
+                bulk: &bulk_receiver,
+                control: &control_receiver,
+            };
+            let result = serve_resident_generation(
+                WakeReason::AcquireLease(first_lease_sender),
+                &snapshot,
+                &channels,
+                Duration::from_millis(20),
+                |_, _| panic!("lease-only owner test received an embedding request"),
+            );
+            let _ = done_sender.send(result);
+        });
+
+        first_lease_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first lease handoff")
+            .expect("first lease grant");
+        let (second_lease_sender, second_lease_receiver) = bounded(1);
+        control_sender
+            .send(Control::AcquireLease {
+                response: second_lease_sender,
+            })
+            .expect("queue second lease");
+        second_lease_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("second lease handoff")
+            .expect("second lease grant");
+
+        assert!(
+            done_receiver
+                .recv_timeout(Duration::from_millis(60))
+                .is_err()
+        );
+        control_sender
+            .send(Control::ReleaseLease)
+            .expect("release first lease");
+        assert!(
+            done_receiver
+                .recv_timeout(Duration::from_millis(60))
+                .is_err()
+        );
+        control_sender
+            .send(Control::ReleaseLease)
+            .expect("release final lease");
+        assert!(matches!(
+            done_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("owner should sleep after the injected timeout"),
+            ResidentRunResult::Sleeping(_)
+        ));
+        worker.join().expect("owner test worker");
+    }
+
+    fn test_lifecycle_snapshot() -> EngineLifecycleSnapshot {
+        EngineLifecycleSnapshot {
+            identity: EngineIdentity {
+                model_digest: MODEL_SHA256,
+                ggml_build_identity: GGML_BUILD_IDENTITY,
+                backend: "test".into(),
+                adapter_name: "test".into(),
+                adapter_description: "test".into(),
+                policy: ExecutionPolicy::CpuExplicit,
+                embedded_model: true,
+                materialized_path: PathBuf::from("test.gguf"),
+                materialized_reused: true,
+                initialization_duration: Duration::ZERO,
+                smoke_duration: Duration::ZERO,
+                adapter_memory_total: 0,
+                adapter_memory_free_before_load: 0,
+                adapter_memory_free_after_load: 0,
+                execution_device_names: Vec::new(),
+                model_layer_count: 13,
+                offloaded_layer_count: 0,
+                accelerator_execution_verified: false,
+            },
+            residency: EngineResidency::Resident,
+            load_generation: 1,
+            model_load_count: 1,
+            worker_alive: true,
+            load_error: None,
         }
     }
 }

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -6,12 +6,16 @@ use crate::in_process_embedding::{
 };
 #[cfg(not(feature = "test-support"))]
 use crate::in_process_embedding::{
+    ProcessEmbeddingResidencyLease, acquire_process_embedding_residency,
     process_embedding_identity, process_embedding_identity_if_initialized,
 };
-#[cfg(not(feature = "test-support"))]
-use anyhow::anyhow;
 use anyhow::{Result, bail};
 use std::path::PathBuf;
+#[cfg(test)]
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 #[cfg(not(feature = "test-support"))]
 use std::time::Instant;
 
@@ -58,6 +62,44 @@ pub struct EmbeddingEngineSnapshot {
     pub probe: EmbeddingRuntimeProbe,
     pub device: EmbeddingDeviceReadiness,
     pub identity: Option<ProcessEmbeddingIdentity>,
+}
+
+#[derive(Debug)]
+pub struct ProductEmbeddingResidencyLease {
+    #[cfg(not(feature = "test-support"))]
+    _inner: Option<ProcessEmbeddingResidencyLease>,
+    identity: Option<ProcessEmbeddingIdentity>,
+    #[cfg(test)]
+    drop_probe: Option<Arc<AtomicBool>>,
+}
+
+impl ProductEmbeddingResidencyLease {
+    pub(crate) fn identity(&self) -> Option<&ProcessEmbeddingIdentity> {
+        self.identity.as_ref()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_lease(identity: ProcessEmbeddingIdentity) -> (Self, Arc<AtomicBool>) {
+        let active = Arc::new(AtomicBool::new(true));
+        (
+            Self {
+                #[cfg(not(feature = "test-support"))]
+                _inner: None,
+                identity: Some(identity),
+                drop_probe: Some(active.clone()),
+            },
+            active,
+        )
+    }
+}
+
+#[cfg(test)]
+impl Drop for ProductEmbeddingResidencyLease {
+    fn drop(&mut self) {
+        if let Some(active) = self.drop_probe.as_ref() {
+            active.store(false, Ordering::Release);
+        }
+    }
 }
 
 /// Cheap cloneable handle into the one engine owned by this process.
@@ -155,6 +197,33 @@ pub fn ensure_product_embedding_backend_for_runtime(runtime: &SidecarRuntimeConf
     }
 }
 
+pub fn acquire_product_embedding_residency_for_runtime(
+    runtime: &SidecarRuntimeConfig,
+) -> Result<ProductEmbeddingResidencyLease> {
+    #[cfg(feature = "test-support")]
+    {
+        let _ = runtime;
+        Ok(ProductEmbeddingResidencyLease {
+            identity: None,
+            #[cfg(test)]
+            drop_probe: None,
+        })
+    }
+    #[cfg(not(feature = "test-support"))]
+    {
+        let lease =
+            acquire_process_embedding_residency(&runtime.cache_root, runtime.embedding.allow_cpu)?;
+        let identity = lease.identity().clone();
+        validate_identity(&identity, runtime.embedding.allow_cpu)?;
+        Ok(ProductEmbeddingResidencyLease {
+            _inner: Some(lease),
+            identity: Some(identity),
+            #[cfg(test)]
+            drop_probe: None,
+        })
+    }
+}
+
 /// Observes readiness without starting the engine or materializing the model.
 pub fn probe_product_embedding_runtime() -> EmbeddingRuntimeProbe {
     probe_product_embedding_runtime_for_runtime(&SidecarRuntimeConfig::local())
@@ -202,37 +271,59 @@ pub fn embedding_engine_snapshot_for_runtime(
     #[cfg(not(feature = "test-support"))]
     {
         let started = Instant::now();
-        let result = process_embedding_identity_if_initialized(
+        let observed = process_embedding_identity_if_initialized(
             &runtime.cache_root,
             runtime.embedding.allow_cpu,
-        )
-        .and_then(|identity| {
-            let identity =
-                identity.ok_or_else(|| anyhow!("retrieval embeddings not initialized"))?;
-            validate_identity(&identity, runtime.embedding.allow_cpu)?;
-            Ok(identity)
-        });
+        );
         let elapsed_ms = Some(elapsed_ms(started));
-        match result {
-            Ok(identity) => EmbeddingEngineSnapshot {
-                probe: EmbeddingRuntimeProbe {
-                    reachable: true,
-                    detail: "retrieval embeddings ready".into(),
-                    elapsed_ms,
-                },
-                device: readiness_from_identity(&identity, runtime.embedding.allow_cpu),
-                identity: Some(identity),
-            },
-            Err(error) => EmbeddingEngineSnapshot {
-                probe: EmbeddingRuntimeProbe {
-                    reachable: false,
-                    detail: format!("retrieval embeddings unavailable: {error}"),
-                    elapsed_ms,
-                },
-                device: unavailable_readiness(runtime.embedding.allow_cpu, &error.to_string()),
-                identity: None,
-            },
+        match observed {
+            Ok(Some(identity)) => observed_engine_snapshot(runtime, elapsed_ms, identity),
+            Ok(None) => unavailable_engine_snapshot(
+                runtime,
+                elapsed_ms,
+                "retrieval embeddings not initialized".into(),
+                None,
+            ),
+            Err(error) => unavailable_engine_snapshot(runtime, elapsed_ms, error.to_string(), None),
         }
+    }
+}
+
+#[cfg(any(not(feature = "test-support"), test))]
+fn observed_engine_snapshot(
+    runtime: &SidecarRuntimeConfig,
+    elapsed_ms: Option<u64>,
+    identity: ProcessEmbeddingIdentity,
+) -> EmbeddingEngineSnapshot {
+    if let Err(error) = validate_identity(&identity, runtime.embedding.allow_cpu) {
+        return unavailable_engine_snapshot(runtime, elapsed_ms, error.to_string(), Some(identity));
+    }
+    EmbeddingEngineSnapshot {
+        probe: EmbeddingRuntimeProbe {
+            reachable: true,
+            detail: "retrieval embeddings ready".into(),
+            elapsed_ms,
+        },
+        device: readiness_from_identity(&identity, runtime.embedding.allow_cpu),
+        identity: Some(identity),
+    }
+}
+
+#[cfg(any(not(feature = "test-support"), test))]
+fn unavailable_engine_snapshot(
+    runtime: &SidecarRuntimeConfig,
+    elapsed_ms: Option<u64>,
+    detail: String,
+    identity: Option<ProcessEmbeddingIdentity>,
+) -> EmbeddingEngineSnapshot {
+    EmbeddingEngineSnapshot {
+        probe: EmbeddingRuntimeProbe {
+            reachable: false,
+            detail: format!("retrieval embeddings unavailable: {detail}"),
+            elapsed_ms,
+        },
+        device: unavailable_readiness(runtime.embedding.allow_cpu, &detail),
+        identity,
     }
 }
 
@@ -277,6 +368,18 @@ pub fn ensure_embedding_accelerator_smoke_for_runtime(
 
 #[cfg(any(not(feature = "test-support"), test))]
 fn validate_identity(identity: &ProcessEmbeddingIdentity, allow_cpu: bool) -> Result<()> {
+    if !identity.worker_alive {
+        bail!("embedding engine worker is not running");
+    }
+    if let Some(error) = identity.load_error.as_deref() {
+        bail!("embedding engine could not restore residency: {error}");
+    }
+    if !matches!(identity.residency, "resident" | "sleeping") {
+        bail!(
+            "embedding engine reported unknown residency {}",
+            identity.residency
+        );
+    }
     if !identity.embedded_model {
         bail!("embedding model is not embedded in this executable");
     }
@@ -319,7 +422,7 @@ fn validate_identity(identity: &ProcessEmbeddingIdentity, allow_cpu: bool) -> Re
     Ok(())
 }
 
-#[cfg(not(feature = "test-support"))]
+#[cfg(any(not(feature = "test-support"), test))]
 fn readiness_from_identity(
     identity: &ProcessEmbeddingIdentity,
     allow_cpu: bool,
@@ -347,7 +450,7 @@ fn readiness_from_identity(
     }
 }
 
-#[cfg(not(feature = "test-support"))]
+#[cfg(any(not(feature = "test-support"), test))]
 fn unavailable_readiness(allow_cpu: bool, reason: &str) -> EmbeddingDeviceReadiness {
     EmbeddingDeviceReadiness {
         requested_policy: requested_policy(allow_cpu),
@@ -384,7 +487,11 @@ mod tests {
     fn identity(policy: &'static str) -> ProcessEmbeddingIdentity {
         ProcessEmbeddingIdentity {
             instance_id: "test".into(),
+            load_generation: 1,
             model_load_count: 1,
+            residency: "resident",
+            worker_alive: true,
+            load_error: None,
             model_digest: codestory_llama_sys::MODEL_SHA256,
             ggml_build_identity: codestory_llama_sys::GGML_BUILD_IDENTITY,
             backend: if policy == "accelerated" {
@@ -431,6 +538,37 @@ mod tests {
     fn cpu_identity_is_accepted_only_under_explicit_policy() {
         let identity = identity("cpu_explicit");
         assert!(validate_identity(&identity, true).is_ok());
+        assert!(validate_identity(&identity, false).is_err());
+    }
+
+    #[test]
+    fn sleeping_identity_remains_ready_until_a_wake_fails() {
+        let mut identity = identity("accelerated");
+        identity.residency = "sleeping";
+        assert!(validate_identity(&identity, false).is_ok());
+        let sleeping =
+            observed_engine_snapshot(&SidecarRuntimeConfig::local(), Some(0), identity.clone());
+        assert!(sleeping.probe.reachable);
+        assert_eq!(
+            sleeping.identity.map(|identity| identity.residency),
+            Some("sleeping")
+        );
+
+        identity.load_error = Some("adapter disappeared".into());
+        assert!(validate_identity(&identity, false).is_err());
+        let snapshot = unavailable_engine_snapshot(
+            &SidecarRuntimeConfig::local(),
+            Some(0),
+            "adapter disappeared".into(),
+            Some(identity.clone()),
+        );
+        assert!(!snapshot.probe.reachable);
+        assert_eq!(
+            snapshot.identity.and_then(|identity| identity.load_error),
+            Some("adapter disappeared".into())
+        );
+        identity.load_error = None;
+        identity.worker_alive = false;
         assert!(validate_identity(&identity, false).is_err());
     }
 }

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -273,6 +273,12 @@ pub struct InfrastructureHealth {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding_engine_instance_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_engine_residency: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_engine_load_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_engine_load_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding_model_load_count: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding_smoke_ms: Option<u64>,
@@ -391,6 +397,15 @@ pub fn probe_infrastructure_health(runtime: &SidecarRuntimeConfig) -> Infrastruc
         embedding_engine_instance_id: identity
             .as_ref()
             .map(|identity| identity.instance_id.clone()),
+        embedding_engine_residency: identity
+            .as_ref()
+            .map(|identity| identity.residency.to_string()),
+        embedding_engine_load_generation: identity
+            .as_ref()
+            .map(|identity| identity.load_generation),
+        embedding_engine_load_error: identity
+            .as_ref()
+            .and_then(|identity| identity.load_error.clone()),
         embedding_model_load_count: identity.as_ref().map(|identity| identity.model_load_count),
         embedding_smoke_ms: identity.as_ref().map(|identity| identity.smoke_ms),
         embedding_initialization_ms: identity.as_ref().map(|identity| identity.initialization_ms),

--- a/crates/codestory-retrieval/src/in_process_embedding.rs
+++ b/crates/codestory-retrieval/src/in_process_embedding.rs
@@ -1,19 +1,23 @@
 use anyhow::{Result, anyhow, bail};
-use codestory_llama_sys::{EmbeddingEngine, ExecutionPolicy};
+#[cfg(not(feature = "test-support"))]
+use codestory_llama_sys::EmbeddingResidencyLease;
+use codestory_llama_sys::{EmbeddingEngine, EngineLifecycleSnapshot, ExecutionPolicy};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 type ProcessEngineState = Option<Arc<ProcessEmbeddingEngine>>;
 
 static PROCESS_ENGINE: OnceLock<Mutex<ProcessEngineState>> = OnceLock::new();
 static PROCESS_EXIT_HOOK: OnceLock<Result<(), String>> = OnceLock::new();
-static MODEL_LOAD_COUNT: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 pub struct ProcessEmbeddingIdentity {
     pub instance_id: String,
+    pub load_generation: u64,
     pub model_load_count: u64,
+    pub residency: &'static str,
+    pub worker_alive: bool,
+    pub load_error: Option<String>,
     pub model_digest: &'static str,
     pub ggml_build_identity: &'static str,
     pub backend: String,
@@ -41,12 +45,28 @@ struct ProcessEmbeddingEngine {
     instance_id: String,
 }
 
+#[derive(Debug)]
+#[cfg(not(feature = "test-support"))]
+pub struct ProcessEmbeddingResidencyLease {
+    _process: Arc<ProcessEmbeddingEngine>,
+    _lease: EmbeddingResidencyLease,
+    identity: ProcessEmbeddingIdentity,
+}
+
+#[cfg(not(feature = "test-support"))]
+impl ProcessEmbeddingResidencyLease {
+    pub fn identity(&self) -> &ProcessEmbeddingIdentity {
+        &self.identity
+    }
+}
+
 pub fn process_embedding_identity(
     cache_root: &Path,
     allow_cpu: bool,
 ) -> Result<ProcessEmbeddingIdentity> {
     let process = process_engine(cache_root, allow_cpu)?;
-    Ok(identity_from_process(&process))
+    let snapshot = process.engine.ensure_resident()?;
+    Ok(identity_from_snapshot(&process, &snapshot))
 }
 
 /// Observes the process engine without starting it. Status and doctor surfaces
@@ -65,7 +85,23 @@ pub fn process_embedding_identity_if_initialized(
         return Ok(None);
     };
     validate_process_selection(process, cache_root, allow_cpu)?;
-    Ok(Some(identity_from_process(process)))
+    let snapshot = process.engine.snapshot()?;
+    Ok(Some(identity_from_snapshot(process, &snapshot)))
+}
+
+#[cfg(not(feature = "test-support"))]
+pub fn acquire_process_embedding_residency(
+    cache_root: &Path,
+    allow_cpu: bool,
+) -> Result<ProcessEmbeddingResidencyLease> {
+    let process = process_engine(cache_root, allow_cpu)?;
+    let lease = process.engine.acquire_residency_lease()?;
+    let identity = identity_from_snapshot(&process, lease.snapshot());
+    Ok(ProcessEmbeddingResidencyLease {
+        _process: process,
+        _lease: lease,
+        identity,
+    })
 }
 
 pub fn embed_prepared_in_process(
@@ -113,7 +149,6 @@ fn process_engine(cache_root: &Path, allow_cpu: bool) -> Result<Arc<ProcessEmbed
         // atexit callbacks run in reverse order, so this drops the live model
         // and context before ggml releases the selected Metal/Vulkan device.
         ensure_process_exit_hook()?;
-        MODEL_LOAD_COUNT.fetch_add(1, Ordering::AcqRel);
         *state = Some(Arc::new(ProcessEmbeddingEngine {
             engine,
             cache_root: cache_root.to_path_buf(),
@@ -156,11 +191,18 @@ fn validate_process_selection(
     Ok(())
 }
 
-fn identity_from_process(process: &ProcessEmbeddingEngine) -> ProcessEmbeddingIdentity {
-    let identity = process.engine.identity();
+fn identity_from_snapshot(
+    process: &ProcessEmbeddingEngine,
+    snapshot: &EngineLifecycleSnapshot,
+) -> ProcessEmbeddingIdentity {
+    let identity = &snapshot.identity;
     ProcessEmbeddingIdentity {
         instance_id: process.instance_id.clone(),
-        model_load_count: MODEL_LOAD_COUNT.load(Ordering::Acquire),
+        load_generation: snapshot.load_generation,
+        model_load_count: snapshot.model_load_count,
+        residency: snapshot.residency.as_str(),
+        worker_alive: snapshot.worker_alive,
+        load_error: snapshot.load_error.clone(),
         model_digest: identity.model_digest,
         ggml_build_identity: identity.ggml_build_identity,
         backend: identity.backend.clone(),

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -82,6 +82,7 @@ struct GenerationRetentionContext<'a> {
     workspace_id: &'a str,
     previous_manifest: Option<&'a RetrievalIndexManifest>,
     embedding_device: &'a crate::embeddings::EmbeddingDeviceReadiness,
+    embedding_residency: crate::embeddings::ProductEmbeddingResidencyLease,
 }
 
 const SIDECAR_INPUT_BATCH_SIZE: usize = 4096;
@@ -135,6 +136,9 @@ pub fn finalize_index_for_runtime_with_progress(
     let _generation_lock = GenerationRetentionLock::acquire(&layout.state_file, &project_id)
         .context("lock sidecar generation publication and retention")?;
     layout.ensure_data_dirs()?;
+    let embedding_residency =
+        crate::embeddings::acquire_product_embedding_residency_for_runtime(runtime)
+            .context("mandatory retrieval embedding runtime could not be pinned")?;
     let degraded_modes = Vec::new();
     let scip_stubbed = false;
 
@@ -178,6 +182,7 @@ pub fn finalize_index_for_runtime_with_progress(
         workspace_id: &workspace_id,
         previous_manifest: previous_manifest.as_ref(),
         embedding_device: &embedding_device,
+        embedding_residency,
     };
 
     if let Some(previous) = previous_manifest.as_ref() {
@@ -652,6 +657,16 @@ fn semantic_ready_point_count(semantic: &SemanticGeneration<'_>) -> Option<u64> 
     health.ready.then_some(health.point_count)
 }
 
+fn with_embedding_publication_residency<T>(
+    residency: &crate::embeddings::ProductEmbeddingResidencyLease,
+    publish: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    if residency.identity().is_none() && !cfg!(feature = "test-support") {
+        bail!("embedding publication fence is missing its residency lease identity");
+    }
+    publish()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn persist_finalized_manifest(
     project_root: &Path,
@@ -671,38 +686,47 @@ fn persist_finalized_manifest(
         crate::embeddings::embedding_runtime_id_for_runtime(retention_context.runtime);
     let embedding_dim = i32::try_from(crate::embeddings::semantic_vector_dim())
         .unwrap_or(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32);
-    promote_retrieval_manifest(
-        &mut storage,
-        sidecar_input,
-        &manifest,
-        |storage| {
-            let lexical_source = lexical_source_input(project_root)
-                .context("rescan lexical source at publication fence")?;
-            let embedding_contract = SidecarEmbeddingContract {
-                backend: &embedding_backend,
-                dimension: embedding_dim,
-            };
-            let current_input = compute_sidecar_input_fingerprint_with_lexical_source(
-                storage,
-                project_root,
-                &project_id,
-                &embedding_contract,
-                lexical_source,
-            )?;
-            if let Some(reason) = manifest_unavailable_reason_for_runtime(
-                &project_id,
-                storage,
-                &manifest,
-                retention_context.runtime,
-            ) {
-                bail!(
-                    "mandatory retrieval sidecar manifest would be unavailable immediately for {project_id}: {reason}"
-                );
-            }
-            Ok(current_input)
-        },
-        || validate_candidate_generation(&project_id, sidecar_input, &manifest, retention_context),
-    )?;
+    with_embedding_publication_residency(&retention_context.embedding_residency, || {
+        promote_retrieval_manifest(
+            &mut storage,
+            sidecar_input,
+            &manifest,
+            |storage| {
+                let lexical_source = lexical_source_input(project_root)
+                    .context("rescan lexical source at publication fence")?;
+                let embedding_contract = SidecarEmbeddingContract {
+                    backend: &embedding_backend,
+                    dimension: embedding_dim,
+                };
+                let current_input = compute_sidecar_input_fingerprint_with_lexical_source(
+                    storage,
+                    project_root,
+                    &project_id,
+                    &embedding_contract,
+                    lexical_source,
+                )?;
+                if let Some(reason) = manifest_unavailable_reason_for_runtime(
+                    &project_id,
+                    storage,
+                    &manifest,
+                    retention_context.runtime,
+                ) {
+                    bail!(
+                        "mandatory retrieval sidecar manifest would be unavailable immediately for {project_id}: {reason}"
+                    );
+                }
+                Ok(current_input)
+            },
+            || {
+                validate_candidate_generation(
+                    &project_id,
+                    sidecar_input,
+                    &manifest,
+                    retention_context,
+                )
+            },
+        )
+    })?;
 
     let (generation_retention_plan, generation_retention) =
         retain_published_generations(storage_path, retention_context, &project_id, &manifest)?;
@@ -857,14 +881,28 @@ fn embedding_identity_matches(
     after: &crate::in_process_embedding::ProcessEmbeddingIdentity,
 ) -> bool {
     before.instance_id == after.instance_id
-        && before.model_load_count == 1
-        && after.model_load_count == 1
+        && before.load_generation == after.load_generation
+        && before.model_load_count == after.model_load_count
+        && before.residency == "resident"
+        && after.residency == "resident"
+        && before.worker_alive
+        && after.worker_alive
+        && before.load_error.is_none()
+        && after.load_error.is_none()
         && before.model_digest == after.model_digest
         && before.ggml_build_identity == after.ggml_build_identity
         && before.backend == after.backend
         && before.adapter_name == after.adapter_name
         && before.policy == after.policy
         && before.accelerator_execution_verified == after.accelerator_execution_verified
+}
+
+fn embedding_identity_matches_lease(
+    lease: &crate::in_process_embedding::ProcessEmbeddingIdentity,
+    before: &crate::in_process_embedding::ProcessEmbeddingIdentity,
+    after: &crate::in_process_embedding::ProcessEmbeddingIdentity,
+) -> bool {
+    embedding_identity_matches(lease, before) && embedding_identity_matches(before, after)
 }
 
 fn validate_candidate_generation(
@@ -914,6 +952,17 @@ fn validate_candidate_generation(
         context.runtime.embedding.allow_cpu,
     )
     .context("validate in-process embedding identity after final probes")?;
+    if let Some(lease_identity) = context.embedding_residency.identity() {
+        if !embedding_identity_matches_lease(
+            lease_identity,
+            &embedding_identity_before,
+            &embedding_identity_after,
+        ) {
+            bail!("embedding engine load generation changed inside the publication fence");
+        }
+    } else if !cfg!(feature = "test-support") {
+        bail!("embedding publication fence is missing its residency lease identity");
+    }
     let evidence = CandidateGenerationEvidence {
         lexical_matches: crate::lexical_index::shard_matches_lexical_input(
             &context.layout.lexical_data_dir,
@@ -1344,7 +1393,11 @@ mod tests {
         let accelerated = policy == "accelerated";
         crate::in_process_embedding::ProcessEmbeddingIdentity {
             instance_id: "inprocess:test".into(),
+            load_generation: 1,
             model_load_count: 1,
+            residency: "resident",
+            worker_alive: true,
+            load_error: None,
             model_digest: codestory_llama_sys::MODEL_SHA256,
             ggml_build_identity: codestory_llama_sys::GGML_BUILD_IDENTITY,
             backend: if accelerated { "Metal" } else { "CPU" }.into(),
@@ -1412,6 +1465,44 @@ mod tests {
         .expect("progress wrapper should return action result");
 
         assert_eq!(&*phases.borrow(), &["lexical sidecar"]);
+    }
+
+    #[test]
+    fn publication_requires_one_pinned_embedding_load_generation() {
+        let before = test_embedding_identity("accelerated");
+        let mut after = before.clone();
+        assert!(embedding_identity_matches_lease(&before, &before, &after));
+
+        after.load_generation += 1;
+        after.model_load_count += 1;
+        assert!(!embedding_identity_matches_lease(&before, &before, &after));
+
+        after = before.clone();
+        after.residency = "sleeping";
+        assert!(!embedding_identity_matches_lease(&before, &before, &after));
+
+        let mut lease = before.clone();
+        lease.load_generation += 1;
+        lease.model_load_count += 1;
+        assert!(!embedding_identity_matches_lease(&lease, &before, &before));
+    }
+
+    #[test]
+    fn publication_scope_retains_the_residency_guard_through_commit() {
+        use std::sync::atomic::Ordering;
+
+        let (residency, active) = crate::embeddings::ProductEmbeddingResidencyLease::test_lease(
+            test_embedding_identity("accelerated"),
+        );
+        with_embedding_publication_residency(&residency, || {
+            assert!(active.load(Ordering::Acquire));
+            Ok(())
+        })
+        .expect("publication under residency guard");
+        assert!(active.load(Ordering::Acquire));
+
+        drop(residency);
+        assert!(!active.load(Ordering::Acquire));
     }
 
     #[test]

--- a/docs/architecture/host-integration.md
+++ b/docs/architecture/host-integration.md
@@ -47,6 +47,8 @@ One stdio process can therefore serve repositories A, B, then A again:
 - process startup defaults are captured once and are not reread when projects
   switch;
 - the in-process embedding engine and materialized model are shared;
+- the heavy model and accelerator allocation sleep after 60 idle seconds and
+  wake automatically on the next product request;
 - small request-local and project-local caches are reset or selected explicitly,
   rather than leaking the prior project.
 
@@ -60,9 +62,10 @@ flowchart LR
     B --> Engine
 ```
 
-Switching projects changes the selected runtime and cache, not the model
-instance. Returning to A reuses both A's project state and the already-warm
-engine without making either visible to B.
+Switching projects changes the selected runtime and cache, not the engine
+owner. Returning to A during an active burst reuses the warm model. Returning
+after the idle window reloads the same verified model automatically without
+making either project's state visible to the other.
 
 ## Managed activation
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -16,7 +16,7 @@ flowchart LR
     Select --> Runtime["project RuntimeContext"]
     Runtime --> Graph["core graph and local navigation"]
     Runtime --> Retrieval["retrieval publication and broad evidence"]
-    Retrieval --> Engine["one process-wide embedding engine"]
+    Retrieval --> Engine["one sleeping or resident engine owner"]
 ```
 
 The launcher provisions only the exact CodeStory executable required by the
@@ -25,9 +25,11 @@ handshake, then hands requests to that executable. It does not provision a
 model or backend separately.
 
 Every MCP request carries an absolute project root. The stdio process retains
-one isolated runtime context per project while all projects share one lazily
-initialized model and accelerator context. Hook-written active-project files
-are diagnostics; they never route requests.
+one isolated runtime context per project while all projects share one embedding
+owner. Its model and accelerator context stay warm during active request bursts
+and are released after 60 idle seconds. The next product request restores them
+automatically. Hook-written active-project files are diagnostics; they never
+route requests.
 
 ## Data topology
 
@@ -65,7 +67,7 @@ evidence.
 
 | Scope | Identity and state | Lifetime |
 | --- | --- | --- |
-| Process | captured startup defaults and one embedding engine | one CLI or stdio process |
+| Process | captured startup defaults and one embedding owner | one CLI or stdio process |
 | Project | repository identity, cache namespace, immutable runtime config | retained across requests in multi-project stdio |
 | Publication | core generation/run plus retrieval generation/input/producer | one atomic old-or-new published view |
 | Request | explicit project, tool arguments, task and retry budget | one tool or CLI call |

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -19,6 +19,13 @@ process. Initialization freezes process-level cache-root and CPU-policy
 compatibility; a later project cannot silently reconfigure the shared engine.
 One-shot CLI processes pay cold initialization themselves.
 
+The existing model worker also owns residency. It keeps the verified backend,
+model, and context warm while requests are active, then drops all three after
+60 seconds without a completed request or publication lease. The lightweight
+worker and its last verified identity remain. A later product request reloads
+the content-addressed model, reruns the timed accelerator smoke, and continues
+without a download, repair command, or consent step.
+
 The engine has one model worker with bounded interactive-query and bulk queues.
 Interactive queries take priority, including between bulk batches. Embedding
 uses the pinned CodeRank tokenizer, the
@@ -92,6 +99,10 @@ project-local retrieval publication, not evidence of an external service.
 5. Reject drift and leave the previous generation active, or atomically publish
    the complete candidate and manifest.
 
+The writer holds one embedding residency lease from backend validation through
+candidate publication. The lease pins the owner and load generation, so the
+idle policy cannot divide one publication across two runtime instances.
+
 Failure, cancellation, incomplete discovery, or source drift never authorizes a
 partial publication or deletion inferred from absence. Retention removes only
 proved CodeStory-owned generations through the shared handle-relative deletion
@@ -133,7 +144,7 @@ publication. Broad agent surfaces additionally require:
 
 - a current core and source identity;
 - the exact in-process producer identity;
-- a live timed embedding smoke;
+- a current or automatically restorable timed embedding smoke;
 - `accelerated` or explicitly permitted `cpu_explicit` policy;
 - an allowed packet/search/context surface.
 
@@ -145,6 +156,11 @@ timing details stay in maintainer diagnostics.
 Status and doctor observe this state. A broad product call may initialize the
 engine and build a missing generation automatically; it never asks the user to
 approve or repair an internal subsystem.
+
+Sleeping is healthy because the owner, packaged model, immutable policy, and
+last verified adapter identity remain available for automatic wake. A failed
+wake records the load error and blocks broad retrieval until a later product
+request proves a successful reload.
 
 ## Ownership and evidence
 

--- a/docs/architecture/subsystems/llama-sys.md
+++ b/docs/architecture/subsystems/llama-sys.md
@@ -22,6 +22,8 @@ execution remains available only through the caller's explicit
 - verified content-addressed model materialization for mmap;
 - physical backend and adapter selection, including software-adapter rejection;
 - one model worker with bounded query and bulk queues;
+- owner-thread residency with a 60-second idle unload and automatic wake;
+- RAII residency leases for operations that must retain one load generation;
 - query priority between bulk batches;
 - the CodeRank query prefix (`Represent this query for searching relevant code: `),
   no document prefix, batching, CLS pooling, and L2 normalization;
@@ -42,6 +44,8 @@ accelerator failure by silently selecting CPU.
 
 - the runtime downloads a model or backend;
 - more than one model context is loaded in a multi-project process;
+- an idle task retains its model, context, or accelerator allocation after the
+  residency window;
 - WARP, llvmpipe, lavapipe, or SwiftShader satisfies accelerated policy;
 - model bytes are materialized without digest verification and atomic publish;
 - backend details leak into normal user-facing readiness messages.

--- a/docs/architecture/subsystems/retrieval.md
+++ b/docs/architecture/subsystems/retrieval.md
@@ -44,6 +44,11 @@ The embedding engine is process-wide, while manifests and artifacts are
 project-local. An incompatible cache-root or CPU-policy request fails rather
 than replacing an already initialized engine.
 
+Retrieval finalization holds an embedding residency lease across candidate
+build, validation, and publication. Manifest compatibility uses the stable
+producer contract; the lease's owner/load generation is a live publication
+fence and is not persisted as vector compatibility.
+
 ## Extension rules
 
 - add artifact formats and identity fields here before teaching runtime about

--- a/docs/contributors/debugging.md
+++ b/docs/contributors/debugging.md
@@ -98,8 +98,9 @@ Recovery order:
 4. Require `codestory-cli retrieval status --project . --format json` to report
    `retrieval_mode: "full"` before trusting packet/search evidence.
 5. If `doctor` reports an engine failure, inspect its model digest, ggml build,
-   backend, adapter, policy, and live-smoke fields. Do not enable CPU merely to
-   hide an acceleration failure.
+   backend, adapter, policy, residency, load generation, and live-smoke fields.
+   `sleeping` is healthy and must not initialize the engine; a recorded wake
+   failure is not. Do not enable CPU merely to hide an acceleration failure.
 6. If semantic retrieval is still the only failing part, inspect the reported degraded-state reason before touching lexical ranking or CLI rendering.
 
 ## If Cold Indexing Is Slow

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -72,6 +72,8 @@ Focused proof covers:
 - prohibited silent CPU fallback and software-adapter rejection;
 - live embedding smoke and layer-offload evidence;
 - one engine/model load shared across repositories;
+- owner-thread idle unload, observational sleeping status, and automatic wake;
+- publication leases that retain one load generation through commit;
 - generation-coherent query reads and producer migration;
 - cleanup confined to proved owned generations.
 
@@ -89,6 +91,12 @@ They must report `cpu_explicit` and make no acceleration claim.
 archive in an isolated offline environment. It requires one native executable,
 version/help, full retrieval, plugin packet/search, multi-repository engine
 reuse, restart/materialization reuse, and no helper-process lifecycle state.
+
+Protected hardware proof also passes `--idle-residency-proof`. It records an
+uninitialized process-memory baseline, verifies the owner becomes `sleeping`
+after the idle window, requires memory to return near that baseline, then wakes
+the same owner and requires a second verified load from the unchanged
+materialized model. macOS uses physical footprint; Windows uses working set.
 
 Use `--plugin-handoff`, `--engine-policy`, `--expected-backend`, and `--offline`
 to make the claim explicit. The harness self-test is:


### PR DESCRIPTION
## Context

The CodeRankEmbed task moved embeddings in-process, but every task-scoped CLI worker kept its model and accelerator allocation resident for its entire lifetime. With several Codex tasks open, that multiplied Metal/Vulkan memory even when most workers were idle.

Closes #1171
Refs #899

## What changed

- Keeps one lightweight owner thread per CLI process and gives it two states: resident and sleeping.
- Automatically wakes on the first activating embedding request, then unloads the backend, model, context, and GPU allocation after 60 seconds without a completed request or residency lease. On Windows, the owner trims released allocator and driver pages from the working set before publishing sleeping.
- Adds an internal RAII residency lease across retrieval generation build, validation, and publication.
- Separates stable producer compatibility from live owner/load-generation identity.
- Keeps status and doctor observational: a healthy sleeping engine remains retrieval-ready and does not wake for diagnostics.
- Fails activating work closed when reload fails, records the failure before returning it, and recovers automatically after the model is available again.
- Extends packaged Mac and Windows hardware proof through warm, sleep, failed wake, recovery, and content-addressed model reuse.
- Does not add a daemon, broker, IPC, watchdog, port, download, repair, consent, signing, or release path.

## Review notes

The concurrency review found four issues in the first implementation: a cancelled lease handoff could pin forever, reload errors could escape before diagnostics were published, publication was not explicitly fenced to the acquired lease snapshot, and tests stopped short of the real owner loop. All four are fixed. Exact-head re-review found no P0-P2 blockers.

The code-simplifier pass kept the lifecycle and proof sequence explicit because ordering and destruction are the contract. One low-risk snapshot duplication was collapsed; larger rewrites were deferred because they would increase concurrency risk without removing a product boundary.

## Verification

Exact head: `d722cb0d850eb8f353b63bdc37f1194eeca98bd5`

Passed locally:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- focused owner/retrieval suites and all-feature checks
- plugin static tests, docs links, workflow policy, proof-script self-test
- explicit-CPU packaged proof
- repo-scale stats lane: 997 dense documents embedded on the cold run, all 997 reused on repeat refresh
- three concurrent task workers: each remained warm at 30 seconds, slept after 60 seconds, recorded a forced reload failure, then recovered on load generation 2

Exact packaged Apple M5 Metal proof:

- backend `MTL`, adapter `MTL0`, Apple M5, 13/13 layers offloaded
- owner remained stable across sleep/wake
- baseline physical footprint: 5,505,024 bytes
- resident physical footprint: 111,463,629 bytes
- sleeping physical footprint: 44,040,192 bytes
- acceptance allowance: 52,428,800 bytes
- recovery: load generation 2, load count 2, 280 ms initialization, 16 ms smoke
- no downloads, helper processes, ports, repair, or consent

Exact packaged Windows RX 7900 XT Vulkan proof:

- package executable SHA-256 `8a573c6234e0742f32f601c9e2f74ed66abcfb7edb314557ccfdcbec32d1fda8`; archive SHA-256 `d49db5e291e04d5ffbe07b20805db2e01af2dedb4d54f53467fd8fb802537c87`
- backend `Vulkan`, adapter `AMD Radeon RX 7900 XT`, accelerated policy verified with CPU fallback disabled
- baseline working set: 14,503,936 bytes
- resident working set: 235,454,464 bytes
- sleeping working set: 8,941,568 bytes
- acceptance allowance: 55,237,632 bytes
- successful `ground`, `search`, second-repository `search`, and `packet`; both repositories shared one in-process engine with load count 1 during the activity burst
- public status remained readiness-only while maintainer diagnostics carried backend and adapter identity
- offline archive execution, embedded-model/cache reuse, failed-wake recording, generation-2 recovery, and proof-owned process cleanup passed; no `llama-server` helper was created

No Linux GPU claim is made. This PR does not promote `main`, sign, notarize, or release.

## Line delta

- Production: +672 / -173 (net +499)
- Tests and hardware proof: +612 / -31 (net +581)
- Documentation: +53 / -11 (net +42)
- Total: +1,337 / -215 (net +1,122)

The production growth is the owner-state/lease/fence contract. Most remaining growth is packaged hardware proof and focused lifecycle boundaries; no external lifecycle machinery was added.
