### PR TITLE
[P2] Set the native vector spike largest workload to 75k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   nested real-anchor workload while retaining 100 incremental anchors, two
   clean roots, six paired counterbalanced blocks, and the existing identity,
   failure, and replay proof. The frozen input now binds the declared workload
-  criteria, and changed fixtures use a new selection seed and schema.
+  criteria byte-for-byte, and changed fixtures use a new selection seed and
+  schema.
 - Incremental freshness now carries forward unchanged verified structural-unit
   exclusions even though they intentionally have no parser-backed file row.
   This stops managed activation from republishing the same excluded inputs as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   and presentation uncertainty. The stdio schema and `ground --why` render the
   same contract, so weak orientation cannot be reported as high-confidence
   coverage.
+- The native sqlite-vec/USearch evidence harness now uses 75,000 as its largest
+  nested real-anchor workload while retaining 100 incremental anchors, two
+  clean roots, six paired counterbalanced blocks, and the existing identity,
+  failure, and replay proof. The frozen input now binds the declared workload
+  criteria, and changed fixtures use a new selection seed and schema.
 - Incremental freshness now carries forward unchanged verified structural-unit
   exclusions even though they intentionally have no parser-backed file row.
   This stops managed activation from republishing the same excluded inputs as

--- a/benchmarks/vector-backend-spike/README.md
+++ b/benchmarks/vector-backend-spike/README.md
@@ -18,9 +18,16 @@ an exact current source publication and both clean paired evidence roots exist,
 #1202 is **inconclusive** and #1196 must not choose a backend from this work.
 
 The runner uses six counterbalanced paired blocks for each declared nested
-real-anchor workload in two fresh evidence roots. It snapshots the admitted
+real-anchor workload in two fresh evidence roots. The declared workloads are
+1,000, 10,000, 25,000, and 75,000 vectors. Fixture preparation therefore
+requires at least 75,100 distinct anchors: the 75,000-vector largest workload
+plus the unchanged 100-anchor incremental generation. Clearing that size floor
+does not prove publication completeness; the retained 84,025-anchor core-only
+publication still lacks the retrieval manifest and vectors required by this
+harness. The runner snapshots the admitted
 `vectors.sqlite3`, its `vector-generation-manifest.json`, and the fixture into
-the evidence root together with the reviewed catalog. Before any candidate
+the evidence root together with the reviewed catalog and declared criteria.
+Before any candidate
 starts, the same digest-bound binary re-resolves every catalog file/symbol and
 document hash against the frozen source, re-embeds every query through the
 product transport, and rechecks the exact clean corpus and publication

--- a/benchmarks/vector-backend-spike/README.md
+++ b/benchmarks/vector-backend-spike/README.md
@@ -26,8 +26,11 @@ does not prove publication completeness; the retained 84,025-anchor core-only
 publication still lacks the retrieval manifest and vectors required by this
 harness. The runner snapshots the admitted
 `vectors.sqlite3`, its `vector-generation-manifest.json`, and the fixture into
-the evidence root together with the reviewed catalog and declared criteria.
-Before any candidate
+the evidence root together with the reviewed catalog and exact digest-pinned
+declared criteria. Any change to the workload, dimensions, query count, top-k,
+warmups, root/block matrix, candidate versions, decision rules, or required
+measurements requires an explicit executable-contract update and otherwise
+fails closed. Before any candidate
 starts, the same digest-bound binary re-resolves every catalog file/symbol and
 document hash against the frozen source, re-embeds every query through the
 product transport, and rechecks the exact clean corpus and publication

