### PR TITLE
[codex] attest CodeStoryDev CLI handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Release
 
+- The local `CodeStoryDev` installer now binds one clean committed plugin
+  package to one explicit staged CLI through a versioned receipt. The cached
+  launcher verifies package, marketplace, platform, filename, byte count,
+  checksum, executable, and CLI version before using that development
+  override. Missing or changed receipt inputs and simultaneous raw overrides
+  fail closed without falling through to the production release installer.
 - MCP repository resources now advertise canonical project-bound URI templates
   while the static agent guide remains project-free. Strict URI parsing
   preserves native path identity across spaces, percent characters, Unicode,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   checksum, executable, and CLI version before using that development
   override. Missing or changed receipt inputs and simultaneous raw overrides
   fail closed without falling through to the production release installer.
+  The launcher now owns the MCP initialize handshake and relays the verified
+  native runtime through explicit pipes instead of grandchild stdio inheritance.
 - MCP repository resources now advertise canonical project-bound URI templates
   while the static agent guide remains project-free. Strict URI parsing
   preserves native path identity across spaces, percent characters, Unicode,

--- a/docs/architecture/host-integration.md
+++ b/docs/architecture/host-integration.md
@@ -34,6 +34,16 @@ The fail-open catalog prevents installation work from looking like a missing
 plugin. It keeps diagnostics and the complete tool schema visible while the
 native executable is prepared, then forwards requests to that executable.
 
+The local `CodeStoryDev` marketplace uses a separate, explicit trust contract.
+Its repository-owned staging installer copies one clean committed plugin
+package and one exact CLI into the development package, then writes a receipt
+that binds the package digest, plugin identity and version, platform target,
+direct executable path, size, checksum, and CLI version. The cached launcher
+revalidates that receipt before treating the CLI as a local-development
+override. A declared but invalid receipt, or a receipt combined with the raw
+`CODESTORY_CLI` override, fails closed and cannot fall through to managed
+release provisioning.
+
 ## Request routing
 
 Every tool and resource request includes an absolute `project` root. The

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -140,6 +140,21 @@ cargo build --release --locked -p codestory-cli
 On Windows, use `.\target\release\codestory-cli.exe`. Set `CODESTORY_CLI` to
 that exact binary when testing the plugin adapter against a local build.
 
+To refresh the installed local `CodeStoryDev` package, use the attested staging
+installer after committing the plugin source:
+
+```sh
+node scripts/install-codestory-dev-plugin.mjs \
+  --cli "$(pwd)/target/release/codestory-cli"
+```
+
+The installer requires the exact platform filename and matching plugin/CLI
+version, rejects plugin-source drift, stages a package-and-CLI receipt, refreshes
+only `codestory@CodeStoryDev`, and leaves plugin data intact. Start a fresh
+Codex host after the package refresh. Do not edit the checked-in `.mcp.json` or
+add `CODESTORY_CLI` to it; production packages continue to use the authenticated
+managed-release path.
+
 Read commands default to `--refresh none`. Use `--refresh incremental` when a
 read should refresh an existing cache. Reserve full refresh for an empty cache,
 schema change, diagnosed corruption, or an explicit proof lane.

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -16,7 +16,7 @@ Criterion targets.
 | Store/publication | Store tests plus named fault/concurrency cases | Workspace source gate |
 | Retrieval/embedding | Retrieval tests, runtime admission tests, engine proof self-test | Same-run quality/performance gate and required hardware proof |
 | CLI/stdio | Named CLI contract suites | Workspace source gate and packaged proof when package behavior changed |
-| Plugin launcher | `node --test plugins/codestory/tests/plugin-static.test.mjs` | Packaged plugin handoff |
+| Plugin launcher or CodeStoryDev staging | Installer tests plus `plugin-static` | Packaged plugin handoff |
 | Worktree setup | Node suite plus one platform adapter smoke | Mac/Windows platform cell when adapter changed |
 | Docs only | Read changed pages, doc links, `git diff --check` | No package matrix |
 | Release/version | Release and workflow policy scripts | Main-only signing, notarization, publish, install, and live runtime proof |
