### PR TITLE
Guard every collector with the source cap

### DIFF
--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1627,9 +1627,65 @@ impl WorkspaceIndexer {
             .compilation_db
             .as_ref()
             .and_then(|db| db.get_parsed_info(&full_path));
-        let Some(mut language_config) =
-            get_language_config_for_path(&full_path, compilation_info.as_ref())
-        else {
+        let language_config = get_language_config_for_path(&full_path, compilation_info.as_ref());
+        let source_language = language_config
+            .as_ref()
+            .map(|config| config.language_name)
+            .or_else(|| template_pipeline::template_surface_language(&full_path))
+            .or_else(|| {
+                structural::is_structural_candidate_path(&full_path)
+                    .then(|| structural::structural_language_name(&full_path))
+            })
+            .or_else(|| {
+                is_text_only_candidate_path(&full_path).then(|| text_only_language_name(&full_path))
+            })
+            .or_else(|| is_openapi_candidate_path(&full_path).then_some("openapi"));
+        let Some(source_language) = source_language else {
+            return Ok(PreparedIndexWork::Immediate(IntermediateStorage::default()));
+        };
+
+        let file_size = match std::fs::metadata(&full_path) {
+            Ok(metadata) => metadata.len(),
+            Err(e) => {
+                let local_storage = incomplete_file_storage(
+                    &full_path,
+                    None,
+                    source_language,
+                    codestory_contracts::graph::ErrorInfo {
+                        message: format!("Failed to inspect {:?}: {}", path, e),
+                        file_id: None,
+                        line: None,
+                        column: None,
+                        is_fatal: true,
+                        index_step: codestory_contracts::graph::IndexStep::Collection,
+                        coverage_reason: Some(FileCoverageReason::Unreadable),
+                    },
+                );
+                return Err(local_storage);
+            }
+        };
+        if file_size > self.source_file_byte_cap {
+            let local_storage = incomplete_file_storage(
+                &full_path,
+                None,
+                source_language,
+                codestory_contracts::graph::ErrorInfo {
+                    message: format!(
+                        "Skipped oversized source file {:?}: {} bytes exceeds {} byte cap",
+                        path, file_size, self.source_file_byte_cap
+                    ),
+                    file_id: None,
+                    line: None,
+                    column: None,
+                    is_fatal: false,
+                    index_step: codestory_contracts::graph::IndexStep::Indexing,
+                    coverage_reason: Some(FileCoverageReason::Oversized),
+                },
+            );
+            return Err(local_storage);
+        }
+
+        let Some(mut language_config) = language_config else {
             match self.prepare_openapi_schema_work(&full_path) {
                 Ok(Some(local_storage)) => return Ok(PreparedIndexWork::Immediate(local_storage)),
                 Ok(None) => {}
@@ -1713,47 +1769,6 @@ impl WorkspaceIndexer {
             }
             return Ok(PreparedIndexWork::Immediate(IntermediateStorage::default()));
         };
-
-        let file_size = match std::fs::metadata(&full_path) {
-            Ok(metadata) => metadata.len(),
-            Err(e) => {
-                let local_storage = incomplete_file_storage(
-                    &full_path,
-                    None,
-                    language_config.language_name,
-                    codestory_contracts::graph::ErrorInfo {
-                        message: format!("Failed to inspect {:?}: {}", path, e),
-                        file_id: None,
-                        line: None,
-                        column: None,
-                        is_fatal: true,
-                        index_step: codestory_contracts::graph::IndexStep::Collection,
-                        coverage_reason: Some(FileCoverageReason::Unreadable),
-                    },
-                );
-                return Err(local_storage);
-            }
-        };
-        if file_size > self.source_file_byte_cap {
-            let local_storage = incomplete_file_storage(
-                &full_path,
-                None,
-                language_config.language_name,
-                codestory_contracts::graph::ErrorInfo {
-                    message: format!(
-                        "Skipped oversized source file {:?}: {} bytes exceeds {} byte cap",
-                        path, file_size, self.source_file_byte_cap
-                    ),
-                    file_id: None,
-                    line: None,
-                    column: None,
-                    is_fatal: false,
-                    index_step: codestory_contracts::graph::IndexStep::Indexing,
-                    coverage_reason: Some(FileCoverageReason::Oversized),
-                },
-            );
-            return Err(local_storage);
-        }
 
         let bytes = match std::fs::read(&full_path) {
             Ok(bytes) => bytes,
@@ -20615,6 +20630,164 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert!(
             !nodes.iter().any(|node| node.serialized_name == "too_large"),
             "oversized parser-backed source should not be read and parsed"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_source_byte_cap_precedes_special_collector_reads() -> Result<()> {
+        use codestory_store::Store as Storage;
+        use codestory_workspace::RefreshInfo;
+        use std::fs;
+        use tempfile::tempdir;
+
+        const CAP: usize = 512;
+        let dir = tempdir()?;
+        let cases = [
+            (
+                "openapi",
+                "oversized-openapi.json",
+                "small-openapi.json",
+                r#"{
+  "openapi": "3.1.0",
+  "paths": {
+    "/small": {
+      "get": { "operationId": "getSmall" }
+    }
+  }
+}"#,
+            ),
+            (
+                "svelte",
+                "Oversized.svelte",
+                "Small.svelte",
+                r#"<script>
+  export function smallTemplate() { return 1; }
+</script>
+<h1>Small</h1>"#,
+            ),
+            (
+                "docker_compose",
+                "docker-compose.override.yml",
+                "compose.yaml",
+                "services:\n  web:\n    image: example/web:latest\n",
+            ),
+            (
+                "csharp",
+                "oversized.cshtml",
+                "small.cshtml",
+                "[HttpGet(\"/small\")]\n",
+            ),
+        ];
+
+        let mut files_to_index = Vec::new();
+        let mut oversized_paths = Vec::new();
+        let mut control_paths = Vec::new();
+        for (_, oversized_name, control_name, source) in cases {
+            assert!(source.len() <= CAP, "control fixture must remain below cap");
+            let oversized_path = dir.path().join(oversized_name);
+            let mut oversized_source = source.as_bytes().to_vec();
+            oversized_source.resize(CAP + 1, b' ');
+            fs::write(&oversized_path, oversized_source)?;
+            files_to_index.push(oversized_path.clone());
+            oversized_paths.push(oversized_path);
+
+            let control_path = dir.path().join(control_name);
+            fs::write(&control_path, source)?;
+            files_to_index.push(control_path.clone());
+            control_paths.push(control_path);
+        }
+        let unsupported_path = dir.path().join("oversized.bin");
+        fs::write(&unsupported_path, vec![b'x'; CAP + 1])?;
+        files_to_index.push(unsupported_path.clone());
+
+        let mut storage = Storage::new_in_memory()?;
+        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf())
+            .with_source_file_byte_cap(CAP as u64)
+            .with_batch_config(IncrementalIndexingConfig {
+                file_batch_size: files_to_index.len(),
+                node_batch_size: 256,
+                edge_batch_size: 256,
+                occurrence_batch_size: 256,
+                error_batch_size: 256,
+            });
+        indexer.run_incremental(
+            &mut storage,
+            &RefreshInfo {
+                mode: codestory_workspace::BuildMode::Incremental,
+                files_to_index,
+                files_to_remove: Vec::new(),
+                existing_file_ids: HashMap::new(),
+            },
+            &EventBus::new(),
+            None,
+        )?;
+
+        let files = storage.get_files()?;
+        let nodes = storage.get_nodes()?;
+        let edges = storage.get_edges()?;
+        let errors = storage.get_errors(None)?;
+        assert_eq!(
+            errors
+                .iter()
+                .filter(|error| error.coverage_reason == Some(FileCoverageReason::Oversized))
+                .count(),
+            oversized_paths.len()
+        );
+
+        for ((expected_language, _, _, _), path) in cases.iter().zip(&oversized_paths) {
+            let file = files
+                .iter()
+                .find(|file| file.path == *path)
+                .expect("oversized collector candidate must retain a diagnostic file row");
+            assert!(!file.complete);
+            assert_eq!(&file.language, expected_language);
+            assert!(errors.iter().any(|error| {
+                error.file_id == Some(NodeId(file.id))
+                    && error.coverage_reason == Some(FileCoverageReason::Oversized)
+            }));
+            assert_eq!(storage.get_file_content_hash(file.id)?, None);
+            assert!(
+                storage
+                    .get_callable_projection_states_for_file(file.id)?
+                    .is_empty(),
+                "oversized collector candidate cannot retain callable projection state"
+            );
+            assert!(
+                nodes
+                    .iter()
+                    .filter(|node| node.id != NodeId(file.id))
+                    .all(|node| node.file_node_id != Some(NodeId(file.id))),
+                "oversized collector candidate cannot emit non-file graph nodes"
+            );
+            assert!(
+                edges
+                    .iter()
+                    .all(|edge| edge.file_node_id != Some(NodeId(file.id))),
+                "oversized collector candidate cannot emit graph edges"
+            );
+        }
+
+        for path in control_paths {
+            let file = files
+                .iter()
+                .find(|file| file.path == path)
+                .expect("below-cap collector control must retain a file row");
+            assert!(
+                file.complete,
+                "below-cap collector control must remain usable"
+            );
+            assert!(
+                nodes.iter().any(|node| {
+                    node.kind != NodeKind::FILE && node.file_node_id == Some(NodeId(file.id))
+                }),
+                "below-cap collector control must still emit collector evidence"
+            );
+        }
+        assert!(
+            files.iter().all(|file| file.path != unsupported_path),
+            "ordinary unsupported paths must remain ignored"
         );
 
         Ok(())

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -6179,6 +6179,8 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
     static SOURCE_POLICY_BEFORE_REVALIDATE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
         const { std::cell::RefCell::new(None) };
+    static SOURCE_POLICY_AFTER_PLAN_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(test)]
@@ -6212,6 +6214,22 @@ fn arm_source_policy_before_revalidate_hook(hook: impl FnOnce() + 'static) {
 #[cfg(test)]
 fn run_source_policy_before_revalidate_hook() {
     SOURCE_POLICY_BEFORE_REVALIDATE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(test)]
+fn arm_source_policy_after_plan_hook(hook: impl FnOnce() + 'static) {
+    SOURCE_POLICY_AFTER_PLAN_HOOK.with(|slot| {
+        *slot.borrow_mut() = Some(Box::new(hook));
+    });
+}
+
+#[cfg(test)]
+fn run_source_policy_after_plan_hook() {
+    SOURCE_POLICY_AFTER_PLAN_HOOK.with(|slot| {
         if let Some(hook) = slot.borrow_mut().take() {
             hook();
         }
@@ -14283,6 +14301,9 @@ fn index_full_for_runtime(
         file_count: total_files,
     });
 
+    #[cfg(test)]
+    run_source_policy_after_plan_hook();
+
     let mut staged = SnapshotStore::open_staged(storage_path)
         .map_err(|e| ApiError::internal(format!("Failed to open staged storage: {e}")))?;
     let can_copy_forward = !recovering_incomplete_run && storage_path.exists();
@@ -22262,6 +22283,56 @@ fn build_llm_symbol_doc_text() -> String {
                 .expect_err("incompatible reader must fail closed");
             assert_eq!(error.code, "source_verification_failed");
         }
+    }
+
+    #[test]
+    fn special_collector_growth_after_planning_cannot_publish() {
+        let _env = hybrid_test_env();
+        let workspace = tempdir().expect("workspace");
+        let source_path = workspace.path().join("schema.sql");
+        fs::write(&source_path, "CREATE TABLE drifted (id INTEGER);\n")
+            .expect("write below-cap structural source");
+        let storage_path = workspace.path().join(".cache/codestory.db");
+        let controller = AppController::new_with_source_index_policy(
+            test_sidecar_runtime_from_env(),
+            SourceIndexPolicy::oversized(64),
+        );
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary");
+
+        let changed_path = source_path.clone();
+        arm_source_policy_after_plan_hook(move || {
+            let mut bytes = fs::read(&changed_path).expect("read planned structural source");
+            bytes.resize(65, b' ');
+            fs::write(&changed_path, bytes).expect("grow structural source after planning");
+        });
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect_err("post-plan oversized structural source must reject publication");
+        assert_eq!(error.code, "source_oversized");
+        assert!(error.details.as_ref().is_some_and(|details| {
+            details.coverage_gaps.iter().any(|gap| {
+                gap.path == "schema.sql"
+                    && gap.reason == FileCoverageReason::Oversized
+                    && !gap.verified_source
+                    && !gap.projection_available
+            })
+        }));
+        if storage_path.exists() {
+            assert!(
+                Storage::open(&storage_path)
+                    .expect("open rejected live storage")
+                    .get_index_publication()
+                    .expect("read rejected publication")
+                    .is_none()
+            );
+        }
+        assert_no_staged_publication_artifacts(&storage_path);
     }
 
     #[test]


### PR DESCRIPTION
## Context

The oversized-source policy was already applied to parser-backed files, but `WorkspaceIndexer::prepare_index_work` routed OpenAPI, template, structural, and text-only candidates to their collectors before reaching that fallback. A file that grew beyond the captured cap after workspace planning could therefore be read and projected by those collector paths.

## What changed

- Resolve the supported collector language without reading source, preserving structural path precedence over generic OpenAPI extension eligibility.
- Apply one metadata and `source_file_byte_cap` guard before every parser or special-collector read.
- Preserve the existing fail-closed contract for oversized candidates: one incomplete diagnostic file row and attached `Oversized` error, with no verified content hash, callable projection, non-file graph node, or graph edge.
- Preserve ordinary unsupported-path behavior and below-cap collector behavior.
- Add a full-runtime test seam proving that a structural source which grows after planning is rejected before any core publication.

## Review order

1. The read-free language routing and shared pre-read guard in `prepare_index_work`.
2. The direct indexer matrix covering OpenAPI, Svelte templates, Docker Compose structural YAML, and `.cshtml` text-only sources at cap+1, plus below-cap and unsupported controls.
3. The full-runtime post-plan SQL growth test and staged-publication assertions.

## Verification

Exact head: `d5353ff80f29a47320592cc77c3772091a76fe93`

Base: `54f939a47564cd4fe8cf93368b77b2ccdeccb608` (`origin/dev/codestory-next`)

- `cargo test --locked -p codestory-indexer test_source_byte_cap_precedes_special_collector_reads`
- `cargo test --locked -p codestory-indexer --lib` — 193 passed
- `cargo test --locked -p codestory-indexer --test integration` — 21 passed
- `cargo test --locked -p codestory-runtime special_collector_growth_after_planning_cannot_publish`
- `cargo test --locked -p codestory-runtime non_default_source_policy_cap_is_shared_by_planning_indexer_publication_and_readers`
- `cargo test --locked -p codestory-runtime full_refresh_publishes_verified_` — 3 passed
- `cargo check --locked -p codestory-indexer -p codestory-runtime`
- `cargo clippy --locked -p codestory-indexer -p codestory-runtime --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Risk and non-claims

The guard uses the indexer's existing injected or process-captured cap; there is no new policy source or path-role exemption. Generic JSON/YAML remains only an OpenAPI candidate until below-cap content verification, while known structural YAML keeps its structural diagnostic language.

No cap was raised. No corpus, package, platform, installed-runtime, or release-readiness claim is made by this PR. The current changelog wording remains accurate, so this correction does not add a second entry.

Closes #1283
Refs #1277
Refs #1198
Refs #1237