### PR TITLE
[codex] Attribute full-refresh wall time and semantic preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Performance
 
+- Full-refresh telemetry now reconciles exclusive outer wall stages and exposes
+  previously hidden source preparation, complete projection transactions,
+  semantic node/context loading, and final Tantivy commit/reload time. The
+  repo-scale evidence artifact retains the complete first and repeat timing
+  payloads instead of dropping unrecognized diagnostics.
 - Full refresh now persists each ordered parser-artifact chunk in one SQLite
   transaction instead of one autocommit per parsed file. Index telemetry
   reports artifact-cache rows, transactions, and write time separately.

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8063,13 +8063,14 @@ mod tests {
     use crate::runtime::{cache_root_for_project, fnv1a_hex, resolve_refresh_request};
     use codestory_contracts::api::{
         AgentAnswerDto, AgentCitationDto, AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto,
-        AgentRetrievalTraceDto, EdgeId, EdgeKind, GraphEdgeDto, GraphNodeDto, GraphResponse,
-        IndexMode, IndexedFileDto, IndexedFileIncompleteReasonCountDto, IndexedFileRoleDto,
-        IndexedFilesDto, IndexedFilesSummaryDto, IndexingPhaseTimings, NodeDetailsDto, NodeId,
-        PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetUsageDto, PacketClaimDto,
-        PacketPlanDto, PacketPlanQueryDto, PacketRetrievalTraceSummaryDto, PacketSufficiencyDto,
-        ProjectSummary, RetrievalModeDto, RetrievalStateDto, SearchHit, SearchHitOrigin,
-        SemanticModeDto, SourcePolicyExclusionDto, StorageStatsDto, TrailContextDto,
+        AgentRetrievalTraceDto, EdgeId, EdgeKind, FullRefreshWallTimings, GraphEdgeDto,
+        GraphNodeDto, GraphResponse, IndexMode, IndexedFileDto,
+        IndexedFileIncompleteReasonCountDto, IndexedFileRoleDto, IndexedFilesDto,
+        IndexedFilesSummaryDto, IndexingPhaseTimings, NodeDetailsDto, NodeId, PacketBudgetDto,
+        PacketBudgetLimitsDto, PacketBudgetUsageDto, PacketClaimDto, PacketPlanDto,
+        PacketPlanQueryDto, PacketRetrievalTraceSummaryDto, PacketSufficiencyDto, ProjectSummary,
+        RetrievalModeDto, RetrievalStateDto, SearchHit, SearchHitOrigin, SemanticModeDto,
+        SourcePolicyExclusionDto, StorageStatsDto, TrailContextDto,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -8930,6 +8931,24 @@ mod tests {
             edge_resolution_ms: 30,
             error_flush_ms: 4,
             cleanup_ms: 5,
+            full_refresh_wall: Some(FullRefreshWallTimings {
+                core_refresh_ms: 1_000,
+                live_inspection_ms: 10,
+                source_discovery_ms: 20,
+                stage_open_ms: 30,
+                indexer_execution_ms: 400,
+                coverage_validation_ms: 40,
+                copy_forward_ms: 50,
+                semantic_stage_ms: 150,
+                snapshot_stage_ms: 100,
+                publication_prepare_ms: 50,
+                search_generation_ms: 100,
+                catalog_publication_ms: 30,
+                unattributed_ms: 20,
+            }),
+            source_prepare_ms: Some(41),
+            projection_batch_wall_ms: Some(50),
+            projection_batch_transactions: Some(2),
             artifact_cache_write_ms: Some(6),
             artifact_cache_writes: Some(24),
             artifact_cache_write_transactions: Some(1),
@@ -8956,8 +8975,13 @@ mod tests {
             search_symbol_index_docs_written: Some(8192),
             search_symbol_index_writer_count: Some(1),
             search_symbol_index_commit_count: Some(1),
+            search_symbol_index_commit_ms: Some(64),
             search_symbol_index_reload_count: Some(1),
+            search_symbol_index_reload_ms: Some(65),
             runtime_cache_publish_ms: Some(63),
+            semantic_node_load_ms: Some(66),
+            semantic_node_load_rows: Some(8_192),
+            semantic_context_ms: Some(67),
             semantic_doc_build_ms: Some(7),
             semantic_embedding_ms: Some(8),
             semantic_db_upsert_ms: Some(9),
@@ -9196,11 +9220,16 @@ mod tests {
             "full_refresh_chunking: target_bytes=8388608 target_nodes=120000 file_ceiling=512 max_files=384 max_planned_bytes=7500000 max_nodes=98000 overruns=0 planning_ms=5"
         ));
         assert!(markdown.contains(
-            "symbol_index: stream_ms=60 stream_rows=8192 stream_batches=2 docs=8192 writers=1 commits=1 reloads=1"
+            "symbol_index: stream_ms=60 stream_rows=8192 stream_batches=2 docs=8192 writers=1 commits=1 commit_ms=64 reloads=1 reload_ms=65"
         ));
+        assert!(markdown.contains(
+            "full_refresh_wall_ms: core_refresh=1000 live_inspection=10 source_discovery=20 stage_open=30 indexer_execution=400 coverage_validation=40 copy_forward=50 semantic_stage=150 snapshot_stage=100 publication_prepare=50 search_generation=100 catalog_publication=30 unattributed=20"
+        ));
+        assert!(markdown.contains("indexer_io_ms: source_prepare=41 projection_batch_wall=50"));
+        assert!(markdown.contains("projection_batches: transactions=2"));
         assert!(
             markdown
-                .contains("semantic_ms: doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")
+                .contains("semantic_ms: node_load=66 node_rows=8192 context=67 doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")
         );
         assert!(markdown.contains("semantic_docs: reused=11 embedded=12 pending=13 stale=14"));
         assert!(markdown.contains(

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -306,6 +306,25 @@ fn append_index_phase_timings(markdown: &mut String, timings: &IndexingPhaseTimi
         timings.cleanup_ms,
         timings.cache_refresh_ms.unwrap_or(0)
     );
+    if let Some(wall) = timings.full_refresh_wall.as_ref() {
+        let _ = writeln!(
+            markdown,
+            "full_refresh_wall_ms: core_refresh={} live_inspection={} source_discovery={} stage_open={} indexer_execution={} coverage_validation={} copy_forward={} semantic_stage={} snapshot_stage={} publication_prepare={} search_generation={} catalog_publication={} unattributed={}",
+            wall.core_refresh_ms,
+            wall.live_inspection_ms,
+            wall.source_discovery_ms,
+            wall.stage_open_ms,
+            wall.indexer_execution_ms,
+            wall.coverage_validation_ms,
+            wall.copy_forward_ms,
+            wall.semantic_stage_ms,
+            wall.snapshot_stage_ms,
+            wall.publication_prepare_ms,
+            wall.search_generation_ms,
+            wall.catalog_publication_ms,
+            wall.unattributed_ms,
+        );
+    }
     append_index_cache_timings(markdown, timings);
     let _ = writeln!(
         markdown,
@@ -330,6 +349,19 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
             ("search_index", timings.search_symbol_index_ms),
             ("runtime_publish", timings.runtime_cache_publish_ms),
         ],
+    );
+    append_optional_timings_line(
+        markdown,
+        "indexer_io_ms",
+        &[
+            ("source_prepare", timings.source_prepare_ms),
+            ("projection_batch_wall", timings.projection_batch_wall_ms),
+        ],
+    );
+    append_optional_timings_line(
+        markdown,
+        "projection_batches",
+        &[("transactions", timings.projection_batch_transactions)],
     );
     append_optional_timings_line(
         markdown,
@@ -386,7 +418,9 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
             ("docs", timings.search_symbol_index_docs_written),
             ("writers", timings.search_symbol_index_writer_count),
             ("commits", timings.search_symbol_index_commit_count),
+            ("commit_ms", timings.search_symbol_index_commit_ms),
             ("reloads", timings.search_symbol_index_reload_count),
+            ("reload_ms", timings.search_symbol_index_reload_ms),
         ],
     );
     append_optional_timings_line(
@@ -429,6 +463,9 @@ fn append_index_semantic_timings(markdown: &mut String, timings: &IndexingPhaseT
         markdown,
         "semantic_ms",
         &[
+            ("node_load", timings.semantic_node_load_ms),
+            ("node_rows", timings.semantic_node_load_rows),
+            ("context", timings.semantic_context_ms),
             ("doc_build", timings.semantic_doc_build_ms),
             ("embedding", timings.semantic_embedding_ms),
             ("db_upsert", timings.semantic_db_upsert_ms),

--- a/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
+++ b/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
@@ -21,6 +21,7 @@ struct RepoE2eStats {
     embed_batch_size: u32,
     search_dir_unchanged: bool,
     index_seconds: f64,
+    phase_timings: Value,
     graph_phase_seconds: f64,
     semantic_phase_seconds: f64,
     semantic_embedding_ms: u64,
@@ -37,6 +38,7 @@ struct RepoE2eStats {
     semantic_docs_pending: u64,
     semantic_docs_stale: u64,
     repeat_full_refresh_seconds: f64,
+    repeat_phase_timings: Value,
     repeat_graph_phase_seconds: f64,
     repeat_semantic_phase_seconds: f64,
     repeat_semantic_doc_build_ms: u64,
@@ -348,6 +350,29 @@ fn parse_repeat_full_refresh_seconds(value: &str) -> Option<f64> {
 fn parse_stats_seconds(value: &str) -> Option<f64> {
     let value = value.replace(',', "");
     value.parse::<f64>().ok().filter(|value| value.is_finite())
+}
+
+fn retained_phase_timings(index_json: &Value) -> Value {
+    index_json
+        .get("phase_timings")
+        .filter(|value| value.is_object())
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+#[test]
+fn retained_phase_timings_preserve_additive_diagnostics() {
+    let index_json = serde_json::json!({
+        "phase_timings": {
+            "parse_index_ms": 12,
+            "future_additive_diagnostic": {"rows": 34}
+        }
+    });
+
+    let retained = retained_phase_timings(&index_json);
+
+    assert_eq!(retained["parse_index_ms"], 12);
+    assert_eq!(retained["future_additive_diagnostic"]["rows"], 34);
 }
 
 #[derive(Debug)]
@@ -1044,6 +1069,7 @@ fn codestory_repo_release_e2e_emits_stats() {
         embed_batch_size: 128,
         search_dir_unchanged,
         index_seconds,
+        phase_timings: retained_phase_timings(&index_json),
         graph_phase_seconds: graph_phase_ms as f64 / 1000.0,
         semantic_phase_seconds,
         semantic_embedding_ms: optional_u64_field(
@@ -1099,6 +1125,7 @@ fn codestory_repo_release_e2e_emits_stats() {
             &["phase_timings", "semantic_docs_stale"],
         ),
         repeat_full_refresh_seconds,
+        repeat_phase_timings: retained_phase_timings(&repeat_index_json),
         repeat_graph_phase_seconds: repeat_graph_phase_ms as f64 / 1000.0,
         repeat_semantic_phase_seconds: repeat_semantic_phase_ms as f64 / 1000.0,
         repeat_semantic_doc_build_ms,

--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -68,7 +68,7 @@ pub use errors::{
     ApiError, ApiErrorDetails, COMMAND_FAILURE_SCHEMA_VERSION, CommandFailureEnvelope,
     EmbeddingCapacityPressureDto, EmbeddingRetryStateDto,
 };
-pub use events::{AppEventPayload, IndexingPhaseTimings};
+pub use events::{AppEventPayload, FullRefreshWallTimings, IndexingPhaseTimings};
 pub use ids::{EdgeId, NodeId};
 pub use types::{
     EdgeKind, IndexMode, LayoutDirection, MemberAccess, NodeKind, TrailCallerScope, TrailDirection,

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -1,8 +1,27 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct FullRefreshWallTimings {
+    pub core_refresh_ms: u32,
+    pub live_inspection_ms: u32,
+    pub source_discovery_ms: u32,
+    pub stage_open_ms: u32,
+    pub indexer_execution_ms: u32,
+    pub coverage_validation_ms: u32,
+    pub copy_forward_ms: u32,
+    pub semantic_stage_ms: u32,
+    pub snapshot_stage_ms: u32,
+    pub publication_prepare_ms: u32,
+    pub search_generation_ms: u32,
+    pub catalog_publication_ms: u32,
+    pub unattributed_ms: u32,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Type)]
 pub struct IndexingPhaseTimings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_refresh_wall: Option<FullRefreshWallTimings>,
     pub parse_index_ms: u32,
     pub projection_flush_ms: u32,
     pub edge_resolution_ms: u32,
@@ -42,6 +61,12 @@ pub struct IndexingPhaseTimings {
     pub full_refresh_chunk_budget_overruns: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_refresh_chunk_planning_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_prepare_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection_batch_wall_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection_batch_transactions: Option<u32>,
     pub cache_refresh_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_projection_rebuild_ms: Option<u32>,
@@ -62,7 +87,17 @@ pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_symbol_index_reload_count: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_index_commit_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_symbol_index_reload_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_cache_publish_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_node_load_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_node_load_rows: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_context_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_doc_build_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -242,6 +277,7 @@ mod tests {
     #[test]
     fn test_indexing_phase_timings_omits_optional_resolution_fields_when_none() {
         let timings = IndexingPhaseTimings {
+            full_refresh_wall: None,
             parse_index_ms: 1,
             projection_flush_ms: 2,
             edge_resolution_ms: 3,
@@ -264,6 +300,9 @@ mod tests {
             full_refresh_chunk_max_nodes: None,
             full_refresh_chunk_budget_overruns: None,
             full_refresh_chunk_planning_ms: None,
+            source_prepare_ms: None,
+            projection_batch_wall_ms: None,
+            projection_batch_transactions: None,
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_stream_ms: None,
@@ -274,7 +313,12 @@ mod tests {
             search_symbol_index_writer_count: None,
             search_symbol_index_commit_count: None,
             search_symbol_index_reload_count: None,
+            search_symbol_index_commit_ms: None,
+            search_symbol_index_reload_ms: None,
             runtime_cache_publish_ms: None,
+            semantic_node_load_ms: None,
+            semantic_node_load_rows: None,
+            semantic_context_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
             semantic_db_upsert_ms: None,
@@ -350,6 +394,7 @@ mod tests {
         };
 
         let value = serde_json::to_value(timings).expect("serialize timings");
+        assert!(value.get("full_refresh_wall").is_none());
         assert!(value.get("artifact_cache_write_ms").is_none());
         assert!(value.get("artifact_cache_writes").is_none());
         assert!(value.get("artifact_cache_write_transactions").is_none());
@@ -367,11 +412,17 @@ mod tests {
         assert!(value.get("full_refresh_chunk_max_nodes").is_none());
         assert!(value.get("full_refresh_chunk_budget_overruns").is_none());
         assert!(value.get("full_refresh_chunk_planning_ms").is_none());
+        assert!(value.get("source_prepare_ms").is_none());
+        assert!(value.get("projection_batch_wall_ms").is_none());
+        assert!(value.get("projection_batch_transactions").is_none());
         assert!(value.get("resolution_unresolved_counts_ms").is_none());
         assert!(value.get("resolution_calls_ms").is_none());
         assert!(value.get("resolution_imports_ms").is_none());
         assert!(value.get("resolution_cleanup_ms").is_none());
         assert!(value.get("semantic_doc_build_ms").is_none());
+        assert!(value.get("semantic_node_load_ms").is_none());
+        assert!(value.get("semantic_node_load_rows").is_none());
+        assert!(value.get("semantic_context_ms").is_none());
         assert!(value.get("semantic_embedding_ms").is_none());
         assert!(value.get("semantic_db_upsert_ms").is_none());
         assert!(value.get("semantic_reload_ms").is_none());
@@ -385,6 +436,8 @@ mod tests {
         assert!(value.get("search_symbol_index_writer_count").is_none());
         assert!(value.get("search_symbol_index_commit_count").is_none());
         assert!(value.get("search_symbol_index_reload_count").is_none());
+        assert!(value.get("search_symbol_index_commit_ms").is_none());
+        assert!(value.get("search_symbol_index_reload_ms").is_none());
         assert!(value.get("runtime_cache_publish_ms").is_none());
         assert!(value.get("semantic_docs_reused").is_none());
         assert!(value.get("semantic_docs_embedded").is_none());
@@ -457,5 +510,57 @@ mod tests {
         assert!(value.get("resolved_imports_global_unique").is_none());
         assert!(value.get("resolved_imports_fuzzy").is_none());
         assert!(value.get("resolved_imports_semantic").is_none());
+    }
+
+    #[test]
+    fn test_indexing_phase_timings_accepts_legacy_json_without_full_refresh_wall() {
+        let timings: IndexingPhaseTimings = serde_json::from_value(serde_json::json!({
+            "parse_index_ms": 1,
+            "projection_flush_ms": 2,
+            "edge_resolution_ms": 3,
+            "error_flush_ms": 4,
+            "cleanup_ms": 5,
+            "cache_refresh_ms": null,
+            "unresolved_calls_start": 6,
+            "unresolved_imports_start": 7,
+            "resolved_calls": 8,
+            "resolved_imports": 9,
+            "unresolved_calls_end": 10,
+            "unresolved_imports_end": 11
+        }))
+        .expect("deserialize legacy timings");
+
+        assert!(timings.full_refresh_wall.is_none());
+        assert!(timings.semantic_node_load_ms.is_none());
+        assert!(timings.search_symbol_index_commit_ms.is_none());
+    }
+
+    #[test]
+    fn test_indexing_phase_timings_round_trips_full_refresh_wall() {
+        let wall = FullRefreshWallTimings {
+            core_refresh_ms: 78,
+            live_inspection_ms: 1,
+            source_discovery_ms: 2,
+            stage_open_ms: 3,
+            indexer_execution_ms: 4,
+            coverage_validation_ms: 5,
+            copy_forward_ms: 6,
+            semantic_stage_ms: 7,
+            snapshot_stage_ms: 8,
+            publication_prepare_ms: 9,
+            search_generation_ms: 10,
+            catalog_publication_ms: 11,
+            unattributed_ms: 12,
+        };
+        let timings = IndexingPhaseTimings {
+            full_refresh_wall: Some(wall.clone()),
+            ..IndexingPhaseTimings::default()
+        };
+
+        let value = serde_json::to_value(&timings).expect("serialize timings");
+        assert_eq!(value["full_refresh_wall"]["core_refresh_ms"], 78);
+        let decoded: IndexingPhaseTimings =
+            serde_json::from_value(value).expect("deserialize timings");
+        assert_eq!(decoded.full_refresh_wall, Some(wall));
     }
 }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -805,6 +805,9 @@ pub enum IndexingEvent {
 pub struct IncrementalIndexingStats {
     pub setup_existing_projection_ids_ms: u64,
     pub setup_seed_symbol_table_ms: u64,
+    /// Full source preparation wall time, including artifact-cache lookups.
+    pub source_prepare_ms: u64,
+    /// Backward-compatible alias for `source_prepare_ms`.
     pub artifact_cache_lookup_ms: u64,
     pub artifact_cache_write_ms: u64,
     pub artifact_cache_hits: usize,
@@ -828,6 +831,8 @@ pub struct IncrementalIndexingStats {
     pub full_refresh_chunk_planning_ms: u64,
     pub parse_index_ms: u64,
     pub projection_flush_ms: u64,
+    pub projection_batch_wall_ms: u64,
+    pub projection_batch_transactions: usize,
     pub flush_files_ms: u64,
     pub flush_nodes_ms: u64,
     pub flush_edges_ms: u64,
@@ -1165,6 +1170,7 @@ impl<'a> ProjectionWriter<'a> {
                 self.storage,
                 &mut self.batched_storage,
                 &mut self.had_edges,
+                &mut self.stats,
             )?;
             accumulate_flush_breakdown(&mut self.stats, breakdown);
             WorkspaceIndexer::flush_file_errors(
@@ -1194,6 +1200,7 @@ impl<'a> ProjectionWriter<'a> {
             self.storage,
             &mut self.batched_storage,
             &mut self.had_edges,
+            &mut self.stats,
         )?;
         accumulate_flush_breakdown(&mut self.stats, breakdown);
         WorkspaceIndexer::flush_file_errors(
@@ -1678,9 +1685,11 @@ impl WorkspaceIndexer {
             }
         }
         let progress_already_emitted = serial_progress.map_or(0, |_| storages.len());
+        let source_prepare_ms = duration_ms_u64(lookup_started.elapsed());
+        stats.source_prepare_ms = stats.source_prepare_ms.saturating_add(source_prepare_ms);
         stats.artifact_cache_lookup_ms = stats
             .artifact_cache_lookup_ms
-            .saturating_add(duration_ms_u64(lookup_started.elapsed()));
+            .saturating_add(source_prepare_ms);
 
         let parse_started = Instant::now();
         let parse_results: Vec<PreparedIndexJobResult> = parse_jobs
@@ -2330,8 +2339,11 @@ impl WorkspaceIndexer {
         storage: &mut Storage,
         batched_storage: &mut IntermediateStorage,
         had_edges: &mut bool,
+        stats: &mut IncrementalIndexingStats,
     ) -> Result<codestory_store::ProjectionFlushBreakdown> {
         reconcile_rust_impl_anchors(storage, batched_storage)?;
+        let has_rows = projection_batch_has_rows(batched_storage);
+        let flush_started = has_rows.then(Instant::now);
         let breakdown = storage
             .projections()
             .flush_projection_batch(codestory_store::ProjectionBatch {
@@ -2344,6 +2356,14 @@ impl WorkspaceIndexer {
                 callable_projection_states: &batched_storage.callable_projection_states,
             })
             .map_err(|e| anyhow!("Storage error: {:?}", e))?;
+        if let Some(flush_started) = flush_started {
+            let batch_wall_ms = duration_ms_u64(flush_started.elapsed());
+            debug_assert!(batch_wall_ms >= projection_flush_breakdown_ms(&breakdown));
+            stats.projection_batch_wall_ms =
+                stats.projection_batch_wall_ms.saturating_add(batch_wall_ms);
+            stats.projection_batch_transactions =
+                stats.projection_batch_transactions.saturating_add(1);
+        }
         if !batched_storage.edges.is_empty() {
             *had_edges = true;
         }
@@ -2964,6 +2984,25 @@ fn duration_ms_u64(duration: std::time::Duration) -> u64 {
     duration.as_millis().min(u64::MAX as u128) as u64
 }
 
+fn projection_batch_has_rows(storage: &IntermediateStorage) -> bool {
+    !storage.files.is_empty()
+        || !storage.file_content_hashes.is_empty()
+        || !storage.nodes.is_empty()
+        || !storage.edges.is_empty()
+        || !storage.occurrences.is_empty()
+        || !storage.component_access.is_empty()
+        || !storage.callable_projection_states.is_empty()
+}
+
+fn projection_flush_breakdown_ms(breakdown: &codestory_store::ProjectionFlushBreakdown) -> u64 {
+    u64::from(breakdown.files_ms)
+        .saturating_add(u64::from(breakdown.nodes_ms))
+        .saturating_add(u64::from(breakdown.edges_ms))
+        .saturating_add(u64::from(breakdown.occurrences_ms))
+        .saturating_add(u64::from(breakdown.component_access_ms))
+        .saturating_add(u64::from(breakdown.callable_projection_ms))
+}
+
 fn accumulate_projection_writer_stats(
     stats: &mut IncrementalIndexingStats,
     writer_stats: &IncrementalIndexingStats,
@@ -2986,6 +3025,12 @@ fn accumulate_projection_writer_stats(
     stats.projection_flush_ms = stats
         .projection_flush_ms
         .saturating_add(writer_stats.projection_flush_ms);
+    stats.projection_batch_wall_ms = stats
+        .projection_batch_wall_ms
+        .saturating_add(writer_stats.projection_batch_wall_ms);
+    stats.projection_batch_transactions = stats
+        .projection_batch_transactions
+        .saturating_add(writer_stats.projection_batch_transactions);
     stats.flush_files_ms = stats
         .flush_files_ms
         .saturating_add(writer_stats.flush_files_ms);
@@ -3014,12 +3059,7 @@ fn accumulate_flush_breakdown(
     stats: &mut IncrementalIndexingStats,
     breakdown: codestory_store::ProjectionFlushBreakdown,
 ) {
-    let total = u64::from(breakdown.files_ms)
-        .saturating_add(u64::from(breakdown.nodes_ms))
-        .saturating_add(u64::from(breakdown.edges_ms))
-        .saturating_add(u64::from(breakdown.occurrences_ms))
-        .saturating_add(u64::from(breakdown.component_access_ms))
-        .saturating_add(u64::from(breakdown.callable_projection_ms));
+    let total = projection_flush_breakdown_ms(&breakdown);
     stats.projection_flush_ms = stats.projection_flush_ms.saturating_add(total);
     stats.flush_files_ms = stats
         .flush_files_ms
@@ -21623,6 +21663,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert_eq!(stats.full_refresh_chunk_max_planned_bytes, 0);
         assert_eq!(stats.full_refresh_chunk_max_nodes, 0);
         assert_eq!(stats.full_refresh_chunk_budget_overruns, 0);
+        assert_eq!(stats.projection_batch_transactions, 0);
+        assert_eq!(stats.projection_batch_wall_ms, 0);
         Ok(())
     }
 
@@ -21703,6 +21745,9 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert_eq!(stats.artifact_cache_misses, 1);
         assert_eq!(stats.artifact_cache_hits, 1);
         assert_eq!(stats.artifact_cache_write_transactions, 1);
+        assert_eq!(stats.source_prepare_ms, stats.artifact_cache_lookup_ms);
+        assert_eq!(stats.projection_batch_transactions, 1);
+        assert!(stats.projection_batch_wall_ms >= stats.projection_flush_ms);
         assert_eq!(
             storage
                 .get_nodes()?
@@ -21783,9 +21828,24 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert_eq!(serial_stats.full_refresh_queue_capacity, 0);
         assert_eq!(pipeline_stats.full_refresh_queue_capacity, 1);
         assert_eq!(
+            serial_stats.source_prepare_ms,
+            serial_stats.artifact_cache_lookup_ms
+        );
+        assert_eq!(
+            pipeline_stats.source_prepare_ms,
+            pipeline_stats.artifact_cache_lookup_ms
+        );
+        assert_eq!(
             serial_stats.artifact_cache_write_transactions,
             pipeline_stats.artifact_cache_write_transactions
         );
+        assert_eq!(
+            serial_stats.projection_batch_transactions,
+            pipeline_stats.projection_batch_transactions
+        );
+        assert!(serial_stats.projection_batch_transactions > 0);
+        assert!(serial_stats.projection_batch_wall_ms >= serial_stats.projection_flush_ms);
+        assert!(pipeline_stats.projection_batch_wall_ms >= pipeline_stats.projection_flush_ms);
         Ok(())
     }
 

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -14,29 +14,29 @@ use codestory_contracts::api::{
     AgentHybridWeightsDto, AgentPacketDto, AgentPacketRequestDto, ApiError, AppEventPayload,
     BookmarkCategoryDto, BookmarkDto, CreateBookmarkCategoryRequest, CreateBookmarkRequest, EdgeId,
     EdgeKind, EdgeOccurrencesRequest, EmbeddingProfileContractDto, FileCoverageDiagnosticDto,
-    FrameworkRouteCoverageDto, GraphEdgeDto, GraphNodeDto, GraphRequest, GraphResponse,
-    GroundingBudgetDto, GroundingCoverageBucketDto, GroundingFileDigestDto, GroundingSnapshotDto,
-    GroundingSymbolDigestDto, IndexDryRunDto, IndexFreshnessChangeKindDto, IndexFreshnessDto,
-    IndexFreshnessSampleDto, IndexFreshnessStatusDto, IndexMode, IndexPublicationDto,
-    IndexPublicationModeDto, IndexedFileDto, IndexedFileIncompleteReasonCountDto,
-    IndexedFileLanguageCountDto, IndexedFileRoleDto, IndexedFilesDto, IndexedFilesRequest,
-    IndexedFilesSummaryDto, IndexingPhaseTimings, ListChildrenSymbolsRequest,
-    ListRootSymbolsRequest, MemberAccess, NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind,
-    NodeOccurrencesRequest, OpenContainingFolderRequest, OpenDefinitionRequest, OpenProjectRequest,
-    ProjectSummary, ReadFileTextRequest, ReadFileTextResponse, RepoTextScanStatsDto,
-    RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalScoreBreakdownDto, RetrievalStateDto,
-    RouteEndpointHandlerDto, RouteEndpointKindDto, RouteEndpointMetadataDto, SearchHit,
-    SearchHitOrigin, SearchHybridLimitsDto, SearchMatchQualityDto, SearchPlanAnchorGroupDto,
-    SearchPlanBridgeConfidenceDto, SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto,
-    SearchPlanBridgeStatusDto, SearchPlanCandidateWindowDto, SearchPlanChannelDto,
-    SearchPlanDroppedTermDto, SearchPlanDto, SearchPlanNextActionDto, SearchPlanPromotionStatusDto,
-    SearchPlanRejectedHitDto, SearchPlanSubqueryDto, SearchPlanTermsDto, SearchQueryAssessmentDto,
-    SearchRepoTextMode, SearchRequest, SearchResultsDto, SemanticModeDto, SnippetContextDto,
-    SourceOccurrenceDto, SourcePolicyExclusionDto, StartIndexingRequest, StorageStatsDto,
-    StoredSemanticDocsContractDto, SummaryGenerationDto, SymbolContextDto, SymbolSummaryDto,
-    SystemActionResponse, TrailConfigDto, TrailContextDto, TrailFilterOptionsDto,
-    UpdateBookmarkCategoryRequest, UpdateBookmarkRequest, WorkspaceMemberIndexDto,
-    WriteFileResponse, WriteFileTextRequest,
+    FrameworkRouteCoverageDto, FullRefreshWallTimings, GraphEdgeDto, GraphNodeDto, GraphRequest,
+    GraphResponse, GroundingBudgetDto, GroundingCoverageBucketDto, GroundingFileDigestDto,
+    GroundingSnapshotDto, GroundingSymbolDigestDto, IndexDryRunDto, IndexFreshnessChangeKindDto,
+    IndexFreshnessDto, IndexFreshnessSampleDto, IndexFreshnessStatusDto, IndexMode,
+    IndexPublicationDto, IndexPublicationModeDto, IndexedFileDto,
+    IndexedFileIncompleteReasonCountDto, IndexedFileLanguageCountDto, IndexedFileRoleDto,
+    IndexedFilesDto, IndexedFilesRequest, IndexedFilesSummaryDto, IndexingPhaseTimings,
+    ListChildrenSymbolsRequest, ListRootSymbolsRequest, MemberAccess, NodeDetailsDto,
+    NodeDetailsRequest, NodeId, NodeKind, NodeOccurrencesRequest, OpenContainingFolderRequest,
+    OpenDefinitionRequest, OpenProjectRequest, ProjectSummary, ReadFileTextRequest,
+    ReadFileTextResponse, RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalModeDto,
+    RetrievalScoreBreakdownDto, RetrievalStateDto, RouteEndpointHandlerDto, RouteEndpointKindDto,
+    RouteEndpointMetadataDto, SearchHit, SearchHitOrigin, SearchHybridLimitsDto,
+    SearchMatchQualityDto, SearchPlanAnchorGroupDto, SearchPlanBridgeConfidenceDto,
+    SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto, SearchPlanBridgeStatusDto,
+    SearchPlanCandidateWindowDto, SearchPlanChannelDto, SearchPlanDroppedTermDto, SearchPlanDto,
+    SearchPlanNextActionDto, SearchPlanPromotionStatusDto, SearchPlanRejectedHitDto,
+    SearchPlanSubqueryDto, SearchPlanTermsDto, SearchQueryAssessmentDto, SearchRepoTextMode,
+    SearchRequest, SearchResultsDto, SemanticModeDto, SnippetContextDto, SourceOccurrenceDto,
+    SourcePolicyExclusionDto, StartIndexingRequest, StorageStatsDto, StoredSemanticDocsContractDto,
+    SummaryGenerationDto, SymbolContextDto, SymbolSummaryDto, SystemActionResponse, TrailConfigDto,
+    TrailContextDto, TrailFilterOptionsDto, UpdateBookmarkCategoryRequest, UpdateBookmarkRequest,
+    WorkspaceMemberIndexDto, WriteFileResponse, WriteFileTextRequest,
 };
 use codestory_contracts::events::{Event, EventBus};
 use codestory_contracts::graph::{
@@ -4763,6 +4763,9 @@ fn read_line_capped<R: BufRead>(
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SemanticProjectionStats {
     reported: bool,
+    node_load_ms: u32,
+    node_load_rows: u32,
+    context_ms: u32,
     doc_build_ms: u32,
     embedding_ms: u32,
     db_upsert_ms: u32,
@@ -4804,6 +4807,8 @@ struct SearchStateBuildStats {
     search_symbol_index_writer_count: u32,
     search_symbol_index_commit_count: u32,
     search_symbol_index_reload_count: u32,
+    search_symbol_index_commit_ms: u32,
+    search_symbol_index_reload_ms: u32,
 }
 
 struct SearchStateBuildResult {
@@ -4828,6 +4833,9 @@ fn apply_semantic_projection_stats(
     if !stats.reported {
         return;
     }
+    timings.semantic_node_load_ms = Some(stats.node_load_ms);
+    timings.semantic_node_load_rows = Some(stats.node_load_rows);
+    timings.semantic_context_ms = Some(stats.context_ms);
     timings.semantic_doc_build_ms = Some(stats.doc_build_ms);
     timings.semantic_embedding_ms = Some(stats.embedding_ms);
     timings.semantic_db_upsert_ms = Some(stats.db_upsert_ms);
@@ -4861,6 +4869,8 @@ fn apply_cache_refresh_stats(timings: &mut IndexingPhaseTimings, stats: CacheRef
         Some(stats.search_stats.search_symbol_index_commit_count);
     timings.search_symbol_index_reload_count =
         Some(stats.search_stats.search_symbol_index_reload_count);
+    timings.search_symbol_index_commit_ms = Some(stats.search_stats.search_symbol_index_commit_ms);
+    timings.search_symbol_index_reload_ms = Some(stats.search_stats.search_symbol_index_reload_ms);
     timings.runtime_cache_publish_ms = stats.runtime_cache_publish_ms;
     apply_semantic_projection_stats(timings, stats.semantic_stats);
 }
@@ -4941,6 +4951,12 @@ fn build_search_state_for_nodes(
         search_symbol_index_writer_count: clamp_usize_to_u32(symbol_write_stats.writer_count),
         search_symbol_index_commit_count: clamp_usize_to_u32(symbol_write_stats.commit_count),
         search_symbol_index_reload_count: clamp_usize_to_u32(symbol_write_stats.reload_count),
+        search_symbol_index_commit_ms: clamp_u128_to_u32(
+            symbol_write_stats.commit_duration.as_millis(),
+        ),
+        search_symbol_index_reload_ms: clamp_u128_to_u32(
+            symbol_write_stats.reload_duration.as_millis(),
+        ),
     };
     engine.index_llm_symbol_docs(Vec::new());
     Ok(SearchStateBuildResult {
@@ -8461,12 +8477,14 @@ fn sync_llm_symbol_projection_for_runtime(
     let component_access = storage
         .get_component_access_map_for_nodes(&semantic_node_ids)
         .map_err(|e| ApiError::internal(format!("Failed to load symbol access metadata: {e}")))?;
+    let context_started = Instant::now();
     let graph_context = SemanticDocGraphContext::build_for_scope(
         storage,
         &context_nodes,
         nodes,
         semantic_doc_scope_from_value(&runtime.retrieval.semantic_doc_scope),
     )?;
+    stats.context_ms = clamp_u128_to_u32(context_started.elapsed().as_millis());
     let file_cache_started = Instant::now();
     let file_text_cache = build_semantic_file_text_cache(&graph_context, &semantic_nodes);
     doc_build_ns = doc_build_ns.saturating_add(file_cache_started.elapsed().as_nanos());
@@ -8795,16 +8813,19 @@ fn finalize_staged_semantic_docs_for_runtime(
     if is_indexing_cancelled(cancel_token) {
         return Err(indexing_cancelled_error());
     }
+    let node_load_started = Instant::now();
     let nodes = storage
         .get_nodes()
         .map_err(|error| ApiError::internal(format!("Failed to load staged nodes: {error}")))?;
+    let node_load_ms = clamp_u128_to_u32(node_load_started.elapsed().as_millis());
+    let node_load_rows = clamp_usize_to_u32(nodes.len());
     let node_names = nodes
         .iter()
         .map(|node| (node.id, node_display_name(node)))
         .collect::<HashMap<_, _>>();
     let mut engine = SearchEngine::new(None)
         .map_err(|error| ApiError::internal(format!("Failed to init semantic engine: {error}")))?;
-    sync_llm_symbol_projection_for_runtime(
+    let mut stats = sync_llm_symbol_projection_for_runtime(
         storage,
         &nodes,
         &node_names,
@@ -8817,7 +8838,10 @@ fn finalize_staged_semantic_docs_for_runtime(
         source_identity,
         cancel_token,
         runtime,
-    )
+    )?;
+    stats.node_load_ms = node_load_ms;
+    stats.node_load_rows = node_load_rows;
+    Ok(stats)
 }
 
 fn load_persisted_semantic_docs_for_runtime(
@@ -14148,6 +14172,58 @@ struct IndexingRunSummary {
     prepared_search_state: Option<SearchStateBuildResult>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct FullRefreshWallDurations {
+    live_inspection: Duration,
+    source_discovery: Duration,
+    stage_open: Duration,
+    indexer_execution: Duration,
+    coverage_validation: Duration,
+    copy_forward: Duration,
+    semantic_stage: Duration,
+    snapshot_stage: Duration,
+    publication_prepare: Duration,
+    search_generation: Duration,
+    catalog_publication: Duration,
+}
+
+impl FullRefreshWallDurations {
+    fn finish(self, core_refresh: Duration) -> FullRefreshWallTimings {
+        let accounted = [
+            self.live_inspection,
+            self.source_discovery,
+            self.stage_open,
+            self.indexer_execution,
+            self.coverage_validation,
+            self.copy_forward,
+            self.semantic_stage,
+            self.snapshot_stage,
+            self.publication_prepare,
+            self.search_generation,
+            self.catalog_publication,
+        ]
+        .into_iter()
+        .fold(Duration::ZERO, Duration::saturating_add);
+        let unattributed = core_refresh.saturating_sub(accounted);
+
+        FullRefreshWallTimings {
+            core_refresh_ms: clamp_u128_to_u32(core_refresh.as_millis()),
+            live_inspection_ms: clamp_u128_to_u32(self.live_inspection.as_millis()),
+            source_discovery_ms: clamp_u128_to_u32(self.source_discovery.as_millis()),
+            stage_open_ms: clamp_u128_to_u32(self.stage_open.as_millis()),
+            indexer_execution_ms: clamp_u128_to_u32(self.indexer_execution.as_millis()),
+            coverage_validation_ms: clamp_u128_to_u32(self.coverage_validation.as_millis()),
+            copy_forward_ms: clamp_u128_to_u32(self.copy_forward.as_millis()),
+            semantic_stage_ms: clamp_u128_to_u32(self.semantic_stage.as_millis()),
+            snapshot_stage_ms: clamp_u128_to_u32(self.snapshot_stage.as_millis()),
+            publication_prepare_ms: clamp_u128_to_u32(self.publication_prepare.as_millis()),
+            search_generation_ms: clamp_u128_to_u32(self.search_generation.as_millis()),
+            catalog_publication_ms: clamp_u128_to_u32(self.catalog_publication.as_millis()),
+            unattributed_ms: clamp_u128_to_u32(unattributed.as_millis()),
+        }
+    }
+}
+
 fn next_index_publication(
     previous: Option<&IndexPublicationRecord>,
     mode: IndexPublicationMode,
@@ -14248,6 +14324,9 @@ fn index_full_for_runtime(
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
     source_index_policy: &SourceIndexPolicy,
 ) -> Result<IndexingRunSummary, ApiError> {
+    let core_refresh_started = Instant::now();
+    let mut wall_durations = FullRefreshWallDurations::default();
+    let mut wall_stage_started = Instant::now();
     let previous_publication = if storage_path.exists() {
         Store::database_index_publication(storage_path).map_err(|error| {
             ApiError::internal(format!(
@@ -14334,11 +14413,15 @@ fn index_full_for_runtime(
                 }
             }
         });
+    wall_durations.live_inspection = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     let workspace = WorkspaceManifest::open(root.to_path_buf())
         .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
     let (execution_plan, policy_exclusions) =
         full_refresh_execution_plan_with_coverage(root, &workspace, source_index_policy)?;
 
+    wall_durations.source_discovery = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     let total_files = execution_plan.files_to_index.len().min(u32::MAX as usize) as u32;
     let _ = events_tx.send(AppEventPayload::IndexingStarted {
         file_count: total_files,
@@ -14357,6 +14440,8 @@ fn index_full_for_runtime(
     let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
     let indexer = V2WorkspaceIndexer::new(root.to_path_buf())
         .with_source_file_byte_cap(source_index_policy.byte_cap);
+    wall_durations.stage_open = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     let result = indexer.run(staged.store_mut(), &execution_plan, &bus, cancel_token);
 
     drop(bus);
@@ -14377,6 +14462,8 @@ fn index_full_for_runtime(
             return Err(ApiError::internal(format!("Indexing failed: {err}")));
         }
     };
+    wall_durations.indexer_execution = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     let coverage_gaps = match stored_file_coverage_diagnostics(root, staged.store_mut()) {
         Ok(coverage_gaps) => coverage_gaps,
         Err(error) => {
@@ -14422,6 +14509,8 @@ fn index_full_for_runtime(
             blocking_gaps,
         ));
     }
+    wall_durations.coverage_validation = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     if can_copy_forward {
         match staged
             .store_mut()
@@ -14458,6 +14547,8 @@ fn index_full_for_runtime(
             }
         }
     }
+    wall_durations.copy_forward = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     let staged_semantic_stats = match finalize_staged_semantic_docs_for_runtime(
         staged.store_mut(),
         None,
@@ -14476,6 +14567,8 @@ fn index_full_for_runtime(
         let _ = staged.discard();
         return Err(indexing_cancelled_error());
     }
+    wall_durations.semantic_stage = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     let staged_finalize_stats = match staged.snapshots().finalize_staged() {
         Ok(stats) => stats,
         Err(err) => {
@@ -14499,6 +14592,8 @@ fn index_full_for_runtime(
         let _ = staged.discard();
         return Err(indexing_cancelled_error());
     }
+    wall_durations.snapshot_stage = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     if recovering_incomplete_run && let Err(err) = staged.store_mut().begin_incremental_run() {
         let _ = staged.discard();
         return Err(ApiError::internal(format!(
@@ -14549,6 +14644,8 @@ fn index_full_for_runtime(
             "Failed to persist staged full publication identity: {error}"
         )));
     }
+    wall_durations.publication_prepare = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     let prepared_search_state = match rebuild_search_state_from_storage_for_runtime(
         staged.store_mut(),
         storage_path,
@@ -14571,6 +14668,8 @@ fn index_full_for_runtime(
         discard_unpublished_search_generation(storage_path, &publication);
         return Err(indexing_cancelled_error());
     }
+    wall_durations.search_generation = wall_stage_started.elapsed();
+    wall_stage_started = Instant::now();
     let staged_path = staged.path().to_path_buf();
     #[cfg(test)]
     if let Err(error) =
@@ -14649,11 +14748,14 @@ fn index_full_for_runtime(
         }
     };
     let publish_ms = clamp_u128_to_u32(publish_started.elapsed().as_millis());
+    wall_durations.catalog_publication = wall_stage_started.elapsed();
+    let full_refresh_wall = wall_durations.finish(core_refresh_started.elapsed());
     let resolution_telemetry = OptionalResolutionTelemetry::from_incremental_stats(&index_stats);
     let full_refresh_pipeline_enabled = index_stats.full_refresh_queue_capacity > 0;
     let full_refresh_chunking_enabled = index_stats.full_refresh_chunk_target_bytes > 0;
     Ok(IndexingRunSummary {
         phase_timings: IndexingPhaseTimings {
+            full_refresh_wall: Some(full_refresh_wall),
             parse_index_ms: clamp_u64_to_u32(index_stats.parse_index_ms),
             projection_flush_ms: clamp_u64_to_u32(index_stats.projection_flush_ms),
             edge_resolution_ms: clamp_u64_to_u32(index_stats.edge_resolution_ms),
@@ -14698,6 +14800,11 @@ fn index_full_for_runtime(
             ),
             full_refresh_chunk_planning_ms: full_refresh_chunking_enabled
                 .then_some(clamp_u64_to_u32(index_stats.full_refresh_chunk_planning_ms)),
+            source_prepare_ms: Some(clamp_u64_to_u32(index_stats.source_prepare_ms)),
+            projection_batch_wall_ms: Some(clamp_u64_to_u32(index_stats.projection_batch_wall_ms)),
+            projection_batch_transactions: Some(clamp_usize_to_u32(
+                index_stats.projection_batch_transactions,
+            )),
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_stream_ms: None,
@@ -14708,7 +14815,12 @@ fn index_full_for_runtime(
             search_symbol_index_writer_count: None,
             search_symbol_index_commit_count: None,
             search_symbol_index_reload_count: None,
+            search_symbol_index_commit_ms: None,
+            search_symbol_index_reload_ms: None,
             runtime_cache_publish_ms: None,
+            semantic_node_load_ms: None,
+            semantic_node_load_rows: None,
+            semantic_context_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
             semantic_db_upsert_ms: None,
@@ -15323,6 +15435,7 @@ fn run_incremental_indexing_common(
 
     Ok(IndexingRunSummary {
         phase_timings: IndexingPhaseTimings {
+            full_refresh_wall: None,
             parse_index_ms: clamp_u64_to_u32(index_stats.parse_index_ms),
             projection_flush_ms: clamp_u64_to_u32(index_stats.projection_flush_ms),
             edge_resolution_ms: clamp_u64_to_u32(index_stats.edge_resolution_ms),
@@ -15347,6 +15460,11 @@ fn run_incremental_indexing_common(
             full_refresh_chunk_max_nodes: None,
             full_refresh_chunk_budget_overruns: None,
             full_refresh_chunk_planning_ms: None,
+            source_prepare_ms: Some(clamp_u64_to_u32(index_stats.source_prepare_ms)),
+            projection_batch_wall_ms: Some(clamp_u64_to_u32(index_stats.projection_batch_wall_ms)),
+            projection_batch_transactions: Some(clamp_usize_to_u32(
+                index_stats.projection_batch_transactions,
+            )),
             cache_refresh_ms: None,
             search_projection_rebuild_ms: None,
             search_symbol_stream_ms: None,
@@ -15357,7 +15475,12 @@ fn run_incremental_indexing_common(
             search_symbol_index_writer_count: None,
             search_symbol_index_commit_count: None,
             search_symbol_index_reload_count: None,
+            search_symbol_index_commit_ms: None,
+            search_symbol_index_reload_ms: None,
             runtime_cache_publish_ms: None,
+            semantic_node_load_ms: None,
+            semantic_node_load_rows: None,
+            semantic_context_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
             semantic_db_upsert_ms: None,
@@ -15657,6 +15780,12 @@ fn build_persisted_search_state_from_canonical_symbols(
             search_symbol_index_writer_count: clamp_usize_to_u32(symbol_write_stats.writer_count),
             search_symbol_index_commit_count: clamp_usize_to_u32(symbol_write_stats.commit_count),
             search_symbol_index_reload_count: clamp_usize_to_u32(symbol_write_stats.reload_count),
+            search_symbol_index_commit_ms: clamp_u128_to_u32(
+                symbol_write_stats.commit_duration.as_millis(),
+            ),
+            search_symbol_index_reload_ms: clamp_u128_to_u32(
+                symbol_write_stats.reload_duration.as_millis(),
+            ),
         },
         semantic_stats,
     })
@@ -15858,6 +15987,21 @@ mod tests {
 
     #[path = "activation_coverage_tests.rs"]
     mod activation_coverage_tests;
+
+    #[test]
+    fn full_refresh_wall_residual_uses_raw_durations_before_millis_conversion() {
+        let wall = FullRefreshWallDurations {
+            live_inspection: Duration::from_micros(750),
+            source_discovery: Duration::from_micros(250),
+            ..FullRefreshWallDurations::default()
+        }
+        .finish(Duration::from_micros(1_500));
+
+        assert_eq!(wall.core_refresh_ms, 1);
+        assert_eq!(wall.live_inspection_ms, 0);
+        assert_eq!(wall.source_discovery_ms, 0);
+        assert_eq!(wall.unattributed_ms, 0);
+    }
 
     fn all_permutations<T: Clone>(values: &[T]) -> Vec<Vec<T>> {
         fn visit<T: Clone>(values: &mut [T], index: usize, output: &mut Vec<Vec<T>>) {
@@ -25531,6 +25675,33 @@ fn build_llm_symbol_doc_text() -> String {
         assert_eq!(full_timings.search_symbol_index_writer_count, Some(1));
         assert_eq!(full_timings.search_symbol_index_commit_count, Some(1));
         assert_eq!(full_timings.search_symbol_index_reload_count, Some(1));
+        assert!(full_timings.search_symbol_index_commit_ms.is_some());
+        assert!(full_timings.search_symbol_index_reload_ms.is_some());
+        assert!(full_timings.semantic_node_load_ms.is_some());
+        assert!(
+            full_timings
+                .semantic_node_load_rows
+                .is_some_and(|rows| rows > 0)
+        );
+        assert!(full_timings.semantic_context_ms.is_some());
+        let full_refresh_wall = full_timings
+            .full_refresh_wall
+            .as_ref()
+            .expect("full refresh wall accounting");
+        let accounted_ms = full_refresh_wall
+            .live_inspection_ms
+            .saturating_add(full_refresh_wall.source_discovery_ms)
+            .saturating_add(full_refresh_wall.stage_open_ms)
+            .saturating_add(full_refresh_wall.indexer_execution_ms)
+            .saturating_add(full_refresh_wall.coverage_validation_ms)
+            .saturating_add(full_refresh_wall.copy_forward_ms)
+            .saturating_add(full_refresh_wall.semantic_stage_ms)
+            .saturating_add(full_refresh_wall.snapshot_stage_ms)
+            .saturating_add(full_refresh_wall.publication_prepare_ms)
+            .saturating_add(full_refresh_wall.search_generation_ms)
+            .saturating_add(full_refresh_wall.catalog_publication_ms)
+            .saturating_add(full_refresh_wall.unattributed_ms);
+        assert!(accounted_ms <= full_refresh_wall.core_refresh_ms);
         assert_eq!(
             Storage::open(&storage_path)
                 .expect("open full publication")
@@ -25567,6 +25738,7 @@ fn build_llm_symbol_doc_text() -> String {
                 .is_none()
         );
         assert!(incremental_timings.full_refresh_chunk_planning_ms.is_none());
+        assert!(incremental_timings.full_refresh_wall.is_none());
         assert!(
             incremental_timings
                 .staged_sqlite_wal_autocheckpoint_bytes

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -15,6 +15,7 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tantivy::collector::TopDocs;
 use tantivy::doc;
 use tantivy::query::QueryParser;
@@ -387,6 +388,8 @@ pub struct SymbolIndexWriteStats {
     pub writer_count: usize,
     pub commit_count: usize,
     pub reload_count: usize,
+    pub commit_duration: Duration,
+    pub reload_duration: Duration,
 }
 
 pub struct SymbolIndexSession<'a> {
@@ -1110,14 +1113,20 @@ impl SymbolIndexSession<'_> {
         let writer_count = usize::from(self.writer.is_some());
         let mut commit_count = 0;
         let mut reload_count = 0;
+        let mut commit_duration = Duration::ZERO;
+        let mut reload_duration = Duration::ZERO;
         if let Some(mut writer) = self.writer.take() {
             #[cfg(test)]
             if take_symbol_index_test_fault(SymbolIndexTestFault::Commit) {
                 bail!("injected symbol index commit failure");
             }
+            let commit_started = Instant::now();
             writer.commit()?;
+            commit_duration = commit_started.elapsed();
             commit_count = 1;
+            let reload_started = Instant::now();
             self.engine.reader.reload()?;
+            reload_duration = reload_started.elapsed();
             reload_count = 1;
         }
         self.finished = true;
@@ -1126,6 +1135,8 @@ impl SymbolIndexSession<'_> {
             writer_count,
             commit_count,
             reload_count,
+            commit_duration,
+            reload_duration,
         })
     }
 }

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -274,6 +274,13 @@ Full-refresh timing output includes produced and persisted chunk counts, queue
 capacity and high-water mark, producer backpressure time, and writer idle time.
 Those fields are omitted for the serial incremental path.
 
+`source_prepare_ms` covers the cache-key source read, hashing, decode, and
+artifact lookup before a file is parsed or reused. `projection_batch_wall_ms`
+covers complete nonempty store flush calls, including transaction setup and
+commit; `projection_flush_ms` and its per-table breakdown are nested inside it.
+The accompanying transaction count is therefore a persistence boundary count,
+not a row count.
+
 ### 8. Resolution happens after flushes
 
 Once all batched projection data has been flushed, the indexer runs `ResolutionPass`.
@@ -407,12 +414,15 @@ and publishes the attested generation. Core indexing never loads the model.
 
 The index summary reports graph and semantic work separately:
 
-- `timings_ms.cache_refresh`: wrapper time for canonical symbol streaming, search indexing, semantic sync, and runtime publication
+- `full_refresh_wall_ms`: mutually exclusive full-refresh stages from live-state inspection through catalog publication. `core_refresh_ms` is their wall envelope and `unattributed_ms` is the raw-duration residual after subtracting the named siblings. This object is absent for incremental refresh.
+- `timings_ms.cache_refresh`: post-core runtime-cache installation. A prepared full publication has already built semantic and search state, so this is not their wrapper.
 - `cache_ms.search_projection`: compatibility timing for the retired SQLite search-symbol projection rebuild; fresh product builds report zero
 - `cache_ms.search_index`: runtime search index construction for symbol names
 - `symbol_index.stream_ms`, `stream_rows`, and `stream_batches`: nested canonical-node read telemetry; stream time is part of `cache_ms.search_index`, not an additive phase
-- `symbol_index`: documents written plus Tantivy writer, commit, and reader-reload counts; completed-generation reuse reports zero for each count
+- `symbol_index`: documents written plus Tantivy writer, commit, and reader-reload counts and final commit/reload durations; all are nested inside `cache_ms.search_index`, and completed-generation reuse reports zero
 - `cache_ms.runtime_publish`: publishing the rebuilt search state into the live runtime
+- `semantic_ms.node_load` and `node_rows`: loading the complete staged node set before semantic selection
+- `semantic_ms.context`: loading the graph context used by generated semantic documents
 - `semantic_ms.doc_build`: generated semantic text and hashes
 - `semantic_ms.embedding`: always zero for core indexing; retained as a compatibility field
 - `semantic_ms.db_upsert`: SQLite writes for symbol docs and embedding-free dense inputs
@@ -424,6 +434,13 @@ The index summary reports graph and semantic work separately:
 - `semantic_docs.pending`: changed dense-anchor inputs that require the next retrieval-generation decision
 - `semantic_docs.stale`: persisted dense-anchor inputs pruned because they no longer match the refreshed symbol set
 - `semantic_dense_docs_skipped` and `semantic_dense_*`: policy skip and dense-reason counters for `graph_first_v1`
+
+Only the sibling fields inside `full_refresh_wall_ms` are additive. Indexer
+children, semantic diagnostics, search stream/commit/reload timings, snapshot
+timings, SQLite checkpoint/sync timings, and runtime-cache publication are
+nested diagnostics and must not be added again. The repo-scale evidence
+artifact retains the complete first and repeat `phase_timings` objects so new
+diagnostics are not silently lost by a hand-maintained field list.
 
 Use these fields before changing parser, graph, or SQLite code for a slow
 `index` run.


### PR DESCRIPTION
Closes #1301

Refs #1275

## Context

The retained 3h57m exact-corpus run left 62.7% of wall time unattributed. Existing phase fields mixed nested diagnostics with incomplete outer envelopes, and the repo-scale artifact discarded most additive timing fields. That made the merged #1275 performance work impossible to judge cleanly on the next combined run.

Base: `c7e845d9f613fd2d638eb8fa533c231e9d427134`

Candidate: `1e98fe28`

## What changed

- adds an optional full-refresh-only wall object with mutually exclusive outer stages and a residual computed from raw durations before millisecond conversion
- times staged semantic node loading and graph-context construction that previously happened before `semantic_doc_build_ms`
- exposes source preparation plus complete nonempty projection-batch wall time and transaction counts
- times the final Tantivy commit and reader reload separately while retaining the one-writer/one-commit contract
- retains the complete first and repeat `phase_timings` JSON objects in repo-scale evidence
- renders and documents which fields are siblings versus nested diagnostics

Incremental refresh omits the full-refresh wall object. Existing timing meanings and old serialized JSON remain compatible.

## How to review

1. Check `FullRefreshWallDurations` boundaries in runtime: every successful full-refresh interval belongs to one sequential sibling, and the residual uses raw `Duration` values.
2. Check `IncrementalIndexingStats`: the source timing preserves the old cache-lookup alias; projection wall time wraps the store call through commit/invalidation and empty flushes do not count.
3. Check semantic/search propagation through `finish_successful_indexing`; prepared full state must retain staged semantic timings when cache stats are applied.
4. Check the CLI/evidence output and architecture nesting rules. Only full-refresh wall siblings are additive.

## Verification

- `cargo test -p codestory-contracts --lib --locked` (40 passed)
- focused indexer empty, exact-transaction, and serial/pipeline equivalence tests
- focused runtime raw residual, full/incremental durable-generation, and persisted multi-page writer tests
- `cargo test -p codestory-cli --bin codestory-cli render_index_markdown_includes_rich_timing_breakdown_when_available --locked`
- `cargo test -p codestory-cli --test codestory_repo_e2e_stats retained_phase_timings_preserve_additive_diagnostics --locked`
- `cargo check -p codestory-indexer -p codestory-runtime -p codestory-cli --locked`
- `cargo clippy -p codestory-contracts -p codestory-indexer -p codestory-runtime -p codestory-cli --all-targets --locked -- -D warnings`
- `node .github/scripts/check-doc-links.mjs`
- `cargo fmt --all --check`
- `git diff --check`
- independent exact-base review: no P0-P3 findings

The broad CLI unit pass was 226/227. The lone `hostile_drill_pin_change_retries_before_building_the_active_summary` failure reproduces unchanged on base `c7e845d9` and is not in this diff.

## Risk and proof boundary

The change is diagnostic and additive, but it touches the public timing DTO and the full publication path. Focused full/incremental and cancellation-adjacent publication coverage stayed green; independent review found no publication-fence change.

The retained exact corpus proof was not rerun or mutated. The final combined #1275 head owns the next large run.

Packaged CodeStory grounding did not converge at `CoreFreshness` and routed to exact-head source inspection.
