### PR TITLE
[codex] fail closed on uncovered exact paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@
   resolve to exact path/node citations rather than display-name searches and
   cannot promote packet sufficiency. CLI and stdio share a combined 16-probe
   limit and 240-character field limit.
+- Architecture packets now keep explicit exact paths as relevance constraints
+  through initial sufficiency and output-budget rebuilds. Each requested path
+  needs a separate proof-bearing claim before the packet can report
+  `sufficient`; missing paths produce explicit gaps and targeted follow-ups,
+  while diagnostic exact-path citations no longer discourage source reads.
 - Markdown/MDX, generic YAML, TOML, JSON, non-parser shell, and PowerShell now
   emit bounded exact-source structural units through the same verified
   publication and cache contract as the existing collectors. Dedicated

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -40,8 +40,8 @@ use crate::agent::packet_plan::{
     build_packet_plan_with_extra, packet_plan_annotation, packet_rank_terms,
 };
 use crate::agent::packet_probe::{
-    exact_packet_probe_citations, normalize_packet_probe_request, resolve_packet_probes,
-    resolved_packet_probe_queries,
+    exact_packet_probe_citations, exact_packet_probe_paths, normalize_packet_probe_request,
+    resolve_packet_probes, resolved_packet_probe_queries,
 };
 #[cfg(test)]
 use crate::agent::packet_required_probes::packet_sufficiency_required_probe_queries;
@@ -56,16 +56,16 @@ use crate::agent::packet_scoring::{
     normalize_identifier, packet_citation_rank, packet_display_path,
 };
 use crate::agent::packet_source_patterns::packet_sql_identifier_after;
