### PR TITLE
[codex] require route proof for packet sufficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 - Project switching now preserves isolated per-project state across A/B/A MCP routing. Requests require an explicit project, and status remains observational instead of activating or repairing a repository.
 - `affected` now handles native path identity, renames, copies, stale evidence, and bounded results more accurately across Unix and Windows.
 - CLI JSON failures retain their runtime error codes and details across search, packet, activation, and retrieval indexing.
-- Route-tracing packets now require cited executable endpoints, ordered claims, and one matching directed call graph before reporting sufficient. Self-edges, unrelated graph neighborhoods, generic helpers, fixture prose, and wrong-kind symbols fail closed with bounded follow-up gaps.
+- Route-tracing packets now require cited executable endpoints in explicit question order plus one matching directed call graph before reporting sufficient. Self-edges, unrelated graph neighborhoods, generic helpers, fixture prose, and wrong-kind symbols fail closed with bounded follow-up gaps.
 - Rust 2024 sources, including `unsafe extern` blocks and let-chains, are now accepted. Dart direct-call extraction has been updated for the current grammar shape.
 - Linux ARM64 packages retain the portable runtime-loaded CPU backend alongside Vulkan. Windows packages use architecture-matched Vulkan components rather than mutable runner-image contents.
 - Updated `serde_with` to 3.21.0, removing the affected `KeyValueMap` panic advisory while preserving CodeStory's existing DTO encoding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 - Project switching now preserves isolated per-project state across A/B/A MCP routing. Requests require an explicit project, and status remains observational instead of activating or repairing a repository.
 - `affected` now handles native path identity, renames, copies, stale evidence, and bounded results more accurately across Unix and Windows.
 - CLI JSON failures retain their runtime error codes and details across search, packet, activation, and retrieval indexing.
+- Route-tracing packets now require cited executable endpoints, ordered claims, and one matching directed call graph before reporting sufficient. Self-edges, unrelated graph neighborhoods, generic helpers, fixture prose, and wrong-kind symbols fail closed with bounded follow-up gaps.
 - Rust 2024 sources, including `unsafe extern` blocks and let-chains, are now accepted. Dart direct-call extraction has been updated for the current grammar shape.
 - Linux ARM64 packages retain the portable runtime-loaded CPU backend alongside Vulkan. Windows packages use architecture-matched Vulkan components rather than mutable runner-image contents.
 - Updated `serde_with` to 3.21.0, removing the affected `KeyValueMap` panic advisory while preserving CodeStory's existing DTO encoding.

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -5645,6 +5645,12 @@ version = "0.11.20"
             text.contains(REPO_CONTENT_BOUNDARY_LINE),
             "stdio packet text should preserve the repo-content boundary: {text}"
         );
