### PR TITLE
Publish structural-text evidence tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   deterministic ledger and summary, and rejects stale, duplicate,
   identity-incomplete, aggregate-host, cross-version, target-host-mismatched,
   retained-package-mismatched or cross-release evidence.
+- Collector-backed workflow, Compose, Cargo manifest, HTML, CSS, and SQL
+  anchors now publish the explicit `structural_text` evidence tier, collector
+  provenance, and `source_range_only` resolution through grounding, search, and
+  packet results. They remain non-sufficient diagnostic evidence rather than
+  parser-backed or semantic claims.
 - Exact-head source and platform proof now require one coherent workflow ref,
   reviewed SHA, Actions SHA, concurrency identity, checkout, and cache
   namespace. PR coordinators are label-only; manual runs must select the live

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -10,11 +10,12 @@ use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use codestory_contracts::api::{
     AgentPacketDto, BookmarkCategoryDto, BookmarkDto, ClaimReadinessDto, GroundingBudgetDto,
     IndexDryRunDto, IndexFreshnessDto, IndexedFileRoleDto, IndexingPhaseTimings, LayoutDirection,
-    NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto, ProjectSummary, ReadinessGoalDto,
-    ReadinessStatusDto, ReadinessVerdictDto, RepoTextScanStatsDto, RetrievalScoreBreakdownDto,
-    RetrievalShadowDto, RetrievalStateDto, SearchHitOrigin, SearchMatchQualityDto, SearchPlanDto,
-    SearchQueryAssessmentDto, SnippetContextDto, SummaryGenerationDto, SymbolContextDto,
-    TrailCallerScope, TrailContextDto, TrailDirection, TrailMode,
+    NodeId, NodeKind, PacketBudgetModeDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto,
+    PacketTaskClassDto, ProjectSummary, ReadinessGoalDto, ReadinessStatusDto, ReadinessVerdictDto,
+    RepoTextScanStatsDto, RetrievalScoreBreakdownDto, RetrievalShadowDto, RetrievalStateDto,
+    SearchHitOrigin, SearchMatchQualityDto, SearchPlanDto, SearchQueryAssessmentDto,
+    SnippetContextDto, SummaryGenerationDto, SymbolContextDto, TrailCallerScope, TrailContextDto,
+    TrailDirection, TrailMode,
 };
 use serde::Serialize;
 use std::{collections::BTreeMap, path::PathBuf};
@@ -1559,6 +1560,14 @@ pub(crate) struct SearchHitOutput {
     pub(crate) origin: SearchHitOrigin,
     pub(crate) match_quality: SearchMatchQualityDto,
     pub(crate) resolvable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) evidence_tier: Option<PacketEvidenceTierDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) evidence_producer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) resolution_status: Option<PacketEvidenceResolutionDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) eligible_for_sufficiency: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) score_breakdown: Option<RetrievalScoreBreakdownDto>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -3024,7 +3024,12 @@ fn drill_packet_verification_target(
 }
 
 fn drill_packet_citation_is_typed_resolvable(citation: &AgentCitationDto) -> bool {
-    citation.resolvable && citation.kind != NodeKind::UNKNOWN
+    citation.resolvable
+        && citation.kind != NodeKind::UNKNOWN
+        && citation.evidence_tier
+            != Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText)
+        && citation.resolution_status
+            != Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
 }
 
 fn drill_packet_verification_targets(
@@ -10271,6 +10276,48 @@ mod tests {
             &[citation],
         );
         assert!(anchors[0].chosen_anchor.is_none());
+    }
+
+    #[test]
+    fn drill_packet_keeps_structural_source_ranges_navigable_but_not_typed() {
+        let project_root = Path::new("C:/repo");
+        let mut structural =
+            sample_task_brief_citation("Cargo package", NodeKind::PACKAGE, "Cargo.toml", 2);
+        structural.evidence_tier =
+            Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText);
+        structural.evidence_producer = Some("structural_cargo_manifest_collector".to_string());
+        structural.resolution_status =
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly);
+
+        let navigable =
+            drill_search_hit_from_packet_citation(project_root, "Cargo package", &structural);
+        assert!(navigable.resolvable);
+        assert!(!drill_packet_citation_is_typed_resolvable(&structural));
+
+        let anchors = drill_packet_anchors(
+            project_root,
+            &["Cargo package".to_string()],
+            std::slice::from_ref(&structural),
+        );
+        assert_eq!(anchors[0].typed_hit_count, 0);
+        assert!(anchors[0].chosen_anchor.is_none());
+        assert!(anchors[0].verification_targets.is_empty());
+        assert!(drill_packet_verification_targets(project_root, &[structural.clone()]).is_empty());
+
+        let mut packet = sample_task_brief_packet();
+        packet.sufficiency.covered_claims[0].citations = vec![
+            structural,
+            sample_task_brief_citation("SearchService", NodeKind::STRUCT, "src/search.rs", 24),
+        ];
+        assert!(drill_packet_bridges(project_root, &packet).is_empty());
+
+        let mut source_range_only =
+            sample_task_brief_citation("source range", NodeKind::FUNCTION, "src/lib.rs", 8);
+        source_range_only.resolution_status =
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly);
+        assert!(!drill_packet_citation_is_typed_resolvable(
+            &source_range_only
+        ));
     }
 
     #[test]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -104,7 +104,7 @@ use output::{
 };
 use runtime::{
     AmbiguousTargetError, RuntimeContext, ensure_index_ready, map_api_error, refresh_label,
-    resolve_refresh_request, resolve_target,
+    resolve_refresh_request, resolve_source_target, resolve_target,
 };
 use serde::Deserialize;
 #[cfg(test)]
