### PR TITLE
[codex] Bind true-idle materialization proof to replacement

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -5860,7 +5860,20 @@ def derive_scenario_assertions(
             },
         )
         absent = transition("owner_absent_after_true_idle", {"old_server_instance_id"})
-        respawned = transition("server_respawned", {"new_server_instance_id"})
+        respawned = transition(
+            "server_respawned",
+            {
+                "new_server_instance_id",
+                "load_generation",
+                "model_load_count",
+                "materialized_model_sha256",
+                "materialized_reused",
+            },
+        )
+        absent_transition_observation = observations_by_kind[
+            "owner_absent_after_true_idle"
+        ][0]
+        respawn_transition_observation = observations_by_kind["server_respawned"][0]
         timeout_ms = require_positive_int(
             waited["contract_idle_timeout_ms"],
             "true idle contract timeout",
@@ -5881,10 +5894,68 @@ def derive_scenario_assertions(
             idle_surfaces["last_idle_connection_close_client_elapsed_ns"],
             "true idle last connection close ns",
         )
-        absent_observed = any(
-            observation.get("phase") == "true_idle_after_wait"
-            and observation.get("snapshot") is None
+        absent_observations = [
+            observation
             for observation in process_observations
+            if observation.get("phase") == "true_idle_after_wait"
+        ]
+        require(
+            len(absent_observations) == 1
+            and absent_observations[0].get("snapshot") is None,
+            "true idle must retain exactly one absent-owner witness",
+        )
+        respawn_observations = [
+            observation
+            for observation in process_observations
+            if observation.get("phase") == "true_idle_respawned"
+        ]
+        require(
+            len(respawn_observations) == 1
+            and isinstance(respawn_observations[0].get("snapshot"), dict)
+            and respawn_observations[0]["snapshot"].get("engine") is not None,
+            "true idle must retain exactly one replacement-engine witness",
+        )
+        absent_observed_ns = require_nonnegative_int(
+            absent_observations[0].get("observed_ns"),
+            "true idle absent-owner witness time",
+        )
+        respawn_observed_ns = require_nonnegative_int(
+            respawn_observations[0].get("observed_ns"),
+            "true idle replacement witness time",
+        )
+        respawn_snapshot = respawn_observations[0]["snapshot"]
+        respawn_engine = respawn_snapshot["engine"]
+        absent_transition_ns = require_nonnegative_int(
+            absent_transition_observation.get("observed_ns"),
+            "true idle absence transition time",
+        )
+        respawn_transition_ns = require_nonnegative_int(
+            respawn_transition_observation.get("observed_ns"),
+            "true idle respawn transition time",
+        )
+        post_absence_invocations = [
+            invocation
+            for invocation in invocations
+            if isinstance(invocation.get("started_ns"), int)
+            and not isinstance(invocation.get("started_ns"), bool)
+            and absent_transition_ns <= invocation["started_ns"]
+            <= respawn_transition_ns
+        ]
+        absent_observed = (
+            len(absent_observations) == 1
+            and absent_observations[0].get("snapshot") is None
+        )
+        respawn_load_generation = require_positive_int(
+            respawned["load_generation"],
+            "true idle respawn load generation",
+        )
+        respawn_model_load_count = require_positive_int(
+            respawned["model_load_count"],
+            "true idle respawn model load count",
+        )
+        respawn_materialized_sha256 = require_sha256(
+            respawned["materialized_model_sha256"],
+            "true idle respawn materialized model",
         )
         require_nonnegative_int(
             waited["server_idle_epoch_ns"], "true idle server epoch"
@@ -5933,11 +6004,33 @@ def derive_scenario_assertions(
             ),
             "next_product_operation_respawns_without_consent": (
                 absent["old_server_instance_id"] != respawned["new_server_instance_id"]
-                and any(invocation.get("operation") == "query" for invocation in invocations)
+                and absent_observed_ns <= absent_transition_ns
+                and len(post_absence_invocations) == 1
+                and post_absence_invocations[0].get("operation") == "query"
+                and post_absence_invocations[0].get("exit_code") == 0
+                and post_absence_invocations[0].get("termination") == "exited"
+                and isinstance(post_absence_invocations[0].get("finished_ns"), int)
+                and not isinstance(
+                    post_absence_invocations[0].get("finished_ns"), bool
+                )
+                and post_absence_invocations[0]["started_ns"]
+                <= post_absence_invocations[0]["finished_ns"]
+                <= respawn_observed_ns <= respawn_transition_ns
+                and respawn_snapshot["process"]["server_instance_id"]
+                == respawned["new_server_instance_id"]
             ),
             "verified_materialization_reused": (
                 isinstance(materialization, dict)
-                and materialization.get("reused_on_rejoin") is True
+                and respawn_materialized_sha256
+                == require_sha256(
+                    materialization.get("sha256"),
+                    "retained materialized model",
+                )
+                and respawned["materialized_reused"] is True
+                and respawn_load_generation
+                == respawn_engine["load_generation"]
+                and respawn_model_load_count
+                == respawn_engine["model_load_count"] == 1
             ),
         }
     else:
@@ -9544,6 +9637,281 @@ def self_test() -> None:
             raise ProofFailure(
                 "post-reset cold-race split escaped its exact identity assertions"
             )
+        true_idle_before = json.loads(json.dumps(first_snapshot))
+        true_idle_respawned = json.loads(json.dumps(first_snapshot))
+        true_idle_respawned["process"]["server_instance_id"] = "respawned-server"
+        true_idle_respawned["process"]["pid"] = 303
+        true_idle_respawned["process"]["process_start_id"] = "process-start-303"
+        true_idle_respawned["authority"]["lifetime_authority_id"] = (
+            "respawned-authority"
+        )
+        true_idle_respawned["authority"]["listener_id"] = "respawned-listener"
+        true_idle_respawned["engine"]["engine_owner_id"] = "respawned-engine-owner"
+        true_idle_respawned["engine"]["native_worker_id"] = "respawned-native-worker"
+        true_idle_process_observations = [
+            {
+                "phase": "true_idle_before",
+                "observed_ns": 100,
+                "snapshot": true_idle_before,
+            },
+            {
+                "phase": "true_idle_after_wait",
+                "observed_ns": 200,
+                "snapshot": None,
+            },
+            {
+                "phase": "true_idle_respawned",
+                "observed_ns": 400,
+                "snapshot": true_idle_respawned,
+            },
+        ]
+        active_scheduler = {
+            "query_capacity": 64,
+            "query_depth": 1,
+            "bulk_capacity": 64,
+            "bulk_depth": 1,
+            "active_request_count": 1,
+            "lease_count": 1,
+            "active_request_class": "query",
+        }
+        reclaimed_scheduler = {
+            "query_capacity": 64,
+            "query_depth": 0,
+            "bulk_capacity": 64,
+            "bulk_depth": 0,
+            "active_request_count": 0,
+            "lease_count": 0,
+            "active_request_class": None,
+        }
+        materialized_sha256 = "c" * 64
+        true_idle_transitions = {
+            "anti_idle_work_observed": [{"values": active_scheduler}],
+            "owner_preserved_across_idle_boundary": [
+                {
+                    "values": {
+                        "held_started_ns": 0,
+                        "held_observed_ns": 60_000_000_000,
+                        "contract_idle_timeout_ms": 60_000,
+                        "server_instance_id": true_idle_before["process"][
+                            "server_instance_id"
+                        ],
+                    }
+                }
+            ],
+            "anti_idle_work_reclaimed": [{"values": reclaimed_scheduler}],
+            "true_idle_wait": [
+                {
+                    "values": {
+                        "server_idle_epoch_ns": 1,
+                        "server_idle_elapsed_before_client_wait_ns": 59_000_000_000,
+                        "client_wait_required_ns": 1_000_000_000,
+                        "client_wait_elapsed_ns": 1_000_000_000,
+                        "contract_idle_timeout_ms": 60_000,
+                        "clock_boot_id": "boot-1",
+                    }
+                }
+            ],
+            "idle_surfaces_exercised": [
+                {
+                    "values": {
+                        "diagnostic_count": 2,
+                        "idle_connection_close_count": 2,
+                        "last_diagnostic_client_elapsed_ns": 30_000_000_000,
+                        "last_idle_connection_close_client_elapsed_ns": 30_000_000_000,
+                    }
+                }
+            ],
+            "owner_absent_after_true_idle": [
+                {
+                    "observed_ns": 225,
+                    "values": {
+                        "old_server_instance_id": true_idle_before["process"][
+                            "server_instance_id"
+                        ]
+                    }
+                }
+            ],
+            "server_respawned": [
+                {
+                    "observed_ns": 450,
+                    "values": {
+                        "new_server_instance_id": true_idle_respawned["process"][
+                            "server_instance_id"
+                        ],
+                        "load_generation": 1,
+                        "model_load_count": 1,
+                        "materialized_model_sha256": materialized_sha256,
+                        "materialized_reused": True,
+                    }
+                }
+            ],
+        }
+        true_idle_invocations = [
+            {
+                "operation": "query",
+                "started_ns": 250,
+                "finished_ns": 350,
+                "exit_code": 0,
+                "termination": "exited",
+            },
+            {
+                "operation": "query",
+                "started_ns": 10,
+                "finished_ns": 20,
+                "exit_code": 0,
+                "termination": "exited",
+            },
+        ]
+        true_idle_assertions = derive_scenario_assertions(
+            "true_idle_respawn",
+            observations_by_kind=true_idle_transitions,
+            process_observations=true_idle_process_observations,
+            invocations=true_idle_invocations,
+            control_actions=[],
+            same_account={},
+            materialization={
+                "sha256": materialized_sha256,
+                "reused_on_rejoin": False,
+            },
+        )
+        require(
+            all(true_idle_assertions.values()),
+            "cold first-use state contaminated replacement materialization proof",
+        )
+        for field, hostile_value in (
+            ("materialized_reused", False),
+            ("materialized_model_sha256", "d" * 64),
+        ):
+            hostile_transitions = json.loads(json.dumps(true_idle_transitions))
+            hostile_transitions["server_respawned"][0]["values"][field] = hostile_value
+            try:
+                derive_scenario_assertions(
+                    "true_idle_respawn",
+                    observations_by_kind=hostile_transitions,
+                    process_observations=true_idle_process_observations,
+                    invocations=true_idle_invocations,
+                    control_actions=[],
+                    same_account={},
+                    materialization={
+                        "sha256": materialized_sha256,
+                        "reused_on_rejoin": False,
+                    },
+                )
+            except ProofFailure as error:
+                require(
+                    str(error)
+                    == "qualification scenario true_idle_respawn raw evidence failed assertions: verified_materialization_reused",
+                    f"hostile true-idle {field} changed its exact failure",
+                )
+            else:
+                raise ProofFailure(
+                    f"hostile true-idle {field} escaped replacement binding"
+                )
+        historical_only_invocations = json.loads(json.dumps(true_idle_invocations[1:]))
+        try:
+            derive_scenario_assertions(
+                "true_idle_respawn",
+                observations_by_kind=true_idle_transitions,
+                process_observations=true_idle_process_observations,
+                invocations=historical_only_invocations,
+                control_actions=[],
+                same_account={},
+                materialization={
+                    "sha256": materialized_sha256,
+                    "reused_on_rejoin": False,
+                },
+            )
+        except ProofFailure as error:
+            require(
+                str(error)
+                == "qualification scenario true_idle_respawn raw evidence failed assertions: next_product_operation_respawns_without_consent",
+                "historical true-idle query changed its exact temporal failure",
+            )
+        else:
+            raise ProofFailure("historical query satisfied true-idle respawn proof")
+        failed_then_successful_invocations = [
+            {
+                "operation": "query",
+                "started_ns": 230,
+                "finished_ns": 240,
+                "exit_code": 1,
+                "termination": "exited",
+            },
+            *true_idle_invocations,
+        ]
+        try:
+            derive_scenario_assertions(
+                "true_idle_respawn",
+                observations_by_kind=true_idle_transitions,
+                process_observations=true_idle_process_observations,
+                invocations=failed_then_successful_invocations,
+                control_actions=[],
+                same_account={},
+                materialization={
+                    "sha256": materialized_sha256,
+                    "reused_on_rejoin": False,
+                },
+            )
+        except ProofFailure as error:
+            require(
+                str(error)
+                == "qualification scenario true_idle_respawn raw evidence failed assertions: next_product_operation_respawns_without_consent",
+                "failed first true-idle query changed its exact failure",
+            )
+        else:
+            raise ProofFailure("failed first query was hidden by a later respawn success")
+        historical_respawn_transition = json.loads(json.dumps(true_idle_transitions))
+        historical_respawn_transition["server_respawned"][0]["observed_ns"] = 150
+        try:
+            derive_scenario_assertions(
+                "true_idle_respawn",
+                observations_by_kind=historical_respawn_transition,
+                process_observations=true_idle_process_observations,
+                invocations=true_idle_invocations,
+                control_actions=[],
+                same_account={},
+                materialization={
+                    "sha256": materialized_sha256,
+                    "reused_on_rejoin": False,
+                },
+            )
+        except ProofFailure as error:
+            require(
+                str(error)
+                == "qualification scenario true_idle_respawn raw evidence failed assertions: next_product_operation_respawns_without_consent",
+                "historical true-idle respawn transition changed its temporal failure",
+            )
+        else:
+            raise ProofFailure("historical respawn transition was accepted")
+        duplicate_absence = json.loads(json.dumps(true_idle_process_observations))
+        duplicate_absence.insert(
+            -1,
+            {
+                "phase": "true_idle_after_wait",
+                "observed_ns": 225,
+                "snapshot": None,
+            },
+        )
+        try:
+            derive_scenario_assertions(
+                "true_idle_respawn",
+                observations_by_kind=true_idle_transitions,
+                process_observations=duplicate_absence,
+                invocations=true_idle_invocations,
+                control_actions=[],
+                same_account={},
+                materialization={
+                    "sha256": materialized_sha256,
+                    "reused_on_rejoin": False,
+                },
+            )
+        except ProofFailure as error:
+            require(
+                str(error) == "true idle must retain exactly one absent-owner witness",
+                "duplicate true-idle absence changed its cardinality failure",
+            )
+        else:
+            raise ProofFailure("duplicate true-idle absence witness was accepted")
         measurement_contract = verify_package_server_contracts(
             manifest,
             MEASUREMENT_PROTOCOL,

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1547,6 +1547,7 @@ function validatePackagedProof(workflows, violations, graph) {
       'if [ "$PROOF_SCOPE" = server ]',
       "--server-behavior-only",
       'test -f "$quality_path"',
+      "--timeout-secs 1800",
     ],
   );
   const candidateStage = namedStep(job, "Stage isolated candidate-managed Linux install");

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -165,6 +165,30 @@ jobs:
   assert.match(basicWorkflowViolations("fixture.yml", invalid).join("\n"), /full-length SHA/u);
 });
 
