### PR TITLE
[codex] skip empty-stage parser cache reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@
 
 ### Performance
 
+- Fresh disposable full-refresh stages now declare the parser artifact cache
+  `known_empty` instead of issuing guaranteed-miss queries. Structural
+  read-through is enabled only when verified rows were copied from the prior
+  publication, so an entirely fresh stage opens no second SQLite reader.
+  Parser and structural telemetry now report policy, logical lookups, physical
+  queries, hits, misses, reader opens, and lookup wall time independently.
 - Staged builds now create the four edge endpoint indexes immediately before
   semantic context reads instead of issuing thousands of bounded endpoint
   queries against an unindexed edge table. The normal deferred schema still

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ dependencies = [
  "nucleo-matcher",
  "parking_lot",
  "rayon",
+ "rusqlite",
  "serde",
  "serde_json",
  "tantivy",

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8952,6 +8952,8 @@ mod tests {
             artifact_cache_write_ms: Some(6),
             artifact_cache_writes: Some(24),
             artifact_cache_write_transactions: Some(1),
+            parser_artifact_cache: None,
+            structural_artifact_cache: None,
             full_refresh_chunks_produced: Some(2),
             full_refresh_chunks_persisted: Some(2),
             full_refresh_queue_capacity: Some(1),

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -11,8 +11,9 @@ use codestory_contracts::api::IndexFreshnessStatusDto;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentResponseBlockDto, AgentRetrievalPolicyModeDto,
     AgentRetrievalPresetDto, AgentRetrievalStepDto, AgentRetrievalStepKindDto,
-    AgentRetrievalStepStatusDto, GraphArtifactDto, GroundingSnapshotDto, IndexingPhaseTimings,
-    NodeDetailsDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto, RepoTextScanStatsDto,
+    AgentRetrievalStepStatusDto, ArtifactCacheAccessTimings, ArtifactCachePolicyDto,
+    GraphArtifactDto, GroundingSnapshotDto, IndexingPhaseTimings, NodeDetailsDto,
+    PacketEvidenceResolutionDto, PacketEvidenceTierDto, RepoTextScanStatsDto,
     RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalStateDto, SearchHit, SearchHitOrigin,
     SearchPlanBridgeConfidenceDto, SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto,
     SearchPlanBridgeStatusDto, SearchPlanChannelDto, SearchPlanDto, SearchPlanPromotionStatusDto,
@@ -371,6 +372,16 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
             ("transactions", timings.artifact_cache_write_transactions),
         ],
     );
+    append_artifact_cache_access(
+        markdown,
+        "parser_artifact_cache",
+        timings.parser_artifact_cache.as_ref(),
+    );
+    append_artifact_cache_access(
+        markdown,
+        "structural_artifact_cache",
+        timings.structural_artifact_cache.as_ref(),
+    );
     append_optional_timings_line(
         markdown,
         "full_refresh_pipeline",
@@ -455,6 +466,30 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
             ),
             ("seed_symbol_table", timings.setup_seed_symbol_table_ms),
         ],
+    );
+}
+
+fn append_artifact_cache_access(
+    markdown: &mut String,
+    label: &str,
+    timings: Option<&ArtifactCacheAccessTimings>,
+) {
+    let Some(timings) = timings else {
+        return;
+    };
+    let policy = match timings.policy {
+        ArtifactCachePolicyDto::KnownEmpty => "known_empty",
+        ArtifactCachePolicyDto::ReadThrough => "read_through",
+    };
+    let _ = writeln!(
+        markdown,
+        "{label}: policy={policy} logical_lookups={} physical_queries={} hits={} misses={} reader_opens={} lookup_wall_ms={}",
+        timings.logical_lookups,
+        timings.physical_queries,
+        timings.hits,
+        timings.misses,
+        timings.reader_opens,
+        timings.lookup_wall_ms,
     );
 }
 
