### PR TITLE
[codex] approve Linux ARM64 v2 release baseline

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,11 @@
 retrieval-setup = "run --locked -p codestory-cli -- retrieval bootstrap --project ."
 retrieval-status = "run --locked -p codestory-cli -- retrieval status --project ."
 
+[env]
+# llama-cpp-sys 0.1.151 selects both a fixed ARM baseline and dynamic CPU
+# variants on Linux ARM64. CMake rejects that combination before compiling.
+CMAKE_PROJECT_INCLUDE_BEFORE = { value = ".cargo/llama-dynamic-backends.cmake", relative = true }
+
 # Windows and Linux release archives keep the dynamically linked llama.cpp
 # core and runtime-selected CPU/Vulkan modules beside the executable.
 [target.'cfg(target_os = "linux")']

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,8 +4,8 @@ retrieval-setup = "run --locked -p codestory-cli -- retrieval bootstrap --projec
 retrieval-status = "run --locked -p codestory-cli -- retrieval status --project ."
 
 [env]
-# llama-cpp-sys 0.1.151 selects both a fixed ARM baseline and dynamic CPU
-# variants on Linux ARM64. CMake rejects that combination before compiling.
+# llama-cpp-sys 0.1.151 selects both a fixed ARM baseline and every dynamic CPU
+# variant on Linux ARM64. The checked-in include resolves that pinned mismatch.
 CMAKE_PROJECT_INCLUDE_BEFORE = { value = ".cargo/llama-dynamic-backends.cmake", relative = true }
 
 # Windows and Linux release archives keep the dynamically linked llama.cpp

--- a/.cargo/llama-dynamic-backends.cmake
+++ b/.cargo/llama-dynamic-backends.cmake
@@ -1,6 +1,7 @@
-# llama-cpp-sys 0.1.151 sets GGML_CPU_ARM_ARCH=armv8-a for Linux ARM64 and
-# GGML_CPU_ALL_VARIANTS=ON for dynamic backends. The latter already selects
-# portable ARM variants, and upstream CMake rejects both selectors together.
+# llama-cpp-sys 0.1.151 sets GGML_CPU_ARM_ARCH=armv8-a for Linux ARM64 while
+# dynamic backends also request every upstream CPU variant. That combination is
+# rejected, and its newest SME variants exceed the pinned GCC 13 toolchain.
+# Keep the portable ARM baseline as a runtime-loaded CPU backend beside Vulkan.
 if(GGML_CPU_ALL_VARIANTS AND GGML_CPU_ARM_ARCH)
-  set(GGML_CPU_ARM_ARCH "" CACHE STRING "ggml: CPU architecture for ARM" FORCE)
+  set(GGML_CPU_ALL_VARIANTS OFF CACHE BOOL "ggml: build all variants of the CPU backend (requires GGML_BACKEND_DL)" FORCE)
 endif()

--- a/.cargo/llama-dynamic-backends.cmake
+++ b/.cargo/llama-dynamic-backends.cmake
@@ -1,0 +1,6 @@
+# llama-cpp-sys 0.1.151 sets GGML_CPU_ARM_ARCH=armv8-a for Linux ARM64 and
+# GGML_CPU_ALL_VARIANTS=ON for dynamic backends. The latter already selects
+# portable ARM variants, and upstream CMake rejects both selectors together.
+if(GGML_CPU_ALL_VARIANTS AND GGML_CPU_ARM_ARCH)
+  set(GGML_CPU_ARM_ARCH "" CACHE STRING "ggml: CPU architecture for ARM" FORCE)
+endif()

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1090,6 +1090,7 @@ function validatePluginAndDraftWorkflows(workflows, violations) {
       "crates/codestory-llama-sys/model_staging.rs",
       "crates/codestory-llama-sys/Cargo.toml",
       "crates/codestory-llama-sys/tests/model_staging.rs",
+      "scripts/release-evidence/serde-json-codestory-project.json",
     ];
     for (const event of ["pull_request", "push"]) {
       add(violations, includesAll(at(plugin, "on", event, "paths"), requiredPaths), `${pluginFile} ${event} paths must cover policy and release surfaces`);

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -51,6 +51,7 @@ on:
       - crates/codestory-llama-sys/Cargo.toml
       - crates/codestory-llama-sys/tests/model_staging.rs
       - scripts/release-evidence/machine-contract.json
+      - scripts/release-evidence/serde-json-codestory-project.json
       - scripts/codex-worktree-setup.*
       - scripts/tests/codex-worktree-setup.test.mjs
       - .codex/environments/environment.toml
@@ -107,6 +108,7 @@ on:
       - crates/codestory-llama-sys/Cargo.toml
       - crates/codestory-llama-sys/tests/model_staging.rs
       - scripts/release-evidence/machine-contract.json
+      - scripts/release-evidence/serde-json-codestory-project.json
       - scripts/codex-worktree-setup.*
       - scripts/tests/codex-worktree-setup.test.mjs
       - .codex/environments/environment.toml

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -88,7 +88,7 @@ jobs:
           CODESTORY_RELEASE_EVIDENCE_DRILL_OUTPUT_DIR: ${{ github.workspace }}/target/release-evidence/drill
           CODESTORY_RELEASE_EVIDENCE_STATS_PATH: ${{ github.workspace }}/target/release-evidence/stats.json
           CODESTORY_RELEASE_EVIDENCE_COMMIT: ${{ inputs.ref }}
-          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-ripgrep-rust-v1
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-js-ts-v1
           CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-inprocess-v1
           CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
           CODESTORY_REAL_REPO_DRILL_CASES: ${{ inputs.drill_manifest }}
@@ -104,8 +104,8 @@ jobs:
         env:
           CODESTORY_RELEASE_EVIDENCE_COMMIT: ${{ inputs.ref }}
           CODESTORY_RELEASE_EVIDENCE_PROFILE: ${{ inputs.profile }}
-          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-ripgrep-rust-v1
-          CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT: benchmarks/release-evidence/corpus-contracts/v0.16-axios-ripgrep-rust-v1.json
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-js-ts-v1
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT: benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json
           CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-inprocess-v1
           CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
           CODESTORY_EMBED_ALLOW_CPU: "1"
@@ -115,7 +115,7 @@ jobs:
             --packet-runtime \
             --packet-runtime-mode cold-cli \
             --task-suite holdout-retrieval \
-            --task-ids axios-request-dispatch,ripgrep-search-pipeline \
+            --task-ids axios-request-dispatch \
             --materialize-repos \
             --repeats 3 \
             --publishable \

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -88,7 +88,7 @@ jobs:
           CODESTORY_RELEASE_EVIDENCE_DRILL_OUTPUT_DIR: ${{ github.workspace }}/target/release-evidence/drill
           CODESTORY_RELEASE_EVIDENCE_STATS_PATH: ${{ github.workspace }}/target/release-evidence/stats.json
           CODESTORY_RELEASE_EVIDENCE_COMMIT: ${{ inputs.ref }}
-          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v1
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-ripgrep-rust-v1
           CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-inprocess-v1
           CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
           CODESTORY_REAL_REPO_DRILL_CASES: ${{ inputs.drill_manifest }}
@@ -104,7 +104,8 @@ jobs:
         env:
           CODESTORY_RELEASE_EVIDENCE_COMMIT: ${{ inputs.ref }}
           CODESTORY_RELEASE_EVIDENCE_PROFILE: ${{ inputs.profile }}
-          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v1
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-ripgrep-rust-v1
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT: benchmarks/release-evidence/corpus-contracts/v0.16-axios-ripgrep-rust-v1.json
           CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-inprocess-v1
           CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
           CODESTORY_EMBED_ALLOW_CPU: "1"
@@ -114,6 +115,7 @@ jobs:
             --packet-runtime \
             --packet-runtime-mode cold-cli \
             --task-suite holdout-retrieval \
+            --task-ids axios-request-dispatch,ripgrep-search-pipeline \
             --materialize-repos \
             --repeats 3 \
             --publishable \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 ### Changed
 
-- v0.16 release evidence now uses a checked Axios JavaScript/TypeScript plus
-  Ripgrep Rust corpus. The benchmark binds task and project-manifest bytes,
-  installs the Rust-only Ripgrep manifest into its owned pinned checkout, and
-  rejects evidence whose selected tasks or provenance drift from that scope.
-  Cache preparation, status capture, and packet measurement also share one
-  explicit agent retrieval namespace so the measured packets consume the
-  semantic generation prepared by the harness.
+- v0.16 release evidence now uses a checked Axios JavaScript/TypeScript corpus
+  with three cold CLI repeats. The benchmark binds the exact task-manifest
+  bytes and rejects missing, substituted, or extra packet rows. Ripgrep's
+  pinned Rust task and project template remain as follow-up diagnostics after a
+  retained run missed its preregistered packet-quality thresholds. Cache
+  preparation, status capture, and packet measurement share one explicit agent
+  retrieval namespace, while cold packet provenance binds an executed semantic
+  stage, full sidecar diagnostics, and zero fallback to the prepared generation.
 - Affected analysis now resolves native workspace path identities once per
   bounded operation, preserving Unix device/inode and Windows volume/file
   identity without pairwise metadata scans or long-lived path caches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   Ripgrep Rust corpus. The benchmark binds task and project-manifest bytes,
   installs the Rust-only Ripgrep manifest into its owned pinned checkout, and
   rejects evidence whose selected tasks or provenance drift from that scope.
+  Cache preparation, status capture, and packet measurement also share one
+  explicit agent retrieval namespace so the measured packets consume the
+  semantic generation prepared by the harness.
 - Affected analysis now resolves native workspace path identities once per
   bounded operation, preserving Unix device/inode and Windows volume/file
   identity without pairwise metadata scans or long-lived path caches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@
   lane builds from source. The hosted lane remains source/protocol evidence
   rather than a packaged or Vulkan-hardware claim.
 - Linux ARM64 release builds now resolve the pinned llama.cpp binding's
-  mutually exclusive fixed-ARM and dynamic CPU-variant CMake selectors in the
-  checked-in Cargo build environment, preserving portable runtime-selected
-  CPU modules without runner-local patches.
+  incompatible fixed-ARM and all-variant CMake selectors in the checked-in
+  Cargo build environment. Packages retain the portable runtime-loaded ARM CPU
+  backend beside Vulkan without runner-local patches.
 - Draft source CI now restores exact-lock retrieval output or narrowly scoped
   prior-lock output before rebuilding. The base retrieval lane serially seeds
   the exact five test-profile targets used by draft proof, while a versioned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   incompatible fixed-ARM and all-variant CMake selectors in the checked-in
   Cargo build environment. Packages retain the portable runtime-loaded ARM CPU
   backend beside Vulkan without runner-local patches.
+- Linux ARM64 release evidence now checksum-binds an explicit Serde project
+  manifest, keeping intentional compiler-failure UI fixtures outside the valid
+  source corpus without weakening fail-closed production indexing.
 - Draft source CI now restores exact-lock retrieval output or narrowly scoped
   prior-lock output before rebuilding. The base retrieval lane serially seeds
   the exact five test-profile targets used by draft proof, while a versioned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   protected Windows artifact records the same native tool versions when that
   lane builds from source. The hosted lane remains source/protocol evidence
   rather than a packaged or Vulkan-hardware claim.
+- Linux ARM64 release builds now resolve the pinned llama.cpp binding's
+  mutually exclusive fixed-ARM and dynamic CPU-variant CMake selectors in the
+  checked-in Cargo build environment, preserving portable runtime-selected
+  CPU modules without runner-local patches.
 - Draft source CI now restores exact-lock retrieval output or narrowly scoped
   prior-lock output before rebuilding. The base retrieval lane serially seeds
   the exact five test-profile targets used by draft proof, while a versioned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- v0.16 release evidence now uses a checked Axios JavaScript/TypeScript plus
+  Ripgrep Rust corpus. The benchmark binds task and project-manifest bytes,
+  installs the Rust-only Ripgrep manifest into its owned pinned checkout, and
+  rejects evidence whose selected tasks or provenance drift from that scope.
 - Affected analysis now resolves native workspace path identities once per
   bounded operation, preserving Unix device/inode and Windows volume/file
   identity without pairwise metadata scans or long-lived path caches.

--- a/benchmarks/release-evidence/approved-baselines.json
+++ b/benchmarks/release-evidence/approved-baselines.json
@@ -64,6 +64,42 @@
         "indexing_seconds": { "reference": 14.496289933, "threshold": 18.13, "unit": "seconds", "aggregation": "cold full-refresh wall time", "direction": "max", "source": "linux-arm64-v1-b09b8c44.json" },
         "storage_growth_ratio": { "reference": 1, "threshold": 1.1, "reference_bytes": 617172808, "unit": "ratio", "aggregation": "candidate bytes divided by approved same-corpus bytes", "direction": "max", "source": "linux-arm64-v1-b09b8c44.json" }
       }
