### PR TITLE
Prepare the release model automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Existing semantic indexes rebuild once after upgrade. The last complete index stays available during safe refreshes, and CodeStory refuses to mix results from different generations.
 - The packaged executable works offline after installation, reuses its verified model material across restarts, and does not start helper processes or open retrieval ports.
 - Everyday plugin messages say whether broader search is ready, preparing, or unavailable. Model, backend, adapter, and timing details stay in maintainer diagnostics.
+- Source release builds now reuse or prepare the pinned model automatically, so `cargo build --release` no longer requires an internal environment variable.
 
 ### Upgrade note
 

--- a/crates/codestory-llama-sys/build.rs
+++ b/crates/codestory-llama-sys/build.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 const MODEL_FILE_NAME: &str = "coderankembed.Q8_0.gguf";
 const MODEL_SIZE: u64 = 146_029_792;
@@ -41,14 +42,14 @@ fn main() {
     )
     .expect("write embedding model contract");
     let generated = out_dir.join("embedded_model.rs");
-    let source = env::var_os("CODESTORY_EMBED_MODEL_SOURCE").map(PathBuf::from);
+    let source = resolve_model_source();
 
     match source {
         Some(source) => {
             println!("cargo:rerun-if-changed={}", source.display());
             verify_model(&source).unwrap_or_else(|error| {
                 panic!(
-                    "invalid CODESTORY_EMBED_MODEL_SOURCE {}: {error}",
+                    "invalid embedded model source {}: {error}",
                     source.display()
                 )
             });
@@ -69,11 +70,6 @@ fn main() {
             )
             .expect("write embedded model bindings");
         }
-        None if env::var("DEBUG").as_deref() == Ok("false") => {
-            panic!(
-                "release builds require CODESTORY_EMBED_MODEL_SOURCE pointing to the checksum-pinned {MODEL_FILE_NAME}"
-            );
-        }
         None => {
             fs::write(
                 &generated,
@@ -86,6 +82,51 @@ fn main() {
             );
         }
     }
+}
+
+fn resolve_model_source() -> Option<PathBuf> {
+    if let Some(source) = env::var_os("CODESTORY_EMBED_MODEL_SOURCE") {
+        return Some(PathBuf::from(source));
+    }
+    if env::var("DEBUG").as_deref() != Ok("false") {
+        return None;
+    }
+
+    Some(prepare_release_model())
+}
+
+fn prepare_release_model() -> PathBuf {
+    let manifest_dir =
+        PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("Cargo sets CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("codestory-llama-sys lives under the workspace crates directory");
+    let script = workspace_root.join("scripts/prepare-embedded-model.mjs");
+    println!("cargo:rerun-if-changed={}", script.display());
+    let output = Command::new("node")
+        .arg(&script)
+        .current_dir(workspace_root)
+        .output()
+        .unwrap_or_else(|error| {
+            panic!("failed to start automatic embedded-model preparation with Node.js: {error}")
+        });
+    if !output.status.success() {
+        panic!(
+            "automatic embedded-model preparation failed (status {}):\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let source = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+    verify_model(&source).unwrap_or_else(|error| {
+        panic!(
+            "automatic embedded-model preparation produced invalid {}: {error}",
+            source.display()
+        )
+    });
+    source
 }
 
 fn verify_model(path: &Path) -> Result<(), String> {

--- a/docs/architecture/subsystems/llama-sys.md
+++ b/docs/architecture/subsystems/llama-sys.md
@@ -7,9 +7,13 @@ CodeStory release executable. It has no public product or network surface.
 ## Build identity
 
 `build.rs` pins the model filename, size, SHA-256, llama source revision, and
-ggml build identity. Release builds require the model source at build time and
-embed its bytes. Development builds may omit it so source checks remain
-practical, but such a binary cannot claim full product retrieval.
+ggml build identity. Release builds invoke the checksum-pinned preparation
+script, which reuses or prepares the verified workspace build asset before Rust
+independently verifies and embeds its bytes.
+`CODESTORY_EMBED_MODEL_SOURCE` remains an optional explicit input for hermetic
+or offline builds and fails closed when invalid. Development builds may omit the
+model so source checks remain practical, but such a binary cannot claim full
+product retrieval.
 
 Native features select Metal on macOS and Vulkan on Windows/Linux. CPU
 execution remains available only through the caller's explicit

--- a/docs/contributors/debugging.md
+++ b/docs/contributors/debugging.md
@@ -187,6 +187,16 @@ Check:
 - whether JSON and markdown output still match the runtime DTO shape
 - whether the change belongs in runtime rather than the adapter layer
 
+## If A Release Build Cannot Prepare The Embedded Model
+
+`cargo build --release --locked -p codestory-cli` normally reuses the verified
+workspace build asset or runs `scripts/prepare-embedded-model.mjs`
+automatically. If preparation fails, check the emitted Node.js or network error
+and leave the partial file for the script's bounded cleanup path. For a
+hermetic or offline build, point `CODESTORY_EMBED_MODEL_SOURCE` at the exact
+checksum-pinned GGUF; an invalid override fails closed and is never replaced by
+a download.
+
 ## Cache Reset Cookbook
 
 Use this when you need to wipe state instead of debugging a clearly broken cache:

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -12,16 +12,16 @@ Line Tools. Apple Silicon is the protected Metal cell; Intel Mac development
 uses explicit CPU operation and never claims Metal.
 
 Debug Rust builds compile without embedding the release model. A release build
-requires the exact pinned model at build time:
+automatically reuses or prepares the exact pinned model at build time:
 
 ```sh
-MODEL_PATH="$(node scripts/prepare-embedded-model.mjs)"
-CODESTORY_EMBED_MODEL_SOURCE="$MODEL_PATH" cargo build --release --locked -p codestory-cli
+cargo build --release --locked -p codestory-cli
 ```
 
 The preparation script verifies the declared size and digest before publishing
-the build input. The resulting executable contains the model; product runtime
-does not download it.
+the build input. Set `CODESTORY_EMBED_MODEL_SOURCE` only when a hermetic or
+offline build must provide an explicit preverified source. The resulting
+executable contains the model; product runtime does not download it.
 
 ## Establish the proof target
 
@@ -119,8 +119,7 @@ Use the built binary rather than `cargo run` when the shipped command boundary
 is part of the claim:
 
 ```sh
-MODEL_PATH="$(node scripts/prepare-embedded-model.mjs)"
-CODESTORY_EMBED_MODEL_SOURCE="$MODEL_PATH" cargo build --release --locked -p codestory-cli
+cargo build --release --locked -p codestory-cli
 ./target/release/codestory-cli index --project . --refresh auto
 ./target/release/codestory-cli ready --project . --goal local
 ./target/release/codestory-cli ground --project . --why


### PR DESCRIPTION
## Context

A normal `cargo build -p codestory-cli --release` panicked unless contributors manually prepared the model and exported `CODESTORY_EMBED_MODEL_SOURCE`, even when the checksum-pinned asset already existed locally.

Closes #1177
Refs #899

## What changed

- Keeps `CODESTORY_EMBED_MODEL_SOURCE` as the highest-priority explicit input for hermetic or offline builds.
- With no override, release builds invoke the existing preparation script. That script owns canonical cache placement, pinned URLs, bounded streaming, digest verification, atomic publication, and reuse.
- Rust independently rechecks the returned file's exact 146,029,792-byte size and SHA-256 before embedding it.
- Debug builds remain model-free.
- Updates contributor, debugging, subsystem, and changelog guidance so raw Cargo is the normal release-build path.
- Adds no runtime download, helper, port, downloader, or build dependency.

## Verification

Exact head: `6bd968588448cdbcd940527049ecbda6d93dc704`

- Environment-free release build passed and crossed the previously failing build-script boundary.
- Automatically prepared model: 146,029,792 bytes; SHA-256 `666db8df27c88570cdc07adca28646260038b8ca65354911d57b936ebf56efaa`.
- Resulting executable: 197 MB; `codestory-cli 0.16.0`.
- A second environment-free release build reused the prepared asset.
- `cargo test --locked -p codestory-llama-sys --lib` — 5 passed.
- `cargo check --locked -p codestory-llama-sys`.
- `cargo clippy --locked -p codestory-llama-sys --all-targets -- -D warnings`.
- `cargo fmt --all -- --check`.
- `git diff --check`.
- `node .github/scripts/check-doc-links.mjs`.

## Risk or follow-up

The automatic step runs only at source-build time. Packaged runtime remains offline and contains the verified model. This PR does not promote `main`, sign, package, or release.