@@ -308,6 +308,7 @@ schema/adapter fixtures enforce the combined 16-probe and 240-character limits.
 Plugin adapter changes run:
 
 ```sh
+node --test scripts/tests/install-codestory-dev-plugin.test.mjs
 node --test plugins/codestory/tests/plugin-static.test.mjs
 ```
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -69,6 +69,28 @@ Marketplace refresh updates the catalog only. Package refresh replaces the
 installed plugin, and a fresh host session loads that replacement. See the
 [Codex update guide](../../docs/users/codex.md#update).
 
+## CodeStoryDev refresh
+
+Maintainers dogfood an unpublished head through the local `CodeStoryDev`
+marketplace. Build the exact CLI, commit the plugin package, then run:
+
+```sh
+node scripts/install-codestory-dev-plugin.mjs \
+  --cli "$(pwd)/target/release/codestory-cli"
+```
+
+The installer stages the clean committed `plugins/codestory` package, the
+platform-native CLI, and `.codestory-dev-cli.json`, then refreshes only
+`codestory@CodeStoryDev`. The receipt binds the source-package digest, plugin
+ID/version, platform, direct executable name/path, bytes, SHA-256, and reported
+CLI version. It preserves `~/.codex/plugins/data/codestory-CodeStoryDev`.
+
+The installed launcher validates the cached receipt again with an empty
+`PATH`. If the receipt, package, cache copy, or CLI changed—or if
+`CODESTORY_CLI` is also set—it reports the receipt failure and does not try the
+production release installer. Start a fresh Codex host after a successful
+refresh to load the new adapter.
+
 ## Diagnostics
 
 Normal calls prepare the repository automatically. Agents call the intended
@@ -85,6 +107,7 @@ Blocked session steps: [Troubleshooting](../../docs/users/troubleshooting.md).
 
 ```sh
 node scripts/generate-codestory-skill-syntax.mjs --check
+node --test scripts/tests/install-codestory-dev-plugin.test.mjs
 node --test plugins/codestory/tests/plugin-static.test.mjs
 node .github/scripts/check-doc-links.mjs
 git diff --check

--- a/plugins/codestory/scripts/codestory-dev-cli-contract.cjs
+++ b/plugins/codestory/scripts/codestory-dev-cli-contract.cjs
@@ -1,0 +1,296 @@
+const { createHash } = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const receiptName = '.codestory-dev-cli.json';
+const receiptSchemaVersion = 1;
+const receiptPurpose = 'codestory-dev-plugin-cli';
+const receiptPluginId = 'codestory@CodeStoryDev';
+const receiptPluginName = 'codestory';
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+const commitPattern = /^[0-9a-f]{40}$/u;
+
+function assetTarget(platform = process.platform, arch = process.arch) {
+  if (platform === 'win32' && arch === 'x64') return 'windows-x64';
+  if (platform === 'win32' && arch === 'arm64') return 'windows-arm64';
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64';
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64';
+  if (platform === 'darwin' && arch === 'x64') return 'macos-x64';
+  if (platform === 'darwin' && arch === 'arm64') return 'macos-arm64';
+  return null;
+}
+
+function expectedBinaryName(platform = process.platform) {
+  return platform === 'win32' ? 'codestory-cli.exe' : 'codestory-cli';
+}
+
+function directDirectory(pathname, label) {
+  const metadata = fs.lstatSync(pathname);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new Error(`${label}_not_direct_directory`);
+  }
+}
+
+function directFile(pathname, label) {
+  const metadata = fs.lstatSync(pathname);
+  if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
+    throw new Error(`${label}_not_direct_file`);
+  }
+  return metadata;
+}
+
+function pathInside(candidate, root) {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate));
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function collectDirectoryFiles(root, relative = '', files = []) {
+  const directory = relative ? path.join(root, relative) : root;
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+    Buffer.from(left.name).compare(Buffer.from(right.name)))) {
+    const childRelative = relative ? path.join(relative, entry.name) : entry.name;
+    const child = path.join(root, childRelative);
+    const metadata = fs.lstatSync(child);
+    if (metadata.isSymbolicLink()) {
+      throw new Error(`directory_contract_symlink:${childRelative.split(path.sep).join('/')}`);
+    }
+    if (metadata.isDirectory()) {
+      collectDirectoryFiles(root, childRelative, files);
+      continue;
+    }
+    if (!metadata.isFile()) {
+      throw new Error(`directory_contract_non_file:${childRelative.split(path.sep).join('/')}`);
+    }
+    files.push(childRelative);
+  }
+  return files;
+}
+
+function directoryContractSha256(root, options = {}) {
+  directDirectory(root, 'directory_contract_root');
+  const excluded = new Set((options.exclude || []).map((entry) => entry.split('/').join(path.sep)));
+  const files = collectDirectoryFiles(root).filter((entry) => !excluded.has(entry));
+  if (files.length === 0) throw new Error('directory_contract_empty');
+  const digest = createHash('sha256');
+  for (const relativeNative of files.sort((left, right) =>
+    Buffer.from(left.split(path.sep).join('/')).compare(Buffer.from(right.split(path.sep).join('/'))))) {
+    const relative = Buffer.from(relativeNative.split(path.sep).join('/'), 'utf8');
+    const payload = fs.readFileSync(path.join(root, relativeNative));
+    const relativeLength = Buffer.alloc(8);
+    relativeLength.writeBigUInt64LE(BigInt(relative.length));
+    const payloadLength = Buffer.alloc(8);
+    payloadLength.writeBigUInt64LE(BigInt(payload.length));
+    digest.update(relativeLength);
+    digest.update(relative);
+    digest.update(payloadLength);
+    digest.update(payload);
+  }
+  return digest.digest('hex');
+}
+
+function exactKeys(value, expected) {
+  return value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && Object.keys(value).sort().join(',') === [...expected].sort().join(',');
+}
+
+function pluginCacheIdentity(root) {
+  const version = path.basename(root);
+  const pluginName = path.basename(path.dirname(root));
+  const marketplace = path.basename(path.dirname(path.dirname(root)));
+  const cache = path.basename(path.dirname(path.dirname(path.dirname(root))));
+  if (cache !== 'cache' || pluginName !== receiptPluginName || marketplace !== 'CodeStoryDev') {
+    return null;
+  }
+  return {
+    pluginId: `${pluginName}@${marketplace}`,
+    pluginName,
+    version,
+  };
+}
+
+function readReceipt(receiptPath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`codestory_dev_receipt_json:${error.message}`);
+  }
+  return parsed;
+}
+
+function normalizeVersion(value) {
+  const match = String(value || '').match(/\bcodestory-cli\s+v?(\d+\.\d+\.\d+)\b/u);
+  return match ? match[1] : null;
+}
+
+function validateDevCliReceipt(root, options = {}) {
+  const receiptPath = path.join(root, receiptName);
+  try {
+    fs.lstatSync(receiptPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') return { state: 'absent' };
+    return {
+      state: 'invalid',
+      receiptPath,
+      reason: `codestory_dev_receipt_stat:${error.message}`,
+    };
+  }
+  try {
+    directDirectory(root, 'codestory_dev_plugin_root');
+    directFile(receiptPath, 'codestory_dev_receipt');
+    const receipt = readReceipt(receiptPath);
+    if (!exactKeys(receipt, [
+      'schema_version',
+      'purpose',
+      'plugin_id',
+      'plugin_name',
+      'plugin_version',
+      'source_commit',
+      'source_package_sha256',
+      'target',
+      'cli',
+    ])) {
+      throw new Error('codestory_dev_receipt_keys');
+    }
+    if (
+      receipt.schema_version !== receiptSchemaVersion
+      || receipt.purpose !== receiptPurpose
+      || receipt.plugin_id !== receiptPluginId
+      || receipt.plugin_name !== receiptPluginName
+    ) {
+      throw new Error('codestory_dev_receipt_identity');
+    }
+    if (!/^\d+\.\d+\.\d+$/u.test(String(receipt.plugin_version || ''))) {
+      throw new Error('codestory_dev_receipt_plugin_version');
+    }
+    if (
+      options.expectedPluginVersion
+      && receipt.plugin_version !== options.expectedPluginVersion
+    ) {
+      throw new Error('codestory_dev_receipt_plugin_version_mismatch');
+    }
+    if (!commitPattern.test(String(receipt.source_commit || ''))) {
+      throw new Error('codestory_dev_receipt_source_commit');
+    }
+    if (!sha256Pattern.test(String(receipt.source_package_sha256 || ''))) {
+      throw new Error('codestory_dev_receipt_source_digest');
+    }
+    const target = assetTarget(options.platform, options.arch);
+    if (!target || receipt.target !== target) {
+      throw new Error('codestory_dev_receipt_target');
+    }
+    const cacheIdentity = pluginCacheIdentity(root);
+    if (options.requireCacheIdentity !== false) {
+      if (
+        !cacheIdentity
+        || cacheIdentity.pluginId !== receipt.plugin_id
+        || cacheIdentity.pluginName !== receipt.plugin_name
+        || cacheIdentity.version !== receipt.plugin_version
+      ) {
+        throw new Error('codestory_dev_receipt_cache_identity');
+      }
+    }
+    if (!exactKeys(receipt.cli, ['path', 'name', 'bytes', 'sha256', 'version'])) {
+      throw new Error('codestory_dev_receipt_cli_keys');
+    }
+    const binary = expectedBinaryName(options.platform);
+    const expectedRelative = `bin/${binary}`;
+    if (
+      receipt.cli.path !== expectedRelative
+      || receipt.cli.name !== binary
+      || receipt.cli.version !== receipt.plugin_version
+      || !Number.isSafeInteger(receipt.cli.bytes)
+      || receipt.cli.bytes <= 0
+      || !sha256Pattern.test(String(receipt.cli.sha256 || ''))
+    ) {
+      throw new Error('codestory_dev_receipt_cli_identity');
+    }
+    const cliPath = path.resolve(root, ...receipt.cli.path.split('/'));
+    if (!pathInside(cliPath, root)) throw new Error('codestory_dev_receipt_cli_escape');
+    directDirectory(path.dirname(cliPath), 'codestory_dev_cli_parent');
+    const cliMetadata = directFile(cliPath, 'codestory_dev_cli');
+    if (!pathInside(fs.realpathSync(cliPath), fs.realpathSync(root))) {
+      throw new Error('codestory_dev_receipt_cli_realpath_escape');
+    }
+    if (path.basename(cliPath) !== receipt.cli.name) {
+      throw new Error('codestory_dev_receipt_cli_name');
+    }
+    if (cliMetadata.size !== receipt.cli.bytes) {
+      throw new Error('codestory_dev_receipt_cli_size');
+    }
+    if ((options.platform || process.platform) !== 'win32' && (cliMetadata.mode & 0o111) === 0) {
+      throw new Error('codestory_dev_receipt_cli_not_executable');
+    }
+    const actualCliSha256 = createHash('sha256').update(fs.readFileSync(cliPath)).digest('hex');
+    if (actualCliSha256 !== receipt.cli.sha256) {
+      throw new Error('codestory_dev_receipt_cli_digest');
+    }
+    const actualSourceDigest = directoryContractSha256(root, {
+      exclude: [receiptName, receipt.cli.path],
+    });
+    if (actualSourceDigest !== receipt.source_package_sha256) {
+      throw new Error('codestory_dev_receipt_package_digest');
+    }
+    const probe = options.probeVersion
+      ? options.probeVersion(cliPath)
+      : spawnSync(cliPath, ['--version'], {
+        encoding: 'utf8',
+        shell: false,
+        timeout: 3000,
+        windowsHide: true,
+      });
+    if (probe.error || probe.status !== 0) {
+      throw new Error('codestory_dev_receipt_cli_probe');
+    }
+    const probedVersion = options.probeVersion
+      ? normalizeVersion(probe.stdout)
+      : normalizeVersion(`${probe.stdout || ''}\n${probe.stderr || ''}`);
+    if (probedVersion !== receipt.cli.version) {
+      throw new Error('codestory_dev_receipt_cli_version');
+    }
+    const finalCliMetadata = directFile(cliPath, 'codestory_dev_cli');
+    const finalCliSha256 = createHash('sha256').update(fs.readFileSync(cliPath)).digest('hex');
+    if (finalCliMetadata.size !== receipt.cli.bytes || finalCliSha256 !== actualCliSha256) {
+      throw new Error('codestory_dev_receipt_cli_changed');
+    }
+    const finalSourceDigest = directoryContractSha256(root, {
+      exclude: [receiptName, receipt.cli.path],
+    });
+    if (finalSourceDigest !== actualSourceDigest) {
+      throw new Error('codestory_dev_receipt_package_changed');
+    }
+    return {
+      state: 'verified',
+      path: cliPath,
+      sha256: finalCliSha256,
+      version: receipt.plugin_version,
+      cliVersion: probedVersion,
+      receiptPath,
+      sourceCommit: receipt.source_commit,
+      sourcePackageSha256: finalSourceDigest,
+      target,
+    };
+  } catch (error) {
+    return {
+      state: 'invalid',
+      receiptPath,
+      reason: error.message,
+    };
+  }
+}
+
+module.exports = {
+  assetTarget,
+  directoryContractSha256,
+  expectedBinaryName,
+  pluginCacheIdentity,
+  receiptName,
+  receiptPluginId,
+  receiptPluginName,
+  receiptPurpose,
+  receiptSchemaVersion,
+  validateDevCliReceipt,
+};

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -11,6 +11,9 @@ const path = require('path');
 const { Transform, pipeline } = require('stream');
 const { TextDecoder } = require('util');
 const zlib = require('zlib');
+const {
+  validateDevCliReceipt,
+} = require('./codestory-dev-cli-contract.cjs');
 
 const pluginRoot = path.dirname(__dirname);
 const launchCwd = process.cwd();
@@ -1367,6 +1370,66 @@ async function resolveManagedCli(dataDir, version, warnings, options = {}) {
 async function resolveCli(options = {}) {
   const version = pluginVersion();
   const warnings = [];
+  const devReceipt = validateDevCliReceipt(pluginRoot, {
+    expectedPluginVersion: version,
+  });
+  if (process.env.CODESTORY_CLI && devReceipt.state !== 'absent') {
+    const reason = 'codestory_dev_cli_ambiguous_override';
+    warnings.push(reason);
+    return {
+      source: 'local_dev_receipt_invalid',
+      path: null,
+      sha256: null,
+      version,
+      cliVersion: null,
+      repoRef: null,
+      buildSource: 'local_dev_receipt_invalid',
+      sourcePackageSha256: null,
+      archiveSha256: null,
+      archiveUrl: null,
+      provisionedAt: null,
+      localDevReceiptFailure: reason,
+      warnings,
+    };
+  }
+  if (devReceipt.state === 'verified') {
+    warnings.push('codestory_dev_receipt:verified');
+    return {
+      source: 'local_dev_override',
+      path: devReceipt.path,
+      sha256: devReceipt.sha256,
+      version,
+      cliVersion: devReceipt.cliVersion,
+      repoRef: devReceipt.sourceCommit,
+      buildSource: 'codestory_dev_receipt',
+      sourcePackageSha256: devReceipt.sourcePackageSha256,
+      archiveSha256: null,
+      archiveUrl: null,
+      provisionedAt: null,
+      manifestPath: devReceipt.receiptPath,
+      warnings,
+    };
+  }
+  if (devReceipt.state === 'invalid') {
+    const reason = `codestory_dev_receipt_invalid:${devReceipt.reason}`;
+    warnings.push(reason);
+    return {
+      source: 'local_dev_receipt_invalid',
+      path: null,
+      sha256: null,
+      version,
+      cliVersion: null,
+      repoRef: null,
+      buildSource: 'local_dev_receipt_invalid',
+      sourcePackageSha256: null,
+      archiveSha256: null,
+      archiveUrl: null,
+      provisionedAt: null,
+      manifestPath: devReceipt.receiptPath,
+      localDevReceiptFailure: reason,
+      warnings,
+    };
+  }
   if (process.env.CODESTORY_CLI) {
     const cliPath = path.isAbsolute(process.env.CODESTORY_CLI)
       ? process.env.CODESTORY_CLI
@@ -1383,6 +1446,7 @@ async function resolveCli(options = {}) {
       cliVersion: null,
       repoRef: null,
       buildSource: 'local_dev_override',
+      sourcePackageSha256: null,
       archiveSha256: null,
       archiveUrl: null,
       provisionedAt: null,
@@ -1406,6 +1470,7 @@ async function resolveCli(options = {}) {
     cliVersion: null,
     repoRef: null,
     buildSource: 'managed_unavailable',
+    sourcePackageSha256: null,
     archiveSha256: null,
     archiveUrl: null,
     provisionedAt: null,
@@ -1453,6 +1518,9 @@ function failOpenReasonForProbe(resolved, probe) {
   if (batchRejection) return batchRejection;
   if (resolved.source === 'managed_unavailable') {
     return resolved.managedProvisionFailure || 'managed_cli_unavailable';
+  }
+  if (resolved.source === 'local_dev_receipt_invalid') {
+    return resolved.localDevReceiptFailure || 'codestory_dev_receipt_invalid';
   }
   if (probe.error || probe.status !== 0) {
     return `${resolved.source}_cli_unspawnable`;
@@ -1888,6 +1956,7 @@ function pluginRuntimeForResolved(resolved) {
     cli_sha256: resolved.sha256,
     build_source: resolved.buildSource,
     repo_ref: resolved.repoRef,
+    source_package_sha256: resolved.sourcePackageSha256 || null,
     local_dev_override: resolved.source === 'local_dev_override',
     managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
     managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
@@ -2572,6 +2641,7 @@ function rememberLaunch(resolved, runtimeCwd = process.cwd()) {
       cliVersion: resolved.cliVersion || null,
       repoRef: resolved.repoRef || null,
       buildSource: resolved.buildSource || null,
+      sourcePackageSha256: resolved.sourcePackageSha256 || null,
       archiveSha256: resolved.archiveSha256 || null,
       archiveUrl: resolved.archiveUrl || null,
       provisionedAt: resolved.provisionedAt || null,
@@ -2598,6 +2668,7 @@ function stdioRuntimeEnv(resolved, runtimeCwd) {
     CODESTORY_PLUGIN_CLI_MANIFEST_PATH: resolved.manifestPath || '',
     CODESTORY_PLUGIN_CLI_BUILD_SOURCE: resolved.buildSource || '',
     CODESTORY_PLUGIN_CLI_REPO_REF: resolved.repoRef || '',
+    CODESTORY_PLUGIN_SOURCE_PACKAGE_SHA256: resolved.sourcePackageSha256 || '',
     CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256: resolved.archiveSha256 || '',
     CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
     CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -2760,37 +2760,33 @@ async function main() {
   }
   resolved.managedCliRetention = managedCliRetentionReport(resolved, probe);
   rememberLaunch(resolved, runtimeCwd);
-  const child = spawnStdioRuntime(resolved, runtimeCwd, 'inherit');
-
-  child.on('exit', (code, signal) => {
-    if (signal) process.kill(process.pid, signal);
-    if (!code) {
-      process.exit(0);
-      return;
-    }
-    runFailOpenMcp(fallbackDiagnostic(resolved, {
-      ...probe,
-      status: code,
-      error: `codestory-cli serve --stdio exited with status ${code}`,
-      stderr: probe.stderr || '',
-    }, 'runtime_stdio_child_exit', {
-      projectRoot: null,
-      projectRootSource: 'request_argument',
-      summary: 'CodeStory plugin MCP launched codestory-cli, but the stdio runtime exited before it could serve requests.',
-    }));
+  let status = fallbackDiagnostic(resolved, probe, 'runtime_stdio_handoff', {
+    projectRoot: null,
+    projectRootSource: 'request_argument',
+    summary: 'CodeStory is handing the initialized MCP session to its verified stdio runtime.',
   });
-
-  child.on('error', (error) => {
-    runFailOpenMcp(fallbackDiagnostic(resolved, {
-      status: null,
-      error: error.message,
-      version: null,
-      stdout: '',
-      stderr: '',
-    }, `${resolved.source}_cli_unspawnable`, {
-      projectRoot: null,
-      projectRootSource: 'request_argument',
-    }));
+  let handoffReady = true;
+  runFailOpenMcp(() => status, {
+    shouldHandoff: () => handoffReady,
+    startRuntime: () => spawnStdioRuntime(resolved, runtimeCwd, ['pipe', 'pipe', 'pipe']),
+    onRuntimeFailure: (failure) => {
+      handoffReady = false;
+      const reason = failure.error ? `${resolved.source}_cli_unspawnable` : 'runtime_stdio_child_exit';
+      const error = failure.error?.message
+        || (failure.code != null
+          ? `codestory-cli serve --stdio exited with status ${failure.code}`
+          : failure.reason);
+      status = fallbackDiagnostic(resolved, {
+        ...probe,
+        status: failure.code ?? null,
+        error,
+        stderr: probe.stderr || '',
+      }, reason, {
+        projectRoot: null,
+        projectRootSource: 'request_argument',
+        summary: 'CodeStory launched its verified CLI, but the stdio runtime failed during handoff.',
+      });
+    },
   });
 }
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -29,6 +29,22 @@ const {
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+function launcherHandoffInput() {
+  return [
+    {
+      jsonrpc: "2.0",
+      id: "initialize",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "plugin-static", version: "1" },
+      },
+    },
+    { jsonrpc: "2.0", id: "native-tools", method: "tools/list" },
+  ].map((request) => JSON.stringify(request)).join("\n") + "\n";
+}
+
 async function stopChildProcess(child) {
   if (!child || child.exitCode !== null || child.signalCode !== null) return;
   const closed = once(child, "close").catch(() => []);
@@ -782,6 +798,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
         PATH: "",
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
+      input: launcherHandoffInput(),
       encoding: "utf8",
     });
 
@@ -823,6 +840,7 @@ test("mcp launcher uses an attested CodeStoryDev CLI from the installed cache wi
         TEST_OUT: outFile,
         PATH: "",
       },
+      input: launcherHandoffInput(),
       encoding: "utf8",
     });
 
@@ -1817,6 +1835,7 @@ test("mcp launcher starts projectless when host launches from plugin root", asyn
         TEST_LOG: logFile,
         TEST_OUT: marker,
       },
+      input: launcherHandoffInput(),
       encoding: "utf8",
       timeout: 15000,
     });
@@ -1854,18 +1873,11 @@ test("multi-project stdio ignores mutable active-workspace state", async () => {
 });
 
 test("mcp launcher fails open when delegated stdio runtime exits", async () => {
-  const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-delegated-stdio-exit-"));
   const binDir = await mkdtemp(join(tmpdir(), "codestory-delegated-stdio-bin-"));
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const realRepoRoot = await realpath(repoRoot);
-  const input = JSON.stringify({
-    jsonrpc: "2.0",
-    id: "status",
-    method: "resources/read",
-    params: { uri: statusUri },
-  }) + "\n";
   const cliPath = await writeNodeCli(
     binDir,
     [
@@ -1876,6 +1888,7 @@ test("mcp launcher fails open when delegated stdio runtime exits", async () => {
     ].join("\n"),
   );
 
+  let child = null;
   try {
     await writeFile(
       join(dataDir, ".codestory-active"),
@@ -1886,7 +1899,7 @@ test("mcp launcher fails open when delegated stdio runtime exits", async () => {
       }),
       "utf8",
     );
-    const result = spawnSync(process.execPath, [launcher], {
+    child = spawn(process.execPath, [launcher], {
       cwd: pluginRoot,
       env: {
         ...process.env,
@@ -1895,15 +1908,60 @@ test("mcp launcher fails open when delegated stdio runtime exits", async () => {
         PLUGIN_DATA: dataDir,
         TEST_CODESTORY_VERSION: version,
       },
-      input,
-      encoding: "utf8",
-      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
     });
+    const responses = [];
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      const lines = stdout.split(/\r?\n/u);
+      stdout = lines.pop() || "";
+      for (const line of lines) {
+        if (line) responses.push(JSON.parse(line));
+      }
+    });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    const responseFor = async (id) => {
+      const deadline = Date.now() + 3000;
+      while (Date.now() < deadline) {
+        const response = responses.find((candidate) => candidate.id === id);
+        if (response) return response;
+        await delay(10);
+      }
+      assert.fail(`timed out waiting for ${id}: ${stderr}`);
+    };
+    const completed = once(child, "close");
 
-    assert.equal(result.status, 0, result.stderr);
-    const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.equal(responses.length, 1, result.stdout);
-    const status = JSON.parse(responses[0].result.contents[0].text);
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: "initialize",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "plugin-static", version: "1" },
+      },
+    })}\n`);
+    assert.equal((await responseFor("initialize")).result.serverInfo.version, version);
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: "delegate",
+      method: "tools/list",
+    })}\n`);
+    assert.match(
+      (await responseFor("delegate")).error.message,
+      /stdio handoff exited before completing the request/u,
+    );
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: "status",
+      method: "resources/read",
+      params: { uri: statusUri },
+    })}\n`);
+    const status = JSON.parse((await responseFor("status")).result.contents[0].text);
     assert.equal(status.degraded_reason, "runtime_stdio_child_exit");
     assert.equal(status.project_root, realRepoRoot);
     assert.equal(status.project_root_source, "resource_uri");
