### PR TITLE
Build the vector backend decision harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - The packaged executable works offline after installation, reuses its verified model material across restarts, and does not start helper processes or open retrieval ports.
 - Everyday plugin messages say whether broader search is ready, preparing, or unavailable. Model, backend, adapter, and timing details stay in maintainer diagnostics.
 - Source release builds now use one checked-in contract for acquisition, embedding semantics, producer identity, and model-license provenance. Producer name/version bind both runtime and persisted vector compatibility, so implementation upgrades rebuild instead of reusing incompatible vectors. Model acquisition is an explicit pre-Cargo step; Cargo verifies only the supplied regular file, publishes it through a create-new/no-clobber staging path, and never starts Node.js or performs network access. Executable fault tests prove partial writes and racing destinations cannot publish or clobber model bytes.
+- The non-adopting Windows x64 vector-backend comparison now freezes production-attested inputs through a native-identity-pinned, create-new publication boundary. Parent replacement, SQLite sidecar drift, and incompatible query-engine evidence fail closed before an artifact can count toward the backend decision.
 
 ### Upgrade note
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "codestory-bench"
 version = "0.16.0"
 dependencies = [
@@ -482,9 +493,14 @@ dependencies = [
  "codestory-store",
  "codestory-workspace",
  "criterion",
+ "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
+ "sqlite-vec",
  "tempfile",
+ "toml",
+ "usearch",
  "uuid",
 ]
 
@@ -869,6 +885,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ae9bf77fbf2d39ef573205d554d87e86c12f1994e9ea335b0651b9b278bcf1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00424da159cc5adcb4eeea7e7b5cb1d96df41f5fa695ec596922181bdc36232a"
+dependencies = [
+ "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash 0.2.0",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e05269dbed4dab7072ae0f04ef31799ad189d52ce2ac12710c2997b754f86a"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f017b07e0da7f425642339faff0edc9f0de6459a18180183d086d1f3381e89"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293d267f43a5778bf3b89fff2a658f081166e7f152d9640e2ee3d917d065a5fc"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd233dc128223fe85d2afa5c617c79743c0f47fb495b69234b5da680d4986a"
+dependencies = [
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1825,6 +1903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2820,6 +2907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3119,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ba424237a9a5db2f6071f193319e2b6a32f7f3961debb2fbbfe67067abce3f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3283,6 +3385,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3876,6 +3987,16 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usearch"
+version = "2.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd7f672d20412962c457b11c858c6c5aecb949808a5345a95e1d671112bcf72"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "anyhow",
  "codestory-contracts",
  "codestory-indexer",
+ "codestory-retrieval",
  "codestory-runtime",
  "codestory-store",
  "codestory-workspace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ rusqlite = { version = "0.38", features = ["backup", "bundled", "hooks"] }
 # Search
 nucleo-matcher = "0.3"
 tantivy = "0.26"
+sqlite-vec = "=0.1.9"
+usearch = { version = "=2.26.0", default-features = false }
 
 # Utilities
 serde = { version = "1.0", features = ["derive"] }

--- a/benchmarks/vector-backend-spike/README.md
+++ b/benchmarks/vector-backend-spike/README.md
@@ -134,7 +134,10 @@ cargo test --release --locked --no-default-features --features fixture-generator
 
 `CODESTORY_VECTOR_SPIKE_FIXTURE_JSON` must name a new file whose parent already
 exists outside both the source generation and `CODESTORY_CACHE_ROOT`. Fixture
-publication never replaces an existing destination.
+publication captures that parent's native filesystem identity before opening
+it, proves the retained directory handle names the same object, and never
+replaces an existing destination. The fixture fails closed if the parent is
+replaced before the handle is pinned or changes while preparation is running.
 
 Run each predeclared vector count from a clean, exact, release-built Git tree on
 the approved Windows x64 production host:

--- a/benchmarks/vector-backend-spike/README.md
+++ b/benchmarks/vector-backend-spike/README.md
@@ -72,6 +72,7 @@ nonzero, and L2-normalized within `1e-3`. Its shape is:
     {
       "query_id": "symbol-query-001",
       "kind": "symbol",
+      "query_text": "Where is the published vector generation validated?",
       "vector": [1.0],
       "expected": [{ "node_id": "...", "document_hash": "..." }]
     }
@@ -83,8 +84,60 @@ nonzero, and L2-normalized within `1e-3`. Its shape is:
 ```
 
 The abbreviated vectors above illustrate the schema only; real vectors contain
-768 values. Run each predeclared vector count from a clean, exact, release-built
-Git tree on the approved Windows x64 production host:
+768 values. `query_text` is required for decision fixtures; older synthetic
+smoke fixtures may omit it.
+
+Create the source publication under an isolated cache root. The retrieval index
+command is the existing product publication path; the spike does not export or
+rewrite production state:
+
+```powershell
+$env:CODESTORY_CACHE_ROOT = 'C:\evidence\codestory-cache'
+cargo run --release --locked -p codestory-cli -- index --project 'C:\source\representative-repo' --refresh full --format json
+cargo run --release --locked -p codestory-cli -- retrieval index --project 'C:\source\representative-repo' --refresh full --format json
+Get-ChildItem -LiteralPath $env:CODESTORY_CACHE_ROOT -Recurse -Filter vector-generation-manifest.json
+```
+
+Select the intended `vector-generation-manifest.json` from that isolated root;
+its adjacent `vectors.sqlite3` is the source. An independently reviewed query
+catalog supplies only source-truth labels, never vectors or model neighbors:
+
+```json
+{
+  "schema_version": 1,
+  "queries": [
+    {
+      "query_id": "symbol-query-001",
+      "kind": "symbol",
+      "query_text": "Where is the published vector generation validated?",
+      "expected_node_ids": ["..."]
+    }
+  ]
+}
+```
+
+The entry above is illustrative; the decision catalog must contain the 30
+predeclared representative and symbol queries.
+
+Freeze the fixture with the linked production query embedder. The source must
+contain the requested base rows plus the real ordered tail rows; the generator
+fails instead of synthesizing missing increments or expected identities:
+
+```powershell
+$env:CODESTORY_VECTOR_SPIKE_SOURCE_SQLITE = 'C:\evidence\codestory-cache\semantic\collections\<generation>\vectors.sqlite3'
+$env:CODESTORY_VECTOR_SPIKE_QUERY_CATALOG_JSON = 'C:\evidence\vector-spike-query-catalog.json'
+$env:CODESTORY_VECTOR_SPIKE_FIXTURE_JSON = 'C:\evidence\vector-spike-fixture.json'
+$env:CODESTORY_VECTOR_SPIKE_VECTOR_COUNT = '100000'
+$env:CODESTORY_VECTOR_SPIKE_INCREMENTAL_COUNT = '100'
+cargo test --release --locked --no-default-features --features fixture-generator -p codestory-bench --test vector_backend_spike prepare_vector_backend_fixture -- --ignored --exact --nocapture
+```
+
+`CODESTORY_VECTOR_SPIKE_FIXTURE_JSON` must name a new file whose parent already
+exists outside both the source generation and `CODESTORY_CACHE_ROOT`. Fixture
+publication never replaces an existing destination.
+
+Run each predeclared vector count from a clean, exact, release-built Git tree on
+the approved Windows x64 production host:
 
 ```powershell
 $env:CODESTORY_VECTOR_SPIKE_PROFILE = 'decision'

--- a/benchmarks/vector-backend-spike/README.md
+++ b/benchmarks/vector-backend-spike/README.md
@@ -1,0 +1,113 @@
+# Vector backend comparison spike
+
+This directory owns the predeclared decision criteria and the reproducible
+comparison harness for issue #1202. It deliberately does not select or adopt a
+backend. The current decision remains blocked until every required platform and
+production-representative evidence item in `criteria.json` is present.
+
+## Harness
+
+The ignored `vector_backend_spike` integration test builds sqlite-vec and
+USearch indexes from the same identified vectors and runs the same identified
+queries against both. Both candidates and the Rust oracle use cosine distance.
+It measures build, load, query latency, disk use, exact-oracle recall, frozen
+expected-identity Hit@20, incremental reuse, concurrent readers, immutable
+generation publication, pointer rollback, and corrupt-candidate rejection.
+
+Each backend publishes a complete, validated generation directory under
+`generations/` and atomically swaps one `publication.json` record containing
+the current and rollback pointer pair. Readers that already opened a generation
+retain it; new readers resolve the new pointer. The harness hashes the unchanged
+old generation before and after publication and exercises corrupt rejection and
+rollback through the same paired-pointer protocol. Each generation manifest
+binds the exact candidate index SHA-256 and a canonical digest of every
+non-manifest file in the generation. A post-publication index tamper must make a
+new reader fail closed while an already-open reader remains usable.
+
+The artifact hashes the criteria, complete publication identity, selected
+node/document/vector records, fixture, queries, incremental records, Git head
+and tree, dirty worktree, toolchain, build profile, target, CPU, RAM, and ISA
+envelope. Production source rows are selected deterministically with
+`ORDER BY node_id` before applying the declared vector-count limit.
+
+The default command is a fast synthetic harness check. Its output validates the
+measurement path only and is not decision evidence:
+
+```powershell
+$env:CODESTORY_VECTOR_SPIKE_OUTPUT = 'target/vector-backend-spike/windows-x86_64-smoke.json'
+cargo test --locked --no-default-features -p codestory-bench --test vector_backend_spike compare_vector_backends -- --ignored --nocapture
+```
+
+A decision-input run must use a complete CodeStory `vectors.sqlite3`
+publication and a frozen JSON fixture. Before any rows are sampled, the harness
+requires the fixture's predeclared production attestation, compares its exact
+database SHA-256, runs SQLite `quick_check`, compares the complete metadata
+identity, and recomputes the production `codestory-vector-digest-v1` digest and
+row coverage across the entire database. Validation and sampling share one
+pinned read transaction; the database is rehashed after sampling before records
+are accepted. WAL, shared-memory, or rollback-journal sidecars are rejected
+because their bytes are not covered by `database_sha256`. The fixture also
+carries representative and symbol query records with expected node/document
+identities and identified incremental records. Every vector must be finite,
+nonzero, and L2-normalized within `1e-3`. Its shape is:
+
+```json
+{
+  "schema_version": 2,
+  "source_attestation": {
+    "schema_version": 1,
+    "generation": "...",
+    "input_hash": "...",
+    "embedding_backend": "...",
+    "embedding_dim": 768,
+    "point_count": 100000,
+    "producer_identity": "...",
+    "evidence_contract_identity": "...",
+    "vector_digest": "...",
+    "database_sha256": "..."
+  },
+  "incremental_set_id": "frozen-delta-001",
+  "queries": [
+    {
+      "query_id": "symbol-query-001",
+      "kind": "symbol",
+      "vector": [1.0],
+      "expected": [{ "node_id": "...", "document_hash": "..." }]
+    }
+  ],
+  "incremental_records": [
+    { "node_id": "...", "document_hash": "...", "vector": [1.0] }
+  ]
+}
+```
+
+The abbreviated vectors above illustrate the schema only; real vectors contain
+768 values. Run each predeclared vector count from a clean, exact, release-built
+Git tree on each required platform:
+
+```powershell
+$env:CODESTORY_VECTOR_SPIKE_PROFILE = 'decision'
+$env:CODESTORY_VECTOR_SPIKE_SOURCE_SQLITE = 'C:\evidence\vectors.sqlite3'
+$env:CODESTORY_VECTOR_SPIKE_FIXTURE_JSON = 'C:\evidence\vector-spike-fixture.json'
+$env:CODESTORY_VECTOR_SPIKE_VECTOR_COUNT = '25000'
+$env:CODESTORY_VECTOR_SPIKE_OUTPUT = 'target/vector-backend-spike/windows-x86_64-25000.json'
+cargo test --release --locked --no-default-features -p codestory-bench --test vector_backend_spike compare_vector_backends -- --ignored --nocapture
+```
+
+The decision profile rejects synthetic or mismatched inputs, a missing or
+mismatched database attestation, incomplete canonical row coverage, missing
+evidence identity, missing query expectations or query kinds, synthetic increments,
+non-normalized vectors, dirty Git state, debug builds, or unavailable host
+identity. The smoke repeats the candidates in reversed order, but its artifact
+sets `timing_comparable` to `false`: same-process timings and
+`first_query_after_open_ms` are diagnostics, not cold-cache or candidate-choice
+evidence. Isolated clean-host timing remains required.
+
+USearch's own lower-bound memory estimate is reported, while sqlite-vec memory
+is marked unmeasured. Cold-cache latency, isolated RSS, cancellation,
+deep-validation time, the existing-scan regression baseline, package/archive
+size, offline builds, license review, and native packaging remain explicit
+external evidence gaps rather than inferred values.
+
+Do not turn these results into an implementation issue until all criteria are
+satisfied. If neither candidate clears them, keep the existing embedded scan.

--- a/benchmarks/vector-backend-spike/README.md
+++ b/benchmarks/vector-backend-spike/README.md
@@ -106,11 +106,12 @@ evidence. Isolated clean-host timing remains required.
 
 USearch's own lower-bound memory estimate is reported, while sqlite-vec memory
 is marked unmeasured. Cold-cache latency, isolated RSS, cancellation,
-deep-validation time, and the existing-scan regression baseline remain required
-Windows x64 decision evidence rather than inferred values.
+deep-validation time, the existing-scan regression baseline, Windows offline
+build and archive-size implications, license and native-dependency review, and
+reversible fallback proof remain required Windows x64 decision evidence rather
+than inferred values.
 
-Linux and macOS proof, cross-platform offline builds and native packaging,
-archive-size measurement, license review, and implementation fallback proof do
+Linux and macOS quality/publication proof and their offline/native packaging do
 not block this comparison PR. If the Windows x64 decision selects a candidate,
-track those items in the later adoption implementation. If neither candidate
-clears the Windows x64 criteria, keep the existing embedded scan.
+track those platform items in the later adoption implementation. If neither
+candidate clears the Windows x64 criteria, keep the existing embedded scan.

--- a/benchmarks/vector-backend-spike/README.md
+++ b/benchmarks/vector-backend-spike/README.md
@@ -2,8 +2,9 @@
 
 This directory owns the predeclared decision criteria and the reproducible
 comparison harness for issue #1202. It deliberately does not select or adopt a
-backend. The current decision remains blocked until every required platform and
-production-representative evidence item in `criteria.json` is present.
+backend. The current decision remains blocked until the approved Windows x64
+production evidence in `criteria.json` is present. For this non-adopting
+comparison, Windows x64 is the only blocking platform.
 
 ## Harness
 
@@ -83,7 +84,7 @@ nonzero, and L2-normalized within `1e-3`. Its shape is:
 
 The abbreviated vectors above illustrate the schema only; real vectors contain
 768 values. Run each predeclared vector count from a clean, exact, release-built
-Git tree on each required platform:
+Git tree on the approved Windows x64 production host:
 
 ```powershell
 $env:CODESTORY_VECTOR_SPIKE_PROFILE = 'decision'
@@ -105,9 +106,11 @@ evidence. Isolated clean-host timing remains required.
 
 USearch's own lower-bound memory estimate is reported, while sqlite-vec memory
 is marked unmeasured. Cold-cache latency, isolated RSS, cancellation,
-deep-validation time, the existing-scan regression baseline, package/archive
-size, offline builds, license review, and native packaging remain explicit
-external evidence gaps rather than inferred values.
+deep-validation time, and the existing-scan regression baseline remain required
+Windows x64 decision evidence rather than inferred values.
 
-Do not turn these results into an implementation issue until all criteria are
-satisfied. If neither candidate clears them, keep the existing embedded scan.
+Linux and macOS proof, cross-platform offline builds and native packaging,
+archive-size measurement, license review, and implementation fallback proof do
+not block this comparison PR. If the Windows x64 decision selects a candidate,
+track those items in the later adoption implementation. If neither candidate
+clears the Windows x64 criteria, keep the existing embedded scan.

--- a/benchmarks/vector-backend-spike/criteria.json
+++ b/benchmarks/vector-backend-spike/criteria.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "issue": 1202,
   "decision_status": "blocked_pending_required_evidence",
   "non_goal": "This spike does not adopt either backend.",
@@ -22,9 +22,7 @@
     "inputs": "one complete immutable CodeStory vectors.sqlite3 with no unbound SQLite sidecars plus a predeclared production attestation containing its exact database SHA-256 and complete publication identity, and one attestation-bound fixture containing frozen representative and symbol query identities and frozen incremental records, reused byte-for-byte for both candidates; validation and sampling use one pinned read transaction and rehash after sampling"
   },
   "required_platforms": [
-    "windows-x86_64",
-    "linux-x86_64",
-    "macos-aarch64"
+    "windows-x86_64"
   ],
   "required_measurements": [
     "build_ms",
@@ -64,18 +62,22 @@
     "warm_rss_growth_mib_max": 96,
     "replacement_speedup_100000_min_fraction": 0.30,
     "current_repo_p95_regression_max_fraction": 0.05,
-    "memory_storage_and_package_regression_max_fraction": 0.10
+    "memory_and_storage_regression_max_fraction": 0.10
   },
-  "adoption_requires": [
-    "all required platform artifacts pass the same quality and publication gates",
+  "decision_requires": [
+    "the approved Windows x64 production artifacts pass the declared quality and publication gates",
     "artifacts bind the criteria hash, predeclared source database SHA-256, complete source publication and evidence identity, fixture identity, exact Git tree, toolchain, build profile, target, CPU, RAM, and ISA envelope",
     "comparative timing comes from isolated clean-host runs; same-process smoke timing is diagnostic only",
     "the 100000-vector workload clears the replacement speedup gate",
     "current-repository retrieval p95 does not regress beyond the declared limit",
-    "memory, storage, and packaged archive size remain within the declared limit",
-    "offline build and native packaging checks pass on every shipped architecture",
-    "license and native dependency review is complete",
-    "a reversible fallback to the existing embedded scan remains available"
+    "Windows x64 memory and storage remain within the declared limit"
+  ],
+  "non_blocking_adoption_follow_up": [
+    "Linux x64 and macOS arm64 quality and publication proof",
+    "offline build and native packaging checks on every shipped architecture",
+    "packaged archive size measurement",
+    "license and native dependency review",
+    "a reversible fallback to the existing embedded scan in the adoption implementation"
   ],
   "synthetic_smoke_is_decision_evidence": false
 }

--- a/benchmarks/vector-backend-spike/criteria.json
+++ b/benchmarks/vector-backend-spike/criteria.json
@@ -62,7 +62,7 @@
     "warm_rss_growth_mib_max": 96,
     "replacement_speedup_100000_min_fraction": 0.30,
     "current_repo_p95_regression_max_fraction": 0.05,
-    "memory_and_storage_regression_max_fraction": 0.10
+    "memory_storage_and_windows_package_regression_max_fraction": 0.10
   },
   "decision_requires": [
     "the approved Windows x64 production artifacts pass the declared quality and publication gates",
@@ -70,14 +70,14 @@
     "comparative timing comes from isolated clean-host runs; same-process smoke timing is diagnostic only",
     "the 100000-vector workload clears the replacement speedup gate",
     "current-repository retrieval p95 does not regress beyond the declared limit",
-    "Windows x64 memory and storage remain within the declared limit"
+    "Windows x64 memory, storage, and packaged archive size remain within the declared limit",
+    "the Windows x64 offline build and native dependency checks pass",
+    "license and native dependency review is complete for the Windows x64 comparison",
+    "a reversible fallback to the existing embedded scan is demonstrated"
   ],
   "non_blocking_adoption_follow_up": [
     "Linux x64 and macOS arm64 quality and publication proof",
-    "offline build and native packaging checks on every shipped architecture",
-    "packaged archive size measurement",
-    "license and native dependency review",
-    "a reversible fallback to the existing embedded scan in the adoption implementation"
+    "Linux x64 and macOS arm64 offline build and native packaging checks"
   ],
   "synthetic_smoke_is_decision_evidence": false
 }

--- a/benchmarks/vector-backend-spike/criteria.json
+++ b/benchmarks/vector-backend-spike/criteria.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 3,
+  "issue": 1202,
+  "decision_status": "blocked_pending_required_evidence",
+  "non_goal": "This spike does not adopt either backend.",
+  "candidates": {
+    "sqlite-vec": {
+      "crate_version": "0.1.9",
+      "mode": "vec0 float[768] distance_metric=cosine exact KNN"
+    },
+    "usearch": {
+      "crate_version": "2.26.0",
+      "mode": "HNSW cosine F32 with default features disabled"
+    }
+  },
+  "shared_workload": {
+    "dimensions": 768,
+    "vector_counts": [1000, 10000, 25000, 100000],
+    "top_k": 20,
+    "warmups": 5,
+    "queries": 30,
+    "inputs": "one complete immutable CodeStory vectors.sqlite3 with no unbound SQLite sidecars plus a predeclared production attestation containing its exact database SHA-256 and complete publication identity, and one attestation-bound fixture containing frozen representative and symbol query identities and frozen incremental records, reused byte-for-byte for both candidates; validation and sampling use one pinned read transaction and rehash after sampling"
+  },
+  "required_platforms": [
+    "windows-x86_64",
+    "linux-x86_64",
+    "macos-aarch64"
+  ],
+  "required_measurements": [
+    "build_ms",
+    "load_ms",
+    "first_query_after_open_ms",
+    "cold_query_ms",
+    "warm_query_p50_ms",
+    "warm_query_p95_ms",
+    "memory_bytes",
+    "disk_bytes",
+    "incremental_reuse_ms",
+    "concurrent_reader_consistency",
+    "pinned_old_reader_after_publication",
+    "new_current_reader_observed_incremental",
+    "old_generation_unchanged",
+    "atomic_publication_pointer_pair",
+    "referenced_generation_tamper_rejected",
+    "pinned_reader_after_referenced_tamper",
+    "rollback_pointer_readable",
+    "failed_candidate_preserved_current_pointer",
+    "corrupt_candidate_rejected"
+  ],
+  "quality_gates": {
+    "ann_recall_at_20_min": 0.99,
+    "expected_identity_hit_at_20": 1.0,
+    "representative_query_hit_at_20": 1.0,
+    "symbol_query_hit_at_20": 1.0,
+    "cancellation_p95_ms_max": 50,
+    "publication_contract": "complete immutable generation directories whose manifests bind exact index bytes and canonical directory contents, atomic current and rollback pointer swaps, pinned old-or-new readers, rollback through the pointer protocol, fail-closed corrupt candidates before pointer mutation, and fail-closed new readers after referenced-generation tamper while already-pinned readers remain usable"
+  },
+  "performance_gates": {
+    "query_p95_ms_max": {
+      "25000": 500,
+      "100000": 1500
+    },
+    "deep_validation_100000_ms_max": 5000,
+    "warm_rss_growth_mib_max": 96,
+    "replacement_speedup_100000_min_fraction": 0.30,
+    "current_repo_p95_regression_max_fraction": 0.05,
+    "memory_storage_and_package_regression_max_fraction": 0.10
+  },
+  "adoption_requires": [
+    "all required platform artifacts pass the same quality and publication gates",
+    "artifacts bind the criteria hash, predeclared source database SHA-256, complete source publication and evidence identity, fixture identity, exact Git tree, toolchain, build profile, target, CPU, RAM, and ISA envelope",
+    "comparative timing comes from isolated clean-host runs; same-process smoke timing is diagnostic only",
+    "the 100000-vector workload clears the replacement speedup gate",
+    "current-repository retrieval p95 does not regress beyond the declared limit",
+    "memory, storage, and packaged archive size remain within the declared limit",
+    "offline build and native packaging checks pass on every shipped architecture",
+    "license and native dependency review is complete",
+    "a reversible fallback to the existing embedded scan remains available"
+  ],
+  "synthetic_smoke_is_decision_evidence": false
+}

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -6,11 +6,13 @@ publish = false
 
 [features]
 default = ["runtime-bench"]
+fixture-generator = []
 runtime-bench = ["dep:codestory-runtime"]
 
 [dependencies]
 codestory-contracts = { workspace = true }
 codestory-indexer = { workspace = true }
+codestory-retrieval = { workspace = true }
 codestory-runtime = { workspace = true, optional = true }
 codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -4,10 +4,14 @@ version = "0.16.0"
 edition = "2024"
 publish = false
 
+[features]
+default = ["runtime-bench"]
+runtime-bench = ["dep:codestory-runtime"]
+
 [dependencies]
 codestory-contracts = { workspace = true }
 codestory-indexer = { workspace = true }
-codestory-runtime = { workspace = true }
+codestory-runtime = { workspace = true, optional = true }
 codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }
 criterion = { workspace = true }
@@ -17,10 +21,18 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 
+[dev-dependencies]
+rusqlite = { workspace = true }
+sha2 = { workspace = true }
+sqlite-vec = { workspace = true }
+toml = { workspace = true }
+usearch = { workspace = true }
+
 [[bench]]
 name = "indexing"
 harness = false
 bench = false
+required-features = ["runtime-bench"]
 
 [[bench]]
 name = "graph_fidelity"
@@ -36,11 +48,13 @@ bench = false
 name = "ask_latency"
 harness = false
 bench = false
+required-features = ["runtime-bench"]
 
 [[bench]]
 name = "grounding"
 harness = false
 bench = false
+required-features = ["runtime-bench"]
 
 [[bench]]
 name = "incremental_cleanup"
@@ -51,3 +65,4 @@ bench = false
 name = "browser_stress"
 harness = false
 bench = false
+required-features = ["runtime-bench"]

--- a/crates/codestory-bench/tests/vector_backend_spike.rs
+++ b/crates/codestory-bench/tests/vector_backend_spike.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result, ensure};
 use rusqlite::{Connection, OpenFlags, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+#[cfg(feature = "fixture-generator")]
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
@@ -18,7 +20,6 @@ const DECISION_QUERIES: usize = 30;
 const DECISION_WARMUPS: usize = 5;
 const DECISION_COUNTS: [usize; 4] = [1_000, 10_000, 25_000, 100_000];
 const VECTOR_NORM_TOLERANCE: f64 = 1.0e-3;
-const VECTOR_DIGEST_DOMAIN: &[u8] = b"codestory-vector-digest-v1\0";
 const PRODUCTION_VECTOR_SCHEMA_VERSION: i64 = 2;
 const REPETITIONS: usize = 2;
 
@@ -228,6 +229,8 @@ enum QueryKind {
 struct FrozenQuery {
     query_id: String,
     kind: QueryKind,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    query_text: String,
     vector: Vec<f32>,
     expected: Vec<Identity>,
 }
@@ -239,13 +242,29 @@ struct FrozenVectorRecord {
     vector: Vec<f32>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct FrozenFixture {
     schema_version: u32,
     source_attestation: ProductionSourceAttestation,
     incremental_set_id: String,
     queries: Vec<FrozenQuery>,
     incremental_records: Vec<FrozenVectorRecord>,
+}
+
+#[cfg(feature = "fixture-generator")]
+#[derive(Deserialize)]
+struct FixtureQueryCatalog {
+    schema_version: u32,
+    queries: Vec<FixtureCatalogQuery>,
+}
+
+#[cfg(feature = "fixture-generator")]
+#[derive(Deserialize)]
+struct FixtureCatalogQuery {
+    query_id: String,
+    kind: QueryKind,
+    query_text: String,
+    expected_node_ids: Vec<String>,
 }
 
 struct Dataset {
@@ -275,7 +294,7 @@ impl Dataset {
             match (&config.source_sqlite, &loaded_fixture) {
                 (Some(path), Some(loaded)) => {
                     let (records, publication, source_label, source_artifact_sha256) =
-                        load_published_vectors(
+                        load_validated_source_sample(
                             path,
                             config.vector_count,
                             &loaded.fixture.source_attestation,
@@ -353,6 +372,12 @@ impl Dataset {
                 !incremental_set_id.trim().is_empty(),
                 "decision incremental set identity must be non-empty"
             );
+            ensure!(
+                queries
+                    .iter()
+                    .all(|query| !query.query_text.trim().is_empty()),
+                "decision fixture queries must retain their source query text"
+            );
         }
 
         Ok(Self {
@@ -370,177 +395,38 @@ impl Dataset {
     }
 }
 
-fn load_published_vectors(
+fn load_validated_source_sample(
     path: &Path,
     limit: usize,
     expected_attestation: &ProductionSourceAttestation,
-) -> Result<(Vec<VectorRecord>, PublicationIdentity, String, String)> {
-    load_published_vectors_with_hook(path, limit, expected_attestation, || Ok(()))
-}
-
-fn load_published_vectors_with_hook(
-    path: &Path,
-    limit: usize,
-    expected_attestation: &ProductionSourceAttestation,
-    before_sample: impl FnOnce() -> Result<()>,
 ) -> Result<(Vec<VectorRecord>, PublicationIdentity, String, String)> {
     expected_attestation.validate()?;
-    ensure_no_sqlite_sidecars(path)?;
-    let database_sha256 = sha256_file(path)
-        .with_context(|| format!("hash attested vector database {}", path.display()))?;
+    let sample = codestory_retrieval::load_validated_vector_fixture_sample(path, limit)?;
+    let source_attestation = fixture_source_attestation(sample.attestation())?;
     ensure!(
-        database_sha256 == expected_attestation.database_sha256,
-        "vector database SHA-256 does not match the predeclared source attestation"
+        &source_attestation == expected_attestation,
+        "production vector source does not match the predeclared fixture attestation"
     );
-    let connection = open_sqlite_read_only(path)?;
-    connection.execute_batch("BEGIN DEFERRED TRANSACTION")?;
-    let quick_check: String =
-        connection.query_row("PRAGMA quick_check(1)", [], |row| row.get(0))?;
-    ensure!(
-        quick_check == "ok",
-        "source SQLite quick_check failed: {quick_check}"
-    );
-    let metadata_rows: i64 =
-        connection.query_row("SELECT count(*) FROM metadata", [], |row| row.get(0))?;
-    ensure!(
-        metadata_rows == 1,
-        "source metadata must contain exactly one row"
-    );
-    let metadata = connection
-        .query_row(
-            "SELECT schema_version, generation, input_hash, embedding_backend,
-                    embedding_dim, point_count, producer_identity,
-                    evidence_contract_identity, vector_digest
-             FROM metadata WHERE singleton = 1",
-            [],
-            |row| {
-                Ok((
-                    row.get::<_, i64>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, String>(3)?,
-                    row.get::<_, i64>(4)?,
-                    row.get::<_, i64>(5)?,
-                    row.get::<_, String>(6)?,
-                    row.get::<_, String>(7)?,
-                    row.get::<_, String>(8)?,
-                ))
-            },
-        )
-        .with_context(|| format!("read publication identity from {}", path.display()))?;
-    let publication = PublicationIdentity {
-        schema_version: metadata.0,
-        generation: metadata.1,
-        input_hash: metadata.2,
-        embedding_backend: metadata.3,
-        embedding_dim: usize::try_from(metadata.4)
-            .context("publication embedding dimension must fit usize")?,
-        point_count: usize::try_from(metadata.5)
-            .context("publication point count must fit usize")?,
-        producer_identity: metadata.6,
-        evidence_contract_identity: metadata.7,
-        vector_digest: metadata.8,
-    };
-    publication.validate()?;
-    ensure!(
-        publication == expected_attestation.publication,
-        "source metadata does not match the predeclared publication identity"
-    );
-    let actual_count: i64 =
-        connection.query_row("SELECT count(*) FROM vectors", [], |row| row.get(0))?;
-    ensure!(
-        actual_count == publication.point_count as i64,
-        "publication metadata point count {} does not match complete table count {actual_count}",
-        publication.point_count
-    );
-    ensure!(
-        publication.point_count >= limit,
-        "publication has {} points but the run requires {limit}",
-        publication.point_count
-    );
-
-    let (canonical_digest, canonical_count) =
-        canonical_source_vector_digest(&connection, publication.embedding_dim)?;
-    ensure!(
-        canonical_count == publication.point_count,
-        "canonical source coverage expected {} rows, found {canonical_count}",
-        publication.point_count
-    );
-    ensure!(
-        canonical_digest == expected_attestation.publication.vector_digest,
-        "canonical source vector digest does not match the predeclared attestation"
-    );
-    before_sample()?;
-
-    let mut statement = connection.prepare(
-        "SELECT node_id, document_hash, vector FROM vectors ORDER BY node_id ASC LIMIT ?1",
-    )?;
-    let rows = statement.query_map([limit as i64], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, Vec<u8>>(2)?,
-        ))
-    })?;
-    let mut records = Vec::with_capacity(limit);
-    for row in rows {
-        let (node_id, document_hash, bytes) = row?;
-        records.push(VectorRecord {
-            identity: Identity {
-                node_id: node_id.clone(),
-                document_hash,
-            },
-            vector: decode_vector(&node_id, &bytes, publication.embedding_dim)?,
-        });
-    }
-    drop(statement);
-    let database_sha256_after_sampling = sha256_file(path)
-        .with_context(|| format!("rehash attested vector database {}", path.display()))?;
-    ensure!(
-        database_sha256_after_sampling == expected_attestation.database_sha256,
-        "vector database changed while its pinned source snapshot was sampled"
-    );
-    ensure_no_sqlite_sidecars(path)?;
-    connection.execute_batch("ROLLBACK")?;
-    drop(connection);
+    let records = fixture_records(sample.records());
     Ok((
         records,
-        publication,
+        source_attestation.publication,
         format!("CodeStory publication {}", path.display()),
-        expected_attestation.database_sha256.clone(),
+        source_attestation.database_sha256,
     ))
 }
 
-fn canonical_source_vector_digest(
-    connection: &Connection,
-    embedding_dim: usize,
-) -> Result<(String, usize)> {
-    let mut statement = connection
-        .prepare("SELECT node_id, document_hash, vector FROM vectors ORDER BY node_id ASC")?;
-    let mut rows = statement.query([])?;
-    let mut digest = Sha256::new();
-    digest.update(VECTOR_DIGEST_DOMAIN);
-    let mut seen = HashSet::new();
-    let mut count = 0_usize;
-    while let Some(row) = rows.next()? {
-        let node_id: String = row.get(0)?;
-        let document_hash: String = row.get(1)?;
-        let vector: Vec<u8> = row.get(2)?;
-        ensure!(
-            seen.insert(node_id.clone()),
-            "duplicate source vector row {node_id}"
-        );
-        ensure!(
-            !node_id.trim().is_empty() && !document_hash.trim().is_empty(),
-            "source vector row identities must be non-empty"
-        );
-        decode_vector(&node_id, &vector, embedding_dim)?;
-        hash_len_prefixed(&mut digest, node_id.as_bytes());
-        hash_len_prefixed(&mut digest, document_hash.as_bytes());
-        hash_len_prefixed(&mut digest, &vector);
-        count += 1;
-    }
-    Ok((format!("{:x}", digest.finalize()), count))
+fn fixture_records(records: &[codestory_retrieval::VectorFixtureRecord]) -> Vec<VectorRecord> {
+    records
+        .iter()
+        .map(|record| VectorRecord {
+            identity: Identity {
+                node_id: record.node_id.clone(),
+                document_hash: record.document_hash.clone(),
+            },
+            vector: record.vector.clone(),
+        })
+        .collect()
 }
 
 type FixtureParts = (Vec<FrozenQuery>, Vec<VectorRecord>, String, String, String);
@@ -607,6 +493,131 @@ fn select_frozen_fixture(
     ))
 }
 
+#[cfg(feature = "fixture-generator")]
+fn split_fixture_records(
+    mut records: Vec<VectorRecord>,
+    base_count: usize,
+    incremental_count: usize,
+) -> Result<(Vec<VectorRecord>, Vec<VectorRecord>)> {
+    let required = base_count
+        .checked_add(incremental_count)
+        .context("fixture base plus tail count overflow")?;
+    ensure!(
+        records.len() == required,
+        "fixture source needs {required} base-plus-tail rows, found {}",
+        records.len()
+    );
+    let incremental = records.split_off(base_count);
+    Ok((records, incremental))
+}
+
+#[cfg(feature = "fixture-generator")]
+fn build_frozen_fixture(
+    source_attestation: &ProductionSourceAttestation,
+    catalog: &FixtureQueryCatalog,
+    base_records: &[VectorRecord],
+    incremental_records: &[VectorRecord],
+    dimensions: usize,
+    mut embed_query: impl FnMut(&str) -> Result<Vec<f32>>,
+) -> Result<FrozenFixture> {
+    source_attestation.validate()?;
+    ensure!(
+        catalog.schema_version == 1,
+        "fixture query catalog schema must be 1"
+    );
+    ensure!(
+        !catalog.queries.is_empty(),
+        "fixture query catalog is empty"
+    );
+    validate_records(base_records, dimensions)?;
+    validate_records(incremental_records, dimensions)?;
+    let base_by_node = base_records
+        .iter()
+        .map(|record| (record.identity.node_id.as_str(), &record.identity))
+        .collect::<BTreeMap<_, _>>();
+    ensure!(
+        incremental_records
+            .iter()
+            .all(|record| !base_by_node.contains_key(record.identity.node_id.as_str())),
+        "fixture incremental rows overlap the selected base publication"
+    );
+
+    let mut query_ids = HashSet::new();
+    let queries = catalog
+        .queries
+        .iter()
+        .map(|query| -> Result<FrozenQuery> {
+            ensure!(
+                !query.query_id.trim().is_empty() && query_ids.insert(&query.query_id),
+                "fixture query identities must be non-empty and unique"
+            );
+            ensure!(
+                !query.query_text.trim().is_empty(),
+                "fixture query {} has empty query text",
+                query.query_id
+            );
+            ensure!(
+                !query.expected_node_ids.is_empty(),
+                "fixture query {} needs expected node ids",
+                query.query_id
+            );
+            let mut expected_node_ids = HashSet::new();
+            let expected = query
+                .expected_node_ids
+                .iter()
+                .map(|node_id| {
+                    ensure!(
+                        expected_node_ids.insert(node_id),
+                        "fixture query {} repeats expected node id {node_id}",
+                        query.query_id
+                    );
+                    base_by_node
+                        .get(node_id.as_str())
+                        .map(|identity| (*identity).clone())
+                        .with_context(|| {
+                            format!(
+                                "fixture query {} expects node {node_id} outside the selected source rows",
+                                query.query_id
+                            )
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(FrozenQuery {
+                query_id: query.query_id.clone(),
+                kind: query.kind,
+                query_text: query.query_text.clone(),
+                vector: checked_vector(
+                    &query.query_id,
+                    embed_query(&query.query_text)?,
+                    dimensions,
+                )?,
+                expected,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    validate_queries(&queries, base_records, dimensions)?;
+
+    let incremental_set_id = format!(
+        "production-tail-{}-{}",
+        base_records.len(),
+        &records_sha256(incremental_records)[..16]
+    );
+    Ok(FrozenFixture {
+        schema_version: 2,
+        source_attestation: source_attestation.clone(),
+        incremental_set_id,
+        queries,
+        incremental_records: incremental_records
+            .iter()
+            .map(|record| FrozenVectorRecord {
+                node_id: record.identity.node_id.clone(),
+                document_hash: record.identity.document_hash.clone(),
+                vector: record.vector.clone(),
+            })
+            .collect(),
+    })
+}
+
 fn synthetic_publication(
     count: usize,
     dimensions: usize,
@@ -655,6 +666,7 @@ fn synthetic_fixture(
                 } else {
                     QueryKind::Symbol
                 },
+                query_text: String::new(),
                 vector: record.vector.clone(),
                 expected: vec![record.identity.clone()],
             }
@@ -692,21 +704,6 @@ fn frozen_record(record: FrozenVectorRecord, dimensions: usize) -> Result<Vector
         },
         vector: checked_vector(&record.node_id, record.vector, dimensions)?,
     })
-}
-
-fn decode_vector(node_id: &str, bytes: &[u8], dimensions: usize) -> Result<Vec<f32>> {
-    ensure!(
-        bytes.len() == dimensions * 4,
-        "vector byte length for {node_id} does not match {dimensions} dimensions"
-    );
-    checked_vector(
-        node_id,
-        bytes
-            .chunks_exact(4)
-            .map(|chunk| f32::from_le_bytes(chunk.try_into().expect("four-byte chunk")))
-            .collect(),
-        dimensions,
-    )
 }
 
 fn checked_vector(label: &str, vector: Vec<f32>, dimensions: usize) -> Result<Vec<f32>> {
@@ -1118,50 +1115,7 @@ fn vector_contract_rejects_invalid_norms_and_values() {
 }
 
 #[test]
-fn production_source_requires_and_revalidates_predeclared_attestation() -> Result<()> {
-    let temp = tempfile::tempdir()?;
-    let path = temp.path().join("vectors.sqlite3");
-    let attestation = write_test_source_database(&path)?;
-
-    let (records, publication, _, database_sha256) =
-        load_published_vectors(&path, 2, &attestation)?;
-    assert_eq!(records.len(), 2);
-    assert_eq!(publication, attestation.publication);
-    assert_eq!(database_sha256, attestation.database_sha256);
-
-    let mut wrong_database = attestation.clone();
-    wrong_database.database_sha256 = "0".repeat(64);
-    let error = load_published_vectors(&path, 2, &wrong_database)
-        .expect_err("mismatched predeclared database hash must fail");
-    assert!(format!("{error:#}").contains("predeclared source attestation"));
-
-    let wrong_digest = "1".repeat(64);
-    let connection = Connection::open(&path)?;
-    connection.execute(
-        "UPDATE metadata SET vector_digest = ?1 WHERE singleton = 1",
-        [&wrong_digest],
-    )?;
-    drop(connection);
-    let mut copied_metadata = attestation.clone();
-    copied_metadata.publication.vector_digest = wrong_digest;
-    copied_metadata.database_sha256 = sha256_file(&path)?;
-    let error = load_published_vectors(&path, 2, &copied_metadata)
-        .expect_err("copied metadata with a fresh database hash must not replace canonical proof");
-    assert!(format!("{error:#}").contains("canonical source vector digest"));
-
-    let connection = Connection::open(&path)?;
-    connection.execute(
-        "UPDATE metadata SET vector_digest = ?1, point_count = 1 WHERE singleton = 1",
-        [&attestation.publication.vector_digest],
-    )?;
-    drop(connection);
-    let mut incomplete_coverage = attestation.clone();
-    incomplete_coverage.publication.point_count = 1;
-    incomplete_coverage.database_sha256 = sha256_file(&path)?;
-    let error = load_published_vectors(&path, 1, &incomplete_coverage)
-        .expect_err("inexact complete-row coverage must fail");
-    assert!(format!("{error:#}").contains("complete table count"));
-
+fn decision_fixture_requires_source_attestation() {
     let missing_attestation = serde_json::json!({
         "schema_version": 2,
         "incremental_set_id": "missing-attestation",
@@ -1169,105 +1123,455 @@ fn production_source_requires_and_revalidates_predeclared_attestation() -> Resul
         "incremental_records": []
     });
     assert!(serde_json::from_value::<FrozenFixture>(missing_attestation).is_err());
-    Ok(())
 }
 
-#[test]
-fn pinned_source_snapshot_rejects_concurrent_wal_drift_before_sampling() -> Result<()> {
-    let temp = tempfile::tempdir()?;
-    let path = temp.path().join("vectors.sqlite3");
-    let mut attestation = write_test_source_database(&path)?;
-    let connection = Connection::open(&path)?;
-    let journal_mode: String =
-        connection.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
-    ensure!(
-        journal_mode == "wal",
-        "test database did not enter WAL mode"
-    );
-    drop(connection);
-    ensure_no_sqlite_sidecars(&path)?;
-    attestation.database_sha256 = sha256_file(&path)?;
-
-    let writer_path = path.clone();
-    let error = load_published_vectors_with_hook(&path, 2, &attestation, move || {
-        let writer = Connection::open(&writer_path)?;
-        writer.execute(
-            "UPDATE vectors SET document_hash = ?1 WHERE node_id = 'node-a'",
-            [sha256_bytes(b"concurrent-drift")],
-        )?;
-        drop(writer);
-        Ok(())
-    })
-    .expect_err("WAL drift between attestation and sampling must fail closed");
-    assert!(
-        format!("{error:#}").contains("unbound sidecar"),
-        "unexpected drift rejection: {error:#}"
-    );
-    Ok(())
+#[cfg(feature = "fixture-generator")]
+fn required_env_path(name: &str) -> Result<PathBuf> {
+    let value = std::env::var_os(name).with_context(|| format!("{name} is required"))?;
+    ensure!(!value.is_empty(), "{name} must not be empty");
+    let path = PathBuf::from(value);
+    ensure!(path.is_absolute(), "{name} must be an absolute path");
+    Ok(path)
 }
 
-fn write_test_source_database(path: &Path) -> Result<ProductionSourceAttestation> {
-    let connection = Connection::open(path)?;
-    connection.execute_batch(
-        "CREATE TABLE metadata (
-             singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-             schema_version INTEGER NOT NULL,
-             generation TEXT NOT NULL,
-             input_hash TEXT NOT NULL,
-             embedding_backend TEXT NOT NULL,
-             embedding_dim INTEGER NOT NULL,
-             point_count INTEGER NOT NULL,
-             producer_identity TEXT NOT NULL,
-             evidence_contract_identity TEXT NOT NULL,
-             vector_digest TEXT NOT NULL
-         );
-         CREATE TABLE vectors (
-             node_id TEXT PRIMARY KEY NOT NULL,
-             document_hash TEXT NOT NULL,
-             vector BLOB NOT NULL
-         );",
-    )?;
-    let rows = [
-        ("node-a", sha256_bytes(b"document-a"), vec![1.0_f32, 0.0]),
-        ("node-b", sha256_bytes(b"document-b"), vec![0.0_f32, 1.0]),
-    ];
-    for (node_id, document_hash, vector) in &rows {
-        connection.execute(
-            "INSERT INTO vectors (node_id, document_hash, vector) VALUES (?1, ?2, ?3)",
-            params![node_id, document_hash, vector_blob(vector)],
-        )?;
-    }
-    let (vector_digest, point_count) = canonical_source_vector_digest(&connection, 2)?;
-    let publication = PublicationIdentity {
-        schema_version: 2,
-        generation: "test-generation".to_owned(),
-        input_hash: sha256_bytes(b"test-input"),
-        embedding_backend: "test-backend".to_owned(),
-        embedding_dim: 2,
-        point_count,
-        producer_identity: "test-producer".to_owned(),
-        evidence_contract_identity: sha256_bytes(b"test-evidence-contract"),
-        vector_digest,
-    };
-    connection.execute(
-        "INSERT INTO metadata VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-        params![
-            publication.schema_version,
-            publication.generation,
-            publication.input_hash,
-            publication.embedding_backend,
-            publication.embedding_dim as i64,
-            publication.point_count as i64,
-            publication.producer_identity,
-            publication.evidence_contract_identity,
-            publication.vector_digest,
-        ],
-    )?;
-    drop(connection);
+fn fixture_source_attestation(
+    source: &codestory_retrieval::VectorDatabaseAttestation,
+) -> Result<ProductionSourceAttestation> {
     Ok(ProductionSourceAttestation {
-        publication,
-        database_sha256: sha256_file(path)?,
+        publication: PublicationIdentity {
+            schema_version: source.schema_version,
+            generation: source.generation.clone(),
+            input_hash: source.input_hash.clone(),
+            embedding_backend: source.embedding_backend.clone(),
+            embedding_dim: source.embedding_dim,
+            point_count: usize::try_from(source.point_count)
+                .context("production vector point count must fit usize")?,
+            producer_identity: source.producer_identity.clone(),
+            evidence_contract_identity: source.evidence_contract_identity.clone(),
+            vector_digest: source.vector_digest.clone(),
+        },
+        database_sha256: source.database_sha256.clone(),
     })
+}
+
+#[cfg(feature = "fixture-generator")]
+struct ValidatedFixtureOutput {
+    requested_parent: PathBuf,
+    destination: PathBuf,
+    parent_identity: PathBuf,
+    source_generation_path: PathBuf,
+    source_generation_identity: PathBuf,
+    cache_root_path: PathBuf,
+    cache_root_identity: PathBuf,
+}
+
+#[cfg(feature = "fixture-generator")]
+impl ValidatedFixtureOutput {
+    fn revalidate_destination(&self) -> Result<&Path> {
+        let parent = self.requested_parent.canonicalize().with_context(|| {
+            format!(
+                "revalidate fixture output parent {}",
+                self.requested_parent.display()
+            )
+        })?;
+        ensure!(
+            codestory_workspace::same_workspace_path(&parent, &self.parent_identity),
+            "fixture output parent identity changed during preparation"
+        );
+        let source_generation = self
+            .source_generation_path
+            .canonicalize()
+            .with_context(|| {
+                format!(
+                    "revalidate source generation {}",
+                    self.source_generation_path.display()
+                )
+            })?;
+        let cache_root = self
+            .cache_root_path
+            .canonicalize()
+            .with_context(|| format!("revalidate cache root {}", self.cache_root_path.display()))?;
+        ensure!(
+            codestory_workspace::same_workspace_path(
+                &source_generation,
+                &self.source_generation_identity,
+            ) && codestory_workspace::same_workspace_path(&cache_root, &self.cache_root_identity),
+            "fixture source or cache root identity changed during preparation"
+        );
+        validate_fixture_destination_roots(&self.destination, &source_generation, &cache_root)?;
+        ensure!(
+            !self.destination.try_exists().with_context(|| format!(
+                "inspect fixture output destination {}",
+                self.destination.display()
+            ))?,
+            "fixture output must be a new path"
+        );
+        Ok(&self.destination)
+    }
+}
+
+#[cfg(feature = "fixture-generator")]
+fn validate_fixture_output_path(
+    output: &Path,
+    source_sqlite: &Path,
+    cache_root: &Path,
+) -> Result<ValidatedFixtureOutput> {
+    let source_generation = source_sqlite
+        .parent()
+        .context("production vector database has no generation directory")?;
+    let output_parent = output.parent().context("fixture output has no parent")?;
+    ensure!(
+        output_parent.is_dir(),
+        "fixture output parent must already exist"
+    );
+    let parent_identity = output_parent
+        .canonicalize()
+        .with_context(|| format!("resolve fixture output parent {}", output_parent.display()))?;
+    let file_name = output
+        .file_name()
+        .context("fixture output has no file name")?;
+    let destination = parent_identity.join(file_name);
+    let source_generation_identity = source_generation
+        .canonicalize()
+        .with_context(|| format!("resolve source generation {}", source_generation.display()))?;
+    let cache_root_identity = cache_root
+        .canonicalize()
+        .with_context(|| format!("resolve cache root {}", cache_root.display()))?;
+    validate_fixture_destination_roots(
+        &destination,
+        &source_generation_identity,
+        &cache_root_identity,
+    )?;
+    let validated = ValidatedFixtureOutput {
+        requested_parent: output_parent.to_path_buf(),
+        destination,
+        parent_identity,
+        source_generation_path: source_generation.to_path_buf(),
+        source_generation_identity,
+        cache_root_path: cache_root.to_path_buf(),
+        cache_root_identity,
+    };
+    validated.revalidate_destination()?;
+    Ok(validated)
+}
+
+#[cfg(feature = "fixture-generator")]
+fn validate_fixture_destination_roots(
+    destination: &Path,
+    source_generation: &Path,
+    cache_root: &Path,
+) -> Result<()> {
+    ensure!(
+        codestory_workspace::workspace_relative_path(source_generation, destination).is_none(),
+        "fixture output must be outside the source generation"
+    );
+    ensure!(
+        codestory_workspace::workspace_relative_path(cache_root, destination).is_none(),
+        "fixture output must be outside CODESTORY_CACHE_ROOT"
+    );
+    Ok(())
+}
+
+#[cfg(feature = "fixture-generator")]
+fn write_fixture_no_replace(output: &ValidatedFixtureOutput, bytes: &[u8]) -> Result<()> {
+    let path = output.revalidate_destination()?;
+    let (temp_path, mut file) =
+        codestory_workspace::atomic_file::create_unique_temp_file(path, "vector-backend-fixture")?;
+    let write_result = (|| -> Result<()> {
+        file.write_all(bytes)
+            .context("write fixture temporary file")?;
+        file.sync_all().context("sync fixture temporary file")
+    })();
+    drop(file);
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error);
+    }
+    let result = (|| -> Result<()> {
+        ensure!(
+            fs::read(&temp_path)? == bytes,
+            "fixture temporary file validation failed"
+        );
+        let path = output.revalidate_destination()?;
+        fs::hard_link(&temp_path, path)
+            .with_context(|| format!("publish new fixture {}", path.display()))?;
+        let _ = fs::remove_file(&temp_path);
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(feature = "fixture-generator")]
+#[test]
+fn fixture_builder_is_deterministic_and_uses_source_truth() -> Result<()> {
+    let source_attestation = ProductionSourceAttestation {
+        publication: PublicationIdentity {
+            schema_version: 2,
+            generation: "fixture-generation".to_owned(),
+            input_hash: sha256_bytes(b"fixture-input"),
+            embedding_backend: "fixture-backend".to_owned(),
+            embedding_dim: 2,
+            point_count: 3,
+            producer_identity: "fixture-producer".to_owned(),
+            evidence_contract_identity: sha256_bytes(b"fixture-contract"),
+            vector_digest: sha256_bytes(b"fixture-vectors"),
+        },
+        database_sha256: sha256_bytes(b"fixture-database"),
+    };
+    let base = vec![
+        VectorRecord {
+            identity: Identity {
+                node_id: "node-a".to_owned(),
+                document_hash: "document-a".to_owned(),
+            },
+            vector: vec![1.0, 0.0],
+        },
+        VectorRecord {
+            identity: Identity {
+                node_id: "node-b".to_owned(),
+                document_hash: "document-b".to_owned(),
+            },
+            vector: vec![0.0, 1.0],
+        },
+    ];
+    let tail = vec![VectorRecord {
+        identity: Identity {
+            node_id: "node-c".to_owned(),
+            document_hash: "document-c".to_owned(),
+        },
+        vector: vec![-1.0, 0.0],
+    }];
+    let catalog = FixtureQueryCatalog {
+        schema_version: 1,
+        queries: vec![
+            FixtureCatalogQuery {
+                query_id: "representative-001".to_owned(),
+                kind: QueryKind::Representative,
+                query_text: "representative query".to_owned(),
+                expected_node_ids: vec!["node-b".to_owned()],
+            },
+            FixtureCatalogQuery {
+                query_id: "symbol-001".to_owned(),
+                kind: QueryKind::Symbol,
+                query_text: "symbol query".to_owned(),
+                expected_node_ids: vec!["node-a".to_owned()],
+            },
+        ],
+    };
+    let embed = |text: &str| -> Result<Vec<f32>> {
+        Ok(match text {
+            "representative query" => vec![0.0, 1.0],
+            "symbol query" => vec![1.0, 0.0],
+            _ => anyhow::bail!("unexpected query text"),
+        })
+    };
+
+    let first = build_frozen_fixture(&source_attestation, &catalog, &base, &tail, 2, embed)?;
+    let second = build_frozen_fixture(&source_attestation, &catalog, &base, &tail, 2, embed)?;
+    assert_eq!(
+        serde_json::to_vec(&first)?,
+        serde_json::to_vec(&second)?,
+        "the same source and catalog must freeze identically"
+    );
+    assert_eq!(first.schema_version, 2);
+    assert_eq!(first.queries[0].expected[0].node_id, "node-b");
+    assert_eq!(first.queries[0].expected[0].document_hash, "document-b");
+    assert_eq!(first.incremental_records[0].node_id, "node-c");
+    assert!(split_fixture_records(base.clone(), 2, 1).is_err());
+    Ok(())
+}
+
+#[cfg(feature = "fixture-generator")]
+#[test]
+fn fixture_output_rejects_source_generation_and_cache_root() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let cache_root = temp.path().join("cache");
+    let source_generation = cache_root
+        .join("semantic")
+        .join("collections")
+        .join("generation");
+    let outside = temp.path().join("evidence");
+    fs::create_dir_all(&source_generation)?;
+    fs::create_dir_all(&outside)?;
+    let source_sqlite = source_generation.join("vectors.sqlite3");
+    File::create(&source_sqlite)?;
+
+    assert!(
+        validate_fixture_output_path(
+            &source_generation.join("fixture.json"),
+            &source_sqlite,
+            &cache_root,
+        )
+        .is_err()
+    );
+    assert!(
+        validate_fixture_output_path(
+            &cache_root.join("fixture.json"),
+            &source_sqlite,
+            &cache_root,
+        )
+        .is_err()
+    );
+    assert!(!source_generation.join("fixture.json").exists());
+    assert!(!cache_root.join("fixture.json").exists());
+    validate_fixture_output_path(&outside.join("fixture.json"), &source_sqlite, &cache_root)?;
+    Ok(())
+}
+
+#[cfg(feature = "fixture-generator")]
+#[test]
+fn fixture_publication_never_replaces_an_existing_path() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let cache_root = temp.path().join("cache");
+    let source_generation = cache_root.join("source");
+    let output_parent = temp.path().join("evidence");
+    fs::create_dir_all(&source_generation)?;
+    fs::create_dir_all(&output_parent)?;
+    let source_sqlite = source_generation.join("vectors.sqlite3");
+    File::create(&source_sqlite)?;
+    let output_path = output_parent.join("fixture.json");
+    let output = validate_fixture_output_path(&output_path, &source_sqlite, &cache_root)?;
+    write_fixture_no_replace(&output, b"first")?;
+    let error = write_fixture_no_replace(&output, b"second")
+        .expect_err("fixture publication must use create-new semantics");
+    assert!(error.to_string().contains("new path"));
+    assert_eq!(fs::read(&output_path)?, b"first");
+    assert_eq!(fs::read_dir(&output_parent)?.count(), 1);
+    Ok(())
+}
+
+#[cfg(all(feature = "fixture-generator", windows))]
+fn create_directory_link(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(target, link)
+}
+
+#[cfg(all(feature = "fixture-generator", windows))]
+fn remove_directory_link(link: &Path) -> std::io::Result<()> {
+    fs::remove_dir(link)
+}
+
+#[cfg(all(feature = "fixture-generator", unix))]
+fn create_directory_link(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(all(feature = "fixture-generator", unix))]
+fn remove_directory_link(link: &Path) -> std::io::Result<()> {
+    fs::remove_file(link)
+}
+
+#[cfg(all(feature = "fixture-generator", any(windows, unix)))]
+#[test]
+fn fixture_publication_rejects_changed_parent_identity() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let cache_root = temp.path().join("cache");
+    let source_generation = cache_root.join("source");
+    let safe_parent = temp.path().join("safe-evidence");
+    let parent_link = temp.path().join("evidence-link");
+    fs::create_dir_all(&source_generation)?;
+    fs::create_dir_all(&safe_parent)?;
+    let source_sqlite = source_generation.join("vectors.sqlite3");
+    File::create(&source_sqlite)?;
+    if let Err(error) = create_directory_link(&safe_parent, &parent_link) {
+        if error.kind() == std::io::ErrorKind::PermissionDenied {
+            return Ok(());
+        }
+        return Err(error.into());
+    }
+    let output_path = parent_link.join("fixture.json");
+    let output = validate_fixture_output_path(&output_path, &source_sqlite, &cache_root)?;
+    remove_directory_link(&parent_link)?;
+    create_directory_link(&cache_root, &parent_link)?;
+
+    let error = write_fixture_no_replace(&output, b"blocked")
+        .expect_err("changed output parent identity must fail closed");
+    assert!(error.to_string().contains("parent identity changed"));
+    assert!(!safe_parent.join("fixture.json").exists());
+    assert!(!cache_root.join("fixture.json").exists());
+    Ok(())
+}
+
+#[cfg(feature = "fixture-generator")]
+#[test]
+#[ignore = "fixture preparation lane; run explicitly against an isolated production publication"]
+fn prepare_vector_backend_fixture() -> Result<()> {
+    let source_sqlite = required_env_path("CODESTORY_VECTOR_SPIKE_SOURCE_SQLITE")?;
+    let catalog_path = required_env_path("CODESTORY_VECTOR_SPIKE_QUERY_CATALOG_JSON")?;
+    let output_path = required_env_path("CODESTORY_VECTOR_SPIKE_FIXTURE_JSON")?;
+    let configured_cache_root = required_env_path("CODESTORY_CACHE_ROOT")?;
+    let output =
+        validate_fixture_output_path(&output_path, &source_sqlite, &configured_cache_root)?;
+    let runtime = codestory_retrieval::SidecarRuntimeConfig::local();
+    ensure!(
+        codestory_workspace::same_workspace_path(&runtime.cache_root, &configured_cache_root),
+        "retrieval runtime did not retain the explicit isolated CODESTORY_CACHE_ROOT"
+    );
+    let base_count = parse_env_usize(
+        "CODESTORY_VECTOR_SPIKE_VECTOR_COUNT",
+        *DECISION_COUNTS
+            .last()
+            .expect("decision counts are non-empty"),
+    )?;
+    let incremental_count = parse_env_usize("CODESTORY_VECTOR_SPIKE_INCREMENTAL_COUNT", 100)?;
+    ensure!(
+        base_count
+            == *DECISION_COUNTS
+                .last()
+                .expect("decision counts are non-empty"),
+        "fixture generator base count must cover the largest predeclared decision workload"
+    );
+    ensure!(
+        incremental_count > 0,
+        "fixture incremental tail count must be positive"
+    );
+    let required = base_count
+        .checked_add(incremental_count)
+        .context("fixture base plus tail count overflow")?;
+
+    let source = codestory_retrieval::open_validated_vector_fixture_source_for_runtime(
+        &source_sqlite,
+        &runtime,
+        required,
+    )?;
+    let source_attestation = fixture_source_attestation(source.attestation())?;
+    let publication = source_attestation.publication.clone();
+    let records = fixture_records(source.records());
+    let (base, incremental) = split_fixture_records(records, base_count, incremental_count)?;
+
+    let catalog_bytes = fs::read(&catalog_path)
+        .with_context(|| format!("read fixture query catalog {}", catalog_path.display()))?;
+    let catalog: FixtureQueryCatalog = serde_json::from_slice(&catalog_bytes)
+        .with_context(|| format!("parse fixture query catalog {}", catalog_path.display()))?;
+    ensure!(
+        catalog.queries.len() == DECISION_QUERIES,
+        "decision fixture catalog must contain exactly {DECISION_QUERIES} queries"
+    );
+    let fixture = build_frozen_fixture(
+        &source_attestation,
+        &catalog,
+        &base,
+        &incremental,
+        publication.embedding_dim,
+        |query_text| source.embed_query(query_text),
+    )?;
+    for vector_count in DECISION_COUNTS {
+        validate_queries(
+            &fixture.queries,
+            &base[..vector_count],
+            publication.embedding_dim,
+        )
+        .with_context(|| {
+            format!("fixture query truth is not covered by the {vector_count}-row workload")
+        })?;
+    }
+    let bytes = serde_json::to_vec_pretty(&fixture)?;
+    write_fixture_no_replace(&output, &bytes)?;
+    println!("vector backend fixture: {}", output_path.display());
+    println!("fixture SHA-256: {}", sha256_bytes(&bytes));
+    Ok(())
 }
 
 #[test]
@@ -2814,20 +3118,6 @@ fn sha256_file(path: &Path) -> Result<String> {
         digest.update(&buffer[..read]);
     }
     Ok(format!("{:x}", digest.finalize()))
-}
-
-fn ensure_no_sqlite_sidecars(path: &Path) -> Result<()> {
-    for suffix in ["-wal", "-shm", "-journal"] {
-        let mut sidecar = path.as_os_str().to_owned();
-        sidecar.push(suffix);
-        let sidecar = PathBuf::from(sidecar);
-        ensure!(
-            !sidecar.exists(),
-            "attested SQLite source has an unbound sidecar: {}",
-            sidecar.display()
-        );
-    }
-    Ok(())
 }
 
 fn sha256_bytes(bytes: &[u8]) -> String {

--- a/crates/codestory-bench/tests/vector_backend_spike.rs
+++ b/crates/codestory-bench/tests/vector_backend_spike.rs
@@ -907,6 +907,8 @@ struct Artifact {
     criteria_sha256: String,
     profile: String,
     decision_profile: bool,
+    decision_scope: &'static str,
+    blocking_platform: &'static str,
     timing_comparable: bool,
     timing_protocol: &'static str,
     build: BuildIdentity,
@@ -1018,6 +1020,7 @@ struct QueryMeasurements {
 fn decision_criteria_are_predeclared() {
     let criteria: serde_json::Value = serde_json::from_str(CRITERIA).expect("criteria JSON");
     assert_eq!(criteria["issue"], 1202);
+    assert_eq!(criteria["schema_version"], 4);
     assert_eq!(
         criteria["decision_status"],
         "blocked_pending_required_evidence"
@@ -1033,6 +1036,23 @@ fn decision_criteria_are_predeclared() {
         criteria["shared_workload"]["vector_counts"],
         serde_json::json!(DECISION_COUNTS)
     );
+    assert_eq!(
+        criteria["required_platforms"],
+        serde_json::json!(["windows-x86_64"])
+    );
+    let adoption_follow_up = criteria["non_blocking_adoption_follow_up"]
+        .as_array()
+        .expect("non-blocking adoption follow-up list");
+    assert!(adoption_follow_up.iter().any(|value| {
+        value
+            .as_str()
+            .is_some_and(|value| value.contains("Linux x64"))
+    }));
+    assert!(adoption_follow_up.iter().any(|value| {
+        value
+            .as_str()
+            .is_some_and(|value| value.contains("macOS arm64"))
+    }));
     let required = criteria["required_measurements"]
         .as_array()
         .expect("required measurement list");
@@ -1278,12 +1298,14 @@ fn compare_vector_backends() -> Result<()> {
     }
 
     let artifact = Artifact {
-        schema_version: 3,
+        schema_version: 4,
         issue: 1202,
         generated_at_unix_seconds: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
         criteria_sha256: sha256_bytes(CRITERIA.as_bytes()),
         profile: config.profile.clone(),
         decision_profile: config.profile == "decision",
+        decision_scope: "approved Windows x64 production comparison only; no backend adoption",
+        blocking_platform: "windows-x86_64",
         timing_comparable: false,
         timing_protocol: "two same-process repetitions with reversed candidate order; timings remain diagnostic until isolated clean-host runs exist",
         build,
@@ -1315,7 +1337,8 @@ fn compare_vector_backends() -> Result<()> {
         runs,
         limitations: vec![
             "same-process smoke timings are diagnostic and not candidate-comparison evidence",
-            "cold-cache latency, isolated RSS, cancellation, deep validation, current-scan regression, offline build, archive size, license, and native package checks remain external evidence",
+            "cold-cache latency, isolated RSS, cancellation, deep validation, and current-scan regression remain required Windows x64 decision evidence",
+            "Linux/macOS proof, cross-platform offline/native packaging, archive size, license review, and implementation fallback proof are non-blocking adoption follow-up",
             "one artifact covers only its recorded host, source publication, fixture, and vector count",
         ],
     };
@@ -1357,6 +1380,12 @@ fn validate_decision_identity(
     ensure!(
         !build.target.is_empty(),
         "decision target triple is unavailable"
+    );
+    ensure!(
+        host.os == "windows"
+            && host.architecture == "x86_64"
+            && build.target.starts_with("x86_64-pc-windows-"),
+        "decision profile requires the approved Windows x64 production host"
     );
     ensure!(
         host.cpu_model.is_some(),

--- a/crates/codestory-bench/tests/vector_backend_spike.rs
+++ b/crates/codestory-bench/tests/vector_backend_spike.rs
@@ -1158,7 +1158,9 @@ fn fixture_source_attestation(
 struct ValidatedFixtureOutput {
     requested_parent: PathBuf,
     destination: PathBuf,
+    destination_name: std::ffi::OsString,
     parent_identity: PathBuf,
+    publication_root: codestory_workspace::owned_publication::OwnedFilePublicationRoot,
     source_generation_path: PathBuf,
     source_generation_identity: PathBuf,
     cache_root_path: PathBuf,
@@ -1167,7 +1169,7 @@ struct ValidatedFixtureOutput {
 
 #[cfg(feature = "fixture-generator")]
 impl ValidatedFixtureOutput {
-    fn revalidate_destination(&self) -> Result<&Path> {
+    fn revalidate_destination(&self) -> Result<()> {
         let parent = self.requested_parent.canonicalize().with_context(|| {
             format!(
                 "revalidate fixture output parent {}",
@@ -1206,7 +1208,7 @@ impl ValidatedFixtureOutput {
             ))?,
             "fixture output must be a new path"
         );
-        Ok(&self.destination)
+        Ok(())
     }
 }
 
@@ -1229,8 +1231,9 @@ fn validate_fixture_output_path(
         .with_context(|| format!("resolve fixture output parent {}", output_parent.display()))?;
     let file_name = output
         .file_name()
-        .context("fixture output has no file name")?;
-    let destination = parent_identity.join(file_name);
+        .context("fixture output has no file name")?
+        .to_owned();
+    let destination = parent_identity.join(&file_name);
     let source_generation_identity = source_generation
         .canonicalize()
         .with_context(|| format!("resolve source generation {}", source_generation.display()))?;
@@ -1242,10 +1245,15 @@ fn validate_fixture_output_path(
         &source_generation_identity,
         &cache_root_identity,
     )?;
+    let publication_root =
+        codestory_workspace::owned_publication::OwnedFilePublicationRoot::open(&parent_identity)
+            .with_context(|| format!("pin fixture output parent {}", parent_identity.display()))?;
     let validated = ValidatedFixtureOutput {
         requested_parent: output_parent.to_path_buf(),
         destination,
+        destination_name: file_name,
         parent_identity,
+        publication_root,
         source_generation_path: source_generation.to_path_buf(),
         source_generation_identity,
         cache_root_path: cache_root.to_path_buf(),
@@ -1274,34 +1282,21 @@ fn validate_fixture_destination_roots(
 
 #[cfg(feature = "fixture-generator")]
 fn write_fixture_no_replace(output: &ValidatedFixtureOutput, bytes: &[u8]) -> Result<()> {
-    let path = output.revalidate_destination()?;
-    let (temp_path, mut file) =
-        codestory_workspace::atomic_file::create_unique_temp_file(path, "vector-backend-fixture")?;
-    let write_result = (|| -> Result<()> {
-        file.write_all(bytes)
-            .context("write fixture temporary file")?;
-        file.sync_all().context("sync fixture temporary file")
-    })();
-    drop(file);
-    if let Err(error) = write_result {
-        let _ = fs::remove_file(&temp_path);
-        return Err(error);
-    }
-    let result = (|| -> Result<()> {
-        ensure!(
-            fs::read(&temp_path)? == bytes,
-            "fixture temporary file validation failed"
-        );
-        let path = output.revalidate_destination()?;
-        fs::hard_link(&temp_path, path)
-            .with_context(|| format!("publish new fixture {}", path.display()))?;
-        let _ = fs::remove_file(&temp_path);
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&temp_path);
-    }
-    result
+    write_fixture_no_replace_with_hook(output, bytes, || Ok(()))
+}
+
+#[cfg(feature = "fixture-generator")]
+fn write_fixture_no_replace_with_hook(
+    output: &ValidatedFixtureOutput,
+    bytes: &[u8],
+    before_publish: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    output.revalidate_destination()?;
+    before_publish()?;
+    output
+        .publication_root
+        .publish_new_bytes(&output.destination_name, "vector-backend-fixture", bytes)
+        .with_context(|| format!("publish new fixture {}", output.destination.display()))
 }
 
 #[cfg(feature = "fixture-generator")]
@@ -1491,6 +1486,36 @@ fn fixture_publication_rejects_changed_parent_identity() -> Result<()> {
     assert!(error.to_string().contains("parent identity changed"));
     assert!(!safe_parent.join("fixture.json").exists());
     assert!(!cache_root.join("fixture.json").exists());
+    Ok(())
+}
+
+#[cfg(all(feature = "fixture-generator", any(windows, unix)))]
+#[test]
+fn fixture_publication_cannot_be_redirected_after_revalidation() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let cache_root = temp.path().join("cache");
+    let source_generation = cache_root.join("source-generation");
+    let safe_parent = temp.path().join("safe-parent");
+    let parent_link = temp.path().join("parent-link");
+    fs::create_dir_all(&source_generation)?;
+    fs::create_dir_all(&safe_parent)?;
+    let source_sqlite = source_generation.join("vectors.sqlite3");
+    File::create(&source_sqlite)?;
+    create_directory_link(&safe_parent, &parent_link)?;
+
+    let output_path = parent_link.join("fixture.json");
+    let output = validate_fixture_output_path(&output_path, &source_sqlite, &cache_root)?;
+    write_fixture_no_replace_with_hook(&output, b"pinned", || {
+        remove_directory_link(&parent_link)?;
+        create_directory_link(&cache_root, &parent_link)?;
+        Ok(())
+    })?;
+
+    assert_eq!(fs::read(safe_parent.join("fixture.json"))?, b"pinned");
+    assert!(
+        !cache_root.join("fixture.json").exists(),
+        "handle-bound publication must not follow the replacement parent"
+    );
     Ok(())
 }
 

--- a/crates/codestory-bench/tests/vector_backend_spike.rs
+++ b/crates/codestory-bench/tests/vector_backend_spike.rs
@@ -1,0 +1,2898 @@
+use anyhow::{Context, Result, ensure};
+use rusqlite::{Connection, OpenFlags, params};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Once};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
+
+const CRITERIA: &str = include_str!("../../../benchmarks/vector-backend-spike/criteria.json");
+const TOP_K: usize = 20;
+const DECISION_DIMENSIONS: usize = 768;
+const DECISION_QUERIES: usize = 30;
+const DECISION_WARMUPS: usize = 5;
+const DECISION_COUNTS: [usize; 4] = [1_000, 10_000, 25_000, 100_000];
+const VECTOR_NORM_TOLERANCE: f64 = 1.0e-3;
+const VECTOR_DIGEST_DOMAIN: &[u8] = b"codestory-vector-digest-v1\0";
+const PRODUCTION_VECTOR_SCHEMA_VERSION: i64 = 2;
+const REPETITIONS: usize = 2;
+
+static REGISTER_SQLITE_VEC: Once = Once::new();
+
+#[derive(Debug)]
+struct Config {
+    profile: String,
+    vector_count: usize,
+    dimensions: usize,
+    query_count: usize,
+    warmups: usize,
+    source_sqlite: Option<PathBuf>,
+    fixture_json: Option<PathBuf>,
+    output: PathBuf,
+}
+
+impl Config {
+    fn from_env() -> Result<Self> {
+        let profile =
+            std::env::var("CODESTORY_VECTOR_SPIKE_PROFILE").unwrap_or_else(|_| "smoke".to_owned());
+        ensure!(
+            profile == "smoke" || profile == "decision",
+            "unknown profile {profile}"
+        );
+        let source_sqlite =
+            std::env::var_os("CODESTORY_VECTOR_SPIKE_SOURCE_SQLITE").map(PathBuf::from);
+        let fixture_json =
+            std::env::var_os("CODESTORY_VECTOR_SPIKE_FIXTURE_JSON").map(PathBuf::from);
+        let vector_count = parse_env_usize(
+            "CODESTORY_VECTOR_SPIKE_VECTOR_COUNT",
+            if profile == "decision" { 100_000 } else { 512 },
+        )?;
+        let dimensions = if profile == "decision" {
+            DECISION_DIMENSIONS
+        } else {
+            parse_env_usize("CODESTORY_VECTOR_SPIKE_DIMENSIONS", DECISION_DIMENSIONS)?
+        };
+        let query_count = if profile == "decision" {
+            DECISION_QUERIES
+        } else {
+            parse_env_usize("CODESTORY_VECTOR_SPIKE_QUERY_COUNT", 8)?
+        };
+        let warmups = if profile == "decision" {
+            DECISION_WARMUPS
+        } else {
+            parse_env_usize("CODESTORY_VECTOR_SPIKE_WARMUPS", 2)?
+        };
+        ensure!(vector_count > 0, "vector count must be positive");
+        ensure!(dimensions > 0, "dimensions must be positive");
+        ensure!(query_count > 1, "query count must be at least two");
+
+        if profile == "decision" {
+            ensure!(
+                DECISION_COUNTS.contains(&vector_count),
+                "decision vector count must be one of {DECISION_COUNTS:?}"
+            );
+            ensure!(
+                source_sqlite.is_some(),
+                "decision profile requires a complete CodeStory vector publication"
+            );
+            ensure!(
+                fixture_json.is_some(),
+                "decision profile requires an evidence-bound frozen query and incremental fixture"
+            );
+        }
+
+        let default_output = workspace_root()
+            .join("target")
+            .join("vector-backend-spike")
+            .join(format!(
+                "{}-{}-{profile}-{vector_count}.json",
+                std::env::consts::OS,
+                std::env::consts::ARCH
+            ));
+        let output = std::env::var_os("CODESTORY_VECTOR_SPIKE_OUTPUT")
+            .map(PathBuf::from)
+            .map(|path| {
+                if path.is_absolute() {
+                    path
+                } else {
+                    workspace_root().join(path)
+                }
+            })
+            .unwrap_or(default_output);
+
+        Ok(Self {
+            profile,
+            vector_count,
+            dimensions,
+            query_count,
+            warmups,
+            source_sqlite,
+            fixture_json,
+            output,
+        })
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("benchmark crate must be beneath the workspace root")
+        .to_owned()
+}
+
+fn parse_env_usize(name: &str, default: usize) -> Result<usize> {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse::<usize>()
+            .with_context(|| format!("parse {name}={value}")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(error).with_context(|| format!("read {name}")),
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+struct Identity {
+    node_id: String,
+    document_hash: String,
+}
+
+#[derive(Clone, Debug)]
+struct VectorRecord {
+    identity: Identity,
+    vector: Vec<f32>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct PublicationIdentity {
+    schema_version: i64,
+    generation: String,
+    input_hash: String,
+    embedding_backend: String,
+    embedding_dim: usize,
+    point_count: usize,
+    producer_identity: String,
+    evidence_contract_identity: String,
+    vector_digest: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct ProductionSourceAttestation {
+    #[serde(flatten)]
+    publication: PublicationIdentity,
+    database_sha256: String,
+}
+
+impl ProductionSourceAttestation {
+    fn validate(&self) -> Result<()> {
+        self.publication.validate()?;
+        ensure!(
+            self.publication.schema_version == PRODUCTION_VECTOR_SCHEMA_VERSION,
+            "source attestation schema version must match the production vector contract"
+        );
+        validate_sha256(
+            "source attestation vector_digest",
+            &self.publication.vector_digest,
+        )?;
+        validate_sha256("source attestation database_sha256", &self.database_sha256)
+    }
+}
+
+impl PublicationIdentity {
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.schema_version > 0,
+            "publication schema version must be positive"
+        );
+        ensure!(
+            self.embedding_dim > 0,
+            "publication embedding dimension must be positive"
+        );
+        ensure!(
+            self.point_count > 0,
+            "publication point count must be positive"
+        );
+        for (name, value) in [
+            ("generation", &self.generation),
+            ("input_hash", &self.input_hash),
+            ("embedding_backend", &self.embedding_backend),
+            ("producer_identity", &self.producer_identity),
+            (
+                "evidence_contract_identity",
+                &self.evidence_contract_identity,
+            ),
+            ("vector_digest", &self.vector_digest),
+        ] {
+            ensure!(
+                !value.trim().is_empty(),
+                "publication {name} must be non-empty"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum QueryKind {
+    Representative,
+    Symbol,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct FrozenQuery {
+    query_id: String,
+    kind: QueryKind,
+    vector: Vec<f32>,
+    expected: Vec<Identity>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct FrozenVectorRecord {
+    node_id: String,
+    document_hash: String,
+    vector: Vec<f32>,
+}
+
+#[derive(Deserialize)]
+struct FrozenFixture {
+    schema_version: u32,
+    source_attestation: ProductionSourceAttestation,
+    incremental_set_id: String,
+    queries: Vec<FrozenQuery>,
+    incremental_records: Vec<FrozenVectorRecord>,
+}
+
+struct Dataset {
+    records: Vec<VectorRecord>,
+    queries: Vec<FrozenQuery>,
+    incremental_records: Vec<VectorRecord>,
+    publication: PublicationIdentity,
+    source_attestation: Option<ProductionSourceAttestation>,
+    source_label: String,
+    source_artifact_sha256: String,
+    fixture_label: String,
+    fixture_sha256: String,
+    incremental_set_id: String,
+}
+
+impl Dataset {
+    fn load(config: &Config) -> Result<Self> {
+        let loaded_fixture = match (&config.source_sqlite, &config.fixture_json) {
+            (Some(_), Some(path)) => Some(read_frozen_fixture(path)?),
+            (None, None) => None,
+            (Some(_), None) => {
+                anyhow::bail!("a production source requires a predeclared source attestation")
+            }
+            (None, Some(_)) => anyhow::bail!("a frozen fixture requires its attested source"),
+        };
+        let (records, publication, source_attestation, source_label, source_artifact_sha256) =
+            match (&config.source_sqlite, &loaded_fixture) {
+                (Some(path), Some(loaded)) => {
+                    let (records, publication, source_label, source_artifact_sha256) =
+                        load_published_vectors(
+                            path,
+                            config.vector_count,
+                            &loaded.fixture.source_attestation,
+                        )?;
+                    (
+                        records,
+                        publication,
+                        Some(loaded.fixture.source_attestation.clone()),
+                        source_label,
+                        source_artifact_sha256,
+                    )
+                }
+                (None, None) => {
+                    let (records, publication, source_label, source_artifact_sha256) =
+                        synthetic_publication(config.vector_count, config.dimensions);
+                    (
+                        records,
+                        publication,
+                        None,
+                        source_label,
+                        source_artifact_sha256,
+                    )
+                }
+                _ => unreachable!("source and fixture presence was validated"),
+            };
+        publication.validate()?;
+        ensure!(
+            publication.embedding_dim == config.dimensions,
+            "expected {} dimensions, found {}",
+            config.dimensions,
+            publication.embedding_dim
+        );
+        ensure!(
+            records.len() == config.vector_count,
+            "expected {} selected vectors, found {}",
+            config.vector_count,
+            records.len()
+        );
+        validate_records(&records, config.dimensions)?;
+
+        let (queries, incremental_records, incremental_set_id, fixture_label, fixture_sha256) =
+            match loaded_fixture {
+                Some(loaded) => select_frozen_fixture(
+                    loaded,
+                    &publication,
+                    &records,
+                    config.dimensions,
+                    config.query_count,
+                )?,
+                None => synthetic_fixture(&publication, &records, config.query_count),
+            };
+        validate_queries(&queries, &records, config.dimensions)?;
+        validate_records(&incremental_records, config.dimensions)?;
+        let base_identities = records
+            .iter()
+            .map(|record| record.identity.clone())
+            .collect::<HashSet<_>>();
+        ensure!(
+            incremental_records
+                .iter()
+                .all(|record| !base_identities.contains(&record.identity)),
+            "incremental identities must not collide with the base publication"
+        );
+
+        if config.profile == "decision" {
+            ensure!(
+                queries.len() == DECISION_QUERIES,
+                "decision fixture must contain exactly {DECISION_QUERIES} selected queries"
+            );
+            ensure!(
+                !incremental_records.is_empty(),
+                "decision fixture must contain frozen incremental records"
+            );
+            ensure!(
+                !incremental_set_id.trim().is_empty(),
+                "decision incremental set identity must be non-empty"
+            );
+        }
+
+        Ok(Self {
+            records,
+            queries,
+            incremental_records,
+            publication,
+            source_attestation,
+            source_label,
+            source_artifact_sha256,
+            fixture_label,
+            fixture_sha256,
+            incremental_set_id,
+        })
+    }
+}
+
+fn load_published_vectors(
+    path: &Path,
+    limit: usize,
+    expected_attestation: &ProductionSourceAttestation,
+) -> Result<(Vec<VectorRecord>, PublicationIdentity, String, String)> {
+    load_published_vectors_with_hook(path, limit, expected_attestation, || Ok(()))
+}
+
+fn load_published_vectors_with_hook(
+    path: &Path,
+    limit: usize,
+    expected_attestation: &ProductionSourceAttestation,
+    before_sample: impl FnOnce() -> Result<()>,
+) -> Result<(Vec<VectorRecord>, PublicationIdentity, String, String)> {
+    expected_attestation.validate()?;
+    ensure_no_sqlite_sidecars(path)?;
+    let database_sha256 = sha256_file(path)
+        .with_context(|| format!("hash attested vector database {}", path.display()))?;
+    ensure!(
+        database_sha256 == expected_attestation.database_sha256,
+        "vector database SHA-256 does not match the predeclared source attestation"
+    );
+    let connection = open_sqlite_read_only(path)?;
+    connection.execute_batch("BEGIN DEFERRED TRANSACTION")?;
+    let quick_check: String =
+        connection.query_row("PRAGMA quick_check(1)", [], |row| row.get(0))?;
+    ensure!(
+        quick_check == "ok",
+        "source SQLite quick_check failed: {quick_check}"
+    );
+    let metadata_rows: i64 =
+        connection.query_row("SELECT count(*) FROM metadata", [], |row| row.get(0))?;
+    ensure!(
+        metadata_rows == 1,
+        "source metadata must contain exactly one row"
+    );
+    let metadata = connection
+        .query_row(
+            "SELECT schema_version, generation, input_hash, embedding_backend,
+                    embedding_dim, point_count, producer_identity,
+                    evidence_contract_identity, vector_digest
+             FROM metadata WHERE singleton = 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, String>(8)?,
+                ))
+            },
+        )
+        .with_context(|| format!("read publication identity from {}", path.display()))?;
+    let publication = PublicationIdentity {
+        schema_version: metadata.0,
+        generation: metadata.1,
+        input_hash: metadata.2,
+        embedding_backend: metadata.3,
+        embedding_dim: usize::try_from(metadata.4)
+            .context("publication embedding dimension must fit usize")?,
+        point_count: usize::try_from(metadata.5)
+            .context("publication point count must fit usize")?,
+        producer_identity: metadata.6,
+        evidence_contract_identity: metadata.7,
+        vector_digest: metadata.8,
+    };
+    publication.validate()?;
+    ensure!(
+        publication == expected_attestation.publication,
+        "source metadata does not match the predeclared publication identity"
+    );
+    let actual_count: i64 =
+        connection.query_row("SELECT count(*) FROM vectors", [], |row| row.get(0))?;
+    ensure!(
+        actual_count == publication.point_count as i64,
+        "publication metadata point count {} does not match complete table count {actual_count}",
+        publication.point_count
+    );
+    ensure!(
+        publication.point_count >= limit,
+        "publication has {} points but the run requires {limit}",
+        publication.point_count
+    );
+
+    let (canonical_digest, canonical_count) =
+        canonical_source_vector_digest(&connection, publication.embedding_dim)?;
+    ensure!(
+        canonical_count == publication.point_count,
+        "canonical source coverage expected {} rows, found {canonical_count}",
+        publication.point_count
+    );
+    ensure!(
+        canonical_digest == expected_attestation.publication.vector_digest,
+        "canonical source vector digest does not match the predeclared attestation"
+    );
+    before_sample()?;
+
+    let mut statement = connection.prepare(
+        "SELECT node_id, document_hash, vector FROM vectors ORDER BY node_id ASC LIMIT ?1",
+    )?;
+    let rows = statement.query_map([limit as i64], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, Vec<u8>>(2)?,
+        ))
+    })?;
+    let mut records = Vec::with_capacity(limit);
+    for row in rows {
+        let (node_id, document_hash, bytes) = row?;
+        records.push(VectorRecord {
+            identity: Identity {
+                node_id: node_id.clone(),
+                document_hash,
+            },
+            vector: decode_vector(&node_id, &bytes, publication.embedding_dim)?,
+        });
+    }
+    drop(statement);
+    let database_sha256_after_sampling = sha256_file(path)
+        .with_context(|| format!("rehash attested vector database {}", path.display()))?;
+    ensure!(
+        database_sha256_after_sampling == expected_attestation.database_sha256,
+        "vector database changed while its pinned source snapshot was sampled"
+    );
+    ensure_no_sqlite_sidecars(path)?;
+    connection.execute_batch("ROLLBACK")?;
+    drop(connection);
+    Ok((
+        records,
+        publication,
+        format!("CodeStory publication {}", path.display()),
+        expected_attestation.database_sha256.clone(),
+    ))
+}
+
+fn canonical_source_vector_digest(
+    connection: &Connection,
+    embedding_dim: usize,
+) -> Result<(String, usize)> {
+    let mut statement = connection
+        .prepare("SELECT node_id, document_hash, vector FROM vectors ORDER BY node_id ASC")?;
+    let mut rows = statement.query([])?;
+    let mut digest = Sha256::new();
+    digest.update(VECTOR_DIGEST_DOMAIN);
+    let mut seen = HashSet::new();
+    let mut count = 0_usize;
+    while let Some(row) = rows.next()? {
+        let node_id: String = row.get(0)?;
+        let document_hash: String = row.get(1)?;
+        let vector: Vec<u8> = row.get(2)?;
+        ensure!(
+            seen.insert(node_id.clone()),
+            "duplicate source vector row {node_id}"
+        );
+        ensure!(
+            !node_id.trim().is_empty() && !document_hash.trim().is_empty(),
+            "source vector row identities must be non-empty"
+        );
+        decode_vector(&node_id, &vector, embedding_dim)?;
+        hash_len_prefixed(&mut digest, node_id.as_bytes());
+        hash_len_prefixed(&mut digest, document_hash.as_bytes());
+        hash_len_prefixed(&mut digest, &vector);
+        count += 1;
+    }
+    Ok((format!("{:x}", digest.finalize()), count))
+}
+
+type FixtureParts = (Vec<FrozenQuery>, Vec<VectorRecord>, String, String, String);
+
+struct LoadedFrozenFixture {
+    fixture: FrozenFixture,
+    label: String,
+    sha256: String,
+}
+
+fn read_frozen_fixture(path: &Path) -> Result<LoadedFrozenFixture> {
+    let bytes = fs::read(path).with_context(|| format!("read fixture {}", path.display()))?;
+    let fixture: FrozenFixture = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse fixture {}", path.display()))?;
+    ensure!(
+        fixture.schema_version == 2,
+        "fixture schema version must be 2"
+    );
+    fixture.source_attestation.validate()?;
+    Ok(LoadedFrozenFixture {
+        fixture,
+        label: format!("frozen fixture {}", path.display()),
+        sha256: sha256_bytes(&bytes),
+    })
+}
+
+fn select_frozen_fixture(
+    loaded: LoadedFrozenFixture,
+    publication: &PublicationIdentity,
+    records: &[VectorRecord],
+    dimensions: usize,
+    query_count: usize,
+) -> Result<FixtureParts> {
+    let fixture = loaded.fixture;
+    ensure!(
+        fixture.source_attestation.publication == *publication,
+        "fixture attestation does not exactly match the complete source publication"
+    );
+    ensure!(
+        fixture.queries.len() >= query_count,
+        "fixture needs at least {query_count} queries"
+    );
+    let queries = fixture
+        .queries
+        .into_iter()
+        .take(query_count)
+        .map(|mut query| {
+            query.vector = checked_vector(&query.query_id, query.vector, dimensions)?;
+            Ok(query)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let incremental = fixture
+        .incremental_records
+        .into_iter()
+        .map(|record| frozen_record(record, dimensions))
+        .collect::<Result<Vec<_>>>()?;
+    validate_queries(&queries, records, dimensions)?;
+    Ok((
+        queries,
+        incremental,
+        fixture.incremental_set_id,
+        loaded.label,
+        loaded.sha256,
+    ))
+}
+
+fn synthetic_publication(
+    count: usize,
+    dimensions: usize,
+) -> (Vec<VectorRecord>, PublicationIdentity, String, String) {
+    let records = (0..count)
+        .map(|index| VectorRecord {
+            identity: Identity {
+                node_id: format!("synthetic-node-{index:06}"),
+                document_hash: sha256_bytes(format!("synthetic-document-{index}").as_bytes()),
+            },
+            vector: synthetic_vector(index as u64, dimensions),
+        })
+        .collect::<Vec<_>>();
+    let digest = records_sha256(&records);
+    let publication = PublicationIdentity {
+        schema_version: 1,
+        generation: "synthetic-smoke-generation".to_owned(),
+        input_hash: sha256_bytes(b"synthetic-smoke-input"),
+        embedding_backend: "synthetic-smoke".to_owned(),
+        embedding_dim: dimensions,
+        point_count: count,
+        producer_identity: "vector-backend-spike-smoke".to_owned(),
+        evidence_contract_identity: "synthetic-not-decision-evidence".to_owned(),
+        vector_digest: digest.clone(),
+    };
+    (
+        records,
+        publication,
+        "deterministic synthetic smoke publication".to_owned(),
+        digest,
+    )
+}
+
+fn synthetic_fixture(
+    publication: &PublicationIdentity,
+    records: &[VectorRecord],
+    count: usize,
+) -> FixtureParts {
+    let queries = (0..count)
+        .map(|index| {
+            let record = &records[index * records.len() / count];
+            FrozenQuery {
+                query_id: format!("synthetic-query-{index:03}"),
+                kind: if index % 2 == 0 {
+                    QueryKind::Representative
+                } else {
+                    QueryKind::Symbol
+                },
+                vector: record.vector.clone(),
+                expected: vec![record.identity.clone()],
+            }
+        })
+        .collect::<Vec<_>>();
+    let incremental_count = (records.len() / 100).clamp(1, 100);
+    let incremental = (0..incremental_count)
+        .map(|offset| VectorRecord {
+            identity: Identity {
+                node_id: format!("synthetic-increment-{offset:06}"),
+                document_hash: sha256_bytes(format!("synthetic-increment-{offset}").as_bytes()),
+            },
+            vector: synthetic_vector((records.len() + offset) as u64, publication.embedding_dim),
+        })
+        .collect::<Vec<_>>();
+    let fixture_hash = sha256_bytes(
+        serde_json::to_string(&(publication, &queries))
+            .expect("serialize synthetic fixture identity")
+            .as_bytes(),
+    );
+    (
+        queries,
+        incremental,
+        "synthetic-incremental-smoke".to_owned(),
+        "deterministic synthetic smoke fixture".to_owned(),
+        fixture_hash,
+    )
+}
+
+fn frozen_record(record: FrozenVectorRecord, dimensions: usize) -> Result<VectorRecord> {
+    Ok(VectorRecord {
+        identity: Identity {
+            node_id: record.node_id.clone(),
+            document_hash: record.document_hash,
+        },
+        vector: checked_vector(&record.node_id, record.vector, dimensions)?,
+    })
+}
+
+fn decode_vector(node_id: &str, bytes: &[u8], dimensions: usize) -> Result<Vec<f32>> {
+    ensure!(
+        bytes.len() == dimensions * 4,
+        "vector byte length for {node_id} does not match {dimensions} dimensions"
+    );
+    checked_vector(
+        node_id,
+        bytes
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes(chunk.try_into().expect("four-byte chunk")))
+            .collect(),
+        dimensions,
+    )
+}
+
+fn checked_vector(label: &str, vector: Vec<f32>, dimensions: usize) -> Result<Vec<f32>> {
+    ensure!(
+        vector.len() == dimensions,
+        "{label} expected {dimensions} values, found {}",
+        vector.len()
+    );
+    let mut norm_squared = 0.0_f64;
+    for value in &vector {
+        ensure!(
+            value.is_finite(),
+            "{label} contains a non-finite vector value"
+        );
+        norm_squared += f64::from(*value) * f64::from(*value);
+    }
+    ensure!(
+        norm_squared.is_finite() && norm_squared > f64::EPSILON,
+        "{label} vector norm must be finite and non-zero"
+    );
+    let norm = norm_squared.sqrt();
+    ensure!(
+        (norm - 1.0).abs() <= VECTOR_NORM_TOLERANCE,
+        "{label} vector must be L2-normalized; norm={norm:.8}"
+    );
+    Ok(vector)
+}
+
+fn validate_records(records: &[VectorRecord], dimensions: usize) -> Result<()> {
+    ensure!(!records.is_empty(), "vector records must not be empty");
+    let mut identities = HashSet::with_capacity(records.len());
+    let mut node_ids = HashSet::with_capacity(records.len());
+    for record in records {
+        ensure!(
+            !record.identity.node_id.trim().is_empty(),
+            "node identity must be non-empty"
+        );
+        ensure!(
+            !record.identity.document_hash.trim().is_empty(),
+            "document hash must be non-empty"
+        );
+        ensure!(
+            identities.insert(record.identity.clone()),
+            "duplicate vector identity {} / {}",
+            record.identity.node_id,
+            record.identity.document_hash
+        );
+        ensure!(
+            node_ids.insert(record.identity.node_id.clone()),
+            "duplicate vector node identity {}",
+            record.identity.node_id
+        );
+        checked_vector(&record.identity.node_id, record.vector.clone(), dimensions)?;
+    }
+    Ok(())
+}
+
+fn validate_queries(
+    queries: &[FrozenQuery],
+    records: &[VectorRecord],
+    dimensions: usize,
+) -> Result<()> {
+    ensure!(!queries.is_empty(), "query set must not be empty");
+    let identities = records
+        .iter()
+        .map(|record| record.identity.clone())
+        .collect::<HashSet<_>>();
+    let mut query_ids = HashSet::new();
+    let mut representative = 0;
+    let mut symbol = 0;
+    for query in queries {
+        ensure!(
+            !query.query_id.trim().is_empty(),
+            "query identity must be non-empty"
+        );
+        ensure!(
+            query_ids.insert(&query.query_id),
+            "duplicate query identity {}",
+            query.query_id
+        );
+        checked_vector(&query.query_id, query.vector.clone(), dimensions)?;
+        ensure!(
+            !query.expected.is_empty(),
+            "query {} needs expected identities",
+            query.query_id
+        );
+        ensure!(
+            query
+                .expected
+                .iter()
+                .all(|expected| identities.contains(expected)),
+            "query {} expects an identity outside the selected publication",
+            query.query_id
+        );
+        match query.kind {
+            QueryKind::Representative => representative += 1,
+            QueryKind::Symbol => symbol += 1,
+        }
+    }
+    ensure!(representative > 0, "query set needs representative queries");
+    ensure!(symbol > 0, "query set needs representative symbol queries");
+    Ok(())
+}
+
+fn synthetic_vector(seed: u64, dimensions: usize) -> Vec<f32> {
+    let mut vector = vec![0.0; dimensions];
+    let mut state = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    for _ in 0..24 {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let slot = (state as usize) % dimensions;
+        let value = (((state >> 32) % 2001) as f32 - 1000.0) / 1000.0;
+        vector[slot] += value;
+    }
+    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+    for value in &mut vector {
+        *value /= norm;
+    }
+    vector
+}
+
+#[derive(Clone, Copy)]
+enum Candidate {
+    SqliteVec,
+    Usearch,
+}
+
+impl Candidate {
+    fn from_name(name: &str) -> Result<Self> {
+        match name {
+            "sqlite-vec" => Ok(Self::SqliteVec),
+            "usearch" => Ok(Self::Usearch),
+            _ => anyhow::bail!("unknown vector backend in generation pointer: {name}"),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::SqliteVec => "sqlite-vec",
+            Self::Usearch => "usearch",
+        }
+    }
+
+    fn version(self) -> &'static str {
+        match self {
+            Self::SqliteVec => "0.1.9",
+            Self::Usearch => "2.26.0",
+        }
+    }
+
+    fn index_file(self) -> &'static str {
+        match self {
+            Self::SqliteVec => "index.sqlite3",
+            Self::Usearch => "index.usearch",
+        }
+    }
+}
+
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
+struct GenerationPointer {
+    schema_version: u32,
+    backend: String,
+    generation: String,
+    manifest_sha256: String,
+}
+
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
+struct PublicationPointers {
+    schema_version: u32,
+    current: GenerationPointer,
+    rollback: Option<GenerationPointer>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct GenerationManifest {
+    schema_version: u32,
+    backend: String,
+    backend_version: String,
+    generation: String,
+    metric: String,
+    dimensions: usize,
+    point_count: usize,
+    index_sha256: String,
+    directory_contents_sha256: String,
+    records_sha256: String,
+    identities_sha256: String,
+    source_publication: PublicationIdentity,
+    source_attestation: Option<ProductionSourceAttestation>,
+    incremental_set_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct Artifact {
+    schema_version: u32,
+    issue: u32,
+    generated_at_unix_seconds: u64,
+    criteria_sha256: String,
+    profile: String,
+    decision_profile: bool,
+    timing_comparable: bool,
+    timing_protocol: &'static str,
+    build: BuildIdentity,
+    host: HostIdentity,
+    source: SourceIdentity,
+    fixture: FixtureIdentity,
+    workload: Workload,
+    runs: Vec<BackendResult>,
+    limitations: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct BuildIdentity {
+    git_head: String,
+    git_tree: String,
+    git_dirty: bool,
+    worktree_sha256: String,
+    rustc: String,
+    cargo: String,
+    build_profile: &'static str,
+    target: String,
+}
+
+#[derive(Serialize)]
+struct HostIdentity {
+    os: &'static str,
+    architecture: &'static str,
+    cpu_model: Option<String>,
+    logical_cpus: Option<usize>,
+    total_memory_bytes: Option<u64>,
+    isa: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct SourceIdentity {
+    label: String,
+    artifact_sha256: String,
+    publication: PublicationIdentity,
+    production_attestation: Option<ProductionSourceAttestation>,
+    selected_records_sha256: String,
+}
+
+#[derive(Serialize)]
+struct FixtureIdentity {
+    label: String,
+    artifact_sha256: String,
+    incremental_set_id: String,
+    incremental_records_sha256: String,
+}
+
+#[derive(Serialize)]
+struct Workload {
+    dimensions: usize,
+    vector_count: usize,
+    query_count: usize,
+    top_k: usize,
+    warmups: usize,
+    repetitions: usize,
+    metric: &'static str,
+    records_sha256: String,
+    queries_sha256: String,
+}
+
+#[derive(Serialize)]
+struct BackendResult {
+    repetition: usize,
+    order_position: usize,
+    backend: &'static str,
+    version: &'static str,
+    build_ms: f64,
+    load_ms: f64,
+    first_query_after_open_ms: f64,
+    warm_query_p50_ms: f64,
+    warm_query_p95_ms: f64,
+    disk_bytes: u64,
+    memory_bytes: Option<u64>,
+    memory_method: &'static str,
+    recall_at_20: f64,
+    expected_identity_hit_at_20: f64,
+    representative_query_hit_at_20: f64,
+    symbol_query_hit_at_20: f64,
+    incremental_reuse_ms: f64,
+    concurrent_readers: usize,
+    concurrent_reader_consistency: bool,
+    pinned_old_reader_after_publication: bool,
+    new_current_reader_observed_incremental: bool,
+    old_generation_unchanged: bool,
+    atomic_publication_pointer_pair: bool,
+    referenced_generation_tamper_rejected: bool,
+    pinned_reader_after_referenced_tamper: bool,
+    corrupt_candidate_rejected: bool,
+    failed_candidate_preserved_current_pointer: bool,
+    rollback_pointer_readable: bool,
+    pinned_incremental_reader_after_rollback: bool,
+}
+
+#[derive(Default)]
+struct QueryMeasurements {
+    first_after_open_ms: f64,
+    warm_p50_ms: f64,
+    warm_p95_ms: f64,
+    recall: f64,
+    expected_hit: f64,
+    representative_hit: f64,
+    symbol_hit: f64,
+}
+
+#[test]
+fn decision_criteria_are_predeclared() {
+    let criteria: serde_json::Value = serde_json::from_str(CRITERIA).expect("criteria JSON");
+    assert_eq!(criteria["issue"], 1202);
+    assert_eq!(
+        criteria["decision_status"],
+        "blocked_pending_required_evidence"
+    );
+    assert_eq!(
+        criteria["shared_workload"]["dimensions"],
+        DECISION_DIMENSIONS
+    );
+    assert_eq!(criteria["shared_workload"]["top_k"], TOP_K);
+    assert_eq!(criteria["shared_workload"]["warmups"], DECISION_WARMUPS);
+    assert_eq!(criteria["shared_workload"]["queries"], DECISION_QUERIES);
+    assert_eq!(
+        criteria["shared_workload"]["vector_counts"],
+        serde_json::json!(DECISION_COUNTS)
+    );
+    let required = criteria["required_measurements"]
+        .as_array()
+        .expect("required measurement list");
+    for measurement in [
+        "cold_query_ms",
+        "memory_bytes",
+        "pinned_old_reader_after_publication",
+        "atomic_publication_pointer_pair",
+        "referenced_generation_tamper_rejected",
+        "pinned_reader_after_referenced_tamper",
+        "corrupt_candidate_rejected",
+        "rollback_pointer_readable",
+    ] {
+        assert!(
+            required.iter().any(|value| value == measurement),
+            "missing required measurement {measurement}"
+        );
+    }
+    let manifest: toml::Value =
+        toml::from_str(include_str!("../Cargo.toml")).expect("bench manifest");
+    let indexing = manifest["bench"]
+        .as_array()
+        .expect("bench targets")
+        .iter()
+        .find(|bench| bench["name"].as_str() == Some("indexing"))
+        .expect("indexing bench target");
+    assert_eq!(
+        indexing["required-features"]
+            .as_array()
+            .expect("indexing required features")[0]
+            .as_str(),
+        Some("runtime-bench")
+    );
+    assert_eq!(criteria["synthetic_smoke_is_decision_evidence"], false);
+}
+
+#[test]
+fn vector_contract_rejects_invalid_norms_and_values() {
+    assert!(checked_vector("zero", vec![0.0, 0.0], 2).is_err());
+    assert!(checked_vector("not-normalized", vec![2.0, 0.0], 2).is_err());
+    assert!(checked_vector("non-finite", vec![f32::NAN, 0.0], 2).is_err());
+    assert!(checked_vector("normalized", vec![1.0, 0.0], 2).is_ok());
+}
+
+#[test]
+fn production_source_requires_and_revalidates_predeclared_attestation() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let path = temp.path().join("vectors.sqlite3");
+    let attestation = write_test_source_database(&path)?;
+
+    let (records, publication, _, database_sha256) =
+        load_published_vectors(&path, 2, &attestation)?;
+    assert_eq!(records.len(), 2);
+    assert_eq!(publication, attestation.publication);
+    assert_eq!(database_sha256, attestation.database_sha256);
+
+    let mut wrong_database = attestation.clone();
+    wrong_database.database_sha256 = "0".repeat(64);
+    let error = load_published_vectors(&path, 2, &wrong_database)
+        .expect_err("mismatched predeclared database hash must fail");
+    assert!(format!("{error:#}").contains("predeclared source attestation"));
+
+    let wrong_digest = "1".repeat(64);
+    let connection = Connection::open(&path)?;
+    connection.execute(
+        "UPDATE metadata SET vector_digest = ?1 WHERE singleton = 1",
+        [&wrong_digest],
+    )?;
+    drop(connection);
+    let mut copied_metadata = attestation.clone();
+    copied_metadata.publication.vector_digest = wrong_digest;
+    copied_metadata.database_sha256 = sha256_file(&path)?;
+    let error = load_published_vectors(&path, 2, &copied_metadata)
+        .expect_err("copied metadata with a fresh database hash must not replace canonical proof");
+    assert!(format!("{error:#}").contains("canonical source vector digest"));
+
+    let connection = Connection::open(&path)?;
+    connection.execute(
+        "UPDATE metadata SET vector_digest = ?1, point_count = 1 WHERE singleton = 1",
+        [&attestation.publication.vector_digest],
+    )?;
+    drop(connection);
+    let mut incomplete_coverage = attestation.clone();
+    incomplete_coverage.publication.point_count = 1;
+    incomplete_coverage.database_sha256 = sha256_file(&path)?;
+    let error = load_published_vectors(&path, 1, &incomplete_coverage)
+        .expect_err("inexact complete-row coverage must fail");
+    assert!(format!("{error:#}").contains("complete table count"));
+
+    let missing_attestation = serde_json::json!({
+        "schema_version": 2,
+        "incremental_set_id": "missing-attestation",
+        "queries": [],
+        "incremental_records": []
+    });
+    assert!(serde_json::from_value::<FrozenFixture>(missing_attestation).is_err());
+    Ok(())
+}
+
+#[test]
+fn pinned_source_snapshot_rejects_concurrent_wal_drift_before_sampling() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let path = temp.path().join("vectors.sqlite3");
+    let mut attestation = write_test_source_database(&path)?;
+    let connection = Connection::open(&path)?;
+    let journal_mode: String =
+        connection.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
+    ensure!(
+        journal_mode == "wal",
+        "test database did not enter WAL mode"
+    );
+    drop(connection);
+    ensure_no_sqlite_sidecars(&path)?;
+    attestation.database_sha256 = sha256_file(&path)?;
+
+    let writer_path = path.clone();
+    let error = load_published_vectors_with_hook(&path, 2, &attestation, move || {
+        let writer = Connection::open(&writer_path)?;
+        writer.execute(
+            "UPDATE vectors SET document_hash = ?1 WHERE node_id = 'node-a'",
+            [sha256_bytes(b"concurrent-drift")],
+        )?;
+        drop(writer);
+        Ok(())
+    })
+    .expect_err("WAL drift between attestation and sampling must fail closed");
+    assert!(
+        format!("{error:#}").contains("unbound sidecar"),
+        "unexpected drift rejection: {error:#}"
+    );
+    Ok(())
+}
+
+fn write_test_source_database(path: &Path) -> Result<ProductionSourceAttestation> {
+    let connection = Connection::open(path)?;
+    connection.execute_batch(
+        "CREATE TABLE metadata (
+             singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+             schema_version INTEGER NOT NULL,
+             generation TEXT NOT NULL,
+             input_hash TEXT NOT NULL,
+             embedding_backend TEXT NOT NULL,
+             embedding_dim INTEGER NOT NULL,
+             point_count INTEGER NOT NULL,
+             producer_identity TEXT NOT NULL,
+             evidence_contract_identity TEXT NOT NULL,
+             vector_digest TEXT NOT NULL
+         );
+         CREATE TABLE vectors (
+             node_id TEXT PRIMARY KEY NOT NULL,
+             document_hash TEXT NOT NULL,
+             vector BLOB NOT NULL
+         );",
+    )?;
+    let rows = [
+        ("node-a", sha256_bytes(b"document-a"), vec![1.0_f32, 0.0]),
+        ("node-b", sha256_bytes(b"document-b"), vec![0.0_f32, 1.0]),
+    ];
+    for (node_id, document_hash, vector) in &rows {
+        connection.execute(
+            "INSERT INTO vectors (node_id, document_hash, vector) VALUES (?1, ?2, ?3)",
+            params![node_id, document_hash, vector_blob(vector)],
+        )?;
+    }
+    let (vector_digest, point_count) = canonical_source_vector_digest(&connection, 2)?;
+    let publication = PublicationIdentity {
+        schema_version: 2,
+        generation: "test-generation".to_owned(),
+        input_hash: sha256_bytes(b"test-input"),
+        embedding_backend: "test-backend".to_owned(),
+        embedding_dim: 2,
+        point_count,
+        producer_identity: "test-producer".to_owned(),
+        evidence_contract_identity: sha256_bytes(b"test-evidence-contract"),
+        vector_digest,
+    };
+    connection.execute(
+        "INSERT INTO metadata VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            publication.schema_version,
+            publication.generation,
+            publication.input_hash,
+            publication.embedding_backend,
+            publication.embedding_dim as i64,
+            publication.point_count as i64,
+            publication.producer_identity,
+            publication.evidence_contract_identity,
+            publication.vector_digest,
+        ],
+    )?;
+    drop(connection);
+    Ok(ProductionSourceAttestation {
+        publication,
+        database_sha256: sha256_file(path)?,
+    })
+}
+
+#[test]
+#[ignore = "measurement lane; run explicitly and retain the JSON artifact"]
+fn compare_vector_backends() -> Result<()> {
+    let config = Config::from_env()?;
+    let dataset = Dataset::load(&config)?;
+    let build = build_identity()?;
+    let host = host_identity();
+    validate_decision_identity(&config, &dataset, &build, &host)?;
+    let expected = dataset
+        .queries
+        .iter()
+        .map(|query| exact_top_k(&dataset.records, &query.vector, TOP_K))
+        .collect::<Vec<_>>();
+    let temp = tempfile::tempdir().context("create comparison directory")?;
+    let orders = [
+        [Candidate::SqliteVec, Candidate::Usearch],
+        [Candidate::Usearch, Candidate::SqliteVec],
+    ];
+    let mut runs = Vec::with_capacity(REPETITIONS * 2);
+    for (repetition, order) in orders.into_iter().enumerate() {
+        for (position, candidate) in order.into_iter().enumerate() {
+            let root = temp
+                .path()
+                .join(format!("run-{}-{}", repetition + 1, candidate.name()));
+            let result = match candidate {
+                Candidate::SqliteVec => run_sqlite_vec(
+                    &root,
+                    &dataset,
+                    &expected,
+                    config.warmups,
+                    repetition + 1,
+                    position + 1,
+                ),
+                Candidate::Usearch => run_usearch(
+                    &root,
+                    &dataset,
+                    &expected,
+                    config.warmups,
+                    repetition + 1,
+                    position + 1,
+                ),
+            }
+            .with_context(|| format!("run {} repetition {}", candidate.name(), repetition + 1))?;
+            runs.push(result);
+        }
+    }
+
+    let artifact = Artifact {
+        schema_version: 3,
+        issue: 1202,
+        generated_at_unix_seconds: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+        criteria_sha256: sha256_bytes(CRITERIA.as_bytes()),
+        profile: config.profile.clone(),
+        decision_profile: config.profile == "decision",
+        timing_comparable: false,
+        timing_protocol: "two same-process repetitions with reversed candidate order; timings remain diagnostic until isolated clean-host runs exist",
+        build,
+        host,
+        source: SourceIdentity {
+            label: dataset.source_label,
+            artifact_sha256: dataset.source_artifact_sha256,
+            publication: dataset.publication,
+            production_attestation: dataset.source_attestation,
+            selected_records_sha256: records_sha256(&dataset.records),
+        },
+        fixture: FixtureIdentity {
+            label: dataset.fixture_label,
+            artifact_sha256: dataset.fixture_sha256,
+            incremental_set_id: dataset.incremental_set_id,
+            incremental_records_sha256: records_sha256(&dataset.incremental_records),
+        },
+        workload: Workload {
+            dimensions: config.dimensions,
+            vector_count: dataset.records.len(),
+            query_count: dataset.queries.len(),
+            top_k: TOP_K,
+            warmups: config.warmups,
+            repetitions: REPETITIONS,
+            metric: "cosine",
+            records_sha256: records_sha256(&dataset.records),
+            queries_sha256: queries_sha256(&dataset.queries),
+        },
+        runs,
+        limitations: vec![
+            "same-process smoke timings are diagnostic and not candidate-comparison evidence",
+            "cold-cache latency, isolated RSS, cancellation, deep validation, current-scan regression, offline build, archive size, license, and native package checks remain external evidence",
+            "one artifact covers only its recorded host, source publication, fixture, and vector count",
+        ],
+    };
+    let output = serde_json::to_vec_pretty(&artifact)?;
+    if let Some(parent) = config.output.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    codestory_workspace::atomic_file::write_bytes_atomic(
+        &config.output,
+        "vector-backend-spike",
+        &output,
+    )?;
+    println!("vector backend spike artifact: {}", config.output.display());
+    println!("{}", String::from_utf8_lossy(&output));
+    Ok(())
+}
+
+fn validate_decision_identity(
+    config: &Config,
+    dataset: &Dataset,
+    build: &BuildIdentity,
+    host: &HostIdentity,
+) -> Result<()> {
+    if config.profile != "decision" {
+        return Ok(());
+    }
+    ensure!(
+        !build.git_dirty,
+        "decision profile requires a clean exact Git tree"
+    );
+    ensure!(
+        build.build_profile == "release",
+        "decision profile requires a release build"
+    );
+    ensure!(
+        !build.git_head.is_empty() && !build.git_tree.is_empty(),
+        "decision Git identity is incomplete"
+    );
+    ensure!(
+        !build.target.is_empty(),
+        "decision target triple is unavailable"
+    );
+    ensure!(
+        host.cpu_model.is_some(),
+        "decision CPU model is unavailable"
+    );
+    ensure!(
+        host.total_memory_bytes.is_some(),
+        "decision total RAM is unavailable"
+    );
+    ensure!(!host.isa.is_empty(), "decision ISA envelope is unavailable");
+    ensure!(
+        dataset.source_artifact_sha256.len() == 64,
+        "decision source artifact hash is missing"
+    );
+    let attestation = dataset
+        .source_attestation
+        .as_ref()
+        .context("decision source attestation is missing")?;
+    attestation.validate()?;
+    ensure!(
+        dataset.source_artifact_sha256 == attestation.database_sha256,
+        "decision source artifact does not match its database attestation"
+    );
+    ensure!(
+        dataset.fixture_sha256.len() == 64,
+        "decision fixture hash is missing"
+    );
+    ensure!(
+        dataset.publication.embedding_backend != "synthetic-smoke",
+        "synthetic source cannot be decision evidence"
+    );
+    Ok(())
+}
+
+fn run_sqlite_vec(
+    root: &Path,
+    dataset: &Dataset,
+    expected: &[Vec<u64>],
+    warmups: usize,
+    repetition: usize,
+    order_position: usize,
+) -> Result<BackendResult> {
+    register_sqlite_vec();
+    fs::create_dir_all(root)?;
+    let started = Instant::now();
+    let initial = create_sqlite_generation(
+        root,
+        &GenerationBuild {
+            generation: "generation-0001",
+            base: None,
+            additions: &dataset.records,
+            complete: &dataset.records,
+            publication: &dataset.publication,
+            source_attestation: dataset.source_attestation.as_ref(),
+            incremental_set_id: None,
+            corrupt: false,
+        },
+    )?;
+    write_publication(
+        root,
+        &PublicationPointers {
+            schema_version: 1,
+            current: initial.clone(),
+            rollback: None,
+        },
+    )?;
+    let build_ms = elapsed_ms(started);
+    let initial_dir = generation_dir(root, &initial)?;
+    let disk_bytes = directory_size(&initial_dir)?;
+    let old_generation_hash = directory_sha256(&initial_dir)?;
+
+    let started = Instant::now();
+    let pinned_old = open_sqlite_current(root)?;
+    let load_ms = elapsed_ms(started);
+    let measurements = measure_queries(
+        &dataset.queries,
+        expected,
+        &pinned_old.identities,
+        warmups,
+        |query| sqlite_vec_search(&pinned_old.connection, query, TOP_K),
+    )?;
+    let concurrent_readers = 4;
+    let expected_first =
+        sqlite_vec_search(&pinned_old.connection, &dataset.queries[0].vector, TOP_K)?;
+    let concurrent_reader_consistency = sqlite_concurrent_readers(
+        root,
+        &dataset.queries[0].vector,
+        &expected_first,
+        concurrent_readers,
+    )?;
+
+    let mut complete = dataset.records.clone();
+    complete.extend(dataset.incremental_records.clone());
+    let started = Instant::now();
+    let incremental = create_sqlite_generation(
+        root,
+        &GenerationBuild {
+            generation: "generation-0002",
+            base: Some(&initial),
+            additions: &dataset.incremental_records,
+            complete: &complete,
+            publication: &dataset.publication,
+            source_attestation: dataset.source_attestation.as_ref(),
+            incremental_set_id: Some(&dataset.incremental_set_id),
+            corrupt: false,
+        },
+    )?;
+    publish_incremental(root, &incremental)?;
+    let incremental_reuse_ms = elapsed_ms(started);
+    let published = read_publication(root)?;
+    let atomic_publication_pointer_pair =
+        published.current == incremental && published.rollback.as_ref() == Some(&initial);
+    let pinned_old_reader_after_publication =
+        sqlite_vec_search(&pinned_old.connection, &dataset.queries[0].vector, TOP_K)?
+            == expected_first
+            && pinned_old.pointer == initial;
+    let pinned_incremental = open_sqlite_current(root)?;
+    let new_current_reader_observed_incremental = pinned_incremental.pointer == incremental
+        && pinned_incremental.identities.len() == complete.len();
+    let old_generation_unchanged = directory_sha256(&initial_dir)? == old_generation_hash;
+
+    let publication_before_failure = read_publication(root)?;
+    let current_query_before = sqlite_vec_search(
+        &pinned_incremental.connection,
+        &dataset.queries[0].vector,
+        TOP_K,
+    )?;
+    let corrupt_candidate_rejected = create_sqlite_generation(
+        root,
+        &GenerationBuild {
+            generation: "generation-0003-corrupt",
+            base: Some(&incremental),
+            additions: &[],
+            complete: &complete,
+            publication: &dataset.publication,
+            source_attestation: dataset.source_attestation.as_ref(),
+            incremental_set_id: Some(&dataset.incremental_set_id),
+            corrupt: true,
+        },
+    )
+    .is_err();
+    let publication_after_failure = read_publication(root)?;
+    let reopened_after_failure = open_sqlite_current(root)?;
+    let failed_candidate_preserved_current_pointer = publication_after_failure
+        == publication_before_failure
+        && sqlite_vec_search(
+            &reopened_after_failure.connection,
+            &dataset.queries[0].vector,
+            TOP_K,
+        )? == current_query_before;
+
+    rollback_publication(root)?;
+    let rollback_publication = read_publication(root)?;
+    let rolled_back = open_sqlite_current(root)?;
+    let rollback_pointer_readable = rollback_publication.current == initial
+        && rollback_publication.rollback.as_ref() == Some(&incremental)
+        && rolled_back.pointer == initial
+        && rolled_back.identities.len() == dataset.records.len();
+    let pinned_incremental_reader_after_rollback = pinned_incremental.pointer == incremental
+        && sqlite_vec_search(
+            &pinned_incremental.connection,
+            &dataset.queries[0].vector,
+            TOP_K,
+        )? == current_query_before;
+    let rolled_back_query_before_tamper =
+        sqlite_vec_search(&rolled_back.connection, &dataset.queries[0].vector, TOP_K)?;
+    tamper_published_index(&initial_dir.join(Candidate::SqliteVec.index_file()))?;
+    let referenced_generation_tamper_rejected = open_sqlite_current(root).is_err();
+    let pinned_reader_after_referenced_tamper =
+        sqlite_vec_search(&rolled_back.connection, &dataset.queries[0].vector, TOP_K)?
+            == rolled_back_query_before_tamper;
+
+    Ok(BackendResult {
+        repetition,
+        order_position,
+        backend: Candidate::SqliteVec.name(),
+        version: Candidate::SqliteVec.version(),
+        build_ms,
+        load_ms,
+        first_query_after_open_ms: measurements.first_after_open_ms,
+        warm_query_p50_ms: measurements.warm_p50_ms,
+        warm_query_p95_ms: measurements.warm_p95_ms,
+        disk_bytes,
+        memory_bytes: None,
+        memory_method: "unmeasured; isolated RSS runner required",
+        recall_at_20: measurements.recall,
+        expected_identity_hit_at_20: measurements.expected_hit,
+        representative_query_hit_at_20: measurements.representative_hit,
+        symbol_query_hit_at_20: measurements.symbol_hit,
+        incremental_reuse_ms,
+        concurrent_readers,
+        concurrent_reader_consistency,
+        pinned_old_reader_after_publication,
+        new_current_reader_observed_incremental,
+        old_generation_unchanged,
+        atomic_publication_pointer_pair,
+        referenced_generation_tamper_rejected,
+        pinned_reader_after_referenced_tamper,
+        corrupt_candidate_rejected,
+        failed_candidate_preserved_current_pointer,
+        rollback_pointer_readable,
+        pinned_incremental_reader_after_rollback,
+    })
+}
+
+fn run_usearch(
+    root: &Path,
+    dataset: &Dataset,
+    expected: &[Vec<u64>],
+    warmups: usize,
+    repetition: usize,
+    order_position: usize,
+) -> Result<BackendResult> {
+    fs::create_dir_all(root)?;
+    let started = Instant::now();
+    let initial = create_usearch_generation(
+        root,
+        &GenerationBuild {
+            generation: "generation-0001",
+            base: None,
+            additions: &dataset.records,
+            complete: &dataset.records,
+            publication: &dataset.publication,
+            source_attestation: dataset.source_attestation.as_ref(),
+            incremental_set_id: None,
+            corrupt: false,
+        },
+    )?;
+    write_publication(
+        root,
+        &PublicationPointers {
+            schema_version: 1,
+            current: initial.clone(),
+            rollback: None,
+        },
+    )?;
+    let build_ms = elapsed_ms(started);
+    let initial_dir = generation_dir(root, &initial)?;
+    let disk_bytes = directory_size(&initial_dir)?;
+    let old_generation_hash = directory_sha256(&initial_dir)?;
+
+    let started = Instant::now();
+    let pinned_old = open_usearch_current(root)?;
+    let load_ms = elapsed_ms(started);
+    let memory_bytes = pinned_old.index.memory_usage() as u64;
+    let measurements = measure_queries(
+        &dataset.queries,
+        expected,
+        &pinned_old.identities,
+        warmups,
+        |query| usearch_search(&pinned_old.index, query, TOP_K),
+    )?;
+    let concurrent_readers = 4;
+    let expected_first = usearch_search(&pinned_old.index, &dataset.queries[0].vector, TOP_K)?;
+    let concurrent_reader_consistency = usearch_concurrent_readers(
+        root,
+        &dataset.queries[0].vector,
+        &expected_first,
+        concurrent_readers,
+    )?;
+
+    let mut complete = dataset.records.clone();
+    complete.extend(dataset.incremental_records.clone());
+    let started = Instant::now();
+    let incremental = create_usearch_generation(
+        root,
+        &GenerationBuild {
+            generation: "generation-0002",
+            base: Some(&initial),
+            additions: &dataset.incremental_records,
+            complete: &complete,
+            publication: &dataset.publication,
+            source_attestation: dataset.source_attestation.as_ref(),
+            incremental_set_id: Some(&dataset.incremental_set_id),
+            corrupt: false,
+        },
+    )?;
+    publish_incremental(root, &incremental)?;
+    let incremental_reuse_ms = elapsed_ms(started);
+    let published = read_publication(root)?;
+    let atomic_publication_pointer_pair =
+        published.current == incremental && published.rollback.as_ref() == Some(&initial);
+    let pinned_old_reader_after_publication =
+        usearch_search(&pinned_old.index, &dataset.queries[0].vector, TOP_K)? == expected_first
+            && pinned_old.pointer == initial;
+    let pinned_incremental = open_usearch_current(root)?;
+    let new_current_reader_observed_incremental = pinned_incremental.pointer == incremental
+        && pinned_incremental.identities.len() == complete.len();
+    let old_generation_unchanged = directory_sha256(&initial_dir)? == old_generation_hash;
+
+    let publication_before_failure = read_publication(root)?;
+    let current_query_before =
+        usearch_search(&pinned_incremental.index, &dataset.queries[0].vector, TOP_K)?;
+    let corrupt_candidate_rejected = create_usearch_generation(
+        root,
+        &GenerationBuild {
+            generation: "generation-0003-corrupt",
+            base: Some(&incremental),
+            additions: &[],
+            complete: &complete,
+            publication: &dataset.publication,
+            source_attestation: dataset.source_attestation.as_ref(),
+            incremental_set_id: Some(&dataset.incremental_set_id),
+            corrupt: true,
+        },
+    )
+    .is_err();
+    let publication_after_failure = read_publication(root)?;
+    let reopened_after_failure = open_usearch_current(root)?;
+    let failed_candidate_preserved_current_pointer = publication_after_failure
+        == publication_before_failure
+        && usearch_search(
+            &reopened_after_failure.index,
+            &dataset.queries[0].vector,
+            TOP_K,
+        )? == current_query_before;
+
+    rollback_publication(root)?;
+    let rollback_publication = read_publication(root)?;
+    let rolled_back = open_usearch_current(root)?;
+    let rollback_pointer_readable = rollback_publication.current == initial
+        && rollback_publication.rollback.as_ref() == Some(&incremental)
+        && rolled_back.pointer == initial
+        && rolled_back.identities.len() == dataset.records.len();
+    let pinned_incremental_reader_after_rollback = pinned_incremental.pointer == incremental
+        && usearch_search(&pinned_incremental.index, &dataset.queries[0].vector, TOP_K)?
+            == current_query_before;
+    let rolled_back_query_before_tamper =
+        usearch_search(&rolled_back.index, &dataset.queries[0].vector, TOP_K)?;
+    tamper_published_index(&initial_dir.join(Candidate::Usearch.index_file()))?;
+    let referenced_generation_tamper_rejected = open_usearch_current(root).is_err();
+    let pinned_reader_after_referenced_tamper =
+        usearch_search(&rolled_back.index, &dataset.queries[0].vector, TOP_K)?
+            == rolled_back_query_before_tamper;
+
+    Ok(BackendResult {
+        repetition,
+        order_position,
+        backend: Candidate::Usearch.name(),
+        version: Candidate::Usearch.version(),
+        build_ms,
+        load_ms,
+        first_query_after_open_ms: measurements.first_after_open_ms,
+        warm_query_p50_ms: measurements.warm_p50_ms,
+        warm_query_p95_ms: measurements.warm_p95_ms,
+        disk_bytes,
+        memory_bytes: Some(memory_bytes),
+        memory_method: "USearch memory_usage lower-bound estimate",
+        recall_at_20: measurements.recall,
+        expected_identity_hit_at_20: measurements.expected_hit,
+        representative_query_hit_at_20: measurements.representative_hit,
+        symbol_query_hit_at_20: measurements.symbol_hit,
+        incremental_reuse_ms,
+        concurrent_readers,
+        concurrent_reader_consistency,
+        pinned_old_reader_after_publication,
+        new_current_reader_observed_incremental,
+        old_generation_unchanged,
+        atomic_publication_pointer_pair,
+        referenced_generation_tamper_rejected,
+        pinned_reader_after_referenced_tamper,
+        corrupt_candidate_rejected,
+        failed_candidate_preserved_current_pointer,
+        rollback_pointer_readable,
+        pinned_incremental_reader_after_rollback,
+    })
+}
+
+struct GenerationBuild<'a> {
+    generation: &'a str,
+    base: Option<&'a GenerationPointer>,
+    additions: &'a [VectorRecord],
+    complete: &'a [VectorRecord],
+    publication: &'a PublicationIdentity,
+    source_attestation: Option<&'a ProductionSourceAttestation>,
+    incremental_set_id: Option<&'a str>,
+    corrupt: bool,
+}
+
+fn create_sqlite_generation(root: &Path, build: &GenerationBuild<'_>) -> Result<GenerationPointer> {
+    let stage = create_stage_directory(root, build.generation)?;
+    let index_path = stage.join(Candidate::SqliteVec.index_file());
+    match build.base {
+        Some(pointer) => {
+            let base_dir = generation_dir(root, pointer)?;
+            fs::copy(
+                base_dir.join(Candidate::SqliteVec.index_file()),
+                &index_path,
+            )?;
+            append_sqlite_vec(
+                &index_path,
+                build.complete.len() - build.additions.len(),
+                build.additions,
+            )?;
+        }
+        None => write_sqlite_vec(&index_path, build.additions)?,
+    }
+    let manifest = write_generation_metadata(
+        &stage,
+        Candidate::SqliteVec,
+        build.generation,
+        build.complete,
+        build.publication,
+        build.source_attestation,
+        build.incremental_set_id,
+    )?;
+    if build.corrupt {
+        write_corrupt_file(&index_path)?;
+    }
+    validate_generation(&stage, Candidate::SqliteVec, Some(build.complete))?;
+    publish_generation_directory(
+        root,
+        &stage,
+        build.generation,
+        Candidate::SqliteVec,
+        &manifest,
+    )
+}
+
+fn create_usearch_generation(
+    root: &Path,
+    build: &GenerationBuild<'_>,
+) -> Result<GenerationPointer> {
+    let stage = create_stage_directory(root, build.generation)?;
+    let index_path = stage.join(Candidate::Usearch.index_file());
+    let index = match build.base {
+        Some(pointer) => {
+            let base_dir = generation_dir(root, pointer)?;
+            Index::restore(
+                &base_dir
+                    .join(Candidate::Usearch.index_file())
+                    .to_string_lossy(),
+            )?
+        }
+        None => new_usearch_index(build.publication.embedding_dim, build.complete.len())?,
+    };
+    index.reserve(build.complete.len())?;
+    let first_key = build.complete.len() - build.additions.len();
+    for (offset, record) in build.additions.iter().enumerate() {
+        index.add((first_key + offset) as u64, &record.vector)?;
+    }
+    index.save(&index_path.to_string_lossy())?;
+    sync_file(&index_path)?;
+    drop(index);
+    let manifest = write_generation_metadata(
+        &stage,
+        Candidate::Usearch,
+        build.generation,
+        build.complete,
+        build.publication,
+        build.source_attestation,
+        build.incremental_set_id,
+    )?;
+    if build.corrupt {
+        write_corrupt_file(&index_path)?;
+    }
+    validate_generation(&stage, Candidate::Usearch, Some(build.complete))?;
+    publish_generation_directory(
+        root,
+        &stage,
+        build.generation,
+        Candidate::Usearch,
+        &manifest,
+    )
+}
+
+fn create_stage_directory(root: &Path, generation: &str) -> Result<PathBuf> {
+    fs::create_dir_all(root.join("generations"))?;
+    let stage = root.join(format!(".staging-{generation}"));
+    ensure!(
+        !stage.exists(),
+        "staging generation already exists: {}",
+        stage.display()
+    );
+    fs::create_dir(&stage)?;
+    Ok(stage)
+}
+
+fn write_generation_metadata(
+    stage: &Path,
+    candidate: Candidate,
+    generation: &str,
+    records: &[VectorRecord],
+    publication: &PublicationIdentity,
+    source_attestation: Option<&ProductionSourceAttestation>,
+    incremental_set_id: Option<&str>,
+) -> Result<Vec<u8>> {
+    let identities = records
+        .iter()
+        .map(|record| record.identity.clone())
+        .collect::<Vec<_>>();
+    let identity_bytes = serde_json::to_vec(&identities)?;
+    write_synced(&stage.join("identities.json"), &identity_bytes)?;
+    let index_sha256 = sha256_file(&stage.join(candidate.index_file()))?;
+    let directory_contents_sha256 = canonical_directory_contents_sha256(stage)?;
+    let manifest = GenerationManifest {
+        schema_version: 2,
+        backend: candidate.name().to_owned(),
+        backend_version: candidate.version().to_owned(),
+        generation: generation.to_owned(),
+        metric: "cosine".to_owned(),
+        dimensions: publication.embedding_dim,
+        point_count: records.len(),
+        index_sha256,
+        directory_contents_sha256,
+        records_sha256: records_sha256(records),
+        identities_sha256: sha256_bytes(&identity_bytes),
+        source_publication: publication.clone(),
+        source_attestation: source_attestation.cloned(),
+        incremental_set_id: incremental_set_id.map(str::to_owned),
+    };
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest)?;
+    write_synced(&stage.join("manifest.json"), &manifest_bytes)?;
+    Ok(manifest_bytes)
+}
+
+fn publish_generation_directory(
+    root: &Path,
+    stage: &Path,
+    generation: &str,
+    candidate: Candidate,
+    manifest_bytes: &[u8],
+) -> Result<GenerationPointer> {
+    let destination = root.join("generations").join(generation);
+    ensure!(
+        !destination.exists(),
+        "immutable generation already exists: {generation}"
+    );
+    fs::rename(stage, &destination).with_context(|| {
+        format!(
+            "publish immutable generation {} to {}",
+            stage.display(),
+            destination.display()
+        )
+    })?;
+    Ok(GenerationPointer {
+        schema_version: 1,
+        backend: candidate.name().to_owned(),
+        generation: generation.to_owned(),
+        manifest_sha256: sha256_bytes(manifest_bytes),
+    })
+}
+
+fn generation_dir(root: &Path, pointer: &GenerationPointer) -> Result<PathBuf> {
+    let path = root.join("generations").join(&pointer.generation);
+    ensure!(
+        path.is_dir(),
+        "generation directory is missing: {}",
+        path.display()
+    );
+    let manifest_bytes = fs::read(path.join("manifest.json"))?;
+    ensure!(
+        sha256_bytes(&manifest_bytes) == pointer.manifest_sha256,
+        "generation manifest hash does not match pointer"
+    );
+    let manifest: GenerationManifest = serde_json::from_slice(&manifest_bytes)?;
+    ensure!(
+        manifest.backend == pointer.backend,
+        "pointer backend mismatch"
+    );
+    ensure!(
+        manifest.generation == pointer.generation,
+        "pointer generation mismatch"
+    );
+    Ok(path)
+}
+
+fn write_publication(root: &Path, publication: &PublicationPointers) -> Result<()> {
+    validate_pointed_generation(root, &publication.current)?;
+    if let Some(rollback) = &publication.rollback {
+        validate_pointed_generation(root, rollback)?;
+        ensure!(
+            rollback != &publication.current,
+            "current and rollback generations must differ"
+        );
+    }
+    let bytes = serde_json::to_vec_pretty(publication)?;
+    codestory_workspace::atomic_file::write_bytes_atomic(
+        &root.join("publication.json"),
+        "publication",
+        &bytes,
+    )
+}
+
+fn read_publication(root: &Path) -> Result<PublicationPointers> {
+    let path = root.join("publication.json");
+    let publication: PublicationPointers = serde_json::from_slice(
+        &fs::read(&path).with_context(|| format!("read {}", path.display()))?,
+    )
+    .with_context(|| format!("parse {}", path.display()))?;
+    ensure!(
+        publication.schema_version == 1,
+        "publication pointer schema version mismatch"
+    );
+    validate_pointed_generation(root, &publication.current)?;
+    if let Some(rollback) = &publication.rollback {
+        validate_pointed_generation(root, rollback)?;
+        ensure!(
+            rollback != &publication.current,
+            "current and rollback generations must differ"
+        );
+    }
+    Ok(publication)
+}
+
+fn validate_pointed_generation(root: &Path, pointer: &GenerationPointer) -> Result<()> {
+    let directory = generation_dir(root, pointer)?;
+    let candidate = Candidate::from_name(&pointer.backend)?;
+    validate_generation(&directory, candidate, None)?;
+    Ok(())
+}
+
+fn publish_incremental(root: &Path, next: &GenerationPointer) -> Result<()> {
+    let publication = read_publication(root)?;
+    generation_dir(root, next)?;
+    write_publication(
+        root,
+        &PublicationPointers {
+            schema_version: 1,
+            current: next.clone(),
+            rollback: Some(publication.current),
+        },
+    )
+}
+
+fn rollback_publication(root: &Path) -> Result<()> {
+    let publication = read_publication(root)?;
+    let rollback = publication
+        .rollback
+        .context("publication has no rollback generation")?;
+    write_publication(
+        root,
+        &PublicationPointers {
+            schema_version: 1,
+            current: rollback,
+            rollback: Some(publication.current),
+        },
+    )
+}
+
+fn validate_generation(
+    directory: &Path,
+    candidate: Candidate,
+    expected_records: Option<&[VectorRecord]>,
+) -> Result<(GenerationManifest, Vec<Identity>)> {
+    let manifest_bytes = fs::read(directory.join("manifest.json"))?;
+    let manifest: GenerationManifest = serde_json::from_slice(&manifest_bytes)?;
+    ensure!(
+        manifest.schema_version == 2,
+        "generation schema version mismatch"
+    );
+    ensure!(
+        manifest.backend == candidate.name(),
+        "generation backend mismatch"
+    );
+    ensure!(
+        manifest.backend_version == candidate.version(),
+        "generation version mismatch"
+    );
+    ensure!(
+        manifest.metric == "cosine",
+        "generation metric must be cosine"
+    );
+    manifest.source_publication.validate()?;
+    if let Some(attestation) = &manifest.source_attestation {
+        attestation.validate()?;
+        ensure!(
+            attestation.publication == manifest.source_publication,
+            "generation source attestation does not match its publication identity"
+        );
+    } else {
+        ensure!(
+            manifest.source_publication.embedding_backend == "synthetic-smoke",
+            "non-synthetic generation is missing its production source attestation"
+        );
+    }
+    let index_path = directory.join(candidate.index_file());
+    ensure!(
+        sha256_file(&index_path)? == manifest.index_sha256,
+        "generation index SHA-256 mismatch"
+    );
+    ensure!(
+        canonical_directory_contents_sha256(directory)? == manifest.directory_contents_sha256,
+        "generation directory contents SHA-256 mismatch"
+    );
+    let identity_bytes = fs::read(directory.join("identities.json"))?;
+    ensure!(
+        sha256_bytes(&identity_bytes) == manifest.identities_sha256,
+        "identity sidecar hash mismatch"
+    );
+    let identities: Vec<Identity> = serde_json::from_slice(&identity_bytes)?;
+    ensure!(
+        identities.len() == manifest.point_count,
+        "identity count mismatch"
+    );
+    if let Some(records) = expected_records {
+        ensure!(
+            records.len() == manifest.point_count,
+            "manifest point count mismatch"
+        );
+        ensure!(
+            records_sha256(records) == manifest.records_sha256,
+            "record digest mismatch"
+        );
+        ensure!(
+            identities
+                == records
+                    .iter()
+                    .map(|record| record.identity.clone())
+                    .collect::<Vec<_>>(),
+            "identity sidecar does not match records"
+        );
+    }
+    match candidate {
+        Candidate::SqliteVec => {
+            validate_sqlite_index(directory, &manifest, &identities, expected_records)?
+        }
+        Candidate::Usearch => validate_usearch_index(directory, &manifest, expected_records)?,
+    }
+    Ok((manifest, identities))
+}
+
+fn validate_sqlite_index(
+    directory: &Path,
+    manifest: &GenerationManifest,
+    identities: &[Identity],
+    expected_records: Option<&[VectorRecord]>,
+) -> Result<()> {
+    let connection = open_sqlite_read_only(&directory.join(Candidate::SqliteVec.index_file()))?;
+    let check: String = connection.query_row("PRAGMA quick_check", [], |row| row.get(0))?;
+    ensure!(check == "ok", "SQLite quick_check failed: {check}");
+    let vector_count: i64 =
+        connection.query_row("SELECT count(*) FROM vec_items", [], |row| row.get(0))?;
+    let identity_count: i64 =
+        connection.query_row("SELECT count(*) FROM identities", [], |row| row.get(0))?;
+    ensure!(
+        vector_count == manifest.point_count as i64,
+        "sqlite-vec count mismatch"
+    );
+    ensure!(
+        identity_count == manifest.point_count as i64,
+        "SQLite identity count mismatch"
+    );
+    let schema: String = connection.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'vec_items'",
+        [],
+        |row| row.get(0),
+    )?;
+    ensure!(
+        schema
+            .to_ascii_lowercase()
+            .contains("distance_metric=cosine"),
+        "sqlite-vec index is not configured for cosine distance"
+    );
+    let mut statement = connection
+        .prepare("SELECT vector_key, node_id, document_hash FROM identities ORDER BY vector_key")?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            Identity {
+                node_id: row.get(1)?,
+                document_hash: row.get(2)?,
+            },
+        ))
+    })?;
+    for (expected_key, row) in rows.enumerate() {
+        let (actual_key, identity) = row?;
+        ensure!(actual_key == expected_key as i64, "SQLite identity key gap");
+        ensure!(
+            identity == identities[expected_key],
+            "SQLite identity row mismatch"
+        );
+    }
+    if let Some(records) = expected_records {
+        let mut statement =
+            connection.prepare("SELECT rowid, embedding FROM vec_items ORDER BY rowid")?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?))
+        })?;
+        for (expected_key, row) in rows.enumerate() {
+            let (actual_rowid, vector) = row?;
+            ensure!(
+                actual_rowid == (expected_key + 1) as i64,
+                "sqlite-vec rowid gap"
+            );
+            ensure!(
+                vector == vector_blob(&records[expected_key].vector),
+                "sqlite-vec vector differs at key {expected_key}"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_usearch_index(
+    directory: &Path,
+    manifest: &GenerationManifest,
+    expected_records: Option<&[VectorRecord]>,
+) -> Result<()> {
+    let index = Index::restore(
+        &directory
+            .join(Candidate::Usearch.index_file())
+            .to_string_lossy(),
+    )?;
+    ensure!(
+        index.size() == manifest.point_count,
+        "USearch point count mismatch"
+    );
+    ensure!(
+        index.dimensions() == manifest.dimensions,
+        "USearch dimension mismatch"
+    );
+    ensure!(
+        index.metric_kind() == MetricKind::Cos,
+        "USearch metric must be cosine"
+    );
+    ensure!(
+        index.scalar_kind() == ScalarKind::F32,
+        "USearch scalar kind must be F32"
+    );
+    if let Some(records) = expected_records {
+        let mut actual = vec![0.0_f32; manifest.dimensions];
+        for (key, record) in records.iter().enumerate() {
+            ensure!(
+                index.get(key as u64, &mut actual)? == 1,
+                "USearch key {key} is missing"
+            );
+            ensure!(
+                actual
+                    .iter()
+                    .zip(&record.vector)
+                    .all(|(left, right)| left.to_bits() == right.to_bits()),
+                "USearch vector differs at key {key}"
+            );
+        }
+    }
+    Ok(())
+}
+
+struct OpenSqliteGeneration {
+    connection: Connection,
+    identities: Vec<Identity>,
+    pointer: GenerationPointer,
+}
+
+fn open_sqlite_current(root: &Path) -> Result<OpenSqliteGeneration> {
+    let pointer = read_publication(root)?.current;
+    let directory = generation_dir(root, &pointer)?;
+    let (_, identities) = validate_generation(&directory, Candidate::SqliteVec, None)?;
+    let connection = open_sqlite_read_only(&directory.join(Candidate::SqliteVec.index_file()))?;
+    Ok(OpenSqliteGeneration {
+        connection,
+        identities,
+        pointer,
+    })
+}
+
+struct OpenUsearchGeneration {
+    index: Index,
+    identities: Vec<Identity>,
+    pointer: GenerationPointer,
+}
+
+fn open_usearch_current(root: &Path) -> Result<OpenUsearchGeneration> {
+    let pointer = read_publication(root)?.current;
+    let directory = generation_dir(root, &pointer)?;
+    let (_, identities) = validate_generation(&directory, Candidate::Usearch, None)?;
+    let index = Index::restore(
+        &directory
+            .join(Candidate::Usearch.index_file())
+            .to_string_lossy(),
+    )?;
+    Ok(OpenUsearchGeneration {
+        index,
+        identities,
+        pointer,
+    })
+}
+
+fn register_sqlite_vec() {
+    REGISTER_SQLITE_VEC.call_once(|| unsafe {
+        rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute::<
+            *const (),
+            unsafe extern "C" fn(
+                *mut rusqlite::ffi::sqlite3,
+                *mut *mut i8,
+                *const rusqlite::ffi::sqlite3_api_routines,
+            ) -> i32,
+        >(
+            sqlite_vec::sqlite3_vec_init as *const ()
+        )));
+    });
+}
+
+fn write_sqlite_vec(path: &Path, records: &[VectorRecord]) -> Result<()> {
+    ensure!(
+        !records.is_empty(),
+        "initial sqlite-vec records must not be empty"
+    );
+    let mut connection = Connection::open(path)?;
+    connection.execute_batch(&format!(
+        "PRAGMA journal_mode=DELETE;
+         PRAGMA synchronous=FULL;
+         CREATE VIRTUAL TABLE vec_items USING vec0(
+             embedding float[{}] distance_metric=cosine
+         );
+         CREATE TABLE identities (
+             vector_key INTEGER PRIMARY KEY NOT NULL,
+             node_id TEXT NOT NULL,
+             document_hash TEXT NOT NULL,
+             UNIQUE(node_id, document_hash)
+         );",
+        records[0].vector.len()
+    ))?;
+    append_sqlite_records(&mut connection, 0, records)?;
+    drop(connection);
+    sync_file(path)
+}
+
+fn append_sqlite_vec(path: &Path, first_key: usize, records: &[VectorRecord]) -> Result<()> {
+    if records.is_empty() {
+        sync_file(path)?;
+        return Ok(());
+    }
+    let mut connection = Connection::open(path)?;
+    append_sqlite_records(&mut connection, first_key, records)?;
+    drop(connection);
+    sync_file(path)
+}
+
+fn append_sqlite_records(
+    connection: &mut Connection,
+    first_key: usize,
+    records: &[VectorRecord],
+) -> Result<()> {
+    let transaction = connection.transaction()?;
+    {
+        let mut insert_vector =
+            transaction.prepare("INSERT INTO vec_items(rowid, embedding) VALUES (?1, ?2)")?;
+        let mut insert_identity = transaction.prepare(
+            "INSERT INTO identities(vector_key, node_id, document_hash) VALUES (?1, ?2, ?3)",
+        )?;
+        for (offset, record) in records.iter().enumerate() {
+            let key = first_key + offset;
+            insert_vector.execute(params![(key + 1) as i64, vector_blob(&record.vector)])?;
+            insert_identity.execute(params![
+                key as i64,
+                record.identity.node_id,
+                record.identity.document_hash
+            ])?;
+        }
+    }
+    transaction.commit()?;
+    Ok(())
+}
+
+fn open_sqlite_read_only(path: &Path) -> Result<Connection> {
+    register_sqlite_vec();
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("open {} read-only", path.display()))
+}
+
+fn sqlite_vec_search(connection: &Connection, query: &[f32], count: usize) -> Result<Vec<u64>> {
+    let mut statement = connection.prepare(
+        "SELECT rowid FROM vec_items
+         WHERE embedding MATCH ?1 AND k = ?2
+         ORDER BY distance",
+    )?;
+    let rows = statement.query_map(params![vector_blob(query), count as i64], |row| {
+        row.get::<_, i64>(0)
+    })?;
+    rows.map(|row| {
+        let key = row?;
+        ensure!(key > 0, "sqlite-vec returned a non-positive rowid");
+        Ok((key - 1) as u64)
+    })
+    .collect()
+}
+
+fn sqlite_concurrent_readers(
+    root: &Path,
+    query: &[f32],
+    expected: &[u64],
+    readers: usize,
+) -> Result<bool> {
+    let root = root.to_owned();
+    let query = query.to_owned();
+    let expected = expected.to_owned();
+    let handles = (0..readers)
+        .map(|_| {
+            let root = root.clone();
+            let query = query.clone();
+            let expected = expected.clone();
+            std::thread::spawn(move || -> Result<bool> {
+                let opened = open_sqlite_current(&root)?;
+                Ok(sqlite_vec_search(&opened.connection, &query, TOP_K)? == expected)
+            })
+        })
+        .collect::<Vec<_>>();
+    handles
+        .into_iter()
+        .map(|handle| {
+            handle
+                .join()
+                .map_err(|_| anyhow::anyhow!("sqlite reader panicked"))?
+        })
+        .try_fold(true, |all, result| {
+            result.map(|consistent| all && consistent)
+        })
+}
+
+fn new_usearch_index(dimensions: usize, capacity: usize) -> Result<Index> {
+    let options = IndexOptions {
+        dimensions,
+        metric: MetricKind::Cos,
+        quantization: ScalarKind::F32,
+        ..IndexOptions::default()
+    };
+    let index = Index::new(&options)?;
+    index.reserve(capacity)?;
+    Ok(index)
+}
+
+fn usearch_search(index: &Index, query: &[f32], count: usize) -> Result<Vec<u64>> {
+    Ok(index.search(query, count)?.keys)
+}
+
+fn usearch_concurrent_readers(
+    root: &Path,
+    query: &[f32],
+    expected: &[u64],
+    readers: usize,
+) -> Result<bool> {
+    let opened = open_usearch_current(root)?;
+    let index = Arc::new(opened.index);
+    let handles = (0..readers)
+        .map(|_| {
+            let index = Arc::clone(&index);
+            let query = query.to_owned();
+            let expected = expected.to_owned();
+            std::thread::spawn(move || -> Result<bool> {
+                Ok(usearch_search(&index, &query, TOP_K)? == expected)
+            })
+        })
+        .collect::<Vec<_>>();
+    handles
+        .into_iter()
+        .map(|handle| {
+            handle
+                .join()
+                .map_err(|_| anyhow::anyhow!("USearch reader panicked"))?
+        })
+        .try_fold(true, |all, result| {
+            result.map(|consistent| all && consistent)
+        })
+}
+
+fn measure_queries(
+    queries: &[FrozenQuery],
+    expected: &[Vec<u64>],
+    identities: &[Identity],
+    warmups: usize,
+    mut search: impl FnMut(&[f32]) -> Result<Vec<u64>>,
+) -> Result<QueryMeasurements> {
+    let started = Instant::now();
+    search(&queries[0].vector)?;
+    let first_after_open_ms = elapsed_ms(started);
+    for _ in 0..warmups {
+        search(&queries[0].vector)?;
+    }
+    let mut latencies = Vec::with_capacity(queries.len());
+    let mut actual = Vec::with_capacity(queries.len());
+    for query in queries {
+        let started = Instant::now();
+        actual.push(search(&query.vector)?);
+        latencies.push(elapsed_ms(started));
+    }
+    let recall = actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| recall_at_k(actual, expected))
+        .sum::<f64>()
+        / queries.len() as f64;
+    let hits = queries
+        .iter()
+        .zip(&actual)
+        .map(|(query, keys)| -> Result<(QueryKind, f64)> {
+            let returned = keys
+                .iter()
+                .map(|key| {
+                    identities
+                        .get(*key as usize)
+                        .cloned()
+                        .with_context(|| format!("query returned out-of-range key {key}"))
+                })
+                .collect::<Result<HashSet<_>>>()?;
+            Ok((
+                query.kind,
+                if query
+                    .expected
+                    .iter()
+                    .any(|expected| returned.contains(expected))
+                {
+                    1.0
+                } else {
+                    0.0
+                },
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let expected_hit = hits.iter().map(|(_, hit)| hit).sum::<f64>() / hits.len() as f64;
+    let representative_hit = hit_for_kind(&hits, QueryKind::Representative);
+    let symbol_hit = hit_for_kind(&hits, QueryKind::Symbol);
+    Ok(QueryMeasurements {
+        first_after_open_ms,
+        warm_p50_ms: percentile(&latencies, 0.50),
+        warm_p95_ms: percentile(&latencies, 0.95),
+        recall,
+        expected_hit,
+        representative_hit,
+        symbol_hit,
+    })
+}
+
+fn hit_for_kind(hits: &[(QueryKind, f64)], kind: QueryKind) -> f64 {
+    let selected = hits
+        .iter()
+        .filter(|(actual, _)| *actual == kind)
+        .map(|(_, hit)| *hit)
+        .collect::<Vec<_>>();
+    selected.iter().sum::<f64>() / selected.len() as f64
+}
+
+fn exact_top_k(records: &[VectorRecord], query: &[f32], count: usize) -> Vec<u64> {
+    let mut scored = records
+        .iter()
+        .enumerate()
+        .map(|(key, record)| (key as u64, cosine_similarity(&record.vector, query)))
+        .collect::<Vec<_>>();
+    scored.sort_unstable_by(|left, right| {
+        right
+            .1
+            .total_cmp(&left.1)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    scored.truncate(count.min(scored.len()));
+    scored.into_iter().map(|(key, _)| key).collect()
+}
+
+fn cosine_similarity(left: &[f32], right: &[f32]) -> f32 {
+    let dot = left.iter().zip(right).map(|(a, b)| a * b).sum::<f32>();
+    let left_norm = left.iter().map(|value| value * value).sum::<f32>().sqrt();
+    let right_norm = right.iter().map(|value| value * value).sum::<f32>().sqrt();
+    dot / (left_norm * right_norm)
+}
+
+fn recall_at_k(actual: &[u64], expected: &[u64]) -> f64 {
+    let actual = actual.iter().copied().collect::<HashSet<_>>();
+    expected.iter().filter(|key| actual.contains(key)).count() as f64 / expected.len() as f64
+}
+
+fn build_identity() -> Result<BuildIdentity> {
+    let root = workspace_root();
+    let git_head = command_text(
+        Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["rev-parse", "HEAD"]),
+    )?;
+    let git_tree = command_text(
+        Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["rev-parse", "HEAD^{tree}"]),
+    )?;
+    let status = command_bytes(Command::new("git").arg("-C").arg(&root).args([
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+    ]))?;
+    let diff = command_bytes(
+        Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["diff", "--binary", "HEAD"]),
+    )?;
+    let untracked = command_bytes(Command::new("git").arg("-C").arg(&root).args([
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+    ]))?;
+    let mut fingerprint = Sha256::new();
+    fingerprint.update(b"codestory-vector-spike-worktree-v1\0");
+    fingerprint.update(&status);
+    fingerprint.update(&diff);
+    for path in untracked
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+    {
+        fingerprint.update(path);
+        let relative = String::from_utf8(path.to_vec()).context("untracked path is not UTF-8")?;
+        fingerprint.update(fs::read(root.join(relative))?);
+    }
+    let rustc = command_text(Command::new("rustc").arg("-Vv"))?;
+    let cargo = command_text(Command::new("cargo").arg("-V"))?;
+    let target = rustc
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .unwrap_or_default()
+        .to_owned();
+    Ok(BuildIdentity {
+        git_head,
+        git_tree,
+        git_dirty: !status.is_empty(),
+        worktree_sha256: format!("{:x}", fingerprint.finalize()),
+        rustc,
+        cargo,
+        build_profile: if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        },
+        target,
+    })
+}
+
+fn host_identity() -> HostIdentity {
+    HostIdentity {
+        os: std::env::consts::OS,
+        architecture: std::env::consts::ARCH,
+        cpu_model: cpu_model(),
+        logical_cpus: std::thread::available_parallelism().ok().map(usize::from),
+        total_memory_bytes: total_memory_bytes(),
+        isa: isa_features(),
+    }
+}
+
+fn cpu_model() -> Option<String> {
+    if let Ok(value) = std::env::var("PROCESSOR_IDENTIFIER")
+        && !value.trim().is_empty()
+    {
+        return Some(value);
+    }
+    #[cfg(target_os = "linux")]
+    if let Ok(cpuinfo) = fs::read_to_string("/proc/cpuinfo") {
+        return cpuinfo.lines().find_map(|line| {
+            line.strip_prefix("model name")
+                .and_then(|value| value.split_once(':'))
+                .map(|(_, value)| value.trim().to_owned())
+        });
+    }
+    #[cfg(target_os = "macos")]
+    if let Ok(output) = Command::new("sysctl")
+        .args(["-n", "machdep.cpu.brand_string"])
+        .output()
+        && output.status.success()
+    {
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        if !value.is_empty() {
+            return Some(value);
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn total_memory_bytes() -> Option<u64> {
+    #[repr(C)]
+    struct MemoryStatusEx {
+        length: u32,
+        memory_load: u32,
+        total_phys: u64,
+        avail_phys: u64,
+        total_page_file: u64,
+        avail_page_file: u64,
+        total_virtual: u64,
+        avail_virtual: u64,
+        avail_extended_virtual: u64,
+    }
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn GlobalMemoryStatusEx(status: *mut MemoryStatusEx) -> i32;
+    }
+    let mut status = MemoryStatusEx {
+        length: std::mem::size_of::<MemoryStatusEx>() as u32,
+        memory_load: 0,
+        total_phys: 0,
+        avail_phys: 0,
+        total_page_file: 0,
+        avail_page_file: 0,
+        total_virtual: 0,
+        avail_virtual: 0,
+        avail_extended_virtual: 0,
+    };
+    let success = unsafe { GlobalMemoryStatusEx(&mut status) };
+    (success != 0).then_some(status.total_phys)
+}
+
+#[cfg(target_os = "linux")]
+fn total_memory_bytes() -> Option<u64> {
+    fs::read_to_string("/proc/meminfo")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("MemTotal:"))?
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()
+        .map(|kib| kib * 1024)
+}
+
+#[cfg(target_os = "macos")]
+fn total_memory_bytes() -> Option<u64> {
+    let output = Command::new("sysctl")
+        .args(["-n", "hw.memsize"])
+        .output()
+        .ok()?;
+    output.status.success().then_some(())?;
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+fn total_memory_bytes() -> Option<u64> {
+    None
+}
+
+fn isa_features() -> Vec<&'static str> {
+    let mut features = Vec::new();
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        for (enabled, name) in [
+            (std::is_x86_feature_detected!("sse2"), "sse2"),
+            (std::is_x86_feature_detected!("sse4.1"), "sse4.1"),
+            (std::is_x86_feature_detected!("avx"), "avx"),
+            (std::is_x86_feature_detected!("avx2"), "avx2"),
+            (std::is_x86_feature_detected!("fma"), "fma"),
+        ] {
+            if enabled {
+                features.push(name);
+            }
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        features.push("neon");
+    }
+    features
+}
+
+fn command_text(command: &mut Command) -> Result<String> {
+    let output = command.output().context("run identity command")?;
+    ensure!(
+        output.status.success(),
+        "identity command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+fn command_bytes(command: &mut Command) -> Result<Vec<u8>> {
+    let output = command.output().context("run identity command")?;
+    ensure!(
+        output.status.success(),
+        "identity command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(output.stdout)
+}
+
+fn records_sha256(records: &[VectorRecord]) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"codestory-vector-backend-records-v2\0");
+    digest.update((records.len() as u64).to_le_bytes());
+    for record in records {
+        hash_len_prefixed(&mut digest, record.identity.node_id.as_bytes());
+        hash_len_prefixed(&mut digest, record.identity.document_hash.as_bytes());
+        for value in &record.vector {
+            digest.update(value.to_le_bytes());
+        }
+    }
+    format!("{:x}", digest.finalize())
+}
+
+fn queries_sha256(queries: &[FrozenQuery]) -> String {
+    sha256_bytes(&serde_json::to_vec(queries).expect("serialize frozen queries"))
+}
+
+fn hash_len_prefixed(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_le_bytes());
+    digest.update(bytes);
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn ensure_no_sqlite_sidecars(path: &Path) -> Result<()> {
+    for suffix in ["-wal", "-shm", "-journal"] {
+        let mut sidecar = path.as_os_str().to_owned();
+        sidecar.push(suffix);
+        let sidecar = PathBuf::from(sidecar);
+        ensure!(
+            !sidecar.exists(),
+            "attested SQLite source has an unbound sidecar: {}",
+            sidecar.display()
+        );
+    }
+    Ok(())
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn validate_sha256(label: &str, value: &str) -> Result<()> {
+    ensure!(
+        value.len() == 64
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "{label} must be a canonical lowercase SHA-256"
+    );
+    Ok(())
+}
+
+fn canonical_directory_contents_sha256(path: &Path) -> Result<String> {
+    let mut files = fs::read_dir(path)?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    files.sort();
+    let mut digest = Sha256::new();
+    digest.update(b"codestory-vector-backend-generation-contents-v1\0");
+    let mut count = 0_u64;
+    for file in files {
+        ensure!(file.is_file(), "generation contains a non-file entry");
+        if file.file_name().and_then(|name| name.to_str()) == Some("manifest.json") {
+            continue;
+        }
+        let name = file
+            .file_name()
+            .and_then(|name| name.to_str())
+            .context("generation filename is not UTF-8")?;
+        hash_len_prefixed(&mut digest, name.as_bytes());
+        hash_len_prefixed(&mut digest, &fs::read(&file)?);
+        count += 1;
+    }
+    ensure!(count > 0, "generation contents are empty");
+    digest.update(count.to_le_bytes());
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn directory_sha256(path: &Path) -> Result<String> {
+    let mut files = fs::read_dir(path)?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    files.sort();
+    let mut digest = Sha256::new();
+    for file in files {
+        ensure!(file.is_file(), "generation contains a non-file entry");
+        hash_len_prefixed(
+            &mut digest,
+            file.file_name()
+                .and_then(|name| name.to_str())
+                .context("generation filename is not UTF-8")?
+                .as_bytes(),
+        );
+        hash_len_prefixed(&mut digest, &fs::read(file)?);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn directory_size(path: &Path) -> Result<u64> {
+    fs::read_dir(path)?.try_fold(0_u64, |total, entry| {
+        let entry = entry?;
+        Ok(total + entry.metadata()?.len())
+    })
+}
+
+fn vector_blob(vector: &[f32]) -> Vec<u8> {
+    vector
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+fn write_synced(path: &Path, bytes: &[u8]) -> Result<()> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn write_corrupt_file(path: &Path) -> Result<()> {
+    let mut file = OpenOptions::new().write(true).truncate(true).open(path)?;
+    file.write_all(b"corrupt vector generation")?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn tamper_published_index(path: &Path) -> Result<()> {
+    let mut file = OpenOptions::new().append(true).open(path)?;
+    file.write_all(b"post-publication-tamper")?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn sync_file(path: &Path) -> Result<()> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?
+        .sync_all()?;
+    Ok(())
+}
+
+fn percentile(values: &[f64], percentile: f64) -> f64 {
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let index = ((sorted.len() as f64 * percentile).ceil() as usize).saturating_sub(1);
+    sorted[index]
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
+}

--- a/crates/codestory-bench/tests/vector_backend_spike.rs
+++ b/crates/codestory-bench/tests/vector_backend_spike.rs
@@ -1159,7 +1159,6 @@ struct ValidatedFixtureOutput {
     requested_parent: PathBuf,
     destination: PathBuf,
     destination_name: std::ffi::OsString,
-    parent_identity: PathBuf,
     publication_root: codestory_workspace::owned_publication::OwnedFilePublicationRoot,
     source_generation_path: PathBuf,
     source_generation_identity: PathBuf,
@@ -1177,7 +1176,12 @@ impl ValidatedFixtureOutput {
             )
         })?;
         ensure!(
-            codestory_workspace::same_workspace_path(&parent, &self.parent_identity),
+            self.publication_root
+                .matches_path(&parent)
+                .with_context(|| format!(
+                    "compare fixture output parent identity {}",
+                    parent.display()
+                ))?,
             "fixture output parent identity changed during preparation"
         );
         let source_generation = self
@@ -1218,6 +1222,16 @@ fn validate_fixture_output_path(
     source_sqlite: &Path,
     cache_root: &Path,
 ) -> Result<ValidatedFixtureOutput> {
+    validate_fixture_output_path_with_hook(output, source_sqlite, cache_root, || Ok(()))
+}
+
+#[cfg(feature = "fixture-generator")]
+fn validate_fixture_output_path_with_hook(
+    output: &Path,
+    source_sqlite: &Path,
+    cache_root: &Path,
+    before_parent_open: impl FnOnce() -> Result<()>,
+) -> Result<ValidatedFixtureOutput> {
     let source_generation = source_sqlite
         .parent()
         .context("production vector database has no generation directory")?;
@@ -1229,6 +1243,16 @@ fn validate_fixture_output_path(
     let parent_identity = output_parent
         .canonicalize()
         .with_context(|| format!("resolve fixture output parent {}", output_parent.display()))?;
+    let publication_identity =
+        codestory_workspace::owned_publication::OwnedFilePublicationRoot::capture_identity(
+            &parent_identity,
+        )
+        .with_context(|| {
+            format!(
+                "capture fixture output parent identity {}",
+                parent_identity.display()
+            )
+        })?;
     let file_name = output
         .file_name()
         .context("fixture output has no file name")?
@@ -1245,14 +1269,17 @@ fn validate_fixture_output_path(
         &source_generation_identity,
         &cache_root_identity,
     )?;
+    before_parent_open()?;
     let publication_root =
-        codestory_workspace::owned_publication::OwnedFilePublicationRoot::open(&parent_identity)
-            .with_context(|| format!("pin fixture output parent {}", parent_identity.display()))?;
+        codestory_workspace::owned_publication::OwnedFilePublicationRoot::open_verified(
+            &parent_identity,
+            publication_identity,
+        )
+        .with_context(|| format!("pin fixture output parent {}", parent_identity.display()))?;
     let validated = ValidatedFixtureOutput {
         requested_parent: output_parent.to_path_buf(),
         destination,
         destination_name: file_name,
-        parent_identity,
         publication_root,
         source_generation_path: source_generation.to_path_buf(),
         source_generation_identity,
@@ -1438,16 +1465,6 @@ fn fixture_publication_never_replaces_an_existing_path() -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "fixture-generator", windows))]
-fn create_directory_link(target: &Path, link: &Path) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_dir(target, link)
-}
-
-#[cfg(all(feature = "fixture-generator", windows))]
-fn remove_directory_link(link: &Path) -> std::io::Result<()> {
-    fs::remove_dir(link)
-}
-
 #[cfg(all(feature = "fixture-generator", unix))]
 fn create_directory_link(target: &Path, link: &Path) -> std::io::Result<()> {
     std::os::unix::fs::symlink(target, link)
@@ -1458,7 +1475,7 @@ fn remove_directory_link(link: &Path) -> std::io::Result<()> {
     fs::remove_file(link)
 }
 
-#[cfg(all(feature = "fixture-generator", any(windows, unix)))]
+#[cfg(all(feature = "fixture-generator", unix))]
 #[test]
 fn fixture_publication_rejects_changed_parent_identity() -> Result<()> {
     let temp = tempfile::tempdir()?;
@@ -1470,12 +1487,7 @@ fn fixture_publication_rejects_changed_parent_identity() -> Result<()> {
     fs::create_dir_all(&safe_parent)?;
     let source_sqlite = source_generation.join("vectors.sqlite3");
     File::create(&source_sqlite)?;
-    if let Err(error) = create_directory_link(&safe_parent, &parent_link) {
-        if error.kind() == std::io::ErrorKind::PermissionDenied {
-            return Ok(());
-        }
-        return Err(error.into());
-    }
+    create_directory_link(&safe_parent, &parent_link)?;
     let output_path = parent_link.join("fixture.json");
     let output = validate_fixture_output_path(&output_path, &source_sqlite, &cache_root)?;
     remove_directory_link(&parent_link)?;
@@ -1490,6 +1502,40 @@ fn fixture_publication_rejects_changed_parent_identity() -> Result<()> {
 }
 
 #[cfg(all(feature = "fixture-generator", any(windows, unix)))]
+#[test]
+fn fixture_publication_rejects_replacement_before_parent_open() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let cache_root = temp.path().join("cache");
+    let source_generation = cache_root.join("source-generation");
+    let safe_parent = temp.path().join("safe-parent");
+    let displaced_parent = temp.path().join("displaced-parent");
+    fs::create_dir_all(&source_generation)?;
+    fs::create_dir_all(&safe_parent)?;
+    let source_sqlite = source_generation.join("vectors.sqlite3");
+    File::create(&source_sqlite)?;
+    let output_path = safe_parent.join("fixture.json");
+
+    let error = match validate_fixture_output_path_with_hook(
+        &output_path,
+        &source_sqlite,
+        &cache_root,
+        || {
+            fs::rename(&safe_parent, &displaced_parent)?;
+            fs::create_dir(&safe_parent)?;
+            Ok(())
+        },
+    ) {
+        Ok(_) => anyhow::bail!("replacement parent must not satisfy the captured identity"),
+        Err(error) => error,
+    };
+
+    assert!(format!("{error:#}").contains("identity changed before it was pinned"));
+    assert!(!safe_parent.join("fixture.json").exists());
+    assert!(!displaced_parent.join("fixture.json").exists());
+    Ok(())
+}
+
+#[cfg(all(feature = "fixture-generator", unix))]
 #[test]
 fn fixture_publication_cannot_be_redirected_after_revalidation() -> Result<()> {
     let temp = tempfile::tempdir()?;

--- a/crates/codestory-bench/tests/vector_backend_spike.rs
+++ b/crates/codestory-bench/tests/vector_backend_spike.rs
@@ -1053,6 +1053,26 @@ fn decision_criteria_are_predeclared() {
             .as_str()
             .is_some_and(|value| value.contains("macOS arm64"))
     }));
+    let decision_requires = criteria["decision_requires"]
+        .as_array()
+        .expect("blocking decision requirement list");
+    for required in [
+        "Windows x64 offline build",
+        "license and native dependency review",
+        "reversible fallback",
+        "packaged archive size",
+    ] {
+        assert!(
+            decision_requires
+                .iter()
+                .any(|value| { value.as_str().is_some_and(|value| value.contains(required)) })
+        );
+        assert!(
+            !adoption_follow_up
+                .iter()
+                .any(|value| { value.as_str().is_some_and(|value| value.contains(required)) })
+        );
+    }
     let required = criteria["required_measurements"]
         .as_array()
         .expect("required measurement list");
@@ -1337,8 +1357,8 @@ fn compare_vector_backends() -> Result<()> {
         runs,
         limitations: vec![
             "same-process smoke timings are diagnostic and not candidate-comparison evidence",
-            "cold-cache latency, isolated RSS, cancellation, deep validation, and current-scan regression remain required Windows x64 decision evidence",
-            "Linux/macOS proof, cross-platform offline/native packaging, archive size, license review, and implementation fallback proof are non-blocking adoption follow-up",
+            "cold-cache latency, isolated RSS, cancellation, deep validation, current-scan regression, Windows offline build/archive size, license/native review, and reversible fallback remain required Windows x64 decision evidence",
+            "Linux/macOS quality, publication, offline-build, and native-packaging proof are non-blocking adoption follow-up",
             "one artifact covers only its recorded host, source publication, fixture, and vector count",
         ],
     };

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -2052,10 +2052,11 @@ mod tests {
         let generation_dir = root.path().join("fixture-generation");
         std::fs::create_dir_all(&generation_dir).expect("create fixture generation");
         let path = generation_dir.join(VECTOR_INDEX_FILE);
+        let embedding_dim = crate::embeddings::RETRIEVAL_EMBEDDING_DIM;
         let evidence = build_vector_producer_evidence(
             &accelerated_device(),
             Some(&accelerated_identity()),
-            2,
+            u32::try_from(embedding_dim).expect("canonical embedding dimension fits u32"),
             EmbeddingVectorPublicationIdentityDto {
                 core_generation_id: "fixture-core".into(),
                 core_run_id: "fixture-run".into(),
@@ -2066,7 +2067,7 @@ mod tests {
         );
         let contract = VectorEvidenceContract::new(
             crate::embeddings::embedding_backend_label(),
-            2,
+            embedding_dim,
             crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
             vector_compatibility_identity(&evidence).expect("compatibility identity"),
         );
@@ -2081,8 +2082,12 @@ mod tests {
             &contract,
             Some(&expected),
             |visit| {
-                visit(attested_point("node-b", "document-b", vec![0.0, 1.0]))?;
-                visit(attested_point("node-a", "document-a", vec![1.0, 0.0]))
+                let mut node_b = vec![0.0; embedding_dim];
+                node_b[1] = 1.0;
+                visit(attested_point("node-b", "document-b", node_b))?;
+                let mut node_a = vec![0.0; embedding_dim];
+                node_a[0] = 1.0;
+                visit(attested_point("node-a", "document-a", node_a))
             },
         )
         .expect("write fixture source");

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -1,6 +1,8 @@
 use crate::candidate::{CandidateHit, CandidateSource};
 use crate::config::{SidecarLayout, SidecarRuntimeConfig};
-use crate::embeddings::{EmbeddingDeviceReadiness, InProcessEmbeddingClient};
+use crate::embeddings::{
+    EmbeddingDeviceReadiness, InProcessEmbeddingClient, ProductEmbeddingResidencyLease,
+};
 use crate::in_process_embedding::ProcessEmbeddingIdentity;
 use crate::sidecar_search::SearchExecutionContext;
 use anyhow::{Context, Result, bail};
@@ -255,7 +257,7 @@ pub(crate) fn producer_evidence_mismatches(
 /// atomically renamed into the generation and is intended to be copied into
 /// the retrieval manifest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct VectorDatabaseAttestation {
+pub struct VectorDatabaseAttestation {
     pub schema_version: i64,
     pub generation: String,
     pub input_hash: String,
@@ -318,6 +320,185 @@ impl VectorGenerationManifest {
         }
         Ok(())
     }
+}
+
+/// One ordered record sampled from a production-validated vector generation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorFixtureRecord {
+    pub node_id: String,
+    pub document_hash: String,
+    pub vector: Vec<f32>,
+}
+
+/// A pinned, production-validated record sample and its publication attestation.
+#[derive(Debug)]
+pub struct ValidatedVectorFixtureSample {
+    attestation: VectorDatabaseAttestation,
+    records: Vec<VectorFixtureRecord>,
+}
+
+impl ValidatedVectorFixtureSample {
+    pub fn attestation(&self) -> &VectorDatabaseAttestation {
+        &self.attestation
+    }
+
+    pub fn records(&self) -> &[VectorFixtureRecord] {
+        &self.records
+    }
+}
+
+/// A production-validated source for freezing vector-backend comparison queries.
+pub struct ValidatedVectorFixtureSource {
+    sample: ValidatedVectorFixtureSample,
+    embedding: InProcessEmbeddingClient,
+    _residency: ProductEmbeddingResidencyLease,
+}
+
+impl ValidatedVectorFixtureSource {
+    pub fn attestation(&self) -> &VectorDatabaseAttestation {
+        self.sample.attestation()
+    }
+
+    pub fn records(&self) -> &[VectorFixtureRecord] {
+        self.sample.records()
+    }
+
+    pub fn embed_query(&self, query_text: &str) -> Result<Vec<f32>> {
+        self.embedding.embed_query(query_text)
+    }
+}
+
+/// Sample an immutable production vector generation through its canonical manifest contract.
+pub fn load_validated_vector_fixture_sample(
+    source_sqlite: &Path,
+    record_limit: usize,
+) -> Result<ValidatedVectorFixtureSample> {
+    load_validated_vector_fixture_sample_with_hook(source_sqlite, record_limit, || Ok(()))
+        .map(|(sample, _)| sample)
+}
+
+/// Open an immutable production vector generation and retain the exact compatible query engine.
+pub fn open_validated_vector_fixture_source_for_runtime(
+    source_sqlite: &Path,
+    runtime: &SidecarRuntimeConfig,
+    record_limit: usize,
+) -> Result<ValidatedVectorFixtureSource> {
+    let (sample, manifest) =
+        load_validated_vector_fixture_sample_with_hook(source_sqlite, record_limit, || Ok(()))?;
+
+    let residency = crate::embeddings::acquire_product_embedding_residency_for_runtime(runtime)
+        .context("initialize the production fixture query engine")?;
+    let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
+    let current_evidence = build_vector_producer_evidence(
+        &embedding_device,
+        residency.identity(),
+        u32::try_from(crate::embeddings::RETRIEVAL_EMBEDDING_DIM)
+            .context("retrieval embedding dimension overflow")?,
+        manifest.evidence.publication.clone(),
+    );
+    validate_fixture_producer_contract(&manifest, &current_evidence)?;
+    validate_execution_evidence_for_runtime(
+        &manifest.evidence,
+        runtime,
+        &embedding_device,
+        residency.identity(),
+    )?;
+
+    Ok(ValidatedVectorFixtureSource {
+        sample,
+        embedding: InProcessEmbeddingClient::new(runtime),
+        _residency: residency,
+    })
+}
+
+fn load_validated_vector_fixture_sample_with_hook(
+    source_sqlite: &Path,
+    record_limit: usize,
+    before_sample: impl FnOnce() -> Result<()>,
+) -> Result<(ValidatedVectorFixtureSample, VectorGenerationManifest)> {
+    if source_sqlite.file_name().and_then(|name| name.to_str()) != Some(VECTOR_INDEX_FILE) {
+        bail!("vector fixture source must be a production {VECTOR_INDEX_FILE}");
+    }
+    if record_limit == 0 {
+        bail!("vector fixture record limit must be positive");
+    }
+    let source_dir = source_sqlite
+        .parent()
+        .context("production vector fixture source has no generation directory")?;
+    let manifest = read_generation_manifest(&source_dir.join(VECTOR_GENERATION_MANIFEST_FILE))?;
+    ensure_no_sqlite_sidecars(source_sqlite)?;
+    let connection = open_read_only(source_sqlite)?;
+    connection.execute_batch("BEGIN DEFERRED TRANSACTION")?;
+    let result = (|| -> Result<_> {
+        let expected_anchors = read_fixture_source_anchors(&connection)?;
+        let persisted_contract = VectorEvidenceContract::new(
+            manifest.vectors.embedding_backend.clone(),
+            manifest.vectors.embedding_dim,
+            manifest.vectors.producer_identity.clone(),
+            manifest.vectors.evidence_contract_identity.clone(),
+        );
+        let attestation = validate_database_connection(
+            source_sqlite,
+            &connection,
+            &manifest.vectors.generation,
+            &manifest.vectors.input_hash,
+            &persisted_contract,
+            &expected_anchors,
+            Some(&manifest.vectors),
+        )?;
+        let record_limit_u64 =
+            u64::try_from(record_limit).context("vector fixture record limit overflow")?;
+        if attestation.point_count < record_limit_u64 {
+            bail!(
+                "production vector fixture source has {} points but {record_limit} were requested",
+                attestation.point_count
+            );
+        }
+        before_sample()?;
+        let records = sample_fixture_records(&connection, record_limit, attestation.embedding_dim)?;
+        if records.len() != record_limit {
+            bail!(
+                "production vector fixture source yielded {} of {record_limit} requested records",
+                records.len()
+            );
+        }
+        if sha256_file(source_sqlite)? != attestation.database_sha256 {
+            bail!("production vector fixture source changed while its pinned sample was read");
+        }
+        ensure_no_sqlite_sidecars(source_sqlite)?;
+        Ok(ValidatedVectorFixtureSample {
+            attestation,
+            records,
+        })
+    })();
+    let rollback = connection.execute_batch("ROLLBACK");
+    if result.is_ok() {
+        rollback.context("release pinned production vector fixture source")?;
+    }
+    result.map(|sample| (sample, manifest))
+}
+
+fn validate_fixture_producer_contract(
+    manifest: &VectorGenerationManifest,
+    current_evidence: &EmbeddingVectorProducerEvidenceDto,
+) -> Result<()> {
+    let mismatches = producer_evidence_mismatches(current_evidence, &manifest.evidence);
+    if !mismatches.is_empty() {
+        bail!(
+            "vector fixture source is incompatible with the current query engine: {}",
+            mismatches.join(", ")
+        );
+    }
+    let compatibility = vector_compatibility_identity(current_evidence)?;
+    if compatibility != manifest.compatibility_sha256
+        || compatibility != manifest.vectors.evidence_contract_identity
+        || manifest.vectors.embedding_backend != crate::embeddings::embedding_backend_label()
+        || manifest.vectors.embedding_dim != crate::embeddings::RETRIEVAL_EMBEDDING_DIM
+        || manifest.vectors.producer_identity != crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID
+    {
+        bail!("vector fixture source does not match the current production embedding contract");
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_generation_evidence_for_publication(
@@ -692,13 +873,7 @@ impl EmbeddedVectorIndex {
         collection: &str,
     ) -> Result<VectorGenerationManifest> {
         let path = generation_manifest_path(layout, collection);
-        let manifest = serde_json::from_slice::<VectorGenerationManifest>(
-            &std::fs::read(&path)
-                .with_context(|| format!("read vector generation manifest {}", path.display()))?,
-        )
-        .with_context(|| format!("parse vector generation manifest {}", path.display()))?;
-        manifest.validate()?;
-        Ok(manifest)
+        read_generation_manifest(&path)
     }
 
     pub(crate) fn health(
@@ -776,6 +951,87 @@ fn generation_manifest_path(layout: &SidecarLayout, collection: &str) -> PathBuf
         .parent()
         .expect("vector index path always has a collection parent")
         .join(VECTOR_GENERATION_MANIFEST_FILE)
+}
+
+fn read_generation_manifest(path: &Path) -> Result<VectorGenerationManifest> {
+    let manifest = serde_json::from_slice::<VectorGenerationManifest>(
+        &std::fs::read(path)
+            .with_context(|| format!("read vector generation manifest {}", path.display()))?,
+    )
+    .with_context(|| format!("parse vector generation manifest {}", path.display()))?;
+    manifest.validate()?;
+    Ok(manifest)
+}
+
+fn read_fixture_source_anchors(connection: &Connection) -> Result<BTreeMap<String, String>> {
+    validate_sqlite_quick_check(connection)?;
+    let mut statement =
+        connection.prepare("SELECT node_id, document_hash FROM vectors ORDER BY node_id ASC")?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut anchors = BTreeMap::new();
+    for row in rows {
+        let (node_id, document_hash) = row?;
+        if node_id.trim().is_empty() || document_hash.trim().is_empty() {
+            bail!("embedded vector row identities must be non-empty");
+        }
+        if anchors.insert(node_id.clone(), document_hash).is_some() {
+            bail!("duplicate embedded vector row {node_id}");
+        }
+    }
+    Ok(anchors)
+}
+
+fn sample_fixture_records(
+    connection: &Connection,
+    record_limit: usize,
+    embedding_dim: usize,
+) -> Result<Vec<VectorFixtureRecord>> {
+    let limit = i64::try_from(record_limit).context("vector fixture record limit overflow")?;
+    let mut statement = connection.prepare(
+        "SELECT node_id, document_hash, vector FROM vectors ORDER BY node_id ASC LIMIT ?1",
+    )?;
+    let rows = statement.query_map([limit], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, Vec<u8>>(2)?,
+        ))
+    })?;
+    rows.map(|row| {
+        let (node_id, document_hash, bytes) = row?;
+        validate_vector_bytes(&node_id, &bytes, embedding_dim)?;
+        let vector = bytes
+            .chunks_exact(4)
+            .map(|chunk| {
+                f32::from_bits(u32::from_le_bytes(
+                    chunk.try_into().expect("four-byte vector chunk"),
+                ))
+            })
+            .collect();
+        Ok(VectorFixtureRecord {
+            node_id,
+            document_hash,
+            vector,
+        })
+    })
+    .collect()
+}
+
+fn ensure_no_sqlite_sidecars(path: &Path) -> Result<()> {
+    for suffix in ["-wal", "-shm", "-journal"] {
+        let mut sidecar = path.as_os_str().to_owned();
+        sidecar.push(suffix);
+        let sidecar = PathBuf::from(sidecar);
+        if sidecar.exists() {
+            bail!(
+                "production vector fixture source has an unbound SQLite sidecar: {}",
+                sidecar.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -980,10 +1236,30 @@ fn validate_database(
     expected_anchors: &BTreeMap<String, String>,
     expected_attestation: Option<&VectorDatabaseAttestation>,
 ) -> Result<VectorDatabaseAttestation> {
-    contract.validate()?;
     let connection = open_read_only(path)?;
-    validate_sqlite_quick_check(&connection)?;
-    let metadata = read_metadata(&connection)?;
+    validate_database_connection(
+        path,
+        &connection,
+        generation,
+        input_hash,
+        contract,
+        expected_anchors,
+        expected_attestation,
+    )
+}
+
+fn validate_database_connection(
+    path: &Path,
+    connection: &Connection,
+    generation: &str,
+    input_hash: &str,
+    contract: &VectorEvidenceContract,
+    expected_anchors: &BTreeMap<String, String>,
+    expected_attestation: Option<&VectorDatabaseAttestation>,
+) -> Result<VectorDatabaseAttestation> {
+    contract.validate()?;
+    validate_sqlite_quick_check(connection)?;
+    let metadata = read_metadata(connection)?;
     if metadata.schema_version != VECTOR_INDEX_SCHEMA_VERSION
         || metadata.generation != generation
         || metadata.input_hash != input_hash
@@ -1006,7 +1282,7 @@ fn validate_database(
         );
     }
     let (vector_digest, actual_anchors) =
-        validate_and_digest_vectors(&connection, contract.embedding_dim, expected_anchors)?;
+        validate_and_digest_vectors(connection, contract.embedding_dim, expected_anchors)?;
     if actual_anchors != expected_anchors.len() || vector_digest != metadata.vector_digest {
         bail!("embedded vector canonical digest does not match metadata");
     }
@@ -1710,6 +1986,163 @@ mod tests {
                 .iter()
                 .any(|mismatch| mismatch == field),
             "missing compatibility check for {field}"
+        );
+    }
+
+    #[test]
+    fn vector_fixture_source_rejects_current_query_engine_contract_drift() {
+        let evidence = build_vector_producer_evidence(
+            &accelerated_device(),
+            Some(&accelerated_identity()),
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            EmbeddingVectorPublicationIdentityDto {
+                core_generation_id: "fixture-core".into(),
+                core_run_id: "fixture-run".into(),
+                retrieval_generation: "fixture-retrieval".into(),
+                retrieval_input_hash: "fixture-input".into(),
+                semantic_generation: "fixture-semantic".into(),
+            },
+        );
+        let compatibility =
+            vector_compatibility_identity(&evidence).expect("fixture compatibility identity");
+        let manifest = VectorGenerationManifest::new(
+            evidence.clone(),
+            VectorDatabaseAttestation {
+                schema_version: VECTOR_INDEX_SCHEMA_VERSION,
+                generation: "fixture-retrieval".into(),
+                input_hash: "fixture-input".into(),
+                embedding_backend: crate::embeddings::embedding_backend_label().into(),
+                embedding_dim: crate::embeddings::RETRIEVAL_EMBEDDING_DIM,
+                point_count: 1,
+                producer_identity: crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into(),
+                evidence_contract_identity: compatibility,
+                vector_digest: "0".repeat(64),
+                database_sha256: "1".repeat(64),
+            },
+        )
+        .expect("fixture manifest");
+        validate_fixture_producer_contract(&manifest, &evidence)
+            .expect("matching current engine contract");
+
+        for mutate in [
+            |current: &mut EmbeddingVectorProducerEvidenceDto| {
+                current.model.model_sha256 = "2".repeat(64);
+            },
+            |current: &mut EmbeddingVectorProducerEvidenceDto| {
+                current.semantics.query_prefix.push_str("drift");
+            },
+            |current: &mut EmbeddingVectorProducerEvidenceDto| {
+                current.engine.backend.push_str("-drift");
+            },
+            |current: &mut EmbeddingVectorProducerEvidenceDto| {
+                current.execution.eligibility.push_str("-drift");
+            },
+        ] {
+            let mut current = evidence.clone();
+            mutate(&mut current);
+            let error = validate_fixture_producer_contract(&manifest, &current)
+                .expect_err("current query engine drift must fail closed");
+            assert!(error.to_string().contains("incompatible"));
+        }
+    }
+
+    #[test]
+    fn vector_fixture_sampling_is_ordered_and_fails_closed_on_wal_drift() {
+        let root = tempdir().expect("tempdir");
+        let generation_dir = root.path().join("fixture-generation");
+        std::fs::create_dir_all(&generation_dir).expect("create fixture generation");
+        let path = generation_dir.join(VECTOR_INDEX_FILE);
+        let evidence = build_vector_producer_evidence(
+            &accelerated_device(),
+            Some(&accelerated_identity()),
+            2,
+            EmbeddingVectorPublicationIdentityDto {
+                core_generation_id: "fixture-core".into(),
+                core_run_id: "fixture-run".into(),
+                retrieval_generation: "fixture-generation".into(),
+                retrieval_input_hash: "fixture-input".into(),
+                semantic_generation: "fixture-semantic".into(),
+            },
+        );
+        let contract = VectorEvidenceContract::new(
+            crate::embeddings::embedding_backend_label(),
+            2,
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            vector_compatibility_identity(&evidence).expect("compatibility identity"),
+        );
+        let expected = BTreeMap::from([
+            ("node-a".to_string(), "document-a".to_string()),
+            ("node-b".to_string(), "document-b".to_string()),
+        ]);
+        write_database(
+            &path,
+            "fixture-generation",
+            "fixture-input",
+            &contract,
+            Some(&expected),
+            |visit| {
+                visit(attested_point("node-b", "document-b", vec![0.0, 1.0]))?;
+                visit(attested_point("node-a", "document-a", vec![1.0, 0.0]))
+            },
+        )
+        .expect("write fixture source");
+        let attestation = validate_database(
+            &path,
+            "fixture-generation",
+            "fixture-input",
+            &contract,
+            &expected,
+            None,
+        )
+        .expect("attest fixture source");
+        let mut manifest =
+            VectorGenerationManifest::new(evidence, attestation).expect("fixture manifest");
+        let manifest_path = generation_dir.join(VECTOR_GENERATION_MANIFEST_FILE);
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec_pretty(&manifest).expect("serialize fixture manifest"),
+        )
+        .expect("write fixture manifest");
+
+        let sample = load_validated_vector_fixture_sample(&path, 2)
+            .expect("sample validated fixture source");
+        assert_eq!(sample.attestation(), &manifest.vectors);
+        assert_eq!(
+            sample
+                .records()
+                .iter()
+                .map(|record| record.node_id.as_str())
+                .collect::<Vec<_>>(),
+            ["node-a", "node-b"]
+        );
+
+        let connection = Connection::open(&path).expect("open fixture source for WAL mode");
+        let journal_mode: String = connection
+            .query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))
+            .expect("enable WAL mode");
+        assert_eq!(journal_mode, "wal");
+        drop(connection);
+        ensure_no_sqlite_sidecars(&path).expect("closed WAL source has no sidecars");
+        manifest.vectors.database_sha256 = sha256_file(&path).expect("rehash WAL source");
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec_pretty(&manifest).expect("serialize updated fixture manifest"),
+        )
+        .expect("update fixture manifest");
+        let writer_path = path.clone();
+        let error = load_validated_vector_fixture_sample_with_hook(&path, 2, move || {
+            let writer = Connection::open(&writer_path)?;
+            writer.execute(
+                "UPDATE vectors SET document_hash = 'drift' WHERE node_id = 'node-a'",
+                [],
+            )?;
+            drop(writer);
+            Ok(())
+        })
+        .expect_err("WAL drift during pinned sampling must fail closed");
+        assert!(
+            format!("{error:#}").contains("unbound SQLite sidecar"),
+            "unexpected drift rejection: {error:#}"
         );
     }
 

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -52,6 +52,12 @@ pub use config::{
 pub use config::{
     active_test_cache_root, enable_automatic_test_cache_root_for_process, with_test_cache_root,
 };
+#[doc(hidden)]
+pub use embedded_vector::{
+    ValidatedVectorFixtureSample, ValidatedVectorFixtureSource, VectorDatabaseAttestation,
+    VectorFixtureRecord, load_validated_vector_fixture_sample,
+    open_validated_vector_fixture_source_for_runtime,
+};
 #[cfg(feature = "test-support")]
 pub use embeddings::TEST_EMBEDDING_UNAVAILABLE_MARKER;
 pub use embeddings::{

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -26,6 +26,7 @@ use uuid::Uuid;
 
 pub mod atomic_file;
 pub mod owned_deletion;
+pub mod owned_publication;
 mod repository_identity;
 pub use repository_identity::{
     PROJECT_IDENTITY_SCHEMA_VERSION, PROJECT_IDENTITY_V3_SCHEMA_VERSION, ProjectIdentityV2,

--- a/crates/codestory-workspace/src/owned_publication.rs
+++ b/crates/codestory-workspace/src/owned_publication.rs
@@ -1,0 +1,277 @@
+//! Handle-bound, no-replace publication below an already trusted directory.
+
+use fs_at::{OpenOptions as AtOpenOptions, OpenOptionsWriteMode};
+use std::{
+    ffi::{OsStr, OsString},
+    fs::{self, File},
+    io::{self, Read, Seek, SeekFrom, Write},
+    path::{Component, Path},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A publication boundary pinned to one open directory handle.
+///
+/// Callers establish the directory identity before opening this boundary, then
+/// retain it through staging, validation, and the final no-replace link. On
+/// Unix every operation is relative to the open directory. On Windows the
+/// directory is held without delete sharing, so its canonical path cannot be
+/// renamed or replaced while the final hard link is created.
+#[derive(Debug)]
+pub struct OwnedFilePublicationRoot {
+    root: File,
+    #[cfg(windows)]
+    stable_path: std::path::PathBuf,
+}
+
+impl OwnedFilePublicationRoot {
+    /// Pin a directory that the caller has already established as trusted.
+    pub fn open(root: &Path) -> io::Result<Self> {
+        let root_handle = open_root(root)?;
+        #[cfg(windows)]
+        let stable_path = fs::canonicalize(root)?;
+        Ok(Self {
+            root: root_handle,
+            #[cfg(windows)]
+            stable_path,
+        })
+    }
+
+    /// Publish complete bytes at a new leaf name without replacing any entry.
+    pub fn publish_new_bytes(
+        &self,
+        file_name: &OsStr,
+        temp_stem: &str,
+        bytes: &[u8],
+    ) -> io::Result<()> {
+        validate_leaf_name(file_name)?;
+        validate_leaf_name(OsStr::new(temp_stem))?;
+
+        let (temp_name, mut temp_file) = self.create_unique_temp_file(temp_stem)?;
+        let write_result = (|| {
+            temp_file.write_all(bytes)?;
+            temp_file.sync_all()?;
+            verify_file_bytes(&mut temp_file, bytes)
+        })();
+        drop(temp_file);
+        if let Err(error) = write_result {
+            let _ = self.unlink(&temp_name);
+            return Err(error);
+        }
+
+        let publish_result = self.link_new(&temp_name, file_name);
+        let _ = self.unlink(&temp_name);
+        publish_result?;
+        self.sync_root()
+    }
+
+    fn create_unique_temp_file(&self, stem: &str) -> io::Result<(OsString, File)> {
+        loop {
+            let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let name = OsString::from(format!(".{stem}.{}.{}.tmp", std::process::id(), counter));
+            let mut options = AtOpenOptions::default();
+            options
+                .read(true)
+                .write(OpenOptionsWriteMode::Write)
+                .create_new(true)
+                .follow(false);
+            match options.open_at(&self.root, Path::new(&name)) {
+                Ok(file) => return Ok((name, file)),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn unlink(&self, name: &OsStr) -> io::Result<()> {
+        AtOpenOptions::default().unlink_at(&self.root, Path::new(name))
+    }
+
+    #[cfg(unix)]
+    fn link_new(&self, source: &OsStr, destination: &OsStr) -> io::Result<()> {
+        use std::ffi::CString;
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let source = CString::new(source.as_bytes()).map_err(invalid_name)?;
+        let destination = CString::new(destination.as_bytes()).map_err(invalid_name)?;
+        // SAFETY: both names are null-terminated, contain no interior nulls,
+        // and are resolved relative to the live directory descriptor.
+        if unsafe {
+            libc::linkat(
+                self.root.as_raw_fd(),
+                source.as_ptr(),
+                self.root.as_raw_fd(),
+                destination.as_ptr(),
+                0,
+            )
+        } == 0
+        {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    #[cfg(windows)]
+    fn link_new(&self, source: &OsStr, destination: &OsStr) -> io::Result<()> {
+        fs::hard_link(
+            self.stable_path.join(Path::new(source)),
+            self.stable_path.join(Path::new(destination)),
+        )
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn link_new(&self, _source: &OsStr, _destination: &OsStr) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "handle-bound publication is unsupported on this platform",
+        ))
+    }
+
+    #[cfg(unix)]
+    fn sync_root(&self) -> io::Result<()> {
+        self.root.sync_all()
+    }
+
+    #[cfg(not(unix))]
+    fn sync_root(&self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn validate_leaf_name(name: &OsStr) -> io::Result<()> {
+    let mut components = Path::new(name).components();
+    if matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none() {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "owned publication requires one relative leaf name: {}",
+                Path::new(name).display()
+            ),
+        ))
+    }
+}
+
+fn verify_file_bytes(file: &mut File, expected: &[u8]) -> io::Result<()> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut offset = 0usize;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        let end = offset
+            .checked_add(count)
+            .ok_or_else(|| io::Error::other("published file length overflow"))?;
+        if end > expected.len() || buffer[..count] != expected[offset..end] {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "temporary publication bytes differ from input",
+            ));
+        }
+        offset = end;
+    }
+    if offset == expected.len() {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "temporary publication bytes differ from input",
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn invalid_name(error: std::ffi::NulError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, error)
+}
+
+#[cfg(unix)]
+fn open_root(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn open_root(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+    let root = options.open(path)?;
+    let metadata = root.metadata()?;
+    if !metadata.is_dir() {
+        return Err(io::Error::other(
+            "owned publication root is not a directory",
+        ));
+    }
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(io::Error::other("owned publication refuses reparse points"));
+    }
+    Ok(root)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_root(path: &Path) -> io::Result<File> {
+    File::open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OwnedFilePublicationRoot;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn publishes_complete_bytes_without_replacement() {
+        let root = tempdir().expect("create publication root");
+        let publication =
+            OwnedFilePublicationRoot::open(root.path()).expect("pin publication root");
+        publication
+            .publish_new_bytes("fixture.json".as_ref(), "fixture", b"complete")
+            .expect("publish fixture");
+        assert_eq!(
+            fs::read(root.path().join("fixture.json")).expect("read fixture"),
+            b"complete"
+        );
+
+        let error = publication
+            .publish_new_bytes("fixture.json".as_ref(), "fixture", b"replacement")
+            .expect_err("published destination must not be replaced");
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            fs::read(root.path().join("fixture.json")).expect("read preserved fixture"),
+            b"complete"
+        );
+        assert_eq!(fs::read_dir(root.path()).expect("read root").count(), 1);
+    }
+
+    #[test]
+    fn rejects_non_leaf_destinations() {
+        let root = tempdir().expect("create publication root");
+        let publication =
+            OwnedFilePublicationRoot::open(root.path()).expect("pin publication root");
+        for name in ["", ".", "..", "nested/fixture.json"] {
+            let error = publication
+                .publish_new_bytes(name.as_ref(), "fixture", b"blocked")
+                .expect_err("non-leaf destination must be rejected");
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        }
+    }
+}

--- a/crates/codestory-workspace/src/owned_publication.rs
+++ b/crates/codestory-workspace/src/owned_publication.rs
@@ -11,6 +11,23 @@ use std::{
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Native filesystem identity captured for a trusted publication directory.
+///
+/// The token is intentionally opaque. Callers capture it while making their
+/// trust decision, then require [`OwnedFilePublicationRoot::open_verified`] to
+/// prove that the opened directory handle names the same filesystem object.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedFilePublicationIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(windows)]
+    volume_serial_number: u64,
+    #[cfg(windows)]
+    file_id: [u8; 16],
+}
+
 /// A publication boundary pinned to one open directory handle.
 ///
 /// Callers establish the directory identity before opening this boundary, then
@@ -21,21 +38,49 @@ static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[derive(Debug)]
 pub struct OwnedFilePublicationRoot {
     root: File,
+    identity: OwnedFilePublicationIdentity,
     #[cfg(windows)]
     stable_path: std::path::PathBuf,
 }
 
 impl OwnedFilePublicationRoot {
-    /// Pin a directory that the caller has already established as trusted.
+    /// Capture the native identity used to establish a trusted directory.
+    pub fn capture_identity(root: &Path) -> io::Result<OwnedFilePublicationIdentity> {
+        let root = open_root(root)?;
+        identity_from_file(&root)
+    }
+
+    /// Capture and pin a directory without a separate caller trust decision.
     pub fn open(root: &Path) -> io::Result<Self> {
+        let identity = Self::capture_identity(root)?;
+        Self::open_verified(root, identity)
+    }
+
+    /// Pin a directory only when its handle matches a previously captured identity.
+    pub fn open_verified(
+        root: &Path,
+        expected_identity: OwnedFilePublicationIdentity,
+    ) -> io::Result<Self> {
         let root_handle = open_root(root)?;
+        let opened_identity = identity_from_file(&root_handle)?;
+        if opened_identity != expected_identity {
+            return Err(io::Error::other(
+                "owned publication root identity changed before it was pinned",
+            ));
+        }
         #[cfg(windows)]
         let stable_path = fs::canonicalize(root)?;
         Ok(Self {
             root: root_handle,
+            identity: opened_identity,
             #[cfg(windows)]
             stable_path,
         })
+    }
+
+    /// Return whether an existing path still names the pinned directory object.
+    pub fn matches_path(&self, path: &Path) -> io::Result<bool> {
+        Ok(Self::capture_identity(path)? == self.identity)
     }
 
     /// Publish complete bytes at a new leaf name without replacing any entry.
@@ -187,6 +232,55 @@ fn verify_file_bytes(file: &mut File, expected: &[u8]) -> io::Result<()> {
 }
 
 #[cfg(unix)]
+fn identity_from_file(file: &File) -> io::Result<OwnedFilePublicationIdentity> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let metadata = file.metadata()?;
+    Ok(OwnedFilePublicationIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(windows)]
+fn identity_from_file(file: &File) -> io::Result<OwnedFilePublicationIdentity> {
+    use std::mem::MaybeUninit;
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ID_INFO, FileIdInfo, GetFileInformationByHandleEx,
+    };
+
+    let mut information = MaybeUninit::<FILE_ID_INFO>::uninit();
+    // SAFETY: `file` owns a valid handle for the duration of the call and the
+    // output points to correctly sized, writable storage.
+    if unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileIdInfo,
+            information.as_mut_ptr().cast(),
+            u32::try_from(std::mem::size_of::<FILE_ID_INFO>()).expect("FILE_ID_INFO size fits u32"),
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: a successful `GetFileInformationByHandleEx` initializes all fields.
+    let information = unsafe { information.assume_init() };
+    Ok(OwnedFilePublicationIdentity {
+        volume_serial_number: information.VolumeSerialNumber,
+        file_id: information.FileId.Identifier,
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn identity_from_file(_file: &File) -> io::Result<OwnedFilePublicationIdentity> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "owned publication identity is unsupported on this platform",
+    ))
+}
+
+#[cfg(unix)]
 fn invalid_name(error: std::ffi::NulError) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidInput, error)
 }
@@ -272,6 +366,61 @@ mod tests {
                 .publish_new_bytes(name.as_ref(), "fixture", b"blocked")
                 .expect_err("non-leaf destination must be rejected");
             assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn rejects_a_replacement_between_identity_capture_and_open() {
+        let root = tempdir().expect("create test root");
+        let trusted = root.path().join("trusted");
+        let displaced = root.path().join("displaced");
+        fs::create_dir(&trusted).expect("create trusted root");
+        let identity =
+            OwnedFilePublicationRoot::capture_identity(&trusted).expect("capture trusted identity");
+
+        fs::rename(&trusted, &displaced).expect("displace trusted root");
+        fs::create_dir(&trusted).expect("create replacement root");
+        let error = OwnedFilePublicationRoot::open_verified(&trusted, identity)
+            .expect_err("replacement root must not satisfy captured identity");
+        assert!(error.to_string().contains("identity changed"));
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn publication_remains_bound_to_the_opened_directory() {
+        let root = tempdir().expect("create test root");
+        let trusted = root.path().join("trusted");
+        let displaced = root.path().join("displaced");
+        fs::create_dir(&trusted).expect("create trusted root");
+        let publication =
+            OwnedFilePublicationRoot::open(&trusted).expect("pin trusted publication root");
+
+        let rename = fs::rename(&trusted, &displaced);
+        #[cfg(unix)]
+        {
+            rename.expect("rename opened directory");
+            fs::create_dir(&trusted).expect("create replacement root");
+            publication
+                .publish_new_bytes("fixture.json".as_ref(), "fixture", b"pinned")
+                .expect("publish through retained directory handle");
+            assert_eq!(
+                fs::read(displaced.join("fixture.json")).expect("read pinned publication"),
+                b"pinned"
+            );
+            assert!(!trusted.join("fixture.json").exists());
+        }
+        #[cfg(windows)]
+        {
+            rename.expect_err("opened directory must reject replacement on Windows");
+            publication
+                .publish_new_bytes("fixture.json".as_ref(), "fixture", b"pinned")
+                .expect("publish through retained directory handle");
+            assert_eq!(
+                fs::read(trusted.join("fixture.json")).expect("read pinned publication"),
+                b"pinned"
+            );
+            assert!(!displaced.exists());
         }
     }
 }


### PR DESCRIPTION
## Context

Issue #1202 needs a predeclared, reproducible comparison between sqlite-vec and USearch before CodeStory can replace its current embedded vector scan. This draft adds the comparison and evidence machinery without selecting or adopting either backend.

Current remote head: `e718ac01832199a91e9a9b910b37a78dee28a1d5`, based on `dev/codestory-next` at `6de1c2717b68e6f97996ae21f38256a2645d7a5a`.

On 2026-07-16 the owner changed the blocking decision profile from Windows x64 to macOS arm64 on the local Apple Silicon host. The live issue and Project reflect that decision. A replacement branch head aligning the criteria, harness, workflow, and documentation is in progress; the current remote head still contains the prior Windows-specific contract.

Closes #1202
Refs #1179

## What changed on the current remote head

- Pin sqlite-vec 0.1.9 and USearch 2.26.0 for the benchmark-only lane.
- Add machine-readable adoption criteria and operating documentation.
- Add an evidence-bound comparison harness using identical production-attested inputs, representative query identities, cosine semantics, and an exact oracle.
- Model both candidates as immutable generations behind one atomic current/rollback pointer pair.
- Validate exact index and directory bytes on every reader open; cover corrupt candidates, rollback, pinned readers, referenced-generation tampering, and failed publication.
- Require complete source attestation, canonical database validation, and one pinned SQLite read transaction before sampling.
- Add an opt-in fixture freezer that uses retrieval-owned attestation, ordered records, and the exact compatible production query engine.
- Publish frozen fixtures through an opaque native directory-identity token captured before open and used with create-new publication.

The replacement head will change only the blocking profile and evidence infrastructure. It will not adopt a backend.

## How to review

1. Start with `benchmarks/vector-backend-spike/criteria.json`; it is the decision contract.
2. Review retrieval-owned source attestation and pinned sampling in `crates/codestory-retrieval/src/embedded_vector.rs`.
3. Review native identity capture, handle comparison, and no-replace publication in `crates/codestory-workspace/src/owned_publication.rs`.
4. Review the isolated candidate runner, aggregate gate evaluation, and fixture-path checks in `crates/codestory-bench/tests/vector_backend_spike.rs` and its driver.
5. Confirm synthetic smoke output remains diagnostic and decision mode fails closed without complete production fixtures and every required measurement.
6. Review the protected macOS arm64 manual workflow and its retained raw/aggregate artifacts.

## Verification

Focused checks on exact remote head `e718ac01832199a91e9a9b910b37a78dee28a1d5`:

- `cargo test --locked -p codestory-workspace owned_publication` — 4 passed.
- `cargo test --locked -p codestory-retrieval vector_fixture_sampling_is_ordered_and_fails_closed_on_wal_drift` — 1 passed.
- `cargo test --locked -p codestory-bench --no-default-features --features fixture-generator --test vector_backend_spike` — 9 passed, 2 intentionally ignored.
- Native and `x86_64-pc-windows-msvc` `codestory-workspace` Clippy with warnings denied — passed.
- `cargo check --locked -p codestory-workspace --target x86_64-pc-windows-msvc` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `node .github/scripts/check-doc-links.mjs` — 73 files, 243 relative links.

Those checks prove the current source contract only. Replacement-head checks and independent exact-head review are required after the Mac evidence lane lands.

## Risk and remaining evidence

This PR cannot support a backend recommendation yet and must remain draft. `criteria.json` remains `blocked_pending_required_evidence`.

Missing decision evidence includes:

- an independently reviewed 30-query production catalog;
- one real production publication with more than 100,100 anchors for the declared 1k, 10k, 25k, and 100k workloads plus the real incremental tail;
- isolated macOS arm64 artifacts for every declared workload;
- cold/warm timing, peak and warm RSS, cancellation, deep validation, and current embedded-scan comparison;
- macOS offline-build, native-dependency, storage, archive-size, and license review;
- a demonstrated reversible fallback to the existing embedded scan;
- retained raw and aggregate artifacts, explicit gate results, limitations, a clear recommendation, and independent reproduction.

Existing local caches do not contain a complete decision corpus. Synthetic or undersized data remains non-decision evidence. Linux and Windows packaging proof is non-blocking for this non-adopting spike; if a candidate wins, those platforms move to the later adoption PR. Keep the existing embedded scan unless one candidate clears every predeclared macOS arm64 gate.
