### PR TITLE
[codex] Build exact-head release closeout ledger framework

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1111,8 +1111,10 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       ".github/actionlint.yaml",
       "release-claims.json",
       "scripts/codestory-release-claims.mjs",
+      "scripts/codestory-release-closeout.mjs",
       "scripts/codestory-release-evidence-gate.mjs",
       "scripts/tests/codestory-release-claims.test.mjs",
+      "scripts/tests/codestory-release-closeout.test.mjs",
       "scripts/tests/codestory-release-evidence-gate.test.mjs",
       "scripts/tests/fixtures/release-claims/**",
       "benchmarks/release-evidence/**",
@@ -1156,6 +1158,7 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
     ]);
     requireStepRun(violations, pluginFile, job, "Check release claim and evidence contracts", [
       "scripts/tests/codestory-release-claims.test.mjs",
+      "scripts/tests/codestory-release-closeout.test.mjs",
       "scripts/tests/codestory-release-evidence-gate.test.mjs",
     ]);
     requireStepRun(violations, pluginFile, job, "Check CI proof routing fixtures", ["node .github/scripts/route-ci-proof.mjs --self-test"]);
@@ -1304,6 +1307,7 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   ]);
   requireStepRun(violations, releaseFile, policy, "Check release claim and evidence contracts", [
     "scripts/tests/codestory-release-claims.test.mjs",
+    "scripts/tests/codestory-release-closeout.test.mjs",
     "scripts/tests/codestory-release-evidence-gate.test.mjs",
   ]);
   requireStepRun(violations, releaseFile, policy, "Enforce workflow policy", ["node .github/scripts/check-workflow-policy.mjs"]);
