### PR TITLE
[codex] preserve typed runtime errors in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- Direct CLI JSON failures now retain runtime API error codes and details across
+  packet, search, activation, and retrieval indexing instead of collapsing
+  typed failures into a generic `command_failed` envelope.
 - Stdio/MCP now retains a bounded set of project contexts keyed by native
   workspace identity and immutable configuration, so A/B/A routing preserves
   isolated per-project state without rereading process defaults.

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -198,6 +198,11 @@ async fn main() -> ExitCode {
             if json {
                 let envelope = structured
                     .map(|failure| failure.envelope.clone())
+                    .or_else(|| {
+                        runtime::api_error_in_chain(&error)
+                            .cloned()
+                            .map(CommandFailureEnvelope::new)
+                    })
                     .unwrap_or_else(|| generic_command_failure(&error));
                 let output_file = structured
                     .and_then(|failure| failure.output_file.as_deref())
@@ -212,7 +217,7 @@ async fn main() -> ExitCode {
                     eprintln!("Error: failed to write {}: {write_error}", path.display());
                     return ExitCode::FAILURE;
                 }
-                eprintln!("Error: {}", error);
+                eprintln!("Error: {}", command_failure_message(&error));
             }
             ExitCode::FAILURE
         }
@@ -325,6 +330,14 @@ fn generic_command_failure(error: &anyhow::Error) -> CommandFailureEnvelope {
             "causes": error.chain().skip(1).map(ToString::to_string).collect::<Vec<_>>()
         }),
     )
+}
+
+fn command_failure_message(error: &anyhow::Error) -> String {
+    if runtime::api_error_in_chain(error).is_some() {
+        format!("{error:#}")
+    } else {
+        error.to_string()
+    }
 }
 
 fn json_output_requested(args: &[OsString]) -> bool {
@@ -7979,6 +7992,28 @@ mod tests {
             first_index < second_index,
             "expected `{first}` before `{second}` in:\n{markdown}"
         );
+    }
+
+    #[test]
+    fn command_failure_message_keeps_typed_guidance_through_outer_context() {
+        let error = map_api_error(ApiError::retrieval_unavailable(
+            "retrieval is unavailable",
+            "/tmp/project",
+            vec!["codestory-cli retrieval index --project /tmp/project".to_string()],
+        ))
+        .context("retrieval index finalize");
+
+        let message = command_failure_message(&error);
+        assert!(message.starts_with("retrieval index finalize:"));
+        assert!(message.contains("retrieval_unavailable: retrieval is unavailable"));
+        assert!(message.contains("Minimum next:"));
+    }
+
+    #[test]
+    fn command_failure_message_leaves_untyped_errors_unchanged() {
+        let error = anyhow::anyhow!("storage unavailable").context("open project");
+
+        assert_eq!(command_failure_message(&error), "open project");
     }
 
     #[test]

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -725,34 +725,59 @@ pub(crate) fn map_api_error_for_project(error: ApiError, project: &Path) -> anyh
     map_api_error_with_project(error, Some(project))
 }
 
