### PR TITLE
[codex] keep one activation identity across retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Release
 
+- Project activation retries now retain one operation ID with monotonic
+  revision, stage, attempt, and progress fields. Request cancellation no longer
+  replaces shared preparation, and failed replacements bind any still-complete
+  core publication as `retained` local evidence while broad search remains
+  unavailable without a matching retrieval/runtime proof. Native MCP failures
+  return the same-tool retry when applicable plus project-bound status and
+  retained `affected` follow-ups.
 - Structural JSON, YAML, TOML, Markdown, and other tooling sources that exceed
   the 2,048-unit collector bound without exceeding the source-byte cap now
   publish as verified source-policy exclusions instead of blocking the entire

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1001,6 +1001,13 @@ fn handle_stdio_message(
                 if let Err(error) = activation {
                     state.status_cache = None;
                     let operation = runtime.activation.snapshot();
+                    let retained_local = operation.as_ref().is_some_and(|snapshot| {
+                        matches!(
+                            snapshot.capabilities.local_navigation,
+                            codestory_runtime::ActivationCapabilityState::Ready
+                                | codestory_runtime::ActivationCapabilityState::Retained
+                        )
+                    });
                     let allowed = !observes_complete_core
                         && operation
                             .as_ref()
@@ -1019,6 +1026,42 @@ fn handle_stdio_message(
                             .and_then(|details| details.cause_code.clone())
                             .unwrap_or_else(|| error.code.clone());
                         let details = error.details.clone();
+                        let diagnostics_uri = stdio_resource_uri_for_project(
+                            &StdioResource::Status,
+                            &runtime.project_root,
+                        );
+                        let mut recommended_next_calls = Vec::new();
+                        if preparing {
+                            recommended_next_calls.push(serde_json::json!({
+                                "method": "tools/call",
+                                "tool": name,
+                                "arguments": request
+                                    .pointer("/params/arguments")
+                                    .cloned()
+                                    .unwrap_or_else(|| serde_json::json!({})),
+                                "after_ms": operation
+                                    .as_ref()
+                                    .and_then(|snapshot| snapshot.retry_after_ms)
+                                    .unwrap_or(250),
+                            }));
+                        }
+                        if retained_local {
+                            recommended_next_calls.push(serde_json::json!({
+                                "method": "tools/call",
+                                "tool": "affected",
+                                "arguments": {
+                                    "project": crate::display::clean_path_string(
+                                        &runtime.project_root.to_string_lossy()
+                                    ),
+                                    "paths": ["<changed-project-path>"]
+                                },
+                                "evidence_scope": "retained_core_publication",
+                            }));
+                        }
+                        recommended_next_calls.push(serde_json::json!({
+                            "method": "resources/read",
+                            "uri": diagnostics_uri.clone(),
+                        }));
                         let error = serde_json::json!({
                             "code": if error.code == "cancelled" {
                                 "cancelled"
@@ -1043,10 +1086,15 @@ fn handle_stdio_message(
                                 .as_ref()
                                 .and_then(|snapshot| snapshot.retry_after_ms),
                             "operation": operation,
-                            "diagnostics_uri": stdio_resource_uri_for_project(
-                                &StdioResource::Status,
-                                &runtime.project_root,
-                            ),
+                            "next_action": if preparing {
+                                "retry_intended_tool"
+                            } else if retained_local {
+                                "continue_with_retained_local_navigation"
+                            } else {
+                                "use_focused_source_inspection"
+                            },
+                            "recommended_next_calls": recommended_next_calls,
+                            "diagnostics_uri": diagnostics_uri,
                         });
                         return Some(stdio_jsonrpc_success(id, stdio_tool_call_error(&error)));
                     }
@@ -3738,10 +3786,12 @@ fn stdio_status_with_activation(
         .as_ref()
         .filter(|snapshot| snapshot.state != codestory_runtime::ActivationState::Ready);
     let working_locally = active.is_some_and(|snapshot| {
-        snapshot.capabilities.local_navigation
-            == codestory_runtime::ActivationCapabilityState::Ready
-            && snapshot.capabilities.broad_search
-                != codestory_runtime::ActivationCapabilityState::Ready
+        matches!(
+            snapshot.capabilities.local_navigation,
+            codestory_runtime::ActivationCapabilityState::Ready
+                | codestory_runtime::ActivationCapabilityState::Retained
+        ) && snapshot.capabilities.broad_search
+            != codestory_runtime::ActivationCapabilityState::Ready
     });
     let (state, next_action) = match active.map(|snapshot| snapshot.state) {
         Some(_) if working_locally => ("working_locally", "continue_with_local_navigation"),
@@ -3760,6 +3810,7 @@ fn stdio_status_with_activation(
     };
     let capability_label = |capability| match capability {
         codestory_runtime::ActivationCapabilityState::Ready => "ready",
+        codestory_runtime::ActivationCapabilityState::Retained => "retained",
         codestory_runtime::ActivationCapabilityState::Retryable => "retryable",
         codestory_runtime::ActivationCapabilityState::Unavailable => "unavailable",
         codestory_runtime::ActivationCapabilityState::Cancelled => "cancelled",
@@ -4513,15 +4564,26 @@ fn build_stdio_status_readiness(
         effective_freshness.as_ref(),
         retrieval_status,
     );
-    if local_refresh.as_ref().is_some_and(|refresh| {
+    let serves_retained_core = runtime.activation.snapshot().is_some_and(|snapshot| {
+        snapshot.capabilities.local_navigation
+            == codestory_runtime::ActivationCapabilityState::Retained
+            && snapshot.retained_core_publication.as_ref() == summary.publication.as_ref()
+    });
+    let serves_refreshing_core = local_refresh.as_ref().is_some_and(|refresh| {
         refresh.state == crate::readiness::LocalRefreshState::Refreshing
             && refresh.serving_publication.is_some()
-    }) && let Some(local) = readiness
-        .iter_mut()
-        .find(|verdict| verdict.goal == ReadinessGoalDto::LocalNavigation)
+    });
+    if (serves_refreshing_core || serves_retained_core)
+        && let Some(local) = readiness
+            .iter_mut()
+            .find(|verdict| verdict.goal == ReadinessGoalDto::LocalNavigation)
     {
         local.status = ReadinessStatusDto::Ready;
-        local.summary = "Serving the last complete publication while a single refresh writer builds the next generation.".to_string();
+        local.summary = if serves_retained_core {
+            "Serving the retained complete core publication while replacement activation remains unavailable.".to_string()
+        } else {
+            "Serving the last complete publication while a single refresh writer builds the next generation.".to_string()
+        };
         local.minimum_next.clear();
         local.full_repair.clear();
     }
@@ -7218,8 +7280,10 @@ version = "0.11.20"
             active.runtime.activation.set_snapshot_for_test(Some(
                 codestory_runtime::ActivationSnapshot {
                     operation_id: format!("activation-{index}"),
+                    revision: 1,
                     state: codestory_runtime::ActivationState::Unavailable,
                     stage: codestory_runtime::ActivationStage::Validation,
+                    progress: 90,
                     attempt: 1,
                     retry_after_ms: None,
                     failure_code: Some("project_unavailable".to_string()),
@@ -7227,6 +7291,7 @@ version = "0.11.20"
                     failure_details: None,
                     embedding_capacity: None,
                     embedding_retry: None,
+                    retained_core_publication: None,
                     capabilities: codestory_runtime::ActivationCapabilities {
                         local_navigation: codestory_runtime::ActivationCapabilityState::Unavailable,
                         broad_search: codestory_runtime::ActivationCapabilityState::Unavailable,
@@ -7738,8 +7803,10 @@ version = "0.11.20"
             .activation
             .set_snapshot_for_test(Some(codestory_runtime::ActivationSnapshot {
                 operation_id: "activation-live".to_string(),
+                revision: 4,
                 state: codestory_runtime::ActivationState::Preparing,
                 stage: codestory_runtime::ActivationStage::DensePreparation,
+                progress: 60,
                 attempt: 1,
                 retry_after_ms: Some(375),
                 failure_code: None,
@@ -7747,6 +7814,7 @@ version = "0.11.20"
                 failure_details: None,
                 embedding_capacity: None,
                 embedding_retry: None,
+                retained_core_publication: None,
                 capabilities: codestory_runtime::ActivationCapabilities {
                     local_navigation: codestory_runtime::ActivationCapabilityState::Ready,
                     broad_search: codestory_runtime::ActivationCapabilityState::Retryable,
@@ -7781,8 +7849,10 @@ version = "0.11.20"
             .activation
             .set_snapshot_for_test(Some(codestory_runtime::ActivationSnapshot {
                 operation_id: "activation-live".to_string(),
+                revision: 8,
                 state: codestory_runtime::ActivationState::Retryable,
                 stage: codestory_runtime::ActivationStage::Validation,
+                progress: 90,
                 attempt: 2,
                 retry_after_ms: Some(250),
                 failure_code: Some("activation_retryable".to_string()),
@@ -7796,6 +7866,7 @@ version = "0.11.20"
                     retry_condition: "the incompatible owner exits while fully idle".into(),
                     capacity: None,
                 }),
+                retained_core_publication: None,
                 capabilities: codestory_runtime::ActivationCapabilities {
                     local_navigation: codestory_runtime::ActivationCapabilityState::Ready,
                     broad_search: codestory_runtime::ActivationCapabilityState::Retryable,
@@ -7833,8 +7904,10 @@ version = "0.11.20"
             .activation
             .set_snapshot_for_test(Some(codestory_runtime::ActivationSnapshot {
                 operation_id: "activation-live".to_string(),
+                revision: 10,
                 state: codestory_runtime::ActivationState::Unavailable,
                 stage: codestory_runtime::ActivationStage::Validation,
+                progress: 90,
                 attempt: 3,
                 retry_after_ms: None,
                 failure_code: Some("project_unavailable".to_string()),
@@ -7842,6 +7915,7 @@ version = "0.11.20"
                 failure_details: None,
                 embedding_capacity: None,
                 embedding_retry: None,
+                retained_core_publication: None,
                 capabilities: codestory_runtime::ActivationCapabilities {
                     local_navigation: codestory_runtime::ActivationCapabilityState::Ready,
                     broad_search: codestory_runtime::ActivationCapabilityState::Unavailable,

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -5318,3 +5318,186 @@ fn packet_preserves_typed_source_failure_diagnostics() {
         Some(&json!(true))
     );
 }
+
+#[test]
+fn failed_replacement_retries_keep_identity_and_offer_retained_local_analysis() {
+    let fixture = indexed_fixture();
+    fs::write(
+        fixture.workspace.path().join("codestory_workspace.json"),
+        r#"{"members":["src","missing"]}"#,
+    )
+    .expect("write incomplete replacement fixture");
+    let mut server = spawn_stdio_server(&fixture);
+    let packet_request = |id: &str| {
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {
+                "name": "packet",
+                "arguments": {"question": "How does AppController open a project?"}
+            }
+        })
+    };
+
+    let first = send_json(&mut server, packet_request("retained-packet-first"));
+    let first_error = assert_tool_error(&first, json!("retained-packet-first"));
+    assert_eq!(first_error["code"], json!("codestory_unavailable"));
+    assert_eq!(
+        first_error["cause_code"],
+        json!("source_discovery_incomplete")
+    );
+    assert_eq!(first_error["retry_tool"], Value::Null);
+    assert!(first_error["retry_after_ms"].is_null());
+    assert_eq!(
+        first_error["operation"]["capabilities"]["local_navigation"],
+        json!("retained")
+    );
+    assert_eq!(
+        first_error["operation"]["capabilities"]["broad_search"],
+        json!("unavailable")
+    );
+    assert!(
+        first_error["operation"]["retained_core_publication"]["generation_id"]
+            .as_str()
+            .is_some()
+    );
+    assert!(
+        first_error["operation"]["revision"].as_u64().is_some()
+            && first_error["operation"]["progress"].as_u64().is_some()
+    );
+    assert_eq!(
+        first_error["next_action"],
+        json!("continue_with_retained_local_navigation")
+    );
+    assert!(
+        first_error["recommended_next_calls"]
+            .as_array()
+            .is_some_and(|calls| {
+                calls.iter().any(|call| {
+                    call["method"] == "tools/call"
+                        && call["tool"] == "affected"
+                        && call["arguments"]["paths"] == json!(["<changed-project-path>"])
+                }) && calls.iter().any(|call| {
+                    call["method"] == "resources/read"
+                        && call["uri"]
+                            .as_str()
+                            .is_some_and(|uri| uri.starts_with("codestory://status?project="))
+                })
+            }),
+        "terminal MCP response must provide useful native follow-ups: {first_error}"
+    );
+
+    let first_operation = first_error["operation"].clone();
+    let second = send_json(&mut server, packet_request("retained-packet-second"));
+    let second_error = assert_tool_error(&second, json!("retained-packet-second"));
+    assert_eq!(
+        second_error["operation"]["operation_id"],
+        first_operation["operation_id"]
+    );
+    assert!(
+        second_error["operation"]["revision"]
+            .as_u64()
+            .zip(first_operation["revision"].as_u64())
+            .is_some_and(|(second, first)| second > first)
+    );
+    assert!(
+        second_error["operation"]["attempt"]
+            .as_u64()
+            .zip(first_operation["attempt"].as_u64())
+            .is_some_and(|(second, first)| second == first + 1)
+    );
+    assert!(
+        second_error["operation"]["progress"]
+            .as_u64()
+            .zip(first_operation["progress"].as_u64())
+            .is_some_and(|(second, first)| second >= first)
+    );
+    assert_eq!(second_error["operation"]["stage"], first_operation["stage"]);
+
+    let affected = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "retained-affected",
+            "method": "tools/call",
+            "params": {
+                "name": "affected",
+                "arguments": {"paths": ["src/runtime.rs"]}
+            }
+        }),
+    );
+    assert_tool_success(&affected, json!("retained-affected"));
+    let affected_result = assert_success_envelope(&affected, json!("retained-affected"));
+    assert!(
+        affected_result["_meta"]["codestory_publication"]["core_publication"]["generation"]
+            .as_u64()
+            .is_some(),
+        "affected must pin the retained core publication: {affected_result}"
+    );
+
+    let ground = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "retained-ground",
+            "method": "tools/call",
+            "params": {
+                "name": "ground",
+                "arguments": {"budget": "strict"}
+            }
+        }),
+    );
+    let ground = assert_tool_success(&ground, json!("retained-ground"));
+    assert!(
+        ground["stats"]["node_count"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "ground must remain usable from the retained core: {ground}"
+    );
+
+    let status = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "retained-status",
+            "method": "tools/call",
+            "params": {"name": "status", "arguments": {}}
+        }),
+    );
+    let status = assert_tool_success(&status, json!("retained-status"));
+    assert_eq!(status["state"], json!("working_locally"));
+    assert_eq!(
+        status["capabilities"]["local_navigation"],
+        json!("retained")
+    );
+    assert_eq!(status["capabilities"]["broad_search"], json!("unavailable"));
+    assert_eq!(
+        status["current_operation"]["operation_id"],
+        first_operation["operation_id"]
+    );
+
+    let diagnostics_uri = first_error["diagnostics_uri"]
+        .as_str()
+        .expect("project-bound status URI");
+    let resource = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "retained-status-resource",
+            "method": "resources/read",
+            "params": {"uri": diagnostics_uri}
+        }),
+    );
+    let resource = assert_success_envelope(&resource, json!("retained-status-resource"));
+    let full_status = json_resource_content(resource, "codestory://status");
+    assert_allowed_surface(&full_status, "affected", true, "local_navigation", "ready");
+    assert_allowed_surface(&full_status, "ground", true, "local_navigation", "ready");
+    assert_allowed_surface(
+        &full_status,
+        "packet",
+        false,
+        "agent_packet_search",
+        "unavailable",
+    );
+}

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -4179,18 +4179,26 @@ pub struct Runtime {
 impl Runtime {
     pub fn new() -> Self {
         let controller = AppController::new();
+        let activation = ActivationService::new(controller.clone());
         Self {
-            activation: ActivationService::new(controller.clone()),
-            public_operation: PublicOperationService::new(controller.clone()),
+            activation: activation.clone(),
+            public_operation: PublicOperationService::new_with_activation(
+                controller.clone(),
+                activation,
+            ),
             controller,
         }
     }
 
     pub fn new_with_config(config: codestory_retrieval::SidecarRuntimeConfig) -> Self {
         let controller = AppController::new_with_config(config);
+        let activation = ActivationService::new(controller.clone());
         Self {
-            activation: ActivationService::new(controller.clone()),
-            public_operation: PublicOperationService::new(controller.clone()),
+            activation: activation.clone(),
+            public_operation: PublicOperationService::new_with_activation(
+                controller.clone(),
+                activation,
+            ),
             controller,
         }
     }

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -1697,6 +1697,40 @@ mod activation_tests {
     }
 
     #[test]
+    fn serial_retries_keep_one_activation_identity_after_terminal_failure() {
+        let project = tempfile::tempdir().expect("project");
+        let missing = project.path().join("missing");
+        let storage_path = project.path().join("cache").join("codestory.db");
+        let service = Runtime::new().activation_service();
+
+        let first = service
+            .activate_project(
+                &missing,
+                &storage_path,
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect_err("missing project must fail activation");
+        assert_eq!(first.code, "project_unavailable");
+        let first_snapshot = service.snapshot().expect("first terminal snapshot");
+
+        let second = service
+            .activate_project(
+                &missing,
+                &storage_path,
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect_err("same missing project must fail activation again");
+        assert_eq!(second.code, "project_unavailable");
+        let second_snapshot = service.snapshot().expect("second terminal snapshot");
+
+        assert_eq!(
+            second_snapshot.operation_id, first_snapshot.operation_id,
+            "serial retries for one project must retain one activation identity"
+        );
+        assert_eq!(second_snapshot.attempt, first_snapshot.attempt + 1);
+    }
+
+    #[test]
     fn activation_error_is_unavailable_instead_of_ready() {
         let project = tempfile::tempdir().expect("project");
         let missing = project.path().join("missing");

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -80,16 +80,28 @@ pub(crate) fn active_public_operation_cancellation() -> Option<Arc<AtomicBool>> 
     ACTIVE_PUBLIC_OPERATION_CANCELLATION.with(|active| active.borrow().clone())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ActivationStage {
     Discovery,
     CoreFreshness,
     SearchPreparation,
     DensePreparation,
-    Validation,
     Publication,
+    Validation,
     Ready,
+}
+
+fn activation_stage_progress(stage: ActivationStage) -> u8 {
+    match stage {
+        ActivationStage::Discovery => 0,
+        ActivationStage::CoreFreshness => 20,
+        ActivationStage::SearchPreparation => 40,
+        ActivationStage::DensePreparation => 60,
+        ActivationStage::Publication => 75,
+        ActivationStage::Validation => 90,
+        ActivationStage::Ready => 100,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -107,6 +119,7 @@ pub enum ActivationState {
 #[serde(rename_all = "snake_case")]
 pub enum ActivationCapabilityState {
     Ready,
+    Retained,
     Retryable,
     Unavailable,
     Cancelled,
@@ -121,8 +134,10 @@ pub struct ActivationCapabilities {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ActivationSnapshot {
     pub operation_id: String,
+    pub revision: u64,
     pub state: ActivationState,
     pub stage: ActivationStage,
+    pub progress: u8,
     pub attempt: u32,
     pub retry_after_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -134,6 +149,8 @@ pub struct ActivationSnapshot {
     pub failure: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_details: Option<Box<ApiErrorDetails>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retained_core_publication: Option<IndexPublicationDto>,
     pub capabilities: ActivationCapabilities,
 }
 
@@ -142,7 +159,10 @@ impl ActivationSnapshot {
         if operation_requires_retrieval(operation) {
             self.capabilities.broad_search == ActivationCapabilityState::Ready
         } else {
-            self.capabilities.local_navigation == ActivationCapabilityState::Ready
+            matches!(
+                self.capabilities.local_navigation,
+                ActivationCapabilityState::Ready | ActivationCapabilityState::Retained
+            )
         }
     }
 }
@@ -229,6 +249,25 @@ impl ActivationService {
             .expect("activation coordinator poisoned")
             .current
             .clone()
+    }
+
+    fn snapshot_for_target(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+    ) -> Option<ActivationSnapshot> {
+        let target = ActivationTarget::new(project_root, storage_path);
+        let state = self
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator poisoned");
+        state
+            .target
+            .as_ref()
+            .is_some_and(|current| current.matches(&target))
+            .then(|| state.current.clone())
+            .flatten()
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -330,6 +369,51 @@ impl ActivationService {
         }
     }
 
+    fn retained_core_publication(
+        &self,
+        storage_path: &Path,
+    ) -> Result<Option<IndexPublicationDto>, ApiError> {
+        if !storage_path.is_file() {
+            return Ok(None);
+        }
+        let storage = Store::open_read_only(storage_path).map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to open retained core publication observationally: {error}"
+            ))
+        })?;
+        let snapshot = storage.read_snapshot().map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to pin retained core publication observation: {error}"
+            ))
+        })?;
+        let retained = if snapshot
+            .storage()
+            .has_incomplete_incremental_run()
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to inspect retained core publication fence: {error}"
+                ))
+            })? {
+            None
+        } else {
+            snapshot
+                .storage()
+                .get_complete_index_publication()
+                .map_err(|error| {
+                    ApiError::internal(format!(
+                        "Failed to inspect retained core publication: {error}"
+                    ))
+                })?
+                .map(crate::index_publication_dto)
+        };
+        snapshot.finish().map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to finish retained core publication observation: {error}"
+            ))
+        })?;
+        Ok(retained)
+    }
+
     pub fn activate_project_with_foreground_budget(
         &self,
         project_root: &Path,
@@ -344,6 +428,8 @@ impl ActivationService {
             ));
         }
         let target = ActivationTarget::new(project_root, storage_path);