+    },
+    "codestory-release-evidence-linux-arm64-v2": {
+      "baseline_id": "codestory-release-evidence-linux-arm64-v2@56cfed37439c34c8e01710074a2f5cb72284d521",
+      "status": "approved",
+      "release_eligible": true,
+      "commit": "56cfed37439c34c8e01710074a2f5cb72284d521",
+      "git_state": "clean",
+      "identity": {
+        "corpus_id": "codestory-release-corpus-v0.16-axios-js-ts-v1",
+        "cache_id": "cold-inprocess-v1",
+        "machine_fingerprint": "codestory-release-evidence-linux-arm64-v2/f9c76f5dd049f937f7fe4307747a466e65db4f05ccb65ad792a404f6f13140dd"
+      },
+      "corpus_contract": {
+        "path": "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json",
+        "sha256": "cca8326d9a10cf980778bc70e18864de012172c4a7c180d0e2c51a6704f605c2"
+      },
+      "approval": {
+        "owner": "Albert Najjar",
+        "approved_at": "2026-07-17",
+        "rationale": "Protected run 29626819203 on the provisioned Linux ARM64 v2 profile passed full-retrieval stats, resolved all 3 Serde anchors with zero failed commands, and passed all 3 scoped Axios packet rows with no publishable blockers. Thresholds use the preregistered multipliers and upward 0.01-second rounding rule."
+      },
+      "artifacts": [
+        {
+          "path": "baselines/linux-arm64-v2-56cfed37.json",
+          "sha256": "835fa7a9d3d7ac5533047cd41ed31c040b5fb8b8d27102d0e4dcb4463112d308"
+        }
+      ],
+      "metrics": {
+        "status_seconds": { "reference": 0.014995754, "threshold": 0.02, "unit": "seconds", "aggregation": "full-retrieval command wall time", "direction": "max", "source": "linux-arm64-v2-56cfed37.json" },
+        "local_grounding_seconds": { "reference": 0.046535663, "threshold": 0.06, "unit": "seconds", "aggregation": "full-retrieval command wall time", "direction": "max", "source": "linux-arm64-v2-56cfed37.json" },
+        "convergence_seconds": { "reference": 15.438115102, "threshold": 17.76, "unit": "seconds", "aggregation": "unchanged-corpus repeat full-refresh wall time", "direction": "max", "source": "linux-arm64-v2-56cfed37.json" },
+        "packet_seconds": { "reference": 1.974697, "threshold": 2.18, "unit": "seconds", "aggregation": "worst quality-gated packet median wall time", "direction": "max", "source": "linux-arm64-v2-56cfed37.json" },
+        "search_seconds": { "reference": 6.573140943, "threshold": 8.22, "unit": "seconds", "aggregation": "full-retrieval command wall time", "direction": "max", "source": "linux-arm64-v2-56cfed37.json" },
+        "indexing_seconds": { "reference": 20.151733549, "threshold": 25.19, "unit": "seconds", "aggregation": "cold full-refresh wall time", "direction": "max", "source": "linux-arm64-v2-56cfed37.json" },
+        "storage_growth_ratio": { "reference": 1, "threshold": 1.1, "reference_bytes": 609245502, "unit": "ratio", "aggregation": "candidate bytes divided by approved same-corpus bytes", "direction": "max", "source": "linux-arm64-v2-56cfed37.json" }
+      }
     }
   }
 }

--- a/benchmarks/release-evidence/baselines/linux-arm64-v2-56cfed37.json
+++ b/benchmarks/release-evidence/baselines/linux-arm64-v2-56cfed37.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "commit": "56cfed37439c34c8e01710074a2f5cb72284d521",
+  "evidence_identity": {
+    "corpus_id": "codestory-release-corpus-v0.16-axios-js-ts-v1",
+    "cache_id": "cold-inprocess-v1",
+    "machine_fingerprint": "codestory-release-evidence-linux-arm64-v2/f9c76f5dd049f937f7fe4307747a466e65db4f05ccb65ad792a404f6f13140dd"
+  },
+  "corpus_contract": {
+    "path": "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json",
+    "sha256": "cca8326d9a10cf980778bc70e18864de012172c4a7c180d0e2c51a6704f605c2",
+    "task_manifest": {
+      "path": "benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json",
+      "sha256": "3dfb002f0dd0b0683c8bca2314a405dc0d728aeeb8533247a6b17e316aed81c0"
+    }
+  },
+  "source_artifacts": {
+    "workflow_run_id": 29626819203,
+    "hosted_artifact": {
+      "id": 8424291310,
+      "name": "release-evidence-56cfed37439c34c8e01710074a2f5cb72284d521",
+      "sha256": "d3bb8113ac29059978780e4099c8cff292fc00ff73225f6635aa06271f6640a6",
+      "bytes": 100547,
+      "expires_at": "2026-08-17T02:37:09Z"
+    },
+    "stats": {
+      "path": "stats.json",
+      "sha256": "a3ddb6724e39c09ba415d777bdb3e147bacb2347a6e3a657a3270f6c15f38dd5",
+      "bytes": 5593
+    },
+    "packet": {
+      "path": "packet/packet-runtime-summary.json",
+      "sha256": "f0dbdce5801848506df2b327bb995e06b6e436acc21674980b4210be86c7a03c",
+      "bytes": 97608
+    },
+    "drill": {
+      "path": "drill/drill-suite-report.json",
+      "sha256": "e2d81efa54d3943cab3101e8cc79145f38e6cadd994a9603785a7a5d69ac185d",
+      "bytes": 12273
+    },
+    "provisioning": {
+      "path": "provisioning.json",
+      "sha256": "1be3114dfd0a32d6766071f30efccaedd8092e740e6eaf48ebca5a4fad9e5bd9",
+      "bytes": 3105
+    }
+  },
+  "quality": {
+    "retrieval_status": "full",
+    "serde_anchor_resolution": "3/3",
+    "packet_rows": 3,
+    "packet_quality_pass_rows": 3,
+    "packet_publishable_blockers": []
+  },
+  "budget_policy": {
+    "command_seconds_multiplier": 1.25,
+    "convergence_seconds_multiplier": 1.15,
+    "packet_seconds_multiplier": 1.1,
+    "storage_growth_ratio": 1.1,
+    "seconds_rounding": "ceil to the next 0.01 seconds"
+  },
+  "metrics": {
+    "status_seconds": 0.014995754,
+    "local_grounding_seconds": 0.046535663,
+    "convergence_seconds": 15.438115102,
+    "packet_seconds": 1.974697,
+    "search_seconds": 6.573140943,
+    "indexing_seconds": 20.151733549,
+    "storage_bytes": 609245502
+  }
+}

--- a/benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json
+++ b/benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json
@@ -4,6 +4,10 @@
   "task_ids": [
     "axios-request-dispatch"
   ],
+  "runtime_modes": [
+    "cold_cli_packet"
+  ],
+  "repeats": 3,
   "task_manifests": {
     "axios-request-dispatch": {
       "path": "benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json",

--- a/benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json
+++ b/benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "corpus_id": "codestory-release-corpus-v0.16-axios-js-ts-v1",
+  "task_ids": [
+    "axios-request-dispatch"
+  ],
+  "task_manifests": {
+    "axios-request-dispatch": {
+      "path": "benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json",
+      "sha256": "3dfb002f0dd0b0683c8bca2314a405dc0d728aeeb8533247a6b17e316aed81c0"
+    }
+  },
+  "project_manifests": {}
+}

--- a/benchmarks/release-evidence/corpus-contracts/v0.16-axios-ripgrep-rust-v1.json
+++ b/benchmarks/release-evidence/corpus-contracts/v0.16-axios-ripgrep-rust-v1.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "corpus_id": "codestory-release-corpus-v0.16-axios-ripgrep-rust-v1",
+  "task_ids": [
+    "axios-request-dispatch",
+    "ripgrep-search-pipeline"
+  ],
+  "task_manifests": {
+    "axios-request-dispatch": {
+      "path": "benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json",
+      "sha256": "3dfb002f0dd0b0683c8bca2314a405dc0d728aeeb8533247a6b17e316aed81c0"
+    },
+    "ripgrep-search-pipeline": {
+      "path": "benchmarks/tasks/holdout-retrieval/ripgrep-search-pipeline.task.json",
+      "sha256": "3b3f1c803a062c7aa532c4152eaa16279c77cb920bf42134e495273b1ac94422"
+    }
+  },
+  "project_manifests": {
+    "ripgrep-search-pipeline": {
+      "path": "benchmarks/tasks/holdout-retrieval/ripgrep-rust-codestory-project.json",
+      "sha256": "85b8ade56e2907ba78366a231cb11970f2b18830725771d9f435d3109bb1972a"
+    }
+  }
+}

--- a/benchmarks/tasks/holdout-retrieval/ripgrep-rust-codestory-project.json
+++ b/benchmarks/tasks/holdout-retrieval/ripgrep-rust-codestory-project.json
@@ -1,0 +1,21 @@
+{
+  "name": "ripgrep-release-evidence-rust",
+  "version": 1,
+  "source_groups": [
+    {
+      "id": "9bf47d5a-7838-5f8d-b7ae-4a2cf12d14e6",
+      "language": "Rust",
+      "standard": "Default",
+      "source_paths": [
+        "."
+      ],
+      "exclude_patterns": [
+        "**/.git/**",
+        "**/target/**"
+      ],
+      "include_paths": [],
+      "defines": {},
+      "language_specific": "Other"
+    }
+  ]
+}

--- a/benchmarks/tasks/holdout-retrieval/ripgrep-search-pipeline.task.json
+++ b/benchmarks/tasks/holdout-retrieval/ripgrep-search-pipeline.task.json
@@ -14,7 +14,11 @@
     ],
     "setup": [
       "No dependency setup is required for read-only benchmark inspection."
-    ]
+    ],
+    "codestory_project_manifest": {
+      "path": "ripgrep-rust-codestory-project.json",
+      "sha256": "85b8ade56e2907ba78366a231cb11970f2b18830725771d9f435d3109bb1972a"
+    }
   },
   "prompt": "Explain how ripgrep parses CLI flags, walks candidate files, and executes a search over each haystack through matcher, searcher, and printer components. Cite the source files that support the path.",
   "expected_files": [

--- a/benchmarks/tasks/manifest.schema.json
+++ b/benchmarks/tasks/manifest.schema.json
@@ -87,6 +87,25 @@
             "minLength": 1
           },
           "uniqueItems": true
+        },
+        "codestory_project_manifest": {
+          "description": "Optional checksum-bound project manifest installed only into a harness-owned pinned checkout before indexing.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "properties": {
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "sha256": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
         }
       }
     },

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -7,15 +7,23 @@ stable between candidates. Ordinary pull requests must not target this runner.
 ## v0.16 corpus boundary
 
 The v0.16 profile uses
-`codestory-release-corpus-v0.16-axios-ripgrep-rust-v1`: Axios
-JavaScript/TypeScript and Ripgrep Rust, each with three cold CLI packet repeats.
-The checked corpus contract binds the exact task-manifest bytes. Ripgrep also
-binds and installs a Rust-only `codestory_project.json` into the harness-owned,
-clean pinned checkout; the installed bytes and ignore proof are recorded in
-every packet row. Redis/C, shell dialects, and general parser completeness are
-outside this release-evidence claim and remain v0.16.1 fidelity work.
+`codestory-release-corpus-v0.16-axios-js-ts-v1`: one Axios
+JavaScript/TypeScript task with three cold CLI packet repeats. The checked
+corpus contract binds the exact task-manifest bytes and rejects missing,
+substituted, or extra task rows. Ripgrep's pinned Rust task and project template
+remain available for follow-up diagnostics, but a retained three-repeat run
+did not meet its preregistered file and citation recall thresholds, so v0.16
+makes no Ripgrep or general Rust packet-quality claim. Redis/C, shell dialects,
+and general parser completeness are also outside this release-evidence claim.
 The approved baseline profile records the corpus-contract path and SHA-256, so
 candidate evidence cannot silently widen, narrow, or replace that scope.
+
+Cold CLI packet provenance is taken from the packet process that actually ran.
+It binds the packet's executed semantic stage, full sidecar diagnostics, and
+zero semantic fallback to the exact semantic generation prepared by the
+harness. A later status process cannot supply the earlier process-local
+embedding-engine instance identity; warm-process evidence still requires that
+live identity directly.
 
 ## Machine contract
 

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -4,6 +4,19 @@ CodeStory release-candidate measurements run on one repository-scoped Linux
 runner so baseline identity, cache state, model bytes, and toolchain remain
 stable between candidates. Ordinary pull requests must not target this runner.
 
+## v0.16 corpus boundary
+
+The v0.16 profile uses
+`codestory-release-corpus-v0.16-axios-ripgrep-rust-v1`: Axios
+JavaScript/TypeScript and Ripgrep Rust, each with three cold CLI packet repeats.
+The checked corpus contract binds the exact task-manifest bytes. Ripgrep also
+binds and installs a Rust-only `codestory_project.json` into the harness-owned,
+clean pinned checkout; the installed bytes and ignore proof are recorded in
+every packet row. Redis/C, shell dialects, and general parser completeness are
+outside this release-evidence claim and remain v0.16.1 fidelity work.
+The approved baseline profile records the corpus-contract path and SHA-256, so
+candidate evidence cannot silently widen, narrow, or replace that scope.
+
 ## Machine contract
 
 The approved host shape for the 0.16 in-process retrieval baseline is:

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -22,6 +22,7 @@ The approved host shape for the 0.16 in-process retrieval baseline is:
 | Machine contract | `scripts/release-evidence/machine-contract.json` |
 | Runner volume | `/srv/codestory-release-evidence` |
 | Drill manifest | `/srv/codestory-release-evidence/drills/real-repo-drill-cases.json` |
+| Drill project manifest | `scripts/release-evidence/serde-json-codestory-project.json` |
 
 The profile ID is a stable comparison key, not evidence about the current
 machine. Provisioning records the observed host, generated Colima VM shape,
@@ -60,7 +61,9 @@ Provisioning is idempotent. It:
 - disables automatic runner updates so baseline changes are deliberate;
 - verifies that the exact candidate contains its checksum-pinned CodeRankEmbed model and
   linked embedding engine without provisioning either one;
-- prepares a source-backed `serde_json` drill at an exact commit;
+- prepares a source-backed `serde_json` drill at an exact commit and installs
+  the checksum-bound project manifest that excludes its intentionally malformed
+  compiler UI fixtures from the valid-source corpus;
 - registers the runner only with `TheGreenCedar/CodeStory`; and
 - keeps Cargo, Rust, temp, XDG, CodeStory, drill, work, and artifact state
   under the proof-owned volume.

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -168,11 +168,14 @@ artifact can become release-eligible.
 The `codestory-release-evidence-linux-arm64-v2` baseline is measured from the
 clean pre-server-change product tree at
 `54c8d51928e99b993a37afb21cfb9a79d6468fe3`, plus the source-bound Linux ARM64
-build compatibility shim in this baseline PR. The first protected attempt
-failed during CMake configuration before any metric producer ran; it did not
-observe candidate measurements. Record the exact successful measurement commit
-in the approved profile; changes made afterward cannot define or move the
-reference values used to evaluate them.
+build compatibility shim in this baseline PR. Protected run `29614084988` at
+`2e25300b5d4899396eb55c3f46501bdc24a0951f` failed during CMake configuration.
+Run `29616049836` at `544ac0575b33d6e64b8183a0c1443623eaac4194`
+cleared that conflict but found that the pinned GCC toolchain cannot compile
+the upstream SME variants. Both stopped before any metric producer ran and
+observed no candidate measurements. Record the exact successful measurement
+commit in the approved profile; changes made afterward cannot define or move
+the reference values used to evaluate them.
 
 Before observing the v2 measurements, its operational budgets are fixed as
 follows:

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -188,6 +188,23 @@ contract and attestation so the drill corpus includes valid Rust source while
 excluding `tests/ui/**`; production parser and publication completeness remain
 unchanged.
 