-use crate::agent::packet_sufficiency::build_packet_sufficiency_with_extra;
+use crate::agent::packet_sufficiency::build_packet_sufficiency_with_probe_context;
 #[cfg(test)]
 use crate::agent::packet_sufficiency::{
     PACKET_MARKDOWN_TRUNCATION_SUFFIX, quote_packet_command_value,
 };
 #[cfg(test)]
 use crate::agent::packet_sufficiency::{
-    build_packet_sufficiency, packet_budget_exceeded_hard_output_cap,
-    packet_claim_can_satisfy_sufficiency, packet_claim_family, packet_supported_claim_family_count,
-    packet_targeted_follow_up_queries,
+    build_packet_sufficiency, build_packet_sufficiency_with_extra,
+    packet_budget_exceeded_hard_output_cap, packet_claim_can_satisfy_sufficiency,
+    packet_claim_family, packet_supported_claim_family_count, packet_targeted_follow_up_queries,
 };
 use crate::agent::packet_terms::{
     packet_probe_terms, packet_terms_have_any, packet_terms_indicate_buffered_io_flow,
@@ -491,6 +491,7 @@ pub(crate) fn agent_packet(
     append_packet_non_trace_phase(&mut answer, "shadow_and_trace", phase_started);
 
     let sufficiency_extra_probes = packet_plan_sufficiency_extra_probes(&plan, &extra_probes);
+    let exact_probe_paths = exact_packet_probe_paths(&plan.probe_resolutions);
     let phase_started = Instant::now();
     let budget = apply_packet_budget_with_extra(
         &project_root,
@@ -506,13 +507,14 @@ pub(crate) fn agent_packet(
     append_packet_evidence_sections(&mut answer, plan.task_class, &limits);
     append_packet_non_trace_phase(&mut answer, "evidence_sections", phase_started);
     let phase_started = Instant::now();
-    let sufficiency = build_packet_sufficiency_with_extra(
+    let sufficiency = build_packet_sufficiency_with_probe_context(
         &project_root,
         &question,
         plan.task_class,
         &answer,
         &budget,
         &sufficiency_extra_probes,
+        &exact_probe_paths,
     );
     append_packet_non_trace_phase(&mut answer, "sufficiency", phase_started);
     let phase_started = Instant::now();

--- a/crates/codestory-runtime/src/agent/packet_budget.rs
+++ b/crates/codestory-runtime/src/agent/packet_budget.rs
@@ -535,10 +535,101 @@ mod tests {
     use codestory_contracts::api::{
         AgentCitationDto, AgentResponseSectionDto, AgentRetrievalPolicyModeDto,
         AgentRetrievalPresetDto, AgentRetrievalStepDto, AgentRetrievalTraceDto, NodeId, NodeKind,
-        PacketClaimDto, PacketCoverageReportDto, PacketPlanDto, PacketPlanQueryDto,
-        PacketRetrievalTraceSummaryDto, PacketSufficiencyDto, PacketSufficiencyStatusDto,
-        SearchHitOrigin,
+        PacketClaimDto, PacketCoverageReportDto, PacketEvidenceResolutionDto,
+        PacketEvidenceTierDto, PacketPlanDto, PacketPlanQueryDto, PacketProbeDto,
+        PacketProbeRejectionCodeDto, PacketProbeRejectionDto, PacketProbeResolutionDto,
+        PacketProbeResolutionStatusDto, PacketRetrievalTraceSummaryDto, PacketSufficiencyDto,
+        PacketSufficiencyStatusDto, SearchHitOrigin,
     };
+
+    #[test]
+    fn post_budget_rebuild_demotes_retained_false_safe_architecture_packet() {
+        let question = "Explain the ownership boundary from the packaged CodeStory plugin request through stdio transport, runtime grounding orchestration, retrieval, and evidence publication. Identify uncertainty or gaps.";
+        let project_root = Path::new("/workspace/CodeStory");
+        let launcher_path = "plugins/codestory/scripts/launcher.mjs";
+        let stdio_path = "crates/codestory-cli/src/stdio_transport.rs";
+        let runtime_path = "crates/codestory-runtime/src/agent/orchestrator.rs";
+        let mut packet = test_packet(question, 96 * 1024);
+        packet.packet_id = "ask-1784577982067658000".to_string();
+        packet.answer.answer_id = packet.packet_id.clone();
+        packet.task_class = Some(PacketTaskClassDto::ArchitectureExplanation);
+        packet.plan.task_class = PacketTaskClassDto::ArchitectureExplanation;
+        packet.plan.probe_resolutions = vec![
+            PacketProbeResolutionDto {
+                input_index: 0,
+                probe: PacketProbeDto::ExactPath {
+                    path: launcher_path.to_string(),
+                },
+                status: PacketProbeResolutionStatusDto::Rejected,
+                normalized_query: None,
+                path: Some(launcher_path.to_string()),
+                symbol_id: None,
+                candidates: Vec::new(),
+                rejection: Some(PacketProbeRejectionDto {
+                    code: PacketProbeRejectionCodeDto::MissingTarget,
+                    message: "exact-path target does not exist".to_string(),
+                }),
+            },
+            retained_exact_path_resolution(1, stdio_path),
+            retained_exact_path_resolution(2, runtime_path),
+        ];
+        packet.answer.citations = vec![
+            retained_graph_citation(
+                "stdio_response_retrieval_publication",
+                project_root.join(stdio_path).to_string_lossy().as_ref(),
+            ),
+            retained_graph_citation(
+                "PacketEvidenceRole::TransportAdapter",
+                project_root
+                    .join("crates/codestory-runtime/src/agent/packet_evidence_roles.rs")
+                    .to_string_lossy()
+                    .as_ref(),
+            ),
+            retained_graph_citation(
+                "transport_adapter_claim",
+                project_root
+                    .join("crates/codestory-runtime/src/agent/packet_claim_profiles.rs")
+                    .to_string_lossy()
+                    .as_ref(),
+            ),
+            retained_graph_citation(
+                "ResolutionPhaseTelemetry::record_semantic_request_stats",
+                project_root
+                    .join("crates/codestory-indexer/src/resolution/mod.rs")
+                    .to_string_lossy()
+                    .as_ref(),
+            ),
+        ];
+        packet.sufficiency.status = PacketSufficiencyStatusDto::Sufficient;
+        packet.sufficiency.gaps.clear();
+        packet.sufficiency.follow_up_commands.clear();
+
+        enforce_packet_output_budget(project_root, &mut packet);
+
+        assert_eq!(
+            packet.sufficiency.status,
+            PacketSufficiencyStatusDto::Partial,
+            "the final post-budget packet must fail closed when the retained answer has no proof-bearing claim from the requested runtime path"
+        );
+        assert!(
+            packet
+                .sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains(runtime_path)),
+            "the final packet should identify the uncovered requested path: {:?}",
+            packet.sufficiency
+        );
+        assert!(
+            packet
+                .sufficiency
+                .follow_up_commands
+                .iter()
+                .any(|command| command.contains(runtime_path)),
+            "the final packet should provide a targeted follow-up for the uncovered path: {:?}",
+            packet.sufficiency
+        );
+    }
 
     #[test]
     fn compact_budget_trims_summary_trace_before_hard_payload_omission() {
@@ -887,6 +978,29 @@ mod tests {
             coverage_role: None,
             eligible_for_sufficiency: Some(true),
         }
+    }
+
+    fn retained_exact_path_resolution(input_index: u32, path: &str) -> PacketProbeResolutionDto {
+        PacketProbeResolutionDto {
+            input_index,
+            probe: PacketProbeDto::ExactPath {
+                path: path.to_string(),
+            },
+            status: PacketProbeResolutionStatusDto::ExactPath,
+            normalized_query: Some(path.to_string()),
+            path: Some(path.to_string()),
+            symbol_id: None,
+            candidates: Vec::new(),
+            rejection: None,
+        }
+    }
+
+    fn retained_graph_citation(display_name: &str, file_path: &str) -> AgentCitationDto {
+        let mut citation = test_citation(display_name, file_path);
+        citation.evidence_tier = Some(PacketEvidenceTierDto::ResolvedGraph);
+        citation.evidence_producer = Some("route_endpoint".to_string());
+        citation.resolution_status = Some(PacketEvidenceResolutionDto::Resolved);
+        citation
     }
 
     fn install_duplicate_summary_trace_payload(packet: &mut AgentPacketDto, repeat: usize) {

--- a/crates/codestory-runtime/src/agent/packet_budget.rs
+++ b/crates/codestory-runtime/src/agent/packet_budget.rs
@@ -1,9 +1,10 @@
 use crate::agent::packet_capping::cap_packet_citations;
 use crate::agent::packet_command_profiles::packet_command_exact_probe_queries;
 use crate::agent::packet_plan::{packet_explicit_request_probe_queries, push_unique_term};
+use crate::agent::packet_probe::exact_packet_probe_paths;
 use crate::agent::packet_required_probes::packet_sufficiency_required_probe_queries_with_extra;
 use crate::agent::packet_sufficiency::{
-    PACKET_MARKDOWN_TRUNCATION_SUFFIX, build_packet_sufficiency_with_extra,
+    PACKET_MARKDOWN_TRUNCATION_SUFFIX, build_packet_sufficiency_with_probe_context,
     quote_packet_command_value, quote_packet_project_arg,
 };
 use crate::agent::trace_export::packet_retrieval_trace_summary;
@@ -236,7 +237,8 @@ fn rebuild_packet_budget_dependents(
     extra_probes: &[String],
 ) {
     packet.retrieval_trace_summary = packet_retrieval_trace_summary(&packet.answer);
-    packet.sufficiency = build_packet_sufficiency_with_extra(
+    let exact_probe_paths = exact_packet_probe_paths(&packet.plan.probe_resolutions);
+    packet.sufficiency = build_packet_sufficiency_with_probe_context(
         project_root,
         &packet.question,
         packet
@@ -245,6 +247,7 @@ fn rebuild_packet_budget_dependents(
         &packet.answer,
         &packet.budget,
         extra_probes,
+        &exact_probe_paths,
     );
     let trim_avoid_opening = packet
         .budget

--- a/crates/codestory-runtime/src/agent/packet_probe.rs
+++ b/crates/codestory-runtime/src/agent/packet_probe.rs
@@ -83,6 +83,25 @@ pub(crate) fn resolved_packet_probe_queries(
         .collect()
 }
 
+pub(crate) fn exact_packet_probe_paths(resolutions: &[PacketProbeResolutionDto]) -> Vec<String> {
+    resolutions
+        .iter()
+        .filter(|resolution| {
+            matches!(
+                resolution.status,
+                PacketProbeResolutionStatusDto::ExactPath
+                    | PacketProbeResolutionStatusDto::ValidUncoveredPath
+            )
+        })
+        .filter_map(|resolution| match &resolution.probe {
+            PacketProbeDto::ExactPath { path } => {
+                Some(resolution.path.clone().unwrap_or_else(|| path.clone()))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
 pub(crate) fn resolve_packet_probes(
     controller: &AppController,
     probes: Vec<PacketProbeDto>,
@@ -895,6 +914,11 @@ mod tests {
         assert!(
             resolved_packet_probe_queries(&resolutions).is_empty(),
             "exact and valid-uncovered paths must not be replaced by broad fuzzy retrieval"
+        );
+        assert_eq!(
+            exact_packet_probe_paths(&resolutions),
+            vec!["assets/desk.svg".to_string()],
+            "only resolved in-project exact paths should constrain architecture sufficiency"
         );
         let citations = exact_packet_probe_citations(&controller, &resolutions, true);
         assert_eq!(citations.len(), 1);

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -1475,22 +1475,91 @@ fn packet_missing_exact_path_claims(
         return Vec::new();
     }
 
+    let exact_probe_paths =
+        exact_probe_paths
+            .iter()
+            .fold(Vec::<&String>::new(), |mut unique_paths, path| {
+                if !unique_paths.iter().any(|existing| {
+                    packet_paths_match_exact_probe(project_root, existing.as_str(), path)
+                }) {
+                    unique_paths.push(path);
+                }
+                unique_paths
+            });
+    let candidate_claims = exact_probe_paths
+        .iter()
+        .map(|path| {
+            sufficiency_claims
+                .iter()
+                .enumerate()
+                .filter_map(|(claim_index, claim)| {
+                    claim
+                        .citations
+                        .iter()
+                        .any(|citation| {
+                            citation_sufficiency_eligible(citation)
+                                && citation.file_path.as_deref().is_some_and(|citation_path| {
+                                    packet_paths_match_exact_probe(
+                                        project_root,
+                                        citation_path,
+                                        path.as_str(),
+                                    )
+                                })
+                        })
+                        .then_some(claim_index)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut assigned_path_by_claim = vec![None; sufficiency_claims.len()];
+    let covered_paths = (0..exact_probe_paths.len())
+        .map(|path_index| {
+            let mut visited_claims = vec![false; sufficiency_claims.len()];
+            packet_assign_exact_path_claim(
+                path_index,
+                &candidate_claims,
+                &mut visited_claims,
+                &mut assigned_path_by_claim,
+            )
+        })
+        .collect::<Vec<_>>();
+
     exact_probe_paths
         .iter()
-        .filter(|path| {
-            !sufficiency_claims.iter().any(|claim| {
-                claim.citations.iter().any(|citation| {
-                    citation_sufficiency_eligible(citation)
-                        && citation.file_path.as_deref().is_some_and(|citation_path| {
-                            packet_paths_match_exact_probe(project_root, citation_path, path)
-                        })
-                })
-            })
-        })
-        .map(|path| packet_display_path(path))
+        .enumerate()
+        .filter(|(path_index, _)| !covered_paths[*path_index])
+        .map(|(_, path)| path)
+        .map(|path| packet_display_path(path.as_str()))
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
+}
+
+fn packet_assign_exact_path_claim(
+    path_index: usize,
+    candidate_claims: &[Vec<usize>],
+    visited_claims: &mut [bool],
+    assigned_path_by_claim: &mut [Option<usize>],
+) -> bool {
+    for &claim_index in &candidate_claims[path_index] {
+        if visited_claims[claim_index] {
+            continue;
+        }
+        visited_claims[claim_index] = true;
+        let can_assign = assigned_path_by_claim[claim_index].is_none_or(|assigned_path| {
+            packet_assign_exact_path_claim(
+                assigned_path,
+                candidate_claims,
+                visited_claims,
+                assigned_path_by_claim,
+            )
+        });
+        if can_assign {
+            assigned_path_by_claim[claim_index] = Some(path_index);
+            return true;
+        }
+    }
+    false
 }
 
 fn packet_paths_match_exact_probe(
@@ -4314,6 +4383,76 @@ mod tests {
         assert!(
             !packet_paths_match_exact_probe(project_root, "src/lib.rs", "crates/foo/src/lib.rs"),
             "a shorter same-suffix citation must not satisfy a different exact path"
+        );
+    }
+
+    #[test]
+    fn architecture_exact_paths_use_distinct_claims_with_overlapping_citations() {
+        let project_root = Path::new("C:/workspace/project");
+        let paths = [
+            "plugins/codestory/scripts/launcher.mjs",
+            "crates/codestory-cli/src/stdio_transport.rs",
+        ];
+        let citations = paths.map(|path| {
+            cited_anchor_with_tier(path, path, PacketEvidenceTierDto::ResolvedGraph, Some(true))
+        });
+        let mut overlapping_claim = cited_claim(
+            "The request crosses the launcher and stdio transport boundary.",
+            Some("transport adapter"),
+            citations[0].clone(),
+            Some(true),
+        );
+        overlapping_claim.citations = citations.to_vec();
+        let launcher_claim = cited_claim(
+            "The launcher delegates the packaged request.",
+            Some("package entrypoint"),
+            citations[0].clone(),
+            Some(true),
+        );
+
+        let missing = packet_missing_exact_path_claims(
+            project_root,
+            PacketTaskClassDto::ArchitectureExplanation,
+            &paths.map(str::to_string),
+            &[overlapping_claim, launcher_claim],
+        );
+
+        assert!(
+            missing.is_empty(),
+            "matching should reassign the overlapping claim to the only path it can uniquely cover: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn architecture_exact_paths_reject_one_broad_claim_for_multiple_paths() {
+        let project_root = Path::new("C:/workspace/project");
+        let paths = [
+            "plugins/codestory/scripts/launcher.mjs",
+            "crates/codestory-cli/src/stdio_transport.rs",
+            "crates/codestory-runtime/src/agent/orchestrator.rs",
+        ];
+        let citations = paths.map(|path| {
+            cited_anchor_with_tier(path, path, PacketEvidenceTierDto::ResolvedGraph, Some(true))
+        });
+        let mut broad_claim = cited_claim(
+            "The request crosses the packaged plugin, stdio, and runtime boundaries.",
+            Some("runtime orchestration"),
+            citations[0].clone(),
+            Some(true),
+        );
+        broad_claim.citations = citations.to_vec();
+
+        let missing = packet_missing_exact_path_claims(
+            project_root,
+            PacketTaskClassDto::ArchitectureExplanation,
+            &paths.map(str::to_string),
+            &[broad_claim],
+        );
+
+        assert_eq!(
+            missing.len(),
+            2,
+            "one proof-bearing claim may bind at most one requested exact path: {missing:?}"
         );
     }
 

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -58,6 +58,7 @@ pub(crate) fn build_packet_sufficiency(
     build_packet_sufficiency_with_extra(project_root, question, task_class, answer, budget, &[])
 }
 
+#[cfg(test)]
 pub(crate) fn build_packet_sufficiency_with_extra(
     project_root: &Path,
     question: &str,
@@ -65,6 +66,26 @@ pub(crate) fn build_packet_sufficiency_with_extra(
     answer: &AgentAnswerDto,
     budget: &PacketBudgetDto,
     extra_probes: &[String],
+) -> PacketSufficiencyDto {
+    build_packet_sufficiency_with_probe_context(
+        project_root,
+        question,
+        task_class,
+        answer,
+        budget,
+        extra_probes,
+        &[],
+    )
+}
+
+pub(crate) fn build_packet_sufficiency_with_probe_context(
+    project_root: &Path,
+    question: &str,
+    task_class: PacketTaskClassDto,
+    answer: &AgentAnswerDto,
+    budget: &PacketBudgetDto,
+    extra_probes: &[String],
+    exact_probe_paths: &[String],
 ) -> PacketSufficiencyDto {
     let supported_claims = packet_supported_claims(answer);
     let missing_required_probe_queries = packet_missing_sufficiency_probe_queries_with_extra(
@@ -74,7 +95,7 @@ pub(crate) fn build_packet_sufficiency_with_extra(
         &supported_claims,
         extra_probes,
     );
-    assemble_packet_sufficiency_with_route_probes(
+    assemble_packet_sufficiency_with_probe_context(
         PacketSufficiencyInput {
             project_root,
             question,
@@ -86,17 +107,27 @@ pub(crate) fn build_packet_sufficiency_with_extra(
             targeted_follow_up_queries: packet_targeted_follow_up_queries(question, task_class),
         },
         extra_probes,
+        exact_probe_paths,
     )
 }
 
 #[cfg(test)]
 fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSufficiencyDto {
-    assemble_packet_sufficiency_with_route_probes(input, &[])
+    assemble_packet_sufficiency_with_probe_context(input, &[], &[])
 }
 
+#[cfg(test)]
 fn assemble_packet_sufficiency_with_route_probes(
     input: PacketSufficiencyInput<'_>,
     selected_probes: &[String],
+) -> PacketSufficiencyDto {
+    assemble_packet_sufficiency_with_probe_context(input, selected_probes, &[])
+}
+
+fn assemble_packet_sufficiency_with_probe_context(
+    input: PacketSufficiencyInput<'_>,
+    selected_probes: &[String],
+    exact_probe_paths: &[String],
 ) -> PacketSufficiencyDto {
     let PacketSufficiencyInput {
         project_root,
@@ -142,6 +173,8 @@ fn assemble_packet_sufficiency_with_route_probes(
     let claim_family_count = packet_supported_claim_family_count(&sufficiency_claims);
     let has_minimum_claim_families =
         packet_has_minimum_claim_family_coverage(task_class, &sufficiency_claims);
+    let missing_exact_path_claims =
+        packet_missing_exact_path_claims(task_class, exact_probe_paths, &sufficiency_claims);
     let route_proof = packet_route_proof_assessment(
         task_class,
         answer,
@@ -184,6 +217,7 @@ fn assemble_packet_sufficiency_with_route_probes(
         has_minimum_claim_families,
         has_required_flow_roles,
         has_route_proof: route_proof.complete,
+        missing_exact_path_claims: &missing_exact_path_claims,
         has_sufficiency_blocking_budget_omission,
         missing_required_probe_queries: &blocking_missing_probe_queries,
         unresolved_sidecar_queries: &blocking_unresolved_sidecar_queries,
@@ -204,6 +238,7 @@ fn assemble_packet_sufficiency_with_route_probes(
         has_minimum_claim_families,
         has_required_flow_roles,
         &route_proof,
+        &missing_exact_path_claims,
         has_sufficiency_blocking_budget_omission,
         &blocking_missing_probe_queries,
         &missing_required_flow_requirements,
@@ -220,6 +255,9 @@ fn assemble_packet_sufficiency_with_route_probes(
     }
     for query in &route_proof.follow_up_queries {
         push_unique_term(&mut blocking_follow_up_probe_queries, query);
+    }
+    for path in &missing_exact_path_claims {
+        push_unique_term(&mut blocking_follow_up_probe_queries, path);
     }
     let follow_up_probe_queries = if blocking_follow_up_probe_queries.is_empty() {
         &missing_required_probe_queries
@@ -241,14 +279,16 @@ fn assemble_packet_sufficiency_with_route_probes(
         flow_context: &flow_context,
         missing_required_flow_requirements: &missing_required_flow_requirements,
         route_proof: &route_proof,
+        missing_exact_path_claims: &missing_exact_path_claims,
         unresolved_sidecar_queries: &unresolved_sidecar_queries,
         budget,
         has_sufficiency_blocking_budget_omission,
     });
     let open_next = follow_up_commands.clone();
-    let avoid_opening_paths = answer
-        .citations
+    let avoid_opening_paths = sufficiency_claims
         .iter()
+        .flat_map(|claim| &claim.citations)
+        .filter(|citation| citation_sufficiency_eligible(citation))
         .filter_map(|citation| citation.file_path.as_ref())
         .map(|path| packet_display_path(path))
         .collect::<BTreeSet<_>>()
@@ -306,6 +346,7 @@ struct PacketSufficiencyStatusInput<'a> {
     has_minimum_claim_families: bool,
     has_required_flow_roles: bool,
     has_route_proof: bool,
+    missing_exact_path_claims: &'a [String],
     has_sufficiency_blocking_budget_omission: bool,
     missing_required_probe_queries: &'a [String],
     unresolved_sidecar_queries: &'a [String],
@@ -322,6 +363,7 @@ fn packet_sufficiency_status(
         || !input.has_minimum_claim_families
         || !input.has_required_flow_roles
         || !input.has_route_proof
+        || !input.missing_exact_path_claims.is_empty()
         || !input.missing_required_probe_queries.is_empty()
         || !input.unresolved_sidecar_queries.is_empty()
         || input.has_sufficiency_blocking_budget_omission
@@ -852,6 +894,7 @@ fn packet_sufficiency_gaps(
     has_minimum_claim_families: bool,
     has_required_flow_roles: bool,
     route_proof: &RouteProofAssessment,
+    missing_exact_path_claims: &[String],
     has_sufficiency_blocking_budget_omission: bool,
     missing_required_probe_queries: &[String],
     missing_required_flow_requirements: &[FlowRequirement],
@@ -901,6 +944,12 @@ fn packet_sufficiency_gaps(
     }
     if task_class == PacketTaskClassDto::RouteTracing && !route_proof.complete {
         gaps.extend(route_proof.gaps.clone());
+    }
+    if !missing_exact_path_claims.is_empty() {
+        gaps.push(format!(
+            "ArchitectureExplanation packet did not establish a proof-bearing claim from explicit exact path(s): {}.",
+            missing_exact_path_claims.join(", ")
+        ));
     }
     if !missing_required_probe_queries.is_empty() {
         gaps.push(format!(
@@ -1412,6 +1461,45 @@ fn packet_claim_is_generic_navigation_or_source_evidence(claim: &PacketClaimDto)
         || (lower.contains(" is defined in cited source ") && lower.contains("exact source anchor"))
 }
 
+fn packet_missing_exact_path_claims(
+    task_class: PacketTaskClassDto,
+    exact_probe_paths: &[String],
+    sufficiency_claims: &[PacketClaimDto],
+) -> Vec<String> {
+    if task_class != PacketTaskClassDto::ArchitectureExplanation {
+        return Vec::new();
+    }
+
+    exact_probe_paths
+        .iter()
+        .filter(|path| {
+            !sufficiency_claims.iter().any(|claim| {
+                claim.citations.iter().any(|citation| {
+                    citation_sufficiency_eligible(citation)
+                        && citation.file_path.as_deref().is_some_and(|citation_path| {
+                            packet_paths_match_exact_probe(citation_path, path)
+                        })
+                })
+            })
+        })
+        .map(|path| packet_display_path(path))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn packet_paths_match_exact_probe(citation_path: &str, exact_probe_path: &str) -> bool {
+    let citation_path = citation_path
+        .trim_start_matches("\\\\?\\")
+        .replace('\\', "/");
+    let exact_probe_path = exact_probe_path
+        .trim_start_matches("\\\\?\\")
+        .replace('\\', "/");
+    citation_path == exact_probe_path
+        || citation_path.ends_with(&format!("/{exact_probe_path}"))
+        || exact_probe_path.ends_with(&format!("/{citation_path}"))
+}
+
 fn packet_role_label_is_generic_source_evidence(role: &str) -> bool {
     normalize_identifier(role) == "sourceevidence"
 }
@@ -1422,6 +1510,7 @@ struct PacketCoverageReportInput<'a> {
     flow_context: &'a PacketFlowContext,
     missing_required_flow_requirements: &'a [FlowRequirement],
     route_proof: &'a RouteProofAssessment,
+    missing_exact_path_claims: &'a [String],
     unresolved_sidecar_queries: &'a [String],
     budget: &'a PacketBudgetDto,
     has_sufficiency_blocking_budget_omission: bool,
@@ -1434,6 +1523,7 @@ fn packet_coverage_report(input: PacketCoverageReportInput<'_>) -> PacketCoverag
         flow_context,
         missing_required_flow_requirements,
         route_proof,
+        missing_exact_path_claims,
         unresolved_sidecar_queries,
         budget,
         has_sufficiency_blocking_budget_omission,
@@ -1470,6 +1560,9 @@ fn packet_coverage_report(input: PacketCoverageReportInput<'_>) -> PacketCoverag
         .collect::<Vec<_>>();
     for route_gap in &route_proof.missing {
         push_unique_term(&mut missing, route_gap);
+    }
+    for path in missing_exact_path_claims {
+        push_unique_term(&mut missing, &format!("exact path: {path}"));
     }
     let budget_omitted = if has_sufficiency_blocking_budget_omission {
         budget.omitted_sections.clone()
@@ -4076,6 +4169,202 @@ mod tests {
                 .all(|entry| entry.contains("tier=\"resolved_graph\"")),
             "ineligible diagnostics should include the citation tier: {report:?}"
         );
+    }
+
+    #[test]
+    fn architecture_exact_paths_require_proof_bearing_claims_from_each_path() {
+        let question = "Explain the architecture represented by these exact paths.";
+        let budget = budget_fixture();
+        let stdio_path = "crates/codestory-cli/src/stdio_transport.rs";
+        let runtime_path = "crates/codestory-runtime/src/agent/orchestrator.rs";
+        let launcher_path = "plugins/codestory/scripts/launcher.mjs";
+        let stdio = cited_anchor_with_tier(
+            "dispatch_stdio_request",
+            stdio_path,
+            PacketEvidenceTierDto::ResolvedGraph,
+            Some(true),
+        );
+        let runtime = cited_anchor_with_tier(
+            "agent_packet",
+            runtime_path,
+            PacketEvidenceTierDto::ResolvedGraph,
+            Some(true),
+        );
+        let publication = cited_anchor_with_tier(
+            "publish_generation",
+            "crates/codestory-store/src/publication.rs",
+            PacketEvidenceTierDto::ResolvedGraph,
+            Some(true),
+        );
+        let mut launcher_probe = cited_anchor_with_tier(
+            launcher_path,
+            launcher_path,
+            PacketEvidenceTierDto::ExactSource,
+            Some(false),
+        );
+        launcher_probe.evidence_producer = Some("packet_exact_path_probe".to_string());
+        launcher_probe.resolution_status = Some(PacketEvidenceResolutionDto::SourceRangeOnly);
+
+        let mut answer = answer_fixture(question);
+        answer.citations = vec![
+            stdio.clone(),
+            runtime.clone(),
+            publication.clone(),
+            launcher_probe,
+        ];
+        let claims = vec![
+            cited_claim(
+                "The stdio adapter dispatches the host request.",
+                Some("transport adapter"),
+                stdio,
+                Some(true),
+            ),
+            cited_claim(
+                "Runtime orchestration coordinates the packet request.",
+                Some("runtime orchestration"),
+                runtime,
+                Some(true),
+            ),
+            cited_claim(
+                "Publication evidence exposes the completed generation.",
+                Some("evidence publication"),
+                publication,
+                Some(true),
+            ),
+        ];
+        let input = || PacketSufficiencyInput {
+            project_root: Path::new("C:/workspace/project"),
+            question,
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            answer: &answer,
+            budget: &budget,
+            supported_claims: claims.clone(),
+            missing_required_probe_queries: Vec::new(),
+            targeted_follow_up_queries: Vec::new(),
+        };
+
+        let without_exact_paths = assemble_packet_sufficiency(input());
+        assert_eq!(
+            without_exact_paths.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "fixture should isolate the exact-path relevance contract: {without_exact_paths:?}"
+        );
+
+        let exact_paths = vec![
+            launcher_path.to_string(),
+            stdio_path.to_string(),
+            runtime_path.to_string(),
+        ];
+        let sufficiency =
+            assemble_packet_sufficiency_with_probe_context(input(), &[], &exact_paths);
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains(launcher_path)),
+            "missing exact-path relevance should be explicit: {sufficiency:?}"
+        );
+        assert!(
+            sufficiency
+                .follow_up_commands
+                .iter()
+                .any(|command| command.contains(launcher_path)),
+            "missing exact path should produce a targeted follow-up: {sufficiency:?}"
+        );
+        assert!(
+            sufficiency
+                .coverage_report
+                .as_ref()
+                .is_some_and(|report| report
+                    .missing
+                    .contains(&format!("exact path: {launcher_path}"))),
+            "coverage report should retain the exact missing path: {sufficiency:?}"
+        );
+        assert!(
+            !sufficiency
+                .avoid_opening_paths
+                .contains(&launcher_path.to_string()),
+            "diagnostic exact-path citations must not discourage source inspection: {sufficiency:?}"
+        );
+    }
+
+    #[test]
+    fn architecture_exact_paths_remain_non_promoting_when_role_backed_claims_cover_them() {
+        let question = "Explain the architecture represented by these exact paths.";
+        let budget = budget_fixture();
+        let paths = [
+            "plugins/codestory/scripts/launcher.mjs",
+            "crates/codestory-cli/src/stdio_transport.rs",
+            "crates/codestory-runtime/src/agent/orchestrator.rs",
+        ];
+        let citations = [
+            cited_anchor_with_tier(
+                "launch",
+                paths[0],
+                PacketEvidenceTierDto::LexicalSource,
+                Some(true),
+            ),
+            cited_anchor_with_tier(
+                "dispatch_stdio_request",
+                paths[1],
+                PacketEvidenceTierDto::ResolvedGraph,
+                Some(true),
+            ),
+            cited_anchor_with_tier(
+                "agent_packet",
+                paths[2],
+                PacketEvidenceTierDto::ResolvedGraph,
+                Some(true),
+            ),
+        ];
+        let mut answer = answer_fixture(question);
+        answer.citations = citations.to_vec();
+        let claims = vec![
+            cited_claim(
+                "The launcher delegates a packaged request to the managed CLI.",
+                Some("package entrypoint"),
+                citations[0].clone(),
+                Some(true),
+            ),
+            cited_claim(
+                "The stdio adapter dispatches the host request.",
+                Some("transport adapter"),
+                citations[1].clone(),
+                Some(true),
+            ),
+            cited_claim(
+                "Runtime orchestration coordinates the packet request.",
+                Some("runtime orchestration"),
+                citations[2].clone(),
+                Some(true),
+            ),
+        ];
+        let exact_paths = paths.map(str::to_string);
+
+        let sufficiency = assemble_packet_sufficiency_with_probe_context(
+            PacketSufficiencyInput {
+                project_root: Path::new("C:/workspace/project"),
+                question,
+                task_class: PacketTaskClassDto::ArchitectureExplanation,
+                answer: &answer,
+                budget: &budget,
+                supported_claims: claims,
+                missing_required_probe_queries: Vec::new(),
+                targeted_follow_up_queries: Vec::new(),
+            },
+            &[],
+            &exact_paths,
+        );
+
+        assert_eq!(
+            sufficiency.status,
+            PacketSufficiencyStatusDto::Sufficient,
+            "exact probes should constrain relevance without promoting diagnostic citations: {sufficiency:?}"
+        );
+        assert!(sufficiency.gaps.is_empty(), "{sufficiency:?}");
+        assert!(sufficiency.follow_up_commands.is_empty(), "{sufficiency:?}");
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -173,8 +173,12 @@ fn assemble_packet_sufficiency_with_probe_context(
     let claim_family_count = packet_supported_claim_family_count(&sufficiency_claims);
     let has_minimum_claim_families =
         packet_has_minimum_claim_family_coverage(task_class, &sufficiency_claims);
-    let missing_exact_path_claims =
-        packet_missing_exact_path_claims(task_class, exact_probe_paths, &sufficiency_claims);
+    let missing_exact_path_claims = packet_missing_exact_path_claims(
+        project_root,
+        task_class,
+        exact_probe_paths,
+        &sufficiency_claims,
+    );
     let route_proof = packet_route_proof_assessment(
         task_class,
         answer,
@@ -1462,6 +1466,7 @@ fn packet_claim_is_generic_navigation_or_source_evidence(claim: &PacketClaimDto)
 }
 
 fn packet_missing_exact_path_claims(
+    project_root: &Path,
     task_class: PacketTaskClassDto,
     exact_probe_paths: &[String],
     sufficiency_claims: &[PacketClaimDto],
@@ -1477,7 +1482,7 @@ fn packet_missing_exact_path_claims(
                 claim.citations.iter().any(|citation| {
                     citation_sufficiency_eligible(citation)
                         && citation.file_path.as_deref().is_some_and(|citation_path| {
-                            packet_paths_match_exact_probe(citation_path, path)
+                            packet_paths_match_exact_probe(project_root, citation_path, path)
                         })
                 })
             })
@@ -1488,16 +1493,23 @@ fn packet_missing_exact_path_claims(
         .collect()
 }
 
-fn packet_paths_match_exact_probe(citation_path: &str, exact_probe_path: &str) -> bool {
-    let citation_path = citation_path
-        .trim_start_matches("\\\\?\\")
-        .replace('\\', "/");
-    let exact_probe_path = exact_probe_path
-        .trim_start_matches("\\\\?\\")
-        .replace('\\', "/");
-    citation_path == exact_probe_path
-        || citation_path.ends_with(&format!("/{exact_probe_path}"))
-        || exact_probe_path.ends_with(&format!("/{citation_path}"))
+fn packet_paths_match_exact_probe(
+    project_root: &Path,
+    citation_path: &str,
+    exact_probe_path: &str,
+) -> bool {
+    let absolute = |path: &str| {
+        let path = Path::new(path.trim_start_matches("\\\\?\\"));
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            project_root.join(path)
+        }
+    };
+    codestory_workspace::same_workspace_path(
+        absolute(citation_path).as_path(),
+        absolute(exact_probe_path).as_path(),
+    )
 }
 
 fn packet_role_label_is_generic_source_evidence(role: &str) -> bool {
@@ -4287,6 +4299,21 @@ mod tests {
                 .avoid_opening_paths
                 .contains(&launcher_path.to_string()),
             "diagnostic exact-path citations must not discourage source inspection: {sufficiency:?}"
+        );
+    }
+
+    #[test]
+    fn architecture_exact_path_matching_rejects_same_suffix_collisions() {
+        let project_root = Path::new("C:/workspace/project");
+
+        assert!(packet_paths_match_exact_probe(
+            project_root,
+            "crates/foo/src/lib.rs",
+            "crates/foo/src/lib.rs"
+        ));
+        assert!(
+            !packet_paths_match_exact_probe(project_root, "src/lib.rs", "crates/foo/src/lib.rs"),
+            "a shorter same-suffix citation must not satisfy a different exact path"
         );
     }
 


### PR DESCRIPTION
## Context

Closes #1351
Refs #1200
Refs #1179

The installed CodeStoryDev `0.16.0` host at source `5f00ef470dd1b09127320a2c9553241af6032e9b` returned a false-safe `architecture_explanation` packet for the packaged plugin → stdio → runtime → retrieval → publication boundary. It reported `sufficient`, no gaps, and no follow-ups while its exact-path citations were diagnostic-only and its proof-bearing claims came from unrelated llama/indexer symbols.

The owning fault was in runtime sufficiency plumbing: normalized exact paths were available in `plan.probe_resolutions`, but both initial sufficiency and output-budget rebuilds received only fuzzy/free-query probes. Exact paths therefore had no relevance effect after their non-promoting diagnostic citations were appended.

## Outcome

Architecture packets cannot report `sufficient` unless every resolved explicit exact path is represented by a separate proof-bearing, sufficiency-eligible claim. Exact-path probes remain non-promoting.

## What changed

- Carry normalized in-project exact-path requirements from typed probe resolution into initial packet sufficiency and every output-budget rebuild.
- Return `partial`, path-specific coverage gaps, and targeted search follow-ups when a requested path lacks a proof-bearing claim.
- Compare cited and requested paths by native workspace identity; a shorter same-suffix path cannot satisfy a different exact target.
- Bind exact paths to eligible claims with deterministic one-to-one matching, so one broad multi-citation claim cannot discharge several requested paths while overlapping legitimate claims can still be reassigned.
- Build `avoid_opening` only from proof-bearing citations attached to sufficiency claims, so diagnostic exact paths do not discourage source inspection.
- Cover the false-safe and fully covered cases, native identity collisions, resolved-versus-rejected extraction, and the retained answer's post-budget rebuild with runtime regressions.
- Record the shipped packet behavior under `Unreleased`.

## How to review

1. `packet_probe.rs`: only successfully resolved in-project exact paths enter the relevance contract.
2. `orchestrator.rs` and `packet_budget.rs`: initial and rebuilt sufficiency receive the same exact-path context.
3. `packet_sufficiency.rs`: exact paths constrain relevance without making diagnostic citations proof-bearing.

## Verification

- `cargo fmt --all -- --check` — passed.
- `cargo check -p codestory-runtime --locked` — passed.
- `cargo test -p codestory-runtime --locked --lib` — 821 passed, 0 failed.
- `git diff --check e9d278875bcee7a195695a7b80b583566e0795df..e50d05a9cafb23cdd91743b7e27deac14ca38c48` — passed.
- Retained false-safe replay fixture (`ask-1784577982067658000`) through final output-budget enforcement — observed `sufficient` is rebuilt as `partial`, with a path-specific gap and follow-up for `crates/codestory-runtime/src/agent/orchestrator.rs`.
- Source release CLI replay — checksum-pinned embedded-model build passed; the live request refreshed the one stale core file, then stopped at the already-running shared host with `embedding_server_owner_unresponsive`. This is an evidence boundary, not an installed-host acceptance claim.

Exact base: `e9d278875bcee7a195695a7b80b583566e0795df`.

Exact source head: `e50d05a9cafb23cdd91743b7e27deac14ca38c48`.

Exact source tree: `50662d634b4250670832ec1c0a4f48bdd2b31eb9`.

## Risk or follow-up

- This deliberately makes architecture packets conservative when a caller supplies exact paths: an uncovered or diagnostic-only path keeps the result partial.
- This source proof does not claim installed-host acceptance. After coordinator integration and dependency disposition, the exact candidate still needs the retained installed interaction replay.
- The PR remains draft pending independent exact-head review and hosted checks; the release coordinator retains integration and release decisions.
