### PR TITLE
[codex] reduce grounding snapshot materialization wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@
 
 ### Performance
 
+- Grounding summary materialization now carries only node IDs and file ranks
+  through its window sort, rejoins full source rows afterward, and loads MEMBER
+  targets once through the existing covering edge index instead of issuing one
+  correlated lookup per snapshot node. The staged snapshot keeps the same rows,
+  file ranks, root direction, timing attribution, and bulk destination-index
+  order.
 - Full staged semantic publication now keyset-pages accepted symbol kinds
   directly from SQLite, resolves graph endpoints through cache-isolated bounded
   reads, and drops each page-local context after document emission instead of

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -1558,6 +1558,78 @@ fn grounding_node_rank_sql(alias: &str) -> String {
     )
 }
 
+fn grounding_node_snapshot_insert_sql() -> String {
+    let rank_sql = grounding_node_rank_sql("n");
+    let display_name = grounding_display_name_expr("n");
+    let indexable = grounding_indexable_predicate("n");
+    format!(
+        "WITH ranked_nodes AS (
+            SELECT
+                n.id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY n.file_node_id
+                    ORDER BY
+                        {rank_sql},
+                        COALESCE(n.start_line, 2147483647),
+                        {display_name},
+                        n.id
+                ) AS file_symbol_rank
+            FROM node n
+            WHERE {indexable}
+        )
+        INSERT INTO grounding_node_snapshot (
+            node_id,
+            kind,
+            serialized_name,
+            qualified_name,
+            canonical_id,
+            file_node_id,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+            display_name,
+            file_path,
+            node_rank,
+            sort_start_line,
+            is_root,
+            file_symbol_rank
+        )
+        SELECT
+            n.id,
+            n.kind,
+            n.serialized_name,
+            n.qualified_name,
+            n.canonical_id,
+            n.file_node_id,
+            n.start_line,
+            n.start_col,
+            n.end_line,
+            n.end_col,
+            {display_name},
+            COALESCE(f.path, file_node.serialized_name),
+            {rank_sql},
+            COALESCE(n.start_line, 2147483647),
+            CASE
+                WHEN n.id IN (
+                    SELECT e.target_node_id
+                    FROM edge e
+                    WHERE e.kind = {member_kind}
+                ) THEN 0
+                ELSE 1
+            END,
+            ranked_nodes.file_symbol_rank
+        FROM ranked_nodes
+        JOIN node n ON n.id = ranked_nodes.id
+        LEFT JOIN file f ON f.id = n.file_node_id
+        LEFT JOIN node file_node
+            ON file_node.id = n.file_node_id
+           AND file_node.kind = {file_kind}",
+        member_kind = EdgeKind::MEMBER as i32,
+        file_kind = NodeKind::FILE as i32,
+    )
+}
+
 fn grounding_file_snapshot_cte_sql() -> String {
     format!(
         "WITH all_files AS (
@@ -4304,9 +4376,6 @@ impl Storage {
         &self,
         build_node_file_rank_index: bool,
     ) -> Result<Duration, StorageError> {
-        let rank_sql = grounding_node_rank_sql("n");
-        let display_name = grounding_display_name_expr("n");
-        let indexable = grounding_indexable_predicate("n");
         let tx = self.conn.unchecked_transaction()?;
 
         tx.execute(
@@ -4337,86 +4406,7 @@ impl Storage {
         tx.execute("DELETE FROM grounding_node_summary_snapshot", [])?;
         tx.execute("DELETE FROM grounding_node_edge_digest_snapshot", [])?;
 
-        let node_snapshot_sql = format!(
-            "WITH indexable_nodes AS (
-                SELECT
-                    n.id,
-                    n.kind,
-                    n.serialized_name,
-                    n.qualified_name,
-                    n.canonical_id,
-                    n.file_node_id,
-                    n.start_line,
-                    n.start_col,
-                    n.end_line,
-                    n.end_col,
-                    {display_name} AS display_name,
-                    COALESCE(f.path, file_node.serialized_name) AS file_path,
-                    {rank_sql} AS node_rank,
-                    COALESCE(n.start_line, 2147483647) AS sort_start_line,
-                    CASE
-                        WHEN EXISTS (
-                            SELECT 1
-                            FROM edge e
-                            WHERE e.kind = {member_kind}
-                              AND e.target_node_id = n.id
-                        ) THEN 0
-                        ELSE 1
-                    END AS is_root,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY n.file_node_id
-                        ORDER BY
-                            {rank_sql},
-                            COALESCE(n.start_line, 2147483647),
-                            {display_name},
-                            n.id
-                    ) AS file_symbol_rank
-                FROM node n
-                LEFT JOIN file f ON f.id = n.file_node_id
-                LEFT JOIN node file_node
-                    ON file_node.id = n.file_node_id
-                   AND file_node.kind = {file_kind}
-                WHERE {indexable}
-            )
-            INSERT INTO grounding_node_snapshot (
-                node_id,
-                kind,
-                serialized_name,
-                qualified_name,
-                canonical_id,
-                file_node_id,
-                start_line,
-                start_col,
-                end_line,
-                end_col,
-                display_name,
-                file_path,
-                node_rank,
-                sort_start_line,
-                is_root,
-                file_symbol_rank
-            )
-            SELECT
-                id,
-                kind,
-                serialized_name,
-                qualified_name,
-                canonical_id,
-                file_node_id,
-                start_line,
-                start_col,
-                end_line,
-                end_col,
-                display_name,
-                file_path,
-                node_rank,
-                sort_start_line,
-                is_root,
-                file_symbol_rank
-            FROM indexable_nodes",
-            member_kind = EdgeKind::MEMBER as i32,
-            file_kind = NodeKind::FILE as i32,
-        );
+        let node_snapshot_sql = grounding_node_snapshot_insert_sql();
         tx.execute(&node_snapshot_sql, [])?;
 
         let node_file_rank_index_duration = if build_node_file_rank_index {

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -6673,6 +6673,53 @@ fn staged_summary_build_uses_bulk_node_file_rank_index_for_file_aggregation()
         assert!(!sqlite_index_exists(&storage, index_name)?);
     }
 
+    let node_snapshot_plan_sql = format!(
+        "EXPLAIN QUERY PLAN {}",
+        grounding_node_snapshot_insert_sql()
+    );
+    let mut node_plan_stmt = storage.conn.prepare(&node_snapshot_plan_sql)?;
+    let node_plan = node_plan_stmt
+        .query_map([], |row| row.get::<_, String>(3))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    assert!(
+        node_plan
+            .iter()
+            .any(|line| line.contains("SCAN ranked_nodes")),
+        "node snapshot did not use the narrow ranking coroutine: {node_plan:?}"
+    );
+    assert!(
+        node_plan.iter().any(|line| {
+            line.contains("SEARCH n USING INTEGER PRIMARY KEY")
+                || line.contains("SEARCH n USING COVERING INDEX")
+        }),
+        "ranked node rows did not rejoin through a source-node index: {node_plan:?}"
+    );
+    assert!(
+        node_plan.iter().any(|line| line.contains("LIST SUBQUERY")),
+        "MEMBER targets were not materialized through one indexed list query: {node_plan:?}"
+    );
+    assert!(
+        node_plan
+            .iter()
+            .any(|line| line.contains("idx_edge_kind_target")),
+        "MEMBER-target root classification lost its covering lookup: {node_plan:?}"
+    );
+    assert!(
+        node_plan.iter().all(|line| !line.contains("CORRELATED")),
+        "MEMBER-target root classification regressed to per-node probes: {node_plan:?}"
+    );
+    assert!(
+        node_plan.iter().all(|line| !line.contains("AUTOMATIC")),
+        "node snapshot built an automatic duplicate index: {node_plan:?}"
+    );
+    assert!(
+        node_plan
+            .iter()
+            .all(|line| !line.contains("grounding_node_snapshot")),
+        "node snapshot maintained a destination index during insertion: {node_plan:?}"
+    );
+    drop(node_plan_stmt);
+
     storage.refresh_grounding_summary_snapshots_for_staged_finalize()?;
     assert!(sqlite_index_exists(
         &storage,
@@ -8015,6 +8062,234 @@ fn test_safe_enum_conversion() -> Result<(), StorageError> {
     let edges = storage.get_edges()?;
     assert_eq!(edges[0].kind, EdgeKind::ANNOTATION_USAGE);
 
+    Ok(())
+}
+
+#[test]
+fn grounding_node_snapshot_preserves_columns_rank_and_member_root_direction()
+-> Result<(), StorageError> {
+    #[derive(Debug, PartialEq)]
+    struct SnapshotRow {
+        node_id: i64,
+        kind: i32,
+        serialized_name: String,
+        qualified_name: Option<String>,
+        canonical_id: Option<String>,
+        file_node_id: Option<i64>,
+        start_line: Option<i64>,
+        start_col: Option<i64>,
+        end_line: Option<i64>,
+        end_col: Option<i64>,
+        display_name: String,
+        file_path: Option<String>,
+        node_rank: i64,
+        sort_start_line: i64,
+        is_root: i64,
+        file_symbol_rank: Option<i64>,
+    }
+
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_file(&FileInfo {
+        id: 100,
+        path: PathBuf::from("src/lib.rs"),
+        language: "rust".to_string(),
+        modification_time: 0,
+        indexed: true,
+        complete: true,
+        line_count: 20,
+        file_role: FileRole::Source,
+    })?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(100),
+            kind: NodeKind::FILE,
+            serialized_name: "source-node-path.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(200),
+            kind: NodeKind::FILE,
+            serialized_name: "generated/fallback.ts".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(101),
+            kind: NodeKind::STRUCT,
+            serialized_name: "Widget".to_string(),
+            qualified_name: Some("crate::Widget".to_string()),
+            canonical_id: Some("rust:struct:Widget".to_string()),
+            file_node_id: Some(NodeId(100)),
+            start_line: Some(2),
+            start_col: Some(3),
+            end_line: Some(8),
+            end_col: Some(1),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(102),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "run".to_string(),
+            file_node_id: Some(NodeId(100)),
+            start_line: Some(10),
+            start_col: Some(1),
+            end_line: Some(12),
+            end_col: Some(2),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(103),
+            kind: NodeKind::MODULE,
+            serialized_name: "\"./types\"".to_string(),
+            file_node_id: Some(NodeId(100)),
+            start_line: Some(1),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(201),
+            kind: NodeKind::CLASS,
+            serialized_name: "Fallback".to_string(),
+            file_node_id: Some(NodeId(200)),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(202),
+            kind: NodeKind::UNKNOWN,
+            serialized_name: "excluded".to_string(),
+            file_node_id: Some(NodeId(200)),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_edges_batch(&[Edge {
+        id: EdgeId(1),
+        source: NodeId(101),
+        target: NodeId(102),
+        kind: EdgeKind::MEMBER,
+        file_node_id: Some(NodeId(100)),
+        ..Default::default()
+    }])?;
+
+    storage.refresh_grounding_summary_snapshots()?;
+    let mut stmt = storage.conn.prepare(
+        "SELECT
+            node_id,
+            kind,
+            serialized_name,
+            qualified_name,
+            canonical_id,
+            file_node_id,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+            display_name,
+            file_path,
+            node_rank,
+            sort_start_line,
+            is_root,
+            file_symbol_rank
+         FROM grounding_node_snapshot
+         ORDER BY node_id",
+    )?;
+    let actual = stmt
+        .query_map([], |row| {
+            Ok(SnapshotRow {
+                node_id: row.get(0)?,
+                kind: row.get(1)?,
+                serialized_name: row.get(2)?,
+                qualified_name: row.get(3)?,
+                canonical_id: row.get(4)?,
+                file_node_id: row.get(5)?,
+                start_line: row.get(6)?,
+                start_col: row.get(7)?,
+                end_line: row.get(8)?,
+                end_col: row.get(9)?,
+                display_name: row.get(10)?,
+                file_path: row.get(11)?,
+                node_rank: row.get(12)?,
+                sort_start_line: row.get(13)?,
+                is_root: row.get(14)?,
+                file_symbol_rank: row.get(15)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    assert_eq!(
+        actual,
+        vec![
+            SnapshotRow {
+                node_id: 101,
+                kind: NodeKind::STRUCT as i32,
+                serialized_name: "Widget".to_string(),
+                qualified_name: Some("crate::Widget".to_string()),
+                canonical_id: Some("rust:struct:Widget".to_string()),
+                file_node_id: Some(100),
+                start_line: Some(2),
+                start_col: Some(3),
+                end_line: Some(8),
+                end_col: Some(1),
+                display_name: "crate::Widget".to_string(),
+                file_path: Some("src/lib.rs".to_string()),
+                node_rank: 0,
+                sort_start_line: 2,
+                is_root: 1,
+                file_symbol_rank: Some(1),
+            },
+            SnapshotRow {
+                node_id: 102,
+                kind: NodeKind::FUNCTION as i32,
+                serialized_name: "run".to_string(),
+                qualified_name: None,
+                canonical_id: None,
+                file_node_id: Some(100),
+                start_line: Some(10),
+                start_col: Some(1),
+                end_line: Some(12),
+                end_col: Some(2),
+                display_name: "run".to_string(),
+                file_path: Some("src/lib.rs".to_string()),
+                node_rank: 1,
+                sort_start_line: 10,
+                is_root: 0,
+                file_symbol_rank: Some(2),
+            },
+            SnapshotRow {
+                node_id: 103,
+                kind: NodeKind::MODULE as i32,
+                serialized_name: "\"./types\"".to_string(),
+                qualified_name: None,
+                canonical_id: None,
+                file_node_id: Some(100),
+                start_line: Some(1),
+                start_col: None,
+                end_line: None,
+                end_col: None,
+                display_name: "\"./types\"".to_string(),
+                file_path: Some("src/lib.rs".to_string()),
+                node_rank: 5,
+                sort_start_line: 1,
+                is_root: 1,
+                file_symbol_rank: Some(3),
+            },
+            SnapshotRow {
+                node_id: 201,
+                kind: NodeKind::CLASS as i32,
+                serialized_name: "Fallback".to_string(),
+                qualified_name: None,
+                canonical_id: None,
+                file_node_id: Some(200),
+                start_line: None,
+                start_col: None,
+                end_line: None,
+                end_col: None,
+                display_name: "Fallback".to_string(),
+                file_path: Some("generated/fallback.ts".to_string()),
+                node_rank: 0,
+                sort_start_line: 2_147_483_647,
+                is_root: 1,
+                file_symbol_rank: Some(1),
+            },
+        ]
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Context

The measurement was taken from exact integration head
`c6bb58ad761e60763a6ebb2f24280520f815a5f8`
(`cddf4e151267a772d825f8b6172119a6b78315cd`), where the production
`grounding_node_snapshot` insert took 791.861 seconds for 3,023,066 rows from
8,552,335 source nodes and 5,690,718 edges. All four summary-destination
indexes were absent and the staged SQLite PRAGMAs matched production.

The unchanged candidate patch is rebased onto current exact integration base
`604b6c4fd38e9ca43e266e973e50596d5edff334`
(`ec3bd83a0312466e6750c3b32b8a0c46a334d344`).

## What changed

- carry only node IDs and `file_symbol_rank` through the per-file window sort;
- rejoin full source rows by the node primary key after ranking;
- classify MEMBER targets with one indexed list subquery instead of one
  correlated edge lookup per snapshot node;
- keep the snapshot schema, ranking expressions, MEMBER target direction,
  destination-index order, and phase timing boundaries unchanged;
- add exact persisted-column/rank/root coverage and query-plan assertions.

## Representative measurement

The candidate used an APFS clone of the same immutable database under
`/Volumes/CodeStoryLinuxCorpus/measurements/issue-1275-current-summary-c6bb58ad`.
It did not index, replay, or modify the retained Linux corpus proof.

- comparable baseline node insert: 815.818 seconds
- baseline CPU: 61.350 seconds (26.346 user, 35.005 system)
- baseline max RSS: 158,859,264 bytes
- candidate node insert: 329.421 seconds
- improvement: 486.397 seconds / 59.6%
- candidate CPU: 65.473 seconds (29.426 user, 36.046 system), +6.7%
- candidate max RSS: 164,823,040 bytes, +3.8%
- output: 3,023,066 rows
- exact equivalence across all 16 persisted columns:
  - candidate minus reference: 0 rows
  - reference minus candidate: 0 rows

Rejected alternatives remain useful controls:

- narrow rank window alone: 753.358 seconds, 4.9% faster, 150,568,960-byte max
  RSS;
- indexed MEMBER list with the old wide window: 721.340 seconds, 8.9% faster.

Only the combined plan produced a material wall reduction with a bounded memory
envelope.

The comparable baseline raw timing log is retained beside the isolated clones
as `issue1334-baseline-node-only-2ee70b33.log`. The earlier 791.861-second
measurement remains the original finding; the fresh 815.818-second run supplies
the same-scope CPU/RSS envelope.

## Review

Candidate head: `2ee70b33747948f38cbcc2b80ff42b7ba0e94a00`

Candidate tree: `99a355d8e7606784ff531522e08c6e9932b42113`

The rebase preserved stable patch ID
`eea434df161fe438e01764731b6797069fd5b29c`; range-diff reports the old and
new commits as equal. The #1331 structural-exclusion CHANGELOG entry is
preserved.

Check the SQL plan first. The window coroutine must carry only `id` and rank,
the source rejoin must use an index, MEMBER targets must use
`idx_edge_kind_target` through a non-correlated list subquery, and no automatic
or destination index may be built during insertion.

## Verification

Completed:

- `cargo test -p codestory-store grounding_node_snapshot_preserves_columns_rank_and_member_root_direction --locked -- --nocapture`
- `cargo test -p codestory-store staged_summary_build_uses_bulk_node_file_rank_index_for_file_aggregation --locked -- --nocapture`
- `cargo test -p codestory-store --locked` (164 passed)
- `cargo test -p codestory-runtime full_refresh_post_summary_index_failure_preserves_live_publication --locked -- --nocapture`
- `cargo test -p codestory-runtime incremental_boundaries_preserve_live_state_and_retry_atomically --locked -- --nocapture`
- `cargo test -p codestory-runtime runtime_service_shared_cancellation_stops_full_refresh_before_core_publication --locked -- --nocapture`
- `cargo check -p codestory-store --locked`
- `cargo clippy -p codestory-store --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- isolated-clone measurement and exact 16-column bidirectional equivalence

Hosted proof:

- Ubuntu draft source checks passed on the exact head
- deny rustdoc warnings passed
- issue-link guard passed
- independent exact-head review is clean
- reviewer confirmed the 16-column candidate/reference EXCEPT is `0` in both
  directions

## Risk

The change is confined to one staged snapshot INSERT inside the existing
transaction. It does not change schemas, publication fences, journal or
rollback behavior, cancellation ownership, source verification, or destination
index timing. The main regression risks are a query-planner fallback or a
ranking/root semantic drift; the new plan and exact-row tests cover both.

Closes #1334
Refs #1275
