### PR TITLE
Publish verified oversized source exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 ### Reliability and compatibility
 
 - Source files larger than the parser byte cap are now hashed and classified
-  before parser scheduling. Complete builds publish their project, workspace,
-  and core-bound exclusion manifest atomically, while `files` diagnostics show
-  the retained source inventory without claiming graph or semantic coverage.
-  Partial discovery and unreadable or changing files still fail closed.
+  before parser scheduling. Complete builds revalidate those bytes at the
+  identity fence and publish their project, workspace, and core-bound exclusion
+  manifest atomically, while `files` diagnostics show the retained source
+  inventory without claiming graph or semantic coverage. Partial discovery and
+  unreadable or changing files still fail closed.
 - Release closeout now derives its exact source, package, protected hardware,
   installed runtime, retrieval, performance, quality, platform and
   post-publish byte-comparison cells from the release claim graph. The generic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 
 ### Reliability and compatibility
 
+- Source files larger than the parser byte cap are now hashed and classified
+  before parser scheduling. Complete builds publish their project, workspace,
+  and core-bound exclusion manifest atomically, while `files` diagnostics show
+  the retained source inventory without claiming graph or semantic coverage.
+  Partial discovery and unreadable or changing files still fail closed.
 - Release closeout now derives its exact source, package, protected hardware,
   installed runtime, retrieval, performance, quality, platform and
   post-publish byte-comparison cells from the release claim graph. The generic

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -5526,6 +5526,7 @@ fn render_files_markdown(output: &codestory_contracts::api::IndexedFilesDto) -> 
     markdown.push_str("# indexed files\n\n");
     render_files_summary(&mut markdown, output);
     render_framework_route_coverage(&mut markdown, output);
+    render_source_policy_exclusions(&mut markdown, output);
     render_indexed_file_rows(&mut markdown, output);
     markdown
 }
@@ -5534,11 +5535,12 @@ fn render_files_summary(markdown: &mut String, output: &codestory_contracts::api
     let status = if output.usable { "usable" } else { "empty" };
     let _ = writeln!(
         markdown,
-        "- index: {status}; whole index files: {}; indexed: {}; incomplete: {}; error files: {}; filtered files: {}; visible rows: {}; truncated: {}",
+        "- index: {status}; whole index files: {}; indexed: {}; incomplete: {}; error files: {}; policy exclusions: {}; filtered files: {}; visible rows: {}; truncated: {}",
         output.summary.file_count,
         output.summary.indexed_file_count,
         output.summary.incomplete_file_count,
         output.summary.error_file_count,
+        output.summary.policy_exclusion_count,
         output.summary.filtered_file_count,
         output.summary.visible_file_count,
         output.summary.truncated
@@ -5578,6 +5580,31 @@ fn render_files_summary(markdown: &mut String, output: &codestory_contracts::api
     }
     for note in &output.summary.coverage_notes {
         let _ = writeln!(markdown, "- coverage: {note}");
+    }
+}
+
+fn render_source_policy_exclusions(
+    markdown: &mut String,
+    output: &codestory_contracts::api::IndexedFilesDto,
+) {
+    if output.policy_exclusions.is_empty() {
+        return;
+    }
+    markdown.push_str(
+        "\nverified policy exclusions (source inventory only; no graph or semantic coverage):\n",
+    );
+    for exclusion in &output.policy_exclusions {
+        let _ = writeln!(
+            markdown,
+            "- {} ({:?}, {} bytes, policy={} cap={}, core={}/{})",
+            exclusion.path,
+            exclusion.role,
+            exclusion.observed_size,
+            exclusion.policy_version,
+            exclusion.byte_cap,
+            exclusion.core_generation_id,
+            exclusion.core_run_id,
+        );
     }
 }
 
@@ -8042,7 +8069,7 @@ mod tests {
         PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetUsageDto, PacketClaimDto,
         PacketPlanDto, PacketPlanQueryDto, PacketRetrievalTraceSummaryDto, PacketSufficiencyDto,
         ProjectSummary, RetrievalModeDto, RetrievalStateDto, SearchHit, SearchHitOrigin,
-        SemanticModeDto, StorageStatsDto, TrailContextDto,
+        SemanticModeDto, SourcePolicyExclusionDto, StorageStatsDto, TrailContextDto,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -8568,6 +8595,7 @@ mod tests {
                 visible_file_count: 1,
                 incomplete_file_count: 1,
                 error_file_count: 0,
+                policy_exclusion_count: 0,
                 incomplete_reason_counts: vec![IndexedFileIncompleteReasonCountDto {
                     reason: "unknown".to_string(),
                     file_count: 1,
@@ -8580,6 +8608,7 @@ mod tests {
                 coverage_notes: Vec::new(),
             },
             coverage_gaps: Vec::new(),
+            policy_exclusions: Vec::new(),
             files: vec![IndexedFileDto {
                 path: "src/lib.rs".to_string(),
                 language: "rust".to_string(),
@@ -8601,6 +8630,55 @@ mod tests {
             markdown.contains("run a full reindex"),
             "incomplete counts need operator-actionable reason text: {markdown}"
         );
+    }
+
+    #[test]
+    fn files_markdown_labels_verified_policy_exclusions_as_non_graph_evidence() {
+        let output = IndexedFilesDto {
+            project_root: "/repo".into(),
+            usable: true,
+            summary: IndexedFilesSummaryDto {
+                file_count: 1,
+                indexed_file_count: 1,
+                filtered_file_count: 1,
+                visible_file_count: 1,
+                incomplete_file_count: 0,
+                error_file_count: 0,
+                policy_exclusion_count: 1,
+                incomplete_reason_counts: Vec::new(),
+                truncated: false,
+                language_counts: Vec::new(),
+                framework_route_coverage: Vec::new(),
+                coverage_notes: vec![
+                    "1 verified source policy exclusion has no parser-backed graph or semantic coverage"
+                        .into(),
+                ],
+            },
+            coverage_gaps: Vec::new(),
+            policy_exclusions: vec![SourcePolicyExclusionDto {
+                path: "vendor/registers.h".into(),
+                role: IndexedFileRoleDto::Vendor,
+                content_hash: "a".repeat(64),
+                observed_size: 2_000_000,
+                policy_version: "oversized-source-v1".into(),
+                byte_cap: 1_000_000,
+                project_id: "project".into(),
+                workspace_id: "workspace".into(),
+                core_generation_id: "generation".into(),
+                core_run_id: "run".into(),
+                graph_coverage: false,
+                semantic_coverage: false,
+            }],
+            files: Vec::new(),
+        };
+
+        let markdown = render_files_markdown(&output);
+        assert!(markdown.contains("policy exclusions: 1"), "{markdown}");
+        assert!(
+            markdown.contains("source inventory only; no graph or semantic coverage"),
+            "{markdown}"
+        );
+        assert!(markdown.contains("vendor/registers.h"), "{markdown}");
     }
 
     #[test]

--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -57,11 +57,12 @@ pub use dto::{
     SearchPlanPromotionStatusDto, SearchPlanRejectedHitDto, SearchPlanSubqueryDto,
     SearchPlanTermsDto, SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest,
     SearchResultsDto, SemanticFallbackRecordDto, SemanticModeDto, SetUiLayoutRequest,
-    SnippetContextDto, SnippetScopeDto, SourceOccurrenceDto, StartIndexingRequest, StorageStatsDto,
-    StoredSemanticDocsContractDto, SummaryGenerationDto, SymbolContextDto, SymbolSummaryDto,
-    SystemActionResponse, TrailConfigDto, TrailContextDto, TrailFilterOptionsDto, TrailStoryDto,
-    TrailStoryStepDto, UpdateBookmarkCategoryRequest, UpdateBookmarkRequest,
-    WorkspaceMemberIndexDto, WriteFileDataUrlRequest, WriteFileResponse, WriteFileTextRequest,
+    SnippetContextDto, SnippetScopeDto, SourceOccurrenceDto, SourcePolicyExclusionDto,
+    StartIndexingRequest, StorageStatsDto, StoredSemanticDocsContractDto, SummaryGenerationDto,
+    SymbolContextDto, SymbolSummaryDto, SystemActionResponse, TrailConfigDto, TrailContextDto,
+    TrailFilterOptionsDto, TrailStoryDto, TrailStoryStepDto, UpdateBookmarkCategoryRequest,
+    UpdateBookmarkRequest, WorkspaceMemberIndexDto, WriteFileDataUrlRequest, WriteFileResponse,
+    WriteFileTextRequest,
 };
 pub use errors::{
     ApiError, ApiErrorDetails, COMMAND_FAILURE_SCHEMA_VERSION, CommandFailureEnvelope,

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -984,6 +984,26 @@ pub struct FileCoverageDiagnosticDto {
     pub projection_available: bool,
 }
 
+/// Verified source intentionally excluded from parser scheduling.
+///
+/// These records are source-inventory evidence only. They never imply parser-backed graph or
+/// semantic coverage.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct SourcePolicyExclusionDto {
+    pub path: String,
+    pub role: IndexedFileRoleDto,
+    pub content_hash: String,
+    pub observed_size: u64,
+    pub policy_version: String,
+    pub byte_cap: u64,
+    pub project_id: String,
+    pub workspace_id: String,
+    pub core_generation_id: String,
+    pub core_run_id: String,
+    pub graph_coverage: bool,
+    pub semantic_coverage: bool,
+}
+
 /// Per-language file count and support claim shown in indexed-file summaries.
 ///
 /// `support_mode` and `evidence_tier` are product evidence from
@@ -1015,6 +1035,8 @@ pub struct IndexedFilesSummaryDto {
     pub incomplete_file_count: u32,
     pub error_file_count: u32,
     #[serde(default)]
+    pub policy_exclusion_count: u32,
+    #[serde(default)]
     pub incomplete_reason_counts: Vec<IndexedFileIncompleteReasonCountDto>,
     pub truncated: bool,
     pub language_counts: Vec<IndexedFileLanguageCountDto>,
@@ -1031,6 +1053,8 @@ pub struct IndexedFilesDto {
     pub summary: IndexedFilesSummaryDto,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub coverage_gaps: Vec<FileCoverageDiagnosticDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub policy_exclusions: Vec<SourcePolicyExclusionDto>,
     pub files: Vec<IndexedFileDto>,
 }
 

--- a/crates/codestory-contracts/src/workspace.rs
+++ b/crates/codestory-contracts/src/workspace.rs
@@ -1,6 +1,24 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// Versioned policy that permits a verified source to remain outside parser scheduling.
+pub const OVERSIZED_SOURCE_POLICY_VERSION: &str = "oversized-source-v1";
+/// Parser input bound shared by workspace planning and the indexer fallback guard.
+pub const DEFAULT_SOURCE_FILE_BYTE_CAP: u64 = 1_000_000;
+
+/// Content-verified oversized source classified before parser scheduling.
+///
+/// Project, workspace, and core-publication identity are deliberately absent here. The
+/// runtime binds those identities only when the complete candidate set is published.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct OversizedSourceExclusionCandidate {
+    pub normalized_path: String,
+    pub content_hash: String,
+    pub observed_size: u64,
+    pub policy_version: String,
+    pub byte_cap: u64,
+}
+
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum RefreshMode {
     Incremental,

--- a/crates/codestory-contracts/src/workspace.rs
+++ b/crates/codestory-contracts/src/workspace.rs
@@ -1,10 +1,50 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 /// Versioned policy that permits a verified source to remain outside parser scheduling.
 pub const OVERSIZED_SOURCE_POLICY_VERSION: &str = "oversized-source-v1";
 /// Parser input bound shared by workspace planning and the indexer fallback guard.
 pub const DEFAULT_SOURCE_FILE_BYTE_CAP: u64 = 1_000_000;
+/// Process-start override for the parser input and verified exclusion boundary.
+pub const SOURCE_FILE_BYTE_CAP_ENV: &str = "CODESTORY_INDEX_SOURCE_FILE_BYTE_CAP";
+
+/// Immutable source-index policy shared by planning, parsing, publication, and reads.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SourceIndexPolicy {
+    pub policy_version: String,
+    pub byte_cap: u64,
+}
+
+impl SourceIndexPolicy {
+    pub fn oversized(byte_cap: u64) -> Self {
+        Self {
+            policy_version: OVERSIZED_SOURCE_POLICY_VERSION.to_string(),
+            byte_cap: byte_cap.max(1),
+        }
+    }
+
+    fn from_process_env() -> Self {
+        let byte_cap = std::env::var(SOURCE_FILE_BYTE_CAP_ENV)
+            .ok()
+            .and_then(|raw| raw.trim().parse::<u64>().ok())
+            .filter(|cap| *cap > 0)
+            .unwrap_or(DEFAULT_SOURCE_FILE_BYTE_CAP);
+        Self::oversized(byte_cap)
+    }
+}
+
+impl Default for SourceIndexPolicy {
+    fn default() -> Self {
+        Self::oversized(DEFAULT_SOURCE_FILE_BYTE_CAP)
+    }
+}
+
+/// Return the source-index policy captured once for this process.
+pub fn process_source_index_policy() -> &'static SourceIndexPolicy {
+    static POLICY: OnceLock<SourceIndexPolicy> = OnceLock::new();
+    POLICY.get_or_init(SourceIndexPolicy::from_process_env)
+}
 
 /// Content-verified oversized source classified before parser scheduling.
 ///

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16,6 +16,7 @@ use codestory_contracts::graph::{
     AccessKind, CallableProjectionState, Edge, EdgeId, EdgeKind, FileCoverageReason, Node, NodeId,
     NodeKind, Occurrence, OccurrenceKind, ResolutionCertainty, SourceLocation,
 };
+use codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP;
 use codestory_store::Store as Storage;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -70,7 +71,6 @@ struct IndexFeatureFlags {
     lazy_graph_execution: bool,
 }
 
-const DEFAULT_SOURCE_FILE_BYTE_CAP: u64 = 1_000_000;
 const SOURCE_FILE_BYTE_CAP_ENV: &str = "CODESTORY_INDEX_SOURCE_FILE_BYTE_CAP";
 
 struct PostProcessedIndexResults {

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16,7 +16,7 @@ use codestory_contracts::graph::{
     AccessKind, CallableProjectionState, Edge, EdgeId, EdgeKind, FileCoverageReason, Node, NodeId,
     NodeKind, Occurrence, OccurrenceKind, ResolutionCertainty, SourceLocation,
 };
-use codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP;
+use codestory_contracts::workspace::process_source_index_policy;
 use codestory_store::Store as Storage;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -70,8 +70,6 @@ struct IndexFeatureFlags {
     legacy_edge_identity: bool,
     lazy_graph_execution: bool,
 }
-
-const SOURCE_FILE_BYTE_CAP_ENV: &str = "CODESTORY_INDEX_SOURCE_FILE_BYTE_CAP";
 
 struct PostProcessedIndexResults {
     nodes: Vec<Node>,
@@ -810,7 +808,7 @@ impl WorkspaceIndexer {
             compilation_db,
             compilation_db_warning,
             batch_config: IncrementalIndexingConfig::default(),
-            source_file_byte_cap: configured_source_file_byte_cap(),
+            source_file_byte_cap: process_source_index_policy().byte_cap,
         }
     }
 
@@ -2193,14 +2191,6 @@ fn file_modification_time(path: &Path) -> i64 {
 
 fn duration_ms_u64(duration: std::time::Duration) -> u64 {
     duration.as_millis().min(u64::MAX as u128) as u64
-}
-
-fn configured_source_file_byte_cap() -> u64 {
-    std::env::var(SOURCE_FILE_BYTE_CAP_ENV)
-        .ok()
-        .and_then(|raw| raw.trim().parse::<u64>().ok())
-        .filter(|cap| *cap > 0)
-        .unwrap_or(DEFAULT_SOURCE_FILE_BYTE_CAP)
 }
 
 fn accumulate_flush_breakdown(

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -32,10 +32,11 @@ use codestory_contracts::api::{
     SearchPlanDroppedTermDto, SearchPlanDto, SearchPlanNextActionDto, SearchPlanPromotionStatusDto,
     SearchPlanRejectedHitDto, SearchPlanSubqueryDto, SearchPlanTermsDto, SearchQueryAssessmentDto,
     SearchRepoTextMode, SearchRequest, SearchResultsDto, SemanticModeDto, SnippetContextDto,
-    SourceOccurrenceDto, StartIndexingRequest, StorageStatsDto, StoredSemanticDocsContractDto,
-    SummaryGenerationDto, SymbolContextDto, SymbolSummaryDto, SystemActionResponse, TrailConfigDto,
-    TrailContextDto, TrailFilterOptionsDto, UpdateBookmarkCategoryRequest, UpdateBookmarkRequest,
-    WorkspaceMemberIndexDto, WriteFileResponse, WriteFileTextRequest,
+    SourceOccurrenceDto, SourcePolicyExclusionDto, StartIndexingRequest, StorageStatsDto,
+    StoredSemanticDocsContractDto, SummaryGenerationDto, SymbolContextDto, SymbolSummaryDto,
+    SystemActionResponse, TrailConfigDto, TrailContextDto, TrailFilterOptionsDto,
+    UpdateBookmarkCategoryRequest, UpdateBookmarkRequest, WorkspaceMemberIndexDto,
+    WriteFileResponse, WriteFileTextRequest,
 };
 use codestory_contracts::events::{Event, EventBus};
 use codestory_contracts::graph::{
@@ -56,8 +57,9 @@ use codestory_store::{
 };
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
 use codestory_workspace::{
-    RefreshExecutionPlan, RefreshInputs, RefreshMode, WorkspaceInventoryOutcome, WorkspaceManifest,
-    WorkspacePathIdentity,
+    DEFAULT_SOURCE_FILE_BYTE_CAP, OVERSIZED_SOURCE_POLICY_VERSION,
+    OversizedSourceExclusionCandidate, RefreshExecutionPlan, RefreshInputs, RefreshMode,
+    WorkspaceInventoryOutcome, WorkspaceManifest, WorkspacePathIdentity, project_identity_v3,
 };
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use fs4::fs_std::FileExt;
@@ -5051,20 +5053,22 @@ fn file_coverage_detail(reason: FileCoverageReason) -> &'static str {
 fn full_refresh_execution_plan_with_coverage(
     root: &Path,
     workspace: &WorkspaceManifest,
-) -> Result<RefreshExecutionPlan, ApiError> {
-    let inventory = workspace.source_inventory().map_err(|error| {
-        ApiError::source_coverage_failure(
-            "source_collector_failure",
-            format!("Failed to collect the full source inventory: {error}"),
-            vec![FileCoverageDiagnosticDto {
-                path: ".".to_string(),
-                reason: FileCoverageReason::CollectorFailure,
-                retryable: true,
-                verified_source: false,
-                projection_available: false,
-            }],
-        )
-    })?;
+) -> Result<(RefreshExecutionPlan, Vec<OversizedSourceExclusionCandidate>), ApiError> {
+    let inventory = workspace
+        .source_inventory_with_oversized_policy()
+        .map_err(|error| {
+            ApiError::source_coverage_failure(
+                "source_collector_failure",
+                format!("Failed to collect the full source inventory: {error}"),
+                vec![FileCoverageDiagnosticDto {
+                    path: ".".to_string(),
+                    reason: FileCoverageReason::CollectorFailure,
+                    retryable: true,
+                    verified_source: false,
+                    projection_available: false,
+                }],
+            )
+        })?;
     if inventory.outcome != WorkspaceInventoryOutcome::Complete {
         let reason = if inventory.outcome == WorkspaceInventoryOutcome::Unreadable {
             FileCoverageReason::Unreadable
@@ -5103,12 +5107,62 @@ fn full_refresh_execution_plan_with_coverage(
             coverage_gaps,
         ));
     }
-    Ok(RefreshExecutionPlan {
-        mode: RefreshMode::FullRefresh,
-        files_to_index: inventory.files,
-        files_to_remove: Vec::new(),
-        existing_file_ids: HashMap::new(),
-    })
+    Ok((
+        RefreshExecutionPlan {
+            mode: RefreshMode::FullRefresh,
+            files_to_index: inventory.files,
+            files_to_remove: Vec::new(),
+            existing_file_ids: HashMap::new(),
+        },
+        inventory.policy_exclusions,
+    ))
+}
+
+fn publish_source_policy_exclusions(
+    storage: &mut Store,
+    root: &Path,
+    publication: &IndexPublicationRecord,
+    exclusions: &[OversizedSourceExclusionCandidate],
+) -> Result<(), ApiError> {
+    let identity = project_identity_v3(root);
+    storage
+        .publish_source_policy_exclusion_generation(
+            publication,
+            &identity.project_id,
+            &identity.workspace_id,
+            OVERSIZED_SOURCE_POLICY_VERSION,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            exclusions,
+        )
+        .map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to publish complete source policy exclusions: {error}"
+            ))
+        })?;
+    Ok(())
+}
+
+fn validate_source_policy_exclusions(
+    storage: &Store,
+    root: &Path,
+    publication: &IndexPublicationRecord,
+) -> Result<(), ApiError> {
+    let identity = project_identity_v3(root);
+    storage
+        .validate_source_policy_exclusion_publication(
+            publication,
+            &identity.project_id,
+            &identity.workspace_id,
+            OVERSIZED_SOURCE_POLICY_VERSION,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+        )
+        .map_err(|error| {
+            ApiError::new(
+                "source_verification_failed",
+                format!("Source policy exclusion publication is incomplete or stale: {error}"),
+            )
+        })?;
+    Ok(())
 }
 
 fn stored_file_coverage_diagnostics(
@@ -5305,6 +5359,28 @@ where
             ));
         }
     }
+    match storage.get_complete_index_publication() {
+        Ok(Some(publication)) => {
+            if let Err(error) = validate_source_policy_exclusions(storage, root, &publication) {
+                return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
+                    format!(
+                        "source policy exclusion publication is incomplete: {}",
+                        error.message
+                    ),
+                    0,
+                    started_at,
+                ));
+            }
+        }
+        Ok(None) => {}
+        Err(error) => {
+            return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
+                format!("failed to read complete core publication: {error}"),
+                0,
+                started_at,
+            ));
+        }
+    }
     #[cfg(test)]
     run_after_index_freshness_fence_test_hook();
     let files = match storage.get_files() {
@@ -5355,9 +5431,10 @@ where
         stored_files,
         inventory: Default::default(),
     };
-    let refresh = match workspace
-        .build_execution_outcome_bounded(&refresh_inputs, INDEX_FRESHNESS_CURRENT_FILE_CAP)
-    {
+    let refresh = match workspace.build_execution_outcome_bounded_with_oversized_policy(
+        &refresh_inputs,
+        INDEX_FRESHNESS_CURRENT_FILE_CAP,
+    ) {
         Ok(refresh) => refresh,
         Err(error) => {
             return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
@@ -5367,8 +5444,9 @@ where
             ));
         }
     };
-    if refresh.inventory_outcome != WorkspaceInventoryOutcome::Complete {
+    if refresh.refresh.inventory_outcome != WorkspaceInventoryOutcome::Complete {
         let detail = refresh
+            .refresh
             .inventory_issues
             .first()
             .map(|issue| format!("{}: {}", issue.path.display(), issue.message));
@@ -5376,18 +5454,19 @@ where
             match detail {
                 Some(detail) => format!(
                     "current workspace inventory is {:?}: {detail}",
-                    refresh.inventory_outcome
+                    refresh.refresh.inventory_outcome
                 ),
                 None => format!(
                     "current workspace inventory is {:?} (>{})",
-                    refresh.inventory_outcome, INDEX_FRESHNESS_CURRENT_FILE_CAP
+                    refresh.refresh.inventory_outcome, INDEX_FRESHNESS_CURRENT_FILE_CAP
                 ),
             },
             indexed_file_count,
             started_at,
         ));
     }
-    let plan = refresh.plan;
+    let current_policy_exclusions = refresh.policy_exclusions;
+    let plan = refresh.refresh.plan;
 
     let mut changed_file_count = 0u32;
     let mut new_file_count = 0u32;
