### PR TITLE
[codex] batch artifact-cache upserts per parse chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Performance
+
+- Full refresh now persists each ordered parser-artifact chunk in one SQLite
+  transaction instead of one autocommit per parsed file. Index telemetry
+  reports artifact-cache rows, transactions, and write time separately.
+
 ## 0.16.0
 
 CodeStory 0.16 makes repository search more accurate and reduces duplicate model memory across agents and projects. The model and embedding engine ship inside CodeStory, compatible processes share one private local server, and startup, readiness, and idle shutdown happen automatically.

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -51,3 +51,8 @@ bench = false
 name = "browser_stress"
 harness = false
 bench = false
+
+[[bench]]
+name = "artifact_cache"
+harness = false
+bench = false

--- a/crates/codestory-bench/benches/artifact_cache.rs
+++ b/crates/codestory-bench/benches/artifact_cache.rs
@@ -1,0 +1,86 @@
+use codestory_store::{IndexArtifactCacheWrite, Store};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const CHUNK_SIZE: usize = 24;
+const ARTIFACT_BYTES: usize = 64 * 1024;
+
+struct ArtifactCacheFixture {
+    _temp: TempDir,
+    store: Store,
+    entries: Vec<(PathBuf, String, Vec<u8>)>,
+}
+
+fn artifact_cache_chunk_persistence(c: &mut Criterion) {
+    let mut group = c.benchmark_group("artifact_cache_chunk_persistence");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(8));
+    group.throughput(Throughput::Elements(CHUNK_SIZE as u64));
+
+    group.bench_function("single_row_autocommits", |b| {
+        b.iter_batched(
+            build_fixture,
+            |fixture| {
+                for (path, cache_key, artifact_blob) in &fixture.entries {
+                    fixture
+                        .store
+                        .upsert_index_artifact_cache(path, cache_key, artifact_blob)
+                        .expect("single artifact-cache upsert");
+                }
+                black_box(fixture.store);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("one_transaction_per_chunk", |b| {
+        b.iter_batched(
+            build_fixture,
+            |fixture| {
+                let writes = fixture
+                    .entries
+                    .iter()
+                    .map(|(path, cache_key, artifact_blob)| IndexArtifactCacheWrite {
+                        path,
+                        cache_key,
+                        artifact_blob,
+                    })
+                    .collect::<Vec<_>>();
+                let written = fixture
+                    .store
+                    .upsert_index_artifact_cache_batch(&writes)
+                    .expect("artifact-cache batch upsert");
+                black_box((written, fixture.store));
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+fn build_fixture() -> ArtifactCacheFixture {
+    let temp = tempfile::tempdir().expect("artifact-cache benchmark tempdir");
+    let store = Store::open_build(&temp.path().join("codestory.db"))
+        .expect("artifact-cache benchmark build store");
+    let entries = (0..CHUNK_SIZE)
+        .map(|index| {
+            (
+                PathBuf::from(format!("src/module_{index}.rs")),
+                format!("v2:benchmark-{index}"),
+                vec![index as u8; ARTIFACT_BYTES],
+            )
+        })
+        .collect();
+    ArtifactCacheFixture {
+        _temp: temp,
+        store,
+        entries,
+    }
+}
+
+criterion_group!(benches, artifact_cache_chunk_persistence);
+criterion_main!(benches);

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8930,6 +8930,9 @@ mod tests {
             edge_resolution_ms: 30,
             error_flush_ms: 4,
             cleanup_ms: 5,
+            artifact_cache_write_ms: Some(6),
+            artifact_cache_writes: Some(24),
+            artifact_cache_write_transactions: Some(1),
             cache_refresh_ms: Some(6),
             search_projection_rebuild_ms: Some(61),
             search_symbol_index_ms: Some(62),
@@ -9158,9 +9161,10 @@ mod tests {
 
         let markdown = render_index_markdown(&output);
 
-        assert!(
-            markdown.contains("cache_ms: search_projection=61 search_index=62 runtime_publish=63")
-        );
+        assert!(markdown.contains(
+            "cache_ms: artifact_write=6 search_projection=61 search_index=62 runtime_publish=63"
+        ));
+        assert!(markdown.contains("artifact_cache: writes=24 transactions=1"));
         assert!(
             markdown
                 .contains("semantic_ms: doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -325,9 +325,18 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
         markdown,
         "cache_ms",
         &[
+            ("artifact_write", timings.artifact_cache_write_ms),
             ("search_projection", timings.search_projection_rebuild_ms),
             ("search_index", timings.search_symbol_index_ms),
             ("runtime_publish", timings.runtime_cache_publish_ms),
+        ],
+    );
+    append_optional_timings_line(
+        markdown,
+        "artifact_cache",
+        &[
+            ("writes", timings.artifact_cache_writes),
+            ("transactions", timings.artifact_cache_write_transactions),
         ],
     );
     append_optional_timings_line(

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -8,6 +8,12 @@ pub struct IndexingPhaseTimings {
     pub edge_resolution_ms: u32,
     pub error_flush_ms: u32,
     pub cleanup_ms: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_cache_write_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_cache_writes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_cache_write_transactions: Option<u32>,
     pub cache_refresh_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_projection_rebuild_ms: Option<u32>,
@@ -193,6 +199,9 @@ mod tests {
             edge_resolution_ms: 3,
             error_flush_ms: 4,
             cleanup_ms: 5,
+            artifact_cache_write_ms: None,
+            artifact_cache_writes: None,
+            artifact_cache_write_transactions: None,
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,
@@ -269,6 +278,9 @@ mod tests {
         };
 
         let value = serde_json::to_value(timings).expect("serialize timings");
+        assert!(value.get("artifact_cache_write_ms").is_none());
+        assert!(value.get("artifact_cache_writes").is_none());
+        assert!(value.get("artifact_cache_write_transactions").is_none());
         assert!(value.get("resolution_unresolved_counts_ms").is_none());
         assert!(value.get("resolution_calls_ms").is_none());
         assert!(value.get("resolution_imports_ms").is_none());

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -17,7 +17,7 @@ use codestory_contracts::graph::{
     NodeKind, Occurrence, OccurrenceKind, ResolutionCertainty, SourceLocation,
 };
 use codestory_contracts::workspace::process_source_index_policy;
-use codestory_store::Store as Storage;
+use codestory_store::{IndexArtifactCacheWrite, Store as Storage};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -681,6 +681,7 @@ pub struct IncrementalIndexingStats {
     pub artifact_cache_misses: usize,
     pub artifact_cache_invalid_entries: usize,
     pub artifact_cache_writes: usize,
+    pub artifact_cache_write_transactions: usize,
     pub parse_index_ms: u64,
     pub projection_flush_ms: u64,
     pub flush_files_ms: u64,
@@ -1015,28 +1016,52 @@ impl WorkspaceIndexer {
                 .parse_index_ms
                 .saturating_add(duration_ms_u64(parse_started.elapsed()));
 
+            let mut cache_writes = Vec::with_capacity(parse_results.len());
+            let mut parsed_storages = Vec::with_capacity(parse_results.len());
             for parsed in parse_results {
                 if let Some(cache_write) = parsed.cache_write {
-                    let cache_write_started = Instant::now();
-                    storage
-                        .upsert_index_artifact_cache(
-                            &cache_write.path,
-                            &cache_write.cache_key,
-                            &cache_write.artifact_blob,
-                        )
-                        .map_err(|e| anyhow!("Storage cache write error: {:?}", e))?;
-                    stats.artifact_cache_write_ms = stats
-                        .artifact_cache_write_ms
-                        .saturating_add(duration_ms_u64(cache_write_started.elapsed()));
-                    stats.artifact_cache_writes += 1;
+                    cache_writes.push(cache_write);
                 }
+                parsed_storages.push(parsed.local_storage);
+            }
 
+            if !cache_writes.is_empty() {
+                let cache_write_started = Instant::now();
+                let batch = cache_writes
+                    .iter()
+                    .map(|write| IndexArtifactCacheWrite {
+                        path: &write.path,
+                        cache_key: &write.cache_key,
+                        artifact_blob: &write.artifact_blob,
+                    })
+                    .collect::<Vec<_>>();
+                let written =
+                    storage
+                        .upsert_index_artifact_cache_batch(&batch)
+                        .map_err(|error| {
+                            anyhow!(
+                                "Storage cache batch write error for {} entries: {error}",
+                                batch.len()
+                            )
+                        })?;
+                stats.artifact_cache_write_ms = stats
+                    .artifact_cache_write_ms
+                    .saturating_add(duration_ms_u64(cache_write_started.elapsed()));
+                stats.artifact_cache_writes = stats.artifact_cache_writes.saturating_add(written);
+                stats.artifact_cache_write_transactions =
+                    stats.artifact_cache_write_transactions.saturating_add(1);
+            }
+
+            // Cancellation observed during this chunk is handled after the complete
+            // ordered cache transaction and projection flush boundary. The staged
+            // full-refresh database still cannot become live until runtime publish.
+            for local_storage in parsed_storages {
                 let current = processed_count.fetch_add(1, Ordering::Relaxed) + 1;
                 event_bus.publish(Event::IndexingProgress {
                     current,
                     total: total_files,
                 });
-                chunk_results.push(parsed.local_storage);
+                chunk_results.push(local_storage);
             }
 
             for mut local_storage in chunk_results {
@@ -20515,9 +20540,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
     }
 
     #[test]
-    fn test_incremental_indexing_batch_flush() -> Result<()> {
+    fn test_full_refresh_batches_artifact_cache_writes_per_file_chunk() -> Result<()> {
         use codestory_store::Store as Storage;
-        use codestory_workspace::RefreshInfo;
         use std::fs;
         use tempfile::tempdir;
 
@@ -20541,14 +20565,17 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             },
         );
 
-        let refresh_info = RefreshInfo {
-            mode: codestory_workspace::BuildMode::Incremental,
+        let plan = codestory_workspace::RefreshExecutionPlan {
+            mode: codestory_workspace::BuildMode::FullRefresh,
             files_to_index: files,
             files_to_remove: vec![],
             existing_file_ids: std::collections::HashMap::new(),
         };
 
-        indexer.run_incremental(&mut storage, &refresh_info, &bus, None)?;
+        let stats = indexer.run(&mut storage, &plan, &bus, None)?;
+
+        assert_eq!(stats.artifact_cache_writes, 12);
+        assert_eq!(stats.artifact_cache_write_transactions, 4);
 
         // Each file should contribute at least one file node and one symbol node.
         let nodes = storage.get_nodes()?;
@@ -20856,6 +20883,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             !stats.resolution_ran,
             "cancellation after indexing flush should skip resolution"
         );
+        assert_eq!(stats.artifact_cache_writes, 64);
+        assert_eq!(stats.artifact_cache_write_transactions, 1);
         assert!(
             !storage.get_edges()?.is_empty(),
             "indexing should flush edges"

--- a/crates/codestory-indexer/tests/oss_language_corpus.rs
+++ b/crates/codestory-indexer/tests/oss_language_corpus.rs
@@ -859,9 +859,11 @@ fn report_json(report: &CorpusReport) -> serde_json::Value {
         "indexing_stats": {
             "parse_index_ms": report.stats.parse_index_ms,
             "edge_resolution_ms": report.stats.edge_resolution_ms,
+            "artifact_cache_write_ms": report.stats.artifact_cache_write_ms,
             "artifact_cache_hits": report.stats.artifact_cache_hits,
             "artifact_cache_misses": report.stats.artifact_cache_misses,
             "artifact_cache_writes": report.stats.artifact_cache_writes,
+            "artifact_cache_write_transactions": report.stats.artifact_cache_write_transactions,
             "resolved_calls": report.stats.resolved_calls,
             "resolved_imports": report.stats.resolved_imports,
             "unresolved_calls_end": report.stats.unresolved_calls_end,

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -14609,6 +14609,11 @@ fn index_full_for_runtime(
             edge_resolution_ms: clamp_u64_to_u32(index_stats.edge_resolution_ms),
             error_flush_ms: clamp_u64_to_u32(index_stats.error_flush_ms),
             cleanup_ms: clamp_u64_to_u32(index_stats.cleanup_ms),
+            artifact_cache_write_ms: Some(clamp_u64_to_u32(index_stats.artifact_cache_write_ms)),
+            artifact_cache_writes: Some(clamp_usize_to_u32(index_stats.artifact_cache_writes)),
+            artifact_cache_write_transactions: Some(clamp_usize_to_u32(
+                index_stats.artifact_cache_write_transactions,
+            )),
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,
@@ -15225,6 +15230,11 @@ fn run_incremental_indexing_common(
             edge_resolution_ms: clamp_u64_to_u32(index_stats.edge_resolution_ms),
             error_flush_ms: clamp_u64_to_u32(index_stats.error_flush_ms),
             cleanup_ms: clamp_u64_to_u32(index_stats.cleanup_ms),
+            artifact_cache_write_ms: Some(clamp_u64_to_u32(index_stats.artifact_cache_write_ms)),
+            artifact_cache_writes: Some(clamp_usize_to_u32(index_stats.artifact_cache_writes)),
+            artifact_cache_write_transactions: Some(clamp_usize_to_u32(
+                index_stats.artifact_cache_write_transactions,
+            )),
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -21,13 +21,13 @@ pub use storage_impl::{
     DENSE_ANCHOR_PUBLICATION_SCHEMA_VERSION, DenseAnchorInput, DenseAnchorInputReuseMetadata,
     DenseAnchorPublicationManifest, DenseReasonCounts, FileContentHash, FileInfo,
     FileProjectionRemovalSummary, FileRole, GroundingEdgeKindCount, GroundingFileSummary,
-    GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState, IndexPublicationMode,
-    IndexPublicationRecord, LlmSymbolDoc, LlmSymbolDocReuseMetadata, LlmSymbolDocStats,
-    ProjectionFlushBreakdown, RetrievalIndexManifest, RetrievalIndexRollbackRecord,
-    SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION, SearchSymbolProjection,
-    SearchSymbolProjectionDetail, SourcePolicyExclusionManifest, SourcePolicyExclusionRecord,
-    Storage as Store, StorageError, StorageOpenMode, StorageStats, SymbolSearchDoc,
-    SymbolSummaryRecord,
+    GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState,
+    IndexArtifactCacheWrite, IndexPublicationMode, IndexPublicationRecord, LlmSymbolDoc,
+    LlmSymbolDocReuseMetadata, LlmSymbolDocStats, ProjectionFlushBreakdown, RetrievalIndexManifest,
+    RetrievalIndexRollbackRecord, SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION,
+    SearchSymbolProjection, SearchSymbolProjectionDetail, SourcePolicyExclusionManifest,
+    SourcePolicyExclusionRecord, Storage as Store, StorageError, StorageOpenMode, StorageStats,
+    SymbolSearchDoc, SymbolSummaryRecord,
 };
 
 impl Store {

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -57,6 +57,17 @@ const EDGE_SELECT_BASE: &str = "SELECT e.id, e.source_node_id, e.target_node_id,
 const EDGE_NODE_LOOKUP_BATCH_SIZE: usize = 200;
 const NODE_LOOKUP_BATCH_SIZE: usize = 200;
 const OCCURRENCE_LOOKUP_BATCH_SIZE: usize = 200;
+const INDEX_ARTIFACT_CACHE_UPSERT_SQL: &str = "INSERT INTO index_artifact_cache (
+    file_path,
+    cache_key,
+    artifact_blob,
+    updated_at_epoch_ms
+ )
+ VALUES (?1, ?2, ?3, ?4)
+ ON CONFLICT(file_path) DO UPDATE SET
+    cache_key = excluded.cache_key,
+    artifact_blob = excluded.artifact_blob,
+    updated_at_epoch_ms = excluded.updated_at_epoch_ms";
 #[cfg(test)]
 const PROMOTION_ABORT_SENTINEL_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_SENTINEL";
 #[cfg(test)]
@@ -925,6 +936,18 @@ fn outside_file_node_predicate(file_param: &str) -> String {
     format!("(file_node_id IS NULL OR file_node_id != {file_param})")
 }
 
+fn upsert_index_artifact_cache_row(
+    statement: &mut rusqlite::Statement<'_>,
+    write: IndexArtifactCacheWrite<'_>,
+) -> Result<usize, StorageError> {
+    Ok(statement.execute(params![
+        write.path.to_string_lossy().to_string(),
+        write.cache_key,
+        write.artifact_blob,
+        current_epoch_ms()
+    ])?)
+}
+
 /// Errors returned by storage facade operations.
 #[derive(Error, Debug)]
 pub enum StorageError {
@@ -936,6 +959,14 @@ pub enum StorageError {
     EnumConversion(#[from] EnumConversionError),
     #[error("Other error: {0}")]
     Other(String),
+}
+
+/// One reusable parser artifact to persist in the index artifact cache.
+#[derive(Debug, Clone, Copy)]
+pub struct IndexArtifactCacheWrite<'a> {
+    pub path: &'a Path,
+    pub cache_key: &'a str,
+    pub artifact_blob: &'a [u8],
 }
 
 /// SQLite-backed graph, search, file, and snapshot store.
@@ -2232,17 +2263,7 @@ impl Storage {
         artifact_blob: &[u8],
     ) -> Result<(), StorageError> {
         self.conn.execute(
-            "INSERT INTO index_artifact_cache (
-                file_path,
-                cache_key,
-                artifact_blob,
-                updated_at_epoch_ms
-             )
-             VALUES (?1, ?2, ?3, ?4)
-             ON CONFLICT(file_path) DO UPDATE SET
-                cache_key = excluded.cache_key,
-                artifact_blob = excluded.artifact_blob,
-                updated_at_epoch_ms = excluded.updated_at_epoch_ms",
+            INDEX_ARTIFACT_CACHE_UPSERT_SQL,
             params![
                 path.to_string_lossy().to_string(),
                 cache_key,
@@ -2251,6 +2272,30 @@ impl Storage {
             ],
         )?;
         Ok(())
+    }
+
+    /// Persist one ordered artifact-cache chunk in a single transaction.
+    ///
+    /// Duplicate paths retain ordered single-row semantics: the last entry wins.
+    /// An empty chunk does not open a transaction, and any row failure rolls the
+    /// complete chunk back.
+    pub fn upsert_index_artifact_cache_batch(
+        &self,
+        writes: &[IndexArtifactCacheWrite<'_>],
+    ) -> Result<usize, StorageError> {
+        if writes.is_empty() {
+            return Ok(0);
+        }
+
+        let transaction = self.conn.unchecked_transaction()?;
+        {
+            let mut statement = transaction.prepare_cached(INDEX_ARTIFACT_CACHE_UPSERT_SQL)?;
+            for write in writes {
+                upsert_index_artifact_cache_row(&mut statement, *write)?;
+            }
+        }
+        transaction.commit()?;
+        Ok(writes.len())
     }
 
     pub fn copy_index_artifact_cache_from(

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -1330,6 +1330,91 @@ fn test_index_artifact_cache_round_trip() -> Result<(), StorageError> {
 }
 
 #[test]
+fn test_index_artifact_cache_batch_is_ordered_and_empty_is_noop() -> Result<(), StorageError> {
+    let storage = Storage::new_in_memory()?;
+    let path = Path::new("src/lib.rs");
+    let empty: [IndexArtifactCacheWrite<'_>; 0] = [];
+
+    assert_eq!(storage.upsert_index_artifact_cache_batch(&empty)?, 0);
+    assert_eq!(
+        storage.upsert_index_artifact_cache_batch(&[
+            IndexArtifactCacheWrite {
+                path,
+                cache_key: "first-key",
+                artifact_blob: b"first",
+            },
+            IndexArtifactCacheWrite {
+                path,
+                cache_key: "last-key",
+                artifact_blob: b"last",
+            },
+        ])?,
+        2
+    );
+
+    assert_eq!(storage.get_index_artifact_cache(path, "first-key")?, None);
+    assert_eq!(
+        storage.get_index_artifact_cache(path, "last-key")?,
+        Some(b"last".to_vec())
+    );
+    Ok(())
+}
+
+#[test]
+fn test_index_artifact_cache_batch_rolls_back_every_row_on_failure() -> Result<(), StorageError> {
+    let storage = Storage::new_in_memory()?;
+    let stable_path = Path::new("stable.rs");
+    storage.upsert_index_artifact_cache(stable_path, "stable-key", b"stable")?;
+    storage.get_connection().execute_batch(
+        "CREATE TRIGGER reject_failed_artifact_cache_write
+         BEFORE INSERT ON index_artifact_cache
+         WHEN NEW.file_path = 'fail.rs'
+         BEGIN
+           SELECT RAISE(ABORT, 'forced artifact-cache batch failure');
+         END;",
+    )?;
+
+    let error = storage
+        .upsert_index_artifact_cache_batch(&[
+            IndexArtifactCacheWrite {
+                path: stable_path,
+                cache_key: "replacement-key",
+                artifact_blob: b"replacement",
+            },
+            IndexArtifactCacheWrite {
+                path: Path::new("new.rs"),
+                cache_key: "new-key",
+                artifact_blob: b"new",
+            },
+            IndexArtifactCacheWrite {
+                path: Path::new("fail.rs"),
+                cache_key: "fail-key",
+                artifact_blob: b"fail",
+            },
+        ])
+        .expect_err("trigger must abort the artifact-cache batch");
+    assert!(
+        error
+            .to_string()
+            .contains("forced artifact-cache batch failure")
+    );
+
+    assert_eq!(
+        storage.get_index_artifact_cache(stable_path, "stable-key")?,
+        Some(b"stable".to_vec())
+    );
+    assert_eq!(
+        storage.get_index_artifact_cache(stable_path, "replacement-key")?,
+        None
+    );
+    assert_eq!(
+        storage.get_index_artifact_cache(Path::new("new.rs"), "new-key")?,
+        None
+    );
+    Ok(())
+}
+
+#[test]
 fn test_resolution_support_snapshot_round_trip_and_invalidation() -> Result<(), StorageError> {
     let storage = Storage::new_in_memory()?;
     let payload = br#"{"support":1}"#;

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -210,6 +210,13 @@ Cache misses become `PreparedIndexInput` values and are parsed in parallel. Each
 
 This phase is where the indexer builds unresolved edges and other graph artifacts. Resolution does not happen yet.
 
+Parsed artifact-cache writes retain Rayon result order and commit once per
+existing file chunk. Duplicate paths therefore keep ordered last-write
+semantics, while a row failure rolls back the whole cache chunk. Cancellation
+is observed at the next chunk boundary: an in-flight cache transaction either
+commits completely or rolls back, and a staged full refresh still cannot
+become live before the runtime publication fence.
+
 ### 7. The indexer flushes projection batches
 
 As file results are merged, `WorkspaceIndexer::run` flushes batches once file, node, edge, or occurrence counts cross the configured thresholds.


### PR DESCRIPTION
## Context

The retained exact Linux corpus proof at `0fb25885d586c3c718e268932896673b9e240a33` showed full-refresh indexing was storage-bound. The indexer parsed in 24-file chunks, then persisted every reusable parser artifact through its own SQLite autocommit. This is the first ordered performance slice under #1275.

Closes #1287
Refs #1275
Refs #1202

## What changed

- added a store-owned ordered artifact-cache batch API that opens one SQLite transaction for a non-empty chunk;
- routed the existing full/incremental indexer chunk producer through that API while retaining the independent single-row API;
- preserved ordered duplicate last-write behavior, made empty batches transaction-free, and added an injected mid-batch rollback test;
- added phase telemetry for artifact-cache write time, rows, and transactions to JSON and markdown output;
- added a staged-build Criterion fixture for the current 24-file chunk shape;
- documented the cancellation boundary and updated `CHANGELOG.md`.

No parse/writer channel, SQLite durability setting, adaptive chunk budget, GPU setting, or thread-count change is included.

## How to review

1. Start in `codestory-store`: the batch API must keep all SQL/transaction ownership there and preserve the existing single-row contract.
2. In `WorkspaceIndexer::run`, verify Rayon result order is retained and one non-empty cache transaction occurs before progress/projection handling for each existing file chunk.
3. Check the new telemetry stays descriptive rather than changing index semantics.
4. Check the benchmark uses `Store::open_build`, 24 rows, 64 KiB artifacts, and no production-only selector.

## Verification

Exact candidate: `0793d0278c80aba87b9cc9c0920e7ebff4ff8c20`

Exact base: `23336305056b79c1d24edbbb806453243e0e383c`

- `cargo fmt --all -- --check`
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs`
- `cargo test --locked -p codestory-store index_artifact_cache -- --nocapture`
- `cargo test --locked -p codestory-indexer test_full_refresh_batches_artifact_cache_writes_per_file_chunk -- --nocapture`
- `cargo test --locked -p codestory-indexer test_incremental_indexing_cancel_after_flush_skips_resolution -- --nocapture`
- `cargo test --locked -p codestory-contracts test_indexing_phase_timings_omits_optional_resolution_fields_when_none -- --nocapture`
- `cargo test --locked -p codestory-cli render_index_markdown_includes_rich_timing_breakdown_when_available -- --nocapture`
- `cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture`
- `cargo check --locked -p codestory-store -p codestory-indexer -p codestory-runtime -p codestory-cli -p codestory-bench`
- `cargo clippy --locked -p codestory-store -p codestory-indexer -p codestory-runtime -p codestory-cli -p codestory-bench --all-targets --all-features -- -D warnings`

Focused benchmark on the retained case-sensitive APFS corpus image, using the release profile and an explicitly prepared embedded-model source:

| 24 × 64 KiB staged-build chunk | Median | Transactions |
| --- | ---: | ---: |
| single-row autocommits | 7.6089 ms | 24 |
| one transaction per chunk | 6.1682 ms | 1 |

That is 18.9% lower median persistence time for this synthetic chunk fixture. It is not an end-to-end corpus speedup claim. Per repository policy, the repo-scale corpus lane remains reserved for the final combined performance candidate.

Independent review of the pre-rebase candidate found no P0–P3 issue. The candidate was then rebased onto the merged typed-source smoke repair in #1290 and the focused tests, checks, clippy, and both publication matrices above were rerun at the exact head. Exact-head re-review is the remaining review gate. Residual nonclaims are the deferred repo-scale/broad workspace gates and no attempt to interrupt SQLite inside `COMMIT`; the injected row failure proves transaction rollback, while the runtime fault/cancel matrices prove old-or-new publication.

## Risk

The transaction retains up to one existing parse chunk of artifact blobs and references before commit. With the current fixed window that is bounded to 24 files for full refresh. A database error now rejects the entire cache chunk instead of leaving earlier cache rows committed; graph publication behavior remains staged and atomic.
