### PR TITLE
[codex] Relax SQLite durability for disposable full builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
   8 MiB source and 120,000 projected-node target plus a 512-file safety
   ceiling. Completed output adjusts the next chunk's node-density estimate,
   and telemetry reports planning time, observed maxima, and target overruns.
+- Fresh full-refresh stages now use a store-owned disposable SQLite profile:
+  WAL remains available to the bounded cache reader, automatic checkpoint work
+  uses a 64 MiB window instead of SQLite's small default, and durability is
+  deferred to a verified NORMAL/TRUNCATE checkpoint plus filesystem sync before
+  promotion. Live, generic build, and incremental-clone profiles remain
+  WAL/NORMAL. Full-refresh telemetry reports the configured checkpoint window,
+  final checkpoint time, and explicit sync time.
 
 ## 0.16.0
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8976,6 +8976,9 @@ mod tests {
             summary_snapshot_ms: Some(8),
             detail_snapshot_ms: Some(9),
             publish_ms: Some(10),
+            staged_sqlite_wal_autocheckpoint_bytes: Some(67_108_864),
+            staged_sqlite_checkpoint_ms: Some(11),
+            staged_sqlite_sync_ms: Some(12),
             setup_existing_projection_ids_ms: Some(11),
             setup_seed_symbol_table_ms: Some(12),
             flush_files_ms: Some(13),
@@ -9197,6 +9200,9 @@ mod tests {
         assert!(markdown.contains("semantic_docs: reused=11 embedded=12 pending=13 stale=14"));
         assert!(markdown.contains(
             "staged_publish_ms: deferred_indexes=7 summary_snapshot=8 detail_snapshot=9 publish=10"
+        ));
+        assert!(markdown.contains(
+            "staged_sqlite: wal_autocheckpoint_bytes=67108864 checkpoint_ms=11 sync_ms=12"
         ));
         assert!(markdown.contains("setup_ms: existing_projection_ids=11 seed_symbol_table=12"));
         assert!(

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -396,6 +396,18 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
             ("publish", timings.publish_ms),
         ],
     );
+    if timings.staged_sqlite_wal_autocheckpoint_bytes.is_some()
+        || timings.staged_sqlite_checkpoint_ms.is_some()
+        || timings.staged_sqlite_sync_ms.is_some()
+    {
+        let _ = writeln!(
+            markdown,
+            "staged_sqlite: wal_autocheckpoint_bytes={} checkpoint_ms={} sync_ms={}",
+            timings.staged_sqlite_wal_autocheckpoint_bytes.unwrap_or(0),
+            timings.staged_sqlite_checkpoint_ms.unwrap_or(0),
+            timings.staged_sqlite_sync_ms.unwrap_or(0),
+        );
+    }
     append_optional_timings_line(
         markdown,
         "setup_ms",

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -420,9 +420,9 @@ fn web_cockpit_stays_deferred_until_browser_surface_gate_opens() {
 fn runtime_snapshot_lifecycle_flows_through_store_snapshot_surface() {
     let runtime = read("crates/codestory-runtime/src/lib.rs");
     assert!(
-        runtime.contains("SnapshotStore::open_staged(storage_path)")
+        runtime.contains("SnapshotStore::open_disposable_full_refresh(storage_path)")
             && runtime.contains("finalize_staged()")
-            && runtime.contains("staged.publish(storage_path)"),
+            && runtime.contains("staged.publish_with_stats(storage_path)"),
         "full refresh should stage, finalize, and publish snapshots through the store snapshot surface"
     );
     assert!(

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -100,6 +100,12 @@ pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub publish_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub staged_sqlite_wal_autocheckpoint_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub staged_sqlite_checkpoint_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub staged_sqlite_sync_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub setup_existing_projection_ids_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub setup_seed_symbol_table_ms: Option<u32>,
@@ -281,6 +287,9 @@ mod tests {
             summary_snapshot_ms: None,
             detail_snapshot_ms: None,
             publish_ms: None,
+            staged_sqlite_wal_autocheckpoint_bytes: None,
+            staged_sqlite_checkpoint_ms: None,
+            staged_sqlite_sync_ms: None,
             setup_existing_projection_ids_ms: None,
             setup_seed_symbol_table_ms: None,
             flush_files_ms: None,
@@ -411,6 +420,13 @@ mod tests {
         assert!(value.get("summary_snapshot_ms").is_none());
         assert!(value.get("detail_snapshot_ms").is_none());
         assert!(value.get("publish_ms").is_none());
+        assert!(
+            value
+                .get("staged_sqlite_wal_autocheckpoint_bytes")
+                .is_none()
+        );
+        assert!(value.get("staged_sqlite_checkpoint_ms").is_none());
+        assert!(value.get("staged_sqlite_sync_ms").is_none());
         assert!(value.get("setup_existing_projection_ids_ms").is_none());
         assert!(value.get("setup_seed_symbol_table_ms").is_none());
         assert!(value.get("flush_files_ms").is_none());

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -14372,7 +14372,7 @@ fn index_full_for_runtime(
     #[cfg(test)]
     run_source_policy_after_plan_hook();
 
-    let mut staged = SnapshotStore::open_staged(storage_path)
+    let mut staged = SnapshotStore::open_disposable_full_refresh(storage_path)
         .map_err(|e| ApiError::internal(format!("Failed to open staged storage: {e}")))?;
     #[cfg(test)]
     run_full_refresh_staged_store_hook(staged.store_mut());
@@ -14662,14 +14662,17 @@ fn index_full_for_runtime(
         discard_unpublished_search_generation(storage_path, &publication);
         return Err(indexing_cancelled_error());
     }
-    if let Err(err) = staged.publish(storage_path) {
-        drop(prepared_search_state);
-        discard_unpublished_search_generation(storage_path, &publication);
-        return Err(ApiError::internal(format!(
-            "Failed to publish staged storage: {err}. Preserved staged snapshot at {}",
-            staged_path.display()
-        )));
-    }
+    let staged_publish_stats = match staged.publish_with_stats(storage_path) {
+        Ok(stats) => stats,
+        Err(err) => {
+            drop(prepared_search_state);
+            discard_unpublished_search_generation(storage_path, &publication);
+            return Err(ApiError::internal(format!(
+                "Failed to publish staged storage: {err}. Preserved staged snapshot at {}",
+                staged_path.display()
+            )));
+        }
+    };
     let publish_ms = clamp_u128_to_u32(publish_started.elapsed().as_millis());
     let resolution_telemetry = OptionalResolutionTelemetry::from_incremental_stats(&index_stats);
     let full_refresh_pipeline_enabled = index_stats.full_refresh_queue_capacity > 0;
@@ -14749,6 +14752,10 @@ fn index_full_for_runtime(
             summary_snapshot_ms: Some(summary_snapshot_ms),
             detail_snapshot_ms,
             publish_ms: Some(publish_ms),
+            staged_sqlite_wal_autocheckpoint_bytes: staged_publish_stats
+                .sqlite_wal_autocheckpoint_bytes,
+            staged_sqlite_checkpoint_ms: staged_publish_stats.sqlite_checkpoint_ms,
+            staged_sqlite_sync_ms: staged_publish_stats.sqlite_sync_ms,
             setup_existing_projection_ids_ms: resolution_telemetry.setup_existing_projection_ids_ms,
             setup_seed_symbol_table_ms: resolution_telemetry.setup_seed_symbol_table_ms,
             flush_files_ms: resolution_telemetry.flush_files_ms,
@@ -15323,14 +15330,17 @@ fn run_incremental_indexing_common(
         discard_unpublished_search_generation(storage_path, &publication);
         return Err(indexing_cancelled_error());
     }
-    if let Err(error) = staged.publish(storage_path) {
-        drop(prepared_search_state);
-        discard_unpublished_search_generation(storage_path, &publication);
-        return Err(ApiError::internal(format!(
-            "Failed to publish staged incremental storage: {error}. Preserved staged snapshot at {}",
-            staged_path.display()
-        )));
-    }
+    let staged_publish_stats = match staged.publish_with_stats(storage_path) {
+        Ok(stats) => stats,
+        Err(error) => {
+            drop(prepared_search_state);
+            discard_unpublished_search_generation(storage_path, &publication);
+            return Err(ApiError::internal(format!(
+                "Failed to publish staged incremental storage: {error}. Preserved staged snapshot at {}",
+                staged_path.display()
+            )));
+        }
+    };
     let publish_ms = clamp_u128_to_u32(publish_started.elapsed().as_millis());
 
     Ok(IndexingRunSummary {
@@ -15388,6 +15398,10 @@ fn run_incremental_indexing_common(
             summary_snapshot_ms: Some(summary_snapshot_ms),
             detail_snapshot_ms: Some(detail_snapshot_ms),
             publish_ms: Some(publish_ms),
+            staged_sqlite_wal_autocheckpoint_bytes: staged_publish_stats
+                .sqlite_wal_autocheckpoint_bytes,
+            staged_sqlite_checkpoint_ms: staged_publish_stats.sqlite_checkpoint_ms,
+            staged_sqlite_sync_ms: staged_publish_stats.sqlite_sync_ms,
             setup_existing_projection_ids_ms: resolution_telemetry.setup_existing_projection_ids_ms,
             setup_seed_symbol_table_ms: resolution_telemetry.setup_seed_symbol_table_ms,
             flush_files_ms: resolution_telemetry.flush_files_ms,
@@ -25341,6 +25355,12 @@ fn build_llm_symbol_doc_text() -> String {
         assert!(full_timings.full_refresh_chunk_max_nodes.is_some());
         assert_eq!(full_timings.full_refresh_chunk_budget_overruns, Some(0));
         assert!(full_timings.full_refresh_chunk_planning_ms.is_some());
+        assert_eq!(
+            full_timings.staged_sqlite_wal_autocheckpoint_bytes,
+            Some(64 * 1024 * 1024)
+        );
+        assert!(full_timings.staged_sqlite_checkpoint_ms.is_some());
+        assert!(full_timings.staged_sqlite_sync_ms.is_some());
         let first = controller
             .index_publication()
             .expect("read first publication")
@@ -25369,6 +25389,13 @@ fn build_llm_symbol_doc_text() -> String {
                 .is_none()
         );
         assert!(incremental_timings.full_refresh_chunk_planning_ms.is_none());
+        assert!(
+            incremental_timings
+                .staged_sqlite_wal_autocheckpoint_bytes
+                .is_none()
+        );
+        assert!(incremental_timings.staged_sqlite_checkpoint_ms.is_none());
+        assert!(incremental_timings.staged_sqlite_sync_ms.is_none());
         let second = controller
             .index_publication()
             .expect("read second publication")

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -15,6 +15,7 @@ pub use file_store::FileStore;
 pub use projection_store::{ProjectionBatch, ProjectionStore};
 pub use snapshot_store::{
     SnapshotRefreshStats, SnapshotStore, StagedSnapshot, StagedSnapshotFinalizeStats,
+    StagedSnapshotPublishStats,
 };
 pub use storage_impl::{
     CURRENT_SCHEMA_VERSION, CallerProjectionRemovalSummary, DENSE_ANCHOR_MIGRATION_STATE_NATIVE,

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -16,6 +16,14 @@ pub struct StagedSnapshotFinalizeStats {
     pub summary_snapshot_ms: u32,
 }
 
+/// SQLite fence timings for a completed staged publication.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StagedSnapshotPublishStats {
+    pub sqlite_wal_autocheckpoint_bytes: Option<u64>,
+    pub sqlite_checkpoint_ms: Option<u32>,
+    pub sqlite_sync_ms: Option<u32>,
+}
+
 /// Derived grounding snapshot facade.
 ///
 /// Summary and detail snapshots are cached read models over the graph tables.
@@ -55,6 +63,14 @@ impl<'a> SnapshotStore<'a> {
     /// Open a fresh staged database in build mode.
     pub fn open_staged(live_path: &Path) -> Result<StagedSnapshot, StorageError> {
         StagedSnapshot::open(live_path)
+    }
+
+    /// Open a fresh, repeatable full-refresh stage with relaxed build writes.
+    ///
+    /// The consuming `publish` call installs the durable WAL checkpoint and
+    /// filesystem fence before promotion can inspect or mutate live state.
+    pub fn open_disposable_full_refresh(live_path: &Path) -> Result<StagedSnapshot, StorageError> {
+        StagedSnapshot::open_disposable_full_refresh(live_path)
     }
 
     /// Clone the live database into a unique staged database in build mode.
@@ -157,6 +173,12 @@ impl StagedSnapshot {
         Ok(Self { path, store })
     }
 
+    fn open_disposable_full_refresh(live_path: &Path) -> Result<Self, StorageError> {
+        let path = SnapshotStore::staged_path(live_path);
+        let store = Store::open_disposable_full_build(&path)?;
+        Ok(Self { path, store })
+    }
+
     fn clone_live(live_path: &Path) -> Result<Self, StorageError> {
         let path = SnapshotStore::staged_path(live_path);
         Store::discard_staged_snapshot(&path)?;
@@ -195,11 +217,27 @@ impl StagedSnapshot {
         SnapshotStore::discard_staged(&path)
     }
 
-    /// Close and promote the staged database to `live_path`.
+    /// Seal, close, and promote the staged database to `live_path`.
     pub fn publish(self, live_path: &Path) -> Result<(), StorageError> {
+        self.publish_with_stats(live_path).map(|_| ())
+    }
+
+    /// Seal, close, and promote while returning full-refresh SQLite timings.
+    pub fn publish_with_stats(
+        self,
+        live_path: &Path,
+    ) -> Result<StagedSnapshotPublishStats, StorageError> {
+        let seal_stats = self.store.seal_disposable_full_build()?;
         let path = self.path;
         drop(self.store);
-        SnapshotStore::promote_staged(&path, live_path)
+        SnapshotStore::promote_staged(&path, live_path)?;
+        Ok(StagedSnapshotPublishStats {
+            sqlite_wal_autocheckpoint_bytes: seal_stats
+                .as_ref()
+                .map(|stats| stats.wal_autocheckpoint_bytes),
+            sqlite_checkpoint_ms: seal_stats.as_ref().map(|stats| stats.checkpoint_ms),
+            sqlite_sync_ms: seal_stats.as_ref().map(|stats| stats.sync_ms),
+        })
     }
 }
 
@@ -321,6 +359,140 @@ mod tests {
         assert_eq!(metadata.summary_state, GroundingSnapshotState::Ready);
         assert_eq!(metadata.detail_state, GroundingSnapshotState::Dirty);
 
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn disposable_full_refresh_seals_wal_before_promotion() {
+        let temp = fresh_temp_root("disposable-promote");
+        let live_path = temp.join("live.sqlite");
+        let mut staged = SnapshotStore::open_disposable_full_refresh(&live_path)
+            .expect("open disposable full-refresh stage");
+        let staged_path = staged.path().to_path_buf();
+        let synchronous: i64 = staged
+            .store_mut()
+            .get_connection()
+            .query_row("PRAGMA synchronous", [], |row| row.get(0))
+            .expect("read disposable synchronous profile");
+        assert_eq!(synchronous, 0);
+
+        staged
+            .store_mut()
+            .insert_files_batch(&[crate::FileInfo {
+                id: 1,
+                path: PathBuf::from("disposable.rs"),
+                language: "rust".to_string(),
+                modification_time: 1,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: crate::FileRole::Source,
+            }])
+            .expect("seed disposable stage");
+        let publication = crate::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "disposable-generation".to_string(),
+            run_id: "disposable-run".to_string(),
+            mode: crate::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        staged
+            .store_mut()
+            .put_index_publication(&publication)
+            .expect("identify disposable publication");
+        publish_empty_source_policy(staged.store_mut(), &publication);
+
+        let publish_stats = staged
+            .publish_with_stats(&live_path)
+            .expect("seal and promote disposable stage");
+        assert_eq!(
+            publish_stats.sqlite_wal_autocheckpoint_bytes,
+            Some(64 * 1024 * 1024)
+        );
+        assert!(publish_stats.sqlite_checkpoint_ms.is_some());
+        assert!(publish_stats.sqlite_sync_ms.is_some());
+
+        let live = Store::open(&live_path).expect("open promoted live store");
+        let quick_check: String = live
+            .get_connection()
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .expect("validate promoted database");
+        assert_eq!(quick_check, "ok");
+        assert_eq!(
+            live.get_complete_index_publication()
+                .expect("read live publication"),
+            Some(publication)
+        );
+        assert_eq!(
+            live.get_files().expect("read promoted files")[0].path,
+            PathBuf::from("disposable.rs")
+        );
+        assert!(!staged_path.exists());
+        assert!(!PathBuf::from(format!("{}-wal", staged_path.display())).exists());
+        assert!(!PathBuf::from(format!("{}-shm", staged_path.display())).exists());
+
+        drop(live);
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn disposable_full_refresh_busy_seal_never_starts_promotion() {
+        let temp = fresh_temp_root("disposable-busy");
+        let live_path = temp.join("live.sqlite");
+        let mut staged = SnapshotStore::open_disposable_full_refresh(&live_path)
+            .expect("open disposable full-refresh stage");
+        let staged_path = staged.path().to_path_buf();
+        let publication = crate::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "busy-generation".to_string(),
+            run_id: "busy-run".to_string(),
+            mode: crate::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        staged
+            .store_mut()
+            .put_index_publication(&publication)
+            .expect("identify busy candidate");
+        publish_empty_source_policy(staged.store_mut(), &publication);
+
+        let reader = rusqlite::Connection::open(&staged_path).expect("open staged reader");
+        reader
+            .execute_batch("BEGIN DEFERRED; SELECT COUNT(*) FROM file;")
+            .expect("pin staged reader snapshot");
+        staged
+            .store_mut()
+            .insert_files_batch(&[crate::FileInfo {
+                id: 2,
+                path: PathBuf::from("newer.rs"),
+                language: "rust".to_string(),
+                modification_time: 2,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: crate::FileRole::Source,
+            }])
+            .expect("write after pinned snapshot");
+
+        let error = staged
+            .publish(&live_path)
+            .expect_err("busy final checkpoint must block promotion");
+        let message = error.to_string().to_ascii_lowercase();
+        assert!(
+            message.contains("seal") || message.contains("locked") || message.contains("busy"),
+            "unexpected seal error: {error}"
+        );
+        assert!(
+            !live_path.exists(),
+            "seal failure must not create live state"
+        );
+        assert!(staged_path.exists(), "failed stage must remain inspectable");
+        assert!(!live_path.with_extension("sqlite.backup").exists());
+        assert!(
+            !PathBuf::from(format!("{}.promotion.prepared.json", live_path.display())).exists()
+        );
+
+        drop(reader);
+        Store::discard_staged_snapshot(&staged_path).expect("discard failed stage");
         let _ = fs::remove_dir_all(&temp);
     }
 

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -22,7 +22,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 mod bookmarks;
@@ -78,6 +78,7 @@ const PROMOTION_ABORT_SENTINEL_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_SENTI
 const PROMOTION_ABORT_SENTINEL: &[u8] = b"after-live-restore-step\n";
 const LEGACY_PROMOTION_JOURNAL_VERSION: u32 = 1;
 const PROMOTION_JOURNAL_VERSION: u32 = 2;
+const DISPOSABLE_FULL_BUILD_WAL_AUTOCHECKPOINT_BYTES: u64 = 64 * 1024 * 1024;
 
 fn clamp_i64_to_u32(value: i64) -> u32 {
     if value <= 0 {
@@ -997,6 +998,7 @@ pub struct Storage {
     conn: Connection,
     cache: StorageCache,
     deferred_secondary_indexes: bool,
+    durability_profile: SqliteDurabilityProfile,
 }
 
 /// Narrow query-only view used while a staged store has one active writer.
@@ -1081,6 +1083,18 @@ pub enum StorageOpenMode {
     Live,
     /// Build stores defer expensive secondary indexes until finalization.
     Build,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SqliteDurabilityProfile {
+    Durable,
+    DisposableFullBuild,
+}
+
+pub(crate) struct DisposableFullBuildSealStats {
+    pub(crate) wal_autocheckpoint_bytes: u64,
+    pub(crate) checkpoint_ms: u32,
+    pub(crate) sync_ms: u32,
 }
 
 /// Per-table timing breakdown for a projection flush.
@@ -2031,6 +2045,7 @@ impl Storage {
             conn,
             cache: StorageCache::default(),
             deferred_secondary_indexes: false,
+            durability_profile: SqliteDurabilityProfile::Durable,
         })
     }
 
@@ -2129,6 +2144,7 @@ impl Storage {
             conn,
             cache: StorageCache::default(),
             deferred_secondary_indexes: false,
+            durability_profile: SqliteDurabilityProfile::Durable,
         })
     }
 
@@ -2155,10 +2171,35 @@ impl Storage {
         Self::open_with_mode(path, StorageOpenMode::Build)
     }
 
+    /// Open a fresh, repeatable full-refresh stage with relaxed write durability.
+    ///
+    /// The resulting database is never publishable until the consuming staged
+    /// snapshot path seals its WAL and syncs the standalone database. Generic
+    /// build stores and incremental clones retain the durable profile.
+    pub(crate) fn open_disposable_full_build<P: AsRef<Path>>(
+        path: P,
+    ) -> Result<Self, StorageError> {
+        let path = path.as_ref();
+        cleanup_sqlite_sidecars(path)?;
+        Self::open_with_mode_and_durability(
+            path,
+            StorageOpenMode::Build,
+            SqliteDurabilityProfile::DisposableFullBuild,
+        )
+    }
+
     /// Open a store with explicit live or build indexing behavior.
     pub fn open_with_mode<P: AsRef<Path>>(
         path: P,
         mode: StorageOpenMode,
+    ) -> Result<Self, StorageError> {
+        Self::open_with_mode_and_durability(path, mode, SqliteDurabilityProfile::Durable)
+    }
+
+    fn open_with_mode_and_durability<P: AsRef<Path>>(
+        path: P,
+        mode: StorageOpenMode,
+        durability_profile: SqliteDurabilityProfile,
     ) -> Result<Self, StorageError> {
         let path = path.as_ref();
         if matches!(mode, StorageOpenMode::Live) {
@@ -2170,7 +2211,20 @@ impl Storage {
         conn.busy_timeout(Duration::from_millis(2_500))?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
         conn.pragma_update(None, "journal_mode", "WAL")?;
-        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        match durability_profile {
+            SqliteDurabilityProfile::Durable => {
+                conn.pragma_update(None, "synchronous", "NORMAL")?;
+            }
+            SqliteDurabilityProfile::DisposableFullBuild => {
+                conn.pragma_update(None, "synchronous", "OFF")?;
+                let page_size: i64 = conn.query_row("PRAGMA page_size", [], |row| row.get(0))?;
+                let page_size = page_size.max(1);
+                let checkpoint_pages = (DISPOSABLE_FULL_BUILD_WAL_AUTOCHECKPOINT_BYTES as i64)
+                    .saturating_add(page_size - 1)
+                    / page_size;
+                conn.pragma_update(None, "wal_autocheckpoint", checkpoint_pages)?;
+            }
+        }
         if matches!(mode, StorageOpenMode::Build) {
             // Favor fewer temp-file round trips and larger page caches while building
             // the staged full-refresh snapshot.
@@ -2182,6 +2236,7 @@ impl Storage {
             conn,
             cache: StorageCache::default(),
             deferred_secondary_indexes: matches!(mode, StorageOpenMode::Build),
+            durability_profile,
         };
         storage.init(mode)?;
         Ok(storage)
@@ -2259,6 +2314,7 @@ impl Storage {
             conn,
             cache: StorageCache::default(),
             deferred_secondary_indexes: false,
+            durability_profile: SqliteDurabilityProfile::Durable,
         };
         storage.init(StorageOpenMode::Live)?;
         Ok(storage)
@@ -3360,6 +3416,50 @@ impl Storage {
         Ok(())
     }
 
+    pub(crate) fn seal_disposable_full_build(
+        &self,
+    ) -> Result<Option<DisposableFullBuildSealStats>, StorageError> {
+        if self.durability_profile != SqliteDurabilityProfile::DisposableFullBuild {
+            return Ok(None);
+        }
+
+        let checkpoint_started = Instant::now();
+        self.conn.pragma_update(None, "synchronous", "NORMAL")?;
+        let (busy, log_frames, checkpointed_frames): (i64, i64, i64) =
+            self.conn
+                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })?;
+        if busy != 0 || log_frames != 0 || checkpointed_frames != 0 {
+            return Err(StorageError::Other(format!(
+                "Disposable full-refresh WAL seal did not complete: busy={busy}, log_frames={log_frames}, checkpointed_frames={checkpointed_frames}"
+            )));
+        }
+        let checkpoint_ms = checkpoint_started
+            .elapsed()
+            .as_millis()
+            .min(u32::MAX as u128) as u32;
+
+        let path = self.conn.path().ok_or_else(|| {
+            StorageError::Other(
+                "Disposable full-refresh WAL seal requires file-backed storage".to_string(),
+            )
+        })?;
+        let sync_started = Instant::now();
+        File::open(path)
+            .and_then(|file| file.sync_all())
+            .map_err(|error| {
+                promotion_path_error("sync staged database", Path::new(path), error)
+            })?;
+        sync_promotion_parent(Path::new(path))?;
+        let sync_ms = sync_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+        Ok(Some(DisposableFullBuildSealStats {
+            wal_autocheckpoint_bytes: DISPOSABLE_FULL_BUILD_WAL_AUTOCHECKPOINT_BYTES,
+            checkpoint_ms,
+            sync_ms,
+        }))
+    }
+
     pub fn create_deferred_secondary_indexes(&self) -> Result<(), StorageError> {
         if self.deferred_secondary_indexes {
             schema::create_deferred_indexes(&self.conn)?;
@@ -3442,6 +3542,7 @@ impl Storage {
 
         let mut live_conn = Connection::open(live_path)?;
         let _ = live_conn.busy_timeout(Duration::from_millis(2_500));
+        live_conn.pragma_update(None, "synchronous", "FULL")?;
 
         #[cfg(test)]
         let restore_result = if let Some(sentinel_path) =

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -1456,6 +1456,51 @@ fn test_index_artifact_cache_reader_observes_committed_batches_without_write_acc
 }
 
 #[test]
+fn disposable_full_build_is_the_only_relaxed_sqlite_profile() -> Result<(), StorageError> {
+    fn profile(storage: &Storage) -> Result<(String, i64, i64, i64), StorageError> {
+        let connection = storage.get_connection();
+        Ok((
+            connection.query_row("PRAGMA journal_mode", [], |row| row.get(0))?,
+            connection.query_row("PRAGMA synchronous", [], |row| row.get(0))?,
+            connection.query_row("PRAGMA wal_autocheckpoint", [], |row| row.get(0))?,
+            connection.query_row("PRAGMA page_size", [], |row| row.get(0))?,
+        ))
+    }
+
+    let dir = tempfile::tempdir().map_err(|error| StorageError::Other(error.to_string()))?;
+    let live_path = dir.path().join("live.sqlite");
+    let generic_build_path = dir.path().join("generic-build.sqlite");
+    let disposable_path = dir.path().join("disposable.sqlite");
+
+    let live = Storage::open(&live_path)?;
+    let generic_build = Storage::open_build(&generic_build_path)?;
+    let disposable = Storage::open_disposable_full_build(&disposable_path)?;
+    let mut incremental_clone = crate::SnapshotStore::clone_live_to_staged(&live_path)?;
+
+    for (name, storage) in [("live", &live), ("generic build", &generic_build)] {
+        let (journal_mode, synchronous, _, _) = profile(storage)?;
+        assert_eq!(journal_mode.to_ascii_lowercase(), "wal", "{name}");
+        assert_eq!(synchronous, 1, "{name} must retain synchronous=NORMAL");
+    }
+    let (journal_mode, synchronous, _, _) = profile(incremental_clone.store_mut())?;
+    assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
+    assert_eq!(
+        synchronous, 1,
+        "incremental clone must retain synchronous=NORMAL"
+    );
+
+    let (journal_mode, synchronous, checkpoint_pages, page_size) = profile(&disposable)?;
+    assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
+    assert_eq!(synchronous, 0);
+    assert_eq!(
+        checkpoint_pages,
+        (DISPOSABLE_FULL_BUILD_WAL_AUTOCHECKPOINT_BYTES as i64 + page_size - 1) / page_size
+    );
+    assert!(checkpoint_pages > 0);
+    Ok(())
+}
+
+#[test]
 fn test_resolution_support_snapshot_round_trip_and_invalidation() -> Result<(), StorageError> {
     let storage = Storage::new_in_memory()?;
     let payload = br#"{"support":1}"#;
@@ -3426,8 +3471,85 @@ fn reader_open_during_healthy_promotion_does_not_recover_active_backup() -> Resu
     Ok(())
 }
 
+const DISPOSABLE_BUILD_ABORT_PATH_ENV: &str = "CODESTORY_TEST_DISPOSABLE_BUILD_ABORT_PATH";
+const DISPOSABLE_BUILD_ABORT_SENTINEL_ENV: &str = "CODESTORY_TEST_DISPOSABLE_BUILD_ABORT_SENTINEL";
 const PROMOTION_ABORT_LIVE_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_LIVE";
 const PROMOTION_ABORT_STAGED_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_STAGED";
+
+#[test]
+fn disposable_full_build_abort_child() {
+    let Some(staged_path) = std::env::var_os(DISPOSABLE_BUILD_ABORT_PATH_ENV).map(PathBuf::from)
+    else {
+        return;
+    };
+    let sentinel_path = PathBuf::from(
+        std::env::var_os(DISPOSABLE_BUILD_ABORT_SENTINEL_ENV)
+            .expect("disposable abort sentinel path"),
+    );
+    let mut staged =
+        Storage::open_disposable_full_build(&staged_path).expect("open disposable child stage");
+    staged
+        .insert_files_batch(&[FileInfo {
+            id: 2,
+            path: PathBuf::from("unpublished.rs"),
+            language: "rust".to_string(),
+            modification_time: 2,
+            indexed: true,
+            complete: true,
+            line_count: 1,
+            file_role: FileRole::Source,
+        }])
+        .expect("write disposable child stage");
+    fs::write(&sentinel_path, b"disposable-stage-written\n").expect("write abort sentinel");
+    File::open(&sentinel_path)
+        .and_then(|file| file.sync_all())
+        .expect("sync abort sentinel");
+    std::process::abort();
+}
+
+#[test]
+fn process_abort_during_disposable_build_never_mutates_live() {
+    let live_path = unique_temp_db_path("disposable-build-abort-live");
+    let staged_path = unique_temp_db_path("disposable-build-abort-staged");
+    let sentinel_path = unique_temp_db_path("disposable-build-abort-sentinel");
+    seed_promotion_file(&live_path, 1, "old.rs").expect("seed live generation");
+
+    let status =
+        std::process::Command::new(std::env::current_exe().expect("resolve store test executable"))
+            .arg("--exact")
+            .arg("storage_impl::tests::disposable_full_build_abort_child")
+            .arg("--nocapture")
+            .env(DISPOSABLE_BUILD_ABORT_PATH_ENV, &staged_path)
+            .env(DISPOSABLE_BUILD_ABORT_SENTINEL_ENV, &sentinel_path)
+            .status()
+            .expect("run disposable build abort child");
+    assert!(!status.success(), "abort child exited successfully");
+    assert_eq!(
+        fs::read(&sentinel_path).expect("read disposable abort sentinel"),
+        b"disposable-stage-written\n"
+    );
+
+    let live = Storage::open(&live_path).expect("reopen live after staged abort");
+    assert_eq!(
+        live.get_files().expect("read preserved live")[0].path,
+        PathBuf::from("old.rs")
+    );
+    assert_eq!(
+        live.get_complete_index_publication()
+            .expect("read preserved publication")
+            .expect("complete preserved publication")
+            .generation,
+        1
+    );
+    drop(live);
+    assert!(!live_path.with_extension("sqlite.backup").exists());
+    assert!(!promotion_prepared_journal_path(&live_path).exists());
+    assert!(!promotion_committed_journal_path(&live_path).exists());
+
+    cleanup_sqlite_sidecars(&live_path).expect("clean live fixture");
+    cleanup_sqlite_sidecars(&staged_path).expect("clean aborted stage");
+    let _ = fs::remove_file(sentinel_path);
+}
 
 fn seed_promotion_file_with_identity(
     path: &Path,
@@ -3469,6 +3591,43 @@ fn seed_promotion_file_with_identity(
 
 fn seed_promotion_file(path: &Path, id: i64, name: &str) -> Result<(), StorageError> {
     seed_promotion_file_with_identity(path, id, name, true)
+}
+
+fn seed_disposable_promotion_file(path: &Path, id: i64, name: &str) -> Result<(), StorageError> {
+    let mut storage = Storage::open_disposable_full_build(path)?;
+    storage.insert_files_batch(&[FileInfo {
+        id,
+        path: PathBuf::from(name),
+        language: "rust".to_string(),
+        modification_time: id,
+        indexed: true,
+        complete: true,
+        line_count: 1,
+        file_role: FileRole::Source,
+    }])?;
+    let publication = IndexPublicationRecord {
+        generation: id.max(0) as u64,
+        generation_id: format!("generation-{id}"),
+        run_id: format!("run-{id}"),
+        mode: IndexPublicationMode::Full,
+        published_at_epoch_ms: id.max(0),
+    };
+    storage.put_index_publication(&publication)?;
+    storage.publish_source_policy_exclusion_generation(
+        &publication,
+        "test-project",
+        "test-workspace",
+        OVERSIZED_SOURCE_POLICY_VERSION,
+        DEFAULT_SOURCE_FILE_BYTE_CAP,
+        &[OversizedSourceExclusionCandidate {
+            normalized_path: format!("vendor/registers-{id}.h"),
+            content_hash: format!("{:064x}", id.max(0)),
+            observed_size: DEFAULT_SOURCE_FILE_BYTE_CAP + id.max(0) as u64,
+            policy_version: OVERSIZED_SOURCE_POLICY_VERSION.to_string(),
+            byte_cap: DEFAULT_SOURCE_FILE_BYTE_CAP,
+        }],
+    )?;
+    storage.seal_disposable_full_build().map(|_| ())
 }
 
 fn seed_unpublished_file(path: &Path, id: i64, name: &str) -> Result<(), StorageError> {
@@ -3697,10 +3856,9 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
     let prepared_path = promotion_prepared_journal_path(&live_path);
     let committed_path = promotion_committed_journal_path(&live_path);
     seed_promotion_file(&live_path, 1, "old.rs").expect("seed live generation");
-    seed_promotion_file(&staged_path, 2, "new.rs").expect("seed staged generation");
+    seed_disposable_promotion_file(&staged_path, 2, "new.rs")
+        .expect("seed sealed disposable staged generation");
     publish_nonempty_test_source_policy(&live_path, 1).expect("publish live exclusion identity");
-    publish_nonempty_test_source_policy(&staged_path, 2)
-        .expect("publish staged exclusion identity");
 
     let status =
         std::process::Command::new(std::env::current_exe().expect("resolve store test executable"))

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -27,7 +27,7 @@ sequenceDiagram
     CLI->>Runtime: parse `index` command and open project
     Runtime->>Workspace: full refresh plan or diff-based refresh plan
     Workspace-->>Runtime: RefreshExecutionPlan + verified policy exclusions
-    Runtime->>Store: open staged store for full refresh or live store for incremental
+    Runtime->>Store: open disposable full stage or durable incremental clone
     Runtime->>Indexer: WorkspaceIndexer::run(plan, store)
     Indexer->>Store: flush files, nodes, edges, occurrences, component access, callable projection state
     Indexer->>Store: run post-flush resolution updates
@@ -115,8 +115,17 @@ flowchart TD
 
 `crates/codestory-runtime/src/lib.rs` owns the orchestration split:
 
-- `index_full` opens a staged store with `SnapshotStore::open_staged`, asks the workspace for a full refresh plan, runs the indexer against the staged store, finalizes the staged snapshot, and then publishes it to the live path
-- `index_incremental` opens the live store, collects refresh inputs from stored inventory, builds a diff-based execution plan, runs the same indexer against the live store, and then refreshes live summary and detail snapshots
+- `index_full` opens a fresh stage with `SnapshotStore::open_disposable_full_refresh`, asks the workspace for a full refresh plan, runs the indexer against the staged store, finalizes every core/search identity, and then seals and publishes it to the live path
+- `index_incremental` clones the current live database into a durable staged store, collects refresh inputs from stored inventory, builds a diff-based execution plan, runs the same indexer against the clone, and publishes the completed replacement
+
+Only the fresh full stage uses relaxed SQLite synchronization. It remains in
+WAL mode for the bounded parser-artifact reader and keeps a nonzero 64 MiB
+automatic-checkpoint budget. The consuming publish call restores NORMAL
+synchronization, completes a blocking TRUNCATE checkpoint, syncs the database
+and containing directory, and only then enters the store's old-or-new promotion
+journal. Its phase telemetry exposes the checkpoint budget, checkpoint time,
+and sync time. Generic build stores and incremental clones keep WAL/NORMAL
+throughout.
 
 The indexer does not know whether the store is staged or live.
 

--- a/docs/architecture/subsystems/store.md
+++ b/docs/architecture/subsystems/store.md
@@ -22,11 +22,19 @@ the candidate, records committed, then performs best-effort cleanup. Recovery
 may restore only a valid recorded prepared backup; a committed publication is
 never rolled back merely because a backup remains.
 
-Incremental refresh updates the live database and refreshes derived snapshots
-in place. Readers that need publication coherence use store read snapshots and
-compare the recorded generation/run identity; retrieval owns the session that
-combines that transaction with immutable generation leases before returning
-evidence.
+The fresh full-refresh stage is explicitly disposable until publication. It
+keeps WAL for the bounded artifact-cache reader, uses relaxed synchronous writes
+with a bounded nonzero checkpoint window, and is never served or resumed. Its
+consuming publish path restores NORMAL synchronization, completes a TRUNCATE
+checkpoint, syncs the standalone database and directory, and permits no later
+stage writes before entering the promotion journal. Live stores, generic build
+callers, and staged incremental clones remain WAL/NORMAL.
+
+Incremental refresh writes a durable clone and promotes the completed
+replacement through the same journal. Readers that need publication coherence
+use store read snapshots and compare the recorded generation/run identity;
+retrieval owns the session that combines that transaction with immutable
+generation leases before returning evidence.
 
 The dense-anchor manifest is part of the core publication boundary. It binds
 the complete row count and digest, policy version, migration state, and every


### PR DESCRIPTION
Closes #1297
Refs #1275

## Context

The retained 94,411-file proof spent most of its wall time in storage and search materialization. Fresh full refreshes currently use WAL/NORMAL with SQLite's small default checkpoint window even though the staged generation is repeatable and cannot be served before atomic promotion.

This child changes only the fresh full-refresh stage. Live stores, generic build callers, and incremental clones retain WAL/NORMAL.

## What changed

- Added a store-owned `DisposableFullBuild` durability profile and a typed `SnapshotStore::open_disposable_full_refresh` entry point used only by the runtime full path.
- Kept WAL and foreign keys, set the disposable writer to `synchronous=OFF`, and moved automatic checkpoints to a bounded 64 MiB page budget.
- Added a consuming publication seal that restores NORMAL, completes a TRUNCATE checkpoint, rejects busy/incomplete results, syncs the standalone database and parent directory where supported, then enters the existing promotion journal.
- Made the promotion restore connection's `synchronous=FULL` assumption explicit.
- Kept the existing `StagedSnapshot::publish -> Result<()>` API and added an additive `publish_with_stats` path for runtime telemetry.
- Exposed the checkpoint target, final checkpoint time, and explicit sync time in JSON and Markdown indexing telemetry.

Exact candidate: `4261ed6b4a865ee35fd4bf7ddaa073e3d39f97e5`

## How to review

1. Confirm `SqliteDurabilityProfile` is independent from `StorageOpenMode` and no ordinary build/incremental caller selects the disposable profile.
2. Follow `StagedSnapshot::publish_with_stats` through the final checkpoint/sync fence into the existing prepared/committed promotion journal.
3. Inspect the busy-checkpoint and subprocess-abort tests for the old-or-new live publication invariant.
4. Confirm optional telemetry is absent for incremental publications and source compatibility is retained for `publish`.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p codestory-contracts -p codestory-store -p codestory-runtime -p codestory-cli --locked`
- `cargo test -p codestory-contracts --locked` (38 unit + 1 public API)
- `cargo test -p codestory-store --locked` (129 unit; includes real subprocess abort and promotion recovery)
- `cargo test -p codestory-runtime --lib full_refresh_ --locked` (12)
- `cargo test -p codestory-runtime --lib publication_transitions_fail_or_cancel_atomically --locked` (2)
- `cargo test -p codestory-runtime --lib full_and_incremental_publications_advance_one_durable_generation --locked` (1)
- `cargo test -p codestory-cli --test architecture_contracts --locked` (12)
- `cargo test -p codestory-cli --bin codestory-cli render_index_markdown_includes_rich_timing_breakdown_when_available --locked` (1)
- `cargo clippy -p codestory-contracts -p codestory-store -p codestory-runtime -p codestory-cli --all-targets --locked -- -D warnings`
- `node .github/scripts/check-doc-links.mjs`
- Independent source review found and resolved one P2 API-compatibility issue; no unresolved P0-P3 findings remain.

## Risk and non-claims

- A process or OS crash may corrupt the disposable stage while it is being built; tests prove that stage cannot mutate the previous live publication and the final seal/promotion validation gate publication.
- The retained corpus has not been rerun. This PR does not claim an end-to-end speedup. #1275 owns the one combined exact-corpus proof after the remaining materialization and telemetry work lands.
- Native Windows execution and an abort injected inside the checkpoint syscall remain final qualification concerns, not evidence claimed by this draft.
- Packaged CodeStory grounding failed closed at CoreFreshness, so the implementation and review used direct exact-head source inspection.
