### PR TITLE
[codex] Bulk-build grounding summary indexes after materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Performance
 
+- Staged full refresh now bulk-builds grounding summary indexes around
+  materialization instead of maintaining them row by row. The node file-rank
+  index is created between node and file materialization for the file join;
+  deferred-index telemetry includes the pre-, mid-, and post-summary builds.
 - Full-refresh telemetry now reconciles exclusive outer wall stages and exposes
   previously hidden source preparation, complete projection transactions,
   semantic node/context loading, and final Tantivy commit/reload time. The

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -25840,6 +25840,61 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
+    fn full_refresh_post_summary_index_failure_preserves_live_publication() {
+        let workspace = tempdir().expect("workspace dir");
+        let source_path = workspace.path().join("lib.rs");
+        fs::write(&source_path, "pub fn retained_generation() -> i32 { 1 }\n")
+            .expect("write baseline source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish baseline");
+        let baseline = Storage::open(&storage_path)
+            .expect("open baseline")
+            .get_complete_index_publication()
+            .expect("read baseline publication")
+            .expect("baseline publication");
+
+        fs::write(&source_path, "pub fn rejected_generation() -> i32 { 2 }\n")
+            .expect("write replacement source");
+        arm_full_refresh_staged_store_hook(|storage| {
+            storage
+                .get_connection()
+                .execute_batch(
+                    "CREATE TABLE idx_grounding_file_snapshot_path (
+                         collision INTEGER
+                     );",
+                )
+                .expect("install post-summary index collision");
+        });
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect_err("post-summary destination index failure must reject the candidate");
+        assert!(
+            error.message.contains("idx_grounding_file_snapshot_path"),
+            "{error:?}"
+        );
+
+        let live = Storage::open(&storage_path).expect("reopen retained live publication");
+        assert_eq!(
+            live.get_complete_index_publication()
+                .expect("read retained publication"),
+            Some(baseline)
+        );
+        assert!(storage_has_symbol(&live, "retained_generation"));
+        assert!(!storage_has_symbol(&live, "rejected_generation"));
+        assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    #[test]
     fn incremental_publication_ignores_changed_files_without_graph_collectors() {
         let workspace = tempdir().expect("workspace dir");
         fs::write(

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -103,20 +103,30 @@ impl<'a> SnapshotStore<'a> {
         self.storage.create_deferred_secondary_indexes()
     }
 
-    /// Create deferred indexes and refresh the summary snapshot for publish.
+    /// Create deferred indexes around the summary snapshot build for publish.
     pub fn finalize_staged(&self) -> Result<StagedSnapshotFinalizeStats, StorageError> {
-        let deferred_started = Instant::now();
-        self.create_deferred_indexes()?;
-        let deferred_indexes_ms = clamp_u128_to_u32(deferred_started.elapsed().as_millis());
+        let pre_summary_indexes_started = Instant::now();
+        self.storage
+            .prepare_deferred_secondary_indexes_for_summary()?;
+        let pre_summary_indexes_duration = pre_summary_indexes_started.elapsed();
 
         let summary_started = Instant::now();
-        self.refresh_summary()?;
-        let summary_snapshot_ms = clamp_u128_to_u32(summary_started.elapsed().as_millis());
+        let node_file_rank_index_duration = self
+            .storage
+            .refresh_grounding_summary_snapshots_for_staged_finalize()?;
+        let summary_with_mid_index_duration = summary_started.elapsed();
 
-        Ok(StagedSnapshotFinalizeStats {
-            deferred_indexes_ms,
-            summary_snapshot_ms,
-        })
+        let post_summary_indexes_started = Instant::now();
+        self.storage
+            .complete_deferred_secondary_indexes_after_summary()?;
+        let post_summary_indexes_duration = post_summary_indexes_started.elapsed();
+
+        Ok(staged_snapshot_finalize_stats(
+            pre_summary_indexes_duration,
+            summary_with_mid_index_duration,
+            node_file_rank_index_duration,
+            post_summary_indexes_duration,
+        ))
     }
 
     /// Return whether the summary snapshot is ready for reads.
@@ -245,6 +255,23 @@ fn clamp_u128_to_u32(value: u128) -> u32 {
     value.min(u32::MAX as u128) as u32
 }
 
+fn staged_snapshot_finalize_stats(
+    pre_summary_indexes_duration: std::time::Duration,
+    summary_with_mid_index_duration: std::time::Duration,
+    node_file_rank_index_duration: std::time::Duration,
+    post_summary_indexes_duration: std::time::Duration,
+) -> StagedSnapshotFinalizeStats {
+    let deferred_indexes_duration = pre_summary_indexes_duration
+        .saturating_add(node_file_rank_index_duration)
+        .saturating_add(post_summary_indexes_duration);
+    let summary_snapshot_duration =
+        summary_with_mid_index_duration.saturating_sub(node_file_rank_index_duration);
+    StagedSnapshotFinalizeStats {
+        deferred_indexes_ms: clamp_u128_to_u32(deferred_indexes_duration.as_millis()),
+        summary_snapshot_ms: clamp_u128_to_u32(summary_snapshot_duration.as_millis()),
+    }
+}
+
 fn unique_staged_suffix() -> String {
     let epoch_ns = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -360,6 +387,106 @@ mod tests {
         assert_eq!(metadata.detail_state, GroundingSnapshotState::Dirty);
 
         let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn staged_finalize_builds_summary_destination_indexes_in_required_order() {
+        const DESTINATION_INDEXES: &[&str] = &[
+            "idx_grounding_file_snapshot_path",
+            "idx_grounding_file_snapshot_rank",
+            "idx_grounding_node_snapshot_file_rank",
+            "idx_grounding_node_snapshot_root_rank",
+        ];
+
+        let temp = fresh_temp_root("summary-index-order");
+        let live_path = temp.join("live.sqlite");
+        let mut staged = SnapshotStore::open_staged(&live_path).expect("open staged");
+        staged
+            .store_mut()
+            .insert_files_batch(&[crate::FileInfo {
+                id: 1,
+                path: PathBuf::from("ordered.rs"),
+                language: "rust".to_string(),
+                modification_time: 1,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: crate::FileRole::Source,
+            }])
+            .expect("seed staged file");
+        staged
+            .store_mut()
+            .get_connection()
+            .execute_batch(
+                "CREATE TRIGGER assert_summary_index_order
+                 BEFORE INSERT ON grounding_file_snapshot
+                 BEGIN
+                   SELECT CASE WHEN NOT EXISTS (
+                     SELECT 1 FROM sqlite_master
+                     WHERE type = 'index'
+                       AND name = 'idx_grounding_node_snapshot_file_rank'
+                   ) THEN RAISE(ABORT, 'node file-rank index missing before file aggregation') END;
+                   SELECT CASE WHEN EXISTS (
+                     SELECT 1 FROM sqlite_master
+                     WHERE type = 'index'
+                       AND name IN (
+                         'idx_grounding_file_snapshot_path',
+                         'idx_grounding_file_snapshot_rank',
+                         'idx_grounding_node_snapshot_root_rank'
+                       )
+                   ) THEN RAISE(ABORT, 'post-summary index built before file aggregation') END;
+                 END;",
+            )
+            .expect("install summary ordering assertion");
+
+        staged
+            .snapshots()
+            .finalize_staged()
+            .expect("finalize staged summary");
+
+        for index_name in DESTINATION_INDEXES {
+            let count: i64 = staged
+                .store_mut()
+                .get_connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                    [index_name],
+                    |row| row.get(0),
+                )
+                .expect("inspect destination index");
+            assert_eq!(count, 1, "missing destination index {index_name}");
+        }
+        assert!(
+            staged
+                .snapshots()
+                .has_ready_summary()
+                .expect("summary readiness")
+        );
+
+        staged.discard().expect("discard staged database");
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn staged_finalize_timing_excludes_mid_summary_index_build() {
+        let stats = staged_snapshot_finalize_stats(
+            std::time::Duration::from_millis(11),
+            std::time::Duration::from_millis(42),
+            std::time::Duration::from_millis(13),
+            std::time::Duration::from_millis(17),
+        );
+
+        assert_eq!(stats.deferred_indexes_ms, 41);
+        assert_eq!(stats.summary_snapshot_ms, 29);
+
+        let sub_millisecond_segments = staged_snapshot_finalize_stats(
+            std::time::Duration::from_micros(400),
+            std::time::Duration::from_micros(900),
+            std::time::Duration::from_micros(400),
+            std::time::Duration::from_micros(400),
+        );
+        assert_eq!(sub_millisecond_segments.deferred_indexes_ms, 1);
+        assert_eq!(sub_millisecond_segments.summary_snapshot_ms, 0);
     }
 
     #[test]

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -938,6 +938,50 @@ fn grounding_node_rank_sql(alias: &str) -> String {
     )
 }
 
+fn grounding_file_snapshot_cte_sql() -> String {
+    format!(
+        "WITH all_files AS (
+            SELECT id, path, language, modification_time, indexed, complete, line_count
+            FROM file
+            UNION ALL
+            SELECT
+                n.id,
+                n.serialized_name,
+                '',
+                0,
+                1,
+                1,
+                0
+            FROM node n
+            WHERE n.kind = {file_kind}
+              AND NOT EXISTS (SELECT 1 FROM file f WHERE f.id = n.id)
+        )",
+        file_kind = NodeKind::FILE as i32,
+    )
+}
+
+const GROUNDING_FILE_SNAPSHOT_SELECT_SQL: &str = "SELECT
+    f.id,
+    f.path,
+    f.language,
+    f.modification_time,
+    f.indexed,
+    f.complete,
+    f.line_count,
+    COUNT(gs.node_id) AS symbol_count,
+    MIN(CASE WHEN gs.node_id IS NULL THEN 255 ELSE gs.node_rank END) AS best_node_rank
+FROM all_files f
+LEFT JOIN grounding_node_snapshot gs
+  ON gs.file_node_id = f.id
+GROUP BY
+    f.id,
+    f.path,
+    f.language,
+    f.modification_time,
+    f.indexed,
+    f.complete,
+    f.line_count";
+
 fn outside_related_file_edge_predicate(file_param: &str) -> String {
     format!(
         "source_node_id NOT IN (SELECT node_id FROM {RELATED_NODE_IDS_TABLE})
@@ -2825,6 +2869,20 @@ impl Storage {
     }
 
     pub fn refresh_grounding_summary_snapshots(&self) -> Result<(), StorageError> {
+        self.refresh_grounding_summary_snapshots_impl(false)
+            .map(|_| ())
+    }
+
+    pub(crate) fn refresh_grounding_summary_snapshots_for_staged_finalize(
+        &self,
+    ) -> Result<Duration, StorageError> {
+        self.refresh_grounding_summary_snapshots_impl(self.deferred_secondary_indexes)
+    }
+
+    fn refresh_grounding_summary_snapshots_impl(
+        &self,
+        build_node_file_rank_index: bool,
+    ) -> Result<Duration, StorageError> {
         let rank_sql = grounding_node_rank_sql("n");
         let display_name = grounding_display_name_expr("n");
         let indexable = grounding_indexable_predicate("n");
@@ -2940,23 +2998,16 @@ impl Storage {
         );
         tx.execute(&node_snapshot_sql, [])?;
 
+        let node_file_rank_index_duration = if build_node_file_rank_index {
+            let started = Instant::now();
+            schema::create_grounding_node_file_rank_index(&tx)?;
+            started.elapsed()
+        } else {
+            Duration::ZERO
+        };
+
         let file_snapshot_sql = format!(
-            "WITH all_files AS (
-                SELECT id, path, language, modification_time, indexed, complete, line_count
-                FROM file
-                UNION ALL
-                SELECT
-                    n.id,
-                    n.serialized_name,
-                    '',
-                    0,
-                    1,
-                    1,
-                    0
-                FROM node n
-                WHERE n.kind = {file_kind}
-                  AND NOT EXISTS (SELECT 1 FROM file f WHERE f.id = n.id)
-            )
+            "{}
             INSERT INTO grounding_file_snapshot (
                 file_id,
                 path,
@@ -2968,28 +3019,9 @@ impl Storage {
                 symbol_count,
                 best_node_rank
             )
-            SELECT
-                f.id,
-                f.path,
-                f.language,
-                f.modification_time,
-                f.indexed,
-                f.complete,
-                f.line_count,
-                COUNT(gs.node_id) AS symbol_count,
-                MIN(CASE WHEN gs.node_id IS NULL THEN 255 ELSE gs.node_rank END) AS best_node_rank
-            FROM all_files f
-            LEFT JOIN grounding_node_snapshot gs
-              ON gs.file_node_id = f.id
-            GROUP BY
-                f.id,
-                f.path,
-                f.language,
-                f.modification_time,
-                f.indexed,
-                f.complete,
-                f.line_count",
-            file_kind = NodeKind::FILE as i32,
+            {}",
+            grounding_file_snapshot_cte_sql(),
+            GROUNDING_FILE_SNAPSHOT_SELECT_SQL,
         );
         tx.execute(&file_snapshot_sql, [])?;
 
@@ -3009,7 +3041,7 @@ impl Storage {
             ],
         )?;
         tx.commit()?;
-        Ok(())
+        Ok(node_file_rank_index_duration)
     }
 
     pub fn hydrate_grounding_detail_snapshots(&self) -> Result<(), StorageError> {
@@ -3421,9 +3453,12 @@ impl Storage {
     }
 
     pub fn finalize_staged_snapshot(&self) -> Result<(), StorageError> {
-        self.refresh_grounding_summary_snapshots()?;
         if self.deferred_secondary_indexes {
-            schema::create_deferred_indexes(&self.conn)?;
+            self.prepare_deferred_secondary_indexes_for_summary()?;
+            self.refresh_grounding_summary_snapshots_for_staged_finalize()?;
+            self.complete_deferred_secondary_indexes_after_summary()?;
+        } else {
+            self.refresh_grounding_summary_snapshots()?;
         }
         Ok(())
     }
@@ -3475,6 +3510,25 @@ impl Storage {
     pub fn create_deferred_secondary_indexes(&self) -> Result<(), StorageError> {
         if self.deferred_secondary_indexes {
             schema::create_deferred_indexes(&self.conn)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn prepare_deferred_secondary_indexes_for_summary(
+        &self,
+    ) -> Result<(), StorageError> {
+        if self.deferred_secondary_indexes {
+            schema::drop_grounding_summary_destination_indexes(&self.conn)?;
+            schema::create_pre_summary_secondary_indexes(&self.conn)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn complete_deferred_secondary_indexes_after_summary(
+        &self,
+    ) -> Result<(), StorageError> {
+        if self.deferred_secondary_indexes {
+            schema::create_post_summary_destination_indexes(&self.conn)?;
         }
         Ok(())
     }

--- a/crates/codestory-store/src/storage_impl/schema.rs
+++ b/crates/codestory-store/src/storage_impl/schema.rs
@@ -330,7 +330,7 @@ const LOAD_TIME_INDEX_STATEMENTS: &[&str] = &[
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_component_access_node ON component_access(node_id)",
 ];
 
-const SECONDARY_INDEX_STATEMENTS: &[&str] = &[
+const PRE_SUMMARY_SECONDARY_INDEX_STATEMENTS: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_occurrence_element ON occurrence(element_id)",
     "CREATE INDEX IF NOT EXISTS idx_occurrence_element_start_line ON occurrence(element_id, start_line)",
     "CREATE INDEX IF NOT EXISTS idx_occurrence_file ON occurrence(file_node_id)",
@@ -372,17 +372,42 @@ const SECONDARY_INDEX_STATEMENTS: &[&str] = &[
      ON search_symbol_projection(display_name)",
     "CREATE INDEX IF NOT EXISTS idx_callable_projection_state_node_id ON callable_projection_state(node_id)",
     "CREATE INDEX IF NOT EXISTS idx_callable_projection_state_file_node ON callable_projection_state(file_id, node_id)",
-    "CREATE INDEX IF NOT EXISTS idx_grounding_file_snapshot_path ON grounding_file_snapshot(path)",
-    "CREATE INDEX IF NOT EXISTS idx_grounding_file_snapshot_rank
-     ON grounding_file_snapshot(best_node_rank, symbol_count DESC, path)",
-    "CREATE INDEX IF NOT EXISTS idx_grounding_node_snapshot_file_rank
-     ON grounding_node_snapshot(file_node_id, file_symbol_rank, node_id)",
-    "CREATE INDEX IF NOT EXISTS idx_grounding_node_snapshot_root_rank
-     ON grounding_node_snapshot(is_root, node_rank, sort_start_line, display_name, node_id)",
     "CREATE INDEX IF NOT EXISTS idx_index_artifact_cache_key
      ON index_artifact_cache(cache_key)",
     "CREATE INDEX IF NOT EXISTS idx_retrieval_index_manifest_built_at
      ON retrieval_index_manifest(built_at_epoch_ms)",
+];
+
+const GROUNDING_FILE_SNAPSHOT_PATH_INDEX: &str =
+    "CREATE INDEX IF NOT EXISTS idx_grounding_file_snapshot_path ON grounding_file_snapshot(path)";
+const GROUNDING_FILE_SNAPSHOT_RANK_INDEX: &str =
+    "CREATE INDEX IF NOT EXISTS idx_grounding_file_snapshot_rank
+     ON grounding_file_snapshot(best_node_rank, symbol_count DESC, path)";
+const GROUNDING_NODE_SNAPSHOT_FILE_RANK_INDEX: &str =
+    "CREATE INDEX IF NOT EXISTS idx_grounding_node_snapshot_file_rank
+     ON grounding_node_snapshot(file_node_id, file_symbol_rank, node_id)";
+const GROUNDING_NODE_SNAPSHOT_ROOT_RANK_INDEX: &str =
+    "CREATE INDEX IF NOT EXISTS idx_grounding_node_snapshot_root_rank
+     ON grounding_node_snapshot(is_root, node_rank, sort_start_line, display_name, node_id)";
+
+const GROUNDING_SUMMARY_DESTINATION_INDEX_STATEMENTS: &[&str] = &[
+    GROUNDING_FILE_SNAPSHOT_PATH_INDEX,
+    GROUNDING_FILE_SNAPSHOT_RANK_INDEX,
+    GROUNDING_NODE_SNAPSHOT_FILE_RANK_INDEX,
+    GROUNDING_NODE_SNAPSHOT_ROOT_RANK_INDEX,
+];
+
+const POST_SUMMARY_DESTINATION_INDEX_STATEMENTS: &[&str] = &[
+    GROUNDING_FILE_SNAPSHOT_PATH_INDEX,
+    GROUNDING_FILE_SNAPSHOT_RANK_INDEX,
+    GROUNDING_NODE_SNAPSHOT_ROOT_RANK_INDEX,
+];
+
+const GROUNDING_SUMMARY_DESTINATION_INDEX_NAMES: &[&str] = &[
+    "idx_grounding_file_snapshot_path",
+    "idx_grounding_file_snapshot_rank",
+    "idx_grounding_node_snapshot_file_rank",
+    "idx_grounding_node_snapshot_root_rank",
 ];
 
 pub(super) fn create_tables(conn: &Connection) -> Result<(), StorageError> {
@@ -400,7 +425,38 @@ pub(super) fn create_load_indexes(conn: &Connection) -> Result<(), StorageError>
 }
 
 pub(super) fn create_secondary_indexes(conn: &Connection) -> Result<(), StorageError> {
-    for statement in SECONDARY_INDEX_STATEMENTS {
+    create_pre_summary_secondary_indexes(conn)?;
+    for statement in GROUNDING_SUMMARY_DESTINATION_INDEX_STATEMENTS {
+        conn.execute(statement, [])?;
+    }
+    Ok(())
+}
+
+pub(super) fn create_pre_summary_secondary_indexes(conn: &Connection) -> Result<(), StorageError> {
+    for statement in PRE_SUMMARY_SECONDARY_INDEX_STATEMENTS {
+        conn.execute(statement, [])?;
+    }
+    Ok(())
+}
+
+pub(super) fn drop_grounding_summary_destination_indexes(
+    conn: &Connection,
+) -> Result<(), StorageError> {
+    for index_name in GROUNDING_SUMMARY_DESTINATION_INDEX_NAMES {
+        conn.execute(&format!("DROP INDEX IF EXISTS {index_name}"), [])?;
+    }
+    Ok(())
+}
+
+pub(super) fn create_grounding_node_file_rank_index(conn: &Connection) -> Result<(), StorageError> {
+    conn.execute(GROUNDING_NODE_SNAPSHOT_FILE_RANK_INDEX, [])?;
+    Ok(())
+}
+
+pub(super) fn create_post_summary_destination_indexes(
+    conn: &Connection,
+) -> Result<(), StorageError> {
+    for statement in POST_SUMMARY_DESTINATION_INDEX_STATEMENTS {
         conn.execute(statement, [])?;
     }
     Ok(())

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -38,6 +38,19 @@ fn unique_temp_db_path(label: &str) -> PathBuf {
     ))
 }
 
+fn sqlite_index_exists(storage: &Storage, index_name: &str) -> Result<bool, StorageError> {
+    storage
+        .conn
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?1
+             )",
+            [index_name],
+            |row| row.get(0),
+        )
+        .map_err(StorageError::from)
+}
+
 fn create_versioned_observation_fixture(path: &Path, version: u32) {
     let connection = Connection::open(path).expect("create observation fixture");
     connection
@@ -4268,6 +4281,131 @@ fn test_resolution_query_plan_prefers_new_indexes() -> Result<(), StorageError> 
             .any(|line| line.contains("idx_edge_kind_resolved_target"))
     );
 
+    Ok(())
+}
+
+#[test]
+fn staged_summary_build_uses_bulk_node_file_rank_index_for_file_aggregation()
+-> Result<(), StorageError> {
+    const DESTINATION_INDEXES: &[&str] = &[
+        "idx_grounding_file_snapshot_path",
+        "idx_grounding_file_snapshot_rank",
+        "idx_grounding_node_snapshot_file_rank",
+        "idx_grounding_node_snapshot_root_rank",
+    ];
+
+    let db_path = unique_temp_db_path("summary-index-phases");
+    let _ = cleanup_sqlite_sidecars(&db_path);
+    let mut storage = Storage::open_build(&db_path)?;
+    storage.insert_files_batch(&[FileInfo {
+        id: 1,
+        path: PathBuf::from("src/lib.rs"),
+        language: "rust".to_string(),
+        modification_time: 1,
+        indexed: true,
+        complete: true,
+        line_count: 5,
+        file_role: FileRole::Source,
+    }])?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::FILE,
+            serialized_name: "src/lib.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(2),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "run".to_string(),
+            file_node_id: Some(NodeId(1)),
+            start_line: Some(1),
+            ..Default::default()
+        },
+    ])?;
+
+    storage.prepare_deferred_secondary_indexes_for_summary()?;
+    assert!(sqlite_index_exists(&storage, "idx_node_file")?);
+    for index_name in DESTINATION_INDEXES {
+        assert!(!sqlite_index_exists(&storage, index_name)?);
+    }
+
+    storage.refresh_grounding_summary_snapshots_for_staged_finalize()?;
+    assert!(sqlite_index_exists(
+        &storage,
+        "idx_grounding_node_snapshot_file_rank"
+    )?);
+    for index_name in [
+        "idx_grounding_file_snapshot_path",
+        "idx_grounding_file_snapshot_rank",
+        "idx_grounding_node_snapshot_root_rank",
+    ] {
+        assert!(!sqlite_index_exists(&storage, index_name)?);
+    }
+    assert!(storage.has_ready_grounding_summary_snapshots()?);
+    assert_eq!(storage.get_grounding_file_summary_count()?, 1);
+
+    let file_snapshot_plan_sql = format!(
+        "EXPLAIN QUERY PLAN\n{}\n{}",
+        grounding_file_snapshot_cte_sql(),
+        GROUNDING_FILE_SNAPSHOT_SELECT_SQL,
+    );
+    let mut plan_stmt = storage.conn.prepare(&file_snapshot_plan_sql)?;
+    let plan = plan_stmt
+        .query_map([], |row| row.get::<_, String>(3))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    assert!(
+        plan.iter()
+            .any(|line| line.contains("idx_grounding_node_snapshot_file_rank")),
+        "file-summary join did not use the persistent file-rank index: {plan:?}"
+    );
+    assert!(
+        plan.iter().all(|line| !line.contains("AUTOMATIC")),
+        "file-summary join built an automatic index: {plan:?}"
+    );
+    drop(plan_stmt);
+
+    storage.complete_deferred_secondary_indexes_after_summary()?;
+    for index_name in DESTINATION_INDEXES {
+        assert!(sqlite_index_exists(&storage, index_name)?);
+    }
+
+    drop(storage);
+    cleanup_sqlite_sidecars(&db_path)?;
+    Ok(())
+}
+
+#[test]
+fn legacy_staged_finalize_builds_complete_secondary_index_set() -> Result<(), StorageError> {
+    let db_path = unique_temp_db_path("legacy-summary-finalize");
+    let _ = cleanup_sqlite_sidecars(&db_path);
+    let mut storage = Storage::open_build(&db_path)?;
+    storage.insert_files_batch(&[FileInfo {
+        id: 1,
+        path: PathBuf::from("legacy.rs"),
+        language: "rust".to_string(),
+        modification_time: 1,
+        indexed: true,
+        complete: true,
+        line_count: 1,
+        file_role: FileRole::Source,
+    }])?;
+
+    storage.finalize_staged_snapshot()?;
+
+    assert!(storage.has_ready_grounding_summary_snapshots()?);
+    for index_name in [
+        "idx_node_file",
+        "idx_grounding_file_snapshot_path",
+        "idx_grounding_file_snapshot_rank",
+        "idx_grounding_node_snapshot_file_rank",
+        "idx_grounding_node_snapshot_root_rank",
+    ] {
+        assert!(sqlite_index_exists(&storage, index_name)?);
+    }
+
+    drop(storage);
+    cleanup_sqlite_sidecars(&db_path)?;
     Ok(())
 }
 

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -317,6 +317,17 @@ The last step belongs to runtime plus store:
 
 Full and incremental snapshot behavior are intentionally not symmetric.
 
+Staged finalization splits deferred indexes around summary materialization. It
+first creates source/core indexes used by the snapshot query, including the
+edge indexes needed for root membership checks. It fills the grounding node
+table with both destination indexes absent, then bulk-builds the node file-rank
+index needed by the file-summary join. After file materialization it bulk-builds
+the node root-rank index and both file-summary indexes before the stage can
+publish. All three index-build segments belong to `deferred_indexes_ms`;
+`summary_snapshot_ms` covers only materialization. Any failure in a build
+segment leaves the candidate unpublished and the previous live generation
+usable.
+
 ### 11. Runtime synchronizes core search inputs
 
 After graph and snapshot work, runtime streams canonical search symbols


### PR DESCRIPTION
Closes #1303

Refs #1275

## Context

The retained exact-corpus run spent 14m30s building the grounding summary snapshot. Its staged finalizer created four empty destination indexes before inserting roughly three million summary rows, forcing row-by-row B-tree maintenance. Leaving all four absent was also wrong: SQLite would build an automatic covering index for the file-summary join.

Base: `bf1bb22797d7d1c4f6a02eb84e5747a5b320c175`

Candidate: `6e8a5402d261684336f8437456d9652834105ffe`

## What changed

- splits deferred indexes into pre-summary source/core indexes and four summary destination indexes
- materializes the node snapshot without destination indexes
- bulk-builds `idx_grounding_node_snapshot_file_rank` inside the summary transaction before file aggregation
- materializes the file snapshot using that persistent index, then bulk-builds the remaining three destination indexes
- keeps live and generic all-index creation compatible
- attributes raw pre-, mid-, and post-summary index durations to `deferred_indexes_ms`, excluding the mid build from `summary_snapshot_ms`
- documents the staged order and release-facing behavior change

## How to review

1. Check that only staged deferred-index finalization uses the split order; live/migration index creation still creates the complete set.
2. Check that the node file-rank index is created transactionally after node materialization and before the exact production file-summary CTE/SELECT runs.
3. Check that a post-summary destination-index failure prevents promotion and leaves the prior publication usable.
4. Check the raw-duration partition before millisecond clamping.

## Verification

- `cargo test -p codestory-store --lib --locked` (135 passed)
- `cargo test -p codestory-runtime --lib full_refresh_post_summary_index_failure_preserves_live_publication --locked`
- `cargo clippy -p codestory-store -p codestory-runtime --all-targets --locked -- -D warnings`
- `node .github/scripts/check-doc-links.mjs`
- `cargo fmt --all --check`
- `git diff --check`
- independent exact-base review: initial P2 proof-shape finding fixed and re-reviewed; no P0-P3 findings remain

The query-plan test composes the same production CTE and SELECT helpers as the INSERT, asserts the persistent file-rank index, and rejects any `AUTOMATIC` plan entry.

## Risk and proof boundary

This changes staged SQLite DDL ordering and timing attribution. The complete index set is still required before promotion. Transactional build-order, legacy staged-finalization, and runtime publication-failure tests cover the safety boundary.

The retained exact corpus proof was not rerun or mutated. The final integrated #1275 candidate owns the next large run and any speedup claim.

Packaged CodeStory grounding did not converge at `CoreFreshness` and routed to exact-head source inspection.