+test("hosted Linux calibration keeps its bounded per-run timeout", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+
+  for (const [name, replacement] of [
+    ["removed", ""],
+    ["shortened", "--timeout-secs 900"],
+  ]) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      const packaged = workflows.get("packaged-platform-proof.yml");
+      const step = draftStep(
+        packaged.jobs.build,
+        "Packaged per-user server calibration or qualification",
+      );
+      step.run = step.run.replace("--timeout-secs 1800", replacement);
+
+      assert.match(
+        validateWorkflows(workflows).join("\n"),
+        /step Packaged per-user server calibration or qualification must run --timeout-secs 1800/u,
+      );
+    });
+  }
+});
+
 test("Cargo lock policy reads executable step commands", () => {
   const workflow = parseWorkflow(`
 on: { workflow_dispatch: null }

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -543,6 +543,7 @@ jobs:
             --qualification-matrix-cell hosted_linux_x64_cpu
             --expected-source-sha "$source_sha"
             --expected-source-tree "$source_tree"
+            --timeout-secs 1800
           )
           if [ "$CALIBRATION_MODE" = true ]; then
             test "$(jq -r .status docs/testing/per-user-embedding-server-constant-set.json)" = unfrozen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@
   replacement server's own engine identity, model digest, load generation, and
   single model load instead of inheriting the original cold server's startup
   state. The respawn proof also requires unique absence/replacement witnesses
-  and the exact successful product query between them.
+  and the exact successful product query between them. Hosted Linux calibration
+  uses the same bounded 30-minute per-run proof ceiling as the other protected
+  qualification lanes.
+- Cold project activation now keeps one election stable when its exact storage
+  path appears during indexing, while still using native filesystem identity
+  to match distinct aliases.
 - v0.16 release evidence now uses a checked Axios JavaScript/TypeScript corpus
   with three cold CLI repeats. The benchmark binds the exact task-manifest
   bytes and rejects missing, substituted, or extra packet rows. Ripgrep's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- True-idle package qualification now binds materialization reuse to the
+  replacement server's own engine identity, model digest, load generation, and
+  single model load instead of inheriting the original cold server's startup
+  state. The respawn proof also requires unique absence/replacement witnesses
+  and the exact successful product query between them.
 - v0.16 release evidence now uses a checked Axios JavaScript/TypeScript corpus
   with three cold CLI repeats. The benchmark binds the exact task-manifest
   bytes and rejects missing, substituted, or extra packet rows. Ripgrep's

--- a/crates/codestory-cli/src/embedding_qualification/scenarios.rs
+++ b/crates/codestory-cli/src/embedding_qualification/scenarios.rs
@@ -2499,12 +2499,35 @@ impl<'a> ScenarioRunner<'a> {
         if before.process.server_instance_id == after.process.server_instance_id {
             bail!("embedding_qualification_true_idle_owner_not_replaced");
         }
+        let after_engine = after.engine.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("embedding_qualification_true_idle_respawn_engine_missing")
+        })?;
+        let respawn_identity =
+            PerUserEmbeddingClient::for_runtime(self.primary_runtime())?.ensure_resident()?;
+        if respawn_identity.server_instance_id != after.process.server_instance_id
+            || respawn_identity.load_generation != after_engine.load_generation
+            || respawn_identity.model_load_count != after_engine.model_load_count
+        {
+            bail!("embedding_qualification_true_idle_respawn_identity_changed");
+        }
         self.transition(
             "server_respawned",
-            btree([(
-                "new_server_instance_id",
-                json!(after.process.server_instance_id),
-            )]),
+            btree([
+                (
+                    "new_server_instance_id",
+                    json!(after.process.server_instance_id),
+                ),
+                ("load_generation", json!(respawn_identity.load_generation)),
+                ("model_load_count", json!(respawn_identity.model_load_count)),
+                (
+                    "materialized_model_sha256",
+                    json!(respawn_identity.materialized_model_sha256),
+                ),
+                (
+                    "materialized_reused",
+                    json!(respawn_identity.materialized_reused),
+                ),
+            ]),
         );
         Ok(())
     }

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -178,7 +178,11 @@ impl ActivationTarget {
     fn matches(&self, other: &Self) -> bool {
         self.project_id == other.project_id
             && self.workspace_id == other.workspace_id
-            && codestory_workspace::same_workspace_path(&self.storage_path, &other.storage_path)
+            && (self.storage_path == other.storage_path
+                || codestory_workspace::same_workspace_path(
+                    &self.storage_path,
+                    &other.storage_path,
+                ))
     }
 }
 
@@ -1492,6 +1496,17 @@ mod activation_tests {
         let aliased = ActivationTarget::new(project.path(), &alias);
 
         assert!(target.matches(&aliased));
+    }
+
+    #[test]
+    fn activation_target_exact_storage_path_does_not_reobserve_filesystem_identity() {
+        let project = tempfile::tempdir().expect("project");
+        let storage = project.path().join("codestory\0.db");
+
+        let target = ActivationTarget::new(project.path(), &storage);
+        let same_target = target.clone();
+
+        assert!(target.matches(&same_target));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Protected v0.16 calibration run `29631273189` exposed two retained release-bound failures:

- `true_idle_respawn` attributed the original cold server's correct first-materialization `false` state to the later replacement server;
- hosted Linux calibration used the evaluator's 900-second default instead of the workflow's bounded 30-minute proof ceiling.

The first amended exact-head source run, `29632216202`, then exposed a separate cold activation election race: creation of the storage database between two native-identity observations could make one waiter reject its own activation target.

## What changed

- Capture the post-idle replacement server's full engine identity after the successful respawn query.
- Bind server ID, load generation, model-load count, materialized model digest, and reuse state to the replacement snapshot before emitting raw evidence.
- Require exact absence/replacement witness cardinality and temporal order, including the sole successful product query between them.
- Add hostile fixtures for false reuse, substituted digest, historical query or transition evidence, failed-then-successful queries, and duplicate absence witnesses.
- Give every hosted Linux calibration and qualification invocation the same explicit 1800-second bound; workflow-policy mutations reject removal or shortening.
- Keep an activation election stable for an exact stored path while preserving native identity matching for distinct aliases.

## Review

Independent review accepted exact head
`4a8e180c542092989e6f5349089a76eeb1af5a66` with no blocker, high, or medium
findings.

## Verification

- packaged per-user embedding server evaluator self-test
- `cargo test -p codestory-cli embedding_qualification --locked` — 9 passed
- activation target exact-path regression — passed
- original failing stdio cold-activation contract — passed
- workflow-policy test suite — 189 passed, including timeout removal and shortening mutations
- workflow policy and actionlint
- focused runtime all-target clippy
- formatting and diff checks

The configured machine-level compiler cache and native child-process inspection require running Cargo proof outside the managed sandbox; no product failure was hidden.

Closes #1251
Closes #1253
Closes #1254
Refs #1213