@@ -5104,7 +5104,7 @@ fn run_snippet(cmd: SnippetCommand) -> Result<()> {
         && cmd.output_file.is_none()
         && std::io::stdout().is_terminal();
     let operation = runtime.run_public_operation(operation, || {
-        let target = resolve_target_or_emit_ambiguity(
+        let target = resolve_source_target_or_emit_ambiguity(
             &runtime,
             cmd.target.selection()?,
             file_filter.as_deref(),
@@ -5997,6 +5997,29 @@ fn resolve_target_or_emit_ambiguity(
     output_file: Option<&std::path::Path>,
 ) -> Result<runtime::ResolvedTarget> {
     match resolve_target(runtime, target, file_filter) {
+        Ok(target) => Ok(target),
+        Err(error) => {
+            if let Some(ambiguous) = error.downcast_ref::<AmbiguousTargetError>() {
+                return structured_ambiguous_target_failure(
+                    runtime,
+                    ambiguous.clone(),
+                    format,
+                    output_file,
+                );
+            }
+            Err(error)
+        }
+    }
+}
+
+fn resolve_source_target_or_emit_ambiguity(
+    runtime: &RuntimeContext,
+    target: args::TargetSelection,
+    file_filter: Option<&str>,
+    format: args::OutputFormat,
+    output_file: Option<&std::path::Path>,
+) -> Result<runtime::ResolvedTarget> {
+    match resolve_source_target(runtime, target, file_filter) {
         Ok(target) => Ok(target),
         Err(error) => {
             if let Some(ambiguous) = error.downcast_ref::<AmbiguousTargetError>() {

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2984,6 +2984,10 @@ fn drill_search_hit_from_packet_citation(
         origin: citation.origin,
         match_quality,
         resolvable: citation.resolvable,
+        evidence_tier: citation.evidence_tier,
+        evidence_producer: citation.evidence_producer.clone(),
+        resolution_status: citation.resolution_status,
+        eligible_for_sufficiency: citation.eligible_for_sufficiency,
         score_breakdown: citation.retrieval_score_breakdown.clone(),
         duplicate_of: None,
         excerpt: None,
@@ -7358,6 +7362,10 @@ fn build_search_hit_output(
             .match_quality
             .unwrap_or_else(|| search_match_quality(query, hit)),
         resolvable: hit.resolvable,
+        evidence_tier: hit.evidence_tier,
+        evidence_producer: hit.evidence_producer.clone(),
+        resolution_status: hit.resolution_status,
+        eligible_for_sufficiency: hit.eligible_for_sufficiency,
         score_breakdown,
         duplicate_of: None,
         excerpt: repo_text_excerpt(project_root, hit),
@@ -9133,6 +9141,147 @@ mod tests {
             output.repo_text_hits[0].origin,
             codestory_contracts::api::SearchHitOrigin::TextMatch
         );
+    }
+
+    #[test]
+    fn cli_search_and_resolution_keep_structural_evidence_metadata() {
+        let root = Path::new("C:/repo");
+        let manifest = SearchHit {
+            node_id: NodeId("cargo-package".to_string()),
+            display_name: "demo".to_string(),
+            kind: NodeKind::PACKAGE,
+            file_path: Some("C:/repo/Cargo.toml".to_string()),
+            line: Some(2),
+            score: 0.9,
+            origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
+            resolvable: true,
+            evidence_tier: Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText),
+            evidence_producer: Some("structural_cargo_manifest_collector".to_string()),
+            resolution_status: Some(
+                codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly,
+            ),
+            eligible_for_sufficiency: Some(false),
+            ..test_search_hit_defaults()
+        };
+        let workflow = SearchHit {
+            node_id: NodeId("workflow-job".to_string()),
+            display_name: "test".to_string(),
+            kind: NodeKind::FUNCTION,
+            file_path: Some("C:/repo/.github/workflows/ci.yml".to_string()),
+            line: Some(12),
+            score: 0.8,
+            origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
+            resolvable: true,
+            evidence_tier: Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText),
+            evidence_producer: Some("structural_github_actions_workflow_collector".to_string()),
+            resolution_status: Some(
+                codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly,
+            ),
+            eligible_for_sufficiency: Some(false),
+            ..test_search_hit_defaults()
+        };
+        let output = build_search_output(SearchOutputParts {
+            project_root: root,
+            query: "demo",
+            retrieval: &sample_retrieval(),
+            retrieval_shadow: None,
+            freshness: None,
+            symbol_hits: &[manifest.clone(), workflow.clone()],
+            repo_text_hits: &[],
+            repo_text_stats: None,
+            query_assessment: None,
+            search_plan: None,
+            suggestions: &[],
+            occurrences_by_node: &HashMap::new(),
+            limit_per_source: 5,
+            repo_text: RepoTextOutputConfig {
+                mode: RepoTextMode::Off,
+                enabled: false,
+            },
+            explain: false,
+        });
+
+        let search_json = serde_json::to_value(&output).expect("serialize CLI search output");
+        for (index, producer) in [
+            (0, "structural_cargo_manifest_collector"),
+            (1, "structural_github_actions_workflow_collector"),
+        ] {
+            let hit = &search_json["indexed_symbol_hits"][index];
+            assert_eq!(hit["evidence_tier"], "structural_text");
+            assert_eq!(hit["evidence_producer"], producer);
+            assert_eq!(hit["resolution_status"], "source_range_only");
+            assert_eq!(hit["eligible_for_sufficiency"], false);
+        }
+        let markdown = render_search_markdown(root, &output);
+        assert!(
+            markdown.contains("evidence_tier=structural_text"),
+            "{markdown}"
+        );
+        assert!(
+            markdown.contains("resolution_status=source_range_only"),
+            "{markdown}"
+        );
+        assert!(
+            markdown.contains("eligible_for_sufficiency=false"),
+            "{markdown}"
+        );
+
+        let target = runtime::ResolvedTarget {
+            selector: QuerySelectorOutput::Query,
+            requested: "demo".to_string(),
+            file_filter: None,
+            selected: manifest.clone(),
+            alternatives: vec![manifest, workflow.clone()],
+        };
+        let resolution = build_query_resolution_output(root, &target);
+        let resolution_json =
+            serde_json::to_value(&resolution).expect("serialize CLI query resolution output");
+        assert_eq!(
+            resolution_json["resolved"]["evidence_tier"],
+            "structural_text"
+        );
+        assert_eq!(
+            resolution_json["resolved"]["resolution_status"],
+            "source_range_only"
+        );
+        assert_eq!(
+            resolution_json["resolved"]["eligible_for_sufficiency"],
+            false
+        );
+        assert_eq!(
+            resolution_json["alternatives"][0]["evidence_producer"],
+            "structural_github_actions_workflow_collector"
+        );
+
+        let citation = AgentCitationDto {
+            node_id: workflow.node_id.clone(),
+            display_name: workflow.display_name.clone(),
+            kind: workflow.kind,
+            file_path: workflow.file_path.clone(),
+            line: workflow.line,
+            score: workflow.score,
+            origin: workflow.origin,
+            resolvable: workflow.resolvable,
+            subgraph_id: None,
+            evidence_edge_ids: Vec::new(),
+            retrieval_score_breakdown: None,
+            evidence_tier: workflow.evidence_tier,
+            evidence_producer: workflow.evidence_producer.clone(),
+            resolution_status: workflow.resolution_status,
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: workflow.eligible_for_sufficiency,
+        };
+        let drill_hit = drill_search_hit_from_packet_citation(root, "test", &citation);
+        assert_eq!(
+            drill_hit.evidence_producer.as_deref(),
+            Some("structural_github_actions_workflow_collector")
+        );
+        assert_eq!(
+            drill_hit.resolution_status,
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
+        assert_eq!(drill_hit.eligible_for_sufficiency, Some(false));
     }
 
     #[test]

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -1994,6 +1994,13 @@ pub(crate) fn render_agent_citation(
     if citation_needs_untrusted_repo_label(citation) {
         let _ = write!(out, " {UNTRUSTED_REPO_EVIDENCE_TRUST}");
     }
+    append_evidence_metadata(
+        &mut out,
+        citation.evidence_tier,
+        citation.evidence_producer.as_deref(),
+        citation.resolution_status,
+        citation.eligible_for_sufficiency,
+    );
     if include_breakdown && let Some(breakdown) = citation.retrieval_score_breakdown.as_ref() {
         let _ = write!(
             out,
@@ -3306,6 +3313,13 @@ fn render_search_hit(project_root: &Path, hit: &SearchHit) -> String {
     }
     let _ = write!(out, " score={:.2}", hit.score);
     let _ = write!(out, " origin={}", hit.origin.as_str());
+    append_evidence_metadata(
+        &mut out,
+        hit.evidence_tier,
+        hit.evidence_producer.as_deref(),
+        hit.resolution_status,
+        hit.eligible_for_sufficiency,
+    );
     if let Some(node_ref) = node_ref(
         project_root,
         hit.file_path.as_deref(),
@@ -3333,6 +3347,13 @@ pub(crate) fn render_search_hit_output(hit: &SearchHitOutput) -> String {
     let _ = write!(out, " score={:.2}", hit.score);
     let _ = write!(out, " origin={}", hit.origin.as_str());
     let _ = write!(out, " match={}", format_match_quality(hit.match_quality));
+    append_evidence_metadata(
+        &mut out,
+        hit.evidence_tier,
+        hit.evidence_producer.as_deref(),
+        hit.resolution_status,
+        hit.eligible_for_sufficiency,
+    );
     if hit.origin == SearchHitOrigin::TextMatch {
         let _ = write!(out, " {UNTRUSTED_REPO_EVIDENCE_TRUST}");
     }
@@ -3349,6 +3370,58 @@ pub(crate) fn render_search_hit_output(hit: &SearchHitOutput) -> String {
         let _ = write!(out, " (see above)");
     }
     out
+}
+
+fn append_evidence_metadata(
+    out: &mut String,
+    evidence_tier: Option<PacketEvidenceTierDto>,
+    evidence_producer: Option<&str>,
+    resolution_status: Option<PacketEvidenceResolutionDto>,
+    eligible_for_sufficiency: Option<bool>,
+) {
+    if let Some(evidence_tier) = evidence_tier {
+        let _ = write!(
+            out,
+            " evidence_tier={}",
+            format_evidence_tier(evidence_tier)
+        );
+    }
+    if let Some(evidence_producer) = evidence_producer {
+        let _ = write!(out, " evidence_producer={evidence_producer}");
+    }
+    if let Some(resolution_status) = resolution_status {
+        let _ = write!(
+            out,
+            " resolution_status={}",
+            format_evidence_resolution(resolution_status)
+        );
+    }
+    if let Some(eligible_for_sufficiency) = eligible_for_sufficiency {
+        let _ = write!(out, " eligible_for_sufficiency={eligible_for_sufficiency}");
+    }
+}
+
+fn format_evidence_tier(tier: PacketEvidenceTierDto) -> &'static str {
+    match tier {
+        PacketEvidenceTierDto::ExactSource => "exact_source",
+        PacketEvidenceTierDto::StructuralText => "structural_text",
+        PacketEvidenceTierDto::ResolvedGraph => "resolved_graph",
+        PacketEvidenceTierDto::LexicalSource => "lexical_source",
+        PacketEvidenceTierDto::SymbolDoc => "symbol_doc",
+        PacketEvidenceTierDto::ComponentReport => "component_report",
+        PacketEvidenceTierDto::DenseSemantic => "dense_semantic",
+        PacketEvidenceTierDto::SyntheticSourceScan => "synthetic_source_scan",
+        PacketEvidenceTierDto::GeneratedSummary => "generated_summary",
+    }
+}
+
+fn format_evidence_resolution(resolution: PacketEvidenceResolutionDto) -> &'static str {
+    match resolution {
+        PacketEvidenceResolutionDto::Resolved => "resolved",
+        PacketEvidenceResolutionDto::SourceRangeOnly => "source_range_only",
+        PacketEvidenceResolutionDto::Unresolved => "unresolved",
+        PacketEvidenceResolutionDto::DiagnosticOnly => "diagnostic_only",
+    }
 }
 
 fn format_match_quality(quality: codestory_contracts::api::SearchMatchQualityDto) -> &'static str {
@@ -4197,6 +4270,10 @@ mod tests {
             origin: SearchHitOrigin::IndexedSymbol,
             match_quality: codestory_contracts::api::SearchMatchQualityDto::NormalizedExact,
             resolvable: true,
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
+            eligible_for_sufficiency: None,
             score_breakdown: Some(RetrievalScoreBreakdownDto {
                 lexical: 0.7,
                 semantic: 0.1,
@@ -4241,6 +4318,67 @@ mod tests {
         hit.resolution_hints = Vec::new();
         hit.why = vec!["repo-text diagnostic match".to_string()];
         hit
+    }
+
+    #[test]
+    fn search_hit_markdown_keeps_structural_evidence_metadata() {
+        let mut hit = sample_search_hit();
+        hit.file_path = Some("Cargo.toml".to_string());
+        hit.evidence_tier = Some(PacketEvidenceTierDto::StructuralText);
+        hit.evidence_producer = Some("structural_cargo_manifest_collector".to_string());
+        hit.resolution_status = Some(PacketEvidenceResolutionDto::SourceRangeOnly);
+        hit.eligible_for_sufficiency = Some(false);
+
+        let markdown = render_search_hit_output(&hit);
+
+        for expected in [
+            "evidence_tier=structural_text",
+            "evidence_producer=structural_cargo_manifest_collector",
+            "resolution_status=source_range_only",
+            "eligible_for_sufficiency=false",
+        ] {
+            assert!(
+                markdown.contains(expected),
+                "missing {expected}: {markdown}"
+            );
+        }
+    }
+
+    #[test]
+    fn citation_markdown_keeps_structural_evidence_metadata() {
+        let citation = AgentCitationDto {
+            node_id: NodeId("workflow-job".to_string()),
+            display_name: "test".to_string(),
+            kind: NodeKind::FUNCTION,
+            file_path: Some("C:/repo/.github/workflows/ci.yml".to_string()),
+            line: Some(12),
+            score: 0.8,
+            origin: SearchHitOrigin::IndexedSymbol,
+            resolvable: true,
+            subgraph_id: None,
+            evidence_edge_ids: Vec::new(),
+            retrieval_score_breakdown: None,
+            evidence_tier: Some(PacketEvidenceTierDto::StructuralText),
+            evidence_producer: Some("structural_github_actions_workflow_collector".to_string()),
+            resolution_status: Some(PacketEvidenceResolutionDto::SourceRangeOnly),
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: Some(false),
+        };
+
+        let markdown = render_agent_citation(Path::new("C:/repo"), &citation, false);
+
+        for expected in [
+            "evidence_tier=structural_text",
+            "evidence_producer=structural_github_actions_workflow_collector",
+            "resolution_status=source_range_only",
+            "eligible_for_sufficiency=false",
+        ] {
+            assert!(
+                markdown.contains(expected),
+                "missing {expected}: {markdown}"
+            );
+        }
     }
 
     #[test]

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -2010,7 +2010,8 @@ fn citation_needs_untrusted_repo_label(citation: &AgentCitationDto) -> bool {
         || matches!(
             citation.evidence_tier,
             Some(
-                PacketEvidenceTierDto::SyntheticSourceScan
+                PacketEvidenceTierDto::StructuralText
+                    | PacketEvidenceTierDto::SyntheticSourceScan
                     | PacketEvidenceTierDto::GeneratedSummary
             )
         )
@@ -4536,6 +4537,9 @@ mod tests {
                 member_count: None,
                 summary: Some("Builds the evidence packet.".to_string()),
                 edge_digest: Vec::new(),
+                evidence_tier: None,
+                evidence_producer: None,
+                resolution_status: None,
             }],
             files: vec![GroundingFileDigestDto {
                 file_path: "C:/repo/src/lib.rs".to_string(),

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -1450,14 +1450,15 @@ fn append_ground_evidence_packet(
                 .as_deref()
                 .map(|value| format!(" ref=`{value}`"))
                 .unwrap_or_default();
-            let _ = writeln!(
-                markdown,
-                "- [{}] {} [{}]{}",
+            let mut citation = format!(
+                "[{}] {} [{}]{}",
                 symbol.id.0,
                 symbol.label,
                 format_kind(symbol.kind),
                 node_ref
             );
+            append_ground_symbol_evidence_metadata(&mut citation, symbol);
+            let _ = writeln!(markdown, "- {citation}");
         }
     }
 
@@ -3717,7 +3718,21 @@ fn render_ground_symbol(symbol: &codestory_contracts::api::GroundingSymbolDigest
     if !symbol.edge_digest.is_empty() {
         let _ = write!(out, " edges={}", symbol.edge_digest.join("; "));
     }
+    append_ground_symbol_evidence_metadata(&mut out, symbol);
     out
+}
+
+fn append_ground_symbol_evidence_metadata(
+    out: &mut String,
+    symbol: &codestory_contracts::api::GroundingSymbolDigestDto,
+) {
+    append_evidence_metadata(
+        out,
+        symbol.evidence_tier,
+        symbol.evidence_producer.as_deref(),
+        symbol.resolution_status,
+        None,
+    );
 }
 
 #[cfg(test)]
@@ -4675,9 +4690,9 @@ mod tests {
                 member_count: None,
                 summary: Some("Builds the evidence packet.".to_string()),
                 edge_digest: Vec::new(),
-                evidence_tier: None,
-                evidence_producer: None,
-                resolution_status: None,
+                evidence_tier: Some(PacketEvidenceTierDto::StructuralText),
+                evidence_producer: Some("structural_cargo_manifest_collector".to_string()),
+                resolution_status: Some(PacketEvidenceResolutionDto::SourceRangeOnly),
             }],
             files: vec![GroundingFileDigestDto {
                 file_path: "C:/repo/src/lib.rs".to_string(),
@@ -4695,9 +4710,30 @@ mod tests {
         };
 
         let markdown = render_ground_markdown(Path::new("C:/repo"), &snapshot, true);
+        let default_markdown = render_ground_markdown(Path::new("C:/repo"), &snapshot, false);
 
         assert_evidence_packet_shape(&markdown, &["short_finding:", "summary:"]);
         assert_order(&markdown, "short_finding:", "confidence:");
+        for rendered in [&default_markdown, &markdown] {
+            assert!(
+                rendered.contains("evidence_tier=structural_text"),
+                "{rendered}"
+            );
+            assert!(
+                rendered.contains("evidence_producer=structural_cargo_manifest_collector"),
+                "{rendered}"
+            );
+            assert!(
+                rendered.contains("resolution_status=source_range_only"),
+                "{rendered}"
+            );
+        }
+        assert!(
+            markdown.contains(
+                "citations:\n- [node-build-packet] build_packet [function] ref=`src/lib.rs:7:build_packet` evidence_tier=structural_text evidence_producer=structural_cargo_manifest_collector resolution_status=source_range_only"
+            ),
+            "{markdown}"
+        );
         assert!(
             !markdown.contains("why:"),
             "ground --why should use the redesigned packet instead of the legacy why block:\n{markdown}"

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -532,13 +532,38 @@ pub(crate) fn resolve_target(
     target: TargetSelection,
     file_filter: Option<&str>,
 ) -> Result<ResolvedTarget> {
+    resolve_target_with(target, file_filter, |target, file_filter| {
+        runtime.browser.resolve_target(target, file_filter)
+    })
+}
+
+/// Resolve an exact source-navigation target while retaining typed query
+/// filtering for query selectors.
+pub(crate) fn resolve_source_target(
+    runtime: &RuntimeContext,
+    target: TargetSelection,
+    file_filter: Option<&str>,
+) -> Result<ResolvedTarget> {
+    resolve_target_with(target, file_filter, |target, file_filter| {
+        runtime.browser.resolve_source_target(target, file_filter)
+    })
+}
+
+fn resolve_target_with(
+    target: TargetSelection,
+    file_filter: Option<&str>,
+    resolve: impl FnOnce(
+        codestory_runtime::TargetSelection,
+        Option<&str>,
+    ) -> std::result::Result<TargetResolution, ApiError>,
+) -> Result<ResolvedTarget> {
     let target = match target {
         TargetSelection::Id(id) => codestory_runtime::TargetSelection::Id(id),
         TargetSelection::Query { query, choose } => {
             codestory_runtime::TargetSelection::Query { query, choose }
         }
     };
-    match runtime.browser.resolve_target(target, file_filter) {
+    match resolve(target, file_filter) {
         Ok(TargetResolution::Resolved(target)) => Ok(ResolvedTarget::from_runtime(*target)),
         Ok(TargetResolution::Ambiguous(ambiguous)) => Err(AmbiguousTargetError {
             query: ambiguous.query,

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -600,6 +600,23 @@ impl SchemaObject {
 }
 
 const TEXT_HIT_ORIGINS: &[&str] = &["indexed_symbol", "text_match"];
+const PACKET_EVIDENCE_TIERS: &[&str] = &[
+    "exact_source",
+    "structural_text",
+    "resolved_graph",
+    "lexical_source",
+    "symbol_doc",
+    "component_report",
+    "dense_semantic",
+    "synthetic_source_scan",
+    "generated_summary",
+];
+const PACKET_EVIDENCE_RESOLUTIONS: &[&str] = &[
+    "resolved",
+    "source_range_only",
+    "unresolved",
+    "diagnostic_only",
+];
 const SEARCH_REPO_TEXT_MODES: &[&str] = &["auto", "on", "off"];
 const INDEXED_FILE_ROLES: &[&str] = &["source", "test", "generated", "vendor", "unknown"];
 const SNIPPET_SCOPES: &[&str] = &["line_context", "function_body"];
@@ -692,6 +709,24 @@ static SEARCH_HIT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::boolean(
             "resolvable",
             "Whether the hit can be used as a symbol target.",
+        ),
+        SchemaProperty::string(
+            "evidence_tier",
+            "Evidence provenance tier. structural_text is collector-backed source-range evidence, not parser-backed graph coverage.",
+        )
+        .with_enum(PACKET_EVIDENCE_TIERS),
+        SchemaProperty::string(
+            "evidence_producer",
+            "Collector or retrieval producer that emitted the evidence.",
+        ),
+        SchemaProperty::string(
+            "resolution_status",
+            "Resolution state. source_range_only has a source span but no typed graph resolution.",
+        )
+        .with_enum(PACKET_EVIDENCE_RESOLUTIONS),
+        SchemaProperty::boolean(
+            "eligible_for_sufficiency",
+            "Whether this hit may satisfy answer-sufficiency requirements.",
         ),
         SchemaProperty::object("score_breakdown", "Optional retrieval score breakdown."),
         SchemaProperty::array(
@@ -1187,6 +1222,24 @@ static AGENT_CITATION_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::boolean(
             "resolvable",
             "Whether the citation can be resolved as a symbol.",
+        ),
+        SchemaProperty::string(
+            "evidence_tier",
+            "Evidence provenance tier. structural_text is collector-backed source-range evidence, not parser-backed graph coverage.",
+        )
+        .with_enum(PACKET_EVIDENCE_TIERS),
+        SchemaProperty::string(
+            "evidence_producer",
+            "Collector or retrieval producer that emitted the evidence.",
+        ),
+        SchemaProperty::string(
+            "resolution_status",
+            "Resolution state. source_range_only has a source span but no typed graph resolution.",
+        )
+        .with_enum(PACKET_EVIDENCE_RESOLUTIONS),
+        SchemaProperty::boolean(
+            "eligible_for_sufficiency",
+            "Whether this citation may satisfy answer-sufficiency requirements.",
         ),
         SchemaProperty::string("subgraph_id", "Related subgraph id.").nullable(),
         SchemaProperty::string_array("evidence_edge_ids", "Evidence edge ids."),

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -38,7 +38,9 @@ use crate::http_transport::{
 use crate::output::{
     REPO_CONTENT_BOUNDARY_LINE, UNTRUSTED_REPO_EVIDENCE_TRUST, context_packet_json,
 };
-use crate::runtime::{AmbiguousTargetError, RuntimeContext, map_api_error, resolve_target};
+use crate::runtime::{
+    AmbiguousTargetError, RuntimeContext, map_api_error, resolve_source_target, resolve_target,
+};
 use crate::stdio_catalog::{
     is_tool_name as is_stdio_tool_name, prompt_get_json as stdio_prompt_get_json,
     prompts_list_json as stdio_prompts_list_json,
@@ -2911,7 +2913,7 @@ fn handle_stdio_snippet(
     runtime: &RuntimeContext,
     request: &serde_json::Value,
 ) -> serde_json::Value {
-    resolve_target(runtime, stdio_target_selection(request), None)
+    resolve_source_target(runtime, stdio_target_selection(request), None)
         .and_then(|target| {
             runtime
                 .browser

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -5738,6 +5738,69 @@ version = "0.11.20"
     }
 
     #[test]
+    fn stdio_search_preserves_structural_workflow_evidence_metadata() {
+        let workflow_hit = codestory_contracts::api::SearchHit {
+            node_id: NodeId("workflow-job".to_string()),
+            display_name: "test".to_string(),
+            kind: NodeKind::FUNCTION,
+            file_path: Some(".github/workflows/ci.yml".to_string()),
+            line: Some(12),
+            score: 0.8,
+            origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
+            match_quality: None,
+            resolvable: true,
+            evidence_tier: Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText),
+            evidence_producer: Some("structural_github_actions_workflow_collector".to_string()),
+            resolution_status: Some(
+                codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly,
+            ),
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: Some(false),
+            score_breakdown: None,
+        };
+        let result = codestory_contracts::api::SearchResultsDto {
+            query: "test".to_string(),
+            retrieval_publication: None,
+            retrieval: codestory_contracts::api::RetrievalStateDto {
+                mode: codestory_contracts::api::RetrievalModeDto::Hybrid,
+                hybrid_configured: true,
+                semantic_ready: true,
+                semantic_mode: codestory_contracts::api::SemanticModeDto::Enabled,
+                semantic_doc_count: 1,
+                embedding_model: None,
+                current_embedding: None,
+                stored_embedding: None,
+                fallback_reason: None,
+                fallback_message: None,
+            },
+            retrieval_shadow: None,
+            freshness: None,
+            limit_per_source: 5,
+            repo_text_mode: SearchRepoTextMode::Off,
+            repo_text_enabled: false,
+            query_assessment: None,
+            search_plan: None,
+            repo_text_stats: None,
+            suggestions: Vec::new(),
+            indexed_symbol_hits: vec![workflow_hit.clone()],
+            repo_text_hits: Vec::new(),
+            hits: vec![workflow_hit],
+        };
+
+        let response = stdio_tool_call_success("search", enrich_stdio_search_result(result));
+        let hit = &response["structuredContent"]["hits"][0];
+
+        assert_eq!(hit["evidence_tier"], "structural_text");
+        assert_eq!(
+            hit["evidence_producer"],
+            "structural_github_actions_workflow_collector"
+        );
+        assert_eq!(hit["resolution_status"], "source_range_only");
+        assert_eq!(hit["eligible_for_sufficiency"], false);
+    }
+
+    #[test]
     fn stdio_installed_host_results_stay_compact() {
         let projection: serde_json::Value = serde_json::from_str(include_str!(
             "../tests/fixtures/stdio_installed_host_search_retrieval.json"

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1061,6 +1061,81 @@ fn app_controller_opens_project() {
 }
 
 #[test]
+fn snippet_exact_id_navigates_openapi_diagnostic_evidence_but_query_stays_typed() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_openapi_workspace(workspace.path());
+    let _search_dir_snapshot =
+        index_tiny_workspace_for_browser_loop(workspace.path(), cache_dir.path());
+    let node_id = ground_symbol_node_id_from_existing_cache(
+        workspace.path(),
+        cache_dir.path(),
+        "openapi::GET /api/users",
+        Some("openapi.json"),
+    );
+
+    let snippet = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "snippet",
+            &format!("--id={node_id}"),
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(
+        snippet["resolution"]["resolved"]["evidence_tier"],
+        "exact_source"
+    );
+    assert_eq!(
+        snippet["resolution"]["resolved"]["evidence_producer"],
+        "openapi_endpoint_schema"
+    );
+    assert_eq!(
+        snippet["resolution"]["resolved"]["resolution_status"],
+        "source_range_only"
+    );
+    assert_eq!(
+        snippet["resolution"]["resolved"]["eligible_for_sufficiency"],
+        false
+    );
+    assert!(
+        snippet["snippet"]["snippet"]
+            .as_str()
+            .is_some_and(|source| source.contains("/api/users")),
+        "snippet should navigate the exact OpenAPI source range: {snippet:#}"
+    );
+
+    let query = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "snippet",
+            "--query=openapi::GET /api/users",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        !query.status.success(),
+        "query snippets must not select source-range-only diagnostic evidence"
+    );
+    let failure: Value = serde_json::from_slice(&query.stdout)
+        .unwrap_or_else(|error| panic!("parse query snippet failure: {error}; output={query:#?}"));
+    assert!(
+        failure["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("No symbol matched query")),
+        "query snippet should retain typed graph filtering: {failure:#}"
+    );
+}
+
+#[test]
 fn files_json_reports_structural_support_tiers_for_cargo_and_compose() {
     let workspace = tempdir().expect("workspace dir");
     let cache_dir = tempdir().expect("cache dir");

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2080,6 +2080,61 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
         "SearchHit outputSchema should still advertise optional match_quality: {search_hit_schema}"
     );
 
+    let citation_schema = tool_output_schema(&tools, "context")
+        .pointer("/properties/citations/items")
+        .unwrap_or_else(|| panic!("context outputSchema should describe agent citations: {tools}"));
+    for (surface, schema) in [
+        ("search hit", search_hit_schema),
+        ("agent citation", citation_schema),
+    ] {
+        for field in [
+            "evidence_tier",
+            "evidence_producer",
+            "resolution_status",
+            "eligible_for_sufficiency",
+        ] {
+            assert!(
+                !required_fields(schema).contains(field),
+                "{surface} evidence field {field} must remain optional: {schema}"
+            );
+        }
+        assert_schema_enum_values(
+            schema,
+            "/properties/evidence_tier/enum",
+            &[
+                "exact_source",
+                "structural_text",
+                "resolved_graph",
+                "lexical_source",
+                "symbol_doc",
+                "component_report",
+                "dense_semantic",
+                "synthetic_source_scan",
+                "generated_summary",
+            ],
+        );
+        assert_schema_enum_values(
+            schema,
+            "/properties/resolution_status/enum",
+            &[
+                "resolved",
+                "source_range_only",
+                "unresolved",
+                "diagnostic_only",
+            ],
+        );
+        assert_eq!(
+            schema_property(schema, "evidence_producer")["type"],
+            "string",
+            "{surface} outputSchema should expose the evidence producer: {schema}"
+        );
+        assert_eq!(
+            schema_property(schema, "eligible_for_sufficiency")["type"],
+            "boolean",
+            "{surface} outputSchema should expose the sufficiency flag: {schema}"
+        );
+    }
+
     let related_hit_schema = tool_output_schema(&tools, "symbol")
         .pointer("/properties/related_hits/items")
         .unwrap_or_else(|| {

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2415,6 +2415,82 @@ fn ground_tool_returns_budgeted_grounding_snapshot() {
 }
 
 #[test]
+fn snippet_tool_exact_id_navigates_structural_evidence_but_query_stays_typed() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let ground_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-structural-snippet",
+            "method": "tools/call",
+            "params": {"name": "ground", "arguments": {"budget": "balanced"}}
+        }),
+    );
+    let grounding = assert_tool_success(&ground_response, json!("ground-structural-snippet"));
+    let node_id = grounding["root_symbols"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .chain(
+            grounding["files"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .flat_map(|file| file["symbols"].as_array().into_iter().flatten()),
+        )
+        .find(|symbol| {
+            symbol["label"]
+                .as_str()
+                .is_some_and(|label| label.starts_with("tiny-stdio-contract-fixture @ "))
+        })
+        .and_then(|symbol| symbol["id"].as_str())
+        .unwrap_or_else(|| panic!("grounding should expose the Cargo package: {grounding:#}"))
+        .to_string();
+
+    let snippet_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "snippet-structural-id",
+            "method": "tools/call",
+            "params": {"name": "snippet", "arguments": {"id": node_id}}
+        }),
+    );
+    let snippet = assert_tool_success(&snippet_response, json!("snippet-structural-id"));
+    assert!(
+        snippet["path"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("Cargo.toml"))
+            && snippet["snippet"]
+                .as_str()
+                .is_some_and(|source| source.contains("[package]")),
+        "stdio snippet should navigate the exact structural source range: {snippet:#}"
+    );
+
+    let query_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "snippet-structural-query",
+            "method": "tools/call",
+            "params": {
+                "name": "snippet",
+                "arguments": {"query": "tiny-stdio-contract-fixture"}
+            }
+        }),
+    );
+    let error = assert_tool_error(&query_response, json!("snippet-structural-query"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("No symbol matched query")),
+        "stdio query snippet should retain typed graph filtering: {error:#}"
+    );
+}
+
+#[test]
 fn files_tool_lists_indexed_files_without_sidecars() {
     let fixture = indexed_fixture();
     let mut server = spawn_stdio_server(&fixture);

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -1290,8 +1290,9 @@ pub struct GroundingSymbolDigestDto {
     pub summary: Option<String>,
     #[serde(default)]
     pub edge_digest: Vec<String>,
-    /// Collector-backed evidence metadata, when the symbol comes from a
-    /// structural source span rather than parser-backed graph coverage.
+    /// Diagnostic source-range evidence metadata, when the symbol comes from
+    /// a structural collector or endpoint schema rather than parser-backed
+    /// graph coverage.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evidence_tier: Option<PacketEvidenceTierDto>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -137,15 +137,18 @@ pub enum SearchMatchQualityDto {
 
 /// Evidence provenance tier used by packet/search/citation surfaces.
 ///
-/// Tiers are compatibility values. `ExactSource`, `ResolvedGraph`,
-/// `LexicalSource`, `SymbolDoc`, `ComponentReport`, and `DenseSemantic` are
-/// product evidence from indexed or sidecar sources. `SyntheticSourceScan` and
-/// `GeneratedSummary` are diagnostic or presentation evidence and should not be
-/// treated as source truth without a follow-up read.
+/// Tiers are compatibility values. `ExactSource`, `StructuralText`,
+/// `ResolvedGraph`, `LexicalSource`, `SymbolDoc`, `ComponentReport`, and
+/// `DenseSemantic` are product evidence from indexed or sidecar sources.
+/// `StructuralText` identifies a collector-backed source span; it does not
+/// imply parser-backed graph coverage or semantic resolution. `SyntheticSourceScan`
+/// and `GeneratedSummary` are diagnostic or presentation evidence and should
+/// not be treated as source truth without a follow-up read.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketEvidenceTierDto {
     ExactSource,
+    StructuralText,
     ResolvedGraph,
     LexicalSource,
     SymbolDoc,
@@ -1287,6 +1290,14 @@ pub struct GroundingSymbolDigestDto {
     pub summary: Option<String>,
     #[serde(default)]
     pub edge_digest: Vec<String>,
+    /// Collector-backed evidence metadata, when the symbol comes from a
+    /// structural source span rather than parser-backed graph coverage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence_tier: Option<PacketEvidenceTierDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence_producer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution_status: Option<PacketEvidenceResolutionDto>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
@@ -2404,6 +2415,15 @@ pub struct BookmarkCategoryDto {
 #[cfg(test)]
 mod packet_tests {
     use super::*;
+
+    #[test]
+    fn structural_text_evidence_tier_serializes_as_a_named_public_contract() {
+        assert_eq!(
+            serde_json::to_value(PacketEvidenceTierDto::StructuralText)
+                .expect("serialize structural-text evidence tier"),
+            serde_json::json!("structural_text")
+        );
+    }
 
     fn producer_evidence() -> EmbeddingVectorProducerEvidenceDto {
         EmbeddingVectorProducerEvidenceDto {

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -138,7 +138,7 @@ pub const LANGUAGE_CLAIM_TIER_CONTRACTS: &[LanguageClaimTierContract] = &[
     },
 ];
 
-/// Structural collector contract for exact-source, non-semantic proof.
+/// Structural collector contract for structural-text, non-semantic proof.
 ///
 /// Each row is a product evidence boundary. `semantic_proof_allowed = false`
 /// means the collector may support navigation or diagnostics, but must not be
@@ -191,7 +191,7 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
         path_pattern: ".github/workflows/*.{yml,yaml}",
         emitted_node_kinds: GITHUB_ACTIONS_WORKFLOW_NODE_KINDS,
         source_span: "1-based source line and column span for the matched workflow, job, or step anchor",
-        evidence_tier: PacketEvidenceTierDto::ExactSource,
+        evidence_tier: PacketEvidenceTierDto::StructuralText,
         resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
         confidence: 1.0,
         unsupported_shape_notes: GITHUB_ACTIONS_WORKFLOW_UNSUPPORTED_SHAPES,
@@ -203,7 +203,7 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
         path_pattern: "compose*.{yml,yaml}, docker-compose*.{yml,yaml}, docker/*-compose.{yml,yaml}",
         emitted_node_kinds: DOCKER_COMPOSE_NODE_KINDS,
         source_span: "1-based source line and column span for the matched stack, service, or service property anchor",
-        evidence_tier: PacketEvidenceTierDto::ExactSource,
+        evidence_tier: PacketEvidenceTierDto::StructuralText,
         resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
         confidence: 1.0,
         unsupported_shape_notes: DOCKER_COMPOSE_UNSUPPORTED_SHAPES,
@@ -227,7 +227,7 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
         path_pattern: "**/Cargo.toml",
         emitted_node_kinds: CARGO_MANIFEST_NODE_KINDS,
         source_span: "1-based source line and column span for matched workspace member, package name, or direct dependency key anchors",
-        evidence_tier: PacketEvidenceTierDto::ExactSource,
+        evidence_tier: PacketEvidenceTierDto::StructuralText,
         resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
         confidence: 1.0,
         unsupported_shape_notes: CARGO_MANIFEST_UNSUPPORTED_SHAPES,
@@ -558,7 +558,7 @@ mod tests {
     }
 
     #[test]
-    fn structural_source_proof_contract_is_exact_source_not_semantic() {
+    fn structural_source_proof_contract_is_structural_text_not_semantic() {
         let contract = STRUCTURAL_SOURCE_PROOF_CONTRACTS
             .iter()
             .find(|contract| contract.collector_name == "github_actions_workflow")
@@ -566,7 +566,10 @@ mod tests {
         assert_eq!(contract.path_pattern, ".github/workflows/*.{yml,yaml}");
         assert!(contract.emitted_node_kinds.contains(&NodeKind::MODULE));
         assert!(contract.emitted_node_kinds.contains(&NodeKind::FUNCTION));
-        assert_eq!(contract.evidence_tier, PacketEvidenceTierDto::ExactSource);
+        assert_eq!(
+            contract.evidence_tier,
+            PacketEvidenceTierDto::StructuralText
+        );
         assert_eq!(
             contract.resolution,
             PacketEvidenceResolutionDto::SourceRangeOnly
@@ -601,7 +604,7 @@ mod tests {
         );
         assert_eq!(
             compose_contract.evidence_tier,
-            PacketEvidenceTierDto::ExactSource
+            PacketEvidenceTierDto::StructuralText
         );
         assert_eq!(
             compose_contract.resolution,
@@ -666,7 +669,7 @@ mod tests {
         );
         assert_eq!(
             cargo_contract.evidence_tier,
-            PacketEvidenceTierDto::ExactSource
+            PacketEvidenceTierDto::StructuralText
         );
         assert_eq!(
             cargo_contract.resolution,

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -14108,6 +14108,9 @@ mod tests {
                 member_count: None,
                 summary: None,
                 edge_digest: Vec::new(),
+                evidence_tier: None,
+                evidence_producer: None,
+                resolution_status: None,
             });
 
         assert_eq!(hit.display_name, "AppController");

--- a/crates/codestory-runtime/src/agent/packet_claims.rs
+++ b/crates/codestory-runtime/src/agent/packet_claims.rs
@@ -109,6 +109,7 @@ fn packet_citation_is_diagnostic_only(citation: &AgentCitationDto) -> bool {
     matches!(
         evidence_tier_for_citation(citation),
         PacketEvidenceTierDto::DenseSemantic
+            | PacketEvidenceTierDto::StructuralText
             | PacketEvidenceTierDto::GeneratedSummary
             | PacketEvidenceTierDto::SyntheticSourceScan
     ) || matches!(

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -6,6 +6,7 @@ use codestory_contracts::api::{
 };
 use codestory_contracts::language_support::{
     is_cargo_manifest_file_path, is_docker_compose_file_path, is_github_actions_workflow_path,
+    structural_language_name_for_path,
 };
 
 const OPENAPI_ENDPOINT_SCHEMA_PRODUCER: &str = "openapi_endpoint_schema";
@@ -39,13 +40,18 @@ pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &
     citation.loss_reason = hit.loss_reason.clone();
     citation.coverage_role = hit.coverage_role.clone();
     if citation_is_diagnostic_source_proof(citation) {
-        citation.evidence_tier = Some(PacketEvidenceTier::ExactSource);
+        let structural_text = citation_is_structural_source_proof(citation);
+        citation.evidence_tier = Some(if structural_text {
+            PacketEvidenceTier::StructuralText
+        } else {
+            PacketEvidenceTier::ExactSource
+        });
         citation.resolution_status = Some(evidence_resolution_for_citation(citation));
-        if citation.evidence_producer.is_none() {
+        if structural_text {
             citation.evidence_producer = citation
                 .file_path
                 .as_deref()
-                .and_then(structural_source_proof_producer)
+                .and_then(|path| structural_text_producer_for_path(Some(path)))
                 .map(str::to_string);
         }
         citation.eligible_for_sufficiency = Some(false);
@@ -73,6 +79,7 @@ pub(crate) fn evidence_is_sufficiency_eligible(
     ) && !matches!(
         tier,
         PacketEvidenceTier::DenseSemantic
+            | PacketEvidenceTier::StructuralText
             | PacketEvidenceTier::SyntheticSourceScan
             | PacketEvidenceTier::GeneratedSummary
     )
@@ -95,7 +102,11 @@ pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool
 
 pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
     if hit_is_diagnostic_source_proof(hit) {
-        return PacketEvidenceTier::ExactSource;
+        return if hit_is_structural_source_proof(hit) {
+            PacketEvidenceTier::StructuralText
+        } else {
+            PacketEvidenceTier::ExactSource
+        };
     }
     if let Some(tier) = hit.evidence_tier {
         return tier;
@@ -149,10 +160,7 @@ pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
         return OPENAPI_ENDPOINT_SCHEMA_PRODUCER.to_string();
     }
     if hit_is_structural_source_proof(hit) {
-        return hit
-            .file_path
-            .as_deref()
-            .and_then(structural_source_proof_producer)
+        return structural_text_producer_for_path(hit.file_path.as_deref())
             .unwrap_or("structural_source_proof_collector")
             .to_string();
     }
@@ -172,7 +180,11 @@ pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
 
 pub(crate) fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
     if citation_is_diagnostic_source_proof(citation) {
-        return PacketEvidenceTier::ExactSource;
+        return if citation_is_structural_source_proof(citation) {
+            PacketEvidenceTier::StructuralText
+        } else {
+            PacketEvidenceTier::ExactSource
+        };
     }
     if let Some(tier) = citation.evidence_tier {
         return tier;
@@ -224,9 +236,7 @@ pub(crate) fn evidence_resolution_for_citation(
 }
 
 fn hit_is_structural_source_proof(hit: &SearchHit) -> bool {
-    hit.file_path
-        .as_deref()
-        .is_some_and(is_structural_source_proof_path)
+    structural_text_producer_for_path(hit.file_path.as_deref()).is_some()
 }
 
 fn hit_is_diagnostic_source_proof(hit: &SearchHit) -> bool {
@@ -238,10 +248,7 @@ fn hit_is_openapi_endpoint_schema(hit: &SearchHit) -> bool {
 }
 
 fn citation_is_structural_source_proof(citation: &AgentCitationDto) -> bool {
-    citation
-        .file_path
-        .as_deref()
-        .is_some_and(is_structural_source_proof_path)
+    structural_text_producer_for_path(citation.file_path.as_deref()).is_some()
 }
 
 fn citation_is_diagnostic_source_proof(citation: &AgentCitationDto) -> bool {
@@ -252,13 +259,12 @@ fn citation_is_openapi_endpoint_schema(citation: &AgentCitationDto) -> bool {
     citation.evidence_producer.as_deref() == Some(OPENAPI_ENDPOINT_SCHEMA_PRODUCER)
 }
 
-fn is_structural_source_proof_path(path: &str) -> bool {
-    is_github_actions_workflow_path(path)
-        || is_docker_compose_file_path(path)
-        || is_cargo_manifest_file_path(path)
-}
-
-fn structural_source_proof_producer(path: &str) -> Option<&'static str> {
+/// Return the stable producer label for an already-indexed structural collector
+/// path. This intentionally does not admit generic text formats: expansion of
+/// the collector inventory belongs to the structural indexing work, not result
+/// publication.
+pub(crate) fn structural_text_producer_for_path(path: Option<&str>) -> Option<&'static str> {
+    let path = path?;
     if is_github_actions_workflow_path(path) {
         return Some("structural_github_actions_workflow_collector");
     }
@@ -268,7 +274,12 @@ fn structural_source_proof_producer(path: &str) -> Option<&'static str> {
     if is_cargo_manifest_file_path(path) {
         return Some("structural_cargo_manifest_collector");
     }
-    None
+    match structural_language_name_for_path(Some(path)) {
+        Some("html") => Some("structural_html_collector"),
+        Some("css") => Some("structural_css_collector"),
+        Some("sql") => Some("structural_sql_collector"),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -310,12 +321,12 @@ mod tests {
     }
 
     #[test]
-    fn github_actions_structural_hit_is_exact_source_diagnostic() {
+    fn github_actions_structural_hit_is_structural_text_diagnostic() {
         let mut hit = workflow_hit();
 
         decorate_search_hit_evidence(&mut hit);
 
-        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::StructuralText));
         assert_eq!(
             hit.resolution_status,
             Some(PacketEvidenceResolution::SourceRangeOnly)
@@ -328,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn docker_compose_structural_hit_is_exact_source_diagnostic() {
+    fn docker_compose_structural_hit_is_structural_text_diagnostic() {
         let mut hit = workflow_hit();
         hit.node_id = NodeId("compose-web".to_string());
         hit.display_name = "web".to_string();
@@ -337,7 +348,7 @@ mod tests {
 
         decorate_search_hit_evidence(&mut hit);
 
-        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::StructuralText));
         assert_eq!(
             hit.resolution_status,
             Some(PacketEvidenceResolution::SourceRangeOnly)
@@ -372,7 +383,7 @@ mod tests {
     }
 
     #[test]
-    fn cargo_manifest_structural_hit_is_exact_source_diagnostic() {
+    fn cargo_manifest_structural_hit_is_structural_text_diagnostic() {
         let mut hit = workflow_hit();
         hit.node_id = NodeId("cargo-serde".to_string());
         hit.display_name = "serde".to_string();
@@ -381,7 +392,7 @@ mod tests {
 
         decorate_search_hit_evidence(&mut hit);
 
-        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::StructuralText));
         assert_eq!(
             hit.resolution_status,
             Some(PacketEvidenceResolution::SourceRangeOnly)
@@ -391,6 +402,89 @@ mod tests {
             Some("structural_cargo_manifest_collector")
         );
         assert_eq!(hit.eligible_for_sufficiency, Some(false));
+    }
+
+    #[test]
+    fn structural_text_producers_cover_existing_collectors_without_admitting_generic_text() {
+        let cases = [
+            (
+                ".github/workflows/ci.yml",
+                "structural_github_actions_workflow_collector",
+            ),
+            (
+                "docker/stack-compose.yaml",
+                "structural_docker_compose_collector",
+            ),
+            (
+                "crates/runtime/Cargo.toml",
+                "structural_cargo_manifest_collector",
+            ),
+            ("web/index.html", "structural_html_collector"),
+            ("web/styles.css", "structural_css_collector"),
+            ("db/schema.sql", "structural_sql_collector"),
+        ];
+
+        for (path, expected_producer) in cases {
+            assert_eq!(
+                structural_text_producer_for_path(Some(path)),
+                Some(expected_producer),
+                "expected existing structural collector for {path}"
+            );
+        }
+
+        for path in [
+            "docs/design.md",
+            "config/service.yaml",
+            "config/service.toml",
+        ] {
+            assert_eq!(
+                structural_text_producer_for_path(Some(path)),
+                None,
+                "generic text remains outside this publication-only slice: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn structural_text_citation_remains_source_range_only_and_non_sufficient() {
+        let mut hit = workflow_hit();
+        decorate_search_hit_evidence(&mut hit);
+        let mut citation = AgentCitationDto {
+            node_id: hit.node_id.clone(),
+            display_name: hit.display_name.clone(),
+            kind: hit.kind,
+            file_path: hit.file_path.clone(),
+            line: hit.line,
+            score: hit.score,
+            origin: hit.origin,
+            resolvable: hit.resolvable,
+            subgraph_id: None,
+            evidence_edge_ids: Vec::new(),
+            retrieval_score_breakdown: None,
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: None,
+        };
+
+        decorate_citation_from_hit(&mut citation, &hit);
+
+        assert_eq!(
+            citation.evidence_tier,
+            Some(PacketEvidenceTier::StructuralText)
+        );
+        assert_eq!(
+            citation.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
+        assert_eq!(
+            citation.evidence_producer.as_deref(),
+            Some("structural_github_actions_workflow_collector")
+        );
+        assert_eq!(citation.eligible_for_sufficiency, Some(false));
+        assert!(!citation_sufficiency_eligible(&citation));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -87,7 +87,7 @@ pub(crate) fn evidence_is_sufficiency_eligible(
 
 pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool {
     if citation_is_diagnostic_source_proof(citation) {
-        return citation.eligible_for_sufficiency.unwrap_or(false);
+        return false;
     }
     let tier = citation
         .evidence_tier
@@ -95,9 +95,10 @@ pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool
     let resolution = citation
         .resolution_status
         .unwrap_or_else(|| evidence_resolution_for_citation(citation));
-    citation
-        .eligible_for_sufficiency
-        .unwrap_or_else(|| evidence_is_sufficiency_eligible(tier, resolution))
+    if !evidence_is_sufficiency_eligible(tier, resolution) {
+        return false;
+    }
+    citation.eligible_for_sufficiency.unwrap_or(true)
 }
 
 pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
@@ -485,6 +486,12 @@ mod tests {
         );
         assert_eq!(citation.eligible_for_sufficiency, Some(false));
         assert!(!citation_sufficiency_eligible(&citation));
+
+        citation.eligible_for_sufficiency = Some(true);
+        assert!(
+            !citation_sufficiency_eligible(&citation),
+            "an adapter-provided eligibility flag must not promote structural evidence"
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -14,6 +14,31 @@ const OPENAPI_ENDPOINT_SCHEMA_PRODUCER: &str = "openapi_endpoint_schema";
 pub(crate) type PacketEvidenceTier = PacketEvidenceTierDto;
 pub(crate) type PacketEvidenceResolution = PacketEvidenceResolutionDto;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DiagnosticSourceEvidence {
+    pub(crate) tier: PacketEvidenceTier,
+    pub(crate) producer: &'static str,
+    pub(crate) resolution: PacketEvidenceResolution,
+}
+
+pub(crate) fn diagnostic_source_evidence(
+    path: Option<&str>,
+    canonical_id: Option<&str>,
+) -> Option<DiagnosticSourceEvidence> {
+    if canonical_id.is_some_and(|value| value.starts_with("openapi:endpoint:")) {
+        return Some(DiagnosticSourceEvidence {
+            tier: PacketEvidenceTier::ExactSource,
+            producer: OPENAPI_ENDPOINT_SCHEMA_PRODUCER,
+            resolution: PacketEvidenceResolution::SourceRangeOnly,
+        });
+    }
+    structural_text_producer_for_path(path).map(|producer| DiagnosticSourceEvidence {
+        tier: PacketEvidenceTier::StructuralText,
+        producer,
+        resolution: PacketEvidenceResolution::SourceRangeOnly,
+    })
+}
+
 pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
     let diagnostic_source_proof = hit_is_diagnostic_source_proof(hit);
     let tier = evidence_tier_for_hit(hit);

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -3217,6 +3217,47 @@ mod tests {
     }
 
     #[test]
+    fn structural_text_cannot_prove_route_endpoints_or_transitions() {
+        let question = "EndpointA -> EndpointB";
+        let answer = route_answer(
+            question,
+            &["EndpointA", "EndpointB"],
+            &[("EndpointA", "EndpointB")],
+        );
+        let claims = [
+            ("EndpointA", "src/EndpointA.html"),
+            ("EndpointB", "src/EndpointB.html"),
+        ]
+        .into_iter()
+        .map(|(name, path)| {
+            let mut citation = cited_anchor(name);
+            citation.file_path = Some(path.to_string());
+            citation.evidence_tier = Some(PacketEvidenceTierDto::StructuralText);
+            citation.evidence_producer = Some("structural_html_collector".to_string());
+            citation.resolution_status = Some(PacketEvidenceResolutionDto::SourceRangeOnly);
+            citation.eligible_for_sufficiency = Some(true);
+            cited_claim(
+                &format!("`{name}` is a requested route endpoint."),
+                Some("route endpoint"),
+                citation,
+                Some(true),
+            )
+        })
+        .collect();
+
+        let sufficiency = route_sufficiency(question, &answer, &budget_fixture(), claims);
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains("route endpoint")),
+            "a real graph transition cannot promote structural endpoint citations: {sufficiency:?}"
+        );
+    }
+
+    #[test]
     fn route_proof_rejects_speculative_call_edges() {
         for (case, certainty, confidence) in [
             ("speculative", Some("speculative"), Some(1.0)),

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -1597,6 +1597,7 @@ fn packet_claim_tier_label(claim: &PacketClaimDto) -> String {
 fn packet_evidence_tier_label(tier: PacketEvidenceTierDto) -> &'static str {
     match tier {
         PacketEvidenceTierDto::ExactSource => "exact_source",
+        PacketEvidenceTierDto::StructuralText => "structural_text",
         PacketEvidenceTierDto::ResolvedGraph => "resolved_graph",
         PacketEvidenceTierDto::LexicalSource => "lexical_source",
         PacketEvidenceTierDto::SymbolDoc => "symbol_doc",
@@ -1610,6 +1611,7 @@ fn packet_evidence_tier_label(tier: PacketEvidenceTierDto) -> &'static str {
 fn packet_evidence_provenance_label(tier: PacketEvidenceTierDto) -> &'static str {
     match tier {
         PacketEvidenceTierDto::ExactSource => "exact",
+        PacketEvidenceTierDto::StructuralText => "structural_text",
         PacketEvidenceTierDto::ResolvedGraph => "graph_neighbor",
         PacketEvidenceTierDto::LexicalSource => "lexical_source",
         PacketEvidenceTierDto::SymbolDoc => "symbol_doc",
@@ -2767,6 +2769,18 @@ mod tests {
         RetrievalShadowDto, SearchHitOrigin,
     };
     use std::path::Path;
+
+    #[test]
+    fn structural_text_labels_stay_explicit_in_packet_diagnostics() {
+        assert_eq!(
+            packet_evidence_tier_label(PacketEvidenceTierDto::StructuralText),
+            "structural_text"
+        );
+        assert_eq!(
+            packet_evidence_provenance_label(PacketEvidenceTierDto::StructuralText),
+            "structural_text"
+        );
+    }
 
     fn claim(text: &str) -> PacketClaimDto {
         PacketClaimDto {

--- a/crates/codestory-runtime/src/browser.rs
+++ b/crates/codestory-runtime/src/browser.rs
@@ -163,6 +163,21 @@ impl ReadOnlyBrowserService {
         })
     }
 
+    pub fn resolve_source_target(
+        &self,
+        target: TargetSelection,
+        file_filter: Option<&str>,
+    ) -> Result<TargetResolution, ApiError> {
+        let operation = match &target {
+            TargetSelection::Id(_) => "graph",
+            TargetSelection::Query { .. } => "resolution",
+        };
+        self.run_public(operation, || {
+            self.controller
+                .resolve_source_target(target.clone(), file_filter)
+        })
+    }
+
     pub fn symbol_workflow(
         &self,
         request: SymbolWorkflowRequest,

--- a/crates/codestory-runtime/src/grounding.rs
+++ b/crates/codestory-runtime/src/grounding.rs
@@ -1,7 +1,5 @@
 use super::*;
-use crate::agent::packet_evidence::{
-    evidence_is_sufficiency_eligible, structural_text_producer_for_path,
-};
+use crate::agent::packet_evidence::{decorate_search_hit_evidence, diagnostic_source_evidence};
 use crate::trail_story::build_trail_story;
 use codestory_contracts::api::SearchHitOrigin;
 #[cfg(test)]
@@ -245,7 +243,8 @@ fn symbol_digest(
     } else {
         display_name.to_string()
     };
-    let evidence_producer = structural_text_producer_for_path(relative_file_path);
+    let diagnostic_evidence =
+        diagnostic_source_evidence(relative_file_path, node.canonical_id.as_deref());
 
     GroundingSymbolDigestDto {
         id: NodeId::from(node.id),
@@ -258,11 +257,9 @@ fn symbol_digest(
         member_count,
         summary: summaries.get(&node.id).map(|record| record.summary.clone()),
         edge_digest: edge_digests.get(&node.id).cloned().unwrap_or_default(),
-        evidence_tier: evidence_producer
-            .map(|_| codestory_contracts::api::PacketEvidenceTierDto::StructuralText),
-        evidence_producer: evidence_producer.map(str::to_string),
-        resolution_status: evidence_producer
-            .map(|_| codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly),
+        evidence_tier: diagnostic_evidence.map(|evidence| evidence.tier),
+        evidence_producer: diagnostic_evidence.map(|evidence| evidence.producer.to_string()),
+        resolution_status: diagnostic_evidence.map(|evidence| evidence.resolution),
     }
 }
 
@@ -573,7 +570,7 @@ fn search_hit_from_grounding_recommendation(candidate: &RecommendationCandidate<
         .symbol
         .resolution_status
         .unwrap_or(codestory_contracts::api::PacketEvidenceResolutionDto::Resolved);
-    SearchHit {
+    let mut hit = SearchHit {
         node_id: candidate.symbol.id.clone(),
         display_name: candidate.name.clone(),
         kind: candidate.symbol.kind,
@@ -592,10 +589,7 @@ fn search_hit_from_grounding_recommendation(candidate: &RecommendationCandidate<
         resolution_status: Some(resolution_status),
         loss_reason: None,
         coverage_role: None,
-        eligible_for_sufficiency: Some(evidence_is_sufficiency_eligible(
-            evidence_tier,
-            resolution_status,
-        )),
+        eligible_for_sufficiency: None,
         score_breakdown: Some(RetrievalScoreBreakdownDto {
             lexical: 0.45,
             semantic: 0.0,
@@ -607,7 +601,9 @@ fn search_hit_from_grounding_recommendation(candidate: &RecommendationCandidate<
             final_rank_reason: None,
             provenance: Vec::new(),
         }),
-    }
+    };
+    decorate_search_hit_evidence(&mut hit);
+    hit
 }
 
 impl AppController {
@@ -1535,6 +1531,82 @@ mod tests {
         assert_eq!(
             hit.evidence_tier,
             Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText)
+        );
+        assert_eq!(
+            hit.resolution_status,
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
+    }
+
+    #[test]
+    fn grounding_snapshot_preserves_openapi_endpoint_source_identity() {
+        let temp = tempdir().expect("temp dir");
+        let db_path = temp.path().join("cache").join("codestory.db");
+        std::fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db parent");
+        let schema = temp.path().join("openapi.json");
+        std::fs::write(&schema, "{\"openapi\":\"3.0.0\"}\n").expect("write schema");
+
+        {
+            let mut storage = Storage::open(&db_path).expect("open storage");
+            insert_file_node(
+                &mut storage,
+                12,
+                &schema,
+                Node {
+                    id: CoreNodeId(102),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "GET /api/users".to_string(),
+                    canonical_id: Some("openapi:endpoint:GET /api/users".to_string()),
+                    file_node_id: Some(CoreNodeId(12)),
+                    start_line: Some(1),
+                    ..Default::default()
+                },
+            )
+            .expect("insert OpenAPI endpoint node");
+        }
+
+        let controller = AppController::new();
+        controller
+            .open_project_with_storage_path(temp.path().to_path_buf(), db_path)
+            .expect("open project");
+        let snapshot = controller
+            .grounding_snapshot(GroundingBudgetDto::Balanced)
+            .expect("grounding snapshot");
+        let symbol = snapshot
+            .files
+            .iter()
+            .flat_map(|file| file.symbols.iter())
+            .find(|symbol| symbol.label.starts_with("GET /api/users"))
+            .expect("OpenAPI endpoint symbol");
+
+        assert_eq!(
+            symbol.evidence_tier,
+            Some(codestory_contracts::api::PacketEvidenceTierDto::ExactSource)
+        );
+        assert_eq!(
+            symbol.evidence_producer.as_deref(),
+            Some("openapi_endpoint_schema")
+        );
+        assert_eq!(
+            symbol.resolution_status,
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
+
+        let candidate = RecommendationCandidate {
+            symbol,
+            name: "GET /api/users".to_string(),
+            path: Some("openapi.json".to_string()),
+            order: 0,
+        };
+        let hit = search_hit_from_grounding_recommendation(&candidate);
+        assert_eq!(
+            hit.evidence_tier,
+            Some(codestory_contracts::api::PacketEvidenceTierDto::ExactSource)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("openapi_endpoint_schema")
         );
         assert_eq!(
             hit.resolution_status,

--- a/crates/codestory-runtime/src/grounding.rs
+++ b/crates/codestory-runtime/src/grounding.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::agent::packet_evidence::{
+    evidence_is_sufficiency_eligible, structural_text_producer_for_path,
+};
 use crate::trail_story::build_trail_story;
 use codestory_contracts::api::SearchHitOrigin;
 #[cfg(test)]
@@ -242,6 +245,7 @@ fn symbol_digest(
     } else {
         display_name.to_string()
     };
+    let evidence_producer = structural_text_producer_for_path(relative_file_path);
 
     GroundingSymbolDigestDto {
         id: NodeId::from(node.id),
@@ -254,6 +258,11 @@ fn symbol_digest(
         member_count,
         summary: summaries.get(&node.id).map(|record| record.summary.clone()),
         edge_digest: edge_digests.get(&node.id).cloned().unwrap_or_default(),
+        evidence_tier: evidence_producer
+            .map(|_| codestory_contracts::api::PacketEvidenceTierDto::StructuralText),
+        evidence_producer: evidence_producer.map(str::to_string),
+        resolution_status: evidence_producer
+            .map(|_| codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly),
     }
 }
 
@@ -556,6 +565,14 @@ pub(crate) fn grounding_explanation_search_hits(
 }
 
 fn search_hit_from_grounding_recommendation(candidate: &RecommendationCandidate<'_>) -> SearchHit {
+    let evidence_tier = candidate
+        .symbol
+        .evidence_tier
+        .unwrap_or(codestory_contracts::api::PacketEvidenceTierDto::ResolvedGraph);
+    let resolution_status = candidate
+        .symbol
+        .resolution_status
+        .unwrap_or(codestory_contracts::api::PacketEvidenceResolutionDto::Resolved);
     SearchHit {
         node_id: candidate.symbol.id.clone(),
         display_name: candidate.name.clone(),
@@ -566,12 +583,19 @@ fn search_hit_from_grounding_recommendation(candidate: &RecommendationCandidate<
         origin: SearchHitOrigin::IndexedSymbol,
         match_quality: None,
         resolvable: true,
-        evidence_tier: Some(codestory_contracts::api::PacketEvidenceTierDto::ResolvedGraph),
-        evidence_producer: Some("grounding_recommendation".to_string()),
-        resolution_status: Some(codestory_contracts::api::PacketEvidenceResolutionDto::Resolved),
+        evidence_tier: Some(evidence_tier),
+        evidence_producer: candidate
+            .symbol
+            .evidence_producer
+            .clone()
+            .or_else(|| Some("grounding_recommendation".to_string())),
+        resolution_status: Some(resolution_status),
         loss_reason: None,
         coverage_role: None,
-        eligible_for_sufficiency: Some(true),
+        eligible_for_sufficiency: Some(evidence_is_sufficiency_eligible(
+            evidence_tier,
+            resolution_status,
+        )),
         score_breakdown: Some(RetrievalScoreBreakdownDto {
             lexical: 0.45,
             semantic: 0.0,
@@ -1297,6 +1321,9 @@ mod tests {
             member_count,
             summary: None,
             edge_digest: Vec::new(),
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
         }
     }
 
@@ -1446,6 +1473,74 @@ mod tests {
         assert_eq!(snapshot.coverage.represented_files, 2);
         assert_eq!(snapshot.files.len(), 2);
         assert!(snapshot.coverage_buckets.is_empty());
+    }
+
+    #[test]
+    fn grounding_snapshot_publishes_structural_text_metadata_without_graph_claims() {
+        let temp = tempdir().expect("temp dir");
+        let db_path = temp.path().join("cache").join("codestory.db");
+        std::fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db parent");
+        let manifest = temp.path().join("Cargo.toml");
+        std::fs::write(&manifest, "[package]\nname = \"demo\"\n").expect("write manifest");
+
+        {
+            let mut storage = Storage::open(&db_path).expect("open storage");
+            insert_file_node(
+                &mut storage,
+                11,
+                &manifest,
+                Node {
+                    id: CoreNodeId(101),
+                    kind: NodeKind::PACKAGE,
+                    serialized_name: "demo".to_string(),
+                    file_node_id: Some(CoreNodeId(11)),
+                    start_line: Some(2),
+                    ..Default::default()
+                },
+            )
+            .expect("insert manifest node");
+        }
+
+        let controller = AppController::new();
+        controller
+            .open_project_with_storage_path(temp.path().to_path_buf(), db_path)
+            .expect("open project");
+        let snapshot = controller
+            .grounding_snapshot(GroundingBudgetDto::Balanced)
+            .expect("grounding snapshot");
+        let symbol = snapshot
+            .files
+            .iter()
+            .flat_map(|file| file.symbols.iter())
+            .find(|symbol| symbol.label.starts_with("demo"))
+            .expect("manifest symbol");
+
+        assert_eq!(
+            symbol.evidence_tier,
+            Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText)
+        );
+        assert_eq!(
+            symbol.evidence_producer.as_deref(),
+            Some("structural_cargo_manifest_collector")
+        );
+        assert_eq!(
+            symbol.resolution_status,
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
+
+        let hit = grounding_explanation_search_hits(&snapshot, 8)
+            .into_iter()
+            .find(|hit| hit.node_id == symbol.id)
+            .expect("grounding explanation hit");
+        assert_eq!(
+            hit.evidence_tier,
+            Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText)
+        );
+        assert_eq!(
+            hit.resolution_status,
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -4,6 +4,7 @@
 //! retrieval sidecar coordination. Packet/search methods are sidecar-primary: degraded retrieval
 //! is surfaced as diagnostics or errors, not as product-equivalent answer evidence.
 
+use crate::agent::packet_evidence::decorate_search_hit_evidence;
 use codestory_contracts::api::{
     AffectedAnalysisBoundsDto, AffectedAnalysisCompletenessDto, AffectedAnalysisDto,
     AffectedAnalysisInput, AffectedAnalysisRequest, AffectedChangeKindDto, AffectedChangeRecordDto,
@@ -10205,7 +10206,7 @@ impl AppController {
             .as_deref()
             .is_some_and(|value| value.starts_with("openapi:endpoint:"));
 
-        Some(SearchHit {
+        let mut hit = SearchHit {
             node_id: NodeId::from(id),
             display_name,
             kind: NodeKind::from(node.kind),
@@ -10237,7 +10238,9 @@ impl AppController {
             coverage_role: None,
             eligible_for_sufficiency: Some(!openapi_endpoint),
             score_breakdown: None,
-        })
+        };
+        decorate_search_hit_evidence(&mut hit);
+        Some(hit)
     }
 
     #[cfg(test)]
@@ -20684,6 +20687,47 @@ fn build_llm_symbol_doc_text() -> String {
         assert_eq!(
             hit.evidence_producer.as_deref(),
             Some("openapi_endpoint_schema")
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
+    }
+
+    #[test]
+    fn build_search_hit_marks_structural_collectors_as_structural_text() {
+        let mut storage = Storage::new_in_memory().expect("storage");
+        storage
+            .insert_nodes_batch(&[
+                Node {
+                    id: CoreNodeId(40),
+                    kind: NodeKind::FILE,
+                    serialized_name: "crates/demo/Cargo.toml".to_string(),
+                    ..Default::default()
+                },
+                Node {
+                    id: CoreNodeId(41),
+                    kind: NodeKind::PACKAGE,
+                    serialized_name: "demo".to_string(),
+                    file_node_id: Some(CoreNodeId(40)),
+                    start_line: Some(2),
+                    ..Default::default()
+                },
+            ])
+            .expect("insert nodes");
+        let node_names = HashMap::from([(CoreNodeId(41), "demo".to_string())]);
+
+        let hit = AppController::build_search_hit(&storage, &node_names, CoreNodeId(41), 1.0)
+            .expect("structural hit");
+
+        assert_eq!(
+            hit.evidence_tier,
+            Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("structural_cargo_manifest_collector")
+        );
+        assert_eq!(
+            hit.resolution_status,
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
         );
         assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }

--- a/crates/codestory-runtime/src/target_resolution.rs
+++ b/crates/codestory-runtime/src/target_resolution.rs
@@ -1,13 +1,13 @@
 use anyhow::{Context, Result};
 use codestory_contracts::api::{
-    ApiError, NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, SearchHit, SearchHitOrigin,
-    SearchMatchQualityDto,
+    ApiError, NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, PacketEvidenceResolutionDto,
+    PacketEvidenceTierDto, SearchHit, SearchHitOrigin, SearchMatchQualityDto,
 };
 use serde::Serialize;
 use std::fs;
 use std::path::Path;
 
-use crate::agent::packet_evidence::decorate_search_hit_evidence;
+use crate::agent::packet_evidence::{decorate_search_hit_evidence, diagnostic_source_evidence};
 use crate::{
     AppController, compare_ranked_hits, retrieval_file_role_for_hit, symbol_name_match_rank,
 };
@@ -122,7 +122,15 @@ pub(crate) fn is_graph_target_candidate(hit: &SearchHit) -> bool {
     !matches!(
         hit.match_quality,
         Some(SearchMatchQualityDto::SemanticSuggestion | SearchMatchQualityDto::RepoText)
-    )
+    ) && hit.evidence_tier != Some(PacketEvidenceTierDto::StructuralText)
+        && !matches!(
+            hit.resolution_status,
+            Some(
+                PacketEvidenceResolutionDto::SourceRangeOnly
+                    | PacketEvidenceResolutionDto::Unresolved
+                    | PacketEvidenceResolutionDto::DiagnosticOnly
+            )
+        )
 }
 
 pub(crate) fn is_name_resolvable_graph_target(query: &str, hit: &SearchHit) -> bool {
@@ -560,13 +568,7 @@ impl AppController {
         match target {
             TargetSelection::Id(id) => {
                 let details = self.node_details(NodeDetailsRequest { id: id.clone() })?;
-                Ok(TargetResolution::Resolved(Box::new(ResolvedTarget {
-                    selector: TargetSelector::Id,
-                    requested: id.0,
-                    file_filter: None,
-                    selected: search_hit_from_node(&details),
-                    alternatives: Vec::new(),
-                })))
+                Ok(resolve_id_target(id, &details))
             }
             TargetSelection::Query { query, choose } => {
                 self.resolve_query_target(query, choose, file_filter)
@@ -749,6 +751,8 @@ fn compare_resolution_candidates(
 }
 
 fn search_hit_from_node(node: &NodeDetailsDto) -> SearchHit {
+    let diagnostic_evidence =
+        diagnostic_source_evidence(node.file_path.as_deref(), node.canonical_id.as_deref());
     let mut hit = SearchHit {
         node_id: node.id.clone(),
         display_name: node.display_name.clone(),
@@ -759,16 +763,46 @@ fn search_hit_from_node(node: &NodeDetailsDto) -> SearchHit {
         origin: SearchHitOrigin::IndexedSymbol,
         match_quality: None,
         resolvable: true,
-        evidence_tier: Some(codestory_contracts::api::PacketEvidenceTierDto::ResolvedGraph),
-        evidence_producer: Some("node_details".to_string()),
-        resolution_status: Some(codestory_contracts::api::PacketEvidenceResolutionDto::Resolved),
+        evidence_tier: Some(
+            diagnostic_evidence
+                .map(|evidence| evidence.tier)
+                .unwrap_or(PacketEvidenceTierDto::ResolvedGraph),
+        ),
+        evidence_producer: Some(
+            diagnostic_evidence
+                .map(|evidence| evidence.producer)
+                .unwrap_or("node_details")
+                .to_string(),
+        ),
+        resolution_status: Some(
+            diagnostic_evidence
+                .map(|evidence| evidence.resolution)
+                .unwrap_or(PacketEvidenceResolutionDto::Resolved),
+        ),
         loss_reason: None,
         coverage_role: None,
-        eligible_for_sufficiency: Some(true),
+        eligible_for_sufficiency: None,
         score_breakdown: None,
     };
     decorate_search_hit_evidence(&mut hit);
     hit
+}
+
+fn resolve_id_target(id: NodeId, details: &NodeDetailsDto) -> TargetResolution {
+    let selected = search_hit_from_node(details);
+    if !selected.resolvable || !is_graph_target_candidate(&selected) {
+        return TargetResolution::Rejected(format!(
+            "id_resolution: Node `{}` is source-range-only diagnostic evidence and cannot be selected as a typed graph target. Its cited source remains available through the node and snippet surfaces.",
+            id.0
+        ));
+    }
+    TargetResolution::Resolved(Box::new(ResolvedTarget {
+        selector: TargetSelector::Id,
+        requested: id.0,
+        file_filter: None,
+        selected,
+        alternatives: Vec::new(),
+    }))
 }
 
 fn no_query_match_error(project_root: &Path, query: &str, file_filter: Option<&str>) -> String {
@@ -955,7 +989,7 @@ mod tests {
 
     #[test]
     fn node_details_target_keeps_structural_text_evidence_explicit() {
-        let hit = search_hit_from_node(&NodeDetailsDto {
+        let details = NodeDetailsDto {
             id: NodeId("cargo-package".to_string()),
             kind: NodeKind::PACKAGE,
             display_name: "demo".to_string(),
@@ -969,7 +1003,8 @@ mod tests {
             end_col: Some(8),
             member_access: None,
             route_endpoint: None,
-        });
+        };
+        let hit = search_hit_from_node(&details);
 
         assert_eq!(
             hit.evidence_tier,
@@ -984,6 +1019,52 @@ mod tests {
             Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
         );
         assert_eq!(hit.eligible_for_sufficiency, Some(false));
+        assert!(hit.resolvable, "the cited source range remains navigable");
+        assert!(!is_graph_target_candidate(&hit));
+        assert!(!is_resolvable_graph_target("demo", &hit));
+        assert!(matches!(
+            resolve_id_target(details.id.clone(), &details),
+            TargetResolution::Rejected(message)
+                if message.contains("source-range-only diagnostic evidence")
+        ));
+    }
+
+    #[test]
+    fn direct_id_openapi_target_keeps_exact_source_identity_but_rejects_typed_resolution() {
+        let details = NodeDetailsDto {
+            id: NodeId("openapi-users".to_string()),
+            kind: NodeKind::FUNCTION,
+            display_name: "GET /api/users".to_string(),
+            serialized_name: "GET /api/users".to_string(),
+            qualified_name: None,
+            canonical_id: Some("openapi:endpoint:GET /api/users".to_string()),
+            file_path: Some("openapi.json".to_string()),
+            start_line: Some(8),
+            start_col: Some(1),
+            end_line: Some(8),
+            end_col: Some(16),
+            member_access: None,
+            route_endpoint: None,
+        };
+        let hit = search_hit_from_node(&details);
+
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTierDto::ExactSource));
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("openapi_endpoint_schema")
+        );
+        assert_eq!(
+            hit.resolution_status,
+            Some(PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
+        assert!(hit.resolvable, "the cited source range remains navigable");
+        assert!(!is_graph_target_candidate(&hit));
+        assert!(matches!(
+            resolve_id_target(details.id.clone(), &details),
+            TargetResolution::Rejected(message)
+                if message.contains("source-range-only diagnostic evidence")
+        ));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/target_resolution.rs
+++ b/crates/codestory-runtime/src/target_resolution.rs
@@ -576,6 +576,27 @@ impl AppController {
         }
     }
 
+    /// Resolve a target for exact source navigation.
+    ///
+    /// Exact ids may name source-range-only diagnostic evidence from structural
+    /// collectors or endpoint schemas. Query selectors still use typed graph
+    /// resolution so snippets cannot silently select diagnostic search hits.
+    pub fn resolve_source_target(
+        &self,
+        target: TargetSelection,
+        file_filter: Option<&str>,
+    ) -> Result<TargetResolution, ApiError> {
+        match target {
+            TargetSelection::Id(id) => {
+                let details = self.node_details(NodeDetailsRequest { id: id.clone() })?;
+                Ok(resolve_source_id_target(id, &details))
+            }
+            TargetSelection::Query { query, choose } => {
+                self.resolve_query_target(query, choose, file_filter)
+            }
+        }
+    }
+
     fn resolve_query_target(
         &self,
         query: String,
@@ -796,6 +817,14 @@ fn resolve_id_target(id: NodeId, details: &NodeDetailsDto) -> TargetResolution {
             id.0
         ));
     }
+    resolved_id_target(id, selected)
+}
+
+fn resolve_source_id_target(id: NodeId, details: &NodeDetailsDto) -> TargetResolution {
+    resolved_id_target(id, search_hit_from_node(details))
+}
+
+fn resolved_id_target(id: NodeId, selected: SearchHit) -> TargetResolution {
     TargetResolution::Resolved(Box::new(ResolvedTarget {
         selector: TargetSelector::Id,
         requested: id.0,
@@ -1027,6 +1056,16 @@ mod tests {
             TargetResolution::Rejected(message)
                 if message.contains("source-range-only diagnostic evidence")
         ));
+        let TargetResolution::Resolved(source_target) =
+            resolve_source_id_target(details.id.clone(), &details)
+        else {
+            panic!("an exact structural id should remain source-navigable");
+        };
+        assert_eq!(source_target.selected.node_id, details.id);
+        assert_eq!(
+            source_target.selected.resolution_status,
+            Some(PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
     }
 
     #[test]
@@ -1065,6 +1104,16 @@ mod tests {
             TargetResolution::Rejected(message)
                 if message.contains("source-range-only diagnostic evidence")
         ));
+        let TargetResolution::Resolved(source_target) =
+            resolve_source_id_target(details.id.clone(), &details)
+        else {
+            panic!("an exact OpenAPI id should remain source-navigable");
+        };
+        assert_eq!(source_target.selected.node_id, details.id);
+        assert_eq!(
+            source_target.selected.evidence_tier,
+            Some(PacketEvidenceTierDto::ExactSource)
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/target_resolution.rs
+++ b/crates/codestory-runtime/src/target_resolution.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use std::fs;
 use std::path::Path;
 
+use crate::agent::packet_evidence::decorate_search_hit_evidence;
 use crate::{
     AppController, compare_ranked_hits, retrieval_file_role_for_hit, symbol_name_match_rank,
 };
@@ -748,7 +749,7 @@ fn compare_resolution_candidates(
 }
 
 fn search_hit_from_node(node: &NodeDetailsDto) -> SearchHit {
-    SearchHit {
+    let mut hit = SearchHit {
         node_id: node.id.clone(),
         display_name: node.display_name.clone(),
         kind: node.kind,
@@ -765,7 +766,9 @@ fn search_hit_from_node(node: &NodeDetailsDto) -> SearchHit {
         coverage_role: None,
         eligible_for_sufficiency: Some(true),
         score_breakdown: None,
-    }
+    };
+    decorate_search_hit_evidence(&mut hit);
+    hit
 }
 
 fn no_query_match_error(project_root: &Path, query: &str, file_filter: Option<&str>) -> String {
@@ -948,6 +951,39 @@ mod tests {
         assert!(!is_graph_target_candidate(&semantic));
         assert!(!is_graph_target_candidate(&repo_text));
         assert!(is_graph_target_candidate(&fuzzy));
+    }
+
+    #[test]
+    fn node_details_target_keeps_structural_text_evidence_explicit() {
+        let hit = search_hit_from_node(&NodeDetailsDto {
+            id: NodeId("cargo-package".to_string()),
+            kind: NodeKind::PACKAGE,
+            display_name: "demo".to_string(),
+            serialized_name: "demo".to_string(),
+            qualified_name: None,
+            canonical_id: None,
+            file_path: Some("crates/demo/Cargo.toml".to_string()),
+            start_line: Some(2),
+            start_col: Some(1),
+            end_line: Some(2),
+            end_col: Some(8),
+            member_access: None,
+            route_endpoint: None,
+        });
+
+        assert_eq!(
+            hit.evidence_tier,
+            Some(codestory_contracts::api::PacketEvidenceTierDto::StructuralText)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("structural_cargo_manifest_collector")
+        );
+        assert_eq!(
+            hit.resolution_status,
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }
 
     #[test]

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -15,7 +15,7 @@ profiles to parser and rule construction in `get_language_for_ext`.
 | Parser-backed graph | Extension routes to a parser and graph rules. | Full semantic navigation. |
 | Fidelity-gated | Core symbol/import/call/member shapes pass fixture suites. | Every language feature is covered. |
 | Semantic-resolution-backed | Targeted resolver tests prove the named behavior. | Broad cross-package or polymorphic dispatch. |
-| Structural source-proof | Dedicated extractor emits exact source anchors for structural files. | Parser-backed graph extraction or semantic code navigation. |
+| Structural source-proof | Dedicated extractor emits exact source anchors and publishes `structural_text` / `source_range_only` result metadata. | Parser-backed graph extraction, semantic code navigation, or packet semantic proof. |
 | Parser compatibility record | A parser crate/version was checked for future use. | Runtime support. |
 | Packet proof gate | A packet-runtime artifact proves the current packet citation and sufficiency contract for the measured tasks. | Public product-grade language quality. |
 | Publishable packet-runtime pass | Success, quality, sufficiency, and cold-SLA gates all pass in one coherent run. | A change to parser-backed or structural language coverage. |
@@ -34,7 +34,7 @@ collector-failed source remains a publication blocker.
 | Runtime claim | Languages | Evidence floor | Safe claim |
 | --- | --- | --- | --- |
 | Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | fidelity lab, tictactoe coverage, raw graph contracts, targeted rule/resolution suites, opt-in OSS corpus | daily graph navigation on typical code, with caveats |
-| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, basename-scoped Cargo manifests, dedicated OpenAPI/Swagger endpoint schema anchors | structural collector and OpenAPI schema-anchor tests | exact-source structural/schema anchors |
+| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, basename-scoped Cargo manifests, dedicated OpenAPI/Swagger endpoint schema anchors | structural collector and OpenAPI schema-anchor tests | structural-text/schema anchors |
 
 Agent-facing packet/search quality is separate. Run-specific A/B artifacts are
 not blanket promotion proof for every parser-backed language.
@@ -61,12 +61,14 @@ No current language profile claims `typed_semantic_edges` or
 ## Agent-Facing Evidence
 
 GitHub Actions workflow support is path-scoped to `.github/workflows/*.{yml,yaml}`.
-The pilot emits workflow, job, and step anchors with `exact_source` /
-`source_range_only` evidence. Docker Compose support is path-scoped to
+The pilot emits workflow, job, and step anchors with `structural_text` /
+`source_range_only` evidence and collector provenance. Docker Compose support
+is path-scoped to
 `compose*.{yml,yaml}`, `docker-compose*.{yml,yaml}`, and
 `docker/*-compose.{yml,yaml}` style manifests; it emits stack, service, image or
-build, ports, environment key, and volume anchors with the same exact-source
-boundary. OpenAPI/Swagger endpoint schemas stay on the dedicated OpenAPI
+build, ports, environment key, and volume anchors with the same structural-text
+boundary. HTML, CSS, SQL, and Cargo manifest collector anchors use that result
+tier too. OpenAPI/Swagger endpoint schemas stay on the dedicated OpenAPI
 indexing path and emit `openapi:endpoint:*` anchors as `exact_source` /
 `source_range_only` diagnostic evidence only; they do not make generic YAML an
 OpenAPI surface. Unsupported shapes stay explicit: YAML anchors and merge keys are not
@@ -79,8 +81,8 @@ route behavior, or generated-client correctness. Neither collector validates
 execution semantics.
 Cargo manifest support is basename-scoped to `Cargo.toml`. It emits `[workspace]`
 member, `[package]` name, and direct dependency-key anchors from `[dependencies]`,
-`[dev-dependencies]`, and `[build-dependencies]` with the same exact-source /
-source-range-only boundary. It does not admit generic TOML, `Cargo.lock`,
+`[dev-dependencies]`, and `[build-dependencies]` with the same `structural_text` /
+`source_range_only` boundary. It does not admit generic TOML, `Cargo.lock`,
 target-scoped dependency tables, `[workspace.dependencies]`, dependency
 subtables, feature tables, patch or replace tables, dependency resolution,
 feature activation, workspace inheritance, build-script behavior, or lockfile
@@ -88,8 +90,11 @@ proof. Packet evidence treats these anchors as diagnostic unless a future
 structural role explicitly admits them; they must not satisfy semantic proof
 roles or semantic dependency proof.
 
-Safe wording: OpenAPI endpoint anchors prove only that a schema declares the
-method/path at the cited source range. Packet-runtime is implemented and
+Safe wording: structural-text anchors prove only that their collector found the
+cited source span; their `source_range_only` status and non-sufficient result
+flag must not be upgraded into graph or semantic proof. OpenAPI endpoint anchors
+prove only that a schema declares the method/path at the cited source range.
+Packet-runtime is implemented and
 can complete measured suites, but publishable agent-facing packet quality is not
 promoted until one coherent run has all quality, sufficiency, and cold-SLA gates
 green. Run-specific scorecards belong in PRs, issues, release notes, or ignored

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -337,6 +337,29 @@
                   "description": "Display name.",
                   "type": "string"
                 },
+                "eligible_for_sufficiency": {
+                  "description": "Whether this hit may satisfy answer-sufficiency requirements.",
+                  "type": "boolean"
+                },
+                "evidence_producer": {
+                  "description": "Collector or retrieval producer that emitted the evidence.",
+                  "type": "string"
+                },
+                "evidence_tier": {
+                  "description": "Evidence provenance tier. structural_text is collector-backed source-range evidence, not parser-backed graph coverage.",
+                  "enum": [
+                    "exact_source",
+                    "structural_text",
+                    "resolved_graph",
+                    "lexical_source",
+                    "symbol_doc",
+                    "component_report",
+                    "dense_semantic",
+                    "synthetic_source_scan",
+                    "generated_summary"
+                  ],
+                  "type": "string"
+                },
                 "file_path": {
                   "description": "Project-relative file path.",
                   "type": [
@@ -392,6 +415,16 @@
                   "enum": [
                     "indexed_symbol",
                     "text_match"
+                  ],
+                  "type": "string"
+                },
+                "resolution_status": {
+                  "description": "Resolution state. source_range_only has a source span but no typed graph resolution.",
+                  "enum": [
+                    "resolved",
+                    "source_range_only",
+                    "unresolved",
+                    "diagnostic_only"
                   ],
                   "type": "string"
                 },
@@ -1541,6 +1574,29 @@
                   "description": "Display name.",
                   "type": "string"
                 },
+                "eligible_for_sufficiency": {
+                  "description": "Whether this hit may satisfy answer-sufficiency requirements.",
+                  "type": "boolean"
+                },
+                "evidence_producer": {
+                  "description": "Collector or retrieval producer that emitted the evidence.",
+                  "type": "string"
+                },
+                "evidence_tier": {
+                  "description": "Evidence provenance tier. structural_text is collector-backed source-range evidence, not parser-backed graph coverage.",
+                  "enum": [
+                    "exact_source",
+                    "structural_text",
+                    "resolved_graph",
+                    "lexical_source",
+                    "symbol_doc",
+                    "component_report",
+                    "dense_semantic",
+                    "synthetic_source_scan",
+                    "generated_summary"
+                  ],
+                  "type": "string"
+                },
                 "file_path": {
                   "description": "Project-relative file path.",
                   "type": [
@@ -1596,6 +1652,16 @@
                   "enum": [
                     "indexed_symbol",
                     "text_match"
+                  ],
+                  "type": "string"
+                },
+                "resolution_status": {
+                  "description": "Resolution state. source_range_only has a source span but no typed graph resolution.",
+                  "enum": [
+                    "resolved",
+                    "source_range_only",
+                    "unresolved",
+                    "diagnostic_only"
                   ],
                   "type": "string"
                 },
@@ -3279,12 +3345,35 @@
                   "description": "Display name.",
                   "type": "string"
                 },
+                "eligible_for_sufficiency": {
+                  "description": "Whether this citation may satisfy answer-sufficiency requirements.",
+                  "type": "boolean"
+                },
                 "evidence_edge_ids": {
                   "description": "Evidence edge ids.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
+                },
+                "evidence_producer": {
+                  "description": "Collector or retrieval producer that emitted the evidence.",
+                  "type": "string"
+                },
+                "evidence_tier": {
+                  "description": "Evidence provenance tier. structural_text is collector-backed source-range evidence, not parser-backed graph coverage.",
+                  "enum": [
+                    "exact_source",
+                    "structural_text",
+                    "resolved_graph",
+                    "lexical_source",
+                    "symbol_doc",
+                    "component_report",
+                    "dense_semantic",
+                    "synthetic_source_scan",
+                    "generated_summary"
+                  ],
+                  "type": "string"
                 },
                 "file_path": {
                   "description": "Project-relative file path.",
@@ -3314,6 +3403,16 @@
                   "enum": [
                     "indexed_symbol",
                     "text_match"
+                  ],
+                  "type": "string"
+                },
+                "resolution_status": {
+                  "description": "Resolution state. source_range_only has a source span but no typed graph resolution.",
+                  "enum": [
+                    "resolved",
+                    "source_range_only",
+                    "unresolved",
+                    "diagnostic_only"
                   ],
                   "type": "string"
                 },


### PR DESCRIPTION
## Context

Closes #1241
Refs #1198
Refs #1179

This is the publication-only slice of #1198. It gives existing structural collectors a named result tier without admitting new text formats or changing indexing/publication ownership. Parent #1198 remains open for the broader source-generation, reuse, format, and discovery-boundary work.

Reconciled base: `2b040e26cdfe3e5836325e82aad67ec10fc512f4`
Draft head: `4437cf3d7204924c5a9bf4ae9eeb483a39e6bdfd`
Original base/head: `54c8d51928e99b993a37afb21cfb9a79d6468fe3` / `4d91ce2cb5ed1ea30ac7d64b6a89d227890acb49`

The reconstruction carried the structural DTO, evidence classification, propagation, adapter, schema, catalog, documentation, and test changes. It dropped the old branch's store freshness and framework-route cleanup commits, preserving the later integration behavior in those owners.

The final rebase onto the merged release-ledger/SQLite head had one expected `CHANGELOG.md` conflict. Its resolution preserves the ledger closeout, structural evidence, and SQLite batching entries. All 20 non-changelog topic blobs are byte-identical to the reviewed pre-rebase head, the aggregate non-changelog patch ID matches, and the final diff has no store or indexer paths.

## What changed

- Adds the public `structural_text` tier and grounding provenance fields.
- Publishes existing workflow, Compose, Cargo manifest, HTML, CSS, and SQL collector anchors as `structural_text` / `source_range_only` with named producers.
- Preserves OpenAPI endpoint-schema anchors as `exact_source` / `source_range_only` diagnostic evidence.
- Carries the OpenAPI canonical endpoint identity through grounding recommendations and direct-ID lookup instead of relabeling it as resolved graph evidence.
- Keeps structural citations navigable but out of parser-backed symbol proof, typed target resolution, route endpoint/transition proof, and packet sufficiency.
- Rejects structural and source-range-only hits in both ordinary typed target selection and the semantic direct-ID bypass.
- Separates exact-ID source navigation from typed graph resolution so CLI and stdio snippets can read structural/OpenAPI source ranges while query snippets remain filtered.
- Hard-fails structural evidence closed even if an adapter supplies `eligible_for_sufficiency=true`.
- Carries tier, producer, resolution, and eligibility through JSON, MCP schemas, search/packet Markdown, and grounding results.
- Regenerates the canonical MCP catalog and documents the boundary.

## Review

Start in `crates/codestory-runtime/src/agent/packet_evidence.rs`, then follow the metadata through grounding, target resolution, packet claims/sufficiency, CLI/MCP adapters, and `plugins/codestory/generated-mcp-catalog.json`.

The direct route regression supplies a real call edge between two named endpoints and verifies that structural source-range citations still cannot prove the endpoints or transition.

## Focused verification on `4437cf3d`

- `cargo fmt --all -- --check`
- `cargo test --locked -p codestory-contracts` — 39 passed
- `cargo test --locked -p codestory-runtime --lib structural_text` — 10 passed
- `cargo test --locked -p codestory-runtime --lib openapi` — 6 passed
- `cargo test --locked -p codestory-runtime --lib target_resolution` — 14 passed
- `cargo test --locked -p codestory-cli structural` — 7 passed across unit/integration targets
- `cargo test --locked -p codestory-cli --test cli_golden_path snippet_exact_id_navigates_openapi_diagnostic_evidence_but_query_stays_typed -- --exact` — passed
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts snippet_tool_exact_id_navigates_structural_evidence_but_query_stays_typed -- --exact` — passed
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools -- --exact` — passed
- `cargo check --locked -p codestory-runtime`
- `cargo check --locked -p codestory-cli`
- `cargo clippy --locked -p codestory-runtime -p codestory-cli --all-targets -- -D warnings`
- `cargo build --locked -p codestory-cli`
- `node scripts/generate-codestory-skill-syntax.mjs --check`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 70 passed, 1 platform skip
- `node .github/scripts/check-doc-links.mjs` — 75 files, 265 links
- `git diff --check`

This remains draft for final exact-head review and fresh CI. The coordinator will run the accepted-head gate before merge.

## Out of scope

- Markdown/MDX, generic YAML/TOML/JSON, shell, or PowerShell collectors
- source-generation publication or content-identity reuse
- generated/vendor/binary/partial-discovery handling
- cache, hook, workflow, candidate, vector, embedding, store, or indexer behavior
