### PR TITLE
Repair C multi-alias typedef collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   publish as explicit coverage limitations. Typed file diagnostics distinguish
   parser partial, source drift, unreadable and oversized source, incomplete
   discovery, and collector failure without weakening source-integrity gates.
+- C headers with one named type and multiple direct `typedef` aliases now emit
+  one type-usage edge per alias instead of failing graph collection and
+  blocking the staged core publication.
 - Safe refreshes preserve the last verified index. Incomplete reads, cancellation, or concurrent source changes cannot publish a partial generation or mix results from different generations.
 - Large full and incremental refreshes now batch file-identity lookups against SQLite's runtime bind-variable limit without changing duplicate or missing-ID semantics.
 - Resolution now skips its optional support cache when the serialized snapshot exceeds SQLite's runtime value limit, while keeping the in-memory result and staged publication intact.

--- a/crates/codestory-indexer/rules/c.scm
+++ b/crates/codestory-indexer/rules/c.scm
@@ -224,13 +224,14 @@
   type: (type_identifier) @target_type
   declarator: (type_identifier) @alias_name)
 {
-  node @target_type.node
-  attr (@target_type.node) kind = "CLASS"
-  attr (@target_type.node) name = (source-text @target_type)
-  attr (@target_type.node) start_row = (start-row @target_type)
-  attr (@target_type.node) start_col = (start-column @target_type)
-  attr (@target_type.node) end_row = (end-row @target_type)
-  attr (@target_type.node) end_col = (end-column @target_type)
+  ;; Each direct declarator is a separate match, so its target must stay local.
+  let target_node = (node)
+  attr (target_node) kind = "CLASS"
+  attr (target_node) name = (source-text @target_type)
+  attr (target_node) start_row = (start-row @target_type)
+  attr (target_node) start_col = (start-column @target_type)
+  attr (target_node) end_row = (end-row @target_type)
+  attr (target_node) end_col = (end-column @target_type)
 
   node @alias_name.node
   attr (@alias_name.node) kind = "CLASS"
@@ -240,8 +241,8 @@
   attr (@alias_name.node) end_row = (end-row @alias_name)
   attr (@alias_name.node) end_col = (end-column @alias_name)
 
-  edge @alias_name.node -> @target_type.node
-  attr (@alias_name.node -> @target_type.node) kind = "TYPE_USAGE"
+  edge @alias_name.node -> target_node
+  attr (@alias_name.node -> target_node) kind = "TYPE_USAGE"
 }
 
 (type_definition

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -198,6 +198,67 @@ fn test_template_collector_failure_records_typed_coverage_reason() -> anyhow::Re
 }
 
 #[test]
