### PR TITLE
[codex] carry forward verified structural exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Release
 
+- Incremental freshness now carries forward unchanged verified structural-unit
+  exclusions even though they intentionally have no parser-backed file row.
+  This stops managed activation from republishing the same excluded inputs as
+  new files on every retry. If a replacement core does publish before later
+  freshness validation fails, retained local navigation now rebinds to that
+  exact live generation so `ground` can continue without widening broad search.
 - Project activation retries now retain one operation ID with monotonic
   revision, stage, attempt, and progress fields. Request cancellation no longer
   replaces shared preparation, and failed replacements bind any still-complete

--- a/crates/codestory-bench/benches/indexing.rs
+++ b/crates/codestory-bench/benches/indexing.rs
@@ -50,6 +50,7 @@ fn refresh_inputs_from_storage(storage: &Storage) -> codestory_workspace::Refres
             .files()
             .inventory()
             .expect("list benchmark storage inventory"),
+        policy_exclusions: Vec::new(),
         inventory: Default::default(),
     }
 }

--- a/crates/codestory-contracts/src/workspace.rs
+++ b/crates/codestory-contracts/src/workspace.rs
@@ -86,6 +86,12 @@ pub struct StoredFileState {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RefreshInputs {
     pub stored_files: Vec<StoredFileState>,
+    /// Complete verified exclusions from the currently published core.
+    ///
+    /// Structurally over-bound sources intentionally have no parser-backed
+    /// file row, so refresh planning must carry their exact content identity
+    /// separately to avoid rediscovering unchanged exclusions as new files.
+    pub policy_exclusions: Vec<OversizedSourceExclusionCandidate>,
     pub inventory: WorkspaceInventory,
 }
 

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -23155,6 +23155,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         let manifest = codestory_workspace::WorkspaceManifest::open(dir.path().to_path_buf())?;
         let outcome = manifest.build_execution_outcome(&codestory_workspace::RefreshInputs {
             stored_files: storage.files().inventory()?,
+            policy_exclusions: Vec::new(),
             inventory: codestory_workspace::WorkspaceInventory::default(),
         })?;
         assert_eq!(outcome.plan.files_to_remove, vec![projected.files[0].id]);

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -346,6 +346,7 @@ fn strict_readiness_unavailable_reason_for_runtime(
     let plan = workspace
         .build_execution_plan(&RefreshInputs {
             stored_files,
+            policy_exclusions: Vec::new(),
             inventory: Default::default(),
         })
         .context("build strict retrieval freshness plan")?;

--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -296,6 +296,7 @@ fn source_cache_freshness(project: &Path, source_db: &Path) -> Result<SourceCach
     let refresh = workspace
         .build_execution_outcome(&RefreshInputs {
             stored_files: storage.files().inventory()?,
+            policy_exclusions: Vec::new(),
             inventory: WorkspaceInventory::default(),
         })
         .context("build source cache refresh plan")?;

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -58,7 +58,7 @@ use codestory_store::{
     DenseAnchorInputReuseMetadata, FileInfo, FileRole as StoreFileRole, GroundingEdgeKindCount,
     GroundingNodeRecord, IndexPublicationMode, IndexPublicationRecord, LlmSymbolDoc,
     LlmSymbolDocStats, SearchSymbolProjection, SnapshotStore, SourcePolicyExclusionPolicyIdentity,
-    Store, SymbolSearchDoc, SymbolSummaryRecord,
+    SourcePolicyExclusionRecord, Store, SymbolSearchDoc, SymbolSummaryRecord,
 };
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
 #[cfg(test)]
@@ -5262,6 +5262,20 @@ fn publish_source_policy_exclusions(
     Ok(())
 }
 
+fn source_policy_exclusion_candidate(
+    record: &SourcePolicyExclusionRecord,
+) -> OversizedSourceExclusionCandidate {
+    OversizedSourceExclusionCandidate {
+        normalized_path: record.normalized_path.clone(),
+        content_hash: record.content_hash.clone(),
+        observed_size: record.observed_size,
+        observed_unit_count: record.observed_unit_count,
+        policy_version: record.policy_version.clone(),
+        byte_cap: record.byte_cap,
+        structural_unit_cap: record.structural_unit_cap,
+    }
+}
+
 fn revalidate_source_policy_exclusions(
     workspace: &WorkspaceManifest,
     exclusions: &[OversizedSourceExclusionCandidate],
@@ -5662,8 +5676,22 @@ where
         .iter()
         .map(|file| (file.id, file.path.clone()))
         .collect::<HashMap<_, _>>();
+    let stored_policy_exclusions = match storage.get_source_policy_exclusions() {
+        Ok(exclusions) => exclusions,
+        Err(error) => {
+            return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
+                format!("failed to read source policy exclusions: {error}"),
+                indexed_file_count,
+                started_at,
+            ));
+        }
+    };
     let refresh_inputs = RefreshInputs {
         stored_files,
+        policy_exclusions: stored_policy_exclusions
+            .iter()
+            .map(source_policy_exclusion_candidate)
+            .collect(),
         inventory: Default::default(),
     };
     let refresh = match workspace.build_execution_outcome_bounded_with_policy(
@@ -5727,16 +5755,6 @@ where
         }
     }
 
