### PR TITLE
[codex] accept valid YAML scalars and JSON streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Release
 
+- Generic YAML structural collection now distinguishes quoted scalars from
+  apostrophes and quotation marks inside plain text, and it permits tabs inside
+  literal or folded block content while retaining fail-closed indentation and
+  delimiter checks. Generic JSON collection accepts complete value streams and
+  still rejects empty, malformed, or truncated input.
 - Dense-anchor centrality now uses complete bounded graph relationship counts
   instead of the six-item member and related-symbol presentation lists. This
   admits genuinely high-degree callables without repository-specific steering,

--- a/crates/codestory-indexer/src/structural/generic.rs
+++ b/crates/codestory-indexer/src/structural/generic.rs
@@ -217,9 +217,18 @@ pub(crate) fn collect_json_entities(
     file_id: NodeId,
     storage: &mut IntermediateStorage,
 ) -> Result<(), StructuralCollectionError> {
-    serde_json::from_str::<serde_json::Value>(source).map_err(|error| {
-        StructuralCollectionError::Malformed(format!("invalid JSON syntax: {error}"))
-    })?;
+    let mut value_count = 0usize;
+    for value in serde_json::Deserializer::from_str(source).into_iter::<serde_json::Value>() {
+        value.map_err(|error| {
+            StructuralCollectionError::Malformed(format!("invalid JSON syntax: {error}"))
+        })?;
+        value_count += 1;
+    }
+    if value_count == 0 {
+        return Err(StructuralCollectionError::Malformed(
+            "invalid JSON syntax: expected at least one JSON value".to_string(),
+        ));
+    }
 
     let bytes = source.as_bytes();
     let mut cursor = 0usize;
@@ -467,6 +476,18 @@ fn validate_yaml_source(source: &str) -> Result<(), StructuralCollectionError> {
     let mut escaped = false;
     let mut block_scalar_parent_indent = None;
     for (line_index, line) in source.lines().enumerate() {
+        let leading_spaces = line
+            .as_bytes()
+            .iter()
+            .take_while(|byte| **byte == b' ')
+            .count();
+        let trimmed = line[leading_spaces..].trim_end();
+        if let Some(parent_indent) = block_scalar_parent_indent {
+            if trimmed.is_empty() || leading_spaces > parent_indent {
+                continue;
+            }
+            block_scalar_parent_indent = None;
+        }
         let indentation = line
             .as_bytes()
             .iter()
@@ -478,15 +499,9 @@ fn validate_yaml_source(source: &str) -> Result<(), StructuralCollectionError> {
                 line_index + 1
             )));
         }
-        let trimmed = line[indentation..].trim_end();
-        if let Some(parent_indent) = block_scalar_parent_indent {
-            if trimmed.is_empty() || indentation > parent_indent {
-                continue;
-            }
-            block_scalar_parent_indent = None;
-        }
         let code = strip_yaml_comment(line);
