### PR TITLE
[codex] bind cold-race proof to its election epoch

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -5473,6 +5473,47 @@ def derive_scenario_assertions(
             "no_server_replacement": len(snapshot_instances) == 1,
         }
     elif scenario_id == "cold_race":
+        election_witnesses = {
+            phase: [
+                observation["snapshot"]
+                for observation in process_observations
+                if observation.get("phase") == phase
+                and observation.get("snapshot") is not None
+            ]
+            for phase in ("cold_race_first", "cold_race_second")
+        }
+        require(
+            all(len(witnesses) == 1 for witnesses in election_witnesses.values()),
+            "cold race must retain exactly one post-reset snapshot from each process",
+        )
+        election_snapshots = [
+            election_witnesses[phase][0]
+            for phase in ("cold_race_first", "cold_race_second")
+        ]
+        require(
+            all(snapshot.get("engine") is not None for snapshot in election_snapshots),
+            "cold race post-reset snapshots must retain engine identity",
+        )
+        election_instances = {
+            snapshot["process"]["server_instance_id"]
+            for snapshot in election_snapshots
+        }
+        election_authorities = {
+            (
+                snapshot["authority"]["lifetime_authority_id"],
+                snapshot["authority"]["listener_id"],
+            )
+            for snapshot in election_snapshots
+        }
+        election_engines = {
+            (
+                snapshot["engine"]["engine_owner_id"],
+                snapshot["engine"]["native_worker_id"],
+                snapshot["engine"]["load_generation"],
+                snapshot["engine"]["model_load_count"],
+            )
+            for snapshot in election_snapshots
+        }
         independent = transition(
             "two_independent_processes",
             {
@@ -5513,20 +5554,20 @@ def derive_scenario_assertions(
                 )
             ),
             "one_lifetime_authority": (
-                len(snapshot_authorities) == 1
+                len(election_authorities) == 1
                 and converged["lifetime_authority_id"]
-                == next(iter(snapshot_authorities))[0]
+                == next(iter(election_authorities))[0]
             ),
-            "one_listener": len({identity[1] for identity in snapshot_authorities}) == 1,
+            "one_listener": len({identity[1] for identity in election_authorities}) == 1,
             "one_server": (
-                len(snapshot_instances) == 1
-                and converged["server_instance_id"] == next(iter(snapshot_instances))
+                len(election_instances) == 1
+                and converged["server_instance_id"] == next(iter(election_instances))
             ),
-            "one_engine_owner": len({identity[0] for identity in snapshot_engines}) == 1,
-            "one_native_worker": len({identity[1] for identity in snapshot_engines}) == 1,
-            "one_load_generation": len({identity[2] for identity in snapshot_engines}) == 1,
+            "one_engine_owner": len({identity[0] for identity in election_engines}) == 1,
+            "one_native_worker": len({identity[1] for identity in election_engines}) == 1,
+            "one_load_generation": len({identity[2] for identity in election_engines}) == 1,
             "one_model_load": (
-                len(snapshot_engines) == 1 and next(iter(snapshot_engines))[3] == 1
+                len(election_engines) == 1 and next(iter(election_engines))[3] == 1
             ),
         }
     elif scenario_id == "frozen_owner":
@@ -9372,6 +9413,108 @@ def self_test() -> None:
         )
         shared = shared_server_identity(first_snapshot, second_snapshot)
         require(shared["model_load_count"] == 1, "shared server identity self-test failed")