@@ -1913,7 +1971,11 @@ test("mcp launcher fails open when delegated stdio runtime exits", async () => {
       /codestory-cli serve --stdio exited with status 17/u,
     );
     assert.equal(status.managed_retrieval.automatic, true);
+    child.stdin.end();
+    assert.equal((await completed)[0], 0);
+    child = null;
   } finally {
+    await stopChildProcess(child);
     await rm(dataDir, { recursive: true, force: true });
     await rm(binDir, { recursive: true, force: true });
   }
@@ -2077,6 +2139,7 @@ test("mcp launcher ignores thread-scoped and global project state", async () => 
         TEST_LOG: logFile,
         TEST_OUT: marker,
       },
+      input: launcherHandoffInput(),
       encoding: "utf8",
       timeout: 5000,
     });
@@ -2630,6 +2693,7 @@ test("mcp launcher infers Codex managed data from installed cache without env", 
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
       cwd: repoRoot,
+      input: launcherHandoffInput(),
       encoding: "utf8",
       timeout: 5000,
     });
@@ -2735,7 +2799,61 @@ test("mcp launcher blocks when managed runtime is unavailable", async () => {
   }
 });
 
-test("mcp launcher starts the multi-project stdio runtime directly", async () => {
+test("mcp launcher owns initialize before handing off to the native runtime", async () => {
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-initialize-owner-"));
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-initialize-owner-bin-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const marker = join(dataDir, "serve-called.txt");
+  const cliPath = await writeNodeCli(
+    binDir,
+    [
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+      "if (args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, 'serve-called'); setInterval(() => {}, 1000); }",
+      "else process.exit(2);",
+    ].join("\n"),
+  );
+  const initialize = {
+    jsonrpc: "2.0",
+    id: "initialize",
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "plugin-static", version: "1" },
+    },
+  };
+
+  try {
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: dataDir,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_OUT: marker,
+      },
+      input: `${JSON.stringify(initialize)}\n`,
+      encoding: "utf8",
+      timeout: 2000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.error, undefined);
+    const response = JSON.parse(result.stdout.trim());
+    assert.equal(response.id, initialize.id);
+    assert.equal(response.result.serverInfo.version, version);
+    await assert.rejects(access(marker));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher starts the multi-project stdio runtime through its bridge", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-direct-stdio-"));
@@ -2760,7 +2878,39 @@ test("mcp launcher starts the multi-project stdio runtime directly", async () =>
         "const command = args[0];",
         "fs.appendFileSync(logFile, JSON.stringify({ args }) + '\\n');",
         "if (command === '--version') { console.log('codestory-cli ' + version); process.exit(0); }",
-        "if (command === 'serve') { fs.writeFileSync(marker, 'serve-called'); process.exit(0); }",
+        "if (command === 'serve') {",
+        "  fs.writeFileSync(marker, 'serve-called');",
+        "  let input = '';",
+        "  process.stdin.setEncoding('utf8');",
+        "  process.stdin.on('data', (chunk) => {",
+        "    input += chunk;",
+        "    const lines = input.split(/\\r?\\n/u);",
+        "    input = lines.pop() || '';",
+        "    for (const line of lines) {",
+        "      if (!line) continue;",
+        "      const request = JSON.parse(line);",
+        "      if (request.method === 'initialize') {",
+        "        console.log(JSON.stringify({",
+        "          jsonrpc: '2.0',",
+        "          id: request.id,",
+        "          result: {",
+        "            protocolVersion: request.params.protocolVersion,",
+        "            capabilities: {},",
+        "            serverInfo: { name: 'codestory', version },",
+        "          },",
+        "        }));",
+        "      } else if (request.method === 'tools/list') {",
+        "        console.log(JSON.stringify({",
+        "          jsonrpc: '2.0',",
+        "          id: request.id,",
+        "          result: { tools: [{ name: 'native-runtime' }] },",
+        "        }));",
+        "      }",
+        "    }",
+        "  });",
+        "  process.stdin.on('end', () => process.exit(0));",
+        "  return;",
+        "}",
         "process.exit(2);",
         "",
       ].join("\n"),
