### PR TITLE
wire authenticated release cells into publication

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1332,6 +1332,11 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     "node .github/scripts/extract-codestory-release-notes.mjs",
     '--version "$VERSION"',
   ]);
+  requireStepRun(violations, releaseFile, preflight, "Refuse existing tag or release", [
+    'git ls-remote --exit-code --tags origin "refs/tags/$TAG"',
+    'gh release view "$TAG"',
+    "exit 1",
+  ]);
 
   const evidence = requireJob(violations, releaseFile, release, "release-evidence");
   add(violations, sameMembers(needs(evidence), releaseChain.dependencies["release-evidence"]), `${releaseFile} release-evidence dependencies must match the release claim graph`);
@@ -1401,10 +1406,27 @@ function validateReleaseCoordinator(workflows, violations, graph) {
 
   const preCloseout = requireJob(violations, releaseFile, release, "pre-publish-closeout");
   add(violations, sameMembers(needs(preCloseout), releaseChain.dependencies["pre-publish-closeout"]), `${releaseFile} pre-publish closeout dependencies must match the release claim graph`);
-  requireStepRun(violations, releaseFile, preCloseout, "Evaluate authenticated pre-publish closeout", [
+  requireStepRun(violations, releaseFile, preCloseout, "Authenticate pre-publish Actions provenance", [
     "producer-map",
     "--phase pre_publish",
+    "artifact_ids",
+  ]);
+  const preDownload = namedStep(preCloseout, "Download selected pre-publish release cells");
+  add(
+    violations,
+    preDownload?.uses === "actions/download-artifact@v8.0.1"
+      && object(preDownload.with)["artifact-ids"] === "${{ steps.pre-publish-provenance.outputs.artifact_ids }}"
+      && object(preDownload.with)["merge-multiple"] === false,
+    `${releaseFile} pre-publish closeout must download selected Actions artifact ids without flattening`,
+  );
+  requireStepRun(violations, releaseFile, preCloseout, "Verify selected pre-publish artifact container digests", [
+    "/actions/artifacts/$artifact_id/zip",
+    "sha256sum",
+    "test \"$actual_digest\" = \"$expected_digest\"",
+  ]);
+  requireStepRun(violations, releaseFile, preCloseout, "Evaluate authenticated pre-publish closeout", [
     "--trusted-producers",
+    "--trusted-exceptions",
     "codestory-release-closeout.mjs evaluate",
   ]);
   requireStepUses(violations, releaseFile, preCloseout, "Upload accepted pre-publish closeout", "actions/upload-artifact@v7.0.1");
@@ -1414,6 +1436,11 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   requireStepRun(violations, releaseFile, publish, "Compose versioned GitHub release notes", [
     "node .github/scripts/extract-codestory-release-notes.mjs",
     "--output target/release-assets/release-notes.md",
+  ]);
+  requireStepRun(violations, releaseFile, publish, "Refuse existing tag or release", [
+    'git ls-remote --exit-code --tags origin "refs/tags/$TAG"',
+    'gh release view "$TAG"',
+    "exit 1",
   ]);
   requireStepRun(violations, releaseFile, publish, "Create GitHub release", [
     "--notes-file target/release-assets/release-notes.md",
@@ -1432,10 +1459,27 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   );
   const postCloseout = requireJob(violations, releaseFile, release, "post-publish-closeout");
   add(violations, sameMembers(needs(postCloseout), releaseChain.dependencies["post-publish-closeout"]), `${releaseFile} post-publish closeout dependencies must match the release claim graph`);
-  requireStepRun(violations, releaseFile, postCloseout, "Evaluate authenticated post-publish closeout", [
+  requireStepRun(violations, releaseFile, postCloseout, "Authenticate post-publish Actions provenance", [
     "producer-map",
     "--phase post_publish",
+    "artifact_ids",
+  ]);
+  const postDownload = namedStep(postCloseout, "Download selected release cells without flattening");
+  add(
+    violations,
+    postDownload?.uses === "actions/download-artifact@v8.0.1"
+      && object(postDownload.with)["artifact-ids"] === "${{ steps.post-publish-provenance.outputs.artifact_ids }}"
+      && object(postDownload.with)["merge-multiple"] === false,
+    `${releaseFile} post-publish closeout must download selected Actions artifact ids without flattening`,
+  );
+  requireStepRun(violations, releaseFile, postCloseout, "Verify selected post-publish artifact container digests", [
+    "/actions/artifacts/$artifact_id/zip",
+    "sha256sum",
+    "test \"$actual_digest\" = \"$expected_digest\"",
+  ]);
+  requireStepRun(violations, releaseFile, postCloseout, "Evaluate authenticated post-publish closeout", [
     "--trusted-producers",
+    "--trusted-exceptions",
     "--pre-publish-ledger",
     "codestory-release-closeout.mjs evaluate",
   ]);
@@ -2569,6 +2613,34 @@ export function releaseWorkflowContractViolations(
   return violations;
 }
 
+function validateReleaseCellUploadOwnership(workflows, violations) {
+  const actual = [];
+  for (const [file, workflow] of workflows) {
+    for (const [jobId, jobValue] of Object.entries(object(workflow.jobs))) {
+      for (const step of Array.isArray(jobValue.steps) ? jobValue.steps : []) {
+        if (step?.uses !== "actions/upload-artifact@v7.0.1") continue;
+        const artifactName = String(object(step.with).name ?? "");
+        if (artifactName.startsWith("release-cell-")) {
+          actual.push(`${file}/${jobId}/${artifactName}`);
+        }
+      }
+    }
+  }
+  const expected = [
+    "source-proof.yml/full-source-gate/release-cell-prepublish-source-attempt-${{ github.run_attempt }}",
+    "release-candidate-evidence.yml/measure/release-cell-prepublish-release-evidence-attempt-${{ github.run_attempt }}",
+    "packaged-platform-proof.yml/build/release-cell-prepublish-package-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}",
+    "macos-metal-proof.yml/packaged-metal/release-cell-prepublish-macos-arm64-metal-attempt-${{ github.run_attempt }}",
+    "windows-vulkan-proof.yml/packaged-vulkan/release-cell-prepublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}",
+    "post-publish-release-smoke.yml/smoke/release-cell-postpublish-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}",
+  ];
+  add(
+    violations,
+    JSON.stringify(actual.sort()) === JSON.stringify(expected.sort()),
+    "release-cell Actions artifact names must have one graph-owned producer job and attempt suffix",
+  );
+}
+
 export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
   const violations = [];
   for (const [file, workflow] of workflows) {
@@ -2582,6 +2654,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   validatePostPublish(workflows, violations, graph);
   validatePackagedCoordinator(workflows, violations, graph);
   validateRemainingWorkflows(workflows, violations);
+  validateReleaseCellUploadOwnership(workflows, violations);
   violations.push(...releaseWorkflowContractViolations(workflows, graph));
   return violations;
 }

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2641,6 +2641,76 @@ function validateReleaseCellUploadOwnership(workflows, violations) {
   );
 }
 
+function validateReleaseArtifactRerunSafety(workflows, violations) {
+  const releaseChainWorkflows = new Set([
+    "source-proof.yml",
+    "release-candidate-evidence.yml",
+    "packaged-platform-proof.yml",
+    "macos-metal-proof.yml",
+    "windows-vulkan-proof.yml",
+    "post-publish-release-smoke.yml",
+    "release.yml",
+  ]);
+  const replaceableStableIntermediates = new Map([
+    ["release-candidate-evidence.yml/measure/Upload release evidence", {
+      name: "release-evidence-${{ inputs.ref }}",
+      path: "target/release-evidence",
+    }],
+    ["packaged-platform-proof.yml/build/Upload hosted Linux calibration runs", {
+      name: "embedding-calibration-linux-${{ inputs.version }}",
+      path: "target/calibration-runs/linux",
+    }],
+    ["packaged-platform-proof.yml/build/Upload release asset", {
+      name: "codestory-cli-${{ matrix.asset_target }}",
+      path: "target/release-dist/*.tar.gz\ntarget/release-dist/*.zip\ntarget/release-dist/*.sha256\ntarget/release-dist/SHA256SUMS.txt\n",
+    }],
+    ["macos-metal-proof.yml/packaged-metal/Upload Metal calibration runs", {
+      name: "embedding-calibration-macos-${{ inputs.version }}",
+      path: "target/calibration-runs/macos",
+    }],
+    ["release.yml/pre-publish-closeout/Upload accepted pre-publish closeout", {
+      name: "release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}",
+      path: "target/release-closeout/trusted-pre-publish-producers.json\ntarget/release-closeout/pre_publish\n",
+    }],
+  ]);
+  const observedStableIntermediates = new Set();
+  for (const [file, workflow] of workflows) {
+    if (!releaseChainWorkflows.has(file)) continue;
+    for (const [jobId, jobValue] of Object.entries(object(workflow.jobs))) {
+      for (const step of list(jobValue?.steps)) {
+        if (step?.uses !== "actions/upload-artifact@v7.0.1") continue;
+        const upload = object(step.with);
+        const artifactName = String(upload.name ?? "");
+        const uploadKey = `${file}/${jobId}/${step.name ?? ""}`;
+        const attemptQualified = artifactName.includes("${{ github.run_attempt }}");
+        const expectedStable = replaceableStableIntermediates.get(uploadKey);
+        const stableIntermediateMatches = expectedStable !== undefined
+          && !observedStableIntermediates.has(uploadKey)
+          && artifactName === expectedStable.name
+          && String(upload.path ?? "") === expectedStable.path
+          && upload.overwrite === true;
+        if (expectedStable !== undefined) {
+          observedStableIntermediates.add(uploadKey);
+        }
+        add(
+          violations,
+          expectedStable !== undefined
+            ? stableIntermediateMatches
+            : attemptQualified && upload.overwrite !== true,
+          `${file} job ${jobId} upload ${step.name ?? artifactName} must be immutable and attempt-qualified unless it is an explicitly allowlisted stable intermediate`,
+        );
+      }
+    }
+  }
+  for (const uploadKey of replaceableStableIntermediates.keys()) {
+    add(
+      violations,
+      observedStableIntermediates.has(uploadKey),
+      `${uploadKey} stable intermediate upload must exist exactly once with its policy-owned artifact name and path`,
+    );
+  }
+}
+
 export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
   const violations = [];
   for (const [file, workflow] of workflows) {
@@ -2655,6 +2725,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   validatePackagedCoordinator(workflows, violations, graph);
   validateRemainingWorkflows(workflows, violations);
   validateReleaseCellUploadOwnership(workflows, violations);
+  validateReleaseArtifactRerunSafety(workflows, violations);
   violations.push(...releaseWorkflowContractViolations(workflows, graph));
   return violations;
 }

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1275,6 +1275,19 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
     requireUniqueCacheSaveLast(violations, sourceFile, full, "source cache", "proof step");
     requireStepRun(violations, sourceFile, full, "Test the complete workspace once", ["cargo test --workspace --locked"]);
     requireStepRun(violations, sourceFile, full, "Lint every workspace target and feature once", ["cargo clippy --workspace --all-targets --all-features --locked -- -D warnings"]);
+    requireStepRun(violations, sourceFile, full, "Emit authenticated source release cell", [
+      "codestory-release-cell-manifest.mjs produce",
+      "--cell-id source_behavior",
+      "--producer-job full-source-gate",
+    ]);
+    const sourceCellUpload = namedStep(full, "Upload authenticated source release cell");
+    add(
+      violations,
+      sourceCellUpload?.uses === "actions/upload-artifact@v7.0.1"
+        && String(sourceCellUpload?.if ?? "").includes("success()")
+        && String(sourceCellUpload?.if ?? "").includes("inputs.emit_release_cells"),
+      `${sourceFile} source release cell must be a success-only retained artifact`,
+    );
   }
 }
 
@@ -1307,6 +1320,7 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   ]);
   requireStepRun(violations, releaseFile, policy, "Check release claim and evidence contracts", [
     "scripts/tests/codestory-release-claims.test.mjs",
+    "scripts/tests/codestory-release-cell-manifest.test.mjs",
     "scripts/tests/codestory-release-closeout.test.mjs",
     "scripts/tests/codestory-release-evidence-gate.test.mjs",
   ]);
@@ -1326,14 +1340,23 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     proof_key: "release-${{ needs.preflight.outputs.version }}",
     profile: releaseChain.evidence_profile,
     drill_manifest: releaseChain.drill_manifest,
+    version: "${{ needs.preflight.outputs.version }}",
+    emit_release_cells: true,
   })) {
     add(violations, object(evidence.with)[key] === value, `${releaseFile} release-evidence with.${key} must equal ${value}`);
   }
+
+  const source = requireJob(violations, releaseFile, release, "source-proof");
+  add(violations, source.uses === "./.github/workflows/source-proof.yml", `${releaseFile} must call exact source proof`);
+  add(violations, sameMembers(needs(source), releaseChain.dependencies["source-proof"]), `${releaseFile} source proof dependencies must match the release claim graph`);
+  add(violations, object(source.with).ref === "${{ github.sha }}", `${releaseFile} source proof must receive the exact release SHA`);
+  add(violations, object(source.with).version === "${{ needs.preflight.outputs.version }}" && object(source.with).emit_release_cells === true, `${releaseFile} source proof must emit its authenticated release cell`);
 
   const packaged = requireJob(violations, releaseFile, release, "packaged-proof");
   add(violations, packaged.uses === "./.github/workflows/packaged-platform-proof.yml", `${releaseFile} packaged-proof must call the package workflow`);
   add(violations, sameMembers(needs(packaged), releaseChain.dependencies["packaged-proof"]), `${releaseFile} packaged-proof dependencies must match the release claim graph`);
   add(violations, object(packaged.with).sign_macos === true, `${releaseFile} packaged-proof must sign Mac assets`);
+  add(violations, object(packaged.with).emit_release_cells === true, `${releaseFile} packaged-proof must emit all package release cells`);
   add(
     violations,
     object(packaged.with).candidate_installed_proof === undefined,
@@ -1362,6 +1385,7 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(violations, metal.uses === "./.github/workflows/macos-metal-proof.yml", `${releaseFile} must call protected Metal proof`);
   add(violations, sameMembers(needs(metal), releaseChain.dependencies["macos-metal-proof"]), `${releaseFile} Metal proof dependencies must match the release claim graph`);
   add(violations, object(metal.with).use_packaged_cli_artifact === true, `${releaseFile} Metal proof must use the packaged CLI`);
+  add(violations, object(metal.with).emit_release_cells === true, `${releaseFile} Metal proof must emit its authenticated release cell`);
   add(
     violations,
     object(metal.with).candidate_installed_proof === undefined
@@ -1373,6 +1397,17 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(violations, vulkan.uses === "./.github/workflows/windows-vulkan-proof.yml", `${releaseFile} must call protected Vulkan proof`);
   add(violations, sameMembers(needs(vulkan), releaseChain.dependencies["windows-vulkan-proof"]), `${releaseFile} Vulkan proof dependencies must match the release claim graph`);
   add(violations, object(vulkan.with).use_packaged_cli_artifact === true, `${releaseFile} Vulkan proof must use the packaged CLI`);
+  add(violations, object(vulkan.with).emit_release_cells === true, `${releaseFile} Vulkan proof must emit its authenticated release cell`);
+
+  const preCloseout = requireJob(violations, releaseFile, release, "pre-publish-closeout");
+  add(violations, sameMembers(needs(preCloseout), releaseChain.dependencies["pre-publish-closeout"]), `${releaseFile} pre-publish closeout dependencies must match the release claim graph`);
+  requireStepRun(violations, releaseFile, preCloseout, "Evaluate authenticated pre-publish closeout", [
+    "producer-map",
+    "--phase pre_publish",
+    "--trusted-producers",
+    "codestory-release-closeout.mjs evaluate",
+  ]);
+  requireStepUses(violations, releaseFile, preCloseout, "Upload accepted pre-publish closeout", "actions/upload-artifact@v7.0.1");
 
   const publish = requireJob(violations, releaseFile, release, "publish");
   add(violations, sameMembers(needs(publish), releaseChain.dependencies.publish), `${releaseFile} publish dependencies must match the release claim graph`);
@@ -1389,6 +1424,22 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   const post = requireJob(violations, releaseFile, release, "post-publish-smoke");
   add(violations, post.uses === "./.github/workflows/post-publish-release-smoke.yml", `${releaseFile} must call post-publish smoke`);
   add(violations, sameMembers(needs(post), releaseChain.dependencies["post-publish-smoke"]), `${releaseFile} post-publish dependencies must match the release claim graph`);
+  add(
+    violations,
+    object(post.with).emit_release_cells === true
+      && String(object(post.with).pre_publish_closeout_artifact ?? "").startsWith("release-closeout-pre-publish-"),
+    `${releaseFile} post-publish smoke must consume the accepted pre-publish ledger and emit authenticated cells`,
+  );
+  const postCloseout = requireJob(violations, releaseFile, release, "post-publish-closeout");
+  add(violations, sameMembers(needs(postCloseout), releaseChain.dependencies["post-publish-closeout"]), `${releaseFile} post-publish closeout dependencies must match the release claim graph`);
+  requireStepRun(violations, releaseFile, postCloseout, "Evaluate authenticated post-publish closeout", [
+    "producer-map",
+    "--phase post_publish",
+    "--trusted-producers",
+    "--pre-publish-ledger",
+    "codestory-release-closeout.mjs evaluate",
+  ]);
+  requireStepUses(violations, releaseFile, postCloseout, "Upload accepted post-publish closeout", "actions/upload-artifact@v7.0.1");
   for (const [jobName, job] of [
     ["Metal proof", metal],
     ["Vulkan proof", vulkan],
@@ -1722,6 +1773,20 @@ function validatePackagedProof(workflows, violations, graph) {
   ).map(message => `${file} ${message}`));
   requireStepUses(violations, file, job, "Upload release asset", "actions/upload-artifact@v7.0.1");
   requireStepUses(violations, file, job, "Upload macOS notarization proof", "actions/upload-artifact@v7.0.1");
+  requireStepRun(violations, file, job, "Emit authenticated package release cell", [
+    "codestory-release-cell-manifest.mjs produce",
+    "package_identity:${{ matrix.asset_target }}",
+    "--producer-job build",
+    "--archive",
+  ]);
+  const packageCellUpload = namedStep(job, "Upload authenticated package release cell");
+  add(
+    violations,
+    packageCellUpload?.uses === "actions/upload-artifact@v7.0.1"
+      && String(packageCellUpload?.if ?? "").includes("success()")
+      && String(packageCellUpload?.if ?? "").includes("inputs.emit_release_cells"),
+    `${file} package release cell must be a success-only retained artifact`,
+  );
 }
 
 function validatePostPublish(workflows, violations, graph) {
@@ -1742,6 +1807,8 @@ function validatePostPublish(workflows, violations, graph) {
         `${file} ${event} ${key} must be a required string`,
       );
     }
+    const closeoutInput = object(at(workflow, "on", event, "inputs", "pre_publish_closeout_artifact"));
+    add(violations, closeoutInput.type === "string", `${file} ${event} pre_publish_closeout_artifact must be a string`);
   }
   const job = requireJob(violations, file, workflow, "smoke");
   const expected = expectedPackageRows(graph).map(({ os, asset_target, extension }) => ({ os, asset_target, extension }));
@@ -1804,6 +1871,34 @@ function validatePostPublish(workflows, violations, graph) {
     job,
     "Download frozen calibration bundle",
     "actions/download-artifact@v8.0.1",
+  );
+  requireStepUses(
+    violations,
+    file,
+    job,
+    "Download accepted pre-publish closeout",
+    "actions/download-artifact@v8.0.1",
+  );
+  requireStepRun(violations, file, job, "Emit authenticated post-publish release cells", [
+    "platform_support:${{ matrix.asset_target }}",
+    "installed_runtime_behavior:${{ matrix.asset_target }}",
+    "post_publish_bytes:${{ matrix.asset_target }}",
+    "--pre-publish-ledger",
+    "release-cell-postpublish-${{ matrix.asset_target }}",
+  ]);
+  requireStepUses(
+    violations,
+    file,
+    job,
+    "Upload authenticated post-publish release cells",
+    "actions/upload-artifact@v7.0.1",
+  );
+  const postCellUpload = namedStep(job, "Upload authenticated post-publish release cells");
+  add(
+    violations,
+    String(postCellUpload?.if ?? "").includes("success()")
+      && String(postCellUpload?.if ?? "").includes("inputs.emit_release_cells"),
+    `${file} post-publish release cells must be success-only artifacts`,
   );
   const calibrationDownload = namedStep(job, "Download frozen calibration bundle");
   add(
@@ -2072,6 +2167,7 @@ function validateRemainingWorkflows(workflows, violations) {
     ]);
     requireStepRun(violations, autoFile, policy, "Check release claim and evidence contracts", [
       "scripts/tests/codestory-release-claims.test.mjs",
+      "scripts/tests/codestory-release-cell-manifest.test.mjs",
       "scripts/tests/codestory-release-closeout.test.mjs",
       "scripts/tests/codestory-release-evidence-gate.test.mjs",
     ]);
@@ -2102,6 +2198,18 @@ function validateRemainingWorkflows(workflows, violations) {
     ));
     requireStepRun(violations, evidenceFile, job, "Produce full-retrieval repo evidence", ["--test-threads=1"]);
     requireStepRun(violations, evidenceFile, job, "Download prior rejected evidence for approval re-evaluation", ["actions/runs/$SOURCE_RUN_ID", "actions/runs/$SOURCE_RUN_ID/artifacts"]);
+    requireStepRun(violations, evidenceFile, job, "Emit authenticated release-evidence cells", [
+      "codestory-release-cell-manifest.mjs release-evidence",
+      "--producer-job measure",
+    ]);
+    const evidenceCellUpload = namedStep(job, "Upload authenticated release-evidence cells");
+    add(
+      violations,
+      evidenceCellUpload?.uses === "actions/upload-artifact@v7.0.1"
+        && String(evidenceCellUpload?.if ?? "").includes("success()")
+        && String(evidenceCellUpload?.if ?? "").includes("inputs.emit_release_cells"),
+      `${evidenceFile} release-evidence cells must be success-only retained artifacts`,
+    );
   }
 
   const metalFile = "macos-metal-proof.yml";
@@ -2193,6 +2301,19 @@ function validateRemainingWorkflows(workflows, violations) {
       "$CODESTORY_CANDIDATE_MACOS_ROOT/data",
       'test -f "$quality_path"',
     ]);
+    requireStepRun(violations, metalFile, job, "Emit authenticated Metal release cell", [
+      "codestory-release-cell-manifest.mjs produce",
+      "accelerator_execution:macos-arm64-metal",
+      "--producer-job packaged-metal",
+    ]);
+    const metalCellUpload = namedStep(job, "Upload authenticated Metal release cell");
+    add(
+      violations,
+      metalCellUpload?.uses === "actions/upload-artifact@v7.0.1"
+        && String(metalCellUpload?.if ?? "").includes("success()")
+        && String(metalCellUpload?.if ?? "").includes("inputs.emit_release_cells"),
+      `${metalFile} Metal release cell must be a success-only retained artifact`,
+    );
   }
 
   const vulkanFile = "windows-vulkan-proof.yml";