-    let stored_policy_exclusions = match storage.get_source_policy_exclusions() {
-        Ok(exclusions) => exclusions,
-        Err(error) => {
-            return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
-                format!("failed to read source policy exclusions: {error}"),
-                indexed_file_count,
-                started_at,
-            ));
-        }
-    };
     let previous_policy_by_path = stored_policy_exclusions
         .iter()
         .map(|entry| (entry.normalized_path.as_str(), entry))
@@ -5755,8 +5773,10 @@ where
             Some(previous)
                 if previous.content_hash == exclusion.content_hash
                     && previous.observed_size == exclusion.observed_size
+                    && previous.observed_unit_count == exclusion.observed_unit_count
                     && previous.policy_version == exclusion.policy_version
-                    && previous.byte_cap == exclusion.byte_cap =>
+                    && previous.byte_cap == exclusion.byte_cap
+                    && previous.structural_unit_cap == exclusion.structural_unit_cap =>
             {
                 continue;
             }
@@ -16843,6 +16863,14 @@ fn workspace_refresh_inputs(store: &Store) -> Result<RefreshInputs, ApiError> {
             .files()
             .inventory()
             .map_err(|e| ApiError::internal(format!("Failed to read workspace inventory: {e}")))?,
+        policy_exclusions: store
+            .get_source_policy_exclusions()
+            .map_err(|e| {
+                ApiError::internal(format!("Failed to read source policy exclusions: {e}"))
+            })?
+            .iter()
+            .map(source_policy_exclusion_candidate)
+            .collect(),
         inventory: Default::default(),
     })
 }
@@ -24203,6 +24231,14 @@ fn build_llm_symbol_doc_text() -> String {
             files.policy_exclusions[0].observed_unit_count,
             codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP + 1
         );