+        let retained_core_publication =
+            self.retained_core_publication(storage_path).unwrap_or(None);
         let mut state = self
             .coordinator
             .state
@@ -382,9 +468,10 @@ impl ActivationService {
             let operation_id = if let Some(snapshot) = state
                 .current
                 .as_mut()
-                .filter(|snapshot| snapshot.state == ActivationState::Retryable)
+                .filter(|snapshot| snapshot.state != ActivationState::Ready)
             {
                 snapshot.attempt += 1;
+                snapshot.revision += 1;
                 snapshot.failure = None;
                 snapshot.failure_code = None;
                 snapshot.failure_details = None;
@@ -392,7 +479,18 @@ impl ActivationService {
                 snapshot.embedding_retry = None;
                 snapshot.retry_after_ms = Some(250);
                 snapshot.state = ActivationState::Preparing;
-                snapshot.stage = ActivationStage::Discovery;
+                let retained_was_ready = snapshot.capabilities.local_navigation
+                    == ActivationCapabilityState::Ready
+                    && snapshot.retained_core_publication == retained_core_publication;
+                snapshot.retained_core_publication = retained_core_publication.clone();
+                snapshot.capabilities.local_navigation = if retained_was_ready {
+                    ActivationCapabilityState::Ready
+                } else if snapshot.retained_core_publication.is_some() {
+                    ActivationCapabilityState::Retained
+                } else {
+                    ActivationCapabilityState::Unavailable
+                };
+                snapshot.capabilities.broad_search = ActivationCapabilityState::Unavailable;
                 snapshot.operation_id.clone()
             } else {
                 let project_scope = target
@@ -407,8 +505,10 @@ impl ActivationService {
                 );
                 state.current = Some(ActivationSnapshot {
                     operation_id: operation_id.clone(),
+                    revision: 1,
                     state: ActivationState::Preparing,
                     stage: ActivationStage::Discovery,
+                    progress: activation_stage_progress(ActivationStage::Discovery),
                     attempt: 1,
                     retry_after_ms: Some(250),
                     embedding_capacity: None,
@@ -416,8 +516,13 @@ impl ActivationService {
                     failure_code: None,
                     failure: None,
                     failure_details: None,
+                    retained_core_publication: retained_core_publication.clone(),
                     capabilities: ActivationCapabilities {
-                        local_navigation: ActivationCapabilityState::Unavailable,
+                        local_navigation: if retained_core_publication.is_some() {
+                            ActivationCapabilityState::Retained
+                        } else {
+                            ActivationCapabilityState::Unavailable
+                        },
                         broad_search: ActivationCapabilityState::Unavailable,
                     },
                 });
@@ -601,7 +706,12 @@ impl ActivationService {
                 "activation did not produce a fresh complete core publication",
             ));
         }
-        operation.set_capability(false, ActivationCapabilityState::Ready);
+        operation.set_local_publication(
+            summary
+                .publication
+                .clone()
+                .expect("fresh complete core has a publication identity"),
+        );
 
         operation.ensure_not_cancelled("search preparation")?;
         operation.set_stage(ActivationStage::SearchPreparation);
@@ -861,6 +971,7 @@ pub struct ActivePublicOperationPublication {
 #[derive(Clone)]
 pub struct PublicOperationService {
     controller: AppController,
+    activation: Option<ActivationService>,
     next_id: Arc<AtomicU64>,
 }
 
@@ -868,8 +979,41 @@ impl PublicOperationService {
     pub(crate) fn new(controller: AppController) -> Self {
         Self {
             controller,
+            activation: None,
             next_id: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    pub(crate) fn new_with_activation(
+        controller: AppController,
+        activation: ActivationService,
+    ) -> Self {
+        Self {
+            controller,
+            activation: Some(activation),
+            next_id: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn retained_core_allows(&self, operation: &str, publication: &IndexPublicationRecord) -> bool {
+        !operation_requires_retrieval(operation)
+            && self.activation.as_ref().is_some_and(|activation| {
+                let Some(project_root) = self.controller.require_project_root().ok() else {
+                    return false;
+                };
+                let Some(storage_path) = self.controller.require_storage_path().ok() else {
+                    return false;
+                };
+                activation
+                    .snapshot_for_target(&project_root, &storage_path)
+                    .is_some_and(|snapshot| {
+                        matches!(
+                            snapshot.capabilities.local_navigation,
+                            ActivationCapabilityState::Ready | ActivationCapabilityState::Retained
+                        ) && snapshot.retained_core_publication.as_ref()
+                            == Some(&crate::index_publication_dto(publication.clone()))
+                    })
+            })
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -923,7 +1067,9 @@ impl PublicOperationService {
         for attempt in 1..=2 {
             let result = self.controller.with_complete_core_snapshot(|publication| {
                 let freshness = self.controller.index_freshness_uncached()?;
-                if freshness.status != IndexFreshnessStatusDto::Fresh {
+                if freshness.status != IndexFreshnessStatusDto::Fresh
+                    && !self.retained_core_allows(operation, publication)
+                {
                     return Err(ApiError::new(
                         "project_unavailable",
                         format!("{operation} requires a fresh complete core publication"),
@@ -945,7 +1091,9 @@ impl PublicOperationService {
                         ));
                     }
                     let after = self.controller.index_freshness_uncached()?;
-                    if after.status != IndexFreshnessStatusDto::Fresh {
+                    if after.status != IndexFreshnessStatusDto::Fresh
+                        && !self.retained_core_allows(operation, publication)
+                    {
                         return Err(ApiError::new(
                             "publication_changed",
                             format!("source inputs changed while running {operation}"),
@@ -1097,8 +1245,29 @@ impl ActivationOperation {
             .as_mut()
             .filter(|snapshot| snapshot.operation_id == self.operation_id)
         {
-            snapshot.stage = stage;
+            snapshot.stage = snapshot.stage.max(stage);
+            snapshot.progress = snapshot.progress.max(activation_stage_progress(stage));
             snapshot.state = ActivationState::Updating;
+            snapshot.revision += 1;
+        }
+        self.service.coordinator.changed.notify_all();
+    }
+
+    fn set_local_publication(&self, publication: IndexPublicationDto) {
+        let mut state = self
+            .service
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator poisoned");
+        if let Some(snapshot) = state
+            .current
+            .as_mut()
+            .filter(|snapshot| snapshot.operation_id == self.operation_id)
+        {
+            snapshot.retained_core_publication = Some(publication);
+            snapshot.capabilities.local_navigation = ActivationCapabilityState::Ready;
+            snapshot.revision += 1;
         }
         self.service.coordinator.changed.notify_all();
     }
@@ -1120,6 +1289,7 @@ impl ActivationOperation {
             } else {
                 snapshot.capabilities.local_navigation = capability;
             }
+            snapshot.revision += 1;
         }
         self.service.coordinator.changed.notify_all();
     }
@@ -1145,7 +1315,10 @@ impl ActivationOperation {
                 | "publication_changed" => ActivationCapabilityState::Retryable,
                 _ => ActivationCapabilityState::Unavailable,
             };
-            if snapshot.capabilities.local_navigation != ActivationCapabilityState::Ready {
+            if !matches!(
+                snapshot.capabilities.local_navigation,
+                ActivationCapabilityState::Ready | ActivationCapabilityState::Retained
+            ) {
                 snapshot.capabilities.local_navigation = capability;
             }
             if snapshot.capabilities.broad_search != ActivationCapabilityState::Ready {
@@ -1156,6 +1329,7 @@ impl ActivationOperation {
                 ActivationCapabilityState::Unavailable => ActivationState::Unavailable,
                 ActivationCapabilityState::Cancelled => ActivationState::Cancelled,
                 ActivationCapabilityState::Ready => ActivationState::Ready,
+                ActivationCapabilityState::Retained => ActivationState::Updating,
             };
             snapshot.embedding_capacity = error
                 .details
@@ -1183,10 +1357,15 @@ impl ActivationOperation {
         } else {
             snapshot.state = ActivationState::Ready;
             snapshot.stage = ActivationStage::Ready;
+            snapshot.progress = activation_stage_progress(ActivationStage::Ready);
             snapshot.retry_after_ms = None;
             snapshot.embedding_capacity = None;
+            snapshot.embedding_retry = None;
+            snapshot.failure_code = None;
+            snapshot.failure_details = None;
             snapshot.failure = None;
         }
+        snapshot.revision += 1;
         let snapshot = snapshot.clone();
         state.running = false;
         state.current_cancel = None;
@@ -1704,21 +1883,13 @@ mod activation_tests {
         let service = Runtime::new().activation_service();
 
         let first = service
-            .activate_project(
-                &missing,
-                &storage_path,
-                Arc::new(AtomicBool::new(false)),
-            )
+            .activate_project(&missing, &storage_path, Arc::new(AtomicBool::new(false)))
             .expect_err("missing project must fail activation");
         assert_eq!(first.code, "project_unavailable");
         let first_snapshot = service.snapshot().expect("first terminal snapshot");
 
         let second = service
-            .activate_project(
-                &missing,
-                &storage_path,
-                Arc::new(AtomicBool::new(false)),
-            )
+            .activate_project(&missing, &storage_path, Arc::new(AtomicBool::new(false)))
             .expect_err("same missing project must fail activation again");
         assert_eq!(second.code, "project_unavailable");
         let second_snapshot = service.snapshot().expect("second terminal snapshot");
@@ -1728,6 +1899,149 @@ mod activation_tests {
             "serial retries for one project must retain one activation identity"
         );
         assert_eq!(second_snapshot.attempt, first_snapshot.attempt + 1);
+        assert!(second_snapshot.revision > first_snapshot.revision);
+        assert!(second_snapshot.stage >= first_snapshot.stage);
+        assert!(second_snapshot.progress >= first_snapshot.progress);
+    }
+
+    #[test]
+    fn cancelling_a_waiter_does_not_cancel_or_replace_shared_activation() {
+        let project = tempfile::tempdir().expect("project");
+        let storage_path = project.path().join("cache").join("codestory.db");
+        fs::write(
+            project.path().join("fixture.rs"),
+            "pub fn shared_activation_fixture() {}\n",
+        )
+        .expect("write fixture");
+        let service = Runtime::new().activation_service();
+
+        let first = service
+            .activate_project_with_foreground_budget(
+                project.path(),
+                &storage_path,
+                Arc::new(AtomicBool::new(false)),
+                Duration::ZERO,
+            )
+            .expect_err("zero foreground budget must return shared progress");
+        assert_eq!(first.code, "activation_preparing");
+        let before = service.snapshot().expect("shared activation snapshot");
+
+        let target = ActivationTarget::new(project.path(), &storage_path);
+        let cancelled = service
+            .wait_for_activation(
+                &target,
+                &before.operation_id,
+                true,
+                &AtomicBool::new(true),
+                Duration::ZERO,
+            )
+            .expect_err("the cancelled waiter must return without joining");
+        assert_eq!(cancelled.code, "cancelled");
+        let after = service
+            .snapshot()
+            .expect("shared activation survives waiter");
+
+        assert_eq!(after.operation_id, before.operation_id);
+        assert_ne!(after.state, ActivationState::Cancelled);
+        service.cancel_and_wait();
+    }
+
+    #[test]
+    fn failed_replacement_retains_exact_local_core_without_broad_capability() {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        let storage_path = cache.path().join("codestory.db");
+        fs::create_dir_all(project.path().join("src")).expect("create source directory");
+        fs::write(
+            project.path().join("src/lib.rs"),
+            "pub fn retained_fixture() {}\n",
+        )
+        .expect("write fixture");
+
+        let seeding_runtime = Runtime::new();
+        seeding_runtime
+            .project_service()
+            .open_project_summary_with_storage_path(
+                project.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open seed project");
+        seeding_runtime
+            .index_service()
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish retained core");
+        let retained = Store::database_complete_index_publication(&storage_path)
+            .expect("read retained publication")
+            .expect("complete retained publication");
+
+        fs::write(
+            project.path().join("codestory_workspace.json"),
+            r#"{"members":["src","missing"]}"#,
+        )
+        .expect("write incomplete synthetic workspace");
+        let runtime = Runtime::new();
+        assert_eq!(
+            runtime
+                .activation_service()
+                .retained_core_publication(&storage_path)
+                .expect("inspect retained core before activation")
+                .as_ref(),
+            Some(&crate::index_publication_dto(retained.clone()))
+        );
+        let error = runtime
+            .activation_service()
+            .activate_project(
+                project.path(),
+                &storage_path,
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect_err("incomplete replacement inventory must fail closed");
+        assert_eq!(error.code, "source_discovery_incomplete");
+
+        let snapshot = runtime
+            .activation_service()
+            .snapshot()
+            .expect("failed replacement snapshot");
+        assert_eq!(
+            snapshot.capabilities.local_navigation,
+            ActivationCapabilityState::Retained
+        );
+        assert_eq!(
+            snapshot.retained_core_publication.as_ref(),
+            Some(&crate::index_publication_dto(retained))
+        );
+        assert_eq!(
+            snapshot.capabilities.broad_search,
+            ActivationCapabilityState::Unavailable
+        );
+        assert!(!snapshot.allows_operation("packet"));
+
+        runtime
+            .activation_service()
+            .ensure_complete_core_for_observation(
+                project.path(),
+                &storage_path,
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect("retained complete core remains admissible for affected analysis");
+        runtime
+            .public_operation_service()
+            .run_observational_with_cancel("affected", Arc::new(AtomicBool::new(false)), || Ok(()))
+            .expect("affected analysis can pin the exact retained core");
+        runtime
+            .public_operation_service()
+            .run_with_cancel("ground", Arc::new(AtomicBool::new(false)), || Ok(()))
+            .expect("local grounding can pin the exact retained core");
+        let mut entered_broad_response = false;
+        let broad = runtime
+            .public_operation_service()
+            .run_with_cancel("packet", Arc::new(AtomicBool::new(false)), || {
+                entered_broad_response = true;
+                Ok(())
+            })
+            .expect_err("broad search must remain fail-closed on a retained core");
+        assert_eq!(broad.code, "project_unavailable");
+        assert!(!entered_broad_response);
     }
 
     #[test]
@@ -2311,8 +2625,10 @@ mod activation_tests {
         };
         let snapshot = ActivationSnapshot {
             operation_id: "activation-source-failure".to_string(),
+            revision: 3,
             state: ActivationState::Unavailable,
             stage: ActivationStage::CoreFreshness,
+            progress: activation_stage_progress(ActivationStage::CoreFreshness),
             attempt: 1,
             retry_after_ms: None,
             embedding_capacity: None,
@@ -2322,6 +2638,7 @@ mod activation_tests {
             failure_details: Some(Box::new(ApiErrorDetails::source_coverage(vec![
                 diagnostic.clone(),
             ]))),
+            retained_core_publication: None,
             capabilities: ActivationCapabilities {
                 local_navigation: ActivationCapabilityState::Unavailable,
                 broad_search: ActivationCapabilityState::Unavailable,
@@ -2442,8 +2759,10 @@ mod activation_tests {
     fn failed_broad_activation_never_becomes_ready_but_can_preserve_local_capability() {
         let snapshot = ActivationSnapshot {
             operation_id: "activation-1".into(),
+            revision: 7,
             state: ActivationState::Unavailable,
             stage: ActivationStage::Validation,
+            progress: activation_stage_progress(ActivationStage::Validation),
             attempt: 1,
             retry_after_ms: None,
             embedding_capacity: None,
@@ -2451,6 +2770,7 @@ mod activation_tests {
             failure_code: Some("project_unavailable".into()),
             failure: Some("embedding backend unavailable".into()),
             failure_details: None,
+            retained_core_publication: None,
             capabilities: ActivationCapabilities {
                 local_navigation: ActivationCapabilityState::Ready,
                 broad_search: ActivationCapabilityState::Unavailable,

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -16,9 +16,13 @@ across repositories.
 | `unavailable` | CodeStory could not converge within the managed path. | Use focused source inspection and state the evidence gap. |
 
 `current_operation` is the runtime-owned activation snapshot. When present it
-contains one stable `operation_id`, `state`, `stage`, `attempt`, retry delay,
-and failure. Concurrent calls for the same native project/configuration key
-join that operation; they do not start another refresh or repair flow.
+contains one stable `operation_id`, monotonic `revision`, `stage`, `attempt`,
+and `progress`, plus retry delay and failure. Concurrent and serial retries for
+the same native project/configuration key join that operation; they do not
+start another refresh or repair flow. A `retained` local-navigation capability
+names the exact complete core publication still usable for observational local
+analysis after a replacement fails. It never upgrades broad search without the
+matching retrieval publication and runtime proof.
 
 When no complete publication exists yet, `ground`, `packet`, `search`, and
 `context` return `codestory_preparing` with `retry_tool` and


### PR DESCRIPTION
## Context

Closes #1333
Refs #1187
Refs #1179

CodeStory product tools join one project-scoped activation operation while local graph and broad retrieval generations prepare. Serial retries after a terminal replacement failure allocated a new operation ID, and a retained complete core publication was reported as unavailable even though exact local analysis could still use it.

The private-safe reproduction commit `2e4493e0` demonstrated the identity break: two serial calls for one missing temporary project returned different activation IDs.

## Outcome

One activation identity now survives concurrent waiters and serial retries. Its revision, stage, attempt, and progress never move backward. A failed replacement can retain an exact, identity-bound local core publication without making broad retrieval ready.

## What changed

- Reuse the existing project-scoped activation operation after a terminal failure, incrementing attempt and revision while retaining stage/progress high-water marks.
- Keep caller cancellation separate from the shared activation worker so a cancelled waiter cannot cancel or replace shared work.
- Bind retained local capability to the exact native project, storage target, source generation, and complete core publication observed through one store snapshot.
- Permit local `ground` and `affected` work only when the runtime pins that same retained publication; `packet` and other broad-retrieval operations remain fail closed.
- Return agent-usable native MCP retry metadata: operation identity, revision, attempt, stage, progress, delay, retry tool, retained capability, and project-bound follow-ups without requiring CLI doctor.
- Describe the stable identity and retained-capability contract in the plugin status reference and changelog.

## How to review

1. Start with `crates/codestory-runtime/src/services.rs`: activation state owns identity, monotonic metadata, retained-publication observation, and exact admission.
2. Verify `PublicOperationService` accepts retained local work only when its pinned core publication matches the activation snapshot. The observational fallback remains `Ready`-only because an exact retained publication is admitted through `CompleteCoreAdmission::Complete`; widening the fallback would admit cold, fenced, or corrupt state.
3. Review `crates/codestory-cli/src/stdio_transport.rs` for capability rendering and same-tool/project-bound follow-ups.
4. Use the runtime and stdio regressions as the executable contract. The retained test runs observational admission, `affected`, and `ground`, then proves `packet` fails before response closure.

## Verification

Exact candidate:

- head: `1bd0c1d3023c6154c687a546f9c83fe1e0ff6c91`
- tree: `6d012324f3051c71a11c2fef5353cc30262897d4`
- base: `a3321ada123ced39390682d2e737ed66102d21d8`

Passed:

- `cargo test --locked -p codestory-runtime services::activation_tests` — 29 passed
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts` — 44 passed
- `cargo check --locked -p codestory-runtime -p codestory-cli`
- `cargo clippy --locked -p codestory-runtime -p codestory-cli --all-targets -- -D warnings`
- `cargo build --locked -p codestory-cli`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node scripts/generate-codestory-skill-syntax.mjs --check`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 74 passed, 1 platform skip
- `node .github/scripts/check-doc-links.mjs` — 75 files, 265 links
- `node .github/scripts/check-runtime-config-boundary.mjs`

## Risk or follow-up

- This remains a draft until independent exact-head review and hosted checks complete.
- It does not change #1331 source-policy storage, status read-only behavior, or broad retrieval admission.
- It has not been installed. Fresh installed-host proof on the combined candidate remains required before #1333 and parent #1187 close.