@@ -2239,6 +2360,19 @@ function validateRemainingWorkflows(workflows, violations) {
       "--calibration-producer-artifact",
     ]);
     add(violations, object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${vulkanFile} engine proof must reject CPU fallback`);
+    requireStepRun(violations, vulkanFile, job, "Emit authenticated Vulkan release cell", [
+      "codestory-release-cell-manifest.mjs produce",
+      "accelerator_execution:windows-x64-vulkan",
+      "--producer-job packaged-vulkan",
+    ]);
+    const vulkanCellUpload = namedStep(job, "Upload authenticated Vulkan release cell");
+    add(
+      violations,
+      vulkanCellUpload?.uses === "actions/upload-artifact@v7.0.1"
+        && String(vulkanCellUpload?.if ?? "").includes("success()")
+        && String(vulkanCellUpload?.if ?? "").includes("inputs.emit_release_cells"),
+      `${vulkanFile} Vulkan release cell must be a success-only retained artifact`,
+    );
   }
 
   const statsFile = "repo-scale-stats.yml";

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2614,6 +2614,9 @@ export function releaseWorkflowContractViolations(
 }
 
 function validateReleaseCellUploadOwnership(workflows, violations) {
+  const evidenceFile = releaseEvidenceWorkflowRef.slice(
+    releaseEvidenceWorkflowRef.lastIndexOf("/") + 1,
+  );
   const actual = [];
   for (const [file, workflow] of workflows) {
     for (const [jobId, jobValue] of Object.entries(object(workflow.jobs))) {
@@ -2628,7 +2631,8 @@ function validateReleaseCellUploadOwnership(workflows, violations) {
   }
   const expected = [
     "source-proof.yml/full-source-gate/release-cell-prepublish-source-attempt-${{ github.run_attempt }}",
-    "release-candidate-evidence.yml/measure/release-cell-prepublish-release-evidence-attempt-${{ github.run_attempt }}",
+    evidenceFile
+      + "/measure/release-cell-prepublish-release-evidence-attempt-${{ github.run_attempt }}",
     "packaged-platform-proof.yml/build/release-cell-prepublish-package-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}",
     "macos-metal-proof.yml/packaged-metal/release-cell-prepublish-macos-arm64-metal-attempt-${{ github.run_attempt }}",
     "windows-vulkan-proof.yml/packaged-vulkan/release-cell-prepublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}",
@@ -2642,9 +2646,12 @@ function validateReleaseCellUploadOwnership(workflows, violations) {
 }
 
 function validateReleaseArtifactRerunSafety(workflows, violations) {
+  const evidenceFile = releaseEvidenceWorkflowRef.slice(
+    releaseEvidenceWorkflowRef.lastIndexOf("/") + 1,
+  );
   const releaseChainWorkflows = new Set([
     "source-proof.yml",
-    "release-candidate-evidence.yml",
+    evidenceFile,
     "packaged-platform-proof.yml",
     "macos-metal-proof.yml",
     "windows-vulkan-proof.yml",
@@ -2652,7 +2659,7 @@ function validateReleaseArtifactRerunSafety(workflows, violations) {
     "release.yml",
   ]);
   const replaceableStableIntermediates = new Map([
-    ["release-candidate-evidence.yml/measure/Upload release evidence", {
+    [`${evidenceFile}/measure/Upload release evidence`, {
       name: "release-evidence-${{ inputs.ref }}",
       path: "target/release-evidence",
     }],

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1472,6 +1472,37 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
         .find(({ name }) => name === "Upload authenticated source release cell");
       step.with.name = "release-cell-prepublish-source";
     }],
+    ["rerun-unsafe diagnostic artifact", workflows => {
+      const step = workflows.get("post-publish-release-smoke.yml").jobs.smoke.steps
+        .find(({ name }) => name === "Upload post-publish proof artifacts");
+      step.with.name = "post-publish-proof-fixed";
+    }],
+    ["rerun-unsafe stable artifact", workflows => {
+      const step = workflows.get("packaged-platform-proof.yml").jobs.build.steps
+        .find(({ name }) => name === "Upload release asset");
+      delete step.with.overwrite;
+    }],
+    ["overwriteable terminal evidence", workflows => {
+      const step = workflows.get("packaged-platform-proof.yml").jobs.build.steps
+        .find(({ name }) => name === "Upload candidate-installed Linux proof");
+      step.name = "Upload hosted Linux calibration runs";
+      step.with.name = "embedding-calibration-linux-${{ inputs.version }}";
+      step.with.path = "target/calibration-runs/linux";
+      step.with.overwrite = true;
+    }],
+    ["attempt-qualified duplicate stable key", workflows => {
+      const steps = workflows.get("packaged-platform-proof.yml").jobs.build.steps;
+      const index = steps.findIndex(({ name }) => name === "Upload hosted Linux calibration runs");
+      steps.splice(index + 1, 0, {
+        name: "Upload hosted Linux calibration runs",
+        uses: "actions/upload-artifact@v7.0.1",
+        with: {
+          name: "diagnostic-attempt-${{ github.run_attempt }}",
+          path: "forged.json",
+          "retention-days": 30,
+        },
+      });
+    }],
     ["rogue artifact producer", workflows => {
       workflows.get("release.yml").jobs["pre-publish-closeout"].steps.push({
         name: "Upload forged release cell",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1420,3 +1420,36 @@ test("controlled semantic workflow fixtures emit class-prefixed diagnostics", as
     });
   }
 });
+
+test("release policy rejects manifest producer, trusted-map, and publication bypasses", () => {
+  const mutations = [
+    ["source emission", workflows => { delete workflows.get("release.yml").jobs["source-proof"].with.emit_release_cells; }],
+    ["publish bypass", workflows => {
+      workflows.get("release.yml").jobs.publish.needs = [
+        "preflight",
+        "packaged-proof",
+        "macos-metal-proof",
+        "windows-vulkan-proof",
+      ];
+    }],
+    ["trusted producer map", workflows => {
+      const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
+        .find(({ name }) => name === "Evaluate authenticated pre-publish closeout");
+      step.run = step.run.replace("--trusted-producers", "--self-attested-producers");
+    }],
+    ["pre-publish ledger", workflows => {
+      const step = workflows.get("release.yml").jobs["post-publish-closeout"].steps
+        .find(({ name }) => name === "Evaluate authenticated post-publish closeout");
+      step.run = step.run.replace("--pre-publish-ledger", "--untrusted-ledger");
+    }],
+    ["success-only post-publish upload", workflows => {
+      delete workflows.get("post-publish-release-smoke.yml").jobs.smoke.steps
+        .find(({ name }) => name === "Upload authenticated post-publish release cells").if;
+    }],
+  ];
+  for (const [label, mutate] of mutations) {
+    const workflows = loadWorkflows();
+    mutate(workflows);
+    assert.notDeepEqual(validateWorkflows(workflows), [], label);
+  }
+});

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1424,6 +1424,16 @@ test("controlled semantic workflow fixtures emit class-prefixed diagnostics", as
 test("release policy rejects manifest producer, trusted-map, and publication bypasses", () => {
   const mutations = [
     ["source emission", workflows => { delete workflows.get("release.yml").jobs["source-proof"].with.emit_release_cells; }],
+    ["full rerun preflight guard", workflows => {
+      workflows.get("release.yml").jobs.preflight.steps = workflows
+        .get("release.yml").jobs.preflight.steps
+        .filter(({ name }) => name !== "Refuse existing tag or release");
+    }],
+    ["publish replay guard", workflows => {
+      const step = workflows.get("release.yml").jobs.publish.steps
+        .find(({ name }) => name === "Refuse existing tag or release");
+      step.run = step.run.replaceAll("exit 1", "true");
+    }],
     ["publish bypass", workflows => {
       workflows.get("release.yml").jobs.publish.needs = [
         "preflight",
@@ -1436,6 +1446,41 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
       const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
         .find(({ name }) => name === "Evaluate authenticated pre-publish closeout");
       step.run = step.run.replace("--trusted-producers", "--self-attested-producers");
+    }],
+    ["trusted exception input", workflows => {
+      const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
+        .find(({ name }) => name === "Evaluate authenticated pre-publish closeout");
+      step.run = step.run.replace("--trusted-exceptions", "--manifest-exceptions");
+    }],
+    ["flattened current-run JSON", workflows => {
+      const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
+        .find(({ name }) => name === "Download selected pre-publish release cells");
+      delete step.with["artifact-ids"];
+      step.with.pattern = "release-cell-prepublish-*";
+      step.with["merge-multiple"] = true;
+    }],
+    ["container digest warning accepted", workflows => {
+      const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
+        .find(({ name }) => name === "Verify selected pre-publish artifact container digests");
+      step.run = step.run.replace(
+        'test "$actual_digest" = "$expected_digest"',
+        'echo "$actual_digest $expected_digest"',
+      );
+    }],
+    ["attempt-free artifact", workflows => {
+      const step = workflows.get("source-proof.yml").jobs["full-source-gate"].steps
+        .find(({ name }) => name === "Upload authenticated source release cell");
+      step.with.name = "release-cell-prepublish-source";
+    }],
+    ["rogue artifact producer", workflows => {
+      workflows.get("release.yml").jobs["pre-publish-closeout"].steps.push({
+        name: "Upload forged release cell",
+        uses: "actions/upload-artifact@v7.0.1",
+        with: {
+          name: "release-cell-prepublish-source-attempt-${{ github.run_attempt }}",
+          path: "forged.json",
+        },
+      });
     }],
     ["pre-publish ledger", workflows => {
       const step = workflows.get("release.yml").jobs["post-publish-closeout"].steps

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -50,6 +50,7 @@ jobs:
         run: >-
           node --test
           scripts/tests/codestory-release-claims.test.mjs
+          scripts/tests/codestory-release-cell-manifest.test.mjs
           scripts/tests/codestory-release-closeout.test.mjs
           scripts/tests/codestory-release-evidence-gate.test.mjs
 

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -398,12 +398,13 @@ jobs:
           path: target/calibration-runs/macos
           if-no-files-found: error
           retention-days: 30
+          overwrite: true
 
       - name: Upload candidate-installed macOS proof
         if: always() && inputs.candidate_installed_proof && !inputs.calibration_mode && (inputs.server_behavior_only || inputs.quality_evidence_artifact != '')
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: candidate-installed-macos-${{ inputs.version }}
+          name: candidate-installed-macos-${{ inputs.version }}-attempt-${{ github.run_attempt }}
           path: target/candidate-installed-macos
           if-no-files-found: error
           retention-days: 30
@@ -450,7 +451,7 @@ jobs:
         if: always() && !inputs.calibration_mode
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: macos-arm64-metal-proof-${{ inputs.version }}
+          name: macos-arm64-metal-proof-${{ inputs.version }}-attempt-${{ github.run_attempt }}
           path: target/macos-metal-proof
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -51,6 +51,11 @@ on:
         required: false
         default: false
         type: boolean
+      emit_release_cells:
+        description: Emit the authenticated protected-hardware cell for production release closeout.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
@@ -400,6 +405,44 @@ jobs:
         with:
           name: candidate-installed-macos-${{ inputs.version }}
           path: target/candidate-installed-macos
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Emit authenticated Metal release cell
+        if: inputs.emit_release_cells && !inputs.calibration_mode
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
+          test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          jq -n \
+            --arg native_engine coderank_q8_embedded \
+            --arg calibration_sha256 "$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$calibration_bundle")" \
+            '{native_engine: $native_engine, calibration_sha256: $calibration_sha256}' \
+            > target/macos-metal-proof/release-cell-identity.json
+          node scripts/codestory-release-cell-manifest.mjs produce \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "${{ inputs.ref }}" \
+            --version "$version" \
+            --cell-id accelerator_execution:macos-arm64-metal \
+            --producer-workflow .github/workflows/macos-metal-proof.yml \
+            --producer-job packaged-metal \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --producer-artifact release-cell-prepublish-macos-arm64-metal \
+            --identity target/macos-metal-proof/release-cell-identity.json \
+            --archive "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz" \
+            --out target/release-cells/accelerator_execution-macos-arm64-metal.json
+
+      - name: Upload authenticated Metal release cell
+        if: success() && inputs.emit_release_cells && !inputs.calibration_mode
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-prepublish-macos-arm64-metal
+          path: target/release-cells/accelerator_execution-macos-arm64-metal.json
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -432,7 +432,7 @@ jobs:
             --producer-job packaged-metal \
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --producer-artifact release-cell-prepublish-macos-arm64-metal \
+            --producer-artifact "release-cell-prepublish-macos-arm64-metal-attempt-$GITHUB_RUN_ATTEMPT" \
             --identity target/macos-metal-proof/release-cell-identity.json \
             --archive "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz" \
             --out target/release-cells/accelerator_execution-macos-arm64-metal.json
@@ -441,7 +441,7 @@ jobs:
         if: success() && inputs.emit_release_cells && !inputs.calibration_mode
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: release-cell-prepublish-macos-arm64-metal
+          name: release-cell-prepublish-macos-arm64-metal-attempt-${{ github.run_attempt }}
           path: target/release-cells/accelerator_execution-macos-arm64-metal.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -830,7 +830,7 @@ jobs:
             --producer-job build \
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --producer-artifact "release-cell-prepublish-package-${{ matrix.asset_target }}" \
+            --producer-artifact "release-cell-prepublish-package-${{ matrix.asset_target }}-attempt-$GITHUB_RUN_ATTEMPT" \
             --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}" \
             --out "target/release-cells/package_identity-${{ matrix.asset_target }}.json"
 
@@ -838,7 +838,7 @@ jobs:
         if: success() && inputs.emit_release_cells
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: release-cell-prepublish-package-${{ matrix.asset_target }}
+          name: release-cell-prepublish-package-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
           path: target/release-cells/package_identity-${{ matrix.asset_target }}.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -470,7 +470,7 @@ jobs:
         if: success() && matrix.asset_target == 'linux-x64'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: linux-glibc-2.31-baseline-proof
+          name: linux-glibc-2.31-baseline-proof-attempt-${{ github.run_attempt }}
           path: target/linux-glibc-baseline
           if-no-files-found: error
           retention-days: 30
@@ -614,12 +614,13 @@ jobs:
           path: target/calibration-runs/linux
           if-no-files-found: error
           retention-days: 30
+          overwrite: true
 
       - name: Upload packaged agent proof artifacts
         if: always() && matrix.asset_target == 'linux-x64'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: packaged-agent-proof-${{ matrix.asset_target }}
+          name: packaged-agent-proof-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
           path: target/packaged-agent-proof
           if-no-files-found: warn
           retention-days: 30
@@ -724,7 +725,7 @@ jobs:
         if: always() && matrix.asset_target == 'linux-x64' && inputs.candidate_installed_proof && !inputs.calibration_mode && (inputs.scope == 'server' || inputs.quality_evidence_artifact != '')
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: candidate-installed-linux-${{ inputs.version }}
+          name: candidate-installed-linux-${{ inputs.version }}-attempt-${{ github.run_attempt }}
           path: target/candidate-installed-linux
           if-no-files-found: error
           retention-days: 30
@@ -771,7 +772,7 @@ jobs:
         if: always() && matrix.asset_target == 'macos-x64'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: packaged-intel-policy-proof-${{ matrix.asset_target }}
+          name: packaged-intel-policy-proof-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
           path: target/packaged-intel-policy-proof
           if-no-files-found: warn
           retention-days: 30
@@ -780,7 +781,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: packaged-version-proof-${{ matrix.asset_target }}
+          name: packaged-version-proof-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
           path: target/packaged-version-smoke/${{ matrix.asset_target }}
           if-no-files-found: warn
           retention-days: 30
@@ -811,7 +812,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: packaged-managed-proof-${{ matrix.asset_target }}
+          name: packaged-managed-proof-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
           path: target/packaged-managed-proof
           if-no-files-found: warn
           retention-days: 30
@@ -854,12 +855,13 @@ jobs:
             target/release-dist/SHA256SUMS.txt
           if-no-files-found: error
           retention-days: 30
+          overwrite: true
 
       - name: Upload macOS notarization proof
         if: always() && runner.os == 'macOS' && inputs.sign_macos
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: macos-notarization-proof-${{ matrix.asset_target }}
+          name: macos-notarization-proof-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
           path: target/notarization-proof/${{ matrix.asset_target }}
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -56,6 +56,11 @@ on:
         required: false
         default: false
         type: boolean
+      emit_release_cells:
+        description: Emit authenticated package cells for the production release coordinator.
+        required: false
+        default: false
+        type: boolean
     secrets:
       APPLE_DEVELOPER_ID_P12_BASE64:
         required: false
@@ -809,6 +814,33 @@ jobs:
           name: packaged-managed-proof-${{ matrix.asset_target }}
           path: target/packaged-managed-proof
           if-no-files-found: warn
+          retention-days: 30
+
+      - name: Emit authenticated package release cell
+        if: inputs.emit_release_cells
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/codestory-release-cell-manifest.mjs produce \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "${{ inputs.ref }}" \
+            --version "${{ inputs.version }}" \
+            --cell-id "package_identity:${{ matrix.asset_target }}" \
+            --producer-workflow .github/workflows/packaged-platform-proof.yml \
+            --producer-job build \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --producer-artifact "release-cell-prepublish-package-${{ matrix.asset_target }}" \
+            --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}" \
+            --out "target/release-cells/package_identity-${{ matrix.asset_target }}.json"
+
+      - name: Upload authenticated package release cell
+        if: success() && inputs.emit_release_cells
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-prepublish-package-${{ matrix.asset_target }}
+          path: target/release-cells/package_identity-${{ matrix.asset_target }}.json
+          if-no-files-found: error
           retention-days: 30
 
       - name: Upload release asset

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -20,6 +20,16 @@ on:
         description: Workflow run that produced the frozen calibration bundle artifact.
         required: true
         type: string
+      pre_publish_closeout_artifact:
+        description: Accepted pre-publish closeout artifact from this release run.
+        required: false
+        default: ""
+        type: string
+      emit_release_cells:
+        description: Emit authenticated post-publish cells for production release closeout.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
@@ -38,6 +48,16 @@ on:
         description: Workflow run that produced the frozen calibration bundle artifact.
         required: true
         type: string
+      pre_publish_closeout_artifact:
+        description: Accepted pre-publish closeout artifact from this release run.
+        required: false
+        default: ""
+        type: string
+      emit_release_cells:
+        description: Emit authenticated post-publish cells.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -94,6 +114,13 @@ jobs:
         with:
           ref: ${{ steps.release.outputs.tag }}
           fetch-depth: 0
+
+      - name: Download accepted pre-publish closeout
+        if: inputs.emit_release_cells
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ inputs.pre_publish_closeout_artifact }}
+          path: target/pre-publish-closeout
 
       - name: Download exact-head publishable packet quality evidence
         if: inputs.quality_evidence_artifact != ''
@@ -363,6 +390,64 @@ jobs:
             "${quality_args[@]}" \
             --timeout-secs 3600 \
             --out-dir target/post-publish-installed-proof
+
+      - name: Emit authenticated post-publish release cells
+        if: inputs.emit_release_cells
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.release.outputs.version }}"
+          archive="${{ steps.asset.outputs.archive }}"
+          calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
+          ledger="$(find target/pre-publish-closeout -type f -name ledger.json -print)"
+          test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          test "$(printf '%s\n' "$ledger" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          mkdir -p target/release-cells
+          jq -n \
+            --arg installer marketplace_managed_plugin \
+            --arg native_engine coderank_q8_embedded \
+            --arg calibration_sha256 "$(python -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$calibration_bundle")" \
+            '{installer: $installer, native_engine: $native_engine, calibration_sha256: $calibration_sha256}' \
+            > target/release-cells/installed-identity.json
+          common=(
+            --repo "$GITHUB_WORKSPACE"
+            --expected-sha "$GITHUB_SHA"
+            --version "$version"
+            --producer-workflow .github/workflows/post-publish-release-smoke.yml
+            --producer-job smoke
+            --producer-run-id "$GITHUB_RUN_ID"
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT"
+            --producer-artifact "release-cell-postpublish-${{ matrix.asset_target }}"
+          )
+          node scripts/codestory-release-cell-manifest.mjs produce \
+            "${common[@]}" \
+            --cell-id "platform_support:${{ matrix.asset_target }}" \
+            --archive "$archive" \
+            --out "target/release-cells/platform_support-${{ matrix.asset_target }}.json"
+          node scripts/codestory-release-cell-manifest.mjs produce \
+            "${common[@]}" \
+            --cell-id "installed_runtime_behavior:${{ matrix.asset_target }}" \
+            --identity target/release-cells/installed-identity.json \
+            --archive "$archive" \
+            --out "target/release-cells/installed_runtime_behavior-${{ matrix.asset_target }}.json"
+          node scripts/codestory-release-cell-manifest.mjs produce \
+            "${common[@]}" \
+            --cell-id "post_publish_bytes:${{ matrix.asset_target }}" \
+            --archive "$archive" \
+            --pre-publish-ledger "$ledger" \
+            --out "target/release-cells/post_publish_bytes-${{ matrix.asset_target }}.json"
+
+      - name: Upload authenticated post-publish release cells
+        if: success() && inputs.emit_release_cells
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-postpublish-${{ matrix.asset_target }}
+          path: |
+            target/release-cells/platform_support-${{ matrix.asset_target }}.json
+            target/release-cells/installed_runtime_behavior-${{ matrix.asset_target }}.json
+            target/release-cells/post_publish_bytes-${{ matrix.asset_target }}.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload post-publish proof artifacts
         if: always()

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -453,7 +453,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: post-publish-proof-${{ matrix.asset_target }}-${{ steps.release.outputs.version }}
+          name: post-publish-proof-${{ matrix.asset_target }}-${{ steps.release.outputs.version }}-attempt-${{ github.run_attempt }}
           path: |
             target/post-publish-version-proof/${{ matrix.asset_target }}
             target/post-publish-installed-proof

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -417,7 +417,7 @@ jobs:
             --producer-job smoke
             --producer-run-id "$GITHUB_RUN_ID"
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT"
-            --producer-artifact "release-cell-postpublish-${{ matrix.asset_target }}"
+            --producer-artifact "release-cell-postpublish-${{ matrix.asset_target }}-attempt-$GITHUB_RUN_ATTEMPT"
           )
           node scripts/codestory-release-cell-manifest.mjs produce \
             "${common[@]}" \
@@ -441,7 +441,7 @@ jobs:
         if: success() && inputs.emit_release_cells
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: release-cell-postpublish-${{ matrix.asset_target }}
+          name: release-cell-postpublish-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
           path: |
             target/release-cells/platform_support-${{ matrix.asset_target }}.json
             target/release-cells/installed_runtime_behavior-${{ matrix.asset_target }}.json

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -20,6 +20,14 @@ on:
         required: false
         type: string
         default: ""
+      version:
+        required: false
+        type: string
+        default: ""
+      emit_release_cells:
+        required: false
+        type: boolean
+        default: false
     secrets:
       CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON:
         required: false
@@ -190,6 +198,32 @@ jobs:
             --mode release \
             --repo "$GITHUB_WORKSPACE" \
             "${approval_args[@]}"
+
+      - name: Emit authenticated release-evidence cells
+        if: inputs.emit_release_cells
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/codestory-release-cell-manifest.mjs release-evidence \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "${{ inputs.ref }}" \
+            --version "${{ inputs.version }}" \
+            --report target/release-evidence/report.json \
+            --producer-workflow .github/workflows/release-candidate-evidence.yml \
+            --producer-job measure \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --producer-artifact release-cell-prepublish-release-evidence \
+            --out-dir target/release-cells
+
+      - name: Upload authenticated release-evidence cells
+        if: success() && inputs.emit_release_cells
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-prepublish-release-evidence
+          path: target/release-cells/*.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload release evidence
         if: always()

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -213,14 +213,14 @@ jobs:
             --producer-job measure \
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --producer-artifact release-cell-prepublish-release-evidence \
+            --producer-artifact "release-cell-prepublish-release-evidence-attempt-$GITHUB_RUN_ATTEMPT" \
             --out-dir target/release-cells
 
       - name: Upload authenticated release-evidence cells
         if: success() && inputs.emit_release_cells
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: release-cell-prepublish-release-evidence
+          name: release-cell-prepublish-release-evidence-attempt-${{ github.run_attempt }}
           path: target/release-cells/*.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -233,3 +233,4 @@ jobs:
           path: target/release-evidence
           if-no-files-found: warn
           retention-days: 30
+          overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         run: >-
           node --test
           scripts/tests/codestory-release-claims.test.mjs
+          scripts/tests/codestory-release-cell-manifest.test.mjs
           scripts/tests/codestory-release-closeout.test.mjs
           scripts/tests/codestory-release-evidence-gate.test.mjs
 
@@ -142,8 +143,19 @@ jobs:
       profile: codestory-release-evidence-linux-arm64-v2
       drill_manifest: /srv/codestory-release-evidence/drills/real-repo-drill-cases.json
       source_run_id: ${{ inputs.source_run_id }}
+      version: ${{ needs.preflight.outputs.version }}
+      emit_release_cells: true
     secrets:
       CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON: ${{ secrets.CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON }}
+
+  source-proof:
+    needs: preflight
+    uses: ./.github/workflows/source-proof.yml
+    with:
+      ref: ${{ github.sha }}
+      proof_key: release-${{ needs.preflight.outputs.version }}
+      version: ${{ needs.preflight.outputs.version }}
+      emit_release_cells: true
 
   packaged-proof:
     needs:
@@ -156,6 +168,7 @@ jobs:
       scope: full
       proof_key: release-${{ needs.preflight.outputs.version }}
       sign_macos: true
+      emit_release_cells: true
       quality_evidence_artifact: release-evidence-${{ github.sha }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id }}
@@ -183,6 +196,7 @@ jobs:
       quality_evidence_artifact: release-evidence-${{ github.sha }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id }}
+      emit_release_cells: true
 
   windows-vulkan-proof:
     needs:
@@ -197,14 +211,71 @@ jobs:
       quality_evidence_artifact: release-evidence-${{ github.sha }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id }}
+      emit_release_cells: true
+
+  pre-publish-closeout:
+    name: Authenticate pre-publish release cells
+    needs:
+      - preflight
+      - source-proof
+      - release-evidence
+      - packaged-proof
+      - macos-metal-proof
+      - windows-vulkan-proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Download pre-publish release cells
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: release-cell-prepublish-*
+          path: target/release-cell-manifests
+          merge-multiple: true
+
+      - name: Evaluate authenticated pre-publish closeout
+        shell: bash
+        run: |
+          set -euo pipefail
+          evaluated_at="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
+          node scripts/codestory-release-cell-manifest.mjs producer-map \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "$GITHUB_SHA" \
+            --phase pre_publish \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --out target/release-closeout/trusted-pre-publish-producers.json
+          node scripts/codestory-release-closeout.mjs evaluate \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "$GITHUB_SHA" \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --phase pre_publish \
+            --evaluated-at "$evaluated_at" \
+            --trusted-producers target/release-closeout/trusted-pre-publish-producers.json \
+            --manifest-dir target/release-cell-manifests \
+            --out-dir target/release-closeout/pre_publish
+
+      - name: Upload accepted pre-publish closeout
+        if: success()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
+          path: |
+            target/release-closeout/trusted-pre-publish-producers.json
+            target/release-closeout/pre_publish
+          if-no-files-found: error
+          retention-days: 30
 
   publish:
     name: Publish GitHub release
     needs:
       - preflight
-      - packaged-proof
-      - macos-metal-proof
-      - windows-vulkan-proof
+      - pre-publish-closeout
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -303,6 +374,72 @@ jobs:
       quality_evidence_artifact: release-evidence-${{ github.sha }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id }}
+      pre_publish_closeout_artifact: release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
+      emit_release_cells: true
     permissions:
       actions: read
       contents: read
+
+  post-publish-closeout:
+    name: Authenticate post-publish release cells
+    needs:
+      - preflight
+      - pre-publish-closeout
+      - post-publish-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Download every release cell
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: release-cell-*
+          path: target/release-cell-manifests
+          merge-multiple: true
+
+      - name: Download accepted pre-publish closeout
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
+          path: target/accepted-pre-publish-closeout
+
+      - name: Evaluate authenticated post-publish closeout
+        shell: bash
+        run: |
+          set -euo pipefail
+          ledger="$(find target/accepted-pre-publish-closeout -type f -name ledger.json -print)"
+          test "$(printf '%s\n' "$ledger" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          evaluated_at="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
+          node scripts/codestory-release-cell-manifest.mjs producer-map \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "$GITHUB_SHA" \
+            --phase post_publish \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --out target/release-closeout/trusted-post-publish-producers.json
+          node scripts/codestory-release-closeout.mjs evaluate \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "$GITHUB_SHA" \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --phase post_publish \
+            --evaluated-at "$evaluated_at" \
+            --trusted-producers target/release-closeout/trusted-post-publish-producers.json \
+            --manifest-dir target/release-cell-manifests \
+            --pre-publish-ledger "$ledger" \
+            --out-dir target/release-closeout/post_publish
+
+      - name: Upload accepted post-publish closeout
+        if: success()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-closeout-post-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
+          path: |
+            target/release-closeout/trusted-post-publish-producers.json
+            target/release-closeout/post_publish
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,18 +231,13 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: Download pre-publish release cells
-        uses: actions/download-artifact@v8.0.1
-        with:
-          pattern: release-cell-prepublish-*
-          path: target/release-cell-manifests
-          merge-multiple: true
-
-      - name: Evaluate authenticated pre-publish closeout
+      - name: Authenticate pre-publish Actions provenance
+        id: pre-publish-provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          evaluated_at="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
           node scripts/codestory-release-cell-manifest.mjs producer-map \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
@@ -250,6 +245,44 @@ jobs:
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
             --out target/release-closeout/trusted-pre-publish-producers.json
+          artifact_ids="$(jq -r '[.artifacts[].id] | join(",")' target/release-closeout/trusted-pre-publish-producers.json)"
+          test -n "$artifact_ids"
+          echo "artifact_ids=$artifact_ids" >> "$GITHUB_OUTPUT"
+
+      - name: Download selected pre-publish release cells
+        uses: actions/download-artifact@v8.0.1
+        with:
+          artifact-ids: ${{ steps.pre-publish-provenance.outputs.artifact_ids }}
+          path: target/release-cell-manifests
+          merge-multiple: false
+
+      - name: Verify selected pre-publish artifact container digests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release-cell-containers
+          jq -r '.artifacts[] | [.id, .digest] | @tsv' target/release-closeout/trusted-pre-publish-producers.json |
+            while IFS=$'\t' read -r artifact_id expected_digest; do
+              archive="target/release-cell-containers/$artifact_id.zip"
+              curl --fail --location --silent --show-error \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer $GH_TOKEN" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
+                --output "$archive"
+              actual_digest="sha256:$(sha256sum "$archive" | awk '{print $1}')"
+              test "$actual_digest" = "$expected_digest"
+            done
+
+      - name: Evaluate authenticated pre-publish closeout
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted_exceptions="$(find target/release-cell-manifests -type f -name trusted-exceptions.json -print)"
+          test "$(printf '%s\n' "$trusted_exceptions" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          evaluated_at="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
           node scripts/codestory-release-closeout.mjs evaluate \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
@@ -257,6 +290,7 @@ jobs:
             --phase pre_publish \
             --evaluated-at "$evaluated_at" \
             --trusted-producers target/release-closeout/trusted-pre-publish-producers.json \
+            --trusted-exceptions "$trusted_exceptions" \
             --manifest-dir target/release-cell-manifests \
             --out-dir target/release-closeout/pre_publish
 
@@ -395,12 +429,50 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: Download every release cell
+      - name: Authenticate post-publish Actions provenance
+        id: post-publish-provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/codestory-release-cell-manifest.mjs producer-map \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "$GITHUB_SHA" \
+            --phase post_publish \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --out target/release-closeout/trusted-post-publish-producers.json
+          artifact_ids="$(jq -r '[.artifacts[].id] | join(",")' target/release-closeout/trusted-post-publish-producers.json)"
+          test -n "$artifact_ids"
+          echo "artifact_ids=$artifact_ids" >> "$GITHUB_OUTPUT"
+
+      - name: Download selected release cells without flattening
         uses: actions/download-artifact@v8.0.1
         with:
-          pattern: release-cell-*
+          artifact-ids: ${{ steps.post-publish-provenance.outputs.artifact_ids }}
           path: target/release-cell-manifests
-          merge-multiple: true
+          merge-multiple: false
+
+      - name: Verify selected post-publish artifact container digests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release-cell-containers
+          jq -r '.artifacts[] | [.id, .digest] | @tsv' target/release-closeout/trusted-post-publish-producers.json |
+            while IFS=$'\t' read -r artifact_id expected_digest; do
+              archive="target/release-cell-containers/$artifact_id.zip"
+              curl --fail --location --silent --show-error \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer $GH_TOKEN" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
+                --output "$archive"
+              actual_digest="sha256:$(sha256sum "$archive" | awk '{print $1}')"
+              test "$actual_digest" = "$expected_digest"
+            done
 
       - name: Download accepted pre-publish closeout
         uses: actions/download-artifact@v8.0.1
@@ -414,14 +486,9 @@ jobs:
           set -euo pipefail
           ledger="$(find target/accepted-pre-publish-closeout -type f -name ledger.json -print)"
           test "$(printf '%s\n' "$ledger" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          trusted_exceptions="$(find target/release-cell-manifests -type f -name trusted-exceptions.json -print)"
+          test "$(printf '%s\n' "$trusted_exceptions" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
           evaluated_at="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
-          node scripts/codestory-release-cell-manifest.mjs producer-map \
-            --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "$GITHUB_SHA" \
-            --phase post_publish \
-            --producer-run-id "$GITHUB_RUN_ID" \
-            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --out target/release-closeout/trusted-post-publish-producers.json
           node scripts/codestory-release-closeout.mjs evaluate \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
@@ -429,6 +496,7 @@ jobs:
             --phase post_publish \
             --evaluated-at "$evaluated_at" \
             --trusted-producers target/release-closeout/trusted-post-publish-producers.json \
+            --trusted-exceptions "$trusted_exceptions" \
             --manifest-dir target/release-cell-manifests \
             --pre-publish-ledger "$ledger" \
             --out-dir target/release-closeout/post_publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,7 @@ jobs:
             target/release-closeout/pre_publish
           if-no-files-found: error
           retention-days: 30
+          overwrite: true
 
   publish:
     name: Publish GitHub release
@@ -505,7 +506,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: release-closeout-post-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
+          name: release-closeout-post-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}-attempt-${{ github.run_attempt }}
           path: |
             target/release-closeout/trusted-post-publish-producers.json
             target/release-closeout/post_publish

--- a/.github/workflows/source-proof.yml
+++ b/.github/workflows/source-proof.yml
@@ -11,6 +11,14 @@ on:
       proof_key:
         required: true
         type: string
+      version:
+        required: false
+        default: ""
+        type: string
+      emit_release_cells:
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       pr_number:
@@ -141,6 +149,32 @@ jobs:
 
       - name: Lint every workspace target and feature once
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+      - name: Emit authenticated source release cell
+        if: inputs.emit_release_cells
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/codestory-release-cell-manifest.mjs produce \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "${{ needs.resolve.outputs.ref }}" \
+            --version "${{ inputs.version }}" \
+            --cell-id source_behavior \
+            --producer-workflow .github/workflows/source-proof.yml \
+            --producer-job full-source-gate \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --producer-artifact release-cell-prepublish-source \
+            --out target/release-cells/source_behavior.json
+
+      - name: Upload authenticated source release cell
+        if: success() && inputs.emit_release_cells
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-prepublish-source
+          path: target/release-cells/source_behavior.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Save Cargo inputs and output
         if: success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''

--- a/.github/workflows/source-proof.yml
+++ b/.github/workflows/source-proof.yml
@@ -164,14 +164,14 @@ jobs:
             --producer-job full-source-gate \
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --producer-artifact release-cell-prepublish-source \
+            --producer-artifact "release-cell-prepublish-source-attempt-$GITHUB_RUN_ATTEMPT" \
             --out target/release-cells/source_behavior.json
 
       - name: Upload authenticated source release cell
         if: success() && inputs.emit_release_cells
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: release-cell-prepublish-source
+          name: release-cell-prepublish-source-attempt-${{ github.run_attempt }}
           path: target/release-cells/source_behavior.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -29,6 +29,10 @@ on:
         required: false
         default: ""
         type: string
+      emit_release_cells:
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
@@ -207,6 +211,43 @@ jobs:
             @qualityArgs `
             --timeout-secs 1800 `
             --out-dir target/windows-vulkan-proof/packaged-agent
+
+      - name: Emit authenticated Vulkan release cell
+        if: inputs.emit_release_cells
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          version="${version#v}"
+          calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
+          test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          jq -n \
+            --arg native_engine coderank_q8_embedded \
+            --arg calibration_sha256 "$(python -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$calibration_bundle")" \
+            '{native_engine: $native_engine, calibration_sha256: $calibration_sha256}' \
+            > target/windows-vulkan-proof/release-cell-identity.json
+          node scripts/codestory-release-cell-manifest.mjs produce \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-sha "${{ inputs.ref }}" \
+            --version "$version" \
+            --cell-id accelerator_execution:windows-x64-vulkan \
+            --producer-workflow .github/workflows/windows-vulkan-proof.yml \
+            --producer-job packaged-vulkan \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --producer-artifact release-cell-prepublish-windows-x64-vulkan \
+            --identity target/windows-vulkan-proof/release-cell-identity.json \
+            --archive "target/release-dist/codestory-cli-v${version}-windows-x64.zip" \
+            --out target/release-cells/accelerator_execution-windows-x64-vulkan.json
+
+      - name: Upload authenticated Vulkan release cell
+        if: success() && inputs.emit_release_cells
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-prepublish-windows-x64-vulkan
+          path: target/release-cells/accelerator_execution-windows-x64-vulkan.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload Vulkan proof artifacts
         if: always()

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -235,7 +235,7 @@ jobs:
             --producer-job packaged-vulkan \
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --producer-artifact release-cell-prepublish-windows-x64-vulkan \
+            --producer-artifact "release-cell-prepublish-windows-x64-vulkan-attempt-$GITHUB_RUN_ATTEMPT" \
             --identity target/windows-vulkan-proof/release-cell-identity.json \
             --archive "target/release-dist/codestory-cli-v${version}-windows-x64.zip" \
             --out target/release-cells/accelerator_execution-windows-x64-vulkan.json
@@ -244,7 +244,7 @@ jobs:
         if: success() && inputs.emit_release_cells
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: release-cell-prepublish-windows-x64-vulkan
+          name: release-cell-prepublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}
           path: target/release-cells/accelerator_execution-windows-x64-vulkan.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -253,7 +253,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: windows-x64-vulkan-proof-${{ inputs.version }}
+          name: windows-x64-vulkan-proof-${{ inputs.version }}-attempt-${{ github.run_attempt }}
           path: target/windows-vulkan-proof
           if-no-files-found: error
           retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@
   depends only on an accepted authenticated 12-cell pre-publish ledger; the
   retained 30-cell post-publish ledger also proves downloaded archive bytes
   match the accepted package digests. Producer workflow, job, run, attempt and
-  artifact identity comes from the current Actions run map instead of the
-  manifest directory.
+  artifact identity comes from current-run Actions artifact and per-attempt job
+  metadata instead of the manifest directory. Immutable attempt-qualified
+  containers support failed-job reruns without accepting a failed newer
+  execution or flattening unrelated JSON. Approved performance exceptions are
+  separately authenticated and evaluated with same-run answer-quality proof.
 - Candidate-installed proof remains outside pre-publish authorization. The
   real installed-runtime tier, including its separate two-session/one-server
   qualification, remains post-publish work owned by #1221.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Release
+
+- The production release chain now emits graph-owned, success-only proof-cell
+  manifests for exact source, release evidence, all six packages, protected
+  Metal and Vulkan execution, and all six post-publish hosts. Publication
+  depends only on an accepted authenticated 12-cell pre-publish ledger; the
+  retained 30-cell post-publish ledger also proves downloaded archive bytes
+  match the accepted package digests. Producer workflow, job, run, attempt and
+  artifact identity comes from the current Actions run map instead of the
+  manifest directory.
+- Candidate-installed proof remains outside pre-publish authorization. The
+  real installed-runtime tier, including its separate two-session/one-server
+  qualification, remains post-publish work owned by #1221.
+
 ### Performance
 
 - The sqlite-vec versus USearch evidence harness now freezes and independently

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
+    "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
     "observed_at": "2026-07-16T11:00:00.000Z",
     "expires_at": "2026-07-17T11:00:00.000Z",
     "requested_claims": [
@@ -91,7 +91,7 @@
         "type": "retrieval_readiness",
         "tier": "live_behavior",
         "status": "pass",
-        "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
+        "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {
@@ -110,7 +110,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
+        "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {
@@ -131,7 +131,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
+        "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+    "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
     "observed_at": "2026-07-16T11:00:00.000Z",
     "expires_at": "2026-07-17T11:00:00.000Z",
     "requested_claims": [
@@ -91,7 +91,7 @@
         "type": "retrieval_readiness",
         "tier": "live_behavior",
         "status": "pass",
-        "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+        "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {
@@ -110,7 +110,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+        "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {
@@ -131,7 +131,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+        "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
         "observed_at": "2026-07-16T11:00:00.000Z",
         "expires_at": "2026-07-17T11:00:00.000Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "d73d2e85c2618b56982b696f1900508e1b6406c454a03465368d2b41a94301cd",
+  "candidate_sha256": "698fbc2b5236a3a12eb9f13e4133f8ab8add3e03769819741d9786a26f22a0a2",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -20,11 +20,74 @@
       "bytes": 5515
     }
   ],
+  "release_cell_evidence": [
+    {
+      "id": "retrieval_readiness-222222222222",
+      "type": "retrieval_readiness",
+      "tier": "live_behavior",
+      "status": "pass",
+      "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+      "observed_at": "2026-07-16T11:00:00.000Z",
+      "expires_at": "2026-07-17T11:00:00.000Z",
+      "identity": {
+        "repository": "TheGreenCedar/CodeStory",
+        "commit": "2222222222222222222222222222222222222222",
+        "source_tree": "d40d3a0d24b170c098461cf6c29d71451d66bff3",
+        "profile": "ci-contract-v1",
+        "corpus_id": "ci-contract-corpus-v1",
+        "cache_id": "cold-full-retrieval-v1",
+        "machine_fingerprint": "ci-contract/windows-x64/8/test-cpu/16GiB",
+        "release_key": "ci-contract-v1"
+      }
+    },
+    {
+      "id": "performance-222222222222",
+      "type": "performance",
+      "tier": "live_behavior",
+      "status": "pass",
+      "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+      "observed_at": "2026-07-16T11:00:00.000Z",
+      "expires_at": "2026-07-17T11:00:00.000Z",
+      "identity": {
+        "repository": "TheGreenCedar/CodeStory",
+        "commit": "2222222222222222222222222222222222222222",
+        "source_tree": "d40d3a0d24b170c098461cf6c29d71451d66bff3",
+        "profile": "ci-contract-v1",
+        "corpus_id": "ci-contract-corpus-v1",
+        "cache_id": "cold-full-retrieval-v1",
+        "machine_fingerprint": "ci-contract/windows-x64/8/test-cpu/16GiB",
+        "release_key": "ci-contract-v1",
+        "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
+        "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1"
+      }
+    },
+    {
+      "id": "answer_quality-222222222222",
+      "type": "answer_quality",
+      "tier": "answer_quality",
+      "status": "pass",
+      "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+      "observed_at": "2026-07-16T11:00:00.000Z",
+      "expires_at": "2026-07-17T11:00:00.000Z",
+      "identity": {
+        "repository": "TheGreenCedar/CodeStory",
+        "commit": "2222222222222222222222222222222222222222",
+        "source_tree": "d40d3a0d24b170c098461cf6c29d71451d66bff3",
+        "profile": "ci-contract-v1",
+        "corpus_id": "ci-contract-corpus-v1",
+        "cache_id": "cold-full-retrieval-v1",
+        "machine_fingerprint": "ci-contract/windows-x64/8/test-cpu/16GiB",
+        "release_key": "ci-contract-v1",
+        "artifact_sha256": "7f519e5d3c2d69aca7d29872ccff103d12cccd863e81f3ddad6615f94a1fe031",
+        "evaluation_contract": "publishable-three-repeat-packet/v1"
+      }
+    }
+  ],
   "release_claim_evaluation": {
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
+    "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-16T11:00:00.000Z",

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "698fbc2b5236a3a12eb9f13e4133f8ab8add3e03769819741d9786a26f22a0a2",
+  "candidate_sha256": "89a62d4bb007d2f8968e7370bfbdc95025d0f416c4d98393fb104529fd1debb1",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "retrieval_readiness",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+      "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {
@@ -45,7 +45,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+      "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {
@@ -66,7 +66,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+      "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {
@@ -83,11 +83,12 @@
       }
     }
   ],
+  "release_cell_exceptions": {},
   "release_claim_evaluation": {
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+    "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-16T11:00:00.000Z",

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -205,7 +205,10 @@ Release-evidence output is one input to the exact-head closeout ledger; it is
 not the ledger itself. Each producer supplies one
 `codestory.release-cell-manifest/v1` document for its graph-owned cell. The
 manifest carries the claim evidence row plus its workflow, run, attempt and
-artifact identity. Native cells also carry the applicable target, concrete
+artifact identity. Production cells are emitted only on producer success, and
+the closeout coordinator checks those fields against a separately derived map
+for the current Actions run; manifests cannot authenticate themselves. Native
+cells also carry the applicable target, concrete
 host, runtime/native engine and calibration identities. The coordinator
 derives the required inventory from `release-claims.json`, so operators must
 not maintain a separate target checklist or combine multiple hosts into one
@@ -220,3 +223,9 @@ version, and platform hosts bind to the package matrix target. Keep the per-cell
 manifests and evaluations with both ledgers. A missing, duplicate, expired, failed,
 cross-commit, cross-tree, identity-incomplete or reused row is a rejection, not
 an operator override.
+
+The production pre-publish inventory is 12 cells and intentionally excludes a
+candidate-installed runtime. Publication is the prerequisite for the
+marketplace-managed tier. The six installed-runtime cells appear only in the
+30-cell post-publish ledger, while #1221 continues to own the real
+two-session/one-server installed-runtime qualification.

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -206,8 +206,13 @@ not the ledger itself. Each producer supplies one
 `codestory.release-cell-manifest/v1` document for its graph-owned cell. The
 manifest carries the claim evidence row plus its workflow, run, attempt and
 artifact identity. Production cells are emitted only on producer success, and
-the closeout coordinator checks those fields against a separately derived map
-for the current Actions run; manifests cannot authenticate themselves. Native
+each immutable Actions artifact name includes its run attempt. The closeout
+coordinator queries artifact and per-attempt job metadata for the current run,
+selects each graph-owned job's latest execution, and requires that execution to
+be successful before binding the container id, digest, creation window and
+unflattened directory to its manifests. A failed newer execution cannot fall
+back to older evidence; jobs absent from a failed-job rerun may retain their
+last successful attempt. Manifests cannot authenticate themselves. Native
 cells also carry the applicable target, concrete
 host, runtime/native engine and calibration identities. The coordinator
 derives the required inventory from `release-claims.json`, so operators must
@@ -223,6 +228,12 @@ version, and platform hosts bind to the package matrix target. Keep the per-cell
 manifests and evaluations with both ledgers. A missing, duplicate, expired, failed,
 cross-commit, cross-tree, identity-incomplete or reused row is a rejection, not
 an operator override.
+
+Approved model-microbenchmark exceptions use a separately authenticated
+`codestory.release-closeout-exceptions/v1` input from the selected
+release-evidence artifact. Performance closeout includes the same-run
+`answer_quality` cell and passes that trusted exception map to the claim
+evaluator. Flattened or loose manifest JSON is never a closeout input.
 
 The production pre-publish inventory is 12 cells and intentionally excludes a
 candidate-installed runtime. Publication is the prerequisite for the

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -318,7 +318,11 @@ coordinator expands native cells from `workflow_policy.package_matrix`, keeps
 protected hardware cells explicit, invokes the claim evaluator for each cell
 and its graph dependencies, then retains canonical copies under `manifests/`
 and `evaluations/` beside `ledger.json` and `summary.json`. A pre-publish run
-records each archive name, byte count, and SHA-256. A post-publish run requires
+accepts 12 cells: exact source, six package targets, two protected-hardware
+targets, and the three release-evidence claims. A post-publish run accepts 30
+cells after adding platform, installed-runtime and downloaded-byte proof for
+all six targets. Package rows record each archive name, byte count, and SHA-256.
+A post-publish run requires
 that accepted pre-publish ledger, requires its current package manifests to
 match the retained rows, and rejects any downloaded archive whose bytes do not
 match the retained digest. Producer and installed-runtime versions must equal
@@ -327,6 +331,14 @@ hosts must match the OS and architecture derived from the package matrix's Rust
 target. Do not use `matrix`, `mixed`, or another
 aggregate placeholder for a host, runner, backend, installer, or native-engine
 identity.
+
+Production producers use `scripts/codestory-release-cell-manifest.mjs`. They
+emit cells only after their job succeeds and bind workflow, job, run, attempt
+and Actions artifact identity. The closeout job independently derives a
+`codestory.release-producer-map/v1` document from the current workflow context;
+an arbitrary manifest directory cannot attest its own producer. Both closeout
+jobs retain that map with the canonical manifests, individual evaluations,
+ledger and summary.
 
 Run the coordinator only with retained producer manifests and a fresh output
 directory:
@@ -338,6 +350,7 @@ node scripts/codestory-release-closeout.mjs evaluate \
   --version <version> \
   --phase pre_publish \
   --evaluated-at <canonical-ISO-timestamp> \
+  --trusted-producers <current-run-producer-map.json> \
   --manifest-dir <producer-manifests> \
   --out-dir <new-closeout-directory>
 ```
@@ -347,6 +360,12 @@ For `--phase post_publish`, pass every graph-owned cell plus
 tested and merged without final evidence; an accepted ledger still requires
 the frozen exact-head producer manifests and does not upgrade source or package
 proof into installed, protected-hardware, or live-behavior proof.
+
+Pre-publish authorization deliberately has no candidate-installed cell. A
+marketplace install cannot exist until publication, and candidate-managed proof
+does not replace it. The six installed-runtime cells remain post-publish and
+the real two-session/one-server installed-runtime qualification remains the
+separate #1221 evidence tier.
 
 The command-line evaluator derives repository, commit, and source-tree identity
 from `--repo` and the full `--expected-sha`; evidence documents cannot supply

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -266,7 +266,7 @@ Workflow edits run:
 ```sh
 npm ci --ignore-scripts
 node scripts/codestory-release-claims.mjs validate --repo .
-node --test scripts/tests/codestory-release-claims.test.mjs scripts/tests/codestory-release-closeout.test.mjs scripts/tests/codestory-release-evidence-gate.test.mjs
+node --test scripts/tests/codestory-release-claims.test.mjs scripts/tests/codestory-release-cell-manifest.test.mjs scripts/tests/codestory-release-closeout.test.mjs scripts/tests/codestory-release-evidence-gate.test.mjs
 node --test .github/scripts/run-actionlint.test.mjs
 node .github/scripts/run-actionlint.mjs
 node .github/scripts/check-workflow-policy.mjs
@@ -334,11 +334,26 @@ identity.
 
 Production producers use `scripts/codestory-release-cell-manifest.mjs`. They
 emit cells only after their job succeeds and bind workflow, job, run, attempt
-and Actions artifact identity. The closeout job independently derives a
-`codestory.release-producer-map/v1` document from the current workflow context;
-an arbitrary manifest directory cannot attest its own producer. Both closeout
-jobs retain that map with the canonical manifests, individual evaluations,
-ledger and summary.
+and Actions artifact identity. Artifact names are immutable and attempt
+qualified. The closeout job queries the current run's Actions artifact and job
+APIs, selects the highest attempt in which each graph-owned job actually ran,
+requires that latest execution to have succeeded, and binds the selected
+container id, digest, creation window and unflattened directory to its cells in
+`codestory.release-actions-provenance/v1`. Loose JSON, expired or duplicate
+containers, a failed newer execution, and artifacts outside the selected job's
+time window are rejected. This permits **Re-run failed jobs** after a partial
+post-publish failure: cells from jobs that did not rerun retain their earlier
+attempt, while rerun cells use the newer successful attempt. Do not use
+**Re-run all jobs** as post-publish recovery; publication is intentionally not
+repeatable after the tag and release exist.
+
+An accepted model-microbenchmark exception is a separate authenticated input,
+not a manifest assertion. The release-evidence container retains
+`codestory.release-closeout-exceptions/v1`; closeout verifies its producer,
+includes same-run `answer_quality` in the performance-cell evaluation, and
+passes the trusted exception map to the claim evaluator. Both closeout jobs
+retain the provenance map and exception input with canonical manifests,
+individual evaluations, ledger and summary.
 
 Run the coordinator only with retained producer manifests and a fresh output
 directory:
@@ -350,8 +365,9 @@ node scripts/codestory-release-closeout.mjs evaluate \
   --version <version> \
   --phase pre_publish \
   --evaluated-at <canonical-ISO-timestamp> \
-  --trusted-producers <current-run-producer-map.json> \
-  --manifest-dir <producer-manifests> \
+  --trusted-producers <actions-provenance-map.json> \
+  --trusted-exceptions <selected-release-evidence-container/trusted-exceptions.json> \
+  --manifest-dir <unflattened-selected-artifact-directories> \
   --out-dir <new-closeout-directory>
 ```
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -347,6 +347,12 @@ attempt, while rerun cells use the newer successful attempt. Do not use
 **Re-run all jobs** as post-publish recovery; publication is intentionally not
 repeatable after the tag and release exist.
 
+Every other release-chain upload is rerun-safe as well. Retained diagnostics
+use attempt-qualified names. Stable intermediate artifacts that a later job
+downloads by name use explicit replacement from a policy-owned allowlist, so a
+retried producer cannot fail on an immutable same-name artifact before it emits
+its authenticated cell. Terminal evidence is never overwriteable.
+
 An accepted model-microbenchmark exception is a separate authenticated input,
 not a manifest assertion. The release-evidence container retains
 `codestory.release-closeout-exceptions/v1`; closeout verifies its producer,

--- a/release-claims.json
+++ b/release-claims.json
@@ -34,6 +34,7 @@
       "evaluation_contract": "versioned_contract",
       "producer_workflow": "workflow_path",
       "producer_job": "identifier",
+      "producer_job_name": "non_empty_text",
       "producer_run_id": "positive_integer",
       "producer_run_attempt": "positive_integer",
       "producer_artifact": "non_empty_text",
@@ -511,6 +512,7 @@
           "source_tree",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -518,7 +520,8 @@
         "identity_constraints": {
           "producer_workflow": ".github/workflows/source-proof.yml",
           "producer_job": "full-source-gate",
-          "producer_artifact": "release-cell-prepublish-source"
+          "producer_job_name": "full-source-gate",
+          "producer_artifact": "release-cell-prepublish-source-attempt-{attempt}"
         },
         "archive_role": "none"
       },
