### PR TITLE
[codex] report fenced freshness from one snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   directories or databases, migrate stores, initialize engines, or activate a
   project. Dirty-marker freshness compares only committed database and WAL
   state, so reader-owned SHM metadata cannot falsely clear a stale marker.
+- Index freshness now reports a durably fenced incomplete core database as
+  stale without repairing it or exposing it through ordinary read,
+  publication, or retrieval surfaces.
 - Fail-open MCP advertises only the diagnostic resources and methods it can
   serve while the native runtime is provisioning or unavailable.
 - Skill command syntax is generated from Clap help instead of being maintained

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -3657,6 +3657,25 @@ const INDEX_FRESHNESS_CACHE_DEFAULT_TTL_SECS: u64 = 60;
 #[cfg(test)]
 const EXACT_SYMBOL_HYBRID_MAX_RESULTS_CAP: usize = 80;
 
+#[cfg(test)]
+thread_local! {
+    static AFTER_INDEX_FRESHNESS_FENCE_TEST_HOOK: RefCell<Option<Box<dyn FnOnce()>>> =
+        const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn arm_after_index_freshness_fence_test_hook(hook: impl FnOnce() + 'static) {
+    AFTER_INDEX_FRESHNESS_FENCE_TEST_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(test)]
+fn run_after_index_freshness_fence_test_hook() {
+    let hook = AFTER_INDEX_FRESHNESS_FENCE_TEST_HOOK.with(|slot| slot.borrow_mut().take());
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 fn not_checked_index_freshness(
     reason: impl Into<String>,
     indexed_file_count: u32,
@@ -3704,17 +3723,6 @@ fn index_freshness_from_storage(
     storage: &Storage,
 ) -> IndexFreshnessDto {
     let started_at = Instant::now();
-    let files = match storage.get_files() {
-        Ok(files) => files,
-        Err(error) => {
-            return not_checked_index_freshness(
-                format!("failed to read indexed file inventory: {error}"),
-                0,
-                started_at,
-            );
-        }
-    };
-    let indexed_file_count = clamp_usize_to_u32(files.len());
     match storage.has_incomplete_incremental_run() {
         Ok(true) => {
             return IndexFreshnessDto {
@@ -3723,7 +3731,7 @@ fn index_freshness_from_storage(
                 new_file_count: 0,
                 removed_file_count: 0,
                 checked_file_count: 0,
-                indexed_file_count,
+                indexed_file_count: 0,
                 duration_ms: clamp_u128_to_u32(started_at.elapsed().as_millis()),
                 reason: Some(
                     "previous_incremental_run_incomplete_full_refresh_required".to_string(),
@@ -3735,11 +3743,24 @@ fn index_freshness_from_storage(
         Err(error) => {
             return not_checked_index_freshness(
                 format!("failed to inspect incomplete index marker: {error}"),
-                indexed_file_count,
+                0,
                 started_at,
             );
         }
     }
+    #[cfg(test)]
+    run_after_index_freshness_fence_test_hook();
+    let files = match storage.get_files() {
+        Ok(files) => files,
+        Err(error) => {
+            return not_checked_index_freshness(
+                format!("failed to read indexed file inventory: {error}"),
+                0,
+                started_at,
+            );
+        }
+    };
+    let indexed_file_count = clamp_usize_to_u32(files.len());
     if files.is_empty() {
         return not_checked_index_freshness(
             "no indexed file inventory is available yet",
@@ -8232,6 +8253,26 @@ impl AppController {
         open_existing_storage_for_read(&storage_path).map(ReadStorage::Owned)
     }
 
+    fn open_storage_for_freshness(&self) -> Result<ReadStorage, ApiError> {
+        if let Some(storage) = ACTIVE_CORE_READ.with(|active| {
+            active
+                .borrow()
+                .as_ref()
+                .filter(|active| active.controller_identity == self.identity())
+                .map(|active| Rc::clone(&active.storage))
+        }) {
+            return Ok(ReadStorage::Pinned(storage));
+        }
+        let storage_path = self.require_storage_path()?;
+        Storage::open_freshness_observational(&storage_path)
+            .map(ReadStorage::Owned)
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to open storage for freshness observation: {error}"
+                ))
+            })
+    }
+
     fn active_core_publication(&self) -> Option<IndexPublicationRecord> {
         ACTIVE_CORE_READ.with(|active| {
             active
@@ -8312,7 +8353,7 @@ impl AppController {
 
     fn index_freshness_uncached(&self) -> Result<IndexFreshnessDto, ApiError> {
         let root = self.require_project_root()?;
-        let storage = self.open_storage_read_only()?;
+        let storage = self.open_storage_for_freshness()?;
         let workspace = WorkspaceManifest::open(root.clone())
             .map_err(|error| ApiError::internal(format!("Failed to open project: {error}")))?;
         Ok(index_freshness_from_storage(&root, &workspace, &storage))
@@ -10794,7 +10835,7 @@ impl AppController {
     pub(crate) fn index_freshness(&self) -> Result<IndexFreshnessDto, ApiError> {
         let root = self.require_project_root()?;
         let storage_path = self.require_storage_path()?;
-        let storage = self.open_storage_read_only()?;
+        let storage = self.open_storage_for_freshness()?;
         let workspace = WorkspaceManifest::open(root.clone())
             .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
         let freshness =
@@ -13213,6 +13254,138 @@ mod tests {
             !indexable_source_path(Path::new("target/run-output.log")),
             "runtime freshness should not count unsupported output artifacts"
         );
+    }
+
+    #[test]
+    fn incomplete_run_fence_wins_before_indexed_inventory() {
+        let project = tempdir().expect("project");
+        let workspace = WorkspaceManifest::open(project.path().to_path_buf()).expect("workspace");
+        let storage = Storage::new_in_memory().expect("storage");
+        storage
+            .begin_incremental_run()
+            .expect("install incomplete-run fence");
+        storage
+            .get_connection()
+            .pragma_update(None, "foreign_keys", "OFF")
+            .expect("disable fixture foreign keys");
+        storage
+            .get_connection()
+            .execute("DROP TABLE file", [])
+            .expect("remove indexed inventory");
+        storage
+            .get_connection()
+            .pragma_update(None, "foreign_keys", "ON")
+            .expect("restore fixture foreign keys");
+
+        let freshness = index_freshness_from_storage(project.path(), &workspace, &storage);
+
+        assert_eq!(freshness.status, IndexFreshnessStatusDto::Stale);
+        assert_eq!(
+            freshness.reason.as_deref(),
+            Some("previous_incremental_run_incomplete_full_refresh_required")
+        );
+        assert_eq!(freshness.changed_file_count, 0);
+        assert_eq!(freshness.new_file_count, 0);
+        assert_eq!(freshness.removed_file_count, 0);
+        assert_eq!(freshness.checked_file_count, 0);
+        assert_eq!(freshness.indexed_file_count, 0);
+        assert!(freshness.samples.is_empty());
+    }
+
+    #[test]
+    fn owned_freshness_observation_pins_fence_and_inventory_across_a_concurrent_writer() {
+        let project = tempdir().expect("project");
+        let source_path = project.path().join("lib.rs");
+        fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        let modification_time = fs::metadata(&source_path)
+            .expect("source metadata")
+            .modified()
+            .expect("source mtime")
+            .duration_since(UNIX_EPOCH)
+            .expect("mtime since epoch")
+            .as_millis()
+            .min(i64::MAX as u128) as i64;
+        let database = tempdir().expect("database directory");
+        let storage_path = database.path().join("codestory.db");
+        let keeper = Storage::open(&storage_path).expect("open fixture storage");
+        keeper
+            .insert_file(&FileInfo {
+                id: 1,
+                path: source_path,
+                language: "rust".into(),
+                modification_time,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: codestory_store::FileRole::Source,
+            })
+            .expect("insert coherent file projection");
+        assert!(
+            storage_path.with_extension("db-wal").is_file(),
+            "fixture must retain WAL state"
+        );
+        assert!(
+            storage_path.with_extension("db-shm").is_file(),
+            "fixture must retain its WAL index"
+        );
+        let workspace = WorkspaceManifest::open(project.path().to_path_buf()).expect("workspace");
+        let observed = Storage::open_freshness_observational(&storage_path)
+            .expect("open owned freshness snapshot");
+
+        let (release_writer, writer_released) = std::sync::mpsc::channel();
+        let (writer_done, await_writer) = std::sync::mpsc::channel();
+        let writer_storage_path = storage_path.clone();
+        let projected_after_fence = project.path().join("removed-after-fence.rs");
+        let writer = std::thread::spawn(move || {
+            writer_released.recv().expect("release concurrent writer");
+            let storage = Storage::open(&writer_storage_path).expect("open concurrent writer");
+            storage
+                .begin_incremental_run()
+                .expect("install concurrent incomplete fence");
+            storage
+                .insert_file(&FileInfo {
+                    id: 2,
+                    path: projected_after_fence,
+                    language: "rust".into(),
+                    modification_time: 0,
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: codestory_store::FileRole::Source,
+                })
+                .expect("mutate projection after the fence read");
+            writer_done.send(()).expect("signal writer completion");
+        });
+        arm_after_index_freshness_fence_test_hook(move || {
+            release_writer.send(()).expect("start concurrent writer");
+            await_writer.recv().expect("wait for concurrent writer");
+        });
+
+        let before = index_freshness_from_storage(project.path(), &workspace, &observed);
+        writer.join().expect("join concurrent writer");
+        assert_eq!(before.status, IndexFreshnessStatusDto::Fresh);
+        assert_eq!(before.changed_file_count, 0);
+        assert_eq!(before.new_file_count, 0);
+        assert_eq!(before.removed_file_count, 0);
+        assert_eq!(before.indexed_file_count, 1);
+        assert!(before.samples.is_empty());
+        drop(observed);
+
+        let fenced = Storage::open_freshness_observational(&storage_path)
+            .expect("open post-writer freshness snapshot");
+        let after = index_freshness_from_storage(project.path(), &workspace, &fenced);
+        assert_eq!(after.status, IndexFreshnessStatusDto::Stale);
+        assert_eq!(
+            after.reason.as_deref(),
+            Some("previous_incremental_run_incomplete_full_refresh_required")
+        );
+        assert_eq!(after.changed_file_count, 0);
+        assert_eq!(after.new_file_count, 0);
+        assert_eq!(after.removed_file_count, 0);
+        assert_eq!(after.indexed_file_count, 0);
+        assert!(after.samples.is_empty());
+        drop(fenced);
+        drop(keeper);
     }
 
     #[test]
@@ -20373,16 +20546,82 @@ fn build_llm_symbol_doc_text() -> String {
                 .expect("live detail readiness"),
             "pre-publication failure must preserve the live detail snapshot"
         );
-        assert_ne!(
-            Storage::database_schema_version(&storage_path).expect("replacement schema"),
-            codestory_store::CURRENT_SCHEMA_VERSION
+        storage
+            .get_connection()
+            .execute(
+                "UPDATE incomplete_index_run
+                 SET started_at_epoch_ms = started_at_epoch_ms
+                 WHERE id = 1",
+                [],
+            )
+            .expect("retain the fence in committed WAL state");
+        let fenced_schema =
+            Storage::database_schema_version(&storage_path).expect("replacement schema");
+        assert_ne!(fenced_schema, codestory_store::CURRENT_SCHEMA_VERSION);
+        let wal_path = storage_path.with_extension("db-wal");
+        assert!(wal_path.is_file(), "fenced fixture must retain WAL state");
+        let database_before =
+            fs::read(&storage_path).expect("read fenced database before freshness");
+        let wal_before = fs::read(&wal_path).expect("read fenced WAL before freshness");
+
+        let cached = controller
+            .index_freshness()
+            .expect("cached recovery freshness");
+        let uncached = controller
+            .index_freshness_uncached()
+            .expect("uncached recovery freshness");
+        for freshness in [&cached, &uncached] {
+            assert_eq!(freshness.status, IndexFreshnessStatusDto::Stale);
+            assert_eq!(
+                freshness.reason.as_deref(),
+                Some("previous_incremental_run_incomplete_full_refresh_required")
+            );
+            assert_eq!(freshness.changed_file_count, 0);
+            assert_eq!(freshness.new_file_count, 0);
+            assert_eq!(freshness.removed_file_count, 0);
+            assert_eq!(freshness.checked_file_count, 0);
+            assert_eq!(freshness.indexed_file_count, 0);
+            assert!(freshness.samples.is_empty());
+        }
+        assert_eq!(
+            fs::read(&storage_path).expect("read fenced database after freshness"),
+            database_before
         );
         assert_eq!(
-            controller
-                .index_freshness()
-                .expect("recovery freshness")
-                .status,
-            IndexFreshnessStatusDto::Stale
+            fs::read(&wal_path).expect("read fenced WAL after freshness"),
+            wal_before
+        );
+        assert_eq!(
+            Storage::database_schema_version(&storage_path).expect("schema after freshness"),
+            fenced_schema
+        );
+        assert!(
+            storage
+                .has_incomplete_incremental_run()
+                .expect("marker after freshness"),
+            "freshness observation must preserve the durable fence"
+        );
+
+        drop(storage);
+        fs::remove_file(&search_path).expect("remove search rebuild blocker");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("successful full recovery");
+        assert_eq!(
+            Storage::database_schema_version(&storage_path).expect("recovered schema"),
+            codestory_store::CURRENT_SCHEMA_VERSION
+        );
+        let readable = Storage::open_read_only(&storage_path).expect("open recovered publication");
+        assert!(
+            !readable
+                .has_incomplete_incremental_run()
+                .expect("read recovered marker")
+        );
+        assert!(
+            readable
+                .get_complete_index_publication()
+                .expect("read recovered publication")
+                .is_some()
         );
     }
 

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -1620,6 +1620,12 @@ pub struct SymbolSummaryRecord {
     pub updated_at_epoch_ms: i64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NonmutatingOpenPolicy {
+    StrictCurrentSchema,
+    FreshnessFence,
+}
+
 impl Storage {
     /// Open a live store, applying schema migrations and secondary indexes.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
@@ -1655,7 +1661,20 @@ impl Storage {
     /// materializing SQLite sidecars. Recovery and schema changes belong to an
     /// activating writer; an observer reports those states instead.
     pub fn open_observational<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
-        let path = path.as_ref();
+        Self::open_nonmutating(path.as_ref(), NonmutatingOpenPolicy::StrictCurrentSchema)
+    }
+
+    /// Open storage only to inspect index freshness without repairing,
+    /// migrating, or exposing a fenced database as a readable publication.
+    ///
+    /// This narrow observer accepts the current schema or the exact incomplete
+    /// incremental sentinel when its durable marker exists. General read and
+    /// observational entry points remain current-schema-only.
+    pub fn open_freshness_observational<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
+        Self::open_nonmutating(path.as_ref(), NonmutatingOpenPolicy::FreshnessFence)
+    }
+
+    fn open_nonmutating(path: &Path, policy: NonmutatingOpenPolicy) -> Result<Self, StorageError> {
         if promotion_artifacts_exist(path) {
             return Err(StorageError::Other(format!(
                 "Observational storage cannot inspect {} while promotion recovery is pending",
@@ -1696,12 +1715,37 @@ impl Storage {
             uri,
             OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
         )?;
+        if policy == NonmutatingOpenPolicy::FreshnessFence {
+            // The freshness decision combines the schema sentinel, durable
+            // fence, stored inventory, and workspace comparison. Pin one
+            // SQLite snapshot before the first read so a concurrent writer
+            // cannot split those database observations across generations.
+            // Closing the read-only connection releases this transaction.
+            conn.execute_batch("BEGIN DEFERRED TRANSACTION")?;
+        }
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         let version = version.max(0) as u32;
-        if version != SCHEMA_VERSION {
-            return Err(StorageError::Other(format!(
-                "Observational storage requires schema version {SCHEMA_VERSION}, found {version}"
-            )));
+        match policy {
+            NonmutatingOpenPolicy::StrictCurrentSchema if version != SCHEMA_VERSION => {
+                return Err(StorageError::Other(format!(
+                    "Observational storage requires schema version {SCHEMA_VERSION}, found {version}"
+                )));
+            }
+            NonmutatingOpenPolicy::FreshnessFence
+                if version == INCOMPLETE_INCREMENTAL_SCHEMA_VERSION =>
+            {
+                if !has_incomplete_incremental_marker(&conn)? {
+                    return Err(StorageError::Other(format!(
+                        "Freshness observation requires the durable incomplete-run marker for schema sentinel {version}"
+                    )));
+                }
+            }
+            NonmutatingOpenPolicy::FreshnessFence if version != SCHEMA_VERSION => {
+                return Err(StorageError::Other(format!(
+                    "Freshness observation requires schema version {SCHEMA_VERSION} or the fenced incomplete sentinel, found {version}"
+                )));
+            }
+            _ => {}
         }
         Ok(Self {
             conn,

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -52,6 +52,20 @@ fn assert_no_sqlite_sidecars(path: &Path) {
     assert!(!PathBuf::from(format!("{}-journal", path.display())).exists());
 }
 
+fn durable_sqlite_state(path: &Path) -> Vec<(PathBuf, Option<Vec<u8>>)> {
+    [path.to_path_buf(), sqlite_sidecar_path(path, "-wal")]
+        .into_iter()
+        .map(|path| {
+            let bytes = if path.is_file() {
+                Some(fs::read(&path).expect("read durable SQLite state"))
+            } else {
+                None
+            };
+            (path, bytes)
+        })
+        .collect()
+}
+
 #[test]
 fn observational_open_preserves_current_database_bytes_without_sidecars() {
     let path = unique_temp_db_path("observational-current");
@@ -72,6 +86,143 @@ fn observational_open_preserves_current_database_bytes_without_sidecars() {
     );
     assert_no_sqlite_sidecars(&path);
     fs::remove_file(path).expect("remove current fixture");
+}
+
+#[test]
+fn freshness_observational_open_accepts_current_schema_without_mutation() {
+    let path = unique_temp_db_path("freshness-observational-current");
+    {
+        let storage = Storage::open(&path).expect("create migrated current fixture");
+        let (busy, log_frames, checkpointed_frames): (i64, i64, i64) = storage
+            .get_connection()
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .expect("checkpoint current fixture");
+        assert_eq!(busy, 0, "current fixture checkpoint remained busy");
+        assert_eq!(log_frames, checkpointed_frames);
+    }
+    let wal_path = sqlite_sidecar_path(&path, "-wal");
+    if wal_path.exists() {
+        assert_eq!(
+            fs::metadata(&wal_path)
+                .expect("inspect checkpointed WAL")
+                .len(),
+            0,
+            "current fixture retained uncheckpointed WAL bytes"
+        );
+        fs::remove_file(&wal_path).expect("remove empty checkpointed WAL");
+    }
+    let shm_path = sqlite_sidecar_path(&path, "-shm");
+    if shm_path.exists() {
+        fs::remove_file(&shm_path).expect("remove closed checkpoint SHM");
+    }
+    let before = durable_sqlite_state(&path);
+    assert_no_sqlite_sidecars(&path);
+
+    let observed = Storage::open_freshness_observational(&path)
+        .expect("freshness observer should accept the current schema");
+    assert_eq!(
+        observed.schema_version().expect("read observed schema"),
+        SCHEMA_VERSION
+    );
+    assert!(
+        !observed
+            .has_incomplete_incremental_run()
+            .expect("read current marker")
+    );
+    drop(observed);
+
+    assert_eq!(durable_sqlite_state(&path), before);
+    assert_no_sqlite_sidecars(&path);
+    fs::remove_file(path).expect("remove current freshness fixture");
+}
+
+#[test]
+fn freshness_observational_open_accepts_only_a_durably_marked_incomplete_sentinel() {
+    let path = unique_temp_db_path("freshness-observational-fenced");
+    {
+        let storage = Storage::open(&path).expect("open fenced fixture");
+        storage
+            .begin_incremental_run()
+            .expect("install incomplete-run fence");
+    }
+    let read_only_error = Storage::open_read_only(&path)
+        .err()
+        .expect("ordinary read-only open must reject the sentinel");
+    assert!(
+        read_only_error
+            .to_string()
+            .contains("requires schema version"),
+        "{read_only_error}"
+    );
+    let observational_error = Storage::open_observational(&path)
+        .err()
+        .expect("ordinary observation must reject the sentinel");
+    assert!(
+        observational_error
+            .to_string()
+            .contains("requires schema version"),
+        "{observational_error}"
+    );
+
+    let before = durable_sqlite_state(&path);
+    let observed = Storage::open_freshness_observational(&path)
+        .expect("freshness observer should accept the fenced sentinel");
+    assert_eq!(
+        observed.schema_version().expect("read fenced schema"),
+        INCOMPLETE_INCREMENTAL_SCHEMA_VERSION
+    );
+    assert!(
+        observed
+            .has_incomplete_incremental_run()
+            .expect("read durable incomplete marker")
+    );
+    drop(observed);
+
+    assert_eq!(durable_sqlite_state(&path), before);
+    let verification = Storage::open(&path).expect("reopen fenced fixture");
+    assert_eq!(
+        verification.schema_version().expect("verify fenced schema"),
+        INCOMPLETE_INCREMENTAL_SCHEMA_VERSION
+    );
+    assert!(
+        verification
+            .has_incomplete_incremental_run()
+            .expect("verify durable marker")
+    );
+    drop(verification);
+    let _ = cleanup_sqlite_sidecars(&path);
+}
+
+#[test]
+fn freshness_observational_open_rejects_unmarked_sentinel_and_arbitrary_schemas_without_mutation() {
+    for (label, version, expected_error) in [
+        (
+            "unmarked-sentinel",
+            INCOMPLETE_INCREMENTAL_SCHEMA_VERSION,
+            "durable incomplete-run marker",
+        ),
+        ("old-schema", SCHEMA_VERSION - 1, "requires schema version"),
+        (
+            "future-schema",
+            SCHEMA_VERSION + 1,
+            "requires schema version",
+        ),
+    ] {
+        let path = unique_temp_db_path(label);
+        create_versioned_observation_fixture(&path, version);
+        let before = durable_sqlite_state(&path);
+        assert_no_sqlite_sidecars(&path);
+
+        let error = Storage::open_freshness_observational(&path)
+            .err()
+            .expect("unsupported freshness schema must fail closed");
+        assert!(error.to_string().contains(expected_error), "{error}");
+        assert_eq!(durable_sqlite_state(&path), before);
+        assert_no_sqlite_sidecars(&path);
+        fs::remove_file(path).expect("remove rejected freshness fixture");
+    }
 }
 
 #[test]
@@ -133,6 +284,57 @@ fn observational_open_reads_committed_wal_without_mutating_durable_sqlite_state(
         fs::remove_file(&shm_path).expect("remove SHM fixture");
     }
     fs::remove_file(path).expect("remove WAL database fixture");
+}
+
+#[test]
+fn freshness_observational_open_preserves_fenced_wal_state_and_marker() {
+    let path = unique_temp_db_path("freshness-observational-fenced-wal");
+    let storage = Storage::open(&path).expect("open fenced WAL fixture");
+    storage
+        .begin_incremental_run()
+        .expect("install fenced WAL marker");
+    let wal_path = sqlite_sidecar_path(&path, "-wal");
+    let shm_path = sqlite_sidecar_path(&path, "-shm");
+    assert!(wal_path.is_file(), "fixture must retain fenced WAL state");
+    assert!(shm_path.is_file(), "fixture must retain its WAL index");
+    let before = durable_sqlite_state(&path);
+    let shm_len_before = fs::metadata(&shm_path)
+        .expect("inspect fenced SHM before observation")
+        .len();
+
+    let observed = Storage::open_freshness_observational(&path)
+        .expect("freshness observer should read the fenced WAL snapshot");
+    assert_eq!(
+        observed.schema_version().expect("read fenced WAL schema"),
+        INCOMPLETE_INCREMENTAL_SCHEMA_VERSION
+    );
+    assert!(
+        observed
+            .has_incomplete_incremental_run()
+            .expect("read fenced WAL marker")
+    );
+    drop(observed);
+
+    assert_eq!(durable_sqlite_state(&path), before);
+    assert_eq!(
+        fs::metadata(&shm_path)
+            .expect("SHM must remain after freshness observation")
+            .len(),
+        shm_len_before,
+        "freshness observation materialized or resized the existing SHM wal-index"
+    );
+    assert_eq!(
+        storage.schema_version().expect("verify live fenced schema"),
+        INCOMPLETE_INCREMENTAL_SCHEMA_VERSION
+    );
+    assert!(
+        storage
+            .has_incomplete_incremental_run()
+            .expect("verify live fenced marker")
+    );
+
+    drop(storage);
+    let _ = cleanup_sqlite_sidecars(&path);
 }
 
 #[test]
@@ -227,6 +429,14 @@ fn observational_open_reports_incomplete_wal_pair_without_materializing_shm() {
         .err()
         .expect("incomplete WAL pair must fail closed");
     assert!(error.to_string().contains("incomplete WAL sidecar pair"));
+    let freshness_error = Storage::open_freshness_observational(&path)
+        .err()
+        .expect("freshness observation must reject an incomplete WAL pair");
+    assert!(
+        freshness_error
+            .to_string()
+            .contains("incomplete WAL sidecar pair")
+    );
 
     assert_eq!(fs::read(&path).expect("reread database"), database_before);
     assert_eq!(fs::read(&wal_path).expect("reread WAL"), wal_before);
@@ -248,6 +458,14 @@ fn observational_open_reports_rollback_journal_without_recovery() {
         .err()
         .expect("rollback recovery must fail closed");
     assert!(error.to_string().contains("rollback recovery is pending"));
+    let freshness_error = Storage::open_freshness_observational(&path)
+        .err()
+        .expect("freshness observation must reject rollback recovery");
+    assert!(
+        freshness_error
+            .to_string()
+            .contains("rollback recovery is pending")
+    );
 
     assert_eq!(fs::read(&path).expect("reread database"), database_before);
     assert_eq!(
@@ -295,6 +513,13 @@ fn observational_open_reports_pending_promotion_without_recovery() {
         .err()
         .expect("pending recovery must fail closed");
     assert!(error.to_string().contains("recovery is pending"), "{error}");
+    let freshness_error = Storage::open_freshness_observational(&path)
+        .err()
+        .expect("freshness observation must reject pending promotion");
+    assert!(
+        freshness_error.to_string().contains("recovery is pending"),
+        "{freshness_error}"
+    );
 
     assert_eq!(
         fs::read(&path).expect("read promotion database after observation"),


### PR DESCRIPTION
## Context

An interrupted incremental writer deliberately fences the core database with a sentinel schema until full recovery. Ordinary readers correctly reject that publication, but freshness used the same strict opener and could not report the durable stale reason. A first repair exposed the fence without pinning one SQLite snapshot; independent review caught that a concurrent writer could then mix a pre-fence marker read with post-fence inventory.

Closes #1216.
Refs #1179.

## What changed

- add a freshness-only observational opener that accepts only the current schema or the exact incomplete-run sentinel with its durable marker
- retain one `BEGIN DEFERRED` read snapshot from schema validation through fence, inventory, and source comparison on the owned/no-pin path
- leave ordinary read-only and observational openers current-schema-only, and reuse existing active-core snapshots without nesting transactions
- report the exact fenced stale reason before attempting inventory reads, with zero counts and samples
- preserve database, WAL, schema, and marker bytes during observation, then prove full recovery restores an ordinary readable publication
- document the behavior under `Unreleased`

## How to review

Start at `Storage::open_freshness_observational`, then follow `AppController::open_storage_for_freshness` into `index_freshness_from_storage`. The concurrency regression is the key safety proof: it pauses after the fence query, lets a WAL writer commit the sentinel plus a projection mutation, and requires the first reader to remain on the coherent old snapshot while a new reader sees the fenced stale state.

## Verification

Head: `63203b6cb35ccb414976c8ead102e873f76567e1`

Completed on the same change content before a conflict-free rebase onto current `dev/codestory-next`:

- focused freshness/WAL/snapshot race tests: pass
- `cargo test --locked -p codestory-store`: 108 passed
- `cargo test --locked -p codestory-runtime`: 685 executed tests passed; 1 repo-scale test ignored by design
- `cargo check --locked -p codestory-store`: pass
- `cargo check --locked -p codestory-runtime`: pass
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass on the exact pushed head
- independent exact-source re-review after the snapshot repair: clean

Hosted exact-head CI remains pending while this PR is draft.

## Risk

The new opener is intentionally narrow. It does not migrate, repair, checkpoint, create sidecars, or expose a fenced database to ordinary readers. Pending promotion, rollback recovery, incomplete WAL pairs, arbitrary schemas, and unmarked sentinels still fail closed.
