### PR TITLE
[codex] adapt full-refresh chunk budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   dedicated staged SQLite writer through a capacity-one queue. Cancellation
   drains only accepted chunks, incremental indexing keeps its serial path, and
   telemetry reports queue pressure plus producer/writer wait time.
+- Full refresh now replaces the fixed small-file parse window with an adaptive
+  8 MiB source and 120,000 projected-node target plus a 512-file safety
+  ceiling. Completed output adjusts the next chunk's node-density estimate,
+  and telemetry reports planning time, observed maxima, and target overruns.
 
 ## 0.16.0
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8939,6 +8939,14 @@ mod tests {
             full_refresh_queue_high_water: Some(1),
             full_refresh_producer_blocked_ms: Some(3),
             full_refresh_writer_idle_ms: Some(4),
+            full_refresh_chunk_target_bytes: Some(8_388_608),
+            full_refresh_chunk_target_nodes: Some(120_000),
+            full_refresh_chunk_file_ceiling: Some(512),
+            full_refresh_chunk_max_files: Some(384),
+            full_refresh_chunk_max_planned_bytes: Some(7_500_000),
+            full_refresh_chunk_max_nodes: Some(98_000),
+            full_refresh_chunk_budget_overruns: Some(0),
+            full_refresh_chunk_planning_ms: Some(5),
             cache_refresh_ms: Some(6),
             search_projection_rebuild_ms: Some(61),
             search_symbol_index_ms: Some(62),
@@ -9177,6 +9185,9 @@ mod tests {
         assert!(markdown.contains("artifact_cache: writes=24 transactions=1"));
         assert!(markdown.contains(
             "full_refresh_pipeline: produced=2 persisted=2 queue_capacity=1 queue_high_water=1 producer_blocked_ms=3 writer_idle_ms=4"
+        ));
+        assert!(markdown.contains(
+            "full_refresh_chunking: target_bytes=8388608 target_nodes=120000 file_ceiling=512 max_files=384 max_planned_bytes=7500000 max_nodes=98000 overruns=0 planning_ms=5"
         ));
         assert!(markdown.contains("symbol_index: docs=8192 writers=1 commits=1 reloads=1"));
         assert!(

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -354,6 +354,28 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
             ("writer_idle_ms", timings.full_refresh_writer_idle_ms),
         ],
     );
+    if timings.full_refresh_chunk_target_bytes.is_some()
+        || timings.full_refresh_chunk_target_nodes.is_some()
+        || timings.full_refresh_chunk_file_ceiling.is_some()
+        || timings.full_refresh_chunk_max_files.is_some()
+        || timings.full_refresh_chunk_max_planned_bytes.is_some()
+        || timings.full_refresh_chunk_max_nodes.is_some()
+        || timings.full_refresh_chunk_budget_overruns.is_some()
+        || timings.full_refresh_chunk_planning_ms.is_some()
+    {
+        let _ = writeln!(
+            markdown,
+            "full_refresh_chunking: target_bytes={} target_nodes={} file_ceiling={} max_files={} max_planned_bytes={} max_nodes={} overruns={} planning_ms={}",
+            timings.full_refresh_chunk_target_bytes.unwrap_or(0),
+            timings.full_refresh_chunk_target_nodes.unwrap_or(0),
+            timings.full_refresh_chunk_file_ceiling.unwrap_or(0),
+            timings.full_refresh_chunk_max_files.unwrap_or(0),
+            timings.full_refresh_chunk_max_planned_bytes.unwrap_or(0),
+            timings.full_refresh_chunk_max_nodes.unwrap_or(0),
+            timings.full_refresh_chunk_budget_overruns.unwrap_or(0),
+            timings.full_refresh_chunk_planning_ms.unwrap_or(0),
+        );
+    }
     append_optional_timings_line(
         markdown,
         "symbol_index",

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -26,6 +26,22 @@ pub struct IndexingPhaseTimings {
     pub full_refresh_producer_blocked_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_refresh_writer_idle_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_chunk_target_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_chunk_target_nodes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_chunk_file_ceiling: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_chunk_max_files: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_chunk_max_planned_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_chunk_max_nodes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_chunk_budget_overruns: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_chunk_planning_ms: Option<u32>,
     pub cache_refresh_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_projection_rebuild_ms: Option<u32>,
@@ -228,6 +244,14 @@ mod tests {
             full_refresh_queue_high_water: None,
             full_refresh_producer_blocked_ms: None,
             full_refresh_writer_idle_ms: None,
+            full_refresh_chunk_target_bytes: None,
+            full_refresh_chunk_target_nodes: None,
+            full_refresh_chunk_file_ceiling: None,
+            full_refresh_chunk_max_files: None,
+            full_refresh_chunk_max_planned_bytes: None,
+            full_refresh_chunk_max_nodes: None,
+            full_refresh_chunk_budget_overruns: None,
+            full_refresh_chunk_planning_ms: None,
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,
@@ -317,6 +341,14 @@ mod tests {
         assert!(value.get("full_refresh_queue_high_water").is_none());
         assert!(value.get("full_refresh_producer_blocked_ms").is_none());
         assert!(value.get("full_refresh_writer_idle_ms").is_none());
+        assert!(value.get("full_refresh_chunk_target_bytes").is_none());
+        assert!(value.get("full_refresh_chunk_target_nodes").is_none());
+        assert!(value.get("full_refresh_chunk_file_ceiling").is_none());
+        assert!(value.get("full_refresh_chunk_max_files").is_none());
+        assert!(value.get("full_refresh_chunk_max_planned_bytes").is_none());
+        assert!(value.get("full_refresh_chunk_max_nodes").is_none());
+        assert!(value.get("full_refresh_chunk_budget_overruns").is_none());
+        assert!(value.get("full_refresh_chunk_planning_ms").is_none());
         assert!(value.get("resolution_unresolved_counts_ms").is_none());
         assert!(value.get("resolution_calls_ms").is_none());
         assert!(value.get("resolution_imports_ms").is_none());

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -670,11 +670,12 @@ struct FullRefreshChunkPlan {
     projected_nodes: usize,
 }
 
-#[derive(Debug)]
 struct AdaptiveFullRefreshChunkPlanner {
     budget: FullRefreshChunkBudget,
     last_source_bytes: u64,
     last_nodes: usize,
+    #[cfg(test)]
+    before_plan_file: Option<FullRefreshChunkTestHook>,
 }
 
 impl AdaptiveFullRefreshChunkPlanner {
@@ -687,6 +688,8 @@ impl AdaptiveFullRefreshChunkPlanner {
             },
             last_source_bytes: 0,
             last_nodes: 0,
+            #[cfg(test)]
+            before_plan_file: None,
         }
     }
 
@@ -695,6 +698,7 @@ impl AdaptiveFullRefreshChunkPlanner {
         files: &[PathBuf],
         root: &Path,
         start: usize,
+        cancel_token: Option<&CancellationToken>,
     ) -> Option<FullRefreshChunkPlan> {
         if start >= files.len() {
             return None;
@@ -704,6 +708,13 @@ impl AdaptiveFullRefreshChunkPlanner {
         let mut projected_nodes = 0usize;
         let mut end = start;
         while end < files.len() && end - start < self.budget.file_ceiling {
+            #[cfg(test)]
+            if let Some(hook) = &self.before_plan_file {
+                hook(end);
+            }
+            if cancel_token.is_some_and(CancellationToken::is_cancelled) {
+                break;
+            }
             let file_bytes =
                 std::fs::metadata(WorkspaceIndexer::normalize_index_path(root, &files[end]))
                     .map(|metadata| metadata.len())
@@ -722,12 +733,21 @@ impl AdaptiveFullRefreshChunkPlanner {
             end += 1;
         }
 
+        if end == start {
+            return None;
+        }
+
         Some(FullRefreshChunkPlan {
             start,
-            end: end.max(start + 1),
+            end,
             source_bytes,
             projected_nodes,
         })
+    }
+
+    #[cfg(test)]
+    fn set_before_plan_file_hook(&mut self, hook: Option<FullRefreshChunkTestHook>) {
+        self.before_plan_file = hook;
     }
 
     fn observe(&mut self, source_bytes: u64, nodes: usize) {
@@ -954,6 +974,7 @@ impl IndexProgress<'_> {
 #[cfg(test)]
 #[derive(Clone, Default)]
 struct FullRefreshPipelineTestHooks {
+    before_plan_file: Option<FullRefreshChunkTestHook>,
     before_prepare_chunk: Option<FullRefreshChunkTestHook>,
     before_parse_job: Option<FullRefreshChunkTestHook>,
     before_writer_chunk: Option<FullRefreshChunkTestHook>,
@@ -1316,6 +1337,9 @@ impl WorkspaceIndexer {
             });
         }
         let mut stats = IncrementalIndexingStats::default();
+        if plan.mode == codestory_workspace::BuildMode::FullRefresh {
+            Self::record_full_refresh_chunk_config(&mut stats, self.full_refresh_chunk_budget);
+        }
         if Self::is_cancelled(cancel_token) {
             return Ok(stats);
         }
@@ -1735,13 +1759,20 @@ impl WorkspaceIndexer {
         );
         if plan.mode == codestory_workspace::BuildMode::FullRefresh {
             let mut planner = AdaptiveFullRefreshChunkPlanner::new(self.full_refresh_chunk_budget);
+            #[cfg(test)]
+            planner.set_before_plan_file_hook(self.pipeline_test_hooks.before_plan_file.clone());
             let mut start = 0usize;
             let mut chunk_index = 0usize;
             let mut planning_duration = Duration::ZERO;
             loop {
                 let planning_started = Instant::now();
-                let next_chunk = planner.next_chunk(&plan.files_to_index, root, start);
+                let next_chunk =
+                    planner.next_chunk(&plan.files_to_index, root, start, cancel_token);
                 planning_duration = planning_duration.saturating_add(planning_started.elapsed());
+                if Self::is_cancelled(cancel_token) {
+                    cancelled.store(true, Ordering::Relaxed);
+                    break;
+                }
                 let Some(chunk_plan) = next_chunk else {
                     break;
                 };
@@ -1844,21 +1875,24 @@ impl WorkspaceIndexer {
             let producer_result = (|| -> Result<()> {
                 let mut planner =
                     AdaptiveFullRefreshChunkPlanner::new(self.full_refresh_chunk_budget);
+                #[cfg(test)]
+                planner
+                    .set_before_plan_file_hook(self.pipeline_test_hooks.before_plan_file.clone());
                 let mut start = 0usize;
                 let mut chunk_index = 0usize;
                 let mut planning_duration = Duration::ZERO;
                 loop {
                     let planning_started = Instant::now();
-                    let next_chunk = planner.next_chunk(files_to_index, root, start);
+                    let next_chunk = planner.next_chunk(files_to_index, root, start, cancel_token);
                     planning_duration =
                         planning_duration.saturating_add(planning_started.elapsed());
-                    let Some(chunk_plan) = next_chunk else {
-                        break;
-                    };
                     if Self::is_cancelled(cancel_token) {
                         cancelled.store(true, Ordering::Relaxed);
                         break;
                     }
+                    let Some(chunk_plan) = next_chunk else {
+                        break;
+                    };
                     let chunk = {
                         let mut cache_access = ArtifactCacheAccess::Reader(cache_reader);
                         self.prepare_index_chunk(
@@ -2001,9 +2035,7 @@ impl WorkspaceIndexer {
         plan: FullRefreshChunkPlan,
         node_count: usize,
     ) {
-        stats.full_refresh_chunk_target_bytes = budget.source_bytes;
-        stats.full_refresh_chunk_target_nodes = budget.projected_nodes;
-        stats.full_refresh_chunk_file_ceiling = budget.file_ceiling;
+        Self::record_full_refresh_chunk_config(stats, budget);
         stats.full_refresh_chunk_max_files = stats
             .full_refresh_chunk_max_files
             .max(plan.end.saturating_sub(plan.start));
@@ -2018,6 +2050,15 @@ impl WorkspaceIndexer {
             stats.full_refresh_chunk_budget_overruns =
                 stats.full_refresh_chunk_budget_overruns.saturating_add(1);
         }
+    }
+
+    fn record_full_refresh_chunk_config(
+        stats: &mut IncrementalIndexingStats,
+        budget: FullRefreshChunkBudget,
+    ) {
+        stats.full_refresh_chunk_target_bytes = budget.source_bytes;
+        stats.full_refresh_chunk_target_nodes = budget.projected_nodes;
+        stats.full_refresh_chunk_file_ceiling = budget.file_ceiling;
     }
 
     fn is_cancelled(cancel_token: Option<&CancellationToken>) -> bool {
@@ -21492,21 +21533,21 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         });
 
         let initial = planner
-            .next_chunk(&files, dir.path(), 0)
+            .next_chunk(&files, dir.path(), 0, None)
             .expect("initial chunk");
         assert_eq!((initial.start, initial.end), (0, 4));
         assert_eq!(initial.source_bytes, 100);
 
         planner.observe(initial.source_bytes, 400);
         let dense = planner
-            .next_chunk(&files, dir.path(), initial.end)
+            .next_chunk(&files, dir.path(), initial.end, None)
             .expect("dense projection chunk");
         assert_eq!((dense.start, dense.end), (4, 5));
         assert_eq!(dense.projected_nodes, 100);
 
         planner.observe(dense.source_bytes, 1);
         let sparse = planner
-            .next_chunk(&files, dir.path(), dense.end)
+            .next_chunk(&files, dir.path(), dense.end, None)
             .expect("sparse projection chunk");
         assert_eq!((sparse.start, sparse.end), (5, 8));
         assert_eq!(sparse.source_bytes, 75);
@@ -21550,6 +21591,37 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert!(stats.full_refresh_chunk_max_files > 24);
         assert!(stats.full_refresh_chunk_max_planned_bytes < 8 * 1024 * 1024);
         assert!(stats.full_refresh_chunk_max_nodes < 120_000);
+        assert_eq!(stats.full_refresh_chunk_budget_overruns, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_full_refresh_reports_adaptive_chunk_config() -> Result<()> {
+        use codestory_store::Store as Storage;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let plan = codestory_workspace::RefreshExecutionPlan {
+            mode: codestory_workspace::BuildMode::FullRefresh,
+            files_to_index: vec![],
+            files_to_remove: vec![],
+            existing_file_ids: HashMap::new(),
+        };
+        let mut storage = Storage::open_build(dir.path().join("staged.sqlite"))?;
+
+        let stats = WorkspaceIndexer::new(dir.path().to_path_buf()).run(
+            &mut storage,
+            &plan,
+            &EventBus::new(),
+            None,
+        )?;
+
+        assert_eq!(stats.full_refresh_chunk_target_bytes, 8 * 1024 * 1024);
+        assert_eq!(stats.full_refresh_chunk_target_nodes, 120_000);
+        assert_eq!(stats.full_refresh_chunk_file_ceiling, 512);
+        assert_eq!(stats.full_refresh_chunk_max_files, 0);
+        assert_eq!(stats.full_refresh_chunk_max_planned_bytes, 0);
+        assert_eq!(stats.full_refresh_chunk_max_nodes, 0);
         assert_eq!(stats.full_refresh_chunk_budget_overruns, 0);
         Ok(())
     }
@@ -21743,6 +21815,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let writer_writer_has_chunk = writer_has_chunk.clone();
         let writer_release_writer = release_writer.clone();
         let hooks = FullRefreshPipelineTestHooks {
+            before_plan_file: None,
             before_prepare_chunk: None,
             before_parse_job: Some(Arc::new(move |chunk_index| {
                 if chunk_index == 1 && !parse_barrier_entered_hook.swap(true, Ordering::SeqCst) {
@@ -21812,6 +21885,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let cancel_token = CancellationToken::new();
         let timeout_cancel_token = cancel_token.clone();
         let hooks = FullRefreshPipelineTestHooks {
+            before_plan_file: None,
             before_prepare_chunk: Some(Arc::new(move |chunk_index| {
                 if chunk_index == 1 {
                     prepare_writer_has_chunk.wait();
@@ -21903,6 +21977,55 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
     }
 
     #[test]
+    fn test_full_refresh_cancellation_during_planning_drops_partial_chunk() -> Result<()> {
+        use codestory_store::Store as Storage;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let mut paths = Vec::new();
+        for index in 0..40 {
+            let path = dir.path().join(format!("plan_cancel_{index}.rs"));
+            std::fs::write(&path, format!("fn plan_cancel_{index}() {{}}\n"))?;
+            paths.push(path);
+        }
+        let cancel_token = CancellationToken::new();
+        let planning_cancel_token = cancel_token.clone();
+        let planned_files = Arc::new(AtomicUsize::new(0));
+        let planned_files_from_hook = planned_files.clone();
+        let hooks = FullRefreshPipelineTestHooks {
+            before_plan_file: Some(Arc::new(move |file_index| {
+                planned_files_from_hook.store(file_index.saturating_add(1), Ordering::SeqCst);
+                if file_index == 5 {
+                    planning_cancel_token.cancel();
+                }
+            })),
+            before_prepare_chunk: None,
+            before_parse_job: None,
+            before_writer_chunk: None,
+            after_send_chunk: None,
+            on_send_timeout: None,
+        };
+        let indexer =
+            WorkspaceIndexer::new(dir.path().to_path_buf()).with_pipeline_test_hooks(hooks);
+        let plan = codestory_workspace::RefreshExecutionPlan {
+            mode: codestory_workspace::BuildMode::FullRefresh,
+            files_to_index: paths,
+            files_to_remove: vec![],
+            existing_file_ids: HashMap::new(),
+        };
+        let mut storage = Storage::open_build(dir.path().join("staged.sqlite"))?;
+
+        let stats = indexer.run(&mut storage, &plan, &EventBus::new(), Some(&cancel_token))?;
+
+        assert!(cancel_token.is_cancelled());
+        assert_eq!(planned_files.load(Ordering::SeqCst), 6);
+        assert_eq!(stats.full_refresh_chunks_produced, 0);
+        assert_eq!(stats.full_refresh_chunks_persisted, 0);
+        assert!(storage.get_nodes()?.is_empty());
+        Ok(())
+    }
+
+    #[test]
     fn test_full_refresh_cancellation_during_parse_drops_unaccepted_chunk() -> Result<()> {
         use codestory_store::Store as Storage;
         use tempfile::tempdir;
@@ -21917,6 +22040,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let cancel_token = CancellationToken::new();
         let parse_cancel_token = cancel_token.clone();
         let hooks = FullRefreshPipelineTestHooks {
+            before_plan_file: None,
             before_prepare_chunk: None,
             before_parse_job: Some(Arc::new(move |_| parse_cancel_token.cancel())),
             before_writer_chunk: None,
@@ -21965,6 +22089,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let cancel_token = CancellationToken::new();
         let writer_cancel_token = cancel_token.clone();
         let hooks = FullRefreshPipelineTestHooks {
+            before_plan_file: None,
             before_prepare_chunk: None,
             before_parse_job: None,
             before_writer_chunk: Some(Arc::new(move |chunk_index| {
@@ -22402,6 +22527,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let parse_hook_ran = Arc::new(AtomicBool::new(false));
         let parse_hook_ran_from_hook = parse_hook_ran.clone();
         let hooks = FullRefreshPipelineTestHooks {
+            before_plan_file: None,
             before_prepare_chunk: None,
             before_parse_job: Some(Arc::new(move |_| {
                 let (current, total) = loop {

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -628,16 +628,123 @@ impl IncrementalIndexingConfig {
         match mode {
             codestory_workspace::BuildMode::Incremental => Self::default(),
             codestory_workspace::BuildMode::FullRefresh => Self {
-                // Full refresh is the highest-risk path for transient memory spikes,
-                // so keep batch sizes conservative even though the staged store can
-                // absorb larger write bursts.
-                file_batch_size: 24,
+                // Full-refresh file scheduling uses the separate adaptive byte/node
+                // budget below. This field remains the serial incremental window and
+                // an explicit caller-provided full-refresh safety ceiling.
+                file_batch_size: Self::default().file_batch_size,
                 node_batch_size: 120_000,
                 edge_batch_size: 120_000,
                 occurrence_batch_size: 120_000,
                 error_batch_size: 2_000,
             },
         }
+    }
+}
+
+const DEFAULT_FULL_REFRESH_CHUNK_SOURCE_BYTES: u64 = 8 * 1024 * 1024;
+const DEFAULT_FULL_REFRESH_CHUNK_PROJECTED_NODES: usize = 120_000;
+const DEFAULT_FULL_REFRESH_CHUNK_FILE_CEILING: usize = 512;
+
+#[derive(Debug, Clone, Copy)]
+struct FullRefreshChunkBudget {
+    source_bytes: u64,
+    projected_nodes: usize,
+    file_ceiling: usize,
+}
+
+impl Default for FullRefreshChunkBudget {
+    fn default() -> Self {
+        Self {
+            source_bytes: DEFAULT_FULL_REFRESH_CHUNK_SOURCE_BYTES,
+            projected_nodes: DEFAULT_FULL_REFRESH_CHUNK_PROJECTED_NODES,
+            file_ceiling: DEFAULT_FULL_REFRESH_CHUNK_FILE_CEILING,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FullRefreshChunkPlan {
+    start: usize,
+    end: usize,
+    source_bytes: u64,
+    projected_nodes: usize,
+}
+
+#[derive(Debug)]
+struct AdaptiveFullRefreshChunkPlanner {
+    budget: FullRefreshChunkBudget,
+    last_source_bytes: u64,
+    last_nodes: usize,
+}
+
+impl AdaptiveFullRefreshChunkPlanner {
+    fn new(budget: FullRefreshChunkBudget) -> Self {
+        Self {
+            budget: FullRefreshChunkBudget {
+                source_bytes: budget.source_bytes.max(1),
+                projected_nodes: budget.projected_nodes.max(1),
+                file_ceiling: budget.file_ceiling.max(1),
+            },
+            last_source_bytes: 0,
+            last_nodes: 0,
+        }
+    }
+
+    fn next_chunk(
+        &self,
+        files: &[PathBuf],
+        root: &Path,
+        start: usize,
+    ) -> Option<FullRefreshChunkPlan> {
+        if start >= files.len() {
+            return None;
+        }
+
+        let mut source_bytes = 0u64;
+        let mut projected_nodes = 0usize;
+        let mut end = start;
+        while end < files.len() && end - start < self.budget.file_ceiling {
+            let file_bytes =
+                std::fs::metadata(WorkspaceIndexer::normalize_index_path(root, &files[end]))
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0);
+            let file_projected_nodes = self.projected_nodes(file_bytes);
+            let next_source_bytes = source_bytes.saturating_add(file_bytes);
+            let next_projected_nodes = projected_nodes.saturating_add(file_projected_nodes);
+            if end > start
+                && (next_source_bytes > self.budget.source_bytes
+                    || next_projected_nodes > self.budget.projected_nodes)
+            {
+                break;
+            }
+            source_bytes = next_source_bytes;
+            projected_nodes = next_projected_nodes;
+            end += 1;
+        }
+
+        Some(FullRefreshChunkPlan {
+            start,
+            end: end.max(start + 1),
+            source_bytes,
+            projected_nodes,
+        })
+    }
+
+    fn observe(&mut self, source_bytes: u64, nodes: usize) {
+        self.last_source_bytes = source_bytes;
+        self.last_nodes = nodes;
+    }
+
+    fn projected_nodes(&self, source_bytes: u64) -> usize {
+        let (density_nodes, density_bytes) = if self.last_source_bytes == 0 {
+            (self.budget.projected_nodes, self.budget.source_bytes)
+        } else {
+            (self.last_nodes.max(1), self.last_source_bytes)
+        };
+        let numerator = u128::from(source_bytes.max(1)).saturating_mul(density_nodes as u128);
+        let projected = numerator.saturating_add(u128::from(density_bytes.saturating_sub(1)))
+            / u128::from(density_bytes);
+        usize::try_from(projected).unwrap_or(usize::MAX).max(1)
     }
 }
 
@@ -691,6 +798,14 @@ pub struct IncrementalIndexingStats {
     pub full_refresh_queue_high_water: usize,
     pub full_refresh_producer_blocked_ms: u64,
     pub full_refresh_writer_idle_ms: u64,
+    pub full_refresh_chunk_target_bytes: u64,
+    pub full_refresh_chunk_target_nodes: usize,
+    pub full_refresh_chunk_file_ceiling: usize,
+    pub full_refresh_chunk_max_files: usize,
+    pub full_refresh_chunk_max_planned_bytes: u64,
+    pub full_refresh_chunk_max_nodes: usize,
+    pub full_refresh_chunk_budget_overruns: usize,
+    pub full_refresh_chunk_planning_ms: u64,
     pub parse_index_ms: u64,
     pub projection_flush_ms: u64,
     pub flush_files_ms: u64,
@@ -811,6 +926,14 @@ struct PreparedIndexChunk {
     before_persist: Option<(usize, FullRefreshChunkTestHook)>,
 }
 
+impl PreparedIndexChunk {
+    fn node_count(&self) -> usize {
+        self.storages.iter().fold(0usize, |total, storage| {
+            total.saturating_add(storage.nodes.len())
+        })
+    }
+}
+
 #[derive(Clone, Copy)]
 struct IndexProgress<'a> {
     processed_count: &'a AtomicUsize,
@@ -834,6 +957,7 @@ struct FullRefreshPipelineTestHooks {
     before_prepare_chunk: Option<FullRefreshChunkTestHook>,
     before_parse_job: Option<FullRefreshChunkTestHook>,
     before_writer_chunk: Option<FullRefreshChunkTestHook>,
+    after_send_chunk: Option<FullRefreshChunkTestHook>,
     on_send_timeout: Option<FullRefreshChunkTestHook>,
 }
 
@@ -1075,6 +1199,7 @@ pub struct WorkspaceIndexer {
     compilation_db: Option<compilation_database::CompilationDatabase>,
     compilation_db_warning: Option<String>,
     batch_config: IncrementalIndexingConfig,
+    full_refresh_chunk_budget: FullRefreshChunkBudget,
     source_file_byte_cap: u64,
     #[cfg(test)]
     pipeline_test_hooks: FullRefreshPipelineTestHooks,
@@ -1109,6 +1234,7 @@ impl WorkspaceIndexer {
             compilation_db,
             compilation_db_warning,
             batch_config: IncrementalIndexingConfig::default(),
+            full_refresh_chunk_budget: FullRefreshChunkBudget::default(),
             source_file_byte_cap: process_source_index_policy().byte_cap,
             #[cfg(test)]
             pipeline_test_hooks: FullRefreshPipelineTestHooks::default(),
@@ -1116,8 +1242,18 @@ impl WorkspaceIndexer {
     }
 
     /// Override incremental flush batch sizes.
+    ///
+    /// An explicit file batch size also becomes the full-refresh file-count
+    /// safety ceiling; normal full refreshes use the adaptive default.
     pub fn with_batch_config(mut self, batch_config: IncrementalIndexingConfig) -> Self {
         self.batch_config = batch_config;
+        self.full_refresh_chunk_budget.file_ceiling = batch_config.file_batch_size.max(1);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_full_refresh_chunk_budget(mut self, budget: FullRefreshChunkBudget) -> Self {
+        self.full_refresh_chunk_budget = AdaptiveFullRefreshChunkPlanner::new(budget).budget;
         self
     }
 
@@ -1221,10 +1357,7 @@ impl WorkspaceIndexer {
         let batch_config = match plan.mode {
             codestory_workspace::BuildMode::Incremental => self.batch_config,
             codestory_workspace::BuildMode::FullRefresh => IncrementalIndexingConfig {
-                file_batch_size: self
-                    .batch_config
-                    .file_batch_size
-                    .min(full_refresh_defaults.file_batch_size),
+                file_batch_size: self.batch_config.file_batch_size,
                 node_batch_size: self
                     .batch_config
                     .node_batch_size
@@ -1600,30 +1733,73 @@ impl WorkspaceIndexer {
             existing_projection_file_ids,
             false,
         );
-        for (chunk_index, file_chunk) in plan
-            .files_to_index
-            .chunks(batch_config.file_batch_size.max(1))
-            .enumerate()
-        {
-            let chunk = {
-                let mut cache_access = ArtifactCacheAccess::Storage(writer.storage_mut());
-                self.prepare_index_chunk(
-                    &mut cache_access,
-                    chunk_index,
-                    file_chunk,
-                    root,
-                    plan.mode,
-                    existing_projection_file_ids,
-                    symbol_table,
-                    cancelled,
-                    cancel_token,
-                    Some(progress),
-                    stats,
-                )
-            };
-            writer.accept_chunk(chunk, progress)?;
-            if cancelled.load(Ordering::Relaxed) {
-                break;
+        if plan.mode == codestory_workspace::BuildMode::FullRefresh {
+            let mut planner = AdaptiveFullRefreshChunkPlanner::new(self.full_refresh_chunk_budget);
+            let mut start = 0usize;
+            let mut chunk_index = 0usize;
+            let mut planning_duration = Duration::ZERO;
+            loop {
+                let planning_started = Instant::now();
+                let next_chunk = planner.next_chunk(&plan.files_to_index, root, start);
+                planning_duration = planning_duration.saturating_add(planning_started.elapsed());
+                let Some(chunk_plan) = next_chunk else {
+                    break;
+                };
+                let chunk = {
+                    let mut cache_access = ArtifactCacheAccess::Storage(writer.storage_mut());
+                    self.prepare_index_chunk(
+                        &mut cache_access,
+                        chunk_index,
+                        &plan.files_to_index[chunk_plan.start..chunk_plan.end],
+                        root,
+                        plan.mode,
+                        existing_projection_file_ids,
+                        symbol_table,
+                        cancelled,
+                        cancel_token,
+                        Some(progress),
+                        stats,
+                    )
+                };
+                let node_count = chunk.node_count();
+                Self::record_full_refresh_chunk(stats, planner.budget, chunk_plan, node_count);
+                planner.observe(chunk_plan.source_bytes, node_count);
+                writer.accept_chunk(chunk, progress)?;
+                start = chunk_plan.end;
+                chunk_index = chunk_index.saturating_add(1);
+                if cancelled.load(Ordering::Relaxed) {
+                    break;
+                }
+            }
+            stats.full_refresh_chunk_planning_ms = stats
+                .full_refresh_chunk_planning_ms
+                .saturating_add(duration_ms_u64(planning_duration));
+        } else {
+            for (chunk_index, file_chunk) in plan
+                .files_to_index
+                .chunks(batch_config.file_batch_size.max(1))
+                .enumerate()
+            {
+                let chunk = {
+                    let mut cache_access = ArtifactCacheAccess::Storage(writer.storage_mut());
+                    self.prepare_index_chunk(
+                        &mut cache_access,
+                        chunk_index,
+                        file_chunk,
+                        root,
+                        plan.mode,
+                        existing_projection_file_ids,
+                        symbol_table,
+                        cancelled,
+                        cancel_token,
+                        Some(progress),
+                        stats,
+                    )
+                };
+                writer.accept_chunk(chunk, progress)?;
+                if cancelled.load(Ordering::Relaxed) {
+                    break;
+                }
             }
         }
         writer.finish()
@@ -1666,10 +1842,19 @@ impl WorkspaceIndexer {
             });
 
             let producer_result = (|| -> Result<()> {
-                for (chunk_index, file_chunk) in files_to_index
-                    .chunks(batch_config.file_batch_size.max(1))
-                    .enumerate()
-                {
+                let mut planner =
+                    AdaptiveFullRefreshChunkPlanner::new(self.full_refresh_chunk_budget);
+                let mut start = 0usize;
+                let mut chunk_index = 0usize;
+                let mut planning_duration = Duration::ZERO;
+                loop {
+                    let planning_started = Instant::now();
+                    let next_chunk = planner.next_chunk(files_to_index, root, start);
+                    planning_duration =
+                        planning_duration.saturating_add(planning_started.elapsed());
+                    let Some(chunk_plan) = next_chunk else {
+                        break;
+                    };
                     if Self::is_cancelled(cancel_token) {
                         cancelled.store(true, Ordering::Relaxed);
                         break;
@@ -1679,7 +1864,7 @@ impl WorkspaceIndexer {
                         self.prepare_index_chunk(
                             &mut cache_access,
                             chunk_index,
-                            file_chunk,
+                            &files_to_index[chunk_plan.start..chunk_plan.end],
                             root,
                             codestory_workspace::BuildMode::FullRefresh,
                             existing_projection_file_ids,
@@ -1694,17 +1879,24 @@ impl WorkspaceIndexer {
                         break;
                     }
 
+                    let node_count = chunk.node_count();
                     let blocked_started = Instant::now();
                     let mut pending_chunk = chunk;
+                    let mut accepted = false;
                     loop {
                         match sender.send_timeout(pending_chunk, SEND_RETRY) {
                             Ok(()) => {
+                                accepted = true;
                                 stats.full_refresh_chunks_produced =
                                     stats.full_refresh_chunks_produced.saturating_add(1);
                                 // A successful bounded send has one linearization
                                 // point at which the capacity-1 queue is occupied,
                                 // even if the receiver immediately dequeues it.
                                 stats.full_refresh_queue_high_water = 1;
+                                #[cfg(test)]
+                                if let Some(hook) = &self.pipeline_test_hooks.after_send_chunk {
+                                    hook(chunk_index);
+                                }
                                 break;
                             }
                             Err(SendTimeoutError::Timeout(chunk)) => {
@@ -1726,10 +1918,24 @@ impl WorkspaceIndexer {
                     stats.full_refresh_producer_blocked_ms = stats
                         .full_refresh_producer_blocked_ms
                         .saturating_add(duration_ms_u64(blocked_started.elapsed()));
+                    if accepted {
+                        Self::record_full_refresh_chunk(
+                            stats,
+                            planner.budget,
+                            chunk_plan,
+                            node_count,
+                        );
+                        planner.observe(chunk_plan.source_bytes, node_count);
+                        start = chunk_plan.end;
+                        chunk_index = chunk_index.saturating_add(1);
+                    }
                     if cancelled.load(Ordering::Relaxed) {
                         break;
                     }
                 }
+                stats.full_refresh_chunk_planning_ms = stats
+                    .full_refresh_chunk_planning_ms
+                    .saturating_add(duration_ms_u64(planning_duration));
                 Ok(())
             })();
             drop(sender);
@@ -1787,6 +1993,31 @@ impl WorkspaceIndexer {
             }
         }
         writer.finish()
+    }
+
+    fn record_full_refresh_chunk(
+        stats: &mut IncrementalIndexingStats,
+        budget: FullRefreshChunkBudget,
+        plan: FullRefreshChunkPlan,
+        node_count: usize,
+    ) {
+        stats.full_refresh_chunk_target_bytes = budget.source_bytes;
+        stats.full_refresh_chunk_target_nodes = budget.projected_nodes;
+        stats.full_refresh_chunk_file_ceiling = budget.file_ceiling;
+        stats.full_refresh_chunk_max_files = stats
+            .full_refresh_chunk_max_files
+            .max(plan.end.saturating_sub(plan.start));
+        stats.full_refresh_chunk_max_planned_bytes = stats
+            .full_refresh_chunk_max_planned_bytes
+            .max(plan.source_bytes);
+        stats.full_refresh_chunk_max_nodes = stats.full_refresh_chunk_max_nodes.max(node_count);
+        if plan.source_bytes > budget.source_bytes
+            || plan.projected_nodes > budget.projected_nodes
+            || node_count > budget.projected_nodes
+        {
+            stats.full_refresh_chunk_budget_overruns =
+                stats.full_refresh_chunk_budget_overruns.saturating_add(1);
+        }
     }
 
     fn is_cancelled(cancel_token: Option<&CancellationToken>) -> bool {
@@ -21243,6 +21474,135 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
     }
 
     #[test]
+    fn test_adaptive_full_refresh_planner_tracks_dense_and_sparse_node_output() -> Result<()> {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let mut files = Vec::new();
+        for index in 0..8 {
+            let path = dir.path().join(format!("planned_{index}.rs"));
+            fs::write(&path, vec![b'x'; 25])?;
+            files.push(path);
+        }
+        let mut planner = AdaptiveFullRefreshChunkPlanner::new(FullRefreshChunkBudget {
+            source_bytes: 100,
+            projected_nodes: 100,
+            file_ceiling: 10,
+        });
+
+        let initial = planner
+            .next_chunk(&files, dir.path(), 0)
+            .expect("initial chunk");
+        assert_eq!((initial.start, initial.end), (0, 4));
+        assert_eq!(initial.source_bytes, 100);
+
+        planner.observe(initial.source_bytes, 400);
+        let dense = planner
+            .next_chunk(&files, dir.path(), initial.end)
+            .expect("dense projection chunk");
+        assert_eq!((dense.start, dense.end), (4, 5));
+        assert_eq!(dense.projected_nodes, 100);
+
+        planner.observe(dense.source_bytes, 1);
+        let sparse = planner
+            .next_chunk(&files, dir.path(), dense.end)
+            .expect("sparse projection chunk");
+        assert_eq!((sparse.start, sparse.end), (5, 8));
+        assert_eq!(sparse.source_bytes, 75);
+        Ok(())
+    }
+
+    #[test]
+    fn test_full_refresh_adaptive_budget_grows_beyond_legacy_file_window() -> Result<()> {
+        use codestory_store::Store as Storage;
+        use std::fs;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let mut files = Vec::new();
+        for index in 0..40 {
+            let path = dir.path().join(format!("tiny_{index}.rs"));
+            fs::write(&path, format!("fn tiny_{index}() {{}}\n"))?;
+            files.push(path);
+        }
+        let plan = codestory_workspace::RefreshExecutionPlan {
+            mode: codestory_workspace::BuildMode::FullRefresh,
+            files_to_index: files,
+            files_to_remove: vec![],
+            existing_file_ids: HashMap::new(),
+        };
+        let mut storage = Storage::open_build(dir.path().join("staged.sqlite"))?;
+
+        let stats = WorkspaceIndexer::new(dir.path().to_path_buf()).run(
+            &mut storage,
+            &plan,
+            &EventBus::new(),
+            None,
+        )?;
+
+        assert_eq!(stats.full_refresh_chunks_produced, 1);
+        assert_eq!(stats.full_refresh_chunks_persisted, 1);
+        assert_eq!(stats.full_refresh_chunk_target_bytes, 8 * 1024 * 1024);
+        assert_eq!(stats.full_refresh_chunk_target_nodes, 120_000);
+        assert_eq!(stats.full_refresh_chunk_file_ceiling, 512);
+        assert_eq!(stats.full_refresh_chunk_max_files, 40);
+        assert!(stats.full_refresh_chunk_max_files > 24);
+        assert!(stats.full_refresh_chunk_max_planned_bytes < 8 * 1024 * 1024);
+        assert!(stats.full_refresh_chunk_max_nodes < 120_000);
+        assert_eq!(stats.full_refresh_chunk_budget_overruns, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_full_refresh_adaptive_budget_advances_one_over_budget_file() -> Result<()> {
+        use codestory_store::Store as Storage;
+        use std::fs;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let large = dir.path().join("large.rs");
+        let small = dir.path().join("small.rs");
+        fs::write(&large, format!("fn large() {{}}\n{}", "x".repeat(64)))?;
+        fs::write(&small, "fn small() {}\n")?;
+        let plan = codestory_workspace::RefreshExecutionPlan {
+            mode: codestory_workspace::BuildMode::FullRefresh,
+            files_to_index: vec![large, small],
+            files_to_remove: vec![],
+            existing_file_ids: HashMap::new(),
+        };
+        let mut storage = Storage::open_build(dir.path().join("staged.sqlite"))?;
+        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf())
+            .with_source_file_byte_cap(256)
+            .with_full_refresh_chunk_budget(FullRefreshChunkBudget {
+                source_bytes: 32,
+                projected_nodes: 100,
+                file_ceiling: 10,
+            });
+
+        let stats = indexer.run(&mut storage, &plan, &EventBus::new(), None)?;
+
+        assert_eq!(stats.full_refresh_chunks_produced, 2);
+        assert_eq!(stats.full_refresh_chunks_persisted, 2);
+        assert_eq!(stats.full_refresh_chunk_max_files, 1);
+        assert!(stats.full_refresh_chunk_max_planned_bytes > 32);
+        assert_eq!(stats.full_refresh_chunk_budget_overruns, 1);
+        assert!(
+            storage
+                .get_nodes()?
+                .iter()
+                .any(|node| node.serialized_name == "large")
+        );
+        assert!(
+            storage
+                .get_nodes()?
+                .iter()
+                .any(|node| node.serialized_name == "small")
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_file_backed_full_refresh_duplicate_paths_keep_serial_cache_semantics() -> Result<()> {
         use codestory_store::Store as Storage;
         use tempfile::tempdir;
@@ -21397,6 +21757,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
                     writer_release_writer.wait();
                 }
             })),
+            after_send_chunk: None,
             on_send_timeout: None,
         };
 
@@ -21463,6 +21824,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
                     writer_release_writer.wait();
                 }
             })),
+            after_send_chunk: None,
             on_send_timeout: Some(Arc::new(move |chunk_index| {
                 if chunk_index == 2 {
                     timeout_cancel_token.cancel();
@@ -21558,6 +21920,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             before_prepare_chunk: None,
             before_parse_job: Some(Arc::new(move |_| parse_cancel_token.cancel())),
             before_writer_chunk: None,
+            after_send_chunk: None,
             on_send_timeout: None,
         };
         let indexer = WorkspaceIndexer::new(dir.path().to_path_buf())
@@ -21602,16 +21965,17 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let cancel_token = CancellationToken::new();
         let writer_cancel_token = cancel_token.clone();
         let hooks = FullRefreshPipelineTestHooks {
-            before_prepare_chunk: Some(Arc::new(move |chunk_index| {
-                if chunk_index == 1 {
-                    producer_accepted.wait();
-                }
-            })),
+            before_prepare_chunk: None,
             before_parse_job: None,
             before_writer_chunk: Some(Arc::new(move |chunk_index| {
                 if chunk_index == 0 {
                     writer_cancel_token.cancel();
                     writer_accepted.wait();
+                }
+            })),
+            after_send_chunk: Some(Arc::new(move |chunk_index| {
+                if chunk_index == 0 {
+                    producer_accepted.wait();
                 }
             })),
             on_send_timeout: None,
@@ -22054,6 +22418,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
                 parse_cancel_token.cancel();
             })),
             before_writer_chunk: None,
+            after_send_chunk: None,
             on_send_timeout: None,
         };
         let indexer = WorkspaceIndexer::new(dir.path().to_path_buf())

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -14673,6 +14673,7 @@ fn index_full_for_runtime(
     let publish_ms = clamp_u128_to_u32(publish_started.elapsed().as_millis());
     let resolution_telemetry = OptionalResolutionTelemetry::from_incremental_stats(&index_stats);
     let full_refresh_pipeline_enabled = index_stats.full_refresh_queue_capacity > 0;
+    let full_refresh_chunking_enabled = index_stats.full_refresh_chunk_target_bytes > 0;
     Ok(IndexingRunSummary {
         phase_timings: IndexingPhaseTimings {
             parse_index_ms: clamp_u64_to_u32(index_stats.parse_index_ms),
@@ -14700,6 +14701,25 @@ fn index_full_for_runtime(
             ),
             full_refresh_writer_idle_ms: full_refresh_pipeline_enabled
                 .then_some(clamp_u64_to_u32(index_stats.full_refresh_writer_idle_ms)),
+            full_refresh_chunk_target_bytes: full_refresh_chunking_enabled
+                .then_some(index_stats.full_refresh_chunk_target_bytes),
+            full_refresh_chunk_target_nodes: full_refresh_chunking_enabled.then_some(
+                clamp_usize_to_u32(index_stats.full_refresh_chunk_target_nodes),
+            ),
+            full_refresh_chunk_file_ceiling: full_refresh_chunking_enabled.then_some(
+                clamp_usize_to_u32(index_stats.full_refresh_chunk_file_ceiling),
+            ),
+            full_refresh_chunk_max_files: full_refresh_chunking_enabled
+                .then_some(clamp_usize_to_u32(index_stats.full_refresh_chunk_max_files)),
+            full_refresh_chunk_max_planned_bytes: full_refresh_chunking_enabled
+                .then_some(index_stats.full_refresh_chunk_max_planned_bytes),
+            full_refresh_chunk_max_nodes: full_refresh_chunking_enabled
+                .then_some(clamp_usize_to_u32(index_stats.full_refresh_chunk_max_nodes)),
+            full_refresh_chunk_budget_overruns: full_refresh_chunking_enabled.then_some(
+                clamp_usize_to_u32(index_stats.full_refresh_chunk_budget_overruns),
+            ),
+            full_refresh_chunk_planning_ms: full_refresh_chunking_enabled
+                .then_some(clamp_u64_to_u32(index_stats.full_refresh_chunk_planning_ms)),
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,
@@ -15331,6 +15351,14 @@ fn run_incremental_indexing_common(
             full_refresh_queue_high_water: None,
             full_refresh_producer_blocked_ms: None,
             full_refresh_writer_idle_ms: None,
+            full_refresh_chunk_target_bytes: None,
+            full_refresh_chunk_target_nodes: None,
+            full_refresh_chunk_file_ceiling: None,
+            full_refresh_chunk_max_files: None,
+            full_refresh_chunk_max_planned_bytes: None,
+            full_refresh_chunk_max_nodes: None,
+            full_refresh_chunk_budget_overruns: None,
+            full_refresh_chunk_planning_ms: None,
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_index_ms: None,
@@ -25276,6 +25304,17 @@ fn build_llm_symbol_doc_text() -> String {
         assert_eq!(full_timings.full_refresh_chunks_persisted, Some(1));
         assert!(full_timings.full_refresh_producer_blocked_ms.is_some());
         assert!(full_timings.full_refresh_writer_idle_ms.is_some());
+        assert_eq!(
+            full_timings.full_refresh_chunk_target_bytes,
+            Some(8 * 1024 * 1024)
+        );
+        assert_eq!(full_timings.full_refresh_chunk_target_nodes, Some(120_000));
+        assert_eq!(full_timings.full_refresh_chunk_file_ceiling, Some(512));
+        assert_eq!(full_timings.full_refresh_chunk_max_files, Some(1));
+        assert!(full_timings.full_refresh_chunk_max_planned_bytes.is_some());
+        assert!(full_timings.full_refresh_chunk_max_nodes.is_some());
+        assert_eq!(full_timings.full_refresh_chunk_budget_overruns, Some(0));
+        assert!(full_timings.full_refresh_chunk_planning_ms.is_some());
         let first = controller
             .index_publication()
             .expect("read first publication")
@@ -25293,6 +25332,17 @@ fn build_llm_symbol_doc_text() -> String {
             .expect("incremental publication");
         assert!(incremental_timings.full_refresh_queue_capacity.is_none());
         assert!(incremental_timings.full_refresh_chunks_produced.is_none());
+        assert!(
+            incremental_timings
+                .full_refresh_chunk_target_bytes
+                .is_none()
+        );
+        assert!(
+            incremental_timings
+                .full_refresh_chunk_target_nodes
+                .is_none()
+        );
+        assert!(incremental_timings.full_refresh_chunk_planning_ms.is_none());
         let second = controller
             .index_publication()
             .expect("read second publication")

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -25279,6 +25279,32 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
+    fn empty_full_refresh_reports_adaptive_chunk_config() {
+        let workspace = tempdir().expect("workspace dir");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(workspace.path().to_path_buf(), storage_path)
+            .expect("open project");
+
+        let timings = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("empty full publication");
+
+        assert_eq!(
+            timings.full_refresh_chunk_target_bytes,
+            Some(8 * 1024 * 1024)
+        );
+        assert_eq!(timings.full_refresh_chunk_target_nodes, Some(120_000));
+        assert_eq!(timings.full_refresh_chunk_file_ceiling, Some(512));
+        assert_eq!(timings.full_refresh_chunk_max_files, Some(0));
+        assert_eq!(timings.full_refresh_chunk_max_planned_bytes, Some(0));
+        assert_eq!(timings.full_refresh_chunk_max_nodes, Some(0));
+        assert_eq!(timings.full_refresh_chunk_budget_overruns, Some(0));
+        assert!(timings.full_refresh_chunk_planning_ms.is_some());
+    }
+
+    #[test]
     fn full_and_incremental_publications_advance_one_durable_generation() {
         let workspace = tempdir().expect("workspace dir");
         fs::write(

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -224,6 +224,16 @@ channel. This overlaps parser work with persistence while preserving one
 SQLite writer and applying backpressure instead of growing an unbounded result
 queue. Incremental indexing and in-memory fixtures retain the serial path.
 
+Full refresh chooses each chunk with an 8 MiB planned-source target and a
+120,000 projected-node target instead of a fixed small file count. The node
+projection uses the previous prepared chunk's observed node density, so tiny
+sparse files can fill a larger Rayon window while dense files reduce the next
+one. A 512-file ceiling bounds empty, tiny, unreadable, or unsupported inputs.
+One file always advances even when it alone exceeds a target; telemetry records
+that overrun plus planning time and the maximum files, planned bytes, and
+produced nodes seen in a chunk. Incremental indexing keeps its existing fixed
+serial window.
+
 At most three prepared chunks can be materialized at once: one owned by the
 writer, one queued, and one being prepared. A cancellation drops work that has
 not crossed the channel boundary; already accepted chunks finish their


### PR DESCRIPTION
Closes #1295
Refs #1275
Refs #1202

## Context

The retained 94,411-file proof spent only 1m46s parsing, but full refresh still selected work through a fixed small file window. At the current merged source, the nominal 24-file containment limit combines with the default configuration to produce a 16-file production window. Tiny files therefore create frequent parse/persist barriers, while a count alone says little about memory for dense files.

This child replaces production full-refresh file-count scheduling with bounded source-byte and projected-node targets. It leaves incremental chunking, projection flush thresholds, SQLite settings, search construction, and publication unchanged. The repo-scale rerun remains reserved for the final combined #1275 head.

## What changed

- plan full-refresh chunks around 8 MiB of current metadata size and 120,000 projected nodes, with a 512-file safety ceiling;
- update the next node-density projection from the previous prepared chunk's actual node output;
- always advance one file when that file alone exceeds a target and count source, projection, or actual-node overruns;
- retain explicit `with_batch_config` file sizes as a full-refresh safety ceiling for compatibility and deterministic fixtures;
- expose targets, observed maxima, overruns, and metadata-planning time through runtime JSON and CLI output;
- check cancellation between synchronous metadata reads and drop any partially planned, unaccepted chunk;
- initialize adaptive configuration telemetry even when a full refresh schedules zero files;
- replace a race-prone cancellation fixture with a post-send synchronization hook that proves an accepted chunk drains after cancellation.

## How to review

1. Check `AdaptiveFullRefreshChunkPlanner`: metadata failures stay bounded by the file ceiling, arithmetic saturates, the first chunk uses the configured density, and later chunks use prepared output without changing source truth.
2. Check both full-refresh execution paths: serial fallback and pipelined production use the same planner, while incremental retains the old fixed loop and progress boundary.
3. Check `record_full_refresh_chunk` and runtime mapping: full telemetry is present, incremental fields remain omitted, and single-file or density-estimate overruns are visible rather than silently called bounded.
4. Check cancellation: planning checks the token between metadata reads, unaccepted pipeline work is still dropped, accepted work still drains, and the capacity-one/max-three ownership contract is unchanged.

## Verification

Exact candidate: `8e836e4974bbd10c2bffeabd882d8509c5891eb7`

- `cargo check --locked -p codestory-contracts -p codestory-indexer -p codestory-runtime -p codestory-cli`
- `cargo test --locked -p codestory-indexer --lib` — 209 passed
- adaptive fixtures prove 40 tiny Rust files form one chunk, dense output contracts the next plan, sparse output expands it, and an over-target single file advances alone with one overrun
- planning cancellation stops after the sixth hook boundary without parsing or persisting the partial chunk; an empty full refresh retains configured adaptive limits with zero observed maxima
- serial/pipelined/cache-replayed projection snapshot equality remains green
- full-refresh cancellation, overlap, backpressure, cache reuse, duplicate fallback, and writer-failure tests remain green
- `cargo test --locked -p codestory-runtime --lib full_refresh_` — 12 passed
- empty full-refresh runtime telemetry maps configured targets and zero maxima instead of omitting the adaptive fields
- full and incremental atomic publication transition matrices — 2 passed
- full/incremental durable-generation and telemetry mapping test
- contracts optional-field omission and CLI rich-timing rendering tests
- `cargo clippy --locked -p codestory-contracts -p codestory-indexer -p codestory-runtime -p codestory-cli --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs`

Not run here: parser fidelity/language-coverage binaries, because parser and extraction behavior did not change; repo-scale stats, because #1275 owns one final combined corpus run.

## Risk

The source-byte limit is a planning target from current filesystem metadata, not a source-identity claim. A file may exceed a target alone, and actual node density can exceed its projection; both cases remain bounded by one prepared chunk plus the capacity-one pipeline and are reported as overruns. Existing hash/drift checks, source byte caps, cache transactions, writer ownership, cancellation, and atomic publication remain authoritative.