@@ -537,6 +540,7 @@
           "target",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -544,7 +548,8 @@
         "identity_constraints": {
           "producer_workflow": ".github/workflows/packaged-platform-proof.yml",
           "producer_job": "build",
-          "producer_artifact": "release-cell-prepublish-package-{target}"
+          "producer_job_name": "Build {target}",
+          "producer_artifact": "release-cell-prepublish-package-{target}-attempt-{attempt}"
         },
         "archive_role": "pre_publish"
       },
@@ -569,6 +574,7 @@
           "calibration_sha256",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -591,7 +597,8 @@
               "backend": "Metal",
               "producer_workflow": ".github/workflows/macos-metal-proof.yml",
               "producer_job": "packaged-metal",
-              "producer_artifact": "release-cell-prepublish-macos-arm64-metal"
+              "producer_job_name": "Packaged Apple Silicon Metal engine",
+              "producer_artifact": "release-cell-prepublish-macos-arm64-metal-attempt-{attempt}"
             }
           },
           {
@@ -604,7 +611,8 @@
               "backend": "Vulkan",
               "producer_workflow": ".github/workflows/windows-vulkan-proof.yml",
               "producer_job": "packaged-vulkan",
-              "producer_artifact": "release-cell-prepublish-windows-x64-vulkan"
+              "producer_job_name": "Packaged Windows Vulkan engine",
+              "producer_artifact": "release-cell-prepublish-windows-x64-vulkan-attempt-{attempt}"
             }
           }
         ],
