### PR TITLE
[P2] Attribute SQLite core-promotion wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@
   Telemetry reports stream batches, endpoint rows/query batches and wall, and
   the peak page-local lookup size; incremental dependency scopes retain their
   existing loader.
+- Core publication telemetry now separates incremental live-to-staged SQLite
+  copy wall and bytes from successful promotion validation, rollback-backup
+  copy, journal sync, staged-to-live restore, validation, and cleanup wall.
+  Candidate, prior-live, and rollback-backup logical bytes plus a saturating
+  promotion residual make the existing copy and validation amplification
+  measurable without changing publication, recovery, journal, checkpoint, or
+  durability behavior.
 - Semantic document preparation now keeps normalized display/read paths once
   per owning file instead of cloning them for every symbol, derives display
   names inside the existing bounded document window, and avoids an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,12 +67,14 @@
   the peak page-local lookup size; incremental dependency scopes retain their
   existing loader.
 - Core publication telemetry now separates incremental live-to-staged SQLite
-  copy wall and bytes from successful promotion validation, rollback-backup
-  copy, journal sync, staged-to-live restore, validation, and cleanup wall.
-  Candidate, prior-live, and rollback-backup logical bytes plus a saturating
-  promotion residual make the existing copy and validation amplification
-  measurable without changing publication, recovery, journal, checkpoint, or
-  durability behavior.
+  backup-call wall and logical bytes from successful promotion validation,
+  rollback-backup copy, journal sync, staged-to-live restore, validation, and
+  cleanup wall. The incremental clone happens before indexing and outside
+  `publish_ms`; promotion subphases remain nested inside it. Candidate,
+  prior-live, and rollback-backup SQLite logical bytes (`page_count *
+  page_size`) plus a saturating promotion residual make the existing copy and
+  validation amplification measurable without changing publication, recovery,
+  journal, checkpoint, or durability behavior.
 - Semantic document preparation now keeps normalized display/read paths once
   per owning file instead of cloning them for every symbol, derives display
   names inside the existing bounded document window, and avoids an

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -7999,9 +7999,9 @@ mod tests {
     use crate::runtime::{cache_root_for_project, fnv1a_hex, resolve_refresh_request};
     use codestory_contracts::api::{
         AgentAnswerDto, AgentCitationDto, AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto,
-        AgentRetrievalTraceDto, EdgeId, EdgeKind, FullRefreshWallTimings, GraphEdgeDto,
-        GraphNodeDto, GraphResponse, IndexMode, IndexedFileDto,
-        IndexedFileIncompleteReasonCountDto, IndexedFileRoleDto, IndexedFilesDto,
+        AgentRetrievalTraceDto, CorePromotionTimings, DatabaseSnapshotCopyTimings, EdgeId,
+        EdgeKind, FullRefreshWallTimings, GraphEdgeDto, GraphNodeDto, GraphResponse, IndexMode,
+        IndexedFileDto, IndexedFileIncompleteReasonCountDto, IndexedFileRoleDto, IndexedFilesDto,
         IndexedFilesSummaryDto, IndexingPhaseTimings, NodeDetailsDto, NodeId, PacketBudgetDto,
         PacketBudgetLimitsDto, PacketBudgetUsageDto, PacketClaimDto, PacketPlanDto,
         PacketPlanQueryDto, PacketRetrievalTraceSummaryDto, PacketSufficiencyDto, ProjectSummary,
@@ -8977,6 +8977,30 @@ mod tests {
             staged_sqlite_wal_autocheckpoint_bytes: Some(67_108_864),
             staged_sqlite_checkpoint_ms: Some(11),
             staged_sqlite_sync_ms: Some(12),
+            staged_snapshot_copy: Some(DatabaseSnapshotCopyTimings {
+                copy_ms: 13,
+                source_bytes: 1_024,
+                target_bytes: 1_024,
+            }),
+            core_promotion: Some(CorePromotionTimings {
+                total_ms: 89,
+                lock_recovery_ms: 1,
+                candidate_validation_ms: 11,
+                previous_validation_ms: 12,
+                rollback_backup_copy_ms: Some(13),
+                backup_validation_ms: Some(14),
+                prepared_journal_write_ms: 2,
+                prepared_journal_file_sync_ms: 3,
+                prepared_journal_directory_sync_ms: 4,
+                staged_to_live_restore_ms: 15,
+                promoted_validation_ms: 10,
+                committed_journal_ms: 2,
+                cleanup_ms: 1,
+                unattributed_ms: 1,
+                candidate_bytes: 2_048,
+                previous_live_bytes: Some(1_024),
+                rollback_backup_bytes: Some(1_024),
+            }),
             setup_existing_projection_ids_ms: Some(11),
             setup_seed_symbol_table_ms: Some(12),
             flush_files_ms: Some(13),
@@ -9223,6 +9247,16 @@ mod tests {
         ));
         assert!(markdown.contains(
             "staged_sqlite: wal_autocheckpoint_bytes=67108864 checkpoint_ms=11 sync_ms=12"
+        ));
+        assert!(
+            markdown
+                .contains("staged_snapshot_copy: copy_ms=13 source_bytes=1024 target_bytes=1024")
+        );
+        assert!(markdown.contains(
+            "core_promotion_ms: total=89 lock_recovery=1 candidate_validation=11 previous_validation=12 rollback_backup_copy=13 backup_validation=14 prepared_journal_write=2 prepared_journal_file_sync=3 prepared_journal_directory_sync=4 staged_to_live_restore=15 promoted_validation=10 committed_journal=2 cleanup=1 unattributed=1"
+        ));
+        assert!(markdown.contains(
+            "core_promotion_bytes: candidate=2048 previous_live=1024 rollback_backup=1024"
         ));
         assert!(markdown.contains("setup_ms: existing_projection_ids=11 seed_symbol_table=12"));
         assert!(

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -492,6 +492,50 @@ fn append_index_cache_timings(markdown: &mut String, timings: &IndexingPhaseTimi
             timings.staged_sqlite_sync_ms.unwrap_or(0),
         );
     }
+    if let Some(copy) = timings.staged_snapshot_copy.as_ref() {
+        let _ = writeln!(
+            markdown,
+            "staged_snapshot_copy: copy_ms={} source_bytes={} target_bytes={}",
+            copy.copy_ms, copy.source_bytes, copy.target_bytes,
+        );
+    }
+    if let Some(promotion) = timings.core_promotion.as_ref() {
+        let rollback_backup_copy_ms = promotion
+            .rollback_backup_copy_ms
+            .map_or_else(|| "none".to_string(), |value| value.to_string());
+        let backup_validation_ms = promotion
+            .backup_validation_ms
+            .map_or_else(|| "none".to_string(), |value| value.to_string());
+        let previous_live_bytes = promotion
+            .previous_live_bytes
+            .map_or_else(|| "none".to_string(), |value| value.to_string());
+        let rollback_backup_bytes = promotion
+            .rollback_backup_bytes
+            .map_or_else(|| "none".to_string(), |value| value.to_string());
+        let _ = writeln!(
+            markdown,
+            "core_promotion_ms: total={} lock_recovery={} candidate_validation={} previous_validation={} rollback_backup_copy={} backup_validation={} prepared_journal_write={} prepared_journal_file_sync={} prepared_journal_directory_sync={} staged_to_live_restore={} promoted_validation={} committed_journal={} cleanup={} unattributed={}",
+            promotion.total_ms,
+            promotion.lock_recovery_ms,
+            promotion.candidate_validation_ms,
+            promotion.previous_validation_ms,
+            rollback_backup_copy_ms,
+            backup_validation_ms,
+            promotion.prepared_journal_write_ms,
+            promotion.prepared_journal_file_sync_ms,
+            promotion.prepared_journal_directory_sync_ms,
+            promotion.staged_to_live_restore_ms,
+            promotion.promoted_validation_ms,
+            promotion.committed_journal_ms,
+            promotion.cleanup_ms,
+            promotion.unattributed_ms,
+        );
+        let _ = writeln!(
+            markdown,
+            "core_promotion_bytes: candidate={} previous_live={} rollback_backup={}",
+            promotion.candidate_bytes, previous_live_bytes, rollback_backup_bytes,
+        );
+    }
     append_optional_timings_line(
         markdown,
         "setup_ms",
@@ -3991,6 +4035,32 @@ mod tests {
         assert!(markdown.contains(
             "structural_artifact_cache: policy=read_through logical_lookups=3 physical_queries=3 hits=2 misses=1 reader_opens=1 lookup_wall_ms=7"
         ));
+    }
+
+    #[test]
+    fn index_timings_render_first_promotion_without_fabricated_backup_work() {
+        let timings = IndexingPhaseTimings {
+            core_promotion: Some(codestory_contracts::api::CorePromotionTimings {
+                total_ms: 9,
+                candidate_validation_ms: 2,
+                previous_validation_ms: 1,
+                staged_to_live_restore_ms: 3,
+                promoted_validation_ms: 2,
+                unattributed_ms: 1,
+                candidate_bytes: 4_096,
+                ..Default::default()
+            }),
+            ..IndexingPhaseTimings::default()
+        };
+        let mut markdown = String::new();
+
+        append_index_phase_timings(&mut markdown, &timings);
+
+        assert!(markdown.contains("rollback_backup_copy=none backup_validation=none"));
+        assert!(markdown.contains(
+            "core_promotion_bytes: candidate=4096 previous_live=none rollback_backup=none"
+        ));
+        assert!(!markdown.contains("staged_snapshot_copy:"));
     }
 
     #[test]

--- a/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
+++ b/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
@@ -365,6 +365,17 @@ fn retained_phase_timings_preserve_additive_diagnostics() {
     let index_json = serde_json::json!({
         "phase_timings": {
             "parse_index_ms": 12,
+            "staged_snapshot_copy": {
+                "copy_ms": 13,
+                "source_bytes": 1024,
+                "target_bytes": 1024
+            },
+            "core_promotion": {
+                "total_ms": 21,
+                "staged_to_live_restore_ms": 8,
+                "candidate_bytes": 2048,
+                "unattributed_ms": 1
+            },
             "future_additive_diagnostic": {"rows": 34}
         }
     });
@@ -372,6 +383,8 @@ fn retained_phase_timings_preserve_additive_diagnostics() {
     let retained = retained_phase_timings(&index_json);
 
     assert_eq!(retained["parse_index_ms"], 12);
+    assert_eq!(retained["staged_snapshot_copy"]["source_bytes"], 1_024);
+    assert_eq!(retained["core_promotion"]["total_ms"], 21);
     assert_eq!(retained["future_additive_diagnostic"]["rows"], 34);
 }
 

--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -72,8 +72,9 @@ pub use errors::{
     EmbeddingCapacityPressureDto, EmbeddingRetryStateDto,
 };
 pub use events::{
-    AppEventPayload, ArtifactCacheAccessTimings, ArtifactCachePolicyDto, FullRefreshWallTimings,
-    IndexingPhaseTimings, ProjectionPersistenceFamilyTimings, ProjectionPersistenceTimings,
+    AppEventPayload, ArtifactCacheAccessTimings, ArtifactCachePolicyDto, CorePromotionTimings,
+    DatabaseSnapshotCopyTimings, FullRefreshWallTimings, IndexingPhaseTimings,
+    ProjectionPersistenceFamilyTimings, ProjectionPersistenceTimings,
 };
 pub use ids::{EdgeId, NodeId};
 pub use types::{

--- a/crates/codestory-contracts/src/api/events.rs
+++ b/crates/codestory-contracts/src/api/events.rs
@@ -18,6 +18,38 @@ pub struct FullRefreshWallTimings {
     pub unattributed_ms: u32,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct DatabaseSnapshotCopyTimings {
+    pub copy_ms: u32,
+    pub source_bytes: u64,
+    pub target_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct CorePromotionTimings {
+    pub total_ms: u32,
+    pub lock_recovery_ms: u32,
+    pub candidate_validation_ms: u32,
+    pub previous_validation_ms: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollback_backup_copy_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_validation_ms: Option<u32>,
+    pub prepared_journal_write_ms: u32,
+    pub prepared_journal_file_sync_ms: u32,
+    pub prepared_journal_directory_sync_ms: u32,
+    pub staged_to_live_restore_ms: u32,
+    pub promoted_validation_ms: u32,
+    pub committed_journal_ms: u32,
+    pub cleanup_ms: u32,
+    pub unattributed_ms: u32,
+    pub candidate_bytes: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_live_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollback_backup_bytes: Option<u64>,
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum ArtifactCachePolicyDto {
@@ -217,6 +249,10 @@ pub struct IndexingPhaseTimings {
     pub staged_sqlite_checkpoint_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub staged_sqlite_sync_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub staged_snapshot_copy: Option<DatabaseSnapshotCopyTimings>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub core_promotion: Option<CorePromotionTimings>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub setup_existing_projection_ids_ms: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -426,6 +462,8 @@ mod tests {
             staged_sqlite_wal_autocheckpoint_bytes: None,
             staged_sqlite_checkpoint_ms: None,
             staged_sqlite_sync_ms: None,
+            staged_snapshot_copy: None,
+            core_promotion: None,
             setup_existing_projection_ids_ms: None,
             setup_seed_symbol_table_ms: None,
             flush_files_ms: None,
@@ -585,6 +623,8 @@ mod tests {
         );
         assert!(value.get("staged_sqlite_checkpoint_ms").is_none());
         assert!(value.get("staged_sqlite_sync_ms").is_none());
+        assert!(value.get("staged_snapshot_copy").is_none());
+        assert!(value.get("core_promotion").is_none());
         assert!(value.get("setup_existing_projection_ids_ms").is_none());
         assert!(value.get("setup_seed_symbol_table_ms").is_none());
         assert!(value.get("flush_files_ms").is_none());
@@ -629,6 +669,8 @@ mod tests {
         assert!(timings.search_symbol_index_commit_ms.is_none());
         assert!(timings.parser_artifact_cache.is_none());
         assert!(timings.structural_artifact_cache.is_none());
+        assert!(timings.staged_snapshot_copy.is_none());
+        assert!(timings.core_promotion.is_none());
     }
 
     #[test]
@@ -734,5 +776,46 @@ mod tests {
         let decoded: IndexingPhaseTimings =
             serde_json::from_value(value).expect("deserialize timings");
         assert_eq!(decoded.full_refresh_wall, Some(wall));
+    }
+
+    #[test]
+    fn test_indexing_phase_timings_round_trips_core_promotion_diagnostics() {
+        let snapshot_copy = DatabaseSnapshotCopyTimings {
+            copy_ms: 13,
+            source_bytes: 1_024,
+            target_bytes: 1_024,
+        };
+        let core_promotion = CorePromotionTimings {
+            total_ms: 89,
+            lock_recovery_ms: 1,
+            candidate_validation_ms: 11,
+            previous_validation_ms: 12,
+            rollback_backup_copy_ms: Some(13),
+            backup_validation_ms: Some(14),
+            prepared_journal_write_ms: 2,
+            prepared_journal_file_sync_ms: 3,
+            prepared_journal_directory_sync_ms: 4,
+            staged_to_live_restore_ms: 15,
+            promoted_validation_ms: 10,
+            committed_journal_ms: 2,
+            cleanup_ms: 1,
+            unattributed_ms: 1,
+            candidate_bytes: 2_048,
+            previous_live_bytes: Some(1_024),
+            rollback_backup_bytes: Some(1_024),
+        };
+        let timings = IndexingPhaseTimings {
+            staged_snapshot_copy: Some(snapshot_copy.clone()),
+            core_promotion: Some(core_promotion.clone()),
+            ..IndexingPhaseTimings::default()
+        };
+
+        let value = serde_json::to_value(&timings).expect("serialize timings");
+        assert_eq!(value["staged_snapshot_copy"]["copy_ms"], 13);
+        assert_eq!(value["core_promotion"]["staged_to_live_restore_ms"], 15);
+        let decoded: IndexingPhaseTimings =
+            serde_json::from_value(value).expect("deserialize timings");
+        assert_eq!(decoded.staged_snapshot_copy, Some(snapshot_copy));
+        assert_eq!(decoded.core_promotion, Some(core_promotion));
     }
 }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -13,7 +13,8 @@ use codestory_contracts::api::{
     AffectedUncoveredInputDto, AffectedUnmatchedPathDto, AgentAnswerDto, AgentAskRequest,
     AgentHybridWeightsDto, AgentPacketDto, AgentPacketRequestDto, ApiError, AppEventPayload,
     ArtifactCacheAccessTimings, ArtifactCachePolicyDto, BookmarkCategoryDto, BookmarkDto,
-    CreateBookmarkCategoryRequest, CreateBookmarkRequest, EdgeId, EdgeKind, EdgeOccurrencesRequest,
+    CorePromotionTimings, CreateBookmarkCategoryRequest, CreateBookmarkRequest,
+    DatabaseSnapshotCopyTimings, EdgeId, EdgeKind, EdgeOccurrencesRequest,
     EmbeddingProfileContractDto, FileCoverageDiagnosticDto, FrameworkRouteCoverageDto,
     FullRefreshWallTimings, GraphEdgeDto, GraphNodeDto, GraphRequest, GraphResponse,
     GroundingBudgetDto, GroundingCoverageBucketDto, GroundingFileDigestDto, GroundingSnapshotDto,
@@ -4341,6 +4342,38 @@ fn projection_persistence_timings(
         callable_projection: projection_persistence_family_timings(stats.callable_projection),
         file_errors: projection_persistence_family_timings(stats.file_errors),
         dirty_state: projection_persistence_family_timings(stats.dirty_state),
+    }
+}
+
+fn database_snapshot_copy_timings(
+    stats: codestory_store::DatabaseSnapshotCopyStats,
+) -> DatabaseSnapshotCopyTimings {
+    DatabaseSnapshotCopyTimings {
+        copy_ms: stats.copy_ms,
+        source_bytes: stats.source_bytes,
+        target_bytes: stats.target_bytes,
+    }
+}
+
+fn core_promotion_timings(stats: codestory_store::CorePromotionStats) -> CorePromotionTimings {
+    CorePromotionTimings {
+        total_ms: stats.total_ms,
+        lock_recovery_ms: stats.lock_recovery_ms,
+        candidate_validation_ms: stats.candidate_validation_ms,
+        previous_validation_ms: stats.previous_validation_ms,
+        rollback_backup_copy_ms: stats.rollback_backup_copy_ms,
+        backup_validation_ms: stats.backup_validation_ms,
+        prepared_journal_write_ms: stats.prepared_journal_write_ms,
+        prepared_journal_file_sync_ms: stats.prepared_journal_file_sync_ms,
+        prepared_journal_directory_sync_ms: stats.prepared_journal_directory_sync_ms,
+        staged_to_live_restore_ms: stats.staged_to_live_restore_ms,
+        promoted_validation_ms: stats.promoted_validation_ms,
+        committed_journal_ms: stats.committed_journal_ms,
+        cleanup_ms: stats.cleanup_ms,
+        unattributed_ms: stats.unattributed_ms,
+        candidate_bytes: stats.candidate_bytes,
+        previous_live_bytes: stats.previous_live_bytes,
+        rollback_backup_bytes: stats.rollback_backup_bytes,
     }
 }
 
@@ -15919,6 +15952,10 @@ fn index_full_for_runtime(
                 .sqlite_wal_autocheckpoint_bytes,
             staged_sqlite_checkpoint_ms: staged_publish_stats.sqlite_checkpoint_ms,
             staged_sqlite_sync_ms: staged_publish_stats.sqlite_sync_ms,
+            staged_snapshot_copy: staged_publish_stats
+                .snapshot_copy
+                .map(database_snapshot_copy_timings),
+            core_promotion: Some(core_promotion_timings(staged_publish_stats.core_promotion)),
             setup_existing_projection_ids_ms: resolution_telemetry.setup_existing_projection_ids_ms,
             setup_seed_symbol_table_ms: resolution_telemetry.setup_seed_symbol_table_ms,
             flush_files_ms: resolution_telemetry.flush_files_ms,
@@ -16660,6 +16697,10 @@ fn run_incremental_indexing_common(
                 .sqlite_wal_autocheckpoint_bytes,
             staged_sqlite_checkpoint_ms: staged_publish_stats.sqlite_checkpoint_ms,
             staged_sqlite_sync_ms: staged_publish_stats.sqlite_sync_ms,
+            staged_snapshot_copy: staged_publish_stats
+                .snapshot_copy
+                .map(database_snapshot_copy_timings),
+            core_promotion: Some(core_promotion_timings(staged_publish_stats.core_promotion)),
             setup_existing_projection_ids_ms: resolution_telemetry.setup_existing_projection_ids_ms,
             setup_seed_symbol_table_ms: resolution_telemetry.setup_seed_symbol_table_ms,
             flush_files_ms: resolution_telemetry.flush_files_ms,
@@ -27838,6 +27879,25 @@ fn build_llm_symbol_doc_text() -> String {
 
     #[test]
     fn full_and_incremental_publications_advance_one_durable_generation() {
+        let assert_promotion_reconciles = |promotion: &CorePromotionTimings| {
+            let named_ms = promotion
+                .lock_recovery_ms
+                .saturating_add(promotion.candidate_validation_ms)
+                .saturating_add(promotion.previous_validation_ms)
+                .saturating_add(promotion.rollback_backup_copy_ms.unwrap_or_default())
+                .saturating_add(promotion.backup_validation_ms.unwrap_or_default())
+                .saturating_add(promotion.prepared_journal_write_ms)
+                .saturating_add(promotion.prepared_journal_file_sync_ms)
+                .saturating_add(promotion.prepared_journal_directory_sync_ms)
+                .saturating_add(promotion.staged_to_live_restore_ms)
+                .saturating_add(promotion.promoted_validation_ms)
+                .saturating_add(promotion.committed_journal_ms)
+                .saturating_add(promotion.cleanup_ms);
+            assert_eq!(
+                named_ms.saturating_add(promotion.unattributed_ms),
+                promotion.total_ms
+            );
+        };
         let workspace = tempdir().expect("workspace dir");
         fs::write(
             workspace.path().join("lib.rs"),
@@ -27913,6 +27973,17 @@ fn build_llm_symbol_doc_text() -> String {
         );
         assert!(full_timings.staged_sqlite_checkpoint_ms.is_some());
         assert!(full_timings.staged_sqlite_sync_ms.is_some());
+        assert!(full_timings.staged_snapshot_copy.is_none());
+        let full_promotion = full_timings
+            .core_promotion
+            .as_ref()
+            .expect("first full promotion telemetry");
+        assert!(full_promotion.previous_live_bytes.is_none());
+        assert!(full_promotion.rollback_backup_copy_ms.is_none());
+        assert!(full_promotion.backup_validation_ms.is_none());
+        assert!(full_promotion.rollback_backup_bytes.is_none());
+        assert!(full_promotion.candidate_bytes > 0);
+        assert_promotion_reconciles(full_promotion);
         assert_eq!(full_timings.search_projection_rebuild_ms, Some(0));
         assert!(full_timings.search_symbol_stream_ms.is_some());
         assert!(
@@ -28065,6 +28136,27 @@ fn build_llm_symbol_doc_text() -> String {
         );
         assert!(incremental_timings.staged_sqlite_checkpoint_ms.is_none());
         assert!(incremental_timings.staged_sqlite_sync_ms.is_none());
+        let incremental_copy = incremental_timings
+            .staged_snapshot_copy
+            .as_ref()
+            .expect("incremental snapshot-copy telemetry");
+        assert!(incremental_copy.source_bytes > 0);
+        assert_eq!(incremental_copy.source_bytes, incremental_copy.target_bytes);
+        let incremental_promotion = incremental_timings
+            .core_promotion
+            .as_ref()
+            .expect("incremental promotion telemetry");
+        assert_eq!(
+            incremental_promotion.previous_live_bytes,
+            Some(incremental_copy.source_bytes)
+        );
+        assert_eq!(
+            incremental_promotion.rollback_backup_bytes,
+            incremental_promotion.previous_live_bytes
+        );
+        assert!(incremental_promotion.rollback_backup_copy_ms.is_some());
+        assert!(incremental_promotion.backup_validation_ms.is_some());
+        assert_promotion_reconciles(incremental_promotion);
         assert_eq!(incremental_timings.search_projection_rebuild_ms, Some(0));
         assert!(incremental_timings.search_symbol_stream_ms.is_some());
         assert!(
@@ -28082,9 +28174,22 @@ fn build_llm_symbol_doc_text() -> String {
         assert_ne!(second.generation_id, first.generation_id);
         assert_ne!(second.run_id, first.run_id);
 
-        controller
+        let second_full_timings = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
             .expect("second full publication");
+        assert!(second_full_timings.staged_snapshot_copy.is_none());
+        let second_full_promotion = second_full_timings
+            .core_promotion
+            .as_ref()
+            .expect("replacement full promotion telemetry");
+        assert!(second_full_promotion.previous_live_bytes.is_some());
+        assert!(second_full_promotion.rollback_backup_copy_ms.is_some());
+        assert!(second_full_promotion.backup_validation_ms.is_some());
+        assert_eq!(
+            second_full_promotion.rollback_backup_bytes,
+            second_full_promotion.previous_live_bytes
+        );
+        assert_promotion_reconciles(second_full_promotion);
         let third = controller
             .index_publication()
             .expect("read third publication")

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -19,8 +19,9 @@ pub use snapshot_store::{
 };
 pub use storage_impl::{
     BUILD_EDGE_SEED_BATCH_SIZE, BuildNodeLookup, CURRENT_SCHEMA_VERSION,
-    CallerProjectionRemovalSummary, DENSE_ANCHOR_MIGRATION_STATE_NATIVE,
-    DENSE_ANCHOR_PUBLICATION_SCHEMA_VERSION, DenseAnchorInput, DenseAnchorInputReuseMetadata,
+    CallerProjectionRemovalSummary, CorePromotionStats,
+    DENSE_ANCHOR_MIGRATION_STATE_NATIVE, DENSE_ANCHOR_PUBLICATION_SCHEMA_VERSION,
+    DatabaseSnapshotCopyStats, DenseAnchorInput, DenseAnchorInputReuseMetadata,
     DenseAnchorPublicationManifest, DenseReasonCounts, FileContentHash, FileInfo,
     FileProjectionRemovalSummary, FileRole, GroundingEdgeKindCount, GroundingFileSummary,
     GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState,

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -19,12 +19,11 @@ pub use snapshot_store::{
 };
 pub use storage_impl::{
     BUILD_EDGE_SEED_BATCH_SIZE, BuildNodeLookup, CURRENT_SCHEMA_VERSION,
-    CallerProjectionRemovalSummary, CorePromotionStats,
-    DENSE_ANCHOR_MIGRATION_STATE_NATIVE, DENSE_ANCHOR_PUBLICATION_SCHEMA_VERSION,
-    DatabaseSnapshotCopyStats, DenseAnchorInput, DenseAnchorInputReuseMetadata,
-    DenseAnchorPublicationManifest, DenseReasonCounts, FileContentHash, FileInfo,
-    FileProjectionRemovalSummary, FileRole, GroundingEdgeKindCount, GroundingFileSummary,
-    GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState,
+    CallerProjectionRemovalSummary, CorePromotionStats, DENSE_ANCHOR_MIGRATION_STATE_NATIVE,
+    DENSE_ANCHOR_PUBLICATION_SCHEMA_VERSION, DatabaseSnapshotCopyStats, DenseAnchorInput,
+    DenseAnchorInputReuseMetadata, DenseAnchorPublicationManifest, DenseReasonCounts,
+    FileContentHash, FileInfo, FileProjectionRemovalSummary, FileRole, GroundingEdgeKindCount,
+    GroundingFileSummary, GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState,
     IndexArtifactCacheReader, IndexArtifactCacheWrite, IndexPublicationMode,
     IndexPublicationRecord, LlmSymbolDoc, LlmSymbolDocReuseMetadata, LlmSymbolDocStats,
     ProjectionFlushBreakdown, ProjectionPersistenceFamilyStats, ProjectionPersistenceStats,

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -329,6 +329,23 @@ mod tests {
         root
     }
 
+    fn logical_database_bytes(path: &Path) -> u64 {
+        let connection =
+            rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .expect("open database for logical byte count");
+        let page_count: i64 = connection
+            .query_row("PRAGMA page_count", [], |row| row.get(0))
+            .expect("read database page count");
+        let page_size: i64 = connection
+            .query_row("PRAGMA page_size", [], |row| row.get(0))
+            .expect("read database page size");
+        let page_count = u64::try_from(page_count).expect("non-negative database page count");
+        let page_size = u64::try_from(page_size).expect("non-negative database page size");
+        page_count
+            .checked_mul(page_size)
+            .expect("logical database bytes")
+    }
+
     fn publish_empty_source_policy(store: &mut Store, publication: &crate::IndexPublicationRecord) {
         store
             .publish_structural_text_unit_generation(publication)
@@ -520,9 +537,7 @@ mod tests {
         assert_promotion_reconciles(&publish_stats.core_promotion);
         assert_eq!(
             publish_stats.core_promotion.candidate_bytes,
-            fs::metadata(&live_path)
-                .expect("read full replacement database size")
-                .len()
+            logical_database_bytes(&live_path)
         );
 
         let _ = fs::remove_dir_all(&temp);
@@ -690,9 +705,7 @@ mod tests {
         assert_promotion_reconciles(&publish_stats.core_promotion);
         assert_eq!(
             publish_stats.core_promotion.candidate_bytes,
-            fs::metadata(&live_path)
-                .expect("read promoted database size")
-                .len()
+            logical_database_bytes(&live_path)
         );
 
         let live = Store::open(&live_path).expect("open promoted live store");
@@ -854,38 +867,51 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_copy_reports_bounded_database_image_bytes() {
+    fn snapshot_copy_reports_wal_backed_logical_database_image_bytes() {
         const PAYLOAD_BYTES: usize = 2 * 1024 * 1024;
 
         let temp = fresh_temp_root("copy-telemetry");
         let source_path = temp.join("source.sqlite");
         let target_path = temp.join("target.sqlite");
-        {
-            let source = Store::open(&source_path).expect("open copy source");
-            source
-                .get_connection()
-                .execute_batch(
-                    "CREATE TABLE bounded_copy_payload (payload BLOB NOT NULL);
-                     INSERT INTO bounded_copy_payload(payload) VALUES (zeroblob(2097152));",
-                )
-                .expect("seed bounded copy payload");
-        }
-        let source_bytes = fs::metadata(&source_path)
+        let source = Store::open(&source_path).expect("open copy source");
+        source
+            .get_connection()
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .expect("disable automatic checkpoint");
+        source
+            .get_connection()
+            .execute_batch(
+                "CREATE TABLE bounded_copy_payload (payload BLOB NOT NULL);
+                 PRAGMA wal_checkpoint(TRUNCATE);",
+            )
+            .expect("checkpoint copy fixture schema");
+        let checkpointed_file_bytes = fs::metadata(&source_path)
             .expect("read source database size")
             .len();
-        assert!(source_bytes >= PAYLOAD_BYTES as u64);
+        source
+            .get_connection()
+            .execute(
+                "INSERT INTO bounded_copy_payload(payload) VALUES (zeroblob(?1))",
+                [PAYLOAD_BYTES as i64],
+            )
+            .expect("seed uncheckpointed WAL payload");
+        let wal_path = PathBuf::from(format!("{}-wal", source_path.display()));
+        assert!(
+            fs::metadata(&wal_path).expect("read source WAL size").len() > 0,
+            "fixture must retain committed pages in WAL"
+        );
+        let source_logical_bytes = logical_database_bytes(&source_path);
+        assert!(
+            source_logical_bytes > checkpointed_file_bytes,
+            "logical bytes must include the uncheckpointed WAL-backed pages"
+        );
 
         let stats =
             Store::copy_database_snapshot(&source_path, &target_path).expect("copy database");
 
-        assert_eq!(stats.source_bytes, source_bytes);
-        assert_eq!(
-            stats.target_bytes,
-            fs::metadata(&target_path)
-                .expect("read target database size")
-                .len()
-        );
+        assert_eq!(stats.source_bytes, source_logical_bytes);
         assert_eq!(stats.source_bytes, stats.target_bytes);
+        assert_eq!(stats.target_bytes, logical_database_bytes(&target_path));
         let copied = Store::open_read_only(&target_path).expect("open copied database");
         let payload_bytes: i64 = copied
             .get_connection()
@@ -897,6 +923,8 @@ mod tests {
             .expect("read copied payload");
         assert_eq!(payload_bytes, PAYLOAD_BYTES as i64);
 
+        drop(copied);
+        drop(source);
         let _ = fs::remove_dir_all(&temp);
     }
 
@@ -1106,9 +1134,7 @@ mod tests {
         assert_promotion_reconciles(&publish_stats.core_promotion);
         assert_eq!(
             publish_stats.core_promotion.candidate_bytes,
-            fs::metadata(&live_path)
-                .expect("read incremental promoted database size")
-                .len()
+            logical_database_bytes(&live_path)
         );
 
         let old_paths = old_reader

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -1,4 +1,7 @@
-use crate::{GroundingSnapshotMetadata, StorageError, StorageOpenMode, Store};
+use crate::{
+    CorePromotionStats, DatabaseSnapshotCopyStats, GroundingSnapshotMetadata, StorageError,
+    StorageOpenMode, Store,
+};
 use std::path::{Path, PathBuf};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -22,6 +25,8 @@ pub struct StagedSnapshotPublishStats {
     pub sqlite_wal_autocheckpoint_bytes: Option<u64>,
     pub sqlite_checkpoint_ms: Option<u32>,
     pub sqlite_sync_ms: Option<u32>,
+    pub snapshot_copy: Option<DatabaseSnapshotCopyStats>,
+    pub core_promotion: CorePromotionStats,
 }
 
 /// Derived grounding snapshot facade.
@@ -38,6 +43,7 @@ pub struct SnapshotStore<'a> {
 pub struct StagedSnapshot {
     path: PathBuf,
     store: Store,
+    snapshot_copy: Option<DatabaseSnapshotCopyStats>,
 }
 
 impl<'a> SnapshotStore<'a> {
@@ -89,7 +95,10 @@ impl<'a> SnapshotStore<'a> {
     }
 
     /// Atomically promote a finalized staged database to the live path.
-    pub fn promote_staged(staged_path: &Path, live_path: &Path) -> Result<(), StorageError> {
+    pub fn promote_staged(
+        staged_path: &Path,
+        live_path: &Path,
+    ) -> Result<CorePromotionStats, StorageError> {
         Store::promote_staged_snapshot(staged_path, live_path)
     }
 
@@ -180,24 +189,39 @@ impl StagedSnapshot {
     fn open(live_path: &Path) -> Result<Self, StorageError> {
         let path = SnapshotStore::staged_path(live_path);
         let store = Store::open_build(&path)?;
-        Ok(Self { path, store })
+        Ok(Self {
+            path,
+            store,
+            snapshot_copy: None,
+        })
     }
 
     fn open_disposable_full_refresh(live_path: &Path) -> Result<Self, StorageError> {
         let path = SnapshotStore::staged_path(live_path);
         let store = Store::open_disposable_full_build(&path)?;
-        Ok(Self { path, store })
+        Ok(Self {
+            path,
+            store,
+            snapshot_copy: None,
+        })
     }
 
     fn clone_live(live_path: &Path) -> Result<Self, StorageError> {
         let path = SnapshotStore::staged_path(live_path);
         Store::discard_staged_snapshot(&path)?;
-        if let Err(error) = Store::copy_database_snapshot(live_path, &path) {
-            let _ = Store::discard_staged_snapshot(&path);
-            return Err(error);
-        }
+        let snapshot_copy = match Store::copy_database_snapshot(live_path, &path) {
+            Ok(stats) => stats,
+            Err(error) => {
+                let _ = Store::discard_staged_snapshot(&path);
+                return Err(error);
+            }
+        };
         match Store::open_with_mode(&path, StorageOpenMode::Build) {
-            Ok(store) => Ok(Self { path, store }),
+            Ok(store) => Ok(Self {
+                path,
+                store,
+                snapshot_copy: Some(snapshot_copy),
+            }),
             Err(error) => {
                 let _ = Store::discard_staged_snapshot(&path);
                 Err(error)
@@ -239,14 +263,17 @@ impl StagedSnapshot {
     ) -> Result<StagedSnapshotPublishStats, StorageError> {
         let seal_stats = self.store.seal_disposable_full_build()?;
         let path = self.path;
+        let snapshot_copy = self.snapshot_copy;
         drop(self.store);
-        SnapshotStore::promote_staged(&path, live_path)?;
+        let core_promotion = SnapshotStore::promote_staged(&path, live_path)?;
         Ok(StagedSnapshotPublishStats {
             sqlite_wal_autocheckpoint_bytes: seal_stats
                 .as_ref()
                 .map(|stats| stats.wal_autocheckpoint_bytes),
             sqlite_checkpoint_ms: seal_stats.as_ref().map(|stats| stats.checkpoint_ms),
             sqlite_sync_ms: seal_stats.as_ref().map(|stats| stats.sync_ms),
+            snapshot_copy,
+            core_promotion,
         })
     }
 }
@@ -316,6 +343,29 @@ mod tests {
                 &[],
             )
             .expect("publish empty source policy identity");
+    }
+
+    fn named_promotion_ms(stats: &CorePromotionStats) -> u32 {
+        stats
+            .lock_recovery_ms
+            .saturating_add(stats.candidate_validation_ms)
+            .saturating_add(stats.previous_validation_ms)
+            .saturating_add(stats.rollback_backup_copy_ms.unwrap_or_default())
+            .saturating_add(stats.backup_validation_ms.unwrap_or_default())
+            .saturating_add(stats.prepared_journal_write_ms)
+            .saturating_add(stats.prepared_journal_file_sync_ms)
+            .saturating_add(stats.prepared_journal_directory_sync_ms)
+            .saturating_add(stats.staged_to_live_restore_ms)
+            .saturating_add(stats.promoted_validation_ms)
+            .saturating_add(stats.committed_journal_ms)
+            .saturating_add(stats.cleanup_ms)
+    }
+
+    fn assert_promotion_reconciles(stats: &CorePromotionStats) {
+        assert_eq!(
+            named_promotion_ms(stats).saturating_add(stats.unattributed_ms),
+            stats.total_ms
+        );
     }
 
     #[test]
@@ -388,6 +438,92 @@ mod tests {
             .expect("metadata row");
         assert_eq!(metadata.summary_state, GroundingSnapshotState::Ready);
         assert_eq!(metadata.detail_state, GroundingSnapshotState::Dirty);
+
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn full_replacement_reports_backup_and_restore_without_incremental_clone() {
+        let temp = fresh_temp_root("full-replacement-telemetry");
+        let live_path = temp.join("live.sqlite");
+        {
+            let mut live = Store::open(&live_path).expect("open previous live store");
+            live.insert_files_batch(&[crate::FileInfo {
+                id: 1,
+                path: PathBuf::from("old.rs"),
+                language: "rust".to_string(),
+                modification_time: 1,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: crate::FileRole::Source,
+            }])
+            .expect("seed previous live file");
+            let publication = crate::IndexPublicationRecord {
+                generation: 1,
+                generation_id: "old-generation".to_string(),
+                run_id: "old-run".to_string(),
+                mode: crate::IndexPublicationMode::Full,
+                published_at_epoch_ms: 1,
+            };
+            live.put_index_publication(&publication)
+                .expect("identify previous live publication");
+            publish_empty_source_policy(&mut live, &publication);
+        }
+
+        let mut staged = SnapshotStore::open_staged(&live_path).expect("open replacement stage");
+        staged
+            .store_mut()
+            .insert_files_batch(&[crate::FileInfo {
+                id: 2,
+                path: PathBuf::from("new.rs"),
+                language: "rust".to_string(),
+                modification_time: 2,
+                indexed: true,
+                complete: true,
+                line_count: 2,
+                file_role: crate::FileRole::Source,
+            }])
+            .expect("seed replacement file");
+        let publication = crate::IndexPublicationRecord {
+            generation: 2,
+            generation_id: "new-generation".to_string(),
+            run_id: "new-run".to_string(),
+            mode: crate::IndexPublicationMode::Full,
+            published_at_epoch_ms: 2,
+        };
+        staged
+            .store_mut()
+            .put_index_publication(&publication)
+            .expect("identify replacement publication");
+        publish_empty_source_policy(staged.store_mut(), &publication);
+
+        let publish_stats = staged
+            .publish_with_stats(&live_path)
+            .expect("publish full replacement");
+        assert!(publish_stats.snapshot_copy.is_none());
+        assert!(
+            publish_stats
+                .core_promotion
+                .rollback_backup_copy_ms
+                .is_some()
+        );
+        assert!(publish_stats.core_promotion.backup_validation_ms.is_some());
+        assert_eq!(
+            publish_stats.core_promotion.previous_live_bytes,
+            publish_stats.core_promotion.rollback_backup_bytes
+        );
+        assert!(
+            publish_stats.core_promotion.previous_live_bytes.is_some(),
+            "full replacement must report the previous live image"
+        );
+        assert_promotion_reconciles(&publish_stats.core_promotion);
+        assert_eq!(
+            publish_stats.core_promotion.candidate_bytes,
+            fs::metadata(&live_path)
+                .expect("read full replacement database size")
+                .len()
+        );
 
         let _ = fs::remove_dir_all(&temp);
     }
@@ -541,6 +677,23 @@ mod tests {
         );
         assert!(publish_stats.sqlite_checkpoint_ms.is_some());
         assert!(publish_stats.sqlite_sync_ms.is_some());
+        assert!(publish_stats.snapshot_copy.is_none());
+        assert!(publish_stats.core_promotion.previous_live_bytes.is_none());
+        assert!(
+            publish_stats
+                .core_promotion
+                .rollback_backup_copy_ms
+                .is_none()
+        );
+        assert!(publish_stats.core_promotion.backup_validation_ms.is_none());
+        assert!(publish_stats.core_promotion.rollback_backup_bytes.is_none());
+        assert_promotion_reconciles(&publish_stats.core_promotion);
+        assert_eq!(
+            publish_stats.core_promotion.candidate_bytes,
+            fs::metadata(&live_path)
+                .expect("read promoted database size")
+                .len()
+        );
 
         let live = Store::open(&live_path).expect("open promoted live store");
         let quick_check: String = live
@@ -696,6 +849,53 @@ mod tests {
         assert!(!staged_path.exists());
         assert!(!PathBuf::from(format!("{}-wal", staged_path.display())).exists());
         assert!(!PathBuf::from(format!("{}-shm", staged_path.display())).exists());
+
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn snapshot_copy_reports_bounded_database_image_bytes() {
+        const PAYLOAD_BYTES: usize = 2 * 1024 * 1024;
+
+        let temp = fresh_temp_root("copy-telemetry");
+        let source_path = temp.join("source.sqlite");
+        let target_path = temp.join("target.sqlite");
+        {
+            let source = Store::open(&source_path).expect("open copy source");
+            source
+                .get_connection()
+                .execute_batch(
+                    "CREATE TABLE bounded_copy_payload (payload BLOB NOT NULL);
+                     INSERT INTO bounded_copy_payload(payload) VALUES (zeroblob(2097152));",
+                )
+                .expect("seed bounded copy payload");
+        }
+        let source_bytes = fs::metadata(&source_path)
+            .expect("read source database size")
+            .len();
+        assert!(source_bytes >= PAYLOAD_BYTES as u64);
+
+        let stats =
+            Store::copy_database_snapshot(&source_path, &target_path).expect("copy database");
+
+        assert_eq!(stats.source_bytes, source_bytes);
+        assert_eq!(
+            stats.target_bytes,
+            fs::metadata(&target_path)
+                .expect("read target database size")
+                .len()
+        );
+        assert_eq!(stats.source_bytes, stats.target_bytes);
+        let copied = Store::open_read_only(&target_path).expect("open copied database");
+        let payload_bytes: i64 = copied
+            .get_connection()
+            .query_row(
+                "SELECT length(payload) FROM bounded_copy_payload",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read copied payload");
+        assert_eq!(payload_bytes, PAYLOAD_BYTES as i64);
 
         let _ = fs::remove_dir_all(&temp);
     }
@@ -880,8 +1080,36 @@ mod tests {
         old_observed_rx
             .recv_timeout(std::time::Duration::from_secs(5))
             .expect("racing reader observed old generation");
-        staged.publish(&live_path).expect("publish new generation");
+        let publish_stats = staged
+            .publish_with_stats(&live_path)
+            .expect("publish new generation");
         racing_reader.join().expect("racing reader");
+        let snapshot_copy = publish_stats
+            .snapshot_copy
+            .expect("incremental clone telemetry");
+        assert_eq!(snapshot_copy.source_bytes, snapshot_copy.target_bytes);
+        assert_eq!(
+            publish_stats.core_promotion.previous_live_bytes,
+            Some(snapshot_copy.source_bytes)
+        );
+        assert_eq!(
+            publish_stats.core_promotion.rollback_backup_bytes,
+            publish_stats.core_promotion.previous_live_bytes
+        );
+        assert!(
+            publish_stats
+                .core_promotion
+                .rollback_backup_copy_ms
+                .is_some()
+        );
+        assert!(publish_stats.core_promotion.backup_validation_ms.is_some());
+        assert_promotion_reconciles(&publish_stats.core_promotion);
+        assert_eq!(
+            publish_stats.core_promotion.candidate_bytes,
+            fs::metadata(&live_path)
+                .expect("read incremental promoted database size")
+                .len()
+        );
 
         let old_paths = old_reader
             .get_files()

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -90,6 +90,10 @@ const STRUCTURAL_TEXT_PROMOTION_MIN_SCHEMA_VERSION: u32 = 28;
 const DISPOSABLE_FULL_BUILD_WAL_AUTOCHECKPOINT_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Successful SQLite backup timing and logical database-image sizes.
+///
+/// Logical bytes are SQLite `page_count * page_size` for the source snapshot
+/// and copied target. They are not filesystem allocation or physical-write
+/// telemetry.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DatabaseSnapshotCopyStats {
     pub copy_ms: u32,
@@ -204,10 +208,29 @@ fn duration_ms(duration: Duration) -> u32 {
     duration.as_millis().min(u32::MAX as u128) as u32
 }
 
-fn database_logical_bytes(path: &Path) -> Result<u64, StorageError> {
-    fs::metadata(path)
-        .map(|metadata| metadata.len())
-        .map_err(|error| promotion_path_error("read database metadata for", path, error))
+fn database_logical_bytes(connection: &Connection) -> Result<u64, StorageError> {
+    let page_count: i64 = connection.query_row("PRAGMA page_count", [], |row| row.get(0))?;
+    let page_size: i64 = connection.query_row("PRAGMA page_size", [], |row| row.get(0))?;
+    let page_count = u64::try_from(page_count).map_err(|_| {
+        promotion_error(format!(
+            "SQLite reported an invalid negative page_count: {page_count}"
+        ))
+    })?;
+    let page_size = u64::try_from(page_size).map_err(|_| {
+        promotion_error(format!(
+            "SQLite reported an invalid negative page_size: {page_size}"
+        ))
+    })?;
+    page_count.checked_mul(page_size).ok_or_else(|| {
+        promotion_error(format!(
+            "SQLite logical database bytes overflowed: page_count={page_count}, page_size={page_size}"
+        ))
+    })
+}
+
+fn database_logical_bytes_at_path(path: &Path) -> Result<u64, StorageError> {
+    let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    database_logical_bytes(&connection)
 }
 
 fn clamp_i64_to_u32(value: i64) -> u32 {
@@ -3436,7 +3459,6 @@ impl Storage {
         source_path: &Path,
         target_path: &Path,
     ) -> Result<DatabaseSnapshotCopyStats, StorageError> {
-        let copy_started = Instant::now();
         recover_interrupted_promotion(source_path)?;
         if let Some(parent) = target_path.parent() {
             fs::create_dir_all(parent).map_err(|err| {
@@ -3446,12 +3468,15 @@ impl Storage {
                 ))
             })?;
         }
-        let source_bytes = database_logical_bytes(source_path)?;
         let source = Connection::open_with_flags(source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let source_bytes = database_logical_bytes(&source)?;
+        let copy_started = Instant::now();
         source.backup(MAIN_DB, target_path, None::<fn(rusqlite::backup::Progress)>)?;
-        let target_bytes = database_logical_bytes(target_path)?;
+        let copy_ms = duration_ms(copy_started.elapsed());
+        let target = Connection::open_with_flags(target_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let target_bytes = database_logical_bytes(&target)?;
         Ok(DatabaseSnapshotCopyStats {
-            copy_ms: duration_ms(copy_started.elapsed()),
+            copy_ms,
             source_bytes,
             target_bytes,
         })
@@ -4816,7 +4841,7 @@ impl Storage {
                 staged_path.display()
             )));
         }
-        let candidate_bytes = database_logical_bytes(staged_path)?;
+        let candidate_bytes = database_logical_bytes_at_path(staged_path)?;
         durations.candidate_validation = candidate_validation_started.elapsed();
 
         let previous_validation_started = Instant::now();
@@ -4833,7 +4858,7 @@ impl Storage {
         cleanup_sqlite_sidecars(&backup_path)?;
         let previous_live_bytes = previous
             .as_ref()
-            .map(|_| database_logical_bytes(live_path))
+            .map(|_| database_logical_bytes_at_path(live_path))
             .transpose()?;
         durations.previous_validation = previous_validation_started.elapsed();
 
@@ -4874,7 +4899,7 @@ impl Storage {
                 &previous_structural_text,
                 "Promotion backup",
             )?;
-            rollback_backup_bytes = Some(database_logical_bytes(&backup_path)?);
+            rollback_backup_bytes = Some(database_logical_bytes_at_path(&backup_path)?);
             durations.backup_validation = Some(backup_validation_started.elapsed());
         }
 

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -89,6 +89,127 @@ const SOURCE_POLICY_PROMOTION_MIN_SCHEMA_VERSION: u32 = 27;
 const STRUCTURAL_TEXT_PROMOTION_MIN_SCHEMA_VERSION: u32 = 28;
 const DISPOSABLE_FULL_BUILD_WAL_AUTOCHECKPOINT_BYTES: u64 = 64 * 1024 * 1024;
 
+/// Successful SQLite backup timing and logical database-image sizes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DatabaseSnapshotCopyStats {
+    pub copy_ms: u32,
+    pub source_bytes: u64,
+    pub target_bytes: u64,
+}
+
+/// Successful core promotion timing and logical database-image sizes.
+///
+/// These phases are nested within the caller's publication wall. Optional
+/// backup phases are present only when a previous live publication existed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CorePromotionStats {
+    pub total_ms: u32,
+    pub lock_recovery_ms: u32,
+    pub candidate_validation_ms: u32,
+    pub previous_validation_ms: u32,
+    pub rollback_backup_copy_ms: Option<u32>,
+    pub backup_validation_ms: Option<u32>,
+    pub prepared_journal_write_ms: u32,
+    pub prepared_journal_file_sync_ms: u32,
+    pub prepared_journal_directory_sync_ms: u32,
+    pub staged_to_live_restore_ms: u32,
+    pub promoted_validation_ms: u32,
+    pub committed_journal_ms: u32,
+    pub cleanup_ms: u32,
+    pub unattributed_ms: u32,
+    pub candidate_bytes: u64,
+    pub previous_live_bytes: Option<u64>,
+    pub rollback_backup_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct PromotionJournalWriteStats {
+    write: Duration,
+    file_sync: Duration,
+    directory_sync: Duration,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct CorePromotionDurations {
+    lock_recovery: Duration,
+    candidate_validation: Duration,
+    previous_validation: Duration,
+    rollback_backup_copy: Option<Duration>,
+    backup_validation: Option<Duration>,
+    prepared_journal_write: Duration,
+    prepared_journal_file_sync: Duration,
+    prepared_journal_directory_sync: Duration,
+    staged_to_live_restore: Duration,
+    promoted_validation: Duration,
+    committed_journal: Duration,
+    cleanup: Duration,
+}
+
+impl CorePromotionDurations {
+    fn finish(
+        self,
+        total: Duration,
+        candidate_bytes: u64,
+        previous_live_bytes: Option<u64>,
+        rollback_backup_bytes: Option<u64>,
+    ) -> CorePromotionStats {
+        let total_ms = duration_ms(total);
+        let lock_recovery_ms = duration_ms(self.lock_recovery);
+        let candidate_validation_ms = duration_ms(self.candidate_validation);
+        let previous_validation_ms = duration_ms(self.previous_validation);
+        let rollback_backup_copy_ms = self.rollback_backup_copy.map(duration_ms);
+        let backup_validation_ms = self.backup_validation.map(duration_ms);
+        let prepared_journal_write_ms = duration_ms(self.prepared_journal_write);
+        let prepared_journal_file_sync_ms = duration_ms(self.prepared_journal_file_sync);
+        let prepared_journal_directory_sync_ms = duration_ms(self.prepared_journal_directory_sync);
+        let staged_to_live_restore_ms = duration_ms(self.staged_to_live_restore);
+        let promoted_validation_ms = duration_ms(self.promoted_validation);
+        let committed_journal_ms = duration_ms(self.committed_journal);
+        let cleanup_ms = duration_ms(self.cleanup);
+        let named_ms = lock_recovery_ms
+            .saturating_add(candidate_validation_ms)
+            .saturating_add(previous_validation_ms)
+            .saturating_add(rollback_backup_copy_ms.unwrap_or_default())
+            .saturating_add(backup_validation_ms.unwrap_or_default())
+            .saturating_add(prepared_journal_write_ms)
+            .saturating_add(prepared_journal_file_sync_ms)
+            .saturating_add(prepared_journal_directory_sync_ms)
+            .saturating_add(staged_to_live_restore_ms)
+            .saturating_add(promoted_validation_ms)
+            .saturating_add(committed_journal_ms)
+            .saturating_add(cleanup_ms);
+        CorePromotionStats {
+            total_ms,
+            lock_recovery_ms,
+            candidate_validation_ms,
+            previous_validation_ms,
+            rollback_backup_copy_ms,
+            backup_validation_ms,
+            prepared_journal_write_ms,
+            prepared_journal_file_sync_ms,
+            prepared_journal_directory_sync_ms,
+            staged_to_live_restore_ms,
+            promoted_validation_ms,
+            committed_journal_ms,
+            cleanup_ms,
+            unattributed_ms: total_ms.saturating_sub(named_ms),
+            candidate_bytes,
+            previous_live_bytes,
+            rollback_backup_bytes,
+        }
+    }
+}
+
+fn duration_ms(duration: Duration) -> u32 {
+    duration.as_millis().min(u32::MAX as u128) as u32
+}
+
+fn database_logical_bytes(path: &Path) -> Result<u64, StorageError> {
+    fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .map_err(|error| promotion_path_error("read database metadata for", path, error))
+}
+
 fn clamp_i64_to_u32(value: i64) -> u32 {
     if value <= 0 {
         0
@@ -747,7 +868,11 @@ fn sync_promotion_parent(path: &Path) -> Result<(), StorageError> {
     Ok(())
 }
 
-fn write_promotion_journal(path: &Path, journal: &PromotionJournal) -> Result<(), StorageError> {
+fn write_promotion_journal(
+    path: &Path,
+    journal: &PromotionJournal,
+) -> Result<PromotionJournalWriteStats, StorageError> {
+    let write_started = Instant::now();
     let bytes = serde_json::to_vec(journal)
         .map_err(|error| promotion_path_error("serialize", path, error))?;
     let mut file = OpenOptions::new()
@@ -755,19 +880,34 @@ fn write_promotion_journal(path: &Path, journal: &PromotionJournal) -> Result<()
         .write(true)
         .open(path)
         .map_err(|error| promotion_path_error("create", path, error))?;
-    let write_result = file.write_all(&bytes).and_then(|()| file.sync_all());
-    drop(file);
-    if let Err(error) = write_result {
+    if let Err(error) = file.write_all(&bytes) {
+        drop(file);
         let _ = fs::remove_file(path);
         let _ = sync_promotion_parent(path);
         return Err(promotion_path_error("persist", path, error));
     }
+    let write = write_started.elapsed();
+    let file_sync_started = Instant::now();
+    if let Err(error) = file.sync_all() {
+        drop(file);
+        let _ = fs::remove_file(path);
+        let _ = sync_promotion_parent(path);
+        return Err(promotion_path_error("persist", path, error));
+    }
+    let file_sync = file_sync_started.elapsed();
+    drop(file);
+    let directory_sync_started = Instant::now();
     if let Err(error) = sync_promotion_parent(path) {
         let _ = fs::remove_file(path);
         let _ = sync_promotion_parent(path);
         return Err(error);
     }
-    Ok(())
+    let directory_sync = directory_sync_started.elapsed();
+    Ok(PromotionJournalWriteStats {
+        write,
+        file_sync,
+        directory_sync,
+    })
 }
 
 fn commit_promotion_journal(
@@ -3295,7 +3435,8 @@ impl Storage {
     pub fn copy_database_snapshot(
         source_path: &Path,
         target_path: &Path,
-    ) -> Result<(), StorageError> {
+    ) -> Result<DatabaseSnapshotCopyStats, StorageError> {
+        let copy_started = Instant::now();
         recover_interrupted_promotion(source_path)?;
         if let Some(parent) = target_path.parent() {
             fs::create_dir_all(parent).map_err(|err| {
@@ -3305,9 +3446,15 @@ impl Storage {
                 ))
             })?;
         }
+        let source_bytes = database_logical_bytes(source_path)?;
         let source = Connection::open_with_flags(source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         source.backup(MAIN_DB, target_path, None::<fn(rusqlite::backup::Progress)>)?;
-        Ok(())
+        let target_bytes = database_logical_bytes(target_path)?;
+        Ok(DatabaseSnapshotCopyStats {
+            copy_ms: duration_ms(copy_started.elapsed()),
+            source_bytes,
+            target_bytes,
+        })
     }
 
     /// Create an in-memory store for tests and short-lived callers.
@@ -4630,7 +4777,11 @@ impl Storage {
     pub fn promote_staged_snapshot(
         staged_path: &Path,
         live_path: &Path,
-    ) -> Result<(), StorageError> {
+    ) -> Result<CorePromotionStats, StorageError> {
+        let promotion_started = Instant::now();
+        let mut durations = CorePromotionDurations::default();
+
+        let lock_recovery_started = Instant::now();
         let _promotion_lock = PromotionLock::acquire(live_path)?;
         recover_interrupted_promotion_locked(live_path)?;
         if promotion_artifacts_exist(live_path) {
@@ -4642,6 +4793,9 @@ impl Storage {
         let backup_path = live_path.with_extension("sqlite.backup");
         let prepared_path = promotion_prepared_journal_path(live_path);
         let committed_path = promotion_committed_journal_path(live_path);
+        durations.lock_recovery = lock_recovery_started.elapsed();
+
+        let candidate_validation_started = Instant::now();
         let candidate = require_complete_promotion_database_identity(
             staged_path,
             "Staged promotion candidate",
@@ -4662,6 +4816,10 @@ impl Storage {
                 staged_path.display()
             )));
         }
+        let candidate_bytes = database_logical_bytes(staged_path)?;
+        durations.candidate_validation = candidate_validation_started.elapsed();
+
+        let previous_validation_started = Instant::now();
         let recovery_contract = RecoveryDatabaseContract::CurrentPromotion;
         let previous = read_recovery_database_identity(live_path, recovery_contract)?;
         let previous_source_policy = match previous.as_ref() {
@@ -4673,8 +4831,15 @@ impl Storage {
             None => None,
         };
         cleanup_sqlite_sidecars(&backup_path)?;
+        let previous_live_bytes = previous
+            .as_ref()
+            .map(|_| database_logical_bytes(live_path))
+            .transpose()?;
+        durations.previous_validation = previous_validation_started.elapsed();
 
+        let mut rollback_backup_bytes = None;
         if previous.is_some() {
+            let rollback_backup_copy_started = Instant::now();
             let live_conn = Connection::open(live_path)?;
             let _ = live_conn.busy_timeout(Duration::from_millis(2_500));
             live_conn.backup(
@@ -4683,6 +4848,9 @@ impl Storage {
                 None::<fn(rusqlite::backup::Progress)>,
             )?;
             drop(live_conn);
+            durations.rollback_backup_copy = Some(rollback_backup_copy_started.elapsed());
+
+            let backup_validation_started = Instant::now();
             let backup_identity = require_recovery_database_identity(
                 &backup_path,
                 "Promotion backup",
@@ -4706,6 +4874,8 @@ impl Storage {
                 &previous_structural_text,
                 "Promotion backup",
             )?;
+            rollback_backup_bytes = Some(database_logical_bytes(&backup_path)?);
+            durations.backup_validation = Some(backup_validation_started.elapsed());
         }
 
         let prepared = PromotionJournal {
@@ -4717,13 +4887,20 @@ impl Storage {
             previous_structural_text,
             candidate_structural_text: candidate_structural_text.clone(),
         };
-        if let Err(error) = write_promotion_journal(&prepared_path, &prepared) {
-            if !prepared_path.exists() {
-                let _ = cleanup_sqlite_sidecars(&backup_path);
+        let journal_write_stats = match write_promotion_journal(&prepared_path, &prepared) {
+            Ok(stats) => stats,
+            Err(error) => {
+                if !prepared_path.exists() {
+                    let _ = cleanup_sqlite_sidecars(&backup_path);
+                }
+                return Err(error);
             }
-            return Err(error);
-        }
+        };
+        durations.prepared_journal_write = journal_write_stats.write;
+        durations.prepared_journal_file_sync = journal_write_stats.file_sync;
+        durations.prepared_journal_directory_sync = journal_write_stats.directory_sync;
 
+        let staged_to_live_restore_started = Instant::now();
         let mut live_conn = Connection::open(live_path)?;
         let _ = live_conn.busy_timeout(Duration::from_millis(2_500));
         live_conn.pragma_update(None, "synchronous", "FULL")?;
@@ -4762,7 +4939,9 @@ impl Storage {
             )));
         }
         drop(live_conn);
+        durations.staged_to_live_restore = staged_to_live_restore_started.elapsed();
 
+        let promoted_validation_started = Instant::now();
         let published =
             require_complete_promotion_database_identity(live_path, "Promoted live database")?;
         if published != candidate {
@@ -4790,14 +4969,18 @@ impl Storage {
             let _ = rollback_prepared_promotion(live_path, &prepared);
             return Err(error);
         }
+        durations.promoted_validation = promoted_validation_started.elapsed();
 
+        let committed_journal_started = Instant::now();
         if let Err(error) = commit_promotion_journal(&prepared_path, &committed_path) {
             if !committed_path.exists() {
                 let _ = rollback_prepared_promotion(live_path, &prepared);
             }
             return Err(error);
         }
+        durations.committed_journal = committed_journal_started.elapsed();
 
+        let cleanup_started = Instant::now();
         if let Err(error) = cleanup_sqlite_sidecars(staged_path) {
             tracing::warn!(
                 staged_path = %staged_path.display(),
@@ -4812,7 +4995,13 @@ impl Storage {
                 "committed promotion retained recovery artifacts"
             );
         }
-        Ok(())
+        durations.cleanup = cleanup_started.elapsed();
+        Ok(durations.finish(
+            promotion_started.elapsed(),
+            candidate_bytes,
+            previous_live_bytes,
+            rollback_backup_bytes,
+        ))
     }
 
     pub fn discard_staged_snapshot(staged_path: &Path) -> Result<(), StorageError> {

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -69,6 +69,26 @@ fn assert_no_sqlite_sidecars(path: &Path) {
     assert!(!PathBuf::from(format!("{}-journal", path.display())).exists());
 }
 
+fn assert_core_promotion_stats_reconcile(stats: &CorePromotionStats) {
+    let named_ms = stats
+        .lock_recovery_ms
+        .saturating_add(stats.candidate_validation_ms)
+        .saturating_add(stats.previous_validation_ms)
+        .saturating_add(stats.rollback_backup_copy_ms.unwrap_or_default())
+        .saturating_add(stats.backup_validation_ms.unwrap_or_default())
+        .saturating_add(stats.prepared_journal_write_ms)
+        .saturating_add(stats.prepared_journal_file_sync_ms)
+        .saturating_add(stats.prepared_journal_directory_sync_ms)
+        .saturating_add(stats.staged_to_live_restore_ms)
+        .saturating_add(stats.promoted_validation_ms)
+        .saturating_add(stats.committed_journal_ms)
+        .saturating_add(stats.cleanup_ms);
+    assert_eq!(
+        named_ms.saturating_add(stats.unattributed_ms),
+        stats.total_ms
+    );
+}
+
 fn durable_sqlite_state(path: &Path) -> Vec<(PathBuf, Option<Vec<u8>>)> {
     [path.to_path_buf(), sqlite_sidecar_path(path, "-wal")]
         .into_iter()
@@ -6000,8 +6020,16 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
     assert!(!prepared_path.exists(), "rollback must consume its journal");
     assert!(!committed_path.exists(), "aborted promotion cannot commit");
 
-    Storage::promote_staged_snapshot(&staged_path, &live_path)
+    let retry_stats = Storage::promote_staged_snapshot(&staged_path, &live_path)
         .expect("retry promotion after abort");
+    assert_core_promotion_stats_reconcile(&retry_stats);
+    assert!(retry_stats.previous_live_bytes.is_some());
+    assert!(retry_stats.rollback_backup_copy_ms.is_some());
+    assert!(retry_stats.backup_validation_ms.is_some());
+    assert_eq!(
+        retry_stats.rollback_backup_bytes,
+        retry_stats.previous_live_bytes
+    );
     let live = Storage::open(&live_path).expect("open recovered live generation");
     assert_eq!(
         live.get_files().expect("read recovered generation")[0].path,
@@ -6051,8 +6079,16 @@ fn retained_committed_promotion_stays_live_and_blocks_the_next_writer() {
         .expect("publish second staged exclusion identity");
     std::fs::write(&cleanup_failure_path, b"blocked").expect("inject cleanup failure");
 
-    Storage::promote_staged_snapshot(&staged_path, &live_path)
+    let committed_stats = Storage::promote_staged_snapshot(&staged_path, &live_path)
         .expect("committed promotion tolerates deferred cleanup");
+    assert_core_promotion_stats_reconcile(&committed_stats);
+    assert!(committed_stats.previous_live_bytes.is_some());
+    assert!(committed_stats.rollback_backup_copy_ms.is_some());
+    assert!(committed_stats.backup_validation_ms.is_some());
+    assert_eq!(
+        committed_stats.rollback_backup_bytes,
+        committed_stats.previous_live_bytes
+    );
     let error = Storage::promote_staged_snapshot(&second_staged_path, &live_path)
         .expect_err("retained committed artifacts must block the next promotion");
     assert!(error.to_string().contains("prior artifacts remain"));

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -128,6 +128,16 @@ old-or-new promotion journal. Its phase telemetry exposes the checkpoint
 budget, checkpoint time, and sync time. Generic build stores and incremental
 clones keep WAL/NORMAL throughout.
 
+Incremental clone telemetry records the successful live-to-staged SQLite
+backup wall and the logical source/target database bytes. Every successful
+core publication also reports nested promotion telemetry for lock/recovery,
+candidate and prior-live validation, the optional rollback-backup copy and
+validation, prepared-journal write/file sync/directory sync, staged-to-live
+restore, promoted-live validation, committed-journal transition, and cleanup.
+The promotion object retains candidate, prior-live, and rollback-backup logical
+bytes plus a saturating residual that reconciles its displayed total. These are
+diagnostics inside publication wall, not additional top-level phases.
+
 The indexer does not know whether the store is staged or live.
 
 ### 3. Workspace computes the refresh plan
@@ -362,9 +372,10 @@ That makes incremental indexing more than just "parse changed files." It also re
 The last step belongs to runtime plus store:
 
 - full refresh finalizes a staged build, creates deferred indexes, refreshes the summary snapshot, and publishes the staged database
-- incremental refresh stays on the live database and refreshes both summary and detail snapshots in place
+- incremental refresh mutates a durable clone, refreshes both summary and detail snapshots there, and publishes the completed replacement
 
-Full and incremental snapshot behavior are intentionally not symmetric.
+Full and incremental stage preparation remain intentionally different even
+though both finish through the same core-promotion journal.
 
 Staged finalization splits deferred indexes around summary materialization. It
 creates the four source, target, resolved-source, and resolved-target edge
@@ -469,9 +480,13 @@ projection state, structural text units, structural file projections, and
 structural cache writes are flushed before `ResolutionPass` runs. Resolution
 then updates unresolved edges using the stored graph state.
 
-### What full refresh publishes that incremental refresh does not
+### How full and incremental core publication differ
 
-Full refresh builds a staged database and publishes it only after staged finalization succeeds. Incremental refresh never publishes a staged build; it updates the live store and refreshes live snapshots in place.
+Full refresh builds a fresh disposable stage and publishes it only after staged
+finalization succeeds. Incremental refresh starts with a coherent SQLite backup
+of the live database, changes only that durable clone, and publishes the
+completed replacement. The previous live database remains usable until either
+candidate enters the shared promotion journal.
 
 Neither core path alone publishes the immutable retrieval generation.
 Retrieval finalization binds its candidate to the resulting core generation and
@@ -531,13 +546,19 @@ The index summary reports graph and semantic work separately:
 - `semantic_docs.pending`: changed dense-anchor inputs that require the next retrieval-generation decision
 - `semantic_docs.stale`: persisted dense-anchor inputs pruned because they no longer match the refreshed symbol set
 - `semantic_dense_docs_skipped` and `semantic_dense_*`: policy skip and dense-reason counters for `graph_first_v1`
+- `staged_snapshot_copy`: successful incremental live-to-staged SQLite backup wall and logical source/target database bytes; absent for full refresh
+- `core_promotion`: successful nested promotion wall, validation/copy/journal/restore/cleanup subphases, logical candidate/prior/rollback database bytes, and its saturating residual; rollback backup fields are absent for a first publication
 
 Only the sibling fields inside `full_refresh_wall_ms` are additive. Indexer
 children, semantic diagnostics, search stream/commit/reload timings, snapshot
-timings, SQLite checkpoint/sync timings, and runtime-cache publication are
-nested diagnostics and must not be added again. The repo-scale evidence
-artifact retains the complete first and repeat `phase_timings` objects so new
-diagnostics are not silently lost by a hand-maintained field list.
+timings, SQLite checkpoint/sync and snapshot-copy timings, core-promotion
+timings, and runtime-cache publication are nested diagnostics and must not be
+added again. Inside `core_promotion`, named millisecond fields plus
+`unattributed_ms` reconcile to `total_ms`; optional backup fields distinguish a
+first publication from a replacement instead of reporting fabricated zero-work
+phases. The repo-scale evidence artifact retains the complete first and repeat
+`phase_timings` objects so new diagnostics are not silently lost by a
+hand-maintained field list.
 
 Use these fields before changing parser, graph, or SQLite code for a slow
 `index` run.

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -129,14 +129,18 @@ budget, checkpoint time, and sync time. Generic build stores and incremental
 clones keep WAL/NORMAL throughout.
 
 Incremental clone telemetry records the successful live-to-staged SQLite
-backup wall and the logical source/target database bytes. Every successful
-core publication also reports nested promotion telemetry for lock/recovery,
-candidate and prior-live validation, the optional rollback-backup copy and
-validation, prepared-journal write/file sync/directory sync, staged-to-live
-restore, promoted-live validation, committed-journal transition, and cleanup.
-The promotion object retains candidate, prior-live, and rollback-backup logical
-bytes plus a saturating residual that reconciles its displayed total. These are
-diagnostics inside publication wall, not additional top-level phases.
+backup call and the logical source/target database bytes. The clone happens
+before incremental indexing begins, so `staged_snapshot_copy` is independent
+of the later `publish_ms` wall. Every successful core publication also reports
+nested promotion telemetry for lock/recovery, candidate and prior-live
+validation, the optional rollback-backup copy and validation, prepared-journal
+write/file sync/directory sync, staged-to-live restore, promoted-live
+validation, committed-journal transition, and cleanup. The promotion object
+retains candidate, prior-live, and rollback-backup logical bytes plus a
+saturating residual that reconciles its displayed total. Logical bytes use
+SQLite `page_count * page_size`, including committed pages still backed by WAL;
+they do not measure filesystem allocation or physical writes. Only
+`core_promotion` is a diagnostic nested inside the publication wall.
 
 The indexer does not know whether the store is staged or live.
 
@@ -546,14 +550,15 @@ The index summary reports graph and semantic work separately:
 - `semantic_docs.pending`: changed dense-anchor inputs that require the next retrieval-generation decision
 - `semantic_docs.stale`: persisted dense-anchor inputs pruned because they no longer match the refreshed symbol set
 - `semantic_dense_docs_skipped` and `semantic_dense_*`: policy skip and dense-reason counters for `graph_first_v1`
-- `staged_snapshot_copy`: successful incremental live-to-staged SQLite backup wall and logical source/target database bytes; absent for full refresh
+- `staged_snapshot_copy`: successful incremental live-to-staged SQLite backup-call wall and logical source/target database bytes (`page_count * page_size`); this clone happens before incremental indexing, is outside `publish_ms`, and is absent for full refresh
 - `core_promotion`: successful nested promotion wall, validation/copy/journal/restore/cleanup subphases, logical candidate/prior/rollback database bytes, and its saturating residual; rollback backup fields are absent for a first publication
 
 Only the sibling fields inside `full_refresh_wall_ms` are additive. Indexer
 children, semantic diagnostics, search stream/commit/reload timings, snapshot
-timings, SQLite checkpoint/sync and snapshot-copy timings, core-promotion
-timings, and runtime-cache publication are nested diagnostics and must not be
-added again. Inside `core_promotion`, named millisecond fields plus
+timings, SQLite checkpoint/sync, core-promotion timings, and runtime-cache
+publication are nested diagnostics and must not be added again.
+`staged_snapshot_copy` is an earlier independent wall and is not part of
+`publish_ms`. Inside `core_promotion`, named millisecond fields plus
 `unattributed_ms` reconcile to `total_ms`; optional backup fields distinguish a
 first publication from a replacement instead of reporting fabricated zero-work
 phases. The repo-scale evidence artifact retains the complete first and repeat

--- a/docs/architecture/subsystems/indexer.md
+++ b/docs/architecture/subsystems/indexer.md
@@ -32,7 +32,7 @@
 The runtime owns orchestration and chooses the store shape for a run:
 
 - full refresh: runtime opens a staged store, passes a full refresh plan to `WorkspaceIndexer`, then asks the store to finalize and publish the staged snapshot
-- incremental refresh: runtime opens the live store, passes a diff-based refresh plan to `WorkspaceIndexer`, then asks the store to refresh live summary and detail snapshots
+- incremental refresh: runtime clones the live database into a durable staged store, passes a diff-based refresh plan to `WorkspaceIndexer`, refreshes summary and detail snapshots on the clone, then publishes the completed replacement
 
 The indexer does not choose staged versus live storage. It only consumes a refresh plan plus a mutable store.
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -248,6 +248,10 @@ named fault and race cases for:
 - prepared versus committed journal recovery;
 - cleanup failure after a committed publication;
 - stale/invalid backup ambiguity;
+- successful first and replacement publication telemetry, including
+  incremental live-to-staged copy bytes, optional rollback-backup phases,
+  candidate/prior/backup logical bytes, and exact named-plus-residual
+  reconciliation inside the promotion wall;
 - structural-unit descriptor determinism across all twelve unit collectors,
   exact source spans, cross-file content-versus-placement identity, and
   zero-unit projection completeness;
@@ -276,6 +280,11 @@ Evidence must show that failure leaves the previous complete publication usable
 and never deletes an outside sentinel. Query drift must return typed
 `publication_changed`; runtime may retry the complete query-and-resolution
 operation once, never an internal fragment against a newly current generation.
+Telemetry-only promotion work must also keep candidate, previous, backup,
+promoted-live, manifest, quick-check, journal, fsync, restore, rollback, and
+cleanup ordering unchanged; the measurements are successful-path diagnostics
+and do not weaken failure behavior. Use a bounded generated SQLite image for
+copy/byte accounting and do not substitute a repo-scale or corpus run.
 Structural evidence tests must also show that grounding, search, details, and
 packet paths read persisted producer/tier/resolution metadata in batches where
 the surface is batched, never infer provenance from a filename, and retain

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -250,8 +250,8 @@ named fault and race cases for:
 - stale/invalid backup ambiguity;
 - successful first and replacement publication telemetry, including
   incremental live-to-staged copy bytes, optional rollback-backup phases,
-  candidate/prior/backup logical bytes, and exact named-plus-residual
-  reconciliation inside the promotion wall;
+  candidate/prior/backup SQLite logical bytes (`page_count * page_size`), and
+  exact named-plus-residual reconciliation inside the promotion wall;
 - structural-unit descriptor determinism across all twelve unit collectors,
   exact source spans, cross-file content-versus-placement identity, and
   zero-unit projection completeness;


### PR DESCRIPTION
Closes #1324
Refs #1275

## Context

CodeStory publishes a completed core SQLite database through a recovery journal that validates the candidate and previous live database, makes a rollback backup when needed, restores the stage into the stable live path, validates the promoted database, commits the journal, and cleans owned artifacts. Incremental indexing first clones live into a durable stage.

Current telemetry exposes only aggregate publication wall, so a 408,744 ms historical publication of a 16,642,293,760-byte database cannot be separated into copy, validation, journal sync, restore, or cleanup cost. This bounded child measures the existing cross-platform publication design before any layout optimization.

The canonical packaged grounding call on the exact worktree failed closed with `managed_cli_provision_failed:managed_cli_asset_fetch_failed`. Exact source inspection defines this candidate; CLI diagnostics are not substituted as packaged-MCP proof.

Exact base: `b3861c67154aa5b33e2b60e1617d945dd8158a7e`

Exact head: `7999341c8103159866736d1c56ba49cd41adb901`

Tree: `3b683e3f6be20773226c3b71fbf88b5125af5fd6`

## Outcome

Successful full and incremental publications now report non-double-counted snapshot-copy and core-promotion diagnostics, including logical database-image bytes and a residual that reconciles named promotion subphases to raw promotion wall.

## What changed

- Record the successful incremental live-to-staged SQLite backup-call wall plus source and target logical bytes from SQLite `page_count * page_size`, including committed WAL-backed pages.
- Split successful promotion into lock/recovery, candidate and previous validation, optional rollback-backup copy and validation, prepared-journal write/file sync/directory sync, staged-to-live restore, promoted validation, committed-journal transition, and cleanup.
- Report candidate, previous-live, and rollback-backup logical database bytes; omit inapplicable backup phases on first publication.
- Propagate optional backward-compatible timing DTOs through runtime events, CLI output, and retained repo-scale phase JSON.
- Document that staged snapshot copy is a pre-index operation outside `publish_ms`, while core-promotion diagnostics are nested inside publication wall.

Publication, journal, recovery, durability, checkpoint, and reader behavior remain unchanged.

## How to review

1. `crates/codestory-store/src/storage_impl/mod.rs`: confirm measurement boundaries do not reorder validation, backup, journal, fsync, restore, rollback, or cleanup behavior.
2. `crates/codestory-store/src/snapshot_store.rs`: confirm full versus incremental copy accounting, logical WAL-backed byte accounting, and old-or-new reader tests.
3. `crates/codestory-contracts/src/api/events.rs`, `crates/codestory-runtime/src/lib.rs`, and `crates/codestory-cli/src/output.rs`: confirm optional compatibility and non-double-counted rendering.
4. `docs/architecture/indexing-pipeline.md`: confirm the operator guidance distinguishes pre-index snapshot copy, nested promotion telemetry, and top-level wall.

## Verification

- `cargo test --locked -p codestory-store --lib` — 162/162
- `cargo test --locked -p codestory-contracts --lib` — 47/47
- runtime full/incremental durable-generation telemetry test — 1/1
- CLI first-promotion/no-fabricated-backup render test — 1/1
- retained phase JSON diagnostic test — 1/1
- `cargo fmt --all -- --check`
- `node .github/scripts/check-doc-links.mjs` — 75 files / 265 links
- `git diff --check b3861c67154aa5b33e2b60e1617d945dd8158a7e...7999341c8103159866736d1c56ba49cd41adb901`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`

Independent exact-head rereview accepted head `7999341c8103159866736d1c56ba49cd41adb901`, tree `3b683e3f6be20773226c3b71fbf88b5125af5fd6`, with no P0-P3 findings. All hosted checks on that head are green.

Before-change evidence is retained in #1324: a warm 332,902,400-byte database measured about 0.39 seconds for SQLite backup and 0.15 seconds for `quick_check`; the historical large-corpus baseline measured 408,744 ms total publication wall. This PR adds bounded deterministic accounting rather than another repo-scale or Linux corpus run.

## Risk and non-claims

The risks were double-counted wall, misleading byte values when committed pages remain in WAL, and measurement code disturbing recovery ordering. Focused tests and independent exact-head review cover those boundaries.

This source PR makes no package, installed-runtime, protected-hardware, marketplace, large-corpus, performance-improvement, or live-release claim.
