### PR TITLE
build semantic endpoint indexes before context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
 
 ### Performance
 
+- Staged builds now create the four edge endpoint indexes immediately before
+  semantic context reads instead of issuing thousands of bounded endpoint
+  queries against an unindexed edge table. The normal deferred schema still
+  owns the indexes, and telemetry reports their wall time separately while
+  retaining it in the deferred-index total.
 - The sqlite-vec versus USearch evidence harness now freezes and independently
   revalidates its reviewed catalog, source publication, query embeddings, and
   exact corpus identity before measurement. Candidate publication validates

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8979,6 +8979,7 @@ mod tests {
             search_symbol_index_reload_count: Some(1),
             search_symbol_index_reload_ms: Some(65),
             runtime_cache_publish_ms: Some(63),
+            semantic_context_index_ms: Some(59),
             semantic_node_load_ms: Some(66),
             semantic_node_load_rows: Some(8_192),
             semantic_context_ms: Some(67),
@@ -9229,7 +9230,7 @@ mod tests {
         assert!(markdown.contains("projection_batches: transactions=2"));
         assert!(
             markdown
-                .contains("semantic_ms: node_load=66 node_rows=8192 context=67 doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")
+                .contains("semantic_ms: context_index=59 node_load=66 node_rows=8192 context=67 doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")
         );
         assert!(markdown.contains("semantic_docs: reused=11 embedded=12 pending=13 stale=14"));
         assert!(markdown.contains(

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -463,6 +463,7 @@ fn append_index_semantic_timings(markdown: &mut String, timings: &IndexingPhaseT
         markdown,
         "semantic_ms",
         &[
+            ("context_index", timings.semantic_context_index_ms),
             ("node_load", timings.semantic_node_load_ms),
             ("node_rows", timings.semantic_node_load_rows),
             ("context", timings.semantic_context_ms),

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -93,6 +93,8 @@ pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_cache_publish_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_context_index_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_node_load_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_node_load_rows: Option<u32>,
@@ -316,6 +318,7 @@ mod tests {
             search_symbol_index_commit_ms: None,
             search_symbol_index_reload_ms: None,
             runtime_cache_publish_ms: None,
+            semantic_context_index_ms: None,
             semantic_node_load_ms: None,
             semantic_node_load_rows: None,
             semantic_context_ms: None,
@@ -419,6 +422,7 @@ mod tests {
         assert!(value.get("resolution_calls_ms").is_none());
         assert!(value.get("resolution_imports_ms").is_none());
         assert!(value.get("resolution_cleanup_ms").is_none());
+        assert!(value.get("semantic_context_index_ms").is_none());
         assert!(value.get("semantic_doc_build_ms").is_none());
         assert!(value.get("semantic_node_load_ms").is_none());
         assert!(value.get("semantic_node_load_rows").is_none());
@@ -531,6 +535,7 @@ mod tests {
         .expect("deserialize legacy timings");
 
         assert!(timings.full_refresh_wall.is_none());
+        assert!(timings.semantic_context_index_ms.is_none());
         assert!(timings.semantic_node_load_ms.is_none());
         assert!(timings.search_symbol_index_commit_ms.is_none());
     }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -4763,6 +4763,7 @@ fn read_line_capped<R: BufRead>(
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SemanticProjectionStats {
     reported: bool,
+    semantic_context_index_ms: u32,
     node_load_ms: u32,
     node_load_rows: u32,
     context_ms: u32,
@@ -4833,6 +4834,7 @@ fn apply_semantic_projection_stats(
     if !stats.reported {
         return;
     }
+    timings.semantic_context_index_ms = Some(stats.semantic_context_index_ms);
     timings.semantic_node_load_ms = Some(stats.node_load_ms);
     timings.semantic_node_load_rows = Some(stats.node_load_rows);
     timings.semantic_context_ms = Some(stats.context_ms);
@@ -6145,6 +6147,7 @@ struct SearchGenerationCatalogGuard {
 #[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PublicationTestBoundary {
+    SemanticContextIndexes,
     Identity,
     SearchBuild,
     SearchSymbolPage,
@@ -8813,6 +8816,24 @@ fn finalize_staged_semantic_docs_for_runtime(
     if is_indexing_cancelled(cancel_token) {
         return Err(indexing_cancelled_error());
     }
+    let semantic_context_index_started = Instant::now();
+    storage
+        .create_semantic_context_endpoint_indexes_for_build()
+        .map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to create staged semantic context endpoint indexes: {error}"
+            ))
+        })?;
+    let semantic_context_index_ms =
+        clamp_u128_to_u32(semantic_context_index_started.elapsed().as_millis());
+    #[cfg(test)]
+    publication_test_checkpoint(
+        PublicationTestBoundary::SemanticContextIndexes,
+        cancel_token,
+    )?;
+    if is_indexing_cancelled(cancel_token) {
+        return Err(indexing_cancelled_error());
+    }
     let node_load_started = Instant::now();
     let nodes = storage
         .get_nodes()
@@ -8839,6 +8860,7 @@ fn finalize_staged_semantic_docs_for_runtime(
         cancel_token,
         runtime,
     )?;
+    stats.semantic_context_index_ms = semantic_context_index_ms;
     stats.node_load_ms = node_load_ms;
     stats.node_load_rows = node_load_rows;
     Ok(stats)
@@ -14578,7 +14600,9 @@ fn index_full_for_runtime(
             )));
         }
     };
-    let deferred_indexes_ms = staged_finalize_stats.deferred_indexes_ms;
+    let deferred_indexes_ms = staged_finalize_stats
+        .deferred_indexes_ms
+        .saturating_add(staged_semantic_stats.semantic_context_index_ms);
     let summary_snapshot_ms = staged_finalize_stats.summary_snapshot_ms;
     let detail_started = Instant::now();
     if let Err(err) = staged.snapshots().refresh_detail() {
@@ -14818,6 +14842,7 @@ fn index_full_for_runtime(
             search_symbol_index_commit_ms: None,
             search_symbol_index_reload_ms: None,
             runtime_cache_publish_ms: None,
+            semantic_context_index_ms: None,
             semantic_node_load_ms: None,
             semantic_node_load_rows: None,
             semantic_context_ms: None,
@@ -15280,7 +15305,9 @@ fn run_incremental_indexing_common(
             return Err(error);
         }
     };
-    let deferred_indexes_ms = staged_finalize_stats.deferred_indexes_ms;
+    let deferred_indexes_ms = staged_finalize_stats
+        .deferred_indexes_ms
+        .saturating_add(staged_semantic_stats.semantic_context_index_ms);
     let summary_snapshot_ms = staged_finalize_stats.summary_snapshot_ms;
     let resolution_telemetry = OptionalResolutionTelemetry::from_incremental_stats(&index_stats);
 
@@ -15478,6 +15505,7 @@ fn run_incremental_indexing_common(
             search_symbol_index_commit_ms: None,
             search_symbol_index_reload_ms: None,
             runtime_cache_publish_ms: None,
+            semantic_context_index_ms: None,
             semantic_node_load_ms: None,
             semantic_node_load_rows: None,
             semantic_context_ms: None,
@@ -25677,7 +25705,12 @@ fn build_llm_symbol_doc_text() -> String {
         assert_eq!(full_timings.search_symbol_index_reload_count, Some(1));
         assert!(full_timings.search_symbol_index_commit_ms.is_some());
         assert!(full_timings.search_symbol_index_reload_ms.is_some());
+        assert!(full_timings.semantic_context_index_ms.is_some());
         assert!(full_timings.semantic_node_load_ms.is_some());
+        assert!(
+            full_timings.deferred_indexes_ms.unwrap_or_default()
+                >= full_timings.semantic_context_index_ms.unwrap_or_default()
+        );
         assert!(
             full_timings
                 .semantic_node_load_rows
@@ -25836,6 +25869,58 @@ fn build_llm_symbol_doc_text() -> String {
                 .iter()
                 .any(|node| node.serialized_name == "retained_value")
         );
+        assert_no_staged_publication_artifacts(&storage_path);
+    }
+
+    #[test]
+    fn full_refresh_semantic_endpoint_index_failure_preserves_live_publication() {
+        let workspace = tempdir().expect("workspace dir");
+        let source_path = workspace.path().join("lib.rs");
+        fs::write(&source_path, "pub fn retained_generation() -> i32 { 1 }\n")
+            .expect("write baseline source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish baseline");
+        let baseline = Storage::open(&storage_path)
+            .expect("open baseline")
+            .get_complete_index_publication()
+            .expect("read baseline publication")
+            .expect("baseline publication");
+
+        fs::write(&source_path, "pub fn rejected_generation() -> i32 { 2 }\n")
+            .expect("write replacement source");
+        arm_full_refresh_staged_store_hook(|storage| {
+            storage
+                .get_connection()
+                .execute_batch(
+                    "CREATE TABLE idx_edge_source (
+                         collision INTEGER
+                     );",
+                )
+                .expect("install semantic endpoint index collision");
+        });
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect_err("semantic endpoint index failure must reject the candidate");
+        assert!(error.message.contains("idx_edge_source"), "{error:?}");
+
+        let live = Storage::open(&storage_path).expect("reopen retained live publication");
+        assert_eq!(
+            live.get_complete_index_publication()
+                .expect("read retained publication"),
+            Some(baseline)
+        );
+        assert!(storage_has_symbol(&live, "retained_generation"));
+        assert!(!storage_has_symbol(&live, "rejected_generation"));
         assert_no_staged_publication_artifacts(&storage_path);
     }
 
@@ -26497,7 +26582,8 @@ fn build_llm_symbol_doc_text() -> String {
         }
     }
 
-    const PUBLICATION_TRANSITION_BOUNDARIES: [PublicationTestBoundary; 10] = [
+    const PUBLICATION_TRANSITION_BOUNDARIES: [PublicationTestBoundary; 11] = [
+        PublicationTestBoundary::SemanticContextIndexes,
         PublicationTestBoundary::Identity,
         PublicationTestBoundary::SearchBuild,
         PublicationTestBoundary::SearchSymbolPage,

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -3514,6 +3514,17 @@ impl Storage {
         Ok(())
     }
 
+    /// Create only the edge endpoint indexes needed by staged semantic context reads.
+    ///
+    /// Live stores already have the complete secondary schema. Build stores defer
+    /// these indexes until semantic projection to keep the ingestion write path lean.
+    pub fn create_semantic_context_endpoint_indexes_for_build(&self) -> Result<(), StorageError> {
+        if self.deferred_secondary_indexes {
+            schema::create_semantic_context_endpoint_indexes(&self.conn)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn prepare_deferred_secondary_indexes_for_summary(
         &self,
     ) -> Result<(), StorageError> {

--- a/crates/codestory-store/src/storage_impl/schema.rs
+++ b/crates/codestory-store/src/storage_impl/schema.rs
@@ -330,12 +330,17 @@ const LOAD_TIME_INDEX_STATEMENTS: &[&str] = &[
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_component_access_node ON component_access(node_id)",
 ];
 
+const SEMANTIC_CONTEXT_ENDPOINT_INDEX_STATEMENTS: &[&str] = &[
+    "CREATE INDEX IF NOT EXISTS idx_edge_source ON edge(source_node_id)",
+    "CREATE INDEX IF NOT EXISTS idx_edge_target ON edge(target_node_id)",
+    "CREATE INDEX IF NOT EXISTS idx_edge_resolved_source ON edge(resolved_source_node_id)",
+    "CREATE INDEX IF NOT EXISTS idx_edge_resolved_target ON edge(resolved_target_node_id)",
+];
+
 const PRE_SUMMARY_SECONDARY_INDEX_STATEMENTS: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_occurrence_element ON occurrence(element_id)",
     "CREATE INDEX IF NOT EXISTS idx_occurrence_element_start_line ON occurrence(element_id, start_line)",
     "CREATE INDEX IF NOT EXISTS idx_occurrence_file ON occurrence(file_node_id)",
-    "CREATE INDEX IF NOT EXISTS idx_edge_source ON edge(source_node_id)",
-    "CREATE INDEX IF NOT EXISTS idx_edge_target ON edge(target_node_id)",
     "CREATE INDEX IF NOT EXISTS idx_edge_file ON edge(file_node_id)",
     "CREATE INDEX IF NOT EXISTS idx_edge_scope_unresolved
      ON edge(kind, resolved_target_node_id, source_node_id, file_node_id)",
@@ -346,8 +351,6 @@ const PRE_SUMMARY_SECONDARY_INDEX_STATEMENTS: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_bookmark_node_category ON bookmark_node(category_id)",
     "CREATE INDEX IF NOT EXISTS idx_bookmark_node_node ON bookmark_node(node_id)",
     "CREATE INDEX IF NOT EXISTS idx_node_kind_serialized_name ON node(kind, serialized_name)",
-    "CREATE INDEX IF NOT EXISTS idx_edge_resolved_source ON edge(resolved_source_node_id)",
-    "CREATE INDEX IF NOT EXISTS idx_edge_resolved_target ON edge(resolved_target_node_id)",
     "CREATE INDEX IF NOT EXISTS idx_edge_kind_source ON edge(kind, source_node_id)",
     "CREATE INDEX IF NOT EXISTS idx_edge_kind_target ON edge(kind, target_node_id)",
     "CREATE INDEX IF NOT EXISTS idx_edge_kind_resolved_target ON edge(kind, resolved_target_node_id)",
@@ -433,7 +436,17 @@ pub(super) fn create_secondary_indexes(conn: &Connection) -> Result<(), StorageE
 }
 
 pub(super) fn create_pre_summary_secondary_indexes(conn: &Connection) -> Result<(), StorageError> {
+    create_semantic_context_endpoint_indexes(conn)?;
     for statement in PRE_SUMMARY_SECONDARY_INDEX_STATEMENTS {
+        conn.execute(statement, [])?;
+    }
+    Ok(())
+}
+
+pub(super) fn create_semantic_context_endpoint_indexes(
+    conn: &Connection,
+) -> Result<(), StorageError> {
+    for statement in SEMANTIC_CONTEXT_ENDPOINT_INDEX_STATEMENTS {
         conn.execute(statement, [])?;
     }
     Ok(())

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -4285,6 +4285,162 @@ fn test_resolution_query_plan_prefers_new_indexes() -> Result<(), StorageError> 
 }
 
 #[test]
+fn semantic_context_endpoint_indexes_replace_edge_scan_without_other_deferred_indexes()
+-> Result<(), StorageError> {
+    const ENDPOINT_INDEXES: &[&str] = &[
+        "idx_edge_source",
+        "idx_edge_target",
+        "idx_edge_resolved_source",
+        "idx_edge_resolved_target",
+    ];
+    const UNRELATED_DEFERRED_INDEXES: &[&str] = &[
+        "idx_edge_file",
+        "idx_edge_kind_source",
+        "idx_node_file",
+        "idx_occurrence_element",
+    ];
+    const REPRESENTATIVE_NODE_COUNT: i64 = 12_000;
+    const REPRESENTATIVE_EDGE_COUNT: i64 = 48_000;
+
+    let db_path = unique_temp_db_path("semantic-endpoint-indexes");
+    let _ = cleanup_sqlite_sidecars(&db_path);
+    let storage = Storage::open_build(&db_path)?;
+    storage.conn.execute_batch(&format!(
+        "WITH RECURSIVE sequence(value) AS (
+             SELECT 1
+             UNION ALL
+             SELECT value + 1 FROM sequence WHERE value < {REPRESENTATIVE_NODE_COUNT}
+         )
+         INSERT INTO node(id, kind, serialized_name)
+         SELECT value, 3, printf('node-%d', value) FROM sequence;
+         WITH RECURSIVE sequence(value) AS (
+             SELECT 1
+             UNION ALL
+             SELECT value + 1 FROM sequence WHERE value < {REPRESENTATIVE_EDGE_COUNT}
+         )
+         INSERT INTO edge(
+             id,
+             source_node_id,
+             target_node_id,
+             kind,
+             resolved_source_node_id,
+             resolved_target_node_id
+         )
+         SELECT
+             value,
+             (value % {REPRESENTATIVE_NODE_COUNT}) + 1,
+             ((value * 17) % {REPRESENTATIVE_NODE_COUNT}) + 1,
+             2,
+             ((value * 19) % {REPRESENTATIVE_NODE_COUNT}) + 1,
+             ((value * 23) % {REPRESENTATIVE_NODE_COUNT}) + 1
+         FROM sequence;"
+    ))?;
+
+    for index_name in ENDPOINT_INDEXES
+        .iter()
+        .chain(UNRELATED_DEFERRED_INDEXES.iter())
+    {
+        assert!(!sqlite_index_exists(&storage, index_name)?);
+    }
+
+    let plan_sql = format!(
+        "EXPLAIN QUERY PLAN
+         {EDGE_SELECT_BASE}
+         WHERE e.source_node_id IN (?1)
+            OR e.target_node_id IN (?2)
+            OR e.resolved_source_node_id IN (?3)
+            OR e.resolved_target_node_id IN (?4)
+         ORDER BY e.id"
+    );
+    let plan = |storage: &Storage| -> Result<Vec<String>, StorageError> {
+        let mut statement = storage.conn.prepare(&plan_sql)?;
+        statement
+            .query_map(rusqlite::params![17_i64, 17_i64, 17_i64, 17_i64], |row| {
+                row.get(3)
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(StorageError::from)
+    };
+    let scan_plan = plan(&storage)?;
+    assert!(
+        scan_plan.iter().any(|line| line.contains("SCAN e")),
+        "semantic endpoint lookup did not scan before early indexes: {scan_plan:?}"
+    );
+
+    let node_ids = [NodeId(17), NodeId(311), NodeId(1_021), NodeId(5_099)];
+    let scan_callbacks = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let scan_counter = std::sync::Arc::clone(&scan_callbacks);
+    storage.conn.progress_handler(
+        100,
+        Some(move || {
+            scan_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            false
+        }),
+    )?;
+    let scan_started = std::time::Instant::now();
+    let scan_edges = storage.get_edges_for_node_ids(&node_ids)?;
+    let scan_elapsed = scan_started.elapsed();
+    storage.conn.progress_handler(0, None::<fn() -> bool>)?;
+
+    storage.create_semantic_context_endpoint_indexes_for_build()?;
+    for index_name in ENDPOINT_INDEXES {
+        assert!(sqlite_index_exists(&storage, index_name)?);
+    }
+    for index_name in UNRELATED_DEFERRED_INDEXES {
+        assert!(!sqlite_index_exists(&storage, index_name)?);
+    }
+
+    let indexed_plan = plan(&storage)?;
+    for index_name in ENDPOINT_INDEXES {
+        assert!(
+            indexed_plan.iter().any(|line| line.contains(index_name)),
+            "semantic endpoint lookup did not use {index_name}: {indexed_plan:?}"
+        );
+    }
+    assert!(
+        indexed_plan.iter().all(|line| !line.contains("SCAN e")),
+        "semantic endpoint lookup still scanned after early indexes: {indexed_plan:?}"
+    );
+
+    let indexed_callbacks = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let indexed_counter = std::sync::Arc::clone(&indexed_callbacks);
+    storage.conn.progress_handler(
+        100,
+        Some(move || {
+            indexed_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            false
+        }),
+    )?;
+    let indexed_started = std::time::Instant::now();
+    let indexed_edges = storage.get_edges_for_node_ids(&node_ids)?;
+    let indexed_elapsed = indexed_started.elapsed();
+    storage.conn.progress_handler(0, None::<fn() -> bool>)?;
+
+    assert_eq!(indexed_edges, scan_edges);
+    for edges in indexed_edges.values() {
+        assert!(
+            edges.windows(2).all(|pair| pair[0].id < pair[1].id),
+            "semantic endpoint results lost deterministic edge-id order"
+        );
+    }
+    let scan_callback_count = scan_callbacks.load(std::sync::atomic::Ordering::Relaxed);
+    let indexed_callback_count = indexed_callbacks.load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        scan_callback_count > indexed_callback_count.saturating_mul(5),
+        "representative endpoint lookup VM work did not improve enough: scan={scan_callback_count}, indexed={indexed_callback_count}"
+    );
+    eprintln!(
+        "semantic endpoint representative proof: nodes={REPRESENTATIVE_NODE_COUNT} edges={REPRESENTATIVE_EDGE_COUNT} scan_callbacks={scan_callback_count} indexed_callbacks={indexed_callback_count} scan_ms={} indexed_ms={}",
+        scan_elapsed.as_millis(),
+        indexed_elapsed.as_millis(),
+    );
+
+    drop(storage);
+    cleanup_sqlite_sidecars(&db_path)?;
+    Ok(())
+}
+
+#[test]
 fn staged_summary_build_uses_bulk_node_file_rank_index_for_file_aggregation()
 -> Result<(), StorageError> {
     const DESTINATION_INDEXES: &[&str] = &[
@@ -4396,6 +4552,10 @@ fn legacy_staged_finalize_builds_complete_secondary_index_set() -> Result<(), St
     assert!(storage.has_ready_grounding_summary_snapshots()?);
     for index_name in [
         "idx_node_file",
+        "idx_edge_source",
+        "idx_edge_target",
+        "idx_edge_resolved_source",
+        "idx_edge_resolved_target",
         "idx_grounding_file_snapshot_path",
         "idx_grounding_file_snapshot_rank",
         "idx_grounding_node_snapshot_file_rank",

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -318,12 +318,15 @@ The last step belongs to runtime plus store:
 Full and incremental snapshot behavior are intentionally not symmetric.
 
 Staged finalization splits deferred indexes around summary materialization. It
-first creates source/core indexes used by the snapshot query, including the
-edge indexes needed for root membership checks. It fills the grounding node
+creates the four source, target, resolved-source, and resolved-target edge
+indexes immediately before semantic context reads. The normal deferred schema
+also retains those statements. Snapshot finalization then creates the remaining
+source/core indexes used by the snapshot query. It fills the grounding node
 table with both destination indexes absent, then bulk-builds the node file-rank
 index needed by the file-summary join. After file materialization it bulk-builds
 the node root-rank index and both file-summary indexes before the stage can
-publish. All three index-build segments belong to `deferred_indexes_ms`;
+publish. All index-build segments belong to `deferred_indexes_ms`;
+`semantic_ms.context_index` isolates the early endpoint-index work and
 `summary_snapshot_ms` covers only materialization. Any failure in a build
 segment leaves the candidate unpublished and the previous live generation
 usable.
@@ -432,6 +435,7 @@ The index summary reports graph and semantic work separately:
 - `symbol_index.stream_ms`, `stream_rows`, and `stream_batches`: nested canonical-node read telemetry; stream time is part of `cache_ms.search_index`, not an additive phase
 - `symbol_index`: documents written plus Tantivy writer, commit, and reader-reload counts and final commit/reload durations; all are nested inside `cache_ms.search_index`, and completed-generation reuse reports zero
 - `cache_ms.runtime_publish`: publishing the rebuilt search state into the live runtime
+- `semantic_ms.context_index`: creating the four staged edge endpoint indexes before semantic context reads; this is nested in `timings_ms.deferred_indexes`
 - `semantic_ms.node_load` and `node_rows`: loading the complete staged node set before semantic selection
 - `semantic_ms.context`: loading the graph context used by generated semantic documents
 - `semantic_ms.doc_build`: generated semantic text and hashes


### PR DESCRIPTION
## Context

The stopped 94,411-file proof spent at least about 2h20m in semantic-context preparation. The staged semantic path queried edge endpoints in 200-ID windows before the four supporting endpoint indexes existed.

This is the first remaining bounded child under #1275. It deliberately does not change the lookup chunk, SQLite journal/durability policy, semantic memory layout, writer count, adaptive budgets, or parser/search thread counts.

## What changed

- creates `idx_edge_source`, `idx_edge_target`, `idx_edge_resolved_source`, and `idx_edge_resolved_target` at the staged semantic boundary;
- keeps the same statements in the ordinary final deferred-index schema path;
- checks cancellation before and after the DDL boundary;
- exposes `semantic_context_index_ms` and includes it once in `deferred_indexes_ms` for full and incremental publication;
- covers plan selection, unrelated-index absence, deterministic output, DDL failure, cancellation, and old-or-new publication.

## Review

Exact base: `4cf779f1399d6f5f616b16a85358f49975769a5c`

Accepted head: `a171c0abd23725b1dcd0fca2b600a643320193c8`

Tree: `eabbed38b42c55d5185c4aec8304dd9b94f5233d`

Independent exact-head rereview found no P0-P3 issues. The pre/post-rebase patch ID is unchanged (`b71887f2c043b88fa6b41a90ee779ba535b0d531`). Canonical CodeStory grounding stayed fail-closed at `activation_preparing` / `CoreFreshness` across the prescribed retries, so review used pinned exact source.

## Verification

- representative store plan proof: 12,000 nodes / 48,000 edges, `SCAN e` before, all four endpoint indexes after, 12,971 vs 45 SQLite progress callbacks, identical ordered results;
- unrelated deferred indexes absent at the early boundary; final deferred schema remains complete;
- injected endpoint-index DDL failure preserves the live publication and disposes the stage;
- full and incremental 11-boundary fail/cancel publication matrices;
- full/incremental durable-generation and timing proof;
- contract serde compatibility and CLI rendering;
- locked targeted tests, check, and all-target clippy;
- fmt, docs links (75 files / 265 links), retrieval generalization lint (1,434 patterns), and diff check.

No complete Linux corpus proof was run. This source PR makes no package, protected-hardware, installed-runtime, live-release, or end-to-end corpus-performance claim.

Closes #1306
Refs #1275