@@ -2783,12 +2933,35 @@ test("mcp launcher starts the multi-project stdio runtime directly", async () =>
         TEST_LOG: logFile,
         TEST_OUT: marker,
       },
+      input: [
+        {
+          jsonrpc: "2.0",
+          id: "initialize",
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "plugin-static", version: "1" },
+          },
+        },
+        { jsonrpc: "2.0", id: "native-tools", method: "tools/list" },
+      ].map((request) => JSON.stringify(request)).join("\n") + "\n",
       encoding: "utf8",
       timeout: 15000,
     });
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(await readFile(marker, "utf8"), "serve-called");
+    const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.equal(responses.filter((response) => response.id === "initialize").length, 1);
+    assert.equal(
+      responses.find((response) => response.id === "initialize")?.result.serverInfo.version,
+      version,
+    );
+    assert.deepEqual(
+      responses.find((response) => response.id === "native-tools")?.result.tools,
+      [{ name: "native-runtime" }],
+    );
     const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
     assert.deepEqual(calls.map((call) => call.args[0]), ["--version", "serve"]);
     assert.ok(calls.some((call) => {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -17,6 +17,7 @@ const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
 const require = createRequire(import.meta.url);
 const launcherTest = require(join(pluginRoot, "scripts", "codestory-mcp.cjs"))._test;
+const devCliContract = require(join(pluginRoot, "scripts", "codestory-dev-cli-contract.cjs"));
 const statusUri = launcherTest.projectBoundResourceUri("codestory://status", repoRoot);
 const {
   dirtyMarkerPathForProject,
@@ -446,6 +447,55 @@ async function writeManagedCliFixture(dataDir, version, body = version) {
   return { cliPath, versionDir };
 }
 
+async function writeAttestedDevPluginFixture(root, version) {
+  const { cp } = await import("node:fs/promises");
+  const installRoot = join(
+    root,
+    ".codex",
+    "plugins",
+    "cache",
+    "CodeStoryDev",
+    "codestory",
+    version,
+  );
+  await cp(pluginRoot, installRoot, { recursive: true });
+  const sourcePackageSha256 = devCliContract.directoryContractSha256(installRoot);
+  const cliName = devCliContract.expectedBinaryName();
+  const cliPath = join(installRoot, "bin", cliName);
+  await mkdir(dirname(cliPath), { recursive: true });
+  await writeFakeCli(cliPath);
+  const cliBytes = await readFile(cliPath);
+  const cliSha256 = createHash("sha256").update(cliBytes).digest("hex");
+  await writeFile(
+    join(installRoot, devCliContract.receiptName),
+    `${JSON.stringify({
+      schema_version: devCliContract.receiptSchemaVersion,
+      purpose: devCliContract.receiptPurpose,
+      plugin_id: devCliContract.receiptPluginId,
+      plugin_name: devCliContract.receiptPluginName,
+      plugin_version: version,
+      source_commit: "a".repeat(40),
+      source_package_sha256: sourcePackageSha256,
+      target: devCliContract.assetTarget(),
+      cli: {
+        path: `bin/${cliName}`,
+        name: cliName,
+        bytes: cliBytes.length,
+        sha256: cliSha256,
+        version,
+      },
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  return {
+    cliPath,
+    cliSha256,
+    installRoot,
+    launcher: join(installRoot, "scripts", "codestory-mcp.cjs"),
+    sourcePackageSha256,
+  };
+}
+
 test("plugin metadata maps skill and direct stdio server", async () => {
   const manifest = JSON.parse(
     await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
@@ -752,6 +802,104 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.deepEqual(observed.args, ["serve", "--stdio", "--multi-project", "--refresh", "none"]);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher uses an attested CodeStoryDev CLI from the installed cache without PATH", async () => {
+  if (process.platform === "win32") return;
+  const root = await mkdtemp(join(tmpdir(), "codestory-attested-dev-cli-"));
+  const dataDir = join(root, "plugin-data");
+  const outFile = join(root, "env.json");
+  const version = await readPluginVersion();
+  try {
+    const fixture = await writeAttestedDevPluginFixture(root, version);
+    await mkdir(dataDir, { recursive: true });
+    const result = spawnSync(process.execPath, [fixture.launcher], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: "",
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_OUT: outFile,
+        PATH: "",
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const observed = JSON.parse(await readFile(outFile, "utf8"));
+    assert.equal(observed.source, "local_dev_override");
+    assert.equal(observed.buildSource, "codestory_dev_receipt");
+    assert.equal(observed.sha256, fixture.cliSha256);
+    assert.equal(await realpath(observed.path), await realpath(fixture.cliPath));
+    assert.equal(await realpath(observed.pluginRoot), await realpath(fixture.installRoot));
+    assert.equal(observed.pluginCacheVersion, version);
+    assert.match(observed.warnings, /codestory_dev_receipt:verified/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("declared CodeStoryDev receipt failures never fall through to raw or managed CLI selection", async () => {
+  if (process.platform === "win32") return;
+  const version = await readPluginVersion();
+  for (const variant of ["invalid-receipt", "ambiguous-raw-override"]) {
+    const root = await mkdtemp(join(tmpdir(), "codestory-dev-receipt-no-fallback-"));
+    const dataDir = join(root, "plugin-data");
+    const runtimeOut = join(root, "runtime.json");
+    try {
+      const fixture = await writeAttestedDevPluginFixture(root, version);
+      const managedDir = join(dataDir, "codestory-cli", version);
+      const managedCli = join(managedDir, process.platform === "win32" ? "codestory-cli.exe" : "codestory-cli");
+      await mkdir(managedDir, { recursive: true });
+      await writeFakeCli(managedCli);
+      const managedSha256 = createHash("sha256").update(await readFile(managedCli)).digest("hex");
+      await writeFile(
+        join(managedDir, "manifest.json"),
+        JSON.stringify(managedReleaseManifest(version, managedCli.slice(managedDir.length + 1), managedSha256)),
+        "utf8",
+      );
+      if (variant === "invalid-receipt") {
+        await writeFile(join(fixture.installRoot, "README.md"), "changed package bytes", "utf8");
+      }
+      const input = `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: variant,
+        method: "resources/read",
+        params: { uri: statusUri },
+      })}\n`;
+      const result = spawnSync(process.execPath, [fixture.launcher], {
+        env: {
+          ...process.env,
+          CODESTORY_CLI: variant === "ambiguous-raw-override" ? fixture.cliPath : "",
+          CODESTORY_PLUGIN_DISABLE_PROVISION: "1",
+          PLUGIN_DATA: dataDir,
+          TEST_CODESTORY_VERSION: version,
+          TEST_OUT: runtimeOut,
+          PATH: "",
+        },
+        input,
+        encoding: "utf8",
+        timeout: 5000,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const response = JSON.parse(result.stdout.trim());
+      const status = JSON.parse(response.result.contents[0].text);
+      assert.equal(status.plugin_runtime.cli_source, "local_dev_receipt_invalid");
+      assert.equal(status.plugin_runtime.cli_path, null);
+      assert.equal(status.plugin_runtime.managed_binary_path, null);
+      if (variant === "invalid-receipt") {
+        assert.equal(
+          status.degraded_reason,
+          "codestory_dev_receipt_invalid:codestory_dev_receipt_package_digest",
+        );
+      } else {
+        assert.equal(status.degraded_reason, "codestory_dev_cli_ambiguous_override");
+      }
+      assert.equal(fs.existsSync(runtimeOut), false, `${variant} unexpectedly launched a runtime`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   }
 });
 
@@ -2431,6 +2579,10 @@ test("mcp launcher infers Codex managed data from installed cache without env", 
       launcher,
       await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8"),
       "utf8",
+    );
+    await copyFile(
+      join(pluginRoot, "scripts", "codestory-dev-cli-contract.cjs"),
+      join(installRoot, "scripts", "codestory-dev-cli-contract.cjs"),
     );
     await copyFile(
       join(pluginRoot, "generated-mcp-catalog.json"),

--- a/scripts/install-codestory-dev-plugin.mjs
+++ b/scripts/install-codestory-dev-plugin.mjs
@@ -1,0 +1,487 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const {
+  assetTarget,
+  directoryContractSha256,
+  expectedBinaryName,
+  receiptName,
+  receiptPluginId,
+  receiptPluginName,
+  receiptPurpose,
+  receiptSchemaVersion,
+  validateDevCliReceipt,
+} = require("../plugins/codestory/scripts/codestory-dev-cli-contract.cjs");
+
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultRepoRoot = path.dirname(path.dirname(scriptPath));
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (!argument.startsWith("--")) fail(`unknown argument: ${argument}`);
+    const name = argument.slice(2).replaceAll("-", "_");
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`${argument} requires a value`);
+    options[name] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function usage() {
+  return `Usage:
+  node scripts/install-codestory-dev-plugin.mjs --cli <absolute-codestory-cli>
+
+Options:
+  --staging-root <path>       Default: ~/.codex/dev-plugins/codestory
+  --marketplace-plugin <path> Default: ~/.codex/dev-marketplaces/CodeStoryDev/plugins/codestory
+  --plugin-data <path>        Default: ~/.codex/plugins/data/codestory-CodeStoryDev
+  --codex <path-or-command>   Default: codex
+
+The source package is the clean committed plugins/codestory directory from this checkout.
+The script stages one exact CLI and receipt, refreshes codestory@CodeStoryDev, and leaves
+the production marketplace package and plugin data untouched.`;
+}
+
+function sha256(pathname) {
+  return createHash("sha256").update(fs.readFileSync(pathname)).digest("hex");
+}
+
+function directFile(pathname, label) {
+  const metadata = fs.lstatSync(pathname);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    fail(`${label}_not_direct_file:${pathname}`);
+  }
+  return metadata;
+}
+
+function directDirectory(pathname, label) {
+  const metadata = fs.lstatSync(pathname);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    fail(`${label}_not_direct_directory:${pathname}`);
+  }
+}
+
+function run(command, args, options = {}) {
+  const completed = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: options.env,
+    shell: false,
+    timeout: options.timeout ?? 30_000,
+    windowsHide: true,
+  });
+  if (completed.error) fail(`${options.label || command}_spawn:${completed.error.message}`);
+  if (completed.status !== 0) {
+    fail(
+      `${options.label || command}_failed:status=${completed.status}:stderr=${String(completed.stderr || "").trim()}`,
+    );
+  }
+  return completed.stdout;
+}
+
+function git(repoRoot, args) {
+  return run("git", args, {
+    cwd: repoRoot,
+    env: process.env,
+    label: `git_${args[0]}`,
+  }).trim();
+}
+
+function listFiles(root, relative = "", files = []) {
+  const directory = relative ? path.join(root, relative) : root;
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const childRelative = relative ? path.join(relative, entry.name) : entry.name;
+    const child = path.join(root, childRelative);
+    const metadata = fs.lstatSync(child);
+    if (metadata.isSymbolicLink()) fail(`source_package_symlink:${childRelative}`);
+    if (metadata.isDirectory()) {
+      listFiles(root, childRelative, files);
+    } else if (metadata.isFile()) {
+      files.push(childRelative.split(path.sep).join("/"));
+    } else {
+      fail(`source_package_non_file:${childRelative}`);
+    }
+  }
+  return files.sort();
+}
+
+function verifyCommittedPluginSource(repoRoot, pluginSource) {
+  directDirectory(repoRoot, "repository_root");
+  directDirectory(pluginSource, "plugin_source");
+  const expectedSource = path.join(repoRoot, "plugins", "codestory");
+  if (fs.realpathSync(pluginSource) !== fs.realpathSync(expectedSource)) {
+    fail(`plugin_source_not_repository_package:${pluginSource}`);
+  }
+  const relativeSource = path.relative(repoRoot, pluginSource).split(path.sep).join("/");
+  const status = git(repoRoot, [
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+    "--ignored=matching",
+    "--",
+    relativeSource,
+  ]);
+  if (status) fail(`plugin_source_not_committed:${status.split(/\r?\n/u)[0]}`);
+  const tracked = git(repoRoot, ["ls-files", "-z", "--", relativeSource])
+    .split("\0")
+    .filter(Boolean)
+    .map((entry) => path.relative(relativeSource, entry).split(path.sep).join("/"))
+    .sort();
+  const actual = listFiles(pluginSource);
+  if (JSON.stringify(tracked) !== JSON.stringify(actual)) {
+    fail("plugin_source_inventory_not_committed");
+  }
+  return {
+    commit: git(repoRoot, ["rev-parse", "HEAD"]),
+    tree: git(repoRoot, ["rev-parse", `HEAD:${relativeSource}`]),
+    sha256: directoryContractSha256(pluginSource),
+  };
+}
+
+function pluginManifest(pluginSource) {
+  const manifestPath = path.join(pluginSource, ".codex-plugin", "plugin.json");
+  directFile(manifestPath, "plugin_manifest");
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    fail(`plugin_manifest_json:${error.message}`);
+  }
+  if (
+    manifest?.name !== receiptPluginName
+    || !/^\d+\.\d+\.\d+$/u.test(String(manifest?.version || ""))
+  ) {
+    fail("plugin_manifest_identity");
+  }
+  return manifest;
+}
+
+function verifyCli(cliPath, version, options = {}) {
+  if (!path.isAbsolute(cliPath)) fail("codestory_cli_must_be_absolute");
+  const resolved = path.resolve(cliPath);
+  const metadata = directFile(resolved, "codestory_cli");
+  const binary = expectedBinaryName(options.platform);
+  if (path.basename(resolved) !== binary) {
+    fail(`codestory_cli_name:expected=${binary}`);
+  }
+  if ((options.platform || process.platform) !== "win32" && (metadata.mode & 0o111) === 0) {
+    fail("codestory_cli_not_executable");
+  }
+  const completed = (options.probeVersion || ((candidate) => spawnSync(candidate, ["--version"], {
+    encoding: "utf8",
+    shell: false,
+    timeout: 3_000,
+    windowsHide: true,
+  })))(resolved);
+  if (completed.error || completed.status !== 0) fail("codestory_cli_version_probe_failed");
+  const output = `${completed.stdout || ""}\n${completed.stderr || ""}`;
+  const match = output.match(/\bcodestory-cli\s+v?(\d+\.\d+\.\d+)\b/u);
+  if (!match || match[1] !== version) {
+    fail(`codestory_cli_version:expected=${version}:actual=${match?.[1] || "unknown"}`);
+  }
+  return {
+    path: resolved,
+    name: binary,
+    bytes: metadata.size,
+    sha256: sha256(resolved),
+    version,
+  };
+}
+
+function marketplaceTargetsStaging(marketplacePlugin, stagingRoot) {
+  const metadata = fs.lstatSync(marketplacePlugin);
+  if (!metadata.isSymbolicLink()) fail("codestory_dev_marketplace_plugin_not_symlink");
+  const link = fs.readlinkSync(marketplacePlugin);
+  const target = path.resolve(path.dirname(marketplacePlugin), link);
+  if (target !== path.resolve(stagingRoot)) {
+    fail("codestory_dev_marketplace_plugin_wrong_target");
+  }
+}
+
+function codexJson(codex, args, options) {
+  const output = run(codex, args, {
+    cwd: options.repoRoot,
+    env: options.env,
+    label: `codex_plugin_${args[1] || args[0]}`,
+  });
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    fail(`codex_plugin_json:${error.message}`);
+  }
+}
+
+function installedEntry(list) {
+  if (!list || !Array.isArray(list.installed)) fail("codex_plugin_list_shape");
+  return list.installed.find((entry) => entry?.pluginId === receiptPluginId) || null;
+}
+
+function verifyRemoveResponse(response) {
+  if (
+    response?.pluginId !== receiptPluginId
+    || response?.name !== receiptPluginName
+    || response?.marketplaceName !== "CodeStoryDev"
+  ) {
+    fail("codex_plugin_remove_identity");
+  }
+}
+
+function verifyAddResponse(response, expectedVersion) {
+  if (
+    response?.pluginId !== receiptPluginId
+    || response?.name !== receiptPluginName
+    || response?.marketplaceName !== "CodeStoryDev"
+    || response?.version !== expectedVersion
+    || response?.authPolicy !== "ON_INSTALL"
+    || typeof response?.installedPath !== "string"
+    || !path.isAbsolute(response.installedPath)
+  ) {
+    fail("codex_plugin_add_identity");
+  }
+  return path.resolve(response.installedPath);
+}
+
+function replaceDirectory(candidate, destination) {
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  const backup = `${destination}.backup-${process.pid}-${Date.now()}`;
+  let previous = false;
+  if (fs.existsSync(destination)) {
+    directDirectory(destination, "codestory_dev_staging_root");
+    fs.renameSync(destination, backup);
+    previous = true;
+  }
+  try {
+    fs.renameSync(candidate, destination);
+    return {
+      backup: previous ? backup : null,
+      commit() {
+        if (previous) fs.rmSync(backup, { recursive: true, force: true });
+      },
+      rollback() {
+        fs.rmSync(destination, { recursive: true, force: true });
+        if (previous) fs.renameSync(backup, destination);
+      },
+    };
+  } catch (error) {
+    if (previous && fs.existsSync(backup) && !fs.existsSync(destination)) {
+      fs.renameSync(backup, destination);
+    }
+    throw error;
+  }
+}
+
+function stageCandidate({
+  cli,
+  pluginSource,
+  sourceIdentity,
+  stagingRoot,
+  version,
+  platform,
+  arch,
+  probeVersion,
+}) {
+  const parent = path.dirname(stagingRoot);
+  fs.mkdirSync(parent, { recursive: true });
+  const candidate = fs.mkdtempSync(path.join(parent, `.${path.basename(stagingRoot)}.staging-`));
+  try {
+    fs.cpSync(pluginSource, candidate, {
+      recursive: true,
+      dereference: false,
+      errorOnExist: false,
+      preserveTimestamps: true,
+    });
+    const binDir = path.join(candidate, "bin");
+    fs.mkdirSync(binDir, { mode: 0o755 });
+    const destination = path.join(binDir, cli.name);
+    fs.copyFileSync(cli.path, destination, fs.constants.COPYFILE_EXCL);
+    if ((platform || process.platform) !== "win32") fs.chmodSync(destination, 0o755);
+    const receipt = {
+      schema_version: receiptSchemaVersion,
+      purpose: receiptPurpose,
+      plugin_id: receiptPluginId,
+      plugin_name: receiptPluginName,
+      plugin_version: version,
+      source_commit: sourceIdentity.commit,
+      source_package_sha256: sourceIdentity.sha256,
+      target: assetTarget(platform, arch),
+      cli: {
+        path: `bin/${cli.name}`,
+        name: cli.name,
+        bytes: cli.bytes,
+        sha256: cli.sha256,
+        version: cli.version,
+      },
+    };
+    fs.writeFileSync(path.join(candidate, receiptName), `${JSON.stringify(receipt, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    const verified = validateDevCliReceipt(candidate, {
+      arch,
+      expectedPluginVersion: version,
+      platform,
+      probeVersion,
+      requireCacheIdentity: false,
+    });
+    if (verified.state !== "verified") {
+      fail(`staged_dev_receipt_invalid:${verified.reason}`);
+    }
+    return candidate;
+  } catch (error) {
+    fs.rmSync(candidate, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export function installDevPlugin(rawOptions = {}) {
+  const repoRoot = path.resolve(rawOptions.repoRoot || defaultRepoRoot);
+  const pluginSource = path.resolve(rawOptions.pluginSource || path.join(repoRoot, "plugins", "codestory"));
+  const home = rawOptions.home || os.homedir();
+  const stagingRoot = path.resolve(
+    rawOptions.stagingRoot || path.join(home, ".codex", "dev-plugins", "codestory"),
+  );
+  const marketplacePlugin = path.resolve(
+    rawOptions.marketplacePlugin
+      || path.join(home, ".codex", "dev-marketplaces", "CodeStoryDev", "plugins", "codestory"),
+  );
+  const pluginData = path.resolve(
+    rawOptions.pluginData
+      || path.join(home, ".codex", "plugins", "data", "codestory-CodeStoryDev"),
+  );
+  const codex = rawOptions.codex || "codex";
+  const env = { ...process.env, ...(rawOptions.env || {}) };
+  const cliPath = rawOptions.cli;
+  if (!cliPath) fail("--cli is required");
+
+  const sourceIdentity = verifyCommittedPluginSource(repoRoot, pluginSource);
+  const manifest = pluginManifest(pluginSource);
+  const cli = verifyCli(path.resolve(cliPath), manifest.version, rawOptions);
+  const target = assetTarget(rawOptions.platform, rawOptions.arch);
+  if (!target) fail(`unsupported_target:${rawOptions.platform || process.platform}-${rawOptions.arch || process.arch}`);
+  marketplaceTargetsStaging(marketplacePlugin, stagingRoot);
+
+  const candidate = stageCandidate({
+    arch: rawOptions.arch,
+    cli,
+    platform: rawOptions.platform,
+    pluginSource,
+    probeVersion: rawOptions.probeVersion,
+    sourceIdentity,
+    stagingRoot,
+    version: manifest.version,
+  });
+  const replacement = replaceDirectory(candidate, stagingRoot);
+  let previouslyInstalled = false;
+  let addAttempted = false;
+  try {
+    const list = codexJson(codex, ["plugin", "list", "--json"], { env, repoRoot });
+    previouslyInstalled = Boolean(installedEntry(list));
+    if (previouslyInstalled) {
+      verifyRemoveResponse(
+        codexJson(codex, ["plugin", "remove", receiptPluginId, "--json"], { env, repoRoot }),
+      );
+    }
+    addAttempted = true;
+    const added = codexJson(codex, ["plugin", "add", receiptPluginId, "--json"], { env, repoRoot });
+    const installedPath = verifyAddResponse(added, manifest.version);
+    directDirectory(installedPath, "installed_plugin_root");
+    const installed = validateDevCliReceipt(installedPath, {
+      arch: rawOptions.arch,
+      expectedPluginVersion: manifest.version,
+      platform: rawOptions.platform,
+      probeVersion: rawOptions.probeVersion,
+    });
+    if (installed.state !== "verified") {
+      fail(`installed_dev_receipt_invalid:${installed.reason}`);
+    }
+    if (
+      installed.sha256 !== cli.sha256
+      || installed.sourcePackageSha256 !== sourceIdentity.sha256
+      || installed.sourceCommit !== sourceIdentity.commit
+    ) {
+      fail("installed_dev_receipt_identity_changed");
+    }
+    replacement.commit();
+    return {
+      schema_version: 1,
+      purpose: "codestory-dev-plugin-install-result",
+      plugin_id: receiptPluginId,
+      plugin_version: manifest.version,
+      source_commit: sourceIdentity.commit,
+      source_tree: sourceIdentity.tree,
+      source_package_sha256: sourceIdentity.sha256,
+      target,
+      staged_plugin_root: stagingRoot,
+      installed_plugin_root: installedPath,
+      plugin_data: pluginData,
+      plugin_data_preserved: fs.existsSync(pluginData),
+      cli: {
+        path: installed.path,
+        name: cli.name,
+        bytes: cli.bytes,
+        sha256: cli.sha256,
+        version: cli.version,
+      },
+    };
+  } catch (error) {
+    replacement.rollback();
+    if ((addAttempted || previouslyInstalled) && rawOptions.restoreOnFailure !== false) {
+      try {
+        codexJson(codex, ["plugin", "remove", receiptPluginId, "--json"], { env, repoRoot });
+      } catch {
+        // Best-effort cleanup before restoring the prior package or empty state.
+      }
+    }
+    if (previouslyInstalled && rawOptions.restoreOnFailure !== false) {
+      try {
+        codexJson(codex, ["plugin", "add", receiptPluginId, "--json"], { env, repoRoot });
+      } catch {
+        // Preserve the original failure. The staged prior package remains available.
+      }
+    }
+    throw error;
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const result = installDevPlugin({
+    cli: args.cli,
+    codex: args.codex,
+    marketplacePlugin: args.marketplace_plugin,
+    pluginData: args.plugin_data,
+    stagingRoot: args.staging_root,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  main().catch((error) => {
+    process.stderr.write(`install-codestory-dev-plugin: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/install-codestory-dev-plugin.test.mjs
+++ b/scripts/tests/install-codestory-dev-plugin.test.mjs
@@ -1,0 +1,363 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import {
+  chmod,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+import { installDevPlugin } from "../install-codestory-dev-plugin.mjs";
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+const sourcePlugin = path.join(repoRoot, "plugins", "codestory");
+const contract = require(path.join(sourcePlugin, "scripts", "codestory-dev-cli-contract.cjs"));
+const version = JSON.parse(
+  await readFile(path.join(sourcePlugin, ".codex-plugin", "plugin.json"), "utf8"),
+).version;
+
+function digest(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function writeFakeCli(cliPath, cliVersion = version, suffix = "") {
+  await mkdir(path.dirname(cliPath), { recursive: true });
+  const body = `#!/bin/sh\necho "codestory-cli ${cliVersion}"\n${suffix}\n`;
+  await writeFile(cliPath, body, "utf8");
+  await chmod(cliPath, 0o755);
+}
+
+function git(root, ...args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+async function writeFakeCodex(script) {
+  const body = `#!${process.execPath}
+const fs=require("fs");
+const path=require("path");
+const args=process.argv.slice(2);
+const stage=process.env.FAKE_STAGE_ROOT;
+const cache=process.env.FAKE_CACHE_ROOT;
+const version=process.env.FAKE_PLUGIN_VERSION;
+const installed=path.join(cache,"CodeStoryDev","codestory",version);
+const command=args[1];
+if(command==="list"){
+  process.stdout.write(JSON.stringify({installed:fs.existsSync(installed)?[{pluginId:"codestory@CodeStoryDev"}]:[]}));
+  process.exit(0);
+}
+if(command==="remove"){
+  fs.rmSync(installed,{recursive:true,force:true});
+  process.stdout.write(JSON.stringify({pluginId:"codestory@CodeStoryDev",name:"codestory",marketplaceName:"CodeStoryDev"}));
+  process.exit(0);
+}
+if(command!=="add")process.exit(11);
+if(process.env.FAKE_ADD_MODE==="exit")process.exit(12);
+fs.mkdirSync(path.dirname(installed),{recursive:true});
+fs.cpSync(stage,installed,{recursive:true});
+if(process.env.FAKE_ADD_MODE==="mutate-package")fs.appendFileSync(path.join(installed,"README.md"),"mutated");
+if(process.env.FAKE_ADD_MODE==="mutate-cli"){
+  const name=process.platform==="win32"?"codestory-cli.exe":"codestory-cli";
+  fs.appendFileSync(path.join(installed,"bin",name),"mutated");
+}
+if(process.env.FAKE_ADD_MODE==="invalid-json"){
+  process.stdout.write("not-json");
+  process.exit(0);
+}
+const response={pluginId:"codestory@CodeStoryDev",name:"codestory",marketplaceName:"CodeStoryDev",version,installedPath:installed,authPolicy:"ON_INSTALL"};
+if(process.env.FAKE_ADD_MODE==="wrong-identity")response.pluginId="codestory@Elsewhere";
+if(process.env.FAKE_ADD_MODE==="wrong-version")response.version="9.9.9";
+if(process.env.FAKE_ADD_MODE==="relative-path")response.installedPath="relative";
+process.stdout.write(JSON.stringify(response));
+`;
+  await writeFile(script, body, "utf8");
+  await chmod(script, 0o755);
+}
+
+async function fixture() {
+  const root = await mkdtemp(path.join(await realpath(os.tmpdir()), "codestory-dev-install-"));
+  const checkout = path.join(root, "repo");
+  const plugin = path.join(checkout, "plugins", "codestory");
+  const home = path.join(root, "home");
+  const stagingRoot = path.join(home, ".codex", "dev-plugins", "codestory");
+  const marketplacePlugin = path.join(
+    home,
+    ".codex",
+    "dev-marketplaces",
+    "CodeStoryDev",
+    "plugins",
+    "codestory",
+  );
+  const pluginData = path.join(home, ".codex", "plugins", "data", "codestory-CodeStoryDev");
+  const cacheRoot = path.join(home, ".codex", "plugins", "cache");
+  const cli = path.join(root, contract.expectedBinaryName());
+  const codex = path.join(root, "codex-fixture");
+  await mkdir(path.dirname(plugin), { recursive: true });
+  await cp(sourcePlugin, plugin, { recursive: true });
+  git(checkout, "init", "-q");
+  git(checkout, "config", "user.email", "fixture@example.invalid");
+  git(checkout, "config", "user.name", "Fixture");
+  git(checkout, "add", ".");
+  git(checkout, "commit", "-qm", "fixture");
+  await mkdir(path.dirname(marketplacePlugin), { recursive: true });
+  await symlink(stagingRoot, marketplacePlugin, "dir");
+  await mkdir(pluginData, { recursive: true });
+  await writeFile(path.join(pluginData, "sentinel"), "keep", "utf8");
+  await writeFakeCli(cli);
+  await writeFakeCodex(codex);
+  const options = {
+    cli,
+    codex,
+    env: {
+      FAKE_CACHE_ROOT: cacheRoot,
+      FAKE_PLUGIN_VERSION: version,
+      FAKE_STAGE_ROOT: stagingRoot,
+    },
+    marketplacePlugin,
+    pluginData,
+    pluginSource: plugin,
+    repoRoot: checkout,
+    stagingRoot,
+  };
+  return {
+    cacheRoot,
+    cli,
+    codex,
+    home,
+    marketplacePlugin,
+    options,
+    plugin,
+    pluginData,
+    root,
+    stagingRoot,
+  };
+}
+
+async function cachedReceiptFixture() {
+  const root = await mkdtemp(path.join(await realpath(os.tmpdir()), "codestory-dev-receipt-"));
+  const pluginRoot = path.join(
+    root,
+    ".codex",
+    "plugins",
+    "cache",
+    "CodeStoryDev",
+    "codestory",
+    version,
+  );
+  await mkdir(path.dirname(pluginRoot), { recursive: true });
+  await cp(sourcePlugin, pluginRoot, { recursive: true });
+  const sourcePackageSha256 = contract.directoryContractSha256(pluginRoot);
+  const cliName = contract.expectedBinaryName();
+  const cliPath = path.join(pluginRoot, "bin", cliName);
+  await writeFakeCli(cliPath);
+  const cliBytes = await readFile(cliPath);
+  const receipt = {
+    schema_version: contract.receiptSchemaVersion,
+    purpose: contract.receiptPurpose,
+    plugin_id: contract.receiptPluginId,
+    plugin_name: contract.receiptPluginName,
+    plugin_version: version,
+    source_commit: "a".repeat(40),
+    source_package_sha256: sourcePackageSha256,
+    target: contract.assetTarget(),
+    cli: {
+      path: `bin/${cliName}`,
+      name: cliName,
+      bytes: cliBytes.length,
+      sha256: digest(cliBytes),
+      version,
+    },
+  };
+  const receiptPath = path.join(pluginRoot, contract.receiptName);
+  await writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+  return { cliPath, pluginRoot, receipt, receiptPath, root };
+}
+
+function install(fixtureValue, overrides = {}) {
+  return installDevPlugin({
+    ...fixtureValue.options,
+    ...overrides,
+    env: {
+      ...fixtureValue.options.env,
+      ...(overrides.env || {}),
+    },
+  });
+}
+
+test("CodeStoryDev installer stages and refreshes an exact receipt while preserving plugin data", {
+  skip: process.platform === "win32" ? "fixture uses a POSIX executable" : false,
+}, async () => {
+  const value = await fixture();
+  try {
+    const first = install(value);
+    assert.equal(first.plugin_id, "codestory@CodeStoryDev");
+    assert.equal(first.plugin_version, version);
+    assert.equal(first.target, contract.assetTarget());
+    assert.equal(first.cli.sha256, digest(await readFile(value.cli)));
+    assert.equal(await readFile(path.join(value.pluginData, "sentinel"), "utf8"), "keep");
+    assert.equal(first.plugin_data_preserved, true);
+    assert.equal(
+      contract.validateDevCliReceipt(first.installed_plugin_root, {
+        expectedPluginVersion: version,
+      }).state,
+      "verified",
+    );
+
+    await writeFakeCli(value.cli, version, "# second exact build");
+    const second = install(value);
+    assert.notEqual(second.cli.sha256, first.cli.sha256);
+    assert.equal(await readFile(path.join(value.pluginData, "sentinel"), "utf8"), "keep");
+    assert.equal(
+      contract.validateDevCliReceipt(second.installed_plugin_root, {
+        expectedPluginVersion: version,
+      }).sha256,
+      second.cli.sha256,
+    );
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("CodeStoryDev installer rejects missing, wrong-name, wrong-version, and symlink CLIs before plugin install", {
+  skip: process.platform === "win32" ? "fixture uses a POSIX executable" : false,
+}, async () => {
+  for (const variant of ["missing", "wrong-name", "wrong-version", "symlink"]) {
+    const value = await fixture();
+    try {
+      let candidate = value.cli;
+      if (variant === "missing") {
+        candidate = path.join(value.root, "missing", contract.expectedBinaryName());
+      } else if (variant === "wrong-name") {
+        candidate = path.join(value.root, "other-cli");
+        await writeFakeCli(candidate);
+      } else if (variant === "wrong-version") {
+        await writeFakeCli(candidate, "9.9.9");
+      } else {
+        const realCli = path.join(value.root, "real", contract.expectedBinaryName());
+        await writeFakeCli(realCli);
+        await rm(candidate, { force: true });
+        await symlink(realCli, candidate);
+      }
+      assert.throws(
+        () => install(value, { cli: candidate }),
+        /codestory_cli|ENOENT/u,
+        variant,
+      );
+      assert.equal(fs.existsSync(path.join(value.cacheRoot, "CodeStoryDev")), false);
+    } finally {
+      await rm(value.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("CodeStoryDev receipt rejects forged identity, digest, size, version, target, path escape, symlink, and package mutation", {
+  skip: process.platform === "win32" ? "fixture uses a POSIX executable" : false,
+}, async () => {
+  const mutations = [
+    ["identity", (value) => { value.receipt.plugin_id = "codestory@Elsewhere"; }],
+    ["digest", (value) => { value.receipt.cli.sha256 = "f".repeat(64); }],
+    ["size", (value) => { value.receipt.cli.bytes += 1; }],
+    ["version", (value) => { value.receipt.cli.version = "9.9.9"; }],
+    ["target", (value) => { value.receipt.target = "wrong-target"; }],
+    ["path escape", (value) => { value.receipt.cli.path = "../../outside"; }],
+    ["source digest", (value) => { value.receipt.source_package_sha256 = "0".repeat(64); }],
+    ["package mutation", async (value) => {
+      await writeFile(path.join(value.pluginRoot, "README.md"), "changed", "utf8");
+    }],
+    ["cli symlink", async (value) => {
+      const outside = path.join(value.root, "outside-cli");
+      await writeFakeCli(outside);
+      await rm(value.cliPath);
+      await symlink(outside, value.cliPath);
+    }],
+    ["dangling receipt", async (value) => {
+      await rm(value.receiptPath);
+      await symlink(path.join(value.root, "missing-receipt"), value.receiptPath);
+    }],
+  ];
+  for (const [label, mutate] of mutations) {
+    const value = await cachedReceiptFixture();
+    try {
+      await mutate(value);
+      if (!["package mutation", "cli symlink", "dangling receipt"].includes(label)) {
+        await writeFile(value.receiptPath, `${JSON.stringify(value.receipt, null, 2)}\n`, "utf8");
+      }
+      const result = contract.validateDevCliReceipt(value.pluginRoot, {
+        expectedPluginVersion: version,
+      });
+      assert.equal(result.state, "invalid", `${label}: ${JSON.stringify(result)}`);
+    } finally {
+      await rm(value.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("CodeStoryDev receipt detects CLI and package changes during version proof", {
+  skip: process.platform === "win32" ? "fixture uses a POSIX executable" : false,
+}, async () => {
+  for (const variant of ["cli", "package"]) {
+    const value = await cachedReceiptFixture();
+    try {
+      const result = contract.validateDevCliReceipt(value.pluginRoot, {
+        expectedPluginVersion: version,
+        probeVersion(candidate) {
+          if (variant === "cli") {
+            fs.appendFileSync(candidate, "changed");
+          } else {
+            fs.appendFileSync(path.join(value.pluginRoot, "README.md"), "changed");
+          }
+          return { status: 0, stdout: `codestory-cli ${version}\n`, stderr: "" };
+        },
+      });
+      assert.equal(result.state, "invalid", `${variant}: ${JSON.stringify(result)}`);
+      assert.match(result.reason, /changed/u);
+    } finally {
+      await rm(value.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("CodeStoryDev installer rejects plugin-add errors and mutated cache copies", {
+  skip: process.platform === "win32" ? "fixture uses a POSIX executable" : false,
+}, async () => {
+  for (const mode of [
+    "exit",
+    "invalid-json",
+    "wrong-identity",
+    "wrong-version",
+    "relative-path",
+    "mutate-package",
+    "mutate-cli",
+  ]) {
+    const value = await fixture();
+    try {
+      assert.throws(
+        () => install(value, {
+          env: { FAKE_ADD_MODE: mode },
+        }),
+        /codex_plugin|installed_dev_receipt/u,
+        mode,
+      );
+      assert.equal(await readFile(path.join(value.pluginData, "sentinel"), "utf8"), "keep");
+      assert.equal(
+        fs.existsSync(path.join(value.cacheRoot, "CodeStoryDev", "codestory", version)),
+        false,
+        `${mode} left an installed cache`,
+      );
+    } finally {
+      await rm(value.root, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
Closes #1327
Refs #1189
Refs #1179

## Context

The local `CodeStoryDev` package could contain current plugin source while its launcher still depended on production release-managed CLI provisioning. At v0.16 development head that path fails closed because no matching published release asset exists. This PR gives the unpublished development marketplace its own authenticated package/CLI handoff without changing the production marketplace contract.

Canonical packaged-MCP grounding was attempted against the exact delegated worktree before source planning and again on the final candidate. It failed closed with `managed_cli_asset_fetch_failed` / `codestory_unavailable`, so focused source inspection was used. CLI diagnostics were not substituted for packaged-MCP proof.

## What changed

- add one versioned CodeStoryDev receipt using the existing directory-contract SHA-256 semantics;
- add a repository-owned installer that requires clean committed plugin source and one exact platform CLI, stages them atomically, validates `codex plugin` JSON identities, and preserves plugin data;
- make the cached launcher validate cache containment, direct files, plugin/source identity, platform/name/size/SHA/version, package digest, and CLI execution before accepting the development override;
- fail closed on declared invalid receipts or simultaneous receipt/raw override without falling through to managed release provisioning;
- have the launcher own MCP initialization and relay the verified native runtime through explicit pipes, avoiding unreliable second-generation inherited stdio in real Codex hosts;
- cover repeat upgrades, hostile receipts, source/cache mutation, add failures, empty-PATH launch, no-fallback behavior, and the bridged runtime lifecycle;
- document the maintainer refresh path and verification lane.

The checked-in production `.mcp.json` remains `env: {}`. Production release-managed routing and the no-PATH contract are unchanged when no development receipt exists.

## Exact candidate

- Base: `1ffafc5d4888a3bc06a32cac640a7582d58eec22`
- Head: `0f2a088731abe39d998a819320ab3ec7d3aa9c7e`
- Tree: `04169f2ad5ff1bff2a837aa51678eb7f14dc0f26`

## Verification

- `node --test scripts/tests/install-codestory-dev-plugin.test.mjs` — 5 passed
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 74 passed, 1 Windows-only skip
- `node .github/scripts/check-doc-links.mjs` — 75 files, 265 links
- Node syntax checks for installer, receipt contract, and launcher
- installer `--help`
- `git diff --check 1ffafc5d4888a3bc06a32cac640a7582d58eec22...0f2a088731abe39d998a819320ab3ec7d3aa9c7e`
- exact-head hosted checks — Linux contracts, plugin static tests, Markdown links, rustdoc warnings, and closing-issue policy all passed

## Installed-host proof

A fresh `codex exec --ephemeral --json` session used normal installed-plugin discovery with `CODESTORY_CLI` unset and no MCP command, argument, working-directory, or proxy override.

- project-scoped `status` returned `working_locally`;
- project-scoped `affected` completed against publication generation 1 for both requested launcher/test paths;
- runtime source: `local_dev_override`;
- installed CLI: `/Users/albert/.codex/plugins/cache/CodeStoryDev/codestory/0.16.0/bin/codestory-cli`;
- plugin and CLI version: `0.16.0`;
- receipt repo ref: `0f2a088731abe39d998a819320ab3ec7d3aa9c7e`;
- build source: `codestory_dev_receipt`;
- installed CLI SHA-256: `cb7bd5fa2a39435b2d215ae8529ce4df3c984207cc442b9e24ecfcefa720cdf6`, independently matched;
- source package SHA-256: `c126ccf93353c75a791e0546732385a11e19a9ac78b1699059fb8978fa218336`.

The source-tool response was bounded and flagged the two requested inputs stale, so this proves installed MCP startup and project-scoped dispatch, not a newly refreshed repository publication.

## Review and risk

Earlier independent analysis found the real-host inherited-stdio failure and shaped the explicit-pipe bridge at this head. At the repository owner's direction, no additional review loop was run after the functional installed-host proof.

The launcher hashes the bounded plugin package and probes the exact CLI at startup for a receipt-bearing local development install. Production packages without a receipt keep the existing path.

## Non-claims

This PR does not claim published v0.16 release assets, production marketplace package proof, protected-hardware proof, final installed-runtime release proof, or live release completion.
