### PR TITLE
[P1] Collapse staged Tantivy symbol indexing to one commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Full refresh now persists each ordered parser-artifact chunk in one SQLite
   transaction instead of one autocommit per parsed file. Index telemetry
   reports artifact-cache rows, transactions, and write time separately.
+- Staged symbol search generations now retain one bounded Tantivy writer across
+  document checkpoints and commit/reload once, instead of reopening and
+  committing the writer for every 8,192 symbols. Index telemetry reports
+  symbol documents, writers, commits, and reloads.
 
 ## 0.16.0
 

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 codestory-contracts = { workspace = true }
 codestory-indexer = { workspace = true }
-codestory-runtime = { workspace = true, features = ["test-support"] }
+codestory-runtime = { workspace = true, features = ["benchmark-support"] }
 codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }
 criterion = { workspace = true }

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 codestory-contracts = { workspace = true }
 codestory-indexer = { workspace = true }
-codestory-runtime = { workspace = true }
+codestory-runtime = { workspace = true, features = ["test-support"] }
 codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }
 criterion = { workspace = true }
@@ -54,5 +54,10 @@ bench = false
 
 [[bench]]
 name = "artifact_cache"
+harness = false
+bench = false
+
+[[bench]]
+name = "tantivy_symbol_commits"
 harness = false
 bench = false