@@ -5412,7 +5491,68 @@ where
         }
     }
 
-    let removed_file_count = clamp_usize_to_u32(plan.files_to_remove.len());
+    let stored_policy_exclusions = match storage.get_source_policy_exclusions() {
+        Ok(exclusions) => exclusions,
+        Err(error) => {
+            return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
+                format!("failed to read source policy exclusions: {error}"),
+                indexed_file_count,
+                started_at,
+            ));
+        }
+    };
+    let previous_policy_by_path = stored_policy_exclusions
+        .iter()
+        .map(|entry| (entry.normalized_path.as_str(), entry))
+        .collect::<HashMap<_, _>>();
+    let current_policy_paths = current_policy_exclusions
+        .iter()
+        .map(|entry| entry.normalized_path.as_str())
+        .collect::<HashSet<_>>();
+    let planned_paths = plan
+        .files_to_index
+        .iter()
+        .map(|path| runtime_relative_path(root, path))
+        .collect::<HashSet<_>>();
+    for exclusion in &current_policy_exclusions {
+        let kind = match previous_policy_by_path.get(exclusion.normalized_path.as_str()) {
+            Some(previous)
+                if previous.content_hash == exclusion.content_hash
+                    && previous.observed_size == exclusion.observed_size
+                    && previous.policy_version == exclusion.policy_version
+                    && previous.byte_cap == exclusion.byte_cap =>
+            {
+                continue;
+            }
+            Some(_) => {
+                changed_file_count = changed_file_count.saturating_add(1);
+                IndexFreshnessChangeKindDto::Changed
+            }
+            None => {
+                new_file_count = new_file_count.saturating_add(1);
+                IndexFreshnessChangeKindDto::New
+            }
+        };
+        if samples.len() < INDEX_FRESHNESS_SAMPLE_LIMIT {
+            samples.push(IndexFreshnessSampleDto {
+                kind,
+                path: exclusion.normalized_path.clone(),
+            });
+        }
+    }
+
+    let removed_policy_exclusions = stored_policy_exclusions
+        .iter()
+        .filter(|entry| {
+            !current_policy_paths.contains(entry.normalized_path.as_str())
+                && !planned_paths.contains(&entry.normalized_path)
+        })
+        .collect::<Vec<_>>();
+    let removed_file_count = clamp_usize_to_u32(
+        plan.files_to_remove
+            .len()
+            .saturating_add(removed_policy_exclusions.len()),
+    );
     for removed_id in &plan.files_to_remove {
         if samples.len() >= INDEX_FRESHNESS_SAMPLE_LIMIT {
             break;
@@ -5423,6 +5563,15 @@ where
                 path: runtime_relative_path(root, path),
             });
         }
+    }
+    for removed in removed_policy_exclusions {
+        if samples.len() >= INDEX_FRESHNESS_SAMPLE_LIMIT {
+            break;
+        }
+        samples.push(IndexFreshnessSampleDto {
+            kind: IndexFreshnessChangeKindDto::Removed,
+            path: removed.normalized_path.clone(),
+        });
     }
 
     let status = if changed_file_count == 0 && new_file_count == 0 && removed_file_count == 0 {
@@ -11166,7 +11315,7 @@ impl AppController {
         Ok(())
     }
 
-    pub(crate) fn complete_core_requires_dense_anchor_repair(
+    pub(crate) fn complete_core_requires_publication_repair(
         &self,
         storage_path: &Path,
     ) -> Result<bool, ApiError> {
@@ -11186,9 +11335,14 @@ impl AppController {
         else {
             return Ok(false);
         };
-        Ok(storage
+        if storage
             .validate_dense_anchor_publication(&publication)
-            .is_err())
+            .is_err()
+        {
+            return Ok(true);
+        }
+        let root = self.require_project_root()?;
+        Ok(validate_source_policy_exclusions(&storage, &root, &publication).is_err())
     }
 
     pub fn run_indexing_blocking(&self, mode: IndexMode) -> Result<IndexingPhaseTimings, ApiError> {
@@ -11981,6 +12135,23 @@ impl AppController {
         self.ensure_consistent_read_state("Files")?;
         let root = self.require_project_root()?;
         let storage = self.open_storage_read_only()?;
+        let publication = storage
+            .get_complete_index_publication()
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to read source policy exclusion publication identity: {error}"
+                ))
+            })?
+            .ok_or_else(|| {
+                ApiError::new(
+                    "source_verification_failed",
+                    "Indexed-file coverage requires a complete core publication.",
+                )
+            })?;
+        validate_source_policy_exclusions(&storage, &root, &publication)?;
+        let source_policy_exclusions = storage.get_source_policy_exclusions().map_err(|error| {
+            ApiError::internal(format!("Failed to load source policy exclusions: {error}"))
+        })?;
         let mut files = storage
             .get_files()
             .map_err(|e| ApiError::internal(format!("Failed to load indexed files: {e}")))?;
@@ -12048,6 +12219,39 @@ impl AppController {
 
         let path_filter = req.path_contains.as_deref().map(normalize_path_key);
         let language_filter = req.language.as_deref().map(str::to_ascii_lowercase);
+        let policy_exclusion_count = source_policy_exclusions.len().min(u32::MAX as usize) as u32;
+        let mut policy_exclusions = source_policy_exclusions
+            .into_iter()
+            .filter(|entry| {
+                let role = path_role_from_key(&normalize_path_key(&entry.normalized_path));
+                req.role.is_none_or(|requested| requested == role)
+                    && path_filter.as_deref().is_none_or(|needle| {
+                        normalize_path_key(&entry.normalized_path).contains(needle)
+                    })
+                    && language_filter.as_deref().is_none_or(|language| {
+                        indexed_file_matches_language_filter(
+                            "unknown",
+                            Path::new(&entry.normalized_path),
+                            language,
+                        )
+                    })
+            })
+            .map(|entry| SourcePolicyExclusionDto {
+                role: path_role_from_key(&normalize_path_key(&entry.normalized_path)),
+                path: entry.normalized_path,
+                content_hash: entry.content_hash,
+                observed_size: entry.observed_size,
+                policy_version: entry.policy_version,
+                byte_cap: entry.byte_cap,
+                project_id: entry.project_id,
+                workspace_id: entry.workspace_id,
+                core_generation_id: entry.core_generation_id,
+                core_run_id: entry.core_run_id,
+                graph_coverage: false,
+                semantic_coverage: false,
+            })
+            .collect::<Vec<_>>();
+        policy_exclusions.truncate(5_000);
         let mut visible = files
             .into_iter()
             .filter(|file| {
@@ -12084,6 +12288,11 @@ impl AppController {
             ));
         } else {
             coverage_notes.push("index usable; no file-level index errors recorded".to_string());
+        }
+        if policy_exclusion_count > 0 {
+            coverage_notes.push(format!(
+                "{policy_exclusion_count} verified source policy exclusions have no parser-backed graph or semantic coverage"
+            ));
         }
         let language_counts = language_counts
             .into_iter()
@@ -12123,6 +12332,7 @@ impl AppController {
                 visible_file_count,
                 incomplete_file_count,
                 error_file_count,
+                policy_exclusion_count,
                 incomplete_reason_counts,
                 truncated,
                 language_counts,
@@ -12130,6 +12340,7 @@ impl AppController {
                 coverage_notes,
             },
             coverage_gaps,
+            policy_exclusions,
             files: visible,
         })
     }