--- a/benchmarks/vector-backend-spike/criteria.json
+++ b/benchmarks/vector-backend-spike/criteria.json
@@ -12,7 +12,7 @@
     "usearch": "2.26.0, HNSW F32, cosine, default features disabled"
   },
   "shared_workload": {
-    "vector_counts": [1000, 10000, 25000, 100000],
+    "vector_counts": [1000, 10000, 25000, 75000],
     "dimensions": 768,
     "query_count": 30,
     "top_k": 20,

--- a/crates/codestory-bench/src/bin/vector_backend_spike.rs
+++ b/crates/codestory-bench/src/bin/vector_backend_spike.rs
@@ -32,6 +32,7 @@ const LARGEST_WORKLOAD_COUNT: usize = 75_000;
 const FIXTURE_ANCHOR_COUNT: usize = LARGEST_WORKLOAD_COUNT + INCREMENTAL_COUNT;
 const FIXTURE_SCHEMA_VERSION: u32 = 5;
 const SELECTION_SEED: &str = "codestory-1202-vector-spike-v2";
+const CRITERIA_SHA256: &str = "4dd32441ae3d8754f7a1cec6c1e1e150ce5a6b4f78a7d94d1eb2d94859f96460";
 const VECTOR_DIGEST_DOMAIN: &[u8] = b"codestory-vector-digest-v1\0";
 const EMBEDDING_AUTHORITY_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
 const EMBEDDING_AUTHORITY_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
@@ -1602,6 +1603,10 @@ fn verify_frozen_input_paths(paths: &FrozenInputPaths) -> Result<()> {
 }
 
 fn verify_criteria_contract(path: &Path) -> Result<()> {
+    ensure!(
+        sha256_file(path)? == CRITERIA_SHA256,
+        "comparison criteria digest does not match the executable evidence contract"
+    );
     let value: serde_json::Value = serde_json::from_slice(
         &fs::read(path).with_context(|| format!("read comparison criteria {}", path.display()))?,
     )
@@ -2726,11 +2731,17 @@ mod tests {
     fn declared_criteria_match_the_executable_workloads() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let criteria = temp.path().join("criteria.json");
-        fs::write(
-            &criteria,
-            include_bytes!("../../../../benchmarks/vector-backend-spike/criteria.json"),
-        )?;
-        verify_criteria_contract(&criteria)
+        let bytes = include_bytes!("../../../../benchmarks/vector-backend-spike/criteria.json");
+        fs::write(&criteria, bytes)?;
+        verify_criteria_contract(&criteria)?;
+
+        let changed =
+            String::from_utf8(bytes.to_vec())?.replace("\"warmups\": 5", "\"warmups\": 4");
+        fs::write(&criteria, changed)?;
+        let error = verify_criteria_contract(&criteria)
+            .expect_err("changed acceptance criteria must fail closed");
+        assert!(error.to_string().contains("criteria digest"));
+        Ok(())
     }
 
     #[test]

--- a/crates/codestory-bench/src/bin/vector_backend_spike.rs
+++ b/crates/codestory-bench/src/bin/vector_backend_spike.rs
@@ -27,7 +27,11 @@ use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 const DIMENSIONS: usize = 768;
 const TOP_K: usize = 20;
 const INCREMENTAL_COUNT: usize = 100;
-const SELECTION_SEED: &str = "codestory-1202-vector-spike-v1";
+const WORKLOAD_COUNTS: [usize; 4] = [1_000, 10_000, 25_000, 75_000];
+const LARGEST_WORKLOAD_COUNT: usize = 75_000;
+const FIXTURE_ANCHOR_COUNT: usize = LARGEST_WORKLOAD_COUNT + INCREMENTAL_COUNT;
+const FIXTURE_SCHEMA_VERSION: u32 = 5;
+const SELECTION_SEED: &str = "codestory-1202-vector-spike-v2";
 const VECTOR_DIGEST_DOMAIN: &[u8] = b"codestory-vector-digest-v1\0";
 const EMBEDDING_AUTHORITY_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
 const EMBEDDING_AUTHORITY_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
@@ -194,6 +198,7 @@ struct FrozenInputManifest {
     source_generation_manifest: FrozenArtifact,
     fixture: FrozenArtifact,
     catalog: FrozenArtifact,
+    criteria: FrozenArtifact,
     fixture_verification: FrozenArtifact,
     binary_sha256: String,
     host_evidence: FrozenArtifact,
@@ -218,6 +223,7 @@ struct FrozenInputPaths {
     source_generation_manifest: PathBuf,
     fixture: PathBuf,
     catalog: PathBuf,
+    criteria: PathBuf,
     fixture_verification: PathBuf,
     host_evidence: PathBuf,
     binary_sha256: String,
@@ -574,8 +580,8 @@ fn prepare(
     let attestation = attest_source(&source)?;
     verify_source_matches_pinned_publication(&source, &attestation, &publication)?;
     ensure!(
-        attestation.point_count > 100_000 + INCREMENTAL_COUNT,
-        "production publication needs more than 100100 dense anchors"
+        attestation.point_count >= FIXTURE_ANCHOR_COUNT,
+        "production publication needs at least {FIXTURE_ANCHOR_COUNT} dense anchors"
     );
     let identities = resolve_catalog(&source, &catalog)?;
     let all_ids = list_node_ids(&source)?;
@@ -590,13 +596,13 @@ fn prepare(
         .filter(|id| !selected.contains(id))
         .collect::<Vec<_>>();
     ranked.sort_by_key(|id| selection_key(id));
-    let remaining = 100_000 + INCREMENTAL_COUNT - selected.len();
+    let remaining = FIXTURE_ANCHOR_COUNT - selected.len();
     selected.extend(ranked.into_iter().take(remaining));
     ensure!(
-        selected.len() == 100_000 + INCREMENTAL_COUNT,
+        selected.len() == FIXTURE_ANCHOR_COUNT,
         "not enough real anchors for nested fixture"
     );
-    let incremental_node_ids = selected.split_off(100_000);
+    let incremental_node_ids = selected.split_off(LARGEST_WORKLOAD_COUNT);
     let embedder = ProductEmbeddingClient::new(&runtime);
     let queries = identities
         .into_iter()
@@ -641,7 +647,7 @@ fn prepare(
         "catalog source checkout changed while freezing the fixture"
     );
     let fixture = Fixture {
-        schema_version: 4,
+        schema_version: FIXTURE_SCHEMA_VERSION,
         source: attestation,
         publication,
         query_embedder,
@@ -1236,7 +1242,10 @@ fn verify_fixture_contract(
     catalog_sha256: &str,
     source: &Path,
 ) -> Result<()> {
-    ensure!(fixture.schema_version == 4, "unsupported fixture schema");
+    ensure!(
+        fixture.schema_version == FIXTURE_SCHEMA_VERSION,
+        "unsupported fixture schema"
+    );
     ensure!(
         catalog.schema_version == 1 && catalog.queries.len() == 30,
         "reviewed catalog does not meet the declared profile"
@@ -1251,20 +1260,7 @@ fn verify_fixture_contract(
             && fixture.corpus_commit == catalog.corpus_commit,
         "fixture is not bound to the reviewed catalog and selection contract"
     );
-    ensure!(
-        fixture.selected_node_ids.len() == 100_000
-            && fixture.incremental_node_ids.len() == INCREMENTAL_COUNT,
-        "fixture does not contain the declared nested real-anchor input"
-    );
-    let selected = fixture
-        .selected_node_ids
-        .iter()
-        .chain(fixture.incremental_node_ids.iter())
-        .collect::<HashSet<_>>();
-    ensure!(
-        selected.len() == 100_000 + INCREMENTAL_COUNT,
-        "fixture selection contains duplicate base or incremental node IDs"
-    );
+    verify_fixture_selection(&fixture.selected_node_ids, &fixture.incremental_node_ids)?;
     ensure!(
         fixture.query_embedder.runtime_id == fixture.source.embedding_backend
             && fixture.query_embedder.embedding_dim == fixture.source.embedding_dim
@@ -1409,7 +1405,7 @@ fn load_frozen_input_paths(inputs: &Path, expected_input_sha256: &str) -> Result
     let input: FrozenInputManifest =
         serde_json::from_slice(&input_bytes).context("parse frozen input manifest")?;
     ensure!(
-        input.schema_version == 2,
+        input.schema_version == 3,
         "unsupported frozen input manifest schema"
     );
     let source = resolve_frozen_artifact(&input_path, &input.source, "source database")?;
@@ -1421,6 +1417,8 @@ fn load_frozen_input_paths(inputs: &Path, expected_input_sha256: &str) -> Result
     )?;
     let fixture = resolve_frozen_artifact(&input_path, &input.fixture, "fixture")?;
     let catalog = resolve_frozen_artifact(&input_path, &input.catalog, "catalog")?;
+    let criteria = resolve_frozen_artifact(&input_path, &input.criteria, "comparison criteria")?;
+    verify_criteria_contract(&criteria)?;
     let fixture_verification = resolve_frozen_artifact(
         &input_path,
         &input.fixture_verification,
@@ -1456,6 +1454,7 @@ fn load_frozen_input_paths(inputs: &Path, expected_input_sha256: &str) -> Result
         source_generation_manifest,
         fixture,
         catalog,
+        criteria,
         fixture_verification,
         host_evidence,
         binary_sha256: input.binary_sha256,
@@ -1594,9 +1593,34 @@ fn verify_frozen_input_paths(paths: &FrozenInputPaths) -> Result<()> {
             && reloaded.source_generation_manifest == paths.source_generation_manifest
             && reloaded.fixture == paths.fixture
             && reloaded.catalog == paths.catalog
+            && reloaded.criteria == paths.criteria
             && reloaded.fixture_verification == paths.fixture_verification
             && reloaded.host_evidence == paths.host_evidence,
         "frozen input manifest resolved to different evidence paths"
+    );
+    Ok(())
+}
+
+fn verify_criteria_contract(path: &Path) -> Result<()> {
+    let value: serde_json::Value = serde_json::from_slice(
+        &fs::read(path).with_context(|| format!("read comparison criteria {}", path.display()))?,
+    )
+    .context("parse comparison criteria")?;
+    let counts = value
+        .pointer("/shared_workload/vector_counts")
+        .and_then(serde_json::Value::as_array)
+        .context("comparison criteria have no vector_counts array")?
+        .iter()
+        .map(|value| {
+            value
+                .as_u64()
+                .and_then(|count| usize::try_from(count).ok())
+                .context("comparison criteria contain a non-integer vector count")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    ensure!(
+        counts == WORKLOAD_COUNTS,
+        "comparison criteria vector counts do not match the executable workload contract"
     );
     Ok(())
 }
@@ -1829,15 +1853,23 @@ fn list_node_ids(source: &Path) -> Result<Vec<String>> {
 }
 
 fn selected_ordinals(fixture: &Fixture, count: usize) -> Result<HashMap<String, u64>> {
+    selected_ordinals_for_queries(&fixture.selected_node_ids, &fixture.queries, count)
+}
+
+fn selected_ordinals_for_queries(
+    selected_node_ids: &[String],
+    queries: &[FrozenQuery],
+    count: usize,
+) -> Result<HashMap<String, u64>> {
     ensure!(
-        [1_000, 10_000, 25_000, 100_000].contains(&count),
+        WORKLOAD_COUNTS.contains(&count),
         "undeclared vector count {count}"
     );
     let mut output = HashMap::with_capacity(count);
-    for (index, id) in fixture.selected_node_ids.iter().take(count).enumerate() {
+    for (index, id) in selected_node_ids.iter().take(count).enumerate() {
         output.insert(id.clone(), index as u64 + 1);
     }
-    for query in &fixture.queries {
+    for query in queries {
         ensure!(
             output.contains_key(&query.expected_node_id),
             "selected {} workload omits catalog target {}",
@@ -1846,6 +1878,26 @@ fn selected_ordinals(fixture: &Fixture, count: usize) -> Result<HashMap<String, 
         );
     }
     Ok(output)
+}
+
+fn verify_fixture_selection(
+    selected_node_ids: &[String],
+    incremental_node_ids: &[String],
+) -> Result<()> {
+    ensure!(
+        selected_node_ids.len() == LARGEST_WORKLOAD_COUNT
+            && incremental_node_ids.len() == INCREMENTAL_COUNT,
+        "fixture does not contain the declared nested real-anchor input"
+    );
+    let selected = selected_node_ids
+        .iter()
+        .chain(incremental_node_ids.iter())
+        .collect::<HashSet<_>>();
+    ensure!(
+        selected.len() == FIXTURE_ANCHOR_COUNT,
+        "fixture selection contains duplicate base or incremental node IDs"
+    );
+    Ok(())
 }
 
 fn selected_ordinals_after_incremental(
@@ -2671,6 +2723,55 @@ mod tests {
     }
 
     #[test]
+    fn declared_criteria_match_the_executable_workloads() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let criteria = temp.path().join("criteria.json");
+        fs::write(
+            &criteria,
+            include_bytes!("../../../../benchmarks/vector-backend-spike/criteria.json"),
+        )?;
+        verify_criteria_contract(&criteria)
+    }
+
+    #[test]
+    fn fixture_selection_requires_75k_plus_100_unique_anchors() -> Result<()> {
+        let selected = (0..LARGEST_WORKLOAD_COUNT)
+            .map(|index| format!("node-{index}"))
+            .collect::<Vec<_>>();
+        let incremental = (LARGEST_WORKLOAD_COUNT..FIXTURE_ANCHOR_COUNT)
+            .map(|index| format!("node-{index}"))
+            .collect::<Vec<_>>();
+        verify_fixture_selection(&selected, &incremental)?;
+
+        let query = FrozenQuery {
+            id: "catalog-target".into(),
+            kind: "symbol".into(),
+            text: "Where is the catalog target?".into(),
+            expected_node_id: selected[0].clone(),
+            expected_document_hash: "document-hash".into(),
+            vector: vec![0.0; DIMENSIONS],
+        };
+        assert!(
+            selected_ordinals_for_queries(
+                &selected,
+                std::slice::from_ref(&query),
+                LARGEST_WORKLOAD_COUNT,
+            )
+            .is_ok()
+        );
+        assert!(
+            selected_ordinals_for_queries(&selected, &[query], 100_000).is_err(),
+            "the superseded 100k workload must fail closed"
+        );
+
+        let mut duplicate_incremental = incremental.clone();
+        duplicate_incremental[0] = selected[0].clone();
+        assert!(verify_fixture_selection(&selected, &duplicate_incremental).is_err());
+        assert!(verify_fixture_selection(&selected[..selected.len() - 1], &incremental).is_err());
+        Ok(())
+    }
+
+    #[test]
     fn reviewed_catalog_binding_rejects_fabricated_source_truth() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let source = temp.path().join("vectors.sqlite3");
@@ -2973,12 +3074,17 @@ mod tests {
         let source_manifest = temp_root.join("vector-generation-manifest.json");
         let fixture = temp_root.join("fixture.json");
         let catalog = temp_root.join("catalog.json");
+        let criteria = temp_root.join("criteria.json");
         let fixture_verification = temp_root.join("fixture-verification.json");
         let host_evidence = temp_root.join("host-evidence.json");
         fs::write(&source, b"source")?;
         fs::write(&source_manifest, b"manifest")?;
         fs::write(&fixture, b"fixture")?;
         fs::write(&catalog, b"catalog")?;
+        fs::write(
+            &criteria,
+            include_bytes!("../../../../benchmarks/vector-backend-spike/criteria.json"),
+        )?;
         fs::write(&fixture_verification, b"verification")?;
         let binary = std::env::current_exe()?.canonicalize()?;
         let binary_sha256 = sha256_file(&binary)?;
@@ -2992,7 +3098,7 @@ mod tests {
             }),
         )?;
         let input = serde_json::json!({
-            "schema_version": 2,
+            "schema_version": 3,
             "source": { "path": "source.sqlite3", "sha256": sha256_file(&source)? },
             "source_generation_manifest": {
                 "path": "vector-generation-manifest.json",
@@ -3000,6 +3106,7 @@ mod tests {
             },
             "fixture": { "path": "fixture.json", "sha256": sha256_file(&fixture)? },
             "catalog": { "path": "catalog.json", "sha256": sha256_file(&catalog)? },
+            "criteria": { "path": "criteria.json", "sha256": sha256_file(&criteria)? },
             "fixture_verification": {
                 "path": "fixture-verification.json",
                 "sha256": sha256_file(&fixture_verification)?,

--- a/scripts/run-vector-backend-spike.mjs
+++ b/scripts/run-vector-backend-spike.mjs
@@ -20,6 +20,11 @@ import {
 import { basename, dirname, join, relative, resolve } from "node:path";
 
 const root = resolve(process.cwd());
+const criteriaInput = resolve(
+  process.env.CODESTORY_VECTOR_SPIKE_CRITERIA_JSON
+    ?? join(root, "benchmarks", "vector-backend-spike", "criteria.json"),
+);
+assertRegularFileWithoutSymlinks(criteriaInput, "declared comparison criteria");
 const binaryInput = resolve(process.env.CODESTORY_VECTOR_SPIKE_BINARY ?? join(root, "target", "release", "vector_backend_spike"));
 assertRegularFileWithoutSymlinks(binaryInput, "vector spike binary");
 const binary = realpathSync(binaryInput);
@@ -45,7 +50,6 @@ const sourceManifestInput = join(dirname(source), "vector-generation-manifest.js
 assertRegularFileWithoutSymlinks(sourceManifestInput, "source generation manifest");
 const sourceManifest = realpathSync(sourceManifestInput);
 const output = resolve(required("CODESTORY_VECTOR_SPIKE_OUTPUT_ROOT"));
-const counts = [1000, 10000, 25000, 100000];
 const blocks = 6;
 const cleanRoots = ["clean-a", "clean-b"];
 const timeoutMs = Number(process.env.CODESTORY_VECTOR_SPIKE_TIMEOUT_MS ?? 20 * 60_000);
@@ -72,6 +76,9 @@ const sourceArtifact = freezeArtifact(source, join(frozenPublicationRoot, "vecto
 const sourceManifestArtifact = freezeArtifact(sourceManifest, join(frozenPublicationRoot, "vector-generation-manifest.json"));
 const fixtureArtifact = freezeArtifact(fixture, join(frozenRoot, "fixture.json"));
 const catalogArtifact = freezeArtifact(catalog, join(frozenRoot, "catalog.json"));
+const criteriaArtifact = freezeArtifact(criteriaInput, join(frozenRoot, "criteria.json"));
+const criteria = JSON.parse(readFileSync(criteriaArtifact, "utf8"));
+const counts = declaredVectorCounts(criteria);
 const hostEvidencePath = join(output, "host-evidence.json");
 const fixtureVerificationPath = join(output, "fixture-verification.json");
 const verificationInputDigests = new Map([
@@ -79,6 +86,7 @@ const verificationInputDigests = new Map([
   [sourceManifestArtifact, sha256(readFileSync(sourceManifestArtifact))],
   [fixtureArtifact, sha256(readFileSync(fixtureArtifact))],
   [catalogArtifact, sha256(readFileSync(catalogArtifact))],
+  [criteriaArtifact, sha256(readFileSync(criteriaArtifact))],
 ]);
 const fixtureVerification = await invokeBinary([
   "verify-fixture",
@@ -99,11 +107,12 @@ const fixtureVerification = await invokeBinary([
 atomicJson(fixtureVerificationPath, fixtureVerification);
 sealFrozenArtifact(fixtureVerificationPath);
 const input = {
-  schema_version: 2,
+  schema_version: 3,
   source: relativeArtifact(output, sourceArtifact),
   source_generation_manifest: relativeArtifact(output, sourceManifestArtifact),
   fixture: relativeArtifact(output, fixtureArtifact),
   catalog: relativeArtifact(output, catalogArtifact),
+  criteria: relativeArtifact(output, criteriaArtifact),
   fixture_verification: relativeArtifact(output, fixtureVerificationPath),
   binary_sha256: hostEvidence.binary.sha256,
   host_evidence: relativeArtifact(output, hostEvidencePath),
@@ -206,6 +215,18 @@ function required(name) {
   const value = process.env[name];
   if (!value) throw new Error(`${name} is required`);
   return value;
+}
+
+function declaredVectorCounts(criteria) {
+  const values = criteria?.shared_workload?.vector_counts;
+  if (!Array.isArray(values)
+    || values.length !== 4
+    || values.some((value, index) => !Number.isInteger(value)
+      || value <= 0
+      || (index > 0 && value <= values[index - 1]))) {
+    throw new Error("comparison criteria need four strictly increasing positive integer vector counts");
+  }
+  return values;
 }
 
 function approvedHostEvidence(binaryPath) {
@@ -325,7 +346,7 @@ function relativeArtifact(rootPath, artifactPath) {
 }
 
 function assertFrozenInputs(inputManifest, manifestPath, expectedManifestSha256) {
-  if (inputManifest.schema_version !== 2) throw new Error("unsupported frozen input manifest schema");
+  if (inputManifest.schema_version !== 3) throw new Error("unsupported frozen input manifest schema");
   assertRegularFileWithoutSymlinks(manifestPath, "frozen input manifest");
   if (sha256(readFileSync(manifestPath)) !== expectedManifestSha256) throw new Error("frozen input manifest changed during the run");
   for (const [label, artifact] of Object.entries({
@@ -333,6 +354,7 @@ function assertFrozenInputs(inputManifest, manifestPath, expectedManifestSha256)
     source_generation_manifest: inputManifest.source_generation_manifest,
     fixture: inputManifest.fixture,
     catalog: inputManifest.catalog,
+    criteria: inputManifest.criteria,
     fixture_verification: inputManifest.fixture_verification,
     host_evidence: inputManifest.host_evidence,
   })) {
@@ -356,7 +378,7 @@ function assertFrozenInputs(inputManifest, manifestPath, expectedManifestSha256)
     || verification.fixture_sha256 !== inputManifest.fixture.sha256
     || verification.catalog_sha256 !== inputManifest.catalog.sha256
     || verification.binary_sha256 !== inputManifest.binary_sha256
-    || verification.selection_seed !== "codestory-1202-vector-spike-v1"
+    || verification.selection_seed !== "codestory-1202-vector-spike-v2"
     || typeof verification.query_vector_digest !== "string"
     || typeof verification.expected_document_digest !== "string") {
     throw new Error("fixture verification does not bind the reviewed frozen inputs");


### PR DESCRIPTION
Closes #1340
Refs #1202, #1196, #1179

## Context

The evidence harness hard-coded a 100,000-vector largest workload and required more than 100,100 source anchors. The accepted retained publication has 84,025 dense anchors, so it could never enter fixture preparation even though 75,000 is the intended largest representative workload. This does not make the retained core-only publication complete or runnable.

## What changed

- Declare nested workloads of 1,000, 10,000, 25,000, and 75,000 vectors.
- Require exactly 75,000 base anchors plus the unchanged 100 distinct incremental anchors.
- Bump the fixture schema and deterministic selection seed so old 100k fixtures fail closed.
- Freeze and digest-bind `criteria.json` into frozen input schema v3.
- Make the Node runner derive its matrix from the frozen criteria while the Rust verifier requires the exact byte-level criteria digest and its executable workload allowlist.
- Preserve two clean roots, six paired counterbalanced blocks, publication and catalog identity, corruption, cancellation, rollback, concurrency, replay, recall, latency, memory, build/load, and digest evidence.
- Document that 84,025 clears size only; a complete retrieval manifest and vectors are still required.

## Review

Start at the fixture admission and verifier constants in `vector_backend_spike.rs`, then check the frozen criteria binding in the Rust input loader and Node orchestrator. The selection tests cover the 75,100 unique-anchor boundary, the 75k allowlist, rejection of 100k, exact criteria consistency, and a negative warmup-policy mutation.

Candidate base: `dbc1b329127400825ddb5f28d25bad69ab66d4bb`

Candidate head: `91254cbb82e03cc3c90f3d6899f37123b845f9ff`

Candidate tree: `34de081cd0356ac5503632eddefda5628a289a47`

## Verification

- `cargo test --locked -p codestory-bench --bin vector_backend_spike` — 10 passed
- `cargo clippy --locked -p codestory-bench --bin vector_backend_spike -- -D warnings`
- `node --check scripts/run-vector-backend-spike.mjs`
- `node .github/scripts/check-doc-links.mjs` — 75 files, 265 links
- `git diff --check`
- independent exact-head re-review — no findings; prior criteria-binding P2 closed
- post-rebase focused test and Clippy replay — passed on the exact head

The paired native matrix was intentionally not run in this policy-only child. No Linux corpus proof was run or resumed.

## Risk and follow-up

Existing fixture schema v4 / selection-seed v1 bundles are intentionally incompatible. The next #1202 step remains producing one complete native retrieval fixture, then running both candidates in two clean roots with six counterbalanced blocks per workload and accepting one explicit disposition.
