### PR TITLE
[codex] restore exact-head all-target Clippy

### DIFF
--- a/crates/codestory-runtime/src/grounding.rs
+++ b/crates/codestory-runtime/src/grounding.rs
@@ -3022,7 +3022,7 @@ mod tests {
         let strict_names = strict
             .root_symbols
             .iter()
-            .map(|symbol| grounding_symbol_name(symbol))
+            .map(grounding_symbol_name)
             .collect::<Vec<_>>();
         assert_eq!(
             strict_names.first().map(String::as_str),

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -8123,7 +8123,6 @@ fn grounding_node_snapshot_preserves_columns_rank_and_member_root_direction()
             start_col: Some(3),
             end_line: Some(8),
             end_col: Some(1),
-            ..Default::default()
         },
         Node {
             id: NodeId(102),


### PR DESCRIPTION
## Context

Closes #1346
Refs #1338
Refs #1179

The v0.16 exact-current-dev all-target/all-feature Clippy gate exposed two inherited test-only lints from the completed grounding wave: a redundant closure in the runtime orientation regression and a no-effect `Default` update in the store grounding-snapshot regression. These findings were already present at base `5c1fb48ab95af2b519d2604715252950d3022a6c` and blocked a clean exact-head gate for the active release wave.

## Outcome

The exact repair head has a clean locked workspace all-target/all-feature Clippy result with no production behavior or assertion changes.

## What changed

- Pass `grounding_symbol_name` directly to the iterator in the runtime test.
- Remove the no-effect `Default` update from a fully specified store test node.

## How to review

1. Confirm both changes are mechanical Clippy substitutions in test code.
2. Confirm the grounding and store assertions are unchanged.
3. Confirm the diff contains no production, fixture-contract, documentation, or release changes.

## Verification

- `cargo fmt --all -- --check` — passed
- `cargo test --locked -p codestory-runtime grounding_snapshot_ranks_cross_language_architecture_and_reports_orientation --lib` — 1 passed
- `cargo test --locked -p codestory-store grounding_node_snapshot_preserves_columns_rank_and_member_root_direction --lib` — 1 passed
- `cargo clippy --locked -p codestory-runtime --all-targets --all-features -- -D warnings` — passed
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` — passed
- `git diff --check` — passed

## Risk or follow-up

- The diff changes only test expression spelling and removes a struct update Clippy proved had no effect.
- This PR does not complete #1338's installed-host replay or prove any release/runtime behavior.
- The #1343 dense-centrality lane remains unchanged.
