### PR TITLE
batch file identity lookups below SQLite bind limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   parser partial, source drift, unreadable and oversized source, incomplete
   discovery, and collector failure without weakening source-integrity gates.
 - Safe refreshes preserve the last verified index. Incomplete reads, cancellation, or concurrent source changes cannot publish a partial generation or mix results from different generations.
+- Large full and incremental refreshes now batch file-identity lookups against SQLite's runtime bind-variable limit without changing duplicate or missing-ID semantics.
 - Existing semantic indexes rebuild once after upgrading. The last complete index remains available while the replacement is prepared.
 - Project switching now preserves isolated per-project state across A/B/A MCP routing. Requests require an explicit project, and status remains observational instead of activating or repairing a repository.
 - `affected` now handles native path identity, renames, copies, stale evidence, and bounded results more accurately across Unix and Windows.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tree-sitter-graph = { path = "vendor/tree-sitter-graph" }
 streaming-iterator = "0.1"
 
 # Storage
-rusqlite = { version = "0.38", features = ["backup", "bundled", "hooks"] }
+rusqlite = { version = "0.38", features = ["backup", "bundled", "hooks", "limits"] }
 
 # Search
 nucleo-matcher = "0.3"

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -870,6 +870,9 @@ impl WorkspaceIndexer {
             });
         }
         let mut stats = IncrementalIndexingStats::default();
+        if Self::is_cancelled(cancel_token) {
+            return Ok(stats);
+        }
         let total_files = plan.files_to_index.len();
         let processed_count = Arc::new(AtomicUsize::new(0));
         let cancelled = Arc::new(AtomicBool::new(false));
@@ -884,6 +887,9 @@ impl WorkspaceIndexer {
         )?;
         stats.setup_existing_projection_ids_ms =
             duration_ms_u64(existing_projection_setup_started.elapsed());
+        if Self::is_cancelled(cancel_token) {
+            return Ok(stats);
+        }
 
         let mut replaced_projection_ids = HashSet::new();
         let symbol_seed_started = Instant::now();
