### PR TITLE
Fix Windows Rust 1.97.1 source builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,13 @@ adapter to compensate for incorrect upstream state.
 
 - On Windows, invoke the Codex npm shim as `codex.cmd`; the extensionless shim
   can fail with `os error 193`.
+- On many Windows development hosts, source builds use Visual Studio 18
+  Community's bundled CMake and Ninja. Prepend its
+  `Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin` and
+  `Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja` directories to `PATH`,
+  set `CMAKE_GENERATOR=Ninja`, and set `CARGO_TARGET_DIR` to a short path such
+  as `C:\tmp\codestory-target`; the repository-local target path can exceed the
+  nested Vulkan build's CMake path limit.
 - Keep secrets out of the repository. Pass credentials through approved
   environment or protected CI secret surfaces, and keep private material out
   of logs, fixtures, generated artifacts, and comments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 
 ### Reliability and compatibility
 
+- Windows source builds now use stable file-handle identity and replace preexisting hard-linked DLLs before runtime staging, allowing Rust 1.97.1 builds to complete.
 - Safe refreshes preserve the last verified index. Incomplete reads, cancellation, or concurrent source changes cannot publish a partial generation or mix results from different generations.
 - Existing semantic indexes rebuild once after upgrading. The last complete index remains available while the replacement is prepared.
 - Project switching now preserves isolated per-project state across A/B/A MCP routing. Requests require an explicit project, and status remains observational instead of activating or repairing a repository.