+        let workspace_manifest =
+            WorkspaceManifest::open(workspace.path().to_path_buf()).expect("workspace manifest");
+        let freshness =
+            index_freshness_from_storage(workspace.path(), &workspace_manifest, &storage);
+        assert_eq!(freshness.status, IndexFreshnessStatusDto::Fresh);
+        assert_eq!(freshness.changed_file_count, 0);
+        assert_eq!(freshness.new_file_count, 0);
+        assert_eq!(freshness.removed_file_count, 0);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -701,6 +701,15 @@ impl ActivationService {
                 .as_ref()
                 .is_some_and(|freshness| freshness.status == IndexFreshnessStatusDto::Fresh);
         if !local_ready {
+            if summary.stats.node_count > 0
+                && summary.stats.fatal_error_count == 0
+                && !self
+                    .controller
+                    .complete_core_requires_publication_repair(&storage_path)?
+                && let Some(publication) = summary.publication.clone()
+            {
+                operation.set_retained_local_publication(publication);
+            }
             return Err(ApiError::new(
                 "project_unavailable",
                 "activation did not produce a fresh complete core publication",
@@ -1267,6 +1276,25 @@ impl ActivationOperation {
         {
             snapshot.retained_core_publication = Some(publication);
             snapshot.capabilities.local_navigation = ActivationCapabilityState::Ready;
+            snapshot.revision += 1;
+        }
+        self.service.coordinator.changed.notify_all();
+    }
+
+    fn set_retained_local_publication(&self, publication: IndexPublicationDto) {
+        let mut state = self
+            .service
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator poisoned");
+        if let Some(snapshot) = state
+            .current
+            .as_mut()
+            .filter(|snapshot| snapshot.operation_id == self.operation_id)
+        {
+            snapshot.retained_core_publication = Some(publication);
+            snapshot.capabilities.local_navigation = ActivationCapabilityState::Retained;
             snapshot.revision += 1;
         }
         self.service.coordinator.changed.notify_all();
@@ -2008,7 +2036,7 @@ mod activation_tests {
         );
         assert_eq!(
             snapshot.retained_core_publication.as_ref(),
-            Some(&crate::index_publication_dto(retained))
+            Some(&crate::index_publication_dto(retained.clone()))
         );
         assert_eq!(
             snapshot.capabilities.broad_search,
@@ -2042,6 +2070,52 @@ mod activation_tests {
             .expect_err("broad search must remain fail-closed on a retained core");
         assert_eq!(broad.code, "project_unavailable");
         assert!(!entered_broad_response);
+
+        fs::remove_file(project.path().join("codestory_workspace.json"))
+            .expect("remove incomplete workspace");
+        fs::write(
+            project.path().join("src/lib.rs"),
+            "pub fn retained_fixture_after_publication() {}\n",
+        )
+        .expect("change source for replacement publication");
+        seeding_runtime
+            .index_service()
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect("advance complete core publication");
+        let advanced = Store::database_complete_index_publication(&storage_path)
+            .expect("read advanced publication")
+            .expect("complete advanced publication");
+        assert_ne!(advanced, retained);
+        fs::write(
+            project.path().join("codestory_workspace.json"),
+            r#"{"members":["src","missing"]}"#,
+        )
+        .expect("restore incomplete workspace");
+
+        let stale_identity = runtime
+            .public_operation_service()
+            .run_with_cancel("ground", Arc::new(AtomicBool::new(false)), || Ok(()))
+            .expect_err("the old retained identity must not admit a newer live core");
+        assert_eq!(stale_identity.code, "project_unavailable");
+
+        ActivationOperation {
+            service: runtime.activation_service(),
+            operation_id: snapshot.operation_id,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+        .set_retained_local_publication(crate::index_publication_dto(advanced.clone()));
+        let rebound = runtime
+            .activation_service()
+            .snapshot()
+            .expect("rebound retained snapshot");
+        assert_eq!(
+            rebound.retained_core_publication.as_ref(),
+            Some(&crate::index_publication_dto(advanced))
+        );
+        runtime
+            .public_operation_service()
+            .run_with_cancel("ground", Arc::new(AtomicBool::new(false)), || Ok(()))
+            .expect("ground admits the exact post-publication retained core");
     }
 
     #[test]

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -1079,13 +1079,14 @@ impl WorkspaceDiscovery {
         inputs: &RefreshInputs,
         policy: &SourceIndexPolicy,
     ) -> Result<WorkspacePolicyRefreshOutcome> {
-        let inventory = self.source_inventory_with_policy_inner(
+        let mut inventory = self.source_inventory_with_policy_inner(
             manifest,
             policy.byte_cap,
             &policy.policy_version,
             policy.structural_unit_cap,
             None,
         )?;
+        self.carry_forward_verified_policy_exclusions(manifest, inputs, policy, &mut inventory);
         let refresh = build_refresh_outcome_from_inventory(
             manifest,
             inputs,
@@ -1136,13 +1137,14 @@ impl WorkspaceDiscovery {
         max_current_files: usize,
         policy: &SourceIndexPolicy,
     ) -> Result<WorkspacePolicyRefreshOutcome> {
-        let inventory = self.source_inventory_with_policy_inner(
+        let mut inventory = self.source_inventory_with_policy_inner(
             manifest,
             policy.byte_cap,
             &policy.policy_version,
             policy.structural_unit_cap,
             Some(max_current_files),
         )?;
+        self.carry_forward_verified_policy_exclusions(manifest, inputs, policy, &mut inventory);
         let refresh = build_refresh_outcome_from_inventory(
             manifest,
             inputs,
@@ -1154,6 +1156,56 @@ impl WorkspaceDiscovery {
             refresh,
             policy_exclusions: inventory.policy_exclusions,
         })
+    }
+
+    fn carry_forward_verified_policy_exclusions(
+        &self,
+        manifest: &WorkspaceManifest,
+        inputs: &RefreshInputs,
+        policy: &SourceIndexPolicy,
+        inventory: &mut WorkspacePolicyFileInventory,
+    ) {
+        if !inventory.outcome.is_complete() || inputs.policy_exclusions.is_empty() {
+            return;
+        }
+
+        let root = workspace_root(manifest);
+        let mut current_policy_paths = inventory
+            .policy_exclusions
+            .iter()
+            .map(|candidate| candidate.normalized_path.clone())
+            .collect::<HashSet<_>>();
+        for candidate in &inputs.policy_exclusions {
+            if current_policy_paths.contains(&candidate.normalized_path)
+                || candidate.observed_unit_count == 0
+                || self
+                    .revalidate_source_policy_exclusions(
+                        manifest,
+                        std::slice::from_ref(candidate),
+                        policy,
+                    )
+                    .is_err()
+            {
+                continue;
+            }
+
+            let candidate_key =
+                normalized_compare_key(&root, &root.join(&candidate.normalized_path));
+            let Some(position) = inventory
+                .files
+                .iter()
+                .position(|path| normalized_compare_key(&root, path) == candidate_key)
+            else {
+                continue;
+            };
+            inventory.files.swap_remove(position);
+            current_policy_paths.insert(candidate.normalized_path.clone());
+            inventory.policy_exclusions.push(candidate.clone());
+        }
+        inventory.files.sort();
+        inventory
+            .policy_exclusions
+            .sort_by(|left, right| left.normalized_path.cmp(&right.normalized_path));
     }
 
     /// Compare current discovery with stored inventory unless discovery exceeds
@@ -2073,6 +2125,7 @@ mod tests {
                     complete: true,
                     retry_required: false,
                 }],
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::default(),
             },
         )?;
@@ -2128,6 +2181,7 @@ mod tests {
             &manifest,
             &RefreshInputs {
                 stored_files: Vec::new(),
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::from_records([(
                     excluded,
                     IndexedFileRecord {
@@ -2244,6 +2298,46 @@ mod tests {
     }
 
     #[test]
+    fn refresh_carries_forward_unchanged_structural_unit_exclusions() -> Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(&root)?;
+        let path = root.join("evidence.json");
+        fs::write(&path, "{\"one\":1,\"two\":2,\"three\":3}\n")?;
+        let policy = SourceIndexPolicy {
+            policy_version: "test-structural-policy-v1".to_string(),
+            byte_cap: 1_000,
+            structural_unit_cap: 2,
+        };
+        let (content_hash, observed_size) = current_content_identity(&path)?;
+        let retained = OversizedSourceExclusionCandidate {
+            normalized_path: "evidence.json".to_string(),
+            content_hash,
+            observed_size,
+            observed_unit_count: 3,
+            policy_version: policy.policy_version.clone(),
+            byte_cap: policy.byte_cap,
+            structural_unit_cap: policy.structural_unit_cap,
+        };
+        let manifest = WorkspaceManifest::open(root)?;
+        let inputs = RefreshInputs {
+            stored_files: Vec::new(),
+            policy_exclusions: vec![retained.clone()],
+            inventory: WorkspaceInventory::default(),
+        };
+
+        let unchanged = manifest.build_execution_outcome_with_policy(&inputs, &policy)?;
+        assert!(unchanged.refresh.plan.files_to_index.is_empty());
+        assert_eq!(unchanged.policy_exclusions, vec![retained.clone()]);
+
+        fs::write(&path, "{\"one\":1,\"two\":2,\"three\":4}\n")?;
+        let changed = manifest.build_execution_outcome_with_policy(&inputs, &policy)?;
+        assert_eq!(changed.refresh.plan.files_to_index, vec![path]);
+        assert!(changed.policy_exclusions.is_empty());
+        Ok(())
+    }
+
+    #[test]
     fn partial_discovery_never_classifies_a_deletion_capable_exclusion_set() -> Result<()> {
         let temp = tempdir()?;
         let root = temp.path().join("repo");
@@ -2283,6 +2377,7 @@ mod tests {
                     complete: true,
                     retry_required: false,
                 }],
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::default(),
             },
         )?;
@@ -2318,6 +2413,7 @@ mod tests {
                     complete: true,
                     retry_required: false,
                 }],
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::default(),
             },
         )?;
@@ -2347,10 +2443,12 @@ mod tests {
                     complete: false,
                     retry_required: false,
                 }],
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::default(),
             },
             RefreshInputs {
                 stored_files: Vec::new(),
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::from_records([(
                     file.clone(),
                     IndexedFileRecord {
@@ -2396,10 +2494,12 @@ mod tests {
                     complete: false,
                     retry_required: true,
                 }],
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::default(),
             },
             RefreshInputs {
                 stored_files: Vec::new(),
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::from_records([(
                     file.clone(),
                     IndexedFileRecord {
@@ -2437,6 +2537,7 @@ mod tests {
             &manifest,
             &RefreshInputs {
                 stored_files: Vec::new(),
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::from_records([
                     (
                         file.clone(),
@@ -2497,6 +2598,7 @@ mod tests {
                 complete: true,
                 retry_required: false,
             }],
+            policy_exclusions: Vec::new(),
             inventory: WorkspaceInventory::default(),
         })?;
 
@@ -2528,6 +2630,7 @@ mod tests {
                 complete: true,
                 retry_required: false,
             }],
+            policy_exclusions: Vec::new(),
             inventory: WorkspaceInventory::default(),
         })?;
 
@@ -2563,6 +2666,7 @@ mod tests {
                 complete: true,
                 retry_required: false,
             }],
+            policy_exclusions: Vec::new(),
             inventory: WorkspaceInventory::default(),
         })?;
 
@@ -2615,6 +2719,7 @@ mod tests {
                     complete: true,
                     retry_required: false,
                 }],
+                policy_exclusions: Vec::new(),
                 inventory: WorkspaceInventory::default(),
             },
             1,


### PR DESCRIPTION
## Context

The installed 0.16 candidate persisted complete structural-unit exclusions, but refresh planning only compared parser-backed file rows. Two unchanged under-byte JSON evidence files therefore appeared new on every managed activation, publishing a new core generation and leaving `ground` unable to pin the retained identity.

## What changed

- carry exact, content-verified structural-unit exclusions into policy-aware refresh planning
- revalidate their path, bytes, policy version, byte cap, and unit cap before removing them from the parser schedule
- include persisted exclusions in runtime freshness and incremental refresh inputs
- rebind retained local navigation to an exact complete core that published before later freshness validation failed, while broad search remains closed
- record the release-visible behavior in `CHANGELOG.md`

## How to review

Start with `RefreshInputs` and `carry_forward_verified_policy_exclusions`, then the runtime freshness wiring and the retained-publication update in `ActivationService::activate_once`.

## Verification

Exact head: `18fafea7c7661e2a658e643557968d98f877b70e`

- `cargo fmt --all -- --check`
- `cargo check --locked -p codestory-workspace -p codestory-runtime`
- `cargo test --locked -p codestory-workspace`
- `cargo test --locked -p codestory-runtime services::activation_tests`
- `cargo test --locked -p codestory-cli --test stdio_protocol_contracts` (44 passed)
- focused structural-exclusion freshness and retained-publication tests
- targeted all-target/all-feature clippy for workspace, runtime, and CLI
- candidate CLI `doctor` against the existing CodeStory cache reports fresh with 0 changed/new/removed
- candidate CLI MCP stdio `ground` pins complete generation 149 and returns a strict repository map

Installed-host proof is deliberately pending until this exact head is reviewed, merged, and installed.

## Risk

The planner only carries forward complete, unchanged unit-bound exclusions. Changed, deleted, unreadable, byte-bound, policy-mismatched, or partially discovered inputs keep the ordinary reevaluation path.

Closes #1331
Refs #1333