+#[derive(Debug)]
+struct CliApiError {
+    error: ApiError,
+    message: String,
+}
+
+impl std::fmt::Display for CliApiError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CliApiError {}
+
+/// Return the typed runtime error retained by the CLI adapter, including when
+/// command-specific context has been attached above it.
+pub(crate) fn api_error_in_chain(error: &anyhow::Error) -> Option<&ApiError> {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<CliApiError>())
+        .map(|error| &error.error)
+}
+
 fn map_api_error_with_project(error: ApiError, project: Option<&Path>) -> anyhow::Error {
-    if api_error_is_cache_busy(&error) {
-        return anyhow!(cache_busy_message(project));
-    }
-    let mut message = format!("{}: {}", error.code, error.message);
-    if let Some((minimum_next, full_repair)) = api_error_repair_groups(&error) {
-        if !minimum_next.is_empty() {
-            message.push_str("\n\nMinimum next:");
-            for command in minimum_next {
+    let message = if api_error_is_cache_busy(&error) {
+        cache_busy_message(project)
+    } else {
+        let mut message = format!("{}: {}", error.code, error.message);
+        if let Some((minimum_next, full_repair)) = api_error_repair_groups(&error) {
+            if !minimum_next.is_empty() {
+                message.push_str("\n\nMinimum next:");
+                for command in minimum_next {
+                    message.push_str("\n  ");
+                    message.push_str(command);
+                }
+            }
+            if !full_repair.is_empty() && full_repair != minimum_next {
+                message.push_str("\n\nAdditional checks:");
+                for command in full_repair {
+                    message.push_str("\n  ");
+                    message.push_str(command);
+                }
+            }
+        } else if let Some(next_commands) = api_error_next_commands(&error) {
+            message.push_str("\n\nNext commands:");
+            for command in next_commands {
                 message.push_str("\n  ");
-                message.push_str(command);
+                message.push_str(&command);
             }
         }
-        if !full_repair.is_empty() && full_repair != minimum_next {
-            message.push_str("\n\nAdditional checks:");
-            for command in full_repair {
-                message.push_str("\n  ");
-                message.push_str(command);
-            }
-        }
-    } else if let Some(next_commands) = api_error_next_commands(&error) {
-        message.push_str("\n\nNext commands:");
-        for command in next_commands {
-            message.push_str("\n  ");
-            message.push_str(&command);
-        }
-    }
-    anyhow!(message)
+        message
+    };
+    anyhow::Error::new(CliApiError { error, message })
 }
 
 /// Rewrite cache-busy errors from non-API paths into the standard CLI message.
@@ -819,6 +844,40 @@ mod tests {
 
     struct EnvSnapshot {
         values: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    #[test]
+    fn api_error_mapping_retains_typed_details_through_outer_context() {
+        let expected = ApiError::retrieval_unavailable(
+            "retrieval is unavailable",
+            "/tmp/project",
+            vec!["codestory-cli retrieval index --project /tmp/project".to_string()],
+        );
+        let mapped = map_api_error(expected.clone()).context("packet activation");
+
+        assert_eq!(api_error_in_chain(&mapped), Some(&expected));
+        assert_eq!(mapped.to_string(), "packet activation");
+        let human = format!("{mapped:#}");
+        assert!(human.contains("retrieval_unavailable: retrieval is unavailable"));
+        assert!(human.contains("Minimum next:"));
+        assert!(human.contains("codestory-cli retrieval index --project /tmp/project"));
+    }
+
+    #[test]
+    fn cache_busy_api_error_keeps_type_and_cli_recovery_rendering() {
+        let expected = ApiError::new("project_unavailable", "sqlite_busy while opening cache");
+        let project = Path::new("/tmp/project");
+        let mapped = map_api_error_for_project(expected.clone(), project);
+
+        assert_eq!(api_error_in_chain(&mapped), Some(&expected));
+        let human = mapped.to_string();
+        let project = quote_command_path(project);
+        assert!(human.starts_with("cache_busy: CodeStory cache is busy or locked."));
+        assert!(human.contains("Minimum next:"));
+        assert!(human.contains(&format!(
+            "codestory-cli ready --project {project} --goal agent"
+        )));
+        assert!(human.contains(&format!("codestory-cli doctor --project {project}")));
     }
 
     #[test]

--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -245,19 +245,24 @@ fn search_json_fails_closed_without_full_sidecars() {
     let failure: Value = serde_json::from_slice(&search.stdout).expect("parse failure envelope");
     let failure_text = failure.to_string();
     assert_eq!(failure["schema_version"], 1);
-    assert_eq!(failure["error"]["code"], "command_failed");
+    assert_eq!(failure["error"]["code"], "retrieval_unavailable");
+    assert_eq!(
+        failure["error"]["details"]["failed_layer"],
+        "retrieval_engine"
+    );
     assert!(
-        failure_text.contains("retrieval_unavailable: retrieval is unavailable or degraded")
+        failure_text.contains("retrieval is unavailable or degraded")
             && failure_text.contains("expected profile=agent mode=full"),
         "search should report the mandatory full-retrieval boundary: {failure:#}"
     );
     assert!(
-        failure_text.contains("Minimum next:")
-            && failure_text.contains("Additional checks:")
+        failure["error"]["details"]["minimum_next"]
+            .as_array()
+            .is_some_and(|commands| commands.len() == 1)
             && failure_text.contains("codestory-cli retrieval index")
             && failure_text.contains("codestory-cli retrieval status")
             && failure_text.contains("codestory-cli doctor"),
-        "search should include retrieval activation and diagnostic commands: {failure:#}"
+        "search should retain typed retrieval activation and diagnostic commands: {failure:#}"
     );
 }
 


### PR DESCRIPTION
## Context

Direct CLI packet/search/activation/indexing paths converted runtime `ApiError` values into display-only `anyhow` text. The top-level JSON renderer could then emit only generic `command_failed`, losing the typed code and details already preserved by stdio/MCP. That boundary would also discard the embedding-owner capacity state planned under #1220.

Closes #1219.
Refs #1213.
Refs #1179.

## What changed

- add a private CLI error carrier that retains the original `ApiError` alongside the existing enriched human message
- recover that typed error through outer `anyhow` contexts when building the top-level JSON envelope
- preserve structured-command precedence, output-file behavior, project-specific guidance, and cache-busy human rendering
- keep unrelated errors on the existing generic `command_failed` envelope
- update the real search subprocess contract to require native `retrieval_unavailable` code/details
- document the behavior under `Unreleased`

## How to review

Review `CliApiError` and `map_api_error_with_project` in CLI runtime first, then the top-level error selection in `main`. The key boundary is intentionally generic: it preserves whatever typed runtime error exists without defining the future embedding-capacity DTO or adding a test hook.

## Verification

Head: `857fe61f316c41a0eefa893cd2b30aade2abb107`

- typed error through nested context: pass on exact rebased head
- cache-busy typed value plus cross-platform human guidance: pass
- typed and untyped top-level human rendering: 2 passed
- real CLI subprocess retains `retrieval_unavailable` details: pass
- shared CLI error-envelope subprocess contract: pass
- `cargo check --locked -p codestory-cli`: pass on exact rebased head
- `cargo clippy --locked -p codestory-cli --all-targets -- -D warnings`: pass on exact rebased head
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass
- independent exact-source review: clean

Hosted CI was green on pre-rebase head `b51f8fd16dc0e668b7d9726305700b8af413a174`, including the full workspace check, generated contracts, clippy, and publication contracts. The rebase onto `46efc115c231cfce61286df597ef62637e5cccec` changed only ancestry; the CLI diff is identical and the exact rebased head passed the focused source checks above. This is a chained prerequisite for #1220, so the redundant hosted rerun is intentionally skipped; #1220's integrated exact head owns the later authoritative hosted and multi-process proof.

## Risk

Only the CLI error boundary changes. No public DTO, scheduler, IPC path, product orchestration, or production-only test hook is added. The typed envelope exposes no new data; it preserves details the runtime already returned and stdio/MCP already carried.
