### PR TITLE
collapse semantic context copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@
 
 ### Performance
 
+- Semantic document preparation now keeps normalized display/read paths once
+  per owning file instead of cloning them for every symbol, derives display
+  names inside the existing bounded document window, and avoids an
+  all-semantic intermediate selection. Telemetry reports selected symbols,
+  retained context files/path bytes, and the still-retained all-node lookup so
+  later streaming work remains measurable.
 - Projection batches now replace errors owned by their refreshed file rows and
   mark grounding and resolution snapshots dirty inside the owning SQLite
   transaction instead of following each flush with a second error transaction

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8944,6 +8944,10 @@ mod tests {
             semantic_context_index_ms: Some(59),
             semantic_node_load_ms: Some(66),
             semantic_node_load_rows: Some(8_192),
+            semantic_selected_nodes: Some(2_048),
+            semantic_context_file_count: Some(128),
+            semantic_context_path_bytes: Some(16_384),
+            semantic_node_lookup_entries: Some(8_192),
             semantic_context_ms: Some(67),
             semantic_doc_build_ms: Some(7),
             semantic_embedding_ms: Some(8),
@@ -9204,8 +9208,11 @@ mod tests {
         ));
         assert!(
             markdown
-                .contains("semantic_ms: context_index=59 node_load=66 node_rows=8192 context=67 doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")
+                .contains("semantic_ms: context_index=59 node_load=66 context=67 doc_build=7 embedding=8 db_upsert=9 reload=10 prune=64")
         );
