### PR TITLE
bound oversized resolution support snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   discovery, and collector failure without weakening source-integrity gates.
 - Safe refreshes preserve the last verified index. Incomplete reads, cancellation, or concurrent source changes cannot publish a partial generation or mix results from different generations.
 - Large full and incremental refreshes now batch file-identity lookups against SQLite's runtime bind-variable limit without changing duplicate or missing-ID semantics.
+- Resolution now skips its optional support cache when the serialized snapshot exceeds SQLite's runtime value limit, while keeping the in-memory result and staged publication intact.
 - Existing semantic indexes rebuild once after upgrading. The last complete index remains available while the replacement is prepared.
 - Project switching now preserves isolated per-project state across A/B/A MCP routing. Requests require an explicit project, and status remains observational instead of activating or repairing a repository.
 - `affected` now handles native path identity, renames, copies, stale evidence, and bounded results more accurately across Unix and Windows.

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8900,6 +8900,9 @@ mod tests {
             resolution_import_candidate_index_ms: Some(31),
             resolution_call_semantic_index_ms: Some(32),
             resolution_import_semantic_index_ms: Some(33),
+            resolution_support_snapshot_limit_bytes: Some(1_000_000_000),
+            resolution_support_snapshot_stored: Some(true),
+            resolution_support_snapshot_skipped_oversize: Some(false),
             resolution_call_semantic_candidates_ms: Some(34),
             resolution_import_semantic_candidates_ms: Some(35),
             resolution_call_semantic_requests: Some(36),
@@ -9099,6 +9102,9 @@ mod tests {
         ));
         assert!(markdown.contains(
             "resolution_indexes_ms: call_candidate=30 import_candidate=31 call_semantic=32 import_semantic=33"
+        ));
+        assert!(markdown.contains(
+            "resolution_support_snapshot: limit_bytes=1000000000 stored=true skipped_oversize=false"
         ));
         assert!(markdown.contains(
             "resolution_detail_ms: call_semantic_candidates=34 import_semantic_candidates=35 call_compute=42 import_compute=43 call_apply=44 import_apply=45 overrides=46"

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -395,6 +395,17 @@ fn append_index_flush_timings(markdown: &mut String, timings: &IndexingPhaseTimi
 fn append_index_resolution_timings(markdown: &mut String, timings: &IndexingPhaseTimings) {
     append_index_resolution_core_timings(markdown, timings);
     append_index_resolution_index_timings(markdown, timings);
+    if let Some(limit_bytes) = timings.resolution_support_snapshot_limit_bytes {
+        let _ = writeln!(
+            markdown,
+            "resolution_support_snapshot: limit_bytes={} stored={} skipped_oversize={}",
+            limit_bytes,
+            timings.resolution_support_snapshot_stored.unwrap_or(false),
+            timings
+                .resolution_support_snapshot_skipped_oversize
+                .unwrap_or(false)
+        );
+    }
     append_index_resolution_detail_timings(markdown, timings);
     append_index_resolution_request_counts(markdown, timings);
 }

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -98,6 +98,12 @@ pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolution_import_semantic_index_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution_support_snapshot_limit_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution_support_snapshot_stored: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution_support_snapshot_skipped_oversize: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolution_call_semantic_candidates_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolution_import_semantic_candidates_ms: Option<u32>,
@@ -235,6 +241,9 @@ mod tests {
             resolution_import_candidate_index_ms: None,
             resolution_call_semantic_index_ms: None,
             resolution_import_semantic_index_ms: None,
+            resolution_support_snapshot_limit_bytes: None,
+            resolution_support_snapshot_stored: None,
+            resolution_support_snapshot_skipped_oversize: None,
             resolution_call_semantic_candidates_ms: None,
             resolution_import_semantic_candidates_ms: None,
             resolution_call_semantic_requests: None,
@@ -288,6 +297,17 @@ mod tests {
         assert!(value.get("resolution_import_candidate_index_ms").is_none());
         assert!(value.get("resolution_call_semantic_index_ms").is_none());
         assert!(value.get("resolution_import_semantic_index_ms").is_none());
+        assert!(
+            value
+                .get("resolution_support_snapshot_limit_bytes")
+                .is_none()
+        );
+        assert!(value.get("resolution_support_snapshot_stored").is_none());
+        assert!(
+            value
+                .get("resolution_support_snapshot_skipped_oversize")
+                .is_none()
+        );
         assert!(
             value
                 .get("resolution_call_semantic_candidates_ms")

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -713,6 +713,9 @@ pub struct IncrementalIndexingStats {
     pub resolution_support_snapshot_load_ms: u64,
     pub resolution_support_snapshot_store_ms: u64,
     pub resolution_support_snapshot_hit: bool,
+    pub resolution_support_snapshot_limit_bytes: u64,
+    pub resolution_support_snapshot_stored: bool,
+    pub resolution_support_snapshot_skipped_oversize: bool,
     pub resolution_call_semantic_candidates_ms: u64,
     pub resolution_import_semantic_candidates_ms: u64,
     pub resolution_call_semantic_requests: usize,
@@ -1255,6 +1258,12 @@ impl WorkspaceIndexer {
             stats.resolution_support_snapshot_store_ms =
                 resolution_stats.telemetry.support_snapshot_store_ms;
             stats.resolution_support_snapshot_hit = resolution_stats.telemetry.support_snapshot_hit;
+            stats.resolution_support_snapshot_limit_bytes =
+                resolution_stats.telemetry.support_snapshot_limit_bytes;
+            stats.resolution_support_snapshot_stored =
+                resolution_stats.telemetry.support_snapshot_stored;
+            stats.resolution_support_snapshot_skipped_oversize =
+                resolution_stats.telemetry.support_snapshot_skipped_oversize;
             stats.resolution_call_semantic_candidates_ms =
                 resolution_stats.telemetry.call_semantic_candidates_ms;
             stats.resolution_import_semantic_candidates_ms =

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -14,13 +14,14 @@ use crate::semantic::{
 };
 use anyhow::Result;
 use codestory_contracts::graph::{EdgeKind, NodeKind, ResolutionCertainty};
-use codestory_store::Store as Storage;
+use codestory_store::{StorageError, Store as Storage};
 use rayon::prelude::*;
 #[cfg(test)]
 use rusqlite::OptionalExtension;
-use rusqlite::{params, params_from_iter, types::Value};
+use rusqlite::{limits::Limit, params, params_from_iter, types::Value};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::io::{self, Write};
 use std::sync::RwLock;
 use std::time::Instant;
 
@@ -196,6 +197,112 @@ struct ResolutionSupportSnapshot {
     node_names: Vec<(i64, String)>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SnapshotCapacityExceeded {
+    limit_bytes: usize,
+    attempted_bytes: usize,
+}
+
+impl std::fmt::Display for SnapshotCapacityExceeded {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "resolution support snapshot exceeded its {0}-byte SQLite value limit while writing byte {1}",
+            self.limit_bytes, self.attempted_bytes
+        )
+    }
+}
+
+impl std::error::Error for SnapshotCapacityExceeded {}
+
+struct BoundedWriter<W> {
+    inner: W,
+    limit_bytes: usize,
+    written_bytes: usize,
+    capacity_exceeded: Option<SnapshotCapacityExceeded>,
+}
+
+impl<W> BoundedWriter<W> {
+    fn new(inner: W, limit_bytes: usize) -> Self {
+        Self {
+            inner,
+            limit_bytes,
+            written_bytes: 0,
+            capacity_exceeded: None,
+        }
+    }
+
+    fn written_bytes(&self) -> usize {
+        self.written_bytes
+    }
+
+    fn capacity_exceeded(&self) -> Option<SnapshotCapacityExceeded> {
+        self.capacity_exceeded
+    }
+}
+
+impl<W: Write> Write for BoundedWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        let attempted_bytes = self.written_bytes.saturating_add(bytes.len());
+        if attempted_bytes > self.limit_bytes {
+            let capacity_exceeded = SnapshotCapacityExceeded {
+                limit_bytes: self.limit_bytes,
+                attempted_bytes,
+            };
+            self.capacity_exceeded = Some(capacity_exceeded);
+            return Err(io::Error::other(capacity_exceeded));
+        }
+
+        self.inner.write_all(bytes)?;
+        self.written_bytes = attempted_bytes;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+enum SnapshotSerialization {
+    Complete(Vec<u8>),
+    Oversized(SnapshotCapacityExceeded),
+}
+
+fn serialize_json_with_limit<T: Serialize>(
+    value: &T,
+    limit_bytes: usize,
+) -> Result<SnapshotSerialization> {
+    // Measure through a sink first. An oversized snapshot therefore never
+    // allocates a value larger than SQLite can accept merely to discover its
+    // serialized length.
+    let mut counter = BoundedWriter::new(io::sink(), limit_bytes);
+    if let Err(error) = serde_json::to_writer(&mut counter, value) {
+        if let Some(capacity_exceeded) = counter.capacity_exceeded() {
+            return Ok(SnapshotSerialization::Oversized(capacity_exceeded));
+        }
+        return Err(error.into());
+    }
+
+    let measured_bytes = counter.written_bytes();
+    let mut snapshot_blob = Vec::new();
+    snapshot_blob.try_reserve_exact(measured_bytes)?;
+    let written_bytes = {
+        let mut writer = BoundedWriter::new(&mut snapshot_blob, limit_bytes);
+        if let Err(error) = serde_json::to_writer(&mut writer, value) {
+            if writer.capacity_exceeded().is_some() {
+                anyhow::bail!(
+                    "resolution support snapshot changed size between bounded measurement and serialization"
+                );
+            }
+            return Err(error.into());
+        }
+        writer.written_bytes()
+    };
+    debug_assert_eq!(written_bytes, measured_bytes);
+
+    Ok(SnapshotSerialization::Complete(snapshot_blob))
+}
+
 impl OverrideSupport {
     fn from_snapshot(
         override_members: Vec<OverrideMemberSnapshot>,
@@ -311,6 +418,9 @@ pub struct ResolutionPhaseTelemetry {
     pub support_snapshot_load_ms: u64,
     pub support_snapshot_store_ms: u64,
     pub support_snapshot_hit: bool,
+    pub support_snapshot_limit_bytes: u64,
+    pub support_snapshot_stored: bool,
+    pub support_snapshot_skipped_oversize: bool,
     pub call_prepare_ms: u64,
     pub call_cleanup_ms: u64,
     pub call_unresolved_load_ms: u64,
@@ -1383,10 +1493,21 @@ impl PreparedResolutionState {
         flags: ResolutionFlags,
         telemetry: &mut ResolutionPhaseTelemetry,
     ) -> Result<Self> {
+        let snapshot_limit_bytes =
+            usize::try_from(storage.get_connection().limit(Limit::SQLITE_LIMIT_LENGTH)?)?;
+        telemetry.support_snapshot_limit_bytes = snapshot_limit_bytes as u64;
         let snapshot_load_started = Instant::now();
-        if let Some(snapshot_blob) =
-            storage.get_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION)?
-        {
+        let snapshot_blob =
+            match storage.get_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION) {
+                Ok(snapshot_blob) => snapshot_blob,
+                Err(StorageError::ResolutionSupportSnapshotTooBig) => {
+                    storage.invalidate_resolution_support_snapshot()?;
+                    telemetry.support_snapshot_skipped_oversize = true;
+                    None
+                }
+                Err(error) => return Err(error.into()),
+            };
+        if let Some(snapshot_blob) = snapshot_blob {
             match serde_json::from_slice::<ResolutionSupportSnapshot>(&snapshot_blob) {
                 Ok(snapshot) if snapshot.enable_semantic == flags.enable_semantic => {
                     telemetry.support_snapshot_load_ms =
@@ -1454,9 +1575,26 @@ impl PreparedResolutionState {
         };
 
         let snapshot_store_started = Instant::now();
-        let snapshot_blob = serde_json::to_vec(&prepared.snapshot(flags))?;
-        storage
-            .put_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION, &snapshot_blob)?;
+        match serialize_json_with_limit(&prepared.snapshot(flags), snapshot_limit_bytes)? {
+            SnapshotSerialization::Complete(snapshot_blob) => {
+                match storage.put_resolution_support_snapshot(
+                    RESOLUTION_SUPPORT_SNAPSHOT_VERSION,
+                    &snapshot_blob,
+                ) {
+                    Ok(()) => telemetry.support_snapshot_stored = true,
+                    Err(StorageError::ResolutionSupportSnapshotTooBig) => {
+                        storage.invalidate_resolution_support_snapshot()?;
+                        telemetry.support_snapshot_skipped_oversize = true;
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            }
+            SnapshotSerialization::Oversized(capacity_exceeded) => {
+                debug_assert_eq!(capacity_exceeded.limit_bytes, snapshot_limit_bytes);
+                storage.invalidate_resolution_support_snapshot()?;
+                telemetry.support_snapshot_skipped_oversize = true;
+            }
+        }
         telemetry.support_snapshot_store_ms = duration_ms_u64(snapshot_store_started.elapsed());
 
         Ok(prepared)
@@ -3256,6 +3394,7 @@ fn duration_ms_u64(duration: std::time::Duration) -> u64 {
 mod tests {
     use super::*;
     use rusqlite::{Connection, params};
+    use serde::Serializer;
     use std::collections::HashSet;
     use std::time::Instant;
     use tempfile::tempdir;
@@ -3272,6 +3411,103 @@ mod tests {
                 start_line INTEGER
             );",
         )?;
+        Ok(())
+    }
+
+    fn empty_resolution_support_snapshot() -> ResolutionSupportSnapshot {
+        ResolutionSupportSnapshot {
+            enable_semantic: false,
+            call_candidates: Vec::new(),
+            call_import_binding_node_ids: Vec::new(),
+            import_candidates: Vec::new(),
+            relative_import_candidates: Vec::new(),
+            call_semantic_nodes: Vec::new(),
+            import_semantic_nodes: Vec::new(),
+            override_members: Vec::new(),
+            override_inheritance: Vec::new(),
+            override_inheritance_by_name: Vec::new(),
+            node_names: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_snapshot_serialization_stops_at_the_explicit_capacity() -> Result<()> {
+        let mut snapshot = empty_resolution_support_snapshot();
+        snapshot.node_names = vec![(1, "target".repeat(128))];
+        let expected = serde_json::to_vec(&snapshot)?;
+
+        let complete = serialize_json_with_limit(&snapshot, expected.len())?;
+        match complete {
+            SnapshotSerialization::Complete(blob) => assert_eq!(blob, expected),
+            SnapshotSerialization::Oversized(_) => {
+                anyhow::bail!("snapshot at the exact limit should fit")
+            }
+        }
+
+        let limit_bytes = expected.len() - 1;
+        let oversized = serialize_json_with_limit(&snapshot, limit_bytes)?;
+        match oversized {
+            SnapshotSerialization::Oversized(capacity) => {
+                assert_eq!(capacity.limit_bytes, limit_bytes);
+                assert!(capacity.attempted_bytes > capacity.limit_bytes);
+            }
+            SnapshotSerialization::Complete(_) => {
+                anyhow::bail!("snapshot beyond the limit should not allocate a result")
+            }
+        }
+
+        Ok(())
+    }
+
+    struct FailingSerialization;
+
+    impl Serialize for FailingSerialization {
+        fn serialize<S>(&self, _serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            Err(serde::ser::Error::custom("injected serialization failure"))
+        }
+    }
+
+    #[test]
+    fn test_snapshot_serialization_does_not_reclassify_real_errors_as_capacity() {
+        match serialize_json_with_limit(&FailingSerialization, 1_024) {
+            Err(error) => assert!(error.to_string().contains("injected serialization failure")),
+            Ok(_) => panic!("real serializer failure must remain fatal"),
+        }
+    }
+
+    #[test]
+    fn test_snapshot_persistence_failure_below_limit_remains_fatal() -> Result<()> {
+        let storage = Storage::new_in_memory()?;
+        storage.invalidate_resolution_support_snapshot()?;
+        storage.get_connection().execute_batch(
+            "CREATE TRIGGER reject_resolution_support_snapshot
+             BEFORE UPDATE ON resolution_support_snapshot
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected snapshot persistence failure');
+             END;",
+        )?;
+
+        let flags = ResolutionFlags {
+            legacy_mode: false,
+            enable_semantic: false,
+            store_candidates: false,
+            parallel_compute: false,
+        };
+        let mut telemetry = ResolutionPhaseTelemetry::default();
+        let error = match PreparedResolutionState::load(&storage, flags, &mut telemetry) {
+            Err(error) => error,
+            Ok(_) => anyhow::bail!("persistence failure below the capacity boundary must fail"),
+        };
+        assert!(
+            format!("{error:#}").contains("injected snapshot persistence failure"),
+            "unexpected error: {error:#}"
+        );
+        assert!(!telemetry.support_snapshot_skipped_oversize);
+        assert!(!telemetry.support_snapshot_stored);
+
         Ok(())
     }
 
@@ -3295,19 +3531,7 @@ mod tests {
             },
         ])?;
 
-        let stale_snapshot = ResolutionSupportSnapshot {
-            enable_semantic: false,
-            call_candidates: Vec::new(),
-            call_import_binding_node_ids: Vec::new(),
-            import_candidates: Vec::new(),
-            relative_import_candidates: Vec::new(),
-            call_semantic_nodes: Vec::new(),
-            import_semantic_nodes: Vec::new(),
-            override_members: Vec::new(),
-            override_inheritance: Vec::new(),
-            override_inheritance_by_name: Vec::new(),
-            node_names: Vec::new(),
-        };
+        let stale_snapshot = empty_resolution_support_snapshot();
         storage.put_resolution_support_snapshot(
             RESOLUTION_SUPPORT_SNAPSHOT_VERSION,
             &serde_json::to_vec(&stale_snapshot)?,

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -5,6 +5,7 @@ use codestory_contracts::graph::{
 use codestory_indexer::resolution::{RESOLUTION_SUPPORT_SNAPSHOT_VERSION, ResolutionPass};
 use codestory_indexer::{IncrementalIndexingStats, WorkspaceIndexer};
 use codestory_store::Store as Storage;
+use rusqlite::limits::Limit;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
@@ -306,6 +307,9 @@ fn test_incremental_indexing_second_run_reuses_unchanged_extraction_cache_and_re
     assert_eq!(first_stats.artifact_cache_hits, 0);
     assert_eq!(first_stats.artifact_cache_misses, 1);
     assert!(!first_stats.resolution_support_snapshot_hit);
+    assert!(first_stats.resolution_support_snapshot_limit_bytes > 0);
+    assert!(first_stats.resolution_support_snapshot_stored);
+    assert!(!first_stats.resolution_support_snapshot_skipped_oversize);
     assert!(storage.has_ready_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION)?);
 
     let second_stats = run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
@@ -314,9 +318,171 @@ fn test_incremental_indexing_second_run_reuses_unchanged_extraction_cache_and_re
 
     let resolution_stats = ResolutionPass::new().run(&mut storage)?;
     assert!(resolution_stats.telemetry.support_snapshot_hit);
+    assert!(!resolution_stats.telemetry.support_snapshot_stored);
+    assert!(!resolution_stats.telemetry.support_snapshot_skipped_oversize);
 
     let nodes = storage.get_nodes()?;
     assert!(nodes.iter().any(|node| node.serialized_name == "run"));
+
+    Ok(())
+}
+
+#[test]
+fn test_resolution_skips_oversized_optional_snapshot_without_changing_results() -> anyhow::Result<()>
+{
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("main.rs");
+    fs::write(&file_path, "fn helper() {}\nfn run() { helper(); }\n")?;
+
+    let mut storage = Storage::new_in_memory()?;
+    run_incremental_indexing(root, &mut storage, vec![file_path])?;
+
+    let nodes = storage.get_nodes()?;
+    let file_node_id = nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::FILE)
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing file node"))?;
+    let helper_id = nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::FUNCTION && node.serialized_name == "helper")
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing helper node"))?;
+    let run_id = nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::FUNCTION && node.serialized_name == "run")
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing run node"))?;
+    let original_call = storage
+        .get_edges()?
+        .into_iter()
+        .find(|edge| edge.kind == EdgeKind::CALL && edge.source == run_id)
+        .ok_or_else(|| anyhow::anyhow!("missing run-to-helper call"))?;
+    assert_eq!(original_call.resolved_target, Some(helper_id));
+
+    let noise_nodes = (0..32)
+        .map(|index| codestory_contracts::graph::Node {
+            id: NodeId(9_000_000 + index),
+            kind: NodeKind::FUNCTION,
+            serialized_name: format!("unrelated_snapshot_candidate_{index}"),
+            qualified_name: Some(format!("fixture::unrelated_snapshot_candidate_{index}")),
+            file_node_id: Some(file_node_id),
+            ..Default::default()
+        })
+        .collect::<Vec<_>>();
+    storage.insert_nodes_batch(&noise_nodes)?;
+    storage
+        .put_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION, &vec![b'x'; 2_048])?;
+    storage.get_connection().execute(
+        "UPDATE edge
+         SET resolved_target_node_id = NULL, confidence = NULL, certainty = NULL
+         WHERE id = ?1",
+        [original_call.id.0],
+    )?;
+
+    let previous_limit = storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, 1_024)?;
+    let result = ResolutionPass::new().run(&mut storage);
+    storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, previous_limit)?;
+    let stats = result?;
+
+    assert_eq!(stats.resolved_calls, 1);
+    assert_eq!(stats.telemetry.support_snapshot_limit_bytes, 1_024);
+    assert!(stats.telemetry.support_snapshot_skipped_oversize);
+    assert!(!stats.telemetry.support_snapshot_stored);
+    assert!(!stats.telemetry.support_snapshot_hit);
+    assert!(!storage.has_ready_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION)?);
+
+    let resolved_call = storage
+        .get_edges()?
+        .into_iter()
+        .find(|edge| edge.id == original_call.id)
+        .ok_or_else(|| anyhow::anyhow!("missing resolved call"))?;
+    assert_eq!(resolved_call.resolved_target, original_call.resolved_target);
+    assert_eq!(storage.get_nodes()?, {
+        let mut expected = nodes;
+        expected.extend(noise_nodes);
+        expected.sort_by_key(|node| node.id);
+        expected
+    });
+
+    Ok(())
+}
+
+#[test]
+fn test_resolution_skips_snapshot_rejected_by_sqlite_row_capacity_without_changing_results()
+-> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("main.rs");
+    fs::write(&file_path, "fn helper() {}\nfn run() { helper(); }\n")?;
+
+    let mut storage = Storage::new_in_memory()?;
+    run_incremental_indexing(root, &mut storage, vec![file_path])?;
+
+    let nodes = storage.get_nodes()?;
+    let helper_id = nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::FUNCTION && node.serialized_name == "helper")
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing helper node"))?;
+    let run_id = nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::FUNCTION && node.serialized_name == "run")
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing run node"))?;
+    let original_call = storage
+        .get_edges()?
+        .into_iter()
+        .find(|edge| edge.kind == EdgeKind::CALL && edge.source == run_id)
+        .ok_or_else(|| anyhow::anyhow!("missing run-to-helper call"))?;
+    assert_eq!(original_call.resolved_target, Some(helper_id));
+
+    let snapshot_blob = storage
+        .get_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION)?
+        .ok_or_else(|| anyhow::anyhow!("missing initial resolution support snapshot"))?;
+    storage.invalidate_resolution_support_snapshot()?;
+    storage.get_connection().execute(
+        "UPDATE edge
+         SET resolved_target_node_id = NULL, confidence = NULL, certainty = NULL
+         WHERE id = ?1",
+        [original_call.id.0],
+    )?;
+
+    // The rebuilt JSON is identical to the snapshot above and therefore fits
+    // this value limit exactly. SQLite still rejects the complete row because
+    // its record header and the other columns also count toward LENGTH.
+    let snapshot_limit = i32::try_from(snapshot_blob.len())?;
+    let previous_limit = storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, snapshot_limit)?;
+    let result = ResolutionPass::new().run(&mut storage);
+    storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, previous_limit)?;
+    let stats = result?;
+
+    assert_eq!(stats.resolved_calls, 1);
+    assert_eq!(
+        stats.telemetry.support_snapshot_limit_bytes,
+        snapshot_blob.len() as u64
+    );
+    assert!(stats.telemetry.support_snapshot_skipped_oversize);
+    assert!(!stats.telemetry.support_snapshot_stored);
+    assert!(!stats.telemetry.support_snapshot_hit);
+    assert!(!storage.has_ready_resolution_support_snapshot(RESOLUTION_SUPPORT_SNAPSHOT_VERSION)?);
+
+    let resolved_call = storage
+        .get_edges()?
+        .into_iter()
+        .find(|edge| edge.id == original_call.id)
+        .ok_or_else(|| anyhow::anyhow!("missing resolved call"))?;
+    assert_eq!(resolved_call.resolved_target, original_call.resolved_target);
+    assert_eq!(storage.get_nodes()?, nodes);
 
     Ok(())
 }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -4247,6 +4247,9 @@ struct OptionalResolutionTelemetry {
     resolution_import_candidate_index_ms: Option<u32>,
     resolution_call_semantic_index_ms: Option<u32>,
     resolution_import_semantic_index_ms: Option<u32>,
+    resolution_support_snapshot_limit_bytes: Option<u64>,
+    resolution_support_snapshot_stored: Option<bool>,
+    resolution_support_snapshot_skipped_oversize: Option<bool>,
     resolution_call_semantic_candidates_ms: Option<u32>,
     resolution_import_semantic_candidates_ms: Option<u32>,
     resolution_call_semantic_requests: Option<u32>,
@@ -4323,6 +4326,12 @@ impl OptionalResolutionTelemetry {
         self.resolution_import_semantic_index_ms = Some(clamp_u64_to_u32(
             index_stats.resolution_import_semantic_index_ms,
         ));
+        self.resolution_support_snapshot_limit_bytes =
+            Some(index_stats.resolution_support_snapshot_limit_bytes);
+        self.resolution_support_snapshot_stored =
+            Some(index_stats.resolution_support_snapshot_stored);
+        self.resolution_support_snapshot_skipped_oversize =
+            Some(index_stats.resolution_support_snapshot_skipped_oversize);
         self.resolution_call_semantic_candidates_ms = Some(clamp_u64_to_u32(
             index_stats.resolution_call_semantic_candidates_ms,
         ));
@@ -14280,6 +14289,12 @@ fn index_full_for_runtime(
                 .resolution_call_semantic_index_ms,
             resolution_import_semantic_index_ms: resolution_telemetry
                 .resolution_import_semantic_index_ms,
+            resolution_support_snapshot_limit_bytes: resolution_telemetry
+                .resolution_support_snapshot_limit_bytes,
+            resolution_support_snapshot_stored: resolution_telemetry
+                .resolution_support_snapshot_stored,
+            resolution_support_snapshot_skipped_oversize: resolution_telemetry
+                .resolution_support_snapshot_skipped_oversize,
             resolution_call_semantic_candidates_ms: resolution_telemetry
                 .resolution_call_semantic_candidates_ms,
             resolution_import_semantic_candidates_ms: resolution_telemetry
@@ -14817,6 +14832,12 @@ where
                 .resolution_call_semantic_index_ms,
             resolution_import_semantic_index_ms: resolution_telemetry
                 .resolution_import_semantic_index_ms,
+            resolution_support_snapshot_limit_bytes: resolution_telemetry
+                .resolution_support_snapshot_limit_bytes,
+            resolution_support_snapshot_stored: resolution_telemetry
+                .resolution_support_snapshot_stored,
+            resolution_support_snapshot_skipped_oversize: resolution_telemetry
+                .resolution_support_snapshot_skipped_oversize,
             resolution_call_semantic_candidates_ms: resolution_telemetry
                 .resolution_call_semantic_candidates_ms,
             resolution_import_semantic_candidates_ms: resolution_telemetry

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -727,6 +727,8 @@ fn outside_file_node_predicate(file_param: &str) -> String {
 pub enum StorageError {
     #[error("Database error: {0}")]
     Sqlite(#[from] rusqlite::Error),
+    #[error("Resolution support snapshot exceeds the current SQLite value limit")]
+    ResolutionSupportSnapshotTooBig,
     #[error("Invalid enum value: {0}")]
     EnumConversion(#[from] EnumConversionError),
     #[error("Other error: {0}")]
@@ -2028,8 +2030,25 @@ impl Storage {
             snapshot_version,
             GroundingSnapshotState::Ready.db_value()
         ])?;
-        if let Some(row) = rows.next()? {
-            return Ok(Some(row.get(0)?));
+        let row = match rows.next() {
+            Ok(row) => row,
+            Err(rusqlite::Error::SqliteFailure(error, _))
+                if error.code == rusqlite::ffi::ErrorCode::TooBig =>
+            {
+                return Err(StorageError::ResolutionSupportSnapshotTooBig);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if let Some(row) = row {
+            return match row.get(0) {
+                Ok(snapshot) => Ok(Some(snapshot)),
+                Err(rusqlite::Error::SqliteFailure(error, _))
+                    if error.code == rusqlite::ffi::ErrorCode::TooBig =>
+                {
+                    Err(StorageError::ResolutionSupportSnapshotTooBig)
+                }
+                Err(error) => Err(error.into()),
+            };
         }
         Ok(None)
     }
@@ -2039,7 +2058,7 @@ impl Storage {
         snapshot_version: i64,
         snapshot_blob: &[u8],
     ) -> Result<(), StorageError> {
-        self.conn.execute(
+        let result = self.conn.execute(
             "INSERT INTO resolution_support_snapshot (
                 id,
                 snapshot_version,
@@ -2059,8 +2078,16 @@ impl Storage {
                 snapshot_blob,
                 current_epoch_ms()
             ],
-        )?;
-        Ok(())
+        );
+        match result {
+            Ok(_) => Ok(()),
+            Err(rusqlite::Error::SqliteFailure(error, _))
+                if error.code == rusqlite::ffi::ErrorCode::TooBig =>
+            {
+                Err(StorageError::ResolutionSupportSnapshotTooBig)
+            }
+            Err(error) => Err(error.into()),
+        }
     }
 
     pub fn invalidate_resolution_support_snapshot(&self) -> Result<(), StorageError> {

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -1210,6 +1210,50 @@ fn test_resolution_support_snapshot_round_trip_and_invalidation() -> Result<(), 
 }
 
 #[test]
+fn test_resolution_support_snapshot_read_classifies_runtime_capacity() -> Result<(), StorageError> {
+    let storage = Storage::new_in_memory()?;
+    storage.put_resolution_support_snapshot(1, &vec![b'x'; 2_048])?;
+
+    let previous_limit = storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, 1_024)?;
+    assert!(matches!(
+        storage.get_resolution_support_snapshot(1),
+        Err(StorageError::ResolutionSupportSnapshotTooBig)
+    ));
+    storage.invalidate_resolution_support_snapshot()?;
+    storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, previous_limit)?;
+    assert!(!storage.has_ready_resolution_support_snapshot(1)?);
+
+    Ok(())
+}
+
+#[test]
+fn test_resolution_support_snapshot_write_classifies_runtime_row_capacity()
+-> Result<(), StorageError> {
+    let storage = Storage::new_in_memory()?;
+    let snapshot_blob = vec![b'x'; 1_024];
+    let previous_limit = storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, snapshot_blob.len() as i32)?;
+
+    assert!(matches!(
+        storage.put_resolution_support_snapshot(1, &snapshot_blob),
+        Err(StorageError::ResolutionSupportSnapshotTooBig)
+    ));
+    storage.invalidate_resolution_support_snapshot()?;
+
+    storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, previous_limit)?;
+    assert!(!storage.has_ready_resolution_support_snapshot(1)?);
+
+    Ok(())
+}
+
+#[test]
 fn test_update_file_metadata_preserves_resolution_support_snapshot() -> Result<(), StorageError> {
     let storage = Storage::new_in_memory()?;
     storage.insert_file(&FileInfo {


### PR DESCRIPTION
## Context

The approved 94,523-file corpus cleared the bind lookup added in #1271, then failed while persisting the optional resolution-support snapshot because the serialized JSON BLOB exceeded SQLite's per-connection `SQLITE_LIMIT_LENGTH`.

This change keeps that optional cache from blocking an otherwise usable in-memory resolution result.

## What changed

- Read SQLite's runtime value-length limit from the active store connection.
- Measure resolution-support JSON through a bounded sink before allocating the serialized buffer.
- Skip and invalidate the optional ready snapshot when serialization exceeds that limit, while continuing with the already-built in-memory state.
- Classify SQLite `TOOBIG` from both reading an older oversized snapshot and writing a snapshot whose complete SQLite row exceeds the limit as the same optional-cache capacity outcome.
- Keep serializer, allocation, and every non-`TOOBIG` database failure fatal.
- Carry explicit limit/stored/skipped telemetry through indexer, runtime, contracts, and CLI output.
- Add lowered-limit regressions for oversized serialization, older ready snapshots, and JSON that fits the configured value limit but fails SQLite's full-row accounting.

## Review

The central boundary is in `crates/codestory-indexer/src/resolution/mod.rs`; the typed SQLite read/write classification is in `crates/codestory-store/src/storage_impl/mod.rs`.

The exact-head review confirmed that only SQLite capacity exhaustion is downgraded, the optional ready snapshot is absent after that path, resolution results are preserved, and genuine persistence errors still abort. No P0-P3 findings remain.

## Verification

Exact base: `83c52d1e91b7b03e31f047530972741aeda1e6c7`  
Exact head: `5852fb9e61d4c15692ca7a06b3f2ff81ac003657`

Exact-head focused proof:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p codestory-store resolution_support_snapshot -- --nocapture` (4 passed)
- direct write regression: a 1,024-byte BLOB at a 1,024-byte limit is classified as optional capacity when SQLite rejects the full row
- end-to-end resolution regression: measured JSON fits the exact limit, the write returns `TOOBIG`, the cache remains absent, and resolved calls/nodes remain unchanged
- injected non-`TOOBIG` snapshot persistence failure remains fatal
- `cargo test --locked -p codestory-indexer --test integration` (20 passed)
- `cargo test --locked -p codestory-indexer --lib` (192 passed)
- focused contracts, CLI telemetry, and both runtime publication-preservation tests
- `cargo clippy --locked -p codestory-contracts -p codestory-store -p codestory-indexer -p codestory-runtime -p codestory-cli --all-targets -- -D warnings`
- fresh GitHub checks: Ubuntu draft source checks, rustdoc warnings, and saga closing-link guard passed

## Exact corpus proof

A locked native arm64 release binary from the exact head was run once against the clean Linux corpus at `37e2f878a7a660a216cc7a60459995fefd150f25`.

- CLI SHA-256: `0911456f3743fa7d5a498d453b2dce7e37edc274663a890ad68f4d6f8da7a8e0`
- processed: `94,523 / 94,523`
- elapsed: `2546.09 s`
- maximum resident set size: `7,097,761,792` bytes
- peak memory footprint: `12,022,196,736` bytes
- former snapshot failure: did not recur; no `SQLITE_TOOBIG`, `string or blob too big`, or panic
- terminal result: `source_verification_failed`
- blocking gaps: `112` oversized files and `2` retryable collector failures
- core publication created: `false`
- result JSON SHA-256: `43cac034ec3881b44e6f12b6b65cfa3e90ca8b1b8676be09e29d946db78334d1`
- combined log SHA-256: `e63ee379883a3758119363cdba80eaf991d4b505d04ce8c8f4b90e3afdeae2a4`
- retained run record: `/Volumes/CodeStoryLinuxCorpus/runs/issue-1237-5852fb9-6ALkvz/`

Post-run doctor reported zero live files, nodes, and edges; the staged candidate was discarded. The corpus and source worktree remained clean.

## Non-claims

This PR proves the #1276 optional-cache slice, not successful corpus publication. The exact run exposed separate source-verification blockers now owned by #1277 and #1278 under #1198; #1237 remains open.

The change bounds serialized JSON bytes, not the owned in-memory snapshot structure or total peak RSS. It does not weaken fail-closed source verification or permit partial publication.

Closes #1276
Refs #1273
Refs #1237
Refs #1198
Refs #1179