### PR TITLE
[codex] bind exact proof identity

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -91,16 +91,12 @@ function requireStepRun(violations, file, job, name, fragments) {
   }
 }
 
-function normalizedExecutableRunText(run) {
-  return executableRunText(run)
-    .split(/\r?\n/u)
-    .map(line => line.trim())
-    .filter(Boolean)
-    .join("\n");
+function exactResolverRunText(run) {
+  return run.replace(/\r\n/gu, "\n");
 }
 
 function requireExactResolverContract(violations, file, job, expectedDigest) {
-  const run = normalizedExecutableRunText(stepRun(job, "Resolve trusted exact head"));
+  const run = exactResolverRunText(stepRun(job, "Resolve trusted exact head"));
   const digest = createHash("sha256").update(run).digest("hex");
   add(
     violations,
@@ -111,7 +107,10 @@ function requireExactResolverContract(violations, file, job, expectedDigest) {
 
 function requireUniqueCacheSaveLast(violations, file, job, cacheName, finalStepDescription) {
   const steps = list(job?.steps).map(object);
-  const saves = steps.filter(step => typeof step.uses === "string" && step.uses.startsWith("actions/cache/save@"));
+  const saves = steps.filter(
+    step => typeof step.uses === "string"
+      && step.uses.toLowerCase().startsWith("actions/cache/save@"),
+  );
   add(
     violations,
     saves.length === 1,
@@ -155,8 +154,8 @@ const draftCachePaths = [
   "~/.cargo/git",
   "target",
 ];
-const sourceResolverContractDigest = "946592c43809ff6049df3b9bc6e1b2f7314c9c563b1a5d158c59327093d5960f";
-const platformResolverContractDigest = "db104676ffd2647b2dec25f88299374532ac45459fdb7903ebe77a52b75106c0";
+const sourceResolverContractDigest = "2fe869b675010f5db29259aff38d83456c01dbc9885989afbf7c92a2826791af";
+const platformResolverContractDigest = "331ee01b021f17d3221c7bc482d256ba36314116284a6bc22a2df87bd7487843";
 const draftProofCommands = [
   "cargo test --locked -p codestory-llama-sys --test native_staging",
   "cargo test --locked -p codestory-llama-sys --test model_staging",

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -91,21 +91,37 @@ function requireStepRun(violations, file, job, name, fragments) {
   }
 }
 
-function requireResolverSemantics(violations, file, job, exactLines) {
-  const run = executableRunText(stepRun(job, "Resolve trusted exact head"));
-  const lines = run.split(/\r?\n/u).map(line => line.trim()).filter(Boolean);
+function normalizedExecutableRunText(run) {
+  return executableRunText(run)
+    .split(/\r?\n/u)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function requireExactResolverContract(violations, file, job, expectedDigest) {
+  const run = normalizedExecutableRunText(stepRun(job, "Resolve trusted exact head"));
+  const digest = createHash("sha256").update(run).digest("hex");
   add(
     violations,
-    !lines.some(line => /^true\s*\|\|/u.test(line) || /^if\s+false(?:\s|;|&&)/u.test(line)),
-    `${file} resolver must not short-circuit trusted branch or SHA checks`,
+    run.length > 0 && digest === expectedDigest,
+    `${file} resolver must match the exact normalized trusted resolver script contract`,
   );
-  for (const expected of exactLines) {
-    add(
-      violations,
-      lines.includes(expected),
-      `${file} resolver must execute exact line ${expected}`,
-    );
-  }
+}
+
+function requireUniqueCacheSaveLast(violations, file, job, cacheName, finalStepDescription) {
+  const steps = list(job?.steps).map(object);
+  const saves = steps.filter(step => typeof step.uses === "string" && step.uses.startsWith("actions/cache/save@"));
+  add(
+    violations,
+    saves.length === 1,
+    `${file} ${cacheName} must contain exactly one actions/cache/save action`,
+  );
+  add(
+    violations,
+    saves.length === 1 && steps.at(-1) === saves[0],
+    `${file} ${cacheName} unique cache save must run after every ${finalStepDescription}`,
+  );
 }
 
 function requireStepUses(violations, file, job, name, expected) {
@@ -139,6 +155,8 @@ const draftCachePaths = [
   "~/.cargo/git",
   "target",
 ];
+const sourceResolverContractDigest = "946592c43809ff6049df3b9bc6e1b2f7314c9c563b1a5d158c59327093d5960f";
+const platformResolverContractDigest = "db104676ffd2647b2dec25f88299374532ac45459fdb7903ebe77a52b75106c0";
 const draftProofCommands = [
   "cargo test --locked -p codestory-llama-sys --test native_staging",
   "cargo test --locked -p codestory-llama-sys --test model_staging",
@@ -1221,15 +1239,7 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       'test "$GITHUB_SHA" = "$CALLER_REF"',
       "--ref $head_ref",
     ]);
-    requireResolverSemantics(violations, sourceFile, resolve, [
-      'if [ -n "$EVENT_PR_NUMBER" ]; then',
-      'test "$current_head" = "$EVENT_HEAD_SHA" || {',
-      'if [ -n "$PR_NUMBER" ]; then',
-      'test "$head_sha" = "$EXPECTED_HEAD_SHA" || {',
-      'test "$GITHUB_REF" = "refs/heads/$head_ref" || {',
-      'test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA" || {',
-      'test "$GITHUB_SHA" = "$CALLER_REF" || {',
-    ]);
+    requireExactResolverContract(violations, sourceFile, resolve, sourceResolverContractDigest);
     const full = requireJob(violations, sourceFile, source, "full-source-gate");
     add(violations, sameMembers(needs(full), ["resolve"]), `${sourceFile} full source gate must need resolve`);
     const restore = namedStep(full, "Restore Cargo inputs and output");
@@ -1260,12 +1270,7 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
         && object(save?.with).key === "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}",
       `${sourceFile} source cache must save only a successful exact miss`,
     );
-    const fullSteps = list(full.steps).map(object);
-    add(
-      violations,
-      fullSteps.findIndex(step => step.name === "Save Cargo inputs and output") === fullSteps.length - 1,
-      `${sourceFile} source cache save must run after every proof step`,
-    );
+    requireUniqueCacheSaveLast(violations, sourceFile, full, "source cache", "proof step");
     requireStepRun(violations, sourceFile, full, "Test the complete workspace once", ["cargo test --workspace --locked"]);
     requireStepRun(violations, sourceFile, full, "Lint every workspace target and feature once", ["cargo clippy --workspace --all-targets --all-features --locked -- -D warnings"]);
   }
@@ -1550,11 +1555,7 @@ function validatePackagedProof(workflows, violations, graph) {
       && object(packageSave?.with).key === "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}",
     `${file} native build cache must save only a successful exact miss`,
   );
-  add(
-    violations,
-    packageSteps.findIndex(step => step.name === "Save Cargo registry, git sources, and build output") === packageSteps.length - 1,
-    `${file} native build cache save must run after every proof and cleanup step`,
-  );
+  requireUniqueCacheSaveLast(violations, file, job, "native build cache", "proof and cleanup step");
   const linuxBuildDockerfile = fs.readFileSync(
     path.join(repositoryRoot, ".github", "docker", "linux-glibc-build.Dockerfile"),
     "utf8",
@@ -1894,17 +1895,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     'test "$GITHUB_SHA" = "$dev_head"',
     "--ref $head_ref",
   ]);
-  requireResolverSemantics(violations, file, route, [
-    'if [ "$mode" = "integration" ]; then',
-    'test "$INPUT_HEAD_SHA" = "$dev_head" || {',
-    'test "$GITHUB_REF" = "refs/heads/dev/codestory-next" || {',
-    'test "$GITHUB_SHA" = "$dev_head" || {',
-    'if [ -n "$EVENT_HEAD_REPO" ]; then',
-    'test "$current_head" = "$EVENT_HEAD_SHA" || {',
-    'test "$INPUT_HEAD_SHA" = "$current_head" || {',
-    'test "$GITHUB_REF" = "refs/heads/$head_ref" || {',
-    'test "$GITHUB_SHA" = "$INPUT_HEAD_SHA" || {',
-  ]);
+  requireExactResolverContract(violations, file, route, platformResolverContractDigest);
   requireStepRun(violations, file, route, "Require successful exact-head source proof", [
     "actions/runs?head_sha=$HEAD_SHA",
     '.path == ".github/workflows/source-proof.yml"',
@@ -1965,12 +1956,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && object(macosSave?.with).key === "${{ steps.macos-source-cache-restore.outputs.cache-primary-key }}",
     `${file} macOS source cache must save only a successful exact miss`,
   );
-  const macosSourceSteps = list(macosSource.steps).map(object);
-  add(
-    violations,
-    macosSourceSteps.findIndex(step => step.name === "Save exact-head macOS source cache") === macosSourceSteps.length - 1,
-    `${file} macOS source cache save must run after every proof step`,
-  );
+  requireUniqueCacheSaveLast(violations, file, macosSource, "macOS source cache", "proof step");
   const calibrationAssemble = requireJob(
     violations,
     file,

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -91,6 +91,23 @@ function requireStepRun(violations, file, job, name, fragments) {
   }
 }
 
+function requireResolverSemantics(violations, file, job, exactLines) {
+  const run = executableRunText(stepRun(job, "Resolve trusted exact head"));
+  const lines = run.split(/\r?\n/u).map(line => line.trim()).filter(Boolean);
+  add(
+    violations,
+    !lines.some(line => /^true\s*\|\|/u.test(line) || /^if\s+false(?:\s|;|&&)/u.test(line)),
+    `${file} resolver must not short-circuit trusted branch or SHA checks`,
+  );
+  for (const expected of exactLines) {
+    add(
+      violations,
+      lines.includes(expected),
+      `${file} resolver must execute exact line ${expected}`,
+    );
+  }
+}
+
 function requireStepUses(violations, file, job, name, expected) {
   add(
     violations,
@@ -1190,7 +1207,11 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
     );
     add(violations, trigger(source, "pull_request_target") === undefined, `${sourceFile} must not execute pull-request code through pull_request_target`);
     const resolve = requireJob(violations, sourceFile, source, "resolve");
-    add(violations, String(resolve.if ?? "").includes("review-accepted"), `${sourceFile} resolve job must require review-accepted`);
+    add(
+      violations,
+      resolve.if === "github.event_name != 'pull_request' || (github.event.action == 'labeled' && github.event.label.name == 'review-accepted')",
+      `${sourceFile} resolve job must execute dispatch/call runs and only review-accepted labeled PR runs`,
+    );
     requireStepRun(violations, sourceFile, resolve, "Resolve trusted exact head", [
       'test "$EVENT_HEAD_REPO" = "$GITHUB_REPOSITORY"',
       'test "$current_head" = "$EVENT_HEAD_SHA"',
@@ -1199,6 +1220,15 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       'test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA"',
       'test "$GITHUB_SHA" = "$CALLER_REF"',
       "--ref $head_ref",
+    ]);
+    requireResolverSemantics(violations, sourceFile, resolve, [
+      'if [ -n "$EVENT_PR_NUMBER" ]; then',
+      'test "$current_head" = "$EVENT_HEAD_SHA" || {',
+      'if [ -n "$PR_NUMBER" ]; then',
+      'test "$head_sha" = "$EXPECTED_HEAD_SHA" || {',
+      'test "$GITHUB_REF" = "refs/heads/$head_ref" || {',
+      'test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA" || {',
+      'test "$GITHUB_SHA" = "$CALLER_REF" || {',
     ]);
     const full = requireJob(violations, sourceFile, source, "full-source-gate");
     add(violations, sameMembers(needs(full), ["resolve"]), `${sourceFile} full source gate must need resolve`);
@@ -1229,6 +1259,12 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
         && save?.if === "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''"
         && object(save?.with).key === "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}",
       `${sourceFile} source cache must save only a successful exact miss`,
+    );
+    const fullSteps = list(full.steps).map(object);
+    add(
+      violations,
+      fullSteps.findIndex(step => step.name === "Save Cargo inputs and output") === fullSteps.length - 1,
+      `${sourceFile} source cache save must run after every proof step`,
     );
     requireStepRun(violations, sourceFile, full, "Test the complete workspace once", ["cargo test --workspace --locked"]);
     requireStepRun(violations, sourceFile, full, "Lint every workspace target and feature once", ["cargo clippy --workspace --all-targets --all-features --locked -- -D warnings"]);
@@ -1513,6 +1549,11 @@ function validatePackagedProof(workflows, violations, graph) {
       && packageSave?.if === "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''"
       && object(packageSave?.with).key === "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}",
     `${file} native build cache must save only a successful exact miss`,
+  );
+  add(
+    violations,
+    packageSteps.findIndex(step => step.name === "Save Cargo registry, git sources, and build output") === packageSteps.length - 1,
+    `${file} native build cache save must run after every proof and cleanup step`,
   );
   const linuxBuildDockerfile = fs.readFileSync(
     path.join(repositoryRoot, ".github", "docker", "linux-glibc-build.Dockerfile"),
@@ -1836,6 +1877,11 @@ function validatePackagedCoordinator(workflows, violations, graph) {
   add(violations, object(workflow.permissions).actions === "read", `${file} must read source-proof runs`);
   add(violations, object(workflow.permissions).contents === "read", `${file} must use read-only contents permission`);
   const route = requireJob(violations, file, workflow, "route");
+  add(
+    violations,
+    route.if === "github.event_name != 'pull_request' || (github.event.action == 'labeled' && github.event.label.name == 'platform-proof')",
+    `${file} route job must execute dispatch runs and only platform-proof labeled PR runs`,
+  );
   requireStepRun(violations, file, route, "Resolve trusted exact head", [
     'test "$head_repo" = "$GITHUB_REPOSITORY"',
     'test "$current_head" = "$EVENT_HEAD_SHA"',
@@ -1847,6 +1893,17 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     'test "$GITHUB_REF" = "refs/heads/dev/codestory-next"',
     'test "$GITHUB_SHA" = "$dev_head"',
     "--ref $head_ref",
+  ]);
+  requireResolverSemantics(violations, file, route, [
+    'if [ "$mode" = "integration" ]; then',
+    'test "$INPUT_HEAD_SHA" = "$dev_head" || {',
+    'test "$GITHUB_REF" = "refs/heads/dev/codestory-next" || {',
+    'test "$GITHUB_SHA" = "$dev_head" || {',
+    'if [ -n "$EVENT_HEAD_REPO" ]; then',
+    'test "$current_head" = "$EVENT_HEAD_SHA" || {',
+    'test "$INPUT_HEAD_SHA" = "$current_head" || {',
+    'test "$GITHUB_REF" = "refs/heads/$head_ref" || {',
+    'test "$GITHUB_SHA" = "$INPUT_HEAD_SHA" || {',
   ]);
   requireStepRun(violations, file, route, "Require successful exact-head source proof", [
     "actions/runs?head_sha=$HEAD_SHA",
@@ -1907,6 +1964,12 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && macosSave?.if === "success() && steps.macos-source-cache-restore.outputs.cache-hit != 'true' && steps.macos-source-cache-restore.outputs.cache-primary-key != ''"
       && object(macosSave?.with).key === "${{ steps.macos-source-cache-restore.outputs.cache-primary-key }}",
     `${file} macOS source cache must save only a successful exact miss`,
+  );
+  const macosSourceSteps = list(macosSource.steps).map(object);
+  add(
+    violations,
+    macosSourceSteps.findIndex(step => step.name === "Save exact-head macOS source cache") === macosSourceSteps.length - 1,
+    `${file} macOS source cache save must run after every proof step`,
   );
   const calibrationAssemble = requireJob(
     violations,

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1060,7 +1060,7 @@ function validateIssueWorkflows(workflows, violations) {
   }
 }
 
-function validatePluginAndDraftWorkflows(workflows, violations) {
+function validatePluginAndDraftWorkflows(workflows, violations, graph) {
   const pluginFile = "plugin-static.yml";
   const plugin = workflows.get(pluginFile);
   if (!plugin) {
@@ -1165,16 +1165,71 @@ function validatePluginAndDraftWorkflows(workflows, violations) {
   if (!source) {
     violations.push(`${sourceFile} must exist`);
   } else {
-    add(violations, sameMembers(at(source, "on", "pull_request", "types"), ["labeled", "synchronize"]), `${sourceFile} pull request types must be labeled and synchronize`);
+    const promotion = graph.workflow_policy.promotion;
+    const sourceConcurrency = [
+      "source-proof-",
+      promotion.proof_run_sha_expression,
+      "-${{ inputs.proof_key || inputs.pr_number || github.event.pull_request.number || github.ref }}-",
+      "${{ github.event.action == 'labeled' && github.event.label.name || 'dispatch' }}",
+    ].join("");
+    add(
+      violations,
+      sameMembers(at(source, "on", "pull_request", "types"), promotion.required_events),
+      `${sourceFile} pull request trigger must be label-only`,
+    );
+    add(
+      violations,
+      at(source, "concurrency", "group") === sourceConcurrency,
+      `${sourceFile} concurrency must bind the Actions SHA, proof identity, and exact label`,
+    );
+    add(
+      violations,
+      String(at(source, "on", "workflow_dispatch", "inputs", "pr_number", "description") ?? "")
+        .includes(promotion.manual_pr_ref_hint),
+      `${sourceFile} manual PR input must require ${promotion.manual_pr_ref_hint}`,
+    );
     add(violations, trigger(source, "pull_request_target") === undefined, `${sourceFile} must not execute pull-request code through pull_request_target`);
     const resolve = requireJob(violations, sourceFile, source, "resolve");
     add(violations, String(resolve.if ?? "").includes("review-accepted"), `${sourceFile} resolve job must require review-accepted`);
     requireStepRun(violations, sourceFile, resolve, "Resolve trusted exact head", [
       'test "$EVENT_HEAD_REPO" = "$GITHUB_REPOSITORY"',
       'test "$current_head" = "$EVENT_HEAD_SHA"',
+      'head_ref="$(jq -r \'.head.ref\'',
+      'test "$GITHUB_REF" = "refs/heads/$head_ref"',
+      'test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA"',
+      'test "$GITHUB_SHA" = "$CALLER_REF"',
+      "--ref $head_ref",
     ]);
     const full = requireJob(violations, sourceFile, source, "full-source-gate");
     add(violations, sameMembers(needs(full), ["resolve"]), `${sourceFile} full source gate must need resolve`);
+    const restore = namedStep(full, "Restore Cargo inputs and output");
+    const restoreWith = object(restore?.with);
+    const expectedSourceKey = [
+      "${{ runner.os }}-",
+      promotion.source_cache_namespace,
+      "-${{ needs.resolve.outputs.ref }}-${{ steps.rust-cache-key.outputs.version }}-",
+      "${{ steps.rust-cache-key.outputs.target }}-workspace-all-targets-all-features-${{ hashFiles('Cargo.lock') }}",
+    ].join("");
+    add(
+      violations,
+      restore?.uses === "actions/cache/restore@v5"
+        && restore?.["continue-on-error"] === true
+        && restoreWith.key === expectedSourceKey,
+      `${sourceFile} source cache must use the versioned exact-SHA namespace`,
+    );
+    add(
+      violations,
+      restoreWith["restore-keys"] === undefined,
+      `${sourceFile} source cache must not use fallback restore keys`,
+    );
+    const save = namedStep(full, "Save Cargo inputs and output");
+    add(
+      violations,
+      save?.uses === "actions/cache/save@v5"
+        && save?.if === "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''"
+        && object(save?.with).key === "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}",
+      `${sourceFile} source cache must save only a successful exact miss`,
+    );
     requireStepRun(violations, sourceFile, full, "Test the complete workspace once", ["cargo test --workspace --locked"]);
     requireStepRun(violations, sourceFile, full, "Lint every workspace target and feature once", ["cargo clippy --workspace --all-targets --all-features --locked -- -D warnings"]);
   }
@@ -1346,6 +1401,12 @@ function validatePackagedProof(workflows, violations, graph) {
     return;
   }
   add(violations, trigger(workflow, "workflow_call") !== undefined, `${file} must be reusable`);
+  const refInput = object(at(workflow, "on", "workflow_call", "inputs", "ref"));
+  add(
+    violations,
+    refInput.required === true && refInput.type === "string" && refInput.default === undefined,
+    `${file} must require one exact source SHA`,
+  );
   add(violations, object(workflow.permissions).contents === "read", `${file} must use read-only contents permission`);
   add(violations, object(workflow.permissions).actions === "read", `${file} must read the prior-run calibration artifact`);
   for (const key of ["calibration_bundle_artifact", "calibration_bundle_run_id"]) {
@@ -1383,6 +1444,11 @@ function validatePackagedProof(workflows, violations, graph) {
     `${file} must pin the glslc build image`,
   );
   const job = requireJob(violations, file, workflow, "build");
+  add(
+    violations,
+    at(workflow, "concurrency", "group") === "packaged-platform-proof-${{ github.sha }}-${{ inputs.ref }}-${{ inputs.proof_key || github.ref }}",
+    `${file} concurrency must bind caller SHA, exact package SHA, and proof identity`,
+  );
   validatePackageMatrixExpression(violations, at(job, "strategy", "matrix"), graph);
   add(violations, String(job.environment ?? "").includes("macos-release-signing"), `${file} signed Mac cells must use the protected signing environment`);
   const packageSteps = list(job.steps).map(object);
@@ -1426,10 +1492,27 @@ function validatePackagedProof(workflows, violations, graph) {
       && nativeIdentityIndex < linuxBuildIndex,
     `${file} native build identity must run immediately after Rust selection and before cache restore or any native build`,
   );
+  const expectedPackageKey = [
+    "${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-",
+    "${{ matrix.rust_target }}-",
+    graph.workflow_policy.promotion.packaged_cache_namespace,
+    "-${{ inputs.ref }}-${{ steps.rust-cache-key.outputs.generator }}-cmake-${{ steps.rust-cache-key.outputs.cmake }}-",
+    "ninja-${{ steps.rust-cache-key.outputs.ninja }}-default-features-",
+    "${{ hashFiles('Cargo.lock', '.github/docker/linux-glibc-build.Dockerfile', '.github/docker/glslc') }}",
+  ].join("");
   add(
     violations,
-    object(packageRestore?.with).key === "${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-native-v3-${{ steps.rust-cache-key.outputs.generator }}-cmake-${{ steps.rust-cache-key.outputs.cmake }}-ninja-${{ steps.rust-cache-key.outputs.ninja }}-default-features-${{ hashFiles('Cargo.lock', '.github/docker/linux-glibc-build.Dockerfile', '.github/docker/glslc') }}",
-    `${file} native build cache must bind generator, CMake, Ninja, target, features, and lock identity`,
+    object(packageRestore?.with).key === expectedPackageKey
+      && object(packageRestore?.with)["restore-keys"] === undefined,
+    `${file} native build cache must bind generator, CMake, Ninja, target, features, lock identity, and exact SHA/versioned namespace without fallbacks`,
+  );
+  const packageSave = namedStep(job, "Save Cargo registry, git sources, and build output");
+  add(
+    violations,
+    packageSave?.uses === "actions/cache/save@v5"
+      && packageSave?.if === "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''"
+      && object(packageSave?.with).key === "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}",
+    `${file} native build cache must save only a successful exact miss`,
   );
   const linuxBuildDockerfile = fs.readFileSync(
     path.join(repositoryRoot, ".github", "docker", "linux-glibc-build.Dockerfile"),
@@ -1703,14 +1786,36 @@ function validatePostPublish(workflows, violations, graph) {
   add(violations, !scalarStrings(workflow).some(value => value.includes("sha256sum")), `${file} must use the portable Python checksum gate`);
 }
 
-function validatePackagedCoordinator(workflows, violations) {
+function validatePackagedCoordinator(workflows, violations, graph) {
   const file = "packaged-platform-pr.yml";
   const workflow = workflows.get(file);
   if (!workflow) {
     violations.push(`${file} must exist`);
     return;
   }
-  add(violations, sameMembers(at(workflow, "on", "pull_request", "types"), ["labeled", "synchronize"]), `${file} pull request types must be labeled and synchronize`);
+  const promotion = graph.workflow_policy.promotion;
+  const expectedConcurrency = [
+    "proof-",
+    promotion.proof_run_sha_expression,
+    "-${{ inputs.mode || 'platform' }}-${{ inputs.pr_number || github.event.pull_request.number || 'dev' }}-",
+    "${{ github.event.action == 'labeled' && github.event.label.name || 'dispatch' }}",
+  ].join("");
+  add(
+    violations,
+    sameMembers(at(workflow, "on", "pull_request", "types"), promotion.required_events),
+    `${file} pull request trigger must be label-only`,
+  );
+  add(
+    violations,
+    at(workflow, "concurrency", "group") === expectedConcurrency,
+    `${file} concurrency must bind the Actions SHA, mode, PR identity, and exact label`,
+  );
+  add(
+    violations,
+    String(at(workflow, "on", "workflow_dispatch", "inputs", "pr_number", "description") ?? "")
+      .includes(promotion.manual_pr_ref_hint),
+    `${file} manual PR input must require ${promotion.manual_pr_ref_hint}`,
+  );
   add(
     violations,
     sameMembers(
@@ -1733,9 +1838,15 @@ function validatePackagedCoordinator(workflows, violations) {
   const route = requireJob(violations, file, workflow, "route");
   requireStepRun(violations, file, route, "Resolve trusted exact head", [
     'test "$head_repo" = "$GITHUB_REPOSITORY"',
-    'test "$current_head" = "$expected_head"',
+    'test "$current_head" = "$EVENT_HEAD_SHA"',
+    'test "$INPUT_HEAD_SHA" = "$current_head"',
+    'test "$GITHUB_REF" = "refs/heads/$head_ref"',
+    'test "$GITHUB_SHA" = "$INPUT_HEAD_SHA"',
     'test "$base_ref" = "dev/codestory-next"',
-    'test "$GITHUB_SHA" = "$current_head"',
+    'test "$INPUT_HEAD_SHA" = "$dev_head"',
+    'test "$GITHUB_REF" = "refs/heads/dev/codestory-next"',
+    'test "$GITHUB_SHA" = "$dev_head"',
+    "--ref $head_ref",
   ]);
   requireStepRun(violations, file, route, "Require successful exact-head source proof", [
     "actions/runs?head_sha=$HEAD_SHA",
@@ -1752,6 +1863,13 @@ function validatePackagedCoordinator(workflows, violations) {
     'freeze_transition=false\nif [ -n "$BASE_SHA" ] \\\n  && [ "$base_frozen" = false ] \\\n  && [ "$frozen" = true ]; then',
   ]);
   requireCalibrationProducerAuthentication(violations, file, route);
+  const routeSteps = list(route.steps).map(object);
+  add(
+    violations,
+    routeSteps.findIndex(step => step.name === "Resolve trusted exact head") === 0
+      && routeSteps.findIndex(step => step.uses === "actions/checkout@v5") > 0,
+    `${file} must resolve exact workflow/ref identity before checkout`,
+  );
   const calibrationLinux = requireJob(violations, file, workflow, "calibration-linux");
   add(
     violations,
@@ -1765,6 +1883,30 @@ function validatePackagedCoordinator(workflows, violations) {
     calibrationMacos.uses === "./.github/workflows/macos-metal-proof.yml"
       && object(calibrationMacos.with).calibration_mode === true,
     `${file} protected macOS calibration must call Metal proof in calibration mode`,
+  );
+  const macosSource = requireJob(violations, file, workflow, "macos-source");
+  const macosRestore = namedStep(macosSource, "Restore exact-head macOS source cache");
+  const expectedMacosKey = [
+    "${{ runner.os }}-",
+    promotion.macos_source_cache_namespace,
+    "-${{ needs.route.outputs.head_sha }}-${{ steps.rust-cache-key.outputs.version }}-",
+    "${{ matrix.target }}-workspace-default-features-${{ hashFiles('Cargo.lock') }}",
+  ].join("");
+  add(
+    violations,
+    macosRestore?.uses === "actions/cache/restore@v5"
+      && macosRestore?.["continue-on-error"] === true
+      && object(macosRestore?.with).key === expectedMacosKey
+      && object(macosRestore?.with)["restore-keys"] === undefined,
+    `${file} macOS source cache must be an exact-SHA restore without fallbacks`,
+  );
+  const macosSave = namedStep(macosSource, "Save exact-head macOS source cache");
+  add(
+    violations,
+    macosSave?.uses === "actions/cache/save@v5"
+      && macosSave?.if === "success() && steps.macos-source-cache-restore.outputs.cache-hit != 'true' && steps.macos-source-cache-restore.outputs.cache-primary-key != ''"
+      && object(macosSave?.with).key === "${{ steps.macos-source-cache-restore.outputs.cache-primary-key }}",
+    `${file} macOS source cache must save only a successful exact miss`,
   );
   const calibrationAssemble = requireJob(
     violations,
@@ -2222,14 +2364,19 @@ export function releaseWorkflowContractViolations(
     add(
       violations,
       sameMembers(at(workflow, "on", "pull_request", "types"), policy.promotion.required_events),
-      `[persistent_label] ${file} must re-evaluate labels on ${policy.promotion.required_events.join(" and ")}`,
+      `[proof_identity] ${file} must use only ${policy.promotion.required_events.join(" and ")} pull-request events`,
+    );
+    add(
+      violations,
+      String(at(workflow, "concurrency", "group") ?? "").includes(policy.promotion.proof_run_sha_expression),
+      `[proof_identity] ${file} concurrency must bind ${policy.promotion.proof_run_sha_expression}`,
     );
     const resolver = findNamedStep(workflow, "Resolve trusted exact head");
     const run = executableRunText(String(resolver?.run ?? ""));
     add(
       violations,
-      run.includes("current_head") && (run.includes("EVENT_HEAD_SHA") || run.includes("expected_head")),
-      `[persistent_label] ${file} must resolve the current head and compare its exact SHA before executing labeled work`,
+      run.includes("current_head") && run.includes("EVENT_HEAD_SHA"),
+      `[proof_identity] ${file} must resolve the current head and compare its exact SHA before executing labeled work`,
     );
   }
   return violations;
@@ -2242,11 +2389,11 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   }
   validateLockedSetupSurfaces(violations);
   validateIssueWorkflows(workflows, violations);
-  validatePluginAndDraftWorkflows(workflows, violations);
+  validatePluginAndDraftWorkflows(workflows, violations, graph);
   validateReleaseCoordinator(workflows, violations, graph);
   validatePackagedProof(workflows, violations, graph);
   validatePostPublish(workflows, violations, graph);
-  validatePackagedCoordinator(workflows, violations);
+  validatePackagedCoordinator(workflows, violations, graph);
   validateRemainingWorkflows(workflows, violations);
   violations.push(...releaseWorkflowContractViolations(workflows, graph));
   return violations;

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -55,6 +55,15 @@ function draftStep(job, name) {
   return matches[0];
 }
 
+function moveNamedStepBefore(job, movedName, beforeName) {
+  const movedIndex = job.steps.findIndex(step => step.name === movedName);
+  assert.notEqual(movedIndex, -1, `missing ${movedName}`);
+  const [moved] = job.steps.splice(movedIndex, 1);
+  const beforeIndex = job.steps.findIndex(step => step.name === beforeName);
+  assert.notEqual(beforeIndex, -1, `missing ${beforeName}`);
+  job.steps.splice(beforeIndex, 0, moved);
+}
+
 function runResolver(file, jobName, environment) {
   const workflow = loadWorkflows().get(file);
   const run = draftStep(workflow.jobs[jobName], "Resolve trusted exact head").run;
@@ -203,7 +212,8 @@ jobs:
   assert.match(basicWorkflowViolations("fixture.yml", invalid).join("\n"), /full-length SHA/u);
 });
 
-test("proof resolvers reject hostile workflow refs before proof work", async (t) => {
+test("proof resolvers reject hostile refs, SHAs, and labeled-event drift before proof work", async (t) => {
+  const otherSha = "2".repeat(40);
   const sourceEnvironment = {
     PR_NUMBER: "1230",
     EXPECTED_HEAD_SHA: fullSha,
@@ -222,11 +232,42 @@ test("proof resolvers reject hostile workflow refs before proof work", async (t)
     assert.notEqual(rejected.status, 0);
     assert.match(rejected.stdout, /--ref codex\/exact-head/u);
 
+    const wrongSha = runResolver("source-proof.yml", "resolve", {
+      ...sourceEnvironment,
+      GITHUB_REF: "refs/heads/codex/exact-head",
+      GITHUB_SHA: otherSha,
+    });
+    assert.notEqual(wrongSha.status, 0);
+    assert.match(wrongSha.stdout, /Workflow SHA .* is not reviewed PR head/u);
+
     const accepted = runResolver("source-proof.yml", "resolve", {
       ...sourceEnvironment,
       GITHUB_REF: "refs/heads/codex/exact-head",
     });
     assert.equal(accepted.status, 0, accepted.stderr || accepted.stdout);
+  });
+
+  await t.test("source labeled event", () => {
+    const environment = {
+      PR_NUMBER: "",
+      EXPECTED_HEAD_SHA: "",
+      CALLER_REF: "",
+      EVENT_PR_NUMBER: "1230",
+      EVENT_HEAD_SHA: fullSha,
+      EVENT_HEAD_REPO: "TheGreenCedar/CodeStory",
+      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_REF: "refs/pull/1230/merge",
+      GITHUB_SHA: fullSha,
+    };
+    const accepted = runResolver("source-proof.yml", "resolve", environment);
+    assert.equal(accepted.status, 0, accepted.stderr || accepted.stdout);
+
+    const drifted = runResolver("source-proof.yml", "resolve", {
+      ...environment,
+      EVENT_HEAD_SHA: otherSha,
+    });
+    assert.notEqual(drifted.status, 0);
+    assert.match(drifted.stdout, /moved after the review-accepted label event/u);
   });
 
   const packagedEnvironment = {
@@ -250,11 +291,42 @@ test("proof resolvers reject hostile workflow refs before proof work", async (t)
     assert.notEqual(rejected.status, 0);
     assert.match(rejected.stdout, /--ref codex\/exact-head/u);
 
+    const wrongSha = runResolver("packaged-platform-pr.yml", "route", {
+      ...packagedEnvironment,
+      GITHUB_REF: "refs/heads/codex/exact-head",
+      GITHUB_SHA: otherSha,
+    });
+    assert.notEqual(wrongSha.status, 0);
+    assert.match(wrongSha.stdout, /Workflow SHA .* is not accepted PR head/u);
+
     const accepted = runResolver("packaged-platform-pr.yml", "route", {
       ...packagedEnvironment,
       GITHUB_REF: "refs/heads/codex/exact-head",
     });
     assert.equal(accepted.status, 0, accepted.stderr || accepted.stdout);
+  });
+
+  await t.test("platform labeled event", () => {
+    const environment = {
+      ...packagedEnvironment,
+      INPUT_PR_NUMBER: "",
+      INPUT_HEAD_SHA: "",
+      INPUT_MODE: "",
+      EVENT_PR_NUMBER: "1230",
+      EVENT_HEAD_SHA: fullSha,
+      EVENT_HEAD_REPO: "TheGreenCedar/CodeStory",
+      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_REF: "refs/pull/1230/merge",
+    };
+    const accepted = runResolver("packaged-platform-pr.yml", "route", environment);
+    assert.equal(accepted.status, 0, accepted.stderr || accepted.stdout);
+
+    const drifted = runResolver("packaged-platform-pr.yml", "route", {
+      ...environment,
+      EVENT_HEAD_SHA: otherSha,
+    });
+    assert.notEqual(drifted.status, 0);
+    assert.match(drifted.stdout, /moved after the platform-proof label event/u);
   });
 
   await t.test("integration dispatch", () => {
@@ -301,6 +373,24 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
       sourceResolver(workflow).run = sourceResolver(workflow).run
         .replace('test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA"', 'test -n "$GITHUB_SHA"');
     }, /GITHUB_SHA.*EXPECTED_HEAD_SHA/u],
+    ["source manual SHA short-circuit", sourceFile, workflow => {
+      sourceResolver(workflow).run = sourceResolver(workflow).run
+        .replace(
+          'test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA" || {',
+          'true || test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA" || {',
+        );
+    }, /must not short-circuit/u],
+    ["source labeled branch disabled", sourceFile, workflow => {
+      sourceResolver(workflow).run = sourceResolver(workflow).run
+        .replace(
+          'if [ -n "$EVENT_PR_NUMBER" ]; then',
+          'if false && [ -n "$EVENT_PR_NUMBER" ]; then',
+        );
+    }, /must not short-circuit|must execute exact line/u],
+    ["source labeled job disabled", sourceFile, workflow => {
+      workflow.jobs.resolve.if
+        = "false && (github.event.action == 'labeled' && github.event.label.name == 'review-accepted')";
+    }, /only review-accepted labeled PR runs/u],
     ["source manual ref equality", sourceFile, workflow => {
       sourceResolver(workflow).run = sourceResolver(workflow).run
         .replace('test "$GITHUB_REF" = "refs\/heads\/$head_ref"', 'test -n "$GITHUB_REF"');
@@ -309,6 +399,24 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
       packagedResolver(workflow).run = packagedResolver(workflow).run
         .replace('test "$GITHUB_SHA" = "$INPUT_HEAD_SHA"', 'test -n "$GITHUB_SHA"');
     }, /GITHUB_SHA.*INPUT_HEAD_SHA/u],
+    ["platform manual SHA short-circuit", packagedCoordinatorFile, workflow => {
+      packagedResolver(workflow).run = packagedResolver(workflow).run
+        .replace(
+          'test "$GITHUB_SHA" = "$INPUT_HEAD_SHA" || {',
+          'true || test "$GITHUB_SHA" = "$INPUT_HEAD_SHA" || {',
+        );
+    }, /must not short-circuit/u],
+    ["platform labeled branch disabled", packagedCoordinatorFile, workflow => {
+      packagedResolver(workflow).run = packagedResolver(workflow).run
+        .replace(
+          'if [ -n "$EVENT_HEAD_REPO" ]; then',
+          'if false && [ -n "$EVENT_HEAD_REPO" ]; then',
+        );
+    }, /must not short-circuit|must execute exact line/u],
+    ["platform labeled job disabled", packagedCoordinatorFile, workflow => {
+      workflow.jobs.route.if
+        = "false && (github.event.action == 'labeled' && github.event.label.name == 'platform-proof')";
+    }, /only platform-proof labeled PR runs/u],
     ["integration live dev SHA equality", packagedCoordinatorFile, workflow => {
       packagedResolver(workflow).run = packagedResolver(workflow).run
         .replace('test "$GITHUB_SHA" = "$dev_head"', 'test -n "$GITHUB_SHA"');
@@ -325,10 +433,24 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
       draftStep(workflow.jobs["full-source-gate"], "Save Cargo inputs and output").if
         = "always() && steps.cargo-cache-restore.outputs.cache-hit != 'true'";
     }, /save only a successful exact miss/u],
+    ["source cache save before final proof", sourceFile, workflow => {
+      moveNamedStepBefore(
+        workflow.jobs["full-source-gate"],
+        "Save Cargo inputs and output",
+        "Test the complete workspace once",
+      );
+    }, /source cache save must run after every proof step/u],
     ["macOS source cache loses exact SHA", packagedCoordinatorFile, workflow => {
       const restore = draftStep(workflow.jobs["macos-source"], "Restore exact-head macOS source cache");
       restore.with.key = restore.with.key.replace("-${{ needs.route.outputs.head_sha }}", "");
     }, /macOS source cache must be an exact-SHA restore/u],
+    ["macOS source cache save before final proof", packagedCoordinatorFile, workflow => {
+      moveNamedStepBefore(
+        workflow.jobs["macos-source"],
+        "Save exact-head macOS source cache",
+        "Capture Rust cache identity",
+      );
+    }, /macOS source cache save must run after every proof step/u],
     ["packaged cache loses exact SHA", packagedProofFile, workflow => {
       const restore = draftStep(workflow.jobs.build, "Restore Cargo registry, git sources, and build output");
       restore.with.key = restore.with.key.replace("-${{ inputs.ref }}", "");
@@ -337,6 +459,13 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
       draftStep(workflow.jobs.build, "Save Cargo registry, git sources, and build output").if
         = "always() && steps.cargo-cache-restore.outputs.cache-hit != 'true'";
     }, /save only a successful exact miss/u],
+    ["packaged cache save before final proof", packagedProofFile, workflow => {
+      moveNamedStepBefore(
+        workflow.jobs.build,
+        "Save Cargo registry, git sources, and build output",
+        "Build codestory-cli",
+      );
+    }, /native build cache save must run after every proof and cleanup step/u],
   ];
 
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -64,6 +64,14 @@ function moveNamedStepBefore(job, movedName, beforeName) {
   job.steps.splice(beforeIndex, 0, moved);
 }
 
+function cloneCacheSaveBefore(job, sourceName, beforeName) {
+  const clone = structuredClone(draftStep(job, sourceName));
+  clone.name = `${sourceName} clone`;
+  const beforeIndex = job.steps.findIndex(step => step.name === beforeName);
+  assert.notEqual(beforeIndex, -1, `missing ${beforeName}`);
+  job.steps.splice(beforeIndex, 0, clone);
+}
+
 function runResolver(file, jobName, environment) {
   const workflow = loadWorkflows().get(file);
   const run = draftStep(workflow.jobs[jobName], "Resolve trusted exact head").run;
@@ -379,14 +387,21 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
           'test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA" || {',
           'true || test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA" || {',
         );
-    }, /must not short-circuit/u],
+    }, /exact normalized trusted resolver script contract/u],
     ["source labeled branch disabled", sourceFile, workflow => {
       sourceResolver(workflow).run = sourceResolver(workflow).run
         .replace(
           'if [ -n "$EVENT_PR_NUMBER" ]; then',
           'if false && [ -n "$EVENT_PR_NUMBER" ]; then',
         );
-    }, /must not short-circuit|must execute exact line/u],
+    }, /exact normalized trusted resolver script contract/u],
+    ["source resolver exits before trusted checks", sourceFile, workflow => {
+      sourceResolver(workflow).run = sourceResolver(workflow).run
+        .replace(
+          "set -euo pipefail",
+          'set -euo pipefail\necho "ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"\nexit 0',
+        );
+    }, /exact normalized trusted resolver script contract/u],
     ["source labeled job disabled", sourceFile, workflow => {
       workflow.jobs.resolve.if
         = "false && (github.event.action == 'labeled' && github.event.label.name == 'review-accepted')";
@@ -405,14 +420,21 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
           'test "$GITHUB_SHA" = "$INPUT_HEAD_SHA" || {',
           'true || test "$GITHUB_SHA" = "$INPUT_HEAD_SHA" || {',
         );
-    }, /must not short-circuit/u],
+    }, /exact normalized trusted resolver script contract/u],
     ["platform labeled branch disabled", packagedCoordinatorFile, workflow => {
       packagedResolver(workflow).run = packagedResolver(workflow).run
         .replace(
           'if [ -n "$EVENT_HEAD_REPO" ]; then',
           'if false && [ -n "$EVENT_HEAD_REPO" ]; then',
         );
-    }, /must not short-circuit|must execute exact line/u],
+    }, /exact normalized trusted resolver script contract/u],
+    ["platform resolver exits before trusted checks", packagedCoordinatorFile, workflow => {
+      packagedResolver(workflow).run = packagedResolver(workflow).run
+        .replace(
+          "set -euo pipefail",
+          'set -euo pipefail\necho "head_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"\nexit 0',
+        );
+    }, /exact normalized trusted resolver script contract/u],
     ["platform labeled job disabled", packagedCoordinatorFile, workflow => {
       workflow.jobs.route.if
         = "false && (github.event.action == 'labeled' && github.event.label.name == 'platform-proof')";
@@ -439,7 +461,14 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
         "Save Cargo inputs and output",
         "Test the complete workspace once",
       );
-    }, /source cache save must run after every proof step/u],
+    }, /source cache unique cache save must run after every proof step/u],
+    ["source cache clone before proof", sourceFile, workflow => {
+      cloneCacheSaveBefore(
+        workflow.jobs["full-source-gate"],
+        "Save Cargo inputs and output",
+        "Test the complete workspace once",
+      );
+    }, /source cache must contain exactly one actions\/cache\/save action/u],
     ["macOS source cache loses exact SHA", packagedCoordinatorFile, workflow => {
       const restore = draftStep(workflow.jobs["macos-source"], "Restore exact-head macOS source cache");
       restore.with.key = restore.with.key.replace("-${{ needs.route.outputs.head_sha }}", "");
@@ -450,7 +479,14 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
         "Save exact-head macOS source cache",
         "Capture Rust cache identity",
       );
-    }, /macOS source cache save must run after every proof step/u],
+    }, /macOS source cache unique cache save must run after every proof step/u],
+    ["macOS source cache clone before proof", packagedCoordinatorFile, workflow => {
+      cloneCacheSaveBefore(
+        workflow.jobs["macos-source"],
+        "Save exact-head macOS source cache",
+        "Capture Rust cache identity",
+      );
+    }, /macOS source cache must contain exactly one actions\/cache\/save action/u],
     ["packaged cache loses exact SHA", packagedProofFile, workflow => {
       const restore = draftStep(workflow.jobs.build, "Restore Cargo registry, git sources, and build output");
       restore.with.key = restore.with.key.replace("-${{ inputs.ref }}", "");
@@ -465,7 +501,14 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
         "Save Cargo registry, git sources, and build output",
         "Build codestory-cli",
       );
-    }, /native build cache save must run after every proof and cleanup step/u],
+    }, /native build cache unique cache save must run after every proof and cleanup step/u],
+    ["packaged cache clone before proof", packagedProofFile, workflow => {
+      cloneCacheSaveBefore(
+        workflow.jobs.build,
+        "Save Cargo registry, git sources, and build output",
+        "Build codestory-cli",
+      );
+    }, /native build cache must contain exactly one actions\/cache\/save action/u],
   ];
 
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -64,9 +64,10 @@ function moveNamedStepBefore(job, movedName, beforeName) {
   job.steps.splice(beforeIndex, 0, moved);
 }
 
-function cloneCacheSaveBefore(job, sourceName, beforeName) {
+function cloneCacheSaveBefore(job, sourceName, beforeName, uses) {
   const clone = structuredClone(draftStep(job, sourceName));
   clone.name = `${sourceName} clone`;
+  if (uses !== undefined) clone.uses = uses;
   const beforeIndex = job.steps.findIndex(step => step.name === beforeName);
   assert.notEqual(beforeIndex, -1, `missing ${beforeName}`);
   job.steps.splice(beforeIndex, 0, clone);
@@ -402,6 +403,10 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
           'set -euo pipefail\necho "ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"\nexit 0',
         );
     }, /exact normalized trusted resolver script contract/u],
+    ["source resolver blank line", sourceFile, workflow => {
+      sourceResolver(workflow).run = sourceResolver(workflow).run
+        .replace("set -euo pipefail\n", "set -euo pipefail\n\n");
+    }, /exact normalized trusted resolver script contract/u],
     ["source labeled job disabled", sourceFile, workflow => {
       workflow.jobs.resolve.if
         = "false && (github.event.action == 'labeled' && github.event.label.name == 'review-accepted')";
@@ -433,6 +438,13 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
         .replace(
           "set -euo pipefail",
           'set -euo pipefail\necho "head_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"\nexit 0',
+        );
+    }, /exact normalized trusted resolver script contract/u],
+    ["platform resolver backslash continuation blank line", packagedCoordinatorFile, workflow => {
+      packagedResolver(workflow).run = packagedResolver(workflow).run
+        .replace(
+          'if [ -n "$INPUT_SOURCE_RUN_ID" ] \\\n    ||',
+          'if [ -n "$INPUT_SOURCE_RUN_ID" ] \\\n\n    ||',
         );
     }, /exact normalized trusted resolver script contract/u],
     ["platform labeled job disabled", packagedCoordinatorFile, workflow => {
@@ -469,6 +481,14 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
         "Test the complete workspace once",
       );
     }, /source cache must contain exactly one actions\/cache\/save action/u],
+    ["source mixed-case cache clone before proof", sourceFile, workflow => {
+      cloneCacheSaveBefore(
+        workflow.jobs["full-source-gate"],
+        "Save Cargo inputs and output",
+        "Test the complete workspace once",
+        "Actions/Cache/Save@v5",
+      );
+    }, /source cache must contain exactly one actions\/cache\/save action/u],
     ["macOS source cache loses exact SHA", packagedCoordinatorFile, workflow => {
       const restore = draftStep(workflow.jobs["macos-source"], "Restore exact-head macOS source cache");
       restore.with.key = restore.with.key.replace("-${{ needs.route.outputs.head_sha }}", "");
@@ -485,6 +505,14 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
         workflow.jobs["macos-source"],
         "Save exact-head macOS source cache",
         "Capture Rust cache identity",
+      );
+    }, /macOS source cache must contain exactly one actions\/cache\/save action/u],
+    ["macOS source mixed-case cache clone before proof", packagedCoordinatorFile, workflow => {
+      cloneCacheSaveBefore(
+        workflow.jobs["macos-source"],
+        "Save exact-head macOS source cache",
+        "Capture Rust cache identity",
+        "Actions/Cache/Save@v5",
       );
     }, /macOS source cache must contain exactly one actions\/cache\/save action/u],
     ["packaged cache loses exact SHA", packagedProofFile, workflow => {
@@ -507,6 +535,14 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
         workflow.jobs.build,
         "Save Cargo registry, git sources, and build output",
         "Build codestory-cli",
+      );
+    }, /native build cache must contain exactly one actions\/cache\/save action/u],
+    ["packaged mixed-case cache clone before proof", packagedProofFile, workflow => {
+      cloneCacheSaveBefore(
+        workflow.jobs.build,
+        "Save Cargo registry, git sources, and build output",
+        "Build codestory-cli",
+        "Actions/Cache/Save@v5",
       );
     }, /native build cache must contain exactly one actions\/cache\/save action/u],
   ];

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -51,6 +53,42 @@ function draftStep(job, name) {
   const matches = job.steps.filter(step => step.name === name);
   assert.equal(matches.length, 1, `expected one ${name} step`);
   return matches[0];
+}
+
+function runResolver(file, jobName, environment) {
+  const workflow = loadWorkflows().get(file);
+  const run = draftStep(workflow.jobs[jobName], "Resolve trusted exact head").run;
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-proof-resolver-"));
+  const fakeGh = path.join(directory, "gh");
+  const baseSha = "1".repeat(40);
+  writeFileSync(fakeGh, `#!/bin/sh
+case "$*" in
+  *"branches/dev/codestory-next"*) printf '%s\\n' '${fullSha}' ;;
+  *) printf '%s\\n' '${JSON.stringify({
+    head: {
+      repo: { full_name: "TheGreenCedar/CodeStory" },
+      sha: fullSha,
+      ref: "codex/exact-head",
+    },
+    base: { sha: baseSha, ref: "dev/codestory-next" },
+    labels: [{ name: "review-accepted" }],
+  })}' ;;
+esac
+`);
+  chmodSync(fakeGh, 0o755);
+  const output = path.join(directory, "github-output");
+  writeFileSync(output, "");
+  return spawnSync("bash", ["-c", run], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${directory}:${process.env.PATH}`,
+      GH_TOKEN: "test-token",
+      GITHUB_REPOSITORY: "TheGreenCedar/CodeStory",
+      GITHUB_OUTPUT: output,
+      ...environment,
+    },
+  });
 }
 
 function windowsManifestJob(workflow) {
@@ -163,6 +201,152 @@ jobs:
   const invalid = structuredClone(valid);
   invalid.jobs.check.steps[0].uses = "vendor/action@main";
   assert.match(basicWorkflowViolations("fixture.yml", invalid).join("\n"), /full-length SHA/u);
+});
+
+test("proof resolvers reject hostile workflow refs before proof work", async (t) => {
+  const sourceEnvironment = {
+    PR_NUMBER: "1230",
+    EXPECTED_HEAD_SHA: fullSha,
+    CALLER_REF: "",
+    EVENT_PR_NUMBER: "",
+    EVENT_HEAD_SHA: "",
+    EVENT_HEAD_REPO: "",
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_SHA: fullSha,
+  };
+  await t.test("source PR dispatch", () => {
+    const rejected = runResolver("source-proof.yml", "resolve", {
+      ...sourceEnvironment,
+      GITHUB_REF: "refs/heads/main",
+    });
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stdout, /--ref codex\/exact-head/u);
+
+    const accepted = runResolver("source-proof.yml", "resolve", {
+      ...sourceEnvironment,
+      GITHUB_REF: "refs/heads/codex/exact-head",
+    });
+    assert.equal(accepted.status, 0, accepted.stderr || accepted.stdout);
+  });
+
+  const packagedEnvironment = {
+    INPUT_PR_NUMBER: "1230",
+    INPUT_HEAD_SHA: fullSha,
+    INPUT_MODE: "platform",
+    EVENT_PR_NUMBER: "",
+    EVENT_HEAD_SHA: "",
+    EVENT_HEAD_REPO: "",
+    INPUT_SOURCE_RUN_ID: "",
+    INPUT_CALIBRATION_ARTIFACT: "",
+    INPUT_CALIBRATION_RUN_ID: "",
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_SHA: fullSha,
+  };
+  await t.test("platform PR dispatch", () => {
+    const rejected = runResolver("packaged-platform-pr.yml", "route", {
+      ...packagedEnvironment,
+      GITHUB_REF: "refs/heads/main",
+    });
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stdout, /--ref codex\/exact-head/u);
+
+    const accepted = runResolver("packaged-platform-pr.yml", "route", {
+      ...packagedEnvironment,
+      GITHUB_REF: "refs/heads/codex/exact-head",
+    });
+    assert.equal(accepted.status, 0, accepted.stderr || accepted.stdout);
+  });
+
+  await t.test("integration dispatch", () => {
+    const rejected = runResolver("packaged-platform-pr.yml", "route", {
+      ...packagedEnvironment,
+      INPUT_PR_NUMBER: "",
+      INPUT_MODE: "integration",
+      GITHUB_REF: "refs/heads/main",
+    });
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stdout, /--ref dev\/codestory-next/u);
+
+    const accepted = runResolver("packaged-platform-pr.yml", "route", {
+      ...packagedEnvironment,
+      INPUT_PR_NUMBER: "",
+      INPUT_MODE: "integration",
+      GITHUB_REF: "refs/heads/dev/codestory-next",
+    });
+    assert.equal(accepted.status, 0, accepted.stderr || accepted.stdout);
+  });
+});
+
+test("exact proof policy rejects trigger, identity, and cache downgrades", async (t) => {
+  const sourceFile = "source-proof.yml";
+  const packagedCoordinatorFile = "packaged-platform-pr.yml";
+  const packagedProofFile = "packaged-platform-proof.yml";
+  const sourceResolver = workflow => draftStep(workflow.jobs.resolve, "Resolve trusted exact head");
+  const packagedResolver = workflow => draftStep(workflow.jobs.route, "Resolve trusted exact head");
+
+  const mutations = [
+    ["source synchronize trigger", sourceFile, workflow => {
+      workflow.on.pull_request.types.push("synchronize");
+    }, /trigger must be label-only/u],
+    ["platform synchronize trigger", packagedCoordinatorFile, workflow => {
+      workflow.on.pull_request.types.push("synchronize");
+    }, /trigger must be label-only/u],
+    ["source PR-number-only concurrency", sourceFile, workflow => {
+      workflow.concurrency.group = "source-proof-${{ inputs.pr_number || github.event.pull_request.number }}";
+    }, /concurrency must bind the Actions SHA/u],
+    ["platform PR-number-only concurrency", packagedCoordinatorFile, workflow => {
+      workflow.concurrency.group = "proof-${{ inputs.mode }}-${{ inputs.pr_number }}";
+    }, /concurrency must bind the Actions SHA/u],
+    ["source manual SHA equality", sourceFile, workflow => {
+      sourceResolver(workflow).run = sourceResolver(workflow).run
+        .replace('test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA"', 'test -n "$GITHUB_SHA"');
+    }, /GITHUB_SHA.*EXPECTED_HEAD_SHA/u],
+    ["source manual ref equality", sourceFile, workflow => {
+      sourceResolver(workflow).run = sourceResolver(workflow).run
+        .replace('test "$GITHUB_REF" = "refs\/heads\/$head_ref"', 'test -n "$GITHUB_REF"');
+    }, /GITHUB_REF.*head_ref/u],
+    ["platform manual SHA equality", packagedCoordinatorFile, workflow => {
+      packagedResolver(workflow).run = packagedResolver(workflow).run
+        .replace('test "$GITHUB_SHA" = "$INPUT_HEAD_SHA"', 'test -n "$GITHUB_SHA"');
+    }, /GITHUB_SHA.*INPUT_HEAD_SHA/u],
+    ["integration live dev SHA equality", packagedCoordinatorFile, workflow => {
+      packagedResolver(workflow).run = packagedResolver(workflow).run
+        .replace('test "$GITHUB_SHA" = "$dev_head"', 'test -n "$GITHUB_SHA"');
+    }, /GITHUB_SHA.*dev_head/u],
+    ["source unversioned cache", sourceFile, workflow => {
+      const restore = draftStep(workflow.jobs["full-source-gate"], "Restore Cargo inputs and output");
+      restore.with.key = restore.with.key.replace("source-proof-v2", "source-proof");
+    }, /versioned exact-SHA namespace/u],
+    ["source broad cache fallback", sourceFile, workflow => {
+      draftStep(workflow.jobs["full-source-gate"], "Restore Cargo inputs and output")
+        .with["restore-keys"] = "Linux-source-proof-";
+    }, /must not use fallback restore keys/u],
+    ["source cache always-save", sourceFile, workflow => {
+      draftStep(workflow.jobs["full-source-gate"], "Save Cargo inputs and output").if
+        = "always() && steps.cargo-cache-restore.outputs.cache-hit != 'true'";
+    }, /save only a successful exact miss/u],
+    ["macOS source cache loses exact SHA", packagedCoordinatorFile, workflow => {
+      const restore = draftStep(workflow.jobs["macos-source"], "Restore exact-head macOS source cache");
+      restore.with.key = restore.with.key.replace("-${{ needs.route.outputs.head_sha }}", "");
+    }, /macOS source cache must be an exact-SHA restore/u],
+    ["packaged cache loses exact SHA", packagedProofFile, workflow => {
+      const restore = draftStep(workflow.jobs.build, "Restore Cargo registry, git sources, and build output");
+      restore.with.key = restore.with.key.replace("-${{ inputs.ref }}", "");
+    }, /native build cache.*exact SHA/u],
+    ["packaged cache always-save", packagedProofFile, workflow => {
+      draftStep(workflow.jobs.build, "Save Cargo registry, git sources, and build output").if
+        = "always() && steps.cargo-cache-restore.outputs.cache-hit != 'true'";
+    }, /save only a successful exact miss/u],
+  ];
+
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  for (const [name, file, mutate, expectedReason] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(validateWorkflows(workflows).join("\n"), expectedReason);
+    });
+  }
 });
 
 test("hosted Linux calibration keeps its bounded per-run timeout", async (t) => {

--- a/.github/scripts/fixtures/workflow-policy-invalid.json
+++ b/.github/scripts/fixtures/workflow-policy-invalid.json
@@ -127,8 +127,8 @@
       "value": []
     },
     {
-      "id": "persistent-label",
-      "class_prefix": "[persistent_label]",
+      "id": "synchronize-proof-trigger",
+      "class_prefix": "[proof_identity]",
       "workflow": "source-proof.yml",
       "field": [
         "on",
@@ -136,8 +136,19 @@
         "types"
       ],
       "value": [
-        "labeled"
+        "labeled",
+        "synchronize"
       ]
+    },
+    {
+      "id": "pr-number-only-proof-concurrency",
+      "class_prefix": "[proof_identity]",
+      "workflow": "packaged-platform-pr.yml",
+      "field": [
+        "concurrency",
+        "group"
+      ],
+      "value": "proof-${{ inputs.mode || 'platform' }}-${{ inputs.pr_number || github.event.pull_request.number || 'dev' }}"
     }
   ]
 }

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -2,7 +2,7 @@ name: Platform and integration proof
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled]
   workflow_dispatch:
     inputs:
       mode:
@@ -12,11 +12,11 @@ on:
         type: choice
         options: [platform, calibration, release-evidence, integration]
       pr_number:
-        description: Same-repository pull request for platform mode.
+        description: Same-repository pull request. Dispatch PR modes with --ref <same-repository PR head branch>.
         required: false
         type: string
       expected_head_sha:
-        description: Exact accepted head SHA.
+        description: Exact accepted head SHA. The selected --ref, github.sha, and live PR or dev head must match.
         required: true
         type: string
       scope:
@@ -44,7 +44,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: proof-${{ inputs.mode || 'platform' }}-${{ inputs.pr_number || github.event.pull_request.number || 'dev' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'platform-proof' && github.event.label.name || 'candidate' }}
+  group: proof-${{ github.sha }}-${{ inputs.mode || 'platform' }}-${{ inputs.pr_number || github.event.pull_request.number || 'dev' }}-${{ github.event.action == 'labeled' && github.event.label.name || 'dispatch' }}
   cancel-in-progress: true
 
 jobs:
@@ -86,6 +86,14 @@ jobs:
               echo "::error::Integration proof requires current dev head $dev_head, not $INPUT_HEAD_SHA."
               exit 1
             }
+            test "$GITHUB_REF" = "refs/heads/dev/codestory-next" || {
+              echo "::error::Integration proof must be dispatched with --ref dev/codestory-next, not $GITHUB_REF."
+              exit 1
+            }
+            test "$GITHUB_SHA" = "$dev_head" || {
+              echo "::error::Workflow SHA $GITHUB_SHA is not current dev head $dev_head. Dispatch with --ref dev/codestory-next."
+              exit 1
+            }
             {
               echo "head_sha=$dev_head"
               echo "base_sha="
@@ -96,11 +104,11 @@ jobs:
           fi
           test "$mode" = "platform" || test "$mode" = "calibration" || test "$mode" = "release-evidence"
           pr_number="${EVENT_PR_NUMBER:-$INPUT_PR_NUMBER}"
-          expected_head="${EVENT_HEAD_SHA:-$INPUT_HEAD_SHA}"
-          test -n "$pr_number" && test -n "$expected_head"
+          test -n "$pr_number"
           pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number")"
           head_repo="$(jq -r '.head.repo.full_name' <<<"$pr")"
           current_head="$(jq -r '.head.sha' <<<"$pr")"
+          head_ref="$(jq -r '.head.ref' <<<"$pr")"
           base_sha="$(jq -r '.base.sha' <<<"$pr")"
           base_ref="$(jq -r '.base.ref' <<<"$pr")"
           test "$head_repo" = "$GITHUB_REPOSITORY" || {
@@ -109,14 +117,22 @@ jobs:
           }
           if [ -n "$EVENT_HEAD_REPO" ]; then
             test "$EVENT_HEAD_REPO" = "$GITHUB_REPOSITORY" || exit 1
-          fi
-          test "$current_head" = "$expected_head" || {
-            echo "::error::PR #$pr_number moved from promoted head $expected_head to $current_head."
-            exit 1
-          }
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            test "$GITHUB_SHA" = "$current_head" || {
-              echo "::error::Workflow ref $GITHUB_SHA is not exact PR head $current_head."
+            test "$current_head" = "$EVENT_HEAD_SHA" || {
+              echo "::error::PR #$pr_number moved after the platform-proof label event."
+              exit 1
+            }
+          else
+            test -n "$INPUT_HEAD_SHA"
+            test "$INPUT_HEAD_SHA" = "$current_head" || {
+              echo "::error::PR #$pr_number moved from promoted head $INPUT_HEAD_SHA to $current_head."
+              exit 1
+            }
+            test "$GITHUB_REF" = "refs/heads/$head_ref" || {
+              echo "::error::Platform proof must be dispatched with --ref $head_ref (the same-repository PR head branch), not $GITHUB_REF."
+              exit 1
+            }
+            test "$GITHUB_SHA" = "$INPUT_HEAD_SHA" || {
+              echo "::error::Workflow SHA $GITHUB_SHA is not accepted PR head $INPUT_HEAD_SHA. Dispatch with --ref $head_ref."
               exit 1
             }
           fi
@@ -400,16 +416,29 @@ jobs:
         shell: bash
         run: |
           echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v5
+      - name: Restore exact-head macOS source cache
+        id: macos-source-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-macos-source-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.target }}-workspace-default-features-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-macos-source-v2-${{ needs.route.outputs.head_sha }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.target }}-workspace-default-features-${{ hashFiles('Cargo.lock') }}
       - run: cargo check --workspace --locked
       - run: node --test scripts/tests/codex-worktree-setup.test.mjs
       - run: test -x plugins/codestory/skills/codestory-grounding/scripts/setup.sh
+      - name: Save exact-head macOS source cache
+        if: success() && steps.macos-source-cache-restore.outputs.cache-hit != 'true' && steps.macos-source-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.macos-source-cache-restore.outputs.cache-primary-key }}
 
   repo-scale-stats:
     if: needs.route.outputs.mode != 'release-evidence' && needs.route.outputs.mode != 'calibration'

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -9,8 +9,7 @@ on:
         type: string
       ref:
         description: Exact source SHA to package.
-        required: false
-        default: ""
+        required: true
         type: string
       scope:
         description: Native package matrix scope (windows, macos, or full).
@@ -76,7 +75,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: packaged-platform-proof-${{ inputs.proof_key || github.event.pull_request.number || github.ref }}
+  group: packaged-platform-proof-${{ github.sha }}-${{ inputs.ref }}-${{ inputs.proof_key || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -141,7 +140,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-native-v3-${{ steps.rust-cache-key.outputs.generator }}-cmake-${{ steps.rust-cache-key.outputs.cmake }}-ninja-${{ steps.rust-cache-key.outputs.ninja }}-default-features-${{ hashFiles('Cargo.lock', '.github/docker/linux-glibc-build.Dockerfile', '.github/docker/glslc') }}
+          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-native-v4-${{ inputs.ref }}-${{ steps.rust-cache-key.outputs.generator }}-cmake-${{ steps.rust-cache-key.outputs.cmake }}-ninja-${{ steps.rust-cache-key.outputs.ninja }}-default-features-${{ hashFiles('Cargo.lock', '.github/docker/linux-glibc-build.Dockerfile', '.github/docker/glslc') }}
 
       - name: Prove native workspace path identity
         if: runner.os == 'Windows'

--- a/.github/workflows/source-proof.yml
+++ b/.github/workflows/source-proof.yml
@@ -2,7 +2,7 @@ name: Exact-head source proof
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled]
   workflow_call:
     inputs:
       ref:
@@ -14,11 +14,11 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: Same-repository pull request accepted by exact-head review.
+        description: Same-repository pull request accepted by exact-head review. Dispatch with --ref <same-repository PR head branch>.
         required: true
         type: string
       expected_head_sha:
-        description: Exact reviewed head SHA. The gate refuses a newer or older head.
+        description: Exact reviewed head SHA. The selected --ref, github.sha, and live PR head must match.
         required: true
         type: string
 
@@ -27,7 +27,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: source-proof-${{ inputs.proof_key || inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ github.event.action == 'labeled' && github.event.label.name != 'review-accepted' && github.event.label.name || 'candidate' }}
+  group: source-proof-${{ github.sha }}-${{ inputs.proof_key || inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ github.event.action == 'labeled' && github.event.label.name || 'dispatch' }}
   cancel-in-progress: true
 
 jobs:
@@ -56,7 +56,12 @@ jobs:
               exit 1
             }
             pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$EVENT_PR_NUMBER")"
+            head_repo="$(jq -r '.head.repo.full_name' <<<"$pr")"
             current_head="$(jq -r '.head.sha' <<<"$pr")"
+            test "$head_repo" = "$GITHUB_REPOSITORY" || {
+              echo "::error::Exact-head proof does not execute fork pull requests."
+              exit 1
+            }
             test "$current_head" = "$EVENT_HEAD_SHA" || {
               echo "::error::PR #$EVENT_PR_NUMBER moved after the review-accepted label event."
               exit 1
@@ -68,6 +73,7 @@ jobs:
             pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
             head_repo="$(jq -r '.head.repo.full_name' <<<"$pr")"
             head_sha="$(jq -r '.head.sha' <<<"$pr")"
+            head_ref="$(jq -r '.head.ref' <<<"$pr")"
             test "$head_repo" = "$GITHUB_REPOSITORY" || {
               echo "::error::Exact-head proof does not execute fork pull requests."
               exit 1
@@ -76,9 +82,21 @@ jobs:
               echo "::error::PR #$PR_NUMBER moved from reviewed head $EXPECTED_HEAD_SHA to $head_sha."
               exit 1
             }
+            test "$GITHUB_REF" = "refs/heads/$head_ref" || {
+              echo "::error::Exact-head proof must be dispatched with --ref $head_ref (the same-repository PR head branch), not $GITHUB_REF."
+              exit 1
+            }
+            test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA" || {
+              echo "::error::Workflow SHA $GITHUB_SHA is not reviewed PR head $EXPECTED_HEAD_SHA. Dispatch with --ref $head_ref."
+              exit 1
+            }
             echo "ref=$head_sha" >> "$GITHUB_OUTPUT"
           else
             test -n "$CALLER_REF"
+            test "$GITHUB_SHA" = "$CALLER_REF" || {
+              echo "::error::Reusable source proof ref $CALLER_REF does not match workflow SHA $GITHUB_SHA."
+              exit 1
+            }
             echo "ref=$CALLER_REF" >> "$GITHUB_OUTPUT"
           fi
 
@@ -116,7 +134,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-source-proof-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-all-targets-all-features-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-source-proof-v2-${{ needs.resolve.outputs.ref }}-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-all-targets-all-features-${{ hashFiles('Cargo.lock') }}
 
       - name: Test the complete workspace once
         run: cargo test --workspace --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 
 ### Reliability and compatibility
 
+- Exact-head source and platform proof now require one coherent workflow ref,
+  reviewed SHA, Actions SHA, concurrency identity, checkout, and cache
+  namespace. PR coordinators are label-only; manual runs must select the live
+  same-repository PR branch (or current `dev/codestory-next` for integration),
+  and failed, cancelled, wrong-ref, or stale-head work cannot publish proof
+  caches.
 - Windows source builds now use stable file-handle identity and replace preexisting hard-linked DLLs before runtime staging, allowing Rust 1.97.1 builds to complete.
 - Managed activation now repairs migrated cores that are missing a completed
   search generation instead of entering through the fail-closed reader and

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "4f10bcec540fddaea2a962e7fccec222050bed470c596a4cb213ab2697e9492c",
+    "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
     "observed_at": "2026-07-16T11:00:00.000Z",
     "expires_at": "2026-07-17T11:00:00.000Z",
     "requested_claims": [
@@ -91,7 +91,7 @@
         "type": "retrieval_readiness",
         "tier": "live_behavior",
         "status": "pass",
-        "graph_sha256": "4f10bcec540fddaea2a962e7fccec222050bed470c596a4cb213ab2697e9492c",
+        "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {
@@ -110,7 +110,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "4f10bcec540fddaea2a962e7fccec222050bed470c596a4cb213ab2697e9492c",
+        "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {
@@ -131,7 +131,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "4f10bcec540fddaea2a962e7fccec222050bed470c596a4cb213ab2697e9492c",
+        "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "66e625a3e519278da149ad2f7099e53699ee837f753ef2f2559610f14587114c",
+  "candidate_sha256": "196dfafdcdfedc3ce996376f4dc5ac8dfae2f9764a2b7b84d784e220f0aaad3f",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -24,7 +24,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "4f10bcec540fddaea2a962e7fccec222050bed470c596a4cb213ab2697e9492c",
+    "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-16T11:00:00.000Z",

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -340,8 +340,11 @@ controlled-invalid fixtures must retain their class-prefixed diagnostics.
 
 Draft pushes run focused checks and one Linux source check. Exact-head review
 runs the broad source gate once. Packaged matrices and protected hardware run
-only through the coordinator/platform-proof gate. New pushes cancel stale runs,
-and each target is built once then reused by its proof steps.
+only through the coordinator/platform-proof gate. Draft pushes cancel stale
+draft work. Exact source and platform coordinators run only when their label is
+applied; their concurrency and cache identities include the exact Actions SHA,
+so a later push cannot cancel or populate proof for an accepted old head. Each
+target is built once then reused by its proof steps.
 
 Release signing, notarization, post-publish quarantine/Gatekeeper checks,
 installed plugin readback, and live full retrieval run only from the main

--- a/release-claims.json
+++ b/release-claims.json
@@ -1,6 +1,6 @@
 {
   "schema": "codestory.release-claims/v1",
-  "graph_version": 1,
+  "graph_version": 2,
   "graph_id": "codestory-release-claims",
   "evidence_policy": {
     "selection": "all_matching_rows_must_pass",
@@ -632,13 +632,17 @@
       "source_branch": "dev/codestory-next",
       "release_branch": "main",
       "exact_sha_expression": "${{ github.sha }}",
+      "proof_run_sha_expression": "${{ github.sha }}",
+      "manual_pr_ref_hint": "--ref <same-repository PR head branch>",
+      "source_cache_namespace": "source-proof-v2",
+      "macos_source_cache_namespace": "macos-source-v2",
+      "packaged_cache_namespace": "codestory-cli-native-v4",
       "label_routed_workflows": [
         "source-proof.yml",
         "packaged-platform-pr.yml"
       ],
       "required_events": [
-        "labeled",
-        "synchronize"
+        "labeled"
       ]
     },
     "actionlint": {

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -158,8 +158,8 @@ export function releaseClaimGraphDigest(graph) {
 
 export function validateReleaseClaimGraph(graph) {
   object(graph, "release claim graph");
-  if (graph.schema !== GRAPH_SCHEMA || graph.graph_version !== 1) {
-    fail(`release claim graph must use ${GRAPH_SCHEMA} graph_version 1`);
+  if (graph.schema !== GRAPH_SCHEMA || graph.graph_version !== 2) {
+    fail(`release claim graph must use ${GRAPH_SCHEMA} graph_version 2`);
   }
   nonEmptyText(graph.graph_id, "release claim graph.graph_id");
   const evidencePolicy = object(graph.evidence_policy, "release claim graph.evidence_policy");
@@ -357,6 +357,11 @@ export function validateReleaseClaimGraph(graph) {
   nonEmptyText(promotion.source_branch, "workflow_policy.promotion.source_branch");
   nonEmptyText(promotion.release_branch, "workflow_policy.promotion.release_branch");
   nonEmptyText(promotion.exact_sha_expression, "workflow_policy.promotion.exact_sha_expression");
+  nonEmptyText(promotion.proof_run_sha_expression, "workflow_policy.promotion.proof_run_sha_expression");
+  nonEmptyText(promotion.manual_pr_ref_hint, "workflow_policy.promotion.manual_pr_ref_hint");
+  nonEmptyText(promotion.source_cache_namespace, "workflow_policy.promotion.source_cache_namespace");
+  nonEmptyText(promotion.macos_source_cache_namespace, "workflow_policy.promotion.macos_source_cache_namespace");
+  nonEmptyText(promotion.packaged_cache_namespace, "workflow_policy.promotion.packaged_cache_namespace");
   stringArray(promotion.label_routed_workflows, "workflow_policy.promotion.label_routed_workflows", { nonEmpty: true });
   stringArray(promotion.required_events, "workflow_policy.promotion.required_events", { nonEmpty: true });
 

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -109,6 +109,12 @@ test("versioned claim graph has one deterministic digest and all declared contro
     ],
   );
   assert.ok(graph.claims.every((claim) => claim.prerequisite_checks.every(({ command }) => command.length > 0)));
+  assert.deepEqual(graph.workflow_policy.promotion.required_events, ["labeled"]);
+  assert.equal(graph.workflow_policy.promotion.proof_run_sha_expression, "${{ github.sha }}");
+  assert.equal(graph.workflow_policy.promotion.manual_pr_ref_hint, "--ref <same-repository PR head branch>");
+  assert.equal(graph.workflow_policy.promotion.source_cache_namespace, "source-proof-v2");
+  assert.equal(graph.workflow_policy.promotion.macos_source_cache_namespace, "macos-source-v2");
+  assert.equal(graph.workflow_policy.promotion.packaged_cache_namespace, "codestory-cli-native-v4");
 });
 
 test("positive fixture evaluates deterministically", () => {
@@ -152,6 +158,21 @@ test("graph rejects ambiguous dependencies and unstructured proof lanes", () => 
   malformedConstraint.evidence_types.find(({ id }) => id === "answer_quality")
     .identity_constraints.evaluation_contract = "unversioned";
   assert.throws(() => validateReleaseClaimGraph(malformedConstraint), /does not match versioned_contract/u);
+
+  for (const field of [
+    "proof_run_sha_expression",
+    "manual_pr_ref_hint",
+    "source_cache_namespace",
+    "macos_source_cache_namespace",
+    "packaged_cache_namespace",
+  ]) {
+    const incompletePromotion = structuredClone(graph);
+    delete incompletePromotion.workflow_policy.promotion[field];
+    assert.throws(
+      () => validateReleaseClaimGraph(incompletePromotion),
+      new RegExp(`workflow_policy\\.promotion\\.${field}`, "u"),
+    );
+  }
 });
 
 test("evaluation requires exact repository and source-tree identity", () => {

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "4f10bcec540fddaea2a962e7fccec222050bed470c596a4cb213ab2697e9492c",
+      "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

Closes #1230
Refs #1179

CodeStory's exact-head source and packaged-platform proof workflows could start from `synchronize`, group unrelated SHAs under PR-number concurrency, and restore caches before every trusted ref/Actions-SHA identity had converged. That allowed review, source proof, platform proof, and cache receipts to describe different commits.

This draft starts from `dev/codestory-next` at `ea3cd4d5dd4c1a7841aaa5bea3f06ab147530f4a` and binds the proof chain to head `0e4c9590bcb67d81acb3d1db56a9902f08987ddf`.

## Outcome

Evidence dispatch is label-only, fails before checkout/cache/expensive work when the live ref, expected SHA, and Actions SHA disagree, and uses versioned exact-SHA caches without fallback or failed/cancelled-run saves.

## What changed

- Removes `synchronize` evidence triggers from source and packaged-platform PR coordinators.
- Keys concurrency by actual Actions SHA plus proof mode, PR, and label identity.
- Resolves manual PR proof only when the live same-repository head ref, expected SHA, and `GITHUB_SHA` agree.
- Resolves integration proof only when `GITHUB_SHA` equals the live `dev/codestory-next` head.
- Moves source, macOS-source, and packaged-native caches to versioned exact-SHA keys with no restore prefix and save-after-success-on-miss guards.
- Advances the declarative release-claim graph to schema v2 and reattests its candidate/report fixtures.
- Updates workflow policy, hostile fixtures, tests, changelog, and testing guidance with the same contract.

## How to review

1. Inspect the event/manual resolver branches in `source-proof.yml` and `packaged-platform-pr.yml`; rejection must happen before checkout or cache access.
2. Check concurrency grouping for unrelated labels and old SHAs.
3. Follow exact-SHA cache keys and save guards through source, macOS-source, and packaged reusable proof.
4. Verify graph-v2 digest and candidate/report reattestation are derived from the same current claim graph.

## Verification

- `npm ci --ignore-scripts` — pass, 0 vulnerabilities
- `node scripts/codestory-release-claims.mjs validate --repo .` — pass; graph v2 digest `753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43`
- `node --test scripts/tests/codestory-release-claims.test.mjs scripts/tests/codestory-release-evidence-gate.test.mjs` — 30/30
- `node .github/scripts/check-workflow-policy.mjs` — pass
- `node --test .github/scripts/check-workflow-policy.test.mjs` — 230/230, including hostile wrong-ref/wrong-SHA, labeled-event drift, cache-save reordering/mixed-case cloning, raw resolver-body mutation, and source/platform/integration rejection
- `node --test .github/scripts/run-actionlint.test.mjs` — 3/3
- `node .github/scripts/run-actionlint.mjs` — pass; controlled-invalid fixture rejected
- `node .github/scripts/route-ci-proof.mjs --self-test` — pass
- `python3 .github/scripts/check-codestory-release.py --version 0.16.0` — pass
- `node .github/scripts/check-doc-links.mjs` — 75 files / 265 links
- `git diff --check` — pass

### Live exact-head dispatch

- Expected wrong-ref rejection: run `29652945646` failed in the resolver before checkout or reusable work because the Actions ref was not `codex/1230-exact-proof-identity-v2`.
- Trusted PR-ref source: run `29652959938` recorded head `0e4c9590bcb67d81acb3d1db56a9902f08987ddf`; resolver, complete workspace test, and all-target/all-feature lint passed.
- PR-ref platform handoff: run `29653516107` recorded the same head and its `route` job found the successful exact-head source run. Downstream package work did not establish platform proof: macOS exposed the open embedding-server activation blocker, Linux was dispatched without the frozen calibration inputs, and the unrelated repo-scale job was cancelled once the required identity handoff was retained.
- Independent exact-head review found no P0-P3 issue or merge blocker at `0e4c9590bcb67d81acb3d1db56a9902f08987ddf`.

## Risk or follow-up

- The live dispatch proves workflow/ref/run/cache identity only. It does not convert the downstream macOS activation failure or missing Linux calibration input into package, installed-runtime, server, or release evidence.
- #1221 retains the macOS per-user server qualification failure; the frozen calibration bundle remains live but was not consumed by this platform attempt.
- This draft does not run the full package/platform matrix, add expensive proof labels, or establish release readiness.