+        assert!(markdown.contains(
+            "semantic_context: node_rows=8192 selected_nodes=2048 files=128 path_bytes=16384 lookup_entries=8192"
+        ));
         assert!(markdown.contains("semantic_docs: reused=11 embedded=12 pending=13 stale=14"));
         assert!(markdown.contains(
             "staged_publish_ms: deferred_indexes=7 summary_snapshot=8 detail_snapshot=9 publish=10"

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -536,13 +536,23 @@ fn append_index_semantic_timings(markdown: &mut String, timings: &IndexingPhaseT
         &[
             ("context_index", timings.semantic_context_index_ms),
             ("node_load", timings.semantic_node_load_ms),
-            ("node_rows", timings.semantic_node_load_rows),
             ("context", timings.semantic_context_ms),
             ("doc_build", timings.semantic_doc_build_ms),
             ("embedding", timings.semantic_embedding_ms),
             ("db_upsert", timings.semantic_db_upsert_ms),
             ("reload", timings.semantic_reload_ms),
             ("prune", timings.semantic_prune_ms),
+        ],
+    );
+    append_optional_timings_line(
+        markdown,
+        "semantic_context",
+        &[
+            ("node_rows", timings.semantic_node_load_rows),
+            ("selected_nodes", timings.semantic_selected_nodes),
+            ("files", timings.semantic_context_file_count),
+            ("path_bytes", timings.semantic_context_path_bytes),
+            ("lookup_entries", timings.semantic_node_lookup_entries),
         ],
     );
     append_optional_timings_line(

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -152,6 +152,14 @@ pub struct IndexingPhaseTimings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_node_load_rows: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_selected_nodes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_context_file_count: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_context_path_bytes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_node_lookup_entries: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_context_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_doc_build_ms: Option<u32>,
@@ -377,6 +385,10 @@ mod tests {
             semantic_context_index_ms: None,
             semantic_node_load_ms: None,
             semantic_node_load_rows: None,
+            semantic_selected_nodes: None,
+            semantic_context_file_count: None,
+            semantic_context_path_bytes: None,
+            semantic_node_lookup_entries: None,
             semantic_context_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
@@ -483,6 +495,10 @@ mod tests {
         assert!(value.get("semantic_doc_build_ms").is_none());
         assert!(value.get("semantic_node_load_ms").is_none());
         assert!(value.get("semantic_node_load_rows").is_none());
+        assert!(value.get("semantic_selected_nodes").is_none());
+        assert!(value.get("semantic_context_file_count").is_none());
+        assert!(value.get("semantic_context_path_bytes").is_none());
+        assert!(value.get("semantic_node_lookup_entries").is_none());
         assert!(value.get("semantic_context_ms").is_none());
         assert!(value.get("semantic_embedding_ms").is_none());
         assert!(value.get("semantic_db_upsert_ms").is_none());

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -4827,6 +4827,10 @@ struct SemanticProjectionStats {
     semantic_context_index_ms: u32,
     node_load_ms: u32,
     node_load_rows: u32,
+    selected_nodes: u32,
+    context_file_count: u32,
+    context_path_bytes: u32,
+    node_lookup_entries: u32,
     context_ms: u32,
     doc_build_ms: u32,
     embedding_ms: u32,
@@ -4898,6 +4902,10 @@ fn apply_semantic_projection_stats(
     timings.semantic_context_index_ms = Some(stats.semantic_context_index_ms);
     timings.semantic_node_load_ms = Some(stats.node_load_ms);
     timings.semantic_node_load_rows = Some(stats.node_load_rows);
+    timings.semantic_selected_nodes = Some(stats.selected_nodes);
+    timings.semantic_context_file_count = Some(stats.context_file_count);
+    timings.semantic_context_path_bytes = Some(stats.context_path_bytes);
+    timings.semantic_node_lookup_entries = Some(stats.node_lookup_entries);
     timings.semantic_context_ms = Some(stats.context_ms);
     timings.semantic_doc_build_ms = Some(stats.doc_build_ms);
     timings.semantic_embedding_ms = Some(stats.embedding_ms);
@@ -7301,11 +7309,6 @@ fn semantic_file_table_path_map(files: Vec<FileInfo>) -> HashMap<GraphNodeId, St
     display_paths
 }
 
-fn semantic_file_table_read_path_map(files: Vec<FileInfo>) -> HashMap<GraphNodeId, String> {
-    let (_, read_paths) = semantic_file_table_path_maps(files);
-    read_paths
-}
-
 #[derive(Default)]
 struct SemanticDocGraphContext {
     child_labels: HashMap<GraphNodeId, Vec<String>>,
@@ -7322,11 +7325,17 @@ impl SemanticDocGraphContext {
         semantic_nodes: &[&GraphNode],
         all_nodes: &[GraphNode],
     ) -> Result<Self, ApiError> {
+        let files = storage
+            .get_files()
+            .map_err(|e| ApiError::internal(format!("Failed to load semantic doc files: {e}")))?;
+        let (file_paths, file_read_paths) = semantic_file_table_path_maps(files);
         Self::build_for_scope(
             storage,
             semantic_nodes,
             all_nodes,
             semantic_doc_scope_from_env(),
+            file_paths,
+            file_read_paths,
         )
     }
 
@@ -7335,6 +7344,8 @@ impl SemanticDocGraphContext {
         semantic_nodes: &[&GraphNode],
         all_nodes: &[GraphNode],
         scope: SemanticDocScope,
+        mut file_paths: HashMap<GraphNodeId, String>,
+        mut file_read_paths: HashMap<GraphNodeId, String>,
     ) -> Result<Self, ApiError> {
         let nodes_by_id = all_nodes
             .iter()
@@ -7347,29 +7358,29 @@ impl SemanticDocGraphContext {
         let edges_by_node = storage.get_edges_for_node_ids(&node_ids).map_err(|e| {
             ApiError::internal(format!("Failed to load semantic doc graph context: {e}"))
         })?;
-        let files = storage
-            .get_files()
-            .map_err(|e| ApiError::internal(format!("Failed to load semantic doc files: {e}")))?;
-        let file_table_paths = semantic_file_table_path_map(files.clone());
-        let file_table_read_paths = semantic_file_table_read_path_map(files);
-
-        let mut context = Self::default();
-        for node in semantic_nodes {
-            if let Some(file_id) = node.file_node_id
-                && let Some(file_node) = nodes_by_id.get(&file_id)
-            {
-                let file_path = file_table_paths
-                    .get(&file_id)
-                    .cloned()
-                    .unwrap_or_else(|| file_node.serialized_name.clone());
-                context.file_paths.insert(node.id, file_path);
-                let read_path = file_table_read_paths
-                    .get(&file_id)
-                    .cloned()
-                    .unwrap_or_else(|| file_node.serialized_name.clone());
-                context.file_read_paths.insert(node.id, read_path);
+        let context_file_ids = semantic_nodes
+            .iter()
+            .filter_map(|node| node.file_node_id)
+            .collect::<HashSet<_>>();
+        file_paths.retain(|file_id, _| context_file_ids.contains(file_id));
+        file_read_paths.retain(|file_id, _| context_file_ids.contains(file_id));
+        for file_id in context_file_ids {
+            if let Some(file_node) = nodes_by_id.get(&file_id) {
+                file_paths
+                    .entry(file_id)
+                    .or_insert_with(|| file_node.serialized_name.clone());
+                file_read_paths
+                    .entry(file_id)
+                    .or_insert_with(|| file_node.serialized_name.clone());
             }
+        }
 
+        let mut context = Self {
+            file_paths,
+            file_read_paths,
+            ..Default::default()
+        };
+        for node in semantic_nodes {
             let edges = edges_by_node
                 .get(&node.id)
                 .map(Vec::as_slice)
@@ -7391,14 +7402,18 @@ impl SemanticDocGraphContext {
     }
 
     fn file_path_for_node(&self, node: &GraphNode) -> Option<&str> {
-        self.file_paths.get(&node.id).map(String::as_str)
+        node.file_node_id
+            .and_then(|file_id| self.file_paths.get(&file_id))
+            .map(String::as_str)
     }
 
     fn file_read_path_for_node(&self, node: &GraphNode) -> Option<&str> {
-        self.file_read_paths
-            .get(&node.id)
-            .or_else(|| self.file_paths.get(&node.id))
-            .map(String::as_str)
+        node.file_node_id.and_then(|file_id| {
+            self.file_read_paths
+                .get(&file_id)
+                .or_else(|| self.file_paths.get(&file_id))
+                .map(String::as_str)
+        })
     }
 }
 
@@ -8474,7 +8489,6 @@ fn flush_pending_dense_anchor_inputs(
 fn sync_llm_symbol_projection_for_runtime(
     storage: &mut Storage,
     nodes: &[codestory_contracts::graph::Node],
-    node_names: &HashMap<codestory_contracts::graph::NodeId, String>,
     engine: &mut SearchEngine,
     refresh_scope: SemanticRefreshScope<'_>,
     hydrate_semantic_docs: bool,
@@ -8541,19 +8555,11 @@ fn sync_llm_symbol_projection_for_runtime(
     let mut component_report_node_ids = Vec::<codestory_contracts::graph::NodeId>::new();
     let mut dense_component_report_node_ids = Vec::<codestory_contracts::graph::NodeId>::new();
     let mut doc_build_ns = 0_u128;
-    let all_semantic_nodes = nodes
+    let semantic_scope = semantic_doc_scope_from_value(&runtime.retrieval.semantic_doc_scope);
+    let semantic_nodes = nodes
         .iter()
-        .filter(|node| {
-            llm_indexable_kind_for_scope(
-                node.kind,
-                semantic_doc_scope_from_value(&runtime.retrieval.semantic_doc_scope),
-            )
-        })
+        .filter(|node| llm_indexable_kind_for_scope(node.kind, semantic_scope))
         .filter(|node| !is_retrieval_artifact_node(node))
-        .collect::<Vec<_>>();
-    let semantic_nodes = all_semantic_nodes
-        .iter()
-        .copied()
         .filter(|node| {
             effective_llm_refresh_file_scope
                 .map(|scope| {
@@ -8564,11 +8570,10 @@ fn sync_llm_symbol_projection_for_runtime(
                 .unwrap_or(true)
         })
         .collect::<Vec<_>>();
-    let file_paths = semantic_file_table_path_map(
-        storage
-            .get_files()
-            .map_err(|e| ApiError::internal(format!("Failed to load semantic doc files: {e}")))?,
-    );
+    let files = storage
+        .get_files()
+        .map_err(|e| ApiError::internal(format!("Failed to load semantic doc files: {e}")))?;
+    let (file_paths, file_read_paths) = semantic_file_table_path_maps(files);
     let effective_component_report_scope = if expand_semantic_scope_for_contract_repair {
         None
     } else if let Some(refresh) = refresh_scope.component_reports {
@@ -8615,9 +8620,10 @@ fn sync_llm_symbol_projection_for_runtime(
             }
         }
     }
-    let report_semantic_nodes = all_semantic_nodes
+    let report_semantic_nodes = nodes
         .iter()
-        .copied()
+        .filter(|node| llm_indexable_kind_for_scope(node.kind, semantic_scope))
+        .filter(|node| !is_retrieval_artifact_node(node))
         .filter(|node| {
             effective_component_report_scope
                 .as_ref()
@@ -8652,9 +8658,22 @@ fn sync_llm_symbol_projection_for_runtime(
         storage,
         &context_nodes,
         nodes,
-        semantic_doc_scope_from_value(&runtime.retrieval.semantic_doc_scope),
+        semantic_scope,
+        file_paths,
+        file_read_paths,
     )?;
     stats.context_ms = clamp_u128_to_u32(context_started.elapsed().as_millis());
+    stats.selected_nodes = clamp_usize_to_u32(semantic_nodes.len());
+    stats.context_file_count = clamp_usize_to_u32(graph_context.file_paths.len());
+    stats.context_path_bytes = clamp_usize_to_u32(
+        graph_context
+            .file_paths
+            .values()
+            .chain(graph_context.file_read_paths.values())
+            .map(String::len)
+            .sum(),
+    );
+    stats.node_lookup_entries = clamp_usize_to_u32(nodes.len());
     let file_cache_started = Instant::now();
     let file_text_cache = build_semantic_file_text_cache(&graph_context, &semantic_nodes);
     doc_build_ns = doc_build_ns.saturating_add(file_cache_started.elapsed().as_nanos());
@@ -8667,10 +8686,7 @@ fn sync_llm_symbol_projection_for_runtime(
         let built_docs = semantic_window
             .par_iter()
             .map(|node| {
-                let display_name = node_names
-                    .get(&node.id)
-                    .cloned()
-                    .unwrap_or_else(|| node_display_name(node));
+                let display_name = node_display_name(node);
                 let file_path = graph_context
                     .file_path_for_node(node)
                     .map(ToString::to_string);
@@ -9007,16 +9023,11 @@ fn finalize_staged_semantic_docs_for_runtime(
         .map_err(|error| ApiError::internal(format!("Failed to load staged nodes: {error}")))?;
     let node_load_ms = clamp_u128_to_u32(node_load_started.elapsed().as_millis());
     let node_load_rows = clamp_usize_to_u32(nodes.len());
-    let node_names = nodes
-        .iter()
-        .map(|node| (node.id, node_display_name(node)))
-        .collect::<HashMap<_, _>>();
     let mut engine = SearchEngine::new(None)
         .map_err(|error| ApiError::internal(format!("Failed to init semantic engine: {error}")))?;
     let mut stats = sync_llm_symbol_projection_for_runtime(
         storage,
         &nodes,
-        &node_names,
         &mut engine,
         SemanticRefreshScope {
             file_ids: llm_refresh_file_scope,
@@ -15109,6 +15120,10 @@ fn index_full_for_runtime(
             semantic_context_index_ms: None,
             semantic_node_load_ms: None,
             semantic_node_load_rows: None,
+            semantic_selected_nodes: None,
+            semantic_context_file_count: None,
+            semantic_context_path_bytes: None,
+            semantic_node_lookup_entries: None,
             semantic_context_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
@@ -15842,6 +15857,10 @@ fn run_incremental_indexing_common(
             semantic_context_index_ms: None,
             semantic_node_load_ms: None,
             semantic_node_load_rows: None,
+            semantic_selected_nodes: None,
+            semantic_context_file_count: None,
+            semantic_context_path_bytes: None,
+            semantic_node_lookup_entries: None,
             semantic_context_ms: None,
             semantic_doc_build_ms: None,
             semantic_embedding_ms: None,
@@ -19392,16 +19411,19 @@ mod tests {
         }
     }
 
-    fn semantic_policy_context(path: &str, node_id: CoreNodeId) -> SemanticDocGraphContext {
+    fn semantic_policy_context(path: &str, node: &Node) -> SemanticDocGraphContext {
         let mut context = SemanticDocGraphContext::default();
-        context.file_paths.insert(node_id, path.to_string());
+        context.file_paths.insert(
+            node.file_node_id.expect("semantic policy test file id"),
+            path.to_string(),
+        );
         context
     }
 
     #[test]
     fn dense_policy_skips_private_trivial_helpers() {
         let node = semantic_policy_node(10, NodeKind::FUNCTION, "helper", 1);
-        let context = semantic_policy_context("src/internal/helper.rs", node.id);
+        let context = semantic_policy_context("src/internal/helper.rs", &node);
 
         let reason = dense_anchor_reason_for_node(
             &context,
@@ -19418,7 +19440,7 @@ mod tests {
     #[test]
     fn dense_policy_does_not_treat_every_handler_name_as_entrypoint() {
         let node = semantic_policy_node(14, NodeKind::FUNCTION, "handler", 1);
-        let context = semantic_policy_context("src/internal/request.rs", node.id);
+        let context = semantic_policy_context("src/internal/request.rs", &node);
 
         let reason = dense_anchor_reason_for_node(
             &context,
@@ -19436,10 +19458,7 @@ mod tests {
     fn dense_policy_only_embeds_high_signal_central_nodes() {
         let ordinary = semantic_policy_node(15, NodeKind::FUNCTION, "ordinary", 1);
         let central = semantic_policy_node(16, NodeKind::FUNCTION, "central", 1);
-        let mut context = semantic_policy_context("src/internal/graph.rs", ordinary.id);
-        context
-            .file_paths
-            .insert(central.id, "src/internal/graph.rs".to_string());
+        let mut context = semantic_policy_context("src/internal/graph.rs", &ordinary);
         context.child_labels.insert(
             ordinary.id,
             ["a", "b", "c", "d"]
@@ -19486,7 +19505,7 @@ mod tests {
         let public_node = semantic_policy_node(11, NodeKind::STRUCT, "ReportBuilder", 1);
         let entrypoint_node = semantic_policy_node(12, NodeKind::FUNCTION, "main", 1);
         let documented_node = semantic_policy_node(13, NodeKind::METHOD, "parse_config", 1);
-        let context = semantic_policy_context("src/lib.rs", public_node.id);
+        let context = semantic_policy_context("src/lib.rs", &public_node);
 
         assert_eq!(
             dense_anchor_reason_for_node(
@@ -19526,30 +19545,34 @@ mod tests {
     #[test]
     fn dense_policy_classifies_cross_language_entrypoints_and_surfaces() {
         let python_app = semantic_policy_node(21, NodeKind::FUNCTION, "app", 1);
-        let go_command = semantic_policy_node(22, NodeKind::FUNCTION, "run", 1);
-        let csharp_program = semantic_policy_node(23, NodeKind::CLASS, "Program", 1);
-        let java_application = semantic_policy_node(24, NodeKind::CLASS, "Application", 1);
-        let c_header_api = semantic_policy_node(25, NodeKind::STRUCT, "ClientApi", 1);
-        let python_package_api = semantic_policy_node(26, NodeKind::CLASS, "PackageClient", 1);
+        let go_command = semantic_policy_node(22, NodeKind::FUNCTION, "run", 2);
+        let csharp_program = semantic_policy_node(23, NodeKind::CLASS, "Program", 3);
+        let java_application = semantic_policy_node(24, NodeKind::CLASS, "Application", 4);
+        let c_header_api = semantic_policy_node(25, NodeKind::STRUCT, "ClientApi", 5);
+        let python_package_api = semantic_policy_node(26, NodeKind::CLASS, "PackageClient", 6);
         let mut context = SemanticDocGraphContext::default();
-        context
-            .file_paths
-            .insert(python_app.id, "service/app.py".to_string());
-        context
-            .file_paths
-            .insert(go_command.id, "cmd/server/main.go".to_string());
-        context
-            .file_paths
-            .insert(csharp_program.id, "src/Program.cs".to_string());
         context.file_paths.insert(
-            java_application.id,
+            python_app.file_node_id.expect("file id"),
+            "service/app.py".to_string(),
+        );
+        context.file_paths.insert(
+            go_command.file_node_id.expect("file id"),
+            "cmd/server/main.go".to_string(),
+        );
+        context.file_paths.insert(
+            csharp_program.file_node_id.expect("file id"),
+            "src/Program.cs".to_string(),
+        );
+        context.file_paths.insert(
+            java_application.file_node_id.expect("file id"),
             "src/main/java/com/acme/Application.java".to_string(),
         );
-        context
-            .file_paths
-            .insert(c_header_api.id, "include/acme/client_api.hpp".to_string());
         context.file_paths.insert(
-            python_package_api.id,
+            c_header_api.file_node_id.expect("file id"),
+            "include/acme/client_api.hpp".to_string(),
+        );
+        context.file_paths.insert(
+            python_package_api.file_node_id.expect("file id"),
             "packages/acme_sdk/__init__.py".to_string(),
         );
 
@@ -19603,7 +19626,7 @@ mod tests {
     #[test]
     fn dense_policy_does_not_embed_plain_public_callables_by_default() {
         let node = semantic_policy_node(17, NodeKind::FUNCTION, "plain_public_function", 1);
-        let context = semantic_policy_context("src/lib.rs", node.id);
+        let context = semantic_policy_context("src/lib.rs", &node);
 
         let reason = dense_anchor_reason_for_node(
             &context,
@@ -19620,7 +19643,7 @@ mod tests {
     #[test]
     fn dense_policy_embeds_package_public_callables_for_dynamic_frameworks() {
         let node = semantic_policy_node(19, NodeKind::FUNCTION, "handle", 1);
-        let context = semantic_policy_context("lib/router/index.js", node.id);
+        let context = semantic_policy_context("lib/router/index.js", &node);
 
         let reason = dense_anchor_reason_for_node(
             &context,
@@ -19635,7 +19658,7 @@ mod tests {
 
         let windows_node = semantic_policy_node(29, NodeKind::METHOD, "GET /json", 1);
         let windows_path = r"\\?\C:\repo\expressjs-express\lib\response.js";
-        let windows_context = semantic_policy_context(windows_path, windows_node.id);
+        let windows_context = semantic_policy_context(windows_path, &windows_node);
 
         let windows_reason = dense_anchor_reason_for_node(
             &windows_context,
@@ -19652,7 +19675,7 @@ mod tests {
     #[test]
     fn dense_policy_does_not_embed_comment_only_symbols_by_default() {
         let node = semantic_policy_node(18, NodeKind::FUNCTION, "commented_helper", 1);
-        let context = semantic_policy_context("src/internal/helper.rs", node.id);
+        let context = semantic_policy_context("src/internal/helper.rs", &node);
 
         let reason = dense_anchor_reason_for_node(
             &context,
@@ -19669,7 +19692,7 @@ mod tests {
     #[test]
     fn component_reports_are_extracted_dense_anchors_with_virtual_ids() {
         let node = semantic_policy_node(20, NodeKind::FUNCTION, "central_service", 1);
-        let mut context = semantic_policy_context("crates/app/src/service.rs", node.id);
+        let mut context = semantic_policy_context("crates/app/src/service.rs", &node);
         context
             .edge_digests
             .insert(node.id, vec!["CALL=9".to_string()]);
@@ -19713,7 +19736,7 @@ mod tests {
     }
 
     #[test]
-    fn semantic_graph_context_uses_repo_relative_file_table_paths() {
+    fn semantic_graph_context_keeps_normalized_paths_once_per_file() {
         let temp = tempdir().expect("create temp dir");
         let storage_path = temp.path().join("codestory.db");
         let mut storage = Storage::open(&storage_path).expect("open storage");
@@ -19744,15 +19767,37 @@ mod tests {
             start_line: Some(1),
             ..Default::default()
         };
+        let second_function_node = Node {
+            id: CoreNodeId(102),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "nvm_echo".to_string(),
+            file_node_id: Some(CoreNodeId(11)),
+            start_line: Some(2),
+            ..Default::default()
+        };
         storage
-            .insert_nodes_batch(&[file_node.clone(), function_node.clone()])
+            .insert_nodes_batch(&[
+                file_node.clone(),
+                function_node.clone(),
+                second_function_node.clone(),
+            ])
             .expect("insert nodes");
-        let nodes = vec![file_node, function_node.clone()];
-        let semantic_nodes = vec![&function_node];
+        let nodes = vec![
+            file_node,
+            function_node.clone(),
+            second_function_node.clone(),
+        ];
+        let semantic_nodes = vec![&function_node, &second_function_node];
         let context =
             SemanticDocGraphContext::build(&storage, &semantic_nodes, &nodes).expect("context");
 
+        assert_eq!(context.file_paths.len(), 1);
+        assert_eq!(context.file_read_paths.len(), 1);
         assert_eq!(context.file_path_for_node(&function_node), Some("nvm.sh"));
+        assert_eq!(
+            context.file_path_for_node(&second_function_node),
+            Some("nvm.sh")
+        );
         assert_eq!(
             context.file_read_path_for_node(&function_node),
             Some("C:/work/nvm/nvm.sh")
@@ -19843,10 +19888,11 @@ mod tests {
             start_line: Some(1),
             ..Default::default()
         };
-        context.file_paths.insert(node.id, display_path.to_string());
+        let file_id = node.file_node_id.expect("semantic cache test file id");
+        context.file_paths.insert(file_id, display_path.to_string());
         context
             .file_read_paths
-            .insert(node.id, read_path.to_string_lossy().to_string());
+            .insert(file_id, read_path.to_string_lossy().to_string());
         node
     }
 
@@ -26573,6 +26619,25 @@ fn build_llm_symbol_doc_text() -> String {
             full_timings
                 .semantic_node_load_rows
                 .is_some_and(|rows| rows > 0)
+        );
+        assert!(
+            full_timings
+                .semantic_selected_nodes
+                .is_some_and(|rows| rows > 0)
+        );
+        assert!(
+            full_timings
+                .semantic_context_file_count
+                .is_some_and(|files| files > 0)
+        );
+        assert!(
+            full_timings
+                .semantic_context_path_bytes
+                .is_some_and(|bytes| bytes > 0)
+        );
+        assert_eq!(
+            full_timings.semantic_node_lookup_entries,
+            full_timings.semantic_node_load_rows
         );
         assert!(full_timings.semantic_context_ms.is_some());
         let full_refresh_wall = full_timings

--- a/docs/architecture/subsystems/runtime.md
+++ b/docs/architecture/subsystems/runtime.md
@@ -45,6 +45,14 @@ manifest on freshness and read surfaces. `files` exposes those paths as source
 inventory with explicit false graph and semantic coverage; packet and search
 never treat them as indexed evidence.
 
+Semantic document preparation normalizes the file table once and retains
+display/read paths by owning file-node identity. Symbols resolve those paths
+through `file_node_id`; runtime does not duplicate path strings or retain a
+second owned display-name map per symbol. The current all-node load and graph
+lookup remain a separate bounded-streaming concern. Index telemetry exposes
+selected symbols, retained context files and path bytes, and lookup entries so
+that boundary stays visible.
+
 ## Extension rules
 
 - put reusable product workflows here and expose typed contract DTOs;

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -89,6 +89,13 @@ The repo-scale stats lane runs once on the final merge-ready head only when
 default indexing, symbol/dense persistence, embedding reuse, or cold-start
 behavior changed. Intermediate commits do not append telemetry.
 
+Semantic document allocation changes use focused runtime proof before the
+broad gate. Cover shared-file path cardinality, byte-identical and
+deterministically ordered symbol documents and dense inputs, cancellation, and
+injected staged-publication failure. Telemetry must distinguish selected
+symbols, retained file/path state, and the all-node lookup still awaiting its
+own streaming change.
+
 ## Retrieval engine
 
 The supported product path is one packaged executable whose hidden mode owns


### PR DESCRIPTION
## Context

Semantic document preparation retained normalized display/read paths once per selected symbol and built a second owned display-name map for every loaded node. On the representative CodeStory publication, 26,741 selected symbols referenced 443 files while repeated path text alone occupied 2,659,923 bytes. Full-node loading and the graph lookup remain separate streaming work.

Base: `90a4e3b773dc15df42928c2407d61f750151a1dd`
Accepted head: `cd04c66bc594c829c285425d40821bcf9ca35d36`
Tree: `3116980f1a3be0628253d46fbd15e876d57255e6`

## What changed

- normalize the file table once, then retain display/read paths by owning file-node identity;
- resolve symbol paths through `file_node_id` with the existing normalization and fallback behavior;
- derive display names inside the existing bounded document window;
- remove the all-semantic intermediate selection while preserving full, incremental, and component-report scopes;
- report selected symbols, retained files/path bytes, and the still-retained all-node lookup;
- document the allocation boundary and focused proof contract.

## How to review

Start with `SemanticDocGraphContext::build_for_scope`, then follow `sync_llm_symbol_projection_for_runtime` into the new `IndexingPhaseTimings` fields and CLI rendering. Check that incremental component-report scope uses the complete normalized file table before the context maps are narrowed to owning files.

Independent exact-head review found no P0-P3 findings on the accepted head/tree. The packaged grounding MCP failed closed in this host with schema 28 exceeding its supported schema 26, so source review used the pinned diff; CLI diagnostics were not treated as MCP proof.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- full and incremental publication fail/cancel matrices
- runtime unit suite: 798/798
- docs links and `git diff --check`
- one-time repo-scale self-index/retrieval lane on the accepted head

Repo-scale result: 26,741 selected symbols retained 443 context files and 66,855 combined display/read path bytes, a conservative 39.8x reduction from the measured repeated path text. The all-node lookup remains visible at 165,503 entries. Full and repeat refreshes retained zero unattributed top-level wall and one complete old-or-new publication.

The repo-scale harness passed with the same machine-sensitive retrieval-index/status/search warnings already represented by its stats baseline. No Linux corpus, package, installed-runtime, protected-hardware, or live-release claim is made here.

## Risk and follow-up

The full node vector and `nodes_by_id` lookup remain intentionally unchanged. A later child can stream those without mixing identity or output changes into this slice.

Closes #1321
Refs #1275