@@ -627,6 +635,7 @@
           "release_key",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -634,7 +643,8 @@
         "identity_constraints": {
           "producer_workflow": ".github/workflows/release-candidate-evidence.yml",
           "producer_job": "measure",
-          "producer_artifact": "release-cell-prepublish-release-evidence"
+          "producer_job_name": "Measure release candidate",
+          "producer_artifact": "release-cell-prepublish-release-evidence-attempt-{attempt}"
         },
         "archive_role": "none"
       },
@@ -657,6 +667,7 @@
           "release_key",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -664,7 +675,8 @@
         "identity_constraints": {
           "producer_workflow": ".github/workflows/release-candidate-evidence.yml",
           "producer_job": "measure",
-          "producer_artifact": "release-cell-prepublish-release-evidence"
+          "producer_job_name": "Measure release candidate",
+          "producer_artifact": "release-cell-prepublish-release-evidence-attempt-{attempt}"
         },
         "archive_role": "none"
       },
@@ -687,6 +699,7 @@
           "evaluation_contract",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -694,7 +707,8 @@
         "identity_constraints": {
           "producer_workflow": ".github/workflows/release-candidate-evidence.yml",
           "producer_job": "measure",
-          "producer_artifact": "release-cell-prepublish-release-evidence"
+          "producer_job_name": "Measure release candidate",
+          "producer_artifact": "release-cell-prepublish-release-evidence-attempt-{attempt}"
         },
         "archive_role": "none"
       },
@@ -715,6 +729,7 @@
           "host_arch",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -726,7 +741,8 @@
         "identity_constraints": {
           "producer_workflow": ".github/workflows/post-publish-release-smoke.yml",
           "producer_job": "smoke",
-          "producer_artifact": "release-cell-postpublish-{target}"
+          "producer_job_name": "Published {target} smoke",
+          "producer_artifact": "release-cell-postpublish-{target}-attempt-{attempt}"
         },
         "archive_role": "none"
       },
@@ -751,6 +767,7 @@
           "calibration_sha256",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -764,7 +781,8 @@
         "identity_constraints": {
           "producer_workflow": ".github/workflows/post-publish-release-smoke.yml",
           "producer_job": "smoke",
-          "producer_artifact": "release-cell-postpublish-{target}"
+          "producer_job_name": "Published {target} smoke",
+          "producer_artifact": "release-cell-postpublish-{target}-attempt-{attempt}"
         },
         "archive_role": "none"
       },
@@ -784,6 +802,7 @@
           "target",
           "producer_workflow",
           "producer_job",
+          "producer_job_name",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -791,7 +810,8 @@
         "identity_constraints": {
           "producer_workflow": ".github/workflows/post-publish-release-smoke.yml",
           "producer_job": "smoke",
-          "producer_artifact": "release-cell-postpublish-{target}"
+          "producer_job_name": "Published {target} smoke",
+          "producer_artifact": "release-cell-postpublish-{target}-attempt-{attempt}"
         },
         "archive_role": "post_publish_compare"
       }

--- a/release-claims.json
+++ b/release-claims.json
@@ -33,6 +33,7 @@
       "release_key": "identifier",
       "evaluation_contract": "versioned_contract",
       "producer_workflow": "workflow_path",
+      "producer_job": "identifier",
       "producer_run_id": "positive_integer",
       "producer_run_attempt": "positive_integer",
       "producer_artifact": "non_empty_text",
@@ -509,12 +510,15 @@
           "commit",
           "source_tree",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
         ],
         "identity_constraints": {
-          "producer_workflow": ".github/workflows/source-proof.yml"
+          "producer_workflow": ".github/workflows/source-proof.yml",
+          "producer_job": "full-source-gate",
+          "producer_artifact": "release-cell-prepublish-source"
         },
         "archive_role": "none"
       },
@@ -532,12 +536,15 @@
           "producer_version",
           "target",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
         ],
         "identity_constraints": {
-          "producer_workflow": ".github/workflows/packaged-platform-proof.yml"
+          "producer_workflow": ".github/workflows/packaged-platform-proof.yml",
+          "producer_job": "build",
+          "producer_artifact": "release-cell-prepublish-package-{target}"
         },
         "archive_role": "pre_publish"
       },
@@ -561,6 +568,7 @@
           "native_engine",
           "calibration_sha256",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -581,7 +589,9 @@
               "host_arch": "ARM64",
               "runner": "codestory-metal",
               "backend": "Metal",
-              "producer_workflow": ".github/workflows/macos-metal-proof.yml"
+              "producer_workflow": ".github/workflows/macos-metal-proof.yml",
+              "producer_job": "packaged-metal",
+              "producer_artifact": "release-cell-prepublish-macos-arm64-metal"
             }
           },
           {
@@ -592,7 +602,9 @@
               "host_arch": "X64",
               "runner": "codestory-vulkan",
               "backend": "Vulkan",
-              "producer_workflow": ".github/workflows/windows-vulkan-proof.yml"
+              "producer_workflow": ".github/workflows/windows-vulkan-proof.yml",
+              "producer_job": "packaged-vulkan",
+              "producer_artifact": "release-cell-prepublish-windows-x64-vulkan"
             }
           }
         ],
@@ -614,12 +626,15 @@
           "machine_fingerprint",
           "release_key",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
         ],
         "identity_constraints": {
-          "producer_workflow": ".github/workflows/release-candidate-evidence.yml"
+          "producer_workflow": ".github/workflows/release-candidate-evidence.yml",
+          "producer_job": "measure",
+          "producer_artifact": "release-cell-prepublish-release-evidence"
         },
         "archive_role": "none"
       },
@@ -641,12 +656,15 @@
           "baseline_sha256",
           "release_key",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
         ],
         "identity_constraints": {
-          "producer_workflow": ".github/workflows/release-candidate-evidence.yml"
+          "producer_workflow": ".github/workflows/release-candidate-evidence.yml",
+          "producer_job": "measure",
+          "producer_artifact": "release-cell-prepublish-release-evidence"
         },
         "archive_role": "none"
       },
@@ -668,12 +686,15 @@
           "artifact_sha256",
           "evaluation_contract",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
         ],
         "identity_constraints": {
-          "producer_workflow": ".github/workflows/release-candidate-evidence.yml"
+          "producer_workflow": ".github/workflows/release-candidate-evidence.yml",
+          "producer_job": "measure",
+          "producer_artifact": "release-cell-prepublish-release-evidence"
         },
         "archive_role": "none"
       },
@@ -693,6 +714,7 @@
           "host_os",
           "host_arch",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -702,7 +724,9 @@
           "host_arch"
         ],
         "identity_constraints": {
-          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml"
+          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml",
+          "producer_job": "smoke",
+          "producer_artifact": "release-cell-postpublish-{target}"
         },
         "archive_role": "none"
       },
@@ -726,6 +750,7 @@
           "native_engine",
           "calibration_sha256",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
@@ -737,7 +762,9 @@
           "native_engine"
         ],
         "identity_constraints": {
-          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml"
+          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml",
+          "producer_job": "smoke",
+          "producer_artifact": "release-cell-postpublish-{target}"
         },
         "archive_role": "none"
       },
@@ -756,12 +783,15 @@
           "producer_version",
           "target",
           "producer_workflow",
+          "producer_job",
           "producer_run_id",
           "producer_run_attempt",
           "producer_artifact"
         ],
         "identity_constraints": {
-          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml"
+          "producer_workflow": ".github/workflows/post-publish-release-smoke.yml",
+          "producer_job": "smoke",
+          "producer_artifact": "release-cell-postpublish-{target}"
         },
         "archive_role": "post_publish_compare"
       }
@@ -870,6 +900,7 @@
       "evidence_profile": "codestory-release-evidence-linux-arm64-v2",
       "drill_manifest": "/srv/codestory-release-evidence/drills/real-repo-drill-cases.json",
       "exact_sha_jobs": [
+        "source-proof",
         "release-evidence",
         "packaged-proof",
         "macos-metal-proof",
@@ -880,6 +911,9 @@
           "workflow-policy"
         ],
         "release-evidence": [
+          "preflight"
+        ],
+        "source-proof": [
           "preflight"
         ],
         "packaged-proof": [
@@ -894,24 +928,37 @@
           "preflight",
           "packaged-proof"
         ],
-        "publish": [
+        "pre-publish-closeout": [
           "preflight",
+          "source-proof",
+          "release-evidence",
           "packaged-proof",
           "macos-metal-proof",
           "windows-vulkan-proof"
         ],
+        "publish": [
+          "preflight",
+          "pre-publish-closeout"
+        ],
         "post-publish-smoke": [
           "preflight",
           "publish"
+        ],
+        "post-publish-closeout": [
+          "preflight",
+          "pre-publish-closeout",
+          "post-publish-smoke"
         ]
       }
     },
     "artifact_workflows": [
+      "source-proof.yml",
       "release-candidate-evidence.yml",
       "packaged-platform-proof.yml",
       "macos-metal-proof.yml",
       "windows-vulkan-proof.yml",
       "post-publish-release-smoke.yml",
+      "release.yml",
       "repo-scale-stats.yml"
     ],
     "promotion": {

--- a/scripts/codestory-release-cell-manifest.mjs
+++ b/scripts/codestory-release-cell-manifest.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  canonicalReleaseClaimValue,
+  deriveTrustedGitIdentity,
+  loadReleaseClaimGraph,
+  releaseClaimGraphDigest,
+} from "./codestory-release-claims.mjs";
+import {
+  deriveReleaseCells,
+  validateReleaseCellManifest,
+} from "./codestory-release-closeout.mjs";
+
+const PRODUCER_MAP_SCHEMA = "codestory.release-producer-map/v1";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function text(value, label) {
+  if (typeof value !== "string" || value.trim() !== value || value === "") {
+    fail(`${label} must be non-empty trimmed text`);
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  return `${JSON.stringify(canonicalReleaseClaimValue(value), null, 2)}\n`;
+}
+
+function fileAttestation(filePath) {
+  const absolute = path.resolve(text(filePath, "artifact path"));
+  const stat = statSync(absolute);
+  if (!stat.isFile() || stat.size <= 0) fail(`artifact ${absolute} must be a non-empty regular file`);
+  const bytes = readFileSync(absolute);
+  return {
+    path: absolute,
+    name: path.basename(absolute),
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    bytes: bytes.length,
+  };
+}
+
+function writeJson(filePath, value) {
+  const absolute = path.resolve(text(filePath, "output path"));
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, canonicalJson(value));
+}
+
+function parseArgs(argv) {
+  const command = argv.shift();
+  const values = {};
+  while (argv.length > 0) {
+    const key = argv.shift();
+    const value = argv.shift();
+    if (!key?.startsWith("--") || value === undefined) fail("arguments must be --key value pairs");
+    const name = key.slice(2);
+    if (values[name] !== undefined) fail(`argument --${name} was supplied more than once`);
+    values[name] = value;
+  }
+  return { command, values };
+}
+
+function canonicalTimestamp(value, label) {
+  const selected = value ?? new Date().toISOString();
+  const parsed = Date.parse(selected);
+  if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== selected) {
+    fail(`${label} must be a canonical ISO timestamp`);
+  }
+  return selected;
+}
+
+function authenticatedProducer(values, gitIdentity, { requireJob = true } = {}) {
+  const producer = {
+    producer_workflow: text(values["producer-workflow"], "--producer-workflow"),
+    producer_job: text(values["producer-job"], "--producer-job"),
+    producer_run_id: text(values["producer-run-id"], "--producer-run-id"),
+    producer_run_attempt: text(values["producer-run-attempt"], "--producer-run-attempt"),
+    producer_artifact: text(values["producer-artifact"], "--producer-artifact"),
+  };
+  if (process.env.GITHUB_ACTIONS === "true") {
+    const expected = {
+      GITHUB_REPOSITORY: gitIdentity.repository,
+      GITHUB_SHA: gitIdentity.commit,
+      GITHUB_RUN_ID: producer.producer_run_id,
+      GITHUB_RUN_ATTEMPT: producer.producer_run_attempt,
+      ...(requireJob ? { GITHUB_JOB: producer.producer_job } : {}),
+    };
+    for (const [name, expectedValue] of Object.entries(expected)) {
+      if (process.env[name] !== expectedValue) {
+        fail(`${name} does not authenticate the requested release-cell producer`);
+      }
+    }
+  }
+  return producer;
+}
+
+function selectedCell(graph, cellId) {
+  const matches = deriveReleaseCells(graph, "post_publish").filter(({ id }) => id === cellId);
+  if (matches.length !== 1) fail(`release claim graph does not derive one cell ${cellId}`);
+  return matches[0];
+}
+
+function evidenceType(graph, id) {
+  const matches = graph.evidence_types.filter(({ id: candidate }) => candidate === id);
+  if (matches.length !== 1) fail(`release claim graph does not define one evidence type ${id}`);
+  return matches[0];
+}
+
+function retainedPackageRow(prePublishLedger, target) {
+  const rows = Array.isArray(prePublishLedger?.cells)
+    ? prePublishLedger.cells.filter(({ id }) => id === `package_identity:${target}`)
+    : [];
+  if (prePublishLedger?.decision !== "accept" || prePublishLedger?.phase !== "pre_publish" || rows.length !== 1) {
+    fail(`accepted pre-publish ledger must retain one package_identity:${target}`);
+  }
+  return rows[0];
+}
+
+export function produceReleaseCellManifest({
+  graph,
+  gitIdentity,
+  version,
+  cell,
+  identity: suppliedIdentity,
+  producer,
+  observedAt,
+  artifactPath = null,
+  archivePath = null,
+  prePublishLedger = null,
+  evidence = null,
+}) {
+  const graphSha256 = releaseClaimGraphDigest(graph);
+  const type = evidenceType(graph, cell.evidence_type);
+  const observed = canonicalTimestamp(evidence?.observed_at ?? observedAt, "observed_at");
+  const expires = evidence?.expires_at ?? new Date(
+    Date.parse(observed) + type.maximum_validity_hours * 60 * 60 * 1000,
+  ).toISOString();
+  const identity = {
+    ...(evidence?.identity ?? {}),
+    ...(suppliedIdentity ?? {}),
+    ...gitIdentity,
+    ...cell.identity_constraints,
+    ...producer,
+  };
+  if (cell.required_identity.includes("producer_version")) identity.producer_version = version;
+  if (cell.required_identity.includes("runtime_version")) identity.runtime_version = version;
+
+  const artifact = archivePath ? fileAttestation(archivePath) : artifactPath ? fileAttestation(artifactPath) : null;
+  if (artifact && cell.required_identity.includes("artifact_sha256")) {
+    identity.artifact_sha256 = artifact.sha256;
+  }
+  const manifest = {
+    schema: graph.closeout.manifest_schema,
+    cell_id: cell.id,
+    phase: cell.phase,
+    version,
+    graph_sha256: graphSha256,
+    evidence: {
+      ...(evidence ?? {}),
+      id: evidence?.id ?? `${cell.id}:${producer.producer_run_id}:${producer.producer_run_attempt}`,
+      type: cell.evidence_type,
+      tier: type.tier,
+      status: evidence?.status ?? "pass",
+      graph_sha256: graphSha256,
+      observed_at: observed,
+      expires_at: expires,
+      identity,
+    },
+  };
+  if (cell.archive_role === "pre_publish") {
+    if (!artifact || !archivePath) fail(`${cell.id} requires --archive`);
+    manifest.archive = { name: artifact.name, sha256: artifact.sha256, bytes: artifact.bytes };
+  } else if (cell.archive_role === "post_publish_compare") {
+    if (!artifact || !archivePath) fail(`${cell.id} requires --archive`);
+    const packageRow = retainedPackageRow(prePublishLedger, identity.target);
+    identity.pre_publish_artifact_sha256 = packageRow.archive.sha256;
+    manifest.comparison = {
+      pre_publish_cell_id: packageRow.id,
+      pre_publish_manifest_sha256: packageRow.manifest.sha256,
+      pre_publish_artifact_sha256: packageRow.archive.sha256,
+      published_artifact_name: artifact.name,
+      published_artifact_sha256: artifact.sha256,
+    };
+    if (artifact.name !== packageRow.archive.name || artifact.sha256 !== packageRow.archive.sha256
+        || artifact.bytes !== packageRow.archive.bytes) {
+      fail(`${cell.id} published archive bytes do not match the retained pre-publish archive`);
+    }
+  }
+  const problems = validateReleaseCellManifest({ manifest, cell, graph, version });
+  if (problems.length > 0) fail(`${cell.id} manifest is invalid: ${problems.join("; ")}`);
+  return manifest;
+}
+
+function common(values) {
+  const repoRoot = path.resolve(values.repo ?? path.resolve(path.dirname(process.argv[1]), ".."));
+  const graph = loadReleaseClaimGraph(repoRoot);
+  const gitIdentity = deriveTrustedGitIdentity({
+    repoRoot,
+    expectedSha: text(values["expected-sha"], "--expected-sha"),
+  });
+  return { repoRoot, graph, gitIdentity };
+}
+
+function produceOne(values) {
+  const { graph, gitIdentity } = common(values);
+  const version = text(values.version, "--version").replace(/^v/u, "");
+  const cell = selectedCell(graph, text(values["cell-id"], "--cell-id"));
+  const producer = authenticatedProducer(values, gitIdentity);
+  const identity = values.identity ? JSON.parse(readFileSync(values.identity, "utf8")) : {};
+  const prePublishLedger = values["pre-publish-ledger"]
+    ? JSON.parse(readFileSync(values["pre-publish-ledger"], "utf8"))
+    : null;
+  const manifest = produceReleaseCellManifest({
+    graph,
+    gitIdentity,
+    version,
+    cell,
+    identity,
+    producer,
+    observedAt: values["observed-at"],
+    artifactPath: values.artifact,
+    archivePath: values.archive,
+    prePublishLedger,
+  });
+  writeJson(text(values.out, "--out"), manifest);
+}
+
+function produceReleaseEvidence(values) {
+  const { graph, gitIdentity } = common(values);
+  const version = text(values.version, "--version").replace(/^v/u, "");
+  const producer = authenticatedProducer(values, gitIdentity);
+  const report = JSON.parse(readFileSync(text(values.report, "--report"), "utf8"));
+  if (!new Set(["pass", "pass_with_exception"]).has(report.status)) {
+    fail("release evidence report must be accepted before manifests are emitted");
+  }
+  const rows = Array.isArray(report.release_cell_evidence) ? report.release_cell_evidence : [];
+  const outDir = path.resolve(text(values["out-dir"], "--out-dir"));
+  for (const cellId of ["retrieval_readiness", "performance", "answer_quality"]) {
+    const matches = rows.filter(({ type }) => type === cellId);
+    if (matches.length !== 1) fail(`release evidence report must contain one ${cellId} row`);
+    const cell = selectedCell(graph, cellId);
+    const manifest = produceReleaseCellManifest({
+      graph,
+      gitIdentity,
+      version,
+      cell,
+      identity: {},
+      producer,
+      evidence: matches[0],
+    });
+    writeJson(path.join(outDir, `${cellId}.json`), manifest);
+  }
+}
+
+function produceMap(values) {
+  const { graph, gitIdentity } = common(values);
+  const phase = text(values.phase, "--phase");
+  const runId = text(values["producer-run-id"], "--producer-run-id");
+  const runAttempt = text(values["producer-run-attempt"], "--producer-run-attempt");
+  if (process.env.GITHUB_ACTIONS === "true") {
+    if (process.env.GITHUB_REPOSITORY !== gitIdentity.repository
+        || process.env.GITHUB_SHA !== gitIdentity.commit
+        || process.env.GITHUB_RUN_ID !== runId
+        || process.env.GITHUB_RUN_ATTEMPT !== runAttempt) {
+      fail("current workflow context does not authenticate the trusted producer map");
+    }
+  }
+  const producers = deriveReleaseCells(graph, phase).map((cell) => ({
+    cell_id: cell.id,
+    producer_workflow: cell.identity_constraints.producer_workflow,
+    producer_job: cell.identity_constraints.producer_job,
+    producer_run_id: runId,
+    producer_run_attempt: runAttempt,
+    producer_artifact: cell.identity_constraints.producer_artifact,
+  }));
+  writeJson(text(values.out, "--out"), {
+    schema: PRODUCER_MAP_SCHEMA,
+    phase,
+    identity: gitIdentity,
+    producers,
+  });
+}
+
+function main() {
+  const { command, values } = parseArgs(process.argv.slice(2));
+  if (command === "produce") produceOne(values);
+  else if (command === "release-evidence") produceReleaseEvidence(values);
+  else if (command === "producer-map") produceMap(values);
+  else fail("command must be produce, release-evidence, or producer-map");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) main();