@@ -3872,6 +3907,41 @@ mod tests {
     use serde_json::json;
     use std::path::Path;
     use tempfile::tempdir;
+
+    #[test]
+    fn index_timings_render_separate_artifact_cache_access() {
+        let timings = IndexingPhaseTimings {
+            parser_artifact_cache: Some(ArtifactCacheAccessTimings {
+                policy: ArtifactCachePolicyDto::KnownEmpty,
+                logical_lookups: 4,
+                physical_queries: 0,
+                hits: 0,
+                misses: 4,
+                reader_opens: 0,
+                lookup_wall_ms: 0,
+            }),
+            structural_artifact_cache: Some(ArtifactCacheAccessTimings {
+                policy: ArtifactCachePolicyDto::ReadThrough,
+                logical_lookups: 3,
+                physical_queries: 3,
+                hits: 2,
+                misses: 1,
+                reader_opens: 1,
+                lookup_wall_ms: 7,
+            }),
+            ..IndexingPhaseTimings::default()
+        };
+        let mut markdown = String::new();
+
+        append_index_phase_timings(&mut markdown, &timings);
+
+        assert!(markdown.contains(
+            "parser_artifact_cache: policy=known_empty logical_lookups=4 physical_queries=0 hits=0 misses=4 reader_opens=0 lookup_wall_ms=0"
+        ));
+        assert!(markdown.contains(
+            "structural_artifact_cache: policy=read_through logical_lookups=3 physical_queries=3 hits=2 misses=1 reader_opens=1 lookup_wall_ms=7"
+        ));
+    }
 
     #[test]
     fn public_operation_metadata_is_json_only() {

--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -68,7 +68,10 @@ pub use errors::{
     ApiError, ApiErrorDetails, COMMAND_FAILURE_SCHEMA_VERSION, CommandFailureEnvelope,
     EmbeddingCapacityPressureDto, EmbeddingRetryStateDto,
 };
-pub use events::{AppEventPayload, FullRefreshWallTimings, IndexingPhaseTimings};
+pub use events::{
+    AppEventPayload, ArtifactCacheAccessTimings, ArtifactCachePolicyDto, FullRefreshWallTimings,
+    IndexingPhaseTimings,
+};
 pub use ids::{EdgeId, NodeId};
 pub use types::{
     EdgeKind, IndexMode, LayoutDirection, MemberAccess, NodeKind, TrailCallerScope, TrailDirection,

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -18,6 +18,25 @@ pub struct FullRefreshWallTimings {
     pub unattributed_ms: u32,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactCachePolicyDto {
+    KnownEmpty,
+    #[default]
+    ReadThrough,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct ArtifactCacheAccessTimings {
+    pub policy: ArtifactCachePolicyDto,
+    pub logical_lookups: u32,
+    pub physical_queries: u32,
+    pub hits: u32,
+    pub misses: u32,
+    pub reader_opens: u32,
+    pub lookup_wall_ms: u32,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Type)]
 pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -33,6 +52,10 @@ pub struct IndexingPhaseTimings {
     pub artifact_cache_writes: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_cache_write_transactions: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parser_artifact_cache: Option<ArtifactCacheAccessTimings>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structural_artifact_cache: Option<ArtifactCacheAccessTimings>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_refresh_chunks_produced: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -288,6 +311,8 @@ mod tests {
             artifact_cache_write_ms: None,
             artifact_cache_writes: None,
             artifact_cache_write_transactions: None,
+            parser_artifact_cache: None,
+            structural_artifact_cache: None,
             full_refresh_chunks_produced: None,
             full_refresh_chunks_persisted: None,
             full_refresh_queue_capacity: None,
@@ -538,6 +563,44 @@ mod tests {
         assert!(timings.semantic_context_index_ms.is_none());
         assert!(timings.semantic_node_load_ms.is_none());
         assert!(timings.search_symbol_index_commit_ms.is_none());
+        assert!(timings.parser_artifact_cache.is_none());
+        assert!(timings.structural_artifact_cache.is_none());
+    }
+
+    #[test]
+    fn test_indexing_phase_timings_round_trips_separate_artifact_cache_families() {
+        let timings = IndexingPhaseTimings {
+            parser_artifact_cache: Some(ArtifactCacheAccessTimings {
+                policy: ArtifactCachePolicyDto::KnownEmpty,
+                logical_lookups: 3,
+                physical_queries: 0,
+                hits: 0,
+                misses: 3,
+                reader_opens: 0,
+                lookup_wall_ms: 0,
+            }),
+            structural_artifact_cache: Some(ArtifactCacheAccessTimings {
+                policy: ArtifactCachePolicyDto::ReadThrough,
+                logical_lookups: 2,
+                physical_queries: 2,
+                hits: 1,
+                misses: 1,
+                reader_opens: 1,
+                lookup_wall_ms: 4,
+            }),
+            ..IndexingPhaseTimings::default()
+        };
+
+        let value = serde_json::to_value(&timings).expect("serialize timings");
+        assert_eq!(value["parser_artifact_cache"]["policy"], "known_empty");
+        assert_eq!(value["structural_artifact_cache"]["policy"], "read_through");
+        let decoded: IndexingPhaseTimings =
+            serde_json::from_value(value).expect("deserialize timings");
+        assert_eq!(decoded.parser_artifact_cache, timings.parser_artifact_cache);
+        assert_eq!(
+            decoded.structural_artifact_cache,
+            timings.structural_artifact_cache
+        );
     }
 
     #[test]

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1003,6 +1003,19 @@ struct ArtifactCacheAccess<'a> {
     policies: ArtifactCachePolicies,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArtifactCacheFamily {
+    Parser,
+    Structural,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct FullRefreshCacheReadPlan {
+    parser: bool,
+    structural: bool,
+    reader_owner: Option<ArtifactCacheFamily>,
+}
+
 impl<'a> ArtifactCacheAccess<'a> {
     fn storage(storage: &'a mut Storage, policies: ArtifactCachePolicies) -> Self {
         Self {
@@ -1588,27 +1601,26 @@ impl WorkspaceIndexer {
         let writer_output = if plan.mode == codestory_workspace::BuildMode::FullRefresh
             && Self::full_refresh_pipeline_paths_are_unique(&root, &plan.files_to_index)
         {
-            let (has_parser_lookups, has_structural_lookups) =
-                self.full_refresh_cache_lookup_families(&root, &plan.files_to_index);
-            let needs_parser_reader =
-                self.artifact_cache_policies.parser.reads_storage() && has_parser_lookups;
-            let needs_structural_reader =
-                self.artifact_cache_policies.structural.reads_storage() && has_structural_lookups;
-            let needs_cache_reader = needs_parser_reader || needs_structural_reader;
+            let cache_read_plan = self.full_refresh_cache_read_plan(&root, &plan.files_to_index);
+            let needs_cache_reader = cache_read_plan.reader_owner.is_some();
             let cache_reader = needs_cache_reader
                 .then(|| storage.index_artifact_cache_reader())
                 .transpose()?
                 .flatten();
             if cache_reader.is_some() || !needs_cache_reader {
                 if cache_reader.is_some() {
-                    if needs_parser_reader {
-                        stats.parser_artifact_cache.reader_opens =
-                            stats.parser_artifact_cache.reader_opens.saturating_add(1);
-                    } else {
-                        stats.structural_artifact_cache.reader_opens = stats
-                            .structural_artifact_cache
-                            .reader_opens
-                            .saturating_add(1);
+                    match cache_read_plan.reader_owner {
+                        Some(ArtifactCacheFamily::Parser) => {
+                            stats.parser_artifact_cache.reader_opens =
+                                stats.parser_artifact_cache.reader_opens.saturating_add(1);
+                        }
+                        Some(ArtifactCacheFamily::Structural) => {
+                            stats.structural_artifact_cache.reader_opens = stats
+                                .structural_artifact_cache
+                                .reader_opens
+                                .saturating_add(1);
+                        }
+                        None => unreachable!("opened cache reader must have one owning family"),
                     }
                 }
                 self.run_full_refresh_pipeline(
@@ -2305,9 +2317,12 @@ impl WorkspaceIndexer {
         })
     }
 
-    fn full_refresh_cache_lookup_families(&self, root: &Path, files: &[PathBuf]) -> (bool, bool) {
-        let mut parser = false;
-        let mut structural = false;
+    fn full_refresh_cache_read_plan(
+        &self,
+        root: &Path,
+        files: &[PathBuf],
+    ) -> FullRefreshCacheReadPlan {
+        let mut plan = FullRefreshCacheReadPlan::default();
         for path in files {
             let full_path = Self::normalize_index_path(root, path);
             if workspace_structural_source_exclusion(root, &full_path).is_some() {
@@ -2318,15 +2333,25 @@ impl WorkspaceIndexer {
                 .as_ref()
                 .and_then(|database| database.get_parsed_info(&full_path));
             if get_language_config_for_path(&full_path, compilation_info.as_ref()).is_some() {
-                parser = true;
+                plan.parser = true;
+                if plan.reader_owner.is_none()
+                    && self.artifact_cache_policies.parser.reads_storage()
+                {
+                    plan.reader_owner = Some(ArtifactCacheFamily::Parser);
+                }
             } else if structural::is_structural_candidate_path(&full_path) {
-                structural = true;
+                plan.structural = true;
+                if plan.reader_owner.is_none()
+                    && self.artifact_cache_policies.structural.reads_storage()
+                {
+                    plan.reader_owner = Some(ArtifactCacheFamily::Structural);
+                }
             }
-            if parser && structural {
+            if plan.parser && plan.structural && plan.reader_owner.is_some() {
                 break;
             }
         }
-        (parser, structural)
+        plan
     }
 
     fn seed_symbol_table(
@@ -22230,6 +22255,76 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert_eq!(stats.structural_artifact_cache.reader_opens, 0);
         assert!(storage.get_nodes()?.len() >= 24);
         Ok(())
+    }
+
+    fn assert_mixed_full_refresh_reader_owner(
+        files_to_index: Vec<PathBuf>,
+        expected_owner: ArtifactCacheFamily,
+    ) -> Result<()> {
+        use codestory_store::Store as Storage;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        std::fs::write(dir.path().join("lib.rs"), "pub fn parser_source() {}\n")?;
+        std::fs::write(
+            dir.path().join("config.json"),
+            "{\"service\":{\"name\":\"api\"}}\n",
+        )?;
+        let mut storage = Storage::open_build(dir.path().join("mixed.sqlite"))?;
+        let plan = codestory_workspace::RefreshExecutionPlan {
+            mode: codestory_workspace::BuildMode::FullRefresh,
+            files_to_index,
+            files_to_remove: Vec::new(),
+            existing_file_ids: HashMap::new(),
+        };
+
+        let stats = WorkspaceIndexer::new(dir.path().to_path_buf()).run(
+            &mut storage,
+            &plan,
+            &EventBus::new(),
+            None,
+        )?;
+
+        assert_eq!(stats.parser_artifact_cache.logical_lookups, 1);
+        assert_eq!(stats.parser_artifact_cache.physical_queries, 1);
+        assert_eq!(stats.structural_artifact_cache.logical_lookups, 1);
+        assert_eq!(stats.structural_artifact_cache.physical_queries, 1);
+        assert_eq!(
+            stats
+                .parser_artifact_cache
+                .reader_opens
+                .saturating_add(stats.structural_artifact_cache.reader_opens),
+            1,
+            "one shared reader open must be attributed exactly once"
+        );
+        match expected_owner {
+            ArtifactCacheFamily::Parser => {
+                assert_eq!(stats.parser_artifact_cache.reader_opens, 1);
+                assert_eq!(stats.structural_artifact_cache.reader_opens, 0);
+            }
+            ArtifactCacheFamily::Structural => {
+                assert_eq!(stats.parser_artifact_cache.reader_opens, 0);
+                assert_eq!(stats.structural_artifact_cache.reader_opens, 1);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn mixed_full_refresh_attributes_reader_open_to_structural_when_scheduled_first() -> Result<()>
+    {
+        assert_mixed_full_refresh_reader_owner(
+            vec![PathBuf::from("config.json"), PathBuf::from("lib.rs")],
+            ArtifactCacheFamily::Structural,
+        )
+    }
+
+    #[test]
+    fn mixed_full_refresh_attributes_reader_open_to_parser_when_scheduled_first() -> Result<()> {
+        assert_mixed_full_refresh_reader_owner(
+            vec![PathBuf::from("lib.rs"), PathBuf::from("config.json")],
+            ArtifactCacheFamily::Parser,
+        )
     }
 
     #[test]

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -803,6 +803,57 @@ pub enum IndexingEvent {
     Finished,
 }
 
+/// Storage access policy for one artifact-cache family.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ArtifactCachePolicy {
+    KnownEmpty,
+    #[default]
+    ReadThrough,
+}
+
+impl ArtifactCachePolicy {
+    fn reads_storage(self) -> bool {
+        matches!(self, Self::ReadThrough)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ArtifactCachePolicies {
+    pub parser: ArtifactCachePolicy,
+    pub structural: ArtifactCachePolicy,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ArtifactCacheFamilyStats {
+    pub policy: ArtifactCachePolicy,
+    pub logical_lookups: usize,
+    pub physical_queries: usize,
+    pub hits: usize,
+    pub misses: usize,
+    pub reader_opens: usize,
+    pub lookup_wall_ns: u64,
+}
+
+impl ArtifactCacheFamilyStats {
+    fn new(policy: ArtifactCachePolicy) -> Self {
+        Self {
+            policy,
+            ..Self::default()
+        }
+    }
+
+    fn record_lookup(&mut self) {
+        self.logical_lookups = self.logical_lookups.saturating_add(1);
+    }
+
+    fn record_query(&mut self, elapsed: Duration) {
+        self.physical_queries = self.physical_queries.saturating_add(1);
+        self.lookup_wall_ns = self
+            .lookup_wall_ns
+            .saturating_add(elapsed.as_nanos().min(u64::MAX as u128) as u64);
+    }
+}
+
 /// Timings and counters collected during a workspace indexing run.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct IncrementalIndexingStats {
@@ -816,6 +867,8 @@ pub struct IncrementalIndexingStats {
     pub artifact_cache_hits: usize,
     pub artifact_cache_misses: usize,
     pub artifact_cache_invalid_entries: usize,
+    pub parser_artifact_cache: ArtifactCacheFamilyStats,
+    pub structural_artifact_cache: ArtifactCacheFamilyStats,
     pub artifact_cache_writes: usize,
     pub artifact_cache_write_transactions: usize,
     pub full_refresh_chunks_produced: usize,
@@ -937,38 +990,107 @@ struct ArtifactCacheWrite {
 #[cfg(test)]
 type FullRefreshChunkTestHook = Arc<dyn Fn(usize) + Send + Sync>;
 
-enum ArtifactCacheAccess<'a> {
+enum ArtifactCacheBackend<'a> {
     Storage(&'a mut Storage),
     Reader(&'a IndexArtifactCacheReader),
+    None,
+    #[cfg(test)]
+    FailReads,
 }
 
-impl ArtifactCacheAccess<'_> {
-    fn get(
+struct ArtifactCacheAccess<'a> {
+    backend: ArtifactCacheBackend<'a>,
+    policies: ArtifactCachePolicies,
+}
+
+impl<'a> ArtifactCacheAccess<'a> {
+    fn storage(storage: &'a mut Storage, policies: ArtifactCachePolicies) -> Self {
+        Self {
+            backend: ArtifactCacheBackend::Storage(storage),
+            policies,
+        }
+    }
+
+    fn reader(
+        reader: Option<&'a IndexArtifactCacheReader>,
+        policies: ArtifactCachePolicies,
+    ) -> Self {
+        Self {
+            backend: reader
+                .map(ArtifactCacheBackend::Reader)
+                .unwrap_or(ArtifactCacheBackend::None),
+            policies,
+        }
+    }
+
+    #[cfg(test)]
+    fn failing(policies: ArtifactCachePolicies) -> Self {
+        Self {
+            backend: ArtifactCacheBackend::FailReads,
+            policies,
+        }
+    }
+
+    fn get_parser(
         &self,
         path: &Path,
         cache_key: &str,
+        stats: &mut ArtifactCacheFamilyStats,
     ) -> std::result::Result<Option<Vec<u8>>, StorageError> {
-        match self {
-            Self::Storage(storage) => storage.get_index_artifact_cache(path, cache_key),
-            Self::Reader(reader) => reader.get(path, cache_key),
+        if !self.policies.parser.reads_storage() {
+            return Ok(None);
         }
+        let started = Instant::now();
+        let result = match &self.backend {
+            ArtifactCacheBackend::Storage(storage) => {
+                storage.get_index_artifact_cache(path, cache_key)
+            }
+            ArtifactCacheBackend::Reader(reader) => reader.get(path, cache_key),
+            ArtifactCacheBackend::None => {
+                unreachable!("read-through parser cache access requires a storage connection")
+            }
+            #[cfg(test)]
+            ArtifactCacheBackend::FailReads => Err(StorageError::Other(
+                "injected parser cache read failure".into(),
+            )),
+        };
+        stats.record_query(started.elapsed());
+        result
     }
 
     fn get_structural(
         &self,
         path: &Path,
         cache_key: &str,
+        stats: &mut ArtifactCacheFamilyStats,
     ) -> std::result::Result<Option<Vec<u8>>, StorageError> {
-        match self {
-            Self::Storage(storage) => storage.get_structural_text_artifact_cache(path, cache_key),
-            Self::Reader(reader) => reader.get_structural(path, cache_key),
+        if !self.policies.structural.reads_storage() {
+            return Ok(None);
         }
+        let started = Instant::now();
+        let result = match &self.backend {
+            ArtifactCacheBackend::Storage(storage) => {
+                storage.get_structural_text_artifact_cache(path, cache_key)
+            }
+            ArtifactCacheBackend::Reader(reader) => reader.get_structural(path, cache_key),
+            ArtifactCacheBackend::None => {
+                unreachable!("read-through structural cache access requires a storage connection")
+            }
+            #[cfg(test)]
+            ArtifactCacheBackend::FailReads => Err(StorageError::Other(
+                "injected structural cache read failure".into(),
+            )),
+        };
+        stats.record_query(started.elapsed());
+        result
     }
 
     fn storage_mut(&mut self) -> Option<&mut Storage> {
-        match self {
-            Self::Storage(storage) => Some(*storage),
-            Self::Reader(_) => None,
+        match &mut self.backend {
+            ArtifactCacheBackend::Storage(storage) => Some(*storage),
+            ArtifactCacheBackend::Reader(_) | ArtifactCacheBackend::None => None,
+            #[cfg(test)]
+            ArtifactCacheBackend::FailReads => None,
         }
     }
 }
@@ -1269,6 +1391,7 @@ pub struct WorkspaceIndexer {
     batch_config: IncrementalIndexingConfig,
     full_refresh_chunk_budget: FullRefreshChunkBudget,
     source_file_byte_cap: u64,
+    artifact_cache_policies: ArtifactCachePolicies,
     #[cfg(test)]
     pipeline_test_hooks: FullRefreshPipelineTestHooks,
 }
@@ -1304,6 +1427,7 @@ impl WorkspaceIndexer {
             batch_config: IncrementalIndexingConfig::default(),
             full_refresh_chunk_budget: FullRefreshChunkBudget::default(),
             source_file_byte_cap: process_source_index_policy().byte_cap,
+            artifact_cache_policies: ArtifactCachePolicies::default(),
             #[cfg(test)]
             pipeline_test_hooks: FullRefreshPipelineTestHooks::default(),
         }
@@ -1328,6 +1452,12 @@ impl WorkspaceIndexer {
     /// Override the parser-backed source file byte cap.
     pub fn with_source_file_byte_cap(mut self, source_file_byte_cap: u64) -> Self {
         self.source_file_byte_cap = source_file_byte_cap.max(1);
+        self
+    }
+
+    /// Select cache access independently for parser-backed and structural artifacts.
+    pub fn with_artifact_cache_policies(mut self, policies: ArtifactCachePolicies) -> Self {
+        self.artifact_cache_policies = policies;
         self
     }
 
@@ -1383,7 +1513,15 @@ impl WorkspaceIndexer {
                 message: message.clone(),
             });
         }
-        let mut stats = IncrementalIndexingStats::default();
+        let mut stats = IncrementalIndexingStats {
+            parser_artifact_cache: ArtifactCacheFamilyStats::new(
+                self.artifact_cache_policies.parser,
+            ),
+            structural_artifact_cache: ArtifactCacheFamilyStats::new(
+                self.artifact_cache_policies.structural,
+            ),
+            ..IncrementalIndexingStats::default()
+        };
         if plan.mode == codestory_workspace::BuildMode::FullRefresh {
             Self::record_full_refresh_chunk_config(&mut stats, self.full_refresh_chunk_budget);
         }
@@ -1450,10 +1588,32 @@ impl WorkspaceIndexer {
         let writer_output = if plan.mode == codestory_workspace::BuildMode::FullRefresh
             && Self::full_refresh_pipeline_paths_are_unique(&root, &plan.files_to_index)
         {
-            if let Some(cache_reader) = storage.index_artifact_cache_reader()? {
+            let (has_parser_lookups, has_structural_lookups) =
+                self.full_refresh_cache_lookup_families(&root, &plan.files_to_index);
+            let needs_parser_reader =
+                self.artifact_cache_policies.parser.reads_storage() && has_parser_lookups;
+            let needs_structural_reader =
+                self.artifact_cache_policies.structural.reads_storage() && has_structural_lookups;
+            let needs_cache_reader = needs_parser_reader || needs_structural_reader;
+            let cache_reader = needs_cache_reader
+                .then(|| storage.index_artifact_cache_reader())
+                .transpose()?
+                .flatten();
+            if cache_reader.is_some() || !needs_cache_reader {
+                if cache_reader.is_some() {
+                    if needs_parser_reader {
+                        stats.parser_artifact_cache.reader_opens =
+                            stats.parser_artifact_cache.reader_opens.saturating_add(1);
+                    } else {
+                        stats.structural_artifact_cache.reader_opens = stats
+                            .structural_artifact_cache
+                            .reader_opens
+                            .saturating_add(1);
+                    }
+                }
                 self.run_full_refresh_pipeline(
                     storage,
-                    &cache_reader,
+                    cache_reader.as_ref(),
                     &plan.files_to_index,
                     &root,
                     batch_config,
@@ -1838,7 +1998,10 @@ impl WorkspaceIndexer {
                     break;
                 };
                 let chunk = {
-                    let mut cache_access = ArtifactCacheAccess::Storage(writer.storage_mut());
+                    let mut cache_access = ArtifactCacheAccess::storage(
+                        writer.storage_mut(),
+                        self.artifact_cache_policies,
+                    );
                     self.prepare_index_chunk(
                         &mut cache_access,
                         chunk_index,
@@ -1873,7 +2036,10 @@ impl WorkspaceIndexer {
                 .enumerate()
             {
                 let chunk = {
-                    let mut cache_access = ArtifactCacheAccess::Storage(writer.storage_mut());
+                    let mut cache_access = ArtifactCacheAccess::storage(
+                        writer.storage_mut(),
+                        self.artifact_cache_policies,
+                    );
                     self.prepare_index_chunk(
                         &mut cache_access,
                         chunk_index,
@@ -1901,7 +2067,7 @@ impl WorkspaceIndexer {
     fn run_full_refresh_pipeline(
         &self,
         storage: &mut Storage,
-        cache_reader: &IndexArtifactCacheReader,
+        cache_reader: Option<&IndexArtifactCacheReader>,
         files_to_index: &[PathBuf],
         root: &Path,
         batch_config: IncrementalIndexingConfig,
@@ -1955,7 +2121,8 @@ impl WorkspaceIndexer {
                         break;
                     };
                     let chunk = {
-                        let mut cache_access = ArtifactCacheAccess::Reader(cache_reader);
+                        let mut cache_access =
+                            ArtifactCacheAccess::reader(cache_reader, self.artifact_cache_policies);
                         self.prepare_index_chunk(
                             &mut cache_access,
                             chunk_index,
@@ -2136,6 +2303,30 @@ impl WorkspaceIndexer {
             // one filesystem canonicalization syscall per corpus file.
             identities.insert(Self::normalize_index_path(root, path))
         })
+    }
+
+    fn full_refresh_cache_lookup_families(&self, root: &Path, files: &[PathBuf]) -> (bool, bool) {
+        let mut parser = false;
+        let mut structural = false;
+        for path in files {
+            let full_path = Self::normalize_index_path(root, path);
+            if workspace_structural_source_exclusion(root, &full_path).is_some() {
+                continue;
+            }
+            let compilation_info = self
+                .compilation_db
+                .as_ref()
+                .and_then(|database| database.get_parsed_info(&full_path));
+            if get_language_config_for_path(&full_path, compilation_info.as_ref()).is_some() {
+                parser = true;
+            } else if structural::is_structural_candidate_path(&full_path) {
+                structural = true;
+            }
+            if parser && structural {
+                break;
+            }
+        }
+        (parser, structural)
     }
 
     fn seed_symbol_table(
@@ -2628,9 +2819,11 @@ impl WorkspaceIndexer {
                 flags.lazy_graph_execution,
             )
         });
+        stats.parser_artifact_cache.record_lookup();
 
         let Some(cache_path) = artifact_cache_path.as_ref() else {
             stats.artifact_cache_misses += 1;
+            stats.parser_artifact_cache.misses += 1;
             return Ok(PreparedIndexWork::Parse(PreparedIndexInput {
                 full_path,
                 artifact_cache_path,
@@ -2643,6 +2836,7 @@ impl WorkspaceIndexer {
         };
         let Some(cache_key) = artifact_cache_key.as_ref() else {
             stats.artifact_cache_misses += 1;
+            stats.parser_artifact_cache.misses += 1;
             return Ok(PreparedIndexWork::Parse(PreparedIndexInput {
                 full_path,
                 artifact_cache_path,
@@ -2654,7 +2848,7 @@ impl WorkspaceIndexer {
             }));
         };
 
-        match cache_access.get(cache_path, cache_key) {
+        match cache_access.get_parser(cache_path, cache_key, &mut stats.parser_artifact_cache) {
             Ok(Some(blob)) => match serde_json::from_slice::<CachedIndexArtifact>(&blob) {
                 Ok(artifact) => {
                     let mut artifact = rebase_cached_index_artifact(
@@ -2671,6 +2865,7 @@ impl WorkspaceIndexer {
                         &content_hash,
                     )?;
                     stats.artifact_cache_hits += 1;
+                    stats.parser_artifact_cache.hits += 1;
                     if existing_projection_id.is_some() {
                         let Some(storage) = cache_access.storage_mut() else {
                             let mut local_storage = IntermediateStorage::default();
@@ -2744,6 +2939,7 @@ impl WorkspaceIndexer {
                 Err(_) => {
                     stats.artifact_cache_invalid_entries += 1;
                     stats.artifact_cache_misses += 1;
+                    stats.parser_artifact_cache.misses += 1;
                     Ok(PreparedIndexWork::Parse(PreparedIndexInput {
                         full_path,
                         artifact_cache_path,
@@ -2757,6 +2953,7 @@ impl WorkspaceIndexer {
             },
             Ok(None) => {
                 stats.artifact_cache_misses += 1;
+                stats.parser_artifact_cache.misses += 1;
                 Ok(PreparedIndexWork::Parse(PreparedIndexInput {
                     full_path,
                     artifact_cache_path,
@@ -2769,6 +2966,7 @@ impl WorkspaceIndexer {
             }
             Err(_) => {
                 stats.artifact_cache_misses += 1;
+                stats.parser_artifact_cache.misses += 1;
                 Ok(PreparedIndexWork::Parse(PreparedIndexInput {
                     full_path,
                     artifact_cache_path,
@@ -2871,6 +3069,7 @@ impl WorkspaceIndexer {
         let artifact_cache_key = artifact_cache_path.as_ref().and_then(|cache_path| {
             build_structural_artifact_cache_key(cache_path, source.as_bytes(), producer)
         });
+        stats.structural_artifact_cache.record_lookup();
         let prepared_input = || PreparedStructuralInput {
             full_path: full_path.clone(),
             artifact_cache_path: artifact_cache_path.clone(),
@@ -2880,21 +3079,29 @@ impl WorkspaceIndexer {
         };
         let Some(cache_path) = artifact_cache_path.as_ref() else {
             stats.artifact_cache_misses += 1;
+            stats.structural_artifact_cache.misses += 1;
             return Ok(PreparedIndexWork::Structural(prepared_input()));
         };
         let Some(cache_key) = artifact_cache_key.as_ref() else {
             stats.artifact_cache_misses += 1;
+            stats.structural_artifact_cache.misses += 1;
             return Ok(PreparedIndexWork::Structural(prepared_input()));
         };
 
-        let cached = cache_access.get_structural(cache_path, cache_key);
+        let cached = cache_access.get_structural(
+            cache_path,
+            cache_key,
+            &mut stats.structural_artifact_cache,
+        );
         let Ok(Some(blob)) = cached else {
             stats.artifact_cache_misses += 1;
+            stats.structural_artifact_cache.misses += 1;
             return Ok(PreparedIndexWork::Structural(prepared_input()));
         };
         let Ok(mut artifact) = serde_json::from_slice::<CachedStructuralArtifact>(&blob) else {
             stats.artifact_cache_invalid_entries += 1;
             stats.artifact_cache_misses += 1;
+            stats.structural_artifact_cache.misses += 1;
             return Ok(PreparedIndexWork::Structural(prepared_input()));
         };
         if artifact.descriptor_version != codestory_store::STRUCTURAL_TEXT_UNIT_DESCRIPTOR_VERSION
@@ -2911,6 +3118,7 @@ impl WorkspaceIndexer {
         {
             stats.artifact_cache_invalid_entries += 1;
             stats.artifact_cache_misses += 1;
+            stats.structural_artifact_cache.misses += 1;
             return Ok(PreparedIndexWork::Structural(prepared_input()));
         }
         let modification_time = verify_source_snapshot(&full_path, &content_hash)
@@ -2953,9 +3161,11 @@ impl WorkspaceIndexer {
         {
             stats.artifact_cache_invalid_entries += 1;
             stats.artifact_cache_misses += 1;
+            stats.structural_artifact_cache.misses += 1;
             return Ok(PreparedIndexWork::Structural(prepared_input()));
         }
         stats.artifact_cache_hits += 1;
+        stats.structural_artifact_cache.hits += 1;
         if existing_projection_id.is_some() {
             let Some(storage) = cache_access.storage_mut() else {
                 return Err(incomplete_file_storage(
@@ -21725,15 +21935,26 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             existing_file_ids: std::collections::HashMap::new(),
         };
 
-        indexer.run_incremental(&mut storage, &refresh_info, &bus, None)?;
+        let first_stats = indexer.run_incremental(&mut storage, &refresh_info, &bus, None)?;
+        let reused_stats = indexer.run_incremental(&mut storage, &refresh_info, &bus, None)?;
+
+        assert_eq!(first_stats.parser_artifact_cache.misses, 1);
+        assert_eq!(
+            reused_stats.parser_artifact_cache.policy,
+            ArtifactCachePolicy::ReadThrough
+        );
+        assert_eq!(reused_stats.parser_artifact_cache.logical_lookups, 1);
+        assert_eq!(reused_stats.parser_artifact_cache.physical_queries, 1);
+        assert_eq!(reused_stats.parser_artifact_cache.hits, 1);
+        assert_eq!(reused_stats.parser_artifact_cache.misses, 0);
+        assert_eq!(reused_stats.parser_artifact_cache.reader_opens, 0);
 
         let file_id = WorkspaceIndexer::canonical_file_node_id_for_path(&f1);
         assert_eq!(
             storage.get_file_content_hash(file_id)?.as_deref(),
             Some(source_content_hash(source.as_bytes()).as_str())
         );
-        let cached_stats = indexer.run_incremental(&mut storage, &refresh_info, &bus, None)?;
-        assert_eq!(cached_stats.artifact_cache_hits, 1);
+        assert_eq!(reused_stats.artifact_cache_hits, 1);
 
         // Check verification
         let nodes = storage.get_nodes().unwrap();
@@ -21963,15 +22184,18 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
 
         let database_path = dir.path().join("staged.sqlite");
         let mut storage = Storage::open_build(&database_path)?;
-        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf()).with_batch_config(
-            IncrementalIndexingConfig {
+        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf())
+            .with_artifact_cache_policies(ArtifactCachePolicies {
+                parser: ArtifactCachePolicy::KnownEmpty,
+                structural: ArtifactCachePolicy::ReadThrough,
+            })
+            .with_batch_config(IncrementalIndexingConfig {
                 file_batch_size: 3,
                 node_batch_size: 4,
                 edge_batch_size: 4,
                 occurrence_batch_size: 8,
                 error_batch_size: 128,
-            },
-        );
+            });
         let plan = codestory_workspace::RefreshExecutionPlan {
             mode: codestory_workspace::BuildMode::FullRefresh,
             files_to_index: files,
@@ -21987,6 +22211,23 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert_eq!(stats.full_refresh_queue_high_water, 1);
         assert_eq!(stats.artifact_cache_writes, 12);
         assert_eq!(stats.artifact_cache_write_transactions, 4);
+        assert_eq!(
+            stats.parser_artifact_cache.policy,
+            ArtifactCachePolicy::KnownEmpty
+        );
+        assert_eq!(stats.parser_artifact_cache.logical_lookups, 12);
+        assert_eq!(stats.parser_artifact_cache.physical_queries, 0);
+        assert_eq!(stats.parser_artifact_cache.hits, 0);
+        assert_eq!(stats.parser_artifact_cache.misses, 12);
+        assert_eq!(stats.parser_artifact_cache.reader_opens, 0);
+        assert_eq!(stats.parser_artifact_cache.lookup_wall_ns, 0);
+        assert_eq!(
+            stats.structural_artifact_cache.policy,
+            ArtifactCachePolicy::ReadThrough
+        );
+        assert_eq!(stats.structural_artifact_cache.logical_lookups, 0);
+        assert_eq!(stats.structural_artifact_cache.physical_queries, 0);
+        assert_eq!(stats.structural_artifact_cache.reader_opens, 0);
         assert!(storage.get_nodes()?.len() >= 24);
         Ok(())
     }
@@ -22035,6 +22276,15 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert_eq!(cached_stats.artifact_cache_misses, 0);
         assert_eq!(cached_stats.artifact_cache_writes, 0);
         assert_eq!(cached_stats.artifact_cache_write_transactions, 0);
+        assert_eq!(
+            cached_stats.parser_artifact_cache.policy,
+            ArtifactCachePolicy::ReadThrough
+        );
+        assert_eq!(cached_stats.parser_artifact_cache.logical_lookups, 6);
+        assert_eq!(cached_stats.parser_artifact_cache.physical_queries, 6);
+        assert_eq!(cached_stats.parser_artifact_cache.hits, 6);
+        assert_eq!(cached_stats.parser_artifact_cache.misses, 0);
+        assert_eq!(cached_stats.parser_artifact_cache.reader_opens, 1);
         assert_eq!(cached_stats.full_refresh_chunks_produced, 3);
         assert_eq!(cached_stats.full_refresh_chunks_persisted, 3);
         assert!(target.get_nodes()?.len() >= 12);
@@ -22060,11 +22310,11 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             files_to_remove: vec![],
             existing_file_ids: HashMap::new(),
         };
-        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf());
+        let source_indexer = WorkspaceIndexer::new(dir.path().to_path_buf());
 
         let source_path = dir.path().join("structural-cache-source.sqlite");
         let mut source = Storage::open_build(&source_path)?;
-        let source_stats = indexer.run(&mut source, &plan, &EventBus::new(), None)?;
+        let source_stats = source_indexer.run(&mut source, &plan, &EventBus::new(), None)?;
         assert_eq!(source_stats.artifact_cache_misses, 1);
         assert!(
             !source
@@ -22085,10 +22335,32 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             target.copy_structural_text_artifact_cache_from(&source_path)?,
             1
         );
+        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf()).with_artifact_cache_policies(
+            ArtifactCachePolicies {
+                parser: ArtifactCachePolicy::KnownEmpty,
+                structural: ArtifactCachePolicy::ReadThrough,
+            },
+        );
         let cached_stats = indexer.run(&mut target, &plan, &EventBus::new(), None)?;
 
         assert_eq!(cached_stats.artifact_cache_hits, 1);
         assert_eq!(cached_stats.artifact_cache_misses, 0);
+        assert_eq!(
+            cached_stats.parser_artifact_cache.policy,
+            ArtifactCachePolicy::KnownEmpty
+        );
+        assert_eq!(cached_stats.parser_artifact_cache.logical_lookups, 0);
+        assert_eq!(cached_stats.parser_artifact_cache.physical_queries, 0);
+        assert_eq!(cached_stats.parser_artifact_cache.reader_opens, 0);
+        assert_eq!(
+            cached_stats.structural_artifact_cache.policy,
+            ArtifactCachePolicy::ReadThrough
+        );
+        assert_eq!(cached_stats.structural_artifact_cache.logical_lookups, 1);
+        assert_eq!(cached_stats.structural_artifact_cache.physical_queries, 1);
+        assert_eq!(cached_stats.structural_artifact_cache.hits, 1);
+        assert_eq!(cached_stats.structural_artifact_cache.misses, 0);
+        assert_eq!(cached_stats.structural_artifact_cache.reader_opens, 1);
         assert!(
             !target
                 .get_structural_text_units_for_nodes(
@@ -22100,6 +22372,77 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
                 )?
                 .is_empty()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn parser_and_structural_cache_read_failures_recollect_as_physical_misses() -> Result<()> {
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let parser_path = dir.path().join("lib.rs");
+        let structural_path = dir.path().join("config.json");
+        std::fs::write(&parser_path, "pub fn cached_value() -> i32 { 1 }\n")?;
+        std::fs::write(&structural_path, "{\"service\":{\"name\":\"api\"}}\n")?;
+        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf());
+        let symbol_table = Arc::new(SymbolTable::new());
+
+        let mut parser_stats = IncrementalIndexingStats {
+            parser_artifact_cache: ArtifactCacheFamilyStats::new(ArtifactCachePolicy::ReadThrough),
+            structural_artifact_cache: ArtifactCacheFamilyStats::new(
+                ArtifactCachePolicy::ReadThrough,
+            ),
+            ..IncrementalIndexingStats::default()
+        };
+        let parser_work = {
+            let mut access = ArtifactCacheAccess::failing(ArtifactCachePolicies::default());
+            indexer.prepare_index_work(
+                &mut access,
+                &PathBuf::from("lib.rs"),
+                dir.path(),
+                None,
+                &symbol_table,
+                &mut parser_stats,
+            )
+        };
+        assert!(matches!(parser_work, Ok(PreparedIndexWork::Parse(_))));
+        assert_eq!(parser_stats.parser_artifact_cache.logical_lookups, 1);
+        assert_eq!(parser_stats.parser_artifact_cache.physical_queries, 1);
+        assert_eq!(parser_stats.parser_artifact_cache.hits, 0);
+        assert_eq!(parser_stats.parser_artifact_cache.misses, 1);
+
+        let mut structural_stats = IncrementalIndexingStats {
+            parser_artifact_cache: ArtifactCacheFamilyStats::new(ArtifactCachePolicy::ReadThrough),
+            structural_artifact_cache: ArtifactCacheFamilyStats::new(
+                ArtifactCachePolicy::ReadThrough,
+            ),
+            ..IncrementalIndexingStats::default()
+        };
+        let structural_work = {
+            let mut access = ArtifactCacheAccess::failing(ArtifactCachePolicies::default());
+            indexer.prepare_index_work(
+                &mut access,
+                &PathBuf::from("config.json"),
+                dir.path(),
+                None,
+                &symbol_table,
+                &mut structural_stats,
+            )
+        };
+        assert!(matches!(
+            structural_work,
+            Ok(PreparedIndexWork::Structural(_))
+        ));
+        assert_eq!(
+            structural_stats.structural_artifact_cache.logical_lookups,
+            1
+        );
+        assert_eq!(
+            structural_stats.structural_artifact_cache.physical_queries,
+            1
+        );
+        assert_eq!(structural_stats.structural_artifact_cache.hits, 0);
+        assert_eq!(structural_stats.structural_artifact_cache.misses, 1);
         Ok(())
     }
 
@@ -22275,7 +22618,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
 
         for relative in ["vendor/unreadable.json", "secrets/missing.json"] {
             let work = {
-                let mut cache_access = ArtifactCacheAccess::Storage(&mut storage);
+                let mut cache_access =
+                    ArtifactCacheAccess::storage(&mut storage, ArtifactCachePolicies::default());
                 indexer.prepare_index_work(
                     &mut cache_access,
                     &PathBuf::from(relative),
@@ -22446,7 +22790,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
 
         for (relative, _, expected_producer) in fixtures {
             let prepared = {
-                let mut cache_access = ArtifactCacheAccess::Storage(&mut storage);
+                let mut cache_access =
+                    ArtifactCacheAccess::storage(&mut storage, ArtifactCachePolicies::default());
                 indexer.prepare_index_work(
                     &mut cache_access,
                     &PathBuf::from(relative),
@@ -22471,7 +22816,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
 
         for relative in ["openapi.json", "openapi.yaml"] {
             let prepared = {
-                let mut cache_access = ArtifactCacheAccess::Storage(&mut storage);
+                let mut cache_access =
+                    ArtifactCacheAccess::storage(&mut storage, ArtifactCachePolicies::default());
                 indexer.prepare_index_work(
                     &mut cache_access,
                     &PathBuf::from(relative),
@@ -22506,7 +22852,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         }
 
         let bash = {
-            let mut cache_access = ArtifactCacheAccess::Storage(&mut storage);
+            let mut cache_access =
+                ArtifactCacheAccess::storage(&mut storage, ArtifactCachePolicies::default());
             indexer.prepare_index_work(
                 &mut cache_access,
                 &PathBuf::from("scripts/run.sh"),
@@ -22647,7 +22994,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let symbol_table = Arc::new(SymbolTable::new());
         let mut legacy_stats = IncrementalIndexingStats::default();
         let legacy_prepared = {
-            let mut access = ArtifactCacheAccess::Storage(&mut legacy_cache);
+            let mut access =
+                ArtifactCacheAccess::storage(&mut legacy_cache, ArtifactCachePolicies::default());
             indexer.prepare_index_work(
                 &mut access,
                 &PathBuf::from("many.json"),
@@ -22670,7 +23018,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         )?;
         let mut over_limit_hit_stats = IncrementalIndexingStats::default();
         let over_limit_hit_prepared = {
-            let mut access = ArtifactCacheAccess::Storage(&mut legacy_cache);
+            let mut access =
+                ArtifactCacheAccess::storage(&mut legacy_cache, ArtifactCachePolicies::default());
             indexer.prepare_index_work(
                 &mut access,
                 &PathBuf::from("many.json"),
@@ -22692,7 +23041,8 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let mut fresh_cache = Storage::new_in_memory()?;
         let mut fresh_stats = IncrementalIndexingStats::default();
         let fresh_prepared = {
-            let mut access = ArtifactCacheAccess::Storage(&mut fresh_cache);
+            let mut access =
+                ArtifactCacheAccess::storage(&mut fresh_cache, ArtifactCachePolicies::default());
             indexer.prepare_index_work(
                 &mut access,
                 &PathBuf::from("many.json"),

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -28,4 +28,5 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 codestory-retrieval = { workspace = true, features = ["test-support"] }
+rusqlite = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -5345,6 +5345,8 @@ const EXACT_SYMBOL_HYBRID_MAX_RESULTS_CAP: usize = 80;
 type ActivationSearchRevalidateHook = Box<dyn FnOnce(&Path)>;
 #[cfg(test)]
 type FullRefreshStagedStoreHook = Box<dyn FnOnce(&mut Storage)>;
+#[cfg(test)]
+type IncrementalStagedStoreHook = Box<dyn FnOnce(&mut Storage)>;
 
 #[cfg(test)]
 thread_local! {
@@ -6290,6 +6292,8 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
     static FULL_REFRESH_STAGED_STORE_HOOK: std::cell::RefCell<Option<FullRefreshStagedStoreHook>> =
         const { std::cell::RefCell::new(None) };
+    static INCREMENTAL_STAGED_STORE_HOOK: std::cell::RefCell<Option<IncrementalStagedStoreHook>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(test)]
@@ -6355,6 +6359,22 @@ fn arm_full_refresh_staged_store_hook(hook: impl FnOnce(&mut Storage) + 'static)
 #[cfg(test)]
 fn run_full_refresh_staged_store_hook(storage: &mut Storage) {
     FULL_REFRESH_STAGED_STORE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook(storage);
+        }
+    });
+}
+
+#[cfg(test)]
+fn arm_incremental_staged_store_hook(hook: impl FnOnce(&mut Storage) + 'static) {
+    INCREMENTAL_STAGED_STORE_HOOK.with(|slot| {
+        *slot.borrow_mut() = Some(Box::new(hook));
+    });
+}
+
+#[cfg(test)]
+fn run_incremental_staged_store_hook(storage: &mut Storage) {
+    INCREMENTAL_STAGED_STORE_HOOK.with(|slot| {
         if let Some(hook) = slot.borrow_mut().take() {
             hook(storage);
         }
@@ -15424,6 +15444,8 @@ fn run_incremental_indexing_common(
             file_count: total_files,
         });
 
+        #[cfg(test)]
+        run_incremental_staged_store_hook(staged.store_mut());
         let bus = EventBus::new();
         let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
         if is_indexing_cancelled(cancel_token) {
@@ -26953,6 +26975,152 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
+    fn incremental_cache_read_faults_recollect_in_staged_candidate_and_preserve_live_publication() {
+        for (family, cache_table) in [
+            ("parser", "index_artifact_cache"),
+            ("structural", "structural_text_artifact_cache"),
+        ] {
+            let workspace = tempdir().expect("workspace dir");
+            let rust_path = workspace.path().join("lib.rs");
+            let json_path = workspace.path().join("config.json");
+            fs::write(&rust_path, "pub fn retained_parser() -> i32 { 1 }\n")
+                .expect("write parser source");
+            fs::write(&json_path, "{\"service\":{\"name\":\"api\"}}\n")
+                .expect("write structural source");
+            let storage_path = workspace.path().join(".cache/codestory.db");
+            let controller = AppController::new();
+            controller
+                .open_project_summary_with_storage_path(
+                    workspace.path().to_path_buf(),
+                    storage_path.clone(),
+                )
+                .expect("open cache fault project");
+            controller
+                .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+                .expect("publish cache fault baseline");
+
+            let parser_baseline = parser_cache_live_identity(&storage_path);
+            let structural_baseline = structural_live_identity(&storage_path);
+            assert_eq!(parser_baseline.cache_rows.len(), 1);
+            assert_eq!(structural_baseline.cache_rows.len(), 1);
+            assert_eq!(
+                parser_baseline.publication, structural_baseline.publication,
+                "cache families must belong to the same complete publication"
+            );
+
+            let changed_path = if family == "parser" {
+                fs::write(&rust_path, "pub fn replacement_parser() -> i32 { 2 }\n")
+                    .expect("change parser source");
+                &rust_path
+            } else {
+                fs::write(&json_path, "{\"replacement\":{\"name\":\"api\"}}\n")
+                    .expect("change structural source");
+                &json_path
+            };
+            std::fs::File::options()
+                .write(true)
+                .open(changed_path)
+                .expect("open changed cache source")
+                .set_times(
+                    std::fs::FileTimes::new()
+                        .set_modified(std::time::SystemTime::now() + Duration::from_secs(2)),
+                )
+                .expect("advance changed cache source mtime");
+
+            let denied_reads = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let staged_cache_writes = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let denied_reads_hook = denied_reads.clone();
+            let staged_cache_writes_hook = staged_cache_writes.clone();
+            arm_incremental_staged_store_hook(move |storage| {
+                let denied_reads = denied_reads_hook.clone();
+                storage
+                    .get_connection()
+                    .authorizer(Some(move |context: rusqlite::hooks::AuthContext<'_>| {
+                        if matches!(
+                            context.action,
+                            rusqlite::hooks::AuthAction::Read { table_name, .. }
+                                if table_name == cache_table
+                        ) && denied_reads
+                            .compare_exchange(
+                                0,
+                                1,
+                                std::sync::atomic::Ordering::SeqCst,
+                                std::sync::atomic::Ordering::SeqCst,
+                            )
+                            .is_ok()
+                        {
+                            rusqlite::hooks::Authorization::Deny
+                        } else {
+                            rusqlite::hooks::Authorization::Allow
+                        }
+                    }))
+                    .expect("install staged cache read fault");
+                storage
+                    .get_connection()
+                    .update_hook(Some(move |action, _: &str, updated_table: &str, _| {
+                        if updated_table == cache_table
+                            && matches!(
+                                action,
+                                rusqlite::hooks::Action::SQLITE_INSERT
+                                    | rusqlite::hooks::Action::SQLITE_UPDATE
+                            )
+                        {
+                            staged_cache_writes_hook
+                                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        }
+                    }))
+                    .expect("observe staged cache writes");
+            });
+            arm_publication_test_fault(
+                PublicationTestBoundary::SearchBuild,
+                PublicationTestAction::Fail,
+            );
+
+            let error = controller
+                .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+                .expect_err("later publication fault must reject recollected candidate");
+            assert!(
+                error.message.contains("SearchBuild"),
+                "{family} candidate did not reach the later publication boundary: {error:?}"
+            );
+            assert_eq!(
+                denied_reads.load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "{family} staged cache read fault was not exercised exactly once"
+            );
+            assert!(
+                staged_cache_writes.load(std::sync::atomic::Ordering::SeqCst) > 0,
+                "{family} read failure did not recollect and persist a staged cache entry"
+            );
+            PUBLICATION_TEST_FAULT.with(|fault| {
+                assert!(
+                    fault.borrow().is_none(),
+                    "{family} candidate did not reach the armed publication fault"
+                );
+            });
+
+            assert_eq!(
+                parser_cache_live_identity(&storage_path),
+                parser_baseline,
+                "{family} candidate changed the live parser cache or publication"
+            );
+            assert_eq!(
+                structural_live_identity(&storage_path),
+                structural_baseline,
+                "{family} candidate changed the live structural cache, manifest, or publication"
+            );
+            let live =
+                Storage::open_read_only(&storage_path).expect("open preserved live publication");
+            assert!(storage_has_symbol(&live, "retained_parser"));
+            assert!(storage_has_symbol(&live, "service"));
+            assert!(!storage_has_symbol(&live, "replacement_parser"));
+            assert!(!storage_has_symbol(&live, "replacement"));
+            drop(live);
+            assert_no_staged_publication_artifacts(&storage_path);
+        }
+    }
+
+    #[test]
     fn structural_publication_survives_cancellation_and_promotion_rollback_boundaries() {
         for (boundary, action, mode) in [
             (
@@ -27860,6 +28028,41 @@ fn build_llm_symbol_doc_text() -> String {
         publication: IndexPublicationRecord,
         manifest: codestory_store::StructuralTextUnitPublicationManifest,
         cache_rows: Vec<(String, i64, String, String, i64, String, String)>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ParserCacheLiveIdentity {
+        publication: IndexPublicationRecord,
+        cache_rows: Vec<(String, String, Vec<u8>, i64)>,
+    }
+
+    fn parser_cache_live_identity(storage_path: &Path) -> ParserCacheLiveIdentity {
+        let storage = Storage::open_read_only(storage_path).expect("open parser publication");
+        let publication = storage
+            .get_complete_index_publication()
+            .expect("read parser core publication")
+            .expect("complete parser core publication");
+        let cache_rows = {
+            let mut statement = storage
+                .get_connection()
+                .prepare(
+                    "SELECT file_path, cache_key, artifact_blob, updated_at_epoch_ms
+                     FROM index_artifact_cache
+                     ORDER BY file_path",
+                )
+                .expect("prepare parser cache identity");
+            statement
+                .query_map([], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+                })
+                .expect("query parser cache identity")
+                .map(|row| row.expect("read parser cache identity"))
+                .collect()
+        };
+        ParserCacheLiveIdentity {
+            publication,
+            cache_rows,
+        }
     }
 
     fn structural_live_identity(storage_path: &Path) -> StructuralLiveIdentity {

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -12,31 +12,32 @@ use codestory_contracts::api::{
     AffectedMatchedFileDto, AffectedRouteDto, AffectedSymbolDto, AffectedTestFileDto,
     AffectedUncoveredInputDto, AffectedUnmatchedPathDto, AgentAnswerDto, AgentAskRequest,
     AgentHybridWeightsDto, AgentPacketDto, AgentPacketRequestDto, ApiError, AppEventPayload,
-    BookmarkCategoryDto, BookmarkDto, CreateBookmarkCategoryRequest, CreateBookmarkRequest, EdgeId,
-    EdgeKind, EdgeOccurrencesRequest, EmbeddingProfileContractDto, FileCoverageDiagnosticDto,
-    FrameworkRouteCoverageDto, FullRefreshWallTimings, GraphEdgeDto, GraphNodeDto, GraphRequest,
-    GraphResponse, GroundingBudgetDto, GroundingCoverageBucketDto, GroundingFileDigestDto,
-    GroundingSnapshotDto, GroundingSymbolDigestDto, IndexDryRunDto, IndexFreshnessChangeKindDto,
-    IndexFreshnessDto, IndexFreshnessSampleDto, IndexFreshnessStatusDto, IndexMode,
-    IndexPublicationDto, IndexPublicationModeDto, IndexedFileDto,
-    IndexedFileIncompleteReasonCountDto, IndexedFileLanguageCountDto, IndexedFileRoleDto,
-    IndexedFilesDto, IndexedFilesRequest, IndexedFilesSummaryDto, IndexingPhaseTimings,
-    ListChildrenSymbolsRequest, ListRootSymbolsRequest, MemberAccess, NodeDetailsDto,
-    NodeDetailsRequest, NodeId, NodeKind, NodeOccurrencesRequest, OpenContainingFolderRequest,
-    OpenDefinitionRequest, OpenProjectRequest, ProjectSummary, ReadFileTextRequest,
-    ReadFileTextResponse, RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalModeDto,
-    RetrievalScoreBreakdownDto, RetrievalStateDto, RouteEndpointHandlerDto, RouteEndpointKindDto,
-    RouteEndpointMetadataDto, SearchHit, SearchHitOrigin, SearchHybridLimitsDto,
-    SearchMatchQualityDto, SearchPlanAnchorGroupDto, SearchPlanBridgeConfidenceDto,
-    SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto, SearchPlanBridgeStatusDto,
-    SearchPlanCandidateWindowDto, SearchPlanChannelDto, SearchPlanDroppedTermDto, SearchPlanDto,
-    SearchPlanNextActionDto, SearchPlanPromotionStatusDto, SearchPlanRejectedHitDto,
-    SearchPlanSubqueryDto, SearchPlanTermsDto, SearchQueryAssessmentDto, SearchRepoTextMode,
-    SearchRequest, SearchResultsDto, SemanticModeDto, SnippetContextDto, SourceOccurrenceDto,
-    SourcePolicyExclusionDto, StartIndexingRequest, StorageStatsDto, StoredSemanticDocsContractDto,
-    SummaryGenerationDto, SymbolContextDto, SymbolSummaryDto, SystemActionResponse, TrailConfigDto,
-    TrailContextDto, TrailFilterOptionsDto, UpdateBookmarkCategoryRequest, UpdateBookmarkRequest,
-    WorkspaceMemberIndexDto, WriteFileResponse, WriteFileTextRequest,
+    ArtifactCacheAccessTimings, ArtifactCachePolicyDto, BookmarkCategoryDto, BookmarkDto,
+    CreateBookmarkCategoryRequest, CreateBookmarkRequest, EdgeId, EdgeKind, EdgeOccurrencesRequest,
+    EmbeddingProfileContractDto, FileCoverageDiagnosticDto, FrameworkRouteCoverageDto,
+    FullRefreshWallTimings, GraphEdgeDto, GraphNodeDto, GraphRequest, GraphResponse,
+    GroundingBudgetDto, GroundingCoverageBucketDto, GroundingFileDigestDto, GroundingSnapshotDto,
+    GroundingSymbolDigestDto, IndexDryRunDto, IndexFreshnessChangeKindDto, IndexFreshnessDto,
+    IndexFreshnessSampleDto, IndexFreshnessStatusDto, IndexMode, IndexPublicationDto,
+    IndexPublicationModeDto, IndexedFileDto, IndexedFileIncompleteReasonCountDto,
+    IndexedFileLanguageCountDto, IndexedFileRoleDto, IndexedFilesDto, IndexedFilesRequest,
+    IndexedFilesSummaryDto, IndexingPhaseTimings, ListChildrenSymbolsRequest,
+    ListRootSymbolsRequest, MemberAccess, NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind,
+    NodeOccurrencesRequest, OpenContainingFolderRequest, OpenDefinitionRequest, OpenProjectRequest,
+    ProjectSummary, ReadFileTextRequest, ReadFileTextResponse, RepoTextScanStatsDto,
+    RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalScoreBreakdownDto, RetrievalStateDto,
+    RouteEndpointHandlerDto, RouteEndpointKindDto, RouteEndpointMetadataDto, SearchHit,
+    SearchHitOrigin, SearchHybridLimitsDto, SearchMatchQualityDto, SearchPlanAnchorGroupDto,
+    SearchPlanBridgeConfidenceDto, SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto,
+    SearchPlanBridgeStatusDto, SearchPlanCandidateWindowDto, SearchPlanChannelDto,
+    SearchPlanDroppedTermDto, SearchPlanDto, SearchPlanNextActionDto, SearchPlanPromotionStatusDto,
+    SearchPlanRejectedHitDto, SearchPlanSubqueryDto, SearchPlanTermsDto, SearchQueryAssessmentDto,
+    SearchRepoTextMode, SearchRequest, SearchResultsDto, SemanticModeDto, SnippetContextDto,
+    SourceOccurrenceDto, SourcePolicyExclusionDto, StartIndexingRequest, StorageStatsDto,
+    StoredSemanticDocsContractDto, SummaryGenerationDto, SymbolContextDto, SymbolSummaryDto,
+    SystemActionResponse, TrailConfigDto, TrailContextDto, TrailFilterOptionsDto,
+    UpdateBookmarkCategoryRequest, UpdateBookmarkRequest, WorkspaceMemberIndexDto,
+    WriteFileResponse, WriteFileTextRequest,
 };
 use codestory_contracts::events::{Event, EventBus};
 use codestory_contracts::graph::{
@@ -47,7 +48,8 @@ use codestory_contracts::language_support::{
     language_support_profile_for_language_name,
 };
 use codestory_indexer::{
-    CancellationToken, IncrementalIndexingStats, WorkspaceIndexer as V2WorkspaceIndexer,
+    ArtifactCacheFamilyStats, ArtifactCachePolicies, ArtifactCachePolicy, CancellationToken,
+    IncrementalIndexingStats, WorkspaceIndexer as V2WorkspaceIndexer,
 };
 use codestory_store::{
     CURRENT_SCHEMA_VERSION, DenseAnchorInput, DenseAnchorInputReuseMetadata, FileInfo,
@@ -4288,6 +4290,21 @@ struct OptionalResolutionTelemetry {
     resolved_imports_global_unique: Option<u32>,
     resolved_imports_fuzzy: Option<u32>,
     resolved_imports_semantic: Option<u32>,
+}
+
+fn artifact_cache_access_timings(stats: &ArtifactCacheFamilyStats) -> ArtifactCacheAccessTimings {
+    ArtifactCacheAccessTimings {
+        policy: match stats.policy {
+            ArtifactCachePolicy::KnownEmpty => ArtifactCachePolicyDto::KnownEmpty,
+            ArtifactCachePolicy::ReadThrough => ArtifactCachePolicyDto::ReadThrough,
+        },
+        logical_lookups: clamp_usize_to_u32(stats.logical_lookups),
+        physical_queries: clamp_usize_to_u32(stats.physical_queries),
+        hits: clamp_usize_to_u32(stats.hits),
+        misses: clamp_usize_to_u32(stats.misses),
+        reader_opens: clamp_usize_to_u32(stats.reader_opens),
+        lookup_wall_ms: clamp_u64_to_u32(stats.lookup_wall_ns / 1_000_000),
+    }
 }
 
 impl OptionalResolutionTelemetry {
@@ -14600,7 +14617,7 @@ fn index_full_for_runtime(
     #[cfg(test)]
     run_full_refresh_staged_store_hook(staged.store_mut());
     let can_copy_forward = !recovering_incomplete_run && storage_path.exists();
-    if has_verified_live_publication {
+    let copied_structural_artifacts = if has_verified_live_publication {
         match staged
             .store_mut()
             .copy_structural_text_artifact_cache_from(storage_path)
@@ -14609,20 +14626,32 @@ fn index_full_for_runtime(
                 tracing::debug!(
                     copied,
                     "Copied verified structural artifacts into staged storage"
-                )
+                );
+                copied
             }
             Err(error) => {
                 tracing::warn!(
                     "Failed to copy verified structural artifacts into staged storage; recollecting: {error}"
-                )
+                );
+                0
             }
         }
-    }
+    } else {
+        0
+    };
 
     let bus = EventBus::new();
     let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
     let indexer = V2WorkspaceIndexer::new(root.to_path_buf())
-        .with_source_file_byte_cap(source_index_policy.byte_cap);
+        .with_source_file_byte_cap(source_index_policy.byte_cap)
+        .with_artifact_cache_policies(ArtifactCachePolicies {
+            parser: ArtifactCachePolicy::KnownEmpty,
+            structural: if copied_structural_artifacts > 0 {
+                ArtifactCachePolicy::ReadThrough
+            } else {
+                ArtifactCachePolicy::KnownEmpty
+            },
+        });
     wall_durations.stage_open = wall_stage_started.elapsed();
     wall_stage_started = Instant::now();
     let result = indexer.run(staged.store_mut(), &execution_plan, &bus, cancel_token);
@@ -14959,6 +14988,12 @@ fn index_full_for_runtime(
             artifact_cache_writes: Some(clamp_usize_to_u32(index_stats.artifact_cache_writes)),
             artifact_cache_write_transactions: Some(clamp_usize_to_u32(
                 index_stats.artifact_cache_write_transactions,
+            )),
+            parser_artifact_cache: Some(artifact_cache_access_timings(
+                &index_stats.parser_artifact_cache,
+            )),
+            structural_artifact_cache: Some(artifact_cache_access_timings(
+                &index_stats.structural_artifact_cache,
             )),
             full_refresh_chunks_produced: full_refresh_pipeline_enabled
                 .then_some(clamp_usize_to_u32(index_stats.full_refresh_chunks_produced)),
@@ -15701,6 +15736,12 @@ fn run_incremental_indexing_common(
             artifact_cache_writes: Some(clamp_usize_to_u32(index_stats.artifact_cache_writes)),
             artifact_cache_write_transactions: Some(clamp_usize_to_u32(
                 index_stats.artifact_cache_write_transactions,
+            )),
+            parser_artifact_cache: Some(artifact_cache_access_timings(
+                &index_stats.parser_artifact_cache,
+            )),
+            structural_artifact_cache: Some(artifact_cache_access_timings(
+                &index_stats.structural_artifact_cache,
             )),
             full_refresh_chunks_produced: None,
             full_refresh_chunks_persisted: None,
@@ -26387,6 +26428,25 @@ fn build_llm_symbol_doc_text() -> String {
         let full_timings = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
             .expect("first full publication");
+        let parser_cache = full_timings
+            .parser_artifact_cache
+            .as_ref()
+            .expect("parser cache telemetry");
+        assert_eq!(parser_cache.policy, ArtifactCachePolicyDto::KnownEmpty);
+        assert_eq!(parser_cache.logical_lookups, 1);
+        assert_eq!(parser_cache.physical_queries, 0);
+        assert_eq!(parser_cache.hits, 0);
+        assert_eq!(parser_cache.misses, 1);
+        assert_eq!(parser_cache.reader_opens, 0);
+        assert_eq!(parser_cache.lookup_wall_ms, 0);
+        let structural_cache = full_timings
+            .structural_artifact_cache
+            .as_ref()
+            .expect("structural cache telemetry");
+        assert_eq!(structural_cache.policy, ArtifactCachePolicyDto::KnownEmpty);
+        assert_eq!(structural_cache.logical_lookups, 0);
+        assert_eq!(structural_cache.physical_queries, 0);
+        assert_eq!(structural_cache.reader_opens, 0);
         assert_eq!(full_timings.full_refresh_queue_capacity, Some(1));
         assert_eq!(full_timings.full_refresh_queue_high_water, Some(1));
         assert_eq!(full_timings.full_refresh_chunks_produced, Some(1));
@@ -26476,6 +26536,19 @@ fn build_llm_symbol_doc_text() -> String {
         let incremental_timings = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
             .expect("incremental publication");
+        let incremental_parser_cache = incremental_timings
+            .parser_artifact_cache
+            .as_ref()
+            .expect("incremental parser cache telemetry");
+        assert_eq!(
+            incremental_parser_cache.policy,
+            ArtifactCachePolicyDto::ReadThrough
+        );
+        assert_eq!(incremental_parser_cache.logical_lookups, 1);
+        assert_eq!(incremental_parser_cache.physical_queries, 1);
+        assert_eq!(incremental_parser_cache.hits, 0);
+        assert_eq!(incremental_parser_cache.misses, 1);
+        assert_eq!(incremental_parser_cache.reader_opens, 0);
         assert!(incremental_timings.full_refresh_queue_capacity.is_none());
         assert!(incremental_timings.full_refresh_chunks_produced.is_none());
         assert!(
@@ -26544,9 +26617,23 @@ fn build_llm_symbol_doc_text() -> String {
             )
             .expect("open project");
 
-        controller
+        let first_timings = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
             .expect("publish first structural generation");
+        let first_structural_cache = first_timings
+            .structural_artifact_cache
+            .as_ref()
+            .expect("first structural cache telemetry");
+        assert_eq!(
+            first_structural_cache.policy,
+            ArtifactCachePolicyDto::KnownEmpty
+        );
+        assert_eq!(first_structural_cache.logical_lookups, 2);
+        assert_eq!(first_structural_cache.physical_queries, 0);
+        assert_eq!(first_structural_cache.hits, 0);
+        assert_eq!(first_structural_cache.misses, 2);
+        assert_eq!(first_structural_cache.reader_opens, 0);
+        assert_eq!(first_structural_cache.lookup_wall_ms, 0);
         let first = Store::database_index_publication(&storage_path)
             .expect("read first publication")
             .expect("first publication");
@@ -26575,9 +26662,22 @@ fn build_llm_symbol_doc_text() -> String {
         assert_eq!(first_cache.len(), 2);
 
         fs::write(&markdown_path, "# Replacement\n").expect("change markdown");
-        controller
+        let second_timings = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
             .expect("publish second structural generation");
+        let second_structural_cache = second_timings
+            .structural_artifact_cache
+            .as_ref()
+            .expect("second structural cache telemetry");
+        assert_eq!(
+            second_structural_cache.policy,
+            ArtifactCachePolicyDto::ReadThrough
+        );
+        assert_eq!(second_structural_cache.logical_lookups, 2);
+        assert_eq!(second_structural_cache.physical_queries, 2);
+        assert_eq!(second_structural_cache.hits, 1);
+        assert_eq!(second_structural_cache.misses, 1);
+        assert_eq!(second_structural_cache.reader_opens, 1);
         let second = Store::database_index_publication(&storage_path)
             .expect("read second publication")
             .expect("second publication");
@@ -26620,9 +26720,22 @@ fn build_llm_symbol_doc_text() -> String {
                     .set_modified(std::time::SystemTime::now() + Duration::from_secs(2)),
             )
             .expect("advance changed sql mtime");
-        controller
+        let incremental_timings = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
             .expect("publish structural incremental");
+        let incremental_structural_cache = incremental_timings
+            .structural_artifact_cache
+            .as_ref()
+            .expect("incremental structural cache telemetry");
+        assert_eq!(
+            incremental_structural_cache.policy,
+            ArtifactCachePolicyDto::ReadThrough
+        );
+        assert_eq!(incremental_structural_cache.logical_lookups, 1);
+        assert_eq!(incremental_structural_cache.physical_queries, 1);
+        assert_eq!(incremental_structural_cache.hits, 0);
+        assert_eq!(incremental_structural_cache.misses, 1);
+        assert_eq!(incremental_structural_cache.reader_opens, 0);
         let third = Store::database_index_publication(&storage_path)
             .expect("read incremental publication")
             .expect("incremental publication");

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -119,13 +119,14 @@ flowchart TD
 - `index_incremental` clones the current live database into a durable staged store, collects refresh inputs from stored inventory, builds a diff-based execution plan, runs the same indexer against the clone, and publishes the completed replacement
 
 Only the fresh full stage uses relaxed SQLite synchronization. It remains in
-WAL mode for the bounded parser-artifact reader and keeps a nonzero 64 MiB
-automatic-checkpoint budget. The consuming publish call restores NORMAL
-synchronization, completes a blocking TRUNCATE checkpoint, syncs the database
-and containing directory, and only then enters the store's old-or-new promotion
-journal. Its phase telemetry exposes the checkpoint budget, checkpoint time,
-and sync time. Generic build stores and incremental clones keep WAL/NORMAL
-throughout.
+WAL mode so a bounded cache reader is available when verified structural rows
+were copied forward, and keeps a nonzero 64 MiB automatic-checkpoint budget.
+An entirely fresh stage opens no second reader. The consuming publish call
+restores NORMAL synchronization, completes a blocking TRUNCATE checkpoint,
+syncs the database and containing directory, and only then enters the store's
+old-or-new promotion journal. Its phase telemetry exposes the checkpoint
+budget, checkpoint time, and sync time. Generic build stores and incremental
+clones keep WAL/NORMAL throughout.
 
 The indexer does not know whether the store is staged or live.
 
@@ -183,6 +184,14 @@ Compilation metadata matters mostly for native-language parsing and is part of t
 Structural collectors use a separate, versioned cache whose payload contains
 only collector-owned source units and their graph projection. Copy-forward
 never relabels parser artifacts as structural units.
+
+Runtime supplies an explicit access policy for each cache family. A fresh
+disposable full stage uses `known_empty` for parser artifacts because no parser
+rows are copied into it. Structural access remains `known_empty` unless the
+verified prior publication copied at least one structural row; only then does
+it use `read_through`. Incremental clones retain both cache families and use
+`read_through`. `known_empty` still records one logical miss per eligible file,
+but performs no SQLite query and cannot produce a hit.
 
 The parser cache key includes:
 
@@ -246,12 +255,22 @@ Cancellation is observed at the next chunk boundary: an in-flight transaction
 either commits completely or rolls back, and a staged full refresh still
 cannot become live before the runtime publication fence.
 
-File-backed full refreshes use a query-only artifact-cache connection while a
-single writer connection remains on a dedicated scoped thread. The producer
+File-backed full refreshes open one query-only artifact-cache connection only
+when a scheduled cache family uses `read_through`; the connection is attributed
+to the first scheduled enabled family in reader-open telemetry and can serve
+both families. A copied structural cache with no scheduled structural files
+does not cause a reader open. When both policies are `known_empty`, the same
+bounded producer/writer pipeline runs without a second connection. The producer
 prepares and parses the next chunk, then sends it through a capacity-one
-channel. This overlaps parser work with persistence while preserving one
-SQLite writer and applying backpressure instead of growing an unbounded result
-queue. Incremental indexing and in-memory fixtures retain the serial path.
+channel. This overlaps parser work with persistence while preserving one SQLite
+writer and applying backpressure instead of growing an unbounded result queue.
+Incremental indexing and in-memory fixtures retain the serial path.
+
+Index telemetry reports parser and structural policy, logical lookups, physical
+queries, hits, misses, reader opens, and physical-query wall time separately.
+Compare cache timings only when the cache state and selected policies match;
+aggregate artifact-cache writes and transactions remain separate writer
+telemetry.
 
 Full refresh chooses each chunk with an 8 MiB planned-source target and a
 120,000 projected-node target instead of a fixed small file count. The node

--- a/docs/architecture/subsystems/store.md
+++ b/docs/architecture/subsystems/store.md
@@ -26,12 +26,14 @@ may restore only a valid recorded prepared backup; a committed publication is
 never rolled back merely because a backup remains.
 
 The fresh full-refresh stage is explicitly disposable until publication. It
-keeps WAL for the bounded artifact-cache reader, uses relaxed synchronous writes
-with a bounded nonzero checkpoint window, and is never served or resumed. Its
-consuming publish path restores NORMAL synchronization, completes a TRUNCATE
-checkpoint, syncs the standalone database and directory, and permits no later
-stage writes before entering the promotion journal. Live stores, generic build
-callers, and staged incremental clones remain WAL/NORMAL.
+keeps WAL so a bounded artifact-cache reader can be opened when verified
+structural rows were copied forward, uses relaxed synchronous writes with a
+bounded nonzero checkpoint window, and is never served or resumed. Parser rows
+are not copied, and a stage with no copied structural rows opens no cache
+reader. Its consuming publish path restores NORMAL synchronization, completes a
+TRUNCATE checkpoint, syncs the standalone database and directory, and permits
+no later stage writes before entering the promotion journal. Live stores,
+generic build callers, and staged incremental clones remain WAL/NORMAL.
 
 Incremental refresh writes a durable clone and promotes the completed
 replacement through the same journal. Readers that need publication coherence

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -35,6 +35,17 @@ Do not serialize tests to hide leaked global state. CLI integration tests use
 their isolated test support, never the real user cache, and drain anything they
 start.
 
+Artifact-cache access-policy changes prove four separate boundaries with
+focused tests: a file-backed `known_empty` full refresh still uses the
+capacity-one pipeline without opening a reader; verified copied structural rows
+use structural read-through while parser reads stay disabled; repeat
+incremental work still reuses retained parser and structural rows; and an
+injected writer or collector failure preserves the previous publication. Check
+the parser and structural telemetry independently, including policy, logical
+lookups, physical queries, hits, misses, reader opens, and lookup wall time.
+Journal or checkpoint lanes are required only when those store contracts
+change.
+
 ## Exact-head source gate
 
 After independent review finds no blocker, run once on the unchanged head:

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -40,6 +40,8 @@ before drawing conclusions:
 | Phase field | Use |
 | --- | --- |
 | Graph phase | File discovery, parse/extract, graph writes, and snapshot/store refresh. |
+| Parser artifact cache | Access policy, logical lookups, physical queries, hits, misses, reader opens, and query wall time for parser-backed files. A fresh disposable full stage should report `known_empty`, zero physical queries, and zero reader opens. |
+| Structural artifact cache | The same access fields for structural collectors. Repeat full refresh can use `read_through` only after verified structural rows were copied; incremental clones retain normal read-through. |
 | Search projection | Search projection rebuild and symbol-index write time. |
 | Semantic doc build | Semantic document text construction, file text cache, and graph-context shaping. |
 | Semantic embedding | Embedding backend wall time, batch/request shape, and request concurrency setting. |
@@ -51,8 +53,10 @@ engine saturation rather than graph/store contention, and do not promote a
 runtime tuning switch.
 
 Do not collapse these into one "index got faster/slower" claim unless the
-repo-scale e2e row shows the same project, cache state, semantic backend, and
-command flags before and after.
+repo-scale e2e row shows the same project, cache state, cache-family policies,
+semantic backend, and command flags before and after. Cache lookup wall time is
+physical-query time, not source preparation; a `known_empty` run can still
+spend time reading and hashing source files.
 
 Prefer existing gates before adding a new harness:
 


### PR DESCRIPTION
Closes #1312
Refs #1275
Refs #1179

## Context

Fresh disposable full-refresh stages have no reusable parser artifacts, so parser-cache reads are guaranteed misses. Verified structural rows may still be copied from the previous complete publication and must remain reusable.

Base: `462794dd94988da64f168f7c622b218bb1a3a198`
Accepted head: `7fab5edc6922f39263c18a5da5839c667c71c135`
Accepted tree: `fb009c1121cf885d3932bfc4345d5a3d4322c5fb`

Canonical packaged grounding failed closed at `CoreFreshness`; the source candidate and review use pinned source/runtime evidence. CLI diagnostics are not claimed as packaged-MCP proof.

## What changed

- declare the parser cache `known_empty` for fresh disposable full stages;
- retain structural read-through only when verified structural rows were copied forward;
- avoid the second reader when no cache family needs storage;
- expose parser/structural policy, logical lookup, physical query, hit, miss, reader-open, and wall telemetry separately;
- attribute one shared reader open to the first scheduled read-through family without double counting;
- preserve incremental and generic read-through behavior;
- add real staged parser/structural read-fault and publication-survival proof;
- update release notes, architecture, performance guidance, and the testing matrix.

## Review

Independent review rejected the initial candidate for mixed-family reader attribution and preparation-only fault coverage. The accepted head fixes both. Exact-head rereview accepted `7fab5edc6922f39263c18a5da5839c667c71c135` / tree `fb009c1121cf885d3932bfc4345d5a3d4322c5fb` with no findings.

Review the access-plan scheduling in `codestory-indexer`, the disposable-stage policy selection in `codestory-runtime`, and the staged read-fault matrix first.

## Verification

Passed on the accepted exact head:

- affected `cargo check --locked`;
- affected all-target `cargo clippy --locked -- -D warnings`;
- focused parser/structural KnownEmpty, repeat-full, incremental, corruption, transaction rollback, cancellation, and publication tests;
- parser-first and structural-first mixed-reader ownership tests;
- real parser/structural staged SQLite read-fault matrix with later publication rejection and live identity survival;
- seven-file representative fixture: first full 7 logical misses / 0 queries / 0 readers; repeat full 7 structural queries / 7 hits / 1 reader; parser remained KnownEmpty; DB 2,007,040 bytes; residual WAL 0;
- formatting, docs links, committed diff check.

## Risk and non-claims

The policy is selected only for disposable full-stage parser reads; incremental/live/generic stores keep read-through. `rusqlite` is a test-only runtime dependency used to inject real cache-table read faults.

This PR does not change journal/checkpoint policy, cache write transaction semantics, parser concurrency, the Linux corpus, packages, installed runtime, protected hardware, marketplace state, or live release behavior. It makes no release or large-corpus performance claim.
