### PR TITLE
[P1] Repair stale typed-source retrieval smoke

### DIFF
--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -5100,10 +5100,10 @@ fn packet_repairs_a_missing_search_generation_before_rendering_same_tool_retry()
 fn packet_preserves_typed_source_failure_diagnostics() {
     let fixture = unindexed_fixture();
     fs::write(
-        fixture.workspace.path().join("src/lib.rs"),
-        "x".repeat(1_000_001),
+        fixture.workspace.path().join("codestory_workspace.json"),
+        r#"{"members":["src","missing"]}"#,
     )
-    .expect("write oversized source fixture");
+    .expect("write incomplete discovery fixture");
     let mut server = spawn_stdio_server(&fixture);
 
     let response = send_json(
@@ -5121,14 +5121,14 @@ fn packet_preserves_typed_source_failure_diagnostics() {
     let error = assert_tool_error(&response, json!("packet-typed-source-failure"));
 
     assert_eq!(error["code"], json!("codestory_unavailable"));
-    assert_eq!(error["cause_code"], json!("source_oversized"));
+    assert_eq!(error["cause_code"], json!("source_discovery_incomplete"));
     assert_eq!(error["retry_tool"], Value::Null);
     assert_eq!(
         error.pointer("/details/coverage_gaps/0/reason"),
-        Some(&json!("oversized"))
+        Some(&json!("discovery_incomplete"))
     );
     assert_eq!(
         error.pointer("/details/coverage_gaps/0/retryable"),
-        Some(&json!(false))
+        Some(&json!(true))
     );
 }


### PR DESCRIPTION
Closes #1289
Refs #1277, #1260, #1287

## Context

Verified oversized sources became publishable policy exclusions in #1277. The stdio typed-source contract still treated one as a blocking `source_oversized` failure, so hosted retrieval smoke proceeded to the next valid gate and failed the stale assertion with `native_model_not_embedded`.

This is reproducible on integrated base `0fb25885d586c3c718e268932896673b9e240a33` and on the three preceding retrieval-smoke runs. It is not caused by the artifact-cache batching candidate.

## Change

Use an incomplete workspace-discovery fixture for the typed blocking-source test. The contract now proves that packet preserves:

- `codestory_unavailable`
- `source_discovery_incomplete`
- no retry tool
- structured `discovery_incomplete`, retryable coverage details

The product behavior for stable oversized sources is unchanged.

## Verification

Candidate: `9bd5ca4feca11c651b249effac5891b6d713322a`

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts packet_preserves_typed_source_failure_diagnostics -- --nocapture`
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts` — 43 passed
- `cargo test --locked -p codestory-runtime --lib first_full_refresh_publishes_verified_oversized_exclusion_without_graph_coverage`
- `cargo test --locked -p codestory-runtime --lib partial_discovery_keeps_oversized_candidates_blocking_and_publishes_nothing`

## Risk

Test-only fixture correction. It deliberately keeps incomplete discovery blocking and verified oversized exclusions publishable.