--- a/crates/codestory-cli/src/embedding_server_transport.rs
+++ b/crates/codestory-cli/src/embedding_server_transport.rs
@@ -52,17 +52,11 @@ impl ExactExecutable {
         let path = std::env::current_exe().context("resolve current CodeStory executable")?;
         let file = File::open(&path)
             .with_context(|| format!("open current executable {}", path.display()))?;
-        let before = executable_file_identity(
-            &file
-                .metadata()
-                .with_context(|| format!("inspect current executable {}", path.display()))?,
-        )?;
+        let before = executable_file_identity(&file)
+            .with_context(|| format!("inspect current executable {}", path.display()))?;
         let sha256 = sha256_reader(&file, &path)?;
-        let after = executable_file_identity(
-            &file
-                .metadata()
-                .with_context(|| format!("reinspect current executable {}", path.display()))?,
-        )?;
+        let after = executable_file_identity(&file)
+            .with_context(|| format!("reinspect current executable {}", path.display()))?;
         if before != after {
             bail!(
                 "embedding_executable_changed: current executable changed while it was being verified"
@@ -164,10 +158,10 @@ impl NativeEmbeddingClientTransport {
                 self.executable.path().display()
             )
         })?;
-        let before = executable_file_identity(&candidate.metadata()?)?;
+        let before = executable_file_identity(&candidate)?;
         #[cfg(windows)]
         let digest = sha256_reader(&candidate, self.executable.path())?;
-        let after = executable_file_identity(&candidate.metadata()?)?;
+        let after = executable_file_identity(&candidate)?;
         let digest_matches = {
             #[cfg(unix)]
             {
@@ -683,23 +677,22 @@ fn classify_windows_data_pipe_open_error(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ExecutableFileIdentity {
-    file_identity_a: u64,
-    file_identity_b: u64,
+    native_identity: codestory_workspace::WorkspacePathIdentity,
     file_size: u64,
     write_stamp: i128,
     change_stamp: i128,
 }
 
 #[cfg(unix)]
-fn executable_file_identity(metadata: &std::fs::Metadata) -> Result<ExecutableFileIdentity> {
+fn executable_file_identity(file: &File) -> Result<ExecutableFileIdentity> {
     use std::os::unix::fs::MetadataExt;
 
+    let metadata = file.metadata()?;
     if !metadata.is_file() {
         bail!("expected a regular executable");
     }
     Ok(ExecutableFileIdentity {
-        file_identity_a: metadata.dev(),
-        file_identity_b: metadata.ino(),
+        native_identity: codestory_workspace::workspace_file_identity(file)?,
         file_size: metadata.len(),
         write_stamp: (i128::from(metadata.mtime()) << 64)
             | i128::from(metadata.mtime_nsec() as u64),
@@ -709,15 +702,15 @@ fn executable_file_identity(metadata: &std::fs::Metadata) -> Result<ExecutableFi
 }
 
 #[cfg(windows)]
-fn executable_file_identity(metadata: &std::fs::Metadata) -> Result<ExecutableFileIdentity> {
+fn executable_file_identity(file: &File) -> Result<ExecutableFileIdentity> {
     use std::os::windows::fs::MetadataExt;
 
+    let metadata = file.metadata()?;
     if !metadata.is_file() {
         bail!("expected a regular executable");
     }
     Ok(ExecutableFileIdentity {
-        file_identity_a: metadata.volume_serial_number().unwrap_or_default() as u64,
-        file_identity_b: metadata.file_index().unwrap_or_default(),
+        native_identity: codestory_workspace::workspace_file_identity(file)?,
         file_size: metadata.file_size(),
         write_stamp: i128::from(metadata.last_write_time()),
         change_stamp: 0,
@@ -2526,6 +2519,7 @@ mod platform {
     use std::ffi::c_void;
     use std::io::{Read, Write};
     use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use std::path::PathBuf;
     use std::process::Command;
     use std::ptr::{null, null_mut};
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -3590,8 +3584,7 @@ mod tests {
         let executable = ExactExecutable::capture().expect("capture exact executable");
         let file = File::open(executable.path()).expect("open exact executable");
         let identity =
-            executable_file_identity(&file.metadata().expect("read executable metadata"))
-                .expect("capture executable metadata identity");
+            executable_file_identity(&file).expect("capture executable metadata identity");
         assert_eq!(identity, executable.file_identity);
         assert!(identity.file_size > 0);
     }

--- a/crates/codestory-llama-sys/build.rs
+++ b/crates/codestory-llama-sys/build.rs
@@ -2,7 +2,7 @@ mod model_staging;
 mod native_staging;
 
 use model_staging::{ExpectedModel, stage_model, verify_model};
-use native_staging::stage_linux_shared_libraries;
+use native_staging::{stage_linux_shared_libraries, stage_windows_runtime_file};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::env;
@@ -438,7 +438,7 @@ fn stage_dynamic_runtime(target_os: &str, out_dir: &std::path::Path) {
     runtime_files.sort_by_key(|entry| entry.0.to_lowercase());
     if target_os == "windows" {
         for (name, source, _) in &runtime_files {
-            fs::copy(source, profile_dir.join(name)).unwrap_or_else(|error| {
+            stage_windows_runtime_file(source, &profile_dir.join(name)).unwrap_or_else(|error| {
                 panic!(
                     "failed to stage native runtime artifact {}: {error}",
                     source.display()

--- a/crates/codestory-llama-sys/native_staging.rs
+++ b/crates/codestory-llama-sys/native_staging.rs
@@ -4,6 +4,26 @@ use std::path::Path;
 
 const UPSTREAM_BUILD_SUPPORT_LIBRARY_NAMES: &[&str] = &["libllama-common.so"];
 
+/// Copy one Windows runtime DLL after removing any upstream hard link.
+pub(crate) fn stage_windows_runtime_file(source: &Path, destination: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(destination) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            return Err(io::Error::new(
+                io::ErrorKind::IsADirectory,
+                format!(
+                    "native runtime destination is a directory: {}",
+                    destination.display()
+                ),
+            ));
+        }
+        Ok(_) => fs::remove_file(destination)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    fs::copy(source, destination)?;
+    Ok(())
+}
+
 /// Stage real Linux shared-library files into every Cargo runtime directory.
 ///
 /// `llama-cpp-sys-2` hard-links only the unversioned `.so` symlinks into these
@@ -129,6 +149,26 @@ fn replace_with_real_hard_link(source: &Path, destination: &Path) -> io::Result<
     }
     fs::hard_link(source, destination)?;
     Ok(())
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+
+    #[test]
+    fn replaces_a_source_hard_link_with_an_independent_runtime_copy() {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        let source = temp.path().join("native.dll");
+        let destination = temp.path().join("target.dll");
+        fs::write(&source, b"native").expect("native DLL");
+        fs::hard_link(&source, &destination).expect("upstream hard link");
+
+        stage_windows_runtime_file(&source, &destination).expect("stage runtime DLL");
+        fs::write(&destination, b"staged").expect("replace staged bytes");
+
+        assert_eq!(fs::read(&source).expect("source DLL"), b"native");
+        assert_eq!(fs::read(&destination).expect("staged DLL"), b"staged");
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -12,6 +12,9 @@ use codestory_llama_sys::{
     EmbeddingOwnerState, EmbeddingRequestClass, EmbeddingRequestContext, EngineError,
     EngineLifecycleSnapshot, NativeDeviceClass,
 };
+use codestory_workspace::{
+    WorkspacePathIdentity, workspace_file_identity, workspace_path_identity,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fmt;
@@ -1813,10 +1816,7 @@ struct PinnedQualificationDirectory {
     handle: File,
 }
 
-#[cfg(any(unix, windows))]
-type NativeFileIdentity = (u64, u64);
-#[cfg(not(any(unix, windows)))]
-type NativeFileIdentity = PathBuf;
+type NativeFileIdentity = WorkspacePathIdentity;
 
 #[derive(Debug)]
 struct ServerQualificationEventLog {
@@ -2508,7 +2508,7 @@ impl PinnedQualificationDirectory {
         let metadata = fs::symlink_metadata(&canonical)
             .context("reinspect canonical embedding qualification directory")?;
         validate_private_qualification_directory_metadata(&metadata)?;
-        let identity = native_metadata_identity(&metadata)?;
+        let identity = native_path_identity(&canonical)?;
         #[cfg(unix)]
         let handle = {
             use std::os::unix::fs::OpenOptionsExt;
@@ -2521,7 +2521,7 @@ impl PinnedQualificationDirectory {
                 .metadata()
                 .context("inspect pinned embedding qualification directory")?;
             validate_private_qualification_directory_metadata(&opened)?;
-            if native_metadata_identity(&opened)? != identity {
+            if native_file_identity(&handle)? != identity {
                 bail!("embedding_qualification_directory_replaced");
             }
             handle
@@ -2540,7 +2540,7 @@ impl PinnedQualificationDirectory {
         let metadata = fs::symlink_metadata(&self.path)
             .context("revalidate embedding qualification directory")?;
         validate_private_qualification_directory_metadata(&metadata)?;
-        if native_metadata_identity(&metadata)? != self.identity {
+        if native_path_identity(&self.path)? != self.identity {
             bail!("embedding_qualification_directory_replaced");
         }
         #[cfg(unix)]
@@ -2550,7 +2550,7 @@ impl PinnedQualificationDirectory {
                 .metadata()
                 .context("revalidate pinned embedding qualification directory")?;
             validate_private_qualification_directory_metadata(&opened)?;
-            if native_metadata_identity(&opened)? != self.identity {
+            if native_file_identity(&self.handle)? != self.identity {
                 bail!("embedding_qualification_directory_replaced");
             }
         }
@@ -2605,14 +2605,14 @@ impl ServerQualificationEventLog {
             &metadata,
             SERVER_QUALIFICATION_MAX_EVENT_BYTES,
         )?;
-        let identity = native_metadata_identity(&metadata)?;
+        let identity = native_file_identity(&file)?;
         let path_metadata =
             fs::symlink_metadata(&path).context("reinspect embedding qualification event log")?;
         validate_private_qualification_file_metadata(
             &path_metadata,
             SERVER_QUALIFICATION_MAX_EVENT_BYTES,
         )?;
-        if native_metadata_identity(&path_metadata)? != identity {
+        if native_path_identity(&path)? != identity {
             bail!("embedding_qualification_event_log_replaced");
         }
         let mut bytes = Vec::with_capacity(metadata.len() as usize);
@@ -2669,8 +2669,8 @@ impl ServerQualificationEventLog {
             .file
             .metadata()
             .context("revalidate opened embedding qualification event log")?;
-        if native_metadata_identity(&path_metadata)? != self.identity
-            || native_metadata_identity(&opened)? != self.identity
+        if native_path_identity(&self.path)? != self.identity
+            || native_file_identity(&self.file)? != self.identity
             || opened.len() != self.bytes
         {
             bail!("embedding_qualification_event_log_replaced");
@@ -2701,8 +2701,8 @@ impl ServerQualificationEventLog {
             .file
             .metadata()
             .context("reinspect opened embedding qualification event log after append")?;
-        if native_metadata_identity(&path_metadata)? != self.identity
-            || native_metadata_identity(&opened)? != self.identity
+        if native_path_identity(&self.path)? != self.identity
+            || native_file_identity(&self.file)? != self.identity
             || path_metadata.len() != next_bytes
             || opened.len() != next_bytes
         {
@@ -2749,29 +2749,14 @@ fn validate_private_qualification_file_metadata(
     Ok(())
 }
 
-#[cfg(unix)]
-fn native_metadata_identity(metadata: &fs::Metadata) -> Result<NativeFileIdentity> {
-    use std::os::unix::fs::MetadataExt;
-    Ok((metadata.dev(), metadata.ino()))
+fn native_path_identity(path: &Path) -> Result<NativeFileIdentity> {
+    workspace_path_identity(path)
+        .context("embedding qualification filesystem path identity is unavailable")
 }
 
-#[cfg(windows)]
-fn native_metadata_identity(metadata: &fs::Metadata) -> Result<NativeFileIdentity> {
-    use std::os::windows::fs::MetadataExt;
-    Ok((
-        metadata
-            .volume_serial_number()
-            .context("embedding qualification filesystem volume identity is unavailable")?
-            as u64,
-        metadata
-            .file_index()
-            .context("embedding qualification filesystem file identity is unavailable")?,
-    ))
-}
-
-#[cfg(not(any(unix, windows)))]
-fn native_metadata_identity(_metadata: &fs::Metadata) -> Result<NativeFileIdentity> {
-    bail!("embedding qualification filesystem identity is unsupported")
+fn native_file_identity(file: &File) -> Result<NativeFileIdentity> {
+    workspace_file_identity(file)
+        .context("embedding qualification filesystem file identity is unavailable")
 }
 
 fn read_server_qualification_command(
@@ -2792,7 +2777,7 @@ fn read_server_qualification_command(
         &path_metadata,
         SERVER_QUALIFICATION_MAX_COMMAND_BYTES,
     )?;
-    let identity = native_metadata_identity(&path_metadata)?;
+    let identity = native_path_identity(&path)?;
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -2807,7 +2792,7 @@ fn read_server_qualification_command(
         .metadata()
         .context("inspect opened embedding qualification command")?;
     validate_private_qualification_file_metadata(&opened, SERVER_QUALIFICATION_MAX_COMMAND_BYTES)?;
-    if native_metadata_identity(&opened)? != identity {
+    if native_file_identity(&file)? != identity {
         bail!("embedding_qualification_command_replaced");
     }
     control.directory.revalidate()?;
@@ -2824,7 +2809,7 @@ fn read_server_qualification_command(
         &path_metadata,
         SERVER_QUALIFICATION_MAX_COMMAND_BYTES,
     )?;
-    if native_metadata_identity(&path_metadata)? != identity {
+    if native_path_identity(&path)? != identity {
         bail!("embedding_qualification_command_replaced");
     }
     control.directory.revalidate()?;
@@ -7057,6 +7042,24 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn qualification_event_log_rejects_a_replaced_windows_path() {
+        let (_temporary, control) = test_qualification_control();
+        let mut events = control.events.lock().expect("event log");
+        let moved_event_path = events.path.with_extension("moved");
+        fs::rename(&events.path, &moved_event_path).expect("move pinned event log");
+        fs::write(&events.path, b"").expect("replacement event log");
+
+        assert!(
+            events
+                .record(&control.directory, &test_qualification_event())
+                .expect_err("replacement event logs are rejected")
+                .to_string()
+                .contains("embedding_qualification_event_log_replaced")
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn qualification_restart_restores_the_last_durable_command_sequence() {
@@ -7220,13 +7223,15 @@ mod tests {
         })
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn test_qualification_control() -> (tempfile::TempDir, ServerQualificationControl) {
+        #[cfg(unix)]
         use std::os::unix::fs::PermissionsExt;
 
         let temporary = tempfile::tempdir().expect("temporary qualification root");
         let directory = temporary.path().join("qualification");
         fs::create_dir(&directory).expect("qualification directory");
+        #[cfg(unix)]
         fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))
             .expect("private qualification directory");
         let canonical = fs::canonicalize(&directory).expect("canonical qualification directory");
@@ -7239,7 +7244,7 @@ mod tests {
         (temporary, control)
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn test_qualification_event() -> ServerQualificationEvent {
         ServerQualificationEvent {
             schema_version: 1,

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -34,7 +34,8 @@ pub use repository_identity::{
     cached_project_identity_v2, cached_project_identity_v3, inspect_repository_identity,
     inspect_repository_identity_v2, project_identity_v2, project_identity_v3,
     project_identity_v3_from_repository, same_workspace_path, sidecar_project_identity,
-    workspace_id_for_root, workspace_id_v3_for_root, workspace_path_identity,
+    workspace_file_identity, workspace_id_for_root, workspace_id_v3_for_root,
+    workspace_path_identity,
 };
 
 /// Source-group language selector used during workspace discovery.

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -652,6 +652,12 @@ pub fn workspace_path_identity(path: &Path) -> io::Result<WorkspacePathIdentity>
     }
 }
 
+/// Observe one already-open file using native filesystem identity.
+pub fn workspace_file_identity(file: &fs::File) -> io::Result<WorkspacePathIdentity> {
+    let metadata = file.metadata()?;
+    existing_workspace_file_identity(file, &metadata)
+}
+
 /// Compare workspace paths through [`workspace_path_identity`].
 ///
 /// The compatibility boolean fails closed when either identity is unavailable.
@@ -679,12 +685,34 @@ fn existing_workspace_path_identity(
     ))
 }
 
+#[cfg(unix)]
+fn existing_workspace_file_identity(
+    _file: &fs::File,
+    metadata: &fs::Metadata,
+) -> io::Result<WorkspacePathIdentity> {
+    existing_workspace_path_identity(Path::new(""), metadata)
+}
+
 #[cfg(windows)]
 fn existing_workspace_path_identity(
     path: &Path,
     _metadata: &fs::Metadata,
 ) -> io::Result<WorkspacePathIdentity> {
     let (volume_serial_number, file_id) = windows_file_identity(path)?;
+    Ok(WorkspacePathIdentity(
+        WorkspacePathIdentityKind::ExistingWindows {
+            volume_serial_number,
+            file_id,
+        },
+    ))
+}
+
+#[cfg(windows)]
+fn existing_workspace_file_identity(
+    file: &fs::File,
+    _metadata: &fs::Metadata,
+) -> io::Result<WorkspacePathIdentity> {
+    let (volume_serial_number, file_id) = windows_file_handle_identity(file)?;
     Ok(WorkspacePathIdentity(
         WorkspacePathIdentityKind::ExistingWindows {
             volume_serial_number,
@@ -701,6 +729,17 @@ fn existing_workspace_path_identity(
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "native workspace path identity is unsupported on this platform",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn existing_workspace_file_identity(
+    _file: &fs::File,
+    _metadata: &fs::Metadata,
+) -> io::Result<WorkspacePathIdentity> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "native workspace file identity is unsupported on this platform",
     ))
 }
 
@@ -756,9 +795,20 @@ fn missing_workspace_path_identity(_path: &Path) -> io::Result<WorkspacePathIden
 
 #[cfg(windows)]
 fn windows_file_identity(path: &Path) -> io::Result<(u64, [u8; 16])> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    let file = fs::OpenOptions::new()
+        .access_mode(0)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)?;
+    windows_file_handle_identity(&file)
+}
+
+#[cfg(windows)]
+fn windows_file_handle_identity(file: &fs::File) -> io::Result<(u64, [u8; 16])> {
     use std::ffi::c_void;
     use std::mem::MaybeUninit;
-    use std::os::windows::fs::OpenOptionsExt;
     use std::os::windows::io::AsRawHandle;
 
     #[repr(C)]
@@ -778,11 +828,6 @@ fn windows_file_identity(path: &Path) -> io::Result<(u64, [u8; 16])> {
     }
 
     const FILE_ID_INFO_CLASS: i32 = 18;
-    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
-    let file = fs::OpenOptions::new()
-        .access_mode(0)
-        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(path)?;
     let mut information = MaybeUninit::<FileIdInfo>::uninit();
     // SAFETY: `file` owns a valid handle for the duration of the call and the
     // output points to correctly sized, writable storage.
@@ -1348,6 +1393,19 @@ mod tests {
         );
         assert!(same_workspace_path(&file, &alias));
         assert!(!same_workspace_path(&file, &project.path().join("missing")));
+    }
+
+    #[test]
+    fn open_file_identity_matches_path_observation() {
+        let project = tempdir().expect("project");
+        let path = project.path().join("identity");
+        fs::write(&path, "identity").expect("identity file");
+        let file = fs::File::open(&path).expect("open identity file");
+
+        assert_eq!(
+            workspace_file_identity(&file).expect("open file identity"),
+            workspace_path_identity(&path).expect("path identity")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

CodeStory v0.16 at `18164bf44a0782fde15844881b2a48432a1b00d7` did not build from source on this Windows host with Rust 1.97.1. Rust's Windows `MetadataExt::volume_serial_number()` and `file_index()` remain unstable, and upstream native DLL hard links caused runtime staging to copy a file onto itself. The nested Vulkan build also needs Visual Studio's bundled CMake/Ninja and a short Cargo target path on many Windows development hosts.

Closes #1261.

## What Changed

- Reused the workspace's stable `GetFileInformationByHandleEx` identity for already-open files.
- Migrated executable and qualification replacement checks away from the unstable Windows metadata methods.
- Removed a preexisting runtime DLL destination before copying, breaking upstream hard links safely.
- Added focused Windows regressions for open-file identity, qualification-log replacement, and DLL staging.
- Recorded the Visual Studio 18 CMake/Ninja, Ninja generator, and short-target requirements in `AGENTS.md` and the shipped fix in `CHANGELOG.md`.

## How To Review

1. Review `workspace_file_identity` as the single native file-handle identity boundary.
2. Confirm CLI and retrieval callers preserve their existing fail-closed replacement checks.
3. Confirm Windows runtime staging removes only the exact destination before copying.
4. Read the Windows host guidance in `AGENTS.md`; it intentionally says “many Windows development hosts.”

## Verification

Verified at `e40934be865961917f0aafdd89cc03a0a90619a0` on Windows with Rust 1.97.1:

- `cargo fmt --all -- --check`
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs`
- `cargo check --workspace --locked`
- `cargo test --locked -p codestory-llama-sys --test native_staging native_staging::windows_tests::replaces_a_source_hard_link_with_an_independent_runtime_copy -- --exact`
- `cargo test --locked -p codestory-workspace repository_identity::tests::open_file_identity_matches_path_observation -- --exact`
- `cargo test --locked -p codestory-cli embedding_server_transport::tests::captured_executable_identity_includes_content_metadata -- --exact`
- `cargo test --locked -p codestory-retrieval per_user_embedding::tests::qualification_event_log_rejects_a_replaced_windows_path -- --exact`
- `cargo build --locked -p codestory-cli`
- `C:\tmp\cs016fix-target\debug\codestory-cli.exe --version` → `codestory-cli 0.16.0`

## Risk

The native identity representation remains the same opaque workspace identity used for path observations, now sourced directly from an open handle. Windows DLL staging removes only the named destination and leaves the source intact. This development build has no embedded model; retrieval readiness, plugin installation, packaging, and live behavior were intentionally not claimed.