-        for ch in code.chars() {
+        let mut chars = code.char_indices().peekable();
+        while let Some((index, ch)) = chars.next() {
             if let Some(active) = quote {
                 if escaped {
                     escaped = false;
@@ -497,12 +512,19 @@ fn validate_yaml_source(source: &str) -> Result<(), StructuralCollectionError> {
                     continue;
                 }
                 if ch == active {
+                    if active == '\'' && chars.peek().is_some_and(|(_, next)| *next == '\'') {
+                        chars.next();
+                        continue;
+                    }
                     quote = None;
                 }
                 continue;
             }
+            if ch == '#' && yaml_comment_starts_at(code, index) {
+                break;
+            }
             match ch {
-                '\'' | '"' => quote = Some(ch),
+                '\'' | '"' if yaml_quote_can_open_at(code, index) => quote = Some(ch),
                 '[' | '{' => flow.push(ch),
                 ']' if flow.pop() != Some('[') => {
                     return Err(StructuralCollectionError::Malformed(format!(
@@ -537,7 +559,63 @@ fn validate_yaml_source(source: &str) -> Result<(), StructuralCollectionError> {
 }
 
 fn strip_yaml_comment(line: &str) -> &str {
-    strip_comment(line, '#')
+    let mut quote = None;
+    let mut escaped = false;
+    let mut chars = line.char_indices().peekable();
+    while let Some((index, ch)) = chars.next() {
+        if let Some(active) = quote {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if active == '"' && ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == active {
+                if active == '\'' && chars.peek().is_some_and(|(_, next)| *next == '\'') {
+                    chars.next();
+                    continue;
+                }
+                quote = None;
+            }
+            continue;
+        }
+        if ch == '#' && yaml_comment_starts_at(line, index) {
+            return &line[..index];
+        }
+        if matches!(ch, '\'' | '"') && yaml_quote_can_open_at(line, index) {
+            quote = Some(ch);
+        }
+    }
+    line
+}
+
+fn yaml_comment_starts_at(value: &str, index: usize) -> bool {
+    index == 0
+        || value[..index]
+            .chars()
+            .next_back()
+            .is_some_and(char::is_whitespace)
+}
+
+fn yaml_quote_can_open_at(value: &str, index: usize) -> bool {
+    let prefix = value[..index].trim_end();
+    let Some(previous) = prefix.chars().next_back() else {
+        return true;
+    };
+    if matches!(previous, ':' | '[' | '{' | ',') {
+        return true;
+    }
+    if !matches!(previous, '-' | '?') {
+        return false;
+    }
+    let marker_index = prefix.len().saturating_sub(previous.len_utf8());
+    marker_index == 0
+        || prefix[..marker_index]
+            .chars()
+            .next_back()
+            .is_some_and(char::is_whitespace)
 }
 
 fn strip_toml_comment(line: &str) -> &str {
@@ -576,12 +654,42 @@ fn strip_comment(line: &str, comment: char) -> &str {
 }
 
 fn yaml_mapping_delimiter(value: &str) -> Option<usize> {
-    let delimiter = assignment_delimiter(value, ':')?;
-    value
-        .as_bytes()
-        .get(delimiter + 1)
-        .is_none_or(u8::is_ascii_whitespace)
-        .then_some(delimiter)
+    let mut quote = None;
+    let mut escaped = false;
+    let mut chars = value.char_indices().peekable();
+    while let Some((index, ch)) = chars.next() {
+        if let Some(active) = quote {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if active == '"' && ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == active {
+                if active == '\'' && chars.peek().is_some_and(|(_, next)| *next == '\'') {
+                    chars.next();
+                    continue;
+                }
+                quote = None;
+            }
+            continue;
+        }
+        if matches!(ch, '\'' | '"') && yaml_quote_can_open_at(value, index) {
+            quote = Some(ch);
+            continue;
+        }
+        if ch == ':'
+            && value
+                .as_bytes()
+                .get(index + 1)
+                .is_none_or(u8::is_ascii_whitespace)
+        {
+            return Some(index);
+        }
+    }
+    None
 }
 
 fn yaml_block_scalar_header(value: &str) -> bool {

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -413,6 +413,7 @@ mod tests {
     use codestory_contracts::graph::{EdgeKind, NodeKind};
     use codestory_store::{ProjectionBatch, Store as Storage};
     use std::collections::HashSet;
+    use std::path::PathBuf;
 
     #[test]
     fn indexes_dedicated_sql_file() {
@@ -762,6 +763,144 @@ mod tests {
         assert!(is_structural_candidate_path(Path::new(
             r"docs\architecture\guide.md"
         )));
+    }
+
+    #[test]
+    fn generic_yaml_accepts_plain_quote_punctuation_and_block_scalar_tabs() {
+        let source = concat!(
+            "description: the controller's state remains plain text\n",
+            "title: 7.9\" display panel\n",
+            "quoted: 'it''s explicitly quoted'\n",
+            "example: |\n",
+            "  command\t--flag=\"value\"\n",
+        );
+        let storage = index_structural_source(Path::new("metadata.yaml"), source)
+            .expect("valid YAML scalar forms should collect");
+
+        for expected in ["description", "title", "quoted", "example"] {
+            assert!(
+                storage
+                    .nodes
+                    .iter()
+                    .any(|node| node.serialized_name == expected),
+                "missing YAML mapping-key anchor {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn generic_json_accepts_complete_value_streams() {
+        let source = "{\"first\":1}\n{\"second\":2}\n";
+        let storage = index_structural_source(Path::new("events.json"), source)
+            .expect("complete JSON values should collect as one stream");
+
+        for expected in ["first", "second"] {
+            assert!(
+                storage
+                    .nodes
+                    .iter()
+                    .any(|node| node.serialized_name == expected),
+                "missing streamed JSON object-key anchor {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn generic_yaml_and_json_keep_genuine_syntax_failures_closed() {
+        for (path, source) in [
+            ("unterminated-quote.yaml", "value: \"unterminated\n"),
+            ("unterminated-flow.yaml", "items: [one, two\n"),
+            ("unmatched-flow.yaml", "items: ]\n"),
+            ("tab-indentation.yaml", "root:\n\tchild: value\n"),
+            ("empty.json", "  \n"),
+            ("truncated.json", "{\"missing_value\":\n"),
+            ("trailing-invalid.json", "{\"valid\":true}\n{invalid}\n"),
+        ] {
+            assert!(
+                matches!(
+                    index_structural_source(Path::new(path), source),
+                    Err(StructuralCollectionError::Malformed(_))
+                ),
+                "{path} should remain malformed"
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "requires an explicit external root and structural-gap manifest"]
+    fn external_structural_path_sweep_is_collector_only() {
+        let root = std::env::var_os("CODESTORY_STRUCTURAL_SWEEP_ROOT")
+            .map(PathBuf::from)
+            .expect("CODESTORY_STRUCTURAL_SWEEP_ROOT");
+        let manifest = std::env::var_os("CODESTORY_STRUCTURAL_SWEEP_MANIFEST")
+            .map(PathBuf::from)
+            .expect("CODESTORY_STRUCTURAL_SWEEP_MANIFEST");
+        let root = root.canonicalize().expect("canonical external sweep root");
+        let document: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(&manifest).expect("read structural sweep manifest"),
+        )
+        .expect("parse structural sweep manifest");
+        let gaps = document
+            .pointer("/error/details/coverage_gaps")
+            .or_else(|| document.pointer("/details/coverage_gaps"))
+            .and_then(serde_json::Value::as_array)
+            .expect("manifest coverage_gaps array");
+        assert!(!gaps.is_empty(), "external structural sweep is empty");
+
+        let mut failures = Vec::new();
+        for gap in gaps {
+            let relative = gap
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .expect("coverage gap path");
+            let path = root.join(relative);
+            let canonical = match path.canonicalize() {
+                Ok(canonical) if canonical.starts_with(&root) => canonical,
+                Ok(canonical) => {
+                    failures.push(format!(
+                        "{relative}: resolved outside {} as {}",
+                        root.display(),
+                        canonical.display()
+                    ));
+                    continue;
+                }
+                Err(error) => {
+                    failures.push(format!("{relative}: {error}"));
+                    continue;
+                }
+            };
+            let bytes = match std::fs::read(&canonical) {
+                Ok(bytes) => bytes,
+                Err(error) => {
+                    failures.push(format!("{relative}: {error}"));
+                    continue;
+                }
+            };
+            let source = match decode_structural_source(bytes) {
+                Ok(source) => source,
+                Err(error) => {
+                    failures.push(format!("{relative}: {error}"));
+                    continue;
+                }
+            };
+            if let Err(error) =
+                index_structural_source_with_unit_cap(&canonical, &source, usize::MAX as u64)
+            {
+                failures.push(format!("{relative}: {error}"));
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "{} of {} external structural paths failed collector-only validation:\n{}",
+            failures.len(),
+            gaps.len(),
+            failures.join("\n")
+        );
+        eprintln!(
+            "collector-only structural sweep accepted {} read-only path(s)",
+            gaps.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closes #1355
Refs #1202
Refs #1179
Refs #1311

CodeStory's generic structural collectors turn bounded YAML and JSON source into exact mapping/object-key evidence. The retained #1202 Linux publication attempt failed closed on 505 files because the YAML validator treated punctuation inside plain text as cross-line quote state, checked block-scalar tabs as indentation, and required `.json` inputs to contain exactly one top-level value.

This slice repairs those format-general boundaries without adding Linux paths, benchmark targets, or source-policy exclusions. Genuine malformed or truncated inputs remain fail-closed.

Base: `dev/codestory-next` at `7c062a78e1ecf4457d1fc604ad100714d6e574a1`

Candidate head: `e706e8c3c7205189f56e7d5385df06417b2804ba`

Candidate tree: `7f88226e224b205a80c315436c5b649530de4046`

## Outcome

Generic structural collection now accepts YAML plain-scalar apostrophes and quotation marks, tabs inside literal/folded block content, and streams containing one or more complete JSON values. Actual YAML indentation tabs, unmatched or unterminated YAML flow/quotes, and empty, malformed, or truncated JSON still fail closed.

## What changed

- YAML quote state begins only at scalar-start positions instead of every apostrophe or quotation mark.
- Block-scalar content is recognized before YAML indentation checks, while tabs in real indentation remain malformed.
- YAML comment and mapping-key scans use the same scalar-aware quote boundary.
- JSON validation uses `serde_json`'s streaming iterator and requires at least one complete value.
- Focused regressions cover the accepted forms and hostile malformed boundaries.
- An opt-in, read-only collector-only sweep consumes an external root and coverage-gap manifest without opening an index, cache, or retrieval publication.
- `CHANGELOG.md` records the v0.16 behavior correction under `Unreleased`.

## How to review

1. Review quote/comment/mapping state and block-scalar ordering in `crates/codestory-indexer/src/structural/generic.rs`.
2. Confirm the positive and negative fixtures in `crates/codestory-indexer/src/structural/mod.rs` are format-general and preserve malformed outcomes.
3. Confirm the ignored external sweep is read-only, path-contained, and contains no corpus-specific production rule.

## Verification

- `cargo test --locked -p codestory-indexer structural::tests` — 24 passed, 1 opt-in sweep ignored.
- `CODESTORY_STRUCTURAL_SWEEP_ROOT=<retained-root> CODESTORY_STRUCTURAL_SWEEP_MANIFEST=<retained-incremental-v2.json> cargo test --locked -p codestory-indexer structural::tests::external_structural_path_sweep_is_collector_only -- --ignored --exact --nocapture` — accepted 505/505 retained paths; collector-only and read-only.
- `cargo check --locked -p codestory-indexer` — passed.
- `cargo clippy --locked -p codestory-indexer --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `node .github/scripts/check-doc-links.mjs` — passed, 75 files and 265 relative links.

## Risk or follow-up

- The custom YAML collector remains deliberately bounded structural evidence rather than parser-backed YAML semantics. Review should concentrate on scalar-start recognition and malformed false negatives.
- The retained core predates structural-unit publication, so a later authorized publication attempt still requires staged full recollection. This PR does not run or authorize it.
- No corpus index, retrieval fixture, vector candidate, package, installed-runtime, marketplace, restart, or release claim is made here.
- Keep this PR draft through independent exact-head review and required hosted checks. The release coordinator retains merge authority.
