### PR TITLE
[P2] Cache compact grounding rank keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   typed orientation confidence with bounded-candidate, entrypoint, subsystem,
   and presentation uncertainty. The stdio schema and `ground --why` render the
   same contract, so weak orientation cannot be reported as high-confidence
-  coverage.
+  coverage. Root ranking derives its path, name, subsystem, and graph evidence
+  once per candidate instead of recomputing it inside every sort comparison.
 - The native sqlite-vec/USearch evidence harness now uses 75,000 as its largest
   nested real-anchor workload while retaining 100 incremental anchors, two
   clean roots, six paired counterbalanced blocks, and the existing identity,

--- a/crates/codestory-runtime/src/grounding.rs
+++ b/crates/codestory-runtime/src/grounding.rs
@@ -5,7 +5,7 @@ use codestory_contracts::api::{
     PacketEvidenceResolutionDto, PacketEvidenceTierDto, SearchHitOrigin,
 };
 use codestory_store::{FileRole, StructuralTextUnit};
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
@@ -428,65 +428,50 @@ fn build_grounding_edge_degree_map(
     degrees
 }
 
-fn compare_grounding_root_records(
-    left: &GroundingNodeRecord,
-    right: &GroundingNodeRecord,
-    root: &Path,
-    file_roles: &HashMap<i64, FileRole>,
-    edge_degrees: &HashMap<codestory_contracts::graph::NodeId, u32>,
-    member_counts: &HashMap<codestory_contracts::graph::NodeId, u32>,
-) -> Ordering {
-    let role = |record: &GroundingNodeRecord| {
-        record
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct GroundingRootSortKey {
+    import_like: bool,
+    entrypoint: Reverse<bool>,
+    file_role_rank: u8,
+    path_rank: u8,
+    edge_degree: Reverse<u32>,
+    member_count: Reverse<u32>,
+    node_rank: u8,
+    start_line: u32,
+    relative_path: Option<String>,
+    display_name: String,
+    node_id: i64,
+}
+
+impl GroundingRootSortKey {
+    fn new(
+        record: &GroundingNodeRecord,
+        root: &Path,
+        file_roles: &HashMap<i64, FileRole>,
+        edge_degrees: &HashMap<codestory_contracts::graph::NodeId, u32>,
+        member_counts: &HashMap<codestory_contracts::graph::NodeId, u32>,
+    ) -> Self {
+        let role = record
             .node
             .file_node_id
-            .and_then(|file_id| file_roles.get(&file_id.0).copied())
-    };
-    is_import_like_symbol(&left.node)
-        .cmp(&is_import_like_symbol(&right.node))
-        .then(
-            is_grounding_entrypoint_root(root, right, file_roles)
-                .cmp(&is_grounding_entrypoint_root(root, left, file_roles)),
-        )
-        .then(
-            grounding_root_file_role_rank(role(left))
-                .cmp(&grounding_root_file_role_rank(role(right))),
-        )
-        .then(grounding_root_path_rank(root, left).cmp(&grounding_root_path_rank(root, right)))
-        .then(
-            edge_degrees
-                .get(&right.node.id)
-                .copied()
-                .unwrap_or(0)
-                .cmp(&edge_degrees.get(&left.node.id).copied().unwrap_or(0)),
-        )
-        .then(
-            member_counts
-                .get(&right.node.id)
-                .copied()
-                .unwrap_or(0)
-                .cmp(&member_counts.get(&left.node.id).copied().unwrap_or(0)),
-        )
-        .then(node_rank(&left.node).cmp(&node_rank(&right.node)))
-        .then(
-            left.node
-                .start_line
-                .unwrap_or(u32::MAX)
-                .cmp(&right.node.start_line.unwrap_or(u32::MAX)),
-        )
-        .then_with(|| {
-            left.file_path
+            .and_then(|file_id| file_roles.get(&file_id.0).copied());
+        Self {
+            import_like: is_import_like_symbol(&record.node),
+            entrypoint: Reverse(is_grounding_entrypoint_root(root, record, file_roles)),
+            file_role_rank: grounding_root_file_role_rank(role),
+            path_rank: grounding_root_path_rank(root, record),
+            edge_degree: Reverse(edge_degrees.get(&record.node.id).copied().unwrap_or(0)),
+            member_count: Reverse(member_counts.get(&record.node.id).copied().unwrap_or(0)),
+            node_rank: node_rank(&record.node),
+            start_line: record.node.start_line.unwrap_or(u32::MAX),
+            relative_path: record
+                .file_path
                 .as_deref()
-                .map(|path| relative_path(root, path))
-                .cmp(
-                    &right
-                        .file_path
-                        .as_deref()
-                        .map(|path| relative_path(root, path)),
-                )
-        })
-        .then_with(|| left.display_name.cmp(&right.display_name))
-        .then(left.node.id.0.cmp(&right.node.id.0))
+                .map(|path| relative_path(root, path)),
+            display_name: record.display_name.clone(),
+            node_id: record.node.id.0,
+        }
+    }
 }
 
 fn append_diversified_grounding_root_tier(
@@ -529,8 +514,8 @@ fn diversify_grounding_root_records(
     edge_degrees: &HashMap<codestory_contracts::graph::NodeId, u32>,
     member_counts: &HashMap<codestory_contracts::graph::NodeId, u32>,
 ) -> Vec<GroundingNodeRecord> {
-    records.sort_by(|left, right| {
-        compare_grounding_root_records(left, right, root, file_roles, edge_degrees, member_counts)
+    records.sort_by_cached_key(|record| {
+        GroundingRootSortKey::new(record, root, file_roles, edge_degrees, member_counts)
     });
     let (production, secondary): (Vec<_>, Vec<_>) = records.into_iter().partition(|record| {
         is_production_file_role(


### PR DESCRIPTION
## Context

The exact installed `0.16.0` orientation replay passed the structural contract
but missed the retained direct-CLI p95 baseline in eight of nine cells. Phase
timing localized most new in-process orientation work to the root-ranking
comparator, which repeatedly rebuilt path, name, subsystem, entrypoint, and
graph-derived evidence while sorting the same bounded candidates.

## What changed

- Derive one stable `GroundingRootSortKey` per candidate with
  `sort_by_cached_key`.
- Preserve the previous comparator field order and all stable tie-breakers.
- Keep the runtime as the owner of architecture ranking; the healthy indexed
  store query is unchanged.
- Record the optimization under `Unreleased`.

## How to review

Compare `GroundingRootSortKey` field order against the removed comparator:
import-like, entrypoint, file role, architecture path, edge degree, member
count, node rank, source line, relative path, display name, and node ID. The
`Reverse` wrappers preserve the prior descending dimensions.

Exact candidate:

- base: `5f00ef470dd1b09127320a2c9553241af6032e9b`
- head: `8c394ed41c37dcfa66b7489948cf90c9fc354541`
- tree: `357e5fa8eeed7e55428ed991aad0155fe23c9adc`
- optimized CLI SHA-256:
  `f2c803dd2762d26bd9f8d5ac6d638b3e42089281ded071c1b4eece0fbe6895ea`
- independent exact-head review: no findings

## Verification

- `cargo test --locked -p codestory-runtime grounding --lib`: 23 passed
- `cargo clippy --locked -p codestory-runtime --lib -- -D warnings`: passed
- `cargo fmt --check`: passed
- `git diff --check`: passed
- Live named-rescue query plan: intended file-rank index, no temporary B-tree
- Exact candidate 3 repositories x 3 budgets x 6 reads: all nine cells
  deterministic, exact strict/balanced/max prefixes, all expected architecture
  areas represented
- Warm CodeStory strict ranking phase: 17.904 ms to 2.514 ms median, an 86.0%
  reduction

Retained evidence:

- `work/repo-coordinator/1338-candidate-orientation-20260720/latency-localization.md`
- `work/repo-coordinator/1338-candidate-orientation-20260720/exact-8c394ed4.json`

## Risk and remaining proof

The change adds one bounded allocation-backed sort key per candidate and removes
repeated allocations from comparisons. Output ordering is protected by the
existing grounding regressions and the exact candidate matrix.

This is source-performance proof only. The absolute candidate p95 still ran
above the retained installed baseline in seven of nine cells while concurrent
release builds and installed hosts were active. It does not claim installed-host
latency acceptance, release qualification, corpus proof, or a newer installed
candidate. The issue remains open until an isolated replay on the final combined
installed candidate clears all nine cells.

Closes #1338
Refs #1197
Refs #1179