@@ -13927,7 +14138,9 @@ fn index_full_for_runtime(
             match live.get_complete_index_publication() {
                 Ok(Some(publication)) if publication == *expected => {
                     match live.validate_dense_anchor_publication(&publication) {
-                        Ok(_) => true,
+                        Ok(_) => {
+                            validate_source_policy_exclusions(&live, root, &publication).is_ok()
+                        }
                         Err(error) => {
                             tracing::debug!(
                                 path = %storage_path.display(),
@@ -13949,7 +14162,8 @@ fn index_full_for_runtime(
         });
     let workspace = WorkspaceManifest::open(root.to_path_buf())
         .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
-    let execution_plan = full_refresh_execution_plan_with_coverage(root, &workspace)?;
+    let (execution_plan, policy_exclusions) =
+        full_refresh_execution_plan_with_coverage(root, &workspace)?;
 
     let total_files = execution_plan.files_to_index.len().min(u32::MAX as usize) as u32;
     let _ = events_tx.send(AppEventPayload::IndexingStarted {
@@ -14125,6 +14339,12 @@ fn index_full_for_runtime(
         return Err(ApiError::internal(format!(
             "Failed to publish complete dense anchor inputs: {error}"
         )));
+    }
+    if let Err(error) =
+        publish_source_policy_exclusions(staged.store_mut(), root, &publication, &policy_exclusions)
+    {
+        let _ = staged.discard();
+        return Err(error);
     }
     if let Err(error) = staged.store_mut().put_index_publication(&publication) {
         let _ = staged.discard();
@@ -14358,18 +14578,7 @@ fn index_incremental_for_runtime(
     cancel_token: Option<&CancellationToken>,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<IndexingRunSummary, ApiError> {
-    run_incremental_indexing_common(
-        root,
-        storage_path,
-        events_tx,
-        cancel_token,
-        runtime,
-        |workspace, inputs| {
-            workspace
-                .build_execution_plan(inputs)
-                .map_err(|e| ApiError::internal(format!("Failed to generate refresh info: {e}")))
-        },
-    )
+    run_incremental_indexing_common(root, storage_path, events_tx, cancel_token, runtime)
 }
 
 fn spawn_progress_forwarder(
@@ -14394,17 +14603,13 @@ fn spawn_progress_forwarder(
     })
 }
 
-fn run_incremental_indexing_common<F>(
+fn run_incremental_indexing_common(
     root: &Path,
     storage_path: &Path,
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
-    refresh_builder: F,
-) -> Result<IndexingRunSummary, ApiError>
-where
-    F: FnOnce(&WorkspaceManifest, &RefreshInputs) -> Result<RefreshExecutionPlan, ApiError>,
-{
+) -> Result<IndexingRunSummary, ApiError> {
     let live_exists = storage_path.exists();
     let live_is_incomplete = live_exists
         && Store::database_has_incomplete_incremental_run(storage_path).map_err(|e| {
@@ -14458,189 +14663,234 @@ where
     )?;
     let dense_anchor_source_identity =
         format!("core:{}:{}", publication.generation_id, publication.run_id);
-    let staged_result =
-        (|| {
-            staged.store_mut().begin_incremental_run().map_err(|e| {
+    let staged_result = (|| {
+        staged.store_mut().begin_incremental_run().map_err(|e| {
+            ApiError::internal(format!(
+                "Failed to persist staged incomplete index marker: {e}"
+            ))
+        })?;
+        staged
+            .store_mut()
+            .invalidate_grounding_snapshots()
+            .map_err(|e| {
                 ApiError::internal(format!(
-                    "Failed to persist staged incomplete index marker: {e}"
+                    "Failed to invalidate staged derived index snapshots: {e}"
                 ))
             })?;
+
+        let workspace = WorkspaceManifest::open(root.to_path_buf())
+            .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
+        let refresh_inputs = workspace_refresh_inputs(staged.store_mut())?;
+        let policy_refresh = workspace
+            .build_execution_outcome_with_oversized_policy(&refresh_inputs)
+            .map_err(|e| ApiError::internal(format!("Failed to generate refresh info: {e}")))?;
+        if policy_refresh.refresh.inventory_outcome != WorkspaceInventoryOutcome::Complete {
+            let reason = if policy_refresh.refresh.inventory_outcome
+                == WorkspaceInventoryOutcome::Unreadable
+            {
+                FileCoverageReason::Unreadable
+            } else {
+                FileCoverageReason::DiscoveryIncomplete
+            };
+            let mut gaps = policy_refresh
+                .refresh
+                .inventory_issues
+                .iter()
+                .map(|issue| FileCoverageDiagnosticDto {
+                    path: runtime_relative_path(root, &issue.path),
+                    reason,
+                    retryable: file_coverage_retryable(reason),
+                    verified_source: false,
+                    projection_available: false,
+                })
+                .collect::<Vec<_>>();
+            if gaps.is_empty() {
+                gaps.push(FileCoverageDiagnosticDto {
+                    path: ".".into(),
+                    reason,
+                    retryable: file_coverage_retryable(reason),
+                    verified_source: false,
+                    projection_available: false,
+                });
+            }
+            return Err(ApiError::source_coverage_failure(
+                source_coverage_failure_code(&gaps),
+                format!(
+                    "Incremental refresh requires a complete source inventory; discovery was {:?}.",
+                    policy_refresh.refresh.inventory_outcome
+                ),
+                gaps,
+            ));
+        }
+        let execution_plan = policy_refresh.refresh.plan;
+        let policy_exclusions = policy_refresh.policy_exclusions;
+        let mut planned_semantic_seed_file_ids = execution_plan
+            .files_to_remove
+            .iter()
+            .copied()
+            .map(codestory_contracts::graph::NodeId)
+            .collect::<HashSet<_>>();
+        for path in &execution_plan.files_to_index {
+            let normalized_path = if path.is_absolute() {
+                path.clone()
+            } else {
+                root.join(path)
+            };
+            if let Some(file_info) = staged
+                .store_mut()
+                .get_file_by_path(&normalized_path)
+                .map_err(|error| {
+                    ApiError::internal(format!(
+                        "Failed to resolve previous semantic scope for {}: {error}",
+                        normalized_path.display()
+                    ))
+                })?
+            {
+                planned_semantic_seed_file_ids
+                    .insert(codestory_contracts::graph::NodeId(file_info.id));
+            }
+        }
+        let previous_semantic_dependents_by_seed = semantic_graph_dependent_file_ids_by_seed(
+            staged.store_mut(),
+            &planned_semantic_seed_file_ids,
+        )?;
+        let existing_file_paths = semantic_file_table_path_map(
             staged
                 .store_mut()
-                .invalidate_grounding_snapshots()
-                .map_err(|e| {
+                .get_files()
+                .map_err(|error| ApiError::internal(format!("Failed to load files: {error}")))?,
+        );
+        let mut removed_component_keys = HashSet::new();
+        for file_id in &execution_plan.files_to_remove {
+            let path = existing_file_paths
+                .get(&codestory_contracts::graph::NodeId(*file_id))
+                .ok_or_else(|| {
                     ApiError::internal(format!(
-                        "Failed to invalidate staged derived index snapshots: {e}"
+                        "Removed file is missing from staged component scope: {file_id}"
                     ))
                 })?;
-
-            let workspace = WorkspaceManifest::open(root.to_path_buf())
-                .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
-            let refresh_inputs = workspace_refresh_inputs(staged.store_mut())?;
-            let execution_plan = refresh_builder(&workspace, &refresh_inputs)?;
-            let mut planned_semantic_seed_file_ids = execution_plan
-                .files_to_remove
-                .iter()
-                .copied()
-                .map(codestory_contracts::graph::NodeId)
-                .collect::<HashSet<_>>();
-            for path in &execution_plan.files_to_index {
-                let normalized_path = if path.is_absolute() {
-                    path.clone()
-                } else {
-                    root.join(path)
-                };
-                if let Some(file_info) = staged
-                    .store_mut()
-                    .get_file_by_path(&normalized_path)
-                    .map_err(|error| {
-                        ApiError::internal(format!(
-                            "Failed to resolve previous semantic scope for {}: {error}",
-                            normalized_path.display()
-                        ))
-                    })?
-                {
-                    planned_semantic_seed_file_ids
-                        .insert(codestory_contracts::graph::NodeId(file_info.id));
-                }
+            if let Some(component_key) = semantic_component_key_for_path(Some(path)) {
+                removed_component_keys.insert(component_key);
             }
-            let previous_semantic_dependents_by_seed = semantic_graph_dependent_file_ids_by_seed(
-                staged.store_mut(),
-                &planned_semantic_seed_file_ids,
-            )?;
-            let existing_file_paths =
-                semantic_file_table_path_map(staged.store_mut().get_files().map_err(|error| {
-                    ApiError::internal(format!("Failed to load files: {error}"))
-                })?);
-            let mut removed_component_keys = HashSet::new();
-            for file_id in &execution_plan.files_to_remove {
-                let path = existing_file_paths
-                    .get(&codestory_contracts::graph::NodeId(*file_id))
-                    .ok_or_else(|| {
-                        ApiError::internal(format!(
-                            "Removed file is missing from staged component scope: {file_id}"
-                        ))
-                    })?;
-                if let Some(component_key) = semantic_component_key_for_path(Some(path)) {
-                    removed_component_keys.insert(component_key);
-                }
-            }
-            let component_report_refresh = ComponentReportRefreshScope {
-                previous_file_paths: existing_file_paths,
-                removed_component_keys,
-            };
+        }
+        let component_report_refresh = ComponentReportRefreshScope {
+            previous_file_paths: existing_file_paths,
+            removed_component_keys,
+        };
 
-            let total_files = execution_plan.files_to_index.len().min(u32::MAX as usize) as u32;
-            let _ = events_tx.send(AppEventPayload::IndexingStarted {
-                file_count: total_files,
-            });
+        let total_files = execution_plan.files_to_index.len().min(u32::MAX as usize) as u32;
+        let _ = events_tx.send(AppEventPayload::IndexingStarted {
+            file_count: total_files,
+        });
 
-            let bus = EventBus::new();
-            let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
-            if is_indexing_cancelled(cancel_token) {
-                drop(bus);
-                let _ = forwarder.join();
-                return Err(indexing_cancelled_error());
-            }
-            let indexer = V2WorkspaceIndexer::new(root.to_path_buf());
-            let result = indexer.run(staged.store_mut(), &execution_plan, &bus, cancel_token);
-
-            // Drop bus so forwarder unblocks.
+        let bus = EventBus::new();
+        let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
+        if is_indexing_cancelled(cancel_token) {
             drop(bus);
             let _ = forwarder.join();
+            return Err(indexing_cancelled_error());
+        }
+        let indexer = V2WorkspaceIndexer::new(root.to_path_buf());
+        let result = indexer.run(staged.store_mut(), &execution_plan, &bus, cancel_token);
 
-            let index_stats = match result {
-                Ok(_) if is_indexing_cancelled(cancel_token) => {
-                    return Err(indexing_cancelled_error());
-                }
-                Ok(stats) => stats,
-                Err(_) if is_indexing_cancelled(cancel_token) => {
-                    return Err(indexing_cancelled_error());
-                }
-                Err(e) => return Err(ApiError::internal(format!("Indexing failed: {e}"))),
+        // Drop bus so forwarder unblocks.
+        drop(bus);
+        let _ = forwarder.join();
+
+        let index_stats = match result {
+            Ok(_) if is_indexing_cancelled(cancel_token) => {
+                return Err(indexing_cancelled_error());
+            }
+            Ok(stats) => stats,
+            Err(_) if is_indexing_cancelled(cancel_token) => {
+                return Err(indexing_cancelled_error());
+            }
+            Err(e) => return Err(ApiError::internal(format!("Indexing failed: {e}"))),
+        };
+        let mut semantic_refresh_seed_file_ids = HashSet::new();
+        for path in &execution_plan.files_to_index {
+            let normalized_path = if path.is_absolute() {
+                path.clone()
+            } else {
+                root.join(path)
             };
-            let mut semantic_refresh_seed_file_ids = HashSet::new();
-            for path in &execution_plan.files_to_index {
-                let normalized_path = if path.is_absolute() {
-                    path.clone()
-                } else {
-                    root.join(path)
-                };
-                let file_info = staged
-                    .store_mut()
-                    .get_file_by_path(&normalized_path)
-                    .map_err(|error| {
-                        ApiError::internal(format!(
-                            "Failed to resolve indexed semantic scope for {}: {error}",
-                            normalized_path.display()
-                        ))
-                    })?;
-                // Workspace refresh plans include discovered files that have no graph
-                // collector, while incomplete reads preserve the last verified graph.
-                // Only complete files can prove that their semantic projection changed.
-                if let Some(file_info) = file_info
-                    && file_info.complete
-                {
-                    semantic_refresh_seed_file_ids
-                        .insert(codestory_contracts::graph::NodeId(file_info.id));
-                }
+            let file_info = staged
+                .store_mut()
+                .get_file_by_path(&normalized_path)
+                .map_err(|error| {
+                    ApiError::internal(format!(
+                        "Failed to resolve indexed semantic scope for {}: {error}",
+                        normalized_path.display()
+                    ))
+                })?;
+            // Workspace refresh plans include discovered files that have no graph
+            // collector, while incomplete reads preserve the last verified graph.
+            // Only complete files can prove that their semantic projection changed.
+            if let Some(file_info) = file_info
+                && file_info.complete
+            {
+                semantic_refresh_seed_file_ids
+                    .insert(codestory_contracts::graph::NodeId(file_info.id));
             }
-            for file_id in &execution_plan.files_to_remove {
-                semantic_refresh_seed_file_ids.insert(codestory_contracts::graph::NodeId(*file_id));
+        }
+        for file_id in &execution_plan.files_to_remove {
+            semantic_refresh_seed_file_ids.insert(codestory_contracts::graph::NodeId(*file_id));
+        }
+        let current_semantic_dependents_by_seed = semantic_graph_dependent_file_ids_by_seed(
+            staged.store_mut(),
+            &semantic_refresh_seed_file_ids,
+        )?;
+        let mut llm_refresh_scope = semantic_refresh_seed_file_ids.clone();
+        for seed_file_id in &semantic_refresh_seed_file_ids {
+            if let Some(file_ids) = previous_semantic_dependents_by_seed.get(seed_file_id) {
+                llm_refresh_scope.extend(file_ids.iter().copied());
             }
-            let current_semantic_dependents_by_seed = semantic_graph_dependent_file_ids_by_seed(
-                staged.store_mut(),
-                &semantic_refresh_seed_file_ids,
-            )?;
-            let mut llm_refresh_scope = semantic_refresh_seed_file_ids.clone();
-            for seed_file_id in &semantic_refresh_seed_file_ids {
-                if let Some(file_ids) = previous_semantic_dependents_by_seed.get(seed_file_id) {
-                    llm_refresh_scope.extend(file_ids.iter().copied());
-                }
-                if let Some(file_ids) = current_semantic_dependents_by_seed.get(seed_file_id) {
-                    llm_refresh_scope.extend(file_ids.iter().copied());
-                }
+            if let Some(file_ids) = current_semantic_dependents_by_seed.get(seed_file_id) {
+                llm_refresh_scope.extend(file_ids.iter().copied());
             }
-            let staged_semantic_stats = finalize_staged_semantic_docs_for_runtime(
-                staged.store_mut(),
-                (!rebuild_complete_dense_anchor_set).then_some(&llm_refresh_scope),
-                (!rebuild_complete_dense_anchor_set).then_some(&component_report_refresh),
-                &dense_anchor_source_identity,
-                cancel_token,
-                runtime,
-            )?;
-            if is_indexing_cancelled(cancel_token) {
-                return Err(indexing_cancelled_error());
-            }
-            let staged_finalize_stats = staged.snapshots().finalize_staged().map_err(|e| {
-                ApiError::internal(format!(
-                    "Failed to finalize staged incremental storage: {e}"
-                ))
-            })?;
-            let detail_started = Instant::now();
-            staged.snapshots().refresh_detail().map_err(|e| {
-                ApiError::internal(format!(
-                    "Failed to refresh staged grounding detail snapshot: {e}"
-                ))
-            })?;
-            let detail_snapshot_ms = clamp_u128_to_u32(detail_started.elapsed().as_millis());
-            if is_indexing_cancelled(cancel_token) {
-                return Err(indexing_cancelled_error());
-            }
-            Ok((
-                index_stats,
-                staged_finalize_stats,
-                detail_snapshot_ms,
-                llm_refresh_scope,
-                staged_semantic_stats,
+        }
+        let staged_semantic_stats = finalize_staged_semantic_docs_for_runtime(
+            staged.store_mut(),
+            (!rebuild_complete_dense_anchor_set).then_some(&llm_refresh_scope),
+            (!rebuild_complete_dense_anchor_set).then_some(&component_report_refresh),
+            &dense_anchor_source_identity,
+            cancel_token,
+            runtime,
+        )?;
+        if is_indexing_cancelled(cancel_token) {
+            return Err(indexing_cancelled_error());
+        }
+        let staged_finalize_stats = staged.snapshots().finalize_staged().map_err(|e| {
+            ApiError::internal(format!(
+                "Failed to finalize staged incremental storage: {e}"
             ))
-        })();
+        })?;
+        let detail_started = Instant::now();
+        staged.snapshots().refresh_detail().map_err(|e| {
+            ApiError::internal(format!(
+                "Failed to refresh staged grounding detail snapshot: {e}"
+            ))
+        })?;
+        let detail_snapshot_ms = clamp_u128_to_u32(detail_started.elapsed().as_millis());
+        if is_indexing_cancelled(cancel_token) {
+            return Err(indexing_cancelled_error());
+        }
+        Ok((
+            index_stats,
+            staged_finalize_stats,
+            detail_snapshot_ms,
+            llm_refresh_scope,
+            staged_semantic_stats,
+            policy_exclusions,
+        ))
+    })();
     let (
         index_stats,
         staged_finalize_stats,
         detail_snapshot_ms,
         llm_refresh_scope,
         staged_semantic_stats,
+        policy_exclusions,
     ) = match staged_result {
         Ok(result) => result,
         Err(error) => {
@@ -14670,6 +14920,12 @@ where
         return Err(ApiError::internal(format!(
             "Failed to publish complete dense anchor inputs: {error}"
         )));
+    }
+    if let Err(error) =
+        publish_source_policy_exclusions(staged.store_mut(), root, &publication, &policy_exclusions)
+    {
+        let _ = staged.discard();
+        return Err(error);
     }
     if let Err(error) = staged.store_mut().put_index_publication(&publication) {
         let _ = staged.discard();
@@ -21455,13 +21711,11 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     fn make_source_exceed_default_index_byte_cap(path: &Path, reason: &str) {
-        const DEFAULT_INDEX_SOURCE_FILE_BYTE_CAP: usize = 1_000_000;
-
         let mut source = fs::read_to_string(path).expect("read source");
         source.push_str("\n// ");
         source.push_str(reason);
         source.push_str("\n// ");
-        let padding = DEFAULT_INDEX_SOURCE_FILE_BYTE_CAP
+        let padding = (DEFAULT_SOURCE_FILE_BYTE_CAP as usize)
             .saturating_sub(source.len())
             .saturating_add(1);
         source.push_str(&"x".repeat(padding));
@@ -21470,13 +21724,13 @@ fn build_llm_symbol_doc_text() -> String {
 
         let size = fs::metadata(path).expect("oversized source metadata").len();
         assert!(
-            size > DEFAULT_INDEX_SOURCE_FILE_BYTE_CAP as u64,
+            size > DEFAULT_SOURCE_FILE_BYTE_CAP,
             "fixture source must exceed the default index byte cap: {size}"
         );
     }
 
     #[test]
-    fn incomplete_first_full_refresh_creates_no_core_or_dense_publication() {
+    fn first_full_refresh_publishes_verified_oversized_exclusion_without_graph_coverage() {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
@@ -21484,6 +21738,18 @@ fn build_llm_symbol_doc_text() -> String {
             &workspace.path().join("rust_tictactoe.rs"),
             "first full-refresh candidate is deliberately oversized",
         );
+        fs::create_dir_all(workspace.path().join("generated")).expect("generated fixture dir");
+        fs::create_dir_all(workspace.path().join("vendor")).expect("vendor fixture dir");
+        fs::write(
+            workspace.path().join("generated/registers.h"),
+            vec![b'g'; DEFAULT_SOURCE_FILE_BYTE_CAP as usize + 1],
+        )
+        .expect("generated oversized fixture");
+        fs::write(
+            workspace.path().join("vendor/bundle.js"),
+            vec![b'v'; DEFAULT_SOURCE_FILE_BYTE_CAP as usize + 1],
+        )
+        .expect("vendor oversized fixture");
         let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
         controller
             .open_project_summary_with_storage_path(
@@ -21491,47 +21757,158 @@ fn build_llm_symbol_doc_text() -> String {
                 storage_path.clone(),
             )
             .expect("open project summary");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("verified oversized source should not block first publication");
+
+        let storage = Storage::open(&storage_path).expect("open published storage");
+        let publication = storage
+            .get_complete_index_publication()
+            .expect("read publication")
+            .expect("complete publication");
+        let manifest = storage
+            .validate_source_policy_exclusion_publication(
+                &publication,
+                &project_identity_v3(workspace.path()).project_id,
+                &project_identity_v3(workspace.path()).workspace_id,
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+            )
+            .expect("verified exclusion manifest");
+        assert_eq!(manifest.exclusion_count, 3);
+        let exclusions = storage
+            .get_source_policy_exclusions()
+            .expect("source exclusions");
+        assert_eq!(
+            exclusions
+                .iter()
+                .map(|entry| entry.normalized_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "generated/registers.h",
+                "rust_tictactoe.rs",
+                "vendor/bundle.js"
+            ]
+        );
+        assert!(
+            exclusions
+                .iter()
+                .all(|entry| entry.observed_size > entry.byte_cap)
+        );
+        assert!(
+            storage
+                .get_file_by_path(&workspace.path().join("rust_tictactoe.rs"))
+                .expect("excluded file lookup")
+                .is_none(),
+            "policy exclusion must not create parser-backed file coverage"
+        );
+        let files = controller
+            .indexed_files(IndexedFilesRequest {
+                path_contains: Some("rust_tictactoe.rs".into()),
+                language: None,
+                role: None,
+                limit: None,
+            })
+            .expect("agent-facing file coverage");
+        assert!(files.coverage_gaps.is_empty());
+        assert_eq!(files.policy_exclusions.len(), 1);
+        assert!(!files.policy_exclusions[0].graph_coverage);
+        assert!(!files.policy_exclusions[0].semantic_coverage);
+        let all_files = controller
+            .indexed_files(IndexedFilesRequest {
+                path_contains: None,
+                language: None,
+                role: None,
+                limit: None,
+            })
+            .expect("all agent-facing file coverage");
+        assert_eq!(all_files.summary.policy_exclusion_count, 3);
+        assert!(
+            all_files
+                .policy_exclusions
+                .iter()
+                .any(|entry| entry.role == IndexedFileRoleDto::Generated)
+        );
+        assert!(
+            all_files
+                .policy_exclusions
+                .iter()
+                .any(|entry| entry.role == IndexedFileRoleDto::Vendor)
+        );
+        let workspace_manifest =
+            WorkspaceManifest::open(workspace.path().to_path_buf()).expect("workspace manifest");
+        let freshness =
+            index_freshness_from_storage(workspace.path(), &workspace_manifest, &storage);
+        assert_eq!(freshness.status, IndexFreshnessStatusDto::Fresh);
+        storage
+            .get_connection()
+            .execute("DELETE FROM source_policy_exclusion_publication", [])
+            .expect("corrupt exclusion publication identity");
+        let incomplete =
+            index_freshness_from_storage(workspace.path(), &workspace_manifest, &storage);
+        assert_eq!(incomplete.status, IndexFreshnessStatusDto::NotChecked);
+        assert!(
+            incomplete
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("source policy exclusion publication"))
+        );
+        assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    #[test]
+    fn partial_discovery_keeps_oversized_candidates_blocking_and_publishes_nothing() {
+        let workspace = tempdir().expect("workspace dir");
+        fs::create_dir_all(workspace.path().join("src")).expect("source directory");
+        fs::write(
+            workspace.path().join("src/large.rs"),
+            vec![b'x'; DEFAULT_SOURCE_FILE_BYTE_CAP as usize + 1],
+        )
+        .expect("oversized source");
+        fs::write(
+            workspace.path().join("codestory_workspace.json"),
+            r#"{"members":["src","missing"]}"#,
+        )
+        .expect("partial workspace manifest");
+        let storage_path = workspace.path().join(".cache/codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open partial project");
         let error = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
-            .expect_err("an incomplete first full refresh must not publish");
+            .expect_err("partial discovery cannot authorize exclusions");
 
-        assert_eq!(error.code, "source_oversized");
+        assert_eq!(error.code, "source_discovery_incomplete");
         assert!(error.details.as_ref().is_some_and(|details| {
-            details.coverage_gaps.iter().any(|entry| {
-                entry.reason == FileCoverageReason::Oversized && !entry.verified_source
-            })
+            details
+                .coverage_gaps
+                .iter()
+                .any(|gap| gap.reason == FileCoverageReason::DiscoveryIncomplete)
         }));
-        assert!(
-            error.message.contains("No core publication was created"),
-            "first-publication failure should not claim that a previous publication was preserved: {}",
-            error.message
-        );
         if storage_path.exists() {
-            let storage = Storage::open(&storage_path).expect("open empty live storage");
-            assert_eq!(
-                storage
-                    .get_index_publication()
-                    .expect("empty core publication"),
-                None
-            );
+            let storage = Storage::open(&storage_path).expect("partial storage");
             assert!(
                 storage
-                    .get_dense_anchor_publication_manifest()
-                    .expect("empty dense publication")
+                    .get_source_policy_exclusion_manifest()
+                    .expect("partial exclusion manifest")
                     .is_none()
             );
             assert!(
                 storage
-                    .get_dense_anchor_inputs_batch_after(None, 1)
-                    .expect("empty dense inputs")
-                    .is_empty()
+                    .get_index_publication()
+                    .expect("partial core publication")
+                    .is_none()
             );
         }
         assert_no_staged_publication_artifacts(&storage_path);
     }
 
     #[test]
-    fn incomplete_incremental_source_preserves_last_verified_dense_anchors() {
+    fn changed_source_is_reevaluated_into_a_new_verified_exclusion() {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
@@ -21552,9 +21929,6 @@ fn build_llm_symbol_doc_text() -> String {
             .get_complete_index_publication()
             .expect("first publication")
             .expect("complete first publication");
-        let first_manifest = first_storage
-            .validate_dense_anchor_publication(&first_publication)
-            .expect("first dense manifest");
         let first_file_id = first_storage
             .get_file_by_path(&source_path)
             .expect("first file lookup")
@@ -21579,34 +21953,72 @@ fn build_llm_symbol_doc_text() -> String {
         );
         controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
-            .expect("incomplete incremental index");
+            .expect("incremental exclusion publication");
 
         let storage = Storage::open(&storage_path).expect("incremental storage");
-        let file = storage
-            .get_file_by_path(&source_path)
-            .expect("file lookup")
-            .expect("source file");
-        assert!(!file.complete, "the source must remain scheduled for retry");
+        assert!(
+            storage
+                .get_file_by_path(&source_path)
+                .expect("file lookup")
+                .is_none(),
+            "excluded source must not retain parser-backed file coverage"
+        );
         let publication = storage
             .get_complete_index_publication()
             .expect("incremental publication")
             .expect("complete incremental publication");
-        let manifest = storage
-            .validate_dense_anchor_publication(&publication)
-            .expect("retained dense publication");
-        assert_eq!(manifest.anchor_digest, first_manifest.anchor_digest);
+        assert_ne!(publication, first_publication);
+        let identity = project_identity_v3(workspace.path());
+        storage
+            .validate_source_policy_exclusion_publication(
+                &publication,
+                &identity.project_id,
+                &identity.workspace_id,
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+            )
+            .expect("complete exclusion publication");
+        let first_exclusion = storage
+            .get_source_policy_exclusions()
+            .expect("first exclusions")
+            .into_iter()
+            .find(|entry| entry.normalized_path == "rust_tictactoe.rs")
+            .expect("Rust exclusion");
         let retained_anchors = storage
             .get_dense_anchor_inputs_batch_after(None, 10_000)
-            .expect("retained anchors")
+            .expect("current anchors")
             .into_iter()
-            .filter(|anchor| anchor.file_node_id == Some(CoreNodeId(file.id)))
+            .filter(|anchor| anchor.file_node_id == Some(CoreNodeId(first_file_id)))
             .map(|anchor| (anchor.node_id, anchor.document_hash, anchor.text))
             .collect::<HashSet<_>>();
-        assert_eq!(retained_anchors, first_anchors);
+        assert!(retained_anchors.is_empty());
+        assert!(!first_anchors.is_empty());
+        drop(storage);
+
+        fs::write(
+            &source_path,
+            format!(
+                "{}\n// changed oversized content\n",
+                fs::read_to_string(&source_path).unwrap()
+            ),
+        )
+        .expect("change oversized source");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect("changed exclusion reevaluation");
+        let changed = Storage::open(&storage_path)
+            .expect("changed storage")
+            .get_source_policy_exclusions()
+            .expect("changed exclusions")
+            .into_iter()
+            .find(|entry| entry.normalized_path == "rust_tictactoe.rs")
+            .expect("changed Rust exclusion");
+        assert_ne!(changed.content_hash, first_exclusion.content_hash);
+        assert!(changed.observed_size > first_exclusion.observed_size);
     }
 
     #[test]
-    fn incomplete_full_refresh_preserves_the_previous_live_publication() {
+    fn full_refresh_replaces_previous_graph_with_verified_exclusion() {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
@@ -21627,9 +22039,6 @@ fn build_llm_symbol_doc_text() -> String {
             .get_complete_index_publication()
             .expect("first publication")
             .expect("complete first publication");
-        let first_manifest = first_storage
-            .validate_dense_anchor_publication(&first_publication)
-            .expect("first dense manifest");
         let first_file = first_storage
             .get_file_by_path(&source_path)
             .expect("first file lookup")
@@ -21652,47 +22061,47 @@ fn build_llm_symbol_doc_text() -> String {
             &source_path,
             "scheduled but deliberately oversized for this full refresh",
         );
-        let error = controller
+        controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
-            .expect_err("incomplete full refresh must not replace the live publication");
-        assert_eq!(error.code, "source_oversized");
-        assert!(
-            error
-                .message
-                .contains("previous complete publication was preserved")
-        );
+            .expect("full refresh should publish the verified exclusion");
 
-        let storage = Storage::open(&storage_path).expect("preserved live storage");
-        let file = storage
-            .get_file_by_path(&source_path)
-            .expect("preserved file lookup")
-            .expect("preserved source file");
+        let storage = Storage::open(&storage_path).expect("replacement live storage");
         assert!(
-            file.complete,
-            "the incomplete candidate must not replace the verified live file row"
+            storage
+                .get_file_by_path(&source_path)
+                .expect("replacement file lookup")
+                .is_none(),
+            "excluded content cannot retain a parser-backed file row"
         );
         let publication = storage
             .get_complete_index_publication()
-            .expect("preserved publication")
-            .expect("complete preserved publication");
-        assert_eq!(publication, first_publication);
+            .expect("replacement publication")
+            .expect("complete replacement publication");
+        assert_ne!(publication, first_publication);
+        let identity = project_identity_v3(workspace.path());
         let manifest = storage
-            .validate_dense_anchor_publication(&publication)
-            .expect("preserved dense publication");
-        assert_eq!(manifest.anchor_digest, first_manifest.anchor_digest);
-        assert_eq!(manifest.anchor_count, first_manifest.anchor_count);
+            .validate_source_policy_exclusion_publication(
+                &publication,
+                &identity.project_id,
+                &identity.workspace_id,
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+            )
+            .expect("replacement exclusion manifest");
+        assert_eq!(manifest.exclusion_count, 1);
         let retained_anchors = storage
             .get_dense_anchor_inputs_batch_after(None, 10_000)
-            .expect("preserved anchors")
+            .expect("replacement anchors")
             .into_iter()
-            .filter(|anchor| anchor.file_node_id == Some(CoreNodeId(file.id)))
+            .filter(|anchor| anchor.file_node_id == Some(CoreNodeId(first_file.id)))
             .map(|anchor| (anchor.node_id, anchor.document_hash, anchor.text))
             .collect::<HashSet<_>>();
-        assert_eq!(retained_anchors, first_anchors);
+        assert!(retained_anchors.is_empty());
+        assert!(!first_anchors.is_empty());
     }
 
     #[test]
-    fn incomplete_full_recovery_preserves_prior_anchors_and_recovery_fence() {
+    fn full_recovery_publishes_verified_exclusion_and_clears_recovery_fence() {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
@@ -21713,13 +22122,6 @@ fn build_llm_symbol_doc_text() -> String {
             .get_complete_index_publication()
             .expect("first publication")
             .expect("complete first publication");
-        let first_manifest = first_storage
-            .validate_dense_anchor_publication(&first_publication)
-            .expect("first dense manifest");
-        let first_anchors = first_storage
-            .get_dense_anchor_inputs_batch_after(None, 10_000)
-            .expect("first anchors");
-        assert!(!first_anchors.is_empty(), "fixture needs dense anchors");
         first_storage
             .begin_incremental_run()
             .expect("mark interrupted incremental run");
@@ -21729,52 +22131,33 @@ fn build_llm_symbol_doc_text() -> String {
             &source_path,
             "recovery candidate is deliberately oversized",
         );
-        let error = controller
+        controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
-            .expect_err("incomplete recovery must preserve the fenced live index");
+            .expect("verified exclusion should complete full recovery");
 
-        assert_eq!(error.code, "source_oversized");
+        let storage = Storage::open(&storage_path).expect("recovered storage");
         assert!(
-            error
-                .message
-                .contains("incomplete-run recovery fence were preserved"),
-            "recovery failure should describe the preserved fence: {}",
-            error.message
-        );
-        let storage = Storage::open(&storage_path).expect("preserved fenced storage");
-        assert_eq!(
-            storage
-                .get_index_publication()
-                .expect("preserved raw publication"),
-            Some(first_publication.clone()),
-            "an incomplete recovery must not advance the raw generation"
-        );
-        assert!(
-            storage
+            !storage
                 .has_incomplete_incremental_run()
-                .expect("preserved recovery fence"),
-            "the interrupted-run fence must remain until a complete recovery publishes"
+                .expect("cleared recovery fence"),
+            "complete recovery must clear the interrupted-run fence"
         );
-        assert_eq!(
-            storage
-                .get_complete_index_publication()
-                .expect("fenced complete publication"),
-            None,
-            "a fenced live index must remain unavailable as a complete publication"
-        );
-        assert_eq!(
-            storage
-                .validate_dense_anchor_publication(&first_publication)
-                .expect("preserved dense manifest"),
-            first_manifest
-        );
-        assert_eq!(
-            storage
-                .get_dense_anchor_inputs_batch_after(None, 10_000)
-                .expect("preserved dense anchors"),
-            first_anchors,
-            "unreadable recovery discovery must not create anchor deletion evidence"
-        );
+        let publication = storage
+            .get_complete_index_publication()
+            .expect("recovered complete publication")
+            .expect("complete recovered publication");
+        assert_ne!(publication, first_publication);
+        let identity = project_identity_v3(workspace.path());
+        let manifest = storage
+            .validate_source_policy_exclusion_publication(
+                &publication,
+                &identity.project_id,
+                &identity.workspace_id,
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+            )
+            .expect("recovered exclusion manifest");
+        assert_eq!(manifest.exclusion_count, 1);
         assert_no_staged_publication_artifacts(&storage_path);
     }
 
@@ -25234,6 +25617,79 @@ fn build_llm_symbol_doc_text() -> String {
         );
         assert!(storage_has_symbol(&storage, "old_generation"));
         assert!(!storage_has_symbol(&storage, "new_generation"));
+        assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    #[test]
+    fn cancelled_full_refresh_preserves_previous_verified_exclusion_manifest() {
+        let workspace = tempdir().expect("workspace dir");
+        let ordinary = workspace.path().join("lib.rs");
+        let oversized = workspace.path().join("generated.rs");
+        fs::write(&ordinary, "pub fn stable() -> i32 { 1 }\n").expect("write ordinary source");
+        fs::write(&oversized, "pub fn generated() {}\n").expect("write generated source");
+        make_source_exceed_default_index_byte_cap(&oversized, "baseline exclusion");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open exclusion cancellation baseline");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish exclusion cancellation baseline");
+        let baseline_storage = Storage::open(&storage_path).expect("baseline storage");
+        let baseline_publication = baseline_storage
+            .get_complete_index_publication()
+            .expect("baseline publication")
+            .expect("complete baseline publication");
+        let baseline_manifest = baseline_storage
+            .get_source_policy_exclusion_manifest()
+            .expect("baseline exclusion manifest")
+            .expect("complete baseline exclusion manifest");
+        let baseline_exclusions = baseline_storage
+            .get_source_policy_exclusions()
+            .expect("baseline exclusions");
+        drop(baseline_storage);
+
+        fs::write(
+            &oversized,
+            format!("{}\n// changed\n", fs::read_to_string(&oversized).unwrap()),
+        )
+        .expect("change excluded source");
+        let cancel_token = CancellationToken::new();
+        arm_publication_test_fault(
+            PublicationTestBoundary::SearchBuild,
+            PublicationTestAction::Cancel,
+        );
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh_with_cancel(
+                IndexMode::Full,
+                &cancel_token,
+            )
+            .expect_err("cancelled exclusion refresh must fail visibly");
+        assert_eq!(error.code, "cancelled");
+
+        let storage = Storage::open(&storage_path).expect("cancelled exclusion storage");
+        assert_eq!(
+            storage
+                .get_complete_index_publication()
+                .expect("preserved complete publication"),
+            Some(baseline_publication)
+        );
+        assert_eq!(
+            storage
+                .get_source_policy_exclusion_manifest()
+                .expect("preserved exclusion manifest"),
+            Some(baseline_manifest)
+        );
+        assert_eq!(
+            storage
+                .get_source_policy_exclusions()
+                .expect("preserved exclusions"),
+            baseline_exclusions
+        );
         assert_no_staged_publication_artifacts(&storage_path);
     }
 

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -56,10 +56,12 @@ use codestory_store::{
     Store, SymbolSearchDoc, SymbolSummaryRecord,
 };
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
+#[cfg(test)]
+use codestory_workspace::{DEFAULT_SOURCE_FILE_BYTE_CAP, OVERSIZED_SOURCE_POLICY_VERSION};
 use codestory_workspace::{
-    DEFAULT_SOURCE_FILE_BYTE_CAP, OVERSIZED_SOURCE_POLICY_VERSION,
     OversizedSourceExclusionCandidate, RefreshExecutionPlan, RefreshInputs, RefreshMode,
-    WorkspaceInventoryOutcome, WorkspaceManifest, WorkspacePathIdentity, project_identity_v3,
+    SourceIndexPolicy, WorkspaceInventoryOutcome, WorkspaceManifest, WorkspacePathIdentity,
+    process_source_index_policy, project_identity_v3,
 };
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use fs4::fs_std::FileExt;
@@ -5053,9 +5055,10 @@ fn file_coverage_detail(reason: FileCoverageReason) -> &'static str {
 fn full_refresh_execution_plan_with_coverage(
     root: &Path,
     workspace: &WorkspaceManifest,
+    policy: &SourceIndexPolicy,
 ) -> Result<(RefreshExecutionPlan, Vec<OversizedSourceExclusionCandidate>), ApiError> {
     let inventory = workspace
-        .source_inventory_with_oversized_policy()
+        .source_inventory_with_policy(policy)
         .map_err(|error| {
             ApiError::source_coverage_failure(
                 "source_collector_failure",
@@ -5123,6 +5126,7 @@ fn publish_source_policy_exclusions(
     root: &Path,
     publication: &IndexPublicationRecord,
     exclusions: &[OversizedSourceExclusionCandidate],
+    policy: &SourceIndexPolicy,
 ) -> Result<(), ApiError> {
     let identity = project_identity_v3(root);
     storage
@@ -5130,8 +5134,8 @@ fn publish_source_policy_exclusions(
             publication,
             &identity.project_id,
             &identity.workspace_id,
-            OVERSIZED_SOURCE_POLICY_VERSION,
-            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            &policy.policy_version,
+            policy.byte_cap,
             exclusions,
         )
         .map_err(|error| {
@@ -5142,10 +5146,28 @@ fn publish_source_policy_exclusions(
     Ok(())
 }
 
+fn revalidate_source_policy_exclusions(
+    workspace: &WorkspaceManifest,
+    exclusions: &[OversizedSourceExclusionCandidate],
+    policy: &SourceIndexPolicy,
+) -> Result<Vec<OversizedSourceExclusionCandidate>, ApiError> {
+    workspace
+        .revalidate_source_policy_exclusions(exclusions, policy)
+        .map_err(|error| {
+            ApiError::new(
+                "source_verification_failed",
+                format!(
+                    "Source policy exclusions changed before publication; the candidate core was discarded: {error}"
+                ),
+            )
+        })
+}
+
 fn validate_source_policy_exclusions(
     storage: &Store,
     root: &Path,
     publication: &IndexPublicationRecord,
+    policy: &SourceIndexPolicy,
 ) -> Result<(), ApiError> {
     let identity = project_identity_v3(root);
     storage
@@ -5153,8 +5175,8 @@ fn validate_source_policy_exclusions(
             publication,
             &identity.project_id,
             &identity.workspace_id,
-            OVERSIZED_SOURCE_POLICY_VERSION,
-            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            &policy.policy_version,
+            policy.byte_cap,
         )
         .map_err(|error| {
             ApiError::new(
@@ -5314,12 +5336,14 @@ fn index_freshness_observation_from_storage(
     root: &Path,
     workspace: &WorkspaceManifest,
     storage: &Storage,
+    policy: &SourceIndexPolicy,
 ) -> IndexFreshnessObservation {
     let mut identities = AffectedOperationIdentityIndex::native();
     index_freshness_observation_from_storage_with_identities(
         root,
         workspace,
         storage,
+        policy,
         &mut identities,
     )
 }
@@ -5328,6 +5352,7 @@ fn index_freshness_observation_from_storage_with_identities<R>(
     root: &Path,
     workspace: &WorkspaceManifest,
     storage: &Storage,
+    policy: &SourceIndexPolicy,
     identities: &mut AffectedOperationIdentityIndex<R>,
 ) -> IndexFreshnessObservation
 where
@@ -5361,7 +5386,9 @@ where
     }
     match storage.get_complete_index_publication() {
         Ok(Some(publication)) => {
-            if let Err(error) = validate_source_policy_exclusions(storage, root, &publication) {
+            if let Err(error) =
+                validate_source_policy_exclusions(storage, root, &publication, policy)
+            {
                 return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
                     format!(
                         "source policy exclusion publication is incomplete: {}",
@@ -5431,9 +5458,10 @@ where
         stored_files,
         inventory: Default::default(),
     };
-    let refresh = match workspace.build_execution_outcome_bounded_with_oversized_policy(
+    let refresh = match workspace.build_execution_outcome_bounded_with_policy(
         &refresh_inputs,
         INDEX_FRESHNESS_CURRENT_FILE_CAP,
+        policy,
     ) {
         Ok(refresh) => refresh,
         Err(error) => {
@@ -5623,12 +5651,27 @@ where
     }
 }
 
+fn index_freshness_from_storage_with_policy(
+    root: &Path,
+    workspace: &WorkspaceManifest,
+    storage: &Storage,
+    policy: &SourceIndexPolicy,
+) -> IndexFreshnessDto {
+    index_freshness_observation_from_storage(root, workspace, storage, policy).freshness
+}
+
+#[cfg(test)]
 fn index_freshness_from_storage(
     root: &Path,
     workspace: &WorkspaceManifest,
     storage: &Storage,
 ) -> IndexFreshnessDto {
-    index_freshness_observation_from_storage(root, workspace, storage).freshness
+    index_freshness_from_storage_with_policy(
+        root,
+        workspace,
+        storage,
+        process_source_index_policy(),
+    )
 }
 
 fn workspace_member_index_summaries(
@@ -6134,6 +6177,8 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
     static ACTIVATION_SEARCH_BEFORE_REVALIDATE_HOOK: std::cell::RefCell<Option<ActivationSearchRevalidateHook>> =
         const { std::cell::RefCell::new(None) };
+    static SOURCE_POLICY_BEFORE_REVALIDATE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(test)]
@@ -6153,6 +6198,22 @@ fn run_activation_search_before_revalidate_hook(storage_path: &Path) {
     ACTIVATION_SEARCH_BEFORE_REVALIDATE_HOOK.with(|slot| {
         if let Some(hook) = slot.borrow_mut().take() {
             hook(storage_path);
+        }
+    });
+}
+
+#[cfg(test)]
+fn arm_source_policy_before_revalidate_hook(hook: impl FnOnce() + 'static) {
+    SOURCE_POLICY_BEFORE_REVALIDATE_HOOK.with(|slot| {
+        *slot.borrow_mut() = Some(Box::new(hook));
+    });
+}
+
+#[cfg(test)]
+fn run_source_policy_before_revalidate_hook() {
+    SOURCE_POLICY_BEFORE_REVALIDATE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
         }
     });
 }
@@ -9846,6 +9907,7 @@ pub struct AppController {
     events_tx: Sender<AppEventPayload>,
     events_rx: Receiver<AppEventPayload>,
     runtime_config: Arc<codestory_retrieval::SidecarRuntimeConfig>,
+    source_index_policy: Arc<SourceIndexPolicy>,
 }
 
 #[derive(Debug)]
@@ -9914,6 +9976,13 @@ impl AppController {
     }
 
     pub fn new_with_config(config: codestory_retrieval::SidecarRuntimeConfig) -> Self {
+        Self::new_with_source_index_policy(config, process_source_index_policy().clone())
+    }
+
+    fn new_with_source_index_policy(
+        config: codestory_retrieval::SidecarRuntimeConfig,
+        source_index_policy: SourceIndexPolicy,
+    ) -> Self {
         let (events_tx, events_rx) = unbounded();
         Self {
             state: Arc::new(Mutex::new(AppState {
@@ -9931,6 +10000,7 @@ impl AppController {
             events_tx,
             events_rx,
             runtime_config: Arc::new(config),
+            source_index_policy: Arc::new(source_index_policy),
         }
     }
 
@@ -10115,7 +10185,12 @@ impl AppController {
         let storage = self.open_storage_for_freshness()?;
         let workspace = WorkspaceManifest::open(root.clone())
             .map_err(|error| ApiError::internal(format!("Failed to open project: {error}")))?;
-        Ok(index_freshness_from_storage(&root, &workspace, &storage))
+        Ok(index_freshness_from_storage_with_policy(
+            &root,
+            &workspace,
+            &storage,
+            &self.source_index_policy,
+        ))
     }
 
     fn resolve_project_file_path(
@@ -11027,6 +11102,7 @@ impl AppController {
                             &events_tx,
                             None,
                             &controller.runtime_config,
+                            &controller.source_index_policy,
                         ),
                         IndexMode::Incremental => index_incremental_for_runtime(
                             &root,
@@ -11034,6 +11110,7 @@ impl AppController {
                             &events_tx,
                             None,
                             &controller.runtime_config,
+                            &controller.source_index_policy,
                         ),
                     };
                     result.and_then(|summary| {
@@ -11099,6 +11176,7 @@ impl AppController {
                 &self.events_tx,
                 cancel_token,
                 &self.runtime_config,
+                &self.source_index_policy,
             ),
             IndexMode::Incremental => index_incremental_for_runtime(
                 &root,
@@ -11106,6 +11184,7 @@ impl AppController {
                 &self.events_tx,
                 cancel_token,
                 &self.runtime_config,
+                &self.source_index_policy,
             ),
         };
 
@@ -11342,7 +11421,13 @@ impl AppController {
             return Ok(true);
         }
         let root = self.require_project_root()?;
-        Ok(validate_source_policy_exclusions(&storage, &root, &publication).is_err())
+        Ok(validate_source_policy_exclusions(
+            &storage,
+            &root,
+            &publication,
+            &self.source_index_policy,
+        )
+        .is_err())
     }
 
     pub fn run_indexing_blocking(&self, mode: IndexMode) -> Result<IndexingPhaseTimings, ApiError> {
@@ -11394,17 +11479,24 @@ impl AppController {
             mode
         };
         let execution_plan = match effective_mode {
-            IndexMode::Full => workspace.full_refresh_execution_plan().map_err(|e| {
-                ApiError::internal(format!("Failed to generate full refresh plan: {e}"))
-            })?,
+            IndexMode::Full => {
+                full_refresh_execution_plan_with_coverage(
+                    &root,
+                    &workspace,
+                    &self.source_index_policy,
+                )?
+                .0
+            }
             IndexMode::Incremental => {
                 workspace
-                    .build_execution_plan(&refresh_inputs)
+                    .build_execution_outcome_with_policy(&refresh_inputs, &self.source_index_policy)
                     .map_err(|e| {
                         ApiError::internal(format!(
                             "Failed to generate incremental refresh plan: {e}"
                         ))
                     })?
+                    .refresh
+                    .plan
             }
         };
         let members =
@@ -12148,7 +12240,12 @@ impl AppController {
                     "Indexed-file coverage requires a complete core publication.",
                 )
             })?;
-        validate_source_policy_exclusions(&storage, &root, &publication)?;
+        validate_source_policy_exclusions(
+            &storage,
+            &root,
+            &publication,
+            &self.source_index_policy,
+        )?;
         let source_policy_exclusions = storage.get_source_policy_exclusions().map_err(|error| {
             ApiError::internal(format!("Failed to load source policy exclusions: {error}"))
         })?;
@@ -12393,6 +12490,7 @@ impl AppController {
             &root,
             &workspace,
             &storage,
+            &self.source_index_policy,
             &mut path_identities,
         );
         let freshness = &freshness_observation.freshness;
@@ -13076,7 +13174,12 @@ impl AppController {
     ) -> IndexFreshnessDto {
         if !matches!(storage.has_incomplete_incremental_run(), Ok(false)) {
             self.state.lock().index_freshness_cache = None;
-            return index_freshness_from_storage(root, workspace, storage);
+            return index_freshness_from_storage_with_policy(
+                root,
+                workspace,
+                storage,
+                &self.source_index_policy,
+            );
         }
         let ttl = Duration::from_secs(index_freshness_cache_ttl_secs());
         let storage_fingerprint = storage_fingerprint(storage_path);
@@ -13092,7 +13195,12 @@ impl AppController {
             }
         }
 
-        let freshness = index_freshness_from_storage(root, workspace, storage);
+        let freshness = index_freshness_from_storage_with_policy(
+            root,
+            workspace,
+            storage,
+            &self.source_index_policy,
+        );
         let mut state = self.state.lock();
         state.index_freshness_cache = Some(CachedIndexFreshness {
             root: root.to_path_buf(),
@@ -14077,6 +14185,7 @@ fn index_full_for_runtime(
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    source_index_policy: &SourceIndexPolicy,
 ) -> Result<IndexingRunSummary, ApiError> {
     let previous_publication = if storage_path.exists() {
         Store::database_index_publication(storage_path).map_err(|error| {
@@ -14138,9 +14247,13 @@ fn index_full_for_runtime(
             match live.get_complete_index_publication() {
                 Ok(Some(publication)) if publication == *expected => {
                     match live.validate_dense_anchor_publication(&publication) {
-                        Ok(_) => {
-                            validate_source_policy_exclusions(&live, root, &publication).is_ok()
-                        }
+                        Ok(_) => validate_source_policy_exclusions(
+                            &live,
+                            root,
+                            &publication,
+                            source_index_policy,
+                        )
+                        .is_ok(),
                         Err(error) => {
                             tracing::debug!(
                                 path = %storage_path.display(),
@@ -14163,7 +14276,7 @@ fn index_full_for_runtime(
     let workspace = WorkspaceManifest::open(root.to_path_buf())
         .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
     let (execution_plan, policy_exclusions) =
-        full_refresh_execution_plan_with_coverage(root, &workspace)?;
+        full_refresh_execution_plan_with_coverage(root, &workspace, source_index_policy)?;
 
     let total_files = execution_plan.files_to_index.len().min(u32::MAX as usize) as u32;
     let _ = events_tx.send(AppEventPayload::IndexingStarted {
@@ -14176,7 +14289,8 @@ fn index_full_for_runtime(
 
     let bus = EventBus::new();
     let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
-    let indexer = V2WorkspaceIndexer::new(root.to_path_buf());
+    let indexer = V2WorkspaceIndexer::new(root.to_path_buf())
+        .with_source_file_byte_cap(source_index_policy.byte_cap);
     let result = indexer.run(staged.store_mut(), &execution_plan, &bus, cancel_token);
 
     drop(bus);
@@ -14340,9 +14454,26 @@ fn index_full_for_runtime(
             "Failed to publish complete dense anchor inputs: {error}"
         )));
     }
-    if let Err(error) =
-        publish_source_policy_exclusions(staged.store_mut(), root, &publication, &policy_exclusions)
-    {
+    #[cfg(test)]
+    run_source_policy_before_revalidate_hook();
+    let policy_exclusions = match revalidate_source_policy_exclusions(
+        &workspace,
+        &policy_exclusions,
+        source_index_policy,
+    ) {
+        Ok(exclusions) => exclusions,
+        Err(error) => {
+            let _ = staged.discard();
+            return Err(error);
+        }
+    };
+    if let Err(error) = publish_source_policy_exclusions(
+        staged.store_mut(),
+        root,
+        &publication,
+        &policy_exclusions,
+        source_index_policy,
+    ) {
         let _ = staged.discard();
         return Err(error);
     }
@@ -14568,6 +14699,7 @@ fn index_incremental(
         events_tx,
         cancel_token,
         &test_sidecar_runtime_from_env(),
+        process_source_index_policy(),
     )
 }
 
@@ -14577,8 +14709,16 @@ fn index_incremental_for_runtime(
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    source_index_policy: &SourceIndexPolicy,
 ) -> Result<IndexingRunSummary, ApiError> {
-    run_incremental_indexing_common(root, storage_path, events_tx, cancel_token, runtime)
+    run_incremental_indexing_common(
+        root,
+        storage_path,
+        events_tx,
+        cancel_token,
+        runtime,
+        source_index_policy,
+    )
 }
 
 fn spawn_progress_forwarder(
@@ -14609,6 +14749,7 @@ fn run_incremental_indexing_common(
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    source_index_policy: &SourceIndexPolicy,
 ) -> Result<IndexingRunSummary, ApiError> {
     let live_exists = storage_path.exists();
     let live_is_incomplete = live_exists
@@ -14620,7 +14761,14 @@ fn run_incremental_indexing_common(
             message: "A prior incremental index run was interrupted; rebuilding through staged full recovery."
                 .to_string(),
         });
-        return index_full_for_runtime(root, storage_path, events_tx, cancel_token, runtime);
+        return index_full_for_runtime(
+            root,
+            storage_path,
+            events_tx,
+            cancel_token,
+            runtime,
+            source_index_policy,
+        );
     }
     if is_indexing_cancelled(cancel_token) {
         return Err(indexing_cancelled_error());
@@ -14682,7 +14830,7 @@ fn run_incremental_indexing_common(
             .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
         let refresh_inputs = workspace_refresh_inputs(staged.store_mut())?;
         let policy_refresh = workspace
-            .build_execution_outcome_with_oversized_policy(&refresh_inputs)
+            .build_execution_outcome_with_policy(&refresh_inputs, source_index_policy)
             .map_err(|e| ApiError::internal(format!("Failed to generate refresh info: {e}")))?;
         if policy_refresh.refresh.inventory_outcome != WorkspaceInventoryOutcome::Complete {
             let reason = if policy_refresh.refresh.inventory_outcome
@@ -14790,7 +14938,8 @@ fn run_incremental_indexing_common(
             let _ = forwarder.join();
             return Err(indexing_cancelled_error());
         }
-        let indexer = V2WorkspaceIndexer::new(root.to_path_buf());
+        let indexer = V2WorkspaceIndexer::new(root.to_path_buf())
+            .with_source_file_byte_cap(source_index_policy.byte_cap);
         let result = indexer.run(staged.store_mut(), &execution_plan, &bus, cancel_token);
 
         // Drop bus so forwarder unblocks.
@@ -14921,9 +15070,28 @@ fn run_incremental_indexing_common(
             "Failed to publish complete dense anchor inputs: {error}"
         )));
     }
-    if let Err(error) =
-        publish_source_policy_exclusions(staged.store_mut(), root, &publication, &policy_exclusions)
-    {
+    #[cfg(test)]
+    run_source_policy_before_revalidate_hook();
+    let workspace = WorkspaceManifest::open(root.to_path_buf())
+        .map_err(|error| ApiError::internal(format!("Failed to reopen project: {error}")))?;
+    let policy_exclusions = match revalidate_source_policy_exclusions(
+        &workspace,
+        &policy_exclusions,
+        source_index_policy,
+    ) {
+        Ok(exclusions) => exclusions,
+        Err(error) => {
+            let _ = staged.discard();
+            return Err(error);
+        }
+    };
+    if let Err(error) = publish_source_policy_exclusions(
+        staged.store_mut(),
+        root,
+        &publication,
+        &policy_exclusions,
+        source_index_policy,
+    ) {
         let _ = staged.discard();
         return Err(error);
     }
@@ -21844,6 +22012,11 @@ fn build_llm_symbol_doc_text() -> String {
             .get_connection()
             .execute("DELETE FROM source_policy_exclusion_publication", [])
             .expect("corrupt exclusion publication identity");
+        assert!(
+            controller
+                .complete_core_requires_publication_repair(&storage_path)
+                .expect("missing migrated manifest requires writer repair")
+        );
         let incomplete =
             index_freshness_from_storage(workspace.path(), &workspace_manifest, &storage);
         assert_eq!(incomplete.status, IndexFreshnessStatusDto::NotChecked);
@@ -21854,6 +22027,241 @@ fn build_llm_symbol_doc_text() -> String {
                 .is_some_and(|reason| reason.contains("source policy exclusion publication"))
         );
         assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    #[test]
+    fn full_refresh_revalidates_excluded_bytes_at_identity_fence_and_preserves_live_core() {
+        let _env = hybrid_test_env();
+        let workspace = copy_tictactoe_workspace();
+        let storage_path = workspace.path().join(".cache/codestory.db");
+        let source_path = workspace.path().join("rust_tictactoe.rs");
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish baseline core");
+        let baseline = Storage::open(&storage_path)
+            .expect("open baseline core")
+            .get_complete_index_publication()
+            .expect("read baseline publication")
+            .expect("baseline publication");
+        make_source_exceed_default_index_byte_cap(
+            &source_path,
+            "full refresh identity-fence drift fixture",
+        );
+        let changed_path = source_path.clone();
+        arm_source_policy_before_revalidate_hook(move || {
+            let mut bytes = fs::read(&changed_path).expect("read classified exclusion");
+            bytes.extend_from_slice(b"\n// changed after classification\n");
+            fs::write(&changed_path, bytes).expect("mutate classified exclusion");
+        });
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect_err("changed exclusion must reject full candidate");
+        assert_eq!(error.code, "source_verification_failed");
+        let live = Storage::open(&storage_path).expect("reopen preserved live core");
+        assert_eq!(
+            live.get_complete_index_publication()
+                .expect("read preserved publication"),
+            Some(baseline.clone())
+        );
+        let manifest = live
+            .validate_source_policy_exclusion_publication(
+                &baseline,
+                &project_identity_v3(workspace.path()).project_id,
+                &project_identity_v3(workspace.path()).workspace_id,
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+            )
+            .expect("baseline exclusion manifest remains valid");
+        assert_eq!(manifest.exclusion_count, 0);
+        assert!(
+            live.get_file_by_path(&source_path)
+                .expect("read preserved file projection")
+                .is_some()
+        );
+        assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    #[test]
+    fn incremental_refresh_revalidates_excluded_bytes_at_identity_fence_and_preserves_live_core() {
+        let _env = hybrid_test_env();
+        let workspace = copy_tictactoe_workspace();
+        let storage_path = workspace.path().join(".cache/codestory.db");
+        let source_path = workspace.path().join("rust_tictactoe.rs");
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish baseline core");
+        let baseline = Storage::open(&storage_path)
+            .expect("open baseline core")
+            .get_complete_index_publication()
+            .expect("read baseline publication")
+            .expect("baseline publication");
+        make_source_exceed_default_index_byte_cap(
+            &source_path,
+            "incremental identity-fence drift fixture",
+        );
+        let changed_path = source_path.clone();
+        arm_source_policy_before_revalidate_hook(move || {
+            let mut bytes = fs::read(&changed_path).expect("read classified exclusion");
+            bytes.extend_from_slice(b"\n// changed after classification\n");
+            fs::write(&changed_path, bytes).expect("mutate classified exclusion");
+        });
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect_err("changed exclusion must reject incremental candidate");
+        assert_eq!(error.code, "source_verification_failed");
+        let live = Storage::open(&storage_path).expect("reopen preserved live core");
+        assert_eq!(
+            live.get_complete_index_publication()
+                .expect("read preserved publication"),
+            Some(baseline.clone())
+        );
+        let manifest = live
+            .validate_source_policy_exclusion_publication(
+                &baseline,
+                &project_identity_v3(workspace.path()).project_id,
+                &project_identity_v3(workspace.path()).workspace_id,
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+            )
+            .expect("baseline exclusion manifest remains valid");
+        assert_eq!(manifest.exclusion_count, 0);
+        assert!(
+            live.get_file_by_path(&source_path)
+                .expect("read preserved file projection")
+                .is_some()
+        );
+        assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    #[test]
+    fn non_default_source_policy_cap_is_shared_by_planning_indexer_publication_and_readers() {
+        let _env = hybrid_test_env();
+        let workspace = tempdir().expect("workspace");
+        let large_path = workspace.path().join("large.rs");
+        fs::write(workspace.path().join("small.rs"), "pub fn small() {}\n")
+            .expect("write small source");
+        fs::write(
+            &large_path,
+            "// oversized\n// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n",
+        )
+        .expect("write policy source");
+        let policy = SourceIndexPolicy::oversized(64);
+        let manifest = WorkspaceManifest::open(workspace.path().to_path_buf()).expect("workspace");
+        let inventory = manifest
+            .source_inventory_with_policy(&policy)
+            .expect("classify with explicit policy");
+        assert_eq!(inventory.policy_exclusions.len(), 1);
+        assert_eq!(inventory.policy_exclusions[0].normalized_path, "large.rs");
+        assert_eq!(inventory.policy_exclusions[0].byte_cap, 64);
+
+        let mut fallback = Storage::new_in_memory().expect("fallback storage");
+        let fallback_plan = RefreshExecutionPlan {
+            mode: RefreshMode::FullRefresh,
+            files_to_index: vec![large_path.clone()],
+            files_to_remove: Vec::new(),
+            existing_file_ids: HashMap::new(),
+        };
+        V2WorkspaceIndexer::new(workspace.path().to_path_buf())
+            .with_source_file_byte_cap(policy.byte_cap)
+            .run(&mut fallback, &fallback_plan, &EventBus::new(), None)
+            .expect("indexer fallback records oversized coverage");
+        assert!(
+            fallback
+                .get_errors(None)
+                .expect("fallback errors")
+                .iter()
+                .any(|error| error.coverage_reason == Some(FileCoverageReason::Oversized)),
+            "the parser fallback must enforce the same 64-byte cap"
+        );
+
+        let storage_path = workspace.path().join(".cache/codestory.db");
+        let controller = AppController::new_with_source_index_policy(
+            test_sidecar_runtime_from_env(),
+            policy.clone(),
+        );
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish non-default policy core");
+        let storage = Storage::open(&storage_path).expect("open policy core");
+        let publication = storage
+            .get_complete_index_publication()
+            .expect("read policy publication")
+            .expect("complete policy publication");
+        let published = storage
+            .validate_source_policy_exclusion_publication(
+                &publication,
+                &project_identity_v3(workspace.path()).project_id,
+                &project_identity_v3(workspace.path()).workspace_id,
+                &policy.policy_version,
+                policy.byte_cap,
+            )
+            .expect("manifest uses the injected policy");
+        assert_eq!(published.byte_cap, 64);
+        assert_eq!(published.exclusion_count, 1);
+        let files = controller
+            .indexed_files(IndexedFilesRequest {
+                path_contains: Some("large.rs".into()),
+                language: None,
+                role: None,
+                limit: None,
+            })
+            .expect("matching policy reader accepts the manifest");
+        assert_eq!(files.policy_exclusions[0].byte_cap, 64);
+
+        for incompatible in [
+            SourceIndexPolicy::oversized(65),
+            SourceIndexPolicy {
+                policy_version: "oversized-source-v2".into(),
+                byte_cap: 64,
+            },
+        ] {
+            let reader = AppController::new_with_source_index_policy(
+                test_sidecar_runtime_from_env(),
+                incompatible,
+            );
+            reader
+                .open_project_summary_with_storage_path(
+                    workspace.path().to_path_buf(),
+                    storage_path.clone(),
+                )
+                .expect("bind incompatible reader");
+            assert!(
+                reader
+                    .complete_core_requires_publication_repair(&storage_path)
+                    .expect("inspect repair requirement")
+            );
+            let error = reader
+                .indexed_files(IndexedFilesRequest {
+                    path_contains: None,
+                    language: None,
+                    role: None,
+                    limit: None,
+                })
+                .expect_err("incompatible reader must fail closed");
+            assert_eq!(error.code, "source_verification_failed");
+        }
     }
 
     #[test]

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -565,7 +565,7 @@ impl ActivationService {
             || summary.stats.node_count == 0
             || self
                 .controller
-                .complete_core_requires_dense_anchor_repair(&storage_path)?
+                .complete_core_requires_publication_repair(&storage_path)?
             || summary
                 .freshness
                 .as_ref()
@@ -590,7 +590,7 @@ impl ActivationService {
             && summary.stats.fatal_error_count == 0
             && !self
                 .controller
-                .complete_core_requires_dense_anchor_repair(&storage_path)?
+                .complete_core_requires_publication_repair(&storage_path)?
             && summary
                 .freshness
                 .as_ref()

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -24,8 +24,10 @@ pub use storage_impl::{
     GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState, IndexPublicationMode,
     IndexPublicationRecord, LlmSymbolDoc, LlmSymbolDocReuseMetadata, LlmSymbolDocStats,
     ProjectionFlushBreakdown, RetrievalIndexManifest, RetrievalIndexRollbackRecord,
-    SearchSymbolProjection, SearchSymbolProjectionDetail, Storage as Store, StorageError,
-    StorageOpenMode, StorageStats, SymbolSearchDoc, SymbolSummaryRecord,
+    SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION, SearchSymbolProjection,
+    SearchSymbolProjectionDetail, SourcePolicyExclusionManifest, SourcePolicyExclusionRecord,
+    Storage as Store, StorageError, StorageOpenMode, StorageStats, SymbolSearchDoc,
+    SymbolSummaryRecord,
 };
 
 impl Store {

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -237,6 +237,19 @@ mod tests {
         root
     }
 
+    fn publish_empty_source_policy(store: &mut Store, publication: &crate::IndexPublicationRecord) {
+        store
+            .publish_source_policy_exclusion_generation(
+                publication,
+                "test-project",
+                "test-workspace",
+                codestory_contracts::workspace::OVERSIZED_SOURCE_POLICY_VERSION,
+                codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP,
+                &[],
+            )
+            .expect("publish empty source policy identity");
+    }
+
     #[test]
     fn snapshot_store_refresh_and_invalidate_cycle_is_visible_through_metadata() {
         let store = Store::new_in_memory().expect("in-memory store");
@@ -285,16 +298,18 @@ mod tests {
             .snapshots()
             .finalize_staged()
             .expect("prepare staged publish");
+        let publication = crate::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "prepared-generation".to_string(),
+            run_id: "prepared-run".to_string(),
+            mode: crate::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
         staged
             .store_mut()
-            .put_index_publication(&crate::IndexPublicationRecord {
-                generation: 1,
-                generation_id: "prepared-generation".to_string(),
-                run_id: "prepared-run".to_string(),
-                mode: crate::IndexPublicationMode::Full,
-                published_at_epoch_ms: 1,
-            })
+            .put_index_publication(&publication)
             .expect("identify staged publication");
+        publish_empty_source_policy(staged.store_mut(), &publication);
         staged.publish(&live_path).expect("promote staged snapshot");
 
         let live = Store::open(&live_path).expect("open live store");
@@ -434,14 +449,16 @@ mod tests {
                 },
             ])
             .expect("seed old generation");
-            live.put_index_publication(&crate::IndexPublicationRecord {
+            let publication = crate::IndexPublicationRecord {
                 generation: 1,
                 generation_id: "old-generation".to_string(),
                 run_id: "old-run".to_string(),
                 mode: crate::IndexPublicationMode::Full,
                 published_at_epoch_ms: 1,
-            })
-            .expect("identify old generation");
+            };
+            live.put_index_publication(&publication)
+                .expect("identify old generation");
+            publish_empty_source_policy(&mut live, &publication);
             live.snapshots()
                 .refresh_all()
                 .expect("finalize old snapshots");
@@ -491,16 +508,18 @@ mod tests {
             .snapshots()
             .refresh_all()
             .expect("finalize new snapshots");
+        let publication = crate::IndexPublicationRecord {
+            generation: 2,
+            generation_id: "new-generation".to_string(),
+            run_id: "new-run".to_string(),
+            mode: crate::IndexPublicationMode::Incremental,
+            published_at_epoch_ms: 2,
+        };
         staged
             .store_mut()
-            .put_index_publication(&crate::IndexPublicationRecord {
-                generation: 2,
-                generation_id: "new-generation".to_string(),
-                run_id: "new-run".to_string(),
-                mode: crate::IndexPublicationMode::Incremental,
-                published_at_epoch_ms: 2,
-            })
+            .put_index_publication(&publication)
             .expect("identify new generation");
+        publish_empty_source_policy(staged.store_mut(), &publication);
         let staged_path = staged.path().to_path_buf();
         let racing_live_path = live_path.clone();
         let (old_observed_tx, old_observed_rx) = mpsc::channel();

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -3,6 +3,7 @@ use codestory_contracts::graph::{
     EnumConversionError, FileCoverageReason, Node, NodeId, NodeKind, Occurrence, OccurrenceKind,
     ResolutionCertainty, TrailCallerScope, TrailConfig, TrailDirection, TrailMode, TrailResult,
 };
+use codestory_contracts::workspace::OversizedSourceExclusionCandidate;
 use fs4::fs_std::FileExt;
 use parking_lot::RwLock;
 use rusqlite::{
@@ -32,7 +33,7 @@ use helpers::{
     numbered_placeholders, question_placeholders, serialize_candidate_targets,
 };
 
-const SCHEMA_VERSION: u32 = 26;
+const SCHEMA_VERSION: u32 = 27;
 // Reserved outside the sequential migration range so a future real schema version cannot
 // accidentally be treated as an interrupted run from this release.
 const INCOMPLETE_INCREMENTAL_SCHEMA_VERSION: u32 = 0x4353_0001;
@@ -184,6 +185,127 @@ struct PromotionJournal {
     version: u32,
     previous: Option<IndexPublicationRecord>,
     candidate: IndexPublicationRecord,
+    #[serde(default)]
+    previous_source_policy: Option<SourcePolicyExclusionRollbackIdentity>,
+    #[serde(default)]
+    candidate_source_policy: Option<SourcePolicyExclusionRollbackIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SourcePolicyExclusionRollbackIdentity {
+    project_id: String,
+    workspace_id: String,
+    core_generation_id: String,
+    core_run_id: String,
+    exclusion_count: u64,
+    exclusion_digest: String,
+    policy_version: String,
+    byte_cap: u64,
+}
+
+fn read_source_policy_exclusion_rollback_identity(
+    path: &Path,
+    publication: &IndexPublicationRecord,
+) -> Result<Option<SourcePolicyExclusionRollbackIdentity>, StorageError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let table_exists: i64 = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master
+            WHERE type = 'table' AND name = 'source_policy_exclusion_publication'
+        )",
+        [],
+        |row| row.get(0),
+    )?;
+    if table_exists == 0 {
+        return Ok(None);
+    }
+    let identity = conn
+        .query_row(
+            "SELECT project_id, workspace_id, core_generation_id, core_run_id,
+                    exclusion_count, exclusion_digest, policy_version, byte_cap
+             FROM source_policy_exclusion_publication
+             WHERE id = 1 AND complete = 1 AND schema_version = ?1",
+            params![SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION as i64],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, i64>(7)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((
+        project_id,
+        workspace_id,
+        core_generation_id,
+        core_run_id,
+        exclusion_count,
+        exclusion_digest,
+        policy_version,
+        byte_cap,
+    )) = identity
+    else {
+        return Ok(None);
+    };
+    let identity = SourcePolicyExclusionRollbackIdentity {
+        project_id,
+        workspace_id,
+        core_generation_id,
+        core_run_id,
+        exclusion_count: u64::try_from(exclusion_count)
+            .map_err(|_| promotion_error("Source policy exclusion rollback count is invalid"))?,
+        exclusion_digest,
+        policy_version,
+        byte_cap: u64::try_from(byte_cap)
+            .map_err(|_| promotion_error("Source policy exclusion rollback cap is invalid"))?,
+    };
+    let records = read_source_policy_exclusions(&conn)?;
+    if identity.core_generation_id != publication.generation_id
+        || identity.core_run_id != publication.run_id
+        || identity.exclusion_count != records.len() as u64
+        || identity.exclusion_digest != source_policy_exclusion_digest(&records)
+        || records.iter().any(|record| {
+            record.project_id != identity.project_id
+                || record.workspace_id != identity.workspace_id
+                || record.core_generation_id != identity.core_generation_id
+                || record.core_run_id != identity.core_run_id
+                || record.policy_version != identity.policy_version
+                || record.byte_cap != identity.byte_cap
+        })
+    {
+        return Err(promotion_error(format!(
+            "Source policy exclusion rollback identity does not match {}",
+            path.display()
+        )));
+    }
+    Ok(Some(identity))
+}
+
+fn require_recorded_source_policy_identity(
+    path: &Path,
+    publication: &IndexPublicationRecord,
+    expected: &Option<SourcePolicyExclusionRollbackIdentity>,
+    role: &str,
+) -> Result<(), StorageError> {
+    if expected.is_none() {
+        return Ok(());
+    }
+    if &read_source_policy_exclusion_rollback_identity(path, publication)? != expected {
+        return Err(promotion_error(format!(
+            "{role} source policy exclusion identity does not match {}",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 fn promotion_lock_path(path: &Path) -> PathBuf {
@@ -480,6 +602,12 @@ fn recover_interrupted_promotion_locked(path: &Path) -> Result<(), StorageError>
                 path.display()
             )));
         }
+        require_recorded_source_policy_identity(
+            path,
+            &live_identity,
+            &committed.candidate_source_policy,
+            "Committed live database",
+        )?;
         if let Err(error) = cleanup_committed_promotion_artifacts(path) {
             tracing::warn!(
                 live_path = %path.display(),
@@ -524,6 +652,23 @@ fn rollback_prepared_promotion(
             live_path.display()
         )));
     }
+    if let Some(live_identity) = live_identity.as_ref() {
+        if live_identity == &prepared.candidate {
+            require_recorded_source_policy_identity(
+                live_path,
+                live_identity,
+                &prepared.candidate_source_policy,
+                "Prepared candidate",
+            )?;
+        } else if prepared.previous.as_ref() == Some(live_identity) {
+            require_recorded_source_policy_identity(
+                live_path,
+                live_identity,
+                &prepared.previous_source_policy,
+                "Prepared previous live database",
+            )?;
+        }
+    }
 
     match prepared.previous.as_ref() {
         Some(expected_previous) => {
@@ -535,6 +680,12 @@ fn rollback_prepared_promotion(
                     live_path.display()
                 )));
             }
+            require_recorded_source_policy_identity(
+                &backup_path,
+                &backup_identity,
+                &prepared.previous_source_policy,
+                "Prepared recovery backup",
+            )?;
             if live_identity.as_ref() != Some(expected_previous) {
                 restore_promotion_database(&backup_path, live_path)?;
             }
@@ -545,6 +696,12 @@ fn rollback_prepared_promotion(
                     live_path.display()
                 )));
             }
+            require_recorded_source_policy_identity(
+                live_path,
+                &restored,
+                &prepared.previous_source_policy,
+                "Restored live database",
+            )?;
             remove_promotion_file(&prepared_path)?;
             cleanup_sqlite_sidecars(&backup_path)
         }
@@ -1593,6 +1750,113 @@ fn dense_anchor_content_summary(
         count = count.saturating_add(1);
     }
     Ok((count, format!("{:x}", hasher.finalize()), policies))
+}
+
+pub const SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION: u32 = 1;
+const SOURCE_POLICY_EXCLUSION_DIGEST_DOMAIN: &[u8] =
+    b"codestory-source-policy-exclusion-publication-v1\0";
+
+/// One verified source excluded from parser scheduling by an explicit policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourcePolicyExclusionRecord {
+    pub normalized_path: String,
+    pub project_id: String,
+    pub workspace_id: String,
+    pub content_hash: String,
+    pub observed_size: u64,
+    pub policy_version: String,
+    pub byte_cap: u64,
+    pub core_generation_id: String,
+    pub core_run_id: String,
+}
+
+/// Complete exclusion set published with one core generation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourcePolicyExclusionManifest {
+    pub schema_version: u32,
+    pub complete: bool,
+    pub project_id: String,
+    pub workspace_id: String,
+    pub core_generation_id: String,
+    pub core_run_id: String,
+    pub exclusion_count: u64,
+    pub exclusion_digest: String,
+    pub policy_version: String,
+    pub byte_cap: u64,
+    pub published_at_epoch_ms: i64,
+}
+
+fn source_policy_exclusion_digest(records: &[SourcePolicyExclusionRecord]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(SOURCE_POLICY_EXCLUSION_DIGEST_DOMAIN);
+    for record in records {
+        for value in [
+            record.normalized_path.as_bytes(),
+            record.project_id.as_bytes(),
+            record.workspace_id.as_bytes(),
+            record.content_hash.as_bytes(),
+            record.policy_version.as_bytes(),
+            record.core_generation_id.as_bytes(),
+            record.core_run_id.as_bytes(),
+        ] {
+            hash_dense_anchor_part(&mut hasher, value);
+        }
+        hash_dense_anchor_part(&mut hasher, &record.observed_size.to_le_bytes());
+        hash_dense_anchor_part(&mut hasher, &record.byte_cap.to_le_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn read_source_policy_exclusions(
+    conn: &Connection,
+) -> Result<Vec<SourcePolicyExclusionRecord>, StorageError> {
+    let mut stmt = conn.prepare(
+        "SELECT normalized_path, project_id, workspace_id, content_hash,
+                observed_size, policy_version, byte_cap, core_generation_id, core_run_id
+         FROM source_policy_exclusion ORDER BY normalized_path ASC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, String>(5)?,
+            row.get::<_, i64>(6)?,
+            row.get::<_, String>(7)?,
+            row.get::<_, String>(8)?,
+        ))
+    })?;
+    rows.map(|row| {
+        let (
+            normalized_path,
+            project_id,
+            workspace_id,
+            content_hash,
+            observed_size,
+            policy_version,
+            byte_cap,
+            core_generation_id,
+            core_run_id,
+        ) = row?;
+        Ok(SourcePolicyExclusionRecord {
+            normalized_path,
+            project_id,
+            workspace_id,
+            content_hash,
+            observed_size: u64::try_from(observed_size).map_err(|_| {
+                StorageError::Other("source policy exclusion has invalid observed size".into())
+            })?,
+            policy_version,
+            byte_cap: u64::try_from(byte_cap).map_err(|_| {
+                StorageError::Other("source policy exclusion has invalid byte cap".into())
+            })?,
+            core_generation_id,
+            core_run_id,
+        })
+    })
+    .collect()
 }
 
 /// Graph-native symbol-search document used by retrieval sidecars.
@@ -2724,6 +2988,8 @@ impl Storage {
         tx.execute("DELETE FROM llm_symbol_doc", [])?;
         tx.execute("DELETE FROM dense_anchor_input", [])?;
         tx.execute("DELETE FROM dense_anchor_publication", [])?;
+        tx.execute("DELETE FROM source_policy_exclusion_publication", [])?;
+        tx.execute("DELETE FROM source_policy_exclusion", [])?;
         tx.execute("DELETE FROM symbol_search_doc", [])?;
         tx.execute("DELETE FROM symbol_summary", [])?;
         tx.execute("DELETE FROM search_symbol_projection", [])?;
@@ -2976,7 +3242,13 @@ impl Storage {
             staged_path,
             "Staged promotion candidate",
         )?;
+        let candidate_source_policy =
+            read_source_policy_exclusion_rollback_identity(staged_path, &candidate)?;
         let previous = read_recovery_database_identity(live_path)?;
+        let previous_source_policy = match previous.as_ref() {
+            Some(previous) => read_source_policy_exclusion_rollback_identity(live_path, previous)?,
+            None => None,
+        };
         cleanup_sqlite_sidecars(&backup_path)?;
 
         if previous.is_some() {
@@ -2996,12 +3268,20 @@ impl Storage {
                     live_path.display()
                 )));
             }
+            require_recorded_source_policy_identity(
+                &backup_path,
+                &backup_identity,
+                &previous_source_policy,
+                "Promotion backup",
+            )?;
         }
 
         let prepared = PromotionJournal {
             version: PROMOTION_JOURNAL_VERSION,
             previous: previous.clone(),
             candidate: candidate.clone(),
+            previous_source_policy,
+            candidate_source_policy: candidate_source_policy.clone(),
         };
         if let Err(error) = write_promotion_journal(&prepared_path, &prepared) {
             if !prepared_path.exists() {
@@ -3056,6 +3336,15 @@ impl Storage {
                 "Promoted live database identity does not match staged candidate {}",
                 staged_path.display()
             )));
+        }
+        if let Err(error) = require_recorded_source_policy_identity(
+            live_path,
+            &published,
+            &candidate_source_policy,
+            "Promoted live database",
+        ) {
+            let _ = rollback_prepared_promotion(live_path, &prepared);
+            return Err(error);
         }
 
         if let Err(error) = commit_promotion_journal(&prepared_path, &committed_path) {
@@ -4532,6 +4821,255 @@ impl Storage {
             )
             .optional()
             .map_err(Into::into)
+    }
+
+    pub fn get_source_policy_exclusions(
+        &self,
+    ) -> Result<Vec<SourcePolicyExclusionRecord>, StorageError> {
+        read_source_policy_exclusions(&self.conn)
+    }
+
+    pub fn get_source_policy_exclusion_manifest(
+        &self,
+    ) -> Result<Option<SourcePolicyExclusionManifest>, StorageError> {
+        self.conn
+            .query_row(
+                "SELECT schema_version, complete, project_id, workspace_id,
+                        core_generation_id, core_run_id, exclusion_count,
+                        exclusion_digest, policy_version, byte_cap, published_at_epoch_ms
+                 FROM source_policy_exclusion_publication WHERE id = 1",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, i64>(6)?,
+                        row.get::<_, String>(7)?,
+                        row.get::<_, String>(8)?,
+                        row.get::<_, i64>(9)?,
+                        row.get::<_, i64>(10)?,
+                    ))
+                },
+            )
+            .optional()?
+            .map(
+                |(
+                    schema_version,
+                    complete,
+                    project_id,
+                    workspace_id,
+                    core_generation_id,
+                    core_run_id,
+                    exclusion_count,
+                    exclusion_digest,
+                    policy_version,
+                    byte_cap,
+                    published_at_epoch_ms,
+                )| {
+                    Ok(SourcePolicyExclusionManifest {
+                        schema_version: u32::try_from(schema_version).map_err(|_| {
+                            StorageError::Other(
+                                "source policy exclusion manifest has invalid schema".into(),
+                            )
+                        })?,
+                        complete: complete == 1,
+                        project_id,
+                        workspace_id,
+                        core_generation_id,
+                        core_run_id,
+                        exclusion_count: u64::try_from(exclusion_count).map_err(|_| {
+                            StorageError::Other(
+                                "source policy exclusion manifest has invalid count".into(),
+                            )
+                        })?,
+                        exclusion_digest,
+                        policy_version,
+                        byte_cap: u64::try_from(byte_cap).map_err(|_| {
+                            StorageError::Other(
+                                "source policy exclusion manifest has invalid byte cap".into(),
+                            )
+                        })?,
+                        published_at_epoch_ms,
+                    })
+                },
+            )
+            .transpose()
+    }
+
+    /// Atomically replace and publish the complete policy-exclusion set in the staged core.
+    pub fn publish_source_policy_exclusion_generation(
+        &mut self,
+        publication: &IndexPublicationRecord,
+        project_id: &str,
+        workspace_id: &str,
+        policy_version: &str,
+        byte_cap: u64,
+        candidates: &[OversizedSourceExclusionCandidate],
+    ) -> Result<SourcePolicyExclusionManifest, StorageError> {
+        if publication.generation_id.trim().is_empty()
+            || publication.run_id.trim().is_empty()
+            || project_id.trim().is_empty()
+            || workspace_id.trim().is_empty()
+            || policy_version.trim().is_empty()
+            || byte_cap == 0
+            || byte_cap > i64::MAX as u64
+        {
+            return Err(StorageError::Other(
+                "source policy exclusion publication identity is invalid".into(),
+            ));
+        }
+        let mut candidates = candidates.to_vec();
+        candidates.sort_by(|left, right| left.normalized_path.cmp(&right.normalized_path));
+        let mut records = Vec::with_capacity(candidates.len());
+        let mut previous_path: Option<&str> = None;
+        for candidate in &candidates {
+            let path = candidate.normalized_path.as_str();
+            if path.trim().is_empty()
+                || path.starts_with('/')
+                || path.contains('\\')
+                || path
+                    .split('/')
+                    .any(|component| component.is_empty() || component == "..")
+                || previous_path == Some(path)
+                || candidate.content_hash.len() != 64
+                || !candidate
+                    .content_hash
+                    .bytes()
+                    .all(|value| value.is_ascii_hexdigit())
+                || candidate.observed_size <= byte_cap
+                || candidate.observed_size > i64::MAX as u64
+                || candidate.policy_version != policy_version
+                || candidate.byte_cap != byte_cap
+            {
+                return Err(StorageError::Other(format!(
+                    "invalid source policy exclusion candidate: {path}"
+                )));
+            }
+            previous_path = Some(path);
+            records.push(SourcePolicyExclusionRecord {
+                normalized_path: candidate.normalized_path.clone(),
+                project_id: project_id.to_string(),
+                workspace_id: workspace_id.to_string(),
+                content_hash: candidate.content_hash.clone(),
+                observed_size: candidate.observed_size,
+                policy_version: candidate.policy_version.clone(),
+                byte_cap: candidate.byte_cap,
+                core_generation_id: publication.generation_id.clone(),
+                core_run_id: publication.run_id.clone(),
+            });
+        }
+
+        let exclusion_digest = source_policy_exclusion_digest(&records);
+        let manifest = SourcePolicyExclusionManifest {
+            schema_version: SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION,
+            complete: true,
+            project_id: project_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            core_generation_id: publication.generation_id.clone(),
+            core_run_id: publication.run_id.clone(),
+            exclusion_count: records.len() as u64,
+            exclusion_digest,
+            policy_version: policy_version.to_string(),
+            byte_cap,
+            published_at_epoch_ms: publication.published_at_epoch_ms,
+        };
+        let tx = self.conn.transaction()?;
+        tx.execute("DELETE FROM source_policy_exclusion_publication", [])?;
+        tx.execute("DELETE FROM source_policy_exclusion", [])?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO source_policy_exclusion (
+                    normalized_path, project_id, workspace_id, content_hash,
+                    observed_size, policy_version, byte_cap, core_generation_id, core_run_id
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            )?;
+            for record in &records {
+                stmt.execute(params![
+                    &record.normalized_path,
+                    &record.project_id,
+                    &record.workspace_id,
+                    &record.content_hash,
+                    record.observed_size as i64,
+                    &record.policy_version,
+                    record.byte_cap as i64,
+                    &record.core_generation_id,
+                    &record.core_run_id,
+                ])?;
+            }
+        }
+        tx.execute(
+            "INSERT INTO source_policy_exclusion_publication (
+                id, schema_version, complete, project_id, workspace_id,
+                core_generation_id, core_run_id, exclusion_count, exclusion_digest,
+                policy_version, byte_cap, published_at_epoch_ms
+             ) VALUES (1, ?1, 1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                manifest.schema_version as i64,
+                &manifest.project_id,
+                &manifest.workspace_id,
+                &manifest.core_generation_id,
+                &manifest.core_run_id,
+                manifest.exclusion_count as i64,
+                &manifest.exclusion_digest,
+                &manifest.policy_version,
+                manifest.byte_cap as i64,
+                manifest.published_at_epoch_ms,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(manifest)
+    }
+
+    pub fn validate_source_policy_exclusion_publication(
+        &self,
+        publication: &IndexPublicationRecord,
+        project_id: &str,
+        workspace_id: &str,
+        policy_version: &str,
+        byte_cap: u64,
+    ) -> Result<SourcePolicyExclusionManifest, StorageError> {
+        let manifest = self
+            .get_source_policy_exclusion_manifest()?
+            .ok_or_else(|| {
+                StorageError::Other("source policy exclusion manifest is missing".into())
+            })?;
+        if manifest.schema_version != SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION
+            || !manifest.complete
+            || manifest.project_id != project_id
+            || manifest.workspace_id != workspace_id
+            || manifest.core_generation_id != publication.generation_id
+            || manifest.core_run_id != publication.run_id
+            || manifest.policy_version != policy_version
+            || manifest.byte_cap != byte_cap
+            || manifest.published_at_epoch_ms != publication.published_at_epoch_ms
+        {
+            return Err(StorageError::Other(
+                "source policy exclusion manifest does not match the complete core publication"
+                    .into(),
+            ));
+        }
+        let records = read_source_policy_exclusions(&self.conn)?;
+        if manifest.exclusion_count != records.len() as u64
+            || manifest.exclusion_digest != source_policy_exclusion_digest(&records)
+            || records.iter().any(|record| {
+                record.project_id != manifest.project_id
+                    || record.workspace_id != manifest.workspace_id
+                    || record.core_generation_id != manifest.core_generation_id
+                    || record.core_run_id != manifest.core_run_id
+                    || record.policy_version != manifest.policy_version
+                    || record.byte_cap != manifest.byte_cap
+                    || record.observed_size <= record.byte_cap
+            })
+        {
+            return Err(StorageError::Other(
+                "source policy exclusion rows do not match their complete manifest".into(),
+            ));
+        }
+        Ok(manifest)
     }
 
     /// Rebind every carried-forward row and atomically publish its complete manifest.

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -4,6 +4,10 @@ use codestory_contracts::graph::{
     ResolutionCertainty, TrailCallerScope, TrailConfig, TrailDirection, TrailMode, TrailResult,
 };
 use codestory_contracts::workspace::OversizedSourceExclusionCandidate;
+#[cfg(test)]
+use codestory_contracts::workspace::{
+    DEFAULT_SOURCE_FILE_BYTE_CAP, OVERSIZED_SOURCE_POLICY_VERSION,
+};
 use fs4::fs_std::FileExt;
 use parking_lot::RwLock;
 use rusqlite::{
@@ -57,7 +61,8 @@ const OCCURRENCE_LOOKUP_BATCH_SIZE: usize = 200;
 const PROMOTION_ABORT_SENTINEL_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_SENTINEL";
 #[cfg(test)]
 const PROMOTION_ABORT_SENTINEL: &[u8] = b"after-live-restore-step\n";
-const PROMOTION_JOURNAL_VERSION: u32 = 1;
+const LEGACY_PROMOTION_JOURNAL_VERSION: u32 = 1;
+const PROMOTION_JOURNAL_VERSION: u32 = 2;
 
 fn clamp_i64_to_u32(value: i64) -> u32 {
     if value <= 0 {
@@ -197,6 +202,7 @@ struct SourcePolicyExclusionRollbackIdentity {
     workspace_id: String,
     core_generation_id: String,
     core_run_id: String,
+    core_published_at_epoch_ms: i64,
     exclusion_count: u64,
     exclusion_digest: String,
     policy_version: String,
@@ -225,7 +231,8 @@ fn read_source_policy_exclusion_rollback_identity(
     let identity = conn
         .query_row(
             "SELECT project_id, workspace_id, core_generation_id, core_run_id,
-                    exclusion_count, exclusion_digest, policy_version, byte_cap
+                    published_at_epoch_ms, exclusion_count, exclusion_digest,
+                    policy_version, byte_cap
              FROM source_policy_exclusion_publication
              WHERE id = 1 AND complete = 1 AND schema_version = ?1",
             params![SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION as i64],
@@ -236,9 +243,10 @@ fn read_source_policy_exclusion_rollback_identity(
                     row.get::<_, String>(2)?,
                     row.get::<_, String>(3)?,
                     row.get::<_, i64>(4)?,
-                    row.get::<_, String>(5)?,
+                    row.get::<_, i64>(5)?,
                     row.get::<_, String>(6)?,
-                    row.get::<_, i64>(7)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, i64>(8)?,
                 ))
             },
         )
@@ -248,6 +256,7 @@ fn read_source_policy_exclusion_rollback_identity(
         workspace_id,
         core_generation_id,
         core_run_id,
+        core_published_at_epoch_ms,
         exclusion_count,
         exclusion_digest,
         policy_version,
@@ -261,6 +270,7 @@ fn read_source_policy_exclusion_rollback_identity(
         workspace_id,
         core_generation_id,
         core_run_id,
+        core_published_at_epoch_ms,
         exclusion_count: u64::try_from(exclusion_count)
             .map_err(|_| promotion_error("Source policy exclusion rollback count is invalid"))?,
         exclusion_digest,
@@ -271,6 +281,7 @@ fn read_source_policy_exclusion_rollback_identity(
     let records = read_source_policy_exclusions(&conn)?;
     if identity.core_generation_id != publication.generation_id
         || identity.core_run_id != publication.run_id
+        || identity.core_published_at_epoch_ms != publication.published_at_epoch_ms
         || identity.exclusion_count != records.len() as u64
         || identity.exclusion_digest != source_policy_exclusion_digest(&records)
         || records.iter().any(|record| {
@@ -306,6 +317,21 @@ fn require_recorded_source_policy_identity(
         )));
     }
     Ok(())
+}
+
+fn require_candidate_source_policy_identity(
+    path: &Path,
+    publication: &IndexPublicationRecord,
+    expected: &Option<SourcePolicyExclusionRollbackIdentity>,
+    role: &str,
+) -> Result<(), StorageError> {
+    if expected.is_none() {
+        return Err(promotion_error(format!(
+            "{role} source policy exclusion manifest is missing for {}",
+            path.display()
+        )));
+    }
+    require_recorded_source_policy_identity(path, publication, expected, role)
 }
 
 fn promotion_lock_path(path: &Path) -> PathBuf {
@@ -445,7 +471,10 @@ fn read_promotion_journal(path: &Path) -> Result<PromotionJournal, StorageError>
     let bytes = fs::read(path).map_err(|error| promotion_path_error("read", path, error))?;
     let journal: PromotionJournal = serde_json::from_slice(&bytes)
         .map_err(|error| promotion_path_error("parse", path, error))?;
-    if journal.version != PROMOTION_JOURNAL_VERSION {
+    if !matches!(
+        journal.version,
+        LEGACY_PROMOTION_JOURNAL_VERSION | PROMOTION_JOURNAL_VERSION
+    ) {
         return Err(promotion_error(format!(
             "Unsupported promotion journal {}: version={}",
             path.display(),
@@ -602,12 +631,21 @@ fn recover_interrupted_promotion_locked(path: &Path) -> Result<(), StorageError>
                 path.display()
             )));
         }
-        require_recorded_source_policy_identity(
-            path,
-            &live_identity,
-            &committed.candidate_source_policy,
-            "Committed live database",
-        )?;
+        if committed.version >= PROMOTION_JOURNAL_VERSION {
+            require_candidate_source_policy_identity(
+                path,
+                &live_identity,
+                &committed.candidate_source_policy,
+                "Committed live database",
+            )?;
+        } else {
+            require_recorded_source_policy_identity(
+                path,
+                &live_identity,
+                &committed.candidate_source_policy,
+                "Legacy committed live database",
+            )?;
+        }
         if let Err(error) = cleanup_committed_promotion_artifacts(path) {
             tracing::warn!(
                 live_path = %path.display(),
@@ -640,6 +678,12 @@ fn rollback_prepared_promotion(
     live_path: &Path,
     prepared: &PromotionJournal,
 ) -> Result<(), StorageError> {
+    if prepared.version >= PROMOTION_JOURNAL_VERSION && prepared.candidate_source_policy.is_none() {
+        return Err(promotion_error(format!(
+            "Prepared promotion candidate source policy identity is missing for {}",
+            live_path.display()
+        )));
+    }
     let backup_path = live_path.with_extension("sqlite.backup");
     let prepared_path = promotion_prepared_journal_path(live_path);
     let live_identity = read_recovery_database_identity(live_path)?;
@@ -654,12 +698,14 @@ fn rollback_prepared_promotion(
     }
     if let Some(live_identity) = live_identity.as_ref() {
         if live_identity == &prepared.candidate {
-            require_recorded_source_policy_identity(
-                live_path,
-                live_identity,
-                &prepared.candidate_source_policy,
-                "Prepared candidate",
-            )?;
+            if prepared.candidate_source_policy.is_some() {
+                require_candidate_source_policy_identity(
+                    live_path,
+                    live_identity,
+                    &prepared.candidate_source_policy,
+                    "Prepared candidate",
+                )?;
+            }
         } else if prepared.previous.as_ref() == Some(live_identity) {
             require_recorded_source_policy_identity(
                 live_path,
@@ -3244,6 +3290,12 @@ impl Storage {
         )?;
         let candidate_source_policy =
             read_source_policy_exclusion_rollback_identity(staged_path, &candidate)?;
+        if candidate_source_policy.is_none() {
+            return Err(promotion_error(format!(
+                "Staged promotion candidate {} has no complete source policy exclusion manifest",
+                staged_path.display()
+            )));
+        }
         let previous = read_recovery_database_identity(live_path)?;
         let previous_source_policy = match previous.as_ref() {
             Some(previous) => read_source_policy_exclusion_rollback_identity(live_path, previous)?,
@@ -3337,7 +3389,7 @@ impl Storage {
                 staged_path.display()
             )));
         }
-        if let Err(error) = require_recorded_source_policy_identity(
+        if let Err(error) = require_candidate_source_policy_identity(
             live_path,
             &published,
             &candidate_source_policy,

--- a/crates/codestory-store/src/storage_impl/schema.rs
+++ b/crates/codestory-store/src/storage_impl/schema.rs
@@ -154,6 +154,31 @@ const TABLE_STATEMENTS: &[&str] = &[
         migration_state TEXT NOT NULL CHECK(length(migration_state) > 0),
         published_at_epoch_ms INTEGER NOT NULL CHECK(published_at_epoch_ms >= 0)
     )",
+    "CREATE TABLE IF NOT EXISTS source_policy_exclusion (
+        normalized_path TEXT PRIMARY KEY CHECK(length(normalized_path) > 0),
+        project_id TEXT NOT NULL CHECK(length(project_id) > 0),
+        workspace_id TEXT NOT NULL CHECK(length(workspace_id) > 0),
+        content_hash TEXT NOT NULL CHECK(length(content_hash) = 64),
+        observed_size INTEGER NOT NULL CHECK(observed_size > 0),
+        policy_version TEXT NOT NULL CHECK(length(policy_version) > 0),
+        byte_cap INTEGER NOT NULL CHECK(byte_cap > 0),
+        core_generation_id TEXT NOT NULL CHECK(length(core_generation_id) > 0),
+        core_run_id TEXT NOT NULL CHECK(length(core_run_id) > 0)
+    )",
+    "CREATE TABLE IF NOT EXISTS source_policy_exclusion_publication (
+        id INTEGER PRIMARY KEY CHECK(id = 1),
+        schema_version INTEGER NOT NULL,
+        complete INTEGER NOT NULL CHECK(complete = 1),
+        project_id TEXT NOT NULL CHECK(length(project_id) > 0),
+        workspace_id TEXT NOT NULL CHECK(length(workspace_id) > 0),
+        core_generation_id TEXT NOT NULL CHECK(length(core_generation_id) > 0),
+        core_run_id TEXT NOT NULL CHECK(length(core_run_id) > 0),
+        exclusion_count INTEGER NOT NULL CHECK(exclusion_count >= 0),
+        exclusion_digest TEXT NOT NULL CHECK(length(exclusion_digest) = 64),
+        policy_version TEXT NOT NULL CHECK(length(policy_version) > 0),
+        byte_cap INTEGER NOT NULL CHECK(byte_cap > 0),
+        published_at_epoch_ms INTEGER NOT NULL CHECK(published_at_epoch_ms >= 0)
+    )",
     "CREATE TABLE IF NOT EXISTS symbol_search_doc (
         node_id INTEGER PRIMARY KEY,
         file_node_id INTEGER,
@@ -522,6 +547,10 @@ pub(super) fn apply_schema_migrations(storage: &Storage) -> Result<(), StorageEr
     if stored_version < 26 {
         storage.set_schema_version(26)?;
     }
+    migrate_v27_source_policy_exclusions(&storage.conn)?;
+    if stored_version < 27 {
+        storage.set_schema_version(27)?;
+    }
     create_llm_symbol_doc_reuse_index(&storage.conn)?;
     create_symbol_summary_indexes(&storage.conn)?;
 
@@ -856,6 +885,41 @@ pub(super) fn migrate_v25_retrieval_rollback(conn: &Connection) -> Result<(), St
 
 pub(super) fn migrate_v26_error_coverage_reason(conn: &Connection) -> Result<(), StorageError> {
     try_add_column(conn, "error", "coverage_reason TEXT")
+}
+
+pub(super) fn migrate_v27_source_policy_exclusions(conn: &Connection) -> Result<(), StorageError> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS source_policy_exclusion (
+            normalized_path TEXT PRIMARY KEY CHECK(length(normalized_path) > 0),
+            project_id TEXT NOT NULL CHECK(length(project_id) > 0),
+            workspace_id TEXT NOT NULL CHECK(length(workspace_id) > 0),
+            content_hash TEXT NOT NULL CHECK(length(content_hash) = 64),
+            observed_size INTEGER NOT NULL CHECK(observed_size > 0),
+            policy_version TEXT NOT NULL CHECK(length(policy_version) > 0),
+            byte_cap INTEGER NOT NULL CHECK(byte_cap > 0),
+            core_generation_id TEXT NOT NULL CHECK(length(core_generation_id) > 0),
+            core_run_id TEXT NOT NULL CHECK(length(core_run_id) > 0)
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS source_policy_exclusion_publication (
+            id INTEGER PRIMARY KEY CHECK(id = 1),
+            schema_version INTEGER NOT NULL,
+            complete INTEGER NOT NULL CHECK(complete = 1),
+            project_id TEXT NOT NULL CHECK(length(project_id) > 0),
+            workspace_id TEXT NOT NULL CHECK(length(workspace_id) > 0),
+            core_generation_id TEXT NOT NULL CHECK(length(core_generation_id) > 0),
+            core_run_id TEXT NOT NULL CHECK(length(core_run_id) > 0),
+            exclusion_count INTEGER NOT NULL CHECK(exclusion_count >= 0),
+            exclusion_digest TEXT NOT NULL CHECK(length(exclusion_digest) = 64),
+            policy_version TEXT NOT NULL CHECK(length(policy_version) > 0),
+            byte_cap INTEGER NOT NULL CHECK(byte_cap > 0),
+            published_at_epoch_ms INTEGER NOT NULL CHECK(published_at_epoch_ms >= 0)
+        )",
+        [],
+    )?;
+    Ok(())
 }
 
 fn create_symbol_summary_indexes(conn: &Connection) -> Result<(), StorageError> {

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -712,6 +712,149 @@ fn index_publication_identity_round_trips_through_typed_and_read_only_reads()
 }
 
 #[test]
+fn source_policy_exclusion_publication_binds_complete_rows_to_core_identity()
+-> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    let publication = IndexPublicationRecord {
+        generation: 4,
+        generation_id: "generation-4".into(),
+        run_id: "run-4".into(),
+        mode: IndexPublicationMode::Full,
+        published_at_epoch_ms: 44,
+    };
+    let candidates = vec![
+        OversizedSourceExclusionCandidate {
+            normalized_path: "src/generated/registers.h".into(),
+            content_hash: "a".repeat(64),
+            observed_size: 4_000_000,
+            policy_version: "oversized-source-v1".into(),
+            byte_cap: 1_000_000,
+        },
+        OversizedSourceExclusionCandidate {
+            normalized_path: "vendor/ordinary.rs".into(),
+            content_hash: "b".repeat(64),
+            observed_size: 1_000_001,
+            policy_version: "oversized-source-v1".into(),
+            byte_cap: 1_000_000,
+        },
+    ];
+
+    let manifest = storage.publish_source_policy_exclusion_generation(
+        &publication,
+        "project-4",
+        "workspace-4",
+        "oversized-source-v1",
+        1_000_000,
+        &candidates,
+    )?;
+    assert_eq!(manifest.exclusion_count, 2);
+    assert_eq!(manifest.exclusion_digest.len(), 64);
+    assert_eq!(storage.get_source_policy_exclusions()?.len(), 2);
+    assert_eq!(
+        storage.validate_source_policy_exclusion_publication(
+            &publication,
+            "project-4",
+            "workspace-4",
+            "oversized-source-v1",
+            1_000_000,
+        )?,
+        manifest
+    );
+
+    storage.conn.execute(
+        "UPDATE source_policy_exclusion SET content_hash = ?1 WHERE normalized_path = ?2",
+        params!["c".repeat(64), "vendor/ordinary.rs"],
+    )?;
+    assert!(
+        storage
+            .validate_source_policy_exclusion_publication(
+                &publication,
+                "project-4",
+                "workspace-4",
+                "oversized-source-v1",
+                1_000_000,
+            )
+            .is_err()
+    );
+    Ok(())
+}
+
+#[test]
+fn source_policy_exclusion_transaction_failure_preserves_previous_manifest()
+-> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    let first_publication = IndexPublicationRecord {
+        generation: 1,
+        generation_id: "generation-1".into(),
+        run_id: "run-1".into(),
+        mode: IndexPublicationMode::Full,
+        published_at_epoch_ms: 11,
+    };
+    let first = vec![OversizedSourceExclusionCandidate {
+        normalized_path: "vendor/first.h".into(),
+        content_hash: "a".repeat(64),
+        observed_size: 2_000_000,
+        policy_version: "oversized-source-v1".into(),
+        byte_cap: 1_000_000,
+    }];
+    let expected = storage.publish_source_policy_exclusion_generation(
+        &first_publication,
+        "project",
+        "workspace",
+        "oversized-source-v1",
+        1_000_000,
+        &first,
+    )?;
+    storage.conn.execute_batch(
+        "CREATE TRIGGER reject_second_policy_exclusion
+         BEFORE INSERT ON source_policy_exclusion
+         WHEN NEW.normalized_path = 'vendor/reject.h'
+         BEGIN
+           SELECT RAISE(ABORT, 'injected exclusion write failure');
+         END;",
+    )?;
+    let second_publication = IndexPublicationRecord {
+        generation: 2,
+        generation_id: "generation-2".into(),
+        run_id: "run-2".into(),
+        mode: IndexPublicationMode::Incremental,
+        published_at_epoch_ms: 22,
+    };
+    let second = vec![OversizedSourceExclusionCandidate {
+        normalized_path: "vendor/reject.h".into(),
+        content_hash: "b".repeat(64),
+        observed_size: 3_000_000,
+        policy_version: "oversized-source-v1".into(),
+        byte_cap: 1_000_000,
+    }];
+    assert!(
+        storage
+            .publish_source_policy_exclusion_generation(
+                &second_publication,
+                "project",
+                "workspace",
+                "oversized-source-v1",
+                1_000_000,
+                &second,
+            )
+            .is_err()
+    );
+    assert_eq!(
+        storage.get_source_policy_exclusion_manifest()?,
+        Some(expected)
+    );
+    assert_eq!(storage.get_source_policy_exclusions()?.len(), 1);
+    storage.validate_source_policy_exclusion_publication(
+        &first_publication,
+        "project",
+        "workspace",
+        "oversized-source-v1",
+        1_000_000,
+    )?;
+    Ok(())
+}
+
+#[test]
 fn index_publication_identity_rejects_negative_published_timestamp() {
     assert!(
         index_publication_record_from_values(
@@ -2790,6 +2933,37 @@ fn schema_26_adds_nullable_error_coverage_reason_idempotently() -> Result<(), St
 }
 
 #[test]
+fn schema_27_adds_source_policy_tables_without_synthesizing_publication() -> Result<(), StorageError>
+{
+    let db_path = unique_temp_db_path("v27-source-policy-exclusion-migration");
+    let _ = std::fs::remove_file(&db_path);
+    {
+        let storage = Storage::open(&db_path)?;
+        storage
+            .conn
+            .execute("DROP TABLE source_policy_exclusion_publication", [])?;
+        storage
+            .conn
+            .execute("DROP TABLE source_policy_exclusion", [])?;
+        storage.set_schema_version(26)?;
+    }
+
+    let storage = Storage::open(&db_path)?;
+    assert_eq!(storage.schema_version()?, SCHEMA_VERSION);
+    assert!(storage.get_source_policy_exclusions()?.is_empty());
+    assert!(
+        storage.get_source_policy_exclusion_manifest()?.is_none(),
+        "migration cannot manufacture verified exclusion evidence"
+    );
+    schema::migrate_v27_source_policy_exclusions(&storage.conn)?;
+    schema::migrate_v27_source_policy_exclusions(&storage.conn)?;
+
+    drop(storage);
+    let _ = cleanup_sqlite_sidecars(&db_path);
+    Ok(())
+}
+
+#[test]
 fn v19_and_v20_manifests_migrate_once_and_new_writes_do_not_recreate_legacy_column()
 -> Result<(), StorageError> {
     for source_version in [19, 20] {
@@ -3081,11 +3255,68 @@ fn promotion_journal(
     previous_path: &Path,
     candidate_path: &Path,
 ) -> Result<PromotionJournal, StorageError> {
+    let previous = read_recovery_database_identity(previous_path)?;
+    let candidate = require_complete_promotion_database_identity(candidate_path, "Test candidate")?;
     Ok(PromotionJournal {
         version: PROMOTION_JOURNAL_VERSION,
-        previous: read_recovery_database_identity(previous_path)?,
-        candidate: require_complete_promotion_database_identity(candidate_path, "Test candidate")?,
+        previous_source_policy: previous
+            .as_ref()
+            .map(|publication| {
+                read_source_policy_exclusion_rollback_identity(previous_path, publication)
+            })
+            .transpose()?
+            .flatten(),
+        candidate_source_policy: read_source_policy_exclusion_rollback_identity(
+            candidate_path,
+            &candidate,
+        )?,
+        previous,
+        candidate,
     })
+}
+
+#[test]
+fn promotion_journal_binds_source_policy_exclusion_count_and_digest() -> Result<(), StorageError> {
+    let previous_path = unique_temp_db_path("promotion-policy-previous");
+    let candidate_path = unique_temp_db_path("promotion-policy-candidate");
+    seed_promotion_file(&previous_path, 1, "old")?;
+    seed_promotion_file(&candidate_path, 2, "new")?;
+
+    for (path, generation) in [(&previous_path, 1_u64), (&candidate_path, 2_u64)] {
+        let mut storage = Storage::open(path)?;
+        let publication = storage
+            .get_complete_index_publication()?
+            .expect("seeded publication");
+        storage.publish_source_policy_exclusion_generation(
+            &publication,
+            "project",
+            "workspace",
+            "oversized-source-v1",
+            1_000_000,
+            &[OversizedSourceExclusionCandidate {
+                normalized_path: format!("vendor/registers-{generation}.h"),
+                content_hash: format!("{generation:x}").repeat(64),
+                observed_size: 1_000_000 + generation,
+                policy_version: "oversized-source-v1".into(),
+                byte_cap: 1_000_000,
+            }],
+        )?;
+    }
+
+    let journal = promotion_journal(&previous_path, &candidate_path)?;
+    let previous = journal
+        .previous_source_policy
+        .expect("previous exclusion rollback identity");
+    let candidate = journal
+        .candidate_source_policy
+        .expect("candidate exclusion rollback identity");
+    assert_eq!(previous.exclusion_count, 1);
+    assert_eq!(candidate.exclusion_count, 1);
+    assert_ne!(previous.exclusion_digest, candidate.exclusion_digest);
+
+    cleanup_sqlite_sidecars(&previous_path)?;
+    cleanup_sqlite_sidecars(&candidate_path)?;
+    Ok(())
 }
 
 #[test]

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -3111,13 +3111,22 @@ fn test_promote_staged_snapshot_replaces_live_db_while_live_reader_is_open()
             line_count: 10,
             file_role: FileRole::Source,
         }])?;
-        seed.put_index_publication(&IndexPublicationRecord {
+        let live_publication = IndexPublicationRecord {
             generation: 1,
             generation_id: "live-generation".to_string(),
             run_id: "live-run".to_string(),
             mode: IndexPublicationMode::Full,
             published_at_epoch_ms: 1,
-        })?;
+        };
+        seed.put_index_publication(&live_publication)?;
+        seed.publish_source_policy_exclusion_generation(
+            &live_publication,
+            "test-project",
+            "test-workspace",
+            OVERSIZED_SOURCE_POLICY_VERSION,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            &[],
+        )?;
         drop(seed);
         let live = Storage::open_read_only(&live_path)?;
 
@@ -3133,13 +3142,22 @@ fn test_promote_staged_snapshot_replaces_live_db_while_live_reader_is_open()
                 line_count: 20,
                 file_role: FileRole::Source,
             }])?;
-            staged.put_index_publication(&IndexPublicationRecord {
+            let staged_publication = IndexPublicationRecord {
                 generation: 2,
                 generation_id: "staged-generation".to_string(),
                 run_id: "staged-run".to_string(),
                 mode: IndexPublicationMode::Full,
                 published_at_epoch_ms: 2,
-            })?;
+            };
+            staged.put_index_publication(&staged_publication)?;
+            staged.publish_source_policy_exclusion_generation(
+                &staged_publication,
+                "test-project",
+                "test-workspace",
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+                &[],
+            )?;
             staged.finalize_staged_snapshot()?;
         }
 
@@ -3232,13 +3250,22 @@ fn seed_promotion_file_with_identity(
         file_role: FileRole::Source,
     }])?;
     if publish {
-        storage.put_index_publication(&IndexPublicationRecord {
+        let publication = IndexPublicationRecord {
             generation: id.max(0) as u64,
             generation_id: format!("generation-{id}"),
             run_id: format!("run-{id}"),
             mode: IndexPublicationMode::Full,
             published_at_epoch_ms: id.max(0),
-        })?;
+        };
+        storage.put_index_publication(&publication)?;
+        storage.publish_source_policy_exclusion_generation(
+            &publication,
+            "test-project",
+            "test-workspace",
+            OVERSIZED_SOURCE_POLICY_VERSION,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            &[],
+        )?;
     }
     storage.finalize_staged_snapshot()
 }
@@ -3249,6 +3276,28 @@ fn seed_promotion_file(path: &Path, id: i64, name: &str) -> Result<(), StorageEr
 
 fn seed_unpublished_file(path: &Path, id: i64, name: &str) -> Result<(), StorageError> {
     seed_promotion_file_with_identity(path, id, name, false)
+}
+
+fn publish_nonempty_test_source_policy(path: &Path, generation: u64) -> Result<(), StorageError> {
+    let mut storage = Storage::open(path)?;
+    let publication = storage
+        .get_complete_index_publication()?
+        .expect("seeded publication");
+    storage.publish_source_policy_exclusion_generation(
+        &publication,
+        "test-project",
+        "test-workspace",
+        OVERSIZED_SOURCE_POLICY_VERSION,
+        DEFAULT_SOURCE_FILE_BYTE_CAP,
+        &[OversizedSourceExclusionCandidate {
+            normalized_path: format!("vendor/registers-{generation}.h"),
+            content_hash: format!("{generation:064x}"),
+            observed_size: DEFAULT_SOURCE_FILE_BYTE_CAP + generation,
+            policy_version: OVERSIZED_SOURCE_POLICY_VERSION.to_string(),
+            byte_cap: DEFAULT_SOURCE_FILE_BYTE_CAP,
+        }],
+    )?;
+    Ok(())
 }
 
 fn promotion_journal(
@@ -3312,11 +3361,123 @@ fn promotion_journal_binds_source_policy_exclusion_count_and_digest() -> Result<
         .expect("candidate exclusion rollback identity");
     assert_eq!(previous.exclusion_count, 1);
     assert_eq!(candidate.exclusion_count, 1);
+    assert_eq!(previous.core_published_at_epoch_ms, 1);
+    assert_eq!(candidate.core_published_at_epoch_ms, 2);
     assert_ne!(previous.exclusion_digest, candidate.exclusion_digest);
 
     cleanup_sqlite_sidecars(&previous_path)?;
     cleanup_sqlite_sidecars(&candidate_path)?;
     Ok(())
+}
+
+#[test]
+fn staged_promotion_rejects_missing_corrupt_or_timestamp_drifted_candidate_manifest() {
+    for corruption in ["missing", "digest", "timestamp"] {
+        let live_path = unique_temp_db_path(&format!("promotion-policy-live-{corruption}"));
+        let staged_path = unique_temp_db_path(&format!("promotion-policy-staged-{corruption}"));
+        seed_promotion_file(&live_path, 1, "old.rs").expect("seed live publication");
+        seed_promotion_file(&staged_path, 2, "new.rs").expect("seed staged publication");
+        let staged = Storage::open(&staged_path).expect("open staged publication");
+        match corruption {
+            "missing" => {
+                staged
+                    .get_connection()
+                    .execute("DELETE FROM source_policy_exclusion_publication", [])
+                    .expect("remove candidate manifest");
+            }
+            "digest" => {
+                staged
+                    .get_connection()
+                    .execute(
+                        "UPDATE source_policy_exclusion_publication SET exclusion_digest = ?1",
+                        params!["0".repeat(64)],
+                    )
+                    .expect("corrupt candidate digest");
+            }
+            "timestamp" => {
+                staged
+                    .get_connection()
+                    .execute(
+                        "UPDATE source_policy_exclusion_publication SET published_at_epoch_ms = published_at_epoch_ms + 1",
+                        [],
+                    )
+                    .expect("drift candidate timestamp");
+            }
+            _ => unreachable!(),
+        }
+        drop(staged);
+
+        let error = Storage::promote_staged_snapshot(&staged_path, &live_path)
+            .expect_err("invalid candidate manifest must block promotion");
+        assert!(
+            error
+                .to_string()
+                .to_ascii_lowercase()
+                .contains("source policy exclusion"),
+            "unexpected promotion error: {error}"
+        );
+        let live = Storage::open(&live_path).expect("reopen preserved live publication");
+        assert_eq!(
+            live.get_complete_index_publication()
+                .expect("live publication")
+                .expect("complete live publication")
+                .generation_id,
+            "generation-1"
+        );
+        assert_eq!(
+            live.get_files().expect("live files")[0].path,
+            PathBuf::from("old.rs")
+        );
+
+        cleanup_sqlite_sidecars(&live_path).expect("clean live fixture");
+        cleanup_sqlite_sidecars(&staged_path).expect("clean staged fixture");
+    }
+}
+
+#[test]
+fn legacy_committed_journal_without_source_policy_identity_recovers_for_runtime_repair() {
+    let live_path = unique_temp_db_path("legacy-committed-policy-live");
+    seed_promotion_file(&live_path, 1, "legacy.rs").expect("seed legacy live publication");
+    let live = Storage::open(&live_path).expect("open legacy live publication");
+    let candidate = live
+        .get_complete_index_publication()
+        .expect("read legacy publication")
+        .expect("complete legacy publication");
+    live.get_connection()
+        .execute("DELETE FROM source_policy_exclusion_publication", [])
+        .expect("remove post-v27 policy identity from legacy fixture");
+    drop(live);
+
+    let committed_path = promotion_committed_journal_path(&live_path);
+    write_promotion_journal(
+        &committed_path,
+        &PromotionJournal {
+            version: LEGACY_PROMOTION_JOURNAL_VERSION,
+            previous: None,
+            candidate: candidate.clone(),
+            previous_source_policy: None,
+            candidate_source_policy: None,
+        },
+    )
+    .expect("write legacy committed journal");
+
+    let recovered = Storage::open(&live_path).expect("recover legacy committed promotion");
+    assert_eq!(
+        recovered
+            .get_complete_index_publication()
+            .expect("recovered publication"),
+        Some(candidate)
+    );
+    assert!(
+        recovered
+            .get_source_policy_exclusion_manifest()
+            .expect("legacy policy manifest")
+            .is_none(),
+        "store recovery must not synthesize policy evidence"
+    );
+    assert!(!committed_path.exists());
+
+    cleanup_sqlite_sidecars(&live_path).expect("clean legacy fixture");
 }
 
 #[test]
@@ -3340,6 +3501,9 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
     let committed_path = promotion_committed_journal_path(&live_path);
     seed_promotion_file(&live_path, 1, "old.rs").expect("seed live generation");
     seed_promotion_file(&staged_path, 2, "new.rs").expect("seed staged generation");
+    publish_nonempty_test_source_policy(&live_path, 1).expect("publish live exclusion identity");
+    publish_nonempty_test_source_policy(&staged_path, 2)
+        .expect("publish staged exclusion identity");
 
     let status =
         std::process::Command::new(std::env::current_exe().expect("resolve store test executable"))
@@ -3379,6 +3543,12 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
         live.get_files().expect("read live generation")[0].path,
         PathBuf::from("old.rs")
     );
+    assert_eq!(
+        live.get_source_policy_exclusions()
+            .expect("read rolled-back exclusions")[0]
+            .normalized_path,
+        "vendor/registers-1.h"
+    );
     drop(live);
     assert!(
         staged_path.exists(),
@@ -3397,6 +3567,12 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
     assert_eq!(
         live.get_files().expect("read recovered generation")[0].path,
         PathBuf::from("new.rs")
+    );
+    assert_eq!(
+        live.get_source_policy_exclusions()
+            .expect("read promoted exclusions")[0]
+            .normalized_path,
+        "vendor/registers-2.h"
     );
     drop(live);
     for artifact in sqlite_sidecar_paths(&staged_path)
@@ -3429,6 +3605,11 @@ fn retained_committed_promotion_stays_live_and_blocks_the_next_writer() {
     seed_promotion_file(&live_path, 1, "old.rs").expect("seed live generation");
     seed_promotion_file(&staged_path, 2, "new.rs").expect("seed staged generation");
     seed_promotion_file(&second_staged_path, 3, "newer.rs").expect("seed second staged generation");
+    publish_nonempty_test_source_policy(&live_path, 1).expect("publish live exclusion identity");
+    publish_nonempty_test_source_policy(&staged_path, 2)
+        .expect("publish staged exclusion identity");
+    publish_nonempty_test_source_policy(&second_staged_path, 3)
+        .expect("publish second staged exclusion identity");
     std::fs::write(&cleanup_failure_path, b"blocked").expect("inject cleanup failure");
 
     Storage::promote_staged_snapshot(&staged_path, &live_path)
@@ -3444,6 +3625,13 @@ fn retained_committed_promotion_stays_live_and_blocks_the_next_writer() {
     assert_eq!(
         reopened.get_files().expect("read committed generation")[0].path,
         PathBuf::from("new.rs")
+    );
+    assert_eq!(
+        reopened
+            .get_source_policy_exclusions()
+            .expect("read committed exclusions")[0]
+            .normalized_path,
+        "vendor/registers-2.h"
     );
     drop(reopened);
     assert!(!backup_path.exists() && !committed_path.exists());

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -14,7 +14,8 @@ use anyhow::{Result, bail};
 pub use codestory_contracts::workspace::{
     BuildMode, DEFAULT_SOURCE_FILE_BYTE_CAP, IndexedFileRecord, OVERSIZED_SOURCE_POLICY_VERSION,
     OversizedSourceExclusionCandidate, RefreshExecutionPlan, RefreshInfo, RefreshInputs,
-    RefreshMode, RefreshPlan, StoredFileRecord, StoredFileState, WorkspaceInventory,
+    RefreshMode, RefreshPlan, SourceIndexPolicy, StoredFileRecord, StoredFileState,
+    WorkspaceInventory, process_source_index_policy,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -423,11 +424,28 @@ impl WorkspaceManifest {
 
     /// Discover parser candidates and content-verified oversized policy exclusions.
     pub fn source_inventory_with_oversized_policy(&self) -> Result<WorkspacePolicyFileInventory> {
+        self.source_inventory_with_policy(process_source_index_policy())
+    }
+
+    /// Discover candidates using one caller-owned immutable source-index policy.
+    pub fn source_inventory_with_policy(
+        &self,
+        policy: &SourceIndexPolicy,
+    ) -> Result<WorkspacePolicyFileInventory> {
         WorkspaceDiscovery.source_inventory_with_policy(
             self,
-            DEFAULT_SOURCE_FILE_BYTE_CAP,
-            OVERSIZED_SOURCE_POLICY_VERSION,
+            policy.byte_cap,
+            &policy.policy_version,
         )
+    }
+
+    /// Re-read every classified exclusion at the publication fence.
+    pub fn revalidate_source_policy_exclusions(
+        &self,
+        candidates: &[OversizedSourceExclusionCandidate],
+        policy: &SourceIndexPolicy,
+    ) -> Result<Vec<OversizedSourceExclusionCandidate>> {
+        WorkspaceDiscovery.revalidate_source_policy_exclusions(self, candidates, policy)
     }
 
     /// Build a full-refresh plan that indexes every currently discovered file.
@@ -469,11 +487,20 @@ impl WorkspaceManifest {
         &self,
         inputs: &RefreshInputs,
     ) -> Result<WorkspacePolicyRefreshOutcome> {
+        self.build_execution_outcome_with_policy(inputs, process_source_index_policy())
+    }
+
+    /// Build a refresh outcome using one caller-owned immutable source-index policy.
+    pub fn build_execution_outcome_with_policy(
+        &self,
+        inputs: &RefreshInputs,
+        policy: &SourceIndexPolicy,
+    ) -> Result<WorkspacePolicyRefreshOutcome> {
         WorkspaceDiscovery.build_refresh_outcome_with_policy(
             self,
             inputs,
-            DEFAULT_SOURCE_FILE_BYTE_CAP,
-            OVERSIZED_SOURCE_POLICY_VERSION,
+            policy.byte_cap,
+            &policy.policy_version,
         )
     }
 
@@ -483,12 +510,26 @@ impl WorkspaceManifest {
         inputs: &RefreshInputs,
         max_current_files: usize,
     ) -> Result<WorkspacePolicyRefreshOutcome> {
+        self.build_execution_outcome_bounded_with_policy(
+            inputs,
+            max_current_files,
+            process_source_index_policy(),
+        )
+    }
+
+    /// Build a bounded refresh outcome using one caller-owned immutable policy.
+    pub fn build_execution_outcome_bounded_with_policy(
+        &self,
+        inputs: &RefreshInputs,
+        max_current_files: usize,
+        policy: &SourceIndexPolicy,
+    ) -> Result<WorkspacePolicyRefreshOutcome> {
         WorkspaceDiscovery.build_refresh_outcome_bounded_with_policy(
             self,
             inputs,
             max_current_files,
-            DEFAULT_SOURCE_FILE_BYTE_CAP,
-            OVERSIZED_SOURCE_POLICY_VERSION,
+            policy.byte_cap,
+            &policy.policy_version,
         )
     }
 
@@ -552,6 +593,53 @@ impl WorkspaceDiscovery {
         policy_version: &str,
     ) -> Result<WorkspacePolicyFileInventory> {
         self.source_inventory_with_policy_inner(manifest, byte_cap, policy_version, None)
+    }
+
+    /// Verify that classified exclusions still name the same stable bytes at publication time.
+    pub fn revalidate_source_policy_exclusions(
+        &self,
+        manifest: &WorkspaceManifest,
+        candidates: &[OversizedSourceExclusionCandidate],
+        policy: &SourceIndexPolicy,
+    ) -> Result<Vec<OversizedSourceExclusionCandidate>> {
+        if policy.byte_cap == 0 || policy.policy_version.trim().is_empty() {
+            bail!("source index policy requires a non-zero cap and non-empty version");
+        }
+        let root = workspace_root(manifest);
+        let mut verified = candidates.to_vec();
+        verified.sort_by(|left, right| left.normalized_path.cmp(&right.normalized_path));
+        let mut previous_path: Option<&str> = None;
+        for candidate in &verified {
+            if candidate.policy_version != policy.policy_version
+                || candidate.byte_cap != policy.byte_cap
+                || previous_path == Some(candidate.normalized_path.as_str())
+            {
+                bail!(
+                    "source policy exclusion `{}` does not match the active policy",
+                    candidate.normalized_path
+                );
+            }
+            previous_path = Some(candidate.normalized_path.as_str());
+            let path = root.join(&candidate.normalized_path);
+            let normalized_path = normalized_policy_path(&root, &path)?;
+            if normalized_path != candidate.normalized_path {
+                bail!(
+                    "source policy exclusion path changed from `{}` to `{normalized_path}`",
+                    candidate.normalized_path
+                );
+            }
+            let (content_hash, observed_size) = current_content_identity(&path)?;
+            if content_hash != candidate.content_hash
+                || observed_size != candidate.observed_size
+                || observed_size <= policy.byte_cap
+            {
+                bail!(
+                    "source policy exclusion `{}` changed before publication",
+                    candidate.normalized_path
+                );
+            }
+        }
+        Ok(verified)
     }
 
     fn source_inventory_with_policy_inner(

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -12,8 +12,9 @@
 
 use anyhow::{Result, bail};
 pub use codestory_contracts::workspace::{
-    BuildMode, IndexedFileRecord, RefreshExecutionPlan, RefreshInfo, RefreshInputs, RefreshMode,
-    RefreshPlan, StoredFileRecord, StoredFileState, WorkspaceInventory,
+    BuildMode, DEFAULT_SOURCE_FILE_BYTE_CAP, IndexedFileRecord, OVERSIZED_SOURCE_POLICY_VERSION,
+    OversizedSourceExclusionCandidate, RefreshExecutionPlan, RefreshInfo, RefreshInputs,
+    RefreshMode, RefreshPlan, StoredFileRecord, StoredFileState, WorkspaceInventory,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -205,12 +206,28 @@ pub struct WorkspaceFileInventory {
     pub issues: Vec<WorkspaceInventoryIssue>,
 }
 
+/// Complete discovery split into parser candidates and verified policy exclusions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspacePolicyFileInventory {
+    pub files: Vec<PathBuf>,
+    pub policy_exclusions: Vec<OversizedSourceExclusionCandidate>,
+    pub outcome: WorkspaceInventoryOutcome,
+    pub issues: Vec<WorkspaceInventoryIssue>,
+}
+
 /// Refresh plan paired with the inventory outcome that made deletion safe or unsafe.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceRefreshOutcome {
     pub plan: RefreshPlan,
     pub inventory_outcome: WorkspaceInventoryOutcome,
     pub inventory_issues: Vec<WorkspaceInventoryIssue>,
+}
+
+/// Refresh plan paired with the complete exclusion set for the same discovery pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspacePolicyRefreshOutcome {
+    pub refresh: WorkspaceRefreshOutcome,
+    pub policy_exclusions: Vec<OversizedSourceExclusionCandidate>,
 }
 
 #[derive(Debug, Clone)]
@@ -404,6 +421,15 @@ impl WorkspaceManifest {
         WorkspaceDiscovery.source_inventory(self)
     }
 
+    /// Discover parser candidates and content-verified oversized policy exclusions.
+    pub fn source_inventory_with_oversized_policy(&self) -> Result<WorkspacePolicyFileInventory> {
+        WorkspaceDiscovery.source_inventory_with_policy(
+            self,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            OVERSIZED_SOURCE_POLICY_VERSION,
+        )
+    }
+
     /// Build a full-refresh plan that indexes every currently discovered file.
     pub fn full_refresh_plan(&self) -> Result<RefreshPlan> {
         Ok(RefreshPlan {
@@ -436,6 +462,34 @@ impl WorkspaceManifest {
         inputs: &RefreshInputs,
     ) -> Result<WorkspaceRefreshOutcome> {
         WorkspaceDiscovery.build_refresh_outcome(self, inputs)
+    }
+
+    /// Build a refresh plan that removes verified oversized sources before parser scheduling.
+    pub fn build_execution_outcome_with_oversized_policy(
+        &self,
+        inputs: &RefreshInputs,
+    ) -> Result<WorkspacePolicyRefreshOutcome> {
+        WorkspaceDiscovery.build_refresh_outcome_with_policy(
+            self,
+            inputs,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            OVERSIZED_SOURCE_POLICY_VERSION,
+        )
+    }
+
+    /// Build a policy-aware refresh outcome with the ordinary current-file discovery bound.
+    pub fn build_execution_outcome_bounded_with_oversized_policy(
+        &self,
+        inputs: &RefreshInputs,
+        max_current_files: usize,
+    ) -> Result<WorkspacePolicyRefreshOutcome> {
+        WorkspaceDiscovery.build_refresh_outcome_bounded_with_policy(
+            self,
+            inputs,
+            max_current_files,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            OVERSIZED_SOURCE_POLICY_VERSION,
+        )
     }
 
     /// Build an incremental refresh plan with a current-file discovery bound.
@@ -488,6 +542,104 @@ impl WorkspaceDiscovery {
     /// Discover source files while retaining traversal failures.
     pub fn source_inventory(&self, manifest: &WorkspaceManifest) -> Result<WorkspaceFileInventory> {
         self.source_inventory_inner(manifest, None)
+    }
+
+    /// Classify oversized sources only after complete discovery and stable content hashing.
+    pub fn source_inventory_with_policy(
+        &self,
+        manifest: &WorkspaceManifest,
+        byte_cap: u64,
+        policy_version: &str,
+    ) -> Result<WorkspacePolicyFileInventory> {
+        self.source_inventory_with_policy_inner(manifest, byte_cap, policy_version, None)
+    }
+
+    fn source_inventory_with_policy_inner(
+        &self,
+        manifest: &WorkspaceManifest,
+        byte_cap: u64,
+        policy_version: &str,
+        max_files: Option<usize>,
+    ) -> Result<WorkspacePolicyFileInventory> {
+        if byte_cap == 0 || policy_version.trim().is_empty() {
+            bail!("oversized source policy requires a non-zero cap and non-empty version");
+        }
+        let inventory = self.source_inventory_inner(manifest, max_files)?;
+        if !inventory.outcome.is_complete() {
+            return Ok(WorkspacePolicyFileInventory {
+                files: inventory.files,
+                policy_exclusions: Vec::new(),
+                outcome: inventory.outcome,
+                issues: inventory.issues,
+            });
+        }
+
+        let root = workspace_root(manifest);
+        let mut files = Vec::with_capacity(inventory.files.len());
+        let mut policy_exclusions = Vec::new();
+        let mut issues = inventory.issues;
+        for path in inventory.files {
+            let metadata = match fs::metadata(&path) {
+                Ok(metadata) => metadata,
+                Err(error) => {
+                    issues.push(WorkspaceInventoryIssue {
+                        path: path.clone(),
+                        message: format!("failed to inspect policy candidate: {error}"),
+                    });
+                    files.push(path);
+                    continue;
+                }
+            };
+            if metadata.len() <= byte_cap {
+                files.push(path);
+                continue;
+            }
+            let normalized_path = match normalized_policy_path(&root, &path) {
+                Ok(path) => path,
+                Err(error) => {
+                    issues.push(WorkspaceInventoryIssue {
+                        path: path.clone(),
+                        message: error.to_string(),
+                    });
+                    files.push(path);
+                    continue;
+                }
+            };
+            let (content_hash, observed_size) = match current_content_identity(&path) {
+                Ok(identity) => identity,
+                Err(error) => {
+                    issues.push(WorkspaceInventoryIssue {
+                        path: path.clone(),
+                        message: format!("failed to verify oversized policy candidate: {error}"),
+                    });
+                    files.push(path);
+                    continue;
+                }
+            };
+            if observed_size <= byte_cap {
+                files.push(path);
+                continue;
+            }
+            policy_exclusions.push(OversizedSourceExclusionCandidate {
+                normalized_path,
+                content_hash,
+                observed_size,
+                policy_version: policy_version.to_string(),
+                byte_cap,
+            });
+        }
+        policy_exclusions.sort_by(|left, right| left.normalized_path.cmp(&right.normalized_path));
+        let outcome = if issues.is_empty() {
+            WorkspaceInventoryOutcome::Complete
+        } else {
+            WorkspaceInventoryOutcome::Partial
+        };
+        Ok(WorkspacePolicyFileInventory {
+            files,
+            policy_exclusions,
+            outcome,
+            issues,
+        })
     }
 
     fn source_inventory_inner(
@@ -642,6 +794,56 @@ impl WorkspaceDiscovery {
         self.build_refresh_outcome_inner(manifest, inputs, None)
     }
 
+    /// Build one refresh plan and complete exclusion set from the same inventory pass.
+    pub fn build_refresh_outcome_with_policy(
+        &self,
+        manifest: &WorkspaceManifest,
+        inputs: &RefreshInputs,
+        byte_cap: u64,
+        policy_version: &str,
+    ) -> Result<WorkspacePolicyRefreshOutcome> {
+        let inventory = self.source_inventory_with_policy(manifest, byte_cap, policy_version)?;
+        let refresh = build_refresh_outcome_from_inventory(
+            manifest,
+            inputs,
+            inventory.files,
+            inventory.outcome,
+            inventory.issues,
+        )?;
+        Ok(WorkspacePolicyRefreshOutcome {
+            refresh,
+            policy_exclusions: inventory.policy_exclusions,
+        })
+    }
+
+    /// Build a bounded policy-aware refresh outcome without losing completeness evidence.
+    pub fn build_refresh_outcome_bounded_with_policy(
+        &self,
+        manifest: &WorkspaceManifest,
+        inputs: &RefreshInputs,
+        max_current_files: usize,
+        byte_cap: u64,
+        policy_version: &str,
+    ) -> Result<WorkspacePolicyRefreshOutcome> {
+        let inventory = self.source_inventory_with_policy_inner(
+            manifest,
+            byte_cap,
+            policy_version,
+            Some(max_current_files),
+        )?;
+        let refresh = build_refresh_outcome_from_inventory(
+            manifest,
+            inputs,
+            inventory.files,
+            inventory.outcome,
+            inventory.issues,
+        )?;
+        Ok(WorkspacePolicyRefreshOutcome {
+            refresh,
+            policy_exclusions: inventory.policy_exclusions,
+        })
+    }
+
     /// Compare current discovery with stored inventory unless discovery exceeds
     /// `max_current_files`.
     pub fn build_refresh_plan_bounded(
@@ -666,56 +868,87 @@ impl WorkspaceDiscovery {
         max_current_files: Option<usize>,
     ) -> Result<WorkspaceRefreshOutcome> {
         let inventory = self.source_inventory_inner(manifest, max_current_files)?;
-        let current_files = inventory.files;
-        let workspace_root = manifest.root_dir();
-        let stored_map = inputs.inventory_map();
-        let normalized_stored_map = stored_map
-            .into_values()
-            .map(|file| (normalized_compare_key(&workspace_root, &file.path), file))
-            .collect::<HashMap<_, _>>();
-
-        let mut files_to_index = Vec::new();
-        let mut files_to_remove = Vec::new();
-        let mut existing_file_ids = HashMap::new();
-        let mut current_file_keys = HashSet::with_capacity(current_files.len());
-
-        for path in current_files {
-            let normalized_key = normalized_compare_key(&workspace_root, &path);
-            current_file_keys.insert(normalized_key.clone());
-            let needs_index = match normalized_stored_map.get(&normalized_key) {
-                Some(file) => {
-                    existing_file_ids.insert(path.clone(), file.id);
-                    stored_file_needs_index(&path, file)
-                }
-                None => true,
-            };
-
-            if needs_index {
-                files_to_index.push(path);
-            }
-        }
-
-        if inventory.outcome.is_complete() {
-            for (normalized_key, stored) in normalized_stored_map {
-                if !current_file_keys.contains(&normalized_key) {
-                    files_to_remove.push(stored.id);
-                }
-            }
-        }
-        files_to_remove.sort_unstable();
-        files_to_remove.dedup();
-
-        Ok(WorkspaceRefreshOutcome {
-            plan: RefreshPlan {
-                mode: RefreshMode::Incremental,
-                files_to_index,
-                files_to_remove,
-                existing_file_ids,
-            },
-            inventory_outcome: inventory.outcome,
-            inventory_issues: inventory.issues,
-        })
+        build_refresh_outcome_from_inventory(
+            manifest,
+            inputs,
+            inventory.files,
+            inventory.outcome,
+            inventory.issues,
+        )
     }
+}
+
+fn build_refresh_outcome_from_inventory(
+    manifest: &WorkspaceManifest,
+    inputs: &RefreshInputs,
+    current_files: Vec<PathBuf>,
+    inventory_outcome: WorkspaceInventoryOutcome,
+    inventory_issues: Vec<WorkspaceInventoryIssue>,
+) -> Result<WorkspaceRefreshOutcome> {
+    let workspace_root = manifest.root_dir();
+    let stored_map = inputs.inventory_map();
+    let normalized_stored_map = stored_map
+        .into_values()
+        .map(|file| (normalized_compare_key(&workspace_root, &file.path), file))
+        .collect::<HashMap<_, _>>();
+
+    let mut files_to_index = Vec::new();
+    let mut files_to_remove = Vec::new();
+    let mut existing_file_ids = HashMap::new();
+    let mut current_file_keys = HashSet::with_capacity(current_files.len());
+
+    for path in current_files {
+        let normalized_key = normalized_compare_key(&workspace_root, &path);
+        current_file_keys.insert(normalized_key.clone());
+        let needs_index = match normalized_stored_map.get(&normalized_key) {
+            Some(file) => {
+                existing_file_ids.insert(path.clone(), file.id);
+                stored_file_needs_index(&path, file)
+            }
+            None => true,
+        };
+
+        if needs_index {
+            files_to_index.push(path);
+        }
+    }
+
+    if inventory_outcome.is_complete() {
+        for (normalized_key, stored) in normalized_stored_map {
+            if !current_file_keys.contains(&normalized_key) {
+                files_to_remove.push(stored.id);
+            }
+        }
+    }
+    files_to_remove.sort_unstable();
+    files_to_remove.dedup();
+
+    Ok(WorkspaceRefreshOutcome {
+        plan: RefreshPlan {
+            mode: RefreshMode::Incremental,
+            files_to_index,
+            files_to_remove,
+            existing_file_ids,
+        },
+        inventory_outcome,
+        inventory_issues,
+    })
+}
+
+fn normalized_policy_path(workspace_root: &Path, path: &Path) -> Result<String> {
+    let relative = workspace_relative_path(workspace_root, path)
+        .ok_or_else(|| anyhow::anyhow!("oversized policy candidate escapes the workspace root"))?;
+    let relative = relative
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("oversized policy candidate path is not valid UTF-8"))?
+        .replace('\\', "/");
+    if relative.is_empty()
+        || relative.starts_with('/')
+        || relative.split('/').any(|component| component == "..")
+    {
+        bail!("oversized policy candidate has an invalid normalized path");
+    }
+    Ok(relative)
 }
 
 fn record_walk_error(
@@ -783,6 +1016,10 @@ fn stored_file_needs_index(path: &Path, file: &StoredFileState) -> bool {
 }
 
 fn current_content_hash(path: &Path) -> Result<String> {
+    current_content_identity(path).map(|(content_hash, _)| content_hash)
+}
+
+fn current_content_identity(path: &Path) -> Result<(String, u64)> {
     let mut file = fs::File::open(path)?;
     let before = file.metadata()?;
     let mut hasher = Sha256::new();
@@ -798,7 +1035,7 @@ fn current_content_hash(path: &Path) -> Result<String> {
     if before.len() != after.len() || before.modified()? != after.modified()? {
         bail!("source metadata changed while hashing {}", path.display());
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok((format!("{:x}", hasher.finalize()), before.len()))
 }
 
 fn workspace_root(manifest: &WorkspaceManifest) -> PathBuf {
@@ -1186,6 +1423,97 @@ mod tests {
         assert_eq!(plan.mode, RefreshMode::Incremental);
         assert_eq!(plan.files_to_index, vec![file]);
         assert!(plan.files_to_remove.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn classifies_generated_vendor_and_ordinary_oversized_sources_before_scheduling() -> Result<()>
+    {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(root.join("generated"))?;
+        fs::create_dir_all(root.join("vendor"))?;
+        fs::create_dir_all(root.join("src"))?;
+        fs::write(root.join("generated/registers.h"), vec![b'g'; 96])?;
+        fs::write(root.join("vendor/bundle.js"), vec![b'v'; 80])?;
+        fs::write(root.join("src/ordinary.rs"), vec![b'o'; 65])?;
+        fs::write(root.join("src/small.rs"), b"fn small() {}\n")?;
+
+        let manifest = WorkspaceManifest::open(root.clone())?;
+        let inventory =
+            WorkspaceDiscovery.source_inventory_with_policy(&manifest, 64, "test-policy-v1")?;
+
+        assert_eq!(inventory.outcome, WorkspaceInventoryOutcome::Complete);
+        assert_eq!(inventory.files, vec![root.join("src/small.rs")]);
+        assert_eq!(inventory.policy_exclusions.len(), 3);
+        assert_eq!(
+            inventory
+                .policy_exclusions
+                .iter()
+                .map(|entry| entry.normalized_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "generated/registers.h",
+                "src/ordinary.rs",
+                "vendor/bundle.js"
+            ]
+        );
+        assert!(inventory.policy_exclusions.iter().all(|entry| {
+            entry.content_hash.len() == 64
+                && entry.observed_size > entry.byte_cap
+                && entry.policy_version == "test-policy-v1"
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn changed_oversized_content_produces_a_new_verified_identity() -> Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(root.join("src"))?;
+        let oversized = root.join("src/large.rs");
+        fs::write(&oversized, vec![b'a'; 65])?;
+        let manifest = WorkspaceManifest::open(root)?;
+        let first =
+            WorkspaceDiscovery.source_inventory_with_policy(&manifest, 64, "test-policy-v1")?;
+        fs::write(&oversized, vec![b'b'; 66])?;
+        let second =
+            WorkspaceDiscovery.source_inventory_with_policy(&manifest, 64, "test-policy-v1")?;
+        let changed_policy =
+            WorkspaceDiscovery.source_inventory_with_policy(&manifest, 64, "test-policy-v2")?;
+
+        assert_ne!(
+            first.policy_exclusions[0].content_hash,
+            second.policy_exclusions[0].content_hash
+        );
+        assert_eq!(second.policy_exclusions[0].observed_size, 66);
+        assert_eq!(
+            changed_policy.policy_exclusions[0].content_hash,
+            second.policy_exclusions[0].content_hash
+        );
+        assert_eq!(
+            changed_policy.policy_exclusions[0].policy_version,
+            "test-policy-v2"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn partial_discovery_never_classifies_a_deletion_capable_exclusion_set() -> Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(root.join("src"))?;
+        let oversized = root.join("src/large.rs");
+        fs::write(&oversized, vec![b'a'; 65])?;
+        write_repo_manifest(&root, vec![PathBuf::from("src"), PathBuf::from("missing")])?;
+        let manifest = WorkspaceManifest::open(root)?;
+        let inventory =
+            WorkspaceDiscovery.source_inventory_with_policy(&manifest, 64, "test-policy-v1")?;
+
+        assert_eq!(inventory.outcome, WorkspaceInventoryOutcome::Partial);
+        assert!(inventory.policy_exclusions.is_empty());
+        assert_eq!(inventory.files, vec![oversized]);
+        assert!(!inventory.issues.is_empty());
         Ok(())
     }
 

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -26,8 +26,9 @@ sequenceDiagram
 
     CLI->>Runtime: parse `index` command and open project
     Runtime->>Workspace: full refresh plan or diff-based refresh plan
-    Workspace-->>Runtime: RefreshExecutionPlan
+    Workspace-->>Runtime: RefreshExecutionPlan + verified policy exclusions
     Runtime->>Store: open staged store for full refresh or live store for incremental
+    Runtime->>Store: publish candidate exclusion manifest
     Runtime->>Indexer: WorkspaceIndexer::run(plan, store)
     Indexer->>Store: flush files, nodes, edges, occurrences, component access, callable projection state
     Indexer->>Store: run post-flush resolution updates
@@ -125,6 +126,9 @@ The indexer does not know whether the store is staged or live.
 
 - `source_files` walks the configured source groups from the workspace manifest, follows directories, applies exclude globs, sorts the result, and removes duplicates
 - `source_inventory` retains whether that walk was complete, partial, unreadable, or stopped by its candidate bound, plus any traversal failures
+- `source_inventory_with_oversized_policy` hashes stable source bytes above the
+  shared parser cap and classifies them before parser scheduling, independent
+  of whether they are generated, vendored, or ordinary project files
 - `build_refresh_plan` compares discovered files against stored inventory and only plans stored-file deletion from a complete inventory. Stored parser-backed rows carry the verified SHA-256 identity of the bytes that produced their projection, so matching millisecond mtimes do not hide changed content
 
 For incremental work, a file is reindexed when:
@@ -139,10 +143,17 @@ fallback. Content comparison reads only rows that already carry a verified
 source hash; it does not add hashing for structural, text-only, or oversized
 files that did not produce one.
 
+Verified oversized candidates are removed from parser scheduling and published
+as a complete exclusion manifest bound to the project, workspace, candidate
+core generation/run, policy version, byte cap, row count, and digest. The rows
+remain source inventory only: they make no parser graph or semantic coverage
+claim. A content or policy change forces reclassification.
+
 Files that disappeared from a complete discovery are collected into
-`files_to_remove`. Partial, unreadable, and bounded inventories retain observed
-files for safe reindexing but never infer deletion from absence. Runtime
-freshness reports those incomplete inventories as `not_checked`.
+`files_to_remove`. Partial, unreadable, bounded, or concurrently changing
+inventories retain observed files for safe reindexing but never infer deletion
+or a complete exclusion set from absence. Runtime treats them as source
+coverage blockers and preserves the previous complete publication.
 
 ### 4. The indexer prepares file work
 

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -28,13 +28,13 @@ sequenceDiagram
     Runtime->>Workspace: full refresh plan or diff-based refresh plan
     Workspace-->>Runtime: RefreshExecutionPlan + verified policy exclusions
     Runtime->>Store: open staged store for full refresh or live store for incremental
-    Runtime->>Store: publish candidate exclusion manifest
     Runtime->>Indexer: WorkspaceIndexer::run(plan, store)
     Indexer->>Store: flush files, nodes, edges, occurrences, component access, callable projection state
     Indexer->>Store: run post-flush resolution updates
     Runtime->>Store: finalize staged snapshot or refresh live snapshots
     Runtime->>Search: rebuild lexical projection, symbol docs, component reports, and dense anchors
     Search->>Store: reuse unchanged anchor metadata or upsert selected embedding-free inputs
+    Runtime->>Store: revalidate and publish the bound exclusion manifest at the identity fence
     Runtime-->>CLI: indexing summary and phase timings
 ```
 

--- a/docs/architecture/subsystems/runtime.md
+++ b/docs/architecture/subsystems/runtime.md
@@ -8,6 +8,8 @@ adapter syntax, SQLite mechanics, parsers, or model execution.
 
 - project open, summary, and refresh orchestration;
 - full and incremental indexing across workspace, indexer, and store;
+- complete source-inventory classification and publication of verified
+  source-policy exclusions before parser scheduling;
 - graph-native symbol-document and dense-anchor synchronization;
 - grounding, trails, symbol workflows, target context, search, and packet
   assembly;
@@ -33,6 +35,12 @@ The per-user engine authority belongs to retrieval/llama-sys and runs in the
 automatically managed embedding server. Runtime may cause lazy server and
 engine activation and hold publication leases, but cannot reconfigure the
 engine per project or infer readiness from `retrieval_mode` alone.
+
+Runtime accepts an oversized-source exclusion set only from a complete
+inventory, publishes it with the candidate core, and requires its bound
+manifest on freshness and read surfaces. `files` exposes those paths as source
+inventory with explicit false graph and semantic coverage; packet and search
+never treat them as indexed evidence.
 
 ## Extension rules
 

--- a/docs/architecture/subsystems/store.md
+++ b/docs/architecture/subsystems/store.md
@@ -9,6 +9,8 @@ recovery.
 - file, node, edge, occurrence, component, callable, bookmark, and trail rows;
 - grounding snapshots and search projections;
 - graph-native symbol documents, component reports, reusable embedding-free dense-anchor inputs, and their complete publication manifest;
+- verified source-policy exclusion rows and their project/workspace/core-bound
+  count-and-digest manifest;
 - core `generation_id`/`run_id` and retrieval-manifest records;
 - schema migrations and a versioned promotion journal.
 
@@ -30,6 +32,11 @@ The dense-anchor manifest is part of the core publication boundary. It binds
 the complete row count and digest, policy version, migration state, and every
 row's source identity to the current core generation/run. A migrated cache has
 no complete manifest until core indexing republishes it.
+
+The source-policy exclusion manifest follows the same fail-closed rule. Rows
+and manifest replace together in one SQLite transaction, and staged promotion
+records their candidate and rollback identities. A schema migration creates no
+synthetic manifest; runtime must republish from a complete verified inventory.
 
 Schema v25 also stores the current retrieval manifest and its deeply verified
 rollback record in the same SQLite row. They change in one transaction. The

--- a/docs/architecture/subsystems/workspace.md
+++ b/docs/architecture/subsystems/workspace.md
@@ -24,11 +24,18 @@ and schedule deletion. `workspace_relative_path` is the shared boundary for
 mapping existing candidates into a project without cross-root or
 case-folding mistakes.
 
+The shared oversized-source policy classifies stable, content-hashed bytes
+above the parser cap before indexer scheduling. Classification is based on
+verified content and the versioned policy, not path role. Partial discovery or
+a file that changes while being hashed cannot produce a deletion-capable
+exclusion set.
+
 ## Refresh planning
 
 Refresh plans compare discovered files with stored inventory using metadata and
 verified source hashes where available. They identify new, changed, retained,
-and removable files without depending on a live store handle.
+removable, and verified policy-excluded files without depending on a live store
+handle.
 
 ## Filesystem safety
 


### PR DESCRIPTION
## Context

The approved Linux corpus processed all 94,523 sources, then correctly refused its first core publication because 112 scheduled files exceeded the 1,000,000-byte parser cap. Those files were known source inputs, but the old path could only report them as unverified blockers.

This change represents a bounded oversized source as verified source-inventory evidence while keeping it outside parser, graph, and semantic coverage.

## What changed

- Classify stable, content-hashed sources above one process-captured source-index policy before parser scheduling. Planning, the parser fallback, publication, freshness, repair, and readers use the same policy version and byte cap.
- Re-read and rehash every exclusion at the full and incremental publication identity fence. A missing, unreadable, resized, changed, or no-longer-oversized candidate discards the staged core and preserves the prior live publication.
- Publish the complete exclusion set in SQLite with project, workspace, normalized path, content hash, observed size, policy/cap, core generation/run/timestamp, count, and digest.
- Require a valid candidate manifest, including a valid empty manifest, before v2 staged promotion can mutate live state. Prepared and committed recovery validate the bound manifest; legacy v1 journals without this field remain recoverable and leave normal runtime repair responsible for republishing migrated cores.
- Require complete discovery and a valid bound manifest for runtime publication, freshness, repair, and file diagnostics. Partial, unreadable, drifting, generic oversized, or identity-incomplete inputs still fail closed.
- Expose verified exclusions through typed `files` JSON and Markdown as source inventory with explicit `graph_coverage=false` and `semantic_coverage=false`.
- Document the identity-fence publication boundary and update the v0.16 changelog.

## Review order

1. Shared immutable policy, candidate contract, workspace classification, and revalidation.
2. Store schema, timestamp-bound manifest, staged promotion, and v1/v2 crash recovery.
3. Runtime full/incremental publication, freshness, repair, and diagnostics.
4. Focused identity-drift, policy-mismatch, first-publication, rollback, cancellation, and rendering tests.

## Verification

Exact head: `77feafd55b2fbfe5ff2b453492650ad4ffe66c31`

Based on: `457f3ca286ba2d829d01fa80924da8de6ae05e39` (`origin/dev/codestory-next`)

- `cargo test --locked -p codestory-contracts`
- `cargo test --locked -p codestory-workspace`
- `cargo test --locked -p codestory-store`
- `cargo test --locked -p codestory-indexer test_oversized_parser_file_is_skipped_before_indexing_read`
- `cargo test --locked -p codestory-runtime revalidates_excluded_bytes_at_identity_fence`
- `cargo test --locked -p codestory-runtime source_policy`
- `cargo test --locked -p codestory-runtime full_refresh_publishes_verified_`
- `cargo test --locked -p codestory-runtime verified_exclusion`
- `cargo test --locked -p codestory-runtime partial_discovery_keeps_oversized_candidates_blocking_and_publishes_nothing`
- `cargo test --locked -p codestory-cli files_markdown_labels_verified_policy_exclusions_as_non_graph_evidence`
- `cargo check --locked -p codestory-contracts -p codestory-workspace -p codestory-store -p codestory-indexer -p codestory-runtime -p codestory-cli`
- `cargo clippy --locked -p codestory-contracts -p codestory-workspace -p codestory-store -p codestory-indexer -p codestory-runtime -p codestory-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

The first-publication activation fixtures introduced by PR #1279 also pass with the required empty-manifest boundary.

## Risk and non-claims

This changes the core schema and makes migrated cores require a normal writer-owned republish before strict readers accept the new exclusion manifest. The indexer retains its generic oversized guard as a blocker if a candidate reaches it without verified policy classification.

No parser cap was raised. Exclusions do not create file rows, symbols, edges, semantic documents, or sufficiency evidence. No corpus, platform, package, installed-runtime, or release-readiness claim is made by this PR.

Closes #1277
Refs #1198
Refs #1237
Refs #1179