--- a/scripts/codestory-release-cell-manifest.mjs
+++ b/scripts/codestory-release-cell-manifest.mjs
@@ -12,10 +12,13 @@ import {
 } from "./codestory-release-claims.mjs";
 import {
   deriveReleaseCells,
+  resolveReleaseCellConstraints,
   validateReleaseCellManifest,
 } from "./codestory-release-closeout.mjs";
 
-const PRODUCER_MAP_SCHEMA = "codestory.release-producer-map/v1";
+const PRODUCER_MAP_SCHEMA = "codestory.release-actions-provenance/v1";
+const TRUSTED_EXCEPTIONS_SCHEMA = "codestory.release-closeout-exceptions/v1";
+const ACTIONS_DIGEST = /^sha256:[0-9a-f]{64}$/u;
 
 function fail(message) {
   throw new Error(message);
@@ -144,7 +147,7 @@ export function produceReleaseCellManifest({
     ...(evidence?.identity ?? {}),
     ...(suppliedIdentity ?? {}),
     ...gitIdentity,
-    ...cell.identity_constraints,
+    ...resolveReleaseCellConstraints(cell, producer.producer_run_attempt),
     ...producer,
   };
   if (cell.required_identity.includes("producer_version")) identity.producer_version = version;
@@ -255,43 +258,230 @@ function produceReleaseEvidence(values) {
     });
     writeJson(path.join(outDir, `${cellId}.json`), manifest);
   }
