### PR TITLE
[codex] add Windows candidate-installed proof

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -87,6 +87,23 @@ MEASUREMENT_PROTOCOL = (
     / "testing"
     / "per-user-embedding-server-measurement-protocol.json"
 )
+CANDIDATE_QUALIFICATION_MATRIX_ALIASES = {
+    "candidate_installed_windows_x64_cpu": {
+        "source_cell_id": "installed_windows_x64_cpu",
+        "source_host_class": "post_publish_windows_x64",
+        "installation_source": "candidate",
+        "cell": {
+            "asset_target": "windows-x64",
+            "proof_tier": "installed_runtime",
+            "host_class": "premerge_candidate_windows_x64",
+            "policy": "cpu_explicit",
+            "backend": "cpu",
+            "cache_state": "reused",
+            "residency_state": "resident",
+            "accelerator_claim": "none",
+        },
+    }
+}
 SERVER_PROTOCOL = MEASUREMENT_PROTOCOL.with_name("per-user-embedding-server-protocol.json")
 SERVER_CONSTANT_SET = MEASUREMENT_PROTOCOL.with_name("per-user-embedding-server-constant-set.json")
 HOLDOUT_TASK_ROOT = (
@@ -6893,8 +6910,21 @@ def selected_qualification_matrix_cell(
         if proof_tier == "calibration"
         else protocol["host_package_matrix"]
     )
-    require(cell_id in matrix, f"unknown qualification matrix cell {cell_id!r}")
-    cell = matrix[cell_id]
+    if cell_id in matrix:
+        cell = matrix[cell_id]
+    else:
+        alias = CANDIDATE_QUALIFICATION_MATRIX_ALIASES.get(cell_id)
+        require(alias is not None, f"unknown qualification matrix cell {cell_id!r}")
+        cell = alias["cell"]
+        source_cell = matrix.get(alias["source_cell_id"])
+        require(
+            source_cell
+            == {
+                **cell,
+                "host_class": alias["source_host_class"],
+            },
+            "candidate qualification matrix alias no longer matches its frozen installed-runtime source cell",
+        )
     require(
         cell["asset_target"] == target
         and cell["policy"] == expected_policy
@@ -6906,6 +6936,18 @@ def selected_qualification_matrix_cell(
         "qualification matrix cell does not match the requested proof tier",
     )
     return cell
+
+
+def require_candidate_matrix_installation_source(
+    cell_id: str | None,
+    installation_source: str,
+) -> None:
+    alias = CANDIDATE_QUALIFICATION_MATRIX_ALIASES.get(cell_id)
+    if alias is not None:
+        require(
+            installation_source == alias["installation_source"],
+            "candidate qualification matrix alias requires candidate-installed provenance",
+        )
 
 
 def qualification_measurement_artifact(
@@ -10087,6 +10129,73 @@ def self_test() -> None:
             self_measurement_protocol,
             require_frozen=False,
         )
+        windows_candidate_cell_id = "candidate_installed_windows_x64_cpu"
+        windows_candidate_cell = selected_qualification_matrix_cell(
+            measurement_contract["measurement_protocol"],
+            cell_id=windows_candidate_cell_id,
+            target="windows-x64",
+            proof_tier="installed_runtime",
+            expected_policy="cpu_explicit",
+            expected_backend="CPU",
+        )
+        require(
+            windows_candidate_cell
+            == {
+                "asset_target": "windows-x64",
+                "proof_tier": "installed_runtime",
+                "host_class": "premerge_candidate_windows_x64",
+                "policy": "cpu_explicit",
+                "backend": "cpu",
+                "cache_state": "reused",
+                "residency_state": "resident",
+                "accelerator_claim": "none",
+            },
+            "Windows candidate-installed alias changed its exact identity",
+        )
+        require_candidate_matrix_installation_source(
+            windows_candidate_cell_id,
+            "candidate",
+        )
+        try:
+            require_candidate_matrix_installation_source(
+                windows_candidate_cell_id,
+                "marketplace",
+            )
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                "Windows candidate-installed alias accepted marketplace provenance"
+            )
+        hostile_windows_alias_values = {
+            "asset_target": "linux-x64",
+            "proof_tier": "protected_hardware",
+            "policy": "accelerated",
+            "backend": "vulkan",
+            "accelerator_claim": "vulkan",
+        }
+        for field, hostile_value in hostile_windows_alias_values.items():
+            hostile_protocol = json.loads(
+                json.dumps(measurement_contract["measurement_protocol"])
+            )
+            hostile_protocol["host_package_matrix"][
+                "installed_windows_x64_cpu"
+            ][field] = hostile_value
+            try:
+                selected_qualification_matrix_cell(
+                    hostile_protocol,
+                    cell_id=windows_candidate_cell_id,
+                    target="windows-x64",
+                    proof_tier="installed_runtime",
+                    expected_policy="cpu_explicit",
+                    expected_backend="CPU",
+                )
+            except ProofFailure:
+                pass
+            else:
+                raise ProofFailure(
+                    f"Windows candidate-installed alias accepted changed {field}"
+                )
         (
             calibration_bundle_path,
             frozen_measurement_contract,
@@ -11003,6 +11112,10 @@ def main() -> int:
         result = prepare_candidate_installed_proof(args)
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0
+    require_candidate_matrix_installation_source(
+        args.qualification_matrix_cell,
+        args.installed_plugin_source,
+    )
     require(args.archive and args.checksum_file and args.expected_version, "archive, checksum, and expected version are required")
     args.archive = args.archive.resolve()
     args.checksum_file = args.checksum_file.resolve()

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1403,6 +1403,11 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(violations, sameMembers(needs(vulkan), releaseChain.dependencies["windows-vulkan-proof"]), `${releaseFile} Vulkan proof dependencies must match the release claim graph`);
   add(violations, object(vulkan.with).use_packaged_cli_artifact === true, `${releaseFile} Vulkan proof must use the packaged CLI`);
   add(violations, object(vulkan.with).emit_release_cells === true, `${releaseFile} Vulkan proof must emit its authenticated release cell`);
+  add(
+    violations,
+    object(vulkan.with).candidate_installed_proof === undefined,
+    `${releaseFile} must leave pre-merge Windows candidate-installed proof to the PR coordinator`,
+  );
 
   const preCloseout = requireJob(violations, releaseFile, release, "pre-publish-closeout");
   add(violations, sameMembers(needs(preCloseout), releaseChain.dependencies["pre-publish-closeout"]), `${releaseFile} pre-publish closeout dependencies must match the release claim graph`);
@@ -2182,6 +2187,11 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     `${file} Vulkan proof must wait for package and exact-head release evidence`,
   );
   add(violations, object(vulkan.with).use_packaged_cli_artifact === true, `${file} Vulkan proof must use the packaged CLI`);
+  add(
+    violations,
+    object(vulkan.with).candidate_installed_proof === true,
+    `${file} must opt the accepted PR Windows package into candidate-installed proof`,
+  );
   const closeout = requireJob(violations, file, workflow, "closeout");
   requireStepRun(violations, file, closeout, "Require one coherent accepted proof", ["dev/codestory-next moved from proved head"]);
   add(violations, !scalarStrings(workflow).some(value => value === "./.github/workflows/release.yml"), `${file} must not publish releases`);
@@ -2366,6 +2376,20 @@ function validateRemainingWorkflows(workflows, violations) {
     violations.push(`${vulkanFile} must exist`);
   } else {
     add(violations, trigger(vulkan, "workflow_call") !== undefined && trigger(vulkan, "workflow_dispatch") !== undefined, `${vulkanFile} must support reusable and manual proof`);
+    const candidateInput = object(at(
+      vulkan,
+      "on",
+      "workflow_call",
+      "inputs",
+      "candidate_installed_proof",
+    ));
+    add(
+      violations,
+      candidateInput.required === false
+        && candidateInput.type === "boolean"
+        && candidateInput.default === false,
+      `${vulkanFile} candidate-installed proof must be an explicit opt-in`,
+    );
     const job = requireJob(violations, vulkanFile, vulkan, "packaged-vulkan");
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
@@ -2404,6 +2428,65 @@ function validateRemainingWorkflows(workflows, violations) {
       "--calibration-producer-artifact",
     ]);
     add(violations, object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${vulkanFile} engine proof must reject CPU fallback`);
+    const candidateStage = namedStep(job, "Stage isolated candidate-managed Windows install");
+    add(
+      violations,
+      String(candidateStage?.if ?? "").includes("inputs.candidate_installed_proof")
+        && String(candidateStage?.if ?? "").includes("inputs.quality_evidence_artifact"),
+      `${vulkanFile} candidate-managed staging must require coordinator opt-in and exact-head quality evidence`,
+    );
+    requireStepRun(violations, vulkanFile, job, "Stage isolated candidate-managed Windows install", [
+      "--prepare-candidate-installed-proof",
+      "--candidate-plugin-root-output",
+      "--candidate-plugin-data-output",
+      "--installed-plugin-provenance-output",
+      "--candidate-producer-workflow-path",
+      "$env:RUNNER_TEMP",
+      "codestory-candidate-installed-windows.",
+      "[IO.Path]::GetFullPath",
+      "$env:GITHUB_WORKSPACE",
+      "CODESTORY_CANDIDATE_WINDOWS_ROOT=",
+    ]);
+    const candidateProof = namedStep(job, "Prove two-host candidate-installed Windows runtime");
+    add(
+      violations,
+      String(candidateProof?.if ?? "").includes("inputs.candidate_installed_proof")
+        && String(candidateProof?.if ?? "").includes("inputs.quality_evidence_artifact"),
+      `${vulkanFile} candidate-installed proof must require coordinator opt-in and exact-head quality evidence`,
+    );
+    requireStepRun(violations, vulkanFile, job, "Prove two-host candidate-installed Windows runtime", [
+      "--proof-tier installed_runtime",
+      "--qualification-matrix-cell candidate_installed_windows_x64_cpu",
+      "--engine-policy cpu_explicit",
+      "--expected-backend CPU",
+      "--installed-plugin-source candidate",
+      "--installed-plugin-provenance",
+      "--installed-plugin-data",
+      "--candidate-producer-workflow-path",
+      "--calibration-producer-run-id",
+      "--calibration-producer-artifact",
+      "--retrieval-quality-evidence",
+      "--expected-source-sha",
+      "--expected-source-tree",
+      "$env:CODESTORY_CANDIDATE_WINDOWS_ROOT",
+    ]);
+    add(
+      violations,
+      object(candidateProof?.env).CODESTORY_EMBED_ALLOW_CPU === "1",
+      `${vulkanFile} candidate-installed proof must opt into explicit CPU execution`,
+    );
+    const candidateUpload = namedStep(job, "Upload candidate-installed Windows proof");
+    add(
+      violations,
+      candidateUpload?.uses === "actions/upload-artifact@v7.0.1"
+        && String(candidateUpload?.if ?? "").includes("always()")
+        && String(candidateUpload?.if ?? "").includes("inputs.candidate_installed_proof")
+        && object(candidateUpload?.with).name
+          === "candidate-installed-windows-${{ inputs.version }}-attempt-${{ github.run_attempt }}"
+        && object(candidateUpload?.with).path === "target/candidate-installed-windows"
+        && object(candidateUpload?.with)["if-no-files-found"] === "error",
+      `${vulkanFile} candidate-installed proof must retain one attempt-scoped artifact`,
+    );
     requireStepRun(violations, vulkanFile, job, "Emit authenticated Vulkan release cell", [
       "codestory-release-cell-manifest.mjs produce",
       "accelerator_execution:windows-x64-vulkan",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1143,6 +1143,73 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
   }
 });
 
+test("Windows candidate-installed proof remains distinct and provenance-bound", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+
+  const coordinatorFile = "packaged-platform-pr.yml";
+  const protectedFile = "windows-vulkan-proof.yml";
+  const releaseFile = "release.yml";
+  const candidateStage = workflow => draftStep(
+    workflow.jobs["packaged-vulkan"],
+    "Stage isolated candidate-managed Windows install",
+  );
+  const candidateProof = workflow => draftStep(
+    workflow.jobs["packaged-vulkan"],
+    "Prove two-host candidate-installed Windows runtime",
+  );
+  const candidateUpload = workflow => draftStep(
+    workflow.jobs["packaged-vulkan"],
+    "Upload candidate-installed Windows proof",
+  );
+
+  const mutations = [
+    ["coordinator opt-in removed", coordinatorFile, workflow => {
+      delete workflow.jobs["windows-vulkan-proof"].with.candidate_installed_proof;
+    }, /accepted PR Windows package into candidate-installed proof/u],
+    ["release enables pre-merge proof", releaseFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].with.candidate_installed_proof = true;
+    }, /leave pre-merge Windows candidate-installed proof/u],
+    ["explicit opt-in removed", protectedFile, workflow => {
+      delete workflow.on.workflow_call.inputs.candidate_installed_proof;
+    }, /candidate-installed proof must be an explicit opt-in/u],
+    ["candidate staging bypassed", protectedFile, workflow => {
+      candidateStage(workflow).run = candidateStage(workflow).run
+        .replace("--prepare-candidate-installed-proof", "--version-only");
+    }, /Stage isolated candidate-managed Windows install/u],
+    ["candidate tier weakened", protectedFile, workflow => {
+      candidateProof(workflow).run = candidateProof(workflow).run
+        .replace("--proof-tier installed_runtime", "--proof-tier protected_hardware");
+    }, /Prove two-host candidate-installed Windows runtime/u],
+    ["candidate cell relabeled", protectedFile, workflow => {
+      candidateProof(workflow).run = candidateProof(workflow).run
+        .replace(
+          "candidate_installed_windows_x64_cpu",
+          "protected_windows_x64_vulkan",
+        );
+    }, /Prove two-host candidate-installed Windows runtime/u],
+    ["candidate CPU opt-in removed", protectedFile, workflow => {
+      candidateProof(workflow).env.CODESTORY_EMBED_ALLOW_CPU = "0";
+    }, /explicit CPU execution/u],
+    ["candidate provenance removed", protectedFile, workflow => {
+      candidateProof(workflow).run = candidateProof(workflow).run
+        .replace("--installed-plugin-provenance", "--untrusted-plugin-provenance");
+    }, /Prove two-host candidate-installed Windows runtime/u],
+    ["candidate artifact loses attempt identity", protectedFile, workflow => {
+      candidateUpload(workflow).with.name = "candidate-installed-windows-${{ inputs.version }}";
+    }, /attempt-scoped artifact/u],
+  ];
+
+  for (const [name, file, mutate, expectedReason] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expectedReason);
+    });
+  }
+});
+
 test("draft source workflow freezes its complete top-level contract", async (t) => {
   assert.deepEqual(draftWorkflowPolicyViolations(draftSourceWorkflow()), []);
   const reordered = draftSourceWorkflow();

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -541,6 +541,7 @@ jobs:
       quality_evidence_artifact: ${{ needs.route.outputs.constants_frozen == 'true' && format('release-evidence-{0}', needs.route.outputs.head_sha) || '' }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact || '' }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id || '' }}
+      candidate_installed_proof: true
 
   closeout:
     if: >-

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -29,6 +29,11 @@ on:
         required: false
         default: ""
         type: string
+      candidate_installed_proof:
+        description: Stage and qualify the exact package through the private candidate-managed launcher boundary.
+        required: false
+        default: false
+        type: boolean
       emit_release_cells:
         required: false
         default: false
@@ -53,6 +58,11 @@ on:
       calibration_bundle_run_id:
         required: true
         type: string
+      candidate_installed_proof:
+        description: Stage and qualify the exact package through the private candidate-managed launcher boundary.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -211,6 +221,109 @@ jobs:
             @qualityArgs `
             --timeout-secs 1800 `
             --out-dir target/windows-vulkan-proof/packaged-agent
+
+      - name: Stage isolated candidate-managed Windows install
+        if: ${{ inputs.candidate_installed_proof && inputs.quality_evidence_artifact != '' }}
+        shell: pwsh
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = $env:VERSION.TrimStart('v')
+          $archive = "target/release-dist/codestory-cli-v$version-windows-x64.zip"
+          $candidateRoot = Join-Path `
+            $env:RUNNER_TEMP `
+            ("codestory-candidate-installed-windows." + [Guid]::NewGuid().ToString("N"))
+          $candidateRoot = [IO.Path]::GetFullPath($candidateRoot)
+          $workspaceRoot = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+          if ($candidateRoot.StartsWith(
+            $workspaceRoot + [IO.Path]::DirectorySeparatorChar,
+            [StringComparison]::OrdinalIgnoreCase
+          )) {
+            throw "candidate-managed root must be outside the source checkout"
+          }
+          New-Item -ItemType Directory -Path $candidateRoot | Out-Null
+          "CODESTORY_CANDIDATE_WINDOWS_ROOT=$candidateRoot" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          New-Item -ItemType Directory -Force target/candidate-installed-windows | Out-Null
+          python .github/scripts/check-packaged-agent-proof.py `
+            --prepare-candidate-installed-proof `
+            --archive $archive `
+            --checksum-file "target/release-dist/codestory-cli-v$version-windows-x64.zip.sha256" `
+            --expected-version $version `
+            --plugin-root plugins/codestory `
+            --candidate-plugin-root-output (Join-Path $candidateRoot "plugin") `
+            --candidate-plugin-data-output (Join-Path $candidateRoot "data") `
+            --installed-plugin-provenance-output target/candidate-installed-windows/provenance.json `
+            --candidate-producer-repository $env:GITHUB_REPOSITORY `
+            --candidate-producer-workflow-path ".github/workflows/packaged-platform-pr.yml" `
+            --candidate-producer-run-id $env:GITHUB_RUN_ID `
+            --candidate-producer-run-attempt $env:GITHUB_RUN_ATTEMPT `
+            --candidate-artifact-name (Split-Path -Leaf $archive)
+
+      - name: Prove two-host candidate-installed Windows runtime
+        if: ${{ inputs.candidate_installed_proof && inputs.quality_evidence_artifact != '' }}
+        shell: pwsh
+        env:
+          VERSION: ${{ inputs.version }}
+          CODESTORY_EMBED_ALLOW_CPU: "1"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = $env:VERSION.TrimStart('v')
+          $archive = "target/release-dist/codestory-cli-v$version-windows-x64.zip"
+          $sourceSha = (git rev-parse HEAD).Trim()
+          $sourceTree = (git rev-parse 'HEAD^{tree}').Trim()
+          $calibrationBundles = @(
+            Get-ChildItem target/calibration-bundle -Recurse -File -Filter calibration-bundle.json
+          )
+          if ($calibrationBundles.Count -ne 1) {
+            throw "expected exactly one frozen calibration-bundle.json"
+          }
+          $qualityPath = "target/release-quality-evidence/packet/packet-runtime-summary.json"
+          if (-not (Test-Path $qualityPath)) {
+            throw "candidate-installed Windows proof requires exact-head quality evidence"
+          }
+          $pluginRoot = Join-Path $env:CODESTORY_CANDIDATE_WINDOWS_ROOT "plugin"
+          $pluginData = Join-Path $env:CODESTORY_CANDIDATE_WINDOWS_ROOT "data"
+          python .github/scripts/check-packaged-agent-proof.py `
+            --archive $archive `
+            --checksum-file "target/release-dist/codestory-cli-v$version-windows-x64.zip.sha256" `
+            --expected-version $version `
+            --project $env:GITHUB_WORKSPACE `
+            --plugin-root $pluginRoot `
+            --plugin-handoff `
+            --engine-policy cpu_explicit `
+            --expected-backend CPU `
+            --offline `
+            --proof-tier installed_runtime `
+            --qualification-matrix-cell candidate_installed_windows_x64_cpu `
+            --produce-qualification-evidence `
+            --qualification-evidence target/candidate-installed-windows/qualification.json `
+            --calibration-bundle $calibrationBundles[0].FullName `
+            --calibration-producer-run-id "${{ inputs.calibration_bundle_run_id }}" `
+            --calibration-producer-artifact "${{ inputs.calibration_bundle_artifact }}" `
+            --retrieval-quality-evidence $qualityPath `
+            --installed-plugin-source candidate `
+            --installed-plugin-provenance target/candidate-installed-windows/provenance.json `
+            --installed-plugin-data $pluginData `
+            --candidate-producer-repository $env:GITHUB_REPOSITORY `
+            --candidate-producer-workflow-path ".github/workflows/packaged-platform-pr.yml" `
+            --candidate-producer-run-id $env:GITHUB_RUN_ID `
+            --candidate-producer-run-attempt $env:GITHUB_RUN_ATTEMPT `
+            --candidate-artifact-name (Split-Path -Leaf $archive) `
+            --expected-source-sha $sourceSha `
+            --expected-source-tree $sourceTree `
+            --timeout-secs 1800 `
+            --out-dir target/candidate-installed-windows/proof
+
+      - name: Upload candidate-installed Windows proof
+        if: always() && inputs.candidate_installed_proof && inputs.quality_evidence_artifact != ''
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: candidate-installed-windows-${{ inputs.version }}-attempt-${{ github.run_attempt }}
+          path: target/candidate-installed-windows
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Emit authenticated Vulkan release cell
         if: inputs.emit_release_cells

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   admits genuinely high-degree callables without repository-specific steering,
   keeps low-degree locals sparse, and advances the policy identity so existing
   vector generations rebuild rather than reusing selections from the old rule.
+- The protected Windows proof workflow now keeps physical Vulkan qualification
+  separate while also staging the exact x64 archive through an isolated
+  candidate-managed plugin root. The installed-runtime lane launches two fresh
+  plugin hosts, requires explicit CPU execution and authenticated candidate
+  provenance, and retains attempt-scoped ownership, admission, lifecycle,
+  identity, memory, and quality evidence for release review.
 - Compact grounding now ranks roots with architecture evidence and reports a
   typed orientation confidence with bounded-candidate, entrypoint, subsystem,
   and presentation uncertainty. The stdio schema and `ground --why` render the


### PR DESCRIPTION
## Context

The candidate-managed installed-runtime proof covered Linux and macOS, but the Windows release path only exercised the protected Vulkan lane directly from the checked-out plugin. That left #1221 without an authenticated Windows candidate-install boundary.

## What changed

- opt the accepted PR coordinator into a Windows candidate-installed proof
- stage the exact checksum-verified Windows x64 archive into an isolated runner-temporary plugin/data root
- bind the install to the coordinator repository, workflow, run, attempt, artifact, source SHA, and source tree
- bind the new premerge Windows cell to the existing frozen `installed_windows_x64_cpu` measurement contract without changing its digest, constants, or thresholds
- launch the existing two-host installed-runtime verifier with explicit CPU policy under `candidate_installed_windows_x64_cpu`
- retain the qualification and proof packet in an attempt-scoped artifact
- keep the protected `protected_windows_x64_vulkan` lane and its no-CPU policy unchanged
- freeze the contract in workflow-policy checks and hostile mutation tests

## How to review

Start with `.github/workflows/windows-vulkan-proof.yml`: the new steps follow the existing Linux/macOS candidate-installed path while remaining conditional on the PR coordinator opt-in and exact-head quality evidence. Then review the matching assertions and mutation tests in `.github/scripts/check-workflow-policy*`.

## Verification

- `node .github/scripts/check-workflow-policy.mjs`
- `node --test .github/scripts/check-workflow-policy.test.mjs` (242 tests)
- `node .github/scripts/run-actionlint.mjs`
- `node --test .github/scripts/run-actionlint.test.mjs`
- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- measurement protocol SHA remains `9b3a883f11d7e33522a74150d45d8a34f4e9b57759a5e55b980b470aed07ee22`, matching the frozen constant-set record
- `git diff --check 86e695b178805aa58db2da8cda92e6436d431644..c7bab699c7b37c422995697472ecde435970f76a`

No workflow was dispatched. Live Windows installed-runtime evidence remains a post-review integration proof, and protected Vulkan evidence remains a separate qualification tier.

Closes #1349
Refs #1221
Refs #1213
Refs #1179
