### PR TITLE
[codex] Stream canonical search symbols without projection rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   document checkpoints and commit/reload once, instead of reopening and
   committing the writer for every 8,192 symbols. Index telemetry reports
   symbol documents, writers, commits, and reloads.
+- Runtime and retrieval now stream canonical search symbols directly from the
+  node table in 4,096-row keyset pages. Fresh full and incremental builds no
+  longer rewrite the legacy SQLite search projection or materialize every
+  complete graph node before search construction; telemetry reports stream
+  time, rows, and batches alongside the single Tantivy commit.
 - File-backed full refreshes now overlap preparation and Rayon parsing with a
   dedicated staged SQLite writer through a capacity-one queue. Cancellation
   drains only accepted chunks, incremental indexing keeps its serial path, and

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8949,6 +8949,9 @@ mod tests {
             full_refresh_chunk_planning_ms: Some(5),
             cache_refresh_ms: Some(6),
             search_projection_rebuild_ms: Some(61),
+            search_symbol_stream_ms: Some(60),
+            search_symbol_stream_rows: Some(8192),
+            search_symbol_stream_batches: Some(2),
             search_symbol_index_ms: Some(62),
             search_symbol_index_docs_written: Some(8192),
             search_symbol_index_writer_count: Some(1),
@@ -9192,7 +9195,9 @@ mod tests {
         assert!(markdown.contains(
             "full_refresh_chunking: target_bytes=8388608 target_nodes=120000 file_ceiling=512 max_files=384 max_planned_bytes=7500000 max_nodes=98000 overruns=0 planning_ms=5"
         ));
-        assert!(markdown.contains("symbol_index: docs=8192 writers=1 commits=1 reloads=1"));
+        assert!(markdown.contains(
+            "symbol_index: stream_ms=60 stream_rows=8192 stream_batches=2 docs=8192 writers=1 commits=1 reloads=1"
+        ));
         assert!(
             markdown
                 .contains("semantic_ms: doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -380,6 +380,9 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
         markdown,
         "symbol_index",
         &[
+            ("stream_ms", timings.search_symbol_stream_ms),
+            ("stream_rows", timings.search_symbol_stream_rows),
+            ("stream_batches", timings.search_symbol_stream_batches),
             ("docs", timings.search_symbol_index_docs_written),
             ("writers", timings.search_symbol_index_writer_count),
             ("commits", timings.search_symbol_index_commit_count),

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -462,8 +462,57 @@ fn staged_publication_identity_and_fence_are_complete_before_publication() {
                 .matches("staged.store_mut().finish_incremental_run()")
                 .count()
                 >= 2
-            && runtime.matches("staged.publish(storage_path)").count() >= 2,
+            && runtime
+                .matches("staged.publish_with_stats(storage_path)")
+                .count()
+                >= 2,
         "full and incremental staging should persist publication identity and clear compatibility fences before publishing"
+    );
+}
+
+#[test]
+fn product_search_builds_stream_canonical_nodes_without_legacy_projection_rebuilds() {
+    let runtime = read("crates/codestory-runtime/src/lib.rs");
+    let persisted_builder = source_between(
+        &runtime,
+        "fn build_persisted_search_state_from_canonical_symbols(",
+        "#[cfg(test)]\nfn rebuild_search_state_from_storage(",
+    );
+    let runtime_rebuild = source_between(
+        &runtime,
+        "fn rebuild_search_state_from_storage_for_runtime(",
+        "fn refresh_caches(",
+    );
+    let retrieval = read("crates/codestory-retrieval/src/index.rs");
+    let retrieval_scip = read("crates/codestory-retrieval/src/scip_index.rs");
+    let scip_emit = source_between(
+        &retrieval_scip,
+        "pub fn emit_scip_artifacts_from_store(",
+        "fn scip_revision_for_symbols(",
+    );
+
+    assert!(
+        persisted_builder.contains("get_canonical_search_symbol_count()")
+            && persisted_builder.contains("get_canonical_search_symbol_batch_after(")
+            && persisted_builder.contains("engine.begin_symbol_index()")
+            && runtime_rebuild.contains("build_persisted_search_state_from_canonical_symbols("),
+        "persisted product search should stream canonical node pages through one symbol writer"
+    );
+    for forbidden in [
+        ".get_nodes()",
+        "rebuild_search_symbol_projection",
+        "get_search_symbol_projection_batch_after",
+    ] {
+        assert!(
+            !persisted_builder.contains(forbidden) && !runtime_rebuild.contains(forbidden),
+            "runtime product search build must not use legacy materialization path {forbidden}"
+        );
+    }
+    assert!(
+        !retrieval.contains("rebuild_search_symbol_projection")
+            && scip_emit.contains("get_canonical_search_symbol_detail_batch_after(")
+            && !scip_emit.contains("get_search_symbol_projection"),
+        "retrieval preparation and SCIP emission should not rebuild or read the legacy search projection"
     );
 }
 

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -46,6 +46,12 @@ pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_projection_rebuild_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_stream_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_stream_rows: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_stream_batches: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_symbol_index_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_symbol_index_docs_written: Option<u32>,
@@ -260,6 +266,9 @@ mod tests {
             full_refresh_chunk_planning_ms: None,
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
+            search_symbol_stream_ms: None,
+            search_symbol_stream_rows: None,
+            search_symbol_stream_batches: None,
             search_symbol_index_ms: None,
             search_symbol_index_docs_written: None,
             search_symbol_index_writer_count: None,
@@ -368,6 +377,9 @@ mod tests {
         assert!(value.get("semantic_reload_ms").is_none());
         assert!(value.get("semantic_prune_ms").is_none());
         assert!(value.get("search_projection_rebuild_ms").is_none());
+        assert!(value.get("search_symbol_stream_ms").is_none());
+        assert!(value.get("search_symbol_stream_rows").is_none());
+        assert!(value.get("search_symbol_stream_batches").is_none());
         assert!(value.get("search_symbol_index_ms").is_none());
         assert!(value.get("search_symbol_index_docs_written").is_none());
         assert!(value.get("search_symbol_index_writer_count").is_none());

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -554,9 +554,7 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
         u32::try_from(embedding_dim).context("negative embedding dimension")?,
     )?;
 
-    let mut storage =
-        Store::open(storage_path).context("open storage for retrieval sidecar input")?;
-    ensure_search_symbol_projection(&mut storage)?;
+    let storage = Store::open(storage_path).context("open storage for retrieval sidecar input")?;
     let lexical_source = lexical_source_input(project_root).context("hash lexical source input")?;
     let input_snapshot = storage
         .read_snapshot()
@@ -1154,15 +1152,6 @@ fn update_precise_semantic_import_status(
 pub fn query_fingerprint(query: &str) -> String {
     let digest = Sha256::digest(query.as_bytes());
     format!("{:x}", digest)[..16].to_string()
-}
-
-fn ensure_search_symbol_projection(storage: &mut Store) -> Result<()> {
-    if storage.get_search_symbol_projection_count().unwrap_or(0) == 0 {
-        storage
-            .rebuild_search_symbol_projection_from_node_table()
-            .context("rebuild search_symbol_projection")?;
-    }
-    Ok(())
 }
 
 fn manifest_matches_sidecar_input(
@@ -2111,7 +2100,7 @@ mod tests {
     use super::*;
     use crate::retention::read_retention_marker;
     use codestory_contracts::graph::{Node, NodeId, NodeKind};
-    use codestory_store::SearchSymbolProjectionDetail;
+    use codestory_store::{SearchSymbolProjection, SearchSymbolProjectionDetail};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -2856,6 +2845,49 @@ mod tests {
         assert!(!semantic_projection_row(&row(NodeKind::VARIABLE)));
         assert!(!semantic_projection_row(&row(NodeKind::FIELD)));
         assert!(!semantic_projection_row(&row(NodeKind::UNKNOWN)));
+    }
+
+    #[test]
+    fn sidecar_input_preparation_ignores_empty_and_stale_legacy_symbol_projection() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "pub fn do_work() {}\n")
+            .expect("write source");
+        let mut storage = Store::new_in_memory().expect("storage");
+        insert_matching_semantic_doc(&mut storage, project.path());
+
+        assert_eq!(
+            storage
+                .get_search_symbol_projection_count()
+                .expect("empty legacy projection count"),
+            0
+        );
+        let empty_projection = compute_sidecar_input_fingerprint(
+            &storage,
+            project.path(),
+            "project",
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            "producer-compatibility-v1",
+        )
+        .expect("prepare sidecar input without legacy projection");
+
+        storage
+            .upsert_search_symbol_projection_batch(&[SearchSymbolProjection {
+                node_id: NodeId(1),
+                display_name: "stale_wrong_name".into(),
+            }])
+            .expect("seed stale legacy projection");
+        let stale_projection = compute_sidecar_input_fingerprint(
+            &storage,
+            project.path(),
+            "project",
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            "producer-compatibility-v1",
+        )
+        .expect("prepare sidecar input with stale legacy projection");
+
+        assert_eq!(empty_projection, stale_projection);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/scip_index.rs
+++ b/crates/codestory-retrieval/src/scip_index.rs
@@ -1,6 +1,6 @@
 //! Emit SCIP-shaped symbol artifacts from the CodeStory SQLite graph.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use codestory_contracts::graph::NodeKind;
 use codestory_store::Store;
 use serde::{Deserialize, Serialize};
@@ -54,7 +54,7 @@ impl ScipProofAdapterContract {
             producer: "codestory-retrieval".into(),
             producer_version: env!("CARGO_PKG_VERSION").into(),
             producer_args: vec!["emit_scip_artifacts_from_store".into()],
-            producer_config: "search_symbol_projection".into(),
+            producer_config: "canonical_node_pages".into(),
             revision: revision.into(),
             package: ScipPackageIdentity {
                 manager: "codestory".into(),
@@ -277,20 +277,26 @@ pub fn emit_scip_artifacts_from_store(
 ) -> Result<Option<String>> {
     std::fs::create_dir_all(project_dir)
         .with_context(|| format!("create scip dir {}", project_dir.display()))?;
-    let mut storage = Store::open(storage_path).context("open storage for scip emit")?;
-    if storage.get_search_symbol_projection_count().unwrap_or(0) == 0 {
-        let _ = storage.rebuild_search_symbol_projection_from_node_table();
-    }
+    let storage = Store::open(storage_path).context("open storage for scip emit")?;
+    let expected_symbol_rows = u64::from(
+        storage
+            .get_canonical_search_symbol_count()
+            .context("count canonical symbols for scip")?,
+    );
 
     let mut symbols = Vec::new();
+    let mut scanned_symbol_rows = 0_u64;
     let mut after = None;
     loop {
         let batch = storage
-            .get_search_symbol_projection_detail_batch_after(after, 4096)
+            .get_canonical_search_symbol_detail_batch_after(after, 4096)
             .context("load symbols for scip")?;
         if batch.is_empty() {
             break;
         }
+        scanned_symbol_rows = scanned_symbol_rows
+            .checked_add(u64::try_from(batch.len()).context("canonical SCIP page size overflow")?)
+            .context("canonical SCIP symbol count overflow")?;
         after = batch.last().map(|row| row.node_id);
         for row in batch {
             if row.node_kind == Some(NodeKind::UNKNOWN as i64) {
@@ -309,6 +315,11 @@ pub fn emit_scip_artifacts_from_store(
                 end_line,
             });
         }
+    }
+    if scanned_symbol_rows != expected_symbol_rows {
+        bail!(
+            "canonical SCIP symbol count changed while streaming: expected {expected_symbol_rows}, scanned {scanned_symbol_rows}"
+        );
     }
 
     if symbols.is_empty() {
@@ -389,7 +400,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn scip_emit_does_not_stop_at_legacy_smoke_cap() {
+    fn scip_emit_streams_canonical_pages_independent_of_legacy_projection() {
         let project = TempDir::new().expect("project");
         let storage_path = project.path().join("codestory.db");
         let mut storage = Store::open(&storage_path).expect("open store");
@@ -422,7 +433,6 @@ mod tests {
             .expect("insert file node");
 
         let mut nodes = Vec::new();
-        let mut projections = Vec::new();
         for index in 0..4_100_i64 {
             let id = NodeId(index + 2);
             nodes.push(Node {
@@ -436,10 +446,6 @@ mod tests {
                 start_col: Some(0),
                 end_line: Some((index + 1) as u32),
                 end_col: Some(10),
-            });
-            projections.push(SearchSymbolProjection {
-                node_id: id,
-                display_name: format!("symbol_{index:04}"),
             });
         }
         let unknown_node_id = NodeId(5_000);
@@ -455,28 +461,51 @@ mod tests {
             end_line: Some(4_101),
             end_col: Some(10),
         });
-        projections.push(SearchSymbolProjection {
-            node_id: unknown_node_id,
-            display_name: "import_alias".to_string(),
-        });
         storage.insert_nodes_batch(&nodes).expect("insert nodes");
-        storage
-            .upsert_search_symbol_projection_batch(&projections)
-            .expect("insert projections");
         drop(storage);
 
-        let scip_dir = project.path().join("scip");
-        emit_scip_artifacts_from_store(&storage_path, &scip_dir).expect("emit scip");
-        let symbols = load_scip_symbols(&scip_dir)
+        let empty_projection_dir = project.path().join("scip-empty-projection");
+        emit_scip_artifacts_from_store(&storage_path, &empty_projection_dir)
+            .expect("emit scip without legacy projection");
+        let symbols = load_scip_symbols(&empty_projection_dir)
             .expect("load scip")
             .expect("symbols");
+
+        let mut storage = Store::open(&storage_path).expect("reopen store");
+        storage
+            .upsert_search_symbol_projection_batch(&[
+                SearchSymbolProjection {
+                    node_id: NodeId(2),
+                    display_name: "stale_wrong_name".into(),
+                },
+                SearchSymbolProjection {
+                    node_id: unknown_node_id,
+                    display_name: "stale_unknown_name".into(),
+                },
+            ])
+            .expect("seed stale legacy projection");
+        drop(storage);
+
+        let stale_projection_dir = project.path().join("scip-stale-projection");
+        emit_scip_artifacts_from_store(&storage_path, &stale_projection_dir)
+            .expect("emit scip with stale legacy projection");
+        let stale_projection_symbols = load_scip_symbols(&stale_projection_dir)
+            .expect("load stale-projection scip")
+            .expect("stale-projection symbols");
 
         assert_eq!(
             symbols.contract.evidence_source,
             SCIP_GRAPH_PROJECTION_PROVENANCE
         );
+        assert_eq!(symbols.contract.producer_config, "canonical_node_pages");
         assert_eq!(symbols.contract.freshness, "fresh");
         assert_eq!(symbols.proofs.len(), symbols.symbols.len());
+        assert_eq!(
+            serde_json::to_value(&symbols).expect("serialize empty-projection symbols"),
+            serde_json::to_value(&stale_projection_symbols)
+                .expect("serialize stale-projection symbols"),
+            "legacy projection contents must not change canonical SCIP output"
+        );
         assert!(
             symbols
                 .symbols
@@ -491,10 +520,7 @@ mod tests {
                 .all(|symbol| symbol.node_id.as_deref() != Some("5000")),
             "unresolvable UNKNOWN nodes should not enter the SCIP candidate lane"
         );
-        assert!(
-            symbols.symbols.len() >= 4_100,
-            "SCIP emit should not truncate at the old 4096-symbol smoke cap"
-        );
+        assert_eq!(symbols.symbols.len(), 4_100);
         assert!(
             symbols
                 .symbols

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -160,7 +160,8 @@ impl PinnedRetrievalRead {
         let session =
             PinnedQuerySession::begin(&project_root, &storage_path, &controller.runtime_config)
                 .map_err(map_pinned_query_error)?;
-        let node_names = crate::load_search_symbol_projection(session.storage(), 10_000)?.0;
+        let node_names =
+            crate::load_canonical_search_symbols(session.storage(), 10_000, None, |_| Ok(()))?.0;
         Ok(Self {
             session,
             project_root,

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -4760,14 +4760,6 @@ fn read_line_capped<R: BufRead>(
     }
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SemanticProjectionMode {
-    PersistBackedDocs,
-    LoadPersistedDocs,
-    SkipPersistence,
-}
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SemanticProjectionStats {
     reported: bool,
@@ -4804,6 +4796,9 @@ struct SemanticRefreshScope<'a> {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SearchStateBuildStats {
     search_projection_rebuild_ms: u32,
+    search_symbol_stream_ms: u32,
+    search_symbol_stream_rows: u32,
+    search_symbol_stream_batches: u32,
     search_symbol_index_ms: u32,
     search_symbol_index_docs_written: u32,
     search_symbol_index_writer_count: u32,
@@ -4854,6 +4849,9 @@ fn apply_semantic_projection_stats(
 
 fn apply_cache_refresh_stats(timings: &mut IndexingPhaseTimings, stats: CacheRefreshStats) {
     timings.search_projection_rebuild_ms = Some(stats.search_stats.search_projection_rebuild_ms);
+    timings.search_symbol_stream_ms = Some(stats.search_stats.search_symbol_stream_ms);
+    timings.search_symbol_stream_rows = Some(stats.search_stats.search_symbol_stream_rows);
+    timings.search_symbol_stream_batches = Some(stats.search_stats.search_symbol_stream_batches);
     timings.search_symbol_index_ms = Some(stats.search_stats.search_symbol_index_ms);
     timings.search_symbol_index_docs_written =
         Some(stats.search_stats.search_symbol_index_docs_written);
@@ -4869,56 +4867,20 @@ fn apply_cache_refresh_stats(timings: &mut IndexingPhaseTimings, stats: CacheRef
 
 #[cfg(test)]
 fn build_search_state(
-    storage: &mut Storage,
     search_storage_path: Option<&Path>,
     nodes: Vec<codestory_contracts::graph::Node>,
-    llm_refresh_file_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
-    semantic_projection_mode: SemanticProjectionMode,
-    hydrate_semantic_docs: bool,
 ) -> Result<SearchStateBuildResult, ApiError> {
-    build_search_state_for_runtime(
-        storage,
-        search_storage_path,
-        nodes,
-        llm_refresh_file_scope,
-        semantic_projection_mode,
-        SearchStateBuildContext {
-            hydrate_semantic_docs,
-            runtime: &test_sidecar_runtime_from_env(),
-            cancel_token: None,
-        },
-    )
+    build_search_state_for_nodes(search_storage_path, nodes, None)
 }
 
-struct SearchStateBuildContext<'a> {
-    hydrate_semantic_docs: bool,
-    runtime: &'a codestory_retrieval::SidecarRuntimeConfig,
-    cancel_token: Option<&'a CancellationToken>,
-}
-
-fn build_search_state_for_runtime(
-    storage: &mut Storage,
+#[cfg(test)]
+fn build_search_state_for_nodes(
     search_storage_path: Option<&Path>,
     nodes: Vec<codestory_contracts::graph::Node>,
-    llm_refresh_file_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
-    semantic_projection_mode: SemanticProjectionMode,
-    context: SearchStateBuildContext<'_>,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<SearchStateBuildResult, ApiError> {
-    let SearchStateBuildContext {
-        hydrate_semantic_docs,
-        runtime,
-        cancel_token,
-    } = context;
-    let projection_started = Instant::now();
-    match llm_refresh_file_scope {
-        Some(scope) => storage.rebuild_search_symbol_projection_for_file_scope(scope),
-        None => storage.rebuild_search_symbol_projection_from_node_table(),
-    }
-    .map_err(|e| ApiError::internal(format!("Failed to rebuild search symbol projection: {e}")))?;
-    let search_projection_rebuild_ms = clamp_u128_to_u32(projection_started.elapsed().as_millis());
-
     let search_index_started = Instant::now();
-    let mut node_names = HashMap::new();
+    let mut node_names = HashMap::with_capacity(nodes.len());
     let mut engine = SearchEngine::new(search_storage_path).map_err(|error| {
         if search::engine::is_persisted_search_index_busy(&error) {
             ApiError::new(
@@ -4968,46 +4930,25 @@ fn build_search_state_for_runtime(
     }
     let search_symbol_index_ms = clamp_u128_to_u32(search_index_started.elapsed().as_millis());
     let search_stats = SearchStateBuildStats {
-        search_projection_rebuild_ms,
+        search_projection_rebuild_ms: 0,
+        search_symbol_stream_ms: 0,
+        search_symbol_stream_rows: clamp_usize_to_u32(nodes.len()),
+        search_symbol_stream_batches: clamp_usize_to_u32(
+            nodes.len().div_ceil(SEARCH_NODE_BATCH_SIZE),
+        ),
         search_symbol_index_ms,
         search_symbol_index_docs_written: clamp_usize_to_u32(symbol_write_stats.docs_written),
         search_symbol_index_writer_count: clamp_usize_to_u32(symbol_write_stats.writer_count),
         search_symbol_index_commit_count: clamp_usize_to_u32(symbol_write_stats.commit_count),
         search_symbol_index_reload_count: clamp_usize_to_u32(symbol_write_stats.reload_count),
     };
-    let semantic_stats = match semantic_projection_mode {
-        SemanticProjectionMode::PersistBackedDocs => sync_llm_symbol_projection_for_runtime(
-            storage,
-            &nodes,
-            &node_names,
-            &mut engine,
-            SemanticRefreshScope {
-                file_ids: llm_refresh_file_scope,
-                component_reports: None,
-            },
-            hydrate_semantic_docs,
-            &dense_anchor_source_identity(storage)?,
-            None,
-            runtime,
-        )?,
-        SemanticProjectionMode::LoadPersistedDocs => load_persisted_semantic_docs_for_runtime(
-            storage,
-            &mut engine,
-            hydrate_semantic_docs,
-            runtime,
-        )?,
-        SemanticProjectionMode::SkipPersistence => {
-            tracing::debug!("Skipping semantic docs for transient search-state build");
-            engine.index_llm_symbol_docs(Vec::new());
-            SemanticProjectionStats::default()
-        }
-    };
+    engine.index_llm_symbol_docs(Vec::new());
     Ok(SearchStateBuildResult {
         publication: None,
         node_names,
         engine,
         search_stats,
-        semantic_stats,
+        semantic_stats: SemanticProjectionStats::default(),
     })
 }
 
@@ -5016,22 +4957,6 @@ fn current_epoch_ms() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
         .unwrap_or(0)
-}
-
-fn dense_anchor_source_identity(storage: &Storage) -> Result<String, ApiError> {
-    storage
-        .get_index_publication()
-        .map_err(|error| {
-            ApiError::internal(format!(
-                "Failed to read core publication identity for dense anchors: {error}"
-            ))
-        })
-        .map(|publication| {
-            publication.map_or_else(
-                || "core:unpublished".to_string(),
-                |publication| format!("core:{}:{}", publication.generation_id, publication.run_id),
-            )
-        })
 }
 
 fn runtime_relative_path(root: &Path, path: &Path) -> String {
@@ -5925,8 +5850,9 @@ fn local_symbol_summary(doc: &LlmSymbolDoc) -> String {
 
 const LLM_SYMBOL_DOC_SCHEMA_VERSION: u32 = 6;
 const LLM_SYMBOL_DOC_VERSION_PREFIX: &str = "semantic_doc_version:";
+#[cfg(test)]
 const SEARCH_NODE_BATCH_SIZE: usize = 8_192;
-const SEARCH_SYMBOL_PROJECTION_BATCH_SIZE: usize = 4_096;
+const SEARCH_SYMBOL_STREAM_BATCH_SIZE: usize = 4_096;
 const LLM_DOC_RELOAD_BATCH_SIZE: usize = 512;
 #[cfg(test)]
 const LLM_DOC_EMBED_BATCH_SIZE: usize = 128;
@@ -6205,6 +6131,7 @@ struct SearchGenerationCatalogGuard {
 enum PublicationTestBoundary {
     Identity,
     SearchBuild,
+    SearchSymbolPage,
     SearchIndexWrite,
     SearchValidation,
     SearchCompletion,
@@ -6548,36 +6475,67 @@ fn discard_unpublished_search_generation(
     }
 }
 
-fn load_search_symbol_projection(
+fn load_canonical_search_symbols(
     storage: &Storage,
     batch_size: usize,
+    cancel_token: Option<&CancellationToken>,
+    mut consume_batch: impl FnMut(Vec<SearchSymbolProjection>) -> Result<(), ApiError>,
 ) -> Result<
     (
         HashMap<codestory_contracts::graph::NodeId, String>,
-        Vec<SearchSymbolProjection>,
+        SearchStateBuildStats,
     ),
     ApiError,
 > {
-    let mut node_names = HashMap::new();
-    let mut entries = Vec::new();
+    let count_started = Instant::now();
+    let expected_rows = storage
+        .get_canonical_search_symbol_count()
+        .map_err(|error| {
+            ApiError::internal(format!("Failed to count canonical search symbols: {error}"))
+        })?;
+    let mut node_names = HashMap::with_capacity(expected_rows as usize);
     let mut after_node_id = None;
     let batch_size = batch_size.max(1);
+    let mut stream_duration = count_started.elapsed();
+    let mut stream_rows = 0_usize;
+    let mut stream_batches = 0_usize;
     loop {
+        let batch_started = Instant::now();
         let batch = storage
-            .get_search_symbol_projection_batch_after(after_node_id, batch_size)
+            .get_canonical_search_symbol_batch_after(after_node_id, batch_size)
             .map_err(|e| {
-                ApiError::internal(format!("Failed to load search symbol projection: {e}"))
+                ApiError::internal(format!("Failed to stream canonical search symbols: {e}"))
             })?;
+        stream_duration = stream_duration.saturating_add(batch_started.elapsed());
         if batch.is_empty() {
             break;
         }
         after_node_id = batch.last().map(|entry| entry.node_id);
-        for entry in batch {
+        stream_rows = stream_rows.saturating_add(batch.len());
+        stream_batches = stream_batches.saturating_add(1);
+        for entry in &batch {
             node_names.insert(entry.node_id, entry.display_name.clone());
-            entries.push(entry);
+        }
+        consume_batch(batch)?;
+        if is_indexing_cancelled(cancel_token) {
+            return Err(indexing_cancelled_error());
         }
     }
-    Ok((node_names, entries))
+    if stream_rows != expected_rows as usize {
+        return Err(ApiError::internal(format!(
+            "Canonical search symbol stream count changed: expected {expected_rows}, loaded {stream_rows}"
+        )));
+    }
+    Ok((
+        node_names,
+        SearchStateBuildStats {
+            search_projection_rebuild_ms: 0,
+            search_symbol_stream_ms: clamp_u128_to_u32(stream_duration.as_millis()),
+            search_symbol_stream_rows: clamp_usize_to_u32(stream_rows),
+            search_symbol_stream_batches: clamp_usize_to_u32(stream_batches),
+            ..SearchStateBuildStats::default()
+        },
+    ))
 }
 
 struct LoadedSearchState {
@@ -6607,23 +6565,28 @@ fn load_persisted_search_state_for_runtime(
         ))
     })?;
     if publication.is_none() {
-        let nodes = storage.get_nodes().map_err(|error| {
-            ApiError::internal(format!("Failed to load legacy search nodes: {error}"))
-        })?;
-        let mut node_names = HashMap::with_capacity(nodes.len());
         let mut engine = SearchEngine::new(None).map_err(|error| {
             ApiError::internal(format!("Failed to init search engine: {error}"))
         })?;
-        let search_nodes = nodes
-            .iter()
-            .map(|node| {
-                let display_name = node_display_name(node);
-                node_names.insert(node.id, display_name.clone());
-                (node.id, display_name)
-            })
-            .collect();
-        engine.index_nodes(search_nodes).map_err(|error| {
-            ApiError::internal(format!("Failed to index legacy search nodes: {error}"))
+        let mut symbol_session = engine.begin_symbol_index().map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to start legacy symbol index writer: {error}"
+            ))
+        })?;
+        let (node_names, _) = load_canonical_search_symbols(storage, 10_000, None, |batch| {
+            symbol_session
+                .add_nodes(
+                    batch
+                        .into_iter()
+                        .map(|entry| (entry.node_id, entry.display_name)),
+                )
+                .map(|_| ())
+                .map_err(|error| {
+                    ApiError::internal(format!("Failed to index legacy search nodes: {error}"))
+                })
+        })?;
+        symbol_session.finish().map_err(|error| {
+            ApiError::internal(format!("Failed to finish legacy symbol index: {error}"))
         })?;
         load_persisted_semantic_docs_for_runtime(storage, &mut engine, false, runtime)?;
         return Ok(LoadedSearchState {
@@ -6632,8 +6595,6 @@ fn load_persisted_search_state_for_runtime(
             engine,
         });
     }
-    let (node_names, projection) =
-        load_search_symbol_projection(storage, SEARCH_SYMBOL_PROJECTION_BATCH_SIZE)?;
     let search_storage_path =
         search_index_path_for_publication(storage_path, publication.as_ref())?;
     let completion = publication.as_ref().and_then(|publication| {
@@ -6641,7 +6602,6 @@ fn load_persisted_search_state_for_runtime(
             .ok()?
             .to_string();
         read_search_generation_completion(&search_storage_path, &generation_id)
-            .filter(|marker| marker.symbol_count == projection.len() as u64)
     });
     if publication.is_some() && completion.is_none() {
         return Err(ApiError::new(
@@ -6659,20 +6619,35 @@ fn load_persisted_search_state_for_runtime(
                 ),
             )
         })?;
-    engine.load_symbol_projection(
-        projection
-            .iter()
-            .map(|entry| (entry.node_id, entry.display_name.clone())),
-    );
-    let completion_count_mismatch = completion
-        .as_ref()
-        .is_some_and(|marker| marker.tantivy_doc_count != engine.tantivy_doc_count() as u64);
-    if engine.full_text_doc_count() != projection.len() || completion_count_mismatch {
+    engine.load_symbol_projection(std::iter::empty());
+    let (node_names, stream_stats) =
+        load_canonical_search_symbols(storage, SEARCH_SYMBOL_STREAM_BATCH_SIZE, None, |batch| {
+            engine.extend_symbol_projection(
+                batch
+                    .into_iter()
+                    .map(|entry| (entry.node_id, entry.display_name)),
+            );
+            Ok(())
+        })?;
+    let completion_count_mismatch = completion.as_ref().is_some_and(|marker| {
+        marker.symbol_count != stream_stats.search_symbol_stream_rows as u64
+            || marker.tantivy_doc_count != engine.tantivy_doc_count() as u64
+    });
+    if engine.full_text_doc_count() != stream_stats.search_symbol_stream_rows as usize
+        || completion_count_mismatch
+    {
         return Err(ApiError::new(
             "cache_busy",
             format!(
-                "Completed search generation {} does not match its core projection.",
-                search_storage_path.display()
+                "Completed search generation {} does not match its core symbols: streamed={}, searchable={}, marker_symbols={}, stored_docs={}, marker_docs={}.",
+                search_storage_path.display(),
+                stream_stats.search_symbol_stream_rows,
+                engine.full_text_doc_count(),
+                completion.as_ref().map_or(0, |marker| marker.symbol_count),
+                engine.tantivy_doc_count(),
+                completion
+                    .as_ref()
+                    .map_or(0, |marker| marker.tantivy_doc_count),
             ),
         ));
     }
@@ -14725,6 +14700,9 @@ fn index_full_for_runtime(
                 .then_some(clamp_u64_to_u32(index_stats.full_refresh_chunk_planning_ms)),
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
+            search_symbol_stream_ms: None,
+            search_symbol_stream_rows: None,
+            search_symbol_stream_batches: None,
             search_symbol_index_ms: None,
             search_symbol_index_docs_written: None,
             search_symbol_index_writer_count: None,
@@ -15371,6 +15349,9 @@ fn run_incremental_indexing_common(
             full_refresh_chunk_planning_ms: None,
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
+            search_symbol_stream_ms: None,
+            search_symbol_stream_rows: None,
+            search_symbol_stream_batches: None,
             search_symbol_index_ms: None,
             search_symbol_index_docs_written: None,
             search_symbol_index_writer_count: None,
@@ -15499,10 +15480,9 @@ fn reuse_completed_search_state(
     storage: &mut Storage,
     search_storage_path: &Path,
     publication: &IndexPublicationRecord,
-    nodes: &[codestory_contracts::graph::Node],
-    llm_refresh_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
     hydrate_semantic_docs: bool,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<Option<SearchStateBuildResult>, ApiError> {
     let generation_id = Uuid::parse_str(&publication.generation_id)
         .map_err(|error| {
@@ -15513,22 +15493,9 @@ fn reuse_completed_search_state(
         })?
         .to_string();
     let Some(marker) = read_search_generation_completion(search_storage_path, &generation_id)
-        .filter(|marker| marker.symbol_count == nodes.len() as u64)
     else {
         return Ok(None);
     };
-
-    let projection_started = Instant::now();
-    match llm_refresh_scope {
-        Some(scope) => storage.rebuild_search_symbol_projection_for_file_scope(scope),
-        None => storage.rebuild_search_symbol_projection_from_node_table(),
-    }
-    .map_err(|error| {
-        ApiError::internal(format!(
-            "Failed to rebuild search symbol projection before generation reuse: {error}"
-        ))
-    })?;
-    let search_projection_rebuild_ms = clamp_u128_to_u32(projection_started.elapsed().as_millis());
 
     let search_index_started = Instant::now();
     let mut engine = match SearchEngine::open_existing(search_storage_path) {
@@ -15541,26 +15508,36 @@ fn reuse_completed_search_state(
             return Ok(None);
         }
     };
-    let mut node_names = HashMap::with_capacity(nodes.len());
-    engine.load_symbol_projection(nodes.iter().map(|node| {
-        let display_name = node_display_name(node);
-        node_names.insert(node.id, display_name.clone());
-        (node.id, display_name)
-    }));
-    if engine.full_text_doc_count() != nodes.len()
+    engine.load_symbol_projection(std::iter::empty());
+    let (node_names, mut search_stats) = load_canonical_search_symbols(
+        storage,
+        SEARCH_SYMBOL_STREAM_BATCH_SIZE,
+        cancel_token,
+        |batch| {
+            engine.extend_symbol_projection(
+                batch
+                    .into_iter()
+                    .map(|entry| (entry.node_id, entry.display_name)),
+            );
+            Ok(())
+        },
+    )?;
+    if marker.symbol_count != search_stats.search_symbol_stream_rows as u64
+        || engine.full_text_doc_count() != search_stats.search_symbol_stream_rows as usize
         || engine.tantivy_doc_count() as u64 != marker.tantivy_doc_count
     {
         tracing::warn!(
             path = %search_storage_path.display(),
             searchable_docs = engine.full_text_doc_count(),
             stored_docs = engine.tantivy_doc_count(),
-            expected_symbols = nodes.len(),
+            expected_symbols = search_stats.search_symbol_stream_rows,
             expected_stored_docs = marker.tantivy_doc_count,
             "Completed persisted search generation count validation failed and will be rebuilt"
         );
         return Ok(None);
     }
-    let search_symbol_index_ms = clamp_u128_to_u32(search_index_started.elapsed().as_millis());
+    search_stats.search_symbol_index_ms =
+        clamp_u128_to_u32(search_index_started.elapsed().as_millis());
     let semantic_stats = load_persisted_semantic_docs_for_runtime(
         storage,
         &mut engine,
@@ -15571,13 +15548,118 @@ fn reuse_completed_search_state(
         publication: Some(publication.clone()),
         node_names,
         engine,
-        search_stats: SearchStateBuildStats {
-            search_projection_rebuild_ms,
-            search_symbol_index_ms,
-            ..SearchStateBuildStats::default()
-        },
+        search_stats,
         semantic_stats,
     }))
+}
+
+fn build_persisted_search_state_from_canonical_symbols(
+    storage: &mut Storage,
+    search_storage_path: &Path,
+    hydrate_semantic_docs: bool,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    cancel_token: Option<&CancellationToken>,
+) -> Result<SearchStateBuildResult, ApiError> {
+    let search_index_started = Instant::now();
+    let count_started = Instant::now();
+    let expected_rows = storage
+        .get_canonical_search_symbol_count()
+        .map_err(|error| {
+            ApiError::internal(format!("Failed to count canonical search symbols: {error}"))
+        })?;
+    let mut stream_duration = count_started.elapsed();
+    let mut engine = SearchEngine::new(Some(search_storage_path)).map_err(|error| {
+        if search::engine::is_persisted_search_index_busy(&error) {
+            ApiError::new(
+                "cache_busy",
+                format!("Failed to init search engine: {error}"),
+            )
+        } else {
+            ApiError::internal(format!("Failed to init search engine: {error}"))
+        }
+    })?;
+    let mut node_names = HashMap::with_capacity(expected_rows as usize);
+    let mut symbol_session = engine.begin_symbol_index().map_err(|error| {
+        ApiError::internal(format!("Failed to start symbol index writer: {error}"))
+    })?;
+    let mut after_node_id = None;
+    let mut stream_rows = 0_usize;
+    let mut stream_batches = 0_usize;
+    loop {
+        let batch_started = Instant::now();
+        let batch = storage
+            .get_canonical_search_symbol_batch_after(after_node_id, SEARCH_SYMBOL_STREAM_BATCH_SIZE)
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to stream canonical search symbols: {error}"
+                ))
+            })?;
+        stream_duration = stream_duration.saturating_add(batch_started.elapsed());
+        if batch.is_empty() {
+            break;
+        }
+        after_node_id = batch.last().map(|entry| entry.node_id);
+        stream_rows = stream_rows.saturating_add(batch.len());
+        stream_batches = stream_batches.saturating_add(1);
+        let symbols = batch
+            .into_iter()
+            .map(|entry| {
+                node_names.insert(entry.node_id, entry.display_name.clone());
+                (entry.node_id, entry.display_name)
+            })
+            .collect::<Vec<_>>();
+        symbol_session.add_nodes(symbols).map_err(|error| {
+            ApiError::internal(format!("Failed to index search nodes: {error}"))
+        })?;
+        #[cfg(test)]
+        publication_test_checkpoint(PublicationTestBoundary::SearchSymbolPage, cancel_token)?;
+        if is_indexing_cancelled(cancel_token) {
+            return Err(indexing_cancelled_error());
+        }
+    }
+    if stream_rows != expected_rows as usize {
+        return Err(ApiError::internal(format!(
+            "Canonical search symbol stream count changed: expected {expected_rows}, loaded {stream_rows}"
+        )));
+    }
+    #[cfg(test)]
+    publication_test_checkpoint(PublicationTestBoundary::SearchIndexWrite, cancel_token)?;
+    if is_indexing_cancelled(cancel_token) {
+        return Err(indexing_cancelled_error());
+    }
+    let symbol_write_stats = symbol_session
+        .finish()
+        .map_err(|error| ApiError::internal(format!("Failed to commit symbol index: {error}")))?;
+    if engine.full_text_doc_count() != stream_rows {
+        return Err(ApiError::internal(format!(
+            "Persisted search generation validation failed: indexed {} docs for {stream_rows} canonical symbols",
+            engine.full_text_doc_count()
+        )));
+    }
+    let search_symbol_index_ms = clamp_u128_to_u32(search_index_started.elapsed().as_millis());
+    let semantic_stats = load_persisted_semantic_docs_for_runtime(
+        storage,
+        &mut engine,
+        hydrate_semantic_docs,
+        runtime,
+    )?;
+    Ok(SearchStateBuildResult {
+        publication: None,
+        node_names,
+        engine,
+        search_stats: SearchStateBuildStats {
+            search_projection_rebuild_ms: 0,
+            search_symbol_stream_ms: clamp_u128_to_u32(stream_duration.as_millis()),
+            search_symbol_stream_rows: clamp_usize_to_u32(stream_rows),
+            search_symbol_stream_batches: clamp_usize_to_u32(stream_batches),
+            search_symbol_index_ms,
+            search_symbol_index_docs_written: clamp_usize_to_u32(symbol_write_stats.docs_written),
+            search_symbol_index_writer_count: clamp_usize_to_u32(symbol_write_stats.writer_count),
+            search_symbol_index_commit_count: clamp_usize_to_u32(symbol_write_stats.commit_count),
+            search_symbol_index_reload_count: clamp_usize_to_u32(symbol_write_stats.reload_count),
+        },
+        semantic_stats,
+    })
 }
 
 #[cfg(test)]
@@ -15604,7 +15686,7 @@ type SearchCompletionValidator<'a> =
 fn rebuild_search_state_from_storage_for_runtime(
     storage: &mut Storage,
     storage_path: &Path,
-    llm_refresh_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
+    _llm_refresh_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
     hydrate_semantic_docs: bool,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
     cancel_token: Option<&CancellationToken>,
@@ -15621,18 +15703,14 @@ fn rebuild_search_state_from_storage_for_runtime(
         .transpose()?;
     let search_storage_path =
         search_index_path_for_publication(storage_path, publication.as_ref())?;
-    let nodes = storage
-        .get_nodes()
-        .map_err(|e| ApiError::internal(format!("Failed to load nodes for search rebuild: {e}")))?;
     let reused = match publication.as_ref() {
         Some(publication) => reuse_completed_search_state(
             storage,
             &search_storage_path,
             publication,
-            &nodes,
-            llm_refresh_scope,
             hydrate_semantic_docs,
             runtime,
+            cancel_token,
         )?,
         None => None,
     };
@@ -15644,17 +15722,12 @@ fn rebuild_search_state_from_storage_for_runtime(
     let built_new = reused.is_none();
     let mut result = match reused {
         Some(result) => result,
-        None => build_search_state_for_runtime(
+        None => build_persisted_search_state_from_canonical_symbols(
             storage,
-            Some(search_storage_path.as_path()),
-            nodes,
-            llm_refresh_scope,
-            SemanticProjectionMode::LoadPersistedDocs,
-            SearchStateBuildContext {
-                hydrate_semantic_docs,
-                runtime,
-                cancel_token,
-            },
+            search_storage_path.as_path(),
+            hydrate_semantic_docs,
+            runtime,
+            cancel_token,
         )
         .map_err(|mut error| {
             error.message = format!("Failed to rebuild search state: {}", error.message);
@@ -21441,7 +21514,7 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
-    fn build_search_state_scopes_projection_rebuild_to_touched_files() {
+    fn build_search_state_ignores_stale_legacy_projection_rows() {
         let mut storage = Storage::new_in_memory().expect("storage");
         storage
             .insert_nodes_batch(&[
@@ -21476,10 +21549,6 @@ fn build_llm_symbol_doc_text() -> String {
             ])
             .expect("insert nodes");
         storage
-            .rebuild_search_symbol_projection_from_node_table()
-            .expect("full projection");
-
-        storage
             .insert_nodes_batch(&[Node {
                 id: CoreNodeId(901),
                 kind: NodeKind::FUNCTION,
@@ -21497,16 +21566,16 @@ fn build_llm_symbol_doc_text() -> String {
             .expect("seed untouched stale projection");
 
         let nodes = storage.get_nodes().expect("nodes");
-        let touched = HashSet::from([CoreNodeId(900)]);
-        build_search_state(
-            &mut storage,
-            None,
-            nodes,
-            Some(&touched),
-            SemanticProjectionMode::SkipPersistence,
-            false,
-        )
-        .expect("scoped search state");
+        let result =
+            build_search_state(None, nodes).expect("build search state from canonical nodes");
+        assert_eq!(
+            result.node_names.get(&CoreNodeId(901)).map(String::as_str),
+            Some("pkg::renamed")
+        );
+        assert_eq!(
+            result.node_names.get(&CoreNodeId(911)).map(String::as_str),
+            Some("pkg::untouched")
+        );
 
         let projection = storage
             .get_search_symbol_projection_batch_after(None, 10)
@@ -21516,16 +21585,85 @@ fn build_llm_symbol_doc_text() -> String {
             .map(|entry| (entry.node_id, entry.display_name))
             .collect();
         assert_eq!(
-            names_by_id.get(&CoreNodeId(900)).map(String::as_str),
-            Some("src/changed.rs")
-        );
-        assert_eq!(
-            names_by_id.get(&CoreNodeId(901)).map(String::as_str),
-            Some("pkg::renamed")
-        );
-        assert_eq!(
             names_by_id.get(&CoreNodeId(911)).map(String::as_str),
             Some("stale_other_file")
+        );
+    }
+
+    #[test]
+    fn persisted_search_build_streams_multiple_pages_through_one_writer() {
+        let _env = hybrid_test_env();
+        let temp = tempdir().expect("search stream tempdir");
+        let storage_path = temp.path().join("codestory.db");
+        let search_path = temp.path().join("search-generation");
+        let mut storage = Storage::open(&storage_path).expect("open storage");
+        let nodes = (1..=4_100_i64)
+            .map(|id| Node {
+                id: CoreNodeId(id),
+                kind: NodeKind::FUNCTION,
+                serialized_name: format!("symbol_{id}"),
+                qualified_name: (id % 2 == 0).then(|| format!("pkg::symbol_{id}")),
+                ..Default::default()
+            })
+            .collect::<Vec<_>>();
+        storage
+            .insert_nodes_batch(&nodes)
+            .expect("insert streamed search nodes");
+
+        let cancelled_search_path = temp.path().join("cancelled-search-generation");
+        let cancel_token = CancellationToken::new();
+        arm_publication_test_fault(
+            PublicationTestBoundary::SearchSymbolPage,
+            PublicationTestAction::Cancel,
+        );
+        let cancelled = match build_persisted_search_state_from_canonical_symbols(
+            &mut storage,
+            &cancelled_search_path,
+            false,
+            &test_sidecar_runtime_from_env(),
+            Some(&cancel_token),
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("cancel after the first non-final page"),
+        };
+        assert_eq!(cancelled.code, "cancelled");
+        assert!(cancel_token.is_cancelled());
+        assert!(
+            !search_generation_completion_path(&cancelled_search_path).exists(),
+            "cancelled page stream must not publish a completion marker"
+        );
+        let cancelled_engine = SearchEngine::open_existing(&cancelled_search_path)
+            .expect("open uncommitted cancelled generation");
+        assert_eq!(
+            cancelled_engine.tantivy_doc_count(),
+            0,
+            "cancelled non-final page must not commit Tantivy documents"
+        );
+        drop(cancelled_engine);
+
+        let result = build_persisted_search_state_from_canonical_symbols(
+            &mut storage,
+            &search_path,
+            false,
+            &test_sidecar_runtime_from_env(),
+            None,
+        )
+        .expect("build persisted search from canonical stream");
+
+        assert_eq!(result.search_stats.search_projection_rebuild_ms, 0);
+        assert_eq!(result.search_stats.search_symbol_stream_rows, 4_100);
+        assert_eq!(result.search_stats.search_symbol_stream_batches, 2);
+        assert_eq!(result.search_stats.search_symbol_index_docs_written, 4_100);
+        assert_eq!(result.search_stats.search_symbol_index_writer_count, 1);
+        assert_eq!(result.search_stats.search_symbol_index_commit_count, 1);
+        assert_eq!(result.search_stats.search_symbol_index_reload_count, 1);
+        assert_eq!(result.node_names.len(), 4_100);
+        assert_eq!(result.engine.full_text_doc_count(), 4_100);
+        assert_eq!(
+            storage
+                .get_search_symbol_projection_count()
+                .expect("count legacy projection"),
+            0
         );
     }
 
@@ -21778,7 +21916,6 @@ fn build_llm_symbol_doc_text() -> String {
 
     #[test]
     fn build_search_state_prefers_qualified_name() {
-        let mut storage = Storage::new_in_memory().expect("storage");
         let nodes = vec![Node {
             id: CoreNodeId(1),
             kind: NodeKind::FUNCTION,
@@ -21787,15 +21924,7 @@ fn build_llm_symbol_doc_text() -> String {
             ..Default::default()
         }];
 
-        let result = build_search_state(
-            &mut storage,
-            None,
-            nodes,
-            None,
-            SemanticProjectionMode::SkipPersistence,
-            true,
-        )
-        .expect("build search state");
+        let result = build_search_state(None, nodes).expect("build search state");
         let node_names = result.node_names;
         let engine = result.engine;
         assert_eq!(
@@ -24253,6 +24382,16 @@ fn build_llm_symbol_doc_text() -> String {
         storage
             .put_index_publication(&old_publication)
             .expect("publish old identity");
+        storage
+            .publish_source_policy_exclusion_generation(
+                &old_publication,
+                "test-project",
+                "test-workspace",
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+                &[],
+            )
+            .expect("publish old source policy identity");
         drop(
             rebuild_search_state_from_storage(&mut storage, &storage_path, None, false)
                 .expect("build old generation"),
@@ -24284,34 +24423,35 @@ fn build_llm_symbol_doc_text() -> String {
                 [],
             )
             .expect("rename symbol in staged core");
-        staged
-            .store_mut()
-            .clear_search_symbol_projection()
-            .expect("clear staged projection");
-        staged
-            .store_mut()
-            .rebuild_search_symbol_projection_from_node_table()
-            .expect("rebuild staged projection");
         let new_publication = test_index_publication(2, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
         staged
             .store_mut()
             .put_index_publication(&new_publication)
             .expect("publish staged identity");
         staged
+            .store_mut()
+            .publish_source_policy_exclusion_generation(
+                &new_publication,
+                "test-project",
+                "test-workspace",
+                OVERSIZED_SOURCE_POLICY_VERSION,
+                DEFAULT_SOURCE_FILE_BYTE_CAP,
+                &[],
+            )
+            .expect("publish staged source policy identity");
+        staged
             .publish(&storage_path)
             .expect("publish replacement core");
 
         let mut live = Storage::open(&storage_path).expect("open replacement core");
-        let nodes = live.get_nodes().expect("load replacement nodes");
         let search_path = search_index_path_for_publication(&storage_path, Some(&new_publication))
             .expect("replacement search path");
-        let mut built = build_search_state(
+        let mut built = build_persisted_search_state_from_canonical_symbols(
             &mut live,
-            Some(&search_path),
-            nodes,
-            None,
-            SemanticProjectionMode::PersistBackedDocs,
+            &search_path,
             false,
+            &test_sidecar_runtime_from_env(),
+            None,
         )
         .expect("build replacement search generation");
         write_search_generation_completion(
@@ -24376,7 +24516,7 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
-    fn missing_or_corrupt_expected_search_generation_is_not_rebuilt_by_a_reader() {
+    fn missing_corrupt_or_count_mismatched_search_generation_is_not_rebuilt_by_a_reader() {
         let _env = hybrid_test_env();
         let temp = tempdir().expect("create temp dir");
         let file_path = write_semantic_fixture(temp.path());
@@ -24401,6 +24541,25 @@ fn build_llm_symbol_doc_text() -> String {
             rebuild_search_state_from_storage(&mut storage, &storage_path, None, false)
                 .expect("writer builds expected generation"),
         );
+        let completion_path = search_generation_completion_path(&expected_path);
+        let correct_completion = fs::read(&completion_path).expect("read completion marker");
+        let mut mismatched_completion: SearchGenerationCompletion =
+            serde_json::from_slice(&correct_completion).expect("decode completion marker");
+        mismatched_completion.symbol_count = mismatched_completion.symbol_count.saturating_add(1);
+        fs::write(
+            &completion_path,
+            serde_json::to_vec(&mismatched_completion).expect("encode mismatched completion"),
+        )
+        .expect("write mismatched completion marker");
+
+        let mismatch_error = match load_persisted_search_state(&mut storage, &storage_path) {
+            Err(error) => error,
+            Ok(_) => panic!("reader must reject a count-mismatched search generation"),
+        };
+        assert_eq!(mismatch_error.code, "cache_busy");
+        assert!(expected_path.is_dir());
+
+        fs::write(&completion_path, correct_completion).expect("restore completion marker");
         fs::remove_dir_all(&expected_path).expect("remove built generation");
         fs::write(&expected_path, b"corrupt search generation")
             .expect("write corrupt generation artifact");
@@ -25361,6 +25520,25 @@ fn build_llm_symbol_doc_text() -> String {
         );
         assert!(full_timings.staged_sqlite_checkpoint_ms.is_some());
         assert!(full_timings.staged_sqlite_sync_ms.is_some());
+        assert_eq!(full_timings.search_projection_rebuild_ms, Some(0));
+        assert!(full_timings.search_symbol_stream_ms.is_some());
+        assert!(
+            full_timings
+                .search_symbol_stream_rows
+                .is_some_and(|rows| rows > 0)
+        );
+        assert_eq!(full_timings.search_symbol_stream_batches, Some(1));
+        assert_eq!(full_timings.search_symbol_index_writer_count, Some(1));
+        assert_eq!(full_timings.search_symbol_index_commit_count, Some(1));
+        assert_eq!(full_timings.search_symbol_index_reload_count, Some(1));
+        assert_eq!(
+            Storage::open(&storage_path)
+                .expect("open full publication")
+                .get_search_symbol_projection_count()
+                .expect("count legacy search projection"),
+            0,
+            "fresh full publication must not materialize the legacy projection table"
+        );
         let first = controller
             .index_publication()
             .expect("read first publication")
@@ -25396,6 +25574,14 @@ fn build_llm_symbol_doc_text() -> String {
         );
         assert!(incremental_timings.staged_sqlite_checkpoint_ms.is_none());
         assert!(incremental_timings.staged_sqlite_sync_ms.is_none());
+        assert_eq!(incremental_timings.search_projection_rebuild_ms, Some(0));
+        assert!(incremental_timings.search_symbol_stream_ms.is_some());
+        assert!(
+            incremental_timings
+                .search_symbol_stream_rows
+                .is_some_and(|rows| rows > full_timings.search_symbol_stream_rows.unwrap_or(0))
+        );
+        assert_eq!(incremental_timings.search_symbol_stream_batches, Some(1));
         let second = controller
             .index_publication()
             .expect("read second publication")
@@ -26084,9 +26270,10 @@ fn build_llm_symbol_doc_text() -> String {
         }
     }
 
-    const PUBLICATION_TRANSITION_BOUNDARIES: [PublicationTestBoundary; 9] = [
+    const PUBLICATION_TRANSITION_BOUNDARIES: [PublicationTestBoundary; 10] = [
         PublicationTestBoundary::Identity,
         PublicationTestBoundary::SearchBuild,
+        PublicationTestBoundary::SearchSymbolPage,
         PublicationTestBoundary::SearchIndexWrite,
         PublicationTestBoundary::SearchValidation,
         PublicationTestBoundary::SearchCompletion,

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -942,6 +942,7 @@ impl SearchEngine {
         })
     }
 
+    #[cfg(any(test, feature = "benchmark-support"))]
     pub fn index_nodes(&mut self, nodes: Vec<(NodeId, String)>) -> Result<()> {
         let mut session = self.begin_symbol_index()?;
         session.add_nodes(nodes)?;
@@ -954,6 +955,13 @@ impl SearchEngine {
         I: IntoIterator<Item = (NodeId, String)>,
     {
         self.symbols.clear();
+        self.extend_symbol_projection(symbols);
+    }
+
+    pub fn extend_symbol_projection<I>(&mut self, symbols: I)
+    where
+        I: IntoIterator<Item = (NodeId, String)>,
+    {
         self.symbols.extend(
             symbols
                 .into_iter()

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -90,6 +90,16 @@ fn clamp_i64_to_u32(value: i64) -> u32 {
     }
 }
 
+fn canonical_search_symbol_batch_limit(
+    operation: &'static str,
+    limit: usize,
+) -> Result<i64, StorageError> {
+    if limit == 0 {
+        return Err(StorageError::InvalidBatchLimit(operation));
+    }
+    Ok(i64::try_from(limit).unwrap_or(i64::MAX))
+}
+
 fn uniform_optional_string(
     min_value: Option<String>,
     max_value: Option<String>,
@@ -972,6 +982,8 @@ fn upsert_index_artifact_cache_row(
 pub enum StorageError {
     #[error("Database error: {0}")]
     Sqlite(#[from] rusqlite::Error),
+    #[error("{0} requires a non-zero batch limit")]
+    InvalidBatchLimit(&'static str),
     #[error("Resolution support snapshot exceeds the current SQLite value limit")]
     ResolutionSupportSnapshotTooBig,
     #[error("Invalid enum value: {0}")]
@@ -4935,6 +4947,103 @@ impl Storage {
                 .query_row("SELECT COUNT(*) FROM search_symbol_projection", [], |row| {
                     row.get::<_, i64>(0)
                 })?;
+        Ok(clamp_i64_to_u32(count))
+    }
+
+    /// Reads one ordered page of lexical-search symbols from the canonical node table.
+    pub fn get_canonical_search_symbol_batch_after(
+        &self,
+        after_node_id: Option<NodeId>,
+        limit: usize,
+    ) -> Result<Vec<SearchSymbolProjection>, StorageError> {
+        let limit =
+            canonical_search_symbol_batch_limit("get_canonical_search_symbol_batch_after", limit)?;
+        let mut sql = String::from(
+            "SELECT
+                node.id,
+                CASE
+                    WHEN node.qualified_name IS NOT NULL
+                         AND TRIM(node.qualified_name) != ''
+                    THEN node.qualified_name
+                    ELSE node.serialized_name
+                END
+             FROM node",
+        );
+        let mut query_params = Vec::with_capacity(2);
+        if let Some(after_node_id) = after_node_id {
+            sql.push_str(" WHERE node.id > ?");
+            query_params.push(Value::Integer(after_node_id.0));
+        }
+        sql.push_str(" ORDER BY node.id ASC LIMIT ?");
+        query_params.push(Value::Integer(limit));
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut rows = stmt.query(params_from_iter(query_params))?;
+        let mut symbols = Vec::new();
+        while let Some(row) = rows.next()? {
+            symbols.push(SearchSymbolProjection {
+                node_id: NodeId(row.get(0)?),
+                display_name: row.get(1)?,
+            });
+        }
+        Ok(symbols)
+    }
+
+    /// Reads one ordered page of canonical lexical-search symbols with source details.
+    pub fn get_canonical_search_symbol_detail_batch_after(
+        &self,
+        after_node_id: Option<NodeId>,
+        limit: usize,
+    ) -> Result<Vec<SearchSymbolProjectionDetail>, StorageError> {
+        let limit = canonical_search_symbol_batch_limit(
+            "get_canonical_search_symbol_detail_batch_after",
+            limit,
+        )?;
+        let mut sql = String::from(
+            "SELECT
+                node.id,
+                CASE
+                    WHEN node.qualified_name IS NOT NULL
+                         AND TRIM(node.qualified_name) != ''
+                    THEN node.qualified_name
+                    ELSE node.serialized_name
+                END,
+                node.kind,
+                file.serialized_name,
+                node.start_line,
+                node.end_line
+             FROM node
+             LEFT JOIN node file ON file.id = node.file_node_id",
+        );
+        let mut query_params = Vec::with_capacity(2);
+        if let Some(after_node_id) = after_node_id {
+            sql.push_str(" WHERE node.id > ?");
+            query_params.push(Value::Integer(after_node_id.0));
+        }
+        sql.push_str(" ORDER BY node.id ASC LIMIT ?");
+        query_params.push(Value::Integer(limit));
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut rows = stmt.query(params_from_iter(query_params))?;
+        let mut symbols = Vec::new();
+        while let Some(row) = rows.next()? {
+            symbols.push(SearchSymbolProjectionDetail {
+                node_id: NodeId(row.get(0)?),
+                display_name: row.get(1)?,
+                node_kind: row.get(2)?,
+                file_path: row.get(3)?,
+                start_line: row.get(4)?,
+                end_line: row.get(5)?,
+            });
+        }
+        Ok(symbols)
+    }
+
+    /// Counts lexical-search symbols in the canonical node table.
+    pub fn get_canonical_search_symbol_count(&self) -> Result<u32, StorageError> {
+        let count = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM node", [], |row| row.get::<_, i64>(0))?;
         Ok(clamp_i64_to_u32(count))
     }
 

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -2357,6 +2357,121 @@ fn test_search_symbol_projection_round_trip_and_backfill() -> Result<(), Storage
 }
 
 #[test]
+fn canonical_search_symbols_page_node_table_independently_of_projection() -> Result<(), StorageError>
+{
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(100),
+            kind: NodeKind::FILE,
+            serialized_name: "src/lib.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(30),
+            kind: NodeKind::METHOD,
+            serialized_name: "whitespace_fallback".to_string(),
+            qualified_name: Some("   ".to_string()),
+            file_node_id: Some(NodeId(100)),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(10),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "qualified_fallback".to_string(),
+            qualified_name: Some("pkg::qualified".to_string()),
+            file_node_id: Some(NodeId(100)),
+            start_line: Some(7),
+            end_line: Some(11),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(20),
+            kind: NodeKind::CLASS,
+            serialized_name: "empty_fallback".to_string(),
+            qualified_name: Some(String::new()),
+            file_node_id: Some(NodeId(100)),
+            ..Default::default()
+        },
+    ])?;
+    storage.upsert_search_symbol_projection_batch(&[SearchSymbolProjection {
+        node_id: NodeId(10),
+        display_name: "stale_projection_name".to_string(),
+    }])?;
+
+    assert_eq!(storage.get_canonical_search_symbol_count()?, 4);
+    let first_page = storage.get_canonical_search_symbol_batch_after(None, 2)?;
+    assert_eq!(
+        first_page,
+        vec![
+            SearchSymbolProjection {
+                node_id: NodeId(10),
+                display_name: "pkg::qualified".to_string(),
+            },
+            SearchSymbolProjection {
+                node_id: NodeId(20),
+                display_name: "empty_fallback".to_string(),
+            },
+        ]
+    );
+    let second_page = storage.get_canonical_search_symbol_batch_after(Some(NodeId(20)), 2)?;
+    assert_eq!(
+        second_page,
+        vec![
+            SearchSymbolProjection {
+                node_id: NodeId(30),
+                display_name: "whitespace_fallback".to_string(),
+            },
+            SearchSymbolProjection {
+                node_id: NodeId(100),
+                display_name: "src/lib.rs".to_string(),
+            },
+        ]
+    );
+    assert!(
+        storage
+            .get_canonical_search_symbol_batch_after(Some(NodeId(100)), 2)?
+            .is_empty()
+    );
+
+    let details = storage.get_canonical_search_symbol_detail_batch_after(None, usize::MAX)?;
+    assert_eq!(details.len(), 4);
+    assert_eq!(details[0].node_id, NodeId(10));
+    assert_eq!(details[0].display_name, "pkg::qualified");
+    assert_eq!(details[0].node_kind, Some(NodeKind::FUNCTION as i64));
+    assert_eq!(details[0].file_path.as_deref(), Some("src/lib.rs"));
+    assert_eq!(details[0].start_line, Some(7));
+    assert_eq!(details[0].end_line, Some(11));
+
+    storage.clear_search_symbol_projection()?;
+    assert_eq!(storage.get_search_symbol_projection_count()?, 0);
+    assert_eq!(
+        storage.get_canonical_search_symbol_batch_after(None, usize::MAX)?,
+        [first_page, second_page].concat()
+    );
+    Ok(())
+}
+
+#[test]
+fn canonical_search_symbol_batches_reject_zero_limit() -> Result<(), StorageError> {
+    let storage = Storage::new_in_memory()?;
+
+    assert!(matches!(
+        storage.get_canonical_search_symbol_batch_after(None, 0),
+        Err(StorageError::InvalidBatchLimit(
+            "get_canonical_search_symbol_batch_after"
+        ))
+    ));
+    assert!(matches!(
+        storage.get_canonical_search_symbol_detail_batch_after(None, 0),
+        Err(StorageError::InvalidBatchLimit(
+            "get_canonical_search_symbol_detail_batch_after"
+        ))
+    ));
+    Ok(())
+}
+
+#[test]
 fn test_scoped_search_symbol_projection_rebuild() -> Result<(), StorageError> {
     let mut storage = Storage::new_in_memory()?;
     storage.insert_nodes_batch(&[

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -101,7 +101,7 @@ flowchart TD
     resolve --> errors["Flush indexing errors"]
     errors --> cleanup["Incremental cleanup for removed files"]
     cleanup --> snapshots["Runtime refreshes or publishes snapshots"]
-    snapshots --> semantic["Runtime syncs lexical search projection, symbol docs, component reports, and dense anchors"]
+    snapshots --> semantic["Runtime streams canonical symbols and syncs symbol docs, component reports, and dense anchors"]
     semantic --> summary["CLI receives retrieval state and phase timings"]
 ```
 
@@ -312,16 +312,24 @@ Full and incremental snapshot behavior are intentionally not symmetric.
 
 ### 11. Runtime synchronizes core search inputs
 
-After graph and snapshot work, runtime rebuilds the search-symbol projection, opens or refreshes the persisted Tantivy search directory, writes graph-native symbol docs, writes deterministic component reports, and synchronizes selected dense-anchor docs. This is part of the default `index` contract.
+After graph and snapshot work, runtime streams canonical search symbols
+directly from the node table, opens or refreshes the persisted Tantivy search
+directory, writes graph-native symbol docs, writes deterministic component
+reports, and synchronizes selected dense-anchor docs. The legacy
+`search_symbol_projection` table remains a compatibility surface; product
+indexing does not rebuild or read it. This is part of the default `index`
+contract.
 
-A new persisted symbol generation uses one 20 MB Tantivy writer across the
-existing 8,192-document checkpoints. Runtime checks cancellation after each
-checkpoint and immediately before the single commit/reload. Dropping an
-unfinished writer restores its in-memory fuzzy projection; the generation is
-not admitted until document-count validation and the completion marker both
-succeed. This protects process failure and cancellation. The completion-marker
-rename does not claim power-loss durability before its parent directory is
-synced.
+A new persisted symbol generation reads the canonical count and then advances
+through 4,096-row node-id keyset pages. It retains only the resident name map
+and search structures, rather than loading every complete graph node or a
+second derived SQLite table into memory. One 20 MB Tantivy writer spans all
+pages and commits/reloads once. Runtime checks cancellation after each page and
+immediately before the commit. Dropping an unfinished writer restores its
+in-memory fuzzy projection; the generation is not admitted until the streamed,
+indexed, and stored document counts agree and the completion marker succeeds.
+This protects process failure and cancellation. The completion-marker rename
+does not claim power-loss durability before its parent directory is synced.
 
 Semantic sync does these pieces of work:
 
@@ -399,9 +407,10 @@ and publishes the attested generation. Core indexing never loads the model.
 
 The index summary reports graph and semantic work separately:
 
-- `timings_ms.cache_refresh`: wrapper time for search projection, search indexing, semantic sync, and runtime publication
-- `cache_ms.search_projection`: SQLite search-symbol projection rebuild from persisted nodes
+- `timings_ms.cache_refresh`: wrapper time for canonical symbol streaming, search indexing, semantic sync, and runtime publication
+- `cache_ms.search_projection`: compatibility timing for the retired SQLite search-symbol projection rebuild; fresh product builds report zero
 - `cache_ms.search_index`: runtime search index construction for symbol names
+- `symbol_index.stream_ms`, `stream_rows`, and `stream_batches`: nested canonical-node read telemetry; stream time is part of `cache_ms.search_index`, not an additive phase
 - `symbol_index`: documents written plus Tantivy writer, commit, and reader-reload counts; completed-generation reuse reports zero for each count
 - `cache_ms.runtime_publish`: publishing the rebuilt search state into the live runtime
 - `semantic_ms.doc_build`: generated semantic text and hashes

--- a/docs/architecture/subsystems/store.md
+++ b/docs/architecture/subsystems/store.md
@@ -7,7 +7,8 @@ recovery.
 ## Durable state
 
 - file, node, edge, occurrence, component, callable, bookmark, and trail rows;
-- grounding snapshots and search projections;
+- grounding snapshots and canonical paged search-symbol reads from the node
+  table; the legacy materialized search projection remains compatibility-only;
 - graph-native symbol documents, component reports, reusable embedding-free dense-anchor inputs, and their complete publication manifest;
 - verified source-policy exclusion rows and their project/workspace/core-bound
   count-and-digest manifest;


### PR DESCRIPTION
Closes #1299
Refs #1275

## Context

The retained v0.16 corpus proof spent 19m20s rebuilding `search_symbol_projection`, then runtime loaded all 8.55M complete `Node` rows before search construction. The derived projection contains only node ID plus the canonical label already available from `node`.

This change removes that materialization from product runtime and retrieval paths while keeping the legacy schema and public store methods compatible.

Exact candidate: `bfdd59c2c2a2842f43481318e55d321dc74346ab`

## What changed

- add store-owned canonical symbol and SCIP-detail keyset readers with explicit bounded limits, stable node-ID ordering, canonical qualified-name fallback, counts, and typed zero-limit rejection;
- stream 4,096-row pages through one Tantivy symbol session for new search generations, while incrementally filling only the resident name/fuzzy structures;
- stream the same source for completed-generation reuse, live rehydration, and pinned retrieval reads, with count and publication revalidation;
- stop retrieval preparation and SCIP emission from repairing or reading `search_symbol_projection`;
- preserve the legacy projection table and compatibility methods without a migration-time delete;
- retain `search_projection_rebuild_ms` as zero and add optional symbol stream time/row/batch telemetry to the DTO and CLI;
- add an architecture contract preventing product runtime/retrieval from returning to whole-node or legacy-projection search construction.

## Review focus

- `crates/codestory-store/src/storage_impl/mod.rs`: canonical SQL and page contract;
- `crates/codestory-runtime/src/lib.rs`: streaming writer, generation reuse/rehydration, cancellation, count validation, and timer boundaries;
- `crates/codestory-retrieval/src/{index,scip_index}.rs`: removal of legacy projection repair and canonical SCIP pages;
- compatibility: `SearchEngine::index_nodes` remains available under `benchmark-support`; legacy store projection APIs remain unchanged.

## Verification

- `cargo test -p codestory-store --lib --locked` — 131 passed
- `cargo test -p codestory-retrieval --lib --locked` — 194 passed, 3 ignored measurement/live-runtime lanes
- runtime persisted generation, full/incremental publication, missing/corrupt/count-mismatch, writer failure, cancellation, and atomic transition lanes — passed
- 4,100-row runtime fixture — two pages, exact rows/docs, one writer/commit/reload, cancellation after the first non-final page commits zero docs
- `cargo test -p codestory-contracts --lib --locked` — 38 passed
- `cargo test -p codestory-cli --test architecture_contracts --locked` — 13 passed
- CLI timing render test — passed
- `cargo check -p codestory-bench --bench tantivy_symbol_commits --locked` — passed
- focused multi-package check and all-target clippy with `-D warnings` — passed
- `node .github/scripts/check-doc-links.mjs` and `git diff --check` — passed
- independent review found two pre-commit issues (benchmark API gating and timer attribution); both were fixed and the narrow re-review found no remaining P0-P3 findings

Packaged CodeStory grounding failed closed at CoreFreshness because `crates/codestory-runtime/src/lib.rs` exceeds the source-size policy, so review used exact-head source inspection as directed.

## Risk and follow-up

The resident node-name and Nucleo structures remain intentionally in memory, and SCIP still buffers its final output artifact. No repo-scale run is claimed here. #1275 owns the single combined 94,411-file rerun and any speedup or peak-memory claim.
