### PR TITLE
[codex] freeze v0.16 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.16.0
+
+CodeStory 0.16 makes repository search more accurate and reduces duplicate model memory across agents and projects. The model and embedding engine ship inside CodeStory, compatible processes share one private local server, and startup, readiness, and idle shutdown happen automatically.
+
 ### Release
 
 - Generic YAML structural collection now distinguishes quoted scalars from
@@ -244,10 +248,6 @@
   promotion. Live, generic build, and incremental-clone profiles remain
   WAL/NORMAL. Full-refresh telemetry reports the configured checkpoint window,
   final checkpoint time, and explicit sync time.
-
-## 0.16.0
-
-CodeStory 0.16 makes repository search more accurate and reduces duplicate model memory across agents and projects. The model and embedding engine ship inside CodeStory, compatible processes share one private local server, and startup, readiness, and idle shutdown happen automatically.
 
 ### Highlights
 


### PR DESCRIPTION
## Context

Closes #1352
Refs #1189
Refs #1179

CodeStory's complete v0.16 Release and Performance notes were still under Unreleased, while the existing 0.16.0 section held the curated overview, highlights, reliability notes, scope, and upgrade guidance. The release workflow extracts the exact version section, so the shipped notes need one stable version boundary before exact-head qualification.

## What Changed

- Moved the existing 0.16.0 heading and introduction above the unchanged Release and Performance blocks.
- Preserved every existing 0.16.0 entry and left Unreleased empty for future work.
- Left version metadata unchanged because the release checker confirms 0.16.0 is synchronized.

The source diff is one file, four insertions, and four deletions. No release-note prose was rewritten.

Exact source:

- Base: `fc33f18a8df56f0dd55d20965b60403e30ad7e32`
- Base tree: `4d7d961f26861cbe981c41eb1f0bb65124a89a8f`
- Head: `e33de4b5fbbf4e17bf3d2a47e001c6ebc3308939`
- Head tree: `639173e7a7174a6f4bfac6832ccdeca100a027ba`

## How To Review

1. Confirm Unreleased is present and empty.
2. Confirm the former Unreleased block occurs byte-for-byte once under 0.16.0.
3. Confirm the prior 0.16.0 introduction and body remain unchanged and ordering is coherent.
4. Confirm the extractor returns the complete 0.16.0 body.

## Verification

- Independent exact-head review - source clean; Release has 19 byte-identical entries, Performance has 16 byte-identical entries, and the former Unreleased block occurs once under 0.16.0 at 17,216 bytes / 242 lines.
- `git diff --check origin/dev/codestory-next...HEAD` - passed; one file, four insertions, four deletions.
- `node .github/scripts/check-doc-links.mjs` - passed; 75 files and 265 relative links.
- `python .github/scripts/check-codestory-release.py --version 0.16.0` - passed; nine workspace crates, Cargo.lock, three plugin manifests, and the embedded-model producer are synchronized.
- `node .github/scripts/check-workflow-policy.mjs` - passed.
- `node .github/scripts/extract-codestory-release-notes.mjs --version 0.16.0` - passed; output exactly matches the trimmed 0.16 body at 24,114 bytes / 315 lines with all six expected subsections.
- `node --test scripts/tests/extract-codestory-release-notes.test.mjs` - passed; 7 tests.

## Risk

Docs-only release-source boundary change. It does not build, install, restart, dispatch, promote, tag, publish, or establish package, platform, installed-runtime, protected-hardware, marketplace, or live-release proof. The retained corpus and vector evidence directories were not touched; the vector experiment is not a v0.16 release gate.
