### PR TITLE
Prepare v0.16.0 qualification and frozen constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.16.0
 
 ### Changed
 


### PR DESCRIPTION
## Context

This is the bounded v0.16.0 qualification and release-preparation lane from the accepted integrated `dev/codestory-next` head.

The initial commit moves the already-reviewed release notes from `Unreleased` to the exact `0.16.0` heading required by release preflight. After one exact-head calibration run, this same PR will add only the generated, hash-bound frozen server constant set. That preserves the preregistered calibration source and lets the package verifier enforce one-file calibration-to-freeze lineage.

Refs #1213, #1221, #1189, #1230, and #1233.

## Scope and non-claims

- v0.16 retrieval evidence remains scoped to Axios JavaScript/TypeScript.
- Ripgrep Rust and parser fidelity remain v0.16.1 follow-up work.
- This PR does not implement or close the #1230 workflow-identity contract or the #1233 exact release-ledger contract. Accepted runs will be operator-pinned to exact branch and SHA identities.
- Draft PRs #1238 and #1239 remain outside this release.

## Verification so far

- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- exact `0.16.0` release-note extraction
- `git diff --check`

The PR remains draft until calibration, the generated freeze, independent exact-head review, source proof, and one authenticated full candidate proof pass.