+        assert!(
+            text.contains(
+                "unsafe_to_claim: true - resolve gaps, open_next, or follow_up_commands before proof claims"
+            ),
+            "partial packet text must fail closed for proof claims: {text}"
+        );
         assert!(text.contains("gaps: none"), "{text}");
         assert!(text.len() <= STDIO_TEXT_MAX_BYTES, "{text}");
     }

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -9089,17 +9089,6 @@ mod tests {
                 "crates/indexer/src/references.rs",
             ),
             (
-                PacketTaskClassDto::RouteTracing,
-                "Trace how a request reaches the selected handler.",
-                vec![
-                    test_packet_citation("RouteDispatcher", "src/router/dispatch.rs", 0.9),
-                    test_packet_citation("RouteHandler", "src/router/handler.rs", 0.8),
-                    test_packet_citation("RouteRegression", "tests/route_regression.rs", 0.7),
-                ],
-                "`RouteHandler` handles route dispatch or handler ownership",
-                "src/router/handler.rs",
-            ),
-            (
                 PacketTaskClassDto::SymbolOwnership,
                 "Who owns workspace planning and graph state?",
                 vec![

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -119,7 +119,7 @@ fn assemble_packet_sufficiency_with_route_probes(
     let min_citations = packet_sufficiency_min_citations(task_class);
     let min_claims = packet_sufficiency_min_claims(task_class);
     let flow_context = PacketFlowContext::new(question, task_class);
-    let route_stages = packet_route_proof_stages(question);
+    let route_stages = packet_route_proof_stages(question, selected_probes);
     let sufficiency_claims = supported_claims
         .iter()
         .filter(|claim| {
@@ -479,11 +479,11 @@ fn packet_route_proof_assessment(
     RouteProofAssessment::not_required()
 }
 
-fn packet_route_proof_stages(question: &str) -> Vec<String> {
-    packet_route_stage_labels(question)
+fn packet_route_proof_stages(question: &str, selected_probes: &[String]) -> Vec<String> {
+    packet_route_stage_labels(question, selected_probes)
 }
 
-fn packet_route_stage_labels(question: &str) -> Vec<String> {
+fn packet_route_stage_labels(question: &str, selected_probes: &[String]) -> Vec<String> {
     let question = question.replace('→', "->");
     let spans = if question.contains("->") {
         question.split("->").map(str::to_string).collect()
@@ -503,12 +503,19 @@ fn packet_route_stage_labels(question: &str) -> Vec<String> {
                     .then_some(index)
             })
             .collect::<Vec<_>>();
-        if markers.is_empty()
-            || (from.is_none()
-                && packet_route_word_is(route_words[markers[0]], "to")
-                && !route_words[..markers[0]]
-                    .iter()
-                    .any(|word| packet_route_token_is_explicit_identifier(word)))
+        if markers.is_empty() {
+            return Vec::new();
+        }
+        if from.is_none()
+            && packet_route_word_is(route_words[markers[0]], "to")
+            && !route_words[..markers[0]]
+                .iter()
+                .any(|word| packet_route_token_is_explicit_identifier(word))
+            && packet_route_selected_probe_stage_label(
+                &route_words[..markers[0]].join(" "),
+                selected_probes,
+            )
+            .is_none()
         {
             return Vec::new();
         }
@@ -524,20 +531,23 @@ fn packet_route_stage_labels(question: &str) -> Vec<String> {
     spans
         .iter()
         .enumerate()
-        .map(|(index, span)| packet_route_stage_label(span, index == 0))
+        .map(|(index, span)| packet_route_stage_label(span, index == 0, selected_probes))
         .collect::<Option<Vec<_>>>()
         .unwrap_or_default()
 }
 
-fn packet_route_stage_label(span: &str, leading: bool) -> Option<String> {
+fn packet_route_stage_label(
+    span: &str,
+    leading: bool,
+    selected_probes: &[String],
+) -> Option<String> {
     let span = span.trim();
-    for quote in ['`', '\'', '"'] {
-        if let Some((_, rest)) = span.split_once(quote)
-            && let Some((label, _)) = rest.split_once(quote)
-            && !label.trim().is_empty()
-        {
-            return Some(label.trim().to_string());
-        }
+    let quoted_identifiers = packet_route_quoted_identifiers(span);
+    if quoted_identifiers.len() > 1 {
+        return None;
+    }
+    if let Some(label) = quoted_identifiers.into_iter().next() {
+        return Some(label);
     }
     let span = packet_route_clean_word(span);
     if span.is_empty() {
@@ -548,6 +558,9 @@ fn packet_route_stage_label(span: &str, leading: bool) -> Option<String> {
         if words.len() == 1 {
             return Some(packet_route_clean_word(words[0]).to_string());
         }
+        if let Some(label) = packet_route_selected_probe_stage_label(span, selected_probes) {
+            return Some(label);
+        }
         if let Some(identifier) = words
             .iter()
             .rev()
@@ -555,15 +568,48 @@ fn packet_route_stage_label(span: &str, leading: bool) -> Option<String> {
         {
             return Some(packet_route_clean_word(identifier).to_string());
         }
-        if words
-            .last()
-            .is_some_and(|word| packet_route_word_is(word, "main"))
-        {
-            return Some("main".to_string());
-        }
         return None;
     }
     Some(span.to_string())
+}
+
+fn packet_route_selected_probe_stage_label(
+    span: &str,
+    selected_probes: &[String],
+) -> Option<String> {
+    if packet_route_label_matches_selected_probe(span, selected_probes) {
+        return Some(span.to_string());
+    }
+    let words = span.split_whitespace().collect::<Vec<_>>();
+    for suffix_start in 1..words.len() {
+        let suffix = words[suffix_start..].join(" ");
+        if packet_route_label_matches_selected_probe(&suffix, selected_probes) {
+            return Some(suffix);
+        }
+    }
+    None
+}
+
+fn packet_route_quoted_identifiers(span: &str) -> Vec<String> {
+    let mut identifiers = Vec::new();
+    let mut active_quote = None;
+    let mut current = String::new();
+    for character in span.chars() {
+        if let Some(quote) = active_quote {
+            if character == quote {
+                if !current.trim().is_empty() {
+                    identifiers.push(current.trim().to_string());
+                }
+                active_quote = None;
+                current.clear();
+            } else {
+                current.push(character);
+            }
+        } else if matches!(character, '`' | '\'' | '"') {
+            active_quote = Some(character);
+        }
+    }
+    identifiers
 }
 
 fn packet_route_token_is_explicit_identifier(token: &str) -> bool {
@@ -601,8 +647,12 @@ fn packet_route_claim_node_ids(
         .filter(|citation| {
             packet_route_label_matches_citation(stage, citation)
                 || selected_probes.iter().any(|probe| {
-                    packet_route_labels_overlap(stage, probe)
-                        && packet_route_label_matches_citation(probe, citation)
+                    packet_route_probe_candidate_labels(probe)
+                        .iter()
+                        .any(|candidate| {
+                            packet_route_labels_overlap(stage, candidate)
+                                && packet_route_label_matches_citation(candidate, citation)
+                        })
                 })
         })
         .map(|citation| citation.node_id.0.clone())
@@ -624,6 +674,53 @@ fn packet_route_labels_overlap(left: &str, right: &str) -> bool {
     !left.is_empty() && left == packet_route_identifier_tokens(right)
 }
 
+fn packet_route_label_matches_selected_probe(label: &str, selected_probes: &[String]) -> bool {
+    selected_probes.iter().any(|probe| {
+        packet_route_probe_candidate_labels(probe)
+            .iter()
+            .any(|candidate| packet_route_labels_overlap(label, candidate))
+    })
+}
+
+fn packet_route_probe_candidate_labels(probe: &str) -> Vec<String> {
+    let bare = packet_route_clean_word(probe.trim()).trim();
+    if bare.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates = vec![bare.to_string()];
+    let words = bare.split_whitespace().collect::<Vec<_>>();
+    let file_scoped = words.len() > 1
+        && words[..words.len() - 1]
+            .iter()
+            .any(|word| word.contains(['/', '\\']));
+    let has_terminal_symbol = file_scoped
+        || words.len() == 1
+        || words
+            .last()
+            .is_some_and(|word| word.contains("::") || word.contains('#'));
+    let symbol = has_terminal_symbol.then(|| words.last().copied()).flatten();
+
+    if let Some(symbol) = symbol {
+        let symbol = packet_route_clean_word(symbol);
+        if !symbol.is_empty() && !candidates.iter().any(|candidate| candidate == symbol) {
+            candidates.push(symbol.to_string());
+        }
+        let has_symbol_scope = symbol.contains("::")
+            || symbol.contains('#')
+            || (!symbol.contains(['/', '\\']) && symbol.contains('.'));
+        if has_symbol_scope
+            && let Some(terminal) = symbol
+                .rsplit(['.', ':', '#', '/', '\\'])
+                .find(|part| !part.is_empty())
+            && !candidates.iter().any(|candidate| candidate == terminal)
+        {
+            candidates.push(terminal.to_string());
+        }
+    }
+    candidates
+}
+
 fn packet_route_identifier_tokens(identifier: &str) -> Vec<String> {
     let characters = identifier.chars().collect::<Vec<_>>();
     let mut tokens = Vec::new();
@@ -640,6 +737,7 @@ fn packet_route_identifier_tokens(identifier: &str) -> Vec<String> {
         let camel_boundary = character.is_ascii_uppercase()
             && previous.is_some_and(|previous| {
                 previous.is_ascii_lowercase()
+                    || previous.is_ascii_digit()
                     || (previous.is_ascii_uppercase()
                         && next.is_some_and(|next| next.is_ascii_lowercase()))
             });
@@ -3212,7 +3310,7 @@ mod tests {
     #[test]
     fn production_claims_prove_lowercase_arrow_route() {
         let (sufficiency, claims) = production_route_sufficiency(
-            "Trace main -> run",
+            "main -> run",
             &["main", "run", "RouteSupport"],
             &[("main", "run")],
         );
@@ -3226,6 +3324,92 @@ mod tests {
             claims
                 .iter()
                 .all(|claim| { claim.coverage_role.as_deref() != Some("route endpoint") })
+        );
+    }
+
+    #[test]
+    fn production_selected_probe_disambiguates_leading_lowercase_stage() {
+        let (sufficiency, claims) = production_route_sufficiency_with_probes(
+            "Trace start -> run",
+            &["start", "run", "RouteSupport"],
+            &[("start", "run")],
+            &["start".to_string()],
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "{sufficiency:?}"
+        );
+        assert!(
+            claims
+                .iter()
+                .all(|claim| claim.coverage_role.as_deref() != Some("route endpoint"))
+        );
+    }
+
+    #[test]
+    fn production_scoped_probes_disambiguate_leading_multiword_stage() {
+        for probe in ["router::dispatch_request", "src/router.rs dispatch_request"] {
+            let (sufficiency, claims) = production_route_sufficiency_with_probes(
+                "Trace request dispatch to CustomExit",
+                &["dispatch_request", "CustomExit", "RouteSupport"],
+                &[("dispatch_request", "CustomExit")],
+                &[probe.to_string()],
+            );
+
+            assert_eq!(
+                sufficiency.status,
+                PacketSufficiencyStatusDto::Sufficient,
+                "probe {probe} should bind the production route: {sufficiency:?}"
+            );
+            assert!(claims.iter().any(|claim| {
+                claim.citations.iter().any(|citation| {
+                    citation.display_name == "dispatch_request"
+                        && claim.coverage_role.as_deref() != Some("route endpoint")
+                })
+            }));
+        }
+    }
+
+    #[test]
+    fn production_digit_boundary_probe_disambiguates_leading_stage() {
+        let (sufficiency, _) = production_route_sufficiency_with_probes(
+            "Trace sha256 digest -> DigestExit",
+            &["sha256Digest", "DigestExit", "RouteSupport"],
+            &[("sha256Digest", "DigestExit")],
+            &["sha256Digest".to_string()],
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "{sufficiency:?}"
+        );
+    }
+
+    #[test]
+    fn production_multiple_quoted_leading_identifiers_fail_closed() {
+        let (sufficiency, _) = production_route_sufficiency_with_probes(
+            "Trace `EntryOne` and \"EntryTwo\" -> ExitStage",
+            &["EntryOne", "EntryTwo", "ExitStage"],
+            &[("EntryOne", "ExitStage")],
+            &["EntryOne".to_string()],
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Partial,
+            "{sufficiency:?}"
+        );
+        assert!(
+            sufficiency
+                .coverage_report
+                .as_ref()
+                .expect("route sufficiency should include a coverage report")
+                .missing
+                .contains(&"route order: unresolved endpoints".to_string()),
+            "{sufficiency:?}"
         );
     }
 
@@ -3577,7 +3761,7 @@ mod tests {
             "question checkpoints must define the route independently of probe order: {sufficiency:?}"
         );
         assert_eq!(
-            packet_route_proof_stages(question),
+            packet_route_proof_stages(question, &[]),
             [
                 "IndexingEntrypoint",
                 "FileDiscovery",
@@ -3594,6 +3778,15 @@ mod tests {
             "dispatch_request"
         ));
         assert!(packet_route_labels_overlap("URL session", "urlSession"));
+        assert!(packet_route_labels_overlap("sha256 digest", "sha256Digest"));
+        assert!(packet_route_label_matches_selected_probe(
+            "request dispatch",
+            &["router::dispatch_request".to_string()]
+        ));
+        assert!(packet_route_label_matches_selected_probe(
+            "request dispatch",
+            &["src/router.rs dispatch_request".to_string()]
+        ));
         assert!(!packet_route_labels_overlap(
             "request dispatch",
             "request_handler"

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -523,16 +523,14 @@ fn packet_route_stage_labels(question: &str) -> Vec<String> {
     };
     spans
         .iter()
-        .map(|span| packet_route_stage_label(span))
+        .enumerate()
+        .map(|(index, span)| packet_route_stage_label(span, index == 0))
         .collect::<Option<Vec<_>>>()
         .unwrap_or_default()
 }
 
-fn packet_route_stage_label(span: &str) -> Option<String> {
-    let span = packet_route_clean_word(span.trim());
-    if span.is_empty() {
-        return None;
-    }
+fn packet_route_stage_label(span: &str, leading: bool) -> Option<String> {
+    let span = span.trim();
     for quote in ['`', '\'', '"'] {
         if let Some((_, rest)) = span.split_once(quote)
             && let Some((label, _)) = rest.split_once(quote)
@@ -540,6 +538,30 @@ fn packet_route_stage_label(span: &str) -> Option<String> {
         {
             return Some(label.trim().to_string());
         }
+    }
+    let span = packet_route_clean_word(span);
+    if span.is_empty() {
+        return None;
+    }
+    if leading {
+        let words = span.split_whitespace().collect::<Vec<_>>();
+        if words.len() == 1 {
+            return Some(packet_route_clean_word(words[0]).to_string());
+        }
+        if let Some(identifier) = words
+            .iter()
+            .rev()
+            .find(|word| packet_route_token_is_explicit_identifier(word))
+        {
+            return Some(packet_route_clean_word(identifier).to_string());
+        }
+        if words
+            .last()
+            .is_some_and(|word| packet_route_word_is(word, "main"))
+        {
+            return Some("main".to_string());
+        }
+        return None;
     }
     Some(span.to_string())
 }
@@ -598,8 +620,39 @@ fn packet_route_claim_binds_stage(
 }
 
 fn packet_route_labels_overlap(left: &str, right: &str) -> bool {
-    let left = normalize_identifier(left);
-    !left.is_empty() && left == normalize_identifier(right)
+    let left = packet_route_identifier_tokens(left);
+    !left.is_empty() && left == packet_route_identifier_tokens(right)
+}
+
+fn packet_route_identifier_tokens(identifier: &str) -> Vec<String> {
+    let characters = identifier.chars().collect::<Vec<_>>();
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for (index, character) in characters.iter().copied().enumerate() {
+        if !character.is_ascii_alphanumeric() {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+        let previous = index.checked_sub(1).and_then(|index| characters.get(index));
+        let next = characters.get(index + 1);
+        let camel_boundary = character.is_ascii_uppercase()
+            && previous.is_some_and(|previous| {
+                previous.is_ascii_lowercase()
+                    || (previous.is_ascii_uppercase()
+                        && next.is_some_and(|next| next.is_ascii_lowercase()))
+            });
+        if camel_boundary && !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+        current.push(character.to_ascii_lowercase());
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens.sort();
+    tokens
 }
 
 fn packet_route_label_matches_citation(label: &str, citation: &AgentCitationDto) -> bool {
@@ -2861,14 +2914,24 @@ mod tests {
         names: &[&str],
         edges: &[(&str, &str)],
     ) -> (PacketSufficiencyDto, Vec<PacketClaimDto>) {
+        production_route_sufficiency_with_probes(question, names, edges, &[])
+    }
+
+    fn production_route_sufficiency_with_probes(
+        question: &str,
+        names: &[&str],
+        edges: &[(&str, &str)],
+        extra_probes: &[String],
+    ) -> (PacketSufficiencyDto, Vec<PacketClaimDto>) {
         let answer = route_answer(question, names, edges);
         let claims = packet_supported_claims(&answer);
-        let sufficiency = build_packet_sufficiency(
+        let sufficiency = build_packet_sufficiency_with_extra(
             Path::new("C:/workspace/project"),
             question,
             PacketTaskClassDto::RouteTracing,
             &answer,
             &budget_fixture(),
+            extra_probes,
         );
         (sufficiency, claims)
     }
@@ -3149,7 +3212,7 @@ mod tests {
     #[test]
     fn production_claims_prove_lowercase_arrow_route() {
         let (sufficiency, claims) = production_route_sufficiency(
-            "main -> run",
+            "Trace main -> run",
             &["main", "run", "RouteSupport"],
             &[("main", "run")],
         );
@@ -3168,15 +3231,16 @@ mod tests {
 
     #[test]
     fn production_source_evidence_proves_explicit_marker_route() {
-        let question = "CustomEntry through request dispatch to CustomExit";
-        let names = ["CustomEntry", "request dispatch", "CustomExit"];
-        let (sufficiency, claims) = production_route_sufficiency(
+        let question = "Trace CustomEntry through request dispatch to CustomExit";
+        let names = ["CustomEntry", "dispatch_request", "CustomExit"];
+        let (sufficiency, claims) = production_route_sufficiency_with_probes(
             question,
             &names,
             &[
-                ("CustomEntry", "request dispatch"),
-                ("request dispatch", "CustomExit"),
+                ("CustomEntry", "dispatch_request"),
+                ("dispatch_request", "CustomExit"),
             ],
+            &["dispatch_request".to_string()],
         );
 
         assert_eq!(
@@ -3194,6 +3258,36 @@ mod tests {
             claims
                 .iter()
                 .all(|claim| claim.coverage_role.as_deref() != Some("route endpoint"))
+        );
+    }
+
+    #[test]
+    fn production_unrelated_probe_does_not_alias_explicit_route_stage() {
+        let question = "Trace CustomEntry through request dispatch to CustomExit";
+        let (sufficiency, _) = production_route_sufficiency_with_probes(
+            question,
+            &["CustomEntry", "request_handler", "CustomExit"],
+            &[
+                ("CustomEntry", "request_handler"),
+                ("request_handler", "CustomExit"),
+            ],
+            &["request_handler".to_string()],
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Partial,
+            "{sufficiency:?}"
+        );
+        assert!(
+            sufficiency
+                .coverage_report
+                .as_ref()
+                .expect("route sufficiency should include a coverage report")
+                .missing
+                .iter()
+                .any(|missing| missing == "route endpoint: request dispatch"),
+            "{sufficiency:?}"
         );
     }
 
@@ -3491,6 +3585,23 @@ mod tests {
                 "StoragePersistence"
             ]
         );
+    }
+
+    #[test]
+    fn selected_probe_aliases_require_exact_identifier_token_multisets() {
+        assert!(packet_route_labels_overlap(
+            "request dispatch",
+            "dispatch_request"
+        ));
+        assert!(packet_route_labels_overlap("URL session", "urlSession"));
+        assert!(!packet_route_labels_overlap(
+            "request dispatch",
+            "request_handler"
+        ));
+        assert!(!packet_route_labels_overlap(
+            "request dispatch",
+            "dispatch_request_request"
+        ));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -7,8 +7,12 @@ use crate::agent::packet_flow_requirements::{
     CoverageMode, FlowRequirement, FlowRole, packet_flow_requirements_for_terms,
 };
 use crate::agent::packet_plan::packet_symbol_probe_queries;
-use crate::agent::packet_required_probes::packet_missing_sufficiency_probe_queries_with_extra;
-use crate::agent::packet_scoring::{normalize_identifier, packet_display_path};
+use crate::agent::packet_required_probes::{
+    packet_citation_satisfies_required_probe, packet_missing_sufficiency_probe_queries_with_extra,
+};
+use crate::agent::packet_scoring::{
+    normalize_identifier, packet_display_name_is_test_like, packet_display_path,
+};
 use crate::agent::packet_terms::{
     packet_probe_terms, packet_terms_indicate_form_validation_flow,
     packet_terms_indicate_html_css_template_structure_flow,
@@ -22,12 +26,12 @@ use crate::agent::packet_terms::{
     packet_terms_indicate_url_session_request_flow,
 };
 use codestory_contracts::api::{
-    AgentAnswerDto, AgentCitationDto, AgentRetrievalStepStatusDto, PacketBudgetDto,
-    PacketBudgetModeDto, PacketClaimDto, PacketCoverageReportDto, PacketEvidenceResolutionDto,
-    PacketEvidenceTierDto, PacketSidecarQueryDiagnosticDto, PacketSufficiencyDto,
-    PacketSufficiencyStatusDto, PacketTaskClassDto,
+    AgentAnswerDto, AgentCitationDto, AgentRetrievalStepStatusDto, EdgeKind, GraphArtifactDto,
+    NodeKind, PacketBudgetDto, PacketBudgetModeDto, PacketClaimDto, PacketCoverageReportDto,
+    PacketEvidenceResolutionDto, PacketEvidenceTierDto, PacketSidecarQueryDiagnosticDto,
+    PacketSufficiencyDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
 };
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::path::Path;
 
 pub(crate) const PACKET_MARKDOWN_TRUNCATION_SUFFIX: &str =
@@ -71,19 +75,30 @@ pub(crate) fn build_packet_sufficiency_with_extra(
         &supported_claims,
         extra_probes,
     );
-    assemble_packet_sufficiency(PacketSufficiencyInput {
-        project_root,
-        question,
-        task_class,
-        answer,
-        budget,
-        supported_claims,
-        missing_required_probe_queries,
-        targeted_follow_up_queries: packet_targeted_follow_up_queries(question, task_class),
-    })
+    assemble_packet_sufficiency_with_route_probes(
+        PacketSufficiencyInput {
+            project_root,
+            question,
+            task_class,
+            answer,
+            budget,
+            supported_claims,
+            missing_required_probe_queries,
+            targeted_follow_up_queries: packet_targeted_follow_up_queries(question, task_class),
+        },
+        extra_probes,
+    )
 }
 
+#[cfg(test)]
 fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSufficiencyDto {
+    assemble_packet_sufficiency_with_route_probes(input, &[])
+}
+
+fn assemble_packet_sufficiency_with_route_probes(
+    input: PacketSufficiencyInput<'_>,
+    selected_probes: &[String],
+) -> PacketSufficiencyDto {
     let PacketSufficiencyInput {
         project_root,
         question,
@@ -125,6 +140,14 @@ fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSuffi
     let missing_required_flow_requirements =
         packet_missing_required_flow_requirements(question, task_class, &sufficiency_claims);
     let has_required_flow_roles = missing_required_flow_requirements.is_empty();
+    let route_proof = packet_route_proof_assessment(
+        question,
+        task_class,
+        answer,
+        &sufficiency_claims,
+        &flow_context,
+        selected_probes,
+    );
     let blocking_missing_probe_queries = packet_blocking_missing_probe_queries(
         question,
         task_class,
@@ -153,6 +176,7 @@ fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSuffi
         has_minimum_claims,
         has_minimum_claim_families,
         has_required_flow_roles,
+        has_route_proof: route_proof.complete,
         has_sufficiency_blocking_budget_omission,
         missing_required_probe_queries: &blocking_missing_probe_queries,
         unresolved_sidecar_queries: &blocking_unresolved_sidecar_queries,
@@ -172,15 +196,24 @@ fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSuffi
         has_minimum_claims,
         has_minimum_claim_families,
         has_required_flow_roles,
+        &route_proof,
         has_sufficiency_blocking_budget_omission,
         &blocking_missing_probe_queries,
         &missing_required_flow_requirements,
         &blocking_unresolved_sidecar_queries,
     );
-    let blocking_follow_up_probe_queries = packet_blocking_follow_up_probe_queries(
+    let mut blocking_follow_up_probe_queries = packet_blocking_follow_up_probe_queries(
         &blocking_missing_probe_queries,
         &blocking_unresolved_sidecar_queries,
     );
+    if blocking_follow_up_probe_queries.is_empty() {
+        for query in &missing_required_probe_queries {
+            push_unique_term(&mut blocking_follow_up_probe_queries, query);
+        }
+    }
+    for query in &route_proof.follow_up_queries {
+        push_unique_term(&mut blocking_follow_up_probe_queries, query);
+    }
     let follow_up_probe_queries = if blocking_follow_up_probe_queries.is_empty() {
         &missing_required_probe_queries
     } else {
@@ -195,15 +228,16 @@ fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSuffi
         targeted_follow_up_queries,
         packet_full_retrieval_available(answer),
     );
-    let coverage_report = packet_coverage_report(
-        &supported_claims,
-        &sufficiency_claims,
-        &flow_context,
-        &missing_required_flow_requirements,
-        &unresolved_sidecar_queries,
+    let coverage_report = packet_coverage_report(PacketCoverageReportInput {
+        supported_claims: &supported_claims,
+        sufficiency_claims: &sufficiency_claims,
+        flow_context: &flow_context,
+        missing_required_flow_requirements: &missing_required_flow_requirements,
+        route_proof: &route_proof,
+        unresolved_sidecar_queries: &unresolved_sidecar_queries,
         budget,
         has_sufficiency_blocking_budget_omission,
-    );
+    });
     let open_next = follow_up_commands.clone();
     let avoid_opening_paths = answer
         .citations
@@ -264,6 +298,7 @@ struct PacketSufficiencyStatusInput<'a> {
     has_minimum_claims: bool,
     has_minimum_claim_families: bool,
     has_required_flow_roles: bool,
+    has_route_proof: bool,
     has_sufficiency_blocking_budget_omission: bool,
     missing_required_probe_queries: &'a [String],
     unresolved_sidecar_queries: &'a [String],
@@ -279,6 +314,7 @@ fn packet_sufficiency_status(
         || !input.has_minimum_claims
         || !input.has_minimum_claim_families
         || !input.has_required_flow_roles
+        || !input.has_route_proof
         || !input.missing_required_probe_queries.is_empty()
         || !input.unresolved_sidecar_queries.is_empty()
         || input.has_sufficiency_blocking_budget_omission
@@ -288,6 +324,550 @@ fn packet_sufficiency_status(
     } else {
         PacketSufficiencyStatusDto::Sufficient
     }
+}
+
+const MAX_ROUTE_PROOF_STAGES: usize = 6;
+const MAX_ROUTE_PROOF_PATHS: usize = 64;
+
+#[derive(Debug, Clone)]
+enum RouteStageMatcher {
+    Requirement(FlowRequirement),
+    Probe(String),
+}
+
+#[derive(Debug, Clone)]
+struct RouteStage {
+    label: String,
+    matcher: RouteStageMatcher,
+}
+
+#[derive(Debug, Clone)]
+struct RouteStageEvidence {
+    label: String,
+    node_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RouteProofAssessment {
+    complete: bool,
+    stage_count: usize,
+    missing_endpoints: Vec<String>,
+    missing_transitions: Vec<String>,
+    claim_order_mismatch: bool,
+    execution_graph_missing: bool,
+    fragmented_execution_graph: bool,
+    follow_up_queries: Vec<String>,
+}
+
+impl RouteProofAssessment {
+    fn not_required() -> Self {
+        Self {
+            complete: true,
+            stage_count: 0,
+            missing_endpoints: Vec::new(),
+            missing_transitions: Vec::new(),
+            claim_order_mismatch: false,
+            execution_graph_missing: false,
+            fragmented_execution_graph: false,
+            follow_up_queries: Vec::new(),
+        }
+    }
+
+    fn gaps(&self) -> Vec<String> {
+        let mut gaps = Vec::new();
+        if self.stage_count < 2 {
+            gaps.push(
+                "RouteTracing packet could not derive two requested route endpoints from the question and selected probes."
+                    .to_string(),
+            );
+        }
+        if !self.missing_endpoints.is_empty() {
+            gaps.push(format!(
+                "RouteTracing packet missed relevant cited route endpoint(s): {}.",
+                self.missing_endpoints.join(", ")
+            ));
+        }
+        if self.claim_order_mismatch {
+            gaps.push(
+                "RouteTracing claims did not describe the requested endpoints in route order."
+                    .to_string(),
+            );
+        }
+        if self.execution_graph_missing {
+            gaps.push(
+                "RouteTracing packet did not include a directed execution graph for the cited route endpoints."
+                    .to_string(),
+            );
+        }
+        if !self.missing_transitions.is_empty() {
+            gaps.push(format!(
+                "RouteTracing execution graph missed ordered transition(s): {}.",
+                self.missing_transitions.join(", ")
+            ));
+        }
+        if self.fragmented_execution_graph {
+            gaps.push(
+                "RouteTracing evidence appeared only in separate graph neighborhoods; no single execution graph represented the claimed ordered route."
+                    .to_string(),
+            );
+        }
+        gaps
+    }
+}
+
+fn packet_route_proof_assessment(
+    question: &str,
+    task_class: PacketTaskClassDto,
+    answer: &AgentAnswerDto,
+    claims: &[PacketClaimDto],
+    flow_context: &PacketFlowContext,
+    selected_probes: &[String],
+) -> RouteProofAssessment {
+    if task_class != PacketTaskClassDto::RouteTracing {
+        return RouteProofAssessment::not_required();
+    }
+
+    let stages = packet_route_proof_stages(question, flow_context, selected_probes);
+    let mut assessment = RouteProofAssessment {
+        complete: false,
+        stage_count: stages.len(),
+        missing_endpoints: Vec::new(),
+        missing_transitions: Vec::new(),
+        claim_order_mismatch: false,
+        execution_graph_missing: !packet_has_execution_graph(answer),
+        fragmented_execution_graph: false,
+        follow_up_queries: Vec::new(),
+    };
+    if stages.len() < 2 {
+        assessment.follow_up_queries = packet_route_fallback_queries(question, selected_probes);
+        return assessment;
+    }
+
+    let mut stage_evidence = Vec::new();
+    let mut previous_claim_index = None;
+    for stage in &stages {
+        let matching_claims = claims
+            .iter()
+            .enumerate()
+            .filter_map(|(index, claim)| {
+                packet_route_claim_node_ids(stage, claim, flow_context)
+                    .filter(|node_ids| !node_ids.is_empty())
+                    .map(|node_ids| (index, node_ids))
+            })
+            .collect::<Vec<_>>();
+        let ordered_match = matching_claims
+            .iter()
+            .find(|(index, _)| previous_claim_index.is_none_or(|previous| *index > previous));
+        if let Some((index, node_ids)) = ordered_match {
+            previous_claim_index = Some(*index);
+            stage_evidence.push(RouteStageEvidence {
+                label: stage.label.clone(),
+                node_ids: node_ids.clone(),
+            });
+            continue;
+        }
+        if matching_claims.is_empty() {
+            assessment.missing_endpoints.push(stage.label.clone());
+        } else {
+            assessment.claim_order_mismatch = true;
+        }
+        push_unique_term(&mut assessment.follow_up_queries, &stage.label);
+    }
+
+    if !assessment.missing_endpoints.is_empty() || assessment.claim_order_mismatch {
+        return assessment;
+    }
+
+    assessment.missing_transitions = packet_missing_route_transitions(answer, &stage_evidence);
+    for transition in &assessment.missing_transitions {
+        if let Some((_, target)) = transition.split_once(" -> ") {
+            push_unique_term(&mut assessment.follow_up_queries, target);
+        }
+    }
+    let has_complete_graph = packet_has_complete_route_graph(answer, &stage_evidence);
+    assessment.fragmented_execution_graph = !has_complete_graph
+        && assessment.missing_transitions.is_empty()
+        && !assessment.execution_graph_missing;
+    assessment.complete = has_complete_graph;
+    assessment
+}
+
+fn packet_route_proof_stages(
+    question: &str,
+    flow_context: &PacketFlowContext,
+    selected_probes: &[String],
+) -> Vec<RouteStage> {
+    let mut requirements = flow_context
+        .requirements
+        .iter()
+        .copied()
+        .filter(flow_requirement_blocks_sufficiency)
+        .enumerate()
+        .collect::<Vec<_>>();
+    requirements.sort_by_key(|(index, requirement)| {
+        (
+            packet_route_requirement_position(question, requirement).unwrap_or(usize::MAX),
+            *index,
+        )
+    });
+    let mut stages = Vec::new();
+    for (_, requirement) in requirements {
+        if stages.iter().any(|stage: &RouteStage| {
+            matches!(
+                &stage.matcher,
+                RouteStageMatcher::Requirement(existing)
+                    if packet_route_requirements_overlap(existing, &requirement)
+            )
+        }) {
+            continue;
+        }
+        stages.push(RouteStage {
+            label: requirement
+                .query_seeds
+                .first()
+                .copied()
+                .unwrap_or(requirement.id)
+                .to_string(),
+            matcher: RouteStageMatcher::Requirement(requirement),
+        });
+    }
+
+    if stages.len() < 2 {
+        for probe in selected_probes {
+            push_route_probe_stage(&mut stages, probe);
+            if stages.len() >= MAX_ROUTE_PROOF_STAGES {
+                break;
+            }
+        }
+    }
+    if stages.len() < 2 {
+        for term in packet_probe_terms(question) {
+            if packet_route_question_term_is_stage(&term) {
+                push_route_probe_stage(&mut stages, &term);
+            }
+            if stages.len() >= MAX_ROUTE_PROOF_STAGES {
+                break;
+            }
+        }
+    }
+    stages.truncate(MAX_ROUTE_PROOF_STAGES);
+    stages
+}
+
+fn packet_route_requirements_overlap(left: &FlowRequirement, right: &FlowRequirement) -> bool {
+    left.query_seeds.iter().any(|left_seed| {
+        let normalized_left = normalize_identifier(left_seed);
+        right
+            .query_seeds
+            .iter()
+            .any(|right_seed| normalize_identifier(right_seed) == normalized_left)
+    })
+}
+
+fn packet_route_requirement_position(
+    question: &str,
+    requirement: &FlowRequirement,
+) -> Option<usize> {
+    let normalized_question = normalize_identifier(question);
+    requirement
+        .query_seeds
+        .iter()
+        .filter_map(|seed| {
+            let positions = packet_probe_terms(seed)
+                .into_iter()
+                .filter_map(|term| normalized_question.find(&normalize_identifier(&term)))
+                .collect::<Vec<_>>();
+            (!positions.is_empty()).then(|| positions.into_iter().max().unwrap_or_default())
+        })
+        .min()
+        .or_else(|| {
+            packet_probe_terms(requirement.id)
+                .into_iter()
+                .filter_map(|term| normalized_question.find(&normalize_identifier(&term)))
+                .max()
+        })
+}
+
+fn push_route_probe_stage(stages: &mut Vec<RouteStage>, probe: &str) {
+    let probe = probe.trim();
+    let normalized = normalize_identifier(probe);
+    if probe.len() < 3
+        || normalized.is_empty()
+        || stages
+            .iter()
+            .any(|stage| normalize_identifier(&stage.label) == normalized)
+    {
+        return;
+    }
+    stages.push(RouteStage {
+        label: probe.to_string(),
+        matcher: RouteStageMatcher::Probe(probe.to_string()),
+    });
+}
+
+fn packet_route_question_term_is_stage(term: &str) -> bool {
+    !matches!(
+        normalize_identifier(term).as_str(),
+        "trace"
+            | "tracing"
+            | "route"
+            | "routes"
+            | "routing"
+            | "flow"
+            | "path"
+            | "paths"
+            | "reach"
+            | "reaches"
+            | "reaching"
+            | "selected"
+            | "through"
+            | "then"
+            | "complete"
+    )
+}
+
+fn packet_route_fallback_queries(question: &str, selected_probes: &[String]) -> Vec<String> {
+    let mut queries = Vec::new();
+    for probe in selected_probes {
+        push_unique_term(&mut queries, probe);
+    }
+    if queries.len() < 2 {
+        for term in packet_probe_terms(question) {
+            if packet_route_question_term_is_stage(&term) {
+                push_unique_term(&mut queries, &term);
+            }
+            if queries.len() >= MAX_ROUTE_PROOF_STAGES {
+                break;
+            }
+        }
+    }
+    queries.truncate(MAX_ROUTE_PROOF_STAGES);
+    queries
+}
+
+fn packet_route_claim_node_ids(
+    stage: &RouteStage,
+    claim: &PacketClaimDto,
+    flow_context: &PacketFlowContext,
+) -> Option<Vec<String>> {
+    let claim_matches = match &stage.matcher {
+        RouteStageMatcher::Requirement(requirement) => {
+            flow_context.claim_satisfies_requirement(claim, requirement, true)
+        }
+        RouteStageMatcher::Probe(probe) => packet_route_probe_matches_claim(probe, claim),
+    };
+    if !claim_matches || packet_claim_is_generic_navigation_or_source_evidence(claim) {
+        return None;
+    }
+    let mut node_ids = claim
+        .citations
+        .iter()
+        .filter(|citation| packet_route_citation_is_endpoint(citation))
+        .filter(|citation| match &stage.matcher {
+            RouteStageMatcher::Requirement(_) => true,
+            RouteStageMatcher::Probe(probe) => {
+                packet_citation_satisfies_required_probe(probe, citation)
+                    || packet_route_probe_matches_text(probe, &claim.claim)
+                    || packet_route_probe_matches_text(probe, &citation.display_name)
+            }
+        })
+        .map(|citation| citation.node_id.0.clone())
+        .collect::<Vec<_>>();
+    node_ids.sort();
+    node_ids.dedup();
+    Some(node_ids)
+}
+
+fn packet_route_probe_matches_claim(probe: &str, claim: &PacketClaimDto) -> bool {
+    packet_route_probe_matches_text(probe, &claim.claim)
+        || claim
+            .citations
+            .iter()
+            .any(|citation| packet_citation_satisfies_required_probe(probe, citation))
+}
+
+fn packet_route_probe_matches_text(probe: &str, text: &str) -> bool {
+    let normalized_probe = normalize_identifier(probe);
+    let normalized_text = normalize_identifier(text);
+    let route_terms = packet_probe_terms(probe)
+        .into_iter()
+        .filter(|term| packet_route_question_term_is_stage(term))
+        .collect::<Vec<_>>();
+    !normalized_probe.is_empty()
+        && (normalized_text.contains(&normalized_probe)
+            || (!route_terms.is_empty()
+                && route_terms
+                    .iter()
+                    .all(|term| normalized_text.contains(&normalize_identifier(term)))))
+}
+
+fn packet_route_citation_is_endpoint(citation: &AgentCitationDto) -> bool {
+    if !citation_sufficiency_eligible(citation)
+        || !matches!(
+            citation.kind,
+            NodeKind::FUNCTION | NodeKind::METHOD | NodeKind::MACRO
+        )
+        || packet_display_name_is_test_like(&citation.display_name)
+    {
+        return false;
+    }
+    let Some(path) = citation.file_path.as_deref() else {
+        return false;
+    };
+    if crate::retrieval_file_role_from_path(path) != crate::RetrievalFileRole::Source {
+        return false;
+    }
+    let terminal = citation
+        .display_name
+        .rsplit(['.', ':', '#'])
+        .next()
+        .map(normalize_identifier)
+        .unwrap_or_default();
+    !matches!(
+        terminal.as_str(),
+        "helper" | "helpers" | "util" | "utils" | "utility" | "generichelper"
+    )
+}
+
+fn packet_has_execution_graph(answer: &AgentAnswerDto) -> bool {
+    answer.graphs.iter().any(|artifact| match artifact {
+        GraphArtifactDto::Uml { graph, .. } => graph
+            .edges
+            .iter()
+            .any(|edge| edge.kind == EdgeKind::CALL && edge.source != edge.target),
+        GraphArtifactDto::Mermaid { .. } => false,
+    })
+}
+
+fn packet_has_complete_route_graph(answer: &AgentAnswerDto, stages: &[RouteStageEvidence]) -> bool {
+    answer.graphs.iter().any(|artifact| match artifact {
+        GraphArtifactDto::Uml { graph, .. } => packet_graph_contains_route(graph, stages),
+        GraphArtifactDto::Mermaid { .. } => false,
+    })
+}
+
+fn packet_graph_contains_route(
+    graph: &codestory_contracts::api::GraphResponse,
+    stages: &[RouteStageEvidence],
+) -> bool {
+    let graph_nodes = graph
+        .nodes
+        .iter()
+        .map(|node| node.id.0.as_str())
+        .collect::<HashSet<_>>();
+    let adjacency = packet_execution_adjacency(graph);
+    let mut paths = stages
+        .first()
+        .into_iter()
+        .flat_map(|stage| &stage.node_ids)
+        .filter(|node_id| graph_nodes.contains(node_id.as_str()))
+        .map(|node_id| vec![node_id.clone()])
+        .collect::<Vec<_>>();
+    for stage in stages.iter().skip(1) {
+        let mut next_paths = Vec::new();
+        for path in &paths {
+            let Some(source) = path.last() else {
+                continue;
+            };
+            for target in &stage.node_ids {
+                if path.contains(target)
+                    || !graph_nodes.contains(target.as_str())
+                    || !packet_execution_path_exists(&adjacency, source, target)
+                {
+                    continue;
+                }
+                let mut next = path.clone();
+                next.push(target.clone());
+                next_paths.push(next);
+                if next_paths.len() >= MAX_ROUTE_PROOF_PATHS {
+                    break;
+                }
+            }
+            if next_paths.len() >= MAX_ROUTE_PROOF_PATHS {
+                break;
+            }
+        }
+        paths = next_paths;
+        if paths.is_empty() {
+            return false;
+        }
+    }
+    !paths.is_empty()
+}
+
+fn packet_missing_route_transitions(
+    answer: &AgentAnswerDto,
+    stages: &[RouteStageEvidence],
+) -> Vec<String> {
+    stages
+        .windows(2)
+        .filter_map(|pair| {
+            let [source, target] = pair else {
+                return None;
+            };
+            let found = answer.graphs.iter().any(|artifact| match artifact {
+                GraphArtifactDto::Uml { graph, .. } => {
+                    let graph_nodes = graph
+                        .nodes
+                        .iter()
+                        .map(|node| node.id.0.as_str())
+                        .collect::<HashSet<_>>();
+                    let adjacency = packet_execution_adjacency(graph);
+                    source.node_ids.iter().any(|source_id| {
+                        graph_nodes.contains(source_id.as_str())
+                            && target.node_ids.iter().any(|target_id| {
+                                graph_nodes.contains(target_id.as_str())
+                                    && source_id != target_id
+                                    && packet_execution_path_exists(
+                                        &adjacency, source_id, target_id,
+                                    )
+                            })
+                    })
+                }
+                GraphArtifactDto::Mermaid { .. } => false,
+            });
+            (!found).then(|| format!("{} -> {}", source.label, target.label))
+        })
+        .collect()
+}
+
+fn packet_execution_adjacency(
+    graph: &codestory_contracts::api::GraphResponse,
+) -> HashMap<String, Vec<String>> {
+    let mut adjacency = HashMap::<String, Vec<String>>::new();
+    for edge in &graph.edges {
+        if edge.kind != EdgeKind::CALL || edge.source == edge.target {
+            continue;
+        }
+        adjacency
+            .entry(edge.source.0.clone())
+            .or_default()
+            .push(edge.target.0.clone());
+    }
+    adjacency
+}
+
+fn packet_execution_path_exists(
+    adjacency: &HashMap<String, Vec<String>>,
+    source: &str,
+    target: &str,
+) -> bool {
+    if source == target {
+        return false;
+    }
+    let mut queue = VecDeque::from([source.to_string()]);
+    let mut visited = HashSet::from([source.to_string()]);
+    while let Some(current) = queue.pop_front() {
+        for next in adjacency.get(&current).into_iter().flatten() {
+            if next == target {
+                return true;
+            }
+            if visited.insert(next.clone()) {
+                queue.push_back(next.clone());
+            }
+        }
+    }
+    false
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -305,6 +885,7 @@ fn packet_sufficiency_gaps(
     has_minimum_claims: bool,
     has_minimum_claim_families: bool,
     has_required_flow_roles: bool,
+    route_proof: &RouteProofAssessment,
     has_sufficiency_blocking_budget_omission: bool,
     missing_required_probe_queries: &[String],
     missing_required_flow_requirements: &[FlowRequirement],
@@ -351,6 +932,9 @@ fn packet_sufficiency_gaps(
             "{:?} packet missed required structural coverage: {}.",
             task_class, missing_labels
         ));
+    }
+    if task_class == PacketTaskClassDto::RouteTracing && !route_proof.complete {
+        gaps.extend(route_proof.gaps());
     }
     if !missing_required_probe_queries.is_empty() {
         gaps.push(format!(
@@ -866,15 +1450,28 @@ fn packet_role_label_is_generic_source_evidence(role: &str) -> bool {
     normalize_identifier(role) == "sourceevidence"
 }
 
-fn packet_coverage_report(
-    supported_claims: &[PacketClaimDto],
-    sufficiency_claims: &[PacketClaimDto],
-    flow_context: &PacketFlowContext,
-    missing_required_flow_requirements: &[FlowRequirement],
-    unresolved_sidecar_queries: &[String],
-    budget: &PacketBudgetDto,
+struct PacketCoverageReportInput<'a> {
+    supported_claims: &'a [PacketClaimDto],
+    sufficiency_claims: &'a [PacketClaimDto],
+    flow_context: &'a PacketFlowContext,
+    missing_required_flow_requirements: &'a [FlowRequirement],
+    route_proof: &'a RouteProofAssessment,
+    unresolved_sidecar_queries: &'a [String],
+    budget: &'a PacketBudgetDto,
     has_sufficiency_blocking_budget_omission: bool,
-) -> PacketCoverageReportDto {
+}
+
+fn packet_coverage_report(input: PacketCoverageReportInput<'_>) -> PacketCoverageReportDto {
+    let PacketCoverageReportInput {
+        supported_claims,
+        sufficiency_claims,
+        flow_context,
+        missing_required_flow_requirements,
+        route_proof,
+        unresolved_sidecar_queries,
+        budget,
+        has_sufficiency_blocking_budget_omission,
+    } = input;
     let covered = sufficiency_claims
         .iter()
         .filter_map(packet_claim_coverage_label)
@@ -899,12 +1496,24 @@ fn packet_coverage_report(
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
-    let missing = missing_required_flow_requirements
+    let mut missing = missing_required_flow_requirements
         .iter()
         .map(|requirement| requirement.id.to_string())
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
+    for endpoint in &route_proof.missing_endpoints {
+        push_unique_term(&mut missing, &format!("route endpoint: {endpoint}"));
+    }
+    for transition in &route_proof.missing_transitions {
+        push_unique_term(&mut missing, &format!("route transition: {transition}"));
+    }
+    if route_proof.claim_order_mismatch {
+        push_unique_term(&mut missing, "route claim order");
+    }
+    if route_proof.execution_graph_missing || route_proof.fragmented_execution_graph {
+        push_unique_term(&mut missing, "route execution graph");
+    }
     let budget_omitted = if has_sufficiency_blocking_budget_omission {
         budget.omitted_sections.clone()
     } else {
@@ -2193,10 +2802,11 @@ mod tests {
     use super::*;
     use codestory_contracts::api::{
         AgentAnswerDto, AgentCitationDto, AgentResponseBlockDto, AgentResponseSectionDto,
-        AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, NodeId,
-        NodeKind, PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetUsageDto,
-        PacketEvidenceResolutionDto, PacketEvidenceTierDto, PacketSidecarQueryDiagnosticDto,
-        RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHitOrigin,
+        AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, EdgeId,
+        GraphArtifactDto, GraphEdgeDto, GraphNodeDto, GraphResponse, NodeId, NodeKind,
+        PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetUsageDto, PacketEvidenceResolutionDto,
+        PacketEvidenceTierDto, PacketSidecarQueryDiagnosticDto, RetrievalScoreBreakdownDto,
+        RetrievalShadowDto, SearchHitOrigin,
     };
     use std::path::Path;
 
@@ -2304,6 +2914,90 @@ mod tests {
                 retrieval_shadow: None,
             },
         }
+    }
+
+    fn route_graph_node(id: &str) -> GraphNodeDto {
+        GraphNodeDto {
+            id: NodeId(id.to_string()),
+            label: id.to_string(),
+            kind: NodeKind::FUNCTION,
+            depth: 1,
+            label_policy: None,
+            badge_visible_members: None,
+            badge_total_members: None,
+            merged_symbol_examples: Vec::new(),
+            file_path: Some(format!("src/{id}.rs")),
+            qualified_name: None,
+            member_access: None,
+        }
+    }
+
+    fn route_graph_edge(id: &str, source: &str, target: &str) -> GraphEdgeDto {
+        GraphEdgeDto {
+            id: EdgeId(id.to_string()),
+            source: NodeId(source.to_string()),
+            target: NodeId(target.to_string()),
+            kind: EdgeKind::CALL,
+            confidence: Some(1.0),
+            certainty: Some("certain".to_string()),
+            callsite_identity: None,
+            candidate_targets: Vec::new(),
+        }
+    }
+
+    fn route_graph(id: &str, nodes: &[&str], edges: &[(&str, &str)]) -> GraphArtifactDto {
+        GraphArtifactDto::Uml {
+            id: id.to_string(),
+            title: "Execution Route".to_string(),
+            graph: GraphResponse {
+                center_id: NodeId(nodes.first().copied().unwrap_or("route").to_string()),
+                nodes: nodes.iter().map(|node| route_graph_node(node)).collect(),
+                edges: edges
+                    .iter()
+                    .enumerate()
+                    .map(|(index, (source, target))| {
+                        route_graph_edge(&format!("edge-{index}"), source, target)
+                    })
+                    .collect(),
+                truncated: false,
+                omitted_edge_count: 0,
+                canonical_layout: None,
+            },
+        }
+    }
+
+    fn route_claim(name: &str) -> PacketClaimDto {
+        cited_claim(
+            &format!("`{name}` is a requested route endpoint and calls into downstream work."),
+            Some("route endpoint"),
+            cited_anchor(name),
+            Some(true),
+        )
+    }
+
+    fn route_answer(question: &str, names: &[&str], edges: &[(&str, &str)]) -> AgentAnswerDto {
+        let mut answer = answer_fixture(question);
+        answer.citations = names.iter().map(|name| cited_anchor(name)).collect();
+        answer.graphs = vec![route_graph("route", names, edges)];
+        answer
+    }
+
+    fn route_sufficiency(
+        question: &str,
+        answer: &AgentAnswerDto,
+        budget: &PacketBudgetDto,
+        claims: Vec<PacketClaimDto>,
+    ) -> PacketSufficiencyDto {
+        assemble_packet_sufficiency(PacketSufficiencyInput {
+            project_root: Path::new("C:/workspace/project"),
+            question,
+            task_class: PacketTaskClassDto::RouteTracing,
+            answer,
+            budget,
+            supported_claims: claims,
+            missing_required_probe_queries: Vec::new(),
+            targeted_follow_up_queries: Vec::new(),
+        })
     }
 
     fn mark_full_retrieval_unavailable(answer: &mut AgentAnswerDto) {
@@ -2417,6 +3111,281 @@ mod tests {
             question.replace('\'', "''")
         ));
         budget
+    }
+
+    #[test]
+    fn route_proof_rejects_wrong_task_types_helpers_fixture_prose_and_self_edges() {
+        let question = "Trace how RequestOwner reaches ValidationGate.";
+        let mut answer = answer_fixture(question);
+        let mut wrong_task = cited_anchor("RequestOwner");
+        wrong_task.kind = NodeKind::ENUM_CONSTANT;
+        let generic_helper = cited_anchor("helper");
+        let mut fixture = cited_anchor("FixtureRoute");
+        fixture.file_path = Some("tests/fixtures/route.md".to_string());
+        answer.citations = vec![wrong_task.clone(), generic_helper.clone(), fixture.clone()];
+        answer.graphs = vec![route_graph("self", &["helper"], &[("helper", "helper")])];
+        let claims = vec![
+            cited_claim(
+                "RequestOwner starts the requested route.",
+                None,
+                wrong_task,
+                Some(true),
+            ),
+            cited_claim(
+                "ValidationGate completes the requested route.",
+                Some("terminal_boundary"),
+                generic_helper,
+                Some(true),
+            ),
+            cited_claim(
+                "Fixture prose describes the expected RequestOwner to ValidationGate path.",
+                Some("route endpoint"),
+                fixture,
+                Some(true),
+            ),
+        ];
+
+        let sufficiency = route_sufficiency(question, &answer, &budget_fixture(), claims);
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains("route endpoint"))
+        );
+        assert!(
+            sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains("execution graph"))
+        );
+        assert!(!sufficiency.follow_up_commands.is_empty());
+    }
+
+    #[test]
+    fn retained_false_safe_packet_shapes_fail_closed_without_route_proof() {
+        let retained_shapes = [
+            (
+                "ask-1784390162944430000",
+                "Identify ownership and validation gates for the complete v0.16 program.",
+            ),
+            (
+                "ask-1784391431801551000",
+                "Where is packet sufficiency for RouteTracing computed, how are selected probes, citations, claims, and execution graphs evaluated, and which tests cover false sufficient routes versus positive compact, standard, and deep route packets?",
+            ),
+        ];
+
+        for (packet_id, question) in retained_shapes {
+            let mut answer = answer_fixture(question);
+            answer.answer_id = packet_id.to_string();
+            mark_full_retrieval_available(&mut answer);
+            let mut task_enum = cited_anchor("RouteTracing");
+            task_enum.kind = NodeKind::ENUM_CONSTANT;
+            let mut evidence_enum = cited_anchor("PacketEvidenceRole");
+            evidence_enum.kind = NodeKind::ENUM;
+            let mut storage_type = cited_anchor("Storage");
+            storage_type.kind = NodeKind::STRUCT;
+            let mut generic_probe = cited_anchor("probe");
+            generic_probe.kind = NodeKind::VARIABLE;
+            let eval_helper = cited_anchor("eval_probes_enabled");
+            answer.citations = vec![
+                task_enum.clone(),
+                evidence_enum.clone(),
+                storage_type.clone(),
+                generic_probe.clone(),
+                eval_helper.clone(),
+            ];
+            answer.graphs = vec![route_graph(
+                "unrelated-eval-neighborhood",
+                &["eval_probes_enabled"],
+                &[("eval_probes_enabled", "eval_probes_enabled")],
+            )];
+            let claims = vec![
+                cited_claim(
+                    "RouteTracing identifies the requested task class.",
+                    Some("route handling"),
+                    task_enum,
+                    Some(true),
+                ),
+                cited_claim(
+                    "PacketEvidenceRole identifies evidence constants.",
+                    Some("source evidence"),
+                    evidence_enum,
+                    Some(true),
+                ),
+                cited_claim(
+                    "Storage owns generic persistence state.",
+                    Some("state_or_storage"),
+                    storage_type,
+                    Some(true),
+                ),
+                cited_claim(
+                    "probe names generic evaluation inputs.",
+                    Some("source evidence"),
+                    generic_probe,
+                    Some(true),
+                ),
+                cited_claim(
+                    "eval_probes_enabled controls an evaluation helper neighborhood.",
+                    Some("dispatch"),
+                    eval_helper,
+                    Some(true),
+                ),
+            ];
+
+            let sufficiency = route_sufficiency(question, &answer, &budget_fixture(), claims);
+
+            assert_eq!(
+                sufficiency.status,
+                PacketSufficiencyStatusDto::Partial,
+                "retained false-safe packet {packet_id} must fail closed: {sufficiency:?}"
+            );
+            assert!(
+                sufficiency.gaps.iter().any(|gap| gap.contains("route")),
+                "retained false-safe packet {packet_id} needs an explicit route gap: {sufficiency:?}"
+            );
+            assert!(
+                !sufficiency.follow_up_commands.is_empty()
+                    && sufficiency.follow_up_commands.len() <= 8,
+                "retained false-safe packet {packet_id} needs bounded useful follow-up: {sufficiency:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn route_proof_requires_claim_and_execution_graph_to_share_endpoint_order() {
+        let question = "Trace how RouteIngress reaches RouteDispatch then RouteEgress.";
+        let answer = route_answer(
+            question,
+            &["RouteIngress", "RouteDispatch", "RouteEgress"],
+            &[
+                ("RouteIngress", "RouteDispatch"),
+                ("RouteDispatch", "RouteEgress"),
+            ],
+        );
+        let claims = vec![
+            route_claim("RouteDispatch"),
+            route_claim("RouteIngress"),
+            route_claim("RouteEgress"),
+        ];
+
+        let sufficiency = route_sufficiency(question, &answer, &budget_fixture(), claims);
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains("claims did not describe"))
+        );
+    }
+
+    #[test]
+    fn route_proof_rejects_transitions_split_across_unrelated_neighborhoods() {
+        let question = "Trace how RouteIngress reaches RouteDispatch then RouteEgress.";
+        let mut answer = route_answer(
+            question,
+            &["RouteIngress", "RouteDispatch", "RouteEgress"],
+            &[],
+        );
+        answer.graphs = vec![
+            route_graph(
+                "first-neighborhood",
+                &["RouteIngress", "RouteDispatch"],
+                &[("RouteIngress", "RouteDispatch")],
+            ),
+            route_graph(
+                "second-neighborhood",
+                &["RouteDispatch", "RouteEgress"],
+                &[("RouteDispatch", "RouteEgress")],
+            ),
+        ];
+        let claims = vec![
+            route_claim("RouteIngress"),
+            route_claim("RouteDispatch"),
+            route_claim("RouteEgress"),
+        ];
+
+        let sufficiency = route_sufficiency(question, &answer, &budget_fixture(), claims);
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains("separate graph neighborhoods"))
+        );
+    }
+
+    #[test]
+    fn route_proof_preserves_complete_route_across_packet_budgets() {
+        let question = "Trace how RouteIngress reaches RouteDispatch then RouteEgress.";
+        let answer = route_answer(
+            question,
+            &["RouteIngress", "RouteDispatch", "RouteEgress"],
+            &[
+                ("RouteIngress", "RouteDispatch"),
+                ("RouteDispatch", "RouteEgress"),
+            ],
+        );
+        let claims = vec![
+            route_claim("RouteIngress"),
+            route_claim("RouteDispatch"),
+            route_claim("RouteEgress"),
+        ];
+
+        for requested in [
+            PacketBudgetModeDto::Compact,
+            PacketBudgetModeDto::Standard,
+            PacketBudgetModeDto::Deep,
+        ] {
+            let mut budget = budget_fixture();
+            budget.requested = requested;
+            let sufficiency = route_sufficiency(question, &answer, &budget, claims.clone());
+
+            assert_eq!(
+                sufficiency.status,
+                PacketSufficiencyStatusDto::Sufficient,
+                "complete retained route should be sufficient for {requested:?}: {sufficiency:?}"
+            );
+            assert!(sufficiency.gaps.is_empty());
+            assert!(sufficiency.follow_up_commands.is_empty());
+        }
+    }
+
+    #[test]
+    fn route_proof_uses_selected_probes_as_ordered_endpoints() {
+        let question = "Follow the requested execution route.";
+        let answer = route_answer(
+            question,
+            &["IngressHook", "RouteSupport", "EgressHook"],
+            &[
+                ("IngressHook", "RouteSupport"),
+                ("RouteSupport", "EgressHook"),
+            ],
+        );
+        let selected_probes = vec!["IngressHook".to_string(), "EgressHook".to_string()];
+        let sufficiency = assemble_packet_sufficiency_with_route_probes(
+            PacketSufficiencyInput {
+                project_root: Path::new("C:/workspace/project"),
+                question,
+                task_class: PacketTaskClassDto::RouteTracing,
+                answer: &answer,
+                budget: &budget_fixture(),
+                supported_claims: vec![
+                    route_claim("IngressHook"),
+                    route_claim("RouteSupport"),
+                    route_claim("EgressHook"),
+                ],
+                missing_required_probe_queries: Vec::new(),
+                targeted_follow_up_queries: Vec::new(),
+            },
+            &selected_probes,
+        );
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
+        assert!(sufficiency.gaps.is_empty());
     }
 
     #[test]
@@ -3323,13 +4292,46 @@ mod tests {
     #[test]
     fn url_session_compact_verbose_truncation_keeps_complete_roles_sufficient() {
         let question = "Trace how a Session creates requests, resumes tasks, validates data requests, and receives URLSession callbacks.";
-        let answer = answer_fixture(question);
+        let answer = route_answer(
+            question,
+            &[
+                "SessionRequest",
+                "RequestResume",
+                "RequestValidation",
+                "SessionCallbacks",
+            ],
+            &[
+                ("SessionRequest", "RequestResume"),
+                ("RequestResume", "RequestValidation"),
+                ("RequestValidation", "SessionCallbacks"),
+            ],
+        );
         let budget = compact_truncated_budget(question, vec!["markdown_blocks", "trail_edges"]);
         let claims = vec![
-            claim("Session.request creates request objects before optional eager execution."),
-            claim("Request.resume resumes the underlying URLSession task."),
-            claim("Request validation methods attach validation behavior."),
-            claim("Session delegate callbacks receive URLSession task events."),
+            cited_claim(
+                "Session.request creates request objects before optional eager execution.",
+                None,
+                cited_anchor("SessionRequest"),
+                Some(true),
+            ),
+            cited_claim(
+                "Request.resume resumes the underlying URLSession task.",
+                None,
+                cited_anchor("RequestResume"),
+                Some(true),
+            ),
+            cited_claim(
+                "Request validation methods attach validation behavior.",
+                None,
+                cited_anchor("RequestValidation"),
+                Some(true),
+            ),
+            cited_claim(
+                "Session delegate callbacks receive URLSession task events.",
+                None,
+                cited_anchor("SessionCallbacks"),
+                Some(true),
+            ),
         ];
 
         let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
@@ -3820,17 +4822,37 @@ mod tests {
     #[test]
     fn generic_request_dispatch_prompt_succeeds_without_benchmark_product_terms() {
         let question = "Trace how a generic HTTP service receives a request, registers a route, dispatches to a handler, finalizes the response, and returns control to the server.";
-        let answer = answer_fixture(question);
+        let answer = route_answer(
+            question,
+            &[
+                "RouteRegistration",
+                "HandlerDispatch",
+                "ResponseFinalization",
+            ],
+            &[
+                ("RouteRegistration", "HandlerDispatch"),
+                ("HandlerDispatch", "ResponseFinalization"),
+            ],
+        );
         let budget = budget_fixture();
         let claims = vec![
-            claim(
+            cited_claim(
                 "Public request entrypoint registers route wrappers before dispatching handler calls.",
+                Some("entrypoint"),
+                cited_anchor("RouteRegistration"),
+                Some(true),
             ),
-            claim(
+            cited_claim(
                 "Dispatch request invokes the selected view function or handler for the matched route.",
+                None,
+                cited_anchor("HandlerDispatch"),
+                Some(true),
             ),
-            claim(
+            cited_claim(
                 "Response finalization boundary writes response output and returns control to the server.",
+                None,
+                cited_anchor("ResponseFinalization"),
+                Some(true),
             ),
         ];
 
@@ -3853,7 +4875,7 @@ mod tests {
             report.missing.is_empty(),
             "generic source-shape role coverage should satisfy request dispatch without product-specific strings: {report:?}"
         );
-        for expected in ["public api/export", "server view dispatch"] {
+        for expected in ["entrypoint", "server view dispatch"] {
             assert!(
                 report.covered.iter().any(|entry| entry == expected),
                 "expected generic coverage report to include {expected}: {report:?}"
@@ -3864,12 +4886,40 @@ mod tests {
     #[test]
     fn role_safe_sufficiency_requires_cited_requested_interceptor_evidence() {
         let question = "Trace how a client creates a request, runs interceptors, dispatches it, and sends it through a transport.";
-        let answer = answer_fixture(question);
+        let answer = route_answer(
+            question,
+            &[
+                "RequestEntry",
+                "InterceptorRegistry::new",
+                "RequestDispatch",
+                "TransportSend",
+            ],
+            &[
+                ("RequestEntry", "InterceptorRegistry::new"),
+                ("InterceptorRegistry::new", "RequestDispatch"),
+                ("RequestDispatch", "TransportSend"),
+            ],
+        );
         let budget = budget_fixture();
         let mut claims = vec![
-            claim("The public client entrypoint creates a request before dispatch."),
-            claim("Request dispatch transforms config and invokes the selected handler."),
-            claim("The transport boundary sends the request and returns a response."),
+            cited_claim(
+                "The public client entrypoint creates a request before dispatch.",
+                None,
+                cited_anchor("RequestEntry"),
+                Some(true),
+            ),
+            cited_claim(
+                "Request dispatch transforms config and invokes the selected handler.",
+                None,
+                cited_anchor("RequestDispatch"),
+                Some(true),
+            ),
+            cited_claim(
+                "The transport boundary sends the request and returns a response.",
+                None,
+                cited_anchor("TransportSend"),
+                Some(true),
+            ),
         ];
 
         let assemble = |supported_claims| {
@@ -3920,16 +4970,23 @@ mod tests {
         let unrelated_type = assemble(claims.clone());
         assert_eq!(unrelated_type.status, PacketSufficiencyStatusDto::Partial);
 
-        let mut interceptor_registry = cited_anchor("InterceptorRegistry");
-        interceptor_registry.kind = NodeKind::CLASS;
-        claims.push(cited_claim(
-            "InterceptorRegistry stores request interceptor handler pairs for chained execution.",
-            Some("interceptor management"),
-            interceptor_registry,
-            Some(true),
-        ));
+        let mut interceptor_registry = cited_anchor("InterceptorRegistry::new");
+        interceptor_registry.kind = NodeKind::METHOD;
+        claims.insert(
+            1,
+            cited_claim(
+                "InterceptorRegistry::new creates the request interceptor chain before dispatch.",
+                Some("interceptor management"),
+                interceptor_registry,
+                Some(true),
+            ),
+        );
         let complete = assemble(claims);
-        assert_eq!(complete.status, PacketSufficiencyStatusDto::Sufficient);
+        assert_eq!(
+            complete.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "{complete:?}"
+        );
         assert!(
             complete
                 .coverage_report
@@ -3942,34 +4999,70 @@ mod tests {
     #[test]
     fn unresolved_sidecar_diagnostics_do_not_block_when_required_roles_are_covered() {
         let question = "Trace how Express creates an application, registers middleware/routes, and handles an incoming request through the router and response helpers.";
-        let mut answer = answer_fixture(question);
+        let mut answer = route_answer(
+            question,
+            &[
+                "AppInitialization",
+                "MiddlewareRegistration",
+                "RequestHandler",
+                "ResponseSend",
+            ],
+            &[
+                ("AppInitialization", "MiddlewareRegistration"),
+                ("MiddlewareRegistration", "RequestHandler"),
+                ("RequestHandler", "ResponseSend"),
+            ],
+        );
         answer.retrieval_trace.packet_sidecar_diagnostics = vec![
             unresolved_sidecar_diagnostic("response send helper"),
             unresolved_sidecar_diagnostic("helpers"),
         ];
         let budget = budget_fixture();
         let claims = vec![
-            claim(
-                "Public request entrypoint registers route wrappers before dispatching handler calls.",
+            cited_claim(
+                "AppInitialization creates the public request entrypoint.",
+                None,
+                cited_anchor("AppInitialization"),
+                Some(true),
             ),
-            claim(
-                "Dispatch request invokes the selected view function or handler for the matched route.",
+            cited_claim(
+                "MiddlewareRegistration registers route wrappers before dispatch.",
+                None,
+                cited_anchor("MiddlewareRegistration"),
+                Some(true),
             ),
-            claim(
-                "Response finalization boundary writes response output and returns control to the server.",
+            cited_claim(
+                "RequestHandler invokes the selected handler for the matched route.",
+                None,
+                cited_anchor("RequestHandler"),
+                Some(true),
+            ),
+            cited_claim(
+                "ResponseSend finalizes response output and returns control to the server.",
+                None,
+                cited_anchor("ResponseSend"),
+                Some(true),
             ),
         ];
 
-        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
-            project_root: Path::new("C:/workspace/express"),
-            question,
-            task_class: PacketTaskClassDto::RouteTracing,
-            answer: &answer,
-            budget: &budget,
-            supported_claims: claims,
-            missing_required_probe_queries: Vec::new(),
-            targeted_follow_up_queries: Vec::new(),
-        });
+        let sufficiency = assemble_packet_sufficiency_with_route_probes(
+            PacketSufficiencyInput {
+                project_root: Path::new("C:/workspace/express"),
+                question,
+                task_class: PacketTaskClassDto::RouteTracing,
+                answer: &answer,
+                budget: &budget,
+                supported_claims: claims,
+                missing_required_probe_queries: Vec::new(),
+                targeted_follow_up_queries: Vec::new(),
+            },
+            &[
+                "app initialization".to_string(),
+                "middleware registration".to_string(),
+                "request handler".to_string(),
+                "response send".to_string(),
+            ],
+        );
 
         assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
         assert!(sufficiency.gaps.is_empty());
@@ -4009,22 +5102,34 @@ mod tests {
             },
         ];
 
-        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
-            project_root: Path::new("C:/workspace/express"),
-            question,
-            task_class: PacketTaskClassDto::RouteTracing,
-            answer: &answer,
-            budget: &budget,
-            supported_claims: claims,
-            missing_required_probe_queries: vec!["response send".to_string()],
-            targeted_follow_up_queries: Vec::new(),
-        });
+        let selected_probes = vec![
+            "app initialization".to_string(),
+            "middleware registration".to_string(),
+            "request handler".to_string(),
+            "response send".to_string(),
+        ];
+        let sufficiency = assemble_packet_sufficiency_with_route_probes(
+            PacketSufficiencyInput {
+                project_root: Path::new("C:/workspace/express"),
+                question,
+                task_class: PacketTaskClassDto::RouteTracing,
+                answer: &answer,
+                budget: &budget,
+                supported_claims: claims,
+                missing_required_probe_queries: vec!["response send".to_string()],
+                targeted_follow_up_queries: Vec::new(),
+            },
+            &selected_probes,
+        );
 
         assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
         let report = sufficiency.coverage_report.as_ref().unwrap();
         assert!(
-            report.missing.is_empty(),
-            "Express route probes may be selected even without canonical flow requirements: {report:?}"
+            report
+                .missing
+                .iter()
+                .any(|gap| gap.starts_with("route endpoint:")),
+            "selected probes without cited endpoints must now remain explicit route gaps: {report:?}"
         );
         assert_eq!(report.unresolved, vec!["response send".to_string()]);
         assert!(

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -334,6 +334,7 @@ fn packet_sufficiency_status(
 }
 
 const MAX_ROUTE_PROOF_STAGES: usize = 6;
+const MAX_ROUTE_STAGE_WORDS: usize = 6;
 const ROUTE_ORDER_GAP: &str = "RouteTracing packet could not resolve at least two ordered endpoints from explicit route syntax in the question.";
 const ROUTE_GRAPH_GAP: &str =
     "RouteTracing packet did not include a directed execution graph for the cited route endpoints.";
@@ -492,7 +493,10 @@ fn packet_route_stage_labels(question: &str, selected_probes: &[String]) -> Vec<
         let from = words
             .iter()
             .position(|word| packet_route_word_is(word, "from"));
-        let route_words = from.map_or(words.as_slice(), |index| &words[index + 1..]);
+        if from.is_some_and(|index| index != 0) {
+            return Vec::new();
+        }
+        let route_words = from.map_or(words.as_slice(), |_| &words[1..]);
         let markers = route_words
             .iter()
             .enumerate()
@@ -506,19 +510,6 @@ fn packet_route_stage_labels(question: &str, selected_probes: &[String]) -> Vec<
         if markers.is_empty() {
             return Vec::new();
         }
-        if from.is_none()
-            && packet_route_word_is(route_words[markers[0]], "to")
-            && !route_words[..markers[0]]
-                .iter()
-                .any(|word| packet_route_token_is_explicit_identifier(word))
-            && packet_route_selected_probe_stage_label(
-                &route_words[..markers[0]].join(" "),
-                selected_probes,
-            )
-            .is_none()
-        {
-            return Vec::new();
-        }
         let mut spans = Vec::new();
         let mut start = 0;
         for marker in markers {
@@ -530,76 +521,56 @@ fn packet_route_stage_labels(question: &str, selected_probes: &[String]) -> Vec<
     };
     spans
         .iter()
-        .enumerate()
-        .map(|(index, span)| packet_route_stage_label(span, index == 0, selected_probes))
+        .map(|span| packet_route_stage_label(span, selected_probes))
         .collect::<Option<Vec<_>>>()
         .unwrap_or_default()
 }
 
-fn packet_route_stage_label(
-    span: &str,
-    leading: bool,
-    selected_probes: &[String],
-) -> Option<String> {
+fn packet_route_stage_label(span: &str, selected_probes: &[String]) -> Option<String> {
     let span = span.trim();
-    let quoted_identifiers = packet_route_quoted_identifiers(span);
-    if quoted_identifiers.len() > 1 {
-        return None;
-    }
-    if let Some(label) = quoted_identifiers.into_iter().next() {
-        return Some(label);
+    match packet_route_quoted_identifier(span) {
+        Ok(Some(label)) => return Some(label),
+        Ok(None) => {}
+        Err(()) => return None,
     }
     let span = packet_route_clean_word(span);
     if span.is_empty() {
         return None;
     }
-    if leading {
-        let words = span.split_whitespace().collect::<Vec<_>>();
-        if words.len() == 1 {
-            return Some(packet_route_clean_word(words[0]).to_string());
-        }
-        if let Some(label) = packet_route_selected_probe_stage_label(span, selected_probes) {
-            return Some(label);
-        }
-        if let Some(identifier) = words
+    let words = span
+        .split_whitespace()
+        .map(packet_route_clean_word)
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    if words.len() == 1 {
+        let word = words[0];
+        return (packet_route_token_is_explicit_identifier(word)
+            || packet_route_token_is_bare_lowercase(word))
+        .then(|| word.to_string());
+    }
+    if words.len() > MAX_ROUTE_STAGE_WORDS
+        || !words
             .iter()
-            .rev()
-            .find(|word| packet_route_token_is_explicit_identifier(word))
-        {
-            return Some(packet_route_clean_word(identifier).to_string());
-        }
+            .all(|word| packet_route_token_is_bare_lowercase(word))
+    {
         return None;
     }
-    Some(span.to_string())
+    let label = words.join(" ");
+    packet_route_label_matches_selected_probe(&label, selected_probes).then_some(label)
 }
 
-fn packet_route_selected_probe_stage_label(
-    span: &str,
-    selected_probes: &[String],
-) -> Option<String> {
-    if packet_route_label_matches_selected_probe(span, selected_probes) {
-        return Some(span.to_string());
-    }
-    let words = span.split_whitespace().collect::<Vec<_>>();
-    for suffix_start in 1..words.len() {
-        let suffix = words[suffix_start..].join(" ");
-        if packet_route_label_matches_selected_probe(&suffix, selected_probes) {
-            return Some(suffix);
-        }
-    }
-    None
-}
-
-fn packet_route_quoted_identifiers(span: &str) -> Vec<String> {
-    let mut identifiers = Vec::new();
+fn packet_route_quoted_identifier(span: &str) -> Result<Option<String>, ()> {
+    let mut identifier = None;
     let mut active_quote = None;
     let mut current = String::new();
+    let mut outside = String::new();
     for character in span.chars() {
         if let Some(quote) = active_quote {
             if character == quote {
-                if !current.trim().is_empty() {
-                    identifiers.push(current.trim().to_string());
+                if current.trim().is_empty() || identifier.is_some() {
+                    return Err(());
                 }
+                identifier = Some(current.trim().to_string());
                 active_quote = None;
                 current.clear();
             } else {
@@ -607,9 +578,17 @@ fn packet_route_quoted_identifiers(span: &str) -> Vec<String> {
             }
         } else if matches!(character, '`' | '\'' | '"') {
             active_quote = Some(character);
+        } else {
+            outside.push(character);
         }
     }
-    identifiers
+    if active_quote.is_some() {
+        return Err(());
+    }
+    if identifier.is_some() && !packet_route_clean_word(outside.trim()).is_empty() {
+        return Err(());
+    }
+    Ok(identifier)
 }
 
 fn packet_route_token_is_explicit_identifier(token: &str) -> bool {
@@ -620,6 +599,17 @@ fn packet_route_token_is_explicit_identifier(token: &str) -> bool {
             .chars()
             .skip(1)
             .any(|character| character.is_ascii_uppercase())
+}
+
+fn packet_route_token_is_bare_lowercase(token: &str) -> bool {
+    let token = packet_route_clean_word(token);
+    !token.is_empty()
+        && token
+            .chars()
+            .any(|character| character.is_ascii_lowercase())
+        && token
+            .chars()
+            .all(|character| character.is_ascii_lowercase() || character.is_ascii_digit())
 }
 
 fn packet_route_clean_word(word: &str) -> &str {
@@ -647,12 +637,9 @@ fn packet_route_claim_node_ids(
         .filter(|citation| {
             packet_route_label_matches_citation(stage, citation)
                 || selected_probes.iter().any(|probe| {
-                    packet_route_probe_candidate_labels(probe)
-                        .iter()
-                        .any(|candidate| {
-                            packet_route_labels_overlap(stage, candidate)
-                                && packet_route_label_matches_citation(candidate, citation)
-                        })
+                    packet_route_probe_is_unscoped(probe)
+                        && packet_route_labels_overlap(stage, probe)
+                        && packet_route_label_matches_citation(probe, citation)
                 })
         })
         .map(|citation| citation.node_id.0.clone())
@@ -676,49 +663,16 @@ fn packet_route_labels_overlap(left: &str, right: &str) -> bool {
 
 fn packet_route_label_matches_selected_probe(label: &str, selected_probes: &[String]) -> bool {
     selected_probes.iter().any(|probe| {
-        packet_route_probe_candidate_labels(probe)
-            .iter()
-            .any(|candidate| packet_route_labels_overlap(label, candidate))
+        packet_route_probe_is_unscoped(probe) && packet_route_labels_overlap(label, probe)
     })
 }
 
-fn packet_route_probe_candidate_labels(probe: &str) -> Vec<String> {
+fn packet_route_probe_is_unscoped(probe: &str) -> bool {
     let bare = packet_route_clean_word(probe.trim()).trim();
-    if bare.is_empty() {
-        return Vec::new();
-    }
-
-    let mut candidates = vec![bare.to_string()];
-    let words = bare.split_whitespace().collect::<Vec<_>>();
-    let file_scoped = words.len() > 1
-        && words[..words.len() - 1]
-            .iter()
-            .any(|word| word.contains(['/', '\\']));
-    let has_terminal_symbol = file_scoped
-        || words.len() == 1
-        || words
-            .last()
-            .is_some_and(|word| word.contains("::") || word.contains('#'));
-    let symbol = has_terminal_symbol.then(|| words.last().copied()).flatten();
-
-    if let Some(symbol) = symbol {
-        let symbol = packet_route_clean_word(symbol);
-        if !symbol.is_empty() && !candidates.iter().any(|candidate| candidate == symbol) {
-            candidates.push(symbol.to_string());
-        }
-        let has_symbol_scope = symbol.contains("::")
-            || symbol.contains('#')
-            || (!symbol.contains(['/', '\\']) && symbol.contains('.'));
-        if has_symbol_scope
-            && let Some(terminal) = symbol
-                .rsplit(['.', ':', '#', '/', '\\'])
-                .find(|part| !part.is_empty())
-            && !candidates.iter().any(|candidate| candidate == terminal)
-        {
-            candidates.push(terminal.to_string());
-        }
-    }
-    candidates
+    !bare.is_empty()
+        && !bare.contains(['/', '\\', ':', '#', '.'])
+        && !bare.contains(['`', '\'', '"'])
+        && packet_route_identifier_tokens(bare).len() <= MAX_ROUTE_STAGE_WORDS
 }
 
 fn packet_route_identifier_tokens(identifier: &str) -> Vec<String> {
@@ -800,10 +754,11 @@ fn packet_execution_graphs(answer: &AgentAnswerDto) -> Vec<&GraphResponse> {
             GraphArtifactDto::Mermaid { .. } => None,
         })
         .filter(|graph| {
-            graph
-                .edges
-                .iter()
-                .any(|edge| edge.kind == EdgeKind::CALL && edge.source != edge.target)
+            graph.edges.iter().any(|edge| {
+                edge.kind == EdgeKind::CALL
+                    && edge.source != edge.target
+                    && !crate::graph_builders::is_speculative_trail_edge(edge)
+            })
         })
         .collect()
 }
@@ -865,7 +820,10 @@ fn packet_execution_path_exists(graph: &GraphResponse, source: &str, target: &st
     let mut visited = HashSet::from([source.to_string()]);
     while let Some(current) = queue.pop_front() {
         for edge in graph.edges.iter().filter(|edge| {
-            edge.kind == EdgeKind::CALL && edge.source.0 == current && edge.source != edge.target
+            edge.kind == EdgeKind::CALL
+                && edge.source.0 == current
+                && edge.source != edge.target
+                && !crate::graph_builders::is_speculative_trail_edge(edge)
         }) {
             if edge.target.0 == target {
                 return true;
@@ -2933,13 +2891,23 @@ mod tests {
     }
 
     fn route_graph_edge(id: &str, source: &str, target: &str) -> GraphEdgeDto {
+        route_graph_edge_with_proof(id, source, target, Some("certain"), Some(1.0))
+    }
+
+    fn route_graph_edge_with_proof(
+        id: &str,
+        source: &str,
+        target: &str,
+        certainty: Option<&str>,
+        confidence: Option<f32>,
+    ) -> GraphEdgeDto {
         GraphEdgeDto {
             id: EdgeId(id.to_string()),
             source: NodeId(source.to_string()),
             target: NodeId(target.to_string()),
             kind: EdgeKind::CALL,
-            confidence: Some(1.0),
-            certainty: Some("certain".to_string()),
+            confidence,
+            certainty: certainty.map(str::to_string),
             callsite_identity: None,
             candidate_targets: Vec::new(),
         }
@@ -3032,6 +3000,23 @@ mod tests {
             extra_probes,
         );
         (sufficiency, claims)
+    }
+
+    fn assert_unresolved_route_order(sufficiency: &PacketSufficiencyDto) {
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Partial,
+            "{sufficiency:?}"
+        );
+        assert!(
+            sufficiency
+                .coverage_report
+                .as_ref()
+                .expect("route sufficiency should include a coverage report")
+                .missing
+                .contains(&"route order: unresolved endpoints".to_string()),
+            "{sufficiency:?}"
+        );
     }
 
     fn mark_full_retrieval_unavailable(answer: &mut AgentAnswerDto) {
@@ -3218,6 +3203,53 @@ mod tests {
     }
 
     #[test]
+    fn route_proof_rejects_speculative_call_edges() {
+        for (case, certainty, confidence) in [
+            ("speculative", Some("speculative"), Some(1.0)),
+            ("uncertain", Some("uncertain"), Some(1.0)),
+            ("probable", Some("probable"), Some(0.70)),
+            ("low-confidence", Some("certain"), Some(0.20)),
+        ] {
+            let question = "EndpointA -> EndpointB";
+            let mut answer = route_answer(
+                question,
+                &["EndpointA", "EndpointB", "RouteSupport"],
+                &[("EndpointA", "EndpointB")],
+            );
+            let GraphArtifactDto::Uml { graph, .. } = &mut answer.graphs[0] else {
+                unreachable!("route fixture must contain UML")
+            };
+            graph.edges[0] = route_graph_edge_with_proof(
+                "route-edge",
+                "EndpointA",
+                "EndpointB",
+                certainty,
+                confidence,
+            );
+
+            let sufficiency = route_sufficiency(
+                question,
+                &answer,
+                &budget_fixture(),
+                vec![route_claim("EndpointA"), route_claim("EndpointB")],
+            );
+
+            assert_eq!(
+                sufficiency.status,
+                PacketSufficiencyStatusDto::Partial,
+                "{case} CALL edge must not prove a route: {sufficiency:?}"
+            );
+            assert!(
+                sufficiency
+                    .gaps
+                    .iter()
+                    .any(|gap| gap.contains("directed execution graph")),
+                "{case} CALL edge must produce an execution graph gap: {sufficiency:?}"
+            );
+        }
+    }
+
+    #[test]
     fn retained_false_safe_packet_shapes_fail_closed_without_route_proof() {
         let retained_shapes = [
             (
@@ -3328,54 +3360,42 @@ mod tests {
     }
 
     #[test]
-    fn production_selected_probe_disambiguates_leading_lowercase_stage() {
-        let (sufficiency, claims) = production_route_sufficiency_with_probes(
+    fn production_framed_and_suffix_routes_fail_closed() {
+        let (framed_single, _) = production_route_sufficiency_with_probes(
             "Trace start -> run",
             &["start", "run", "RouteSupport"],
             &[("start", "run")],
             &["start".to_string()],
         );
+        let (framed_phrase, _) = production_route_sufficiency_with_probes(
+            "Trace request dispatch -> CustomExit",
+            &["dispatch_request", "CustomExit", "RouteSupport"],
+            &[("dispatch_request", "CustomExit")],
+            &["dispatch_request".to_string()],
+        );
 
-        assert_eq!(
-            sufficiency.status,
-            PacketSufficiencyStatusDto::Sufficient,
-            "{sufficiency:?}"
-        );
-        assert!(
-            claims
-                .iter()
-                .all(|claim| claim.coverage_role.as_deref() != Some("route endpoint"))
-        );
+        assert_unresolved_route_order(&framed_single);
+        assert_unresolved_route_order(&framed_phrase);
     }
 
     #[test]
-    fn production_scoped_probes_disambiguate_leading_multiword_stage() {
+    fn production_scoped_probe_owner_mismatch_fails_closed() {
         for probe in ["router::dispatch_request", "src/router.rs dispatch_request"] {
-            let (sufficiency, claims) = production_route_sufficiency_with_probes(
-                "Trace request dispatch to CustomExit",
+            let (sufficiency, _) = production_route_sufficiency_with_probes(
+                "request dispatch -> CustomExit",
                 &["dispatch_request", "CustomExit", "RouteSupport"],
                 &[("dispatch_request", "CustomExit")],
                 &[probe.to_string()],
             );
 
-            assert_eq!(
-                sufficiency.status,
-                PacketSufficiencyStatusDto::Sufficient,
-                "probe {probe} should bind the production route: {sufficiency:?}"
-            );
-            assert!(claims.iter().any(|claim| {
-                claim.citations.iter().any(|citation| {
-                    citation.display_name == "dispatch_request"
-                        && claim.coverage_role.as_deref() != Some("route endpoint")
-                })
-            }));
+            assert_unresolved_route_order(&sufficiency);
         }
     }
 
     #[test]
-    fn production_digit_boundary_probe_disambiguates_leading_stage() {
+    fn production_exact_plain_phrase_matches_unscoped_probe() {
         let (sufficiency, _) = production_route_sufficiency_with_probes(
-            "Trace sha256 digest -> DigestExit",
+            "sha256 digest -> DigestExit",
             &["sha256Digest", "DigestExit", "RouteSupport"],
             &[("sha256Digest", "DigestExit")],
             &["sha256Digest".to_string()],
@@ -3397,25 +3417,29 @@ mod tests {
             &["EntryOne".to_string()],
         );
 
-        assert_eq!(
-            sufficiency.status,
-            PacketSufficiencyStatusDto::Partial,
-            "{sufficiency:?}"
+        assert_unresolved_route_order(&sufficiency);
+    }
+
+    #[test]
+    fn production_multiple_unquoted_and_unclosed_identifiers_fail_closed() {
+        let (multiple, _) = production_route_sufficiency(
+            "EntryOne EntryTwo -> ExitStage",
+            &["EntryOne", "EntryTwo", "ExitStage"],
+            &[("EntryOne", "ExitStage")],
         );
-        assert!(
-            sufficiency
-                .coverage_report
-                .as_ref()
-                .expect("route sufficiency should include a coverage report")
-                .missing
-                .contains(&"route order: unresolved endpoints".to_string()),
-            "{sufficiency:?}"
+        let (unclosed, _) = production_route_sufficiency(
+            "`EntryOne -> ExitStage",
+            &["EntryOne", "ExitStage", "RouteSupport"],
+            &[("EntryOne", "ExitStage")],
         );
+
+        assert_unresolved_route_order(&multiple);
+        assert_unresolved_route_order(&unclosed);
     }
 
     #[test]
     fn production_source_evidence_proves_explicit_marker_route() {
-        let question = "Trace CustomEntry through request dispatch to CustomExit";
+        let question = "from CustomEntry through request dispatch to CustomExit";
         let names = ["CustomEntry", "dispatch_request", "CustomExit"];
         let (sufficiency, claims) = production_route_sufficiency_with_probes(
             question,
@@ -3447,7 +3471,7 @@ mod tests {
 
     #[test]
     fn production_unrelated_probe_does_not_alias_explicit_route_stage() {
-        let question = "Trace CustomEntry through request dispatch to CustomExit";
+        let question = "from CustomEntry through request dispatch to CustomExit";
         let (sufficiency, _) = production_route_sufficiency_with_probes(
             question,
             &["CustomEntry", "request_handler", "CustomExit"],
@@ -3458,21 +3482,7 @@ mod tests {
             &["request_handler".to_string()],
         );
 
-        assert_eq!(
-            sufficiency.status,
-            PacketSufficiencyStatusDto::Partial,
-            "{sufficiency:?}"
-        );
-        assert!(
-            sufficiency
-                .coverage_report
-                .as_ref()
-                .expect("route sufficiency should include a coverage report")
-                .missing
-                .iter()
-                .any(|missing| missing == "route endpoint: request dispatch"),
-            "{sufficiency:?}"
-        );
+        assert_unresolved_route_order(&sufficiency);
     }
 
     #[test]
@@ -3772,7 +3782,7 @@ mod tests {
     }
 
     #[test]
-    fn selected_probe_aliases_require_exact_identifier_token_multisets() {
+    fn unscoped_selected_probe_aliases_require_exact_identifier_token_multisets() {
         assert!(packet_route_labels_overlap(
             "request dispatch",
             "dispatch_request"
@@ -3781,9 +3791,13 @@ mod tests {
         assert!(packet_route_labels_overlap("sha256 digest", "sha256Digest"));
         assert!(packet_route_label_matches_selected_probe(
             "request dispatch",
+            &["dispatch_request".to_string()]
+        ));
+        assert!(!packet_route_label_matches_selected_probe(
+            "request dispatch",
             &["router::dispatch_request".to_string()]
         ));
-        assert!(packet_route_label_matches_selected_probe(
+        assert!(!packet_route_label_matches_selected_probe(
             "request dispatch",
             &["src/router.rs dispatch_request".to_string()]
         ));
@@ -3872,11 +3886,7 @@ mod tests {
             ],
         );
 
-        assert_eq!(
-            sufficiency.status,
-            PacketSufficiencyStatusDto::Sufficient,
-            "route control words must not become evidence stages: {sufficiency:?}"
-        );
+        assert_unresolved_route_order(&sufficiency);
     }
 
     #[test]
@@ -5690,9 +5700,8 @@ mod tests {
         assert!(
             report
                 .missing
-                .iter()
-                .any(|gap| gap.starts_with("route endpoint:")),
-            "selected probes without cited endpoints must now remain explicit route gaps: {report:?}"
+                .contains(&"route order: unresolved endpoints".to_string()),
+            "natural-language framing must fail closed before selected probes imply route order: {report:?}"
         );
         assert_eq!(report.unresolved, vec!["response send".to_string()]);
         assert!(

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -327,18 +327,16 @@ fn packet_sufficiency_status(
 }
 
 const MAX_ROUTE_PROOF_STAGES: usize = 6;
-const MAX_ROUTE_PROOF_PATHS: usize = 64;
-
-#[derive(Debug, Clone)]
-enum RouteStageMatcher {
-    Requirement(FlowRequirement),
-    Probe(String),
-}
 
 #[derive(Debug, Clone)]
 struct RouteStage {
     label: String,
-    matcher: RouteStageMatcher,
+}
+
+#[derive(Debug, Clone)]
+struct RouteStages {
+    stages: Vec<RouteStage>,
+    omitted: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -350,12 +348,8 @@ struct RouteStageEvidence {
 #[derive(Debug, Clone)]
 struct RouteProofAssessment {
     complete: bool,
-    stage_count: usize,
-    missing_endpoints: Vec<String>,
-    missing_transitions: Vec<String>,
-    claim_order_mismatch: bool,
-    execution_graph_missing: bool,
-    fragmented_execution_graph: bool,
+    gaps: Vec<String>,
+    missing: Vec<String>,
     follow_up_queries: Vec<String>,
 }
 
@@ -363,55 +357,10 @@ impl RouteProofAssessment {
     fn not_required() -> Self {
         Self {
             complete: true,
-            stage_count: 0,
-            missing_endpoints: Vec::new(),
-            missing_transitions: Vec::new(),
-            claim_order_mismatch: false,
-            execution_graph_missing: false,
-            fragmented_execution_graph: false,
+            gaps: Vec::new(),
+            missing: Vec::new(),
             follow_up_queries: Vec::new(),
         }
-    }
-
-    fn gaps(&self) -> Vec<String> {
-        let mut gaps = Vec::new();
-        if self.stage_count < 2 {
-            gaps.push(
-                "RouteTracing packet could not derive two requested route endpoints from the question and selected probes."
-                    .to_string(),
-            );
-        }
-        if !self.missing_endpoints.is_empty() {
-            gaps.push(format!(
-                "RouteTracing packet missed relevant cited route endpoint(s): {}.",
-                self.missing_endpoints.join(", ")
-            ));
-        }
-        if self.claim_order_mismatch {
-            gaps.push(
-                "RouteTracing claims did not describe the requested endpoints in route order."
-                    .to_string(),
-            );
-        }
-        if self.execution_graph_missing {
-            gaps.push(
-                "RouteTracing packet did not include a directed execution graph for the cited route endpoints."
-                    .to_string(),
-            );
-        }
-        if !self.missing_transitions.is_empty() {
-            gaps.push(format!(
-                "RouteTracing execution graph missed ordered transition(s): {}.",
-                self.missing_transitions.join(", ")
-            ));
-        }
-        if self.fragmented_execution_graph {
-            gaps.push(
-                "RouteTracing evidence appeared only in separate graph neighborhoods; no single execution graph represented the claimed ordered route."
-                    .to_string(),
-            );
-        }
-        gaps
     }
 }
 
@@ -427,67 +376,104 @@ fn packet_route_proof_assessment(
         return RouteProofAssessment::not_required();
     }
 
-    let stages = packet_route_proof_stages(question, flow_context, selected_probes);
+    let route_stages = packet_route_proof_stages(question, flow_context, selected_probes);
     let mut assessment = RouteProofAssessment {
         complete: false,
-        stage_count: stages.len(),
-        missing_endpoints: Vec::new(),
-        missing_transitions: Vec::new(),
-        claim_order_mismatch: false,
-        execution_graph_missing: !packet_has_execution_graph(answer),
-        fragmented_execution_graph: false,
+        gaps: Vec::new(),
+        missing: Vec::new(),
         follow_up_queries: Vec::new(),
     };
-    if stages.len() < 2 {
-        assessment.follow_up_queries = packet_route_fallback_queries(question, selected_probes);
+    let execution_graphs = packet_execution_graphs(answer);
+    let execution_graph_missing = execution_graphs.is_empty();
+    if execution_graph_missing {
+        assessment.gaps.push(
+            "RouteTracing packet did not include a directed execution graph for the cited route endpoints."
+                .to_string(),
+        );
+        assessment.missing.push("route execution graph".to_string());
+    }
+    if route_stages.stages.len() + route_stages.omitted.len() < 2 {
+        assessment.gaps.push(
+            "RouteTracing packet could not derive two requested route endpoints from the question and selected probes."
+                .to_string(),
+        );
+        assessment.follow_up_queries = route_stages
+            .stages
+            .iter()
+            .map(|stage| stage.label.clone())
+            .collect();
+        return assessment;
+    }
+    if !route_stages.omitted.is_empty() {
+        assessment.gaps.push(format!(
+            "RouteTracing route proof exceeds the bounded {MAX_ROUTE_PROOF_STAGES}-stage capacity; unrepresented required stage(s): {}.",
+            route_stages.omitted.join(", ")
+        ));
+        assessment.missing.extend(
+            route_stages
+                .omitted
+                .iter()
+                .map(|stage| format!("route stage overflow: {stage}")),
+        );
+        assessment.follow_up_queries = route_stages.omitted;
         return assessment;
     }
 
     let mut stage_evidence = Vec::new();
-    let mut previous_claim_index = None;
-    for stage in &stages {
-        let matching_claims = claims
+    let mut missing_endpoints = Vec::new();
+    for stage in &route_stages.stages {
+        let mut node_ids = claims
             .iter()
-            .enumerate()
-            .filter_map(|(index, claim)| {
-                packet_route_claim_node_ids(stage, claim, flow_context)
-                    .filter(|node_ids| !node_ids.is_empty())
-                    .map(|node_ids| (index, node_ids))
-            })
+            .flat_map(|claim| packet_route_claim_node_ids(stage, claim))
             .collect::<Vec<_>>();
-        let ordered_match = matching_claims
-            .iter()
-            .find(|(index, _)| previous_claim_index.is_none_or(|previous| *index > previous));
-        if let Some((index, node_ids)) = ordered_match {
-            previous_claim_index = Some(*index);
+        node_ids.sort();
+        node_ids.dedup();
+        if !node_ids.is_empty() {
             stage_evidence.push(RouteStageEvidence {
                 label: stage.label.clone(),
-                node_ids: node_ids.clone(),
+                node_ids,
             });
             continue;
         }
-        if matching_claims.is_empty() {
-            assessment.missing_endpoints.push(stage.label.clone());
-        } else {
-            assessment.claim_order_mismatch = true;
-        }
+        missing_endpoints.push(stage.label.clone());
+        assessment
+            .missing
+            .push(format!("route endpoint: {}", stage.label));
         push_unique_term(&mut assessment.follow_up_queries, &stage.label);
     }
 
-    if !assessment.missing_endpoints.is_empty() || assessment.claim_order_mismatch {
+    if !missing_endpoints.is_empty() {
+        assessment.gaps.push(format!(
+            "RouteTracing packet missed relevant cited route endpoint(s): {}.",
+            missing_endpoints.join(", ")
+        ));
         return assessment;
     }
 
-    assessment.missing_transitions = packet_missing_route_transitions(answer, &stage_evidence);
-    for transition in &assessment.missing_transitions {
+    let missing_transitions = packet_missing_route_transitions(&execution_graphs, &stage_evidence);
+    for transition in &missing_transitions {
+        assessment
+            .missing
+            .push(format!("route transition: {transition}"));
         if let Some((_, target)) = transition.split_once(" -> ") {
             push_unique_term(&mut assessment.follow_up_queries, target);
         }
     }
-    let has_complete_graph = packet_has_complete_route_graph(answer, &stage_evidence);
-    assessment.fragmented_execution_graph = !has_complete_graph
-        && assessment.missing_transitions.is_empty()
-        && !assessment.execution_graph_missing;
+    let has_complete_graph = execution_graphs
+        .iter()
+        .any(|graph| packet_graph_contains_route(graph, &stage_evidence));
+    if !missing_transitions.is_empty() {
+        assessment.gaps.push(format!(
+            "RouteTracing execution graph missed ordered transition(s): {}.",
+            missing_transitions.join(", ")
+        ));
+    } else if !has_complete_graph && !execution_graph_missing {
+        assessment.gaps.push(
+            "RouteTracing evidence appeared only in separate graph neighborhoods; no single execution graph represented the claimed ordered route."
+                .to_string(),
+        );
+        assessment.missing.push("route execution graph".to_string());
+    }
     assessment.complete = has_complete_graph;
     assessment
 }
@@ -496,186 +482,110 @@ fn packet_route_proof_stages(
     question: &str,
     flow_context: &PacketFlowContext,
     selected_probes: &[String],
-) -> Vec<RouteStage> {
-    let mut requirements = flow_context
+) -> RouteStages {
+    let normalized_question = normalize_identifier(question);
+    let mut candidates = Vec::new();
+    for requirement in flow_context
         .requirements
         .iter()
         .copied()
         .filter(flow_requirement_blocks_sufficiency)
-        .enumerate()
-        .collect::<Vec<_>>();
-    requirements.sort_by_key(|(index, requirement)| {
-        (
-            packet_route_requirement_position(question, requirement).unwrap_or(usize::MAX),
-            *index,
-        )
-    });
-    let mut stages = Vec::new();
-    for (_, requirement) in requirements {
-        if stages.iter().any(|stage: &RouteStage| {
-            matches!(
-                &stage.matcher,
-                RouteStageMatcher::Requirement(existing)
-                    if packet_route_requirements_overlap(existing, &requirement)
-            )
-        }) {
+    {
+        for seed in requirement.query_seeds {
+            let normalized_seed = normalize_identifier(seed);
+            if let Some(position) = normalized_question.find(&normalized_seed) {
+                candidates.push((
+                    position,
+                    RouteStage {
+                        label: (*seed).to_string(),
+                    },
+                ));
+            }
+        }
+    }
+
+    for probe in selected_probes {
+        let probe = probe.trim();
+        let normalized_probe = normalize_identifier(probe);
+        if probe.len() < 3 || normalized_probe.is_empty() {
             continue;
         }
-        stages.push(RouteStage {
-            label: requirement
-                .query_seeds
-                .first()
-                .copied()
-                .unwrap_or(requirement.id)
-                .to_string(),
-            matcher: RouteStageMatcher::Requirement(requirement),
-        });
+        candidates.push((
+            usize::MAX,
+            RouteStage {
+                label: probe.to_string(),
+            },
+        ));
     }
 
-    if stages.len() < 2 {
-        for probe in selected_probes {
-            push_route_probe_stage(&mut stages, probe);
-            if stages.len() >= MAX_ROUTE_PROOF_STAGES {
-                break;
-            }
+    if candidates.is_empty() {
+        for (position, probe) in packet_route_explicit_question_probes(question) {
+            candidates.push((position, RouteStage { label: probe }));
         }
     }
-    if stages.len() < 2 {
-        for term in packet_probe_terms(question) {
-            if packet_route_question_term_is_stage(&term) {
-                push_route_probe_stage(&mut stages, &term);
-            }
-            if stages.len() >= MAX_ROUTE_PROOF_STAGES {
-                break;
-            }
-        }
-    }
-    stages.truncate(MAX_ROUTE_PROOF_STAGES);
-    stages
-}
 
-fn packet_route_requirements_overlap(left: &FlowRequirement, right: &FlowRequirement) -> bool {
-    left.query_seeds.iter().any(|left_seed| {
-        let normalized_left = normalize_identifier(left_seed);
-        right
-            .query_seeds
+    candidates.sort_by_key(|(position, _)| *position);
+    let mut stages = Vec::new();
+    for (_, stage) in candidates {
+        let normalized = normalize_identifier(&stage.label);
+        if !stages
             .iter()
-            .any(|right_seed| normalize_identifier(right_seed) == normalized_left)
-    })
-}
-
-fn packet_route_requirement_position(
-    question: &str,
-    requirement: &FlowRequirement,
-) -> Option<usize> {
-    let normalized_question = normalize_identifier(question);
-    requirement
-        .query_seeds
-        .iter()
-        .filter_map(|seed| {
-            let positions = packet_probe_terms(seed)
-                .into_iter()
-                .filter_map(|term| normalized_question.find(&normalize_identifier(&term)))
-                .collect::<Vec<_>>();
-            (!positions.is_empty()).then(|| positions.into_iter().max().unwrap_or_default())
-        })
-        .min()
-        .or_else(|| {
-            packet_probe_terms(requirement.id)
-                .into_iter()
-                .filter_map(|term| normalized_question.find(&normalize_identifier(&term)))
-                .max()
-        })
-}
-
-fn push_route_probe_stage(stages: &mut Vec<RouteStage>, probe: &str) {
-    let probe = probe.trim();
-    let normalized = normalize_identifier(probe);
-    if probe.len() < 3
-        || normalized.is_empty()
-        || stages
-            .iter()
-            .any(|stage| normalize_identifier(&stage.label) == normalized)
-    {
-        return;
-    }
-    stages.push(RouteStage {
-        label: probe.to_string(),
-        matcher: RouteStageMatcher::Probe(probe.to_string()),
-    });
-}
-
-fn packet_route_question_term_is_stage(term: &str) -> bool {
-    !matches!(
-        normalize_identifier(term).as_str(),
-        "trace"
-            | "tracing"
-            | "route"
-            | "routes"
-            | "routing"
-            | "flow"
-            | "path"
-            | "paths"
-            | "reach"
-            | "reaches"
-            | "reaching"
-            | "selected"
-            | "through"
-            | "then"
-            | "complete"
-    )
-}
-
-fn packet_route_fallback_queries(question: &str, selected_probes: &[String]) -> Vec<String> {
-    let mut queries = Vec::new();
-    for probe in selected_probes {
-        push_unique_term(&mut queries, probe);
-    }
-    if queries.len() < 2 {
-        for term in packet_probe_terms(question) {
-            if packet_route_question_term_is_stage(&term) {
-                push_unique_term(&mut queries, &term);
-            }
-            if queries.len() >= MAX_ROUTE_PROOF_STAGES {
-                break;
-            }
+            .any(|existing: &RouteStage| normalize_identifier(&existing.label) == normalized)
+        {
+            stages.push(stage);
         }
     }
-    queries.truncate(MAX_ROUTE_PROOF_STAGES);
-    queries
-}
-
-fn packet_route_claim_node_ids(
-    stage: &RouteStage,
-    claim: &PacketClaimDto,
-    flow_context: &PacketFlowContext,
-) -> Option<Vec<String>> {
-    let claim_matches = match &stage.matcher {
-        RouteStageMatcher::Requirement(requirement) => {
-            flow_context.claim_satisfies_requirement(claim, requirement, true)
-        }
-        RouteStageMatcher::Probe(probe) => packet_route_probe_matches_claim(probe, claim),
+    let omitted = if stages.len() > MAX_ROUTE_PROOF_STAGES {
+        stages
+            .split_off(MAX_ROUTE_PROOF_STAGES)
+            .into_iter()
+            .map(|stage| stage.label)
+            .collect()
+    } else {
+        Vec::new()
     };
-    if !claim_matches || packet_claim_is_generic_navigation_or_source_evidence(claim) {
-        return None;
+    RouteStages { stages, omitted }
+}
+
+fn packet_route_explicit_question_probes(question: &str) -> Vec<(usize, String)> {
+    question
+        .split_whitespace()
+        .enumerate()
+        .filter_map(|(position, raw)| {
+            let probe = raw.trim_matches(|character: char| {
+                !character.is_alphanumeric() && !matches!(character, '_' | ':' | '.' | '#')
+            });
+            let has_identifier_shape = probe.contains("::")
+                || probe.contains('_')
+                || probe.contains('#')
+                || probe
+                    .chars()
+                    .skip(1)
+                    .any(|character| character.is_ascii_uppercase());
+            (probe.len() >= 3 && has_identifier_shape).then(|| (position, probe.to_string()))
+        })
+        .collect()
+}
+
+fn packet_route_claim_node_ids(stage: &RouteStage, claim: &PacketClaimDto) -> Vec<String> {
+    if !packet_route_probe_matches_claim(&stage.label, claim)
+        || packet_claim_is_generic_navigation_or_source_evidence(claim)
+    {
+        return Vec::new();
     }
     let mut node_ids = claim
         .citations
         .iter()
         .filter(|citation| packet_route_citation_is_endpoint(citation))
-        .filter(|citation| match &stage.matcher {
-            RouteStageMatcher::Requirement(_) => true,
-            RouteStageMatcher::Probe(probe) => {
-                packet_citation_satisfies_required_probe(probe, citation)
-                    || packet_route_probe_matches_text(probe, &claim.claim)
-                    || packet_route_probe_matches_text(probe, &citation.display_name)
-            }
+        .filter(|citation| {
+            packet_citation_satisfies_required_probe(&stage.label, citation)
+                || packet_route_probe_matches_text(&stage.label, &citation.display_name)
         })
         .map(|citation| citation.node_id.0.clone())
         .collect::<Vec<_>>();
     node_ids.sort();
     node_ids.dedup();
-    Some(node_ids)
+    node_ids
 }
 
 fn packet_route_probe_matches_claim(probe: &str, claim: &PacketClaimDto) -> bool {
@@ -689,10 +599,7 @@ fn packet_route_probe_matches_claim(probe: &str, claim: &PacketClaimDto) -> bool
 fn packet_route_probe_matches_text(probe: &str, text: &str) -> bool {
     let normalized_probe = normalize_identifier(probe);
     let normalized_text = normalize_identifier(text);
-    let route_terms = packet_probe_terms(probe)
-        .into_iter()
-        .filter(|term| packet_route_question_term_is_stage(term))
-        .collect::<Vec<_>>();
+    let route_terms = packet_probe_terms(probe);
     !normalized_probe.is_empty()
         && (normalized_text.contains(&normalized_probe)
             || (!route_terms.is_empty()
@@ -729,74 +636,49 @@ fn packet_route_citation_is_endpoint(citation: &AgentCitationDto) -> bool {
     )
 }
 
-fn packet_has_execution_graph(answer: &AgentAnswerDto) -> bool {
-    answer.graphs.iter().any(|artifact| match artifact {
-        GraphArtifactDto::Uml { graph, .. } => graph
-            .edges
-            .iter()
-            .any(|edge| edge.kind == EdgeKind::CALL && edge.source != edge.target),
-        GraphArtifactDto::Mermaid { .. } => false,
-    })
-}
-
-fn packet_has_complete_route_graph(answer: &AgentAnswerDto, stages: &[RouteStageEvidence]) -> bool {
-    answer.graphs.iter().any(|artifact| match artifact {
-        GraphArtifactDto::Uml { graph, .. } => packet_graph_contains_route(graph, stages),
-        GraphArtifactDto::Mermaid { .. } => false,
-    })
+fn packet_execution_graphs(answer: &AgentAnswerDto) -> Vec<HashMap<String, Vec<String>>> {
+    answer
+        .graphs
+        .iter()
+        .filter_map(|artifact| match artifact {
+            GraphArtifactDto::Uml { graph, .. } => Some(packet_execution_adjacency(graph)),
+            GraphArtifactDto::Mermaid { .. } => None,
+        })
+        .filter(|graph| !graph.is_empty())
+        .collect()
 }
 
 fn packet_graph_contains_route(
-    graph: &codestory_contracts::api::GraphResponse,
+    graph: &HashMap<String, Vec<String>>,
     stages: &[RouteStageEvidence],
 ) -> bool {
-    let graph_nodes = graph
-        .nodes
-        .iter()
-        .map(|node| node.id.0.as_str())
-        .collect::<HashSet<_>>();
-    let adjacency = packet_execution_adjacency(graph);
-    let mut paths = stages
+    let mut reachable = stages
         .first()
         .into_iter()
         .flat_map(|stage| &stage.node_ids)
-        .filter(|node_id| graph_nodes.contains(node_id.as_str()))
-        .map(|node_id| vec![node_id.clone()])
-        .collect::<Vec<_>>();
+        .cloned()
+        .collect::<HashSet<_>>();
     for stage in stages.iter().skip(1) {
-        let mut next_paths = Vec::new();
-        for path in &paths {
-            let Some(source) = path.last() else {
-                continue;
-            };
-            for target in &stage.node_ids {
-                if path.contains(target)
-                    || !graph_nodes.contains(target.as_str())
-                    || !packet_execution_path_exists(&adjacency, source, target)
-                {
-                    continue;
-                }
-                let mut next = path.clone();
-                next.push(target.clone());
-                next_paths.push(next);
-                if next_paths.len() >= MAX_ROUTE_PROOF_PATHS {
-                    break;
-                }
-            }
-            if next_paths.len() >= MAX_ROUTE_PROOF_PATHS {
-                break;
-            }
-        }
-        paths = next_paths;
-        if paths.is_empty() {
+        let next = stage
+            .node_ids
+            .iter()
+            .filter(|target| {
+                reachable.iter().any(|source| {
+                    source != *target && packet_execution_path_exists(graph, source, target)
+                })
+            })
+            .cloned()
+            .collect::<HashSet<_>>();
+        if next.is_empty() {
             return false;
         }
+        reachable = next;
     }
-    !paths.is_empty()
+    !reachable.is_empty()
 }
 
 fn packet_missing_route_transitions(
-    answer: &AgentAnswerDto,
+    graphs: &[HashMap<String, Vec<String>>],
     stages: &[RouteStageEvidence],
 ) -> Vec<String> {
     stages
@@ -805,26 +687,13 @@ fn packet_missing_route_transitions(
             let [source, target] = pair else {
                 return None;
             };
-            let found = answer.graphs.iter().any(|artifact| match artifact {
-                GraphArtifactDto::Uml { graph, .. } => {
-                    let graph_nodes = graph
-                        .nodes
-                        .iter()
-                        .map(|node| node.id.0.as_str())
-                        .collect::<HashSet<_>>();
-                    let adjacency = packet_execution_adjacency(graph);
-                    source.node_ids.iter().any(|source_id| {
-                        graph_nodes.contains(source_id.as_str())
-                            && target.node_ids.iter().any(|target_id| {
-                                graph_nodes.contains(target_id.as_str())
-                                    && source_id != target_id
-                                    && packet_execution_path_exists(
-                                        &adjacency, source_id, target_id,
-                                    )
-                            })
+            let found = graphs.iter().any(|graph| {
+                source.node_ids.iter().any(|source_id| {
+                    target.node_ids.iter().any(|target_id| {
+                        source_id != target_id
+                            && packet_execution_path_exists(graph, source_id, target_id)
                     })
-                }
-                GraphArtifactDto::Mermaid { .. } => false,
+                })
             });
             (!found).then(|| format!("{} -> {}", source.label, target.label))
         })
@@ -934,7 +803,7 @@ fn packet_sufficiency_gaps(
         ));
     }
     if task_class == PacketTaskClassDto::RouteTracing && !route_proof.complete {
-        gaps.extend(route_proof.gaps());
+        gaps.extend(route_proof.gaps.clone());
     }
     if !missing_required_probe_queries.is_empty() {
         gaps.push(format!(
@@ -1502,17 +1371,8 @@ fn packet_coverage_report(input: PacketCoverageReportInput<'_>) -> PacketCoverag
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
-    for endpoint in &route_proof.missing_endpoints {
-        push_unique_term(&mut missing, &format!("route endpoint: {endpoint}"));
-    }
-    for transition in &route_proof.missing_transitions {
-        push_unique_term(&mut missing, &format!("route transition: {transition}"));
-    }
-    if route_proof.claim_order_mismatch {
-        push_unique_term(&mut missing, "route claim order");
-    }
-    if route_proof.execution_graph_missing || route_proof.fragmented_execution_graph {
-        push_unique_term(&mut missing, "route execution graph");
+    for route_gap in &route_proof.missing {
+        push_unique_term(&mut missing, route_gap);
     }
     let budget_omitted = if has_sufficiency_blocking_budget_omission {
         budget.omitted_sections.clone()
@@ -2800,6 +2660,7 @@ fn insert_generic_boundary_roles(roles: &mut HashSet<FlowRole>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::packet_budget::{apply_packet_budget, packet_budget_limits};
     use codestory_contracts::api::{
         AgentAnswerDto, AgentCitationDto, AgentResponseBlockDto, AgentResponseSectionDto,
         AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, EdgeId,
@@ -2973,6 +2834,13 @@ mod tests {
             cited_anchor(name),
             Some(true),
         )
+    }
+
+    fn route_transition_claim(source: &str, target: &str) -> PacketClaimDto {
+        let mut claim = route_claim(source);
+        claim.claim = format!("`{source}` calls `{target}` on the requested route.");
+        claim.citations.push(cited_anchor(target));
+        claim
     }
 
     fn route_answer(question: &str, names: &[&str], edges: &[(&str, &str)]) -> AgentAnswerDto {
@@ -3254,7 +3122,7 @@ mod tests {
     }
 
     #[test]
-    fn route_proof_requires_claim_and_execution_graph_to_share_endpoint_order() {
+    fn route_proof_uses_graph_order_when_claim_relevance_order_differs() {
         let question = "Trace how RouteIngress reaches RouteDispatch then RouteEgress.";
         let answer = route_answer(
             question,
@@ -3272,12 +3140,58 @@ mod tests {
 
         let sufficiency = route_sufficiency(question, &answer, &budget_fixture(), claims);
 
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "claim relevance order must not override the cited execution graph: {sufficiency:?}"
+        );
+        assert!(sufficiency.gaps.is_empty());
+    }
+
+    #[test]
+    fn one_transition_claim_can_bind_both_adjacent_stages() {
+        let question = "Trace EndpointA then EndpointB then EndpointC.";
+        let answer = route_answer(
+            question,
+            &["EndpointA", "EndpointB", "EndpointC"],
+            &[("EndpointA", "EndpointB"), ("EndpointB", "EndpointC")],
+        );
+        let claims = vec![
+            route_transition_claim("EndpointB", "EndpointC"),
+            route_transition_claim("EndpointA", "EndpointB"),
+        ];
+
+        let sufficiency = route_sufficiency(question, &answer, &budget_fixture(), claims);
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "one accurate transition claim may bind both cited endpoints: {sufficiency:?}"
+        );
+    }
+
+    #[test]
+    fn stage_binding_does_not_promote_unrelated_citations_from_the_same_claim() {
+        let question = "Trace EndpointA to EndpointC.";
+        let answer = route_answer(
+            question,
+            &["EndpointA", "EndpointB", "EndpointC"],
+            &[("EndpointB", "EndpointC")],
+        );
+        let claims = vec![
+            route_transition_claim("EndpointA", "EndpointB"),
+            route_claim("EndpointC"),
+        ];
+
+        let sufficiency = route_sufficiency(question, &answer, &budget_fixture(), claims);
+
         assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
         assert!(
             sufficiency
                 .gaps
                 .iter()
-                .any(|gap| gap.contains("claims did not describe"))
+                .any(|gap| gap.contains("EndpointA -> EndpointC")),
+            "EndpointB's edge must not stand in for EndpointA: {sufficiency:?}"
         );
     }
 
@@ -3319,9 +3233,9 @@ mod tests {
     }
 
     #[test]
-    fn route_proof_preserves_complete_route_across_packet_budgets() {
+    fn route_proof_observes_actual_citation_and_edge_caps_across_packet_budgets() {
         let question = "Trace how RouteIngress reaches RouteDispatch then RouteEgress.";
-        let answer = route_answer(
+        let mut uncapped_answer = route_answer(
             question,
             &["RouteIngress", "RouteDispatch", "RouteEgress"],
             &[
@@ -3329,29 +3243,194 @@ mod tests {
                 ("RouteDispatch", "RouteEgress"),
             ],
         );
-        let claims = vec![
-            route_claim("RouteIngress"),
-            route_claim("RouteDispatch"),
-            route_claim("RouteEgress"),
-        ];
+        uncapped_answer
+            .citations
+            .extend((0..12).map(|index| cited_anchor(&format!("Filler{index}"))));
+        let GraphArtifactDto::Uml { graph, .. } = &mut uncapped_answer.graphs[0] else {
+            unreachable!("route fixture must contain UML")
+        };
+        let route_edges = std::mem::take(&mut graph.edges);
+        graph
+            .nodes
+            .extend((0..22).map(|index| route_graph_node(&format!("Filler{index}"))));
+        graph.edges.extend((0..21).map(|index| {
+            route_graph_edge(
+                &format!("filler-edge-{index}"),
+                &format!("Filler{index}"),
+                &format!("Filler{}", index + 1),
+            )
+        }));
+        graph.edges.extend(route_edges);
 
         for requested in [
             PacketBudgetModeDto::Compact,
             PacketBudgetModeDto::Standard,
             PacketBudgetModeDto::Deep,
         ] {
-            let mut budget = budget_fixture();
-            budget.requested = requested;
-            let sufficiency = route_sufficiency(question, &answer, &budget, claims.clone());
-
-            assert_eq!(
-                sufficiency.status,
-                PacketSufficiencyStatusDto::Sufficient,
-                "complete retained route should be sufficient for {requested:?}: {sufficiency:?}"
+            let mut answer = uncapped_answer.clone();
+            let limits = packet_budget_limits(requested);
+            let budget = apply_packet_budget(
+                Path::new("C:/workspace/project"),
+                question,
+                PacketTaskClassDto::RouteTracing,
+                requested,
+                limits.clone(),
+                &mut answer,
             );
-            assert!(sufficiency.gaps.is_empty());
-            assert!(sufficiency.follow_up_commands.is_empty());
+            let retained = answer
+                .citations
+                .iter()
+                .map(|citation| citation.node_id.0.as_str())
+                .collect::<HashSet<_>>();
+            let claims = ["RouteIngress", "RouteDispatch", "RouteEgress"]
+                .into_iter()
+                .filter(|name| retained.contains(name))
+                .map(route_claim)
+                .collect();
+            let sufficiency = route_sufficiency(question, &answer, &budget, claims);
+
+            if requested == PacketBudgetModeDto::Compact {
+                assert!(budget.truncated, "compact must exercise real caps");
+                assert!(answer.citations.len() <= limits.max_anchors as usize);
+                let GraphArtifactDto::Uml { graph, .. } = &answer.graphs[0] else {
+                    unreachable!("route fixture must retain UML")
+                };
+                assert_eq!(graph.edges.len(), limits.max_trail_edges as usize);
+                assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+            } else {
+                assert!(!budget.truncated, "{requested:?} should retain the route");
+                assert_eq!(
+                    sufficiency.status,
+                    PacketSufficiencyStatusDto::Sufficient,
+                    "retained route should remain sufficient for {requested:?}: {sufficiency:?}"
+                );
+                assert!(sufficiency.gaps.is_empty());
+            }
         }
+    }
+
+    #[test]
+    fn route_stages_flatten_requested_flow_checkpoints_and_keep_selected_probes() {
+        let question = "Trace the indexing entrypoint through file discovery, symbol extraction, and storage persistence.";
+        let names = [
+            "IndexingEntrypoint",
+            "FileDiscovery",
+            "SymbolExtraction",
+            "StoragePersistence",
+            "SearchPublication",
+        ];
+        let answer = route_answer(
+            question,
+            &names,
+            &[
+                ("IndexingEntrypoint", "FileDiscovery"),
+                ("FileDiscovery", "SymbolExtraction"),
+                ("SymbolExtraction", "StoragePersistence"),
+                ("StoragePersistence", "SearchPublication"),
+            ],
+        );
+        let selected_probes = vec!["SearchPublication".to_string()];
+        let sufficiency = assemble_packet_sufficiency_with_route_probes(
+            PacketSufficiencyInput {
+                project_root: Path::new("C:/workspace/project"),
+                question,
+                task_class: PacketTaskClassDto::RouteTracing,
+                answer: &answer,
+                budget: &budget_fixture(),
+                supported_claims: names.into_iter().map(route_claim).collect(),
+                missing_required_probe_queries: Vec::new(),
+                targeted_follow_up_queries: Vec::new(),
+            },
+            &selected_probes,
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "all requested checkpoints and the selected publication probe must survive: {sufficiency:?}"
+        );
+    }
+
+    #[test]
+    fn route_stage_overflow_fails_closed_instead_of_dropping_the_seventh_probe() {
+        let names = [
+            "StageOne",
+            "StageTwo",
+            "StageThree",
+            "StageFour",
+            "StageFive",
+            "StageSix",
+            "StageSeven",
+        ];
+        let question = "Follow the requested route.";
+        let answer = route_answer(
+            question,
+            &names,
+            &[
+                ("StageOne", "StageTwo"),
+                ("StageTwo", "StageThree"),
+                ("StageThree", "StageFour"),
+                ("StageFour", "StageFive"),
+                ("StageFive", "StageSix"),
+                ("StageSix", "StageSeven"),
+            ],
+        );
+        let probes = names.into_iter().map(str::to_string).collect::<Vec<_>>();
+        let sufficiency = assemble_packet_sufficiency_with_route_probes(
+            PacketSufficiencyInput {
+                project_root: Path::new("C:/workspace/project"),
+                question,
+                task_class: PacketTaskClassDto::RouteTracing,
+                answer: &answer,
+                budget: &budget_fixture(),
+                supported_claims: names.into_iter().map(route_claim).collect(),
+                missing_required_probe_queries: Vec::new(),
+                targeted_follow_up_queries: Vec::new(),
+            },
+            &probes,
+        );
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency.gaps.iter().any(|gap| {
+                gap.contains("bounded 6-stage capacity") && gap.contains("StageSeven")
+            }),
+            "overflow must identify the omitted required stage: {sufficiency:?}"
+        );
+        assert!(sufficiency.coverage_report.as_ref().is_some_and(|report| {
+            report
+                .missing
+                .contains(&"route stage overflow: StageSeven".to_string())
+        }));
+    }
+
+    #[test]
+    fn normal_route_wording_does_not_turn_control_words_into_stages() {
+        let question = "Follow the requested execution call route from IngressHook to EgressHook.";
+        let answer = route_answer(
+            question,
+            &["IngressHook", "RouteSupport", "EgressHook"],
+            &[
+                ("IngressHook", "RouteSupport"),
+                ("RouteSupport", "EgressHook"),
+            ],
+        );
+        let sufficiency = route_sufficiency(
+            question,
+            &answer,
+            &budget_fixture(),
+            vec![
+                route_claim("IngressHook"),
+                route_claim("RouteSupport"),
+                route_claim("EgressHook"),
+            ],
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "route control words must not become evidence stages: {sufficiency:?}"
+        );
     }
 
     #[test]
@@ -3384,7 +3463,11 @@ mod tests {
             &selected_probes,
         );
 
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "{sufficiency:?}"
+        );
         assert!(sufficiency.gaps.is_empty());
     }
 
@@ -4334,18 +4417,30 @@ mod tests {
             ),
         ];
 
-        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
-            project_root: Path::new("C:/workspace/project"),
-            question,
-            task_class: PacketTaskClassDto::RouteTracing,
-            answer: &answer,
-            budget: &budget,
-            supported_claims: claims,
-            missing_required_probe_queries: Vec::new(),
-            targeted_follow_up_queries: Vec::new(),
-        });
+        let sufficiency = assemble_packet_sufficiency_with_route_probes(
+            PacketSufficiencyInput {
+                project_root: Path::new("C:/workspace/project"),
+                question,
+                task_class: PacketTaskClassDto::RouteTracing,
+                answer: &answer,
+                budget: &budget,
+                supported_claims: claims,
+                missing_required_probe_queries: Vec::new(),
+                targeted_follow_up_queries: Vec::new(),
+            },
+            &[
+                "SessionRequest".to_string(),
+                "RequestResume".to_string(),
+                "RequestValidation".to_string(),
+                "SessionCallbacks".to_string(),
+            ],
+        );
 
-        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "{sufficiency:?}"
+        );
         assert!(sufficiency.gaps.is_empty());
         assert!(sufficiency.follow_up_commands.is_empty());
         let report = sufficiency.coverage_report.as_ref().unwrap();
@@ -4856,16 +4951,23 @@ mod tests {
             ),
         ];
 
-        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
-            project_root: Path::new("C:/workspace/synthetic-service"),
-            question,
-            task_class: PacketTaskClassDto::RouteTracing,
-            answer: &answer,
-            budget: &budget,
-            supported_claims: claims,
-            missing_required_probe_queries: Vec::new(),
-            targeted_follow_up_queries: Vec::new(),
-        });
+        let sufficiency = assemble_packet_sufficiency_with_route_probes(
+            PacketSufficiencyInput {
+                project_root: Path::new("C:/workspace/synthetic-service"),
+                question,
+                task_class: PacketTaskClassDto::RouteTracing,
+                answer: &answer,
+                budget: &budget,
+                supported_claims: claims,
+                missing_required_probe_queries: Vec::new(),
+                targeted_follow_up_queries: Vec::new(),
+            },
+            &[
+                "RouteRegistration".to_string(),
+                "HandlerDispatch".to_string(),
+                "ResponseFinalization".to_string(),
+            ],
+        );
 
         assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Sufficient);
         assert!(sufficiency.gaps.is_empty());
@@ -4922,17 +5024,26 @@ mod tests {
             ),
         ];
 
+        let selected_probes = [
+            "RequestEntry".to_string(),
+            "InterceptorRegistry::new".to_string(),
+            "RequestDispatch".to_string(),
+            "TransportSend".to_string(),
+        ];
         let assemble = |supported_claims| {
-            assemble_packet_sufficiency(PacketSufficiencyInput {
-                project_root: Path::new("C:/workspace/generic-client"),
-                question,
-                task_class: PacketTaskClassDto::RouteTracing,
-                answer: &answer,
-                budget: &budget,
-                supported_claims,
-                missing_required_probe_queries: Vec::new(),
-                targeted_follow_up_queries: Vec::new(),
-            })
+            assemble_packet_sufficiency_with_route_probes(
+                PacketSufficiencyInput {
+                    project_root: Path::new("C:/workspace/generic-client"),
+                    question,
+                    task_class: PacketTaskClassDto::RouteTracing,
+                    answer: &answer,
+                    budget: &budget,
+                    supported_claims,
+                    missing_required_probe_queries: Vec::new(),
+                    targeted_follow_up_queries: Vec::new(),
+                },
+                &selected_probes,
+            )
         };
 
         let missing_role = assemble(claims.clone());

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -7,9 +7,7 @@ use crate::agent::packet_flow_requirements::{
     CoverageMode, FlowRequirement, FlowRole, packet_flow_requirements_for_terms,
 };
 use crate::agent::packet_plan::packet_symbol_probe_queries;
-use crate::agent::packet_required_probes::{
-    packet_citation_satisfies_required_probe, packet_missing_sufficiency_probe_queries_with_extra,
-};
+use crate::agent::packet_required_probes::packet_missing_sufficiency_probe_queries_with_extra;
 use crate::agent::packet_scoring::{
     normalize_identifier, packet_display_name_is_test_like, packet_display_path,
 };
@@ -27,11 +25,12 @@ use crate::agent::packet_terms::{
 };
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentRetrievalStepStatusDto, EdgeKind, GraphArtifactDto,
-    NodeKind, PacketBudgetDto, PacketBudgetModeDto, PacketClaimDto, PacketCoverageReportDto,
-    PacketEvidenceResolutionDto, PacketEvidenceTierDto, PacketSidecarQueryDiagnosticDto,
-    PacketSufficiencyDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
+    GraphResponse, NodeKind, PacketBudgetDto, PacketBudgetModeDto, PacketClaimDto,
+    PacketCoverageReportDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto,
+    PacketSidecarQueryDiagnosticDto, PacketSufficiencyDto, PacketSufficiencyStatusDto,
+    PacketTaskClassDto,
 };
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::path::Path;
 
 pub(crate) const PACKET_MARKDOWN_TRUNCATION_SUFFIX: &str =
@@ -120,9 +119,14 @@ fn assemble_packet_sufficiency_with_route_probes(
     let min_citations = packet_sufficiency_min_citations(task_class);
     let min_claims = packet_sufficiency_min_claims(task_class);
     let flow_context = PacketFlowContext::new(question, task_class);
+    let route_stages = packet_route_proof_stages(question);
     let sufficiency_claims = supported_claims
         .iter()
-        .filter(|claim| packet_claim_can_satisfy_sufficiency_in_context(claim, &flow_context))
+        .filter(|claim| {
+            packet_claim_can_satisfy_sufficiency_in_context(claim, &flow_context)
+                || (task_class == PacketTaskClassDto::RouteTracing
+                    && packet_route_claim_binds_stage(&route_stages, selected_probes, claim))
+        })
         .cloned()
         .collect::<Vec<_>>();
     let generic_navigation_claim_count = supported_claims
@@ -130,6 +134,7 @@ fn assemble_packet_sufficiency_with_route_probes(
         .filter(|claim| {
             packet_claim_is_generic_navigation_or_source_evidence(claim)
                 && !flow_context.claim_carries_required_role(claim, false)
+                && !packet_route_claim_binds_stage(&route_stages, selected_probes, claim)
         })
         .count();
     let has_minimum_coverage = answer.citations.len() >= min_citations;
@@ -137,17 +142,19 @@ fn assemble_packet_sufficiency_with_route_probes(
     let claim_family_count = packet_supported_claim_family_count(&sufficiency_claims);
     let has_minimum_claim_families =
         packet_has_minimum_claim_family_coverage(task_class, &sufficiency_claims);
-    let missing_required_flow_requirements =
-        packet_missing_required_flow_requirements(question, task_class, &sufficiency_claims);
-    let has_required_flow_roles = missing_required_flow_requirements.is_empty();
     let route_proof = packet_route_proof_assessment(
-        question,
         task_class,
         answer,
-        &sufficiency_claims,
-        &flow_context,
+        &supported_claims,
+        &route_stages,
         selected_probes,
     );
+    let mut missing_required_flow_requirements =
+        packet_missing_required_flow_requirements(question, task_class, &sufficiency_claims);
+    if task_class == PacketTaskClassDto::RouteTracing && route_proof.complete {
+        missing_required_flow_requirements.clear();
+    }
+    let has_required_flow_roles = missing_required_flow_requirements.is_empty();
     let blocking_missing_probe_queries = packet_blocking_missing_probe_queries(
         question,
         task_class,
@@ -327,17 +334,10 @@ fn packet_sufficiency_status(
 }
 
 const MAX_ROUTE_PROOF_STAGES: usize = 6;
-
-#[derive(Debug, Clone)]
-struct RouteStage {
-    label: String,
-}
-
-#[derive(Debug, Clone)]
-struct RouteStages {
-    stages: Vec<RouteStage>,
-    omitted: Vec<String>,
-}
+const ROUTE_ORDER_GAP: &str = "RouteTracing packet could not resolve at least two ordered endpoints from explicit route syntax in the question.";
+const ROUTE_GRAPH_GAP: &str =
+    "RouteTracing packet did not include a directed execution graph for the cited route endpoints.";
+const ROUTE_FRAGMENT_GAP: &str = "RouteTracing evidence appeared only in separate graph neighborhoods; no single execution graph represented the claimed ordered route.";
 
 #[derive(Debug, Clone)]
 struct RouteStageEvidence {
@@ -362,296 +362,302 @@ impl RouteProofAssessment {
             follow_up_queries: Vec::new(),
         }
     }
+
+    fn blocked(gap: String, missing: Vec<String>, follow_up_queries: Vec<String>) -> Self {
+        Self {
+            complete: false,
+            gaps: vec![gap],
+            missing,
+            follow_up_queries,
+        }
+    }
 }
 
 fn packet_route_proof_assessment(
-    question: &str,
     task_class: PacketTaskClassDto,
     answer: &AgentAnswerDto,
     claims: &[PacketClaimDto],
-    flow_context: &PacketFlowContext,
+    stages: &[String],
     selected_probes: &[String],
 ) -> RouteProofAssessment {
     if task_class != PacketTaskClassDto::RouteTracing {
         return RouteProofAssessment::not_required();
     }
-
-    let route_stages = packet_route_proof_stages(question, flow_context, selected_probes);
-    let mut assessment = RouteProofAssessment {
-        complete: false,
-        gaps: Vec::new(),
-        missing: Vec::new(),
-        follow_up_queries: Vec::new(),
-    };
-    let execution_graphs = packet_execution_graphs(answer);
-    let execution_graph_missing = execution_graphs.is_empty();
-    if execution_graph_missing {
-        assessment.gaps.push(
-            "RouteTracing packet did not include a directed execution graph for the cited route endpoints."
-                .to_string(),
+    if stages.len() < 2 {
+        return RouteProofAssessment::blocked(
+            ROUTE_ORDER_GAP.to_string(),
+            vec!["route order: unresolved endpoints".to_string()],
+            stages.to_vec(),
         );
-        assessment.missing.push("route execution graph".to_string());
     }
-    if route_stages.stages.len() + route_stages.omitted.len() < 2 {
-        assessment.gaps.push(
-            "RouteTracing packet could not derive two requested route endpoints from the question and selected probes."
-                .to_string(),
-        );
-        assessment.follow_up_queries = route_stages
-            .stages
-            .iter()
-            .map(|stage| stage.label.clone())
-            .collect();
-        return assessment;
-    }
-    if !route_stages.omitted.is_empty() {
-        assessment.gaps.push(format!(
-            "RouteTracing route proof exceeds the bounded {MAX_ROUTE_PROOF_STAGES}-stage capacity; unrepresented required stage(s): {}.",
-            route_stages.omitted.join(", ")
-        ));
-        assessment.missing.extend(
-            route_stages
-                .omitted
+    if stages.len() > MAX_ROUTE_PROOF_STAGES {
+        let omitted = stages[MAX_ROUTE_PROOF_STAGES..].to_vec();
+        return RouteProofAssessment::blocked(
+            format!(
+                "RouteTracing route proof exceeds the bounded {MAX_ROUTE_PROOF_STAGES}-stage capacity; unrepresented required stage(s): {}.",
+                omitted.join(", ")
+            ),
+            omitted
                 .iter()
-                .map(|stage| format!("route stage overflow: {stage}")),
+                .map(|stage| format!("route stage overflow: {stage}"))
+                .collect(),
+            omitted,
         );
-        assessment.follow_up_queries = route_stages.omitted;
-        return assessment;
     }
 
-    let mut stage_evidence = Vec::new();
-    let mut missing_endpoints = Vec::new();
-    for stage in &route_stages.stages {
+    let mut evidence = Vec::new();
+    let mut missing = Vec::new();
+    for stage in stages {
         let mut node_ids = claims
             .iter()
-            .flat_map(|claim| packet_route_claim_node_ids(stage, claim))
+            .flat_map(|claim| packet_route_claim_node_ids(stage, selected_probes, claim))
             .collect::<Vec<_>>();
         node_ids.sort();
         node_ids.dedup();
-        if !node_ids.is_empty() {
-            stage_evidence.push(RouteStageEvidence {
-                label: stage.label.clone(),
+        if node_ids.is_empty() {
+            missing.push(stage.clone());
+        } else {
+            evidence.push(RouteStageEvidence {
+                label: stage.clone(),
                 node_ids,
             });
-            continue;
-        }
-        missing_endpoints.push(stage.label.clone());
-        assessment
-            .missing
-            .push(format!("route endpoint: {}", stage.label));
-        push_unique_term(&mut assessment.follow_up_queries, &stage.label);
-    }
-
-    if !missing_endpoints.is_empty() {
-        assessment.gaps.push(format!(
-            "RouteTracing packet missed relevant cited route endpoint(s): {}.",
-            missing_endpoints.join(", ")
-        ));
-        return assessment;
-    }
-
-    let missing_transitions = packet_missing_route_transitions(&execution_graphs, &stage_evidence);
-    for transition in &missing_transitions {
-        assessment
-            .missing
-            .push(format!("route transition: {transition}"));
-        if let Some((_, target)) = transition.split_once(" -> ") {
-            push_unique_term(&mut assessment.follow_up_queries, target);
         }
     }
-    let has_complete_graph = execution_graphs
-        .iter()
-        .any(|graph| packet_graph_contains_route(graph, &stage_evidence));
-    if !missing_transitions.is_empty() {
-        assessment.gaps.push(format!(
-            "RouteTracing execution graph missed ordered transition(s): {}.",
-            missing_transitions.join(", ")
-        ));
-    } else if !has_complete_graph && !execution_graph_missing {
-        assessment.gaps.push(
-            "RouteTracing evidence appeared only in separate graph neighborhoods; no single execution graph represented the claimed ordered route."
-                .to_string(),
+    if !missing.is_empty() {
+        return RouteProofAssessment::blocked(
+            format!(
+                "RouteTracing packet missed relevant cited route endpoint(s): {}.",
+                missing.join(", ")
+            ),
+            missing
+                .iter()
+                .map(|stage| format!("route endpoint: {stage}"))
+                .collect(),
+            missing,
         );
-        assessment.missing.push("route execution graph".to_string());
     }
-    assessment.complete = has_complete_graph;
-    assessment
-}
 
-fn packet_route_proof_stages(
-    question: &str,
-    flow_context: &PacketFlowContext,
-    selected_probes: &[String],
-) -> RouteStages {
-    let normalized_question = normalize_identifier(question);
-    let mut candidates = Vec::new();
-    for requirement in flow_context
-        .requirements
+    let graphs = packet_execution_graphs(answer);
+    if graphs.is_empty() {
+        return RouteProofAssessment::blocked(
+            ROUTE_GRAPH_GAP.to_string(),
+            vec!["route execution graph".to_string()],
+            stages.to_vec(),
+        );
+    }
+    let missing_transitions = packet_missing_route_transitions(&graphs, &evidence);
+    let has_complete_graph = graphs
         .iter()
-        .copied()
-        .filter(flow_requirement_blocks_sufficiency)
-    {
-        for seed in requirement.query_seeds {
-            let normalized_seed = normalize_identifier(seed);
-            if let Some(position) = normalized_question.find(&normalized_seed) {
-                candidates.push((
-                    position,
-                    RouteStage {
-                        label: (*seed).to_string(),
-                    },
-                ));
-            }
-        }
+        .any(|graph| packet_graph_contains_route(graph, &evidence));
+    if !missing_transitions.is_empty() {
+        return RouteProofAssessment::blocked(
+            format!(
+                "RouteTracing execution graph missed ordered transition(s): {}.",
+                missing_transitions.join(", ")
+            ),
+            missing_transitions
+                .iter()
+                .map(|transition| format!("route transition: {transition}"))
+                .collect(),
+            missing_transitions
+                .iter()
+                .filter_map(|transition| {
+                    transition
+                        .split_once(" -> ")
+                        .map(|(_, target)| target.to_string())
+                })
+                .collect(),
+        );
     }
+    if !has_complete_graph {
+        return RouteProofAssessment::blocked(
+            ROUTE_FRAGMENT_GAP.to_string(),
+            vec!["route execution graph".to_string()],
+            Vec::new(),
+        );
+    }
+    RouteProofAssessment::not_required()
+}
 
-    for probe in selected_probes {
-        let probe = probe.trim();
-        let normalized_probe = normalize_identifier(probe);
-        if probe.len() < 3 || normalized_probe.is_empty() {
-            continue;
-        }
-        candidates.push((
-            usize::MAX,
-            RouteStage {
-                label: probe.to_string(),
-            },
-        ));
-    }
+fn packet_route_proof_stages(question: &str) -> Vec<String> {
+    packet_route_stage_labels(question)
+}
 
-    if candidates.is_empty() {
-        for (position, probe) in packet_route_explicit_question_probes(question) {
-            candidates.push((position, RouteStage { label: probe }));
-        }
-    }
-
-    candidates.sort_by_key(|(position, _)| *position);
-    let mut stages = Vec::new();
-    for (_, stage) in candidates {
-        let normalized = normalize_identifier(&stage.label);
-        if !stages
-            .iter()
-            .any(|existing: &RouteStage| normalize_identifier(&existing.label) == normalized)
-        {
-            stages.push(stage);
-        }
-    }
-    let omitted = if stages.len() > MAX_ROUTE_PROOF_STAGES {
-        stages
-            .split_off(MAX_ROUTE_PROOF_STAGES)
-            .into_iter()
-            .map(|stage| stage.label)
-            .collect()
+fn packet_route_stage_labels(question: &str) -> Vec<String> {
+    let question = question.replace('→', "->");
+    let spans = if question.contains("->") {
+        question.split("->").map(str::to_string).collect()
     } else {
-        Vec::new()
+        let words = question.split_whitespace().collect::<Vec<_>>();
+        let from = words
+            .iter()
+            .position(|word| packet_route_word_is(word, "from"));
+        let route_words = from.map_or(words.as_slice(), |index| &words[index + 1..]);
+        let markers = route_words
+            .iter()
+            .enumerate()
+            .filter_map(|(index, word)| {
+                ["through", "via", "to"]
+                    .iter()
+                    .any(|marker| packet_route_word_is(word, marker))
+                    .then_some(index)
+            })
+            .collect::<Vec<_>>();
+        if markers.is_empty()
+            || (from.is_none()
+                && packet_route_word_is(route_words[markers[0]], "to")
+                && !route_words[..markers[0]]
+                    .iter()
+                    .any(|word| packet_route_token_is_explicit_identifier(word)))
+        {
+            return Vec::new();
+        }
+        let mut spans = Vec::new();
+        let mut start = 0;
+        for marker in markers {
+            spans.push(route_words[start..marker].join(" "));
+            start = marker + 1;
+        }
+        spans.push(route_words[start..].join(" "));
+        spans
     };
-    RouteStages { stages, omitted }
+    spans
+        .iter()
+        .map(|span| packet_route_stage_label(span))
+        .collect::<Option<Vec<_>>>()
+        .unwrap_or_default()
 }
 
-fn packet_route_explicit_question_probes(question: &str) -> Vec<(usize, String)> {
-    question
-        .split_whitespace()
-        .enumerate()
-        .filter_map(|(position, raw)| {
-            let probe = raw.trim_matches(|character: char| {
-                !character.is_alphanumeric() && !matches!(character, '_' | ':' | '.' | '#')
-            });
-            let has_identifier_shape = probe.contains("::")
-                || probe.contains('_')
-                || probe.contains('#')
-                || probe
-                    .chars()
-                    .skip(1)
-                    .any(|character| character.is_ascii_uppercase());
-            (probe.len() >= 3 && has_identifier_shape).then(|| (position, probe.to_string()))
-        })
-        .collect()
+fn packet_route_stage_label(span: &str) -> Option<String> {
+    let span = packet_route_clean_word(span.trim());
+    if span.is_empty() {
+        return None;
+    }
+    for quote in ['`', '\'', '"'] {
+        if let Some((_, rest)) = span.split_once(quote)
+            && let Some((label, _)) = rest.split_once(quote)
+            && !label.trim().is_empty()
+        {
+            return Some(label.trim().to_string());
+        }
+    }
+    Some(span.to_string())
 }
 
-fn packet_route_claim_node_ids(stage: &RouteStage, claim: &PacketClaimDto) -> Vec<String> {
-    if !packet_route_probe_matches_claim(&stage.label, claim)
-        || packet_claim_is_generic_navigation_or_source_evidence(claim)
-    {
+fn packet_route_token_is_explicit_identifier(token: &str) -> bool {
+    let token = packet_route_clean_word(token);
+    token.contains("::")
+        || token.contains(['/', '\\', '_', '#', '.'])
+        || token
+            .chars()
+            .skip(1)
+            .any(|character| character.is_ascii_uppercase())
+}
+
+fn packet_route_clean_word(word: &str) -> &str {
+    word.trim_matches(|character: char| {
+        character.is_ascii_punctuation() && !matches!(character, '_' | ':' | '/' | '\\' | '#')
+    })
+}
+
+fn packet_route_word_is(word: &str, marker: &str) -> bool {
+    packet_route_clean_word(word).eq_ignore_ascii_case(marker)
+}
+
+fn packet_route_claim_node_ids(
+    stage: &str,
+    selected_probes: &[String],
+    claim: &PacketClaimDto,
+) -> Vec<String> {
+    if claim.eligible_for_sufficiency == Some(false) {
         return Vec::new();
     }
-    let mut node_ids = claim
+    claim
         .citations
         .iter()
         .filter(|citation| packet_route_citation_is_endpoint(citation))
         .filter(|citation| {
-            packet_citation_satisfies_required_probe(&stage.label, citation)
-                || packet_route_probe_matches_text(&stage.label, &citation.display_name)
+            packet_route_label_matches_citation(stage, citation)
+                || selected_probes.iter().any(|probe| {
+                    packet_route_labels_overlap(stage, probe)
+                        && packet_route_label_matches_citation(probe, citation)
+                })
         })
         .map(|citation| citation.node_id.0.clone())
-        .collect::<Vec<_>>();
-    node_ids.sort();
-    node_ids.dedup();
-    node_ids
+        .collect()
 }
 
-fn packet_route_probe_matches_claim(probe: &str, claim: &PacketClaimDto) -> bool {
-    packet_route_probe_matches_text(probe, &claim.claim)
-        || claim
-            .citations
-            .iter()
-            .any(|citation| packet_citation_satisfies_required_probe(probe, citation))
+fn packet_route_claim_binds_stage(
+    stages: &[String],
+    selected_probes: &[String],
+    claim: &PacketClaimDto,
+) -> bool {
+    stages
+        .iter()
+        .any(|stage| !packet_route_claim_node_ids(stage, selected_probes, claim).is_empty())
 }
 
-fn packet_route_probe_matches_text(probe: &str, text: &str) -> bool {
-    let normalized_probe = normalize_identifier(probe);
-    let normalized_text = normalize_identifier(text);
-    let route_terms = packet_probe_terms(probe);
-    !normalized_probe.is_empty()
-        && (normalized_text.contains(&normalized_probe)
-            || (!route_terms.is_empty()
-                && route_terms
-                    .iter()
-                    .all(|term| normalized_text.contains(&normalize_identifier(term)))))
+fn packet_route_labels_overlap(left: &str, right: &str) -> bool {
+    let left = normalize_identifier(left);
+    !left.is_empty() && left == normalize_identifier(right)
+}
+
+fn packet_route_label_matches_citation(label: &str, citation: &AgentCitationDto) -> bool {
+    let normalized_label = normalize_identifier(label);
+    let display = citation.display_name.as_str();
+    let terminal = display
+        .rsplit(['.', ':', '#', '/', '\\'])
+        .find(|part| !part.is_empty())
+        .unwrap_or(display);
+    normalize_identifier(display) == normalized_label
+        || normalize_identifier(terminal) == normalized_label
+        || citation.file_path.as_deref().is_some_and(|path| {
+            let path = path.replace('\\', "/");
+            let label = label.replace('\\', "/");
+            path == label || path.ends_with(&format!("/{label}"))
+        })
 }
 
 fn packet_route_citation_is_endpoint(citation: &AgentCitationDto) -> bool {
-    if !citation_sufficiency_eligible(citation)
-        || !matches!(
-            citation.kind,
-            NodeKind::FUNCTION | NodeKind::METHOD | NodeKind::MACRO
-        )
-        || packet_display_name_is_test_like(&citation.display_name)
-    {
-        return false;
-    }
-    let Some(path) = citation.file_path.as_deref() else {
-        return false;
-    };
-    if crate::retrieval_file_role_from_path(path) != crate::RetrievalFileRole::Source {
-        return false;
-    }
     let terminal = citation
         .display_name
         .rsplit(['.', ':', '#'])
         .next()
         .map(normalize_identifier)
         .unwrap_or_default();
-    !matches!(
-        terminal.as_str(),
-        "helper" | "helpers" | "util" | "utils" | "utility" | "generichelper"
-    )
+    citation_sufficiency_eligible(citation)
+        && matches!(
+            citation.kind,
+            NodeKind::FUNCTION | NodeKind::METHOD | NodeKind::MACRO
+        )
+        && !packet_display_name_is_test_like(&citation.display_name)
+        && citation.file_path.as_deref().is_some_and(|path| {
+            crate::retrieval_file_role_from_path(path) == crate::RetrievalFileRole::Source
+        })
+        && !matches!(
+            terminal.as_str(),
+            "helper" | "helpers" | "util" | "utils" | "utility" | "generichelper"
+        )
 }
 
-fn packet_execution_graphs(answer: &AgentAnswerDto) -> Vec<HashMap<String, Vec<String>>> {
+fn packet_execution_graphs(answer: &AgentAnswerDto) -> Vec<&GraphResponse> {
     answer
         .graphs
         .iter()
         .filter_map(|artifact| match artifact {
-            GraphArtifactDto::Uml { graph, .. } => Some(packet_execution_adjacency(graph)),
+            GraphArtifactDto::Uml { graph, .. } => Some(graph),
             GraphArtifactDto::Mermaid { .. } => None,
         })
-        .filter(|graph| !graph.is_empty())
+        .filter(|graph| {
+            graph
+                .edges
+                .iter()
+                .any(|edge| edge.kind == EdgeKind::CALL && edge.source != edge.target)
+        })
         .collect()
 }
 
-fn packet_graph_contains_route(
-    graph: &HashMap<String, Vec<String>>,
-    stages: &[RouteStageEvidence],
-) -> bool {
+fn packet_graph_contains_route(graph: &GraphResponse, stages: &[RouteStageEvidence]) -> bool {
     let mut reachable = stages
         .first()
         .into_iter()
@@ -678,7 +684,7 @@ fn packet_graph_contains_route(
 }
 
 fn packet_missing_route_transitions(
-    graphs: &[HashMap<String, Vec<String>>],
+    graphs: &[&GraphResponse],
     stages: &[RouteStageEvidence],
 ) -> Vec<String> {
     stages
@@ -700,39 +706,21 @@ fn packet_missing_route_transitions(
         .collect()
 }
 
-fn packet_execution_adjacency(
-    graph: &codestory_contracts::api::GraphResponse,
-) -> HashMap<String, Vec<String>> {
-    let mut adjacency = HashMap::<String, Vec<String>>::new();
-    for edge in &graph.edges {
-        if edge.kind != EdgeKind::CALL || edge.source == edge.target {
-            continue;
-        }
-        adjacency
-            .entry(edge.source.0.clone())
-            .or_default()
-            .push(edge.target.0.clone());
-    }
-    adjacency
-}
-
-fn packet_execution_path_exists(
-    adjacency: &HashMap<String, Vec<String>>,
-    source: &str,
-    target: &str,
-) -> bool {
+fn packet_execution_path_exists(graph: &GraphResponse, source: &str, target: &str) -> bool {
     if source == target {
         return false;
     }
     let mut queue = VecDeque::from([source.to_string()]);
     let mut visited = HashSet::from([source.to_string()]);
     while let Some(current) = queue.pop_front() {
-        for next in adjacency.get(&current).into_iter().flatten() {
-            if next == target {
+        for edge in graph.edges.iter().filter(|edge| {
+            edge.kind == EdgeKind::CALL && edge.source.0 == current && edge.source != edge.target
+        }) {
+            if edge.target.0 == target {
                 return true;
             }
-            if visited.insert(next.clone()) {
-                queue.push_back(next.clone());
+            if visited.insert(edge.target.0.clone()) {
+                queue.push_back(edge.target.0.clone());
             }
         }
     }
@@ -2868,6 +2856,23 @@ mod tests {
         })
     }
 
+    fn production_route_sufficiency(
+        question: &str,
+        names: &[&str],
+        edges: &[(&str, &str)],
+    ) -> (PacketSufficiencyDto, Vec<PacketClaimDto>) {
+        let answer = route_answer(question, names, edges);
+        let claims = packet_supported_claims(&answer);
+        let sufficiency = build_packet_sufficiency(
+            Path::new("C:/workspace/project"),
+            question,
+            PacketTaskClassDto::RouteTracing,
+            &answer,
+            &budget_fixture(),
+        );
+        (sufficiency, claims)
+    }
+
     fn mark_full_retrieval_unavailable(answer: &mut AgentAnswerDto) {
         answer.retrieval_trace.retrieval_shadow = Some(RetrievalShadowDto {
             retrieval_mode: "unavailable".to_string(),
@@ -2983,7 +2988,7 @@ mod tests {
 
     #[test]
     fn route_proof_rejects_wrong_task_types_helpers_fixture_prose_and_self_edges() {
-        let question = "Trace how RequestOwner reaches ValidationGate.";
+        let question = "RequestOwner -> ValidationGate";
         let mut answer = answer_fixture(question);
         let mut wrong_task = cited_anchor("RequestOwner");
         wrong_task.kind = NodeKind::ENUM_CONSTANT;
@@ -3022,13 +3027,33 @@ mod tests {
                 .iter()
                 .any(|gap| gap.contains("route endpoint"))
         );
+        assert!(!sufficiency.follow_up_commands.is_empty());
+    }
+
+    #[test]
+    fn route_proof_rejects_self_edges_with_exact_endpoints() {
+        let question = "EndpointA -> EndpointB";
+        let mut answer = route_answer(question, &["EndpointA", "EndpointB"], &[]);
+        answer.graphs = vec![route_graph(
+            "self-edges",
+            &["EndpointA", "EndpointB"],
+            &[("EndpointA", "EndpointA"), ("EndpointB", "EndpointB")],
+        )];
+
+        let sufficiency = route_sufficiency(
+            question,
+            &answer,
+            &budget_fixture(),
+            vec![route_claim("EndpointA"), route_claim("EndpointB")],
+        );
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
         assert!(
             sufficiency
                 .gaps
                 .iter()
                 .any(|gap| gap.contains("execution graph"))
         );
-        assert!(!sufficiency.follow_up_commands.is_empty());
     }
 
     #[test]
@@ -3122,8 +3147,112 @@ mod tests {
     }
 
     #[test]
+    fn production_claims_prove_lowercase_arrow_route() {
+        let (sufficiency, claims) = production_route_sufficiency(
+            "main -> run",
+            &["main", "run", "RouteSupport"],
+            &[("main", "run")],
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "{sufficiency:?}"
+        );
+        assert!(
+            claims
+                .iter()
+                .all(|claim| { claim.coverage_role.as_deref() != Some("route endpoint") })
+        );
+    }
+
+    #[test]
+    fn production_source_evidence_proves_explicit_marker_route() {
+        let question = "CustomEntry through request dispatch to CustomExit";
+        let names = ["CustomEntry", "request dispatch", "CustomExit"];
+        let (sufficiency, claims) = production_route_sufficiency(
+            question,
+            &names,
+            &[
+                ("CustomEntry", "request dispatch"),
+                ("request dispatch", "CustomExit"),
+            ],
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "{sufficiency:?}"
+        );
+        assert!(claims.iter().any(|claim| {
+            claim.coverage_role.as_deref() == Some("source evidence")
+                && claim.citations.iter().any(|citation| {
+                    citation.display_name == "CustomEntry" || citation.display_name == "CustomExit"
+                })
+        }));
+        assert!(
+            claims
+                .iter()
+                .all(|claim| claim.coverage_role.as_deref() != Some("route endpoint"))
+        );
+    }
+
+    #[test]
+    fn production_claims_prove_explicit_packaged_runtime_route() {
+        let question = "`plugin launcher` through `stdio transport` via `runtime packet orchestration` to `retrieval` to `packet sufficiency`";
+        let names = [
+            "plugin launcher",
+            "stdio transport",
+            "runtime packet orchestration",
+            "retrieval",
+            "packet sufficiency",
+        ];
+        let edges = [
+            ("plugin launcher", "stdio transport"),
+            ("stdio transport", "runtime packet orchestration"),
+            ("runtime packet orchestration", "retrieval"),
+            ("retrieval", "packet sufficiency"),
+        ];
+        let (sufficiency, claims) = production_route_sufficiency(question, &names, &edges);
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "{sufficiency:?}"
+        );
+        assert!(
+            claims
+                .iter()
+                .all(|claim| claim.coverage_role.as_deref() != Some("route endpoint"))
+        );
+    }
+
+    #[test]
+    fn production_claims_fail_closed_for_retained_ambiguous_release_questions() {
+        let questions = [
+            "Identify ownership and validation gates for the complete v0.16 program.",
+            "Where is packet sufficiency for RouteTracing computed, how are selected probes, citations, claims, and execution graphs evaluated?",
+            "Explain packaged MCP project selection, activation, runtime orchestration, retrieval, and status.",
+        ];
+        for question in questions {
+            let (sufficiency, _) = production_route_sufficiency(
+                question,
+                &["PacketEvidenceRole", "Storage", "eval_probes_enabled"],
+                &[("eval_probes_enabled", "eval_probes_enabled")],
+            );
+
+            assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+            assert!(sufficiency.coverage_report.as_ref().is_some_and(|report| {
+                report
+                    .missing
+                    .contains(&"route order: unresolved endpoints".to_string())
+            }));
+        }
+    }
+
+    #[test]
     fn route_proof_uses_graph_order_when_claim_relevance_order_differs() {
-        let question = "Trace how RouteIngress reaches RouteDispatch then RouteEgress.";
+        let question = "RouteIngress -> RouteDispatch -> RouteEgress";
         let answer = route_answer(
             question,
             &["RouteIngress", "RouteDispatch", "RouteEgress"],
@@ -3150,7 +3279,7 @@ mod tests {
 
     #[test]
     fn one_transition_claim_can_bind_both_adjacent_stages() {
-        let question = "Trace EndpointA then EndpointB then EndpointC.";
+        let question = "EndpointA -> EndpointB -> EndpointC";
         let answer = route_answer(
             question,
             &["EndpointA", "EndpointB", "EndpointC"],
@@ -3172,7 +3301,7 @@ mod tests {
 
     #[test]
     fn stage_binding_does_not_promote_unrelated_citations_from_the_same_claim() {
-        let question = "Trace EndpointA to EndpointC.";
+        let question = "EndpointA to EndpointC";
         let answer = route_answer(
             question,
             &["EndpointA", "EndpointB", "EndpointC"],
@@ -3197,7 +3326,7 @@ mod tests {
 
     #[test]
     fn route_proof_rejects_transitions_split_across_unrelated_neighborhoods() {
-        let question = "Trace how RouteIngress reaches RouteDispatch then RouteEgress.";
+        let question = "RouteIngress -> RouteDispatch -> RouteEgress";
         let mut answer = route_answer(
             question,
             &["RouteIngress", "RouteDispatch", "RouteEgress"],
@@ -3234,7 +3363,7 @@ mod tests {
 
     #[test]
     fn route_proof_observes_actual_citation_and_edge_caps_across_packet_budgets() {
-        let question = "Trace how RouteIngress reaches RouteDispatch then RouteEgress.";
+        let question = "RouteIngress -> RouteDispatch -> RouteEgress";
         let mut uncapped_answer = route_answer(
             question,
             &["RouteIngress", "RouteDispatch", "RouteEgress"],
@@ -3310,8 +3439,9 @@ mod tests {
     }
 
     #[test]
-    fn route_stages_flatten_requested_flow_checkpoints_and_keep_selected_probes() {
-        let question = "Trace the indexing entrypoint through file discovery, symbol extraction, and storage persistence.";
+    fn route_stages_come_only_from_explicit_question_order() {
+        let question =
+            "IndexingEntrypoint -> FileDiscovery -> SymbolExtraction -> StoragePersistence";
         let names = [
             "IndexingEntrypoint",
             "FileDiscovery",
@@ -3329,7 +3459,10 @@ mod tests {
                 ("StoragePersistence", "SearchPublication"),
             ],
         );
-        let selected_probes = vec!["SearchPublication".to_string()];
+        let selected_probes = vec![
+            "SearchPublication".to_string(),
+            "SymbolExtraction".to_string(),
+        ];
         let sufficiency = assemble_packet_sufficiency_with_route_probes(
             PacketSufficiencyInput {
                 project_root: Path::new("C:/workspace/project"),
@@ -3347,12 +3480,21 @@ mod tests {
         assert_eq!(
             sufficiency.status,
             PacketSufficiencyStatusDto::Sufficient,
-            "all requested checkpoints and the selected publication probe must survive: {sufficiency:?}"
+            "question checkpoints must define the route independently of probe order: {sufficiency:?}"
+        );
+        assert_eq!(
+            packet_route_proof_stages(question),
+            [
+                "IndexingEntrypoint",
+                "FileDiscovery",
+                "SymbolExtraction",
+                "StoragePersistence"
+            ]
         );
     }
 
     #[test]
-    fn route_stage_overflow_fails_closed_instead_of_dropping_the_seventh_probe() {
+    fn route_stage_overflow_fails_closed_instead_of_dropping_question_stage() {
         let names = [
             "StageOne",
             "StageTwo",
@@ -3362,7 +3504,7 @@ mod tests {
             "StageSix",
             "StageSeven",
         ];
-        let question = "Follow the requested route.";
+        let question = "StageOne -> StageTwo -> StageThree -> StageFour -> StageFive -> StageSix -> StageSeven";
         let answer = route_answer(
             question,
             &names,
@@ -3375,7 +3517,7 @@ mod tests {
                 ("StageSix", "StageSeven"),
             ],
         );
-        let probes = names.into_iter().map(str::to_string).collect::<Vec<_>>();
+        let probes = vec!["StageSeven".to_string(), "StageOne".to_string()];
         let sufficiency = assemble_packet_sufficiency_with_route_probes(
             PacketSufficiencyInput {
                 project_root: Path::new("C:/workspace/project"),
@@ -3434,7 +3576,7 @@ mod tests {
     }
 
     #[test]
-    fn route_proof_uses_selected_probes_as_ordered_endpoints() {
+    fn selected_probes_do_not_create_route_order_for_ambiguous_prose() {
         let question = "Follow the requested execution route.";
         let answer = route_answer(
             question,
@@ -3465,10 +3607,14 @@ mod tests {
 
         assert_eq!(
             sufficiency.status,
-            PacketSufficiencyStatusDto::Sufficient,
+            PacketSufficiencyStatusDto::Partial,
             "{sufficiency:?}"
         );
-        assert!(sufficiency.gaps.is_empty());
+        assert!(sufficiency.coverage_report.as_ref().is_some_and(|report| {
+            report
+                .missing
+                .contains(&"route order: unresolved endpoints".to_string())
+        }));
     }
 
     #[test]
@@ -4374,7 +4520,7 @@ mod tests {
 
     #[test]
     fn url_session_compact_verbose_truncation_keeps_complete_roles_sufficient() {
-        let question = "Trace how a Session creates requests, resumes tasks, validates data requests, and receives URLSession callbacks.";
+        let question = "SessionRequest -> RequestResume -> RequestValidation -> SessionCallbacks";
         let answer = route_answer(
             question,
             &[
@@ -4916,7 +5062,7 @@ mod tests {
 
     #[test]
     fn generic_request_dispatch_prompt_succeeds_without_benchmark_product_terms() {
-        let question = "Trace how a generic HTTP service receives a request, registers a route, dispatches to a handler, finalizes the response, and returns control to the server.";
+        let question = "RouteRegistration -> HandlerDispatch -> ResponseFinalization";
         let answer = route_answer(
             question,
             &[
@@ -4987,7 +5133,8 @@ mod tests {
 
     #[test]
     fn role_safe_sufficiency_requires_cited_requested_interceptor_evidence() {
-        let question = "Trace how a client creates a request, runs interceptors, dispatches it, and sends it through a transport.";
+        let question =
+            "RequestEntry -> InterceptorRegistry::new -> RequestDispatch -> TransportSend";
         let answer = route_answer(
             question,
             &[
@@ -5055,8 +5202,8 @@ mod tests {
                 .is_some_and(|report| report
                     .missing
                     .iter()
-                    .any(|gap| gap == "request_interceptor_management")),
-            "an explicitly requested role must remain missing without compatible cited evidence: {missing_role:?}"
+                    .any(|gap| gap == "route endpoint: InterceptorRegistry::new")),
+            "an explicitly requested endpoint must remain missing without compatible cited evidence: {missing_role:?}"
         );
 
         let mut unrelated_helper = cited_anchor("requestInterceptorHandler");
@@ -5109,7 +5256,8 @@ mod tests {
 
     #[test]
     fn unresolved_sidecar_diagnostics_do_not_block_when_required_roles_are_covered() {
-        let question = "Trace how Express creates an application, registers middleware/routes, and handles an incoming request through the router and response helpers.";
+        let question =
+            "AppInitialization -> MiddlewareRegistration -> RequestHandler -> ResponseSend";
         let mut answer = route_answer(
             question,
             &[

--- a/crates/codestory-runtime/src/graph_builders.rs
+++ b/crates/codestory-runtime/src/graph_builders.rs
@@ -443,7 +443,7 @@ fn hide_speculative_trail_edges(mut response: GraphResponse) -> GraphResponse {
     response
 }
 
-fn is_speculative_trail_edge(edge: &GraphEdgeDto) -> bool {
+pub(crate) fn is_speculative_trail_edge(edge: &GraphEdgeDto) -> bool {
     if is_speculative_certainty_label(edge.certainty.as_deref()) {
         return true;
     }


### PR DESCRIPTION
## Context

Closes #1266
Refs #1200
Refs #1179

CodeStory packet could label a route-tracing answer `sufficient` even when its citations and graph did not contain the requested endpoints or ordered transitions. Multiple installed/current-source prompts reproduced irrelevant helpers, task enums, and disconnected neighborhoods with no gaps and `unsafe_to_claim=false`.

This draft is rebased on `dev/codestory-next` at `b55ef396e5648235b49bd25b0f553b63ddd51177` and is pinned to head `3755b92f597d9ea382b2ff5a5dca54567287f94d`.

## Outcome

Route-tracing sufficiency now requires eligible citations for the requested stages in question order and one non-self directed call graph carrying the full ordered route. When that proof is absent, the packet reports explicit gaps and remains unsafe to claim.

## What changed

- Derives route stages only from explicit question syntax: `->`/`→`, or spans delimited by `from`, `through`, `via`, and `to`.
- Treats selected probes only as bounded aliases for an already question-derived stage; they cannot add, omit, reorder, or invent execution checkpoints.
- Accepts only one exact quoted identifier, one standalone code-shaped token, one bare lowercase token, or a whole bounded plain phrase that exactly matches an unscoped selected probe.
- Fails closed on framed/suffix text, scoped/file probes, multiple identifiers, multiple or unclosed quotes, and any other ambiguous stage; it never drops text to manufacture a passing route.
- Requires every stage to bind an eligible function/method/macro source citation and one directed call graph carrying the complete route.
- Rejects self-edges, speculative/probable/low-confidence call edges, test/fixture paths, wrong symbol kinds, generic helper endpoints, Mermaid-only evidence, missing transitions, and split graph neighborhoods.
- Requires one bounded directed call graph to carry the complete route.
- Feeds missing endpoint/transition gaps through the existing coverage report and bounded follow-ups so the runtime returns partial and the CLI renders `unsafe_to_claim: true`.
- Keeps retained failing packet IDs/prompts under `#[cfg(test)]`; production contains no repository/prompt table or benchmark-family steering.
- Exercises the production claim generator for `main -> run`, a CamelCase route through a prose intermediate, and the plugin-launcher-to-packet-sufficiency route without a manufactured evidence role.
- Makes the retained release-planning and other ambiguous prose prompts fail closed with `route order: unresolved endpoints`.
- Preserves a real three-stage directed route across compact, standard, and deep budgets.

## How to review

1. Inspect the one explicit route grammar and prove ordinary prose cannot be assigned an execution order.
2. Verify selected probes can only alias an existing unscoped question stage and never add, reorder, or terminalize scoped ownership.
3. Follow exact citation binding, non-speculative same-graph directed path proof, and the six-stage cap.
4. Verify the changed orchestrator fixture removes only the unsafe no-graph assumption.
5. Confirm the large policy addition is the simplest contract that satisfies the generic behavior without repository-specific steering.

## Verification

- `cargo test --locked -p codestory-runtime packet_sufficiency` — 84/84
- `cargo test --locked -p codestory-runtime` — 744 unit tests plus integration/generalization/rejection suites; one repo-scale test ignored by design
- `cargo check --locked -p codestory-runtime` — pass
- `cargo clippy --locked -p codestory-runtime --lib -- -D warnings` — pass
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts` — 42/42, including multi-project interleaving/contention
- `cargo test --locked -p codestory-cli stdio_packet_text_preserves_repo_content_boundary` — pass
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 70 pass, one Windows-only skip
- `cargo fmt --all -- --check` — pass
- `git diff --check` — pass
- Draft CI at exact head `3755b92f597d9ea382b2ff5a5dca54567287f94d` — all required checks green
- Independent exact-head review — no P0-P3 findings or blockers
- Local Apple Silicon installed-candidate replay through the packaged plugin launcher:
  - arm64 `codestory-cli 0.16.0`; archive SHA-256 `1d88ec6a862cab32a842d1be05841cd8dc9f1f4a5bf02ceca307a3517b4560d5`
  - isolated managed runtime path `/private/tmp/codestory-v016-route-replay.gu7EZ0/data/codestory-cli/0.16.0/bin/codestory-cli`; binary SHA-256 `a7d04889314a45a452ceac23c492283b8fb62cf69e18b045554b7fcb35d9be50`
  - installed status reported plugin/CLI/server `0.16.0`, exact project root, fresh 332-file publication, and `retrieval_mode=full`
  - exact retained `route_tracing`/standard interaction returned packet `ask-1784399376173894000`, `partial`, `unsafe_to_claim=true`, explicit unresolved-route and truncation gaps, and bounded follow-ups

## Risk or follow-up

- #1200 remains open through vector adoption, typed probes, broader compactness/latency/planning/contention/search usefulness, and held-out packet quality.
- A separate `architecture_explanation` release-planning prompt still produced a false-safe sufficient packet in this candidate. That is retained as parent #1200 evidence; this slice claims only the explicit `route_tracing` contract.
- This draft does not run the full package/platform matrix or establish release readiness.