+Protected run `29623187686` stopped before measurement after detecting a stale
+retrieval namespace in the harness. Run `29624645979` at
+`dd14e2d0e29b9e09438a0aa4f9a6ea6250e69738` then completed the source and Serde
+gates plus all six cold packet rows. Axios passed all three repeats. Ripgrep
+failed all three at 0.60 file recall and 0.60 citation coverage against the
+fixed 0.70 thresholds, and a later status process could not report the packet
+process's local engine identity. Those failures are retained; they do not
+define a baseline.
+
+Before another protected measurement, v0.16 is narrowed to the new hash-bound
+`codestory-release-corpus-v0.16-axios-js-ts-v1` contract: exactly the Axios task
+and three repeats. Ripgrep remains outside the v0.16 packet-quality claim. The
+harness now proves cold embedding execution from the measured packet's semantic
+stage, full sidecar diagnostics, zero fallback, and semantic-generation match,
+rather than asking a later process to recreate process-local identity. The
+budgets below are unchanged by that scope decision.
+
 Before observing the v2 measurements, its operational budgets are fixed as
 follows:
 

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -163,6 +163,29 @@ hardware-bound release-evidence gate separately re-evaluates repeat graph,
 semantic, and full-refresh limits from `repo-stats-contract.json` before an
 artifact can become release-eligible.
 
+### Linux ARM64 v2 baseline preregistration
+
+The `codestory-release-evidence-linux-arm64-v2` baseline is measured from the
+clean pre-server-change product tree at
+`54c8d51928e99b993a37afb21cfb9a79d6468fe3`. Record the exact measurement
+commit in the approved profile; changes made afterward cannot define or move
+the reference values used to evaluate them.
+
+Before observing the v2 measurements, its operational budgets are fixed as
+follows:
+
+- status, local grounding, search, and cold indexing: reference multiplied by
+  `1.25`;
+- unchanged-corpus convergence: reference multiplied by `1.15`;
+- worst quality-gated packet median: reference multiplied by `1.10`;
+- same-corpus storage growth: reference bytes multiplied by `1.10`; and
+- second-based thresholds round upward to the next `0.01` seconds.
+
+These multipliers are release budgets, not confidence intervals. The baseline
+is one identity-bound observation except for the required three publishable
+packet repeats. Do not tune a multiplier after reading the run, substitute v1
+values, or rerun a valid measurement to seek a more favorable sample.
+
 On rejection, the workflow uploads provisioning, raw, candidate, approval (when
 provided), and report files with `if: always()`. Author an exception against the
 reported hashes and values in the short-lived repository Actions secret

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -220,6 +220,17 @@ is one identity-bound observation except for the required three publishable
 packet repeats. Do not tune a multiplier after reading the run, substitute v1
 values, or rerun a valid measurement to seek a more favorable sample.
 
+Protected run `29626819203` at
+`56cfed37439c34c8e01710074a2f5cb72284d521` is the accepted v2 measurement.
+It passed the full-retrieval and Serde producers, resolved all three Serde
+anchors with zero failed commands, and passed all three scoped Axios packet
+rows with no publishable blocker. The workflow's candidate step failed only
+because the v2 profile did not exist yet; its always-uploaded artifact
+`8424291310` has archive digest
+`d3bb8113ac29059978780e4099c8cff292fc00ff73225f6635aa06271f6640a6`.
+The approved registry derives the fixed budgets from those retained raw bytes.
+That measurement is not repeated after registration.
+
 On rejection, the workflow uploads provisioning, raw, candidate, approval (when
 provided), and report files with `if: always()`. Author an exception against the
 reported hashes and values in the short-lived repository Actions secret

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -177,6 +177,17 @@ observed no candidate measurements. Record the exact successful measurement
 commit in the approved profile; changes made afterward cannot define or move
 the reference values used to evaluate them.
 
+Protected run `29616984735` at
+`42b88537840a2fcb77cad523a5a0d4627f42961f` built the repaired native package
+and produced CodeStory self-corpus stats, then correctly rejected the Serde
+drill because its repository-wide synthetic manifest scheduled the intentional
+compiler-failure fixture `tests/ui/parse_expr.rs`. Packet production and
+candidate evaluation did not run, so those partial stats cannot define the v2
+baseline. The runner now binds a checked-in project manifest into its machine
+contract and attestation so the drill corpus includes valid Rust source while
+excluding `tests/ui/**`; production parser and publication completeness remain
+unchanged.
+
 Before observing the v2 measurements, its operational budgets are fixed as
 follows:
 

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -167,9 +167,12 @@ artifact can become release-eligible.
 
 The `codestory-release-evidence-linux-arm64-v2` baseline is measured from the
 clean pre-server-change product tree at
-`54c8d51928e99b993a37afb21cfb9a79d6468fe3`. Record the exact measurement
-commit in the approved profile; changes made afterward cannot define or move
-the reference values used to evaluate them.
+`54c8d51928e99b993a37afb21cfb9a79d6468fe3`, plus the source-bound Linux ARM64
+build compatibility shim in this baseline PR. The first protected attempt
+failed during CMake configuration before any metric producer ran; it did not
+observe candidate measurements. Record the exact successful measurement commit
+in the approved profile; changes made afterward cannot define or move the
+reference values used to evaluate them.
 
 Before observing the v2 measurements, its operational budgets are fixed as
 follows:

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
@@ -38,6 +39,7 @@ const defaultTaskRoot = path.join(repoRoot, "benchmarks", "tasks");
 const defaultRepoCacheRoot = path.join(repoRoot, "target", "agent-benchmark", "repos");
 const MANIFEST_REPO_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
 const MANIFEST_TASK_ID_PATTERN = /^[a-z0-9][a-z0-9.-]*$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const MAX_PACKET_MANIFEST_EXTRA_PROBES = 12;
 const MAX_REUSED_ARTIFACT_BYTES = 64 * 1024 * 1024;
 const REUSABLE_BASELINE_ARTIFACT_NAME_PATTERN =
@@ -511,6 +513,44 @@ function assertPathInside(base, candidate, label) {
   return path.resolve(candidate);
 }
 
