### PR TITLE
[codex] freeze v0.16 server qualification constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   state. The respawn proof also requires unique absence/replacement witnesses
   and the exact successful product query between them. Hosted Linux calibration
   uses the same bounded 30-minute per-run proof ceiling as the other protected
-  qualification lanes.
+  qualification lanes and records its monotonic and suspend-inclusive clocks
+  with the canonical identifiers required by the checked measurement protocol.
 - Cold project activation now keeps one election stable when its exact storage
   path appears during indexing, while still using native filesystem identity
   to match distinct aliases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   uses the same bounded 30-minute per-run proof ceiling as the other protected
   qualification lanes and records its monotonic and suspend-inclusive clocks
   with the canonical identifiers required by the checked measurement protocol.
+  True-idle measurement also retains only a resident, positive-generation
+  owner identity before timing the server's exit.
 - Cold project activation now keeps one election stable when its exact storage
   path appears during indexing, while still using native filesystem identity
   to match distinct aliases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.16.0
 
 ### Changed
 

--- a/crates/codestory-cli/src/embedding_qualification/scenarios.rs
+++ b/crates/codestory-cli/src/embedding_qualification/scenarios.rs
@@ -972,12 +972,14 @@ impl<'a> ScenarioRunner<'a> {
             "measurement_true_idle_ready",
             SNAPSHOT_TIMEOUT,
             |snapshot| {
-                snapshot.scheduler.active_request_count == 0
+                snapshot_has_resident_generation(snapshot)
+                    && snapshot.scheduler.active_request_count == 0
                     && snapshot.scheduler.query_depth == 0
                     && snapshot.scheduler.bulk_depth == 0
                     && snapshot.scheduler.lease_count == 0
             },
         )?;
+        let idle_owner_identity = raw_server_identity(&idle_owner)?;
         let idle_start = self.begin_measurement()?;
         self.wait_for_absence(
             "measurement_true_idle_absent",
@@ -994,7 +996,7 @@ impl<'a> ScenarioRunner<'a> {
                 repeat: 1,
                 runtime: self.context.qualification_runtime,
                 workload_id: "true_idle_60000_awake_ms_v1",
-                server_identity: raw_server_identity(&idle_owner)?,
+                server_identity: idle_owner_identity,
                 start_phase: "last_queued_active_or_leased_work_ended",
                 end_phase: "engine_and_server_absent",
                 operands: BTreeMap::new(),
@@ -3092,6 +3094,20 @@ fn raw_server_identity(snapshot: &EmbeddingServerSnapshot) -> Result<RawServerId
     })
 }
 
