### PR TITLE
batch component-access lookup below SQLite bind limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   blocking the staged core publication.
 - Safe refreshes preserve the last verified index. Incomplete reads, cancellation, or concurrent source changes cannot publish a partial generation or mix results from different generations.
 - Large full and incremental refreshes now batch file-identity lookups against SQLite's runtime bind-variable limit without changing duplicate or missing-ID semantics.
+- Large semantic-document builds now batch component-access metadata lookups
+  against SQLite's runtime bind-variable limit instead of constructing one
+  repository-wide statement.
 - Resolution now skips its optional support cache when the serialized snapshot exceeds SQLite's runtime value limit, while keeping the in-memory result and staged publication intact.
 - Existing semantic indexes rebuild once after upgrading. The last complete index remains available while the replacement is prepared.
 - Project switching now preserves isolated per-project state across A/B/A MCP routing. Requests require an explicit project, and status remains observational instead of activating or repairing a repository.

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -4608,16 +4608,36 @@ impl Storage {
             return Ok(HashMap::new());
         }
 
-        let placeholders = question_placeholders(node_ids.len());
-        let sql =
-            format!("SELECT node_id, type FROM component_access WHERE node_id IN ({placeholders})");
-        let mut stmt = self.conn.prepare(&sql)?;
-        let mut rows = stmt.query(rusqlite::params_from_iter(node_ids.iter().map(|id| id.0)))?;
+        let variable_limit = usize::try_from(self.conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)?)
+            .map_err(|_| {
+                StorageError::Other(
+                    "SQLite reported a negative bind-variable limit for component-access lookup"
+                        .to_string(),
+                )
+            })?;
+        if variable_limit == 0 {
+            return Err(StorageError::Other(
+                "SQLite bind-variable limit 0 cannot support component-access lookup".to_string(),
+            ));
+        }
+
+        let mut unique_node_ids = node_ids.to_vec();
+        unique_node_ids.sort_unstable_by_key(|id| id.0);
+        unique_node_ids.dedup();
+
         let mut map = HashMap::new();
-        while let Some(row) = rows.next()? {
-            let node_id: i64 = row.get(0)?;
-            let raw: i32 = row.get(1)?;
-            map.insert(NodeId(node_id), row_mapping::access_kind_from_db(raw));
+        for batch in unique_node_ids.chunks(variable_limit) {
+            let placeholders = question_placeholders(batch.len());
+            let sql = format!(
+                "SELECT node_id, type FROM component_access WHERE node_id IN ({placeholders})"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let mut rows = stmt.query(params_from_iter(batch.iter().map(|id| id.0)))?;
+            while let Some(row) = rows.next()? {
+                let node_id: i64 = row.get(0)?;
+                let raw: i32 = row.get(1)?;
+                map.insert(NodeId(node_id), row_mapping::access_kind_from_db(raw));
+            }
         }
         Ok(map)
     }

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -1549,6 +1549,77 @@ fn test_component_access_round_trip() -> Result<(), StorageError> {
 }
 
 #[test]
+fn component_access_lookup_batches_at_runtime_bind_limit() -> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(41),
+            kind: NodeKind::METHOD,
+            serialized_name: "run".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(42),
+            kind: NodeKind::FIELD,
+            serialized_name: "state".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(43),
+            kind: NodeKind::METHOD,
+            serialized_name: "reset".to_string(),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_component_access_batch(&[
+        (NodeId(41), AccessKind::Protected),
+        (NodeId(42), AccessKind::Private),
+        (NodeId(43), AccessKind::Public),
+    ])?;
+
+    let previous_limit = storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 2)?;
+    assert!(previous_limit >= 2);
+
+    let map = storage.get_component_access_map_for_nodes(&[
+        NodeId(99),
+        NodeId(43),
+        NodeId(41),
+        NodeId(42),
+        NodeId(41),
+        NodeId(100),
+    ])?;
+    assert_eq!(map.len(), 3);
+    assert_eq!(map.get(&NodeId(41)), Some(&AccessKind::Protected));
+    assert_eq!(map.get(&NodeId(42)), Some(&AccessKind::Private));
+    assert_eq!(map.get(&NodeId(43)), Some(&AccessKind::Public));
+    storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, previous_limit)?;
+    Ok(())
+}
+
+#[test]
+fn component_access_lookup_rejects_zero_bind_limit() -> Result<(), StorageError> {
+    let storage = Storage::new_in_memory()?;
+    storage
+        .get_connection()
+        .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 0)?;
+
+    let error = storage
+        .get_component_access_map_for_nodes(&[NodeId(41)])
+        .expect_err("component-access lookup must reject a zero-variable runtime limit");
+    assert!(
+        error
+            .to_string()
+            .contains("cannot support component-access lookup"),
+        "unexpected error: {error}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_symbol_search_doc_version_mismatch_detection() -> Result<(), StorageError> {
     let mut storage = Storage::new_in_memory()?;
     storage.insert_nodes_batch(&[Node {


### PR DESCRIPTION
## Context

The exact integrated 94,411-file Linux-corpus proof at
`5f7d762bddcaadc4cca3fc364ac09175da810e79` parsed the complete inventory and
finished semantic resolution, then failed before publication because
`get_component_access_map_for_nodes` serialized 1,900,216 node IDs into one
SQLite `IN` statement. SQLite rejected the 32,767th bind at offset 65,593.

The failed run preserved the old-or-new boundary: no core was published, the
staged DB/WAL were removed, and the unpublished live DB stayed unchanged.

## What changed

- derive component-access read chunks from the connection's runtime
  `SQLITE_LIMIT_VARIABLE_NUMBER`
- sort and deduplicate input node IDs before querying
- merge access rows across every chunk without changing missing-ID or duplicate
  semantics
- reject an unusable zero-variable runtime limit with an attributed storage
  error
- record the v0.16 reliability correction in the changelog

## How to review

Start with `Storage::get_component_access_map_for_nodes`. Each ID is bound once,
so the runtime variable limit is the exact maximum chunk size. The production
failure becomes 58 reads at the current 32,766-variable limit instead of one
1,900,216-variable statement.

The regression lowers the limit to two and crosses several chunks while
covering duplicates, missing IDs, protected/private/public values, and the
zero-limit error.

Exact source candidate: `453d48728057faa441c374f81fc371b24d269b34`.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked -p codestory-store component_access_lookup` (2 passed)
- `cargo test --locked -p codestory-store` (121 passed)
- `cargo check --locked -p codestory-store -p codestory-runtime`
- `cargo clippy --locked -p codestory-store -p codestory-runtime --all-targets -- -D warnings`
- `git diff --check`

The exact-corpus rerun remains required on the integrated merge head. The
retained predecessor no-go is under
`/Volumes/CodeStoryLinuxCorpus/runs/issue-1237-5f7d762-hGztIG/`.

## Risk and nonclaims

The read now executes multiple statements and allocates a sorted/deduplicated
ID vector. At the observed scale that is 58 bounded reads and about 15 MB of raw
ID storage. This PR does not change semantic-document selection, component
access values, publication, vector routing, or the queued #1275 performance
work. Successful corpus publication is not claimed until the integrated exact
run completes.

Closes #1285
Refs #1237
Refs #1202
Refs #1179