@@ -2068,6 +2072,7 @@ function validateRemainingWorkflows(workflows, violations) {
     ]);
     requireStepRun(violations, autoFile, policy, "Check release claim and evidence contracts", [
       "scripts/tests/codestory-release-claims.test.mjs",
+      "scripts/tests/codestory-release-closeout.test.mjs",
       "scripts/tests/codestory-release-evidence-gate.test.mjs",
     ]);
     requireStepRun(violations, autoFile, policy, "Enforce workflow policy", ["node .github/scripts/check-workflow-policy.mjs"]);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -205,6 +205,26 @@ jobs: { check: { runs-on: ubuntu-latest, steps: [ { uses: vendor/action@${fullSh
   assert.deepEqual(block, flow);
 });
 
+test("release workflows retain the closeout coordinator contract test", () => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  for (const [file, jobName] of [
+    ["plugin-static.yml", "plugin-static"],
+    ["release.yml", "workflow-policy"],
+    ["auto-release.yml", "workflow-policy"],
+  ]) {
+    const workflows = loadWorkflows();
+    const step = workflows.get(file).jobs[jobName].steps.find(
+      ({ name }) => name === "Check release claim and evidence contracts",
+    );
+    step.run = step.run.replace("scripts/tests/codestory-release-closeout.test.mjs", "");
+    assert.ok(
+      validateWorkflows(workflows).some((message) =>
+        message.includes(file)
+          && message.includes("scripts/tests/codestory-release-closeout.test.mjs")),
+    );
+  }
+});
+
 test("third-party action policy reads only parsed uses values", () => {
   const valid = parseWorkflow(`
 on: { workflow_dispatch: null }

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -50,6 +50,7 @@ jobs:
         run: >-
           node --test
           scripts/tests/codestory-release-claims.test.mjs
+          scripts/tests/codestory-release-closeout.test.mjs
           scripts/tests/codestory-release-evidence-gate.test.mjs
 
       - name: Enforce workflow policy

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -18,8 +18,10 @@ on:
       - .github/actionlint.yaml
       - release-claims.json
       - scripts/codestory-release-claims.mjs
+      - scripts/codestory-release-closeout.mjs
       - scripts/codestory-release-evidence-gate.mjs
       - scripts/tests/codestory-release-claims.test.mjs
+      - scripts/tests/codestory-release-closeout.test.mjs
       - scripts/tests/codestory-release-evidence-gate.test.mjs
       - scripts/tests/fixtures/release-claims/**
       - benchmarks/release-evidence/**
@@ -75,8 +77,10 @@ on:
       - .github/actionlint.yaml
       - release-claims.json
       - scripts/codestory-release-claims.mjs
+      - scripts/codestory-release-closeout.mjs
       - scripts/codestory-release-evidence-gate.mjs
       - scripts/tests/codestory-release-claims.test.mjs
+      - scripts/tests/codestory-release-closeout.test.mjs
       - scripts/tests/codestory-release-evidence-gate.test.mjs
       - scripts/tests/fixtures/release-claims/**
       - benchmarks/release-evidence/**
@@ -147,6 +151,7 @@ jobs:
         run: >-
           node --test
           scripts/tests/codestory-release-claims.test.mjs
+          scripts/tests/codestory-release-closeout.test.mjs
           scripts/tests/codestory-release-evidence-gate.test.mjs
 
       - name: Check workflow policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         run: >-
           node --test
           scripts/tests/codestory-release-claims.test.mjs
+          scripts/tests/codestory-release-closeout.test.mjs
           scripts/tests/codestory-release-evidence-gate.test.mjs
 
       - name: Enforce workflow policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 
 ### Reliability and compatibility
 
+- Release closeout now derives its exact source, package, protected hardware,
+  installed runtime, retrieval, performance, quality, platform and
+  post-publish byte-comparison cells from the release claim graph. The generic
+  coordinator retains one manifest and evaluator result per cell plus a
+  deterministic ledger and summary, and rejects stale, duplicate,
+  identity-incomplete, aggregate-host or cross-release evidence.
 - Exact-head source and platform proof now require one coherent workflow ref,
   reviewed SHA, Actions SHA, concurrency identity, checkout, and cache
   namespace. PR coordinators are label-only; manual runs must select the live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   post-publish byte-comparison cells from the release claim graph. The generic
   coordinator retains one manifest and evaluator result per cell plus a
   deterministic ledger and summary, and rejects stale, duplicate,
-  identity-incomplete, aggregate-host or cross-release evidence.
+  identity-incomplete, aggregate-host, cross-version, target-host-mismatched,
+  retained-package-mismatched or cross-release evidence.
 - Exact-head source and platform proof now require one coherent workflow ref,
   reviewed SHA, Actions SHA, concurrency identity, checkout, and cache
   namespace. PR coordinators are label-only; manual runs must select the live

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
+    "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
     "observed_at": "2026-07-16T11:00:00.000Z",
     "expires_at": "2026-07-17T11:00:00.000Z",
     "requested_claims": [
@@ -91,7 +91,7 @@
         "type": "retrieval_readiness",
         "tier": "live_behavior",
         "status": "pass",
-        "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
+        "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {
@@ -110,7 +110,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
+        "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {
@@ -131,7 +131,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
+        "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "196dfafdcdfedc3ce996376f4dc5ac8dfae2f9764a2b7b84d784e220f0aaad3f",
+  "candidate_sha256": "d73d2e85c2618b56982b696f1900508e1b6406c454a03465368d2b41a94301cd",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -24,7 +24,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
+    "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-16T11:00:00.000Z",

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -198,3 +198,24 @@ candidate, approval when supplied, and report files that exist. Runner
 provisioning alone does not establish a baseline, execute the real-repo drill,
 or prove a candidate acceptable. The release remains blocked until the selected
 profile exists as an approved, release-eligible baseline.
+
+## Closeout handoff
+
+Release-evidence output is one input to the exact-head closeout ledger; it is
+not the ledger itself. Each producer supplies one
+`codestory.release-cell-manifest/v1` document for its graph-owned cell. The
+manifest carries the claim evidence row plus its workflow, run, attempt and
+artifact identity. Native cells also carry the applicable target, concrete
+host, runtime/native engine and calibration identities. The coordinator
+derives the required inventory from `release-claims.json`, so operators must
+not maintain a separate target checklist or combine multiple hosts into one
+manifest.
+
+First evaluate and retain the `pre_publish` ledger. Package rows preserve the
+archive name, byte count and SHA-256 used by publication. After the GitHub
+release exists, run the `post_publish` phase with that accepted ledger; every
+published download must name its pre-publish package cell and match its
+retained manifest and archive digests exactly. Keep the per-cell manifests and
+evaluations with both ledgers. A missing, duplicate, expired, failed,
+cross-commit, cross-tree, identity-incomplete or reused row is a rejection, not
+an operator override.

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -214,8 +214,9 @@ manifest.
 First evaluate and retain the `pre_publish` ledger. Package rows preserve the
 archive name, byte count and SHA-256 used by publication. After the GitHub
 release exists, run the `post_publish` phase with that accepted ledger; every
-published download must name its pre-publish package cell and match its
-retained manifest and archive digests exactly. Keep the per-cell manifests and
-evaluations with both ledgers. A missing, duplicate, expired, failed,
+current package row and published download must match its retained manifest and
+archive digests exactly. Producer and runtime versions bind to the closeout
+version, and platform hosts bind to the package matrix target. Keep the per-cell
+manifests and evaluations with both ledgers. A missing, duplicate, expired, failed,
 cross-commit, cross-tree, identity-incomplete or reused row is a rejection, not
 an operator override.

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -319,8 +319,12 @@ protected hardware cells explicit, invokes the claim evaluator for each cell
 and its graph dependencies, then retains canonical copies under `manifests/`
 and `evaluations/` beside `ledger.json` and `summary.json`. A pre-publish run
 records each archive name, byte count, and SHA-256. A post-publish run requires
-that accepted pre-publish ledger and rejects any downloaded archive whose bytes
-do not match the retained digest. Do not use `matrix`, `mixed`, or another
+that accepted pre-publish ledger, requires its current package manifests to
+match the retained rows, and rejects any downloaded archive whose bytes do not
+match the retained digest. Producer and installed-runtime versions must equal
+the independently supplied closeout version. Platform and installed-runtime
+hosts must match the OS and architecture derived from the package matrix's Rust
+target. Do not use `matrix`, `mixed`, or another
 aggregate placeholder for a host, runner, backend, installer, or native-engine
 identity.
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -266,7 +266,7 @@ Workflow edits run:
 ```sh
 npm ci --ignore-scripts
 node scripts/codestory-release-claims.mjs validate --repo .
-node --test scripts/tests/codestory-release-claims.test.mjs scripts/tests/codestory-release-evidence-gate.test.mjs
+node --test scripts/tests/codestory-release-claims.test.mjs scripts/tests/codestory-release-closeout.test.mjs scripts/tests/codestory-release-evidence-gate.test.mjs
 node --test .github/scripts/run-actionlint.test.mjs
 node .github/scripts/run-actionlint.mjs
 node .github/scripts/check-workflow-policy.mjs
@@ -312,6 +312,37 @@ prerequisite, non-claims, accepted risks, and higher-tier proof lanes. The
 release evidence gate evaluates that graph; workflow policy consumes its
 runner, target, promotion, retention, and proof-chain facts. Update the graph
 instead of copying those facts into contributor prose.
+
+The same graph declares the exact release-closeout cells. The closeout
+coordinator expands native cells from `workflow_policy.package_matrix`, keeps
+protected hardware cells explicit, invokes the claim evaluator for each cell
+and its graph dependencies, then retains canonical copies under `manifests/`
+and `evaluations/` beside `ledger.json` and `summary.json`. A pre-publish run
+records each archive name, byte count, and SHA-256. A post-publish run requires
+that accepted pre-publish ledger and rejects any downloaded archive whose bytes
+do not match the retained digest. Do not use `matrix`, `mixed`, or another
+aggregate placeholder for a host, runner, backend, installer, or native-engine
+identity.
+
+Run the coordinator only with retained producer manifests and a fresh output
+directory:
+
+```sh
+node scripts/codestory-release-closeout.mjs evaluate \
+  --repo . \
+  --expected-sha <full-commit> \
+  --version <version> \
+  --phase pre_publish \
+  --evaluated-at <canonical-ISO-timestamp> \
+  --manifest-dir <producer-manifests> \
+  --out-dir <new-closeout-directory>
+```
+
+For `--phase post_publish`, pass every graph-owned cell plus
+`--pre-publish-ledger <accepted-pre-publish-ledger.json>`. The framework can be
+tested and merged without final evidence; an accepted ledger still requires
+the frozen exact-head producer manifests and does not upgrade source or package
+proof into installed, protected-hardware, or live-behavior proof.
 
 The command-line evaluator derives repository, commit, and source-tree identity
 from `--repo` and the full `--expected-sha`; evidence documents cannot supply

--- a/release-claims.json
+++ b/release-claims.json
@@ -1,6 +1,6 @@
 {
   "schema": "codestory.release-claims/v1",
-  "graph_version": 2,
+  "graph_version": 3,
   "graph_id": "codestory-release-claims",
   "evidence_policy": {
     "selection": "all_matching_rows_must_pass",
@@ -31,7 +31,14 @@
       "baseline_sha256": "sha256",
       "candidate_sha256": "sha256",
       "release_key": "identifier",
-      "evaluation_contract": "versioned_contract"
+      "evaluation_contract": "versioned_contract",
+      "producer_workflow": "workflow_path",
+      "producer_run_id": "positive_integer",
+      "producer_run_attempt": "positive_integer",
+      "producer_artifact": "non_empty_text",
+      "native_engine": "identifier",
+      "calibration_sha256": "sha256",
+      "pre_publish_artifact_sha256": "sha256"
     }
   },
   "exception_policy": {
@@ -481,6 +488,285 @@
       "command": "cargo test --locked -p codestory-runtime --test retrieval_generalization_guard"
     }
   ],
+  "closeout": {
+    "schema": "codestory.release-closeout/v1",
+    "manifest_schema": "codestory.release-cell-manifest/v1",
+    "ledger_schema": "codestory.release-closeout-ledger/v1",
+    "summary_schema": "codestory.release-closeout-summary/v1",
+    "phases": [
+      "pre_publish",
+      "post_publish"
+    ],
+    "cell_groups": [
+      {
+        "id": "source_behavior",
+        "phase": "pre_publish",
+        "claim": "source_behavior",
+        "evidence_type": "source_behavior",
+        "expansion": "singleton",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "identity_constraints": {
+          "producer_workflow": ".github/workflows/source-proof.yml"
+        },
+        "archive_role": "none"
+      },
+      {
+        "id": "package_identity",
+        "phase": "pre_publish",
+        "claim": "package_identity",
+        "evidence_type": "package_identity",
+        "expansion": "package_matrix",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "artifact_sha256",
+          "producer_version",
+          "target",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "identity_constraints": {
+          "producer_workflow": ".github/workflows/packaged-platform-proof.yml"
+        },
+        "archive_role": "pre_publish"
+      },
+      {
+        "id": "accelerator_execution",
+        "phase": "pre_publish",
+        "claim": "accelerator_execution",
+        "evidence_type": "accelerator_execution",
+        "expansion": "instances",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "artifact_sha256",
+          "producer_version",
+          "target",
+          "host_os",
+          "host_arch",
+          "runner",
+          "backend",
+          "native_engine",
+          "calibration_sha256",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "singleton_identity": [
+          "host_os",
+          "host_arch",
+          "runner",
+          "backend",
+          "native_engine"
+        ],
+        "instances": [
+          {
+            "id": "macos-arm64-metal",
+            "identity_constraints": {
+              "target": "macos-arm64",
+              "host_os": "macOS",
+              "host_arch": "ARM64",
+              "runner": "codestory-metal",
+              "backend": "Metal",
+              "producer_workflow": ".github/workflows/macos-metal-proof.yml"
+            }
+          },
+          {
+            "id": "windows-x64-vulkan",
+            "identity_constraints": {
+              "target": "windows-x64",
+              "host_os": "Windows",
+              "host_arch": "X64",
+              "runner": "codestory-vulkan",
+              "backend": "Vulkan",
+              "producer_workflow": ".github/workflows/windows-vulkan-proof.yml"
+            }
+          }
+        ],
+        "archive_role": "none"
+      },
+      {
+        "id": "retrieval_readiness",
+        "phase": "pre_publish",
+        "claim": "retrieval_readiness",
+        "evidence_type": "retrieval_readiness",
+        "expansion": "singleton",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "profile",
+          "corpus_id",
+          "cache_id",
+          "machine_fingerprint",
+          "release_key",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "identity_constraints": {
+          "producer_workflow": ".github/workflows/release-candidate-evidence.yml"
+        },
+        "archive_role": "none"
+      },
+      {
+        "id": "performance",
+        "phase": "pre_publish",
+        "claim": "performance",
+        "evidence_type": "performance",
+        "expansion": "singleton",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "profile",
+          "corpus_id",
+          "cache_id",
+          "machine_fingerprint",
+          "baseline_id",
+          "baseline_sha256",
+          "release_key",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "identity_constraints": {
+          "producer_workflow": ".github/workflows/release-candidate-evidence.yml"
+        },
+        "archive_role": "none"
+      },
+      {
+        "id": "answer_quality",
+        "phase": "pre_publish",
+        "claim": "answer_quality",
+        "evidence_type": "answer_quality",
+        "expansion": "singleton",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "profile",
+          "corpus_id",
+          "cache_id",
+          "machine_fingerprint",
+          "release_key",
+          "artifact_sha256",
+          "evaluation_contract",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "identity_constraints": {
+          "producer_workflow": ".github/workflows/release-candidate-evidence.yml"
+        },
+        "archive_role": "none"
+      },
+      {
+        "id": "platform_support",
+        "phase": "post_publish",
+        "claim": "platform_support",
+        "evidence_type": "platform_support",
+        "expansion": "package_matrix",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "artifact_sha256",
+          "producer_version",
+          "target",
+          "host_os",
+          "host_arch",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "singleton_identity": [
+          "host_os",
+          "host_arch"
+        ],
+        "identity_constraints": {
+          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml"
+        },
+        "archive_role": "none"
+      },
+      {
+        "id": "installed_runtime_behavior",
+        "phase": "post_publish",
+        "claim": "installed_runtime_behavior",
+        "evidence_type": "installed_runtime_behavior",
+        "expansion": "package_matrix",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "artifact_sha256",
+          "producer_version",
+          "target",
+          "host_os",
+          "host_arch",
+          "installer",
+          "runtime_version",
+          "native_engine",
+          "calibration_sha256",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "singleton_identity": [
+          "host_os",
+          "host_arch",
+          "installer",
+          "native_engine"
+        ],
+        "identity_constraints": {
+          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml"
+        },
+        "archive_role": "none"
+      },
+      {
+        "id": "post_publish_bytes",
+        "phase": "post_publish",
+        "claim": "package_identity",
+        "evidence_type": "package_identity",
+        "expansion": "package_matrix",
+        "required_identity": [
+          "repository",
+          "commit",
+          "source_tree",
+          "artifact_sha256",
+          "pre_publish_artifact_sha256",
+          "producer_version",
+          "target",
+          "producer_workflow",
+          "producer_run_id",
+          "producer_run_attempt",
+          "producer_artifact"
+        ],
+        "identity_constraints": {
+          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml"
+        },
+        "archive_role": "post_publish_compare"
+      }
+    ]
+  },
   "workflow_policy": {
     "artifact_retention_days": 30,
     "package_matrix": [

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -20,6 +20,8 @@ const IDENTITY_FORMATS = new Set([
   "semver",
   "sha256",
   "versioned_contract",
+  "workflow_path",
+  "positive_integer",
 ]);
 const REQUIRED_CLAIMS = [
   "accelerator_execution",
@@ -92,10 +94,14 @@ function identityMatchesFormat(value, format) {
     case "release_target": return /^[A-Za-z0-9][A-Za-z0-9._:/+-]*$/u.test(value);
     case "baseline_id": return /^[A-Za-z0-9][A-Za-z0-9._:/+@-]*$/u.test(value);
     case "versioned_contract": return /^[A-Za-z0-9][A-Za-z0-9._+-]*(?:\/[A-Za-z0-9._+-]+)*\/v[1-9]\d*$/u.test(value);
+    case "workflow_path": return /^\.github\/workflows\/[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml$/u.test(value);
+    case "positive_integer": return /^[1-9]\d*$/u.test(value);
     case "non_empty_text": return value.length > 0;
     default: return false;
   }
 }
+
+export { identityMatchesFormat as releaseClaimIdentityMatchesFormat };
 
 function git(args, repoRoot) {
   const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8" });
@@ -158,8 +164,8 @@ export function releaseClaimGraphDigest(graph) {
 
 export function validateReleaseClaimGraph(graph) {
   object(graph, "release claim graph");
-  if (graph.schema !== GRAPH_SCHEMA || graph.graph_version !== 2) {
-    fail(`release claim graph must use ${GRAPH_SCHEMA} graph_version 2`);
+  if (graph.schema !== GRAPH_SCHEMA || graph.graph_version !== 3) {
+    fail(`release claim graph must use ${GRAPH_SCHEMA} graph_version 3`);
   }
   nonEmptyText(graph.graph_id, "release claim graph.graph_id");
   const evidencePolicy = object(graph.evidence_policy, "release claim graph.evidence_policy");
@@ -309,6 +315,99 @@ export function validateReleaseClaimGraph(graph) {
     if (control.control !== "negative_gate") fail(`failure control ${id} must be a negative_gate`);
     const command = nonEmptyText(control.command, `failure control ${id}.command`);
     if (!command.startsWith("cargo test --locked ")) fail(`failure control ${id} must name a locked executable Cargo test`);
+  }
+
+  const closeout = object(graph.closeout, "release claim graph.closeout");
+  if (closeout.schema !== "codestory.release-closeout/v1") {
+    fail("release claim graph.closeout.schema must be codestory.release-closeout/v1");
+  }
+  for (const [key, expected] of Object.entries({
+    manifest_schema: "codestory.release-cell-manifest/v1",
+    ledger_schema: "codestory.release-closeout-ledger/v1",
+    summary_schema: "codestory.release-closeout-summary/v1",
+  })) {
+    if (closeout[key] !== expected) fail(`release claim graph.closeout.${key} must be ${expected}`);
+  }
+  const phases = stringArray(closeout.phases, "release claim graph.closeout.phases", { nonEmpty: true });
+  if (JSON.stringify(phases) !== JSON.stringify(["pre_publish", "post_publish"])) {
+    fail("release claim graph.closeout.phases must be pre_publish, post_publish");
+  }
+  const cellGroups = uniqueById(closeout.cell_groups, "release claim graph.closeout.cell_groups");
+  const requiredCellGroups = [
+    "accelerator_execution",
+    "answer_quality",
+    "installed_runtime_behavior",
+    "package_identity",
+    "performance",
+    "platform_support",
+    "post_publish_bytes",
+    "retrieval_readiness",
+    "source_behavior",
+  ];
+  if (JSON.stringify([...cellGroups.keys()].sort()) !== JSON.stringify(requiredCellGroups)) {
+    fail(`release claim graph closeout must define exactly ${requiredCellGroups.join(", ")}`);
+  }
+  for (const [id, group] of cellGroups) {
+    if (!phases.includes(group.phase)) fail(`closeout cell group ${id} has unknown phase ${String(group.phase)}`);
+    const claim = claims.get(nonEmptyText(group.claim, `closeout cell group ${id}.claim`));
+    if (!claim) fail(`closeout cell group ${id} references unknown claim ${group.claim}`);
+    const evidenceTypeId = nonEmptyText(group.evidence_type, `closeout cell group ${id}.evidence_type`);
+    const evidenceType = evidenceTypes.get(evidenceTypeId);
+    if (!evidenceType) fail(`closeout cell group ${id} references unknown evidence type ${evidenceTypeId}`);
+    if (!claim.required_evidence.includes(evidenceTypeId)) {
+      fail(`closeout cell group ${id} evidence type ${evidenceTypeId} does not satisfy claim ${group.claim}`);
+    }
+    if (!new Set(["singleton", "package_matrix", "instances"]).has(group.expansion)) {
+      fail(`closeout cell group ${id} has unknown expansion ${String(group.expansion)}`);
+    }
+    if (!new Set(["none", "pre_publish", "post_publish_compare"]).has(group.archive_role)) {
+      fail(`closeout cell group ${id} has unknown archive_role ${String(group.archive_role)}`);
+    }
+    const requiredIdentity = stringArray(
+      group.required_identity,
+      `closeout cell group ${id}.required_identity`,
+      { nonEmpty: true },
+    );
+    for (const key of evidenceType.required_identity) {
+      if (!requiredIdentity.includes(key)) {
+        fail(`closeout cell group ${id} must retain evidence identity ${key}`);
+      }
+    }
+    for (const key of requiredIdentity) {
+      if (!identityFormats[key]) fail(`closeout cell group ${id} identity ${key} must declare a format`);
+    }
+    const constraints = object(group.identity_constraints ?? {}, `closeout cell group ${id}.identity_constraints`);
+    for (const [key, value] of Object.entries(constraints)) {
+      if (!requiredIdentity.includes(key)) fail(`closeout cell group ${id} constrains non-required identity ${key}`);
+      if (!identityMatchesFormat(value, identityFormats[key])) {
+        fail(`closeout cell group ${id} constraint ${key} does not match ${identityFormats[key]}`);
+      }
+    }
+    for (const key of stringArray(group.singleton_identity ?? [], `closeout cell group ${id}.singleton_identity`)) {
+      if (!requiredIdentity.includes(key)) fail(`closeout cell group ${id} singleton identity ${key} is not required`);
+    }
+    if (group.expansion === "package_matrix" && !requiredIdentity.includes("target")) {
+      fail(`closeout cell group ${id} package_matrix expansion must require target`);
+    }
+    if (group.expansion === "instances") {
+      const instances = uniqueById(group.instances, `closeout cell group ${id}.instances`);
+      for (const [instanceId, instance] of instances) {
+        const instanceConstraints = object(
+          instance.identity_constraints,
+          `closeout cell group ${id} instance ${instanceId}.identity_constraints`,
+        );
+        for (const [key, value] of Object.entries(instanceConstraints)) {
+          if (!requiredIdentity.includes(key)) {
+            fail(`closeout cell group ${id} instance ${instanceId} constrains non-required identity ${key}`);
+          }
+          if (!identityMatchesFormat(value, identityFormats[key])) {
+            fail(`closeout cell group ${id} instance ${instanceId} constraint ${key} does not match ${identityFormats[key]}`);
+          }
+        }
+      }
+    } else if (group.instances !== undefined) {
+      fail(`closeout cell group ${id} may declare instances only with instances expansion`);
+    }
   }
 
   const policy = object(graph.workflow_policy, "release claim graph.workflow_policy");

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -61,6 +61,26 @@ function phaseIndex(closeout, phase) {
   return index;
 }
 
+function packageHostIdentity(row) {
+  const rustTarget = text(row.rust_target, "workflow_policy.package_matrix rust_target");
+  const hostArch = rustTarget.startsWith("x86_64-")
+    ? "X64"
+    : rustTarget.startsWith("aarch64-")
+      ? "ARM64"
+      : null;
+  const hostOs = rustTarget.includes("-unknown-linux-")
+    ? "Linux"
+    : rustTarget.includes("-pc-windows-")
+      ? "Windows"
+      : rustTarget.endsWith("-apple-darwin")
+        ? "macOS"
+        : null;
+  if (hostOs === null || hostArch === null) {
+    fail(`package target ${row.asset_target} uses unsupported Rust target ${rustTarget}`);
+  }
+  return { host_os: hostOs, host_arch: hostArch };
+}
+
 export function deriveReleaseCells(graph, phase) {
   const closeout = object(graph.closeout, "release claim graph.closeout");
   const selectedPhase = text(phase, "phase");
@@ -89,7 +109,12 @@ export function deriveReleaseCells(graph, phase) {
       add(null);
     } else if (group.expansion === "package_matrix") {
       for (const row of graph.workflow_policy.package_matrix) {
-        add(row.asset_target, { target: row.asset_target });
+        const constraints = { target: row.asset_target };
+        const hostIdentity = packageHostIdentity(row);
+        for (const key of ["host_os", "host_arch"]) {
+          if (group.required_identity.includes(key)) constraints[key] = hostIdentity[key];
+        }
+        add(row.asset_target, constraints);
       }
     } else if (group.expansion === "instances") {
       for (const instance of group.instances) add(instance.id, instance.identity_constraints);
@@ -138,6 +163,17 @@ function manifestProblems({ manifest, cell, graph, graphSha256, version }) {
     if (identity[key] !== expected) {
       problems.push(`manifest identity ${key} must equal ${expected}`);
     }
+  }
+  if (cell.required_identity.includes("producer_version") && identity.producer_version !== version) {
+    problems.push(`manifest identity producer_version must equal closeout version ${version}`);
+  }
+  if (cell.required_identity.includes("runtime_version") && identity.runtime_version !== version) {
+    problems.push(`manifest identity runtime_version must equal closeout version ${version}`);
+  }
+  if (cell.required_identity.includes("producer_version")
+      && cell.required_identity.includes("runtime_version")
+      && identity.producer_version !== identity.runtime_version) {
+    problems.push("manifest producer_version and runtime_version must match");
   }
   for (const key of cell.singleton_identity) {
     if (AGGREGATE_IDENTITY.test(String(identity[key] ?? ""))) {
@@ -257,7 +293,20 @@ function evaluateCell({ cell, cells, manifests, graph, gitIdentity, evaluatedAt 
   };
 }
 
-function comparePublishedArchive({ manifest, cell, prePublishLedger, graphSha256, gitIdentity, version }) {
+function dependencyValidationProblems({ cell, cells, manifests, graph, problemsByCell }) {
+  const focal = manifests.get(cell.id);
+  const problems = [];
+  for (const claim of transitiveClaims(graph, cell.claim)) {
+    if (claim.id === cell.claim) continue;
+    const dependency = dependencyCell(cells, claim.id, focal.evidence.identity.target);
+    if ((problemsByCell.get(dependency.id) ?? []).length > 0) {
+      problems.push(`dependency cell ${dependency.id} failed closeout validation`);
+    }
+  }
+  return problems;
+}
+
+function prePublishLedgerProblems({ prePublishLedger, graphSha256, gitIdentity, version }) {
   const problems = [];
   if (prePublishLedger === null) {
     return ["post-publish closeout requires the accepted pre-publish ledger"];
@@ -274,16 +323,65 @@ function comparePublishedArchive({ manifest, cell, prePublishLedger, graphSha256
       problems.push(`pre-publish ledger ${key} identity changed`);
     }
   }
-  const target = cell.identity_constraints.target;
+  return problems;
+}
+
+function retainedPackageRow({ prePublishLedger, target, problems }) {
+  if (prePublishLedger === null) return null;
   const packageCellId = `package_identity:${target}`;
   const packageRows = Array.isArray(prePublishLedger.cells)
     ? prePublishLedger.cells.filter(({ id }) => id === packageCellId)
     : [];
   if (packageRows.length !== 1) {
     problems.push(`pre-publish ledger must contain one ${packageCellId}`);
-    return problems;
+    return null;
   }
-  const packageRow = packageRows[0];
+  return packageRows[0];
+}
+
+function compareRetainedPackageManifest({
+  manifest,
+  cell,
+  prePublishLedger,
+  graphSha256,
+  gitIdentity,
+  version,
+}) {
+  const problems = prePublishLedgerProblems({
+    prePublishLedger,
+    graphSha256,
+    gitIdentity,
+    version,
+  });
+  const packageRow = retainedPackageRow({
+    prePublishLedger,
+    target: cell.identity_constraints.target,
+    problems,
+  });
+  if (packageRow === null) return problems;
+  const manifestSha256 = digest(canonicalJson(manifest));
+  if (manifestSha256 !== packageRow.manifest?.sha256) {
+    problems.push("post-publish package manifest does not match the retained pre-publish manifest");
+  }
+  for (const key of ["name", "sha256", "bytes"]) {
+    if (manifest.archive?.[key] !== packageRow.archive?.[key]) {
+      problems.push(`post-publish package archive ${key} does not match the retained pre-publish archive`);
+    }
+  }
+  return problems;
+}
+
+function comparePublishedArchive({ manifest, cell, prePublishLedger, graphSha256, gitIdentity, version }) {
+  const problems = prePublishLedgerProblems({
+    prePublishLedger,
+    graphSha256,
+    gitIdentity,
+    version,
+  });
+  const target = cell.identity_constraints.target;
+  const packageCellId = `package_identity:${target}`;
+  const packageRow = retainedPackageRow({ prePublishLedger, target, problems });
+  if (packageRow === null) return problems;
   const comparison = manifest.comparison ?? {};
   if (comparison.pre_publish_cell_id !== packageCellId) {
     problems.push(`comparison pre_publish_cell_id must be ${packageCellId}`);
@@ -377,6 +475,16 @@ export function evaluateReleaseCloseout({
         version,
       }));
     }
+    if (phase === "post_publish" && cell.archive_role === "pre_publish") {
+      problems.push(...compareRetainedPackageManifest({
+        manifest,
+        cell,
+        prePublishLedger,
+        graphSha256,
+        gitIdentity,
+        version,
+      }));
+    }
     manifests.set(cell.id, manifest);
     problemsByCell.set(cell.id, [...(problemsByCell.get(cell.id) ?? []), ...problems]);
   }
@@ -404,7 +512,14 @@ export function evaluateReleaseCloseout({
     };
     retainedManifests.set(cell.id, { value: manifest, bytes: manifestBytes, record: manifestRecord });
     let evaluation;
-    const problems = problemsByCell.get(cell.id) ?? [];
+    const problems = [...(problemsByCell.get(cell.id) ?? [])];
+    if (problems.length === 0) {
+      try {
+        problems.push(...dependencyValidationProblems({ cell, cells, manifests, graph, problemsByCell }));
+      } catch (error) {
+        problems.push(error.message);
+      }
+    }
     if (problems.length > 0) {
       evaluation = {
         schema: MANIFEST_EVALUATION_SCHEMA,

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -1,0 +1,559 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  canonicalReleaseClaimValue,
+  deriveTrustedGitIdentity,
+  evaluateReleaseClaims,
+  loadReleaseClaimGraph,
+  releaseClaimGraphDigest,
+  releaseClaimIdentityMatchesFormat,
+} from "./codestory-release-claims.mjs";
+
+const MANIFEST_EVALUATION_SCHEMA = "codestory.release-cell-evaluation/v1";
+const SHA256 = /^[0-9a-f]{64}$/u;
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
+const AGGREGATE_IDENTITY = /^(?:aggregate|all|matrix|mixed|multiple|various)$/iu;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function object(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value;
+}
+
+function text(value, label) {
+  if (typeof value !== "string" || value.trim() !== value || value === "") {
+    fail(`${label} must be a non-empty trimmed string`);
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  return `${JSON.stringify(canonicalReleaseClaimValue(value), null, 2)}\n`;
+}
+
+function digest(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function safeFileName(cellId) {
+  return `${cellId.replaceAll(/[^A-Za-z0-9._-]/gu, "_")}.json`;
+}
+
+function phaseIndex(closeout, phase) {
+  const index = closeout.phases.indexOf(phase);
+  if (index < 0) fail(`phase must be one of ${closeout.phases.join(", ")}`);
+  return index;
+}
+
+export function deriveReleaseCells(graph, phase) {
+  const closeout = object(graph.closeout, "release claim graph.closeout");
+  const selectedPhase = text(phase, "phase");
+  const selectedIndex = phaseIndex(closeout, selectedPhase);
+  const cells = [];
+  for (const group of closeout.cell_groups) {
+    if (phaseIndex(closeout, group.phase) > selectedIndex) continue;
+    const add = (suffix, constraints = {}) => {
+      const id = suffix === null ? group.id : `${group.id}:${suffix}`;
+      cells.push({
+        id,
+        group_id: group.id,
+        phase: group.phase,
+        claim: group.claim,
+        evidence_type: group.evidence_type,
+        required_identity: [...group.required_identity],
+        singleton_identity: [...(group.singleton_identity ?? [])],
+        identity_constraints: {
+          ...(group.identity_constraints ?? {}),
+          ...constraints,
+        },
+        archive_role: group.archive_role,
+      });
+    };
+    if (group.expansion === "singleton") {
+      add(null);
+    } else if (group.expansion === "package_matrix") {
+      for (const row of graph.workflow_policy.package_matrix) {
+        add(row.asset_target, { target: row.asset_target });
+      }
+    } else if (group.expansion === "instances") {
+      for (const instance of group.instances) add(instance.id, instance.identity_constraints);
+    } else {
+      fail(`unsupported closeout expansion ${String(group.expansion)}`);
+    }
+  }
+  cells.sort((left, right) => left.id.localeCompare(right.id));
+  const ids = cells.map(({ id }) => id);
+  if (new Set(ids).size !== ids.length) fail("release claim graph derives duplicate closeout cell ids");
+  return cells;
+}
+
+function manifestProblems({ manifest, cell, graph, graphSha256, version }) {
+  const problems = [];
+  if (manifest.schema !== graph.closeout.manifest_schema) {
+    problems.push(`manifest schema must be ${graph.closeout.manifest_schema}`);
+  }
+  if (manifest.cell_id !== cell.id) problems.push(`manifest cell_id must be ${cell.id}`);
+  if (manifest.phase !== cell.phase) problems.push(`manifest phase must be ${cell.phase}`);
+  if (manifest.version !== version) problems.push(`manifest version must be ${version}`);
+  if (manifest.graph_sha256 !== graphSha256) problems.push("manifest graph_sha256 is stale");
+  let evidence = null;
+  try {
+    evidence = object(manifest.evidence, `${cell.id}.evidence`);
+  } catch (error) {
+    problems.push(error.message);
+    return problems;
+  }
+  if (evidence.type !== cell.evidence_type) {
+    problems.push(`manifest evidence type must be ${cell.evidence_type}`);
+  }
+  if (evidence.graph_sha256 !== graphSha256) problems.push("manifest evidence graph_sha256 is stale");
+  const identity = evidence.identity;
+  if (identity === null || typeof identity !== "object" || Array.isArray(identity)) {
+    problems.push("manifest evidence identity must be an object");
+    return problems;
+  }
+  const formats = graph.evidence_policy.identity_formats;
+  for (const key of cell.required_identity) {
+    if (!releaseClaimIdentityMatchesFormat(identity[key], formats[key])) {
+      problems.push(`manifest identity ${key} does not match ${formats[key]}`);
+    }
+  }
+  for (const [key, expected] of Object.entries(cell.identity_constraints)) {
+    if (identity[key] !== expected) {
+      problems.push(`manifest identity ${key} must equal ${expected}`);
+    }
+  }
+  for (const key of cell.singleton_identity) {
+    if (AGGREGATE_IDENTITY.test(String(identity[key] ?? ""))) {
+      problems.push(`manifest identity ${key} must name one concrete value, not ${identity[key]}`);
+    }
+  }
+  if (cell.archive_role === "pre_publish") {
+    const archive = manifest.archive;
+    if (archive === null || typeof archive !== "object" || Array.isArray(archive)) {
+      problems.push("pre-publish package manifest must retain one archive attestation");
+    } else {
+      if (typeof archive.name !== "string" || archive.name === "" || path.basename(archive.name) !== archive.name) {
+        problems.push("archive name must be one plain file name");
+      }
+      if (!SHA256.test(String(archive.sha256 ?? ""))) problems.push("archive sha256 must be SHA-256");
+      if (!Number.isSafeInteger(archive.bytes) || archive.bytes <= 0) {
+        problems.push("archive bytes must be a positive safe integer");
+      }
+      if (archive.sha256 !== identity.artifact_sha256) {
+        problems.push("archive sha256 must match evidence artifact_sha256");
+      }
+      if (archive.name !== identity.producer_artifact) {
+        problems.push("archive name must match evidence producer_artifact");
+      }
+    }
+    if (manifest.comparison !== undefined) problems.push("pre-publish package manifest must not contain a byte comparison");
+  } else if (cell.archive_role === "post_publish_compare") {
+    if (manifest.archive !== undefined) problems.push("post-publish byte manifest must use comparison, not archive");
+    const comparison = manifest.comparison;
+    if (comparison === null || typeof comparison !== "object" || Array.isArray(comparison)) {
+      problems.push("post-publish byte manifest must retain one comparison");
+    } else {
+      if (!SHA256.test(String(comparison.pre_publish_manifest_sha256 ?? ""))) {
+        problems.push("comparison pre_publish_manifest_sha256 must be SHA-256");
+      }
+      if (!SHA256.test(String(comparison.pre_publish_artifact_sha256 ?? ""))) {
+        problems.push("comparison pre_publish_artifact_sha256 must be SHA-256");
+      }
+      if (!SHA256.test(String(comparison.published_artifact_sha256 ?? ""))) {
+        problems.push("comparison published_artifact_sha256 must be SHA-256");
+      }
+      if (comparison.pre_publish_artifact_sha256 !== identity.pre_publish_artifact_sha256) {
+        problems.push("comparison pre-publish digest must match evidence identity");
+      }
+      if (comparison.published_artifact_sha256 !== identity.artifact_sha256) {
+        problems.push("comparison published digest must match evidence artifact_sha256");
+      }
+    }
+  } else if (manifest.archive !== undefined || manifest.comparison !== undefined) {
+    problems.push("non-archive closeout cells must not contain archive attestations");
+  }
+  return problems;
+}
+
+function transitiveClaims(graph, claimId) {
+  const claims = new Map(graph.claims.map((claim) => [claim.id, claim]));
+  const ordered = [];
+  const found = new Set();
+  const visit = (id) => {
+    if (found.has(id)) return;
+    found.add(id);
+    const claim = claims.get(id);
+    if (!claim) fail(`closeout cell references unknown claim ${id}`);
+    for (const dependency of claim.depends_on_claims) visit(dependency);
+    ordered.push(claim);
+  };
+  visit(claimId);
+  return ordered;
+}
+
+function dependencyCell(cells, claimId, target) {
+  let candidates = cells.filter((candidate) => candidate.group_id === claimId);
+  if (target !== undefined) {
+    const sameTarget = candidates.filter((candidate) => candidate.identity_constraints.target === target);
+    if (sameTarget.length > 0) candidates = sameTarget;
+  }
+  if (candidates.length !== 1) {
+    fail(`claim ${claimId} did not resolve to one dependency cell${target ? ` for ${target}` : ""}`);
+  }
+  return candidates[0];
+}
+
+function evaluateCell({ cell, cells, manifests, graph, gitIdentity, evaluatedAt }) {
+  const focal = manifests.get(cell.id);
+  const claims = transitiveClaims(graph, cell.claim);
+  const evidenceCells = [];
+  for (const claim of claims) {
+    evidenceCells.push(
+      claim.id === cell.claim
+        ? cell
+        : dependencyCell(cells, claim.id, focal.evidence.identity.target),
+    );
+  }
+  const evidence = evidenceCells.map((dependency) => manifests.get(dependency.id).evidence);
+  const requestedClaims = claims.map((claim) => ({
+    id: claim.id,
+    accepted_risks: [...claim.accepted_risks],
+  }));
+  const expectedIdentity = { ...focal.evidence.identity, ...gitIdentity };
+  const evaluation = evaluateReleaseClaims({
+    graph,
+    requested_claims: requestedClaims,
+    evidence,
+    expected: {
+      commit: gitIdentity.commit,
+      evaluated_at: evaluatedAt,
+      identity: expectedIdentity,
+      exceptions: {},
+    },
+  });
+  return {
+    schema: MANIFEST_EVALUATION_SCHEMA,
+    cell_id: cell.id,
+    evidence_cells: evidenceCells.map(({ id }) => id),
+    status: evaluation.status,
+    release_claim_evaluation: evaluation,
+  };
+}
+
+function comparePublishedArchive({ manifest, cell, prePublishLedger, graphSha256, gitIdentity, version }) {
+  const problems = [];
+  if (prePublishLedger === null) {
+    return ["post-publish closeout requires the accepted pre-publish ledger"];
+  }
+  if (prePublishLedger.schema !== "codestory.release-closeout-ledger/v1"
+      || prePublishLedger.phase !== "pre_publish"
+      || prePublishLedger.decision !== "accept") {
+    problems.push("pre-publish ledger must be an accepted pre_publish closeout ledger");
+  }
+  if (prePublishLedger.graph_sha256 !== graphSha256) problems.push("pre-publish ledger graph identity changed");
+  if (prePublishLedger.version !== version) problems.push("pre-publish ledger version changed");
+  for (const key of ["repository", "commit", "source_tree"]) {
+    if (prePublishLedger.identity?.[key] !== gitIdentity[key]) {
+      problems.push(`pre-publish ledger ${key} identity changed`);
+    }
+  }
+  const target = cell.identity_constraints.target;
+  const packageCellId = `package_identity:${target}`;
+  const packageRows = Array.isArray(prePublishLedger.cells)
+    ? prePublishLedger.cells.filter(({ id }) => id === packageCellId)
+    : [];
+  if (packageRows.length !== 1) {
+    problems.push(`pre-publish ledger must contain one ${packageCellId}`);
+    return problems;
+  }
+  const packageRow = packageRows[0];
+  const comparison = manifest.comparison ?? {};
+  if (comparison.pre_publish_cell_id !== packageCellId) {
+    problems.push(`comparison pre_publish_cell_id must be ${packageCellId}`);
+  }
+  if (comparison.pre_publish_manifest_sha256 !== packageRow.manifest?.sha256) {
+    problems.push("comparison pre-publish manifest digest does not match the retained ledger manifest");
+  }
+  if (comparison.pre_publish_artifact_sha256 !== packageRow.archive?.sha256
+      || comparison.published_artifact_sha256 !== packageRow.archive?.sha256) {
+    problems.push("published archive bytes are not identical to the retained pre-publish archive");
+  }
+  if (manifest.evidence.identity.producer_artifact !== packageRow.archive?.name) {
+    problems.push("published archive name does not match the retained pre-publish archive");
+  }
+  return problems;
+}
+
+function indexManifests(inputManifests) {
+  const byCell = new Map();
+  const errors = [];
+  for (const [index, value] of inputManifests.entries()) {
+    let manifest;
+    try {
+      manifest = object(value, `manifest[${index}]`);
+    } catch (error) {
+      errors.push(error.message);
+      continue;
+    }
+    const cellId = typeof manifest.cell_id === "string" ? manifest.cell_id : `<manifest-${index}>`;
+    const rows = byCell.get(cellId) ?? [];
+    rows.push(manifest);
+    byCell.set(cellId, rows);
+  }
+  for (const [cellId, rows] of byCell) {
+    if (rows.length > 1) errors.push(`closeout contains duplicate manifest for ${cellId}`);
+  }
+  return { byCell, errors };
+}
+
+export function evaluateReleaseCloseout({
+  graph,
+  phase,
+  version,
+  evaluatedAt,
+  gitIdentity,
+  manifests: inputManifests,
+  prePublishLedger = null,
+}) {
+  if (!SEMVER.test(version)) fail("version must be semantic version text without a leading v");
+  const evaluatedEpoch = Date.parse(evaluatedAt);
+  if (!Number.isFinite(evaluatedEpoch) || new Date(evaluatedEpoch).toISOString() !== evaluatedAt) {
+    fail("evaluatedAt must be a canonical ISO timestamp");
+  }
+  const graphSha256 = releaseClaimGraphDigest(graph);
+  const cells = deriveReleaseCells(graph, phase);
+  const cellIds = new Set(cells.map(({ id }) => id));
+  const indexed = indexManifests(inputManifests);
+  const inputErrors = [...indexed.errors];
+  for (const cellId of indexed.byCell.keys()) {
+    if (!cellIds.has(cellId)) inputErrors.push(`closeout contains undeclared cell ${cellId}`);
+  }
+  const manifests = new Map();
+  const problemsByCell = new Map();
+  const evidenceIds = new Map();
+  for (const cell of cells) {
+    const rows = indexed.byCell.get(cell.id) ?? [];
+    if (rows.length !== 1) continue;
+    const manifest = rows[0];
+    const problems = manifestProblems({ manifest, cell, graph, graphSha256, version });
+    const evidenceId = manifest.evidence?.id;
+    if (typeof evidenceId !== "string" || evidenceId === "") {
+      problems.push("manifest evidence id must be a non-empty string");
+    } else {
+      const owner = evidenceIds.get(evidenceId);
+      if (owner !== undefined) {
+        problems.push(`manifest evidence id ${evidenceId} is reused from ${owner}`);
+        const ownerProblems = problemsByCell.get(owner) ?? [];
+        ownerProblems.push(`manifest evidence id ${evidenceId} is reused by ${cell.id}`);
+        problemsByCell.set(owner, ownerProblems);
+      } else {
+        evidenceIds.set(evidenceId, cell.id);
+      }
+    }
+    if (cell.archive_role === "post_publish_compare") {
+      problems.push(...comparePublishedArchive({
+        manifest,
+        cell,
+        prePublishLedger,
+        graphSha256,
+        gitIdentity,
+        version,
+      }));
+    }
+    manifests.set(cell.id, manifest);
+    problemsByCell.set(cell.id, [...(problemsByCell.get(cell.id) ?? []), ...problems]);
+  }
+
+  const retainedManifests = new Map();
+  const evaluations = new Map();
+  const ledgerCells = [];
+  for (const cell of cells) {
+    const manifest = manifests.get(cell.id);
+    if (!manifest) {
+      ledgerCells.push({
+        id: cell.id,
+        phase: cell.phase,
+        claim: cell.claim,
+        evidence_type: cell.evidence_type,
+        status: "missing",
+      });
+      continue;
+    }
+    const manifestBytes = canonicalJson(manifest);
+    const manifestRecord = {
+      path: `manifests/${safeFileName(cell.id)}`,
+      sha256: digest(manifestBytes),
+      bytes: Buffer.byteLength(manifestBytes),
+    };
+    retainedManifests.set(cell.id, { value: manifest, bytes: manifestBytes, record: manifestRecord });
+    let evaluation;
+    const problems = problemsByCell.get(cell.id) ?? [];
+    if (problems.length > 0) {
+      evaluation = {
+        schema: MANIFEST_EVALUATION_SCHEMA,
+        cell_id: cell.id,
+        evidence_cells: [cell.id],
+        status: "fail",
+        failures: [...new Set(problems)].sort(),
+      };
+    } else {
+      try {
+        evaluation = evaluateCell({ cell, cells, manifests, graph, gitIdentity, evaluatedAt });
+      } catch (error) {
+        evaluation = {
+          schema: MANIFEST_EVALUATION_SCHEMA,
+          cell_id: cell.id,
+          evidence_cells: [cell.id],
+          status: "fail",
+          failures: [error.message],
+        };
+      }
+    }
+    const evaluationBytes = canonicalJson(evaluation);
+    const evaluationRecord = {
+      path: `evaluations/${safeFileName(cell.id)}`,
+      sha256: digest(evaluationBytes),
+      bytes: Buffer.byteLength(evaluationBytes),
+    };
+    evaluations.set(cell.id, { value: evaluation, bytes: evaluationBytes, record: evaluationRecord });
+    ledgerCells.push({
+      id: cell.id,
+      phase: cell.phase,
+      claim: cell.claim,
+      evidence_type: cell.evidence_type,
+      status: evaluation.status,
+      evidence_id: manifest.evidence.id,
+      identity: canonicalReleaseClaimValue(manifest.evidence.identity),
+      manifest: manifestRecord,
+      evaluation: evaluationRecord,
+      ...(manifest.archive ? { archive: canonicalReleaseClaimValue(manifest.archive) } : {}),
+      ...(manifest.comparison ? { comparison: canonicalReleaseClaimValue(manifest.comparison) } : {}),
+    });
+  }
+  const missingCells = ledgerCells.filter(({ status }) => status === "missing").map(({ id }) => id);
+  const failedCells = ledgerCells.filter(({ status }) => status === "fail").map(({ id }) => id);
+  inputErrors.sort();
+  const decision = inputErrors.length === 0 && missingCells.length === 0 && failedCells.length === 0
+    ? "accept"
+    : "reject";
+  const ledger = {
+    schema: graph.closeout.ledger_schema,
+    phase,
+    decision,
+    graph_schema: graph.schema,
+    graph_sha256: graphSha256,
+    version,
+    evaluated_at: evaluatedAt,
+    identity: canonicalReleaseClaimValue(gitIdentity),
+    cells: ledgerCells,
+    input_errors: inputErrors,
+  };
+  const summary = {
+    schema: graph.closeout.summary_schema,
+    phase,
+    decision,
+    graph_sha256: graphSha256,
+    version,
+    identity: canonicalReleaseClaimValue(gitIdentity),
+    counts: {
+      required: ledgerCells.length,
+      passed: ledgerCells.filter(({ status }) => new Set(["pass", "pass_with_exception"]).has(status)).length,
+      failed: failedCells.length,
+      missing: missingCells.length,
+    },
+    failed_cells: failedCells,
+    missing_cells: missingCells,
+    input_errors: inputErrors,
+  };
+  return { decision, ledger, summary, retainedManifests, evaluations };
+}
+
+export function writeReleaseCloseout(outDir, result) {
+  const output = path.resolve(outDir);
+  if (existsSync(output)) {
+    if (!lstatSync(output).isDirectory()) fail(`closeout output ${output} is not a directory`);
+    if (readdirSync(output).length > 0) fail(`closeout output ${output} must be absent or empty`);
+  }
+  mkdirSync(path.join(output, "manifests"), { recursive: true });
+  mkdirSync(path.join(output, "evaluations"), { recursive: true });
+  for (const { bytes, record } of result.retainedManifests.values()) {
+    writeFileSync(path.join(output, record.path), bytes);
+  }
+  for (const { bytes, record } of result.evaluations.values()) {
+    writeFileSync(path.join(output, record.path), bytes);
+  }
+  writeFileSync(path.join(output, "ledger.json"), canonicalJson(result.ledger));
+  writeFileSync(path.join(output, "summary.json"), canonicalJson(result.summary));
+}
+
+function readManifestDirectory(directory) {
+  const root = path.resolve(directory);
+  if (!lstatSync(root).isDirectory()) fail(`manifest directory ${root} is not a directory`);
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.name.endsWith(".json"))
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((entry) => {
+      if (!entry.isFile() || entry.isSymbolicLink()) fail(`manifest input ${entry.name} must be a regular file`);
+      return JSON.parse(readFileSync(path.join(root, entry.name), "utf8"));
+    });
+}
+
+function parseArgs(argv) {
+  const command = argv.shift();
+  const values = {};
+  while (argv.length > 0) {
+    const key = argv.shift();
+    const value = argv.shift();
+    if (!key?.startsWith("--") || value === undefined) fail("arguments must be --key value pairs");
+    const name = key.slice(2);
+    if (values[name] !== undefined) fail(`argument --${name} was supplied more than once`);
+    values[name] = value;
+  }
+  return { command, values };
+}
+
+function main() {
+  const { command, values } = parseArgs(process.argv.slice(2));
+  if (command !== "evaluate") fail("command must be evaluate");
+  const repoRoot = path.resolve(values.repo ?? path.resolve(path.dirname(process.argv[1]), ".."));
+  const graph = loadReleaseClaimGraph(repoRoot);
+  const gitIdentity = deriveTrustedGitIdentity({
+    repoRoot,
+    expectedSha: text(values["expected-sha"], "--expected-sha"),
+  });
+  const phase = text(values.phase, "--phase");
+  const prePublishLedger = values["pre-publish-ledger"]
+    ? JSON.parse(readFileSync(values["pre-publish-ledger"], "utf8"))
+    : null;
+  const result = evaluateReleaseCloseout({
+    graph,
+    phase,
+    version: text(values.version, "--version"),
+    evaluatedAt: text(values["evaluated-at"], "--evaluated-at"),
+    gitIdentity,
+    manifests: readManifestDirectory(text(values["manifest-dir"], "--manifest-dir")),
+    prePublishLedger,
+  });
+  writeReleaseCloseout(text(values["out-dir"], "--out-dir"), result);
+  console.log(JSON.stringify(result.summary, null, 2));
+  if (result.decision !== "accept") process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) main();

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -98,6 +98,9 @@ test("versioned claim graph has one deterministic digest and all declared contro
   assert.match(releaseClaimGraphDigest(graph), /^[0-9a-f]{64}$/u);
   assert.equal(positiveFixture().evidence[0].graph_sha256, releaseClaimGraphDigest(graph));
   assert.equal(graph.claims.length, 8);
+  assert.equal(graph.graph_version, 3);
+  assert.deepEqual(graph.closeout.phases, ["pre_publish", "post_publish"]);
+  assert.equal(graph.closeout.cell_groups.length, 9);
   assert.deepEqual(
     graph.failure_controls.map(({ id }) => id).sort(),
     [
@@ -158,6 +161,22 @@ test("graph rejects ambiguous dependencies and unstructured proof lanes", () => 
   malformedConstraint.evidence_types.find(({ id }) => id === "answer_quality")
     .identity_constraints.evaluation_contract = "unversioned";
   assert.throws(() => validateReleaseClaimGraph(malformedConstraint), /does not match versioned_contract/u);
+
+  const missingCloseoutCell = structuredClone(graph);
+  missingCloseoutCell.closeout.cell_groups = missingCloseoutCell.closeout.cell_groups
+    .filter(({ id }) => id !== "post_publish_bytes");
+  assert.throws(
+    () => validateReleaseClaimGraph(missingCloseoutCell),
+    /closeout must define exactly/u,
+  );
+
+  const aggregateCell = structuredClone(graph);
+  aggregateCell.closeout.cell_groups.find(({ id }) => id === "package_identity")
+    .required_identity.push("undeclared_identity");
+  assert.throws(
+    () => validateReleaseClaimGraph(aggregateCell),
+    /identity undeclared_identity must declare a format/u,
+  );
 
   for (const field of [
     "proof_run_sha_expression",

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -162,6 +162,15 @@ test("cell inventory is derived only from the release claim graph", () => {
     prePublish.filter(({ group_id }) => group_id === "package_identity").map(({ identity_constraints }) => identity_constraints.target),
     graph.workflow_policy.package_matrix.map(({ asset_target: assetTarget }) => assetTarget).sort(),
   );
+  assert.deepEqual(
+    postPublish.find(({ id }) => id === "platform_support:linux-arm64").identity_constraints,
+    {
+      producer_workflow: ".github/workflows/post-publish-release-smoke.yml",
+      target: "linux-arm64",
+      host_os: "Linux",
+      host_arch: "ARM64",
+    },
+  );
 
   const changed = structuredClone(graph);
   changed.workflow_policy.package_matrix[0].asset_target = "linux-future";
@@ -208,6 +217,72 @@ test("post-publish closeout compares every downloaded archive with the retained 
   const rejected = evaluate("post_publish", changed, prePublish.ledger);
   assert.equal(rejected.decision, "reject");
   assert.ok(rejected.summary.failed_cells.includes("post_publish_bytes:linux-x64"));
+});
+
+test("hostile post-publish A/B split cannot replace the retained package used by platform proof", () => {
+  const prePublish = evaluate("pre_publish", manifestsFor("pre_publish"));
+  const manifests = manifestsFor("post_publish", prePublish.ledger);
+  const replacementSha256 = "d".repeat(64);
+  for (const cellId of [
+    "package_identity:linux-x64",
+    "platform_support:linux-x64",
+    "installed_runtime_behavior:linux-x64",
+  ]) {
+    const manifest = manifests.find(({ cell_id: id }) => id === cellId);
+    manifest.evidence.identity.artifact_sha256 = replacementSha256;
+    if (manifest.archive) manifest.archive.sha256 = replacementSha256;
+  }
+
+  const rejected = evaluate("post_publish", manifests, prePublish.ledger);
+  assert.equal(rejected.decision, "reject");
+  for (const cellId of [
+    "package_identity:linux-x64",
+    "platform_support:linux-x64",
+    "installed_runtime_behavior:linux-x64",
+  ]) {
+    assert.ok(rejected.summary.failed_cells.includes(cellId));
+  }
+  assert.ok(rejected.evaluations.get("package_identity:linux-x64").value.failures.some((message) =>
+    message.includes("retained pre-publish manifest")));
+  assert.ok(rejected.evaluations.get("platform_support:linux-x64").value.failures.some((message) =>
+    message.includes("dependency cell package_identity:linux-x64")));
+});
+
+test("hostile producer and runtime semver claims must equal the independently supplied closeout version", () => {
+  const preManifests = manifestsFor("pre_publish");
+  preManifests.find(({ cell_id: id }) => id === "package_identity:linux-x64")
+    .evidence.identity.producer_version = "0.15.0";
+  const rejectedPrePublish = evaluate("pre_publish", preManifests);
+  assert.equal(rejectedPrePublish.decision, "reject");
+  assert.ok(rejectedPrePublish.summary.failed_cells.includes("package_identity:linux-x64"));
+
+  const prePublish = evaluate("pre_publish", manifestsFor("pre_publish"));
+  const postManifests = manifestsFor("post_publish", prePublish.ledger);
+  postManifests.find(({ cell_id: id }) => id === "installed_runtime_behavior:windows-x64")
+    .evidence.identity.runtime_version = "0.15.0";
+  const rejectedPostPublish = evaluate("post_publish", postManifests, prePublish.ledger);
+  assert.equal(rejectedPostPublish.decision, "reject");
+  assert.ok(rejectedPostPublish.summary.failed_cells.includes("installed_runtime_behavior:windows-x64"));
+  assert.ok(rejectedPostPublish.evaluations.get("installed_runtime_behavior:windows-x64").value.failures.some(
+    (message) => message.includes("producer_version and runtime_version must match"),
+  ));
+});
+
+test("hostile platform and installed manifests cannot contradict the package target host", () => {
+  const prePublish = evaluate("pre_publish", manifestsFor("pre_publish"));
+  const platformMismatch = manifestsFor("post_publish", prePublish.ledger);
+  platformMismatch.find(({ cell_id: id }) => id === "platform_support:linux-x64")
+    .evidence.identity.host_os = "Windows";
+  const rejectedPlatform = evaluate("post_publish", platformMismatch, prePublish.ledger);
+  assert.equal(rejectedPlatform.decision, "reject");
+  assert.ok(rejectedPlatform.summary.failed_cells.includes("platform_support:linux-x64"));
+
+  const installedMismatch = manifestsFor("post_publish", prePublish.ledger);
+  installedMismatch.find(({ cell_id: id }) => id === "installed_runtime_behavior:macos-arm64")
+    .evidence.identity.host_arch = "X64";
+  const rejectedInstalled = evaluate("post_publish", installedMismatch, prePublish.ledger);
+  assert.equal(rejectedInstalled.decision, "reject");
+  assert.ok(rejectedInstalled.summary.failed_cells.includes("installed_runtime_behavior:macos-arm64"));
 });
 
 test("missing, duplicate, stale, failed, aggregate, and reused evidence fail closed", async (t) => {

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  deriveReleaseCells,
+  evaluateReleaseCloseout,
+  writeReleaseCloseout,
+} from "../codestory-release-closeout.mjs";
+import {
+  loadReleaseClaimGraph,
+  releaseClaimGraphDigest,
+} from "../codestory-release-claims.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const graph = loadReleaseClaimGraph(root);
+const negativeFixtures = JSON.parse(readFileSync(path.join(
+  root,
+  "scripts/tests/fixtures/release-claims/closeout-negative.json",
+), "utf8"));
+const version = "0.16.0";
+const evaluatedAt = "2026-07-18T12:00:00.000Z";
+const observedAt = "2026-07-18T11:00:00.000Z";
+const expiresAt = "2026-07-19T10:00:00.000Z";
+const gitIdentity = {
+  repository: "TheGreenCedar/CodeStory",
+  commit: "2".repeat(40),
+  source_tree: "a".repeat(40),
+};
+
+function sha(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function packageRow(target) {
+  return graph.workflow_policy.package_matrix.find(({ asset_target: assetTarget }) => assetTarget === target);
+}
+
+function archiveName(target) {
+  const row = packageRow(target);
+  return `codestory-cli-v${version}-${target}.${row.extension}`;
+}
+
+function artifactSha(target) {
+  return sha(`archive:${target}`);
+}
+
+function hostIdentity(target) {
+  if (target.startsWith("linux-")) {
+    return { host_os: "Linux", host_arch: target.endsWith("arm64") ? "ARM64" : "X64" };
+  }
+  if (target.startsWith("windows-")) {
+    return { host_os: "Windows", host_arch: target.endsWith("arm64") ? "ARM64" : "X64" };
+  }
+  return { host_os: "macOS", host_arch: target.endsWith("arm64") ? "ARM64" : "X64" };
+}
+
+function identityFor(cell) {
+  const target = cell.identity_constraints.target;
+  const identity = { ...gitIdentity };
+  for (const key of cell.required_identity) {
+    if (identity[key] !== undefined) continue;
+    if (cell.identity_constraints[key] !== undefined) {
+      identity[key] = cell.identity_constraints[key];
+      continue;
+    }
+    switch (key) {
+      case "artifact_sha256": identity[key] = target ? artifactSha(target) : sha(cell.id); break;
+      case "pre_publish_artifact_sha256": identity[key] = artifactSha(target); break;
+      case "producer_version":
+      case "runtime_version": identity[key] = version; break;
+      case "target": identity[key] = target; break;
+      case "host_os":
+      case "host_arch": identity[key] = hostIdentity(target)[key]; break;
+      case "runner": identity[key] = "hosted-runner"; break;
+      case "backend": identity[key] = "CPU"; break;
+      case "installer": identity[key] = "managed_plugin"; break;
+      case "profile": identity[key] = "codestory-release-evidence-linux-arm64-v2"; break;
+      case "corpus_id": identity[key] = "v0.16-axios-js-ts-v1"; break;
+      case "cache_id": identity[key] = "cold-full-retrieval-v1"; break;
+      case "machine_fingerprint": identity[key] = "fixture/machine"; break;
+      case "baseline_id": identity[key] = "linux-arm64-v2@56cfed37"; break;
+      case "baseline_sha256": identity[key] = "b".repeat(64); break;
+      case "release_key": identity[key] = "release-0.16.0"; break;
+      case "evaluation_contract": identity[key] = "publishable-three-repeat-packet/v1"; break;
+      case "producer_run_id": identity[key] = "12345"; break;
+      case "producer_run_attempt": identity[key] = "1"; break;
+      case "producer_artifact": identity[key] = target ? archiveName(target) : `${cell.id}.json`; break;
+      case "native_engine": identity[key] = "coderank_q8"; break;
+      case "calibration_sha256": identity[key] = "c".repeat(64); break;
+      default: throw new Error(`test fixture has no identity value for ${key}`);
+    }
+  }
+  return identity;
+}
+
+function manifestsFor(phase, prePublishLedger = null) {
+  const graphSha256 = releaseClaimGraphDigest(graph);
+  return deriveReleaseCells(graph, phase).map((cell) => {
+    const identity = identityFor(cell);
+    const evidenceType = graph.evidence_types.find(({ id }) => id === cell.evidence_type);
+    const manifest = {
+      schema: graph.closeout.manifest_schema,
+      cell_id: cell.id,
+      phase: cell.phase,
+      version,
+      graph_sha256: graphSha256,
+      evidence: {
+        id: `${cell.id}-evidence`,
+        type: cell.evidence_type,
+        tier: evidenceType.tier,
+        status: "pass",
+        graph_sha256: graphSha256,
+        observed_at: observedAt,
+        expires_at: expiresAt,
+        identity,
+      },
+    };
+    if (cell.archive_role === "pre_publish") {
+      manifest.archive = {
+        name: identity.producer_artifact,
+        sha256: identity.artifact_sha256,
+        bytes: 1024,
+      };
+    }
+    if (cell.archive_role === "post_publish_compare") {
+      const packageCell = prePublishLedger.cells.find(
+        ({ id }) => id === `package_identity:${identity.target}`,
+      );
+      manifest.comparison = {
+        pre_publish_cell_id: packageCell.id,
+        pre_publish_manifest_sha256: packageCell.manifest.sha256,
+        pre_publish_artifact_sha256: packageCell.archive.sha256,
+        published_artifact_sha256: packageCell.archive.sha256,
+      };
+    }
+    return manifest;
+  });
+}
+
+function evaluate(phase, manifests, prePublishLedger = null) {
+  return evaluateReleaseCloseout({
+    graph,
+    phase,
+    version,
+    evaluatedAt,
+    gitIdentity,
+    manifests,
+    prePublishLedger,
+  });
+}
+
+test("cell inventory is derived only from the release claim graph", () => {
+  const prePublish = deriveReleaseCells(graph, "pre_publish");
+  const postPublish = deriveReleaseCells(graph, "post_publish");
+  assert.equal(prePublish.length, 12);
+  assert.equal(postPublish.length, 30);
+  assert.deepEqual(
+    prePublish.filter(({ group_id }) => group_id === "package_identity").map(({ identity_constraints }) => identity_constraints.target),
+    graph.workflow_policy.package_matrix.map(({ asset_target: assetTarget }) => assetTarget).sort(),
+  );
+
+  const changed = structuredClone(graph);
+  changed.workflow_policy.package_matrix[0].asset_target = "linux-future";
+  const changedCells = deriveReleaseCells(changed, "pre_publish");
+  assert.ok(changedCells.some(({ id }) => id === "package_identity:linux-future"));
+  assert.ok(!changedCells.some(({ id }) => id === "package_identity:linux-x64"));
+});
+
+test("accepted pre-publish closeout retains one manifest and evaluation per cell deterministically", () => {
+  const manifests = manifestsFor("pre_publish");
+  const first = evaluate("pre_publish", manifests);
+  const second = evaluate("pre_publish", structuredClone(manifests));
+  assert.equal(first.decision, "accept");
+  assert.deepEqual(first.ledger, second.ledger);
+  assert.deepEqual(first.summary, second.summary);
+  assert.equal(first.summary.counts.required, 12);
+  assert.equal(first.summary.counts.passed, 12);
+  assert.equal(first.retainedManifests.size, 12);
+  assert.equal(first.evaluations.size, 12);
+
+  const out = mkdtempSync(path.join(os.tmpdir(), "codestory-release-closeout-"));
+  writeReleaseCloseout(out, first);
+  assert.equal(readdirSync(path.join(out, "manifests")).length, 12);
+  assert.equal(readdirSync(path.join(out, "evaluations")).length, 12);
+  assert.deepEqual(JSON.parse(readFileSync(path.join(out, "ledger.json"))), first.ledger);
+  assert.deepEqual(JSON.parse(readFileSync(path.join(out, "summary.json"))), first.summary);
+});
+
+test("post-publish closeout compares every downloaded archive with the retained pre-publish bytes", () => {
+  const prePublish = evaluate("pre_publish", manifestsFor("pre_publish"));
+  const manifests = manifestsFor("post_publish", prePublish.ledger);
+  const postPublish = evaluate("post_publish", manifests, prePublish.ledger);
+  assert.equal(postPublish.decision, "accept");
+  assert.equal(postPublish.summary.counts.required, 30);
+  assert.equal(
+    postPublish.ledger.cells.filter(({ id }) => id.startsWith("post_publish_bytes:")).length,
+    graph.workflow_policy.package_matrix.length,
+  );
+
+  const changed = structuredClone(manifests);
+  const bytes = changed.find(({ cell_id }) => cell_id === "post_publish_bytes:linux-x64");
+  bytes.comparison.published_artifact_sha256 = "d".repeat(64);
+  bytes.evidence.identity.artifact_sha256 = "d".repeat(64);
+  const rejected = evaluate("post_publish", changed, prePublish.ledger);
+  assert.equal(rejected.decision, "reject");
+  assert.ok(rejected.summary.failed_cells.includes("post_publish_bytes:linux-x64"));
+});
+
+test("missing, duplicate, stale, failed, aggregate, and reused evidence fail closed", async (t) => {
+  assert.equal(negativeFixtures.schema, "codestory.release-closeout-negative-fixtures/v1");
+  for (const fixture of negativeFixtures.cases) {
+    await t.test(fixture.id, () => {
+      const manifests = manifestsFor("pre_publish");
+      const operation = fixture.operation;
+      const manifest = manifests.find(({ cell_id: cellId }) => cellId === operation.cell);
+      if (operation.kind === "remove_cell") {
+        manifests.splice(manifests.indexOf(manifest), 1);
+      } else if (operation.kind === "duplicate_cell") {
+        manifests.push(structuredClone(manifest));
+      } else if (operation.kind === "set_identity") {
+        manifest.evidence.identity[operation.key] = operation.value;
+      } else if (operation.kind === "set_evidence") {
+        manifest.evidence[operation.key] = operation.value;
+      } else if (operation.kind === "reuse_evidence") {
+        manifest.evidence.id = manifests.find(
+          ({ cell_id: cellId }) => cellId === operation.source_cell,
+        ).evidence.id;
+      } else {
+        throw new Error(`unknown closeout fixture operation ${operation.kind}`);
+      }
+      const result = evaluate("pre_publish", manifests);
+      assert.equal(result.decision, "reject");
+      for (const cell of fixture.expected_missing_cells ?? []) {
+        assert.ok(result.summary.missing_cells.includes(cell));
+      }
+      for (const cell of fixture.expected_failed_cells ?? []) {
+        assert.ok(result.summary.failed_cells.includes(cell));
+      }
+      if (fixture.expected_input_error) {
+        assert.ok(result.summary.input_errors.some((message) =>
+          message.includes(fixture.expected_input_error)));
+      }
+    });
+  }
+});

--- a/scripts/tests/fixtures/release-claims/closeout-negative.json
+++ b/scripts/tests/fixtures/release-claims/closeout-negative.json
@@ -1,0 +1,95 @@
+{
+  "schema": "codestory.release-closeout-negative-fixtures/v1",
+  "cases": [
+    {
+      "id": "missing-cell",
+      "operation": {
+        "kind": "remove_cell",
+        "cell": "source_behavior"
+      },
+      "expected_missing_cells": [
+        "source_behavior"
+      ]
+    },
+    {
+      "id": "duplicate-cell",
+      "operation": {
+        "kind": "duplicate_cell",
+        "cell": "answer_quality"
+      },
+      "expected_input_error": "duplicate manifest"
+    },
+    {
+      "id": "cross-sha",
+      "operation": {
+        "kind": "set_identity",
+        "cell": "source_behavior",
+        "key": "commit",
+        "value": "3333333333333333333333333333333333333333"
+      },
+      "expected_failed_cells": [
+        "source_behavior"
+      ]
+    },
+    {
+      "id": "cross-tree",
+      "operation": {
+        "kind": "set_identity",
+        "cell": "package_identity:linux-x64",
+        "key": "source_tree",
+        "value": "4444444444444444444444444444444444444444"
+      },
+      "expected_failed_cells": [
+        "package_identity:linux-x64"
+      ]
+    },
+    {
+      "id": "expired",
+      "operation": {
+        "kind": "set_evidence",
+        "cell": "retrieval_readiness",
+        "key": "expires_at",
+        "value": "2026-07-18T12:00:00.000Z"
+      },
+      "expected_failed_cells": [
+        "retrieval_readiness"
+      ]
+    },
+    {
+      "id": "failed-evidence",
+      "operation": {
+        "kind": "set_evidence",
+        "cell": "answer_quality",
+        "key": "status",
+        "value": "fail"
+      },
+      "expected_failed_cells": [
+        "answer_quality"
+      ]
+    },
+    {
+      "id": "aggregate-host",
+      "operation": {
+        "kind": "set_identity",
+        "cell": "accelerator_execution:macos-arm64-metal",
+        "key": "host_os",
+        "value": "matrix"
+      },
+      "expected_failed_cells": [
+        "accelerator_execution:macos-arm64-metal"
+      ]
+    },
+    {
+      "id": "reused-evidence",
+      "operation": {
+        "kind": "reuse_evidence",
+        "cell": "performance",
+        "source_cell": "retrieval_readiness"
+      },
+      "expected_failed_cells": [
+        "performance",
+        "retrieval_readiness"
+      ]
+    }
+  ]
+}

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "753c3cfc1b33a2dcbd132c8e2d4d8ea2cc441efda708102ff5da16bd325e8c43",
+      "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

CodeStory's release claim graph already owns claims, proof tiers, package targets, protected jobs and release dependencies, but it did not declare the exact retained cell inventory needed for one coherent release closeout. This change adds the reusable framework only. It does not manufacture v0.16 evidence or authorize publication.

Exact implementation head: `b837043ffd1538eaf452d427a0ea56227ba7de7b`

Rebased onto `origin/dev/codestory-next` at `1ef8bde18989478a04cbb7cf8e54ae716b950a14`. Both topic commits retain the same stable patch IDs as the independently reviewed pre-rebase commits. The only shared path was `CHANGELOG.md`; the resulting file preserves both this release-ledger entry and #1271's SQLite batching entry.

## What changed

- advanced `release-claims.json` to graph version 3 with graph-owned pre-publish and post-publish cell groups;
- derives six-target package, platform, installed-runtime and byte-comparison cells from the existing package matrix, while keeping the two protected accelerator cells explicit;
- added `scripts/codestory-release-closeout.mjs`, which validates one manifest per required cell, invokes the existing claim evaluator with graph dependencies, and retains canonical manifests, evaluations, a deterministic ledger and a compact summary;
- binds exact Git identity and applicable version, artifact, target, host, workflow/run/attempt, runtime/native engine, calibration and expiry identity;
- preserves pre-publish archive name, byte count and digest, then requires the current post-publish package row and downloaded archive to match the retained manifest and archive digests;
- derives concrete platform and installed-runtime host constraints from each package matrix Rust target;
- rejects missing, duplicate, stale, cross-SHA, cross-tree, expired, failed, aggregate-host, cross-version, target-host-mismatched, retained-package-mismatched and reused evidence through controlled hostile regressions;
- wired the new contract tests into plugin-static, release and auto-release workflow-policy jobs and documented the operator handoff.

## How to review

1. Start with `release-claims.json` and confirm the cell inventory has no separate target matrix.
2. Review `deriveReleaseCells`, manifest validation, dependency-cell selection and post-publish comparison in `scripts/codestory-release-closeout.mjs`.
3. Review the positive pre/post-publish and hostile negative cases in `scripts/tests/codestory-release-closeout.test.mjs`, especially the archive A/B split.
4. Confirm workflow policy requires the coordinator tests but does not yet pretend that final release evidence exists.

## Verification

Rerun on exact rebased head `b837043ffd1538eaf452d427a0ea56227ba7de7b`:

- `node --test scripts/tests/codestory-release-claims.test.mjs scripts/tests/codestory-release-closeout.test.mjs scripts/tests/codestory-release-evidence-gate.test.mjs` — 45 passed
- `node .github/scripts/check-workflow-policy.mjs` — passed
- `node --test .github/scripts/check-workflow-policy.test.mjs` — 231 passed
- `node --test .github/scripts/run-actionlint.test.mjs` — 3 passed
- `node .github/scripts/run-actionlint.mjs` — passed, including controlled-invalid rejection
- `python .github/scripts/check-codestory-release.py --version 0.16.0` — synchronized
- `node .github/scripts/check-doc-links.mjs` — 75 files, 265 links passed
- release graph validation, Node syntax checks and `git diff --check origin/dev/codestory-next...HEAD` — passed

## Risk and follow-up

The framework is fail-closed and is not wired as a final publication dependency in this slice. #1233 remains open for frozen exact-head producer manifests, complete cell ingestion, the accepted pre-publish ledger, release dependency wiring and the real post-publish byte comparison. #1189 remains open for the broader release, marketplace, installed-runtime and live-behavior closeout.

No final ledger, accepted SHA, workflow run ID, current release answer, protected-hardware result or post-publish claim is checked in by this PR.

Closes #1269
Refs #1233
Refs #1189