+function sha256Bytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function normalizeSha256(value, label) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (!SHA256_PATTERN.test(normalized)) {
+    throw new Error(`${label} must be a lowercase SHA-256 digest`);
+  }
+  return normalized;
+}
+
+function normalizeCodestoryProjectManifest(filePath, value) {
+  if (value == null) {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Task manifest codestory_project_manifest must be an object: ${filePath}`);
+  }
+  const declaredPath = String(value.path ?? "").trim();
+  if (!declaredPath || path.isAbsolute(declaredPath) || path.win32.isAbsolute(declaredPath)) {
+    throw new Error(`Task manifest codestory_project_manifest.path must be relative: ${filePath}`);
+  }
+  const sourcePath = assertPathInside(
+    repoRoot,
+    path.resolve(path.dirname(filePath), declaredPath),
+    "Task manifest codestory_project_manifest.path",
+  );
+  if (!existsSync(sourcePath) || !statSync(sourcePath).isFile()) {
+    throw new Error(`Task manifest codestory_project_manifest.path does not name a file: ${filePath}`);
+  }
+  return {
+    declared_path: declaredPath.replaceAll(path.sep, "/"),
+    source_path: sourcePath,
+    sha256: normalizeSha256(value.sha256, `Task manifest codestory_project_manifest.sha256: ${filePath}`),
+  };
+}
+
 function normalizeWorkspaceRoot(filePath, value) {
   if (value == null || String(value).trim() === "" || String(value).trim() === ".") {
     return "";
@@ -557,6 +597,7 @@ function repoConfigFromManifest(repo, opts = {}) {
     ref: repo.ref ?? null,
     languages: Array.isArray(repo.languages) ? repo.languages : [],
     setup: Array.isArray(repo.setup) ? repo.setup : [],
+    codestory_project_manifest: normalizeCodestoryProjectManifest(filePath, repo.codestory_project_manifest),
     prompt: "",
   };
 }
@@ -587,6 +628,7 @@ function registerManifestRepo(repo, opts = {}) {
     manifest_ref: config.ref,
     manifest_workspace_root: config.workspace_root,
     manifest_checkout_path: config.checkout_path,
+    manifest_codestory_project_manifest: config.codestory_project_manifest,
     manifest_overridden_by_builtin: manifestOverriddenByBuiltIn,
     languages: activeConfig.languages?.length ? activeConfig.languages : config.languages,
     setup: activeConfig.setup?.length ? activeConfig.setup : config.setup,
@@ -847,6 +889,104 @@ async function loadTasks(opts) {
   return tasks;
 }
 
+function sortedUniqueStrings(values, label) {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new Error(`${label} must be a non-empty array`);
+  }
+  const normalized = values.map((value) => String(value ?? "").trim());
+  if (normalized.some((value) => !MANIFEST_TASK_ID_PATTERN.test(value))) {
+    throw new Error(`${label} must contain benchmark task IDs`);
+  }
+  const sorted = [...new Set(normalized)].sort();
+  if (sorted.length !== normalized.length || JSON.stringify(sorted) !== JSON.stringify(normalized)) {
+    throw new Error(`${label} must be sorted and unique`);
+  }
+  return sorted;
+}
+
+async function loadReleaseEvidenceCorpusContract(tasks) {
+  const declaredPath = process.env.CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT?.trim();
+  if (!process.env.CODESTORY_RELEASE_EVIDENCE_COMMIT) {
+    if (declaredPath) {
+      throw new Error("CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT requires CODESTORY_RELEASE_EVIDENCE_COMMIT");
+    }
+    return null;
+  }
+  if (!declaredPath) {
+    throw new Error("release evidence requires CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT");
+  }
+  const contractPath = assertPathInside(repoRoot, path.resolve(repoRoot, declaredPath), "Release evidence corpus contract");
+  if (!existsSync(contractPath) || !statSync(contractPath).isFile()) {
+    throw new Error(`Release evidence corpus contract does not exist: ${declaredPath}`);
+  }
+  const bytes = await readFile(contractPath);
+  const contract = JSON.parse(bytes.toString("utf8"));
+  if (contract?.schema_version !== 1 || typeof contract?.corpus_id !== "string") {
+    throw new Error("Release evidence corpus contract must use schema_version 1 and name a corpus_id");
+  }
+  if (contract.corpus_id !== process.env.CODESTORY_RELEASE_EVIDENCE_CORPUS_ID) {
+    throw new Error("Release evidence corpus contract corpus_id does not match CODESTORY_RELEASE_EVIDENCE_CORPUS_ID");
+  }
+  const taskIds = sortedUniqueStrings(contract.task_ids, "Release evidence corpus contract task_ids");
+  const loadedTaskIds = [...new Set(tasks.map((task) => task.id))].sort();
+  if (JSON.stringify(taskIds) !== JSON.stringify(loadedTaskIds)) {
+    throw new Error(
+      `Release evidence task selection does not match corpus contract: expected ${taskIds.join(", ")}, got ${loadedTaskIds.join(", ")}`,
+    );
+  }
+  if (!contract.task_manifests || typeof contract.task_manifests !== "object" || Array.isArray(contract.task_manifests)) {
+    throw new Error("Release evidence corpus contract must bind task_manifests");
+  }
+  const taskManifests = {};
+  for (const task of tasks) {
+    const declaration = contract.task_manifests[task.id];
+    if (!declaration || typeof declaration !== "object") {
+      throw new Error(`Release evidence corpus contract is missing task manifest for ${task.id}`);
+    }
+    const manifestPath = assertPathInside(repoRoot, path.resolve(repoRoot, declaration.path ?? ""), `Task manifest contract path for ${task.id}`);
+    if (path.resolve(task.manifest_path) !== manifestPath) {
+      throw new Error(`Release evidence task manifest path does not match loaded task for ${task.id}`);
+    }
+    const manifestBytes = await readFile(manifestPath);
+    const manifestSha256 = sha256Bytes(manifestBytes);
+    if (manifestSha256 !== normalizeSha256(declaration.sha256, `Task manifest contract hash for ${task.id}`)) {
+      throw new Error(`Release evidence task manifest hash does not match for ${task.id}`);
+    }
+    taskManifests[task.id] = {
+      path: path.relative(repoRoot, manifestPath).replaceAll(path.sep, "/"),
+      sha256: manifestSha256,
+    };
+  }
+  if (Object.keys(contract.task_manifests).some((taskId) => !taskIds.includes(taskId))) {
+    throw new Error("Release evidence corpus contract binds an unselected task manifest");
+  }
+  const projectManifests = {};
+  for (const task of tasks) {
+    const manifest = task.repo_metadata?.codestory_project_manifest;
+    if (!manifest) continue;
+    const config = ALL_REPOS[task.repo];
+    const normalized = config?.manifest_codestory_project_manifest;
+    if (!normalized || normalized.sha256 !== manifest.sha256) {
+      throw new Error(`Release evidence project manifest declaration is inconsistent for ${task.id}`);
+    }
+    projectManifests[task.id] = {
+      path: path.relative(repoRoot, normalized.source_path).replaceAll(path.sep, "/"),
+      sha256: normalized.sha256,
+    };
+  }
+  if (JSON.stringify(contract.project_manifests ?? {}) !== JSON.stringify(projectManifests)) {
+    throw new Error("Release evidence corpus contract project manifest bindings do not match selected tasks");
+  }
+  return {
+    path: path.relative(repoRoot, contractPath).replaceAll(path.sep, "/"),
+    sha256: sha256Bytes(bytes),
+    corpus_id: contract.corpus_id,
+    task_ids: taskIds,
+    task_manifests: taskManifests,
+    project_manifests: projectManifests,
+  };
+}
+
 function publicCoreCorpusAudit(tasks) {
   const classCounts = new Map();
   const repos = new Set();
@@ -1047,6 +1187,66 @@ function assertManifestRepoMaterializationAllowed(tasks, opts = {}) {
   }
 }
 
+async function gitCheckedOutput(args, cwd, timeoutMs) {
+  const result = await runCheckedProcess("git", args, { cwd, timeoutMs });
+  return result.stdout.trim();
+}
+
+async function installCodestoryProjectManifest(config, checkoutPath, opts) {
+  const manifest = config.manifest_codestory_project_manifest ?? null;
+  if (!manifest) {
+    return null;
+  }
+  const workspacePath = path.resolve(config.path);
+  assertPathInside(checkoutPath, workspacePath, "CodeStory project manifest workspace path");
+  const destination = assertPathInside(
+    workspacePath,
+    path.join(workspacePath, "codestory_project.json"),
+    "CodeStory project manifest destination",
+  );
+  const relativeDestination = path.relative(checkoutPath, destination).replaceAll(path.sep, "/");
+  if (!relativeDestination || relativeDestination.startsWith("../") || path.isAbsolute(relativeDestination)) {
+    throw new Error(`CodeStory project manifest destination escapes checkout: ${destination}`);
+  }
+  const tracked = await runProcess("git", ["-C", checkoutPath, "ls-files", "--error-unmatch", "--", relativeDestination], {
+    timeoutMs: opts.timeoutMs,
+  });
+  if (tracked.exitCode === 0) {
+    throw new Error(`Refusing to replace upstream-tracked ${relativeDestination} in ${config.name}`);
+  }
+  const sourceBytes = await readFile(manifest.source_path);
+  const sourceSha256 = sha256Bytes(sourceBytes);
+  if (sourceSha256 !== manifest.sha256) {
+    throw new Error(
+      `CodeStory project manifest hash mismatch for ${config.name}: expected ${manifest.sha256}, got ${sourceSha256}`,
+    );
+  }
+  const infoExclude = path.join(checkoutPath, ".git", "info", "exclude");
+  const ignoreEntry = `/${relativeDestination}`;
+  const currentExclude = existsSync(infoExclude) ? await readFile(infoExclude, "utf8") : "";
+  if (!currentExclude.split(/\r?\n/u).includes(ignoreEntry)) {
+    await writeFile(infoExclude, `${currentExclude}${currentExclude.endsWith("\n") || !currentExclude ? "" : "\n"}${ignoreEntry}\n`, "utf8");
+  }
+  await writeFile(destination, sourceBytes);
+  const installedBytes = await readFile(destination);
+  const installedSha256 = sha256Bytes(installedBytes);
+  if (installedSha256 !== manifest.sha256) {
+    throw new Error(`Installed CodeStory project manifest hash mismatch for ${config.name}`);
+  }
+  await gitCheckedOutput(["-C", checkoutPath, "check-ignore", "-q", "--", relativeDestination], repoRoot, opts.timeoutMs);
+  const dirty = await gitCheckedOutput(["-C", checkoutPath, "status", "--porcelain"], repoRoot, opts.timeoutMs);
+  if (dirty) {
+    throw new Error(`Installing CodeStory project manifest dirtied ${config.name}: ${dirty}`);
+  }
+  return {
+    source_path: path.relative(repoRoot, manifest.source_path).replaceAll(path.sep, "/"),
+    declared_sha256: manifest.sha256,
+    installed_path: relativeDestination,
+    installed_sha256: installedSha256,
+    ignored: true,
+  };
+}
+
 async function materializeRepos(tasks, opts) {
   const repos = uniqueTaskRepos(tasks);
   if (!repos.size) {
@@ -1083,6 +1283,7 @@ async function materializeRepos(tasks, opts) {
     if (!existsSync(config.path)) {
       throw new Error(`Materialized repo ${name} is missing workspace path: ${config.path}`);
     }
+    config.installed_codestory_project_manifest = await installCodestoryProjectManifest(config, checkoutPath, opts);
   }
 }
 
@@ -2961,6 +3162,12 @@ async function repoProvenance(config) {
       ref: config.manifest_ref ?? null,
       workspace_root: config.manifest_workspace_root ?? null,
       checkout_path: config.manifest_checkout_path ?? null,
+      codestory_project_manifest: config.manifest_codestory_project_manifest
+        ? {
+            path: config.manifest_codestory_project_manifest.declared_path,
+            sha256: config.manifest_codestory_project_manifest.sha256,
+          }
+        : null,
     },
     configured: {
       url: config.url ?? null,
@@ -2974,6 +3181,7 @@ async function repoProvenance(config) {
     ),
     git_dirty: statusShort == null ? null : statusShort.length > 0,
     git_status_short: statusShort,
+    installed_codestory_project_manifest: config.installed_codestory_project_manifest ?? null,
   };
 }
 
@@ -5135,6 +5343,7 @@ async function runPacketRuntimeBenchmarkBody(opts, tasks) {
               machine_fingerprint:
                 process.env.CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT,
             },
+            corpus_contract: opts.releaseEvidenceCorpusContract,
             publishable: opts.publishable === true,
             repeats: opts.repeats,
             quality_gate_status:
@@ -6579,6 +6788,7 @@ async function main() {
     return;
   }
   const tasks = await loadTasks(opts);
+  opts.releaseEvidenceCorpusContract = await loadReleaseEvidenceCorpusContract(tasks);
   if (opts.publishable) {
     validatePublishableShape(opts, tasks);
   }

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -2447,11 +2447,42 @@ function estimateCost(usage) {
   return (usage.input_tokens / 1_000_000) * inputCost + (usage.output_tokens / 1_000_000) * outputCost;
 }
 
+const BENCHMARK_AGENT_RUN_ID = "shared-agent";
+
+function benchmarkAgentScopeArgs() {
+  return ["--profile", "agent", "--run-id", BENCHMARK_AGENT_RUN_ID];
+}
+
+function retrievalStatusCommandArgs(project) {
+  return [
+    "retrieval",
+    "status",
+    "--project",
+    project,
+    ...benchmarkAgentScopeArgs(),
+    "--format",
+    "json",
+  ];
+}
+
+function retrievalIndexCommandArgs(project) {
+  return [
+    "retrieval",
+    "index",
+    "--project",
+    project,
+    ...benchmarkAgentScopeArgs(),
+    "--refresh",
+    "auto",
+  ];
+}
+
 function packetCommandArgs(repoConfig, task, opts = {}) {
   const args = [
     "packet",
     "--project",
     repoConfig.path,
+    ...benchmarkAgentScopeArgs(),
     "--question",
     task?.prompt ?? repoConfig.prompt,
     "--budget",
@@ -3305,7 +3336,7 @@ async function codestoryRetrievalStatusSnapshot(
   const started = performance.now();
   const result = await runProcess(
     codestoryCli,
-    ["retrieval", "status", "--project", project, "--format", "json"],
+    retrievalStatusCommandArgs(project),
     { timeoutMs, env },
   );
   const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
@@ -3416,14 +3447,7 @@ async function prepareCodeStoryCaches(opts, tasks) {
       const retrievalStarted = performance.now();
       const retrievalIndex = await runProcess(
         codestoryCli,
-        [
-          "retrieval",
-          "index",
-          "--project",
-          config.path,
-          "--refresh",
-          "auto",
-        ],
+        retrievalIndexCommandArgs(config.path),
         {
           env: childEnv,
           timeoutMs: opts.prepareCodestoryTimeoutMs,
@@ -6953,6 +6977,9 @@ export {
   parseArgs,
   parseJsonLines,
   cachePolicyForRun,
+  benchmarkAgentScopeArgs,
+  retrievalIndexCommandArgs,
+  retrievalStatusCommandArgs,
   packetComposition,
   packetCommandArgs,
   packetForAgentPrompt,

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -537,7 +537,7 @@ function normalizeCodestoryProjectManifest(filePath, value) {
     throw new Error(`Task manifest codestory_project_manifest.path must be relative: ${filePath}`);
   }
   const sourcePath = assertPathInside(
-    repoRoot,
+    path.dirname(filePath),
     path.resolve(path.dirname(filePath), declaredPath),
     "Task manifest codestory_project_manifest.path",
   );
@@ -1247,6 +1247,28 @@ async function installCodestoryProjectManifest(config, checkoutPath, opts) {
   };
 }
 
+async function scrubMaterializedCheckout(config, checkoutPath, opts) {
+  await runCheckedProcess("git", ["-C", checkoutPath, "reset", "--hard", config.ref], {
+    timeoutMs: opts.timeoutMs,
+  });
+  await runCheckedProcess("git", ["-C", checkoutPath, "clean", "-ffdqx"], {
+    timeoutMs: opts.timeoutMs,
+  });
+  const head = (await gitCheckedOutput(["-C", checkoutPath, "rev-parse", "HEAD"], repoRoot, opts.timeoutMs)).toLowerCase();
+  if (head !== String(config.ref).toLowerCase()) {
+    throw new Error(`Materialized repo ${config.name} HEAD ${head} does not match pinned ref ${config.ref}`);
+  }
+  const dirty = await gitCheckedOutput(["-C", checkoutPath, "status", "--porcelain"], repoRoot, opts.timeoutMs);
+  if (dirty) {
+    throw new Error(`Materialized repo ${config.name} is dirty after scrub: ${dirty}`);
+  }
+  const remaining = await gitCheckedOutput(["-C", checkoutPath, "clean", "-ffdqx", "-n"], repoRoot, opts.timeoutMs);
+  if (remaining) {
+    throw new Error(`Materialized repo ${config.name} retains untracked or ignored files after scrub: ${remaining}`);
+  }
+  config.installed_codestory_project_manifest = null;
+}
+
 async function materializeRepos(tasks, opts) {
   const repos = uniqueTaskRepos(tasks);
   if (!repos.size) {
@@ -1280,6 +1302,7 @@ async function materializeRepos(tasks, opts) {
     await runCheckedProcess("git", ["-C", checkoutPath, "checkout", "--detach", "FETCH_HEAD"], {
       timeoutMs: opts.timeoutMs,
     });
+    await scrubMaterializedCheckout(config, checkoutPath, opts);
     if (!existsSync(config.path)) {
       throw new Error(`Materialized repo ${name} is missing workspace path: ${config.path}`);
     }

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -904,7 +904,7 @@ function sortedUniqueStrings(values, label) {
   return sorted;
 }
 
-async function loadReleaseEvidenceCorpusContract(tasks) {
+async function loadReleaseEvidenceCorpusContract(tasks, opts) {
   const declaredPath = process.env.CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT?.trim();
   if (!process.env.CODESTORY_RELEASE_EVIDENCE_COMMIT) {
     if (declaredPath) {
@@ -934,10 +934,20 @@ async function loadReleaseEvidenceCorpusContract(tasks) {
       `Release evidence task selection does not match corpus contract: expected ${taskIds.join(", ")}, got ${loadedTaskIds.join(", ")}`,
     );
   }
+  const selectedRuntimeModes = opts.packetRuntimeMode === "both"
+    ? ["cold_cli_packet", "warm_stdio_packet"]
+    : [`${opts.packetRuntimeMode.replaceAll("-", "_")}_packet`];
+  if (JSON.stringify(contract.runtime_modes) !== JSON.stringify(selectedRuntimeModes)) {
+    throw new Error("Release evidence packet runtime modes do not match corpus contract");
+  }
+  if (!Number.isInteger(contract.repeats) || contract.repeats < 1 || contract.repeats !== opts.repeats) {
+    throw new Error("Release evidence repeat count does not match corpus contract");
+  }
   if (!contract.task_manifests || typeof contract.task_manifests !== "object" || Array.isArray(contract.task_manifests)) {
     throw new Error("Release evidence corpus contract must bind task_manifests");
   }
   const taskManifests = {};
+  const taskRepositories = {};
   for (const task of tasks) {
     const declaration = contract.task_manifests[task.id];
     if (!declaration || typeof declaration !== "object") {
@@ -956,6 +966,7 @@ async function loadReleaseEvidenceCorpusContract(tasks) {
       path: path.relative(repoRoot, manifestPath).replaceAll(path.sep, "/"),
       sha256: manifestSha256,
     };
+    taskRepositories[task.id] = task.repo;
   }
   if (Object.keys(contract.task_manifests).some((taskId) => !taskIds.includes(taskId))) {
     throw new Error("Release evidence corpus contract binds an unselected task manifest");
@@ -982,7 +993,10 @@ async function loadReleaseEvidenceCorpusContract(tasks) {
     sha256: sha256Bytes(bytes),
     corpus_id: contract.corpus_id,
     task_ids: taskIds,
+    runtime_modes: selectedRuntimeModes,
+    repeats: contract.repeats,
     task_manifests: taskManifests,
+    task_repositories: taskRepositories,
     project_manifests: projectManifests,
   };
 }
@@ -3550,6 +3564,16 @@ function packetEmbeddingExecutionProof(packet, cachePreparation, transportMode) 
   const stageTimings = Array.isArray(trace?.retrieval_shadow?.stage_timings)
     ? trace.retrieval_shadow.stage_timings
     : [];
+  const semanticStages = stageTimings.filter(
+    (timing) => timing?.stage === "stage1b_semantic",
+  );
+  const completedSemanticStages = semanticStages.filter(
+    (timing) =>
+      timing?.completion_status === "completed"
+      && timing?.degraded !== true
+      && !timing?.stub_reason
+      && !timing?.cancel_reason,
+  );
   const fullDiagnosticCount = diagnostics.filter(
     (diagnostic) => diagnostic?.retrieval_mode === "full",
   ).length;
@@ -3564,9 +3588,12 @@ function packetEmbeddingExecutionProof(packet, cachePreparation, transportMode) 
       diagnostics.length > 0 && fullDiagnosticCount === diagnostics.length ? "full" : null,
     diagnostic_count: diagnostics.length,
     full_diagnostic_count: fullDiagnosticCount,
-    semantic_stage_count: stageTimings.filter(
-      (timing) => timing?.stage === "stage1b_semantic",
-    ).length,
+    semantic_stage_count: semanticStages.length,
+    completed_semantic_stage_count: completedSemanticStages.length,
+    invalid_semantic_stage_count: semanticStages.length - completedSemanticStages.length,
+    shadow_degraded_reason: trace?.retrieval_shadow?.degraded_reason ?? null,
+    shadow_error: trace?.retrieval_shadow?.error ?? null,
+    shadow_cancel_reason: trace?.retrieval_shadow?.cancel_reason ?? null,
     semantic_fallback_count: trace?.semantic_fallback_count ?? null,
     semantic_generation: trace?.retrieval_publication?.semantic_generation ?? null,
     prepared_semantic_generation:
@@ -6881,7 +6908,7 @@ async function main() {
     return;
   }
   const tasks = await loadTasks(opts);
-  opts.releaseEvidenceCorpusContract = await loadReleaseEvidenceCorpusContract(tasks);
+  opts.releaseEvidenceCorpusContract = await loadReleaseEvidenceCorpusContract(tasks, opts);
   if (opts.publishable) {
     validatePublishableShape(opts, tasks);
   }

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -3542,6 +3542,38 @@ function packetRuntimeCacheObservations(opts, repoName, transportMode) {
   };
 }
 
+function packetEmbeddingExecutionProof(packet, cachePreparation, transportMode) {
+  const trace = packet?.answer?.retrieval_trace ?? null;
+  const diagnostics = Array.isArray(trace?.packet_sidecar_diagnostics)
+    ? trace.packet_sidecar_diagnostics
+    : [];
+  const stageTimings = Array.isArray(trace?.retrieval_shadow?.stage_timings)
+    ? trace.retrieval_shadow.stage_timings
+    : [];
+  const fullDiagnosticCount = diagnostics.filter(
+    (diagnostic) => diagnostic?.retrieval_mode === "full",
+  ).length;
+  const retrievalContract = cachePreparation?.retrieval_contract ?? null;
+  return {
+    source: "packet.answer.retrieval_trace",
+    transport_mode: transportMode,
+    retrieval_contract: retrievalContract?.retrieval_contract ?? null,
+    embedding_engine: retrievalContract?.embedding_engine ?? null,
+    embedding_policy: retrievalContract?.execution_policy ?? null,
+    retrieval_mode:
+      diagnostics.length > 0 && fullDiagnosticCount === diagnostics.length ? "full" : null,
+    diagnostic_count: diagnostics.length,
+    full_diagnostic_count: fullDiagnosticCount,
+    semantic_stage_count: stageTimings.filter(
+      (timing) => timing?.stage === "stage1b_semantic",
+    ).length,
+    semantic_fallback_count: trace?.semantic_fallback_count ?? null,
+    semantic_generation: trace?.retrieval_publication?.semantic_generation ?? null,
+    prepared_semantic_generation:
+      cachePreparation?.retrieval_status?.semantic_generation ?? null,
+  };
+}
+
 async function codestoryCacheProvenance(opts, config, observations = {}) {
   let codestoryCli;
   try {
@@ -3588,12 +3620,16 @@ async function codestoryCacheProvenance(opts, config, observations = {}) {
     indexing_in_timed_run: observations.indexing_in_timed_run ?? null,
     codestory_index_commands_observed: observations.codestory_index_commands_observed ?? null,
     cache_preparation: compactCachePreparation(observations.cache_preparation),
+    packet_embedding_execution: observations.packet_embedding_execution ?? null,
     transport_mode: observations.transport_mode ?? null,
     retrieval_status: retrievalStatus,
     retrieval_mode: retrievalStatus.retrieval_mode ?? null,
     semantic_generation: retrievalStatus.semantic_generation ?? null,
     embedding_engine_instance_id: retrievalStatus.embedding_engine_instance_id ?? null,
-    embedding_policy: retrievalStatus.embedding_policy ?? null,
+    embedding_policy:
+      retrievalStatus.embedding_policy
+      ?? observations.packet_embedding_execution?.embedding_policy
+      ?? null,
     manifest_embedding_backend: retrievalStatus.manifest_embedding_backend ?? null,
     doctor_status: doctor.status,
     doctor_exit_code: doctor.exit_code,
@@ -4396,11 +4432,6 @@ async function runColdPacketRuntime(opts, task, repeat, outDir) {
   const repoConfig = ALL_REPOS[task.repo];
   const codestoryCli = resolveCodeStoryCli(opts);
   const provenance = await repoProvenance(repoConfig);
-  const cacheProvenance = await codestoryCacheProvenance(
-    opts,
-    repoConfig,
-    packetRuntimeCacheObservations(opts, task.repo, "cold_cli_packet"),
-  );
   const args = packetCommandArgs(repoConfig, task, opts);
   const started = performance.now();
   const result = await runProcess(codestoryCli, args, {
@@ -4417,6 +4448,21 @@ async function runColdPacketRuntime(opts, task, repeat, outDir) {
       parseError = error.message;
     }
   }
+  const cacheObservations = packetRuntimeCacheObservations(
+    opts,
+    task.repo,
+    "cold_cli_packet",
+  );
+  cacheObservations.packet_embedding_execution = packetEmbeddingExecutionProof(
+    packet,
+    cacheObservations.cache_preparation,
+    cacheObservations.transport_mode,
+  );
+  const cacheProvenance = await codestoryCacheProvenance(
+    opts,
+    repoConfig,
+    cacheObservations,
+  );
   const quality = packet
     ? scoreQualityFromText(packetPayloadText(packet), JSON.stringify(packet), task)
     : null;
@@ -6988,6 +7034,7 @@ export {
   packetPreludeManifestComplete,
   packetLatencyTelemetry,
   packetRuntimeCacheObservations,
+  packetEmbeddingExecutionProof,
   packetRuntimePublishableBlockers,
   packetRuntimeQualityGateRequired,
   cacheProvenanceBlockers,

--- a/scripts/codestory-evidence-provenance.mjs
+++ b/scripts/codestory-evidence-provenance.mjs
@@ -151,7 +151,9 @@ export function cacheProvenanceBlockers(result) {
       `CodeStory embedding runtime=${provenance.manifest_embedding_backend ?? "unknown"}; expected the pinned in-process CodeRankEmbed runtime`,
     );
   }
-  if (!provenance.embedding_engine_instance_id) {
+  const packetExecutionReasons = packetEmbeddingExecutionProofBlockers(provenance);
+  const packetExecutionProven = packetExecutionReasons.length === 0;
+  if (!provenance.embedding_engine_instance_id && !packetExecutionProven) {
     reasons.push("missing CodeStory embedding engine identity");
   }
   if (!["accelerated", "cpu_explicit"].includes(provenance.embedding_policy)) {
@@ -169,11 +171,79 @@ export function cacheProvenanceBlockers(result) {
   if (provenance.freshness_status !== "fresh") {
     reasons.push(`CodeStory cache freshness=${provenance.freshness_status ?? "unknown"}`);
   }
-  if (provenance.semantic_ready !== true) {
+  if (provenance.semantic_ready !== true && !packetExecutionProven) {
     reasons.push("CodeStory semantic docs are not ready");
+  }
+  if (provenance.packet_embedding_execution && !packetExecutionProven) {
+    reasons.push(...packetExecutionReasons);
   }
   if (provenance.indexing_in_timed_run == null) {
     reasons.push("missing timed-run indexing provenance");
+  }
+  return reasons;
+}
+
+export function packetEmbeddingExecutionProofBlockers(provenance) {
+  const proof = provenance?.packet_embedding_execution;
+  if (!proof) {
+    return ["missing cold packet embedding execution proof"];
+  }
+  const reasons = [];
+  if (proof.source !== "packet.answer.retrieval_trace") {
+    reasons.push(`cold packet embedding execution source=${proof.source ?? "unknown"}; expected packet.answer.retrieval_trace`);
+  }
+  if (proof.transport_mode !== "cold_cli_packet") {
+    reasons.push(`cold packet embedding execution transport=${proof.transport_mode ?? "unknown"}; expected cold_cli_packet`);
+  }
+  if (proof.retrieval_contract !== "in_process_v1") {
+    reasons.push(`cold packet retrieval contract=${proof.retrieval_contract ?? "unknown"}; expected in_process_v1`);
+  }
+  if (proof.embedding_engine !== "process_shared") {
+    reasons.push(`cold packet embedding engine=${proof.embedding_engine ?? "unknown"}; expected process_shared`);
+  }
+  if (!["accelerated", "cpu_explicit"].includes(proof.embedding_policy)) {
+    reasons.push(`cold packet embedding policy=${proof.embedding_policy ?? "unknown"}; expected accelerated or cpu_explicit`);
+  }
+  if (proof.retrieval_mode !== "full") {
+    reasons.push(`cold packet retrieval mode=${proof.retrieval_mode ?? "unknown"}; expected full`);
+  }
+  if (!Number.isInteger(proof.diagnostic_count) || proof.diagnostic_count <= 0) {
+    reasons.push("cold packet embedding execution has no sidecar diagnostics");
+  }
+  if (proof.full_diagnostic_count !== proof.diagnostic_count) {
+    reasons.push("cold packet embedding execution contains a non-full sidecar diagnostic");
+  }
+  if (!Number.isInteger(proof.semantic_stage_count) || proof.semantic_stage_count <= 0) {
+    reasons.push("cold packet embedding execution has no semantic stage");
+  }
+  if (proof.semantic_fallback_count !== 0) {
+    reasons.push(`cold packet semantic fallback count=${proof.semantic_fallback_count ?? "unknown"}; expected 0`);
+  }
+  if (!proof.semantic_generation || !proof.prepared_semantic_generation) {
+    reasons.push("cold packet embedding execution is missing semantic generation identity");
+  } else if (proof.semantic_generation !== proof.prepared_semantic_generation) {
+    reasons.push("cold packet semantic generation does not match the prepared generation");
+  }
+  if (
+    provenance?.semantic_generation
+    && proof.prepared_semantic_generation
+    && provenance.semantic_generation !== proof.prepared_semantic_generation
+  ) {
+    reasons.push("cold packet prepared semantic generation does not match cache provenance");
+  }
+  if (
+    provenance?.transport_mode
+    && proof.transport_mode
+    && provenance.transport_mode !== proof.transport_mode
+  ) {
+    reasons.push("cold packet transport does not match cache provenance");
+  }
+  if (
+    provenance?.embedding_policy
+    && proof.embedding_policy
+    && provenance.embedding_policy !== proof.embedding_policy
+  ) {
+    reasons.push("cold packet embedding policy does not match cache provenance");
   }
   return reasons;
 }

--- a/scripts/codestory-evidence-provenance.mjs
+++ b/scripts/codestory-evidence-provenance.mjs
@@ -216,6 +216,21 @@ export function packetEmbeddingExecutionProofBlockers(provenance) {
   if (!Number.isInteger(proof.semantic_stage_count) || proof.semantic_stage_count <= 0) {
     reasons.push("cold packet embedding execution has no semantic stage");
   }
+  if (proof.completed_semantic_stage_count !== proof.semantic_stage_count) {
+    reasons.push("cold packet embedding execution contains an incomplete semantic stage");
+  }
+  if (proof.invalid_semantic_stage_count !== 0) {
+    reasons.push("cold packet embedding execution contains a degraded, stubbed, or cancelled semantic stage");
+  }
+  if (proof.shadow_degraded_reason != null) {
+    reasons.push("cold packet retrieval shadow is degraded");
+  }
+  if (proof.shadow_error != null) {
+    reasons.push("cold packet retrieval shadow contains an error");
+  }
+  if (proof.shadow_cancel_reason != null) {
+    reasons.push("cold packet retrieval shadow was cancelled");
+  }
   if (proof.semantic_fallback_count !== 0) {
     reasons.push(`cold packet semantic fallback count=${proof.semantic_fallback_count ?? "unknown"}; expected 0`);
   }

--- a/scripts/codestory-evidence-provenance.mjs
+++ b/scripts/codestory-evidence-provenance.mjs
@@ -40,6 +40,10 @@ function normalizeImmutableCommitRef(ref) {
   return isImmutableCommitRef(value) ? value.toLowerCase() : null;
 }
 
+function isSha256(value) {
+  return /^[0-9a-f]{64}$/i.test(String(value ?? "").trim());
+}
+
 export function repoProvenanceBlockers(result) {
   const provenance = result.repo_provenance;
   if (!provenance) {
@@ -89,6 +93,31 @@ export function repoProvenanceBlockers(result) {
   }
   if (provenance.git_dirty !== false) {
     reasons.push(provenance.git_dirty ? "repo checkout is dirty" : "repo cleanliness is unknown");
+  }
+  const declaredProjectManifest = provenance.manifest?.codestory_project_manifest ?? null;
+  const installedProjectManifest = provenance.installed_codestory_project_manifest ?? null;
+  if (declaredProjectManifest) {
+    if (!isSha256(declaredProjectManifest.sha256) || !declaredProjectManifest.path) {
+      reasons.push("manifest CodeStory project manifest declaration is invalid");
+    }
+    if (!installedProjectManifest) {
+      reasons.push("missing installed CodeStory project manifest provenance");
+    } else {
+      if (installedProjectManifest.declared_sha256 !== declaredProjectManifest.sha256) {
+        reasons.push("installed CodeStory project manifest does not match declared manifest hash");
+      }
+      if (installedProjectManifest.installed_sha256 !== declaredProjectManifest.sha256) {
+        reasons.push("installed CodeStory project manifest bytes do not match declared hash");
+      }
+      if (installedProjectManifest.ignored !== true) {
+        reasons.push("installed CodeStory project manifest is not ignored by the checkout");
+      }
+      if (installedProjectManifest.installed_path !== "codestory_project.json") {
+        reasons.push("installed CodeStory project manifest is not rooted at codestory_project.json");
+      }
+    }
+  } else if (installedProjectManifest) {
+    reasons.push("unexpected installed CodeStory project manifest provenance");
   }
   return reasons;
 }

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -43,8 +43,8 @@ const SELECTED_REF_PRODUCERS = new Set([
 ]);
 const RELEASE_CORPUS_CONTRACTS = new Map([
   [
-    "codestory-release-corpus-v0.16-axios-ripgrep-rust-v1",
-    "benchmarks/release-evidence/corpus-contracts/v0.16-axios-ripgrep-rust-v1.json",
+    "codestory-release-corpus-v0.16-axios-js-ts-v1",
+    "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json",
   ],
 ]);
 

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -41,6 +41,12 @@ const SOURCE_RUN_PRODUCERS = new Map([
 const SELECTED_REF_PRODUCERS = new Set([
   ".github/workflows/packaged-platform-pr.yml",
 ]);
+const RELEASE_CORPUS_CONTRACTS = new Map([
+  [
+    "codestory-release-corpus-v0.16-axios-ripgrep-rust-v1",
+    "benchmarks/release-evidence/corpus-contracts/v0.16-axios-ripgrep-rust-v1.json",
+  ],
+]);
 
 function fail(message) { throw new Error(message); }
 function object(value, label) {
@@ -417,7 +423,49 @@ function statsContractFrom(repoRoot) {
   return contract;
 }
 
-function validateRawProvenance(stats, packet, commit, profileName, identity, statsContract) {
+function releaseCorpusContract(repoRoot, identity) {
+  const relativePath = RELEASE_CORPUS_CONTRACTS.get(identity.corpus_id);
+  if (!relativePath) return null;
+  const absolutePath = path.resolve(repoRoot, relativePath);
+  const bytes = readFileSync(absolutePath);
+  const contract = JSON.parse(bytes.toString("utf8"));
+  if (contract.schema_version !== 1 || contract.corpus_id !== identity.corpus_id) {
+    fail("release corpus contract is malformed or has the wrong corpus_id");
+  }
+  if (!Array.isArray(contract.task_ids) || contract.task_ids.length === 0) {
+    fail("release corpus contract must name selected task IDs");
+  }
+  const taskIds = [...new Set(contract.task_ids)].sort();
+  if (taskIds.length !== contract.task_ids.length || JSON.stringify(taskIds) !== JSON.stringify(contract.task_ids)) {
+    fail("release corpus contract task IDs must be sorted and unique");
+  }
+  return {
+    path: relativePath,
+    sha256: sha256(bytes),
+    corpus_id: contract.corpus_id,
+    task_ids: taskIds,
+    task_manifests: contract.task_manifests,
+    project_manifests: contract.project_manifests ?? {},
+  };
+}
+
+export function validatePacketCorpusContract(packetProvenance, rows, repoRoot, identity, profile) {
+  const expected = releaseCorpusContract(repoRoot, identity);
+  if (!expected) return;
+  const approved = object(profile.corpus_contract, "baseline profile corpus_contract");
+  if (approved.path !== expected.path || approved.sha256 !== expected.sha256) {
+    fail("checked-in release corpus contract does not match the approved baseline scope");
+  }
+  if (JSON.stringify(packetProvenance.corpus_contract) !== JSON.stringify(expected)) {
+    fail("raw packet corpus contract does not match the checked-in release scope");
+  }
+  const observedTaskIds = [...new Set(rows.map((row, index) => text(row.task_id, `packet row ${index} task_id`)))].sort();
+  if (JSON.stringify(observedTaskIds) !== JSON.stringify(expected.task_ids)) {
+    fail("raw packet rows do not exactly match the checked-in release task scope");
+  }
+}
+
+function validateRawProvenance(stats, packet, commit, profileName, identity, statsContract, repoRoot, profile) {
   if (fullSha(stats.commit, "stats.commit") !== commit) fail("raw stats commit does not match candidate");
   if (JSON.stringify(stats.evidence_identity) !== JSON.stringify(identity)) fail("raw stats identity does not match profile");
   if (stats.proof_tier !== "full_retrieval"
@@ -450,6 +498,7 @@ function validateRawProvenance(stats, packet, commit, profileName, identity, sta
   if (!Array.isArray(packetProvenance.publishable_blockers) || packetProvenance.publishable_blockers.length !== 0) fail("raw packet artifact contains publishable blockers");
   const rows = packetProvenance.rows;
   if (!Array.isArray(rows) || rows.length === 0) fail("raw packet artifact has no quality rows");
+  validatePacketCorpusContract(packetProvenance, rows, repoRoot, identity, profile);
   const repeats = new Map();
   for (const [index, row] of rows.entries()) {
     const sufficiency = row.sufficiency;
@@ -496,7 +545,7 @@ export function produceCandidate({ baselineDocument, baselineDir, profileName, s
     if (identity[key] !== profile.identity[key]) fail(`candidate ${key} does not match approved profile`);
   }
   const statsContract = statsContractFrom(repoRoot);
-  validateRawProvenance(stats, packet, commit, profileName, identity, statsContract);
+  validateRawProvenance(stats, packet, commit, profileName, identity, statsContract, repoRoot, profile);
   const baseDir = path.dirname(path.resolve(outPath));
   const measured = metricsFrom(stats, packet, profile);
   const baselineSha256 = sha256(Buffer.from(JSON.stringify(profile)));
@@ -561,7 +610,7 @@ export function evaluateCandidate({ baselineDocument, baselineDir, candidatePath
   const stats = readJson(statsPath, "stats artifact");
   const packet = readJson(packetPath, "packet artifact");
   const statsContract = statsContractFrom(repoRoot);
-  validateRawProvenance(stats, packet, commit, candidate.profile, profile.identity, statsContract);
+  validateRawProvenance(stats, packet, commit, candidate.profile, profile.identity, statsContract, repoRoot, profile);
   const measured = metricsFrom(stats, packet, profile);
   if (approvalDocument && approvalDocument.schema_version !== 3) fail("approval schema_version must be 3");
   const approvals = object(approvalDocument?.metrics ?? {}, "approval.metrics");

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -439,12 +439,49 @@ function releaseCorpusContract(repoRoot, identity) {
   if (taskIds.length !== contract.task_ids.length || JSON.stringify(taskIds) !== JSON.stringify(contract.task_ids)) {
     fail("release corpus contract task IDs must be sorted and unique");
   }
+  const runtimeModes = Array.isArray(contract.runtime_modes)
+    ? [...new Set(contract.runtime_modes)].sort()
+    : [];
+  if (
+    runtimeModes.length === 0
+    || runtimeModes.length !== contract.runtime_modes.length
+    || JSON.stringify(runtimeModes) !== JSON.stringify(contract.runtime_modes)
+    || runtimeModes.some((mode) => ![...PACKET_RUNTIME_MODES.values()].includes(mode))
+  ) {
+    fail("release corpus contract runtime modes must be supported, sorted, and unique");
+  }
+  if (!Number.isInteger(contract.repeats) || contract.repeats < 1) {
+    fail("release corpus contract repeats must be a positive integer");
+  }
+  const taskManifestIds = Object.keys(object(contract.task_manifests, "release corpus task_manifests")).sort();
+  if (JSON.stringify(taskManifestIds) !== JSON.stringify(taskIds)) {
+    fail("release corpus contract task manifest keys must exactly match task IDs");
+  }
+  const taskRepositories = {};
+  for (const taskId of taskIds) {
+    const declaration = object(contract.task_manifests[taskId], `release corpus task manifest ${taskId}`);
+    const manifestPath = path.resolve(repoRoot, text(declaration.path, `release corpus task manifest path ${taskId}`));
+    const relativeManifestPath = path.relative(repoRoot, manifestPath);
+    if (relativeManifestPath.startsWith(`..${path.sep}`) || path.isAbsolute(relativeManifestPath)) {
+      fail(`release corpus task manifest path escapes the repository for ${taskId}`);
+    }
+    const manifestBytes = readFileSync(manifestPath);
+    if (sha256(manifestBytes) !== text(declaration.sha256, `release corpus task manifest hash ${taskId}`)) {
+      fail(`release corpus task manifest hash does not match for ${taskId}`);
+    }
+    const manifest = JSON.parse(manifestBytes.toString("utf8"));
+    if (manifest.id !== taskId) fail(`release corpus task manifest ID does not match ${taskId}`);
+    taskRepositories[taskId] = text(manifest.repo?.name, `release corpus task repository ${taskId}`);
+  }
   return {
     path: relativePath,
     sha256: sha256(bytes),
     corpus_id: contract.corpus_id,
     task_ids: taskIds,
+    runtime_modes: runtimeModes,
+    repeats: contract.repeats,
     task_manifests: contract.task_manifests,
+    task_repositories: taskRepositories,
     project_manifests: contract.project_manifests ?? {},
   };
 }
@@ -459,8 +496,27 @@ export function validatePacketCorpusContract(packetProvenance, rows, repoRoot, i
   if (JSON.stringify(packetProvenance.corpus_contract) !== JSON.stringify(expected)) {
     fail("raw packet corpus contract does not match the checked-in release scope");
   }
-  const observedTaskIds = [...new Set(rows.map((row, index) => text(row.task_id, `packet row ${index} task_id`)))].sort();
-  if (JSON.stringify(observedTaskIds) !== JSON.stringify(expected.task_ids)) {
+  const expectedRows = [];
+  for (const taskId of expected.task_ids) {
+    for (const mode of expected.runtime_modes) {
+      for (let repeat = 1; repeat <= expected.repeats; repeat += 1) {
+        expectedRows.push(`${expected.task_repositories[taskId]}/${taskId}/${mode}/${repeat}`);
+      }
+    }
+  }
+  const observedRows = rows.map((row, index) => {
+    const repo = text(row.repo, `packet row ${index} repo`);
+    const taskId = text(row.task_id, `packet row ${index} task_id`);
+    const mode = text(row.mode, `packet row ${index} mode`);
+    if (!Number.isInteger(row.repeat) || row.repeat < 1) {
+      fail(`packet row ${index} repeat must be a positive integer`);
+    }
+    return `${repo}/${taskId}/${mode}/${row.repeat}`;
+  }).sort();
+  if (
+    new Set(observedRows).size !== observedRows.length
+    || JSON.stringify(observedRows) !== JSON.stringify(expectedRows.sort())
+  ) {
     fail("raw packet rows do not exactly match the checked-in release task scope");
   }
 }

--- a/scripts/release-evidence/guest-provision.sh
+++ b/scripts/release-evidence/guest-provision.sh
@@ -39,6 +39,12 @@ rustup_sha=$(get '.guest.rust.rustup_init_sha256')
 snapshot=$(get '.guest.apt_snapshot')
 drill_repository=$(get '.drill.repository')
 drill_commit=$(get '.drill.commit')
+drill_project_manifest_sha=$(get '.drill.project_manifest_sha256')
+drill_project_manifest_source="$(dirname "$contract")/serde-json-codestory-project.json"
+
+test -f "$drill_project_manifest_source"
+test "$(sha256sum "$drill_project_manifest_source" | awk '{print $1}')" = \
+  "$drill_project_manifest_sha"
 
 test "$snapshot" = "$bootstrap_snapshot"
 test "$(get '.guest.apt_packages.jq')" = "$bootstrap_jq_version"
@@ -160,6 +166,17 @@ sudo -u codestory-runner git -C "$drill_repo" checkout --detach --force "$drill_
 sudo -u codestory-runner git -C "$drill_repo" reset --hard "$drill_commit"
 sudo -u codestory-runner git -C "$drill_repo" clean -ffdqx
 test "$(sudo -u codestory-runner git -C "$drill_repo" rev-parse HEAD)" = "$drill_commit"
+test -z "$(sudo -u codestory-runner git -C "$drill_repo" status --porcelain)"
+
+sudo -u codestory-runner grep -qxF /codestory_project.json \
+  "$drill_repo/.git/info/exclude" \
+  || printf '%s\n' /codestory_project.json \
+    | sudo -u codestory-runner tee -a "$drill_repo/.git/info/exclude" >/dev/null
+sudo install -o codestory-runner -g codestory-runner -m 0640 \
+  "$drill_project_manifest_source" "$drill_repo/codestory_project.json"
+test "$(sudo -u codestory-runner sha256sum "$drill_repo/codestory_project.json" \
+  | awk '{print $1}')" = "$drill_project_manifest_sha"
+sudo -u codestory-runner git -C "$drill_repo" check-ignore -q codestory_project.json
 test -z "$(sudo -u codestory-runner git -C "$drill_repo" status --porcelain)"
 
 manifest="$runner_root/drills/real-repo-drill-cases.json"

--- a/scripts/release-evidence/guest-verify.sh
+++ b/scripts/release-evidence/guest-verify.sh
@@ -12,6 +12,12 @@ runner_version=$(get '.runner.version')
 runner_root=$(get '.runner.root')
 data_root=$(get '.runner.data_root')
 drill_commit=$(get '.drill.commit')
+drill_project_manifest_sha=$(get '.drill.project_manifest_sha256')
+drill_project_manifest_source="$(dirname "$contract")/serde-json-codestory-project.json"
+
+test -f "$drill_project_manifest_source"
+test "$(sha256sum "$drill_project_manifest_source" | awk '{print $1}')" = \
+  "$drill_project_manifest_sha"
 
 mount_table=$(findmnt -rn -o TARGET,SOURCE,FSTYPE,OPTIONS | sort)
 printf '%s\n' "$mount_table"
@@ -109,7 +115,16 @@ jq -e --arg profile_id "$profile_id" --arg repository "$repository" \
   ' "$ownership" >/dev/null
 
 test "$(git -C "$runner_root/drills/serde-json" rev-parse HEAD)" = "$drill_commit"
+test "$(sha256sum "$runner_root/drills/serde-json/codestory_project.json" \
+  | awk '{print $1}')" = "$drill_project_manifest_sha"
+git -C "$runner_root/drills/serde-json" check-ignore -q codestory_project.json
 test -z "$(git -C "$runner_root/drills/serde-json" status --porcelain)"
+jq -e '
+  .name == "serde-json-release-evidence" and
+  .source_groups[0].source_paths == ["."] and
+  .source_groups[0].exclude_patterns ==
+    ["**/.git/**", "**/target/**", "tests/ui/**"]
+  ' "$runner_root/drills/serde-json/codestory_project.json" >/dev/null
 jq -e '.cases[0].anchors == ["from_reader", "Deserializer::from_reader", "Value"]' \
   "$runner_root/drills/real-repo-drill-cases.json" >/dev/null
 test -f "$runner_root/validation/source-sha"
@@ -120,6 +135,8 @@ printf '%s\n' "$source_sha" | grep -Eq '^[0-9a-f]{40}$'
 memory_bytes=$(awk '/MemTotal/{printf "%.0f", $2 * 1024}' /proc/meminfo)
 workspace_free_bytes=$(df --output=avail -B1 "$runner_root" | tail -1 | tr -d ' ')
 manifest_sha=$(sha256sum "$runner_root/drills/real-repo-drill-cases.json" | awk '{print $1}')
+project_manifest_sha=$(sha256sum \
+  "$runner_root/drills/serde-json/codestory_project.json" | awk '{print $1}')
 os_pretty=$(sed -n 's/^PRETTY_NAME="\(.*\)"/\1/p' /etc/os-release)
 node_version=$(node --version)
 cargo_version=$(cargo --version)
@@ -147,6 +164,7 @@ jq -n --slurpfile observed "$observed_identity" \
   --arg repository "$repository" --arg runner_name "$runner_name" \
   --arg runner_version "$runner_version" --argjson runner_id "$agent_id" \
   --arg drill_commit "$drill_commit" --arg manifest_sha "$manifest_sha" \
+  --arg project_manifest_sha "$project_manifest_sha" \
   --arg source_sha "$source_sha" --argjson memory_bytes "$memory_bytes" \
   --argjson workspace_free_bytes "$workspace_free_bytes" '
   {
@@ -158,7 +176,9 @@ jq -n --slurpfile observed "$observed_identity" \
     capacity:{observed_memory_bytes:$memory_bytes,observed_workspace_free_bytes:$workspace_free_bytes},
     drill:{repository:"https://github.com/serde-rs/json.git",commit:$drill_commit,
       manifest:"/srv/codestory-release-evidence/drills/real-repo-drill-cases.json",
-      manifest_sha256:$manifest_sha},
+      manifest_sha256:$manifest_sha,
+      project_manifest:"/srv/codestory-release-evidence/drills/serde-json/codestory_project.json",
+      project_manifest_sha256:$project_manifest_sha},
     validation_source:{repository:"https://github.com/TheGreenCedar/CodeStory.git",commit:$source_sha},
     root:"/srv/codestory-release-evidence"
   }' | tee "$runner_root/artifacts/provisioning.json" >/dev/null

--- a/scripts/release-evidence/machine-contract.json
+++ b/scripts/release-evidence/machine-contract.json
@@ -91,6 +91,7 @@
   },
   "drill": {
     "repository": "https://github.com/serde-rs/json.git",
-    "commit": "827a315bf2198558f0325b07bcc1e2cd973aba2f"
+    "commit": "827a315bf2198558f0325b07bcc1e2cd973aba2f",
+    "project_manifest_sha256": "cccd6fdbd3ee5f288315ed015d9fd3ce0e4a3c9b3398a017038e77b91f4c46e7"
   }
 }

--- a/scripts/release-evidence/serde-json-codestory-project.json
+++ b/scripts/release-evidence/serde-json-codestory-project.json
@@ -1,0 +1,22 @@
+{
+  "name": "serde-json-release-evidence",
+  "version": 1,
+  "source_groups": [
+    {
+      "id": "00000000-0000-4000-8000-000000000016",
+      "language": "Rust",
+      "standard": "Default",
+      "source_paths": [
+        "."
+      ],
+      "exclude_patterns": [
+        "**/.git/**",
+        "**/target/**",
+        "tests/ui/**"
+      ],
+      "include_paths": [],
+      "defines": {},
+      "language_specific": "Other"
+    }
+  ]
+}

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -12,6 +12,7 @@ import {
   agentPublishableBlockers,
   assertSafeWindowsCmdArgs,
   baselineSearchPreludeStatus,
+  benchmarkAgentScopeArgs,
   benchmarkRunId,
   commandCategory,
   copyResultArtifact,
@@ -39,6 +40,8 @@ import {
   repoProvenanceBlockers,
   resolveRunArtifactPath,
   resolveCodeStoryCli,
+  retrievalIndexCommandArgs,
+  retrievalStatusCommandArgs,
   scoreQuality,
   summarizeCostAccounting,
   summarizePacketRuntimeRuns,
@@ -499,7 +502,7 @@ test("packet-first command renders manifest text for host shells", () => {
   );
 });
 
-test("packet command keeps manifest-derived extra probes diagnostic-only", () => {
+test("packet and cache preparation share one explicit agent retrieval namespace", () => {
   const task = {
     prompt: "Explain how Requests dispatch works.",
     task_class: "architecture_explanation",
@@ -522,8 +525,32 @@ test("packet command keeps manifest-derived extra probes diagnostic-only", () =>
 
   const args = packetCommandArgs({ path: "C:\\repo" }, task);
   assert.equal(args.filter((arg) => arg === "--extra-probe").length, 0);
-  assert.equal(args.includes("--profile"), false);
-  assert.equal(args.includes("--run-id"), false);
+  assert.deepEqual(benchmarkAgentScopeArgs(), ["--profile", "agent", "--run-id", "shared-agent"]);
+  assert.deepEqual(args.slice(3, 7), benchmarkAgentScopeArgs());
+  assert.deepEqual(retrievalIndexCommandArgs("C:\\repo"), [
+    "retrieval",
+    "index",
+    "--project",
+    "C:\\repo",
+    "--profile",
+    "agent",
+    "--run-id",
+    "shared-agent",
+    "--refresh",
+    "auto",
+  ]);
+  assert.deepEqual(retrievalStatusCommandArgs("C:\\repo"), [
+    "retrieval",
+    "status",
+    "--project",
+    "C:\\repo",
+    "--profile",
+    "agent",
+    "--run-id",
+    "shared-agent",
+    "--format",
+    "json",
+  ]);
 
   const diagnosticArgs = packetCommandArgs(
     { path: "C:\\repo" },

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -1,6 +1,9 @@
 import test from "node:test";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, truncate, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -17,6 +20,7 @@ import {
   loadTaskForResult,
   loadTasks,
   manifestRepoMaterializationBlockers,
+  materializeRepos,
   MAX_REUSED_ARTIFACT_BYTES,
   parseArgs as parseBenchmarkArgs,
   parseJsonLines,
@@ -252,6 +256,12 @@ async function withManifestFile(manifest, callback) {
   }
 }
 
+function gitFixture(args, cwd) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
 test("categorizes commands without treating source paths as cli invocations", () => {
   assert.equal(commandCategory("& $env:CODESTORY_CLI packet --project . --question flow"), "codestory_cli");
   assert.equal(commandCategory('"$CODESTORY_CLI" index --project . --refresh full'), "codestory_cli");
@@ -379,6 +389,82 @@ test("rejects manifest repo and workspace paths outside the cache", async () => 
       );
     },
   );
+
+  await withManifestFile(
+    manifestFixture({
+      repo: {
+        name: "fixture-repo",
+        url: "https://example.com/fixture.git",
+        ref: "main",
+        workspace_root: ".",
+        codestory_project_manifest: {
+          path: "../../outside.json",
+          sha256: "0".repeat(64),
+        },
+      },
+    }),
+    async (manifestPath, dir) => {
+      await assert.rejects(
+        () => loadTasks({ taskManifest: manifestPath, taskSuite: null, taskIds: null, repoCacheDir: path.join(dir, "repos") }),
+        /codestory_project_manifest\.path must stay inside/,
+      );
+    },
+  );
+});
+
+test("materialization scrubs reusable checkouts before installing the bound project manifest", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "codestory-materialized-project-"));
+  try {
+    const source = path.join(dir, "source");
+    const origin = path.join(dir, "origin.git");
+    const repoCacheDir = path.join(dir, "cache");
+    const templatePath = path.join(dir, "project.json");
+    const template = '{"name":"fixture","version":1,"source_groups":[]}\n';
+    await mkdir(source, { recursive: true });
+    gitFixture(["init", "-q"], source);
+    gitFixture(["config", "user.email", "fixture@example.invalid"], source);
+    gitFixture(["config", "user.name", "Fixture"], source);
+    await writeFile(path.join(source, "lib.rs"), "fn main() {}\n");
+    gitFixture(["add", "lib.rs"], source);
+    gitFixture(["commit", "-qm", "fixture"], source);
+    const ref = gitFixture(["rev-parse", "HEAD"], source);
+    gitFixture(["clone", "--bare", source, origin], dir);
+    await writeFile(templatePath, template, "utf8");
+    const manifestPath = path.join(dir, "fixture.task.json");
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify(manifestFixture({
+        repo: {
+          name: "scrub-fixture",
+          url: origin,
+          ref,
+          workspace_root: ".",
+          codestory_project_manifest: {
+            path: "project.json",
+            sha256: createHash("sha256").update(template).digest("hex"),
+          },
+        },
+      }), null, 2)}\n`,
+      "utf8",
+    );
+    const opts = { taskManifest: manifestPath, taskSuite: null, taskIds: null, repoCacheDir, timeoutMs: 10_000 };
+    const tasks = await loadTasks(opts);
+    await materializeRepos(tasks, opts);
+    const checkout = path.join(repoCacheDir, "scrub-fixture");
+    await writeFile(path.join(checkout, "untracked-source.rs"), "fn stale() {}\n");
+    await writeFile(path.join(checkout, ".git", "info", "exclude"), "/ignored-source.rs\n", "utf8");
+    await writeFile(path.join(checkout, "ignored-source.rs"), "fn stale_ignored() {}\n");
+
+    await materializeRepos(tasks, opts);
+
+    assert.equal(existsSync(path.join(checkout, "untracked-source.rs")), false);
+    assert.equal(existsSync(path.join(checkout, "ignored-source.rs")), false);
+    assert.equal(await readFile(path.join(checkout, "codestory_project.json"), "utf8"), template);
+    assert.equal(gitFixture(["status", "--porcelain"], checkout), "");
+    assert.equal(gitFixture(["rev-parse", "HEAD"], checkout), ref);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("packet-first command renders manifest text for host shells", () => {

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -1966,6 +1966,24 @@ test("publishable provenance requires full-SHA clean manifest checkout", () => {
     },
   };
   assert.deepEqual(repoProvenanceBlockers(clean), []);
+  const projectBound = structuredClone(clean);
+  projectBound.repo_provenance.manifest.codestory_project_manifest = {
+    path: "benchmarks/tasks/holdout-retrieval/ripgrep-rust-codestory-project.json",
+    sha256: "85b8ade56e2907ba78366a231cb11970f2b18830725771d9f435d3109bb1972a",
+  };
+  projectBound.repo_provenance.installed_codestory_project_manifest = {
+    source_path: "benchmarks/tasks/holdout-retrieval/ripgrep-rust-codestory-project.json",
+    declared_sha256: "85b8ade56e2907ba78366a231cb11970f2b18830725771d9f435d3109bb1972a",
+    installed_path: "codestory_project.json",
+    installed_sha256: "85b8ade56e2907ba78366a231cb11970f2b18830725771d9f435d3109bb1972a",
+    ignored: true,
+  };
+  assert.deepEqual(repoProvenanceBlockers(projectBound), []);
+  projectBound.repo_provenance.installed_codestory_project_manifest.installed_sha256 = "0".repeat(64);
+  assert.match(
+    repoProvenanceBlockers(projectBound).join("\n"),
+    /installed CodeStory project manifest bytes do not match declared hash/,
+  );
   assert.match(
     repoProvenanceBlockers({
       repo_provenance: {

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -28,6 +28,7 @@ import {
   packetComposition,
   packetCommandArgs,
   packetRuntimeCacheObservations,
+  packetEmbeddingExecutionProof,
   packetForAgentPrompt,
   packetManifestExtraProbes,
   packetManifestQualitySummary,
@@ -49,6 +50,7 @@ import {
   qualityFailureReasons,
   taskSnapshotForResult,
   cachePolicyForRun,
+  cacheProvenanceBlockers,
 } from "../codestory-agent-ab-benchmark.mjs";
 import {
   packetGateSelectionOrThrow,
@@ -118,6 +120,53 @@ test("packet-runtime cache observations preserve prepared cache provenance", () 
     assert.equal(observations.cache_preparation, cachePreparation[0]);
     assert.equal(cachePolicyForRun(observations), "prepared-retrieval-cache-read-only");
   }
+});
+
+test("cold packet embedding execution binds full retrieval to the prepared semantic generation", () => {
+  const preparation = {
+    retrieval_contract: {
+      retrieval_contract: "in_process_v1",
+      embedding_engine: "process_shared",
+      execution_policy: "cpu_explicit",
+    },
+    retrieval_status: { semantic_generation: "semantic-1" },
+  };
+  const packet = {
+    answer: {
+      retrieval_trace: {
+        retrieval_publication: { semantic_generation: "semantic-1" },
+        semantic_fallback_count: 0,
+        packet_sidecar_diagnostics: [
+          { retrieval_mode: "full" },
+          { retrieval_mode: "full" },
+        ],
+        retrieval_shadow: {
+          stage_timings: [
+            { stage: "stage1_lexical" },
+            { stage: "stage1b_semantic" },
+          ],
+        },
+      },
+    },
+  };
+
+  assert.deepEqual(
+    packetEmbeddingExecutionProof(packet, preparation, "cold_cli_packet"),
+    {
+      source: "packet.answer.retrieval_trace",
+      transport_mode: "cold_cli_packet",
+      retrieval_contract: "in_process_v1",
+      embedding_engine: "process_shared",
+      embedding_policy: "cpu_explicit",
+      retrieval_mode: "full",
+      diagnostic_count: 2,
+      full_diagnostic_count: 2,
+      semantic_stage_count: 1,
+      semantic_fallback_count: 0,
+      semantic_generation: "semantic-1",
+      prepared_semantic_generation: "semantic-1",
+    },
+  );
 });
 
 test("packet latency telemetry preserves retrieval shadow cache diagnostics", () => {
@@ -1821,6 +1870,67 @@ function localCacheProvenance(overrides = {}) {
     ...overrides,
   };
 }
+
+function localColdPacketCacheProvenance(overrides = {}) {
+  return localCacheProvenance({
+    embedding_engine_instance_id: null,
+    embedding_policy: "cpu_explicit",
+    semantic_ready: false,
+    packet_embedding_execution: {
+      source: "packet.answer.retrieval_trace",
+      transport_mode: "cold_cli_packet",
+      retrieval_contract: "in_process_v1",
+      embedding_engine: "process_shared",
+      embedding_policy: "cpu_explicit",
+      retrieval_mode: "full",
+      diagnostic_count: 2,
+      full_diagnostic_count: 2,
+      semantic_stage_count: 1,
+      semantic_fallback_count: 0,
+      semantic_generation: "proj-current",
+      prepared_semantic_generation: "proj-current",
+    },
+    ...overrides,
+  });
+}
+
+test("cold packet execution proof replaces only unavailable process-local identity", () => {
+  assert.deepEqual(
+    cacheProvenanceBlockers({
+      codestory_cache_provenance: localColdPacketCacheProvenance(),
+    }),
+    [],
+  );
+
+  for (const [field, value, message] of [
+    ["source", "status", /source=status/],
+    ["transport_mode", "warm_stdio_packet", /transport=warm_stdio_packet/],
+    ["embedding_engine", "other", /embedding engine=other/],
+    ["embedding_policy", "accelerated", /embedding policy does not match cache provenance/],
+    ["retrieval_mode", null, /retrieval mode=unknown/],
+    ["diagnostic_count", 0, /no sidecar diagnostics/],
+    ["full_diagnostic_count", 1, /non-full sidecar diagnostic/],
+    ["semantic_stage_count", 0, /no semantic stage/],
+    ["semantic_fallback_count", 1, /semantic fallback count=1/],
+    ["semantic_generation", "semantic-2", /does not match the prepared generation/],
+  ]) {
+    const provenance = localColdPacketCacheProvenance();
+    provenance.packet_embedding_execution[field] = value;
+    const blockers = cacheProvenanceBlockers({ codestory_cache_provenance: provenance });
+    assert.match(blockers.join("\n"), message);
+  }
+});
+
+test("warm process provenance still requires live engine identity and semantic readiness", () => {
+  const blockers = cacheProvenanceBlockers({
+    codestory_cache_provenance: localCacheProvenance({
+      embedding_engine_instance_id: null,
+      semantic_ready: false,
+    }),
+  });
+  assert.match(blockers.join("\n"), /missing CodeStory embedding engine identity/);
+  assert.match(blockers.join("\n"), /CodeStory semantic docs are not ready/);
+});
 
 function publishableWithCodeStoryResult(overrides = {}) {
   return {

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -143,7 +143,13 @@ test("cold packet embedding execution binds full retrieval to the prepared seman
         retrieval_shadow: {
           stage_timings: [
             { stage: "stage1_lexical" },
-            { stage: "stage1b_semantic" },
+            {
+              stage: "stage1b_semantic",
+              completion_status: "completed",
+              degraded: false,
+              stub_reason: null,
+              cancel_reason: null,
+            },
           ],
         },
       },
@@ -162,6 +168,11 @@ test("cold packet embedding execution binds full retrieval to the prepared seman
       diagnostic_count: 2,
       full_diagnostic_count: 2,
       semantic_stage_count: 1,
+      completed_semantic_stage_count: 1,
+      invalid_semantic_stage_count: 0,
+      shadow_degraded_reason: null,
+      shadow_error: null,
+      shadow_cancel_reason: null,
       semantic_fallback_count: 0,
       semantic_generation: "semantic-1",
       prepared_semantic_generation: "semantic-1",
@@ -1886,6 +1897,11 @@ function localColdPacketCacheProvenance(overrides = {}) {
       diagnostic_count: 2,
       full_diagnostic_count: 2,
       semantic_stage_count: 1,
+      completed_semantic_stage_count: 1,
+      invalid_semantic_stage_count: 0,
+      shadow_degraded_reason: null,
+      shadow_error: null,
+      shadow_cancel_reason: null,
       semantic_fallback_count: 0,
       semantic_generation: "proj-current",
       prepared_semantic_generation: "proj-current",
@@ -1911,6 +1927,11 @@ test("cold packet execution proof replaces only unavailable process-local identi
     ["diagnostic_count", 0, /no sidecar diagnostics/],
     ["full_diagnostic_count", 1, /non-full sidecar diagnostic/],
     ["semantic_stage_count", 0, /no semantic stage/],
+    ["completed_semantic_stage_count", 0, /incomplete semantic stage/],
+    ["invalid_semantic_stage_count", 1, /degraded, stubbed, or cancelled semantic stage/],
+    ["shadow_degraded_reason", "degraded", /retrieval shadow is degraded/],
+    ["shadow_error", "failed", /retrieval shadow contains an error/],
+    ["shadow_cancel_reason", "deadline", /retrieval shadow was cancelled/],
     ["semantic_fallback_count", 1, /semantic fallback count=1/],
     ["semantic_generation", "semantic-2", /does not match the prepared generation/],
   ]) {
@@ -1919,6 +1940,48 @@ test("cold packet execution proof replaces only unavailable process-local identi
     const blockers = cacheProvenanceBlockers({ codestory_cache_provenance: provenance });
     assert.match(blockers.join("\n"), message);
   }
+});
+
+test("skipped or degraded semantic stages cannot replace live engine identity", () => {
+  const preparation = {
+    retrieval_contract: {
+      retrieval_contract: "in_process_v1",
+      embedding_engine: "process_shared",
+      execution_policy: "cpu_explicit",
+    },
+    retrieval_status: { semantic_generation: "proj-current" },
+  };
+  const packet = {
+    answer: {
+      retrieval_trace: {
+        retrieval_publication: { semantic_generation: "proj-current" },
+        semantic_fallback_count: 0,
+        packet_sidecar_diagnostics: [{ retrieval_mode: "full" }],
+        retrieval_shadow: {
+          degraded_reason: "semantic_unavailable",
+          error: "semantic failed",
+          cancel_reason: "deadline",
+          stage_timings: [{
+            stage: "stage1b_semantic",
+            completion_status: "skipped",
+            degraded: true,
+            stub_reason: "stubbed",
+            cancel_reason: "deadline",
+          }],
+        },
+      },
+    },
+  };
+  const proof = packetEmbeddingExecutionProof(packet, preparation, "cold_cli_packet");
+  const provenance = localColdPacketCacheProvenance({ packet_embedding_execution: proof });
+  const blockers = cacheProvenanceBlockers({ codestory_cache_provenance: provenance });
+
+  assert.equal(proof.completed_semantic_stage_count, 0);
+  assert.equal(proof.invalid_semantic_stage_count, 1);
+  assert.match(blockers.join("\n"), /incomplete semantic stage/);
+  assert.match(blockers.join("\n"), /retrieval shadow is degraded/);
+  assert.match(blockers.join("\n"), /retrieval shadow contains an error/);
+  assert.match(blockers.join("\n"), /retrieval shadow was cancelled/);
 });
 
 test("warm process provenance still requires live engine identity and semantic readiness", () => {

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -34,7 +34,7 @@ function reattest(candidate, artifact, filePath) {
 }
 
 test("v0.16 release corpus contract rejects an omitted or substituted packet task", () => {
-  const relativePath = "benchmarks/release-evidence/corpus-contracts/v0.16-axios-ripgrep-rust-v1.json";
+  const relativePath = "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json";
   const bytes = readFileSync(path.join(root, relativePath));
   const contract = JSON.parse(bytes);
   const identity = {
@@ -56,7 +56,11 @@ test("v0.16 release corpus contract rejects an omitted or substituted packet tas
   const rows = contract.task_ids.map((task_id) => ({ task_id }));
   assert.doesNotThrow(() => validatePacketCorpusContract(provenance, rows, root, identity, profile));
   assert.throws(
-    () => validatePacketCorpusContract(provenance, rows.slice(0, 1), root, identity, profile),
+    () => validatePacketCorpusContract(provenance, [], root, identity, profile),
+    /do not exactly match the checked-in release task scope/,
+  );
+  assert.throws(
+    () => validatePacketCorpusContract(provenance, [{ task_id: "ripgrep-search-pipeline" }], root, identity, profile),
     /do not exactly match the checked-in release task scope/,
   );
   assert.throws(

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { validatePacketCorpusContract } from "../codestory-release-evidence-gate.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const script = path.join(root, "scripts/codestory-release-evidence-gate.mjs");
@@ -31,6 +32,38 @@ function reattest(candidate, artifact, filePath) {
   candidate.artifacts[artifact].sha256 = createHash("sha256").update(bytes).digest("hex");
   candidate.artifacts[artifact].bytes = bytes.length;
 }
+
+test("v0.16 release corpus contract rejects an omitted or substituted packet task", () => {
+  const relativePath = "benchmarks/release-evidence/corpus-contracts/v0.16-axios-ripgrep-rust-v1.json";
+  const bytes = readFileSync(path.join(root, relativePath));
+  const contract = JSON.parse(bytes);
+  const identity = {
+    corpus_id: contract.corpus_id,
+    cache_id: "cold-inprocess-v1",
+    machine_fingerprint: "fixture/fingerprint",
+  };
+  const provenance = {
+    corpus_contract: {
+      path: relativePath,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      corpus_id: contract.corpus_id,
+      task_ids: contract.task_ids,
+      task_manifests: contract.task_manifests,
+      project_manifests: contract.project_manifests,
+    },
+  };
+  const profile = { corpus_contract: { path: relativePath, sha256: provenance.corpus_contract.sha256 } };
+  const rows = contract.task_ids.map((task_id) => ({ task_id }));
+  assert.doesNotThrow(() => validatePacketCorpusContract(provenance, rows, root, identity, profile));
+  assert.throws(
+    () => validatePacketCorpusContract(provenance, rows.slice(0, 1), root, identity, profile),
+    /do not exactly match the checked-in release task scope/,
+  );
+  assert.throws(
+    () => validatePacketCorpusContract(provenance, [...rows, { task_id: "redis-server-event-loop" }], root, identity, profile),
+    /do not exactly match the checked-in release task scope/,
+  );
+});
 
 test("fingerprint prefers a validated provisioned machine identity", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "codestory-provisioning-"));

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -48,23 +48,35 @@ test("v0.16 release corpus contract rejects an omitted or substituted packet tas
       sha256: createHash("sha256").update(bytes).digest("hex"),
       corpus_id: contract.corpus_id,
       task_ids: contract.task_ids,
+      runtime_modes: contract.runtime_modes,
+      repeats: contract.repeats,
       task_manifests: contract.task_manifests,
+      task_repositories: { "axios-request-dispatch": "axios" },
       project_manifests: contract.project_manifests,
     },
   };
   const profile = { corpus_contract: { path: relativePath, sha256: provenance.corpus_contract.sha256 } };
-  const rows = contract.task_ids.map((task_id) => ({ task_id }));
+  const rows = Array.from({ length: contract.repeats }, (_, index) => ({
+    repo: "axios",
+    task_id: "axios-request-dispatch",
+    mode: "cold_cli_packet",
+    repeat: index + 1,
+  }));
   assert.doesNotThrow(() => validatePacketCorpusContract(provenance, rows, root, identity, profile));
   assert.throws(
     () => validatePacketCorpusContract(provenance, [], root, identity, profile),
     /do not exactly match the checked-in release task scope/,
   );
   assert.throws(
-    () => validatePacketCorpusContract(provenance, [{ task_id: "ripgrep-search-pipeline" }], root, identity, profile),
+    () => validatePacketCorpusContract(provenance, rows.map((row) => ({ ...row, repo: "substitute" })), root, identity, profile),
     /do not exactly match the checked-in release task scope/,
   );
   assert.throws(
-    () => validatePacketCorpusContract(provenance, [...rows, { task_id: "redis-server-event-loop" }], root, identity, profile),
+    () => validatePacketCorpusContract(provenance, [...rows, { ...rows[0], repo: "substitute" }], root, identity, profile),
+    /do not exactly match the checked-in release task scope/,
+  );
+  assert.throws(
+    () => validatePacketCorpusContract(provenance, rows.map((row) => ({ ...row, task_id: "ripgrep-search-pipeline" })), root, identity, profile),
     /do not exactly match the checked-in release task scope/,
   );
 });


### PR DESCRIPTION
## Context

Closes #1234
Refs #1179
Refs #1245

CodeStory v0.16 selects `codestory-release-evidence-linux-arm64-v2`, but the
approved registry had no release-eligible v2 baseline. This PR establishes one
from product code predating #1235 so the candidate cannot define its own bar.

## Outcome

Approve one identity-bound Linux ARM64 v2 baseline for the scoped v0.16 claim:
Axios JavaScript/TypeScript full retrieval and packet quality, with three cold
CLI repeats. Redis/C, shell dialects, parser completeness, Ripgrep, and a
general Rust packet-quality claim are outside this release boundary.

- final PR head: `3d63496680e05775de457eb26dcf8e3cf22c014f`
- accepted measurement head: `56cfed37439c34c8e01710074a2f5cb72284d521`
- protected measurement: run `29626819203`
- retained artifact: `8424291310`
- archive digest: `d3bb8113ac29059978780e4099c8cff292fc00ff73225f6635aa06271f6640a6`
- checked raw baseline digest: `835fa7a9d3d7ac5533047cd41ed31c040b5fb8b8d27102d0e4dcb4463112d308`

## What changed

- Added the hash-bound `codestory-release-corpus-v0.16-axios-js-ts-v1`
  contract, requiring exactly `axios-request-dispatch` and three cold CLI
  repeats while rejecting missing, duplicated, substituted, or extra rows.
- Kept the pinned Ripgrep task and Rust-only project template as follow-up
  diagnostics while removing them from the v0.16 release claim.
- Bound cold packet proof to the process that actually ran: one completed
  semantic stage, all-full sidecar diagnostics, zero semantic fallback or
  shadow failure, and the exact prepared semantic generation. Warm process
  proof still requires a live engine instance identity.
- Registered the single accepted v2 measurement with preregistered budgets:
  command/index x1.25, convergence x1.15, packet x1.10, storage x1.10, with
  second thresholds rounded upward to 0.01.
- Preserved every failed protected run and its non-claim in the performance
  playbook. Ripgrep follow-up is tracked by #1245.

## Accepted measurement

The protected producer passed full-retrieval stats and its defined Serde gate:
full retrieval, all three anchors resolved, and zero failed commands. All three
Axios rows passed quality and sufficiency with 1.0 file recall, 0.8 symbol
recall, 0.8 claim recall, 1.0 citation coverage, no forbidden claim, 14/14 full
diagnostics, one completed semantic stage, zero fallback, and no publishable
blocker.

The workflow's candidate step failed as expected because the v2 profile did not
exist before this run. The always-uploaded raw artifacts are the approved
reference. The measurement was not repeated after registration.

Approved references and thresholds:

| Metric | Reference | Threshold |
|---|---:|---:|
| Status | 0.014995754 s | 0.02 s |
| Local grounding | 0.046535663 s | 0.06 s |
| Convergence | 15.438115102 s | 17.76 s |
| Packet | 1.974697 s | 2.18 s |
| Search | 6.573140943 s | 8.22 s |
| Cold index | 20.151733549 s | 25.19 s |
| Storage | 609245502 bytes | 1.10 ratio |

## Verification

- Exact implementation source proof at measurement head: run `29626175547`;
  full workspace tests and all-target/all-feature clippy passed. Final registry
  head source proof also passed in run `29627562871`.
- Benchmark and release-gate contract tests: 96 passed on the implementation
  head; release-claims and release-gate tests: 30 passed after registry entry.
- Workflow-policy and actionlint mutation tests: 189 passed.
- Workflow policy, actionlint, retrieval generalization lint, documentation
  links, and diff checks passed.
- Independent implementation review was clean at the measurement head.
- Independent artifact and threshold audit found and corrected an initial
  stats-field selection error, then accepted the committed values and hashes.

Final exact-head draft checks and exact source proof passed. No additional
baseline measurement is planned.

## Risk and follow-up

This baseline does not prove the integrated release candidate. The candidate
must pass one protected qualification against these fixed values. A real
product, quality, provenance, or performance failure stops the release; the
baseline will not be recalibrated. Ripgrep remains outside v0.16 and is tracked
in #1245 without weakening the scoped claim.
