### PR TITLE
[codex] index native workspace path identities

### DIFF
--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -102,6 +102,10 @@ jobs:
             target
           key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-default-features-${{ hashFiles('Cargo.lock') }}
 
+      - name: Prove native workspace path identity
+        if: runner.os == 'Windows'
+        run: cargo test --locked -p codestory-workspace repository_identity
+
       - name: Prepare checksum-pinned embedded model
         run: node scripts/prepare-embedded-model.mjs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- Affected analysis now resolves native workspace path identities once per
+  bounded operation, preserving Unix device/inode and Windows volume/file
+  identity without pairwise metadata scans or long-lived path caches.
 - Direct CLI JSON failures now retain runtime API error codes and details across
   packet, search, activation, and retrieval indexing instead of collapsing
   typed failures into a generic `command_failed` envelope.

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -10224,16 +10224,6 @@ mod tests {
     }
 
     #[test]
-    fn explicit_cache_dir_is_not_hashed() {
-        let root = Path::new("C:/repo");
-        let cache_dir = Path::new("C:/cache/custom");
-        assert_eq!(
-            cache_root_for_project(root, Some(cache_dir)).expect("cache dir"),
-            cache_dir
-        );
-    }
-
-    #[test]
     fn default_cache_root_uses_workspace_identity() {
         let root = Path::new("C:/repo");
         let cache_root = cache_root_for_project(root, None).expect("cache root");

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -1172,6 +1172,26 @@ mod tests {
     }
 
     #[test]
+    fn explicit_cache_override_is_normalized_without_workspace_hashing() {
+        let temp = tempdir().expect("temp dir");
+        let project = temp.path().join("project");
+        let process_cache_root = temp.path().join("process-cache");
+        let override_dir = temp.path().join("explicit-cache");
+        let expected_override =
+            canonicalize_configuration_path(&override_dir).expect("explicit cache identity");
+        let default_cache = canonicalize_configuration_path(
+            &process_cache_root.join(codestory_workspace::workspace_id_v3_for_root(&project)),
+        )
+        .expect("default cache identity");
+
+        let actual = cache_root_for_project_in(&project, Some(&override_dir), &process_cache_root)
+            .expect("explicit cache root");
+
+        assert_eq!(actual, expected_override);
+        assert_ne!(actual, default_cache);
+    }
+
+    #[test]
     fn missing_configuration_path_identity_is_stable_after_creation() {
         let temp = tempdir().expect("temp dir");
         let missing = temp.path().join("cache").join("nested");

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1207,6 +1207,44 @@ fn assert_product_search_fails_closed_without_full_sidecars(
     assert_retrieval_failure_output(output);
 }
 
+fn assert_product_search_fails_closed_on_stale_core(
+    workspace: &Path,
+    cache_dir: &Path,
+    query: &str,
+) {
+    let output = run_cli(
+        workspace,
+        cache_dir,
+        &[
+            "search",
+            "--query",
+            query,
+            "--repo-text",
+            "off",
+            "--limit",
+            "5",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        !output.status.success(),
+        "product search should fail closed on a stale core publication"
+    );
+    let failure: Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|error| panic!("parse stale-core failure: {error}; output={output:#?}"));
+    assert_eq!(
+        failure["error"]["code"], "project_unavailable",
+        "{failure:#}"
+    );
+    assert_eq!(
+        failure["error"]["message"], "search requires a fresh complete core publication",
+        "{failure:#}"
+    );
+}
+
 fn assert_retrieval_failure_output(output: std::process::Output) {
     let failure = format!(
         "{}{}",
@@ -1766,11 +1804,17 @@ fn assert_files_and_affected_read_existing_cache(workspace: &Path, cache_dir: &P
             && affected_markdown.contains("): "),
         "affected markdown should summarize impact:\n{affected_markdown}"
     );
+}
 
-    run_git(workspace, &["init"]);
-    run_git(workspace, &["add", "."]);
+#[test]
+fn affected_git_fallback_refreshes_stale_core_explicitly() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+    run_git(workspace.path(), &["init"]);
+    run_git(workspace.path(), &["add", "."]);
     run_git(
-        workspace,
+        workspace.path(),
         &[
             "-c",
             "user.email=codestory@example.test",
@@ -1783,8 +1827,13 @@ fn assert_files_and_affected_read_existing_cache(workspace: &Path, cache_dir: &P
             "fixture",
         ],
     );
+    run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
     fs::write(
-        workspace.join("src/runtime.rs"),
+        workspace.path().join("src/runtime.rs"),
         r#"pub fn normalize_project(project_name: &str) -> String {
     format!("workspace:{project_name}")
 }
@@ -1799,19 +1848,22 @@ pub fn changed_after_index() -> bool {
 "#,
     )
     .expect("modify runtime fixture for git diff fallback");
-    let affected_git = run_cli_json(
-        workspace,
-        cache_dir,
-        &["affected", "--refresh", "none", "--format", "json"],
+
+    let affected = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["affected", "--refresh", "incremental", "--format", "json"],
     );
+
     assert!(
-        affected_git["changed_paths"]
+        affected["changed_paths"]
             .as_array()
             .expect("changed paths")
             .iter()
             .any(|path| path == "src/runtime.rs"),
-        "affected should default to git diff --name-only HEAD: {affected_git:#}"
+        "affected should default to git diff --name-only HEAD: {affected:#}"
     );
+    assert_eq!(affected["matched_file_count"], 1, "{affected:#}");
 }
 
 fn run_git(workspace: &Path, args: &[&str]) {
@@ -2157,7 +2209,7 @@ fn read_commands_report_stale_index_freshness_without_refreshing_cache() {
     fs::remove_file(workspace.path().join("src").join("removed_after_index.rs"))
         .expect("remove indexed file after indexing");
 
-    assert_product_search_fails_closed_without_full_sidecars(
+    assert_product_search_fails_closed_on_stale_core(
         workspace.path(),
         cache_dir.path(),
         "AppController",

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2223,6 +2223,75 @@ fn affected_tool_maps_explicit_changed_paths_without_sidecars() {
 }
 
 #[test]
+fn affected_tool_matches_existing_alias_by_native_file_identity() {
+    let fixture = indexed_fixture();
+    let alias_dir = fixture.workspace.path().join("target");
+    fs::create_dir_all(&alias_dir).expect("create excluded alias dir");
+    fs::hard_link(
+        fixture.workspace.path().join("src/runtime.rs"),
+        alias_dir.join("runtime-alias.rs"),
+    )
+    .expect("create hard-link alias");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "affected-native-alias",
+            "method": "tools/call",
+            "params": {
+                "name": "affected",
+                "arguments": {
+                    "changed_paths": ["target/runtime-alias.rs"],
+                    "depth": 1
+                }
+            }
+        }),
+    );
+
+    let result = assert_tool_success(&response, json!("affected-native-alias"));
+    assert_eq!(
+        result["matched_file_count"],
+        json!(1),
+        "an excluded alias should match the indexed file by native identity: {result}"
+    );
+    assert_eq!(result["matched_files"][0]["path"], json!("src/runtime.rs"));
+}
+
+#[test]
+fn affected_tool_matches_rename_by_previous_path_identity() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "affected-rename-previous",
+            "method": "tools/call",
+            "params": {
+                "name": "affected",
+                "arguments": {
+                    "change_records": [{
+                        "path": "src/runtime-renamed.rs",
+                        "previous_path": "src/runtime.rs",
+                        "kind": "renamed",
+                        "status": "R"
+                    }],
+                    "depth": 1
+                }
+            }
+        }),
+    );
+
+    let result = assert_tool_success(&response, json!("affected-rename-previous"));
+    assert_eq!(result["matched_file_count"], json!(1));
+    assert_eq!(result["matched_files"][0]["path"], json!("src/runtime.rs"));
+    assert_eq!(result["matched_files"][0]["change_kind"], json!("renamed"));
+}
+
+#[test]
 fn affected_tool_rejects_invalid_arguments_without_transport_crash() {
     let fixture = indexed_fixture();
     let mut server = spawn_stdio_server(&fixture);

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -52,6 +52,7 @@ use codestory_store::{
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
 use codestory_workspace::{
     RefreshExecutionPlan, RefreshInputs, WorkspaceInventoryOutcome, WorkspaceManifest,
+    WorkspacePathIdentity,
 };
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use fs4::fs_std::FileExt;
@@ -78,6 +79,7 @@ mod graph_builders;
 mod graph_canonical;
 mod grounding;
 mod mermaid;
+mod path_identity;
 mod path_resolution;
 mod query_language;
 mod repository_identity;
@@ -96,6 +98,7 @@ pub use browser::{BrowserQueryItem, ReadOnlyBrowserService};
 pub use cache_rehydrate::{CacheRehydrateOutput, CacheRehydrateRequest, rehydrate_cache};
 pub use codestory_contracts as contracts;
 pub(crate) use mermaid::{fallback_mermaid, mermaid_flowchart, mermaid_gantt, mermaid_sequence};
+use path_identity::OperationPathIdentityResolver;
 pub use query_language::{GraphQueryParseError, parse_graph_query};
 pub use repository_identity::{
     REPOSITORY_IDENTITY_SCHEMA_VERSION, RepositoryIdentityReport, inspect_repository_identity,
@@ -383,21 +386,138 @@ fn normalized_affected_change_records(
         .collect()
 }
 
-fn affected_change_record_keys(record: &AffectedChangeRecordDto) -> Vec<String> {
-    let mut keys = Vec::new();
-    let path = normalize_path_key(&record.path);
-    if !path.is_empty() {
-        keys.push(path);
-    }
-    if let Some(previous_path) = record.previous_path.as_deref() {
-        let previous = normalize_path_key(previous_path);
-        if !previous.is_empty() {
-            keys.push(previous);
+fn affected_change_record_paths(root: &Path, record: &AffectedChangeRecordDto) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for raw in std::iter::once(record.path.as_str()).chain(record.previous_path.as_deref()) {
+        if raw.is_empty() {
+            continue;
+        }
+        let requested = Path::new(raw);
+        let path = if requested.is_absolute() {
+            requested.to_path_buf()
+        } else {
+            root.join(requested)
+        };
+        if !paths.contains(&path) {
+            paths.push(path);
         }
     }
-    keys.sort();
-    keys.dedup();
-    keys
+    paths
+}
+
+struct AffectedIdentityMatches {
+    matched_file_ids: HashSet<GraphNodeId>,
+    matched_record_indexes: HashSet<usize>,
+    matched_record_index_by_file_id: HashMap<GraphNodeId, usize>,
+    unavailable_changed_identity_count: usize,
+    unavailable_changed_identity_sample: Option<String>,
+    unavailable_indexed_identity_count: usize,
+    unavailable_indexed_identity_sample: Option<String>,
+    #[cfg(test)]
+    record_bucket_visits: usize,
+    #[cfg(test)]
+    record_index_visits: usize,
+}
+
+fn match_affected_file_identities<'a, I, R>(
+    root: &Path,
+    change_records: &[AffectedChangeRecordDto],
+    indexed_files: I,
+    path_identities: &mut OperationPathIdentityResolver<R>,
+) -> AffectedIdentityMatches
+where
+    I: IntoIterator<Item = (GraphNodeId, &'a Path)>,
+    R: FnMut(&Path) -> io::Result<WorkspacePathIdentity>,
+{
+    let mut record_indexes_by_identity = HashMap::<WorkspacePathIdentity, Vec<usize>>::new();
+    let mut unavailable_changed_identity_count = 0_usize;
+    let mut unavailable_changed_identity_sample = None;
+    for (record_index, record) in change_records.iter().enumerate() {
+        let paths = affected_change_record_paths(root, record);
+        let mut record_identities = HashSet::with_capacity(paths.len());
+        let mut identity_unavailable = false;
+        for path in paths {
+            match path_identities.resolve(&path) {
+                Ok(identity) => {
+                    record_identities.insert(identity);
+                }
+                Err(error) => {
+                    identity_unavailable = true;
+                    unavailable_changed_identity_sample.get_or_insert_with(|| error.to_string());
+                }
+            }
+        }
+        if identity_unavailable {
+            unavailable_changed_identity_count += 1;
+        }
+        for identity in record_identities {
+            record_indexes_by_identity
+                .entry(identity)
+                .or_default()
+                .push(record_index);
+        }
+    }
+
+    let mut matched_file_ids = HashSet::new();
+    let mut matched_record_index_by_file_id = HashMap::new();
+    let mut matched_identities = HashSet::new();
+    let mut unavailable_indexed_identity_count = 0_usize;
+    let mut unavailable_indexed_identity_sample = None;
+    for (file_id, path) in indexed_files {
+        let indexed_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            root.join(path)
+        };
+        let identity = match path_identities.resolve(&indexed_path) {
+            Ok(identity) => identity,
+            Err(error) => {
+                unavailable_indexed_identity_count += 1;
+                unavailable_indexed_identity_sample.get_or_insert_with(|| error.to_string());
+                continue;
+            }
+        };
+        let Some(record_index) = record_indexes_by_identity
+            .get(&identity)
+            .and_then(|indexes| indexes.first())
+        else {
+            continue;
+        };
+        matched_file_ids.insert(file_id);
+        matched_record_index_by_file_id.insert(file_id, *record_index);
+        matched_identities.insert(identity);
+    }
+
+    let mut matched_record_indexes = HashSet::new();
+    #[cfg(test)]
+    let mut record_bucket_visits = 0_usize;
+    #[cfg(test)]
+    let mut record_index_visits = 0_usize;
+    for identity in matched_identities {
+        let Some(record_indexes) = record_indexes_by_identity.get(&identity) else {
+            continue;
+        };
+        #[cfg(test)]
+        {
+            record_bucket_visits += 1;
+            record_index_visits += record_indexes.len();
+        }
+        matched_record_indexes.extend(record_indexes.iter().copied());
+    }
+
+    AffectedIdentityMatches {
+        matched_file_ids,
+        matched_record_indexes,
+        matched_record_index_by_file_id,
+        unavailable_changed_identity_count,
+        unavailable_changed_identity_sample,
+        unavailable_indexed_identity_count,
+        unavailable_indexed_identity_sample,
+        #[cfg(test)]
+        record_bucket_visits,
+        #[cfg(test)]
+        record_index_visits,
+    }
 }
 
 fn affected_unmatched_reason(record: &AffectedChangeRecordDto) -> String {
@@ -10400,48 +10520,36 @@ impl AppController {
         }
 
         let change_records = normalized_affected_change_records(&req);
-        let mut matched_file_ids = HashSet::<GraphNodeId>::new();
-        let mut matched_changed_keys = HashSet::<String>::new();
-        let mut matched_record_by_file_id = HashMap::<GraphNodeId, AffectedChangeRecordDto>::new();
-        for file in &files {
-            let relative_key = normalize_path_key(&runtime_relative_path(&root, &file.path));
-            let absolute_key = normalize_path_key(&file.path.to_string_lossy());
-            let mut matched_records = Vec::new();
-            let matched_keys = change_records
-                .iter()
-                .flat_map(|record| {
-                    affected_change_record_keys(record)
-                        .into_iter()
-                        .map(move |key| (record, key))
-                })
-                .filter_map(|(record, changed)| {
-                    let changed = changed.as_str();
-                    let matched = relative_key == changed
-                        || relative_key.ends_with(changed)
-                        || changed.ends_with(&relative_key)
-                        || absolute_key == changed
-                        || absolute_key.ends_with(changed);
-                    matched.then_some((record, changed.to_string()))
-                })
-                .collect::<Vec<_>>();
-            if !matched_keys.is_empty() {
-                let file_id = codestory_contracts::graph::NodeId(file.id);
-                matched_file_ids.insert(file_id);
-                for (record, key) in matched_keys {
-                    matched_changed_keys.insert(key);
-                    matched_records.push(record.clone());
-                }
-                if let Some(record) = matched_records.first() {
-                    matched_record_by_file_id.insert(file_id, record.clone());
-                }
-            }
-        }
+        let mut path_identities = OperationPathIdentityResolver::native();
+        let identity_matches = match_affected_file_identities(
+            &root,
+            &change_records,
+            files.iter().map(|file| {
+                (
+                    codestory_contracts::graph::NodeId(file.id),
+                    file.path.as_path(),
+                )
+            }),
+            &mut path_identities,
+        );
+        let AffectedIdentityMatches {
+            matched_file_ids,
+            matched_record_indexes,
+            matched_record_index_by_file_id,
+            unavailable_changed_identity_count,
+            unavailable_changed_identity_sample,
+            unavailable_indexed_identity_count,
+            unavailable_indexed_identity_sample,
+            ..
+        } = identity_matches;
         let mut matched_files = files
             .iter()
             .filter(|file| matched_file_ids.contains(&codestory_contracts::graph::NodeId(file.id)))
             .map(|file| {
                 let file_id = codestory_contracts::graph::NodeId(file.id);
-                let record = matched_record_by_file_id.get(&file_id);
+                let record = matched_record_index_by_file_id
+                    .get(&file_id)
+                    .map(|record_index| &change_records[*record_index]);
                 AffectedMatchedFileDto {
                     path: runtime_relative_path(&root, &file.path),
                     role: indexed_file_role(&file.path),
@@ -10457,12 +10565,9 @@ impl AppController {
         matched_files.sort_by(|left, right| left.path.cmp(&right.path));
         let unmatched_paths = change_records
             .iter()
-            .filter(|record| {
-                affected_change_record_keys(record)
-                    .iter()
-                    .all(|key| !matched_changed_keys.contains(key))
-            })
-            .map(|record| AffectedUnmatchedPathDto {
+            .enumerate()
+            .filter(|(record_index, _)| !matched_record_indexes.contains(record_index))
+            .map(|(_, record)| AffectedUnmatchedPathDto {
                 path: record.path.clone(),
                 reason: affected_unmatched_reason(record),
                 change_kind: Some(record.kind.clone()),
@@ -10734,6 +10839,22 @@ impl AppController {
             blind_spots.push(format!(
                 "{} changed paths were unmatched and excluded from graph traversal",
                 unmatched_paths.len()
+            ));
+        }
+        if unavailable_changed_identity_count > 0 {
+            let detail = unavailable_changed_identity_sample
+                .as_deref()
+                .unwrap_or("no identity error sample available");
+            blind_spots.push(format!(
+                "native path identity was unavailable for {unavailable_changed_identity_count} changed records; completeness was downgraded ({detail})"
+            ));
+        }
+        if unavailable_indexed_identity_count > 0 {
+            let detail = unavailable_indexed_identity_sample
+                .as_deref()
+                .unwrap_or("no identity error sample available");
+            blind_spots.push(format!(
+                "native path identity was unavailable for {unavailable_indexed_identity_count} indexed files; completeness was downgraded ({detail})"
             ));
         }
         if matched_files
@@ -13177,6 +13298,107 @@ mod tests {
     use std::sync::MutexGuard as StdMutexGuard;
     use tempfile::tempdir;
 
+    #[test]
+    fn affected_identity_matching_visits_one_bucket_for_all_same_identity_aliases() {
+        let root = tempdir().expect("project");
+        let seed = root.path().join("identity-seed.rs");
+        fs::write(&seed, "pub fn seed() {}\n").expect("write identity seed");
+        let shared_identity =
+            codestory_workspace::workspace_path_identity(&seed).expect("shared native identity");
+        let change_records = (0..200)
+            .map(|index| AffectedChangeRecordDto {
+                path: format!("changed-alias-{index}.rs"),
+                kind: AffectedChangeKindDto::Modified,
+                status: "M".to_string(),
+                previous_path: None,
+            })
+            .collect::<Vec<_>>();
+        let indexed_files = (0..25_000)
+            .map(|index| {
+                (
+                    CoreNodeId(index + 1),
+                    root.path().join(format!("indexed-alias-{index}.rs")),
+                )
+            })
+            .collect::<Vec<_>>();
+        let resolver_calls = std::cell::Cell::new(0_usize);
+        let mut path_identities = OperationPathIdentityResolver::with_resolver(|_: &Path| {
+            resolver_calls.set(resolver_calls.get() + 1);
+            Ok(shared_identity.clone())
+        });
+
+        // The injected identity models 25,000 indexed hardlink spellings and
+        // 200 changed aliases of the same native file without using wall time.
+        let matches = match_affected_file_identities(
+            root.path(),
+            &change_records,
+            indexed_files
+                .iter()
+                .map(|(file_id, path)| (*file_id, path.as_path())),
+            &mut path_identities,
+        );
+
+        assert_eq!(resolver_calls.get(), 25_200);
+        assert_eq!(matches.matched_file_ids.len(), 25_000);
+        assert_eq!(matches.matched_record_indexes.len(), 200);
+        assert_eq!(matches.matched_record_index_by_file_id.len(), 25_000);
+        assert!(
+            matches
+                .matched_record_index_by_file_id
+                .values()
+                .all(|record_index| *record_index == 0)
+        );
+        assert_eq!(matches.record_bucket_visits, 1);
+        assert_eq!(matches.record_index_visits, 200);
+        assert_eq!(matches.unavailable_changed_identity_count, 0);
+        assert_eq!(matches.unavailable_indexed_identity_count, 0);
+    }
+
+    #[test]
+    fn affected_identity_matching_reports_unavailable_observations() {
+        let root = tempdir().expect("project");
+        let change_records = vec![AffectedChangeRecordDto {
+            path: "identity-unavailable.rs".to_string(),
+            kind: AffectedChangeKindDto::Modified,
+            status: "M".to_string(),
+            previous_path: None,
+        }];
+        let indexed_path = PathBuf::from("identity-unavailable.rs");
+        let resolver_calls = std::cell::Cell::new(0_usize);
+        let mut path_identities = OperationPathIdentityResolver::with_resolver(|_: &Path| {
+            resolver_calls.set(resolver_calls.get() + 1);
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "injected identity failure",
+            ))
+        });
+
+        let matches = match_affected_file_identities(
+            root.path(),
+            &change_records,
+            std::iter::once((CoreNodeId(1), indexed_path.as_path())),
+            &mut path_identities,
+        );
+
+        assert_eq!(resolver_calls.get(), 1);
+        assert!(matches.matched_file_ids.is_empty());
+        assert!(matches.matched_record_indexes.is_empty());
+        assert_eq!(matches.unavailable_changed_identity_count, 1);
+        assert_eq!(matches.unavailable_indexed_identity_count, 1);
+        assert!(
+            matches
+                .unavailable_changed_identity_sample
+                .as_deref()
+                .is_some_and(|sample| sample.contains("injected identity failure"))
+        );
+        assert!(
+            matches
+                .unavailable_indexed_identity_sample
+                .as_deref()
+                .is_some_and(|sample| sample.contains("injected identity failure"))
+        );
+    }
+
     struct EnvGuard {
         key: &'static str,
         previous: Option<String>,
@@ -13254,6 +13476,72 @@ mod tests {
             !indexable_source_path(Path::new("target/run-output.log")),
             "runtime freshness should not count unsupported output artifacts"
         );
+    }
+
+    fn insert_current_indexed_file(storage: &Storage, id: i64, path: &Path) {
+        let modification_time = fs::metadata(path)
+            .expect("source metadata")
+            .modified()
+            .expect("source mtime")
+            .duration_since(UNIX_EPOCH)
+            .expect("mtime since epoch")
+            .as_millis()
+            .min(i64::MAX as u128) as i64;
+        storage
+            .insert_file(&FileInfo {
+                id,
+                path: path.to_path_buf(),
+                language: "rust".into(),
+                modification_time,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: codestory_store::FileRole::Source,
+            })
+            .expect("insert current indexed file");
+    }
+
+    #[test]
+    fn newly_discovered_hardlink_alias_remains_new_for_freshness() {
+        let project = tempdir().expect("project");
+        let indexed = project.path().join("lib.rs");
+        let alias = project.path().join("alias.rs");
+        fs::write(&indexed, "pub fn indexed() {}\n").expect("write indexed source");
+        fs::hard_link(&indexed, &alias).expect("create source hardlink alias");
+        let workspace = WorkspaceManifest::open(project.path().to_path_buf()).expect("workspace");
+        let storage = Storage::new_in_memory().expect("storage");
+        insert_current_indexed_file(&storage, 1, &indexed);
+
+        let freshness = index_freshness_from_storage(project.path(), &workspace, &storage);
+
+        assert_eq!(freshness.status, IndexFreshnessStatusDto::Stale);
+        assert_eq!(freshness.changed_file_count, 0);
+        assert_eq!(freshness.new_file_count, 1);
+        assert_eq!(freshness.removed_file_count, 0);
+        assert!(freshness.samples.iter().any(|sample| {
+            sample.kind == IndexFreshnessChangeKindDto::New && sample.path == "alias.rs"
+        }));
+    }
+
+    #[test]
+    fn unsupported_extension_hardlink_alias_stays_outside_freshness() {
+        let project = tempdir().expect("project");
+        let indexed = project.path().join("lib.rs");
+        let alias = project.path().join("source-alias.unsupported-binary");
+        fs::write(&indexed, "pub fn indexed() {}\n").expect("write indexed source");
+        fs::hard_link(&indexed, &alias).expect("create unsupported hardlink alias");
+        assert!(!indexable_source_path(&alias));
+        let workspace = WorkspaceManifest::open(project.path().to_path_buf()).expect("workspace");
+        let storage = Storage::new_in_memory().expect("storage");
+        insert_current_indexed_file(&storage, 1, &indexed);
+
+        let freshness = index_freshness_from_storage(project.path(), &workspace, &storage);
+
+        assert_eq!(freshness.status, IndexFreshnessStatusDto::Fresh);
+        assert_eq!(freshness.changed_file_count, 0);
+        assert_eq!(freshness.new_file_count, 0);
+        assert_eq!(freshness.removed_file_count, 0);
+        assert!(freshness.samples.is_empty());
     }
 
     #[test]

--- a/crates/codestory-runtime/src/path_identity.rs
+++ b/crates/codestory-runtime/src/path_identity.rs
@@ -1,0 +1,116 @@
+use codestory_workspace::{WorkspacePathIdentity, workspace_path_identity};
+use std::collections::HashMap;
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+
+type NativePathIdentityResolver = fn(&Path) -> io::Result<WorkspacePathIdentity>;
+
+#[derive(Debug, Clone)]
+enum CachedPathIdentity {
+    Available(WorkspacePathIdentity),
+    Unavailable {
+        kind: io::ErrorKind,
+        message: String,
+    },
+}
+
+/// One operation's native path observations.
+///
+/// The cache is deliberately owned by a single runtime operation. Keeping it
+/// any longer could reuse an identity after a file is replaced.
+pub(crate) struct OperationPathIdentityResolver<R = NativePathIdentityResolver> {
+    resolver: R,
+    observations: HashMap<PathBuf, CachedPathIdentity>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PathIdentityUnavailable {
+    pub(crate) path: PathBuf,
+    pub(crate) kind: io::ErrorKind,
+    pub(crate) message: String,
+}
+
+impl fmt::Display for PathIdentityUnavailable {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} ({:?}): {}",
+            self.path.display(),
+            self.kind,
+            self.message
+        )
+    }
+}
+
+impl OperationPathIdentityResolver<NativePathIdentityResolver> {
+    pub(crate) fn native() -> Self {
+        Self::with_resolver(workspace_path_identity)
+    }
+}
+
+impl<R> OperationPathIdentityResolver<R>
+where
+    R: FnMut(&Path) -> io::Result<WorkspacePathIdentity>,
+{
+    pub(crate) fn with_resolver(resolver: R) -> Self {
+        Self {
+            resolver,
+            observations: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn resolve(
+        &mut self,
+        path: &Path,
+    ) -> Result<WorkspacePathIdentity, PathIdentityUnavailable> {
+        if let Some(observation) = self.observations.get(path) {
+            return cached_result(path, observation);
+        }
+
+        let observation = match (self.resolver)(path) {
+            Ok(identity) => CachedPathIdentity::Available(identity),
+            Err(error) => CachedPathIdentity::Unavailable {
+                kind: error.kind(),
+                message: error.to_string(),
+            },
+        };
+        let result = cached_result(path, &observation);
+        self.observations.insert(path.to_path_buf(), observation);
+        result
+    }
+}
+
+fn cached_result(
+    path: &Path,
+    observation: &CachedPathIdentity,
+) -> Result<WorkspacePathIdentity, PathIdentityUnavailable> {
+    match observation {
+        CachedPathIdentity::Available(identity) => Ok(identity.clone()),
+        CachedPathIdentity::Unavailable { kind, message } => Err(PathIdentityUnavailable {
+            path: path.to_path_buf(),
+            kind: *kind,
+            message: message.clone(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn unavailable_identity_is_cached_only_for_the_operation() {
+        let calls = Cell::new(0_usize);
+        let mut resolver = OperationPathIdentityResolver::with_resolver(|path: &Path| {
+            calls.set(calls.get() + 1);
+            workspace_path_identity(path)
+        });
+        let malformed = Path::new("identity\0unavailable");
+
+        assert!(resolver.resolve(malformed).is_err());
+        assert!(resolver.resolve(malformed).is_err());
+        assert_eq!(calls.get(), 1);
+    }
+}

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -30,10 +30,11 @@ mod repository_identity;
 pub use repository_identity::{
     PROJECT_IDENTITY_SCHEMA_VERSION, PROJECT_IDENTITY_V3_SCHEMA_VERSION, ProjectIdentityV2,
     ProjectIdentityV3, REPOSITORY_IDENTITY_SCHEMA_VERSION, REPOSITORY_IDENTITY_V2_SCHEMA_VERSION,
-    RepositoryIdentity, RepositoryIdentityV2, SidecarProjectIdentity, cached_project_identity_v2,
-    cached_project_identity_v3, inspect_repository_identity, inspect_repository_identity_v2,
-    project_identity_v2, project_identity_v3, project_identity_v3_from_repository,
-    same_workspace_path, sidecar_project_identity, workspace_id_for_root, workspace_id_v3_for_root,
+    RepositoryIdentity, RepositoryIdentityV2, SidecarProjectIdentity, WorkspacePathIdentity,
+    cached_project_identity_v2, cached_project_identity_v3, inspect_repository_identity,
+    inspect_repository_identity_v2, project_identity_v2, project_identity_v3,
+    project_identity_v3_from_repository, same_workspace_path, sidecar_project_identity,
+    workspace_id_for_root, workspace_id_v3_for_root, workspace_path_identity,
 };
 
 /// Source-group language selector used during workspace discovery.

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
@@ -23,6 +24,30 @@ static PROJECT_IDENTITY_OBSERVATION_CACHE: OnceLock<
 static PROJECT_IDENTITY_V3_OBSERVATION_CACHE: OnceLock<
     Mutex<HashMap<PathBuf, (Instant, ProjectIdentityV3)>>,
 > = OnceLock::new();
+
+/// Hashable native identity for one workspace path observation.
+///
+/// Existing paths use filesystem identity. Missing paths use normalized
+/// platform-lexical identity and remain distinct from existing paths. The
+/// representation is intentionally private so callers cannot manufacture an
+/// identity that did not come from a filesystem observation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WorkspacePathIdentity(WorkspacePathIdentityKind);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum WorkspacePathIdentityKind {
+    #[cfg(unix)]
+    ExistingUnix { device: u64, inode: u64 },
+    #[cfg(windows)]
+    ExistingWindows {
+        volume_serial_number: u64,
+        file_id: [u8; 16],
+    },
+    #[cfg(unix)]
+    MissingUnix(PathBuf),
+    #[cfg(windows)]
+    MissingWindows(Vec<u16>),
+}
 
 /// Git-derived identity used to decide whether portable sidecar cache reuse is
 /// safe for a project root.
@@ -606,62 +631,131 @@ fn normalize_repository_path(value: &str) -> Option<String> {
     (!normalized.is_empty()).then_some(normalized)
 }
 
-/// Compare workspace paths without merging distinct case-sensitive roots.
+/// Observe one path using native filesystem identity when it exists.
 ///
-/// Existing paths use the filesystem's stable file identity. Only two missing
-/// paths use platform lexical rules. Windows missing-path comparison normalizes
-/// separators and dot segments and uses ordinal Unicode case comparison, but
-/// cannot observe a missing path's future per-directory case-sensitivity flag.
+/// Existing Unix paths use device/inode identity and existing Windows paths
+/// use volume/file identity. Missing Unix paths preserve normalized spelling;
+/// missing Windows paths use normalized invariant ordinal ignore-case spelling.
+/// A missing path cannot reveal a future Windows directory's case-sensitivity
+/// flag, so callers must not retain this observation beyond their operation.
+///
+/// Only `NotFound` enters the lexical missing-path contract. Permission,
+/// malformed-path, handle, and platform failures remain errors so callers can
+/// downgrade completeness instead of guessing.
+pub fn workspace_path_identity(path: &Path) -> io::Result<WorkspacePathIdentity> {
+    match fs::metadata(path) {
+        Ok(metadata) => existing_workspace_path_identity(path, &metadata),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            missing_workspace_path_identity(path)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Compare workspace paths through [`workspace_path_identity`].
+///
+/// The compatibility boolean fails closed when either identity is unavailable.
 pub fn same_workspace_path(left: &Path, right: &Path) -> bool {
-    match (fs::metadata(left), fs::metadata(right)) {
-        (Ok(left_metadata), Ok(right_metadata)) => {
-            same_existing_path(left, &left_metadata, right, &right_metadata)
-        }
-        (Err(left_error), Err(right_error))
-            if left_error.kind() == std::io::ErrorKind::NotFound
-                && right_error.kind() == std::io::ErrorKind::NotFound =>
-        {
-            same_missing_path(left, right)
-        }
+    match (
+        workspace_path_identity(left),
+        workspace_path_identity(right),
+    ) {
+        (Ok(left), Ok(right)) => left == right,
         _ => false,
     }
 }
 
 #[cfg(unix)]
-fn same_existing_path(
-    _left_path: &Path,
-    left: &fs::Metadata,
-    _right_path: &Path,
-    right: &fs::Metadata,
-) -> bool {
+fn existing_workspace_path_identity(
+    _path: &Path,
+    metadata: &fs::Metadata,
+) -> io::Result<WorkspacePathIdentity> {
     use std::os::unix::fs::MetadataExt;
-    left.dev() == right.dev() && left.ino() == right.ino()
+    Ok(WorkspacePathIdentity(
+        WorkspacePathIdentityKind::ExistingUnix {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        },
+    ))
 }
 
 #[cfg(windows)]
-fn same_existing_path(
-    left_path: &Path,
-    _left: &fs::Metadata,
-    right_path: &Path,
-    _right: &fs::Metadata,
-) -> bool {
-    windows_file_identity(left_path)
-        .zip(windows_file_identity(right_path))
-        .is_some_and(|(left, right)| left == right)
+fn existing_workspace_path_identity(
+    path: &Path,
+    _metadata: &fs::Metadata,
+) -> io::Result<WorkspacePathIdentity> {
+    let (volume_serial_number, file_id) = windows_file_identity(path)?;
+    Ok(WorkspacePathIdentity(
+        WorkspacePathIdentityKind::ExistingWindows {
+            volume_serial_number,
+            file_id,
+        },
+    ))
 }
 
 #[cfg(not(any(unix, windows)))]
-fn same_existing_path(
-    _left_path: &Path,
-    _left: &fs::Metadata,
-    _right_path: &Path,
-    _right: &fs::Metadata,
-) -> bool {
-    false
+fn existing_workspace_path_identity(
+    _path: &Path,
+    _metadata: &fs::Metadata,
+) -> io::Result<WorkspacePathIdentity> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "native workspace path identity is unsupported on this platform",
+    ))
+}
+
+#[cfg(unix)]
+fn missing_workspace_path_identity(path: &Path) -> io::Result<WorkspacePathIdentity> {
+    Ok(WorkspacePathIdentity(
+        WorkspacePathIdentityKind::MissingUnix(normalize_missing_unix_path(path)),
+    ))
+}
+
+#[cfg(unix)]
+fn normalize_missing_unix_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normalized
+                    .file_name()
+                    .is_some_and(|name| name != std::ffi::OsStr::new(".."))
+                {
+                    normalized.pop();
+                } else if !normalized.has_root() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
 }
 
 #[cfg(windows)]
-fn windows_file_identity(path: &Path) -> Option<(u64, [u8; 16])> {
+fn missing_workspace_path_identity(path: &Path) -> io::Result<WorkspacePathIdentity> {
+    let normalized = normalize_windows_lexical_path(path);
+    let folded = windows_ordinal_case_fold(&normalized)?;
+    Ok(WorkspacePathIdentity(
+        WorkspacePathIdentityKind::MissingWindows(folded),
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn missing_workspace_path_identity(_path: &Path) -> io::Result<WorkspacePathIdentity> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "lexical workspace path identity is unsupported on this platform",
+    ))
+}
+
+#[cfg(windows)]
+fn windows_file_identity(path: &Path) -> io::Result<(u64, [u8; 16])> {
     use std::ffi::c_void;
     use std::mem::MaybeUninit;
     use std::os::windows::fs::OpenOptionsExt;
@@ -688,8 +782,7 @@ fn windows_file_identity(path: &Path) -> Option<(u64, [u8; 16])> {
     let file = fs::OpenOptions::new()
         .access_mode(0)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(path)
-        .ok()?;
+        .open(path)?;
     let mut information = MaybeUninit::<FileIdInfo>::uninit();
     // SAFETY: `file` owns a valid handle for the duration of the call and the
     // output points to correctly sized, writable storage.
@@ -702,19 +795,11 @@ fn windows_file_identity(path: &Path) -> Option<(u64, [u8; 16])> {
         )
     } == 0
     {
-        return None;
+        return Err(io::Error::last_os_error());
     }
     // SAFETY: a successful `GetFileInformationByHandleEx` initializes all fields.
     let information = unsafe { information.assume_init() };
-    Some((information.volume_serial_number, information.file_id))
-}
-
-#[cfg(windows)]
-fn same_missing_path(left: &Path, right: &Path) -> bool {
-    windows_ordinal_case_eq(
-        &normalize_windows_lexical_path(left),
-        &normalize_windows_lexical_path(right),
-    )
+    Ok((information.volume_serial_number, information.file_id))
 }
 
 #[cfg(windows)]
@@ -739,7 +824,7 @@ fn normalize_windows_lexical_path(path: &Path) -> Vec<u16> {
         let unc = [u16::from(b'U'), u16::from(b'N'), u16::from(b'C'), separator];
         if units
             .get(..unc.len())
-            .is_some_and(|prefix| windows_ordinal_case_eq(prefix, &unc))
+            .is_some_and(|prefix| windows_ascii_case_eq(prefix, &unc))
         {
             units.splice(..unc.len(), [separator, separator]);
         }
@@ -795,40 +880,92 @@ fn normalize_windows_lexical_path(path: &Path) -> Vec<u16> {
 }
 
 #[cfg(windows)]
-fn windows_ordinal_case_eq(left: &[u16], right: &[u16]) -> bool {
+fn windows_ascii_case_eq(left: &[u16], right: &[u16]) -> bool {
+    fn uppercase(unit: u16) -> u16 {
+        if (u16::from(b'a')..=u16::from(b'z')).contains(&unit) {
+            unit - u16::from(b'a' - b'A')
+        } else {
+            unit
+        }
+    }
+
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(left, right)| uppercase(*left) == uppercase(*right))
+}
+
+#[cfg(windows)]
+fn windows_ordinal_case_fold(source: &[u16]) -> io::Result<Vec<u16>> {
+    use std::ptr;
+
     #[link(name = "kernel32")]
     unsafe extern "system" {
-        fn CompareStringOrdinal(
-            left: *const u16,
-            left_len: i32,
-            right: *const u16,
-            right_len: i32,
-            ignore_case: i32,
+        fn LCMapStringEx(
+            locale_name: *const u16,
+            map_flags: u32,
+            source: *const u16,
+            source_len: i32,
+            destination: *mut u16,
+            destination_len: i32,
+            version_information: *mut std::ffi::c_void,
+            reserved: *mut std::ffi::c_void,
+            sort_handle: isize,
         ) -> i32;
     }
 
-    if left == right {
-        return true;
+    if source.is_empty() {
+        return Ok(Vec::new());
     }
-    if left.is_empty() || right.is_empty() {
-        return false;
-    }
-    let (Ok(left_len), Ok(right_len)) = (i32::try_from(left.len()), i32::try_from(right.len()))
-    else {
-        return false;
+    let source_len = i32::try_from(source.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "workspace path exceeds the Windows identity length bound",
+        )
+    })?;
+    const LCMAP_UPPERCASE: u32 = 0x0000_0200;
+    let invariant_locale = [0_u16];
+    // SAFETY: `source` remains valid for `source_len`, and null output asks
+    // Windows for the required invariant-uppercase buffer size. The invariant
+    // uppercase table is the same language-independent table used by ordinal
+    // ignore-case comparison.
+    let required = unsafe {
+        LCMapStringEx(
+            invariant_locale.as_ptr(),
+            LCMAP_UPPERCASE,
+            source.as_ptr(),
+            source_len,
+            ptr::null_mut(),
+            0,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            0,
+        )
     };
-    const CSTR_EQUAL: i32 = 2;
-    // SAFETY: both pointers remain valid for their supplied lengths, and the
-    // API only reads them. Windows ordinal ignore-case is the closest lexical
-    // fallback available when a missing path has no filesystem identity.
-    unsafe {
-        CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) == CSTR_EQUAL
+    if required <= 0 {
+        return Err(io::Error::last_os_error());
     }
-}
-
-#[cfg(not(windows))]
-fn same_missing_path(left: &Path, right: &Path) -> bool {
-    left == right
+    let mut folded = vec![0_u16; required as usize];
+    // SAFETY: `folded` has the exact capacity reported by the query above.
+    let written = unsafe {
+        LCMapStringEx(
+            invariant_locale.as_ptr(),
+            LCMAP_UPPERCASE,
+            source.as_ptr(),
+            source_len,
+            folded.as_mut_ptr(),
+            required,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if written <= 0 {
+        return Err(io::Error::last_os_error());
+    }
+    folded.truncate(written as usize);
+    Ok(folded)
 }
 
 fn git_output(project: &Path, args: &[&str]) -> Result<String, ()> {
@@ -1205,8 +1342,32 @@ mod tests {
         fs::write(&file, "identity").expect("identity file");
         fs::hard_link(&file, &alias).expect("hard-link alias");
 
+        assert_eq!(
+            workspace_path_identity(&file).expect("file identity"),
+            workspace_path_identity(&alias).expect("alias identity")
+        );
         assert!(same_workspace_path(&file, &alias));
         assert!(!same_workspace_path(&file, &project.path().join("missing")));
+    }
+
+    #[test]
+    fn existing_and_missing_path_identities_are_distinct() {
+        let project = tempdir().expect("project");
+        let existing = project.path().join("entry");
+        fs::write(&existing, "entry").expect("write entry");
+        let missing = project.path().join("missing");
+
+        assert_ne!(
+            workspace_path_identity(&existing).expect("existing identity"),
+            workspace_path_identity(&missing).expect("missing identity")
+        );
+    }
+
+    #[test]
+    fn unavailable_path_identity_is_an_error() {
+        let malformed = Path::new("identity\0unavailable");
+        assert!(workspace_path_identity(malformed).is_err());
+        assert!(!same_workspace_path(malformed, malformed));
     }
 
     #[cfg(unix)]
@@ -1245,14 +1406,32 @@ mod tests {
             Err(error) => panic!("lower-case path: {error}"),
         }
 
+        let missing = project.path().join("Missing").join(".").join("child");
+        let normalized = project.path().join("Missing").join("child");
+        assert_eq!(
+            workspace_path_identity(&missing).expect("missing dotted identity"),
+            workspace_path_identity(&normalized).expect("missing normalized identity")
+        );
+        assert_ne!(
+            workspace_path_identity(&project.path().join("Missing"))
+                .expect("missing upper identity"),
+            workspace_path_identity(&project.path().join("missing"))
+                .expect("missing lower identity")
+        );
+
         let first = project.path().join(OsString::from_vec(vec![b'r', 0x80]));
         let second = project.path().join(OsString::from_vec(vec![b'r', 0x81]));
         match fs::create_dir(&first) {
             Ok(()) => {}
-            // Darwin rejects non-UTF-8 path components with EILSEQ (92), so
-            // only exercise byte-distinct identities on filesystems that can
-            // materialize those names.
-            Err(error) if cfg!(target_os = "macos") && error.raw_os_error() == Some(92) => return,
+            // Darwin filesystems and sandbox policies can reject non-UTF-8
+            // path components with EILSEQ (92) or EPERM (1), so only exercise
+            // byte-distinct identities where those names can be materialized.
+            Err(error)
+                if cfg!(target_os = "macos")
+                    && matches!(error.raw_os_error(), Some(1) | Some(92)) =>
+            {
+                return;
+            }
             Err(error) => panic!("first non-UTF-8 path: {error}"),
         }
         fs::create_dir(&second).expect("second non-UTF-8 path");
@@ -1274,6 +1453,10 @@ mod tests {
         let existing = project.path().join("CodeStory");
         fs::create_dir(&existing).expect("mixed-case path");
         let existing_alias = project.path().join("codestory");
+        assert_eq!(
+            workspace_path_identity(&existing).expect("existing identity"),
+            workspace_path_identity(&existing_alias).expect("existing alias identity")
+        );
         assert!(same_workspace_path(&existing, &existing_alias));
         assert_eq!(
             crate::workspace_relative_path(&existing, &existing_alias.join("src/lib.rs")),
@@ -1282,6 +1465,10 @@ mod tests {
 
         let missing = project.path().join("Missing");
         let missing_alias = project.path().join("missing");
+        assert_eq!(
+            workspace_path_identity(&missing).expect("missing identity"),
+            workspace_path_identity(&missing_alias).expect("missing alias identity")
+        );
         assert!(same_workspace_path(&missing, &missing_alias));
 
         let dotted = project
@@ -1295,14 +1482,19 @@ mod tests {
         assert!(same_workspace_path(&dotted, &normalized));
 
         let extended = PathBuf::from(format!(r"\\?\{}", project.path().display()));
+        assert_eq!(
+            workspace_path_identity(&extended.join("missing")).expect("extended missing identity"),
+            workspace_path_identity(&project.path().join("MISSING"))
+                .expect("ordinary missing identity")
+        );
         assert!(same_workspace_path(
             &extended.join("missing"),
             &project.path().join("MISSING")
         ));
-        assert!(!same_missing_path(
-            Path::new(r"C:missing"),
-            Path::new(r"C:\missing")
-        ));
+        assert_ne!(
+            workspace_path_identity(Path::new(r"C:missing")).expect("drive-relative identity"),
+            workspace_path_identity(Path::new(r"C:\missing")).expect("drive-rooted identity")
+        );
     }
 
     #[test]

--- a/docs/architecture/subsystems/workspace.md
+++ b/docs/architecture/subsystems/workspace.md
@@ -10,6 +10,10 @@ uses the strongest available repository/native filesystem identity and applies
 platform lexical comparison only to missing paths: case-sensitive on Unix,
 Windows-native case and verbatim-path rules on Windows.
 
+`workspace_path_identity` exposes that same native rule as a fallible hash key
+for bounded operation-local maps. Callers must treat an unavailable identity as
+incomplete evidence and must not retain the key across file replacement.
+
 `codestory_project.json` defines source groups. An optional
 `codestory_workspace.json` can name monorepo members; without either file the
 crate creates a synthetic single-root manifest.


### PR DESCRIPTION
## Context

Exact review of PR #1223 found that native path equality was being evaluated pairwise across the indexed inventory and up to 200 requested changes. At the 25,000-file bound, a live `affected` call on this repository spent about nine seconds in path matching before graph traversal.

This prerequisite gives affected analysis one hashable native identity primitive and an operation-scoped indexing boundary. It deliberately preserves freshness's existing exact-path classification and keeps #1201's copy/SVG/stale/follow-up semantics in PR #1223 rather than mixing them into the performance foundation.

Closes #1226.
Refs #1201.
Refs #1199.
Refs #1179.

## What changed

- export an opaque, fallible `WorkspacePathIdentity` from `codestory-workspace`
- use device/inode identity on Unix and volume/`FILE_ID_128` identity on Windows for existing paths
- use normalized case-sensitive Unix spelling and invariant ordinal case-insensitive Windows spelling only for missing paths
- make `same_workspace_path` delegate to the same primitive and fail closed when identity is unavailable
- cache path observations only inside one runtime operation, including failures
- replace pairwise `affected` matching with identity-indexed production matching that remains linear for unique and duplicate hardlink identities
- preserve path-scoped freshness classification so a new hardlink remains new and unsupported extensions remain excluded
- downgrade affected completeness when a required native identity cannot be observed
- keep the explicit cache-root regression host-native so it asserts normalized identity instead of treating Windows spelling as absolute on Unix
- align stale-core golden paths with the fenced publication contract and isolate Git fallback under explicit incremental refresh
- add platform, hardlink, missing-path, error, freshness, affected, and deterministic 25,000-file plus 200-input work-bound contracts
- execute the workspace identity matrix on Windows inside the existing exact-head packaged-platform proof

## How to review

1. Start with `workspace_path_identity` and its Windows FFI; confirm the representation is opaque and platform rules match `same_workspace_path`.
2. Check that `OperationPathIdentityResolver` is allocated per operation and never retained globally.
3. Review the extracted affected matcher: each path is observed once and each matched record bucket is unioned once, including duplicate hardlinks.
4. Confirm freshness still classifies existing/new files by exact path membership rather than collapsing hardlink aliases.
5. Compare the deterministic counter tests with the production helper they exercise.

## Verification

Exact base: `6fcf83d53c44131cc2f213e1600cb01484ecd584`

Exact head: `b17ffef21aee19c60c640e926cdd637bbef7c1fd`

- workspace repository-identity matrix: pass
- full `codestory-workspace` suite: 48/49 locally; the unrelated Unix-socket test hit sandbox `EPERM`, while its focused identity matrix passed
- runtime operation-identity and production scale contracts: pass
- runtime freshness and affected contracts: pass
- CLI hardlink alias and rename-previous contracts: pass
- CLI unit suite: 185/185 pass outside the process sandbox
- CLI golden paths: 14/14 pass; all CLI test targets pass outside the process sandbox
- workspace/runtime/CLI all-target clippy with warnings denied: pass
- Windows and Linux workspace test-target checks: pass
- workflow policy, hostile policy tests, and actionlint: pass
- formatting, `git diff --check`, and docs links: pass
- independent exact-head review: pass

The hosted exact-head source proof ran twice at this SHA. Both attempts reached the complete `codestory-indexer` library suite and failed only on the same pre-existing Dart raw-graph assertion; this PR does not change indexer code, grammar packages, or graph rules. An initial direct probe mistakenly used a stale July 14 test binary. Rebuilding the exact current source reproduces the Dart failure in isolation, confirming a deterministic indexer/grammar contract regression rather than a suite race. It is being tracked and repaired separately rather than attributed to this path-identity change.

The Mac source proof controls this integration. Hosted Windows execution of the native identity primitive remains required for the final v0.16 platform claim and will continue after merge. PR #1223 must rebase onto this head and rerun its complete copy/rename/delete, exact-stale, excluded/SVG, outside-root, cap, and packaged-plugin contracts.

## Risk and rollback

Existing paths retain native filesystem identity; only missing paths use lexical identity. Identity errors fail closed or downgrade completeness rather than guessing. The cache cannot outlive one operation, so a later operation cannot inherit a stale identity after file replacement.

Reverting this PR restores the previous boolean equality path and pairwise matching. It does not change persisted schemas, package formats, or release metadata.
