### PR TITLE
[codex] stabilize draft caches and Windows readiness proof

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -151,6 +151,7 @@ const draftRunCommands = new Map([
     "cargo clippy --workspace --lib --locked -- -D warnings",
   ]],
   ["Prove focused publication contracts", [
+    "cargo test --locked -p codestory-llama-sys --test native_staging",
     "cargo test --locked -p codestory-llama-sys --test model_staging",
     "cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
     "cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture",

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1302,12 +1302,17 @@ function validatePackagedProof(workflows, violations, graph) {
   const job = requireJob(violations, file, workflow, "build");
   validatePackageMatrixExpression(violations, at(job, "strategy", "matrix"), graph);
   add(violations, String(job.environment ?? "").includes("macos-release-signing"), `${file} signed Mac cells must use the protected signing environment`);
-  const nativeIdentity = namedStep(job, "Capture Rust cache key");
+  const packageSteps = list(job.steps).map(object);
+  const nativeIdentitySteps = packageSteps.filter(step => step.name === "Capture Rust cache key");
+  const nativeIdentity = nativeIdentitySteps[0];
   const nativeIdentityRun = executableRunText(String(nativeIdentity?.run ?? ""));
   add(
     violations,
-    nativeIdentity?.id === "rust-cache-key" && nativeIdentity?.shell === "bash",
-    `${file} native build identity must keep its stable Bash output boundary`,
+    nativeIdentitySteps.length === 1
+      && hasExactKeys(nativeIdentity, ["name", "id", "shell", "run"])
+      && nativeIdentity?.id === "rust-cache-key"
+      && nativeIdentity?.shell === "bash",
+    `${file} native build identity must be unique, unconditional, and keep its exact Bash output boundary`,
   );
   for (const fragment of [
     'cmake=$(cmake --version',
@@ -1325,6 +1330,19 @@ function validatePackagedProof(workflows, violations, graph) {
     );
   }
   const packageRestore = namedStep(job, "Restore Cargo registry, git sources, and build output");
+  const installRustIndex = packageSteps.findIndex(step => step.name === "Install pinned Rust");
+  const nativeIdentityIndex = packageSteps.findIndex(step => step.name === "Capture Rust cache key");
+  const packageRestoreIndex = packageSteps.findIndex(step => step.name === "Restore Cargo registry, git sources, and build output");
+  const packageBuildIndex = packageSteps.findIndex(step => step.name === "Build codestory-cli");
+  const linuxBuildIndex = packageSteps.findIndex(step => step.name === "Build Linux x64 at the glibc 2.31 baseline");
+  add(
+    violations,
+    nativeIdentityIndex === installRustIndex + 1
+      && packageRestoreIndex === nativeIdentityIndex + 1
+      && nativeIdentityIndex < packageBuildIndex
+      && nativeIdentityIndex < linuxBuildIndex,
+    `${file} native build identity must run immediately after Rust selection and before cache restore or any native build`,
+  );
   add(
     violations,
     object(packageRestore?.with).key === "${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-native-v2-${{ steps.rust-cache-key.outputs.generator }}-cmake-${{ steps.rust-cache-key.outputs.cmake }}-ninja-${{ steps.rust-cache-key.outputs.ninja }}-default-features-${{ hashFiles('Cargo.lock') }}",
@@ -1554,6 +1572,19 @@ function validateRemainingWorkflows(workflows, violations) {
     const job = requireJob(violations, vulkanFile, vulkan, "packaged-vulkan");
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
+    const sourceBuildTools = namedStep(job, "Capture source build tool evidence");
+    add(
+      violations,
+      hasExactKeys(object(sourceBuildTools), ["name", "if", "shell", "run"])
+        && sourceBuildTools?.if === "${{ !inputs.use_packaged_cli_artifact }}"
+        && sourceBuildTools?.shell === "pwsh",
+      `${vulkanFile} source build tool evidence must remain source-only and fail closed`,
+    );
+    requireStepRun(violations, vulkanFile, job, "Capture source build tool evidence", [
+      "CMAKE_GENERATOR=Ninja",
+      "cmake --version",
+      "ninja --version",
+    ]);
     requireStepRun(violations, vulkanFile, job, "Prepare checksum-pinned embedded model", ["node scripts/prepare-embedded-model.mjs"]);
     const nativeBuild = namedStep(job, "Build and package native CLI");
     add(

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -101,6 +101,136 @@ function requireJob(violations, file, workflow, name) {
   return object(found);
 }
 
+const draftCachePaths = [
+  "~/.cargo/registry",
+  "~/.cargo/git",
+  "target",
+];
+const draftCachePrimary = "${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}";
+const draftCacheRestoreKeys = [
+  "${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-${{ hashFiles('Cargo.lock') }}",
+  "${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-",
+  "${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-",
+];
+const draftStepSequence = [
+  { uses: "actions/checkout@v5" },
+  { name: "Install Rust stable" },
+  { name: "Install Linux Vulkan build dependencies" },
+  { name: "Capture Rust cache identity" },
+  { name: "Restore Cargo inputs and output" },
+  { name: "Check formatting" },
+  { name: "Check immutable runtime configuration boundary" },
+  { name: "Check the workspace" },
+  { name: "Check generated CodeStory syntax and MCP catalog" },
+  { name: "Lint workspace libraries" },
+  { name: "Prove focused publication contracts" },
+  { name: "Save Cargo inputs and output" },
+];
+const draftRunCommands = new Map([
+  ["Install Rust stable", [
+    "rustup toolchain install stable --profile minimal --component clippy --component rustfmt",
+    "rustup default stable",
+  ]],
+  ["Install Linux Vulkan build dependencies", [
+    "bash .github/scripts/install-linux-vulkan-build-deps.sh",
+  ]],
+  ["Capture Rust cache identity", [
+    `echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"`,
+    `echo "target=$(rustc -Vv | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"`,
+  ]],
+  ["Check formatting", ["cargo fmt --check"]],
+  ["Check immutable runtime configuration boundary", [
+    "node .github/scripts/check-runtime-config-boundary.mjs",
+  ]],
+  ["Check the workspace", ["cargo check --workspace --locked"]],
+  ["Check generated CodeStory syntax and MCP catalog", [
+    "cargo build --locked -p codestory-cli",
+    "node scripts/generate-codestory-skill-syntax.mjs --check",
+  ]],
+  ["Lint workspace libraries", [
+    "cargo clippy --workspace --lib --locked -- -D warnings",
+  ]],
+  ["Prove focused publication contracts", [
+    "cargo test --locked -p codestory-llama-sys --test model_staging",
+    "cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
+    "cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture",
+    "cargo test --locked -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture",
+  ]],
+]);
+
+function nonCommentLines(value) {
+  return String(value ?? "")
+    .split(/\r?\n/u)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith("#"));
+}
+
+function sameStrings(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
+  const violations = [];
+  const job = object(jobValue);
+  const retrievalJob = object(retrievalJobValue);
+  const steps = list(job.steps).map(object);
+
+  add(violations, job["runs-on"] === "ubuntu-latest", "draft source job must use ubuntu-latest");
+  add(violations, job["timeout-minutes"] === 45, "draft source job timeout must remain 45 minutes");
+  add(violations, job.env === undefined && job.defaults === undefined, "draft source job must not override the proof environment or defaults");
+  add(violations, job["continue-on-error"] === undefined && job.strategy === undefined, "draft source job must remain one required serial lane");
+  add(violations, steps.length === draftStepSequence.length, "draft source job must keep its exact serialized step count");
+  for (const [index, expected] of draftStepSequence.entries()) {
+    const step = steps[index];
+    const matches = expected.name === undefined
+      ? step?.uses === expected.uses
+      : step?.name === expected.name;
+    add(violations, matches, `draft source step ${index + 1} must remain ${expected.name ?? expected.uses}`);
+  }
+
+  for (const [name, commands] of draftRunCommands) {
+    const step = namedStep(job, name);
+    add(violations, step !== undefined, `draft source job must contain one ${name} step`);
+    add(violations, sameStrings(nonCommentLines(step?.run), commands), `draft source step ${name} must keep its exact serial command sequence`);
+    add(violations, step?.["continue-on-error"] === undefined && step?.if === undefined, `draft source step ${name} must remain required`);
+    add(violations, step?.env === undefined && step?.["working-directory"] === undefined, `draft source step ${name} must use the shared default build environment`);
+  }
+
+  const identity = namedStep(job, "Capture Rust cache identity");
+  add(violations, identity?.id === "rust-cache-key" && identity?.shell === "bash", "draft source cache identity must keep its stable bash output contract");
+
+  const restore = namedStep(job, "Restore Cargo inputs and output");
+  const restoreWith = object(restore?.with);
+  add(violations, restore?.id === "cargo-cache-restore", "draft source cache restore must keep its stable step id");
+  add(violations, restore?.uses === "actions/cache/restore@v5", "draft source cache restore must use actions/cache/restore@v5");
+  add(violations, restore?.["continue-on-error"] === true && restore?.if === undefined, "draft source cache restore must remain optional without conditional bypasses");
+  add(violations, sameStrings(nonCommentLines(restoreWith.path), draftCachePaths), "draft source cache restore must use only the Cargo registry, git, and default target paths");
+  add(violations, restoreWith.key === draftCachePrimary, "draft source cache primary must bind the v2 platform, toolchain, feature, lock, and manifest identity");
+  add(violations, sameStrings(nonCommentLines(restoreWith["restore-keys"]), draftCacheRestoreKeys), "draft source cache fallbacks must keep the exact retrieval, prior draft, then prior retrieval order");
+
+  const retrievalRestore = namedStep(retrievalJob, "Restore Cargo registry, git sources, and build output");
+  const retrievalRestoreWith = object(retrievalRestore?.with);
+  add(violations, retrievalRestore?.id === "cargo-cache-restore", "retrieval cache producer must keep its stable restore id");
+  add(violations, retrievalRestore?.uses === "actions/cache/restore@v5", "retrieval cache producer must use actions/cache/restore@v5");
+  add(violations, retrievalRestore?.["continue-on-error"] === true, "retrieval cache producer restore must remain non-blocking");
+  add(violations, sameStrings(nonCommentLines(retrievalRestoreWith.path), draftCachePaths), "retrieval cache producer must retain the proof-compatible path set");
+  add(violations, retrievalRestoreWith.key === draftCacheRestoreKeys[0], "retrieval cache producer key must match the draft exact-lock fallback");
+
+  const save = namedStep(job, "Save Cargo inputs and output");
+  const saveWith = object(save?.with);
+  add(violations, save?.uses === "actions/cache/save@v5", "draft source cache promotion must use actions/cache/save@v5");
+  add(violations, save?.["continue-on-error"] === true, "draft source cache promotion must remain non-blocking");
+  add(
+    violations,
+    save?.if === "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''",
+    "draft source cache promotion must require complete proof and a partial or missing primary",
+  );
+  add(violations, sameStrings(nonCommentLines(saveWith.path), draftCachePaths), "draft source cache promotion must use the exact restore path set");
+  add(violations, saveWith.key === "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}", "draft source cache promotion must save the exact primary rather than a matched fallback");
+
+  return violations;
+}
+
 export const releaseEvidenceWorkflowRef = "./.github/workflows/release-candidate-evidence.yml";
 
 export function macosCliDistributionViolations(assessmentStep, executionStep, quarantinedPath) {
@@ -526,18 +656,14 @@ function validatePluginAndDraftWorkflows(workflows, violations) {
       "scripts/generate-codestory-skill-syntax.mjs",
     ]), `${rustFile} must cover workspace source and generated catalog changes`);
     const job = requireJob(violations, rustFile, rust, "linux-draft");
-    add(violations, job["runs-on"] === "ubuntu-latest", `${rustFile} must use one Ubuntu lane`);
-    requireStepRun(violations, rustFile, job, "Check formatting", ["cargo fmt --check"]);
-    requireStepRun(violations, rustFile, job, "Check the workspace", ["cargo check --workspace --locked"]);
-    requireStepRun(violations, rustFile, job, "Check generated CodeStory syntax and MCP catalog", [
-      "cargo build --locked -p codestory-cli",
-      "node scripts/generate-codestory-skill-syntax.mjs --check",
-    ]);
-    requireStepRun(violations, rustFile, job, "Lint workspace libraries", ["cargo clippy --workspace --lib --locked -- -D warnings"]);
-    requireStepRun(violations, rustFile, job, "Prove focused publication contracts", [
-      "cargo test --locked -p codestory-llama-sys --test model_staging",
-      "cargo test --locked",
-    ]);
+    const retrievalJob = object(at(
+      workflows.get("retrieval-engine-smoke.yml"),
+      "jobs",
+      "linux-contracts",
+    ));
+    for (const violation of draftSourcePolicyViolations(job, retrievalJob)) {
+      violations.push(`${rustFile} ${violation}`);
+    }
   }
 
   const sourceFile = "source-proof.yml";

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -179,8 +179,63 @@ const draftWorkflowPaths = [
 const retrievalProducerTriggerPaths = [
   "crates/**/Cargo.toml",
   "vendor/**/Cargo.toml",
+  ".github/scripts/install-windows-vulkan-sdk.ps1",
   ".github/workflows/rust-ci.yml",
 ];
+const windowsVulkanInstaller = ".github/scripts/install-windows-vulkan-sdk.ps1";
+const windowsReadyCommand = "cargo test --locked -p codestory-cli --test ready_command";
+const windowsReadyProofTopologyDigest = createHash("sha256")
+  .update(windowsReadyCommand)
+  .digest("hex");
+const windowsReadyProofTopology = `ready-command-v1-${windowsReadyProofTopologyDigest}`;
+const windowsInstallerHash = `\${{ hashFiles('${windowsVulkanInstaller}') }}`;
+const windowsCachePrimary = [
+  cacheRunner,
+  "cargo-stable",
+  cacheRustVersion,
+  cacheTarget,
+  "windows",
+  windowsReadyProofTopology,
+  "default-features",
+  cacheManifests,
+  windowsInstallerHash,
+  cacheLock,
+].join("-");
+const windowsStepSequence = [
+  { uses: "actions/checkout@v5", keys: ["uses"] },
+  { name: "Install Rust stable", keys: ["name", "shell", "run"] },
+  {
+    name: "Install checksum-pinned Windows Vulkan SDK",
+    keys: ["name", "shell", "run"],
+  },
+  { name: "Capture Rust cache identity", keys: ["name", "id", "shell", "run"] },
+  {
+    name: "Restore Windows Cargo inputs and output",
+    keys: ["name", "id", "uses", "continue-on-error", "with"],
+  },
+  {
+    name: "Prove Windows ready_command manifest-missing contract",
+    keys: ["name", "shell", "run"],
+  },
+  {
+    name: "Save Windows Cargo inputs and output",
+    keys: ["name", "if", "uses", "continue-on-error", "with"],
+  },
+];
+const windowsRunCommands = new Map([
+  ["Install Rust stable", [
+    "rustup toolchain install stable --profile minimal",
+    "rustup default stable",
+  ]],
+  ["Install checksum-pinned Windows Vulkan SDK", [windowsVulkanInstaller]],
+  ["Capture Rust cache identity", [
+    "$release = rustc -Vv | Select-String '^release: ' | ForEach-Object { $_.ToString().Substring(9) }",
+    "$target = rustc -Vv | Select-String '^host: ' | ForEach-Object { $_.ToString().Substring(6) }",
+    `"version=$release" | Out-File -FilePath $env:GITHUB_OUTPUT -Append`,
+    `"target=$target" | Out-File -FilePath $env:GITHUB_OUTPUT -Append`,
+  ]],
+  ["Prove Windows ready_command manifest-missing contract", [windowsReadyCommand]],
+]);
 const draftStepSequence = [
   { uses: "actions/checkout@v5", keys: ["uses"] },
   { name: "Install Rust stable", keys: ["name", "run"] },
@@ -317,6 +372,191 @@ export function retrievalProducerTriggerPolicyViolations(workflowValue) {
     includesAll(at(workflow, "on", "push", "paths"), retrievalProducerTriggerPaths),
     "retrieval cache producer dev push paths must cover every manifest and draft consumer change",
   );
+  return violations;
+}
+
+export function windowsManifestProofPolicyViolations(workflowValue) {
+  const violations = [];
+  const workflow = object(workflowValue);
+  const triggers = object(workflow.on);
+  const job = object(at(workflow, "jobs", "windows-manifest-missing"));
+  const steps = list(job.steps).map(object);
+
+  add(
+    violations,
+    hasExactKeys(workflow.jobs, ["linux-contracts", "windows-manifest-missing"]),
+    "Windows manifest proof workflow must contain exactly linux-contracts and windows-manifest-missing jobs",
+  );
+  add(
+    violations,
+    workflow.env === undefined,
+    "Windows manifest proof workflow must not define top-level env",
+  );
+  add(
+    violations,
+    workflow.defaults === undefined,
+    "Windows manifest proof workflow must not define top-level defaults",
+  );
+  for (const event of ["pull_request", "push"]) {
+    add(
+      violations,
+      includesAll(at(triggers, event, "paths"), [windowsVulkanInstaller]),
+      `Windows manifest proof ${event} paths must cover the Vulkan installer`,
+    );
+  }
+  add(
+    violations,
+    triggers.workflow_dispatch === null,
+    "Windows manifest proof workflow_dispatch must remain input-free",
+  );
+  add(
+    violations,
+    hasExactKeys(job, ["if", "runs-on", "timeout-minutes", "env", "steps"]),
+    "Windows manifest proof job must keep its exact required serial shape",
+  );
+  add(
+    violations,
+    job.if === "github.event_name == 'workflow_dispatch'",
+    "Windows manifest proof must be workflow-dispatch only",
+  );
+  add(
+    violations,
+    !scalarStrings(job).some(value => value.includes("labels")),
+    "Windows manifest proof must not be label-triggered",
+  );
+  add(violations, job["runs-on"] === "windows-latest", "Windows manifest proof must use windows-latest");
+  add(violations, job["timeout-minutes"] === 30, "Windows manifest proof timeout must remain 30 minutes");
+  add(
+    violations,
+    hasExactKeys(job.env, ["CODESTORY_EMBED_ALLOW_CPU"])
+      && job.env.CODESTORY_EMBED_ALLOW_CPU === "1",
+    "Windows manifest proof must explicitly permit only CPU runtime execution",
+  );
+  add(
+    violations,
+    steps.length === windowsStepSequence.length,
+    "Windows manifest proof must keep its exact serialized step count",
+  );
+  for (const [index, expected] of windowsStepSequence.entries()) {
+    const step = steps[index];
+    const matches = expected.name === undefined
+      ? step?.uses === expected.uses
+      : step?.name === expected.name;
+    add(
+      violations,
+      matches,
+      `Windows manifest proof step ${index + 1} must remain ${expected.name ?? expected.uses}`,
+    );
+    add(
+      violations,
+      hasExactKeys(step, expected.keys),
+      `Windows manifest proof step ${index + 1} must keep the exact ${expected.name ?? expected.uses} key shape`,
+    );
+  }
+
+  for (const [name, commands] of windowsRunCommands) {
+    const step = namedStep(job, name);
+    add(violations, step !== undefined, `Windows manifest proof must contain one ${name} step`);
+    add(
+      violations,
+      sameStrings(nonCommentLines(step?.run), commands),
+      `Windows manifest proof step ${name} must keep its exact required command sequence`,
+    );
+    add(
+      violations,
+      step?.shell === "pwsh",
+      `Windows manifest proof step ${name} must use pwsh`,
+    );
+  }
+
+  const identity = namedStep(job, "Capture Rust cache identity");
+  add(
+    violations,
+    identity?.id === "rust-cache-key",
+    "Windows manifest proof cache identity must keep its stable output id",
+  );
+
+  const restore = namedStep(job, "Restore Windows Cargo inputs and output");
+  const restoreWith = object(restore?.with);
+  add(
+    violations,
+    restore?.id === "cargo-cache-restore",
+    "Windows manifest proof cache restore must keep its stable step id",
+  );
+  add(
+    violations,
+    restore?.uses === "actions/cache/restore@v5",
+    "Windows manifest proof cache restore must use actions/cache/restore@v5",
+  );
+  add(
+    violations,
+    restore?.["continue-on-error"] === true && restore?.if === undefined,
+    "Windows manifest proof cache restore must remain optional without conditional bypasses",
+  );
+  add(
+    violations,
+    hasExactKeys(restoreWith, ["path", "key"]),
+    "Windows manifest proof cache restore must use an exact primary without fallbacks",
+  );
+  add(
+    violations,
+    sameStrings(nonCommentLines(restoreWith.path), draftCachePaths),
+    "Windows manifest proof cache restore must use only Cargo registry, git, and default target paths",
+  );
+  add(
+    violations,
+    restoreWith.key === windowsCachePrimary,
+    "Windows manifest proof cache key must bind OS, Rust, target, proof topology, default features, manifests, installer, and lock identities",
+  );
+
+  const proof = namedStep(job, "Prove Windows ready_command manifest-missing contract");
+  const install = namedStep(job, "Install checksum-pinned Windows Vulkan SDK");
+  const restoreIndex = steps.indexOf(restore);
+  const proofIndex = steps.indexOf(proof);
+  add(
+    violations,
+    steps.indexOf(install) < proofIndex && restoreIndex < proofIndex,
+    "Windows manifest proof must install the SDK and restore only compatible output before the Cargo proof",
+  );
+
+  const save = namedStep(job, "Save Windows Cargo inputs and output");
+  const saveWith = object(save?.with);
+  add(
+    violations,
+    save?.uses === "actions/cache/save@v5",
+    "Windows manifest proof cache save must use actions/cache/save@v5",
+  );
+  add(
+    violations,
+    save?.["continue-on-error"] === true,
+    "Windows manifest proof cache save must remain non-blocking",
+  );
+  add(
+    violations,
+    save?.if === cacheSaveCondition,
+    "Windows manifest proof cache save must require full proof success and skip exact hits",
+  );
+  add(
+    violations,
+    hasExactKeys(saveWith, ["path", "key"]),
+    "Windows manifest proof cache save inputs must keep their exact shape",
+  );
+  add(
+    violations,
+    sameStrings(nonCommentLines(saveWith.path), draftCachePaths),
+    "Windows manifest proof cache save must use the exact restore path set",
+  );
+  add(
+    violations,
+    saveWith.key === cacheSaveKey,
+    "Windows manifest proof cache save must use the exact primary rather than a matched key",
+  );
+  add(
+    violations,
+    proofIndex + 1 === steps.indexOf(save),
+    "Windows manifest proof cache save must immediately follow the successful Cargo proof",
+  );
+
   return violations;
 }
 
@@ -1290,9 +1530,9 @@ function validateRemainingWorkflows(workflows, violations) {
   if (!retrieval) {
     violations.push(`${retrievalFile} must exist`);
   } else {
-    const windows = requireJob(violations, retrievalFile, retrieval, "windows-manifest-missing");
-    add(violations, windows.if === "github.event_name == 'workflow_dispatch'", `${retrievalFile} Windows proof must be workflow-dispatch only`);
-    add(violations, !scalarStrings(windows).some(value => value.includes("labels")), `${retrievalFile} Windows proof must not be label-triggered`);
+    for (const violation of windowsManifestProofPolicyViolations(retrieval)) {
+      violations.push(`${retrievalFile} ${violation}`);
+    }
   }
 
   const guardFile = "main-branch-source-guard.yml";

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -183,11 +183,12 @@ const retrievalProducerTriggerPaths = [
   ".github/workflows/rust-ci.yml",
 ];
 const windowsVulkanInstaller = ".github/scripts/install-windows-vulkan-sdk.ps1";
+const windowsNativeGenerator = "Ninja";
 const windowsReadyCommand = "cargo test --locked -p codestory-cli --test ready_command";
 const windowsReadyProofTopologyDigest = createHash("sha256")
-  .update(windowsReadyCommand)
+  .update(`${windowsReadyCommand}\nCMAKE_GENERATOR=${windowsNativeGenerator}`)
   .digest("hex");
-const windowsReadyProofTopology = `ready-command-v1-${windowsReadyProofTopologyDigest}`;
+const windowsReadyProofTopology = `ready-command-v2-${windowsReadyProofTopologyDigest}`;
 const windowsInstallerHash = `\${{ hashFiles('${windowsVulkanInstaller}') }}`;
 const windowsCachePrimary = [
   cacheRunner,
@@ -196,6 +197,12 @@ const windowsCachePrimary = [
   cacheTarget,
   "windows",
   windowsReadyProofTopology,
+  "generator",
+  windowsNativeGenerator.toLowerCase(),
+  "cmake",
+  "${{ steps.rust-cache-key.outputs.cmake }}",
+  "ninja",
+  "${{ steps.rust-cache-key.outputs.ninja }}",
   "default-features",
   cacheManifests,
   windowsInstallerHash,
@@ -231,8 +238,12 @@ const windowsRunCommands = new Map([
   ["Capture Rust cache identity", [
     "$release = rustc -Vv | Select-String '^release: ' | ForEach-Object { $_.ToString().Substring(9) }",
     "$target = rustc -Vv | Select-String '^host: ' | ForEach-Object { $_.ToString().Substring(6) }",
+    "$cmake = (cmake --version | Select-Object -First 1) -replace '^cmake version ', ''",
+    "$ninja = (ninja --version).Trim()",
     `"version=$release" | Out-File -FilePath $env:GITHUB_OUTPUT -Append`,
     `"target=$target" | Out-File -FilePath $env:GITHUB_OUTPUT -Append`,
+    `"cmake=$cmake" | Out-File -FilePath $env:GITHUB_OUTPUT -Append`,
+    `"ninja=$ninja" | Out-File -FilePath $env:GITHUB_OUTPUT -Append`,
   ]],
   ["Prove Windows ready_command manifest-missing contract", [windowsReadyCommand]],
 ]);
@@ -428,9 +439,10 @@ export function windowsManifestProofPolicyViolations(workflowValue) {
   add(violations, job["timeout-minutes"] === 30, "Windows manifest proof timeout must remain 30 minutes");
   add(
     violations,
-    hasExactKeys(job.env, ["CODESTORY_EMBED_ALLOW_CPU"])
-      && job.env.CODESTORY_EMBED_ALLOW_CPU === "1",
-    "Windows manifest proof must explicitly permit only CPU runtime execution",
+    hasExactKeys(job.env, ["CODESTORY_EMBED_ALLOW_CPU", "CMAKE_GENERATOR"])
+      && job.env.CODESTORY_EMBED_ALLOW_CPU === "1"
+      && job.env.CMAKE_GENERATOR === windowsNativeGenerator,
+    "Windows manifest proof must explicitly permit CPU runtime execution and use the Ninja native generator",
   );
   add(
     violations,
@@ -1290,6 +1302,40 @@ function validatePackagedProof(workflows, violations, graph) {
   const job = requireJob(violations, file, workflow, "build");
   validatePackageMatrixExpression(violations, at(job, "strategy", "matrix"), graph);
   add(violations, String(job.environment ?? "").includes("macos-release-signing"), `${file} signed Mac cells must use the protected signing environment`);
+  const nativeIdentity = namedStep(job, "Capture Rust cache key");
+  const nativeIdentityRun = executableRunText(String(nativeIdentity?.run ?? ""));
+  add(
+    violations,
+    nativeIdentity?.id === "rust-cache-key" && nativeIdentity?.shell === "bash",
+    `${file} native build identity must keep its stable Bash output boundary`,
+  );
+  for (const fragment of [
+    'cmake=$(cmake --version',
+    'if [ "$RUNNER_OS" = Windows ]',
+    'generator=ninja',
+    'ninja=$(ninja --version)',
+    'CMAKE_GENERATOR=Ninja',
+    'generator=platform-default',
+    'ninja=not-applicable',
+  ]) {
+    add(
+      violations,
+      nativeIdentityRun.includes(fragment),
+      `${file} native build identity must include ${fragment}`,
+    );
+  }
+  const packageRestore = namedStep(job, "Restore Cargo registry, git sources, and build output");
+  add(
+    violations,
+    object(packageRestore?.with).key === "${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-native-v2-${{ steps.rust-cache-key.outputs.generator }}-cmake-${{ steps.rust-cache-key.outputs.cmake }}-ninja-${{ steps.rust-cache-key.outputs.ninja }}-default-features-${{ hashFiles('Cargo.lock') }}",
+    `${file} native build cache must bind generator, CMake, Ninja, target, features, and lock identity`,
+  );
+  const packageBuild = namedStep(job, "Build codestory-cli");
+  add(
+    violations,
+    packageBuild?.env === undefined,
+    `${file} native package build must not override the selected generator`,
+  );
   requireStepRun(violations, file, job, "Prepare checksum-pinned embedded model", [
     "node scripts/prepare-embedded-model.mjs",
   ]);
@@ -1509,6 +1555,17 @@ function validateRemainingWorkflows(workflows, violations) {
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
     requireStepRun(violations, vulkanFile, job, "Prepare checksum-pinned embedded model", ["node scripts/prepare-embedded-model.mjs"]);
+    const nativeBuild = namedStep(job, "Build and package native CLI");
+    add(
+      violations,
+      hasExactKeys(object(nativeBuild?.env), ["VERSION", "CMAKE_GENERATOR"])
+        && object(nativeBuild?.env).CMAKE_GENERATOR === windowsNativeGenerator,
+      `${vulkanFile} source package build must use the Ninja native generator`,
+    );
+    requireStepRun(violations, vulkanFile, job, "Build and package native CLI", [
+      "cargo build --release --locked -p codestory-cli",
+      "package-codestory-release.py",
+    ]);
     const engine = namedStep(job, "Prove offline Vulkan and multi-repository reuse");
     requireStepRun(violations, vulkanFile, job, "Prove offline Vulkan and multi-repository reuse", ["--engine-policy accelerated", "--expected-backend Vulkan", "--offline"]);
     add(violations, object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${vulkanFile} engine proof must reject CPU fallback`);

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -169,6 +169,13 @@ function sameStrings(actual, expected) {
   return JSON.stringify(actual) === JSON.stringify(expected);
 }
 
+export function draftWorkflowPolicyViolations(workflowValue) {
+  const jobs = Object.keys(object(object(workflowValue).jobs));
+  return sameStrings(jobs, ["linux-draft"])
+    ? []
+    : ["draft source workflow must contain exactly the linux-draft job"];
+}
+
 export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   const violations = [];
   const job = object(jobValue);
@@ -646,6 +653,9 @@ function validatePluginAndDraftWorkflows(workflows, violations) {
   if (!rust) {
     violations.push(`${rustFile} must exist`);
   } else {
+    for (const violation of draftWorkflowPolicyViolations(rust)) {
+      violations.push(`${rustFile} ${violation}`);
+    }
     add(violations, trigger(rust, "push") === undefined, `${rustFile} draft checks must not run on push`);
     add(violations, includesAll(at(rust, "on", "pull_request", "paths"), [
       "Cargo.lock",

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -106,12 +107,58 @@ const draftCachePaths = [
   "~/.cargo/git",
   "target",
 ];
-const draftCachePrimary = "${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}";
-const draftCacheRestoreKeys = [
-  "${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-${{ hashFiles('Cargo.lock') }}",
-  "${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-",
-  "${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-",
+const draftProofCommands = [
+  "cargo test --locked -p codestory-llama-sys --test native_staging",
+  "cargo test --locked -p codestory-llama-sys --test model_staging",
+  "cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
+  "cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture",
+  "cargo test --locked -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture",
 ];
+const draftSeedCommands = [
+  "cargo test --locked -p codestory-llama-sys --test native_staging --no-run",
+  "cargo test --locked -p codestory-llama-sys --test model_staging --no-run",
+  "cargo test --locked -p codestory-cli --test stdio_protocol_contracts --no-run two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
+  "cargo test --locked -p codestory-runtime --no-run publication_transitions_fail_or_cancel_atomically -- --nocapture",
+  "cargo test --locked -p codestory-store --no-run staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture",
+];
+const draftProofTopologyDigest = createHash("sha256")
+  .update(draftSeedCommands.join("\n"))
+  .digest("hex");
+const draftProofTopology = `proof5-v1-${draftProofTopologyDigest}`;
+const cacheRunner = "${{ runner.os }}";
+const cacheRustVersion = "${{ steps.rust-cache-key.outputs.version }}";
+const cacheTarget = "${{ steps.rust-cache-key.outputs.target }}";
+const cacheManifests = "${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}";
+const cacheLock = "${{ hashFiles('Cargo.lock') }}";
+const draftCachePrefix = [
+  cacheRunner,
+  "draft-v2",
+  cacheRustVersion,
+  cacheTarget,
+  "workspace",
+  draftProofTopology,
+  "default-features",
+  cacheManifests,
+].join("-");
+const retrievalCachePrefix = [
+  cacheRunner,
+  "cargo-stable",
+  cacheRustVersion,
+  cacheTarget,
+  "retrieval-contracts",
+  draftProofTopology,
+  "default-features",
+  cacheManifests,
+].join("-");
+const draftCachePrimary = `${draftCachePrefix}-${cacheLock}`;
+const retrievalCachePrimary = `${retrievalCachePrefix}-${cacheLock}`;
+const draftCacheRestoreKeys = [
+  retrievalCachePrimary,
+  `${draftCachePrefix}-`,
+  `${retrievalCachePrefix}-`,
+];
+const cacheSaveCondition = "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''";
+const cacheSaveKey = "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}";
 const draftWorkflowPaths = [
   "Cargo.lock",
   "Cargo.toml",
@@ -125,6 +172,11 @@ const draftWorkflowPaths = [
   "plugins/codestory/generated-mcp-catalog.json",
   "plugins/codestory/skills/codestory-grounding/**",
   "scripts/generate-codestory-skill-syntax.mjs",
+];
+const retrievalProducerTriggerPaths = [
+  "crates/**/Cargo.toml",
+  "vendor/**/Cargo.toml",
+  ".github/workflows/rust-ci.yml",
 ];
 const draftStepSequence = [
   { uses: "actions/checkout@v5", keys: ["uses"] },
@@ -170,13 +222,7 @@ const draftRunCommands = new Map([
   ["Lint workspace libraries", [
     "cargo clippy --workspace --lib --locked -- -D warnings",
   ]],
-  ["Prove focused publication contracts", [
-    "cargo test --locked -p codestory-llama-sys --test native_staging",
-    "cargo test --locked -p codestory-llama-sys --test model_staging",
-    "cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture",
-    "cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture",
-    "cargo test --locked -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture",
-  ]],
+  ["Prove focused publication contracts", draftProofCommands],
 ]);
 
 function nonCommentLines(value) {
@@ -250,6 +296,27 @@ export function draftWorkflowPolicyViolations(workflowValue) {
   return violations;
 }
 
+export function retrievalProducerTriggerPolicyViolations(workflowValue) {
+  const violations = [];
+  const workflow = object(workflowValue);
+  add(
+    violations,
+    includesAll(at(workflow, "on", "pull_request", "paths"), retrievalProducerTriggerPaths),
+    "retrieval cache producer pull_request paths must cover every manifest and draft consumer change",
+  );
+  add(
+    violations,
+    includesAll(at(workflow, "on", "push", "branches"), ["dev/codestory-next"]),
+    "retrieval cache producer must run on dev/codestory-next pushes",
+  );
+  add(
+    violations,
+    includesAll(at(workflow, "on", "push", "paths"), retrievalProducerTriggerPaths),
+    "retrieval cache producer dev push paths must cover every manifest and draft consumer change",
+  );
+  return violations;
+}
+
 export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   const violations = [];
   const job = object(jobValue);
@@ -306,16 +373,62 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
     "draft source cache restore inputs must keep their exact key shape",
   );
   add(violations, sameStrings(nonCommentLines(restoreWith.path), draftCachePaths), "draft source cache restore must use only the Cargo registry, git, and default target paths");
-  add(violations, restoreWith.key === draftCachePrimary, "draft source cache primary must bind the v2 platform, toolchain, feature, lock, and manifest identity");
-  add(violations, sameStrings(nonCommentLines(restoreWith["restore-keys"]), draftCacheRestoreKeys), "draft source cache fallbacks must keep the exact retrieval, prior draft, then prior retrieval order");
+  add(violations, restoreWith.key === draftCachePrimary, "draft source cache primary must bind the v2 platform, toolchain, target, proof topology, feature, manifest, and lock identity");
+  add(violations, sameStrings(nonCommentLines(restoreWith["restore-keys"]), draftCacheRestoreKeys), "draft source cache fallbacks must keep the exact seeded retrieval, prior draft, then prior retrieval order and omit only the lock identity from prior prefixes");
 
   const retrievalRestore = namedStep(retrievalJob, "Restore Cargo registry, git sources, and build output");
   const retrievalRestoreWith = object(retrievalRestore?.with);
+  add(
+    violations,
+    hasExactKeys(retrievalRestore, ["name", "id", "uses", "continue-on-error", "with"]),
+    "retrieval cache producer restore must keep its exact step shape",
+  );
   add(violations, retrievalRestore?.id === "cargo-cache-restore", "retrieval cache producer must keep its stable restore id");
   add(violations, retrievalRestore?.uses === "actions/cache/restore@v5", "retrieval cache producer must use actions/cache/restore@v5");
-  add(violations, retrievalRestore?.["continue-on-error"] === true, "retrieval cache producer restore must remain non-blocking");
+  add(violations, retrievalRestore?.["continue-on-error"] === true && retrievalRestore?.if === undefined, "retrieval cache producer restore must remain non-blocking without conditional bypasses");
+  add(
+    violations,
+    hasExactKeys(retrievalRestoreWith, ["path", "key"]),
+    "retrieval cache producer restore inputs must keep their exact key shape",
+  );
   add(violations, sameStrings(nonCommentLines(retrievalRestoreWith.path), draftCachePaths), "retrieval cache producer must retain the proof-compatible path set");
-  add(violations, retrievalRestoreWith.key === draftCacheRestoreKeys[0], "retrieval cache producer key must match the draft exact-lock fallback");
+  add(violations, retrievalRestoreWith.key === retrievalCachePrimary, "retrieval cache producer key must match the draft exact-lock, manifest, feature, and proof-topology fallback");
+
+  const retrievalSeed = namedStep(retrievalJob, "Seed draft proof test-profile artifacts");
+  add(
+    violations,
+    hasExactKeys(retrievalSeed, ["name", "run"]),
+    "retrieval cache producer seed must keep its exact required step shape",
+  );
+  add(
+    violations,
+    sameStrings(nonCommentLines(retrievalSeed?.run), draftSeedCommands),
+    "retrieval cache producer must seed the exact five test-profile targets in serial order",
+  );
+
+  const retrievalSave = namedStep(retrievalJob, "Save Cargo registry, git sources, and build output");
+  const retrievalSaveWith = object(retrievalSave?.with);
+  add(
+    violations,
+    hasExactKeys(retrievalSave, ["name", "if", "uses", "continue-on-error", "with"]),
+    "retrieval cache producer save must keep its exact post-proof step shape",
+  );
+  add(violations, retrievalSave?.uses === "actions/cache/save@v5", "retrieval cache producer must use actions/cache/save@v5");
+  add(violations, retrievalSave?.["continue-on-error"] === true, "retrieval cache producer save must remain non-blocking");
+  add(violations, retrievalSave?.if === cacheSaveCondition, "retrieval cache producer must save only after every retrieval and seed proof succeeds");
+  add(
+    violations,
+    hasExactKeys(retrievalSaveWith, ["path", "key"]),
+    "retrieval cache producer save inputs must keep their exact key shape",
+  );
+  add(violations, sameStrings(nonCommentLines(retrievalSaveWith.path), draftCachePaths), "retrieval cache producer save must retain the proof-compatible path set");
+  add(violations, retrievalSaveWith.key === cacheSaveKey, "retrieval cache producer must save its exact primary rather than a matched key");
+  const retrievalSteps = list(retrievalJob.steps).map(object);
+  add(
+    violations,
+    retrievalSteps.indexOf(retrievalSeed) + 1 === retrievalSteps.indexOf(retrievalSave),
+    "retrieval cache producer must seed the exact proof targets immediately before saving",
+  );
 
   const save = namedStep(job, "Save Cargo inputs and output");
   const saveWith = object(save?.with);
@@ -328,11 +441,11 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   );
   add(
     violations,
-    save?.if === "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''",
+    save?.if === cacheSaveCondition,
     "draft source cache promotion must require complete proof and a partial or missing primary",
   );
   add(violations, sameStrings(nonCommentLines(saveWith.path), draftCachePaths), "draft source cache promotion must use the exact restore path set");
-  add(violations, saveWith.key === "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}", "draft source cache promotion must save the exact primary rather than a matched fallback");
+  add(violations, saveWith.key === cacheSaveKey, "draft source cache promotion must save the exact primary rather than a matched fallback");
 
   return violations;
 }
@@ -765,8 +878,12 @@ function validatePluginAndDraftWorkflows(workflows, violations) {
       "scripts/generate-codestory-skill-syntax.mjs",
     ]), `${rustFile} must cover workspace source and generated catalog changes`);
     const job = requireJob(violations, rustFile, rust, "linux-draft");
+    const retrievalWorkflow = workflows.get("retrieval-engine-smoke.yml");
+    for (const violation of retrievalProducerTriggerPolicyViolations(retrievalWorkflow)) {
+      violations.push(`retrieval-engine-smoke.yml ${violation}`);
+    }
     const retrievalJob = object(at(
-      workflows.get("retrieval-engine-smoke.yml"),
+      retrievalWorkflow,
       "jobs",
       "linux-contracts",
     ));

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -7,9 +7,12 @@ import { LineCounter, parseDocument } from "yaml";
 import { loadReleaseClaimGraph } from "../../scripts/codestory-release-claims.mjs";
 
 const workflowRoot = path.join(".github", "workflows");
+const retrievalFile = "retrieval-engine-smoke.yml";
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const trustedActionOwners = new Set(["actions", "github"]);
 const fullSha = /^[0-9a-f]{40}$/iu;
+
+export { retrievalFile };
 
 function object(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value) ? value : {};
@@ -878,9 +881,9 @@ function validatePluginAndDraftWorkflows(workflows, violations) {
       "scripts/generate-codestory-skill-syntax.mjs",
     ]), `${rustFile} must cover workspace source and generated catalog changes`);
     const job = requireJob(violations, rustFile, rust, "linux-draft");
-    const retrievalWorkflow = workflows.get("retrieval-engine-smoke.yml");
+    const retrievalWorkflow = workflows.get(retrievalFile);
     for (const violation of retrievalProducerTriggerPolicyViolations(retrievalWorkflow)) {
-      violations.push(`retrieval-engine-smoke.yml ${violation}`);
+      violations.push(`${retrievalFile} ${violation}`);
     }
     const retrievalJob = object(at(
       retrievalWorkflow,
@@ -1283,7 +1286,6 @@ function validateRemainingWorkflows(workflows, violations) {
     requireStepUses(violations, statsFile, job, "Upload repo-scale stats output", "actions/upload-artifact@v7.0.1");
   }
 
-  const retrievalFile = "retrieval-engine-smoke.yml";
   const retrieval = workflows.get(retrievalFile);
   if (!retrieval) {
     violations.push(`${retrievalFile} must exist`);

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -112,19 +112,39 @@ const draftCacheRestoreKeys = [
   "${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-",
   "${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-",
 ];
+const draftWorkflowPaths = [
+  "Cargo.lock",
+  "Cargo.toml",
+  "crates/**",
+  ".github/scripts/check-runtime-config-boundary.mjs",
+  ".github/scripts/install-linux-vulkan-build-deps.sh",
+  ".github/scripts/check-workflow-policy.mjs",
+  ".github/scripts/route-ci-proof.mjs",
+  ".github/workflows/rust-ci.yml",
+  ".github/workflows/source-proof.yml",
+  "plugins/codestory/generated-mcp-catalog.json",
+  "plugins/codestory/skills/codestory-grounding/**",
+  "scripts/generate-codestory-skill-syntax.mjs",
+];
 const draftStepSequence = [
-  { uses: "actions/checkout@v5" },
-  { name: "Install Rust stable" },
-  { name: "Install Linux Vulkan build dependencies" },
-  { name: "Capture Rust cache identity" },
-  { name: "Restore Cargo inputs and output" },
-  { name: "Check formatting" },
-  { name: "Check immutable runtime configuration boundary" },
-  { name: "Check the workspace" },
-  { name: "Check generated CodeStory syntax and MCP catalog" },
-  { name: "Lint workspace libraries" },
-  { name: "Prove focused publication contracts" },
-  { name: "Save Cargo inputs and output" },
+  { uses: "actions/checkout@v5", keys: ["uses"] },
+  { name: "Install Rust stable", keys: ["name", "run"] },
+  { name: "Install Linux Vulkan build dependencies", keys: ["name", "run"] },
+  { name: "Capture Rust cache identity", keys: ["name", "id", "shell", "run"] },
+  {
+    name: "Restore Cargo inputs and output",
+    keys: ["name", "id", "uses", "continue-on-error", "with"],
+  },
+  { name: "Check formatting", keys: ["name", "run"] },
+  { name: "Check immutable runtime configuration boundary", keys: ["name", "run"] },
+  { name: "Check the workspace", keys: ["name", "run"] },
+  { name: "Check generated CodeStory syntax and MCP catalog", keys: ["name", "run"] },
+  { name: "Lint workspace libraries", keys: ["name", "run"] },
+  { name: "Prove focused publication contracts", keys: ["name", "run"] },
+  {
+    name: "Save Cargo inputs and output",
+    keys: ["name", "if", "uses", "continue-on-error", "with"],
+  },
 ];
 const draftRunCommands = new Map([
   ["Install Rust stable", [
@@ -170,11 +190,64 @@ function sameStrings(actual, expected) {
   return JSON.stringify(actual) === JSON.stringify(expected);
 }
 
+function hasExactKeys(value, expected) {
+  return sameMembers(Object.keys(object(value)), expected);
+}
+
 export function draftWorkflowPolicyViolations(workflowValue) {
-  const jobs = Object.keys(object(object(workflowValue).jobs));
-  return sameStrings(jobs, ["linux-draft"])
-    ? []
-    : ["draft source workflow must contain exactly the linux-draft job"];
+  const violations = [];
+  const workflow = object(workflowValue);
+  const triggers = object(workflow.on);
+  const pullRequest = object(triggers.pull_request);
+  const permissions = object(workflow.permissions);
+  const concurrency = object(workflow.concurrency);
+  const jobs = object(workflow.jobs);
+
+  add(
+    violations,
+    hasExactKeys(workflow, ["name", "on", "permissions", "concurrency", "jobs"]),
+    "draft source workflow must keep its exact top-level policy shape",
+  );
+  add(
+    violations,
+    workflow.name === "Draft source checks",
+    "draft source workflow name must remain Draft source checks",
+  );
+  add(
+    violations,
+    hasExactKeys(triggers, ["pull_request", "workflow_dispatch"]),
+    "draft source workflow must use only pull_request and workflow_dispatch",
+  );
+  add(
+    violations,
+    hasExactKeys(pullRequest, ["paths"])
+      && list(pullRequest.paths).length === draftWorkflowPaths.length
+      && sameMembers(pullRequest.paths, draftWorkflowPaths),
+    "draft source pull_request trigger must keep the exact path set",
+  );
+  add(
+    violations,
+    triggers.workflow_dispatch === null,
+    "draft source workflow_dispatch trigger must remain input-free",
+  );
+  add(
+    violations,
+    hasExactKeys(permissions, ["contents"]) && permissions.contents === "read",
+    "draft source workflow permissions must remain contents: read only",
+  );
+  add(
+    violations,
+    hasExactKeys(concurrency, ["group", "cancel-in-progress"])
+      && concurrency.group === "rust-ci-${{ github.event.pull_request.number || github.ref }}"
+      && concurrency["cancel-in-progress"] === true,
+    "draft source workflow concurrency must keep its exact PR/ref cancellation contract",
+  );
+  add(
+    violations,
+    hasExactKeys(jobs, ["linux-draft"]),
+    "draft source workflow must contain exactly the linux-draft job",
+  );
+  return violations;
 }
 
 export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
@@ -183,6 +256,16 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   const retrievalJob = object(retrievalJobValue);
   const steps = list(job.steps).map(object);
 
+  add(
+    violations,
+    hasExactKeys(job, ["name", "runs-on", "timeout-minutes", "steps"]),
+    "draft source job must keep its exact required serial shape",
+  );
+  add(
+    violations,
+    job.name === "Ubuntu draft source checks",
+    "draft source job name must remain Ubuntu draft source checks",
+  );
   add(violations, job["runs-on"] === "ubuntu-latest", "draft source job must use ubuntu-latest");
   add(violations, job["timeout-minutes"] === 45, "draft source job timeout must remain 45 minutes");
   add(violations, job.env === undefined && job.defaults === undefined, "draft source job must not override the proof environment or defaults");
@@ -194,6 +277,11 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
       ? step?.uses === expected.uses
       : step?.name === expected.name;
     add(violations, matches, `draft source step ${index + 1} must remain ${expected.name ?? expected.uses}`);
+    add(
+      violations,
+      hasExactKeys(step, expected.keys),
+      `draft source step ${index + 1} must keep the exact ${expected.name ?? expected.uses} key shape`,
+    );
   }
 
   for (const [name, commands] of draftRunCommands) {
@@ -212,6 +300,11 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   add(violations, restore?.id === "cargo-cache-restore", "draft source cache restore must keep its stable step id");
   add(violations, restore?.uses === "actions/cache/restore@v5", "draft source cache restore must use actions/cache/restore@v5");
   add(violations, restore?.["continue-on-error"] === true && restore?.if === undefined, "draft source cache restore must remain optional without conditional bypasses");
+  add(
+    violations,
+    hasExactKeys(restoreWith, ["path", "key", "restore-keys"]),
+    "draft source cache restore inputs must keep their exact key shape",
+  );
   add(violations, sameStrings(nonCommentLines(restoreWith.path), draftCachePaths), "draft source cache restore must use only the Cargo registry, git, and default target paths");
   add(violations, restoreWith.key === draftCachePrimary, "draft source cache primary must bind the v2 platform, toolchain, feature, lock, and manifest identity");
   add(violations, sameStrings(nonCommentLines(restoreWith["restore-keys"]), draftCacheRestoreKeys), "draft source cache fallbacks must keep the exact retrieval, prior draft, then prior retrieval order");
@@ -228,6 +321,11 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   const saveWith = object(save?.with);
   add(violations, save?.uses === "actions/cache/save@v5", "draft source cache promotion must use actions/cache/save@v5");
   add(violations, save?.["continue-on-error"] === true, "draft source cache promotion must remain non-blocking");
+  add(
+    violations,
+    hasExactKeys(saveWith, ["path", "key"]),
+    "draft source cache promotion inputs must keep their exact key shape",
+  );
   add(
     violations,
     save?.if === "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   basicWorkflowViolations,
+  draftSourcePolicyViolations,
   loadWorkflows,
   macosCliDistributionViolations,
   managedPluginViolations,
@@ -18,6 +19,20 @@ import {
 
 const fullSha = "0123456789abcdef0123456789abcdef01234567";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function draftSourceJob() {
+  return structuredClone(loadWorkflows().get("rust-ci.yml").jobs["linux-draft"]);
+}
+
+function retrievalSourceJob() {
+  return structuredClone(loadWorkflows().get("retrieval-engine-smoke.yml").jobs["linux-contracts"]);
+}
+
+function draftStep(job, name) {
+  const matches = job.steps.filter(step => step.name === name);
+  assert.equal(matches.length, 1, `expected one ${name} step`);
+  return matches[0];
+}
 
 function managedJob() {
   return {
@@ -137,6 +152,119 @@ jobs:
 
   workflow.jobs.check.steps[0].run += "\ncargo check --workspace\n";
   assert.match(basicWorkflowViolations("fixture.yml", workflow).join("\n"), /must use --locked/u);
+});
+
+test("draft source cache reuse preserves exact serial proof structure", async (t) => {
+  assert.deepEqual(draftSourcePolicyViolations(draftSourceJob(), retrievalSourceJob()), []);
+
+  const mutations = [
+    ["unversioned primary", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      step.with.key = step.with.key.replace("-draft-v2-", "-draft-");
+    }],
+    ["lock-only primary", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      step.with.key = step.with.key.replace(
+        "hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml')",
+        "hashFiles('Cargo.lock')",
+      );
+    }],
+    ["fallback order reversal", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      step.with["restore-keys"] = step.with["restore-keys"].trim().split("\n").reverse().join("\n");
+    }],
+    ["overbroad draft fallback", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      const keys = step.with["restore-keys"].trim().split("\n");
+      keys[1] = "${{ runner.os }}-draft-v2-";
+      step.with["restore-keys"] = keys.join("\n");
+    }],
+    ["cross-platform fallback", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      step.with["restore-keys"] = step.with["restore-keys"].replace("${{ runner.os }}-cargo-stable-", "Windows-cargo-stable-");
+    }],
+    ["all-feature fallback", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      step.with["restore-keys"] = step.with["restore-keys"].replace("retrieval-contracts-default-features", "retrieval-contracts-all-features");
+    }],
+    ["source-proof fallback", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      step.with["restore-keys"] = step.with["restore-keys"].replace("retrieval-contracts-default-features", "source-proof-all-targets-all-features");
+    }],
+    ["different restore path", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      step.with.path = step.with.path.replace("target", "target/release");
+    }],
+    ["blocking restore", job => {
+      draftStep(job, "Restore Cargo inputs and output")["continue-on-error"] = false;
+    }],
+    ["matched-key save", job => {
+      draftStep(job, "Save Cargo inputs and output").with.key = "${{ steps.cargo-cache-restore.outputs.cache-matched-key }}";
+    }],
+    ["promotion before complete proof", job => {
+      draftStep(job, "Save Cargo inputs and output").if = "steps.cargo-cache-restore.outputs.cache-hit != 'true'";
+    }],
+    ["removed proof command", job => {
+      const step = draftStep(job, "Prove focused publication contracts");
+      step.run = step.run.trim().split("\n").slice(0, -1).join("\n");
+    }],
+    ["reordered proof commands", job => {
+      const step = draftStep(job, "Prove focused publication contracts");
+      const commands = step.run.trim().split("\n");
+      [commands[0], commands[1]] = [commands[1], commands[0]];
+      step.run = commands.join("\n");
+    }],
+    ["backgrounded Cargo command", job => {
+      const step = draftStep(job, "Check the workspace");
+      step.run = `${step.run} &`;
+    }],
+    ["parallel Cargo commands", job => {
+      const step = draftStep(job, "Check the workspace");
+      step.run = `${step.run} &\nwait`;
+    }],
+    ["reordered proof steps", job => {
+      const left = job.steps.findIndex(step => step.name === "Check the workspace");
+      const right = job.steps.findIndex(step => step.name === "Lint workspace libraries");
+      [job.steps[left], job.steps[right]] = [job.steps[right], job.steps[left]];
+    }],
+    ["optional proof step", job => {
+      draftStep(job, "Lint workspace libraries")["continue-on-error"] = true;
+    }],
+    ["decoy cache step", job => {
+      const restore = draftStep(job, "Restore Cargo inputs and output");
+      const decoy = structuredClone(restore);
+      decoy.name = "Decoy cache contract";
+      restore.with.key = "decoy-primary";
+      job.steps.push(decoy);
+    }],
+  ];
+
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const candidate = draftSourceJob();
+      mutate(candidate);
+      assert.notDeepEqual(draftSourcePolicyViolations(candidate, retrievalSourceJob()), []);
+    });
+  }
+
+  for (const [name, mutate] of [
+    ["incompatible retrieval path", job => {
+      draftStep(job, "Restore Cargo registry, git sources, and build output").with.path = "~/.cargo/registry\ntarget/retrieval\n";
+    }],
+    ["incompatible retrieval key", job => {
+      const step = draftStep(job, "Restore Cargo registry, git sources, and build output");
+      step.with.key = step.with.key.replace("retrieval-contracts-default-features", "retrieval-contracts-all-features");
+    }],
+    ["incompatible retrieval action", job => {
+      draftStep(job, "Restore Cargo registry, git sources, and build output").uses = "actions/cache/restore@v4";
+    }],
+  ]) {
+    await t.test(name, () => {
+      const candidate = retrievalSourceJob();
+      mutate(candidate);
+      assert.notDeepEqual(draftSourcePolicyViolations(draftSourceJob(), candidate), []);
+    });
+  }
 });
 
 test("managed proof rejects structural bypasses and decoy commands", () => {

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -451,6 +451,16 @@ test("Windows manifest-missing proof freezes routing, native topology, and exact
     ["CPU permission disabled", workflow => {
       windowsManifestJob(workflow).env.CODESTORY_EMBED_ALLOW_CPU = "0";
     }],
+    ["native generator removed", workflow => {
+      delete windowsManifestJob(workflow).env.CMAKE_GENERATOR;
+    }],
+    ["native generator changed to Visual Studio", workflow => {
+      windowsManifestJob(workflow).env.CMAKE_GENERATOR = "Visual Studio 18 2026";
+    }],
+    ["native generator moved to proof-step override", workflow => {
+      delete windowsManifestJob(workflow).env.CMAKE_GENERATOR;
+      proofStep(workflow).env = { CMAKE_GENERATOR: "Ninja" };
+    }],
     ["extra product feature environment", workflow => {
       windowsManifestJob(workflow).env.CARGO_FEATURES = "cpu-only";
     }],
@@ -476,9 +486,33 @@ test("Windows manifest-missing proof freezes routing, native topology, and exact
       const proof = job.steps.findIndex(step => step.name === "Prove Windows ready_command manifest-missing contract");
       [job.steps[installer], job.steps[proof]] = [job.steps[proof], job.steps[installer]];
     }],
+    ["CMake cache identity capture removed", workflow => {
+      const identity = windowsManifestStep(workflow, "Capture Rust cache identity");
+      identity.run = identity.run.replace(/.*cmake.*\n/gu, "");
+    }],
+    ["Ninja cache identity capture removed", workflow => {
+      const identity = windowsManifestStep(workflow, "Capture Rust cache identity");
+      identity.run = identity.run.replace(/.*ninja.*\n/gu, "");
+    }],
     ["unversioned proof topology", workflow => {
       keyStep(workflow).with.key = keyStep(workflow).with.key
-        .replace(/ready-command-v1-[0-9a-f]{64}/u, "ready-command");
+        .replace(/ready-command-v2-[0-9a-f]{64}/u, "ready-command");
+    }],
+    ["stale proof topology", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace("ready-command-v2-", "ready-command-v1-");
+    }],
+    ["generator-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace("-generator-ninja", "");
+    }],
+    ["CMake-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace("-cmake-${{ steps.rust-cache-key.outputs.cmake }}", "");
+    }],
+    ["Ninja-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace("-ninja-${{ steps.rust-cache-key.outputs.ninja }}", "");
     }],
     ["OS-free cache", workflow => {
       keyStep(workflow).with.key = keyStep(workflow).with.key.replace("${{ runner.os }}-", "");
@@ -562,6 +596,72 @@ test("Windows manifest-missing proof freezes routing, native topology, and exact
         validateWorkflows(workflows).join("\n"),
         expectedReason,
       );
+    });
+  }
+});
+
+test("Windows source package builds pin Ninja and bind native tool identity", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+
+  const packagedFile = "packaged-platform-proof.yml";
+  const protectedFile = "windows-vulkan-proof.yml";
+  const packagedIdentity = workflow => draftStep(workflow.jobs.build, "Capture Rust cache key");
+  const packagedCache = workflow => draftStep(
+    workflow.jobs.build,
+    "Restore Cargo registry, git sources, and build output",
+  );
+  const packagedBuild = workflow => draftStep(workflow.jobs.build, "Build codestory-cli");
+  const protectedBuild = workflow => draftStep(
+    workflow.jobs["packaged-vulkan"],
+    "Build and package native CLI",
+  );
+
+  const mutations = [
+    ["packaged CMake identity removed", packagedFile, workflow => {
+      packagedIdentity(workflow).run = packagedIdentity(workflow).run
+        .replace(/.*cmake --version.*\n/u, "");
+    }, /native build identity must include cmake/u],
+    ["packaged Ninja identity removed", packagedFile, workflow => {
+      packagedIdentity(workflow).run = packagedIdentity(workflow).run
+        .replace(/.*ninja --version.*\n/u, "");
+    }, /native build identity must include ninja/u],
+    ["packaged Ninja selection removed", packagedFile, workflow => {
+      packagedIdentity(workflow).run = packagedIdentity(workflow).run
+        .replace(/.*CMAKE_GENERATOR=Ninja.*\n/u, "");
+    }, /native build identity must include CMAKE_GENERATOR=Ninja/u],
+    ["packaged generator-free cache", packagedFile, workflow => {
+      packagedCache(workflow).with.key = packagedCache(workflow).with.key
+        .replace("-${{ steps.rust-cache-key.outputs.generator }}", "");
+    }, /native build cache must bind generator, CMake, Ninja/u],
+    ["packaged CMake-free cache", packagedFile, workflow => {
+      packagedCache(workflow).with.key = packagedCache(workflow).with.key
+        .replace("-cmake-${{ steps.rust-cache-key.outputs.cmake }}", "");
+    }, /native build cache must bind generator, CMake, Ninja/u],
+    ["packaged Ninja-free cache", packagedFile, workflow => {
+      packagedCache(workflow).with.key = packagedCache(workflow).with.key
+        .replace("-ninja-${{ steps.rust-cache-key.outputs.ninja }}", "");
+    }, /native build cache must bind generator, CMake, Ninja/u],
+    ["packaged build overrides generator", packagedFile, workflow => {
+      packagedBuild(workflow).env = { CMAKE_GENERATOR: "Visual Studio 18 2026" };
+    }, /native package build must not override the selected generator/u],
+    ["protected generator removed", protectedFile, workflow => {
+      delete protectedBuild(workflow).env.CMAKE_GENERATOR;
+    }, /source package build must use the Ninja native generator/u],
+    ["protected generator changed", protectedFile, workflow => {
+      protectedBuild(workflow).env.CMAKE_GENERATOR = "Visual Studio 18 2026";
+    }, /source package build must use the Ninja native generator/u],
+    ["protected build adds a second generator surface", protectedFile, workflow => {
+      protectedBuild(workflow).env.CMAKE_GENERATOR_PLATFORM = "x64";
+    }, /source package build must use the Ninja native generator/u],
+  ];
+
+  for (const [name, file, mutate, expectedReason] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expectedReason);
     });
   }
 });

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -273,6 +273,135 @@ test("draft source cache reuse preserves exact serial proof structure", async (t
   }
 });
 
+test("draft source workflow freezes its complete top-level contract", async (t) => {
+  assert.deepEqual(draftWorkflowPolicyViolations(draftSourceWorkflow()), []);
+  const reordered = draftSourceWorkflow();
+  [reordered.on.pull_request.paths[0], reordered.on.pull_request.paths[1]]
+    = [reordered.on.pull_request.paths[1], reordered.on.pull_request.paths[0]];
+  assert.deepEqual(
+    draftWorkflowPolicyViolations(reordered),
+    [],
+    "path membership is exact but order-insensitive",
+  );
+
+  const mutations = [
+    ["workflow name", workflow => { workflow.name = "Draft checks"; }],
+    ["missing pull request trigger", workflow => { delete workflow.on.pull_request; }],
+    ["extra push trigger", workflow => { workflow.on.push = { branches: ["main"] }; }],
+    ["missing path", workflow => { workflow.on.pull_request.paths.pop(); }],
+    ["duplicate path", workflow => {
+      workflow.on.pull_request.paths[1] = workflow.on.pull_request.paths[0];
+    }],
+    ["extra path", workflow => { workflow.on.pull_request.paths.push("scripts/**"); }],
+    ["dispatch inputs", workflow => {
+      workflow.on.workflow_dispatch = { inputs: { ref: { required: false, type: "string" } } };
+    }],
+    ["missing dispatch", workflow => { delete workflow.on.workflow_dispatch; }],
+    ["write permission", workflow => { workflow.permissions.contents = "write"; }],
+    ["extra permission", workflow => { workflow.permissions.actions = "read"; }],
+    ["concurrency group", workflow => { workflow.concurrency.group = "draft-${{ github.ref }}"; }],
+    ["disabled concurrency cancellation", workflow => {
+      workflow.concurrency["cancel-in-progress"] = false;
+    }],
+    ["extra concurrency field", workflow => { workflow.concurrency.limit = 1; }],
+    ["top-level env", workflow => { workflow.env = { CARGO_TERM_COLOR: "always" }; }],
+    ["top-level defaults", workflow => {
+      workflow.defaults = { run: { shell: "bash" } };
+    }],
+    ["missing jobs", workflow => { delete workflow.jobs; }],
+    ["cloned job", workflow => {
+      workflow.jobs["extra-draft-lane"] = structuredClone(workflow.jobs["linux-draft"]);
+    }],
+  ];
+
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const candidate = draftSourceWorkflow();
+      mutate(candidate);
+      assert.notDeepEqual(draftWorkflowPolicyViolations(candidate), []);
+    });
+  }
+});
+
+test("draft source job rejects every alternate execution surface", async (t) => {
+  assert.deepEqual(draftSourcePolicyViolations(draftSourceJob(), retrievalSourceJob()), []);
+
+  const mutations = [
+    ["job name", job => { job.name = "Draft source"; }],
+    ["runner", job => { job["runs-on"] = "ubuntu-24.04"; }],
+    ["timeout", job => { job["timeout-minutes"] = 60; }],
+    ["if", job => { job.if = "always()"; }],
+    ["needs", job => { job.needs = ["untrusted"]; }],
+    ["permissions", job => { job.permissions = { contents: "write" }; }],
+    ["continue-on-error", job => { job["continue-on-error"] = true; }],
+    ["strategy", job => { job.strategy = { matrix: { shard: [1, 2] } }; }],
+    ["env", job => { job.env = { RUSTFLAGS: "-Awarnings" }; }],
+    ["defaults", job => { job.defaults = { run: { shell: "bash" } }; }],
+    ["environment", job => { job.environment = "release"; }],
+    ["container", job => { job.container = "ubuntu:latest"; }],
+    ["services", job => { job.services = { cache: { image: "redis" } }; }],
+    ["outputs", job => { job.outputs = { result: "${{ steps.proof.outputs.result }}" }; }],
+  ];
+
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const candidate = draftSourceJob();
+      mutate(candidate);
+      assert.notDeepEqual(draftSourcePolicyViolations(candidate, retrievalSourceJob()), []);
+    });
+  }
+});
+
+test("draft source steps reject checkout and proof bypass mutations", async (t) => {
+  const checkout = job => job.steps[0];
+  const proof = job => draftStep(job, "Prove focused publication contracts");
+  const mutations = [
+    ["checkout ref", job => { checkout(job).with = { ref: "refs/heads/main" }; }],
+    ["checkout persisted credentials", job => {
+      checkout(job).with = { "persist-credentials": true };
+    }],
+    ["checkout if", job => { checkout(job).if = "always()"; }],
+    ["checkout continue-on-error", job => { checkout(job)["continue-on-error"] = true; }],
+    ["checkout env", job => { checkout(job).env = { GH_TOKEN: "token" }; }],
+    ["checkout id", job => { checkout(job).id = "checkout"; }],
+    ["checkout action", job => { checkout(job).uses = "actions/checkout@v4"; }],
+    ["cloned step", job => { job.steps.push(structuredClone(checkout(job))); }],
+    ["deleted step", job => { job.steps.splice(5, 1); }],
+    ["reordered steps", job => {
+      [job.steps[5], job.steps[6]] = [job.steps[6], job.steps[5]];
+    }],
+    ["run step shell", job => { draftStep(job, "Check formatting").shell = "bash"; }],
+    ["restore extra input", job => {
+      draftStep(job, "Restore Cargo inputs and output").with["fail-on-cache-miss"] = false;
+    }],
+    ["save extra input", job => {
+      draftStep(job, "Save Cargo inputs and output").with["restore-keys"] = "decoy";
+    }],
+    ["proof if", job => { proof(job).if = "always()"; }],
+    ["proof continue-on-error", job => { proof(job)["continue-on-error"] = true; }],
+    ["proof env", job => { proof(job).env = { RUST_BACKTRACE: "1" }; }],
+    ["native staging proof removed", job => {
+      proof(job).run = proof(job).run
+        .split("\n")
+        .filter(command => !command.includes("--test native_staging"))
+        .join("\n");
+    }],
+    ["native staging proof reordered", job => {
+      const commands = proof(job).run.trim().split("\n");
+      [commands[0], commands[1]] = [commands[1], commands[0]];
+      proof(job).run = commands.join("\n");
+    }],
+  ];
+
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const candidate = draftSourceJob();
+      mutate(candidate);
+      assert.notDeepEqual(draftSourcePolicyViolations(candidate, retrievalSourceJob()), []);
+    });
+  }
+});
+
 test("draft source workflow rejects cloned top-level jobs", () => {
   const workflows = loadWorkflows();
   const workflow = draftSourceWorkflow();

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -16,6 +16,7 @@ import {
   releaseEvidenceApprovalViolations,
   releaseEvidenceWorkflowRef,
   releaseWorkflowContractViolations,
+  retrievalFile,
   retrievalProducerTriggerPolicyViolations,
   validateWorkflows,
 } from "./check-workflow-policy.mjs";
@@ -34,11 +35,11 @@ function draftSourceWorkflow() {
 }
 
 function retrievalSourceJob() {
-  return structuredClone(loadWorkflows().get("retrieval-engine-smoke.yml").jobs["linux-contracts"]);
+  return structuredClone(loadWorkflows().get(retrievalFile).jobs["linux-contracts"]);
 }
 
 function retrievalSourceWorkflow() {
-  return structuredClone(loadWorkflows().get("retrieval-engine-smoke.yml"));
+  return structuredClone(loadWorkflows().get(retrievalFile));
 }
 
 function draftStep(job, name) {
@@ -351,7 +352,7 @@ test("retrieval cache producer triggers cover every draft manifest consumer", as
           .filter(triggerPath => triggerPath !== requiredPath);
         assert.notDeepEqual(retrievalProducerTriggerPolicyViolations(candidate), []);
         const workflows = loadWorkflows();
-        workflows.set("retrieval-engine-smoke.yml", candidate);
+        workflows.set(retrievalFile, candidate);
         assert.match(
           validateWorkflows(workflows).join("\n"),
           /retrieval cache producer .* paths must cover/u,
@@ -366,7 +367,7 @@ test("retrieval cache producer triggers cover every draft manifest consumer", as
       .filter(branch => branch !== "dev/codestory-next");
     assert.notDeepEqual(retrievalProducerTriggerPolicyViolations(candidate), []);
     const workflows = loadWorkflows();
-    workflows.set("retrieval-engine-smoke.yml", candidate);
+    workflows.set(retrievalFile, candidate);
     assert.match(
       validateWorkflows(workflows).join("\n"),
       /retrieval cache producer must run on dev\/codestory-next pushes/u,

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -19,6 +19,7 @@ import {
   retrievalFile,
   retrievalProducerTriggerPolicyViolations,
   validateWorkflows,
+  windowsManifestProofPolicyViolations,
 } from "./check-workflow-policy.mjs";
 
 const fullSha = "0123456789abcdef0123456789abcdef01234567";
@@ -42,10 +43,22 @@ function retrievalSourceWorkflow() {
   return structuredClone(loadWorkflows().get(retrievalFile));
 }
 
+function windowsManifestWorkflow() {
+  return retrievalSourceWorkflow();
+}
+
 function draftStep(job, name) {
   const matches = job.steps.filter(step => step.name === name);
   assert.equal(matches.length, 1, `expected one ${name} step`);
   return matches[0];
+}
+
+function windowsManifestJob(workflow) {
+  return workflow.jobs["windows-manifest-missing"];
+}
+
+function windowsManifestStep(workflow, name) {
+  return draftStep(windowsManifestJob(workflow), name);
 }
 
 function managedJob() {
@@ -373,6 +386,184 @@ test("retrieval cache producer triggers cover every draft manifest consumer", as
       /retrieval cache producer must run on dev\/codestory-next pushes/u,
     );
   });
+});
+
+test("Windows manifest-missing proof freezes routing, native topology, and exact cache identity", async (t) => {
+  assert.deepEqual(windowsManifestProofPolicyViolations(windowsManifestWorkflow()), []);
+
+  const keyStep = workflow => windowsManifestStep(
+    workflow,
+    "Restore Windows Cargo inputs and output",
+  );
+  const proofStep = workflow => windowsManifestStep(
+    workflow,
+    "Prove Windows ready_command manifest-missing contract",
+  );
+  const saveStep = workflow => windowsManifestStep(
+    workflow,
+    "Save Windows Cargo inputs and output",
+  );
+  const installerHash = "${{ hashFiles('.github/scripts/install-windows-vulkan-sdk.ps1') }}";
+  const lockHash = "${{ hashFiles('Cargo.lock') }}";
+
+  const mutations = [
+    ["cloned Windows job routed on pull requests", workflow => {
+      const clone = structuredClone(windowsManifestJob(workflow));
+      clone.if = "github.event_name == 'pull_request'";
+      clone["continue-on-error"] = true;
+      workflow.jobs["windows-manifest-decoy"] = clone;
+    }, /must contain exactly linux-contracts and windows-manifest-missing jobs/u],
+    ["top-level build target", workflow => {
+      workflow.env = { CARGO_BUILD_TARGET: "x86_64-pc-windows-gnu" };
+    }, /must not define top-level env/u],
+    ["top-level shell default", workflow => {
+      workflow.defaults = { run: { shell: "bash" } };
+    }, /must not define top-level defaults/u],
+    ["top-level working-directory default", workflow => {
+      workflow.defaults = { run: { "working-directory": "crates/codestory-cli" } };
+    }, /must not define top-level defaults/u],
+    ["pull request omits installer", workflow => {
+      workflow.on.pull_request.paths = workflow.on.pull_request.paths
+        .filter(triggerPath => triggerPath !== ".github/scripts/install-windows-vulkan-sdk.ps1");
+    }],
+    ["push omits installer", workflow => {
+      workflow.on.push.paths = workflow.on.push.paths
+        .filter(triggerPath => triggerPath !== ".github/scripts/install-windows-vulkan-sdk.ps1");
+    }],
+    ["dispatch inputs", workflow => {
+      workflow.on.workflow_dispatch = { inputs: { ref: { required: false, type: "string" } } };
+    }],
+    ["pull-request job routing", workflow => {
+      windowsManifestJob(workflow).if = "github.event_name == 'pull_request'";
+    }],
+    ["label routing", workflow => {
+      windowsManifestJob(workflow).if = "contains(github.event.pull_request.labels.*.name, 'proof')";
+    }],
+    ["older runner", workflow => {
+      windowsManifestJob(workflow)["runs-on"] = "windows-2022";
+    }],
+    ["longer timeout", workflow => {
+      windowsManifestJob(workflow)["timeout-minutes"] = 60;
+    }],
+    ["CPU permission removed", workflow => {
+      delete windowsManifestJob(workflow).env.CODESTORY_EMBED_ALLOW_CPU;
+    }],
+    ["CPU permission disabled", workflow => {
+      windowsManifestJob(workflow).env.CODESTORY_EMBED_ALLOW_CPU = "0";
+    }],
+    ["extra product feature environment", workflow => {
+      windowsManifestJob(workflow).env.CARGO_FEATURES = "cpu-only";
+    }],
+    ["job made optional", workflow => {
+      windowsManifestJob(workflow)["continue-on-error"] = true;
+    }],
+    ["checkout alternate ref", workflow => {
+      windowsManifestJob(workflow).steps[0].with = { ref: "main" };
+    }],
+    ["installer removed", workflow => {
+      windowsManifestJob(workflow).steps = windowsManifestJob(workflow).steps
+        .filter(step => step.name !== "Install checksum-pinned Windows Vulkan SDK");
+    }],
+    ["installer replaced", workflow => {
+      windowsManifestStep(workflow, "Install checksum-pinned Windows Vulkan SDK").run = "choco install vulkan-sdk";
+    }],
+    ["installer made optional", workflow => {
+      windowsManifestStep(workflow, "Install checksum-pinned Windows Vulkan SDK")["continue-on-error"] = true;
+    }],
+    ["installer moved after proof", workflow => {
+      const job = windowsManifestJob(workflow);
+      const installer = job.steps.findIndex(step => step.name === "Install checksum-pinned Windows Vulkan SDK");
+      const proof = job.steps.findIndex(step => step.name === "Prove Windows ready_command manifest-missing contract");
+      [job.steps[installer], job.steps[proof]] = [job.steps[proof], job.steps[installer]];
+    }],
+    ["unversioned proof topology", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace(/ready-command-v1-[0-9a-f]{64}/u, "ready-command");
+    }],
+    ["OS-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key.replace("${{ runner.os }}-", "");
+    }],
+    ["Rust-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace("-${{ steps.rust-cache-key.outputs.version }}", "");
+    }],
+    ["target-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace("-${{ steps.rust-cache-key.outputs.target }}", "");
+    }],
+    ["all-feature cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace("-default-features-", "-all-features-");
+    }],
+    ["manifest-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key
+        .replace(`${cacheManifestIdentity}-`, "");
+    }],
+    ["installer-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key.replace(`${installerHash}-`, "");
+    }],
+    ["lock-free cache", workflow => {
+      keyStep(workflow).with.key = keyStep(workflow).with.key.replace(lockHash, "unlocked");
+    }],
+    ["fallback cache prefix", workflow => {
+      keyStep(workflow).with["restore-keys"] = "Windows-cargo-stable-";
+    }],
+    ["alternate cache output", workflow => {
+      keyStep(workflow).with.path = "target/windows";
+    }],
+    ["cache restore bypass", workflow => {
+      keyStep(workflow).if = "always()";
+    }],
+    ["unlocked proof", workflow => {
+      proofStep(workflow).run = proofStep(workflow).run.replace(" --locked", "");
+    }],
+    ["supplied-binary substitute", workflow => {
+      proofStep(workflow).run = "cargo test --locked -p codestory-cli --test ready_command --features supplied-binary";
+    }],
+    ["proof made optional", workflow => {
+      proofStep(workflow)["continue-on-error"] = true;
+    }],
+    ["save before proof", workflow => {
+      const job = windowsManifestJob(workflow);
+      const proof = job.steps.findIndex(step => step.name === "Prove Windows ready_command manifest-missing contract");
+      const save = job.steps.findIndex(step => step.name === "Save Windows Cargo inputs and output");
+      [job.steps[proof], job.steps[save]] = [job.steps[save], job.steps[proof]];
+    }],
+    ["save after failed proof", workflow => {
+      saveStep(workflow).if = "steps.cargo-cache-restore.outputs.cache-hit != 'true'";
+    }],
+    ["save exact hit", workflow => {
+      saveStep(workflow).if = "success()";
+    }],
+    ["save matched key", workflow => {
+      saveStep(workflow).with.key = "${{ steps.cargo-cache-restore.outputs.cache-matched-key }}";
+    }],
+    ["save fallback input", workflow => {
+      saveStep(workflow).with["restore-keys"] = "Windows-cargo-stable-";
+    }],
+    ["decoy proof", workflow => {
+      const decoy = structuredClone(proofStep(workflow));
+      proofStep(workflow).run = "Write-Output skipped";
+      decoy.name = "Decoy ready_command proof";
+      windowsManifestJob(workflow).steps.push(decoy);
+    }],
+  ];
+
+  for (const [name, mutate, expectedReason = /Windows manifest proof/u] of mutations) {
+    await t.test(name, () => {
+      const candidate = windowsManifestWorkflow();
+      mutate(candidate);
+      const violations = windowsManifestProofPolicyViolations(candidate);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expectedReason);
+      const workflows = loadWorkflows();
+      workflows.set(retrievalFile, candidate);
+      assert.match(
+        validateWorkflows(workflows).join("\n"),
+        expectedReason,
+      );
+    });
+  }
 });
 
 test("draft source workflow freezes its complete top-level contract", async (t) => {

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -16,10 +16,13 @@ import {
   releaseEvidenceApprovalViolations,
   releaseEvidenceWorkflowRef,
   releaseWorkflowContractViolations,
+  retrievalProducerTriggerPolicyViolations,
   validateWorkflows,
 } from "./check-workflow-policy.mjs";
 
 const fullSha = "0123456789abcdef0123456789abcdef01234567";
+const proofTopology = "proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5";
+const cacheManifestIdentity = "${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 function draftSourceJob() {
@@ -32,6 +35,10 @@ function draftSourceWorkflow() {
 
 function retrievalSourceJob() {
   return structuredClone(loadWorkflows().get("retrieval-engine-smoke.yml").jobs["linux-contracts"]);
+}
+
+function retrievalSourceWorkflow() {
+  return structuredClone(loadWorkflows().get("retrieval-engine-smoke.yml"));
 }
 
 function draftStep(job, name) {
@@ -170,10 +177,11 @@ test("draft source cache reuse preserves exact serial proof structure", async (t
     }],
     ["lock-only primary", job => {
       const step = draftStep(job, "Restore Cargo inputs and output");
-      step.with.key = step.with.key.replace(
-        "hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml')",
-        "hashFiles('Cargo.lock')",
-      );
+      step.with.key = step.with.key.replace(`${cacheManifestIdentity}-`, "");
+    }],
+    ["mismatched proof topology", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      step.with.key = step.with.key.replace(proofTopology, proofTopology.replace("-v1-", "-v2-"));
     }],
     ["fallback order reversal", job => {
       const step = draftStep(job, "Restore Cargo inputs and output");
@@ -191,11 +199,23 @@ test("draft source cache reuse preserves exact serial proof structure", async (t
     }],
     ["all-feature fallback", job => {
       const step = draftStep(job, "Restore Cargo inputs and output");
-      step.with["restore-keys"] = step.with["restore-keys"].replace("retrieval-contracts-default-features", "retrieval-contracts-all-features");
+      step.with["restore-keys"] = step.with["restore-keys"].replace("-default-features-", "-all-features-");
     }],
     ["source-proof fallback", job => {
       const step = draftStep(job, "Restore Cargo inputs and output");
-      step.with["restore-keys"] = step.with["restore-keys"].replace("retrieval-contracts-default-features", "source-proof-all-targets-all-features");
+      step.with["restore-keys"] = step.with["restore-keys"].replace("-retrieval-contracts-", "-source-proof-");
+    }],
+    ["manifest-free prior retrieval fallback", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      const keys = step.with["restore-keys"].trim().split("\n");
+      keys[2] = keys[2].replace(`${cacheManifestIdentity}-`, "");
+      step.with["restore-keys"] = keys.join("\n");
+    }],
+    ["target-free prior draft fallback", job => {
+      const step = draftStep(job, "Restore Cargo inputs and output");
+      const keys = step.with["restore-keys"].trim().split("\n");
+      keys[1] = keys[1].replace("-${{ steps.rust-cache-key.outputs.target }}-", "-");
+      step.with["restore-keys"] = keys.join("\n");
     }],
     ["different restore path", job => {
       const step = draftStep(job, "Restore Cargo inputs and output");
@@ -259,10 +279,43 @@ test("draft source cache reuse preserves exact serial proof structure", async (t
     }],
     ["incompatible retrieval key", job => {
       const step = draftStep(job, "Restore Cargo registry, git sources, and build output");
-      step.with.key = step.with.key.replace("retrieval-contracts-default-features", "retrieval-contracts-all-features");
+      step.with.key = step.with.key.replace("-default-features-", "-all-features-");
+    }],
+    ["mismatched retrieval topology version", job => {
+      const step = draftStep(job, "Restore Cargo registry, git sources, and build output");
+      step.with.key = step.with.key.replace(proofTopology, proofTopology.replace("-v1-", "-v2-"));
+    }],
+    ["manifest-free retrieval key", job => {
+      const step = draftStep(job, "Restore Cargo registry, git sources, and build output");
+      step.with.key = step.with.key.replace(`${cacheManifestIdentity}-`, "");
     }],
     ["incompatible retrieval action", job => {
       draftStep(job, "Restore Cargo registry, git sources, and build output").uses = "actions/cache/restore@v4";
+    }],
+    ["omitted seed target", job => {
+      const step = draftStep(job, "Seed draft proof test-profile artifacts");
+      step.run = step.run.trim().split("\n").slice(1).join("\n");
+    }],
+    ["reordered seed targets", job => {
+      const step = draftStep(job, "Seed draft proof test-profile artifacts");
+      const commands = step.run.trim().split("\n");
+      [commands[0], commands[1]] = [commands[1], commands[0]];
+      step.run = commands.join("\n");
+    }],
+    ["executable seed target", job => {
+      const step = draftStep(job, "Seed draft proof test-profile artifacts");
+      step.run = step.run.replace(" --no-run", "");
+    }],
+    ["optional seed step", job => {
+      draftStep(job, "Seed draft proof test-profile artifacts")["continue-on-error"] = true;
+    }],
+    ["save before seed", job => {
+      const seed = job.steps.findIndex(step => step.name === "Seed draft proof test-profile artifacts");
+      const save = job.steps.findIndex(step => step.name === "Save Cargo registry, git sources, and build output");
+      [job.steps[seed], job.steps[save]] = [job.steps[save], job.steps[seed]];
+    }],
+    ["producer matched-key save", job => {
+      draftStep(job, "Save Cargo registry, git sources, and build output").with.key = "${{ steps.cargo-cache-restore.outputs.cache-matched-key }}";
     }],
   ]) {
     await t.test(name, () => {
@@ -271,6 +324,54 @@ test("draft source cache reuse preserves exact serial proof structure", async (t
       assert.notDeepEqual(draftSourcePolicyViolations(draftSourceJob(), candidate), []);
     });
   }
+});
+
+test("retrieval cache producer triggers cover every draft manifest consumer", async (t) => {
+  assert.deepEqual(retrievalProducerTriggerPolicyViolations(retrievalSourceWorkflow()), []);
+
+  const reordered = retrievalSourceWorkflow();
+  reordered.on.pull_request.paths.reverse();
+  reordered.on.push.paths.reverse();
+  assert.deepEqual(
+    retrievalProducerTriggerPolicyViolations(reordered),
+    [],
+    "required trigger membership is order-insensitive",
+  );
+
+  const requiredPaths = [
+    "crates/**/Cargo.toml",
+    "vendor/**/Cargo.toml",
+    ".github/workflows/rust-ci.yml",
+  ];
+  for (const event of ["pull_request", "push"]) {
+    for (const requiredPath of requiredPaths) {
+      await t.test(`${event} rejects removal of ${requiredPath}`, () => {
+        const candidate = retrievalSourceWorkflow();
+        candidate.on[event].paths = candidate.on[event].paths
+          .filter(triggerPath => triggerPath !== requiredPath);
+        assert.notDeepEqual(retrievalProducerTriggerPolicyViolations(candidate), []);
+        const workflows = loadWorkflows();
+        workflows.set("retrieval-engine-smoke.yml", candidate);
+        assert.match(
+          validateWorkflows(workflows).join("\n"),
+          /retrieval cache producer .* paths must cover/u,
+        );
+      });
+    }
+  }
+
+  await t.test("push must retain the dev branch", () => {
+    const candidate = retrievalSourceWorkflow();
+    candidate.on.push.branches = candidate.on.push.branches
+      .filter(branch => branch !== "dev/codestory-next");
+    assert.notDeepEqual(retrievalProducerTriggerPolicyViolations(candidate), []);
+    const workflows = loadWorkflows();
+    workflows.set("retrieval-engine-smoke.yml", candidate);
+    assert.match(
+      validateWorkflows(workflows).join("\n"),
+      /retrieval cache producer must run on dev\/codestory-next pushes/u,
+    );
+  });
 });
 
 test("draft source workflow freezes its complete top-level contract", async (t) => {

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -611,6 +611,10 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     "Restore Cargo registry, git sources, and build output",
   );
   const packagedBuild = workflow => draftStep(workflow.jobs.build, "Build codestory-cli");
+  const protectedSourceTools = workflow => draftStep(
+    workflow.jobs["packaged-vulkan"],
+    "Capture source build tool evidence",
+  );
   const protectedBuild = workflow => draftStep(
     workflow.jobs["packaged-vulkan"],
     "Build and package native CLI",
@@ -629,6 +633,22 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
       packagedIdentity(workflow).run = packagedIdentity(workflow).run
         .replace(/.*CMAKE_GENERATOR=Ninja.*\n/u, "");
     }, /native build identity must include CMAKE_GENERATOR=Ninja/u],
+    ["packaged identity made conditional", packagedFile, workflow => {
+      packagedIdentity(workflow).if = "runner.os != 'Windows'";
+    }, /native build identity must be unique, unconditional/u],
+    ["packaged identity made optional", packagedFile, workflow => {
+      packagedIdentity(workflow)["continue-on-error"] = true;
+    }, /native build identity must be unique, unconditional/u],
+    ["packaged identity cloned", packagedFile, workflow => {
+      workflow.jobs.build.steps.push(structuredClone(packagedIdentity(workflow)));
+    }, /native build identity must be unique, unconditional/u],
+    ["packaged identity moved after build", packagedFile, workflow => {
+      const steps = workflow.jobs.build.steps;
+      const identityIndex = steps.findIndex(step => step.name === "Capture Rust cache key");
+      const [identity] = steps.splice(identityIndex, 1);
+      const buildIndex = steps.findIndex(step => step.name === "Build codestory-cli");
+      steps.splice(buildIndex + 1, 0, identity);
+    }, /native build identity must run immediately after Rust selection/u],
     ["packaged generator-free cache", packagedFile, workflow => {
       packagedCache(workflow).with.key = packagedCache(workflow).with.key
         .replace("-${{ steps.rust-cache-key.outputs.generator }}", "");
@@ -653,6 +673,27 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     ["protected build adds a second generator surface", protectedFile, workflow => {
       protectedBuild(workflow).env.CMAKE_GENERATOR_PLATFORM = "x64";
     }, /source package build must use the Ninja native generator/u],
+    ["protected host omits generator selection", protectedFile, workflow => {
+      protectedSourceTools(workflow).run = protectedSourceTools(workflow).run
+        .replace(/.*CMAKE_GENERATOR=Ninja.*\n/u, "");
+    }, /Capture source build tool evidence/u],
+    ["protected host omits CMake version", protectedFile, workflow => {
+      protectedSourceTools(workflow).run = protectedSourceTools(workflow).run
+        .replace(/.*cmake --version.*\n/u, "");
+    }, /Capture source build tool evidence/u],
+    ["protected host omits Ninja version", protectedFile, workflow => {
+      protectedSourceTools(workflow).run = protectedSourceTools(workflow).run
+        .replace(/.*ninja --version.*\n/u, "");
+    }, /Capture source build tool evidence/u],
+    ["protected source evidence made unconditional", protectedFile, workflow => {
+      delete protectedSourceTools(workflow).if;
+    }, /source build tool evidence must remain source-only/u],
+    ["protected source evidence guard inverted", protectedFile, workflow => {
+      protectedSourceTools(workflow).if = "inputs.use_packaged_cli_artifact";
+    }, /source build tool evidence must remain source-only/u],
+    ["protected source evidence made optional", protectedFile, workflow => {
+      protectedSourceTools(workflow)["continue-on-error"] = true;
+    }, /source build tool evidence must remain source-only/u],
   ];
 
   for (const [name, file, mutate, expectedReason] of mutations) {

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   basicWorkflowViolations,
   draftSourcePolicyViolations,
+  draftWorkflowPolicyViolations,
   loadWorkflows,
   macosCliDistributionViolations,
   managedPluginViolations,
@@ -15,6 +16,7 @@ import {
   releaseEvidenceApprovalViolations,
   releaseEvidenceWorkflowRef,
   releaseWorkflowContractViolations,
+  validateWorkflows,
 } from "./check-workflow-policy.mjs";
 
 const fullSha = "0123456789abcdef0123456789abcdef01234567";
@@ -22,6 +24,10 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
 
 function draftSourceJob() {
   return structuredClone(loadWorkflows().get("rust-ci.yml").jobs["linux-draft"]);
+}
+
+function draftSourceWorkflow() {
+  return structuredClone(loadWorkflows().get("rust-ci.yml"));
 }
 
 function retrievalSourceJob() {
@@ -265,6 +271,19 @@ test("draft source cache reuse preserves exact serial proof structure", async (t
       assert.notDeepEqual(draftSourcePolicyViolations(draftSourceJob(), candidate), []);
     });
   }
+});
+
+test("draft source workflow rejects cloned top-level jobs", () => {
+  const workflows = loadWorkflows();
+  const workflow = draftSourceWorkflow();
+  assert.deepEqual(draftWorkflowPolicyViolations(workflow), []);
+
+  workflow.jobs["extra-draft-lane"] = structuredClone(workflow.jobs["linux-draft"]);
+  workflows.set("rust-ci.yml", workflow);
+  assert.match(
+    validateWorkflows(workflows).join("\n"),
+    /must contain exactly the linux-draft job/u,
+  );
 });
 
 test("managed proof rejects structural bypasses and decoy commands", () => {

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -90,6 +90,15 @@ jobs:
         shell: bash
         run: |
           echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "cmake=$(cmake --version | sed -n 's/^cmake version //p')" >> "$GITHUB_OUTPUT"
+          if [ "$RUNNER_OS" = Windows ]; then
+            echo "generator=ninja" >> "$GITHUB_OUTPUT"
+            echo "ninja=$(ninja --version)" >> "$GITHUB_OUTPUT"
+            echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+          else
+            echo "generator=platform-default" >> "$GITHUB_OUTPUT"
+            echo "ninja=not-applicable" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
@@ -100,7 +109,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-default-features-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-native-v2-${{ steps.rust-cache-key.outputs.generator }}-cmake-${{ steps.rust-cache-key.outputs.cmake }}-ninja-${{ steps.rust-cache-key.outputs.ninja }}-default-features-${{ hashFiles('Cargo.lock') }}
 
       - name: Prepare checksum-pinned embedded model
         run: node scripts/prepare-embedded-model.mjs

--- a/.github/workflows/retrieval-engine-smoke.yml
+++ b/.github/workflows/retrieval-engine-smoke.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - Cargo.toml
       - Cargo.lock
+      - crates/**/Cargo.toml
+      - vendor/**/Cargo.toml
       - crates/codestory-llama-sys/**
       - crates/codestory-retrieval/src/embeddings.rs
       - crates/codestory-retrieval/src/health.rs
@@ -20,6 +22,7 @@ on:
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/install-linux-vulkan-build-deps.sh
       - .github/workflows/retrieval-engine-smoke.yml
+      - .github/workflows/rust-ci.yml
       - scripts/prepare-embedded-model.mjs
       - docs/contributors/testing-matrix.md
       - docs/ops/retrieval-engine.md
@@ -32,6 +35,8 @@ on:
     paths:
       - Cargo.toml
       - Cargo.lock
+      - crates/**/Cargo.toml
+      - vendor/**/Cargo.toml
       - crates/codestory-llama-sys/**
       - crates/codestory-retrieval/src/embeddings.rs
       - crates/codestory-retrieval/src/health.rs
@@ -43,6 +48,7 @@ on:
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/install-linux-vulkan-build-deps.sh
       - .github/workflows/retrieval-engine-smoke.yml
+      - .github/workflows/rust-ci.yml
       - scripts/prepare-embedded-model.mjs
       - docs/contributors/testing-matrix.md
       - docs/ops/retrieval-engine.md
@@ -97,7 +103,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Generalization lint regression contracts
         run: cargo test --locked -p codestory-runtime --test retrieval_generalization_guard
@@ -122,6 +128,14 @@ jobs:
 
       - name: Retrieval crate unit tests
         run: cargo test --locked -p codestory-retrieval
+
+      - name: Seed draft proof test-profile artifacts
+        run: |
+          cargo test --locked -p codestory-llama-sys --test native_staging --no-run
+          cargo test --locked -p codestory-llama-sys --test model_staging --no-run
+          cargo test --locked -p codestory-cli --test stdio_protocol_contracts --no-run two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture
+          cargo test --locked -p codestory-runtime --no-run publication_transitions_fail_or_cancel_atomically -- --nocapture
+          cargo test --locked -p codestory-store --no-run staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture
 
       - name: Save Cargo registry, git sources, and build output
         if: success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''

--- a/.github/workflows/retrieval-engine-smoke.yml
+++ b/.github/workflows/retrieval-engine-smoke.yml
@@ -21,6 +21,7 @@ on:
       - crates/codestory-cli/src/stdio_transport.rs
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/install-linux-vulkan-build-deps.sh
+      - .github/scripts/install-windows-vulkan-sdk.ps1
       - .github/workflows/retrieval-engine-smoke.yml
       - .github/workflows/rust-ci.yml
       - scripts/prepare-embedded-model.mjs
@@ -47,6 +48,7 @@ on:
       - crates/codestory-cli/src/stdio_transport.rs
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/install-linux-vulkan-build-deps.sh
+      - .github/scripts/install-windows-vulkan-sdk.ps1
       - .github/workflows/retrieval-engine-smoke.yml
       - .github/workflows/rust-ci.yml
       - scripts/prepare-embedded-model.mjs
@@ -158,19 +160,25 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust stable
+        shell: pwsh
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - name: Capture Rust cache key
+      - name: Install checksum-pinned Windows Vulkan SDK
+        shell: pwsh
+        run: .github/scripts/install-windows-vulkan-sdk.ps1
+
+      - name: Capture Rust cache identity
         id: rust-cache-key
+        shell: pwsh
         run: |
           $release = rustc -Vv | Select-String '^release: ' | ForEach-Object { $_.ToString().Substring(9) }
           $target = rustc -Vv | Select-String '^host: ' | ForEach-Object { $_.ToString().Substring(6) }
           "version=$release" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "target=$target" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      - name: Restore Cargo registry, git sources, and build output
+      - name: Restore Windows Cargo inputs and output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
         continue-on-error: true
@@ -179,12 +187,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-bootstrap-default-features-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-windows-ready-command-v1-a9a54e40da9e875648c2b10dd12a0d6a1bc8ae50fb7bf2f9fc6ce989a5ba5b81-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-${{ hashFiles('.github/scripts/install-windows-vulkan-sdk.ps1') }}-${{ hashFiles('Cargo.lock') }}
 
-      - name: Retrieval readiness manifest-missing contract
+      - name: Prove Windows ready_command manifest-missing contract
+        shell: pwsh
         run: cargo test --locked -p codestory-cli --test ready_command
 
-      - name: Save Cargo registry, git sources, and build output
+      - name: Save Windows Cargo inputs and output
         if: success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
         uses: actions/cache/save@v5
         continue-on-error: true

--- a/.github/workflows/retrieval-engine-smoke.yml
+++ b/.github/workflows/retrieval-engine-smoke.yml
@@ -156,6 +156,7 @@ jobs:
     timeout-minutes: 30
     env:
       CODESTORY_EMBED_ALLOW_CPU: "1"
+      CMAKE_GENERATOR: Ninja
     steps:
       - uses: actions/checkout@v5
 
@@ -175,8 +176,12 @@ jobs:
         run: |
           $release = rustc -Vv | Select-String '^release: ' | ForEach-Object { $_.ToString().Substring(9) }
           $target = rustc -Vv | Select-String '^host: ' | ForEach-Object { $_.ToString().Substring(6) }
+          $cmake = (cmake --version | Select-Object -First 1) -replace '^cmake version ', ''
+          $ninja = (ninja --version).Trim()
           "version=$release" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "target=$target" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "cmake=$cmake" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "ninja=$ninja" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Restore Windows Cargo inputs and output
         id: cargo-cache-restore
@@ -187,7 +192,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-windows-ready-command-v1-a9a54e40da9e875648c2b10dd12a0d6a1bc8ae50fb7bf2f9fc6ce989a5ba5b81-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-${{ hashFiles('.github/scripts/install-windows-vulkan-sdk.ps1') }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-windows-ready-command-v2-a6923d8bb320ad402d87ba9fa9cd27449db876f2c15eac25b865ed25a63ac790-generator-ninja-cmake-${{ steps.rust-cache-key.outputs.cmake }}-ninja-${{ steps.rust-cache-key.outputs.ninja }}-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-${{ hashFiles('.github/scripts/install-windows-vulkan-sdk.ps1') }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Prove Windows ready_command manifest-missing contract
         shell: pwsh

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -56,7 +56,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-draft-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-${{ hashFiles('Cargo.lock') }}
+            ${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-
 
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -56,11 +56,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}
+          key: ${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-${{ hashFiles('Cargo.lock') }}
-            ${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-
-            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
+            ${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-
 
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -56,6 +56,14 @@ jobs:
             Select-Object Name, AdapterCompatibility, DriverVersion, VideoMemoryType |
             Format-List | Out-File -Append target/windows-vulkan-proof/host.txt
 
+      - name: Capture source build tool evidence
+        if: ${{ !inputs.use_packaged_cli_artifact }}
+        shell: pwsh
+        run: |
+          "CMAKE_GENERATOR=Ninja" | Out-File -Append target/windows-vulkan-proof/host.txt
+          cmake --version | Out-File -Append target/windows-vulkan-proof/host.txt
+          ninja --version | Out-File -Append target/windows-vulkan-proof/host.txt
+
       - name: Install pinned Rust
         if: ${{ !inputs.use_packaged_cli_artifact }}
         shell: pwsh

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -72,6 +72,7 @@ jobs:
         shell: pwsh
         env:
           VERSION: ${{ inputs.version }}
+          CMAKE_GENERATOR: Ninja
         run: |
           $version = $env:VERSION.TrimStart('v')
           cargo build --release --locked -p codestory-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Direct CLI JSON failures now retain runtime API error codes and details across
   packet, search, activation, and retrieval indexing instead of collapsing
   typed failures into a generic `command_failed` envelope.
+- Draft source CI now restores proof-compatible exact-lock retrieval output or
+  narrowly scoped prior-lock output before rebuilding, with a versioned cache
+  identity that covers the lockfile and workspace manifests. The existing
+  serial source checks still promote a partial restore only after every proof
+  succeeds.
 - Stdio/MCP now retains a bounded set of project contexts keyed by native
   workspace identity and immutable configuration, so A/B/A routing preserves
   isolated per-project state without rereading process defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
 - Direct CLI JSON failures now retain runtime API error codes and details across
   packet, search, activation, and retrieval indexing instead of collapsing
   typed failures into a generic `command_failed` envelope.
-- Draft source CI now restores proof-compatible exact-lock retrieval output or
-  narrowly scoped prior-lock output before rebuilding, with a versioned cache
-  identity that covers the lockfile and workspace manifests. The existing
-  serial source checks still promote a partial restore only after every proof
-  succeeds.
+- Draft source CI now restores exact-lock retrieval output or narrowly scoped
+  prior-lock output before rebuilding. The base retrieval lane serially seeds
+  the exact five test-profile targets used by draft proof, while a versioned
+  cache identity binds the runner, Rust toolchain, target, feature and proof
+  topology, workspace manifests, and lockfile. Partial restores are promoted
+  only after every unchanged serial proof succeeds.
 - Stdio/MCP now retains a bounded set of project contexts keyed by native
   workspace identity and immutable configuration, so A/B/A routing preserves
   isolated per-project state without rereading process defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
   typed failures into a generic `command_failed` envelope.
 - The manual Windows manifest-missing readiness lane now installs the
   checksum-pinned Vulkan SDK before running the real locked `ready_command`
-  contract with explicit CPU runtime permission. Its exact-only cache binds the
-  hosted platform, Rust and target identities, default native feature and proof
-  shape, workspace manifests, installer, and lockfile; this remains
-  source/protocol evidence rather than a packaged or Vulkan-hardware claim.
+  contract with explicit CPU runtime permission. Windows source-build proof
+  pins the Ninja generator instead of inheriting the hosted Visual Studio
+  generator, and exact caches bind the generator plus CMake and Ninja versions
+  alongside the hosted platform, Rust and target identities, default native
+  feature and proof shape, workspace manifests, installer, and lockfile. The
+  hosted lane remains source/protocol evidence rather than a packaged or
+  Vulkan-hardware claim.
 - Draft source CI now restores exact-lock retrieval output or narrowly scoped
   prior-lock output before rebuilding. The base retrieval lane serially seeds
   the exact five test-profile targets used by draft proof, while a versioned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Direct CLI JSON failures now retain runtime API error codes and details across
   packet, search, activation, and retrieval indexing instead of collapsing
   typed failures into a generic `command_failed` envelope.
+- The manual Windows manifest-missing readiness lane now installs the
+  checksum-pinned Vulkan SDK before running the real locked `ready_command`
+  contract with explicit CPU runtime permission. Its exact-only cache binds the
+  hosted platform, Rust and target identities, default native feature and proof
+  shape, workspace manifests, installer, and lockfile; this remains
+  source/protocol evidence rather than a packaged or Vulkan-hardware claim.
 - Draft source CI now restores exact-lock retrieval output or narrowly scoped
   prior-lock output before rebuilding. The base retrieval lane serially seeds
   the exact five test-profile targets used by draft proof, while a versioned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
   generator, and exact caches bind the generator plus CMake and Ninja versions
   alongside the hosted platform, Rust and target identities, default native
   feature and proof shape, workspace manifests, installer, and lockfile. The
-  hosted lane remains source/protocol evidence rather than a packaged or
-  Vulkan-hardware claim.
+  protected Windows artifact records the same native tool versions when that
+  lane builds from source. The hosted lane remains source/protocol evidence
+  rather than a packaged or Vulkan-hardware claim.
 - Draft source CI now restores exact-lock retrieval output or narrowly scoped
   prior-lock output before rebuilding. The base retrieval lane serially seeds
   the exact five test-profile targets used by draft proof, while a versioned

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -275,7 +275,8 @@ Every Windows source-build proof lane sets `CMAKE_GENERATOR=Ninja`. This keeps
 llama.cpp nested native builds serialized under the repository's supported
 generator instead of inheriting a hosted Visual Studio/MSBuild generator. The
 hosted package cache also binds that generator and its CMake/Ninja tool versions;
-the protected Vulkan lane pins the same generator before building its package.
+the protected Vulkan lane pins the same generator before building its package
+and records both tool versions in the retained host evidence.
 
 That Windows lane is source and protocol evidence on a hosted CPU runner. The
 SDK preserves the production-default native compile topology; it does not prove

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -252,6 +252,16 @@ node --test .github/scripts/check-workflow-policy.test.mjs
 node .github/scripts/route-ci-proof.mjs --self-test
 ```
 
+The base-branch retrieval lane seeds the five draft publication-proof test
+targets with serial `cargo test --no-run` commands before it saves its cache.
+Draft CI first requests the complete retrieval key, then same-topology prior-lock
+draft and retrieval prefixes. Those prefixes retain runner, Rust version, host
+target, feature topology, proof-topology version and command digest, and the
+complete workspace-manifest hash; only the lockfile hash is omitted. A full
+retrieval-key match is a compatible seed. A prior-lock prefix match is partial
+Cargo reuse even though both are reported as `cache-hit=false` against the draft
+primary, so evidence must use the reported matched key to distinguish them.
+
 `release-claims.json` is the release claim and proof-tier source of truth. It
 binds each claim to its evidence identity, expiry, dependency, executable
 prerequisite, non-claims, accepted risks, and higher-tier proof lanes. The

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -266,9 +266,16 @@ The workflow-dispatch-only Windows manifest-missing lane installs the repository
 checksum-pinned Vulkan SDK before it compiles and runs the real locked
 `ready_command` integration target with explicit CPU runtime permission. Its
 exact-only cache binds the hosted OS, Rust release, host target, versioned proof
-shape, default feature topology, workspace and vendor manifests, installer
-script, and lockfile. It has no fallback prefixes, reruns the full contract on
-an exact hit, and saves the exact primary only after the proof succeeds.
+shape, Ninja generator, CMake and Ninja versions, default feature topology,
+workspace and vendor manifests, installer script, and lockfile. It has no
+fallback prefixes, reruns the full contract on an exact hit, and saves the
+exact primary only after the proof succeeds.
+
+Every Windows source-build proof lane sets `CMAKE_GENERATOR=Ninja`. This keeps
+llama.cpp nested native builds serialized under the repository's supported
+generator instead of inheriting a hosted Visual Studio/MSBuild generator. The
+hosted package cache also binds that generator and its CMake/Ninja tool versions;
+the protected Vulkan lane pins the same generator before building its package.
 
 That Windows lane is source and protocol evidence on a hosted CPU runner. The
 SDK preserves the production-default native compile topology; it does not prove

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -262,6 +262,20 @@ retrieval-key match is a compatible seed. A prior-lock prefix match is partial
 Cargo reuse even though both are reported as `cache-hit=false` against the draft
 primary, so evidence must use the reported matched key to distinguish them.
 
+The workflow-dispatch-only Windows manifest-missing lane installs the repository's
+checksum-pinned Vulkan SDK before it compiles and runs the real locked
+`ready_command` integration target with explicit CPU runtime permission. Its
+exact-only cache binds the hosted OS, Rust release, host target, versioned proof
+shape, default feature topology, workspace and vendor manifests, installer
+script, and lockfile. It has no fallback prefixes, reruns the full contract on
+an exact hit, and saves the exact primary only after the proof succeeds.
+
+That Windows lane is source and protocol evidence on a hosted CPU runner. The
+SDK preserves the production-default native compile topology; it does not prove
+Vulkan execution, a packaged archive, an installed runtime, or protected
+hardware behavior. Those claims remain with the package and protected Windows
+Vulkan proof lanes.
+
 `release-claims.json` is the release claim and proof-tier source of truth. It
 binds each claim to its evidence identity, expiry, dependency, executable
 prerequisite, non-claims, accepted risks, and higher-tier proof lanes. The

--- a/docs/ops/retrieval-engine.md
+++ b/docs/ops/retrieval-engine.md
@@ -112,8 +112,9 @@ branch.
 
 Windows source and package proof builds pin `CMAKE_GENERATOR=Ninja`; hosted
 native-build caches include the selected generator and CMake/Ninja versions.
-This is build determinism evidence and does not upgrade a hosted CPU result into
-a Vulkan runtime claim.
+When protected Windows proof builds from source, it records those tool versions
+in its host artifact. This is build determinism evidence and does not upgrade a
+hosted CPU result into a Vulkan runtime claim.
 
 WARP, llvmpipe, lavapipe, and other software adapters cannot satisfy an
 accelerated policy. Production never silently falls back to CPU. Hosted CI may

--- a/docs/ops/retrieval-engine.md
+++ b/docs/ops/retrieval-engine.md
@@ -110,6 +110,11 @@ branch.
 | Windows | Vulkan | Physical adapter, software-adapter rejection, full layer offload, timed live smoke |
 | Linux | Vulkan-capable package | No GPU claim without protected real-hardware evidence |
 
+Windows source and package proof builds pin `CMAKE_GENERATOR=Ninja`; hosted
+native-build caches include the selected generator and CMake/Ninja versions.
+This is build determinism evidence and does not upgrade a hosted CPU result into
+a Vulkan runtime claim.
+
 WARP, llvmpipe, lavapipe, and other software adapters cannot satisfy an
 accelerated policy. Production never silently falls back to CPU. Hosted CI may
 set:


### PR DESCRIPTION
## Context

The Ubuntu draft source gate repeatedly rebuilt native test-profile artifacts even after a compatible retrieval cache existed. Exact reruns were fast, but a compatible fallback still took 26m22s because the producer had not materialized the five proof targets. The required branch producer rehearsal then exposed two Windows cold-path defects: the manual manifest-missing job lacked the pinned Vulkan SDK, and the migrated `windows-latest` image inherited a Visual Studio 18/MSBuild generator that raced llama.cpp's nested shader-generator install.

This PR keeps every proof command and serial ordering intact. It groups the shared workflow/policy boundary: compatible Linux cache selection, producer-side test-profile seeding, and restoration of the real hosted Windows readiness contract.

Closes #1212.
Closes #1215.
Closes #1225.
Refs #1179.

## What changed

- bind producer and draft cache identities to OS, Rust release, host target, default-feature scope, workspace/vendor manifests, `Cargo.lock`, and a versioned digest of the exact five-target proof topology
- restore in order: exact current-lock producer cache, same-topology prior-lock draft cache, then same-topology prior-lock producer cache
- seed native staging, model staging, CLI stdio publication, runtime publication, and store staged-promotion test artifacts with five serial `cargo test --no-run` commands before producer save
- keep the draft lane’s five executable proof commands and order unchanged
- cover every manifest/consumer trigger and freeze workflow/job/step/cache structure with hostile parsed-policy mutations
- install the repository’s checksum-pinned Windows Vulkan SDK before the workflow-dispatch-only real locked `ready_command` contract
- pin `CMAKE_GENERATOR=Ninja` for hosted readiness, hosted package, and protected Windows source-package builds
- give the Windows lane an exact-only v2 cache bound to platform/compiler/target, generator, observed CMake/Ninja versions, default features, proof shape, manifests, installer, and lockfile
- keep the Windows run CPU-permitted source/protocol evidence; it does not claim Vulkan execution, packaging, installation, or protected hardware
- update contributor testing guidance and `CHANGELOG.md`

## How to review

1. Compare the producer seed commands in `.github/workflows/retrieval-engine-smoke.yml` with the unchanged executable proof commands in `.github/workflows/rust-ci.yml`.
2. Check the consumer restore order and confirm prior-lock prefixes omit only the lock identity.
3. Review `draftSourcePolicyViolations`, `retrievalProducerTriggerPolicyViolations`, and `windowsManifestProofPolicyViolations` with their hostile mutations.
4. Confirm the Windows installer precedes cache restore/proof, the job remains manual-only, Ninja is selected at the owning build boundaries, and the exact cache has no fallback prefixes.

## Verification

Current base: `6fcf83d53c44131cc2f213e1600cb01484ecd584`

Current intended head before controlled rehearsal commits: `342b424093b08eff55b74e5d06b68855236add34`

Exact-head local workflow proof:

- workflow policy: pass, 186 hostile tests
- actionlint wrapper tests: 3 passed
- pinned actionlint: all workflows pass; controlled-invalid fixture rejected
- docs links: 74 files / 262 links
- `git diff --check`
- independent Linux topology/policy review: clean
- independent Windows workflow/policy review after bypass repairs: clean
- exact-head Ninja/cache repair review: clean after closing unconditional/reordered identity-step bypasses and keeping protected source-tool capture out of artifact-only proof

Completed hosted Linux evidence on the same cache/command topology before the #1225-only rebase:

- cold-like draft control `29521036530` attempt 1: every proof passed in 22m05s, inside the 23m07s bound; promoted a 1,580,979,360-byte primary
- unchanged exact hit, attempt 2: 1m42s, exact primary restored, save skipped
- branch producer `29522809170`: Linux passed in 27m00s, seeded all five targets in 9m35s, and saved exact retrieval key `...retrieval-contracts-proof5-v1...` at 1,389,112,704 bytes
- first-compatible consumer `29524900863`: restored that exact retrieval key, ran every proof in 2m31s, compiled no `llama-cpp-sys-2`, and promoted a 2,168,552,651-byte draft primary
- unchanged branch exact hit `29525175210`: 1m38s, exact draft primary restored, every proof reran, save skipped

Remaining hosted gates:

- prior Windows run `29526979058`: Linux passed; Windows installed the SDK and took the correct cold miss, then failed in llama.cpp's `vulkan-shaders-gen` `ExternalProject` under inherited Visual Studio 18/MSBuild ordering; no readiness claim
- #1225 Ninja/v2 Windows cold miss and unchanged exact-hit runs on the current head
- controlled prior-lock rehearsal proving the draft prefix wins before retrieval
- controlled incompatible-topology rehearsal proving no v1 cache is restored
- byte-for-byte tree restoration, final policy/actionlint audit, final exact-head branch hit, and final PR checks

This PR remains draft until those logs, keys, archive sizes, timings, and final SHA are attached.

## Risk and rollback

Cargo still validates restored artifacts against checked-out source, lockfile, manifests, features, target, compiler, and fingerprints. No cache result skips a proof command. Restore/save remain non-blocking, and exact promotion happens only after the full job succeeds.

The Windows SDK preserves the production-default compile topology but the job grants CPU runtime permission and makes no backend-execution claim. Reverting this PR changes only workflow, policy, contributor guidance, and changelog; it does not alter product source, dependencies, proof semantics, or runner selection.