+fn test_c_multi_alias_typedef_persists_each_alias_once() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("include/aliases.h");
+    fs::create_dir_all(file_path.parent().expect("fixture parent"))?;
+    fs::write(
+        &file_path,
+        "typedef original_type first_alias_t, second_alias_t;\n",
+    )?;
+
+    let mut storage = Storage::new_in_memory()?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+
+    let errors = storage.get_errors(None)?;
+    assert!(
+        errors.is_empty(),
+        "a deterministic C graph query must not become a retryable collector failure: {errors:?}"
+    );
+    let files = storage.get_files()?;
+    assert_eq!(files.len(), 1);
+    assert!(files[0].indexed);
+    assert!(files[0].complete);
+    let inventory = storage.files().inventory()?;
+    assert_eq!(inventory.len(), 1);
+    assert!(inventory[0].content_hash.is_some());
+    assert!(!inventory[0].retry_required);
+
+    let nodes = storage.get_nodes()?;
+    let node_id = |suffix: &str| {
+        let matches = nodes
+            .iter()
+            .filter(|node| node.serialized_name.ends_with(suffix))
+            .collect::<Vec<_>>();
+        assert_eq!(matches.len(), 1, "expected one persisted node for {suffix}");
+        matches[0].id
+    };
+    let target = node_id("original_type");
+    let first_alias = node_id("first_alias_t");
+    let second_alias = node_id("second_alias_t");
+    let type_usage = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == EdgeKind::TYPE_USAGE)
+        .collect::<Vec<_>>();
+    assert_eq!(type_usage.len(), 2);
+    assert!(
+        type_usage
+            .iter()
+            .any(|edge| edge.source == first_alias && edge.target == target)
+    );
+    assert!(
+        type_usage
+            .iter()
+            .any(|edge| edge.source == second_alias && edge.target == target)
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_svelte_tauri_invoke_surfaces_registered_rust_command_boundary() -> anyhow::Result<()> {
     let storage = index_project(&[
         (

--- a/crates/codestory-indexer/tests/native_rule_regressions.rs
+++ b/crates/codestory-indexer/tests/native_rule_regressions.rs
@@ -536,6 +536,37 @@ typedef struct {
 }
 
 #[test]
+fn test_c_named_type_multi_alias_typedefs_emit_each_direct_usage_once() -> anyhow::Result<()> {
+    let (nodes, edges) = index_project(&[
+        (
+            "direct_aliases.h",
+            "typedef original_type first_alias_t, second_alias_t;\n",
+        ),
+        (
+            "mixed_aliases.h",
+            concat!(
+                "typedef descriptor_type direct_alias_t, *pointer_alias_t, ",
+                "other_alias_t, *other_pointer_alias_t;\n"
+            ),
+        ),
+    ])?;
+
+    for (alias, target) in [
+        ("first_alias_t", "original_type"),
+        ("second_alias_t", "original_type"),
+        ("direct_alias_t", "descriptor_type"),
+        ("other_alias_t", "descriptor_type"),
+    ] {
+        assert!(
+            edge_between(&nodes, &edges, EdgeKind::TYPE_USAGE, alias, target),
+            "expected {alias} -> {target} type-usage edge"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_cpp_template_structs_keep_inheritance_and_members() -> anyhow::Result<()> {
     let (nodes, edges) = index_project(&[(
         "main.cpp",

--- a/crates/codestory-runtime/src/tests/activation_coverage_tests.rs
+++ b/crates/codestory-runtime/src/tests/activation_coverage_tests.rs
@@ -79,6 +79,58 @@ fn full_refresh_publishes_verified_generic_tagged_template_parser_partial() {
 }
 
 #[test]
+fn full_refresh_publishes_verified_c_multi_alias_typedef() {
+    let _env = hybrid_test_env();
+    let workspace = tempdir().expect("workspace");
+    let cache = tempdir().expect("cache");
+    let source_path = workspace.path().join("aliases.h");
+    let storage_path = cache.path().join("codestory.db");
+    fs::write(
+        &source_path,
+        "typedef original_type first_alias_t, second_alias_t;\n",
+    )
+    .expect("write generic C multi-alias fixture");
+
+    let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
+    controller
+        .open_project_summary_with_storage_path(
+            workspace.path().to_path_buf(),
+            storage_path.clone(),
+        )
+        .expect("open project summary");
+    controller
+        .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+        .expect("deterministic C graph collection must publish on the first full refresh");
+
+    let storage = Storage::open(&storage_path).expect("open published storage");
+    let publication = storage
+        .get_complete_index_publication()
+        .expect("read publication")
+        .expect("complete C graph collection must publish a core");
+    storage
+        .validate_dense_anchor_publication(&publication)
+        .expect("C graph collection must retain a coherent dense-anchor publication");
+    let file = storage
+        .get_file_by_path(&source_path)
+        .expect("read source row")
+        .expect("indexed C source");
+    assert!(file.indexed);
+    assert!(file.complete);
+    assert_eq!(file.language, "c");
+    let inventory = storage.files().inventory().expect("file inventory");
+    let stored = inventory
+        .iter()
+        .find(|entry| entry.id == file.id)
+        .expect("stored source inventory");
+    assert!(stored.content_hash.is_some());
+    assert!(!stored.retry_required);
+    assert!(
+        storage.get_errors(None).expect("file errors").is_empty(),
+        "persisted coverage must be clean before publication"
+    );
+}
+
+#[test]
 fn activation_search_repair_rejects_publication_drift_and_discards_the_candidate() {
     let _env = hybrid_test_env();
     let temp = tempdir().expect("create temp dir");


### PR DESCRIPTION
## Result

Repairs the deterministic C graph-collection failure retained by the approved Linux corpus run. Named-type `typedef` declarations with multiple direct aliases now collect without redefining scoped graph state, persist one canonical target, and emit one `TYPE_USAGE` edge per direct alias.

Candidate: `a782a446d8f733f09e73e18a8787f0bf0e71905d`
Base: `95d242824b13a5e6f3af1568b1d7bc958458e97f`

## Root cause and recovery boundary

Tree-sitter Graph executes the type-alias stanza once for each direct alias capture. Those matches share the same target syntax node, so the old rule attempted to create immutable scoped variable `@target_type.node` more than once and failed with `DuplicateVariable`.

Both retained Linux headers and a generic multi-alias fixture produce that same deterministic error. Replaying the collector with unchanged source and rules cannot converge, so #1278 now explicitly rejects generic same-generation replay for this failure. The repair belongs in the owning C rule: each match uses a local target graph node, while CodeStory's source-identity canonicalization persists one target and deduplicates edges.

Unrelated persistent collector failures remain typed and publication-blocking. No retry, cancellation, source-drift, or publication transaction path changed.

## What changed

- repair the named-type C `typedef` stanza without path-specific steering
- cover direct and mixed multi-declarator shapes with generic fixtures
- prove incremental re-indexing preserves exactly one target and one edge per direct alias
- prove a clean first full refresh publishes coherent core and dense-anchor identity
- record the shipped reliability correction in the changelog

## How to review

1. Check that `crates/codestory-indexer/rules/c.scm` keeps the target node local to each alias match.
2. Check the integration regression for persisted-node and edge cardinality after a second incremental index.
3. Check the runtime regression for clean stored coverage before first publication.
4. Confirm pointer-alias support and unrelated collector/publication semantics are unchanged.

## Verification

Passed on exact candidate `a782a446d8f733f09e73e18a8787f0bf0e71905d`:

- bounded direct-file indexing of both retained Linux headers; neither records a collector error
- `cargo test --locked -p codestory-indexer --test native_rule_regressions`
- `cargo test --locked -p codestory-indexer --test integration`
- `cargo test --locked -p codestory-indexer --test fidelity_regression`
- `cargo test --locked -p codestory-indexer --test tictactoe_language_coverage`
- `cargo test --locked -p codestory-store inventory_retries_file_errors_but_not_parser_partial_coverage -- --nocapture`
- `cargo test --locked -p codestory-runtime activation_coverage_tests -- --nocapture`
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts packet_preserves_typed_source_failure_diagnostics -- --nocapture`
- `cargo check --locked -p codestory-indexer -p codestory-store -p codestory-runtime -p codestory-cli`
- `cargo clippy --locked -p codestory-indexer -p codestory-store -p codestory-runtime -p codestory-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- exact-head independent review: no P0-P3 findings

## Risk and non-claims

This draft does not claim a fresh 94,523-file corpus run, package proof, installed-runtime proof, or release readiness. It does not add a generic replay system. Direct pointer aliases remain outside this existing rule's output contract.

Closes #1278
Refs #1198
Refs #1237
Refs #1179