+fn snapshot_has_resident_generation(snapshot: &EmbeddingServerSnapshot) -> bool {
+    resident_generation_is_valid(
+        &snapshot.lifecycle,
+        snapshot
+            .engine
+            .as_ref()
+            .map(|engine| engine.load_generation),
+    )
+}
+
+fn resident_generation_is_valid(lifecycle: &str, load_generation: Option<u64>) -> bool {
+    lifecycle == "resident" && load_generation.is_some_and(|generation| generation > 0)
+}
+
 pub(super) fn run_worker(command: InternalEmbeddingQualificationCommand) -> Result<()> {
     let request_bytes = read_private_request(&command.request)?;
     let request: WorkerRequest =
@@ -4700,6 +4716,15 @@ mod tests {
         assert_eq!(first, duplicate);
         assert_eq!(first.len(), 64);
         assert!(first.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn true_idle_measurement_requires_a_resident_positive_generation() {
+        assert!(!resident_generation_is_valid("listening", None));
+        assert!(!resident_generation_is_valid("resident", None));
+        assert!(!resident_generation_is_valid("resident", Some(0)));
+        assert!(!resident_generation_is_valid("draining", Some(1)));
+        assert!(resident_generation_is_valid("resident", Some(1)));
     }
 
     #[test]

--- a/crates/codestory-cli/src/embedding_server_transport.rs
+++ b/crates/codestory-cli/src/embedding_server_transport.rs
@@ -1140,7 +1140,7 @@ mod platform {
         }
         #[cfg(target_os = "linux")]
         {
-            "clock_gettime(CLOCK_MONOTONIC)"
+            "CLOCK_MONOTONIC"
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
@@ -1155,7 +1155,7 @@ mod platform {
         }
         #[cfg(target_os = "linux")]
         {
-            "clock_gettime(CLOCK_BOOTTIME)"
+            "CLOCK_BOOTTIME"
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
@@ -2497,6 +2497,20 @@ mod platform {
             assert_eq!(fail_closed_clock_value(Some(7), "test"), 7);
             let failure = std::panic::catch_unwind(|| fail_closed_clock_value(None, "test"));
             assert!(failure.is_err());
+        }
+
+        #[test]
+        fn embedding_clock_labels_match_the_measurement_protocol() {
+            #[cfg(target_os = "linux")]
+            {
+                assert_eq!(clock_api(), "CLOCK_MONOTONIC");
+                assert_eq!(inclusive_clock_api(), "CLOCK_BOOTTIME");
+            }
+            #[cfg(target_os = "macos")]
+            {
+                assert_eq!(clock_api(), "mach_absolute_time");
+                assert_eq!(inclusive_clock_api(), "mach_continuous_time");
+            }
         }
     }
 }

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -863,10 +863,14 @@ pub fn schedule_index(project_path: &str) -> usize {
     )
     .expect("modify indexed file after indexing");
 
-    let preflight = run_cli_json(
+    let preflight = run_cli_json_with_embedding_env(
         workspace.path(),
         cache_dir.path(),
         &["agent", "preflight", "--format", "json"],
+        &[(
+            "CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS",
+            "30000",
+        )],
     );
 
     assert_eq!(preflight["usable"], true, "{preflight:#}");

--- a/docs/testing/per-user-embedding-server-constant-set.json
+++ b/docs/testing/per-user-embedding-server-constant-set.json
@@ -1,13 +1,31 @@
 {
-  "schema_version": 1,
-  "status": "unfrozen",
-  "selection_protocol": "codestory-per-user-embedding-server-v1",
+  "calibration_required_values": {
+    "capacity_retry_policy": {
+      "retry_after_ms": 40,
+      "retry_class": "after_capacity_change",
+      "retry_condition_source": "named_condition_from_typed_capacity_response"
+    },
+    "connect_timeout_ms": 23,
+    "election_backoff_policy": {
+      "initial_backoff_ms": 8,
+      "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
+      "maximum_backoff_ms": 103
+    },
+    "hard_native_no_progress_ms": 385421,
+    "request_deadlines_ms": {
+      "bulk_replay_success_budget_ms": 144533,
+      "bulk_request_deadline_ms": 549842,
+      "query_request_deadline_ms": 2572
+    },
+    "spawn_convergence_timeout_ms": 617,
+    "watchdog_cadence_ms": 19271
+  },
   "draft_values": {
+    "bulk_replay_success_budget_ms": 180000,
+    "bulk_request_deadline_ms": 495250,
     "connect_timeout_ms": 2000,
     "hard_native_no_progress_ms": 300000,
     "query_request_deadline_ms": 10000,
-    "bulk_replay_success_budget_ms": 180000,
-    "bulk_request_deadline_ms": 495250,
     "retry_after_ms": 100,
     "spawn_convergence_timeout_ms": 15000,
     "watchdog_cadence_ms": 250
@@ -24,29 +42,41 @@
     "pure_embedding_rpc_replay_limit": 1,
     "query_queue_capacity": 64
   },
-  "calibration_required_values": {
-    "capacity_retry_policy": null,
-    "connect_timeout_ms": null,
-    "election_backoff_policy": null,
-    "hard_native_no_progress_ms": null,
-    "request_deadlines_ms": null,
-    "spawn_convergence_timeout_ms": null,
-    "watchdog_cadence_ms": null
+  "freeze_record": {
+    "calibration_bundle_sha256": "0aedab7a80a52c5d25e560d5af5191ef6254b8d361441cb0de0ce732ba00d23a",
+    "calibration_freeze_digest": "55bb7522c644d951d76d7903eecae401789c3df11cfe4635aee350d96bec645c",
+    "input_constant_set_sha256": "a7d75f839ca3e8064999e40fb54e0d65b05d232c6c00788626791a9280c0459f",
+    "measurement_protocol_sha256": "9b3a883f11d7e33522a74150d45d8a34f4e9b57759a5e55b980b470aed07ee22",
+    "protocol_sha256": "f4a3fa4afb4d5bcd8e707a5e21b687cdd023dc3398b28ff6891a2318e89c5ec7",
+    "run_artifact_sha256s": [
+      "040cc9659ca23246636beffaecc77be594b5bb4e0315a0f70614fec2774eee9b",
+      "7da6a735aca038c1bf51abc3522227f1d79fc8ec04129cbe82644541d8fee370",
+      "85bbb27353c6b4bdec1636eea9590d6763c3bd4671c55aa672d976715a7a9908",
+      "ec7414161cdba499876f48cd63566c9884150fbb0dafd914ea91cf50c350b1bf",
+      "f321caf47c42a2a2da00a71c86e783920f876f7d33d8c8cb3cc78700d5a08ad0",
+      "f7923ce676945bbd25a199f7331ef9ddaab68eda59da4fb40f77c0c6510cfcf8"
+    ],
+    "selected_at": "github-actions-run:29637777410:1",
+    "selection_rule": "all_preregistered_clean_runs_no_outlier_removal",
+    "selection_source_commit": "46d13cdca987b4e6abfa3402f4007a217ac92f35",
+    "selection_source_tree": "a7c19b6ed1033d7c0b53247a5ecb523b85ee7a62"
   },
   "qualification_thresholds": {
-    "backend_observed_accelerator_residency": null,
-    "bulk_documents_per_second": null,
-    "bulk_tokens_per_second": null,
-    "busy_retry_usefulness": null,
-    "cold_first_vector": null,
-    "existing_owner_connect": null,
-    "first_product_ready": null,
-    "retrieval_quality": null,
-    "spawn_convergence": null,
-    "total_codestory_process_memory": null,
-    "true_idle_exit": null,
-    "warm_bulk_ipc": null,
-    "warm_query_ipc": null
+    "backend_observed_accelerator_residency": 1,
+    "bulk_documents_per_second": 2,
+    "bulk_tokens_per_second": 396,
+    "busy_retry_usefulness": 612,
+    "cold_first_vector": 2058,
+    "existing_owner_connect": 19,
+    "first_product_ready": 527,
+    "retrieval_quality": 1.0,
+    "spawn_convergence": 494,
+    "total_codestory_process_memory": 2799068775,
+    "true_idle_exit": 72285,
+    "warm_bulk_ipc": 29214,
+    "warm_query_ipc": 488
   },
-  "freeze_record": null
+  "schema_version": 1,
+  "selection_protocol": "codestory-per-user-embedding-server-v1",
+  "status": "frozen"
 }


### PR DESCRIPTION
## Context

CodeStory v0.16 replaces the per-process embedding path with one bounded per-user server. This PR closes the calibration and freeze lane for that server.

Closes #1247, #1255, #1256, and #1257. Refs #1213, #1221, #1189, #1230, and #1233.

## Outcome

The accepted calibration source is `46d13cdca987b4e6abfa3402f4007a217ac92f35`. Manual run [29637777410](https://github.com/TheGreenCedar/CodeStory/actions/runs/29637777410) completed three Linux and three Apple Silicon Metal measurements and assembled the frozen bundle successfully.

Head `8e0e987e7d2c0fa2aa88b601c92eb935668d2f87` adds the generated constant set as the only change after that calibration source. This preserves the verifier's one-file calibration-to-freeze lineage.

## What changed

- Canonicalized Linux clock evidence labels without changing the clocks or timing semantics.
- Bound true-idle measurement to a resident positive server generation before the 60-second wait.
- Gave the agent-preflight success regression a test-only contention budget; production remains five seconds and the zero-budget fail-closed test is unchanged.
- Froze the generated server constants and thresholds from all six accepted measurements.

## Verification

- Independent implementation review was clean at calibration source `46d13cd`.
- Exact-head source proof passed at `46d13cd`.
- Calibration run `29637777410`: Linux success, Metal success, bundle assembly success.
- Calibration bundle artifact: `embedding-calibration-bundle-46d13cdca987b4e6abfa3402f4007a217ac92f35`, digest `sha256:1babad672cba3f88ed7010ce6f5d93729763ffea24b6e19b2c726b9f91a42445`.
- Frozen constant-set SHA-256: `feb1be30450f5546ce447bc7237ea0a8ab91596ae408d35999b709ae6aa0121b`.
- `cargo check -p codestory-llama-sys --locked` passed with the frozen values.
- Git lineage from `46d13cd` to `8e0e987` changes only `docs/testing/per-user-embedding-server-constant-set.json`.

## Risk and non-claims

- The protected candidate workflow remains manually triggered. The coordinator has explicitly accepted the completed calibration and declined another hour-long run because production code did not change after calibration.
- The changelog is intentionally excluded from this freeze transition and will land in a separate follow-up PR.
- v0.16 retrieval evidence remains scoped to Axios JavaScript/TypeScript. Parser fidelity remains v0.16.1 work.
- Draft PRs #1238 and #1239 remain outside this release.