--- a/crates/codestory-bench/benches/tantivy_symbol_commits.rs
+++ b/crates/codestory-bench/benches/tantivy_symbol_commits.rs
@@ -1,0 +1,192 @@
+use codestory_contracts::graph::NodeId;
+use codestory_runtime::benchmark_support::{SearchEngine, SymbolIndexWriteStats};
+use serde::Serialize;
+use std::fs;
+use std::hint::black_box;
+use std::path::Path;
+use std::time::Instant;
+
+const DEFAULT_DOCUMENTS: usize = 262_144;
+const COMMIT_WINDOW: usize = 8_192;
+const DEFAULT_REPEATS: usize = 3;
+
+#[derive(Debug, Clone, Serialize)]
+struct Measurement {
+    strategy: &'static str,
+    repeat: usize,
+    elapsed_ms: u128,
+    docs_written: usize,
+    writers: usize,
+    commits: usize,
+    reloads: usize,
+    segments: usize,
+    bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct BenchmarkReport {
+    documents: usize,
+    commit_window: usize,
+    repeats: usize,
+    filesystem_root: String,
+    legacy_median_ms: u128,
+    generation_median_ms: u128,
+    measurements: Vec<Measurement>,
+}
+
+fn main() {
+    let document_count = env_usize("CODESTORY_TANTIVY_BENCH_DOCUMENTS", DEFAULT_DOCUMENTS);
+    let repeats = env_usize("CODESTORY_TANTIVY_BENCH_REPEATS", DEFAULT_REPEATS).max(1);
+    let root = std::env::var_os("CODESTORY_TANTIVY_BENCH_ROOT")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    fs::create_dir_all(&root).expect("create Tantivy benchmark root");
+    let nodes = (0..document_count)
+        .map(|index| {
+            (
+                NodeId(index as i64 + 1),
+                format!("module_{:06}::Symbol_{:09}", index % 4096, index),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let mut measurements = Vec::with_capacity(repeats.saturating_mul(2));
+    for repeat in 0..repeats {
+        if repeat % 2 == 0 {
+            measurements.push(run_legacy(&root, &nodes, repeat));
+            measurements.push(run_generation(&root, &nodes, repeat));
+        } else {
+            measurements.push(run_generation(&root, &nodes, repeat));
+            measurements.push(run_legacy(&root, &nodes, repeat));
+        }
+    }
+
+    let report = BenchmarkReport {
+        documents: document_count,
+        commit_window: COMMIT_WINDOW,
+        repeats,
+        filesystem_root: root.display().to_string(),
+        legacy_median_ms: median_ms(&measurements, "legacy_window_commits"),
+        generation_median_ms: median_ms(&measurements, "generation_single_commit"),
+        measurements,
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).expect("serialize Tantivy benchmark report")
+    );
+}
+
+fn run_legacy(root: &Path, nodes: &[(NodeId, String)], repeat: usize) -> Measurement {
+    let directory = tempfile::Builder::new()
+        .prefix("codestory-tantivy-legacy-")
+        .tempdir_in(root)
+        .expect("legacy Tantivy benchmark directory");
+    let started = Instant::now();
+    let mut engine = SearchEngine::new(Some(directory.path())).expect("create legacy engine");
+    let mut stats = SymbolIndexWriteStats::default();
+    for chunk in nodes.chunks(COMMIT_WINDOW) {
+        engine
+            .index_nodes(chunk.to_vec())
+            .expect("legacy symbol-index window");
+        stats.docs_written = stats.docs_written.saturating_add(chunk.len());
+        stats.writer_count = stats.writer_count.saturating_add(1);
+        stats.commit_count = stats.commit_count.saturating_add(1);
+        stats.reload_count = stats.reload_count.saturating_add(1);
+    }
+    let elapsed_ms = started.elapsed().as_millis();
+    let measurement = measurement(
+        "legacy_window_commits",
+        repeat,
+        elapsed_ms,
+        stats,
+        &engine,
+        directory.path(),
+    );
+    black_box(engine);
+    measurement
+}
+
+fn run_generation(root: &Path, nodes: &[(NodeId, String)], repeat: usize) -> Measurement {
+    let directory = tempfile::Builder::new()
+        .prefix("codestory-tantivy-generation-")
+        .tempdir_in(root)
+        .expect("generation Tantivy benchmark directory");
+    let started = Instant::now();
+    let mut engine = SearchEngine::new(Some(directory.path())).expect("create generation engine");
+    let stats = {
+        let mut session = engine
+            .begin_symbol_index()
+            .expect("start generation writer");
+        for chunk in nodes.chunks(COMMIT_WINDOW) {
+            session
+                .add_nodes(chunk.iter().cloned())
+                .expect("generation symbol-index window");
+        }
+        session.finish().expect("commit generation writer")
+    };
+    let elapsed_ms = started.elapsed().as_millis();
+    let measurement = measurement(
+        "generation_single_commit",
+        repeat,
+        elapsed_ms,
+        stats,
+        &engine,
+        directory.path(),
+    );
+    black_box(engine);
+    measurement
+}
+
+fn measurement(
+    strategy: &'static str,
+    repeat: usize,
+    elapsed_ms: u128,
+    stats: SymbolIndexWriteStats,
+    engine: &SearchEngine,
+    directory: &Path,
+) -> Measurement {
+    Measurement {
+        strategy,
+        repeat,
+        elapsed_ms,
+        docs_written: stats.docs_written,
+        writers: stats.writer_count,
+        commits: stats.commit_count,
+        reloads: stats.reload_count,
+        segments: engine.tantivy_segment_count(),
+        bytes: directory_bytes(directory),
+    }
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    fs::read_dir(path)
+        .expect("read Tantivy benchmark directory")
+        .map(|entry| {
+            let entry = entry.expect("read Tantivy benchmark entry");
+            let metadata = entry.metadata().expect("read Tantivy benchmark metadata");
+            if metadata.is_dir() {
+                directory_bytes(&entry.path())
+            } else {
+                metadata.len()
+            }
+        })
+        .sum()
+}
+
+fn median_ms(measurements: &[Measurement], strategy: &str) -> u128 {
+    let mut values = measurements
+        .iter()
+        .filter(|measurement| measurement.strategy == strategy)
+        .map(|measurement| measurement.elapsed_ms)
+        .collect::<Vec<_>>();
+    values.sort_unstable();
+    values[values.len() / 2]
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8936,6 +8936,10 @@ mod tests {
             cache_refresh_ms: Some(6),
             search_projection_rebuild_ms: Some(61),
             search_symbol_index_ms: Some(62),
+            search_symbol_index_docs_written: Some(8192),
+            search_symbol_index_writer_count: Some(1),
+            search_symbol_index_commit_count: Some(1),
+            search_symbol_index_reload_count: Some(1),
             runtime_cache_publish_ms: Some(63),
             semantic_doc_build_ms: Some(7),
             semantic_embedding_ms: Some(8),
@@ -9165,6 +9169,7 @@ mod tests {
             "cache_ms: artifact_write=6 search_projection=61 search_index=62 runtime_publish=63"
         ));
         assert!(markdown.contains("artifact_cache: writes=24 transactions=1"));
+        assert!(markdown.contains("symbol_index: docs=8192 writers=1 commits=1 reloads=1"));
         assert!(
             markdown
                 .contains("semantic_ms: doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -341,6 +341,16 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
     );
     append_optional_timings_line(
         markdown,
+        "symbol_index",
+        &[
+            ("docs", timings.search_symbol_index_docs_written),
+            ("writers", timings.search_symbol_index_writer_count),
+            ("commits", timings.search_symbol_index_commit_count),
+            ("reloads", timings.search_symbol_index_reload_count),
+        ],
+    );
+    append_optional_timings_line(
+        markdown,
         "staged_publish_ms",
         &[
             ("deferred_indexes", timings.deferred_indexes_ms),

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -20,6 +20,14 @@ pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_symbol_index_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_index_docs_written: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_index_writer_count: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_index_commit_count: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_index_reload_count: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_cache_publish_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_doc_build_ms: Option<u32>,
@@ -205,6 +213,10 @@ mod tests {
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,
+            search_symbol_index_docs_written: None,
+            search_symbol_index_writer_count: None,
+            search_symbol_index_commit_count: None,
+            search_symbol_index_reload_count: None,
             runtime_cache_publish_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
@@ -292,6 +304,10 @@ mod tests {
         assert!(value.get("semantic_prune_ms").is_none());
         assert!(value.get("search_projection_rebuild_ms").is_none());
         assert!(value.get("search_symbol_index_ms").is_none());
+        assert!(value.get("search_symbol_index_docs_written").is_none());
+        assert!(value.get("search_symbol_index_writer_count").is_none());
+        assert!(value.get("search_symbol_index_commit_count").is_none());
+        assert!(value.get("search_symbol_index_reload_count").is_none());
         assert!(value.get("runtime_cache_publish_ms").is_none());
         assert!(value.get("semantic_docs_reused").is_none());
         assert!(value.get("semantic_docs_embedded").is_none());

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.16.0"
 edition = "2024"
 
 [features]
+benchmark-support = []
 test-support = []
 
 [dependencies]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -97,6 +97,10 @@ mod query_language;
 mod repository_identity;
 mod search;
 mod search_runtime;
+#[cfg(feature = "test-support")]
+pub mod benchmark_support {
+    pub use crate::search::engine::{SearchEngine, SymbolIndexSession, SymbolIndexWriteStats};
+}
 mod semantic_doc_text;
 mod services;
 mod support;
@@ -4801,6 +4805,10 @@ struct SemanticRefreshScope<'a> {
 struct SearchStateBuildStats {
     search_projection_rebuild_ms: u32,
     search_symbol_index_ms: u32,
+    search_symbol_index_docs_written: u32,
+    search_symbol_index_writer_count: u32,
+    search_symbol_index_commit_count: u32,
+    search_symbol_index_reload_count: u32,
 }
 
 struct SearchStateBuildResult {
@@ -4847,6 +4855,14 @@ fn apply_semantic_projection_stats(
 fn apply_cache_refresh_stats(timings: &mut IndexingPhaseTimings, stats: CacheRefreshStats) {
     timings.search_projection_rebuild_ms = Some(stats.search_stats.search_projection_rebuild_ms);
     timings.search_symbol_index_ms = Some(stats.search_stats.search_symbol_index_ms);
+    timings.search_symbol_index_docs_written =
+        Some(stats.search_stats.search_symbol_index_docs_written);
+    timings.search_symbol_index_writer_count =
+        Some(stats.search_stats.search_symbol_index_writer_count);
+    timings.search_symbol_index_commit_count =
+        Some(stats.search_stats.search_symbol_index_commit_count);
+    timings.search_symbol_index_reload_count =
+        Some(stats.search_stats.search_symbol_index_reload_count);
     timings.runtime_cache_publish_ms = stats.runtime_cache_publish_ms;
     apply_semantic_projection_stats(timings, stats.semantic_stats);
 }
@@ -4866,9 +4882,18 @@ fn build_search_state(
         nodes,
         llm_refresh_file_scope,
         semantic_projection_mode,
-        hydrate_semantic_docs,
-        &test_sidecar_runtime_from_env(),
+        SearchStateBuildContext {
+            hydrate_semantic_docs,
+            runtime: &test_sidecar_runtime_from_env(),
+            cancel_token: None,
+        },
     )
+}
+
+struct SearchStateBuildContext<'a> {
+    hydrate_semantic_docs: bool,
+    runtime: &'a codestory_retrieval::SidecarRuntimeConfig,
+    cancel_token: Option<&'a CancellationToken>,
 }
 
 fn build_search_state_for_runtime(
@@ -4877,9 +4902,13 @@ fn build_search_state_for_runtime(
     nodes: Vec<codestory_contracts::graph::Node>,
     llm_refresh_file_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
     semantic_projection_mode: SemanticProjectionMode,
-    hydrate_semantic_docs: bool,
-    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    context: SearchStateBuildContext<'_>,
 ) -> Result<SearchStateBuildResult, ApiError> {
+    let SearchStateBuildContext {
+        hydrate_semantic_docs,
+        runtime,
+        cancel_token,
+    } = context;
     let projection_started = Instant::now();
     match llm_refresh_file_scope {
         Some(scope) => storage.rebuild_search_symbol_projection_for_file_scope(scope),
@@ -4900,22 +4929,36 @@ fn build_search_state_for_runtime(
             ApiError::internal(format!("Failed to init search engine: {error}"))
         }
     })?;
+    let mut symbol_session = engine.begin_symbol_index().map_err(|error| {
+        ApiError::internal(format!("Failed to start symbol index writer: {error}"))
+    })?;
     let mut search_nodes = Vec::with_capacity(nodes.len().min(SEARCH_NODE_BATCH_SIZE));
     for node in &nodes {
         let display_name = node_display_name(node);
         node_names.insert(node.id, display_name.clone());
         search_nodes.push((node.id, display_name));
         if search_nodes.len() >= SEARCH_NODE_BATCH_SIZE {
-            engine
-                .index_nodes(std::mem::take(&mut search_nodes))
+            symbol_session
+                .add_nodes(std::mem::take(&mut search_nodes))
                 .map_err(|e| ApiError::internal(format!("Failed to index search nodes: {e}")))?;
+            if is_indexing_cancelled(cancel_token) {
+                return Err(indexing_cancelled_error());
+            }
         }
     }
     if !search_nodes.is_empty() {
-        engine
-            .index_nodes(search_nodes)
+        symbol_session
+            .add_nodes(search_nodes)
             .map_err(|e| ApiError::internal(format!("Failed to index search nodes: {e}")))?;
     }
+    #[cfg(test)]
+    publication_test_checkpoint(PublicationTestBoundary::SearchIndexWrite, cancel_token)?;
+    if is_indexing_cancelled(cancel_token) {
+        return Err(indexing_cancelled_error());
+    }
+    let symbol_write_stats = symbol_session
+        .finish()
+        .map_err(|e| ApiError::internal(format!("Failed to commit symbol index: {e}")))?;
     if search_storage_path.is_some() && engine.full_text_doc_count() != nodes.len() {
         return Err(ApiError::internal(format!(
             "Persisted search generation validation failed: indexed {} docs for {} nodes",
@@ -4927,6 +4970,10 @@ fn build_search_state_for_runtime(
     let search_stats = SearchStateBuildStats {
         search_projection_rebuild_ms,
         search_symbol_index_ms,
+        search_symbol_index_docs_written: clamp_usize_to_u32(symbol_write_stats.docs_written),
+        search_symbol_index_writer_count: clamp_usize_to_u32(symbol_write_stats.writer_count),
+        search_symbol_index_commit_count: clamp_usize_to_u32(symbol_write_stats.commit_count),
+        search_symbol_index_reload_count: clamp_usize_to_u32(symbol_write_stats.reload_count),
     };
     let semantic_stats = match semantic_projection_mode {
         SemanticProjectionMode::PersistBackedDocs => sync_llm_symbol_projection_for_runtime(
@@ -6156,6 +6203,7 @@ struct SearchGenerationCatalogGuard {
 enum PublicationTestBoundary {
     Identity,
     SearchBuild,
+    SearchIndexWrite,
     SearchValidation,
     SearchCompletion,
     CatalogLock,
@@ -14617,6 +14665,10 @@ fn index_full_for_runtime(
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,
+            search_symbol_index_docs_written: None,
+            search_symbol_index_writer_count: None,
+            search_symbol_index_commit_count: None,
+            search_symbol_index_reload_count: None,
             runtime_cache_publish_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
@@ -15238,6 +15290,10 @@ fn run_incremental_indexing_common(
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,
+            search_symbol_index_docs_written: None,
+            search_symbol_index_writer_count: None,
+            search_symbol_index_commit_count: None,
+            search_symbol_index_reload_count: None,
             runtime_cache_publish_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
@@ -15432,6 +15488,7 @@ fn reuse_completed_search_state(
         search_stats: SearchStateBuildStats {
             search_projection_rebuild_ms,
             search_symbol_index_ms,
+            ..SearchStateBuildStats::default()
         },
         semantic_stats,
     }))
@@ -15507,8 +15564,11 @@ fn rebuild_search_state_from_storage_for_runtime(
             nodes,
             llm_refresh_scope,
             SemanticProjectionMode::LoadPersistedDocs,
-            hydrate_semantic_docs,
-            runtime,
+            SearchStateBuildContext {
+                hydrate_semantic_docs,
+                runtime,
+                cancel_token,
+            },
         )
         .map_err(|mut error| {
             error.message = format!("Failed to rebuild search state: {}", error.message);
@@ -24284,6 +24344,42 @@ fn build_llm_symbol_doc_text() -> String {
         let finisher_state =
             rebuild_search_state_from_storage(&mut storage, &storage_path, None, false)
                 .expect("indexing finisher builds search generation");
+        assert_eq!(
+            finisher_state.search_stats.search_symbol_index_docs_written,
+            3
+        );
+        assert_eq!(
+            finisher_state.search_stats.search_symbol_index_writer_count,
+            1
+        );
+        assert_eq!(
+            finisher_state.search_stats.search_symbol_index_commit_count,
+            1
+        );
+        assert_eq!(
+            finisher_state.search_stats.search_symbol_index_reload_count,
+            1
+        );
+        let reused_state =
+            rebuild_search_state_from_storage(&mut storage, &storage_path, None, false)
+                .expect("indexing finisher reuses completed search generation");
+        assert_eq!(
+            reused_state.search_stats.search_symbol_index_docs_written,
+            0
+        );
+        assert_eq!(
+            reused_state.search_stats.search_symbol_index_writer_count,
+            0
+        );
+        assert_eq!(
+            reused_state.search_stats.search_symbol_index_commit_count,
+            0
+        );
+        assert_eq!(
+            reused_state.search_stats.search_symbol_index_reload_count,
+            0
+        );
+        drop(reused_state);
         env.push(EnvGuard::set(
             crate::search::engine::SYMBOL_FULL_TEXT_INDEX_ENV,
             "false",
@@ -25771,9 +25867,10 @@ fn build_llm_symbol_doc_text() -> String {
         }
     }
 
-    const PUBLICATION_TRANSITION_BOUNDARIES: [PublicationTestBoundary; 8] = [
+    const PUBLICATION_TRANSITION_BOUNDARIES: [PublicationTestBoundary; 9] = [
         PublicationTestBoundary::Identity,
         PublicationTestBoundary::SearchBuild,
+        PublicationTestBoundary::SearchIndexWrite,
         PublicationTestBoundary::SearchValidation,
         PublicationTestBoundary::SearchCompletion,
         PublicationTestBoundary::CatalogLock,
@@ -26107,6 +26204,70 @@ fn build_llm_symbol_doc_text() -> String {
         assert!(storage_has_symbol(&storage, "old_generation"));
         assert!(!storage_has_symbol(&storage, "new_generation"));
         assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    fn assert_symbol_index_failure_preserves_previous_complete_publication(
+        fault: search::engine::SymbolIndexTestFault,
+        expected_error: &str,
+    ) {
+        let workspace = tempdir().expect("workspace dir");
+        let source_path = workspace.path().join("lib.rs");
+        fs::write(&source_path, "pub fn old_generation() -> i32 { 1 }\n")
+            .expect("write baseline source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open add-failure baseline");
+        controller
+            .run_indexing_blocking(IndexMode::Full)
+            .expect("publish add-failure baseline");
+        let baseline = Storage::open(&storage_path)
+            .expect("open add-failure baseline")
+            .get_complete_index_publication()
+            .expect("read add-failure baseline")
+            .expect("complete add-failure baseline");
+
+        fs::write(
+            &source_path,
+            "pub fn new_generation() -> i32 { 2 }\npub fn another_symbol() {}\n",
+        )
+        .expect("write replacement source");
+        search::engine::arm_symbol_index_test_fault(fault);
+        let error = controller
+            .run_indexing_blocking(IndexMode::Full)
+            .expect_err("symbol index failure must reject the candidate");
+
+        assert!(error.message.contains(expected_error));
+        let storage = Storage::open(&storage_path).expect("open preserved publication");
+        assert_eq!(
+            storage
+                .get_complete_index_publication()
+                .expect("read preserved publication"),
+            Some(baseline)
+        );
+        assert!(storage_has_symbol(&storage, "old_generation"));
+        assert!(!storage_has_symbol(&storage, "new_generation"));
+        assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    #[test]
+    fn symbol_index_add_failure_preserves_previous_complete_publication() {
+        assert_symbol_index_failure_preserves_previous_complete_publication(
+            search::engine::SymbolIndexTestFault::AddDocumentAfterOne,
+            "add-document failure",
+        );
+    }
+
+    #[test]
+    fn symbol_index_commit_failure_preserves_previous_complete_publication() {
+        assert_symbol_index_failure_preserves_previous_complete_publication(
+            search::engine::SymbolIndexTestFault::Commit,
+            "commit failure",
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -97,7 +97,7 @@ mod query_language;
 mod repository_identity;
 mod search;
 mod search_runtime;
-#[cfg(feature = "test-support")]
+#[cfg(feature = "benchmark-support")]
 pub mod benchmark_support {
     pub use crate::search::engine::{SearchEngine, SymbolIndexSession, SymbolIndexWriteStats};
 }

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -849,7 +849,7 @@ impl SearchEngine {
         self.reader.searcher().num_docs() as usize
     }
 
-    #[cfg(feature = "test-support")]
+    #[cfg(feature = "benchmark-support")]
     pub fn tantivy_segment_count(&self) -> usize {
         self.reader.searcher().segment_readers().len()
     }

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 use tantivy::collector::TopDocs;
 use tantivy::doc;
 use tantivy::query::QueryParser;
-use tantivy::schema::Value;
 use tantivy::schema::{FAST, INDEXED, STORED, Schema, TEXT};
+use tantivy::schema::{Field, Value};
 use tantivy::{Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument};
 
 pub const EMBEDDING_DIM: usize = codestory_retrieval::RETRIEVAL_EMBEDDING_DIM;
@@ -379,6 +379,61 @@ pub struct SearchEngine {
     #[cfg(test)]
     query_embedding_cache: HashMap<String, Vec<f32>>,
     _persisted_index_guard: Option<PersistedSearchIndexGuard>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SymbolIndexWriteStats {
+    pub docs_written: usize,
+    pub writer_count: usize,
+    pub commit_count: usize,
+    pub reload_count: usize,
+}
+
+pub struct SymbolIndexSession<'a> {
+    engine: &'a mut SearchEngine,
+    writer: Option<IndexWriter<TantivyDocument>>,
+    name_field: Field,
+    id_field: Field,
+    symbols_start_len: usize,
+    docs_written: usize,
+    finished: bool,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SymbolIndexTestFault {
+    AddDocument,
+    AddDocumentAfterOne,
+    Commit,
+}
+
+#[cfg(test)]
+thread_local! {
+    static SYMBOL_INDEX_TEST_FAULT: std::cell::Cell<Option<SymbolIndexTestFault>> =
+        const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn arm_symbol_index_test_fault(fault: SymbolIndexTestFault) {
+    SYMBOL_INDEX_TEST_FAULT.with(|slot| slot.set(Some(fault)));
+}
+
+#[cfg(test)]
+fn take_symbol_index_test_fault(expected: SymbolIndexTestFault) -> bool {
+    SYMBOL_INDEX_TEST_FAULT.with(|slot| {
+        if expected == SymbolIndexTestFault::AddDocument
+            && slot.get() == Some(SymbolIndexTestFault::AddDocumentAfterOne)
+        {
+            slot.set(Some(SymbolIndexTestFault::AddDocument));
+            return false;
+        }
+        if slot.get() == Some(expected) {
+            slot.set(None);
+            true
+        } else {
+            false
+        }
+    })
 }
 
 struct PersistedSearchIndexGuard {
@@ -794,6 +849,11 @@ impl SearchEngine {
         self.reader.searcher().num_docs() as usize
     }
 
+    #[cfg(feature = "test-support")]
+    pub fn tantivy_segment_count(&self) -> usize {
+        self.reader.searcher().segment_readers().len()
+    }
+
     #[cfg(test)]
     pub fn semantic_index_ready(&self) -> bool {
         self.embedding_runtime.is_some() && !self.llm_docs.is_empty()
@@ -862,32 +922,30 @@ impl SearchEngine {
             .semantic_scores_for_query(query, query_embedding, semantic_limit)
     }
 
-    pub fn index_nodes(&mut self, nodes: Vec<(NodeId, String)>) -> Result<()> {
-        if !self.full_text_index_enabled {
-            self.symbols.extend(
-                nodes
-                    .into_iter()
-                    .map(|(id, name)| (Utf32String::from(name.as_str()), id)),
-            );
-            return Ok(());
-        }
-
-        let mut index_writer: IndexWriter<TantivyDocument> =
-            self.index.writer(SEARCH_WRITER_HEAP_BYTES)?;
+    pub fn begin_symbol_index(&mut self) -> Result<SymbolIndexSession<'_>> {
+        let writer = self
+            .full_text_index_enabled
+            .then(|| self.index.writer(SEARCH_WRITER_HEAP_BYTES))
+            .transpose()?;
         let schema = self.index.schema();
         let name_field = schema.get_field("name")?;
         let id_field = schema.get_field("node_id")?;
+        let symbols_start_len = self.symbols.len();
+        Ok(SymbolIndexSession {
+            engine: self,
+            writer,
+            name_field,
+            id_field,
+            symbols_start_len,
+            docs_written: 0,
+            finished: false,
+        })
+    }
 
-        for (id, name) in nodes {
-            self.symbols.push((Utf32String::from(name.as_str()), id));
-            index_writer.add_document(doc!(
-                name_field => name,
-                id_field => id.0
-            ))?;
-        }
-
-        index_writer.commit()?;
-        self.reader.reload()?;
+    pub fn index_nodes(&mut self, nodes: Vec<(NodeId, String)>) -> Result<()> {
+        let mut session = self.begin_symbol_index()?;
+        session.add_nodes(nodes)?;
+        session.finish()?;
         Ok(())
     }
 
@@ -1013,6 +1071,62 @@ impl SearchEngine {
         }
 
         Ok(results)
+    }
+}
+
+impl SymbolIndexSession<'_> {
+    pub fn add_nodes<I>(&mut self, nodes: I) -> Result<usize>
+    where
+        I: IntoIterator<Item = (NodeId, String)>,
+    {
+        let start_count = self.docs_written;
+        for (id, name) in nodes {
+            #[cfg(test)]
+            if take_symbol_index_test_fault(SymbolIndexTestFault::AddDocument) {
+                bail!("injected symbol index add-document failure");
+            }
+            let fuzzy_name = Utf32String::from(name.as_str());
+            if let Some(writer) = self.writer.as_mut() {
+                writer.add_document(doc!(
+                    self.name_field => name,
+                    self.id_field => id.0
+                ))?;
+            }
+            self.engine.symbols.push((fuzzy_name, id));
+            self.docs_written = self.docs_written.saturating_add(1);
+        }
+        Ok(self.docs_written.saturating_sub(start_count))
+    }
+
+    pub fn finish(mut self) -> Result<SymbolIndexWriteStats> {
+        let writer_count = usize::from(self.writer.is_some());
+        let mut commit_count = 0;
+        let mut reload_count = 0;
+        if let Some(mut writer) = self.writer.take() {
+            #[cfg(test)]
+            if take_symbol_index_test_fault(SymbolIndexTestFault::Commit) {
+                bail!("injected symbol index commit failure");
+            }
+            writer.commit()?;
+            commit_count = 1;
+            self.engine.reader.reload()?;
+            reload_count = 1;
+        }
+        self.finished = true;
+        Ok(SymbolIndexWriteStats {
+            docs_written: self.docs_written,
+            writer_count,
+            commit_count,
+            reload_count,
+        })
+    }
+}
+
+impl Drop for SymbolIndexSession<'_> {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.engine.symbols.truncate(self.symbols_start_len);
+        }
     }
 }
 
@@ -1601,6 +1715,79 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn symbol_index_session_commits_and_reloads_once_across_windows() -> Result<()> {
+        let directory = tempdir()?;
+        let mut engine = SearchEngine::new(Some(directory.path()))?;
+        let stats = {
+            let mut session = engine.begin_symbol_index()?;
+            assert_eq!(
+                session.add_nodes(vec![(NodeId(1), "Alpha".to_string())])?,
+                1
+            );
+            assert_eq!(session.add_nodes(vec![(NodeId(2), "Beta".to_string())])?, 1);
+            session.finish()?
+        };
+
+        assert_eq!(stats.docs_written, 2);
+        assert_eq!(stats.writer_count, 1);
+        assert_eq!(stats.commit_count, 1);
+        assert_eq!(stats.reload_count, 1);
+        assert_eq!(engine.tantivy_doc_count(), 2);
+        assert_eq!(engine.search_symbol("Alpha"), vec![NodeId(1)]);
+        Ok(())
+    }
+
+    #[test]
+    fn unfinished_symbol_index_session_restores_projection_without_committing() -> Result<()> {
+        let directory = tempdir()?;
+        let mut engine = SearchEngine::new(Some(directory.path()))?;
+        {
+            let mut session = engine.begin_symbol_index()?;
+            session.add_nodes(vec![(NodeId(1), "Partial".to_string())])?;
+        }
+
+        assert!(engine.symbols().is_empty());
+        assert_eq!(engine.tantivy_doc_count(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn symbol_index_add_failure_rolls_back_projection_and_uncommitted_docs() -> Result<()> {
+        let directory = tempdir()?;
+        let mut engine = SearchEngine::new(Some(directory.path()))?;
+        let error = {
+            let mut session = engine.begin_symbol_index()?;
+            session.add_nodes(vec![(NodeId(1), "Accepted".to_string())])?;
+            arm_symbol_index_test_fault(SymbolIndexTestFault::AddDocument);
+            session
+                .add_nodes(vec![(NodeId(2), "Rejected".to_string())])
+                .expect_err("injected add-document failure")
+        };
+
+        assert!(error.to_string().contains("add-document failure"));
+        assert!(engine.symbols().is_empty());
+        assert_eq!(engine.tantivy_doc_count(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn symbol_index_commit_failure_rolls_back_projection_and_uncommitted_docs() -> Result<()> {
+        let directory = tempdir()?;
+        let mut engine = SearchEngine::new(Some(directory.path()))?;
+        let error = {
+            let mut session = engine.begin_symbol_index()?;
+            session.add_nodes(vec![(NodeId(1), "Uncommitted".to_string())])?;
+            arm_symbol_index_test_fault(SymbolIndexTestFault::Commit);
+            session.finish().expect_err("injected commit failure")
+        };
+
+        assert!(error.to_string().contains("commit failure"));
+        assert!(engine.symbols().is_empty());
+        assert_eq!(engine.tantivy_doc_count(), 0);
+        Ok(())
     }
 
     #[test]

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -277,6 +277,15 @@ Full and incremental snapshot behavior are intentionally not symmetric.
 
 After graph and snapshot work, runtime rebuilds the search-symbol projection, opens or refreshes the persisted Tantivy search directory, writes graph-native symbol docs, writes deterministic component reports, and synchronizes selected dense-anchor docs. This is part of the default `index` contract.
 
+A new persisted symbol generation uses one 20 MB Tantivy writer across the
+existing 8,192-document checkpoints. Runtime checks cancellation after each
+checkpoint and immediately before the single commit/reload. Dropping an
+unfinished writer restores its in-memory fuzzy projection; the generation is
+not admitted until document-count validation and the completion marker both
+succeed. This protects process failure and cancellation. The completion-marker
+rename does not claim power-loss durability before its parent directory is
+synced.
+
 Semantic sync does these pieces of work:
 
 - build deterministic generated text for durable AST symbols and store it in `symbol_search_doc`
@@ -356,6 +365,7 @@ The index summary reports graph and semantic work separately:
 - `timings_ms.cache_refresh`: wrapper time for search projection, search indexing, semantic sync, and runtime publication
 - `cache_ms.search_projection`: SQLite search-symbol projection rebuild from persisted nodes
 - `cache_ms.search_index`: runtime search index construction for symbol names
+- `symbol_index`: documents written plus Tantivy writer, commit, and reader-reload counts; completed-generation reuse reports zero for each count
 - `cache_ms.runtime_publish`: publishing the rebuilt search state into the live runtime
 - `semantic_ms.doc_build`: generated semantic text and hashes
 - `semantic_ms.embedding`: always zero for core indexing; retained as a compatibility field


### PR DESCRIPTION
## Context

The retained exact-corpus proof spent 1,952 seconds (32m32s, 13.7% of wall time) indexing 8,552,335 symbol names. Runtime supplied 8,192-document windows to Tantivy, and every window opened a writer, committed, and reloaded the reader. This is the second ordered performance slice under #1275.

Closes #1291
Refs #1275
Refs #1202

## What changed

- added a generation-scoped RAII symbol-index session that retains Tantivy's existing 20 MB writer across bounded 8,192-document checkpoints;
- commits and reloads once after all documents are accepted while preserving the existing per-document `add_document` path and in-memory fuzzy projection;
- checks cancellation after every checkpoint and immediately before commit;
- restores the fuzzy projection when a session is dropped unfinished, and injects add-document and commit failures for rollback/publication proof;
- added the `SearchIndexWrite` failure/cancellation boundary to both publication transition matrices;
- reports symbol documents, writers, commits, and reloads in JSON and markdown timing output; completed-generation reuse reports zero writes;
- added a bounded optimized benchmark that compares the old commit window with the accepted writer lifecycle on an explicitly selected filesystem root;
- isolated the benchmark API behind `benchmark-support`, so benchmark builds do not enable the synthetic embedding backend in `test-support`;
- documented the process-failure/cancellation boundary and the remaining completion-marker parent-directory fsync nonclaim.

No SQLite tuning, parse/writer pipeline, adaptive parse window, node-table streaming, GPU setting, writer-heap increase, or thread-count change is included.

## How to review

1. In `search/engine.rs`, verify an unfinished session truncates only the symbols appended since it began and never commits implicitly.
2. In `build_search_state_for_runtime`, verify 8,192 remains a cancellation/backpressure checkpoint rather than a commit boundary.
3. Check that count validation and the completion marker still gate generation admission after the single commit.
4. Check telemetry distinguishes a fresh generation (one writer/commit/reload) from completed-generation reuse (zero).
5. Check the benchmark exercises the product writer APIs and treats its result as mechanism evidence only.

## Verification

Exact base: `72be7e4bc6b487fcb92b914bc0739831ee4112d8`

Exact candidate: `b2a4c4e578cdde160b07e155f38483be5b322311`

- `cargo fmt --all -- --check`
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs`
- `cargo check --locked -p codestory-runtime -p codestory-contracts -p codestory-cli -p codestory-bench`
- `cargo clippy --locked -p codestory-runtime -p codestory-contracts -p codestory-cli -p codestory-bench --all-targets --all-features -- -D warnings`
- `cargo tree -e features -p codestory-bench` (runtime `benchmark-support` enabled; `test-support` absent)
- `cargo check --locked -p codestory-bench --benches`
- `cargo test --locked -p codestory-runtime --lib symbol_index_` (6 passed)
- `cargo test --locked -p codestory-runtime --lib full_publication_transitions_fail_or_cancel_atomically`
- `cargo test --locked -p codestory-runtime --lib incremental_publication_transitions_fail_or_cancel_atomically`
- `cargo test --locked -p codestory-runtime --lib persisted_search_` (4 passed)
- `cargo test --locked -p codestory-runtime --lib search_generation_` (3 passed)
- `cargo test --locked -p codestory-runtime --lib persisted_loader_reuses_generation_built_by_indexing_finisher`
- contracts optional-field and CLI markdown telemetry tests
- optimized 16,384-document benchmark smoke
- optimized 262,144-document benchmark, three alternating repeats, on the retained case-sensitive APFS corpus image

| Strategy | Median | Writers / commits / reloads | Segments | Median bytes |
| --- | ---: | ---: | ---: | ---: |
| legacy commit per 8,192 docs | 8,432 ms | 32 / 32 / 32 | 32 | 19,942,541 |
| one generation-scoped writer | 1,040 ms | 1 / 1 / 1 | 5 | 9,375,953 |

That is an 87.7% lower median (8.1x) for this direct mechanism fixture. It is not an end-to-end corpus speedup claim. The repo-scale lane remains reserved for the final combined #1275 candidate.

The full runtime unit sweep reached 760/766 passing. Its six failures are outside this diff. The search-generation catalog failure and a packet-sufficiency failure both reproduce individually on exact base `72be7e4b`; source-policy fixture failures are also in the inherited test surface. Focused writer, race, reuse, telemetry, and publication tests above are green.

Independent review found that the first candidate enabled runtime `test-support` for all benchmark targets. Exact head replaces that with the narrow `benchmark-support` feature; the normal benchmark feature graph and benchmark smoke were re-proven after the fix, and exact-head re-review reports no P0–P3 findings.

## Risk

The writer remains bounded by Tantivy's existing 20 MB heap and flushes internal segments as needed. `commit()` itself is still a blocking call, so cancellation is checked immediately before it rather than interrupting it. A committed staged directory is not admissible until count validation and its completion marker succeed; power-loss durability of the marker rename remains unclaimed until the parent directory is synced.