-}
-
-function produceMap(values) {
-  const { graph, gitIdentity } = common(values);
-  const phase = text(values.phase, "--phase");
-  const runId = text(values["producer-run-id"], "--producer-run-id");
-  const runAttempt = text(values["producer-run-attempt"], "--producer-run-attempt");
-  if (process.env.GITHUB_ACTIONS === "true") {
-    if (process.env.GITHUB_REPOSITORY !== gitIdentity.repository
-        || process.env.GITHUB_SHA !== gitIdentity.commit
-        || process.env.GITHUB_RUN_ID !== runId
-        || process.env.GITHUB_RUN_ATTEMPT !== runAttempt) {
-      fail("current workflow context does not authenticate the trusted producer map");
-    }
-  }
-  const producers = deriveReleaseCells(graph, phase).map((cell) => ({
-    cell_id: cell.id,
-    producer_workflow: cell.identity_constraints.producer_workflow,
-    producer_job: cell.identity_constraints.producer_job,
-    producer_run_id: runId,
-    producer_run_attempt: runAttempt,
-    producer_artifact: cell.identity_constraints.producer_artifact,
-  }));
-  writeJson(text(values.out, "--out"), {
-    schema: PRODUCER_MAP_SCHEMA,
-    phase,
+  const performanceCell = selectedCell(graph, "performance");
+  const constraints = resolveReleaseCellConstraints(performanceCell, producer.producer_run_attempt);
+  const answerQuality = rows.find(({ type }) => type === "answer_quality");
+  writeJson(path.join(outDir, "trusted-exceptions.json"), {
+    schema: TRUSTED_EXCEPTIONS_SCHEMA,
+    graph_sha256: releaseClaimGraphDigest(graph),
+    version,
     identity: gitIdentity,
-    producers,
+    producer: {
+      ...producer,
+      producer_job_name: constraints.producer_job_name,
+    },
+    trusted_identity: {
+      candidate_sha256: report.candidate_sha256,
+      artifact_sha256: answerQuality?.identity?.artifact_sha256,
+    },
+    exceptions: report.release_cell_exceptions ?? {},
   });
 }
 
-function main() {
+function positiveInteger(value, label) {
+  const selected = text(String(value ?? ""), label);
+  if (!/^[1-9]\d*$/u.test(selected)) fail(`${label} must be a positive integer`);
+  return selected;
+}
+
+function actionsTimestamp(value, label) {
+  const selected = text(value, label);
+  if (!Number.isFinite(Date.parse(selected))) fail(`${label} must be an Actions timestamp`);
+  return selected;
+}
+
+function leafJobName(value) {
+  return text(value, "Actions job name").split(" / ").at(-1);
+}
+
+function flattenJobs(jobsByAttempt) {
+  if (Array.isArray(jobsByAttempt)) return jobsByAttempt;
+  if (jobsByAttempt === null || typeof jobsByAttempt !== "object") {
+    fail("Actions jobs must be grouped by run attempt");
+  }
+  return Object.entries(jobsByAttempt).flatMap(([attempt, jobs]) => {
+    if (!Array.isArray(jobs)) fail(`Actions jobs attempt ${attempt} must be an array`);
+    return jobs.map((job) => ({ ...job, run_attempt: String(job.run_attempt ?? attempt) }));
+  });
+}
+
+export function buildTrustedProducerMap({
+  graph,
+  gitIdentity,
+  phase,
+  runId,
+  currentRunAttempt,
+  artifacts,
+  jobsByAttempt,
+}) {
+  const selectedRunId = positiveInteger(runId, "Actions run id");
+  const selectedCurrentAttempt = positiveInteger(currentRunAttempt, "Actions current run attempt");
+  if (!Array.isArray(artifacts)) fail("Actions artifacts must be an array");
+  const jobs = flattenJobs(jobsByAttempt);
+  const selectionCache = new Map();
+  const producers = deriveReleaseCells(graph, phase).map((cell) => {
+    const jobName = text(cell.identity_constraints.producer_job_name, `${cell.id} producer job name`);
+    const cacheKey = `${jobName}\0${cell.identity_constraints.producer_artifact}`;
+    let selected = selectionCache.get(cacheKey);
+    if (!selected) {
+      const occurrences = jobs.filter((job) =>
+        leafJobName(job.name) === jobName
+        && Number(positiveInteger(job.run_attempt, `${jobName} run attempt`))
+          <= Number(selectedCurrentAttempt));
+      if (occurrences.length === 0) fail(`Actions run has no execution of ${jobName}`);
+      const latestAttempt = Math.max(...occurrences.map(({ run_attempt: attempt }) => Number(attempt)));
+      const latestJobs = occurrences.filter(({ run_attempt: attempt }) => Number(attempt) === latestAttempt);
+      if (latestJobs.length !== 1) {
+        fail(`Actions run attempt ${latestAttempt} has multiple executions of ${jobName}`);
+      }
+      const job = latestJobs[0];
+      if (job.status !== "completed" || job.conclusion !== "success") {
+        fail(`latest execution of ${jobName} in attempt ${latestAttempt} did not succeed`);
+      }
+      if (String(job.run_id) !== selectedRunId || job.head_sha !== gitIdentity.commit) {
+        fail(`Actions job ${jobName} is not bound to the selected run and commit`);
+      }
+      const constraints = resolveReleaseCellConstraints(cell, String(latestAttempt));
+      const matchingArtifacts = artifacts.filter(({ name }) => name === constraints.producer_artifact);
+      if (matchingArtifacts.length !== 1) {
+        fail(`Actions run must retain one ${constraints.producer_artifact} artifact`);
+      }
+      const artifact = matchingArtifacts[0];
+      if (artifact.expired !== false
+          || String(artifact.workflow_run?.id) !== selectedRunId
+          || artifact.workflow_run?.head_sha !== gitIdentity.commit) {
+        fail(`Actions artifact ${constraints.producer_artifact} has stale run provenance`);
+      }
+      if (!ACTIONS_DIGEST.test(String(artifact.digest ?? ""))) {
+        fail(`Actions artifact ${constraints.producer_artifact} has no SHA-256 container digest`);
+      }
+      if (!Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes <= 0) {
+        fail(`Actions artifact ${constraints.producer_artifact} has invalid size`);
+      }
+      const createdAt = actionsTimestamp(artifact.created_at, "Actions artifact created_at");
+      const startedAt = actionsTimestamp(job.started_at, "Actions job started_at");
+      const completedAt = actionsTimestamp(job.completed_at, "Actions job completed_at");
+      if (Date.parse(createdAt) < Date.parse(startedAt)
+          || Date.parse(createdAt) > Date.parse(completedAt)) {
+        fail(`Actions artifact ${constraints.producer_artifact} was not created by the selected job window`);
+      }
+      selected = {
+        constraints,
+        artifact: {
+          id: positiveInteger(artifact.id, "Actions artifact id"),
+          name: artifact.name,
+          digest: artifact.digest,
+          size_in_bytes: artifact.size_in_bytes,
+          expired: false,
+          created_at: createdAt,
+          expires_at: actionsTimestamp(artifact.expires_at, "Actions artifact expires_at"),
+          workflow_run_id: selectedRunId,
+          head_sha: gitIdentity.commit,
+        },
+        job: {
+          id: positiveInteger(job.id, "Actions job id"),
+          run_id: selectedRunId,
+          head_sha: gitIdentity.commit,
+          name: job.name,
+          status: job.status,
+          conclusion: job.conclusion,
+          run_attempt: String(latestAttempt),
+          started_at: startedAt,
+          completed_at: completedAt,
+        },
+      };
+      selectionCache.set(cacheKey, selected);
+    }
+    return {
+      cell_id: cell.id,
+      producer_workflow: selected.constraints.producer_workflow,
+      producer_job: selected.constraints.producer_job,
+      producer_job_name: selected.constraints.producer_job_name,
+      producer_run_id: selectedRunId,
+      producer_run_attempt: selected.job.run_attempt,
+      producer_artifact: selected.constraints.producer_artifact,
+      artifact: selected.artifact,
+      job: selected.job,
+    };
+  });
+  return {
+    schema: PRODUCER_MAP_SCHEMA,
+    phase,
+    manifest_schema: graph.closeout.manifest_schema,
+    graph_sha256: releaseClaimGraphDigest(graph),
+    identity: gitIdentity,
+    run_id: selectedRunId,
+    current_run_attempt: selectedCurrentAttempt,
+    producers,
+    artifacts: [...new Map(producers.map((row) => [row.artifact.id, row.artifact])).values()],
+  };
+}
+
+async function githubPages(url, token, field) {
+  const values = [];
+  for (let page = 1; ; page += 1) {
+    const separator = url.includes("?") ? "&" : "?";
+    const response = await fetch(`${url}${separator}per_page=100&page=${page}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) fail(`GitHub Actions API ${response.status} for ${url}`);
+    const document = await response.json();
+    const rows = document[field];
+    if (!Array.isArray(rows)) fail(`GitHub Actions API omitted ${field}`);
+    values.push(...rows);
+    if (rows.length < 100) return values;
+  }
+}
+
+async function produceMap(values) {
+  const { graph, gitIdentity } = common(values);
+  const phase = text(values.phase, "--phase");
+  const runId = positiveInteger(values["producer-run-id"], "--producer-run-id");
+  const runAttempt = positiveInteger(values["producer-run-attempt"], "--producer-run-attempt");
+  if (process.env.GITHUB_ACTIONS !== "true"
+      || process.env.GITHUB_REPOSITORY !== gitIdentity.repository
+      || process.env.GITHUB_SHA !== gitIdentity.commit
+      || process.env.GITHUB_RUN_ID !== runId
+      || process.env.GITHUB_RUN_ATTEMPT !== runAttempt) {
+    fail("current workflow context does not authenticate the Actions provenance query");
+  }
+  const token = text(process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN, "GitHub Actions token");
+  const apiRoot = text(process.env.GITHUB_API_URL ?? "https://api.github.com", "GitHub API URL");
+  const repositoryPath = gitIdentity.repository.split("/").map(encodeURIComponent).join("/");
+  const runUrl = `${apiRoot}/repos/${repositoryPath}/actions/runs/${runId}`;
+  const artifacts = await githubPages(`${runUrl}/artifacts`, token, "artifacts");
+  const jobsByAttempt = {};
+  for (let attempt = 1; attempt <= Number(runAttempt); attempt += 1) {
+    jobsByAttempt[String(attempt)] = (await githubPages(
+      `${runUrl}/attempts/${attempt}/jobs`,
+      token,
+      "jobs",
+    )).map((job) => ({ ...job, run_attempt: String(attempt) }));
+  }
+  const map = buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase,
+    runId,
+    currentRunAttempt: runAttempt,
+    artifacts,
+    jobsByAttempt,
+  });
+  writeJson(text(values.out, "--out"), map);
+}
+
+async function main() {
   const { command, values } = parseArgs(process.argv.slice(2));
   if (command === "produce") produceOne(values);
   else if (command === "release-evidence") produceReleaseEvidence(values);
-  else if (command === "producer-map") produceMap(values);
+  else if (command === "producer-map") await produceMap(values);
   else fail("command must be produce, release-evidence, or producer-map");
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) main();
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -21,8 +21,10 @@ import {
 } from "./codestory-release-claims.mjs";
 
 const MANIFEST_EVALUATION_SCHEMA = "codestory.release-cell-evaluation/v1";
-const PRODUCER_MAP_SCHEMA = "codestory.release-producer-map/v1";
+const PRODUCER_MAP_SCHEMA = "codestory.release-actions-provenance/v1";
+const TRUSTED_EXCEPTIONS_SCHEMA = "codestory.release-closeout-exceptions/v1";
 const SHA256 = /^[0-9a-f]{64}$/u;
+const ACTIONS_DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 const AGGREGATE_IDENTITY = /^(?:aggregate|all|matrix|mixed|multiple|various)$/iu;
 
@@ -137,6 +139,15 @@ export function deriveReleaseCells(graph, phase) {
   return cells;
 }
 
+export function resolveReleaseCellConstraints(cell, producerRunAttempt) {
+  const attempt = text(producerRunAttempt, "producer run attempt");
+  if (!/^[1-9]\d*$/u.test(attempt)) fail("producer run attempt must be a positive integer");
+  return Object.fromEntries(Object.entries(cell.identity_constraints).map(([key, value]) => [
+    key,
+    typeof value === "string" ? value.replaceAll("{attempt}", attempt) : value,
+  ]));
+}
+
 function manifestProblems({ manifest, cell, graph, graphSha256, version }) {
   const problems = [];
   if (manifest.schema !== graph.closeout.manifest_schema) {
@@ -168,7 +179,13 @@ function manifestProblems({ manifest, cell, graph, graphSha256, version }) {
       problems.push(`manifest identity ${key} does not match ${formats[key]}`);
     }
   }
-  for (const [key, expected] of Object.entries(cell.identity_constraints)) {
+  let resolvedConstraints = cell.identity_constraints;
+  try {
+    resolvedConstraints = resolveReleaseCellConstraints(cell, identity.producer_run_attempt);
+  } catch (error) {
+    problems.push(error.message);
+  }
+  for (const [key, expected] of Object.entries(resolvedConstraints)) {
     if (identity[key] !== expected) {
       problems.push(`manifest identity ${key} must equal ${expected}`);
     }
@@ -258,11 +275,51 @@ function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, pha
     errors.push(`trusted producer map schema must be ${PRODUCER_MAP_SCHEMA}`);
   }
   if (trustedProducers.phase !== phase) errors.push(`trusted producer map phase must be ${phase}`);
+  if (trustedProducers.manifest_schema !== graph.closeout.manifest_schema) {
+    errors.push("trusted producer map manifest schema changed");
+  }
+  if (trustedProducers.graph_sha256 !== releaseClaimGraphDigest(graph)) {
+    errors.push("trusted producer map graph identity changed");
+  }
+  if (!/^[1-9]\d*$/u.test(String(trustedProducers.run_id ?? ""))) {
+    errors.push("trusted producer map run_id must be a positive integer");
+  }
+  if (!/^[1-9]\d*$/u.test(String(trustedProducers.current_run_attempt ?? ""))) {
+    errors.push("trusted producer map current_run_attempt must be a positive integer");
+  }
   for (const key of ["repository", "commit", "source_tree"]) {
     if (trustedProducers.identity?.[key] !== gitIdentity[key]) {
       errors.push(`trusted producer map ${key} identity changed`);
     }
   }
+  const artifactsById = new Map();
+  const artifactNames = new Set();
+  if (!Array.isArray(trustedProducers.artifacts)) {
+    errors.push("trusted producer map artifacts must be an array");
+  } else {
+    for (const [index, artifact] of trustedProducers.artifacts.entries()) {
+      if (artifact === null || typeof artifact !== "object" || Array.isArray(artifact)) {
+        errors.push(`trusted producer map artifact[${index}] must be an object`);
+        continue;
+      }
+      const artifactId = String(artifact.id ?? "");
+      if (!/^[1-9]\d*$/u.test(artifactId)) {
+        errors.push(`trusted producer map artifact[${index}] id is invalid`);
+      } else if (artifactsById.has(artifactId)) {
+        errors.push(`trusted producer map duplicates artifact id ${artifactId}`);
+      } else {
+        artifactsById.set(artifactId, artifact);
+      }
+      if (typeof artifact.name !== "string" || artifact.name === "") {
+        errors.push(`trusted producer map artifact[${index}] name is invalid`);
+      } else if (artifactNames.has(artifact.name)) {
+        errors.push(`trusted producer map duplicates artifact name ${artifact.name}`);
+      } else {
+        artifactNames.add(artifact.name);
+      }
+    }
+  }
+  const usedArtifactIds = new Set();
   const rows = Array.isArray(trustedProducers.producers) ? trustedProducers.producers : [];
   if (!Array.isArray(trustedProducers.producers)) errors.push("trusted producer map producers must be an array");
   const byCell = new Map();
@@ -294,6 +351,7 @@ function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, pha
     for (const key of [
       "producer_workflow",
       "producer_job",
+      "producer_job_name",
       "producer_run_id",
       "producer_run_attempt",
       "producer_artifact",
@@ -301,10 +359,88 @@ function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, pha
       if (!releaseClaimIdentityMatchesFormat(row[key], graph.evidence_policy.identity_formats[key])) {
         errors.push(`trusted producer map ${cell.id} ${key} is invalid`);
       }
-      const constrained = cell.identity_constraints[key];
+      let constrained;
+      try {
+        constrained = resolveReleaseCellConstraints(cell, row.producer_run_attempt)[key];
+      } catch (error) {
+        errors.push(`trusted producer map ${cell.id} ${error.message}`);
+      }
       if (constrained !== undefined && row[key] !== constrained) {
         errors.push(`trusted producer map ${cell.id} ${key} must equal ${constrained}`);
       }
+    }
+    if (row.producer_run_id !== trustedProducers.run_id) {
+      errors.push(`trusted producer map ${cell.id} run identity differs from the Actions run`);
+    }
+    if (/^[1-9]\d*$/u.test(String(row.producer_run_attempt ?? ""))
+        && /^[1-9]\d*$/u.test(String(trustedProducers.current_run_attempt ?? ""))
+        && Number(row.producer_run_attempt) > Number(trustedProducers.current_run_attempt)) {
+      errors.push(`trusted producer map ${cell.id} uses a future run attempt`);
+    }
+    const artifact = row.artifact;
+    if (artifact === null || typeof artifact !== "object" || Array.isArray(artifact)) {
+      errors.push(`trusted producer map ${cell.id} artifact provenance is missing`);
+    } else {
+      if (!/^[1-9]\d*$/u.test(String(artifact.id ?? ""))) {
+        errors.push(`trusted producer map ${cell.id} artifact id is invalid`);
+      } else {
+        usedArtifactIds.add(String(artifact.id));
+        const inventoryArtifact = artifactsById.get(String(artifact.id));
+        if (!inventoryArtifact) {
+          errors.push(`trusted producer map ${cell.id} artifact is missing from the download inventory`);
+        } else if (canonicalJson(inventoryArtifact) !== canonicalJson(artifact)) {
+          errors.push(`trusted producer map ${cell.id} artifact differs from the download inventory`);
+        }
+      }
+      if (artifact.name !== row.producer_artifact) {
+        errors.push(`trusted producer map ${cell.id} artifact name changed`);
+      }
+      if (!ACTIONS_DIGEST.test(String(artifact.digest ?? ""))) {
+        errors.push(`trusted producer map ${cell.id} artifact digest is invalid`);
+      }
+      if (!Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes <= 0) {
+        errors.push(`trusted producer map ${cell.id} artifact size is invalid`);
+      }
+      if (artifact.expired !== false) {
+        errors.push(`trusted producer map ${cell.id} artifact is expired`);
+      }
+      if (artifact.workflow_run_id !== row.producer_run_id
+          || artifact.head_sha !== gitIdentity.commit) {
+        errors.push(`trusted producer map ${cell.id} artifact run identity changed`);
+      }
+    }
+    const job = row.job;
+    if (job === null || typeof job !== "object" || Array.isArray(job)) {
+      errors.push(`trusted producer map ${cell.id} job provenance is missing`);
+    } else {
+      if (!/^[1-9]\d*$/u.test(String(job.id ?? ""))) {
+        errors.push(`trusted producer map ${cell.id} job id is invalid`);
+      }
+      if (job.run_id !== row.producer_run_id || job.head_sha !== gitIdentity.commit) {
+        errors.push(`trusted producer map ${cell.id} job run identity changed`);
+      }
+      if (job.run_attempt !== row.producer_run_attempt
+          || job.conclusion !== "success"
+          || job.status !== "completed") {
+        errors.push(`trusted producer map ${cell.id} job is not a successful matching attempt`);
+      }
+      if (typeof job.name !== "string"
+          || job.name.split(" / ").at(-1) !== row.producer_job_name) {
+        errors.push(`trusted producer map ${cell.id} job name changed`);
+      }
+      const createdAt = Date.parse(String(artifact?.created_at ?? ""));
+      const startedAt = Date.parse(String(job.started_at ?? ""));
+      const completedAt = Date.parse(String(job.completed_at ?? ""));
+      if (![createdAt, startedAt, completedAt].every(Number.isFinite)
+          || createdAt < startedAt
+          || createdAt > completedAt) {
+        errors.push(`trusted producer map ${cell.id} artifact is outside its job window`);
+      }
+    }
+  }
+  for (const artifactId of artifactsById.keys()) {
+    if (!usedArtifactIds.has(artifactId)) {
+      errors.push(`trusted producer map download inventory contains unused artifact ${artifactId}`);
     }
   }
   return { byCell, errors };
@@ -317,6 +453,7 @@ function producerAuthenticationProblems(manifest, trustedProducer) {
   for (const key of [
     "producer_workflow",
     "producer_job",
+    "producer_job_name",
     "producer_run_id",
     "producer_run_attempt",
     "producer_artifact",
@@ -326,6 +463,59 @@ function producerAuthenticationProblems(manifest, trustedProducer) {
     }
   }
   return problems;
+}
+
+function trustedExceptionInput({ document, graph, graphSha256, gitIdentity, version, trustedProducer }) {
+  const errors = [];
+  if (document === null || typeof document !== "object" || Array.isArray(document)) {
+    return {
+      exceptions: {},
+      identity: {},
+      errors: ["closeout requires separately trusted exception inputs"],
+    };
+  }
+  if (document.schema !== TRUSTED_EXCEPTIONS_SCHEMA) {
+    errors.push(`trusted exception schema must be ${TRUSTED_EXCEPTIONS_SCHEMA}`);
+  }
+  if (document.graph_sha256 !== graphSha256) errors.push("trusted exception graph identity changed");
+  if (document.version !== version) errors.push("trusted exception version changed");
+  for (const key of ["repository", "commit", "source_tree"]) {
+    if (document.identity?.[key] !== gitIdentity[key]) {
+      errors.push(`trusted exception ${key} identity changed`);
+    }
+  }
+  for (const key of [
+    "producer_workflow",
+    "producer_job",
+    "producer_job_name",
+    "producer_run_id",
+    "producer_run_attempt",
+    "producer_artifact",
+  ]) {
+    if (document.producer?.[key] !== trustedProducer?.[key]) {
+      errors.push(`trusted exception ${key} does not match authenticated release evidence`);
+    }
+  }
+  const exceptions = document.exceptions;
+  if (exceptions === null || typeof exceptions !== "object" || Array.isArray(exceptions)) {
+    errors.push("trusted exception inputs must be an object keyed by evidence id");
+    return { exceptions: {}, identity: {}, errors };
+  }
+  const trustedIdentity = document.trusted_identity;
+  if (trustedIdentity === null || typeof trustedIdentity !== "object" || Array.isArray(trustedIdentity)) {
+    errors.push("trusted exception identity must be an object");
+  } else {
+    for (const key of [graph.exception_policy.artifact_binding, "artifact_sha256"]) {
+      if (!SHA256.test(String(trustedIdentity[key] ?? ""))) {
+        errors.push(`trusted exception identity ${key} must be SHA-256`);
+      }
+    }
+  }
+  return {
+    exceptions: canonicalReleaseClaimValue(exceptions),
+    identity: canonicalReleaseClaimValue(trustedIdentity ?? {}),
+    errors,
+  };
 }
 
 function transitiveClaims(graph, claimId) {
@@ -344,6 +534,21 @@ function transitiveClaims(graph, claimId) {
   return ordered;
 }
 
+function evaluationClaims(graph, cell, manifest) {
+  const claims = transitiveClaims(graph, cell.claim);
+  if (manifest.evidence?.status !== "pass_with_exception") return claims;
+  const policy = graph.exception_policy;
+  if (manifest.evidence.type !== policy.eligible_evidence_type) return claims;
+  const seen = new Set(claims.map(({ id }) => id));
+  for (const claim of transitiveClaims(graph, policy.full_product_benefit_evidence_type)) {
+    if (!seen.has(claim.id)) {
+      seen.add(claim.id);
+      claims.push(claim);
+    }
+  }
+  return claims;
+}
+
 function dependencyCell(cells, claimId, target) {
   let candidates = cells.filter((candidate) => candidate.group_id === claimId);
   if (target !== undefined) {
@@ -356,9 +561,18 @@ function dependencyCell(cells, claimId, target) {
   return candidates[0];
 }
 
-function evaluateCell({ cell, cells, manifests, graph, gitIdentity, evaluatedAt }) {
+function evaluateCell({
+  cell,
+  cells,
+  manifests,
+  graph,
+  gitIdentity,
+  evaluatedAt,
+  trustedExceptions,
+  trustedExceptionIdentity,
+}) {
   const focal = manifests.get(cell.id);
-  const claims = transitiveClaims(graph, cell.claim);
+  const claims = evaluationClaims(graph, cell, focal);
   const evidenceCells = [];
   for (const claim of claims) {
     evidenceCells.push(
@@ -372,7 +586,12 @@ function evaluateCell({ cell, cells, manifests, graph, gitIdentity, evaluatedAt 
     id: claim.id,
     accepted_risks: [...claim.accepted_risks],
   }));
-  const expectedIdentity = { ...focal.evidence.identity, ...gitIdentity };
+  const expectedIdentity = {
+    ...Object.assign({}, ...evidence.map((row) => row.identity ?? {})),
+    ...focal.evidence.identity,
+    ...(focal.evidence.status === "pass_with_exception" ? trustedExceptionIdentity : {}),
+    ...gitIdentity,
+  };
   const evaluation = evaluateReleaseClaims({
     graph,
     requested_claims: requestedClaims,
@@ -381,7 +600,7 @@ function evaluateCell({ cell, cells, manifests, graph, gitIdentity, evaluatedAt 
       commit: gitIdentity.commit,
       evaluated_at: evaluatedAt,
       identity: expectedIdentity,
-      exceptions: {},
+      exceptions: trustedExceptions,
     },
   });
   return {
@@ -396,7 +615,7 @@ function evaluateCell({ cell, cells, manifests, graph, gitIdentity, evaluatedAt 
 function dependencyValidationProblems({ cell, cells, manifests, graph, problemsByCell }) {
   const focal = manifests.get(cell.id);
   const problems = [];
-  for (const claim of transitiveClaims(graph, cell.claim)) {
+  for (const claim of evaluationClaims(graph, cell, focal)) {
     if (claim.id === cell.claim) continue;
     const dependency = dependencyCell(cells, claim.id, focal.evidence.identity.target);
     if ((problemsByCell.get(dependency.id) ?? []).length > 0) {
@@ -418,6 +637,12 @@ function prePublishLedgerProblems({ prePublishLedger, graphSha256, gitIdentity, 
   }
   if (prePublishLedger.graph_sha256 !== graphSha256) problems.push("pre-publish ledger graph identity changed");
   if (prePublishLedger.version !== version) problems.push("pre-publish ledger version changed");
+  if (!SHA256.test(String(prePublishLedger.producer_provenance_sha256 ?? ""))) {
+    problems.push("pre-publish ledger omitted authenticated producer provenance");
+  }
+  if (!SHA256.test(String(prePublishLedger.trusted_exceptions_sha256 ?? ""))) {
+    problems.push("pre-publish ledger omitted trusted exception provenance");
+  }
   for (const key of ["repository", "commit", "source_tree"]) {
     if (prePublishLedger.identity?.[key] !== gitIdentity[key]) {
       problems.push(`pre-publish ledger ${key} identity changed`);
@@ -521,6 +746,48 @@ function indexManifests(inputManifests) {
   return { byCell, errors };
 }
 
+function indexArtifactBindings(inputBindings) {
+  const byCell = new Map();
+  const errors = [];
+  if (!Array.isArray(inputBindings)) {
+    return { byCell, errors: ["closeout requires downloaded artifact bindings"] };
+  }
+  for (const [index, binding] of inputBindings.entries()) {
+    if (binding === null || typeof binding !== "object" || Array.isArray(binding)) {
+      errors.push(`artifact binding[${index}] must be an object`);
+      continue;
+    }
+    if (typeof binding.cell_id !== "string" || binding.cell_id === "") {
+      errors.push(`artifact binding[${index}].cell_id must be non-empty`);
+      continue;
+    }
+    if (byCell.has(binding.cell_id)) {
+      errors.push(`artifact bindings duplicate ${binding.cell_id}`);
+    } else {
+      byCell.set(binding.cell_id, binding);
+    }
+  }
+  return { byCell, errors };
+}
+
+function artifactBindingProblems(manifest, binding, trustedProducer) {
+  if (!binding) return ["manifest is not bound to one selected Actions artifact container"];
+  if (!trustedProducer) return ["manifest artifact has no authenticated producer"];
+  const problems = [];
+  const expected = {
+    producer_artifact: trustedProducer.producer_artifact,
+    artifact_id: trustedProducer.artifact?.id,
+    artifact_digest: trustedProducer.artifact?.digest,
+  };
+  for (const [key, value] of Object.entries(expected)) {
+    if (binding[key] !== value) problems.push(`manifest ${key} does not match Actions provenance`);
+  }
+  if (binding.manifest_sha256 !== digest(canonicalJson(manifest))) {
+    problems.push("downloaded manifest bytes changed after artifact extraction");
+  }
+  return problems;
+}
+
 export function evaluateReleaseCloseout({
   graph,
   phase,
@@ -530,6 +797,8 @@ export function evaluateReleaseCloseout({
   manifests: inputManifests,
   prePublishLedger = null,
   trustedProducers = null,
+  trustedExceptionDocument = null,
+  artifactBindings = null,
 }) {
   if (!SEMVER.test(version)) fail("version must be semantic version text without a leading v");
   const evaluatedEpoch = Date.parse(evaluatedAt);
@@ -539,11 +808,29 @@ export function evaluateReleaseCloseout({
   const graphSha256 = releaseClaimGraphDigest(graph);
   const cells = deriveReleaseCells(graph, phase);
   const trusted = trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, phase });
+  const performanceCell = cells.find(({ id }) => id === graph.exception_policy.eligible_evidence_type);
+  const trustedException = trustedExceptionInput({
+    document: trustedExceptionDocument,
+    graph,
+    graphSha256,
+    gitIdentity,
+    version,
+    trustedProducer: performanceCell ? trusted.byCell.get(performanceCell.id) : null,
+  });
   const cellIds = new Set(cells.map(({ id }) => id));
   const indexed = indexManifests(inputManifests);
-  const inputErrors = [...indexed.errors, ...trusted.errors];
+  const bindings = indexArtifactBindings(artifactBindings);
+  const inputErrors = [
+    ...indexed.errors,
+    ...trusted.errors,
+    ...trustedException.errors,
+    ...bindings.errors,
+  ];
   for (const cellId of indexed.byCell.keys()) {
     if (!cellIds.has(cellId)) inputErrors.push(`closeout contains undeclared cell ${cellId}`);
+  }
+  for (const cellId of bindings.byCell.keys()) {
+    if (!cellIds.has(cellId)) inputErrors.push(`closeout contains undeclared artifact binding ${cellId}`);
   }
   const manifests = new Map();
   const problemsByCell = new Map();
@@ -554,6 +841,11 @@ export function evaluateReleaseCloseout({
     const manifest = rows[0];
     const problems = manifestProblems({ manifest, cell, graph, graphSha256, version });
     problems.push(...producerAuthenticationProblems(manifest, trusted.byCell.get(cell.id)));
+    problems.push(...artifactBindingProblems(
+      manifest,
+      bindings.byCell.get(cell.id),
+      trusted.byCell.get(cell.id),
+    ));
     const evidenceId = manifest.evidence?.id;
     if (typeof evidenceId !== "string" || evidenceId === "") {
       problems.push("manifest evidence id must be a non-empty string");
@@ -590,6 +882,14 @@ export function evaluateReleaseCloseout({
     }
     manifests.set(cell.id, manifest);
     problemsByCell.set(cell.id, [...(problemsByCell.get(cell.id) ?? []), ...problems]);
+  }
+  const exceptionEvidenceIds = new Set([...manifests.values()]
+    .filter(({ evidence }) => evidence?.status === "pass_with_exception")
+    .map(({ evidence }) => evidence.id));
+  for (const evidenceId of Object.keys(trustedException.exceptions)) {
+    if (!exceptionEvidenceIds.has(evidenceId)) {
+      inputErrors.push(`trusted exception input contains unused evidence ${evidenceId}`);
+    }
   }
 
   const retainedManifests = new Map();
@@ -633,7 +933,16 @@ export function evaluateReleaseCloseout({
       };
     } else {
       try {
-        evaluation = evaluateCell({ cell, cells, manifests, graph, gitIdentity, evaluatedAt });
+        evaluation = evaluateCell({
+          cell,
+          cells,
+          manifests,
+          graph,
+          gitIdentity,
+          evaluatedAt,
+          trustedExceptions: trustedException.exceptions,
+          trustedExceptionIdentity: trustedException.identity,
+        });
       } catch (error) {
         evaluation = {
           schema: MANIFEST_EVALUATION_SCHEMA,
@@ -680,6 +989,8 @@ export function evaluateReleaseCloseout({
     version,
     evaluated_at: evaluatedAt,
     identity: canonicalReleaseClaimValue(gitIdentity),
+    producer_provenance_sha256: digest(canonicalJson(trustedProducers)),
+    trusted_exceptions_sha256: digest(canonicalJson(trustedExceptionDocument)),
     cells: ledgerCells,
     input_errors: inputErrors,
   };
@@ -690,6 +1001,8 @@ export function evaluateReleaseCloseout({
     graph_sha256: graphSha256,
     version,
     identity: canonicalReleaseClaimValue(gitIdentity),
+    producer_provenance_sha256: ledger.producer_provenance_sha256,
+    trusted_exceptions_sha256: ledger.trusted_exceptions_sha256,
     counts: {
       required: ledgerCells.length,
       passed: ledgerCells.filter(({ status }) => new Set(["pass", "pass_with_exception"]).has(status)).length,
@@ -700,7 +1013,15 @@ export function evaluateReleaseCloseout({
     missing_cells: missingCells,
     input_errors: inputErrors,
   };
-  return { decision, ledger, summary, retainedManifests, evaluations };
+  return {
+    decision,
+    ledger,
+    summary,
+    retainedManifests,
+    evaluations,
+    trustedProducers: canonicalReleaseClaimValue(trustedProducers),
+    trustedExceptionDocument: canonicalReleaseClaimValue(trustedExceptionDocument),
+  };
 }
 
 export function writeReleaseCloseout(outDir, result) {
@@ -719,18 +1040,81 @@ export function writeReleaseCloseout(outDir, result) {
   }
   writeFileSync(path.join(output, "ledger.json"), canonicalJson(result.ledger));
   writeFileSync(path.join(output, "summary.json"), canonicalJson(result.summary));
+  writeFileSync(path.join(output, "producer-provenance.json"), canonicalJson(result.trustedProducers));
+  writeFileSync(path.join(output, "trusted-exceptions.json"), canonicalJson(result.trustedExceptionDocument));
 }
 
-function readManifestDirectory(directory) {
+export function readReleaseCellArtifacts(directory, trustedProducers) {
   const root = path.resolve(directory);
   if (!lstatSync(root).isDirectory()) fail(`manifest directory ${root} is not a directory`);
-  return readdirSync(root, { withFileTypes: true })
-    .filter((entry) => entry.name.endsWith(".json"))
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .map((entry) => {
-      if (!entry.isFile() || entry.isSymbolicLink()) fail(`manifest input ${entry.name} must be a regular file`);
-      return JSON.parse(readFileSync(path.join(root, entry.name), "utf8"));
-    });
+  const producerRows = Array.isArray(trustedProducers?.producers) ? trustedProducers.producers : [];
+  const selectedArtifacts = new Map();
+  for (const row of producerRows) {
+    const existing = selectedArtifacts.get(row.producer_artifact);
+    if (existing && existing.artifact?.id !== row.artifact?.id) {
+      fail(`trusted producer map gives ${row.producer_artifact} multiple artifact ids`);
+    }
+    selectedArtifacts.set(row.producer_artifact, row);
+  }
+  const entries = readdirSync(root, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      fail(`release-cell input ${entry.name} must be one selected artifact directory`);
+    }
+    if (!selectedArtifacts.has(entry.name)) {
+      fail(`release-cell input contains unexpected artifact container ${entry.name}`);
+    }
+  }
+  for (const artifactName of selectedArtifacts.keys()) {
+    if (!entries.some(({ name }) => name === artifactName)) {
+      fail(`release-cell input is missing selected artifact container ${artifactName}`);
+    }
+  }
+  const manifests = [];
+  const artifactBindings = [];
+  let trustedExceptionCount = 0;
+  for (const [artifactName, producerRow] of selectedArtifacts) {
+    const artifactRoot = path.join(root, artifactName);
+    const files = readdirSync(artifactRoot, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of files) {
+      if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith(".json")) {
+        fail(`artifact container ${artifactName}/${entry.name} must be a regular JSON file`);
+      }
+      const manifestBytes = readFileSync(path.join(artifactRoot, entry.name), "utf8");
+      const manifest = JSON.parse(manifestBytes);
+      if (manifestBytes !== canonicalJson(manifest)) {
+        fail(`artifact container ${artifactName}/${entry.name} is not canonical JSON bytes`);
+      }
+      if (manifest.schema === TRUSTED_EXCEPTIONS_SCHEMA) {
+        if (entry.name !== "trusted-exceptions.json") {
+          fail(`artifact container ${artifactName}/${entry.name} is an unexpected exception document`);
+        }
+        trustedExceptionCount += 1;
+        continue;
+      }
+      if (manifest.schema !== trustedProducers.manifest_schema) {
+        fail(`artifact container ${artifactName}/${entry.name} is not a release-cell manifest`);
+      }
+      if (!producerRows.some((row) =>
+        row.cell_id === manifest.cell_id && row.producer_artifact === artifactName)) {
+        fail(`artifact container ${artifactName} does not own ${String(manifest.cell_id)}`);
+      }
+      manifests.push(manifest);
+      artifactBindings.push({
+        cell_id: manifest.cell_id,
+        producer_artifact: artifactName,
+        artifact_id: producerRow.artifact.id,
+        artifact_digest: producerRow.artifact.digest,
+        manifest_sha256: digest(manifestBytes),
+      });
+    }
+  }
+  if (trustedExceptionCount !== 1) {
+    fail("selected release-cell containers must contain exactly one trusted-exceptions.json");
+  }
+  return { manifests, artifactBindings };
 }
 
 function parseArgs(argv) {
@@ -764,15 +1148,35 @@ function main() {
     text(values["trusted-producers"], "--trusted-producers"),
     "utf8",
   ));
+  const trustedExceptionPath = path.resolve(text(
+    values["trusted-exceptions"],
+    "--trusted-exceptions",
+  ));
+  const trustedExceptionDocument = JSON.parse(readFileSync(trustedExceptionPath, "utf8"));
+  const performanceProducer = trustedProducers.producers?.find(({ cell_id: cellId }) =>
+    cellId === graph.exception_policy.eligible_evidence_type);
+  const expectedExceptionParent = path.join(
+    path.resolve(text(values["manifest-dir"], "--manifest-dir")),
+    String(performanceProducer?.producer_artifact ?? ""),
+  );
+  if (path.dirname(trustedExceptionPath) !== expectedExceptionParent) {
+    fail("trusted exception input must come from the selected release-evidence artifact");
+  }
+  const downloaded = readReleaseCellArtifacts(
+    text(values["manifest-dir"], "--manifest-dir"),
+    trustedProducers,
+  );
   const result = evaluateReleaseCloseout({
     graph,
     phase,
     version: text(values.version, "--version"),
     evaluatedAt: text(values["evaluated-at"], "--evaluated-at"),
     gitIdentity,
-    manifests: readManifestDirectory(text(values["manifest-dir"], "--manifest-dir")),
+    manifests: downloaded.manifests,
     prePublishLedger,
     trustedProducers,
+    trustedExceptionDocument,
+    artifactBindings: downloaded.artifactBindings,
   });
   writeReleaseCloseout(text(values["out-dir"], "--out-dir"), result);
   console.log(JSON.stringify(result.summary, null, 2));

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -21,6 +21,7 @@ import {
 } from "./codestory-release-claims.mjs";
 
 const MANIFEST_EVALUATION_SCHEMA = "codestory.release-cell-evaluation/v1";
+const PRODUCER_MAP_SCHEMA = "codestory.release-producer-map/v1";
 const SHA256 = /^[0-9a-f]{64}$/u;
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 const AGGREGATE_IDENTITY = /^(?:aggregate|all|matrix|mixed|multiple|various)$/iu;
@@ -90,6 +91,17 @@ export function deriveReleaseCells(graph, phase) {
     if (phaseIndex(closeout, group.phase) > selectedIndex) continue;
     const add = (suffix, constraints = {}) => {
       const id = suffix === null ? group.id : `${group.id}:${suffix}`;
+      const expandedConstraints = Object.fromEntries(
+        Object.entries({
+          ...(group.identity_constraints ?? {}),
+          ...constraints,
+        }).map(([key, value]) => [
+          key,
+          typeof value === "string" && suffix !== null
+            ? value.replaceAll("{target}", suffix)
+            : value,
+        ]),
+      );
       cells.push({
         id,
         group_id: group.id,
@@ -98,10 +110,7 @@ export function deriveReleaseCells(graph, phase) {
         evidence_type: group.evidence_type,
         required_identity: [...group.required_identity],
         singleton_identity: [...(group.singleton_identity ?? [])],
-        identity_constraints: {
-          ...(group.identity_constraints ?? {}),
-          ...constraints,
-        },
+        identity_constraints: expandedConstraints,
         archive_role: group.archive_role,
       });
     };
@@ -195,9 +204,6 @@ function manifestProblems({ manifest, cell, graph, graphSha256, version }) {
       if (archive.sha256 !== identity.artifact_sha256) {
         problems.push("archive sha256 must match evidence artifact_sha256");
       }
-      if (archive.name !== identity.producer_artifact) {
-        problems.push("archive name must match evidence producer_artifact");
-      }
     }
     if (manifest.comparison !== undefined) problems.push("pre-publish package manifest must not contain a byte comparison");
   } else if (cell.archive_role === "post_publish_compare") {
@@ -221,9 +227,103 @@ function manifestProblems({ manifest, cell, graph, graphSha256, version }) {
       if (comparison.published_artifact_sha256 !== identity.artifact_sha256) {
         problems.push("comparison published digest must match evidence artifact_sha256");
       }
+      if (typeof comparison.published_artifact_name !== "string"
+          || comparison.published_artifact_name === ""
+          || path.basename(comparison.published_artifact_name) !== comparison.published_artifact_name) {
+        problems.push("comparison published_artifact_name must be one plain file name");
+      }
     }
   } else if (manifest.archive !== undefined || manifest.comparison !== undefined) {
     problems.push("non-archive closeout cells must not contain archive attestations");
+  }
+  return problems;
+}
+
+export function validateReleaseCellManifest({ manifest, cell, graph, version }) {
+  return manifestProblems({
+    manifest,
+    cell,
+    graph,
+    graphSha256: releaseClaimGraphDigest(graph),
+    version,
+  });
+}
+
+function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, phase }) {
+  const errors = [];
+  if (trustedProducers === null || typeof trustedProducers !== "object" || Array.isArray(trustedProducers)) {
+    return { byCell: new Map(), errors: ["closeout requires a separately trusted producer map"] };
+  }
+  if (trustedProducers.schema !== PRODUCER_MAP_SCHEMA) {
+    errors.push(`trusted producer map schema must be ${PRODUCER_MAP_SCHEMA}`);
+  }
+  if (trustedProducers.phase !== phase) errors.push(`trusted producer map phase must be ${phase}`);
+  for (const key of ["repository", "commit", "source_tree"]) {
+    if (trustedProducers.identity?.[key] !== gitIdentity[key]) {
+      errors.push(`trusted producer map ${key} identity changed`);
+    }
+  }
+  const rows = Array.isArray(trustedProducers.producers) ? trustedProducers.producers : [];
+  if (!Array.isArray(trustedProducers.producers)) errors.push("trusted producer map producers must be an array");
+  const byCell = new Map();
+  for (const [index, row] of rows.entries()) {
+    if (row === null || typeof row !== "object" || Array.isArray(row)) {
+      errors.push(`trusted producer map producer[${index}] must be an object`);
+      continue;
+    }
+    if (typeof row.cell_id !== "string" || row.cell_id === "") {
+      errors.push(`trusted producer map producer[${index}].cell_id must be non-empty`);
+      continue;
+    }
+    if (byCell.has(row.cell_id)) {
+      errors.push(`trusted producer map duplicates ${row.cell_id}`);
+    } else {
+      byCell.set(row.cell_id, row);
+    }
+  }
+  const required = new Set(cells.map(({ id }) => id));
+  for (const cellId of byCell.keys()) {
+    if (!required.has(cellId)) errors.push(`trusted producer map contains undeclared cell ${cellId}`);
+  }
+  for (const cell of cells) {
+    const row = byCell.get(cell.id);
+    if (!row) {
+      errors.push(`trusted producer map is missing ${cell.id}`);
+      continue;
+    }
+    for (const key of [
+      "producer_workflow",
+      "producer_job",
+      "producer_run_id",
+      "producer_run_attempt",
+      "producer_artifact",
+    ]) {
+      if (!releaseClaimIdentityMatchesFormat(row[key], graph.evidence_policy.identity_formats[key])) {
+        errors.push(`trusted producer map ${cell.id} ${key} is invalid`);
+      }
+      const constrained = cell.identity_constraints[key];
+      if (constrained !== undefined && row[key] !== constrained) {
+        errors.push(`trusted producer map ${cell.id} ${key} must equal ${constrained}`);
+      }
+    }
+  }
+  return { byCell, errors };
+}
+
+function producerAuthenticationProblems(manifest, trustedProducer) {
+  if (!trustedProducer) return ["manifest producer is absent from the trusted producer map"];
+  const identity = manifest.evidence?.identity ?? {};
+  const problems = [];
+  for (const key of [
+    "producer_workflow",
+    "producer_job",
+    "producer_run_id",
+    "producer_run_attempt",
+    "producer_artifact",
+  ]) {
+    if (identity[key] !== trustedProducer[key]) {
+      problems.push(`manifest ${key} does not match the trusted producer map`);
+    }
   }
   return problems;
 }
@@ -393,7 +493,7 @@ function comparePublishedArchive({ manifest, cell, prePublishLedger, graphSha256
       || comparison.published_artifact_sha256 !== packageRow.archive?.sha256) {
     problems.push("published archive bytes are not identical to the retained pre-publish archive");
   }
-  if (manifest.evidence.identity.producer_artifact !== packageRow.archive?.name) {
+  if (comparison.published_artifact_name !== packageRow.archive?.name) {
     problems.push("published archive name does not match the retained pre-publish archive");
   }
   return problems;
@@ -429,6 +529,7 @@ export function evaluateReleaseCloseout({
   gitIdentity,
   manifests: inputManifests,
   prePublishLedger = null,
+  trustedProducers = null,
 }) {
   if (!SEMVER.test(version)) fail("version must be semantic version text without a leading v");
   const evaluatedEpoch = Date.parse(evaluatedAt);
@@ -437,9 +538,10 @@ export function evaluateReleaseCloseout({
   }
   const graphSha256 = releaseClaimGraphDigest(graph);
   const cells = deriveReleaseCells(graph, phase);
+  const trusted = trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, phase });
   const cellIds = new Set(cells.map(({ id }) => id));
   const indexed = indexManifests(inputManifests);
-  const inputErrors = [...indexed.errors];
+  const inputErrors = [...indexed.errors, ...trusted.errors];
   for (const cellId of indexed.byCell.keys()) {
     if (!cellIds.has(cellId)) inputErrors.push(`closeout contains undeclared cell ${cellId}`);
   }
@@ -451,6 +553,7 @@ export function evaluateReleaseCloseout({
     if (rows.length !== 1) continue;
     const manifest = rows[0];
     const problems = manifestProblems({ manifest, cell, graph, graphSha256, version });
+    problems.push(...producerAuthenticationProblems(manifest, trusted.byCell.get(cell.id)));
     const evidenceId = manifest.evidence?.id;
     if (typeof evidenceId !== "string" || evidenceId === "") {
       problems.push("manifest evidence id must be a non-empty string");
@@ -657,6 +760,10 @@ function main() {
   const prePublishLedger = values["pre-publish-ledger"]
     ? JSON.parse(readFileSync(values["pre-publish-ledger"], "utf8"))
     : null;
+  const trustedProducers = JSON.parse(readFileSync(
+    text(values["trusted-producers"], "--trusted-producers"),
+    "utf8",
+  ));
   const result = evaluateReleaseCloseout({
     graph,
     phase,
@@ -665,6 +772,7 @@ function main() {
     gitIdentity,
     manifests: readManifestDirectory(text(values["manifest-dir"], "--manifest-dir")),
     prePublishLedger,
+    trustedProducers,
   });
   writeReleaseCloseout(text(values["out-dir"], "--out-dir"), result);
   console.log(JSON.stringify(result.summary, null, 2));

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -772,7 +772,10 @@ export function evaluateCandidate({ baselineDocument, baselineDir, candidatePath
   const report = { schema_version: 3, status: reportStatus, decision,
     commit, profile: candidate.profile, baseline_id: profile.baseline_id, baseline_sha256: baselineHash,
     candidate_path: path.relative(repoRoot, path.resolve(candidatePath)).replaceAll(path.sep, "/"), candidate_sha256: candidateHash,
-    artifact_paths: Object.values(candidate.artifacts), release_claim_evaluation: claimEvaluation, metrics: rows };
+    artifact_paths: Object.values(candidate.artifacts),
+    release_cell_evidence: claimDocument.evidence,
+    release_claim_evaluation: claimEvaluation,
+    metrics: rows };
   mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true });
   writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`);
   return report;

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -774,6 +774,7 @@ export function evaluateCandidate({ baselineDocument, baselineDir, candidatePath
     candidate_path: path.relative(repoRoot, path.resolve(candidatePath)).replaceAll(path.sep, "/"), candidate_sha256: candidateHash,
     artifact_paths: Object.values(candidate.artifacts),
     release_cell_evidence: claimDocument.evidence,
+    release_cell_exceptions: expectedExceptions,
     release_claim_evaluation: claimEvaluation,
     metrics: rows };
   mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true });

--- a/scripts/tests/codestory-release-cell-manifest.test.mjs
+++ b/scripts/tests/codestory-release-cell-manifest.test.mjs
@@ -4,8 +4,14 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { produceReleaseCellManifest } from "../codestory-release-cell-manifest.mjs";
-import { deriveReleaseCells } from "../codestory-release-closeout.mjs";
+import {
+  buildTrustedProducerMap,
+  produceReleaseCellManifest,
+} from "../codestory-release-cell-manifest.mjs";
+import {
+  deriveReleaseCells,
+  resolveReleaseCellConstraints,
+} from "../codestory-release-closeout.mjs";
 import { loadReleaseClaimGraph } from "../codestory-release-claims.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -23,13 +29,54 @@ function cell(id) {
 }
 
 function producer(selected) {
+  const constraints = resolveReleaseCellConstraints(selected, "2");
   return {
-    producer_workflow: selected.identity_constraints.producer_workflow,
-    producer_job: selected.identity_constraints.producer_job,
+    producer_workflow: constraints.producer_workflow,
+    producer_job: constraints.producer_job,
     producer_run_id: "12345",
     producer_run_attempt: "2",
-    producer_artifact: selected.identity_constraints.producer_artifact,
+    producer_artifact: constraints.producer_artifact,
   };
+}
+
+function actionsMetadata(phase, overrides = []) {
+  const artifacts = [];
+  const jobsByAttempt = { "1": [], "2": [] };
+  const seen = new Set();
+  let nextId = 1000;
+  const add = (selected, attempt, conclusion = "success") => {
+    const constraints = resolveReleaseCellConstraints(selected, String(attempt));
+    const key = `${attempt}:${constraints.producer_job_name}:${constraints.producer_artifact}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    const hour = attempt === 1 ? "12" : "13";
+    jobsByAttempt[String(attempt)].push({
+      id: nextId++,
+      run_id: 12345,
+      run_attempt: String(attempt),
+      head_sha: gitIdentity.commit,
+      name: `Release / ${constraints.producer_job_name}`,
+      status: "completed",
+      conclusion,
+      started_at: `2026-07-19T${hour}:00:00.000Z`,
+      completed_at: `2026-07-19T${hour}:10:00.000Z`,
+    });
+    if (conclusion === "success") {
+      artifacts.push({
+        id: nextId++,
+        name: constraints.producer_artifact,
+        digest: `sha256:${String(nextId).padStart(64, "0")}`,
+        size_in_bytes: 1024,
+        expired: false,
+        created_at: `2026-07-19T${hour}:05:00.000Z`,
+        expires_at: "2026-08-18T12:05:00.000Z",
+        workflow_run: { id: 12345, head_sha: gitIdentity.commit },
+      });
+    }
+  };
+  for (const selected of deriveReleaseCells(graph, phase)) add(selected, 1);
+  for (const override of overrides) add(cell(override.cell_id), override.attempt, override.conclusion);
+  return { artifacts, jobsByAttempt };
 }
 
 test("package manifest binds workflow artifact identity separately from archive bytes", () => {
@@ -47,7 +94,10 @@ test("package manifest binds workflow artifact identity separately from archive 
     observedAt,
     archivePath: archive,
   });
-  assert.equal(manifest.evidence.identity.producer_artifact, "release-cell-prepublish-package-linux-x64");
+  assert.equal(
+    manifest.evidence.identity.producer_artifact,
+    "release-cell-prepublish-package-linux-x64-attempt-2",
+  );
   assert.equal(manifest.archive.name, "codestory-cli-v0.16.0-linux-x64.tar.gz");
   assert.equal(manifest.archive.sha256, manifest.evidence.identity.artifact_sha256);
 });
@@ -120,11 +170,133 @@ test("release-evidence wrappers retain upstream evidence ids and statuses", () =
   assert.equal(manifest.evidence.graph_sha256, manifest.graph_sha256);
 });
 
-test("all graph-derived cells fix workflow, job, and artifact producer identity", () => {
+test("all graph-derived cells fix workflow, job name, and attempt-qualified artifact identity", () => {
   for (const selected of deriveReleaseCells(graph, "post_publish")) {
-    for (const key of ["producer_workflow", "producer_job", "producer_artifact"]) {
+    for (const key of ["producer_workflow", "producer_job", "producer_job_name", "producer_artifact"]) {
       assert.equal(typeof selected.identity_constraints[key], "string", `${selected.id} lacks ${key}`);
       assert.notEqual(selected.identity_constraints[key], "");
     }
+    assert.match(selected.identity_constraints.producer_artifact, /-attempt-\{attempt\}$/u);
   }
+});
+
+test("Actions provenance recovers a split rerun by selecting each job's latest execution", () => {
+  const metadata = actionsMetadata("post_publish", [{
+    cell_id: "platform_support:linux-x64",
+    attempt: 2,
+    conclusion: "success",
+  }]);
+  const map = buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "post_publish",
+    runId: "12345",
+    currentRunAttempt: "2",
+    ...metadata,
+  });
+  assert.equal(map.producers.length, 30);
+  assert.equal(map.artifacts.length, 16);
+  for (const id of [
+    "platform_support:linux-x64",
+    "installed_runtime_behavior:linux-x64",
+    "post_publish_bytes:linux-x64",
+  ]) {
+    assert.equal(map.producers.find(({ cell_id: cellId }) => cellId === id).producer_run_attempt, "2");
+  }
+  assert.equal(
+    map.producers.find(({ cell_id: cellId }) => cellId === "source_behavior").producer_run_attempt,
+    "1",
+  );
+});
+
+test("Actions provenance rejects a failed latest rerun instead of reusing older proof", () => {
+  const metadata = actionsMetadata("post_publish", [{
+    cell_id: "platform_support:linux-x64",
+    attempt: 2,
+    conclusion: "failure",
+  }]);
+  assert.throws(() => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "post_publish",
+    runId: "12345",
+    currentRunAttempt: "2",
+    ...metadata,
+  }), /latest execution of Published linux-x64 smoke.*did not succeed/u);
+});
+
+test("Actions provenance rejects duplicate or out-of-window artifact containers", () => {
+  const duplicate = actionsMetadata("pre_publish");
+  duplicate.artifacts.push(structuredClone(duplicate.artifacts[0]));
+  assert.throws(() => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: "1",
+    ...duplicate,
+  }), /must retain one .* artifact/u);
+
+  const outsideWindow = actionsMetadata("pre_publish");
+  outsideWindow.artifacts[0].created_at = "2026-07-19T14:00:00.000Z";
+  assert.throws(() => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: "1",
+    ...outsideWindow,
+  }), /was not created by the selected job window/u);
+});
+
+test("Actions provenance rejects missing, expired, malformed, stale, and future metadata", () => {
+  const cases = [
+    ["missing artifact", metadata => {
+      metadata.artifacts.shift();
+    }, /must retain one .* artifact/u],
+    ["expired artifact", metadata => {
+      metadata.artifacts[0].expired = true;
+    }, /has stale run provenance/u],
+    ["invalid digest", metadata => {
+      metadata.artifacts[0].digest = "sha256:invalid";
+    }, /has no SHA-256 container digest/u],
+    ["wrong artifact run", metadata => {
+      metadata.artifacts[0].workflow_run.id = 999;
+    }, /has stale run provenance/u],
+    ["wrong artifact commit", metadata => {
+      metadata.artifacts[0].workflow_run.head_sha = "f".repeat(40);
+    }, /has stale run provenance/u],
+    ["wrong job run", metadata => {
+      metadata.jobsByAttempt["1"][0].run_id = 999;
+    }, /is not bound to the selected run and commit/u],
+    ["wrong job commit", metadata => {
+      metadata.jobsByAttempt["1"][0].head_sha = "f".repeat(40);
+    }, /is not bound to the selected run and commit/u],
+    ["duplicate job", metadata => {
+      metadata.jobsByAttempt["1"].push(structuredClone(metadata.jobsByAttempt["1"][0]));
+    }, /multiple executions/u],
+  ];
+  for (const [label, mutate, pattern] of cases) {
+    const metadata = actionsMetadata("pre_publish");
+    mutate(metadata);
+    assert.throws(() => buildTrustedProducerMap({
+      graph,
+      gitIdentity,
+      phase: "pre_publish",
+      runId: "12345",
+      currentRunAttempt: "1",
+      ...metadata,
+    }), pattern, label);
+  }
+
+  const future = actionsMetadata("pre_publish");
+  future.jobsByAttempt["1"][0].run_attempt = "2";
+  assert.throws(() => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: "1",
+    ...future,
+  }), /no execution/u);
 });

--- a/scripts/tests/codestory-release-cell-manifest.test.mjs
+++ b/scripts/tests/codestory-release-cell-manifest.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { produceReleaseCellManifest } from "../codestory-release-cell-manifest.mjs";
+import { deriveReleaseCells } from "../codestory-release-closeout.mjs";
+import { loadReleaseClaimGraph } from "../codestory-release-claims.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const graph = loadReleaseClaimGraph(root);
+const gitIdentity = {
+  repository: "TheGreenCedar/CodeStory",
+  commit: "2".repeat(40),
+  source_tree: "a".repeat(40),
+};
+const version = "0.16.0";
+const observedAt = "2026-07-19T12:00:00.000Z";
+
+function cell(id) {
+  return deriveReleaseCells(graph, "post_publish").find(({ id: candidate }) => candidate === id);
+}
+
+function producer(selected) {
+  return {
+    producer_workflow: selected.identity_constraints.producer_workflow,
+    producer_job: selected.identity_constraints.producer_job,
+    producer_run_id: "12345",
+    producer_run_attempt: "2",
+    producer_artifact: selected.identity_constraints.producer_artifact,
+  };
+}
+
+test("package manifest binds workflow artifact identity separately from archive bytes", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-release-cell-"));
+  const archive = path.join(directory, "codestory-cli-v0.16.0-linux-x64.tar.gz");
+  writeFileSync(archive, "release archive bytes");
+  const selected = cell("package_identity:linux-x64");
+  const manifest = produceReleaseCellManifest({
+    graph,
+    gitIdentity,
+    version,
+    cell: selected,
+    identity: {},
+    producer: producer(selected),
+    observedAt,
+    archivePath: archive,
+  });
+  assert.equal(manifest.evidence.identity.producer_artifact, "release-cell-prepublish-package-linux-x64");
+  assert.equal(manifest.archive.name, "codestory-cli-v0.16.0-linux-x64.tar.gz");
+  assert.equal(manifest.archive.sha256, manifest.evidence.identity.artifact_sha256);
+});
+
+test("post-publish byte producer refuses an archive that differs from the accepted ledger", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-release-cell-"));
+  const archive = path.join(directory, "codestory-cli-v0.16.0-linux-x64.tar.gz");
+  writeFileSync(archive, "published replacement bytes");
+  const selected = cell("post_publish_bytes:linux-x64");
+  const prePublishLedger = {
+    phase: "pre_publish",
+    decision: "accept",
+    cells: [{
+      id: "package_identity:linux-x64",
+      manifest: { sha256: "b".repeat(64) },
+      archive: {
+        name: path.basename(archive),
+        sha256: "c".repeat(64),
+        bytes: 10,
+      },
+    }],
+  };
+  assert.throws(
+    () => produceReleaseCellManifest({
+      graph,
+      gitIdentity,
+      version,
+      cell: selected,
+      identity: {},
+      producer: producer(selected),
+      observedAt,
+      archivePath: archive,
+      prePublishLedger,
+    }),
+    /published archive bytes do not match/u,
+  );
+});
+
+test("release-evidence wrappers retain upstream evidence ids and statuses", () => {
+  const selected = cell("performance");
+  const upstream = {
+    id: "performance-measurement-1",
+    type: "performance",
+    tier: "live_behavior",
+    status: "pass_with_exception",
+    graph_sha256: "0".repeat(64),
+    observed_at: observedAt,
+    expires_at: "2026-07-20T12:00:00.000Z",
+    identity: {
+      profile: "codestory-release-evidence-linux-arm64-v2",
+      corpus_id: "v0.16-corpus",
+      cache_id: "cold-full-retrieval-v1",
+      machine_fingerprint: "fixture/linux-arm64",
+      baseline_id: "release-baseline@1111111",
+      baseline_sha256: "b".repeat(64),
+      release_key: "release-0.16.0",
+    },
+  };
+  const manifest = produceReleaseCellManifest({
+    graph,
+    gitIdentity,
+    version,
+    cell: selected,
+    identity: {},
+    producer: producer(selected),
+    evidence: upstream,
+  });
+  assert.equal(manifest.evidence.id, upstream.id);
+  assert.equal(manifest.evidence.status, upstream.status);
+  assert.equal(manifest.evidence.graph_sha256, manifest.graph_sha256);
+});
+
+test("all graph-derived cells fix workflow, job, and artifact producer identity", () => {
+  for (const selected of deriveReleaseCells(graph, "post_publish")) {
+    for (const key of ["producer_workflow", "producer_job", "producer_artifact"]) {
+      assert.equal(typeof selected.identity_constraints[key], "string", `${selected.id} lacks ${key}`);
+      assert.notEqual(selected.identity_constraints[key], "");
+    }
+  }
+});

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 import {
   deriveReleaseCells,
   evaluateReleaseCloseout,
+  readReleaseCellArtifacts,
+  resolveReleaseCellConstraints,
   writeReleaseCloseout,
 } from "../codestory-release-closeout.mjs";
 import {
@@ -58,15 +60,12 @@ function hostIdentity(target) {
   return { host_os: "macOS", host_arch: target.endsWith("arm64") ? "ARM64" : "X64" };
 }
 
-function identityFor(cell) {
+function identityFor(cell, producerRunAttempt = "1") {
   const target = cell.identity_constraints.target;
-  const identity = { ...gitIdentity };
+  const constraints = resolveReleaseCellConstraints(cell, producerRunAttempt);
+  const identity = { ...gitIdentity, ...constraints };
   for (const key of cell.required_identity) {
     if (identity[key] !== undefined) continue;
-    if (cell.identity_constraints[key] !== undefined) {
-      identity[key] = cell.identity_constraints[key];
-      continue;
-    }
     switch (key) {
       case "artifact_sha256": identity[key] = target ? artifactSha(target) : sha(cell.id); break;
       case "pre_publish_artifact_sha256": identity[key] = artifactSha(target); break;
@@ -87,9 +86,7 @@ function identityFor(cell) {
       case "release_key": identity[key] = "release-0.16.0"; break;
       case "evaluation_contract": identity[key] = "publishable-three-repeat-packet/v1"; break;
       case "producer_run_id": identity[key] = "12345"; break;
-      case "producer_run_attempt": identity[key] = "1"; break;
-      case "producer_job": identity[key] = cell.identity_constraints.producer_job; break;
-      case "producer_artifact": identity[key] = cell.identity_constraints.producer_artifact; break;
+      case "producer_run_attempt": identity[key] = producerRunAttempt; break;
       case "native_engine": identity[key] = "coderank_q8"; break;
       case "calibration_sha256": identity[key] = "c".repeat(64); break;
       default: throw new Error(`test fixture has no identity value for ${key}`);
@@ -144,22 +141,118 @@ function manifestsFor(phase, prePublishLedger = null) {
 }
 
 function trustedProducersFor(phase) {
-  return {
-    schema: "codestory.release-producer-map/v1",
-    phase,
-    identity: gitIdentity,
-    producers: deriveReleaseCells(graph, phase).map((cell) => ({
+  const artifactByName = new Map();
+  let nextId = 1000;
+  const producers = deriveReleaseCells(graph, phase).map((cell) => {
+    const constraints = resolveReleaseCellConstraints(cell, "1");
+    let artifact = artifactByName.get(constraints.producer_artifact);
+    if (!artifact) {
+      artifact = {
+        id: String(nextId++),
+        name: constraints.producer_artifact,
+        digest: `sha256:${sha(constraints.producer_artifact)}`,
+        size_in_bytes: 1024,
+        expired: false,
+        created_at: "2026-07-18T11:05:00.000Z",
+        expires_at: "2026-08-17T11:05:00.000Z",
+        workflow_run_id: "12345",
+        head_sha: gitIdentity.commit,
+      };
+      artifactByName.set(constraints.producer_artifact, artifact);
+    }
+    return {
       cell_id: cell.id,
-      producer_workflow: cell.identity_constraints.producer_workflow,
-      producer_job: cell.identity_constraints.producer_job,
+      producer_workflow: constraints.producer_workflow,
+      producer_job: constraints.producer_job,
+      producer_job_name: constraints.producer_job_name,
       producer_run_id: "12345",
       producer_run_attempt: "1",
-      producer_artifact: cell.identity_constraints.producer_artifact,
-    })),
+      producer_artifact: constraints.producer_artifact,
+      artifact,
+      job: {
+        id: String(nextId++),
+        run_id: "12345",
+        head_sha: gitIdentity.commit,
+        name: `Release / ${constraints.producer_job_name}`,
+        status: "completed",
+        conclusion: "success",
+        run_attempt: "1",
+        started_at: "2026-07-18T11:00:00.000Z",
+        completed_at: "2026-07-18T11:10:00.000Z",
+      },
+    };
+  });
+  return {
+    schema: "codestory.release-actions-provenance/v1",
+    phase,
+    manifest_schema: graph.closeout.manifest_schema,
+    graph_sha256: releaseClaimGraphDigest(graph),
+    identity: gitIdentity,
+    run_id: "12345",
+    current_run_attempt: "1",
+    producers,
+    artifacts: [...artifactByName.values()],
   };
 }
 
-function evaluate(phase, manifests, prePublishLedger = null, trustedProducers = trustedProducersFor(phase)) {
+function canonicalValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalValue(value[key])]));
+  }
+  return value;
+}
+
+function canonicalManifestBytes(manifest) {
+  return `${JSON.stringify(canonicalValue(manifest), null, 2)}\n`;
+}
+
+function canonicalManifestSha(manifest) {
+  return sha(canonicalManifestBytes(manifest));
+}
+
+function trustedExceptionsFor(trustedProducers, exceptions = {}) {
+  const producer = trustedProducers?.producers?.find(({ cell_id: cellId }) => cellId === "performance") ?? {};
+  return {
+    schema: "codestory.release-closeout-exceptions/v1",
+    graph_sha256: releaseClaimGraphDigest(graph),
+    version,
+    identity: gitIdentity,
+    producer: Object.fromEntries([
+      "producer_workflow",
+      "producer_job",
+      "producer_job_name",
+      "producer_run_id",
+      "producer_run_attempt",
+      "producer_artifact",
+    ].map((key) => [key, producer[key]])),
+    trusted_identity: {
+      candidate_sha256: "d".repeat(64),
+      artifact_sha256: sha("answer_quality"),
+    },
+    exceptions,
+  };
+}
+
+function evaluate(
+  phase,
+  manifests,
+  prePublishLedger = null,
+  trustedProducers = trustedProducersFor(phase),
+  trustedExceptionDocument = trustedExceptionsFor(trustedProducers),
+  artifactBindings = null,
+) {
+  const bindings = artifactBindings ?? manifests.map((manifest) => {
+    const producer = trustedProducers?.producers?.find(({ cell_id: cellId }) =>
+      cellId === manifest.cell_id);
+    return {
+      cell_id: manifest.cell_id,
+      producer_artifact: producer?.producer_artifact,
+      artifact_id: producer?.artifact?.id,
+      artifact_digest: producer?.artifact?.digest,
+      manifest_sha256: canonicalManifestSha(manifest),
+    };
+  });
   return evaluateReleaseCloseout({
     graph,
     phase,
@@ -169,6 +262,8 @@ function evaluate(phase, manifests, prePublishLedger = null, trustedProducers = 
     manifests,
     prePublishLedger,
     trustedProducers,
+    trustedExceptionDocument,
+    artifactBindings: bindings,
   });
 }
 
@@ -186,7 +281,8 @@ test("cell inventory is derived only from the release claim graph", () => {
     {
       producer_workflow: ".github/workflows/post-publish-release-smoke.yml",
       producer_job: "smoke",
-      producer_artifact: "release-cell-postpublish-linux-arm64",
+      producer_job_name: "Published linux-arm64 smoke",
+      producer_artifact: "release-cell-postpublish-linux-arm64-attempt-{attempt}",
       target: "linux-arm64",
       host_os: "Linux",
       host_arch: "ARM64",
@@ -198,6 +294,19 @@ test("cell inventory is derived only from the release claim graph", () => {
   const changedCells = deriveReleaseCells(changed, "pre_publish");
   assert.ok(changedCells.some(({ id }) => id === "package_identity:linux-future"));
   assert.ok(!changedCells.some(({ id }) => id === "package_identity:linux-x64"));
+
+  const targets = graph.workflow_policy.package_matrix
+    .map(({ asset_target: assetTarget }) => assetTarget);
+  assert.equal(targets.length, 6);
+  assert.equal(new Set(targets).size, 6);
+  assert.equal(prePublish.filter(({ group_id }) => group_id === "installed_runtime_behavior").length, 0);
+  assert.deepEqual(
+    postPublish
+      .filter(({ group_id }) => group_id === "installed_runtime_behavior")
+      .map(({ identity_constraints }) => identity_constraints.target)
+      .sort(),
+    [...targets].sort(),
+  );
 });
 
 test("accepted pre-publish closeout retains one manifest and evaluation per cell deterministically", () => {
@@ -218,6 +327,158 @@ test("accepted pre-publish closeout retains one manifest and evaluation per cell
   assert.equal(readdirSync(path.join(out, "evaluations")).length, 12);
   assert.deepEqual(JSON.parse(readFileSync(path.join(out, "ledger.json"))), first.ledger);
   assert.deepEqual(JSON.parse(readFileSync(path.join(out, "summary.json"))), first.summary);
+});
+
+test("approved performance exceptions use trusted input and same-run answer quality", () => {
+  const manifests = manifestsFor("pre_publish");
+  const performance = manifests.find(({ cell_id: cellId }) => cellId === "performance");
+  const answerQuality = manifests.find(({ cell_id: cellId }) => cellId === "answer_quality");
+  const approval = {
+    candidate_sha256: "d".repeat(64),
+    commit: gitIdentity.commit,
+    profile: performance.evidence.identity.profile,
+    baseline_id: performance.evidence.identity.baseline_id,
+    baseline_sha256: performance.evidence.identity.baseline_sha256,
+    metric: "model_bulk_docs_per_second",
+    regression_class: "model_microbenchmark",
+    baseline_value: 100,
+    measured_value: 90,
+    threshold: 95,
+    regression_percent: 10,
+    direction: "min",
+    repeats: 3,
+    release_key: performance.evidence.identity.release_key,
+    owner: "release owner",
+    approved_at: "2026-07-18",
+    expires_at: "2026-08-01",
+    rationale: "Bound model-only exception",
+    rollback_evidence: "revert the candidate and restore the accepted baseline",
+    full_product_benefit: {
+      evidence_id: answerQuality.evidence.id,
+      artifact_sha256: answerQuality.evidence.identity.artifact_sha256,
+      observed_at: answerQuality.evidence.observed_at,
+      metric: "packet_quality_score",
+      baseline_value: 0.5,
+      measured_value: 0.6,
+      direction: "increase",
+      improvement_percent: 20,
+    },
+  };
+  performance.evidence.status = "pass_with_exception";
+  performance.evidence.exception = {
+    schema: "codestory.release-claim-exception/v1",
+    approvals: [approval],
+  };
+  const trustedProducers = trustedProducersFor("pre_publish");
+  const trustedExceptions = trustedExceptionsFor(trustedProducers, {
+    [performance.evidence.id]: structuredClone(performance.evidence.exception),
+  });
+  const accepted = evaluate(
+    "pre_publish",
+    manifests,
+    null,
+    trustedProducers,
+    trustedExceptions,
+  );
+  assert.equal(accepted.decision, "accept");
+  assert.equal(accepted.evaluations.get("performance").value.status, "pass_with_exception");
+  assert.ok(accepted.evaluations.get("performance").value.evidence_cells.includes("answer_quality"));
+
+  const untrusted = evaluate("pre_publish", manifests, null, trustedProducers, null);
+  assert.equal(untrusted.decision, "reject");
+  assert.ok(untrusted.summary.input_errors.some((message) => message.includes("trusted exception")));
+
+  const unused = structuredClone(trustedExceptions);
+  unused.exceptions["unused-performance-evidence"] = structuredClone(performance.evidence.exception);
+  const rejectedUnused = evaluate("pre_publish", manifests, null, trustedProducers, unused);
+  assert.equal(rejectedUnused.decision, "reject");
+  assert.ok(rejectedUnused.summary.input_errors.some((message) =>
+    message.includes("unused evidence")));
+
+  const forged = structuredClone(trustedExceptions);
+  forged.exceptions[performance.evidence.id].approvals[0].measured_value = 110;
+  const rejectedForged = evaluate("pre_publish", manifests, null, trustedProducers, forged);
+  assert.equal(rejectedForged.decision, "reject");
+  assert.ok(rejectedForged.summary.failed_cells.includes("performance"));
+
+  const missingQuality = structuredClone(manifests);
+  missingQuality.splice(missingQuality.findIndex(({ cell_id: cellId }) =>
+    cellId === "answer_quality"), 1);
+  const rejectedMissingQuality = evaluate(
+    "pre_publish",
+    missingQuality,
+    null,
+    trustedProducers,
+    trustedExceptions,
+  );
+  assert.equal(rejectedMissingQuality.decision, "reject");
+  assert.ok(rejectedMissingQuality.summary.missing_cells.includes("answer_quality"));
+});
+
+test("closeout rejects loose JSON and artifact bindings outside selected Actions containers", () => {
+  const trustedProducers = trustedProducersFor("pre_publish");
+  const selected = mkdtempSync(path.join(os.tmpdir(), "codestory-release-cell-selected-"));
+  const selectedManifests = manifestsFor("pre_publish");
+  for (const manifest of selectedManifests) {
+    const producer = trustedProducers.producers.find(({ cell_id: cellId }) =>
+      cellId === manifest.cell_id);
+    const artifactRoot = path.join(selected, producer.producer_artifact);
+    mkdirSync(artifactRoot, { recursive: true });
+    writeFileSync(
+      path.join(artifactRoot, `${manifest.cell_id.replaceAll(":", "_")}.json`),
+      canonicalManifestBytes(manifest),
+    );
+  }
+  const performanceProducer = trustedProducers.producers.find(({ cell_id: cellId }) =>
+    cellId === "performance");
+  writeFileSync(
+    path.join(selected, performanceProducer.producer_artifact, "trusted-exceptions.json"),
+    canonicalManifestBytes(trustedExceptionsFor(trustedProducers)),
+  );
+  const downloaded = readReleaseCellArtifacts(selected, trustedProducers);
+  assert.equal(downloaded.manifests.length, 12);
+  assert.equal(downloaded.artifactBindings.length, 12);
+  writeFileSync(
+    path.join(selected, performanceProducer.producer_artifact, "alternate-exceptions.json"),
+    canonicalManifestBytes(trustedExceptionsFor(trustedProducers)),
+  );
+  assert.throws(
+    () => readReleaseCellArtifacts(selected, trustedProducers),
+    /unexpected exception document/u,
+  );
+
+  const loose = mkdtempSync(path.join(os.tmpdir(), "codestory-release-cell-loose-"));
+  writeFileSync(path.join(loose, "source_behavior.json"), "{}\n");
+  assert.throws(
+    () => readReleaseCellArtifacts(loose, trustedProducers),
+    /must be one selected artifact directory/u,
+  );
+
+  const manifests = manifestsFor("pre_publish");
+  const bindings = manifests.map((manifest) => {
+    const producer = trustedProducers.producers.find(({ cell_id: cellId }) =>
+      cellId === manifest.cell_id);
+    return {
+      cell_id: manifest.cell_id,
+      producer_artifact: producer.producer_artifact,
+      artifact_id: producer.artifact.id,
+      artifact_digest: producer.artifact.digest,
+      manifest_sha256: canonicalManifestSha(manifest),
+    };
+  });
+  const hostileBinding = bindings.find(({ cell_id: cellId }) => cellId === "source_behavior");
+  hostileBinding.artifact_id = "999999";
+  hostileBinding.artifact_digest = `sha256:${"f".repeat(64)}`;
+  const rejected = evaluate(
+    "pre_publish",
+    manifests,
+    null,
+    trustedProducers,
+    trustedExceptionsFor(trustedProducers),
+    bindings,
+  );
+  assert.equal(rejected.decision, "reject");
+  assert.ok(rejected.summary.failed_cells.includes("source_behavior"));
 });
 
 test("post-publish closeout compares every downloaded archive with the retained pre-publish bytes", () => {
@@ -352,6 +613,7 @@ test("producer identity is accepted only from the separately trusted map", () =>
 
   for (const [key, value] of [
     ["producer_workflow", ".github/workflows/arbitrary.yml"],
+    ["producer_job_name", "arbitrary job"],
     ["producer_run_id", "999"],
     ["producer_run_attempt", "2"],
   ]) {
@@ -371,4 +633,78 @@ test("producer identity is accepted only from the separately trusted map", () =>
   const rejectedArtifact = evaluate("pre_publish", manifests, null, wrongArtifact);
   assert.equal(rejectedArtifact.decision, "reject");
   assert.ok(rejectedArtifact.summary.input_errors.some((message) => message.includes("producer_artifact")));
+
+  const wrongContainer = trustedProducersFor("pre_publish");
+  wrongContainer.producers.find(({ cell_id: cellId }) => cellId === "source_behavior")
+    .artifact.workflow_run_id = "999";
+  const rejectedContainer = evaluate("pre_publish", manifests, null, wrongContainer);
+  assert.equal(rejectedContainer.decision, "reject");
+  assert.ok(rejectedContainer.summary.input_errors.some((message) =>
+    message.includes("artifact run identity")));
+
+  const wrongJob = trustedProducersFor("pre_publish");
+  wrongJob.producers.find(({ cell_id: cellId }) => cellId === "source_behavior")
+    .job.head_sha = "f".repeat(40);
+  const rejectedJob = evaluate("pre_publish", manifests, null, wrongJob);
+  assert.equal(rejectedJob.decision, "reject");
+  assert.ok(rejectedJob.summary.input_errors.some((message) =>
+    message.includes("job run identity")));
+
+  const wrongGraph = trustedProducersFor("pre_publish");
+  wrongGraph.graph_sha256 = "f".repeat(64);
+  const rejectedGraph = evaluate("pre_publish", manifests, null, wrongGraph);
+  assert.equal(rejectedGraph.decision, "reject");
+  assert.ok(rejectedGraph.summary.input_errors.some((message) =>
+    message.includes("graph identity")));
+
+  const hostileInventoryCases = [
+    ["artifact id", trusted => {
+      trusted.artifacts[0] = { ...trusted.artifacts[0], id: "999999" };
+    }, "missing from the download inventory"],
+    ["artifact digest", trusted => {
+      trusted.artifacts[0] = {
+        ...trusted.artifacts[0],
+        digest: `sha256:${"f".repeat(64)}`,
+      };
+    }, "differs from the download inventory"],
+    ["artifact name", trusted => {
+      trusted.artifacts[0] = {
+        ...trusted.artifacts[0],
+        name: "release-cell-forged-attempt-1",
+      };
+    }, "differs from the download inventory"],
+    ["unexpected artifact", trusted => {
+      trusted.artifacts.push({
+        ...structuredClone(trusted.artifacts[0]),
+        id: "999999",
+        name: "release-cell-unexpected-attempt-1",
+      });
+    }, "unused artifact"],
+  ];
+  for (const [label, mutate, expected] of hostileInventoryCases) {
+    const trusted = trustedProducersFor("pre_publish");
+    mutate(trusted);
+    const rejected = evaluate("pre_publish", manifests, null, trusted);
+    assert.equal(rejected.decision, "reject", label);
+    assert.ok(rejected.summary.input_errors.some((message) =>
+      message.includes(expected)), label);
+  }
+
+  const futureAttempt = trustedProducersFor("pre_publish");
+  futureAttempt.producers.find(({ cell_id: cellId }) => cellId === "source_behavior")
+    .producer_run_attempt = "2";
+  futureAttempt.producers.find(({ cell_id: cellId }) => cellId === "source_behavior")
+    .job.run_attempt = "2";
+  const rejectedFuture = evaluate("pre_publish", manifests, null, futureAttempt);
+  assert.equal(rejectedFuture.decision, "reject");
+  assert.ok(rejectedFuture.summary.input_errors.some((message) =>
+    message.includes("future run attempt")));
+
+  const wrongWindow = trustedProducersFor("pre_publish");
+  wrongWindow.producers.find(({ cell_id: cellId }) => cellId === "source_behavior")
+    .job.completed_at = "2026-07-18T11:04:00.000Z";
+  const rejectedWindow = evaluate("pre_publish", manifests, null, wrongWindow);
+  assert.equal(rejectedWindow.decision, "reject");
+  assert.ok(rejectedWindow.summary.input_errors.some((message) =>
+    message.includes("outside its job window")));
 });

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -88,7 +88,8 @@ function identityFor(cell) {
       case "evaluation_contract": identity[key] = "publishable-three-repeat-packet/v1"; break;
       case "producer_run_id": identity[key] = "12345"; break;
       case "producer_run_attempt": identity[key] = "1"; break;
-      case "producer_artifact": identity[key] = target ? archiveName(target) : `${cell.id}.json`; break;
+      case "producer_job": identity[key] = cell.identity_constraints.producer_job; break;
+      case "producer_artifact": identity[key] = cell.identity_constraints.producer_artifact; break;
       case "native_engine": identity[key] = "coderank_q8"; break;
       case "calibration_sha256": identity[key] = "c".repeat(64); break;
       default: throw new Error(`test fixture has no identity value for ${key}`);
@@ -121,7 +122,7 @@ function manifestsFor(phase, prePublishLedger = null) {
     };
     if (cell.archive_role === "pre_publish") {
       manifest.archive = {
-        name: identity.producer_artifact,
+        name: archiveName(identity.target),
         sha256: identity.artifact_sha256,
         bytes: 1024,
       };
@@ -134,6 +135,7 @@ function manifestsFor(phase, prePublishLedger = null) {
         pre_publish_cell_id: packageCell.id,
         pre_publish_manifest_sha256: packageCell.manifest.sha256,
         pre_publish_artifact_sha256: packageCell.archive.sha256,
+        published_artifact_name: packageCell.archive.name,
         published_artifact_sha256: packageCell.archive.sha256,
       };
     }
@@ -141,7 +143,23 @@ function manifestsFor(phase, prePublishLedger = null) {
   });
 }
 
-function evaluate(phase, manifests, prePublishLedger = null) {
+function trustedProducersFor(phase) {
+  return {
+    schema: "codestory.release-producer-map/v1",
+    phase,
+    identity: gitIdentity,
+    producers: deriveReleaseCells(graph, phase).map((cell) => ({
+      cell_id: cell.id,
+      producer_workflow: cell.identity_constraints.producer_workflow,
+      producer_job: cell.identity_constraints.producer_job,
+      producer_run_id: "12345",
+      producer_run_attempt: "1",
+      producer_artifact: cell.identity_constraints.producer_artifact,
+    })),
+  };
+}
+
+function evaluate(phase, manifests, prePublishLedger = null, trustedProducers = trustedProducersFor(phase)) {
   return evaluateReleaseCloseout({
     graph,
     phase,
@@ -150,6 +168,7 @@ function evaluate(phase, manifests, prePublishLedger = null) {
     gitIdentity,
     manifests,
     prePublishLedger,
+    trustedProducers,
   });
 }
 
@@ -166,6 +185,8 @@ test("cell inventory is derived only from the release claim graph", () => {
     postPublish.find(({ id }) => id === "platform_support:linux-arm64").identity_constraints,
     {
       producer_workflow: ".github/workflows/post-publish-release-smoke.yml",
+      producer_job: "smoke",
+      producer_artifact: "release-cell-postpublish-linux-arm64",
       target: "linux-arm64",
       host_os: "Linux",
       host_arch: "ARM64",
@@ -321,4 +342,33 @@ test("missing, duplicate, stale, failed, aggregate, and reused evidence fail clo
       }
     });
   }
+});
+
+test("producer identity is accepted only from the separately trusted map", () => {
+  const manifests = manifestsFor("pre_publish");
+  const missingMap = evaluate("pre_publish", manifests, null, null);
+  assert.equal(missingMap.decision, "reject");
+  assert.ok(missingMap.summary.input_errors.includes("closeout requires a separately trusted producer map"));
+
+  for (const [key, value] of [
+    ["producer_workflow", ".github/workflows/arbitrary.yml"],
+    ["producer_run_id", "999"],
+    ["producer_run_attempt", "2"],
+  ]) {
+    const wrongProducer = trustedProducersFor("pre_publish");
+    wrongProducer.producers.find(({ cell_id: cellId }) => cellId === "source_behavior")[key] = value;
+    const rejected = evaluate("pre_publish", manifests, null, wrongProducer);
+    assert.equal(rejected.decision, "reject", key);
+    assert.ok(
+      rejected.summary.failed_cells.includes("source_behavior")
+        || rejected.summary.input_errors.some((message) => message.includes(key)),
+      key,
+    );
+  }
+
+  const wrongArtifact = trustedProducersFor("pre_publish");
+  wrongArtifact.producers.find(({ cell_id: cellId }) => cellId === "performance").producer_artifact = "wrong";
+  const rejectedArtifact = evaluate("pre_publish", manifests, null, wrongArtifact);
+  assert.equal(rejectedArtifact.decision, "reject");
+  assert.ok(rejectedArtifact.summary.input_errors.some((message) => message.includes("producer_artifact")));
 });

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
+      "graph_sha256": "ed95d9c4e2723d7911a2d00a97a1453fe77972511f7c74ca8e1f51727783f6dd",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "4c451514d150ab91aaa1a199d5713267266c641d247df182fa8bd336fff5e538",
+      "graph_sha256": "3ef186d84ca65c41ac9d0089cc5864d73cb2012a76e2e852c2f6361400ab8e3f",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

The v0.16 release chain had no authenticated, graph-derived closeout across source, evidence, packages, protected hardware, and post-publish behavior. It also could not recover safely from a failed-job rerun because artifact identity was run-global or self-attested.

Closes #1305
Refs #1233

## What changed

- derive and evaluate the exact 12 pre-publish and 30 post-publish release cells from `release-claims.json`
- gate publication on accepted source, evidence, six-package, Metal, and Vulkan cells
- authenticate each producer against current-run Actions job and artifact inventory, including run, attempt, job window, artifact ID/name/digest/size/expiry, and an unflattened container
- select the latest successful attempt independently per producer so failed jobs can rerun without rerunning accepted cells
- retain immutable attempt-qualified terminal evidence; allow replacement only for five structurally pinned intermediates consumed by name
- bind performance exceptions to a separate authenticated release-evidence input and require same-run answer-quality evidence
- compare every post-publish archive with the accepted pre-publish package bytes
- retain #1221 installed-runtime behavior as a distinct post-publish evidence tier
- add workflow-policy negatives for provenance, flattening, replay, rerun collisions, artifact spoofing, exception misuse, target collapse, and gate bypass
- update the contributor test command, release guidance, and `Unreleased` changelog

## Review

Base: `afd17fa4300a3117bbd138ae14da74a0b6cf3942`

Accepted head: `a54d82d99a1eca94facb4c08ed7cd4fb98faedd2`

Tree: `9cf868d210b16ed68a9191f5af1d8015ef851f60`

The highest-risk surfaces are:

1. `scripts/codestory-release-closeout.mjs` producer selection and container binding
2. `.github/workflows/release.yml` pre/post closeout and replay fences
3. release-chain artifact naming/replacement rules
4. performance-exception provenance and answer-quality coupling
5. `.github/scripts/check-workflow-policy.mjs` structural bypass protection

## Verification

- release contract: 56/56
- workflow policy: 232/232 plus policy runner
- actionlint harness: 3/3 plus runner
- CI route self-test
- retrieval generalization lint
- synchronized v0.16 release version and manifests
- docs links: 75 files / 265 relative links
- Node and JSON syntax
- `git diff --check`
- independent exact-head review: no P0–P3 findings at the accepted head

CodeStory grounding failed closed during review because the current source could not produce a complete core publication; review used pinned exact source as the documented fallback.

## Risk and non-claims

This is source/workflow proof. It does not claim final packages, protected-hardware execution, installed-runtime behavior, marketplace propagation, or live release behavior. Those remain owned by the final #1233/#1259 release ledger and post-publish program.
