### PR TITLE
Upgrade Tree-sitter runtime and grammars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Search quality and reliability
 
+- Tree-sitter and every wired language grammar now use their current compatible crate releases, including the vendored graph runtime's Tree-sitter 0.26 compatibility pin.
+- Windows contributor setup now names the LLVM/libclang, Vulkan, developer-shell, Ninja, and short-path requirements used by source builds.
 - Rust 2024 sources, including `unsafe extern` blocks and let-chains, now remain parser-complete. CodeStory uses the current Rust grammar and a compatible Tree-sitter runtime instead of rejecting valid modern Rust files and withholding a full publication.
 - Windows x64 and arm64 package builders now install and verify the architecture-matched, checksum-pinned LunarG Vulkan SDK instead of depending on mutable runner-image contents. The pinned glibc 2.31 Linux build also imports the Vulkan video headers that accompany its newer compile-time header set, and generic hosted managed-plugin checks use explicit offline CPU evidence instead of implying an unavailable accelerator claim.
 - Core publication now preserves the last verified generation when a scheduled source cannot be read completely: incremental refresh retains the affected projection, while full refresh discards its incomplete staged candidate. Incremental refresh also updates dense inputs for graph-dependent files as edges change and republishes path-bound dense inputs before retrieval after cache rehydrate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
 dependencies = [
  "cc",
  "regex",
@@ -3598,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-bash"
-version = "0.23.3"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3608,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.23.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3618,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c-sharp"
-version = "0.23.0"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c0f6d2209a3cd6d0bb9d2934715da15a15710d3c09c7c1ecd4c9804c3ecd10"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3638,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-dart-orchard"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcc68a1fd54afbeabc13b64a07b1ef611805690800fa2a57c1d1b90970a902e"
+checksum = "da3fb1a73ba0a4a5467969a39daaadcf55379c1f1e83885abe76bf60e9098b99"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3648,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.23.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3682,9 +3682,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3708,9 +3708,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-php"
-version = "0.23.11"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3718,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.23.6"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3748,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-swift"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc72ea9c62a6d188c9f7d64109a9b14b09231852b87229c68c44e8738b9e6b9"
+checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,22 +25,22 @@ codestory-runtime = { path = "crates/codestory-runtime" }
 codestory-bench = { path = "crates/codestory-bench" }
 
 # Parsing (tree-sitter)
-tree-sitter = "0.25.10"
+tree-sitter = "0.26.11"
 tree-sitter-rust = "0.24.2"
-tree-sitter-python = "0.23.6"
-tree-sitter-java = "0.23"
-tree-sitter-cpp = "0.23"
-tree-sitter-c = "0.23"
-tree-sitter-javascript = "0.23.1"
-tree-sitter-typescript = "0.23"
-tree-sitter-go = "0.23.4"
+tree-sitter-python = "0.25.0"
+tree-sitter-java = "0.23.5"
+tree-sitter-cpp = "0.23.4"
+tree-sitter-c = "0.24.2"
+tree-sitter-javascript = "0.25.0"
+tree-sitter-typescript = "0.23.2"
+tree-sitter-go = "0.25.0"
 tree-sitter-ruby = "0.23.1"
-tree-sitter-php = "0.23.11"
-tree-sitter-c-sharp = "=0.23.0"
+tree-sitter-php = "0.24.2"
+tree-sitter-c-sharp = "0.23.5"
 tree-sitter-kotlin-ng = "1.1.0"
-tree-sitter-swift = "0.7.0"
-tree-sitter-dart-orchard = "0.3.2"
-tree-sitter-bash = "0.23.3"
+tree-sitter-swift = "0.7.3"
+tree-sitter-dart-orchard = "0.4.0"
+tree-sitter-bash = "0.25.1"
 
 # Semantic Analysis
 tree-sitter-graph = { path = "vendor/tree-sitter-graph" }

--- a/crates/codestory-indexer/src/framework_routes.rs
+++ b/crates/codestory-indexer/src/framework_routes.rs
@@ -1374,10 +1374,9 @@ fn last_identifier(node: Node<'_>, source: &str) -> Option<String> {
 }
 
 fn node_has_direct_anonymous_token(node: Node<'_>, expected: &[&str]) -> bool {
-    (0..node.child_count()).any(|index| {
-        node.child(index)
-            .is_some_and(|child| !child.is_named() && expected.contains(&child.kind()))
-    })
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .any(|child| !child.is_named() && expected.contains(&child.kind()))
 }
 
 fn commonjs_router_bindings(node: Node<'_>, source: &str) -> HashSet<String> {

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -118,10 +118,10 @@ fidelity coverage land.
 
 Workspace parser policy:
 
-- `tree-sitter = "0.25.10"`
+- `tree-sitter = "0.26.11"`
 - `tree-sitter-rust = "0.24.2"`
 - `tree-sitter-graph = "0.12.0"`, vendored from upstream commit
-  `b930fb59c2177a90b3a6a68e1feeca6918ceb58b` with only the Tree-sitter 0.25
+  `b930fb59c2177a90b3a6a68e1feeca6918ceb58b` with only the Tree-sitter 0.26
   compatibility and current lint adjustments recorded in
   `vendor/tree-sitter-graph/UPSTREAM.md`
 
@@ -132,14 +132,14 @@ paths, not parser-backed runtime claims.
 
 | Language | Candidate crate | Version checked | Decision |
 | --- | --- | ---: | --- |
-| Go | `tree-sitter-go` | `0.23.4` | wired |
+| Go | `tree-sitter-go` | `0.25.0` | wired |
 | Ruby | `tree-sitter-ruby` | `0.23.1` | wired |
-| PHP | `tree-sitter-php` | `0.23.11` | wired |
-| C# | `tree-sitter-c-sharp` | `=0.23.0` | wired |
+| PHP | `tree-sitter-php` | `0.24.2` | wired |
+| C# | `tree-sitter-c-sharp` | `0.23.5` | wired |
 | Kotlin | `tree-sitter-kotlin-ng` | `1.1.0` | wired |
-| Swift | `tree-sitter-swift` | `0.7.0` | wired |
-| Dart | `tree-sitter-dart-orchard` | `0.3.2` | wired |
-| Bash | `tree-sitter-bash` | `0.23.3` | wired |
+| Swift | `tree-sitter-swift` | `0.7.3` | wired |
+| Dart | `tree-sitter-dart-orchard` | `0.4.0` | wired |
+| Bash | `tree-sitter-bash` | `0.25.1` | wired |
 | HTML | `tree-sitter-html` | `0.23.2` | candidate only |
 | CSS | `tree-sitter-css` | `0.25.0` | candidate only |
 | SQL | `tree-sitter-sequel` | `0.3.11` | candidate only |

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -6,10 +6,15 @@ gates belong on an accepted exact head, not every draft commit.
 
 ## Prerequisites
 
-Install the Rust toolchain, Node.js 18 or later, Git, and Python 3. On macOS,
-CodeStory development supports macOS 15 or later and requires the Xcode Command
-Line Tools. Apple Silicon is the protected Metal cell; Intel Mac development
-uses explicit CPU operation and never claims Metal.
+Install the Rust toolchain, Node.js 18 or later, Git, Python 3, CMake, and
+LLVM/libclang. On Windows, set `LIBCLANG_PATH` to the LLVM `bin` directory when
+bindgen cannot find `libclang.dll`, and install the Vulkan SDK used by the
+default native backend. Run native Windows builds from a Visual Studio
+developer shell, use `CMAKE_GENERATOR=Ninja` when the nested Vulkan shader build
+selects MSBuild, and keep the worktree path short enough for CMake's object-path
+limit. On macOS, CodeStory development supports macOS 15 or later and requires
+the Xcode Command Line Tools. Apple Silicon is the protected Metal cell; Intel
+Mac development uses explicit CPU operation and never claims Metal.
 
 Debug Rust builds compile without embedding the release model. A release build
 automatically reuses or prepares the exact pinned model at build time:

--- a/vendor/tree-sitter-graph/Cargo.toml
+++ b/vendor/tree-sitter-graph/Cargo.toml
@@ -24,4 +24,4 @@ serde_json = "1.0"
 smallvec = { version="1.6", features=["union"] }
 streaming-iterator = "0.1.9"
 thiserror = "1.0.7"
-tree-sitter = "0.25.10"
+tree-sitter = "0.26.11"

--- a/vendor/tree-sitter-graph/UPSTREAM.md
+++ b/vendor/tree-sitter-graph/UPSTREAM.md
@@ -7,11 +7,11 @@ CodeStory carries this narrow source copy because the published 0.12.0 crate
 pins `tree-sitter` 0.24, whose runtime cannot load current ABI 15 grammars such
 as `tree-sitter-rust` 0.24.2. The local changes are limited to:
 
-- using `tree-sitter` 0.25.10;
+- using `tree-sitter` 0.26.11;
 - retaining only the library surface CodeStory links, without the upstream CLI,
   development dependencies, or optional terminal coloring;
 - explicit elided lifetimes required by the current lint surface; and
 - disabling publication of the vendored package.
 
 Remove this copy and return to the crates.io dependency after upstream ships a
-release compatible with `tree-sitter` 0.25 or newer.
+release compatible with `tree-sitter` 0.26 or newer.


### PR DESCRIPTION
## Context

CodeStory’s Tree-sitter dependency set was only partially current. This upgrades the runtime and every grammar pin together, fixes the one 0.26 API incompatibility, and records the Windows native-build requirements exposed by full workspace verification.

Closes #1205

## What Changed

- Upgrade `tree-sitter` to 0.26.11 and align all 15 grammar crate pins with their current compatible releases.
- Align the vendored `tree-sitter-graph` runtime pin and compatibility notes.
- Replace numeric child indexing in framework-route detection with the runtime’s child iterator.
- Document LLVM/libclang, Vulkan SDK, Visual Studio developer-shell, Ninja, and short-path requirements for Windows workspace builds.
- Record the dependency and operator-facing changes under `Unreleased`.

## How To Review

- Confirm the root manifest and lockfile contain only the intended Tree-sitter dependency changes.
- Review `node_has_kind` for equivalent descendant-kind detection under the 0.26 API.
- Check the language-support table and Windows setup notes against the upgraded manifests and verified build environment.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked -p codestory-indexer`
- `cargo test --locked -p codestory-indexer --test fidelity_regression` (8 passed)
- `cargo test --locked -p codestory-indexer --test tictactoe_language_coverage` (12 passed)
- `cargo test --locked -p codestory-indexer framework_routes::tests` (26 passed)
- `cargo clippy --locked -p codestory-indexer -- -D warnings`
- `cargo check --workspace --locked`
- `cargo build --workspace --locked`
- `node .github/scripts/check-doc-links.mjs` (73 files, 243 links)
- `git diff --check`

## Risk

Grammar upgrades can change parse trees at language edges. The repository’s full fidelity and language-coverage binaries, focused framework-route tests, clippy lane, and locked workspace build all pass. Hosted checks may still be running when this PR is merged.