+        retired_snapshot = json.loads(json.dumps(first_snapshot))
+        retired_snapshot["process"]["server_instance_id"] = "retired-server"
+        retired_snapshot["authority"]["lifetime_authority_id"] = "retired-authority"
+        retired_snapshot["authority"]["listener_id"] = "retired-listener"
+        retired_snapshot["engine"]["engine_owner_id"] = "retired-engine-owner"
+        retired_snapshot["engine"]["native_worker_id"] = "retired-native-worker"
+        elected_snapshot = json.loads(json.dumps(first_snapshot))
+        cold_process_observations = [
+            {
+                "phase": "cold_race_no_owner_before",
+                "snapshot": retired_snapshot,
+            },
+            {"phase": "cold_race_no_owner", "snapshot": None},
+            {"phase": "cold_race_first", "snapshot": elected_snapshot},
+            {
+                "phase": "cold_race_second",
+                "snapshot": json.loads(json.dumps(elected_snapshot)),
+            },
+        ]
+        cold_transitions = {
+            "two_independent_processes": [
+                {
+                    "values": {
+                        "first_pid": 101,
+                        "second_pid": 102,
+                        "first_project_identity_sha256": "a" * 64,
+                        "second_project_identity_sha256": "b" * 64,
+                        "first_transport_peer_verified": True,
+                        "second_transport_peer_verified": True,
+                    }
+                }
+            ],
+            "single_server_convergence": [
+                {
+                    "values": {
+                        "server_instance_id": elected_snapshot["process"][
+                            "server_instance_id"
+                        ],
+                        "lifetime_authority_id": elected_snapshot["authority"][
+                            "lifetime_authority_id"
+                        ],
+                    }
+                }
+            ],
+        }
+        cold_assertions = derive_scenario_assertions(
+            "cold_race",
+            observations_by_kind=cold_transitions,
+            process_observations=cold_process_observations,
+            invocations=[],
+            control_actions=[],
+            same_account={
+                "relation": "same_os_account",
+                "plugin_hosts": [{"pid": 101}, {"pid": 102}],
+            },
+            materialization={},
+        )
+        require(
+            all(cold_assertions.values()),
+            "retired pre-race owner contaminated post-reset election assertions",
+        )
+        split_process_observations = json.loads(
+            json.dumps(cold_process_observations)
+        )
+        split_snapshot = split_process_observations[-1]["snapshot"]
+        split_snapshot["process"]["server_instance_id"] = "split-server"
+        split_snapshot["authority"]["lifetime_authority_id"] = "split-authority"
+        split_snapshot["authority"]["listener_id"] = "split-listener"
+        split_snapshot["engine"]["engine_owner_id"] = "split-engine-owner"
+        split_snapshot["engine"]["native_worker_id"] = "split-native-worker"
+        expected_split_failures = {
+            "one_engine_owner",
+            "one_lifetime_authority",
+            "one_listener",
+            "one_model_load",
+            "one_native_worker",
+            "one_server",
+        }
+        try:
+            derive_scenario_assertions(
+                "cold_race",
+                observations_by_kind=cold_transitions,
+                process_observations=split_process_observations,
+                invocations=[],
+                control_actions=[],
+                same_account={
+                    "relation": "same_os_account",
+                    "plugin_hosts": [{"pid": 101}, {"pid": 102}],
+                },
+                materialization={},
+            )
+        except ProofFailure as error:
+            require(
+                str(error)
+                == "qualification scenario cold_race raw evidence failed assertions: "
+                + ", ".join(sorted(expected_split_failures)),
+                "post-reset cold-race split changed its exact identity failures",
+            )
+        else:
+            raise ProofFailure(
+                "post-reset cold-race split escaped its exact identity assertions"
+            )
         measurement_contract = verify_package_server_contracts(
             manifest,
             MEASUREMENT_PROTOCOL,

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -5475,10 +5475,9 @@ def derive_scenario_assertions(
     elif scenario_id == "cold_race":
         election_witnesses = {
             phase: [
-                observation["snapshot"]
+                observation
                 for observation in process_observations
                 if observation.get("phase") == phase
-                and observation.get("snapshot") is not None
             ]
             for phase in ("cold_race_first", "cold_race_second")
         }
@@ -5487,11 +5486,14 @@ def derive_scenario_assertions(
             "cold race must retain exactly one post-reset snapshot from each process",
         )
         election_snapshots = [
-            election_witnesses[phase][0]
+            election_witnesses[phase][0]["snapshot"]
             for phase in ("cold_race_first", "cold_race_second")
         ]
         require(
-            all(snapshot.get("engine") is not None for snapshot in election_snapshots),
+            all(
+                isinstance(snapshot, dict) and snapshot.get("engine") is not None
+                for snapshot in election_snapshots
+            ),
             "cold race post-reset snapshots must retain engine identity",
         )
         election_instances = {
@@ -9474,6 +9476,33 @@ def self_test() -> None:
             all(cold_assertions.values()),
             "retired pre-race owner contaminated post-reset election assertions",
         )
+        duplicate_phase_observations = json.loads(
+            json.dumps(cold_process_observations)
+        )
+        duplicate_phase_observations.insert(
+            -1, {"phase": "cold_race_first", "snapshot": None}
+        )
+        try:
+            derive_scenario_assertions(
+                "cold_race",
+                observations_by_kind=cold_transitions,
+                process_observations=duplicate_phase_observations,
+                invocations=[],
+                control_actions=[],
+                same_account={
+                    "relation": "same_os_account",
+                    "plugin_hosts": [{"pid": 101}, {"pid": 102}],
+                },
+                materialization={},
+            )
+        except ProofFailure as error:
+            require(
+                str(error)
+                == "cold race must retain exactly one post-reset snapshot from each process",
+                "duplicate cold-race phase changed its cardinality failure",
+            )
+        else:
+            raise ProofFailure("duplicate cold-race phase observation was accepted")
         split_process_observations = json.loads(
             json.dumps(cold_process_observations)
         )


### PR DESCRIPTION
## Context

Protected v0.16 calibration reached the packaged per-user embedding qualification, where `cold_race` reported six owner-uniqueness failures. The Rust scenario had already proved its two independent workers converged. The later evaluator was pooling the deliberately retired pre-race owner with the two post-reset election witnesses.

Closes #1249. Refs #1213, #1235, and #1247.

## What changed

- Derive cold-race uniqueness only from exactly one `cold_race_first` and one `cold_race_second` snapshot.
- Require both post-reset witnesses to retain engine identity.
- Keep the retired owner and explicit absent-owner observations in raw evidence for reset proof.
- Add a positive regression for retired owner → absence → one elected owner and a hostile regression for a real post-reset split.

## How to review

The product election, transport, scheduler, native worker, model, workflows, and thresholds are unchanged. Review the scenario-specific witness selection and confirm the hostile fixture still fails the same six identity assertions.

## Verification

- `python .github/scripts/check-packaged-agent-proof.py --self-test` — passed
- `git diff --check` — passed
- Independent exact-SHA review of `cbb798b61822f715370163cc372cfe68381bfdf0` — accepted, no findings
- Focused #1235 package replay — passed in 305.32 seconds against archive `5d97658c94129c93f689a6b77907c6ee5fce2627a6306694d7dfeffa6f5646a4`

## Risk and follow-up

This source change invalidated #1235's previous exact-SHA review and focused package proof; both have now been repeated on the accepted repair. Full calibration resumes only after hosted exact-source proof and integration.