@@ -20683,6 +20689,78 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             "indexing should flush edges"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn cancelled_run_skips_file_identity_lookups_and_projection_writes() -> Result<()> {
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let path = dir.path().join("cancelled.rs");
+        std::fs::write(&path, "fn must_not_publish() {}\n")?;
+        let mut storage = Storage::new_in_memory()?;
+        storage.get_connection().execute("DROP TABLE node", [])?;
+        let plan = codestory_workspace::RefreshExecutionPlan {
+            mode: codestory_workspace::BuildMode::Incremental,
+            files_to_index: vec![path],
+            files_to_remove: Vec::new(),
+            existing_file_ids: HashMap::new(),
+        };
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let stats = WorkspaceIndexer::new(dir.path().to_path_buf()).run(
+            &mut storage,
+            &plan,
+            &EventBus::new(),
+            Some(&cancel_token),
+        )?;
+
+        assert_eq!(stats.setup_existing_projection_ids_ms, 0);
+        assert_eq!(stats.setup_seed_symbol_table_ms, 0);
+        assert!(!stats.resolution_ran);
+        assert!(storage.get_files()?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn file_identity_lookup_errors_retain_indexer_stage_context_without_writes() -> Result<()> {
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let path = dir.path().join("lookup.rs");
+        let storage = Storage::new_in_memory()?;
+        storage.get_connection().execute("DROP TABLE node", [])?;
+
+        let identity_error = WorkspaceIndexer::existing_projection_file_ids(
+            &storage,
+            dir.path(),
+            std::slice::from_ref(&path),
+            &HashMap::new(),
+        )
+        .expect_err("missing node storage must fail identity discovery");
+        assert!(
+            identity_error
+                .to_string()
+                .contains("Storage file identity lookup error"),
+            "unexpected identity error: {identity_error:#}"
+        );
+
+        let symbol_error = WorkspaceIndexer::seed_symbol_table(
+            &storage,
+            &SymbolTable::new(),
+            codestory_workspace::BuildMode::Incremental,
+            &HashSet::from([1]),
+        )
+        .expect_err("missing node storage must fail symbol seeding");
+        assert!(
+            symbol_error
+                .to_string()
+                .contains("Storage symbol seed error"),
+            "unexpected symbol error: {symbol_error:#}"
+        );
+        assert!(storage.get_files()?.is_empty());
         Ok(())
     }
 

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -6,13 +6,13 @@ use codestory_contracts::graph::{
 use fs4::fs_std::FileExt;
 use parking_lot::RwLock;
 use rusqlite::{
-    Connection, MAIN_DB, OpenFlags, OptionalExtension, Result, Row, params, params_from_iter,
-    types::Value,
+    Connection, MAIN_DB, OpenFlags, OptionalExtension, Result, Row, limits::Limit, params,
+    params_from_iter, types::Value,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -6764,28 +6764,52 @@ impl Storage {
             return Ok(Vec::new());
         }
 
-        let file_placeholders = question_placeholders(file_ids.len());
-        let sql = format!(
-            "SELECT id, kind
-             FROM node
-             WHERE id IN ({file_placeholders})
-                OR file_node_id IN ({file_placeholders})"
-        );
-        let params = file_ids
-            .iter()
-            .copied()
-            .chain(file_ids.iter().copied())
-            .collect::<Vec<_>>();
-        let mut stmt = self.conn.prepare(&sql)?;
-        let mut rows = stmt.query(params_from_iter(params))?;
-        let mut out = Vec::new();
-        while let Some(row) = rows.next()? {
-            let raw_kind: i32 = row.get(1)?;
-            if let Ok(kind) = NodeKind::try_from(raw_kind) {
-                out.push((NodeId(row.get(0)?), kind));
+        let variable_limit = usize::try_from(self.conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)?)
+            .map_err(|_| {
+                StorageError::Other(
+                    "SQLite reported a negative bind-variable limit for file identity lookup"
+                        .to_string(),
+                )
+            })?;
+        let file_ids_per_batch = variable_limit / 2;
+        if file_ids_per_batch == 0 {
+            return Err(StorageError::Other(format!(
+                "SQLite bind-variable limit {variable_limit} cannot support the two file identity predicates"
+            )));
+        }
+
+        let mut unique_file_ids = file_ids.to_vec();
+        unique_file_ids.sort_unstable();
+        unique_file_ids.dedup();
+
+        // A row can match `id` in one batch and `file_node_id` in another. Keep
+        // one result per node, matching the set semantics of the former single
+        // SELECT, and return stable node-id order regardless of batch layout.
+        let mut node_kinds = BTreeMap::new();
+        for batch in unique_file_ids.chunks(file_ids_per_batch) {
+            let file_placeholders = question_placeholders(batch.len());
+            let sql = format!(
+                "SELECT id, kind
+                 FROM node
+                 WHERE id IN ({file_placeholders})
+                    OR file_node_id IN ({file_placeholders})"
+            );
+            let params = batch
+                .iter()
+                .copied()
+                .chain(batch.iter().copied())
+                .collect::<Vec<_>>();
+            let mut stmt = self.conn.prepare(&sql)?;
+            let mut rows = stmt.query(params_from_iter(params))?;
+            while let Some(row) = rows.next()? {
+                let raw_kind: i32 = row.get(1)?;
+                if let Ok(kind) = NodeKind::try_from(raw_kind) {
+                    let node_id = NodeId(row.get(0)?);
+                    node_kinds.entry(node_id.0).or_insert((node_id, kind));
+                }
             }
         }
-        Ok(out)
+        Ok(node_kinds.into_values().collect())
     }
 
     pub fn get_nodes_for_file_line(

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -67,6 +67,84 @@ fn durable_sqlite_state(path: &Path) -> Vec<(PathBuf, Option<Vec<u8>>)> {
 }
 
 #[test]
+fn file_identity_lookup_batches_above_default_bind_limit_with_set_semantics()
+-> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(&[Node {
+        id: NodeId(40_000),
+        kind: NodeKind::FILE,
+        serialized_name: "large.rs".to_string(),
+        ..Default::default()
+    }])?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "early_match".to_string(),
+            file_node_id: Some(NodeId(40_000)),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(500),
+            kind: NodeKind::CLASS,
+            serialized_name: "direct_match".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(40_001),
+            kind: NodeKind::METHOD,
+            serialized_name: "late_match".to_string(),
+            file_node_id: Some(NodeId(40_000)),
+            ..Default::default()
+        },
+    ])?;
+
+    let previous_limit = storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 64)?;
+    assert!(previous_limit >= 64);
+
+    // Two bindings per candidate made the former single query exceed SQLite's
+    // 32,766 default once this set grew past 16,383 IDs.
+    let mut candidates = (0_i64..=32_766).collect::<Vec<_>>();
+    candidates.extend([40_000, 40_000, 50_000]);
+    let node_kinds = storage.get_node_kinds_for_files(&candidates)?;
+
+    assert_eq!(
+        node_kinds,
+        vec![
+            (NodeId(1), NodeKind::FUNCTION),
+            (NodeId(500), NodeKind::CLASS),
+            (NodeId(40_000), NodeKind::FILE),
+            (NodeId(40_001), NodeKind::METHOD),
+        ]
+    );
+    storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, previous_limit)?;
+    Ok(())
+}
+
+#[test]
+fn file_identity_lookup_rejects_runtime_limit_below_two_bindings() -> Result<(), StorageError> {
+    let storage = Storage::new_in_memory()?;
+    storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 1)?;
+
+    let error = storage
+        .get_node_kinds_for_files(&[1])
+        .expect_err("two-predicate lookup must reject a one-variable runtime limit");
+    assert!(
+        error
+            .to_string()
+            .contains("cannot support the two file identity predicates"),
+        "unexpected error: {error}"
+    );
+    Ok(())
+}
+
+#[test]
 fn observational_open_preserves_current_database_bytes_without_sidecars() {
     let path = unique_temp_db_path("observational-current");
     create_versioned_observation_fixture(&path, SCHEMA_VERSION);


### PR DESCRIPTION
## Context

A clean full index of the retained 94,523-file Linux corpus supplied about 189,046 parameters to one file-identity query and failed before staged publication with SQLite's `too many SQL variables` error.

## What changed

- derive the candidate batch size from the connection's runtime `SQLITE_LIMIT_VARIABLE_NUMBER`
- bind each ID to both identity predicates without crossing that limit
- sort and deduplicate input IDs, then deduplicate rows across batches in stable node-ID order
- stop already-cancelled indexing before either identity lookup or projection writes
- retain distinct indexer error context for identity discovery and symbol seeding
- document the reliability fix in the v0.16 changelog

The change does not select or modify the vector backend.

## How to review

Start with `Storage::get_node_kinds_for_files`. The two indexer callers remain the existing `existing_projection_file_ids` and `seed_symbol_table` paths. The regression lowers SQLite's runtime limit and uses 32,767 candidate IDs so the old two-list query would exceed the 32,766 default; it also covers duplicate candidates, missing IDs, and a row matching in separate batches.

Exact source candidate: `b2cb81777bec2ac65e4f5caf017519e02a7ba3b4`.

## Verification

Completed on the exact candidate:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p codestory-store` (111 passed)
- `cargo test --locked -p codestory-indexer --lib` (189 passed)
- focused indexer cancellation and storage-attribution regressions
- focused runtime old-or-new publication cases
- `cargo check --locked -p codestory-store -p codestory-indexer -p codestory-runtime`
- `cargo clippy --locked -p codestory-store -p codestory-indexer -p codestory-runtime --all-targets -- -D warnings`
- ordinary draft PR CI: green

The native arm64 release CLI was built from the exact candidate with SHA-256 `bda02acffb559f64bbc904ecffeb9add21b62d44f0827f3026e2a4922c936d78`.

### Approved corpus no-go

The clean-cache case-sensitive APFS run used corpus head `37e2f878a7a660a216cc7a60459995fefd150f25`. It crossed the former bind-variable failure and parsed all `94,523 / 94,523` candidates, then failed during resolution before publication:

```text
Indexing failed: Resolution error: Database error: string or blob too big
Caused by:
    0: string or blob too big
    1: Error code 18: string or blob too big
```

Timing was `real 2643.34`, `user 455.48`, `sys 195.64`. The failed transaction rolled back to an empty core; no partial publication occurred.

Source inspection pins this to the pre-existing resolution-support cache: `PreparedResolutionState::load` serializes its full support state to one JSON value and `put_resolution_support_snapshot` binds it as one BLOB. The bundled SQLite build limits a value to 1,000,000,000 bytes. This path predates and is untouched by this branch. The retained result and run metadata are under `/Volumes/CodeStoryLinuxCorpus/runs/issue-1237-b2cb817-DnL7TL/`.

This batching slice is independently ready, but successful corpus publication is not claimed. #1273 must land before the approved proof is rerun and parent #1237 can close.

## Nonclaims

- The new cancellation regression exercises direct `WorkspaceIndexer::run`; it does not add coverage for the legacy `run_incremental` wrapper's earlier file-path lookup.
- Invalid stored `NodeKind` rows continue to be skipped as before, but this branch does not add a focused invalid-kind assertion.
- The approved corpus did not publish successfully, and the final release/platform gate has not run.

## Risk

The read is split into multiple statements, so performance now scales with the number of runtime-limit-sized batches. For the retained corpus this is a small bounded count. Publication semantics stay unchanged: these reads precede projection writes, and runtime continues to stage and validate before swapping the live core.

Closes #1272
Refs #1237
Refs #1202
Refs #1179