### PR TITLE
[codex] Fail closed on incompatible incremental refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@
   still rejects empty, malformed, or truncated input.
 - Explicit incremental refresh now fails closed with typed
   `full_refresh_required` compatibility evidence when the live core lacks its
-  required structural publication. The decision occurs before workspace reads,
-  writer acquisition, or publication changes; `auto` retains deliberate full
-  recovery, and dry-run reports the same requested mode, effective mode, and
-  reason. Full-mode source failures now name the effective mode instead of
-  implying that every caller requested a full refresh.
+  required structural publication or needs a supported schema upgrade. The
+  decision occurs before workspace reads, writer acquisition, or publication
+  changes; `auto` retains deliberate full recovery, and dry-run reports the
+  same requested mode, effective mode, and reason. Full-mode source failures
+  now name the effective mode instead of implying that every caller requested a
+  full refresh.
 - Dense-anchor centrality now uses complete bounded graph relationship counts
   instead of the six-item member and related-symbol presentation lists. This
   admits genuinely high-degree callables without repository-specific steering,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   literal or folded block content while retaining fail-closed indentation and
   delimiter checks. Generic JSON collection accepts complete value streams and
   still rejects empty, malformed, or truncated input.
+- Explicit incremental refresh now fails closed with typed
+  `full_refresh_required` compatibility evidence when the live core lacks its
+  required structural publication. The decision occurs before workspace reads,
+  writer acquisition, or publication changes; `auto` retains deliberate full
+  recovery, and dry-run reports the same requested mode, effective mode, and
+  reason. Full-mode source failures now name the effective mode instead of
+  implying that every caller requested a full refresh.
 - Dense-anchor centrality now uses complete bounded graph relationship counts
   instead of the six-item member and related-symbol presentation lists. This
   admits genuinely high-degree callables without repository-specific steering,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
   changes; `auto` retains deliberate full recovery, and dry-run reports the
   same requested mode, effective mode, and reason. Full-mode source failures
   now name the effective mode instead of implying that every caller requested a
-  full refresh.
+  full refresh. Drill reports omit unavailable pre-refresh metrics and carry
+  the compatibility reason instead of copying post-refresh counts into the
+  before fields.
 - Dense-anchor centrality now uses complete bounded graph relationship counts
   instead of the six-item member and related-symbol presentation lists. This
   admits genuinely high-degree callables without repository-specific steering,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,7 @@ dependencies = [
  "libc",
  "notify",
  "ratatui",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -48,4 +48,5 @@ windows-sys = { workspace = true, features = [
 [dev-dependencies]
 codestory-retrieval = { workspace = true, features = ["test-support"] }
 codestory-runtime = { workspace = true, features = ["test-support"] }
+rusqlite = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -20,7 +20,7 @@ use codestory_contracts::api::{
 use serde::Serialize;
 use std::{collections::BTreeMap, path::PathBuf};
 
-const INDEX_REFRESH_HELP: &str = "Index defaults to `auto`: it chooses `full` for an empty or structurally incompatible cache and `incremental` for a compatible existing publication. An explicit `incremental` request never escalates to `full`; incompatible state returns `full_refresh_required` before workspace reads or writes.";
+const INDEX_REFRESH_HELP: &str = "Index defaults to `auto`: it chooses `full` for an empty, pre-current, or structurally incompatible cache and `incremental` for a compatible existing publication. An explicit `incremental` request never escalates to `full`; incompatible state returns `full_refresh_required` before workspace reads or writes.";
 const READ_REFRESH_HELP: &str = "Read commands default to `none` so they only query the existing cache. Use `incremental` to \
 refresh an existing cache in place, or `full` after a cache reset, schema change, or indexing \
 failure. Explicit `incremental` fails with `full_refresh_required` instead of escalating.";

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -20,13 +20,12 @@ use codestory_contracts::api::{
 use serde::Serialize;
 use std::{collections::BTreeMap, path::PathBuf};
 
-const INDEX_REFRESH_HELP: &str = "Index defaults to `auto`: it chooses `full` for an empty cache and `incremental` once the \
-cache already has indexed files.";
+const INDEX_REFRESH_HELP: &str = "Index defaults to `auto`: it chooses `full` for an empty or structurally incompatible cache and `incremental` for a compatible existing publication. An explicit `incremental` request never escalates to `full`; incompatible state returns `full_refresh_required` before workspace reads or writes.";
 const READ_REFRESH_HELP: &str = "Read commands default to `none` so they only query the existing cache. Use `incremental` to \
 refresh an existing cache in place, or `full` after a cache reset, schema change, or indexing \
-failure.";
+failure. Explicit `incremental` fails with `full_refresh_required` instead of escalating.";
 const DRILL_REFRESH_HELP: &str = "Drill defaults to `full` so each report is mechanically fresh. Use `none` only after a \
-fresh index, or `incremental` to refresh an existing cache in place.";
+fresh index, or `incremental` to refresh a compatible existing cache without allowing full-refresh escalation.";
 const CLI_LONG_ABOUT: &str = "\
 CodeStory turns a local repository into auditable grounding evidence.
 
@@ -1484,6 +1483,8 @@ pub(crate) struct IndexOutput<'a> {
     pub(crate) project: &'a str,
     pub(crate) storage_path: &'a str,
     pub(crate) refresh: &'a str,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) refresh_reason: Option<&'a str>,
     pub(crate) summary: &'a ProjectSummary,
     pub(crate) retrieval: &'a RetrievalStateDto,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1568,6 +1569,10 @@ pub(crate) struct AgentPreflightOutput {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct IndexDryRunOutput<'a> {
+    pub(crate) requested_refresh: &'a str,
+    pub(crate) effective_refresh: &'a str,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) compatibility_reason: Option<&'a str>,
     pub(crate) dry_run: &'a IndexDryRunDto,
 }
 

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1725,10 +1725,16 @@ pub(crate) struct DrillRuntimeTimingsOutput {
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct DrillMechanicalOutput {
-    pub(crate) before_files: u32,
-    pub(crate) before_nodes: u32,
-    pub(crate) before_edges: u32,
-    pub(crate) before_errors: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) before_files: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) before_nodes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) before_edges: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) before_errors: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) before_unavailable_reason: Option<String>,
     pub(crate) after_files: u32,
     pub(crate) after_nodes: u32,
     pub(crate) after_edges: u32,
@@ -1882,10 +1888,14 @@ pub(crate) struct DrillSummaryStatsOutput {
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct DrillSummaryMechanicalOutput {
     pub(crate) refresh: String,
-    pub(crate) before: DrillSummaryStatsOutput,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) before: Option<DrillSummaryStatsOutput>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) before_unavailable_reason: Option<String>,
     pub(crate) after: DrillSummaryStatsOutput,
     pub(crate) index_ready: bool,
-    pub(crate) error_delta: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) error_delta: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) retrieval_status: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/codestory-cli/src/explore.rs
+++ b/crates/codestory-cli/src/explore.rs
@@ -103,6 +103,7 @@ pub(crate) fn run_explore(cmd: ExploreCommand) -> Result<()> {
         let pinned_opened = runtime::OpenedProject {
             summary: runtime.active_project_summary()?,
             refresh_mode: opened.refresh_mode,
+            refresh_reason: opened.refresh_reason.clone(),
             phase_timings: opened.phase_timings.clone(),
         };
         let status = build_explore_status_output(

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -682,7 +682,7 @@ fn run_index_once(cmd: &IndexCommand) -> Result<()> {
         RuntimeContext::new(&cmd.project)?
     };
     if cmd.dry_run {
-        let (_, decision) = runtime.resolve_refresh_with_preflight(cmd.refresh)?;
+        let decision = runtime.resolve_refresh_decision_with_preflight(cmd.refresh)?;
         let refresh_mode = decision.effective_mode.unwrap_or(IndexMode::Incremental);
         let dry_run = runtime.index.dry_run_index(refresh_mode).map_err(|error| {
             map_api_error_for_project(
@@ -8004,9 +8004,8 @@ fn compact_excerpt(line: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::args::RefreshMode;
     use crate::display::{clean_path_string, relative_path};
-    use crate::runtime::{cache_root_for_project, fnv1a_hex, resolve_refresh_request};
+    use crate::runtime::{cache_root_for_project, fnv1a_hex};
     use codestory_contracts::api::{
         AgentAnswerDto, AgentCitationDto, AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto,
         AgentRetrievalTraceDto, CorePromotionTimings, DatabaseSnapshotCopyTimings, EdgeId,
@@ -9157,101 +9156,6 @@ mod tests {
     #[test]
     fn fnv1a_hash_is_stable() {
         assert_eq!(fnv1a_hex(b"abc"), "e71fa2190541574b");
-    }
-
-    #[test]
-    fn auto_refresh_uses_full_for_empty_index() {
-        assert_eq!(
-            resolve_refresh_request(RefreshMode::Auto, &summary_with_files(0)),
-            Ok(runtime::RefreshDecision {
-                effective_mode: Some(IndexMode::Full),
-                reason: Some("complete_core_publication_missing".to_string()),
-            })
-        );
-    }
-
-    #[test]
-    fn auto_refresh_uses_incremental_for_existing_index() {
-        assert_eq!(
-            resolve_refresh_request(RefreshMode::Auto, &summary_with_files(3)),
-            Ok(runtime::RefreshDecision {
-                effective_mode: Some(IndexMode::Incremental),
-                reason: None,
-            })
-        );
-    }
-
-    #[test]
-    fn explicit_incremental_rejects_full_recovery_while_auto_reports_it() {
-        let mut summary = summary_with_files(3);
-        summary.freshness = Some(IndexFreshnessDto {
-            status: IndexFreshnessStatusDto::Stale,
-            changed_file_count: 0,
-            new_file_count: 0,
-            removed_file_count: 0,
-            checked_file_count: 0,
-            indexed_file_count: 3,
-            duration_ms: 0,
-            reason: Some("previous_incremental_run_incomplete_full_refresh_required".to_string()),
-            samples: Vec::new(),
-        });
-
-        let auto = resolve_refresh_request(RefreshMode::Auto, &summary).expect("auto decision");
-        assert_eq!(auto.effective_mode, Some(IndexMode::Full));
-        assert_eq!(
-            auto.reason.as_deref(),
-            Some("incomplete_incremental_publication")
-        );
-
-        let error = resolve_refresh_request(RefreshMode::Incremental, &summary)
-            .expect_err("explicit incremental must not escalate");
-        assert_eq!(error.code, "full_refresh_required");
-        assert!(error.message.contains("requested=incremental"));
-        assert!(error.message.contains("effective=none"));
-        assert!(error.message.contains("required=full"));
-        assert_eq!(
-            error
-                .details
-                .as_ref()
-                .and_then(|details| details.cause_code.as_deref()),
-            Some("incomplete_incremental_publication")
-        );
-    }
-
-    #[test]
-    fn structural_publication_incompatibility_has_auto_and_incremental_parity() {
-        let mut summary = summary_with_files(3);
-        summary.freshness = Some(IndexFreshnessDto {
-            status: IndexFreshnessStatusDto::NotChecked,
-            changed_file_count: 0,
-            new_file_count: 0,
-            removed_file_count: 0,
-            checked_file_count: 0,
-            indexed_file_count: 3,
-            duration_ms: 0,
-            reason: Some(
-                "structural text unit publication is incomplete: publication is missing"
-                    .to_string(),
-            ),
-            samples: Vec::new(),
-        });
-
-        let auto = resolve_refresh_request(RefreshMode::Auto, &summary).expect("auto decision");
-        assert_eq!(auto.effective_mode, Some(IndexMode::Full));
-        assert_eq!(
-            auto.reason.as_deref(),
-            Some("structural_publication_incompatible")
-        );
-        let incremental = resolve_refresh_request(RefreshMode::Incremental, &summary)
-            .expect_err("incremental incompatibility");
-        assert_eq!(incremental.code, "full_refresh_required");
-        assert_eq!(
-            incremental
-                .details
-                .as_ref()
-                .and_then(|details| details.cause_code.as_deref()),
-            Some("structural_publication_incompatible")
-        );
     }
 
     #[test]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -411,8 +411,7 @@ fn open_agent_surface(
     surface: &'static str,
 ) -> Result<OpenedAgentSurface> {
     let runtime = new_agent_surface_runtime(project, profile, run_id)?;
-    let before = runtime.open_project_summary()?;
-    let opened = runtime.ensure_open_from_summary(refresh, before.clone())?;
+    let (before, opened) = runtime.ensure_open_with_before(refresh)?;
     ensure_index_ready(&opened, surface)?;
     codestory_retrieval::ensure_product_embedding_backend_for_runtime(&runtime.sidecar)
         .map_err(map_embedding_preflight_error)
@@ -8053,6 +8052,142 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn agent_surface_refresh_fixture() -> (tempfile::TempDir, ProjectArgs, PathBuf, u32) {
+        let temp = tempdir().expect("create temp dir");
+        let project = temp.path().join("project");
+        let cache = temp.path().join("cache");
+        fs::create_dir_all(project.join("src")).expect("create source directory");
+        fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname = \"agent-surface-refresh-fixture\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/lib.rs"),
+            "pub fn agent_surface_refresh_fixture() -> u32 { 1 }\n",
+        )
+        .expect("write source");
+        let project_args = ProjectArgs {
+            project,
+            cache_dir: Some(cache),
+        };
+        let runtime = RuntimeContext::new_inspect_only(&project_args).expect("create runtime");
+        runtime
+            .ensure_open(args::RefreshMode::Full)
+            .expect("publish current core generation");
+        let storage_path = runtime.storage_path.clone();
+        let schema_version = sqlite_schema_version(&storage_path);
+        (temp, project_args, storage_path, schema_version)
+    }
+
+    fn sqlite_schema_version(path: &Path) -> u32 {
+        let connection =
+            rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .expect("open database read-only");
+        connection
+            .query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))
+            .expect("read schema version")
+    }
+
+    fn stamp_sqlite_schema_version(path: &Path, version: u32) {
+        let connection = rusqlite::Connection::open(path).expect("open database");
+        connection
+            .pragma_update(None, "user_version", version)
+            .expect("stamp schema version");
+    }
+
+    fn durable_database_and_wal(path: &Path) -> (Vec<u8>, Option<Vec<u8>>) {
+        (
+            fs::read(path).expect("read database"),
+            fs::read(path.with_extension("db-wal")).ok(),
+        )
+    }
+
+    #[test]
+    fn agent_surface_preflights_precurrent_schema_before_summary_open() {
+        let _env_lock = crate::config::config_env_test_lock();
+        let _env_snapshot = EnvVarSnapshot::clear(&[
+            "CODESTORY_RETRIEVAL_PROFILE",
+            "CODESTORY_RETRIEVAL_RUN_ID",
+            "CI",
+            "GITHUB_ACTIONS",
+        ]);
+        let (_temp, project_args, storage_path, current_schema) = agent_surface_refresh_fixture();
+        assert!(current_schema > 1, "fixture needs a pre-current schema");
+        let old_schema = current_schema - 1;
+        stamp_sqlite_schema_version(&storage_path, old_schema);
+        let durable_before = durable_database_and_wal(&storage_path);
+
+        let error = match open_agent_surface(
+            &project_args,
+            None,
+            None,
+            args::RefreshMode::Incremental,
+            "packet",
+        ) {
+            Ok(_) => panic!("explicit incremental must reject the old schema"),
+            Err(error) => error,
+        };
+        let api = runtime::api_error_in_chain(&error).expect("typed compatibility error");
+        assert_eq!(api.code, "full_refresh_required");
+        assert_eq!(
+            api.details
+                .as_deref()
+                .and_then(|details| details.cause_code.as_deref()),
+            Some("core_schema_upgrade_required")
+        );
+        assert_eq!(durable_database_and_wal(&storage_path), durable_before);
+        assert_eq!(sqlite_schema_version(&storage_path), old_schema);
+
+        let opened =
+            open_agent_surface(&project_args, None, None, args::RefreshMode::Auto, "packet")
+                .expect("auto may select full recovery");
+        assert_eq!(opened.opened.refresh_mode, Some(IndexMode::Full));
+        assert_eq!(
+            opened.opened.refresh_reason.as_deref(),
+            Some("core_schema_upgrade_required")
+        );
+        assert_eq!(sqlite_schema_version(&storage_path), current_schema);
+    }
+
+    #[test]
+    fn agent_surface_preflight_preserves_pending_promotion_without_recovery() {
+        let _env_lock = crate::config::config_env_test_lock();
+        let _env_snapshot = EnvVarSnapshot::clear(&[
+            "CODESTORY_RETRIEVAL_PROFILE",
+            "CODESTORY_RETRIEVAL_RUN_ID",
+            "CI",
+            "GITHUB_ACTIONS",
+        ]);
+        let (_temp, project_args, storage_path, _current_schema) = agent_surface_refresh_fixture();
+        let prepared_path = PathBuf::from(format!(
+            "{}.promotion.prepared.json",
+            storage_path.display()
+        ));
+        let prepared = b"pending promotion evidence";
+        fs::write(&prepared_path, prepared).expect("write pending promotion marker");
+        let durable_before = durable_database_and_wal(&storage_path);
+
+        for refresh in [args::RefreshMode::Auto, args::RefreshMode::Incremental] {
+            let error = match open_agent_surface(&project_args, None, None, refresh, "packet") {
+                Ok(_) => panic!("pending promotion must fail closed for {refresh:?}"),
+                Err(error) => error,
+            };
+            let api = runtime::api_error_in_chain(&error).expect("typed fail-closed error");
+            assert_eq!(api.code, "internal");
+            assert!(
+                api.message.contains("promotion recovery is pending"),
+                "{api:?}"
+            );
+        }
+
+        assert_eq!(durable_database_and_wal(&storage_path), durable_before);
+        assert_eq!(
+            fs::read(&prepared_path).expect("pending promotion marker remains"),
+            prepared
+        );
     }
 
     fn assert_order(markdown: &str, first: &str, second: &str) {

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -103,8 +103,9 @@ use output::{
     validate_output_file_parent,
 };
 use runtime::{
-    AmbiguousTargetError, RuntimeContext, ensure_index_ready, map_api_error, refresh_label,
-    resolve_refresh_request, resolve_source_target, resolve_target,
+    AmbiguousTargetError, RuntimeContext, annotate_refresh_error, ensure_index_ready,
+    index_mode_name, map_api_error, map_api_error_for_project, refresh_label, refresh_mode_name,
+    resolve_source_target, resolve_target,
 };
 use serde::Deserialize;
 #[cfg(test)]
@@ -681,14 +682,20 @@ fn run_index_once(cmd: &IndexCommand) -> Result<()> {
         RuntimeContext::new(&cmd.project)?
     };
     if cmd.dry_run {
-        let summary = runtime.open_project_summary()?;
-        let refresh_mode =
-            resolve_refresh_request(cmd.refresh, &summary).unwrap_or(IndexMode::Incremental);
-        let dry_run = runtime
-            .index
-            .dry_run_index(refresh_mode)
-            .map_err(map_api_error)?;
-        let output = IndexDryRunOutput { dry_run: &dry_run };
+        let (_, decision) = runtime.resolve_refresh_with_preflight(cmd.refresh)?;
+        let refresh_mode = decision.effective_mode.unwrap_or(IndexMode::Incremental);
+        let dry_run = runtime.index.dry_run_index(refresh_mode).map_err(|error| {
+            map_api_error_for_project(
+                annotate_refresh_error(error, cmd.refresh, refresh_mode),
+                &runtime.project_root,
+            )
+        })?;
+        let output = IndexDryRunOutput {
+            requested_refresh: refresh_mode_name(cmd.refresh),
+            effective_refresh: index_mode_name(refresh_mode),
+            compatibility_reason: decision.reason.as_deref(),
+            dry_run: &dry_run,
+        };
         let markdown = render_index_dry_run_markdown(&output);
         return emit(cmd.format, &output, markdown, cmd.output_file.as_deref());
     }
@@ -731,6 +738,7 @@ fn run_index_once(cmd: &IndexCommand) -> Result<()> {
         project: &opened.summary.root,
         storage_path: &storage_path,
         refresh: &refresh_label,
+        refresh_reason: opened.refresh_reason.as_deref(),
         summary: &opened.summary,
         retrieval,
         phase_timings: opened.phase_timings.as_ref(),
@@ -8002,14 +8010,15 @@ mod tests {
     use codestory_contracts::api::{
         AgentAnswerDto, AgentCitationDto, AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto,
         AgentRetrievalTraceDto, CorePromotionTimings, DatabaseSnapshotCopyTimings, EdgeId,
-        EdgeKind, FullRefreshWallTimings, GraphEdgeDto, GraphNodeDto, GraphResponse, IndexMode,
-        IndexedFileDto, IndexedFileIncompleteReasonCountDto, IndexedFileRoleDto, IndexedFilesDto,
-        IndexedFilesSummaryDto, IndexingPhaseTimings, NodeDetailsDto, NodeId, PacketBudgetDto,
-        PacketBudgetLimitsDto, PacketBudgetUsageDto, PacketClaimDto, PacketPlanDto,
-        PacketPlanQueryDto, PacketRetrievalTraceSummaryDto, PacketSufficiencyDto, ProjectSummary,
-        ProjectionPersistenceFamilyTimings, ProjectionPersistenceTimings, RetrievalModeDto,
-        RetrievalStateDto, SearchHit, SearchHitOrigin, SemanticModeDto, SourcePolicyExclusionDto,
-        StorageStatsDto, TrailContextDto,
+        EdgeKind, FullRefreshWallTimings, GraphEdgeDto, GraphNodeDto, GraphResponse,
+        IndexDryRunDto, IndexMode, IndexedFileDto, IndexedFileIncompleteReasonCountDto,
+        IndexedFileRoleDto, IndexedFilesDto, IndexedFilesSummaryDto, IndexingPhaseTimings,
+        NodeDetailsDto, NodeId, PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetUsageDto,
+        PacketClaimDto, PacketPlanDto, PacketPlanQueryDto, PacketRetrievalTraceSummaryDto,
+        PacketSufficiencyDto, ProjectSummary, ProjectionPersistenceFamilyTimings,
+        ProjectionPersistenceTimings, RetrievalModeDto, RetrievalStateDto, SearchHit,
+        SearchHitOrigin, SemanticModeDto, SourcePolicyExclusionDto, StorageStatsDto,
+        TrailContextDto,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -9154,7 +9163,10 @@ mod tests {
     fn auto_refresh_uses_full_for_empty_index() {
         assert_eq!(
             resolve_refresh_request(RefreshMode::Auto, &summary_with_files(0)),
-            Some(IndexMode::Full)
+            Ok(runtime::RefreshDecision {
+                effective_mode: Some(IndexMode::Full),
+                reason: Some("complete_core_publication_missing".to_string()),
+            })
         );
     }
 
@@ -9162,12 +9174,15 @@ mod tests {
     fn auto_refresh_uses_incremental_for_existing_index() {
         assert_eq!(
             resolve_refresh_request(RefreshMode::Auto, &summary_with_files(3)),
-            Some(IndexMode::Incremental)
+            Ok(runtime::RefreshDecision {
+                effective_mode: Some(IndexMode::Incremental),
+                reason: None,
+            })
         );
     }
 
     #[test]
-    fn interrupted_incremental_resolves_and_labels_staged_full_recovery() {
+    fn explicit_incremental_rejects_full_recovery_while_auto_reports_it() {
         let mut summary = summary_with_files(3);
         summary.freshness = Some(IndexFreshnessDto {
             status: IndexFreshnessStatusDto::Stale,
@@ -9181,18 +9196,94 @@ mod tests {
             samples: Vec::new(),
         });
 
+        let auto = resolve_refresh_request(RefreshMode::Auto, &summary).expect("auto decision");
+        assert_eq!(auto.effective_mode, Some(IndexMode::Full));
         assert_eq!(
-            resolve_refresh_request(RefreshMode::Auto, &summary),
-            Some(IndexMode::Full)
+            auto.reason.as_deref(),
+            Some("incomplete_incremental_publication")
         );
+
+        let error = resolve_refresh_request(RefreshMode::Incremental, &summary)
+            .expect_err("explicit incremental must not escalate");
+        assert_eq!(error.code, "full_refresh_required");
+        assert!(error.message.contains("requested=incremental"));
+        assert!(error.message.contains("effective=none"));
+        assert!(error.message.contains("required=full"));
         assert_eq!(
-            resolve_refresh_request(RefreshMode::Incremental, &summary),
-            Some(IndexMode::Full)
+            error
+                .details
+                .as_ref()
+                .and_then(|details| details.cause_code.as_deref()),
+            Some("incomplete_incremental_publication")
         );
+    }
+
+    #[test]
+    fn structural_publication_incompatibility_has_auto_and_incremental_parity() {
+        let mut summary = summary_with_files(3);
+        summary.freshness = Some(IndexFreshnessDto {
+            status: IndexFreshnessStatusDto::NotChecked,
+            changed_file_count: 0,
+            new_file_count: 0,
+            removed_file_count: 0,
+            checked_file_count: 0,
+            indexed_file_count: 3,
+            duration_ms: 0,
+            reason: Some(
+                "structural text unit publication is incomplete: publication is missing"
+                    .to_string(),
+            ),
+            samples: Vec::new(),
+        });
+
+        let auto = resolve_refresh_request(RefreshMode::Auto, &summary).expect("auto decision");
+        assert_eq!(auto.effective_mode, Some(IndexMode::Full));
         assert_eq!(
-            refresh_label(RefreshMode::Incremental, Some(IndexMode::Full)),
-            "incremental(recovery-full)"
+            auto.reason.as_deref(),
+            Some("structural_publication_incompatible")
         );
+        let incremental = resolve_refresh_request(RefreshMode::Incremental, &summary)
+            .expect_err("incremental incompatibility");
+        assert_eq!(incremental.code, "full_refresh_required");
+        assert_eq!(
+            incremental
+                .details
+                .as_ref()
+                .and_then(|details| details.cause_code.as_deref()),
+            Some("structural_publication_incompatible")
+        );
+    }
+
+    #[test]
+    fn dry_run_reports_requested_effective_and_compatibility_reason() {
+        let dry_run = IndexDryRunDto {
+            root: "/tmp/project".to_string(),
+            storage_path: "/tmp/cache/codestory.db".to_string(),
+            refresh: IndexMode::Full,
+            files_to_index: 4,
+            files_to_remove: 0,
+            sample_files_to_index: Vec::new(),
+            sample_file_ids_to_remove: Vec::new(),
+            members: Vec::new(),
+        };
+        let output = IndexDryRunOutput {
+            requested_refresh: "auto",
+            effective_refresh: "full",
+            compatibility_reason: Some("structural_publication_incompatible"),
+            dry_run: &dry_run,
+        };
+
+        let json = serde_json::to_value(&output).expect("serialize dry-run decision");
+        assert_eq!(json["requested_refresh"], "auto");
+        assert_eq!(json["effective_refresh"], "full");
+        assert_eq!(
+            json["compatibility_reason"],
+            "structural_publication_incompatible"
+        );
+        let markdown = render_index_dry_run_markdown(&output);
+        assert!(markdown.contains("requested_refresh: `auto`"));
+        assert!(markdown.contains("effective_refresh: `full`"));
+        assert!(markdown.contains("compatibility_reason: `structural_publication_incompatible`"));
     }
 
     #[test]
@@ -9203,7 +9294,8 @@ mod tests {
         let output = IndexOutput {
             project: &summary.root,
             storage_path: "C:/repo/.cache/index.sqlite",
-            refresh: "full",
+            refresh: "auto(full)",
+            refresh_reason: Some("structural_publication_incompatible"),
             summary: &summary,
             retrieval: &retrieval,
             phase_timings: Some(&timings),
@@ -9213,6 +9305,9 @@ mod tests {
         };
 
         let markdown = render_index_markdown(&output);
+
+        assert!(markdown.contains("refresh: `auto(full)`"));
+        assert!(markdown.contains("refresh_reason: `structural_publication_incompatible`"));
 
         assert!(markdown.contains(
             "cache_ms: artifact_write=6 search_projection=61 search_index=62 runtime_publish=63"

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -399,7 +399,7 @@ fn new_agent_surface_runtime(
 
 struct OpenedAgentSurface {
     runtime: RuntimeContext,
-    before: ProjectSummary,
+    before: Option<ProjectSummary>,
     opened: runtime::OpenedProject,
 }
 
@@ -2799,6 +2799,13 @@ fn execute_drill(cmd: &DrillCommand) -> Result<codestory_runtime::PublicOperatio
             .context("drill retrieval index finalize")?;
     }
     let refresh = refresh_label(cmd.refresh, opened.refresh_mode);
+    let before_stats = before.as_ref().map(|summary| &summary.stats);
+    let before_unavailable_reason = before.is_none().then(|| {
+        opened
+            .refresh_reason
+            .clone()
+            .unwrap_or_else(|| "pre_refresh_summary_unavailable".to_string())
+    });
     let setup_ms = elapsed_ms(setup_timer);
 
     let drill_anchors = drill_targeting::validated_drill_anchors(&cmd.anchors, "drill")?;
@@ -2863,10 +2870,11 @@ fn execute_drill(cmd: &DrillCommand) -> Result<codestory_runtime::PublicOperatio
             question: cmd.question.clone(),
             output_dir: display::clean_path_string(&cmd.output_dir.to_string_lossy()),
             mechanical: DrillMechanicalOutput {
-                before_files: before.stats.file_count,
-                before_nodes: before.stats.node_count,
-                before_edges: before.stats.edge_count,
-                before_errors: before.stats.error_count,
+                before_files: before_stats.map(|stats| stats.file_count),
+                before_nodes: before_stats.map(|stats| stats.node_count),
+                before_edges: before_stats.map(|stats| stats.edge_count),
+                before_errors: before_stats.map(|stats| stats.error_count),
+                before_unavailable_reason: before_unavailable_reason.clone(),
                 after_files: pinned_summary.stats.file_count,
                 after_nodes: pinned_summary.stats.node_count,
                 after_edges: pinned_summary.stats.edge_count,
@@ -3634,10 +3642,11 @@ fn blocked_drill_suite_repo_output(
             full_report_markdown: String::new(),
             mechanical: DrillSummaryMechanicalOutput {
                 refresh: refresh_label(refresh, None),
-                before: drill_summary_stats(0, 0, 0, 0),
+                before: Some(drill_summary_stats(0, 0, 0, 0)),
+                before_unavailable_reason: None,
                 after: drill_summary_stats(0, 0, 0, 1),
                 index_ready: false,
-                error_delta: 1,
+                error_delta: Some(1),
                 retrieval_status: None,
                 freshness_status: Some("unknown".to_string()),
                 stale_file_count: 0,
@@ -3991,6 +4000,17 @@ fn write_drill_report_file(path: &std::path::Path, content: &str) -> Result<()> 
 
 fn drill_summary(output: &DrillOutput) -> DrillSummaryOutput {
     let sufficiency = &output.evidence_packet.sufficiency;
+    let before_stats = match (
+        output.mechanical.before_files,
+        output.mechanical.before_nodes,
+        output.mechanical.before_edges,
+        output.mechanical.before_errors,
+    ) {
+        (Some(files), Some(nodes), Some(edges), Some(errors)) => {
+            Some(drill_summary_stats(files, nodes, edges, errors))
+        }
+        _ => None,
+    };
     let anchor_statuses: Vec<_> = output
         .anchors
         .iter()
@@ -4129,12 +4149,8 @@ fn drill_summary(output: &DrillOutput) -> DrillSummaryOutput {
         full_report_markdown: "drill-report.md".to_string(),
         mechanical: DrillSummaryMechanicalOutput {
             refresh: output.mechanical.refresh.clone(),
-            before: drill_summary_stats(
-                output.mechanical.before_files,
-                output.mechanical.before_nodes,
-                output.mechanical.before_edges,
-                output.mechanical.before_errors,
-            ),
+            before: before_stats,
+            before_unavailable_reason: output.mechanical.before_unavailable_reason.clone(),
             after: drill_summary_stats(
                 output.mechanical.after_files,
                 output.mechanical.after_nodes,
@@ -4142,8 +4158,9 @@ fn drill_summary(output: &DrillOutput) -> DrillSummaryOutput {
                 output.mechanical.after_errors,
             ),
             index_ready: output.mechanical.after_files > 0 && output.mechanical.after_errors == 0,
-            error_delta: i64::from(output.mechanical.after_errors)
-                - i64::from(output.mechanical.before_errors),
+            error_delta: output.mechanical.before_errors.map(|before_errors| {
+                i64::from(output.mechanical.after_errors) - i64::from(before_errors)
+            }),
             retrieval_status: output
                 .mechanical
                 .retrieval
@@ -8144,6 +8161,10 @@ mod tests {
         let opened =
             open_agent_surface(&project_args, None, None, args::RefreshMode::Auto, "packet")
                 .expect("auto may select full recovery");
+        assert!(
+            opened.before.is_none(),
+            "compatibility recovery has no safe pre-refresh summary"
+        );
         assert_eq!(opened.opened.refresh_mode, Some(IndexMode::Full));
         assert_eq!(
             opened.opened.refresh_reason.as_deref(),
@@ -10482,10 +10503,11 @@ mod tests {
             question: Some(packet.question.clone()),
             output_dir: "artifacts/drill".to_string(),
             mechanical: DrillMechanicalOutput {
-                before_files: 2,
-                before_nodes: 4,
-                before_edges: 2,
-                before_errors: 0,
+                before_files: Some(2),
+                before_nodes: Some(4),
+                before_edges: Some(2),
+                before_errors: Some(0),
+                before_unavailable_reason: None,
                 after_files: 2,
                 after_nodes: 4,
                 after_edges: 2,
@@ -10519,7 +10541,7 @@ mod tests {
             evidence_packet: packet,
         };
         let output_dir = tempdir().expect("output dir");
-        let operation = codestory_runtime::PublicOperation {
+        let mut operation = codestory_runtime::PublicOperation {
             value: output,
             core_publication: None,
             retrieval_publication: None,
@@ -10586,6 +10608,54 @@ mod tests {
                 .map(|value| value.as_str().expect("artifact name").to_string())
                 .collect::<Vec<_>>()
         );
+
+        operation.value.mechanical.before_files = None;
+        operation.value.mechanical.before_nodes = None;
+        operation.value.mechanical.before_edges = None;
+        operation.value.mechanical.before_errors = None;
+        operation.value.mechanical.before_unavailable_reason =
+            Some("core_schema_upgrade_required".to_string());
+        operation.value.mechanical.refresh = "auto->full".to_string();
+        let unavailable_dir = tempdir().expect("unavailable output dir");
+        write_drill_outputs(args::OutputFormat::Json, unavailable_dir.path(), &operation)
+            .expect("write unavailable-before drill fixtures");
+
+        let report: serde_json::Value = serde_json::from_slice(
+            &fs::read(unavailable_dir.path().join("drill-report.json"))
+                .expect("read unavailable-before report"),
+        )
+        .expect("parse unavailable-before report");
+        let summary: serde_json::Value = serde_json::from_slice(
+            &fs::read(unavailable_dir.path().join("drill-summary.json"))
+                .expect("read unavailable-before summary"),
+        )
+        .expect("parse unavailable-before summary");
+        let markdown = fs::read_to_string(unavailable_dir.path().join("drill-report.md"))
+            .expect("read unavailable-before markdown");
+
+        for field in [
+            "/mechanical/before_files",
+            "/mechanical/before_nodes",
+            "/mechanical/before_edges",
+            "/mechanical/before_errors",
+        ] {
+            assert!(report.pointer(field).is_none(), "unexpected {field}");
+        }
+        assert_eq!(
+            report.pointer("/mechanical/before_unavailable_reason"),
+            Some(&serde_json::json!("core_schema_upgrade_required"))
+        );
+        assert!(summary.pointer("/mechanical/before").is_none());
+        assert!(summary.pointer("/mechanical/error_delta").is_none());
+        assert_eq!(
+            summary.pointer("/mechanical/before_unavailable_reason"),
+            Some(&serde_json::json!("core_schema_upgrade_required"))
+        );
+        assert!(
+            markdown.contains("index_before: unavailable reason=core_schema_upgrade_required"),
+            "{markdown}"
+        );
+        assert!(!markdown.contains("index_before: files="), "{markdown}");
     }
 
     #[test]

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -241,6 +241,9 @@ pub(crate) fn render_index_markdown(output: &IndexOutput<'_>) -> String {
         clean_path_string(output.storage_path)
     );
     let _ = writeln!(markdown, "refresh: `{}`", output.refresh);
+    if let Some(reason) = output.refresh_reason {
+        let _ = writeln!(markdown, "refresh_reason: `{reason}`");
+    }
     let _ = writeln!(
         markdown,
         "stats: nodes={} edges={} files={} errors={}",
@@ -841,7 +844,19 @@ pub(crate) fn render_index_dry_run_markdown(output: &IndexDryRunOutput<'_>) -> S
         "storage: `{}`",
         clean_path_string(&dry_run.storage_path)
     );
-    let _ = writeln!(markdown, "refresh: `{:?}`", dry_run.refresh);
+    let _ = writeln!(
+        markdown,
+        "requested_refresh: `{}`",
+        output.requested_refresh
+    );
+    let _ = writeln!(
+        markdown,
+        "effective_refresh: `{}`",
+        output.effective_refresh
+    );
+    if let Some(reason) = output.compatibility_reason {
+        let _ = writeln!(markdown, "compatibility_reason: `{reason}`");
+    }
     let _ = writeln!(
         markdown,
         "plan: would index {} files, remove {} files",

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -2794,14 +2794,27 @@ pub(crate) fn render_drill_markdown(output: &DrillOutput) -> String {
         let _ = writeln!(markdown, "question: {question}");
     }
     let _ = writeln!(markdown, "output_dir: `{}`", output.output_dir);
-    let _ = writeln!(
-        markdown,
-        "index_before: files={} nodes={} edges={} errors={}",
+    match (
         output.mechanical.before_files,
         output.mechanical.before_nodes,
         output.mechanical.before_edges,
-        output.mechanical.before_errors
-    );
+        output.mechanical.before_errors,
+    ) {
+        (Some(files), Some(nodes), Some(edges), Some(errors)) => {
+            let _ = writeln!(
+                markdown,
+                "index_before: files={files} nodes={nodes} edges={edges} errors={errors}"
+            );
+        }
+        _ => {
+            let reason = output
+                .mechanical
+                .before_unavailable_reason
+                .as_deref()
+                .unwrap_or("pre_refresh_summary_unavailable");
+            let _ = writeln!(markdown, "index_before: unavailable reason={reason}");
+        }
+    }
     let _ = writeln!(
         markdown,
         "index_after: files={} nodes={} edges={} errors={} refresh={}",

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -13,7 +13,7 @@ use crate::args::{
     RetrievalStatusCommand,
 };
 use crate::output::{emit, validate_output_file_parent};
-use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error, resolve_refresh_request};
+use crate::runtime::{RuntimeContext, annotate_refresh_error, ensure_index_ready, map_api_error};
 
 pub(crate) fn run_retrieval(cmd: RetrievalCommand) -> Result<()> {
     match cmd.action {
@@ -98,8 +98,8 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
         sidecar_profile.into(),
         cmd.run_id.as_deref(),
     );
-    let summary = runtime.open_project_summary()?;
-    let refresh_mode = resolve_refresh_request(cmd.refresh, &summary);
+    let (_, decision) = runtime.resolve_refresh_with_preflight(cmd.refresh)?;
+    let refresh_mode = decision.effective_mode;
     ensure_retrieval_index_embedding_policy(&sidecar)?;
     run_retrieval_index_refresh(&runtime, cmd.refresh, refresh_mode)?;
     let outcome =
@@ -133,7 +133,7 @@ fn run_retrieval_index_refresh(
     runtime
         .index
         .run_indexing_blocking(mode)
-        .map_err(map_api_error)
+        .map_err(|error| map_api_error(annotate_refresh_error(error, requested_refresh, mode)))
         .map(|_| ())
         .or_else(|error| {
             if !retrieval_index_should_retry_full_refresh(requested_refresh, &error) {
@@ -142,7 +142,13 @@ fn run_retrieval_index_refresh(
             runtime
                 .index
                 .run_indexing_blocking(IndexMode::Full)
-                .map_err(map_api_error)
+                .map_err(|error| {
+                    map_api_error(annotate_refresh_error(
+                        error,
+                        requested_refresh,
+                        IndexMode::Full,
+                    ))
+                })
                 .map(|_| ())
                 .context("retrieval index full refresh after semantic-doc contract repair")
         })

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -98,7 +98,7 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
         sidecar_profile.into(),
         cmd.run_id.as_deref(),
     );
-    let (_, decision) = runtime.resolve_refresh_with_preflight(cmd.refresh)?;
+    let decision = runtime.resolve_refresh_decision_with_preflight(cmd.refresh)?;
     let refresh_mode = decision.effective_mode;
     ensure_retrieval_index_embedding_policy(&sidecar)?;
     run_retrieval_index_refresh(&runtime, cmd.refresh, refresh_mode)?;

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -267,12 +267,11 @@ impl RuntimeContext {
     /// Open an agent surface while retaining a safe before/after summary for
     /// report telemetry. Compatibility is decided before any mutable project
     /// open. When that decision requires full recovery, no trustworthy
-    /// pre-recovery summary exists, so the published after-summary is also used
-    /// as the bounded telemetry baseline.
+    /// pre-recovery summary exists, so the before-summary remains unavailable.
     pub(crate) fn ensure_open_with_before(
         &self,
         refresh: RefreshMode,
-    ) -> Result<(ProjectSummary, OpenedProject)> {
+    ) -> Result<(Option<ProjectSummary>, OpenedProject)> {
         let decision = self.resolve_refresh_decision_with_preflight(refresh)?;
         let before = if decision.reason.is_none() {
             Some(self.open_project_summary()?)
@@ -280,7 +279,6 @@ impl RuntimeContext {
             None
         };
         let opened = self.ensure_open_from_decision(refresh, before.clone(), decision)?;
-        let before = before.unwrap_or_else(|| opened.summary.clone());
         Ok((before, opened))
     }
 

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -32,7 +32,14 @@ const INCOMPLETE_INDEX_RECOVERY_REASON: &str =
 pub(crate) struct OpenedProject {
     pub(crate) summary: ProjectSummary,
     pub(crate) refresh_mode: Option<IndexMode>,
+    pub(crate) refresh_reason: Option<String>,
     pub(crate) phase_timings: Option<IndexingPhaseTimings>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RefreshDecision {
+    pub(crate) effective_mode: Option<IndexMode>,
+    pub(crate) reason: Option<String>,
 }
 
 /// Shared service handles and filesystem roots for a CLI command.
@@ -256,8 +263,8 @@ impl RuntimeContext {
     /// `RefreshMode::None` is read-only with respect to indexing; commands that
     /// require cached graph data must call `ensure_index_ready` after this.
     pub(crate) fn ensure_open(&self, refresh: RefreshMode) -> Result<OpenedProject> {
-        let summary = self.open_project_summary()?;
-        self.ensure_open_from_summary(refresh, summary)
+        let (summary, decision) = self.resolve_refresh_with_preflight(refresh)?;
+        self.ensure_open_from_decision(refresh, summary, decision)
     }
 
     /// Open project state from an already-read summary.
@@ -267,22 +274,91 @@ impl RuntimeContext {
     pub(crate) fn ensure_open_from_summary(
         &self,
         refresh: RefreshMode,
-        mut summary: ProjectSummary,
+        summary: ProjectSummary,
     ) -> Result<OpenedProject> {
-        let refresh_mode = resolve_refresh_request(refresh, &summary);
+        let decision = self.resolve_refresh_from_summary_with_preflight(refresh, &summary)?;
+        self.ensure_open_from_decision(refresh, summary, decision)
+    }
+
+    pub(crate) fn resolve_refresh_with_preflight(
+        &self,
+        refresh: RefreshMode,
+    ) -> Result<(ProjectSummary, RefreshDecision)> {
+        let compatibility = match refresh {
+            RefreshMode::Auto | RefreshMode::Incremental => self
+                .index
+                .ensure_incremental_refresh_compatible_at(&self.project_root, &self.storage_path)
+                .err(),
+            RefreshMode::Full | RefreshMode::None => None,
+        };
+        if refresh == RefreshMode::Incremental
+            && let Some(error) = compatibility.as_ref()
+        {
+            return Err(map_api_error_for_project(error.clone(), &self.project_root));
+        }
+        let summary = self.open_project_summary()?;
+        let decision = if let Some(error) = compatibility {
+            if error.code != "full_refresh_required" {
+                return Err(map_api_error_for_project(error, &self.project_root));
+            }
+            RefreshDecision {
+                effective_mode: Some(IndexMode::Full),
+                reason: Some(refresh_compatibility_reason(&error)),
+            }
+        } else {
+            resolve_refresh_request(refresh, &summary)
+                .map_err(|error| map_api_error_for_project(error, &self.project_root))?
+        };
+        Ok((summary, decision))
+    }
+
+    fn resolve_refresh_from_summary_with_preflight(
+        &self,
+        refresh: RefreshMode,
+        summary: &ProjectSummary,
+    ) -> Result<RefreshDecision> {
+        if matches!(refresh, RefreshMode::Auto | RefreshMode::Incremental)
+            && let Err(error) = self
+                .index
+                .ensure_incremental_refresh_compatible_at(&self.project_root, &self.storage_path)
+        {
+            if refresh == RefreshMode::Incremental || error.code != "full_refresh_required" {
+                return Err(map_api_error_for_project(error, &self.project_root));
+            }
+            return Ok(RefreshDecision {
+                effective_mode: Some(IndexMode::Full),
+                reason: Some(refresh_compatibility_reason(&error)),
+            });
+        }
+        resolve_refresh_request(refresh, summary)
+            .map_err(|error| map_api_error_for_project(error, &self.project_root))
+    }
+
+    fn ensure_open_from_decision(
+        &self,
+        refresh: RefreshMode,
+        mut summary: ProjectSummary,
+        decision: RefreshDecision,
+    ) -> Result<OpenedProject> {
         let mut phase_timings = None;
-        if let Some(mode) = refresh_mode {
+        if let Some(mode) = decision.effective_mode {
             phase_timings = Some(
                 self.index
                     .run_indexing_blocking_without_runtime_refresh(mode)
-                    .map_err(map_api_error)?,
+                    .map_err(|error| {
+                        map_api_error_for_project(
+                            annotate_refresh_error(error, refresh, mode),
+                            &self.project_root,
+                        )
+                    })?,
             );
             summary = self.open_project_summary()?;
         }
 
         Ok(OpenedProject {
             summary,
-            refresh_mode,
+            refresh_mode: decision.effective_mode,
+            refresh_reason: decision.reason,
             phase_timings,
         })
     }
@@ -745,25 +821,123 @@ pub(crate) fn fnv1a_hex(bytes: &[u8]) -> String {
 pub(crate) fn resolve_refresh_request(
     refresh: RefreshMode,
     summary: &ProjectSummary,
-) -> Option<IndexMode> {
-    let requires_full_recovery = summary
+) -> Result<RefreshDecision, ApiError> {
+    let full_refresh_reason = summary_full_refresh_reason(summary);
+    match refresh {
+        RefreshMode::Auto => Ok(RefreshDecision {
+            effective_mode: Some(
+                if summary.stats.node_count == 0 || full_refresh_reason.is_some() {
+                    IndexMode::Full
+                } else {
+                    IndexMode::Incremental
+                },
+            ),
+            reason: full_refresh_reason.map(str::to_string).or_else(|| {
+                (summary.stats.node_count == 0)
+                    .then(|| "complete_core_publication_missing".to_string())
+            }),
+        }),
+        RefreshMode::Full => Ok(RefreshDecision {
+            effective_mode: Some(IndexMode::Full),
+            reason: None,
+        }),
+        RefreshMode::Incremental => {
+            if let Some(reason) = full_refresh_reason {
+                return Err(full_refresh_required_from_summary(summary, reason));
+            }
+            if summary.stats.node_count == 0 {
+                return Err(full_refresh_required_from_summary(
+                    summary,
+                    "complete_core_publication_missing",
+                ));
+            }
+            Ok(RefreshDecision {
+                effective_mode: Some(IndexMode::Incremental),
+                reason: None,
+            })
+        }
+        RefreshMode::None => Ok(RefreshDecision {
+            effective_mode: None,
+            reason: None,
+        }),
+    }
+}
+
+fn summary_full_refresh_reason(summary: &ProjectSummary) -> Option<&str> {
+    let reason = summary
         .freshness
         .as_ref()
-        .and_then(|freshness| freshness.reason.as_deref())
-        == Some(INCOMPLETE_INDEX_RECOVERY_REASON);
-    match refresh {
-        RefreshMode::Auto => Some(if summary.stats.node_count == 0 || requires_full_recovery {
-            IndexMode::Full
-        } else {
-            IndexMode::Incremental
-        }),
-        RefreshMode::Full => Some(IndexMode::Full),
-        RefreshMode::Incremental => Some(if requires_full_recovery {
-            IndexMode::Full
-        } else {
-            IndexMode::Incremental
-        }),
-        RefreshMode::None => None,
+        .and_then(|freshness| freshness.reason.as_deref())?;
+    if reason == INCOMPLETE_INDEX_RECOVERY_REASON {
+        Some("incomplete_incremental_publication")
+    } else if reason.starts_with("structural text unit publication is incomplete:") {
+        Some("structural_publication_incompatible")
+    } else {
+        None
+    }
+}
+
+fn full_refresh_required_from_summary(summary: &ProjectSummary, reason: &str) -> ApiError {
+    let project = summary.root.clone();
+    let command = format!(
+        "codestory-cli index --project {} --refresh full",
+        quote_command_path(Path::new(&project))
+    );
+    ApiError::with_details(
+        "full_refresh_required",
+        format!(
+            "Refresh compatibility rejected the request before workspace reads: requested=incremental effective=none required=full reason={reason}"
+        ),
+        codestory_contracts::api::ApiErrorDetails {
+            cause_code: Some(reason.to_string()),
+            failed_layer: Some("core_publication_compatibility".to_string()),
+            project: Some(project),
+            next_commands: vec![command.clone()],
+            minimum_next: vec![command.clone()],
+            full_repair: vec![command],
+            readiness: None,
+            embedding_capacity: None,
+            embedding_retry: None,
+            coverage_gaps: Vec::new(),
+        },
+    )
+}
+
+fn refresh_compatibility_reason(error: &ApiError) -> String {
+    error
+        .details
+        .as_ref()
+        .and_then(|details| details.cause_code.clone())
+        .unwrap_or_else(|| "full_refresh_required".to_string())
+}
+
+pub(crate) fn annotate_refresh_error(
+    mut error: ApiError,
+    requested: RefreshMode,
+    effective: IndexMode,
+) -> ApiError {
+    error.message = format!(
+        "requested={} effective={}: {}",
+        refresh_mode_name(requested),
+        index_mode_name(effective),
+        error.message
+    );
+    error
+}
+
+pub(crate) fn refresh_mode_name(mode: RefreshMode) -> &'static str {
+    match mode {
+        RefreshMode::Auto => "auto",
+        RefreshMode::Full => "full",
+        RefreshMode::Incremental => "incremental",
+        RefreshMode::None => "none",
+    }
+}
+
+pub(crate) fn index_mode_name(mode: IndexMode) -> &'static str {
+    match mode {
+        IndexMode::Full => "full",
+        IndexMode::Incremental => "incremental",
     }
 }
 
@@ -774,7 +948,7 @@ pub(crate) fn refresh_label(requested: RefreshMode, resolved: Option<IndexMode>)
         (RefreshMode::Auto, Some(IndexMode::Incremental)) => "auto(incremental)".to_string(),
         (RefreshMode::Full, Some(_)) => "full".to_string(),
         (RefreshMode::Incremental, Some(IndexMode::Full)) => {
-            "incremental(recovery-full)".to_string()
+            "requested-incremental(effective-full)".to_string()
         }
         (RefreshMode::Incremental, Some(IndexMode::Incremental)) => "incremental".to_string(),
         (RefreshMode::None, None) => "none".to_string(),

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -255,7 +255,7 @@ impl RuntimeContext {
         })
     }
 
-    /// Open the project and run the resolved refresh request when needed.
+    /// Open project state and run the resolved refresh request when needed.
     ///
     /// `RefreshMode::None` is read-only with respect to indexing; commands that
     /// require cached graph data must call `ensure_index_ready` after this.

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -260,30 +260,28 @@ impl RuntimeContext {
     /// `RefreshMode::None` is read-only with respect to indexing; commands that
     /// require cached graph data must call `ensure_index_ready` after this.
     pub(crate) fn ensure_open(&self, refresh: RefreshMode) -> Result<OpenedProject> {
-        let (summary, decision) = self.resolve_refresh_with_preflight(refresh)?;
-        self.ensure_open_from_decision(refresh, summary, decision)
+        let decision = self.resolve_refresh_decision_with_preflight(refresh)?;
+        self.ensure_open_from_decision(refresh, None, decision)
     }
 
-    /// Open project state from an already-read summary.
-    ///
-    /// This keeps commands such as drill from reading the same summary twice
-    /// before deciding whether a refresh is necessary.
-    pub(crate) fn ensure_open_from_summary(
+    /// Open an agent surface while retaining a safe before/after summary for
+    /// report telemetry. Compatibility is decided before any mutable project
+    /// open. When that decision requires full recovery, no trustworthy
+    /// pre-recovery summary exists, so the published after-summary is also used
+    /// as the bounded telemetry baseline.
+    pub(crate) fn ensure_open_with_before(
         &self,
         refresh: RefreshMode,
-        summary: ProjectSummary,
-    ) -> Result<OpenedProject> {
+    ) -> Result<(ProjectSummary, OpenedProject)> {
         let decision = self.resolve_refresh_decision_with_preflight(refresh)?;
-        self.ensure_open_from_decision(refresh, summary, decision)
-    }
-
-    pub(crate) fn resolve_refresh_with_preflight(
-        &self,
-        refresh: RefreshMode,
-    ) -> Result<(ProjectSummary, RefreshDecision)> {
-        let decision = self.resolve_refresh_decision_with_preflight(refresh)?;
-        let summary = self.open_project_summary()?;
-        Ok((summary, decision))
+        let before = if decision.reason.is_none() {
+            Some(self.open_project_summary()?)
+        } else {
+            None
+        };
+        let opened = self.ensure_open_from_decision(refresh, before.clone(), decision)?;
+        let before = before.unwrap_or_else(|| opened.summary.clone());
+        Ok((before, opened))
     }
 
     pub(crate) fn resolve_refresh_decision_with_preflight(
@@ -314,11 +312,14 @@ impl RuntimeContext {
     fn ensure_open_from_decision(
         &self,
         refresh: RefreshMode,
-        mut summary: ProjectSummary,
+        mut summary: Option<ProjectSummary>,
         decision: RefreshDecision,
     ) -> Result<OpenedProject> {
         let mut phase_timings = None;
         if let Some(mode) = decision.effective_mode {
+            if summary.is_none() {
+                self.open_project_summary()?;
+            }
             phase_timings = Some(
                 self.index
                     .run_indexing_blocking_without_runtime_refresh(mode)
@@ -329,8 +330,12 @@ impl RuntimeContext {
                         )
                     })?,
             );
-            summary = self.open_project_summary()?;
+            summary = Some(self.open_project_summary()?);
         }
+        let summary = match summary {
+            Some(summary) => summary,
+            None => self.open_project_summary()?,
+        };
 
         Ok(OpenedProject {
             summary,

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -21,9 +21,6 @@ use std::sync::atomic::AtomicBool;
 use crate::args::{ProjectArgs, QuerySelectorOutput, RefreshMode, TargetSelection};
 use crate::display::{clean_path_string, quote_command_path};
 
-const INCOMPLETE_INDEX_RECOVERY_REASON: &str =
-    "previous_incremental_run_incomplete_full_refresh_required";
-
 #[derive(Debug)]
 /// Project state after a command has opened or refreshed the repository.
 ///
@@ -276,7 +273,7 @@ impl RuntimeContext {
         refresh: RefreshMode,
         summary: ProjectSummary,
     ) -> Result<OpenedProject> {
-        let decision = self.resolve_refresh_from_summary_with_preflight(refresh, &summary)?;
+        let decision = self.resolve_refresh_decision_with_preflight(refresh)?;
         self.ensure_open_from_decision(refresh, summary, decision)
     }
 
@@ -284,54 +281,34 @@ impl RuntimeContext {
         &self,
         refresh: RefreshMode,
     ) -> Result<(ProjectSummary, RefreshDecision)> {
-        let compatibility = match refresh {
-            RefreshMode::Auto | RefreshMode::Incremental => self
-                .index
-                .ensure_incremental_refresh_compatible_at(&self.project_root, &self.storage_path)
-                .err(),
-            RefreshMode::Full | RefreshMode::None => None,
-        };
-        if refresh == RefreshMode::Incremental
-            && let Some(error) = compatibility.as_ref()
-        {
-            return Err(map_api_error_for_project(error.clone(), &self.project_root));
-        }
+        let decision = self.resolve_refresh_decision_with_preflight(refresh)?;
         let summary = self.open_project_summary()?;
-        let decision = if let Some(error) = compatibility {
-            if error.code != "full_refresh_required" {
-                return Err(map_api_error_for_project(error, &self.project_root));
-            }
-            RefreshDecision {
-                effective_mode: Some(IndexMode::Full),
-                reason: Some(refresh_compatibility_reason(&error)),
-            }
-        } else {
-            resolve_refresh_request(refresh, &summary)
-                .map_err(|error| map_api_error_for_project(error, &self.project_root))?
-        };
         Ok((summary, decision))
     }
 
-    fn resolve_refresh_from_summary_with_preflight(
+    pub(crate) fn resolve_refresh_decision_with_preflight(
         &self,
         refresh: RefreshMode,
-        summary: &ProjectSummary,
     ) -> Result<RefreshDecision> {
-        if matches!(refresh, RefreshMode::Auto | RefreshMode::Incremental)
-            && let Err(error) = self
+        match refresh {
+            RefreshMode::Auto | RefreshMode::Incremental => self
                 .index
                 .ensure_incremental_refresh_compatible_at(&self.project_root, &self.storage_path)
-        {
-            if refresh == RefreshMode::Incremental || error.code != "full_refresh_required" {
-                return Err(map_api_error_for_project(error, &self.project_root));
-            }
-            return Ok(RefreshDecision {
+                .map(|()| RefreshDecision {
+                    effective_mode: Some(IndexMode::Incremental),
+                    reason: None,
+                })
+                .or_else(|error| refresh_decision_from_compatibility_error(refresh, error))
+                .map_err(|error| map_api_error_for_project(error, &self.project_root)),
+            RefreshMode::Full => Ok(RefreshDecision {
                 effective_mode: Some(IndexMode::Full),
-                reason: Some(refresh_compatibility_reason(&error)),
-            });
+                reason: None,
+            }),
+            RefreshMode::None => Ok(RefreshDecision {
+                effective_mode: None,
+                reason: None,
+            }),
         }
-        resolve_refresh_request(refresh, summary)
-            .map_err(|error| map_api_error_for_project(error, &self.project_root))
     }
 
     fn ensure_open_from_decision(
@@ -817,98 +794,25 @@ pub(crate) fn fnv1a_hex(bytes: &[u8]) -> String {
     format!("{hash:016x}")
 }
 
-/// Convert a requested refresh mode into the indexing action to run.
-pub(crate) fn resolve_refresh_request(
-    refresh: RefreshMode,
-    summary: &ProjectSummary,
-) -> Result<RefreshDecision, ApiError> {
-    let full_refresh_reason = summary_full_refresh_reason(summary);
-    match refresh {
-        RefreshMode::Auto => Ok(RefreshDecision {
-            effective_mode: Some(
-                if summary.stats.node_count == 0 || full_refresh_reason.is_some() {
-                    IndexMode::Full
-                } else {
-                    IndexMode::Incremental
-                },
-            ),
-            reason: full_refresh_reason.map(str::to_string).or_else(|| {
-                (summary.stats.node_count == 0)
-                    .then(|| "complete_core_publication_missing".to_string())
-            }),
-        }),
-        RefreshMode::Full => Ok(RefreshDecision {
-            effective_mode: Some(IndexMode::Full),
-            reason: None,
-        }),
-        RefreshMode::Incremental => {
-            if let Some(reason) = full_refresh_reason {
-                return Err(full_refresh_required_from_summary(summary, reason));
-            }
-            if summary.stats.node_count == 0 {
-                return Err(full_refresh_required_from_summary(
-                    summary,
-                    "complete_core_publication_missing",
-                ));
-            }
-            Ok(RefreshDecision {
-                effective_mode: Some(IndexMode::Incremental),
-                reason: None,
-            })
-        }
-        RefreshMode::None => Ok(RefreshDecision {
-            effective_mode: None,
-            reason: None,
-        }),
-    }
-}
-
-fn summary_full_refresh_reason(summary: &ProjectSummary) -> Option<&str> {
-    let reason = summary
-        .freshness
-        .as_ref()
-        .and_then(|freshness| freshness.reason.as_deref())?;
-    if reason == INCOMPLETE_INDEX_RECOVERY_REASON {
-        Some("incomplete_incremental_publication")
-    } else if reason.starts_with("structural text unit publication is incomplete:") {
-        Some("structural_publication_incompatible")
-    } else {
-        None
-    }
-}
-
-fn full_refresh_required_from_summary(summary: &ProjectSummary, reason: &str) -> ApiError {
-    let project = summary.root.clone();
-    let command = format!(
-        "codestory-cli index --project {} --refresh full",
-        quote_command_path(Path::new(&project))
-    );
-    ApiError::with_details(
-        "full_refresh_required",
-        format!(
-            "Refresh compatibility rejected the request before workspace reads: requested=incremental effective=none required=full reason={reason}"
-        ),
-        codestory_contracts::api::ApiErrorDetails {
-            cause_code: Some(reason.to_string()),
-            failed_layer: Some("core_publication_compatibility".to_string()),
-            project: Some(project),
-            next_commands: vec![command.clone()],
-            minimum_next: vec![command.clone()],
-            full_repair: vec![command],
-            readiness: None,
-            embedding_capacity: None,
-            embedding_retry: None,
-            coverage_gaps: Vec::new(),
-        },
-    )
-}
-
 fn refresh_compatibility_reason(error: &ApiError) -> String {
     error
         .details
         .as_ref()
         .and_then(|details| details.cause_code.clone())
         .unwrap_or_else(|| "full_refresh_required".to_string())
+}
+
+fn refresh_decision_from_compatibility_error(
+    refresh: RefreshMode,
+    error: ApiError,
+) -> Result<RefreshDecision, ApiError> {
+    if refresh == RefreshMode::Auto && error.code == "full_refresh_required" {
+        return Ok(RefreshDecision {
+            effective_mode: Some(IndexMode::Full),
+            reason: Some(refresh_compatibility_reason(&error)),
+        });
+    }
+    Err(error)
 }
 
 pub(crate) fn annotate_refresh_error(
@@ -1080,6 +984,7 @@ fn cache_busy_message(project: Option<&Path>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codestory_contracts::api::ApiErrorDetails;
     use std::env;
     use std::ffi::OsString;
     use std::fs;
@@ -1096,6 +1001,65 @@ mod tests {
 
     struct EnvSnapshot {
         values: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    fn full_refresh_required_error(reason: &str) -> ApiError {
+        ApiError::with_details(
+            "full_refresh_required",
+            format!("requested=incremental effective=none required=full reason={reason}"),
+            ApiErrorDetails {
+                cause_code: Some(reason.to_string()),
+                failed_layer: Some("core_publication_compatibility".to_string()),
+                project: Some("/tmp/project".to_string()),
+                next_commands: Vec::new(),
+                minimum_next: Vec::new(),
+                full_repair: Vec::new(),
+                readiness: None,
+                embedding_capacity: None,
+                embedding_retry: None,
+                coverage_gaps: Vec::new(),
+            },
+        )
+    }
+
+    #[test]
+    fn precurrent_schema_selects_full_for_auto_and_rejects_incremental() {
+        for reason in [
+            "complete_core_publication_missing",
+            "incomplete_incremental_publication",
+            "structural_publication_incompatible",
+            "core_schema_upgrade_required",
+        ] {
+            let auto = refresh_decision_from_compatibility_error(
+                RefreshMode::Auto,
+                full_refresh_required_error(reason),
+            )
+            .expect("auto may select explicit full recovery");
+            assert_eq!(auto.effective_mode, Some(IndexMode::Full));
+            assert_eq!(auto.reason.as_deref(), Some(reason));
+
+            let incremental = refresh_decision_from_compatibility_error(
+                RefreshMode::Incremental,
+                full_refresh_required_error(reason),
+            )
+            .expect_err("explicit incremental must not escalate");
+            assert_eq!(incremental.code, "full_refresh_required");
+            assert_eq!(
+                incremental
+                    .details
+                    .as_ref()
+                    .and_then(|details| details.cause_code.as_deref()),
+                Some(reason)
+            );
+        }
+
+        let unsafe_state = ApiError::internal("future or corrupt schema state");
+        assert_eq!(
+            refresh_decision_from_compatibility_error(RefreshMode::Auto, unsafe_state)
+                .expect_err("auto must not widen unsafe state")
+                .code,
+            "internal"
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -11,9 +11,9 @@ use codestory_contracts::api::{
     AffectedFollowUpDto, AffectedFollowUpInvocationDto, AffectedInputClassificationDto,
     AffectedMatchedFileDto, AffectedRouteDto, AffectedSymbolDto, AffectedTestFileDto,
     AffectedUncoveredInputDto, AffectedUnmatchedPathDto, AgentAnswerDto, AgentAskRequest,
-    AgentHybridWeightsDto, AgentPacketDto, AgentPacketRequestDto, ApiError, AppEventPayload,
-    ArtifactCacheAccessTimings, ArtifactCachePolicyDto, BookmarkCategoryDto, BookmarkDto,
-    CorePromotionTimings, CreateBookmarkCategoryRequest, CreateBookmarkRequest,
+    AgentHybridWeightsDto, AgentPacketDto, AgentPacketRequestDto, ApiError, ApiErrorDetails,
+    AppEventPayload, ArtifactCacheAccessTimings, ArtifactCachePolicyDto, BookmarkCategoryDto,
+    BookmarkDto, CorePromotionTimings, CreateBookmarkCategoryRequest, CreateBookmarkRequest,
     DatabaseSnapshotCopyTimings, EdgeId, EdgeKind, EdgeOccurrencesRequest,
     EmbeddingProfileContractDto, FileCoverageDiagnosticDto, FrameworkRouteCoverageDto,
     FullRefreshWallTimings, GraphEdgeDto, GraphNodeDto, GraphRequest, GraphResponse,
@@ -5218,7 +5218,7 @@ fn full_refresh_execution_plan_with_coverage(
                 _ => "source_discovery_incomplete",
             },
             format!(
-                "Full refresh requires a complete source inventory; discovery was {:?}.",
+                "Effective refresh mode `full` requires a complete source inventory; discovery was {:?}.",
                 inventory.outcome
             ),
             coverage_gaps,
@@ -12148,7 +12148,7 @@ impl AppController {
 
     pub fn start_indexing(&self, req: StartIndexingRequest) -> Result<(), ApiError> {
         let (root, storage_path) = {
-            let mut s = self.state.lock();
+            let s = self.state.lock();
             if s.is_indexing {
                 return Err(ApiError::invalid_argument(
                     "Indexing already in progress for this controller.",
@@ -12161,10 +12161,21 @@ impl AppController {
                 .storage_path
                 .clone()
                 .unwrap_or_else(|| root.join("codestory.db"));
-            s.is_indexing = true;
-            s.index_freshness_cache = None;
             (root, storage_path)
         };
+        if req.mode == IndexMode::Incremental {
+            ensure_incremental_refresh_compatible(&root, &storage_path)?;
+        }
+        {
+            let mut s = self.state.lock();
+            if s.is_indexing {
+                return Err(ApiError::invalid_argument(
+                    "Indexing already in progress for this controller.",
+                ));
+            }
+            s.is_indexing = true;
+            s.index_freshness_cache = None;
+        }
 
         let events_tx = self.events_tx.clone();
         let controller = self.clone();
@@ -12224,7 +12235,7 @@ impl AppController {
         cancel_token: Option<&CancellationToken>,
     ) -> Result<IndexingPhaseTimings, ApiError> {
         let (root, storage_path) = {
-            let mut s = self.state.lock();
+            let s = self.state.lock();
             if s.is_indexing {
                 return Err(ApiError::invalid_argument(
                     "Indexing already in progress for this controller.",
@@ -12235,10 +12246,21 @@ impl AppController {
                 .storage_path
                 .clone()
                 .unwrap_or_else(|| root.join("codestory.db"));
-            s.is_indexing = true;
-            s.index_freshness_cache = None;
             (root, storage_path)
         };
+        if mode == IndexMode::Incremental {
+            ensure_incremental_refresh_compatible(&root, &storage_path)?;
+        }
+        {
+            let mut s = self.state.lock();
+            if s.is_indexing {
+                return Err(ApiError::invalid_argument(
+                    "Indexing already in progress for this controller.",
+                ));
+            }
+            s.is_indexing = true;
+            s.index_freshness_cache = None;
+        }
 
         let _writer_guard = match IndexWriterGuard::try_acquire(&storage_path) {
             Ok(guard) => guard,
@@ -12512,6 +12534,21 @@ impl AppController {
         .is_err())
     }
 
+    pub fn ensure_incremental_refresh_compatible(&self) -> Result<(), ApiError> {
+        let state = self.state.lock();
+        let root = state.project_root.as_deref().ok_or_else(no_project_error)?;
+        let storage_path = state.storage_path.as_deref().ok_or_else(no_project_error)?;
+        ensure_incremental_refresh_compatible(root, storage_path)
+    }
+
+    pub fn ensure_incremental_refresh_compatible_at(
+        &self,
+        root: &Path,
+        storage_path: &Path,
+    ) -> Result<(), ApiError> {
+        ensure_incremental_refresh_compatible(root, storage_path)
+    }
+
     pub fn run_indexing_blocking(&self, mode: IndexMode) -> Result<IndexingPhaseTimings, ApiError> {
         self.run_indexing_blocking_inner(mode, true, None)
     }
@@ -12542,25 +12579,19 @@ impl AppController {
     pub fn dry_run_index(&self, mode: IndexMode) -> Result<IndexDryRunDto, ApiError> {
         let root = self.require_project_root()?;
         let storage_path = self.require_storage_path()?;
+        if mode == IndexMode::Incremental {
+            ensure_incremental_refresh_compatible(&root, &storage_path)?;
+        }
         let workspace = runtime_workspace_manifest(&root, &storage_path)
             .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
-        let mut incomplete_incremental_run = false;
         let refresh_inputs = if storage_path.exists() {
             let store = Store::open(&storage_path)
                 .map_err(|e| ApiError::internal(format!("Failed to open storage: {e}")))?;
-            incomplete_incremental_run = store.has_incomplete_incremental_run().map_err(|e| {
-                ApiError::internal(format!("Failed to inspect incomplete index marker: {e}"))
-            })?;
             workspace_refresh_inputs(&store)?
         } else {
             RefreshInputs::default()
         };
-        let effective_mode = if mode == IndexMode::Incremental && incomplete_incremental_run {
-            IndexMode::Full
-        } else {
-            mode
-        };
-        let execution_plan = match effective_mode {
+        let execution_plan = match mode {
             IndexMode::Full => {
                 full_refresh_execution_plan_with_coverage(
                     &root,
@@ -12586,7 +12617,7 @@ impl AppController {
         Ok(IndexDryRunDto {
             root: root.to_string_lossy().to_string(),
             storage_path: storage_path.to_string_lossy().to_string(),
-            refresh: effective_mode,
+            refresh: mode,
             files_to_index: execution_plan.files_to_index.len().min(u32::MAX as usize) as u32,
             files_to_remove: execution_plan.files_to_remove.len().min(u32::MAX as usize) as u32,
             sample_files_to_index: execution_plan
@@ -15569,7 +15600,7 @@ fn index_full_for_runtime(
         return Err(ApiError::source_coverage_failure(
             code,
             format!(
-                "Full refresh could not verify {count} scheduled file(s): {sample}. {preserved_state}."
+                "Effective refresh mode `full` could not verify {count} scheduled file(s): {sample}. {preserved_state}."
             ),
             blocking_gaps,
         ));
@@ -16074,6 +16105,82 @@ fn spawn_progress_forwarder(
     })
 }
 
+const FULL_REFRESH_REQUIRED_ERROR_CODE: &str = "full_refresh_required";
+
+fn full_refresh_required_error(
+    root: &Path,
+    reason_code: &str,
+    reason: impl AsRef<str>,
+) -> ApiError {
+    let project = root.to_string_lossy().to_string();
+    let next_command = format!("codestory-cli index --project {:?} --refresh full", project);
+    ApiError::with_details(
+        FULL_REFRESH_REQUIRED_ERROR_CODE,
+        format!(
+            "Refresh compatibility rejected the request before workspace reads: requested=incremental effective=none required=full reason={}",
+            reason.as_ref()
+        ),
+        ApiErrorDetails {
+            cause_code: Some(reason_code.to_string()),
+            failed_layer: Some("core_publication_compatibility".to_string()),
+            project: Some(project),
+            next_commands: vec![next_command.clone()],
+            minimum_next: vec![next_command.clone()],
+            full_repair: vec![next_command],
+            readiness: None,
+            embedding_capacity: None,
+            embedding_retry: None,
+            coverage_gaps: Vec::new(),
+        },
+    )
+}
+
+fn ensure_incremental_refresh_compatible(root: &Path, storage_path: &Path) -> Result<(), ApiError> {
+    if !storage_path.is_file() {
+        return Err(full_refresh_required_error(
+            root,
+            "complete_core_publication_missing",
+            "complete_core_publication_missing",
+        ));
+    }
+    let storage = Store::open_freshness_observational(storage_path).map_err(|error| {
+        ApiError::internal(format!(
+            "Failed to inspect incremental refresh compatibility: {error}"
+        ))
+    })?;
+    if storage.has_incomplete_incremental_run().map_err(|error| {
+        ApiError::internal(format!(
+            "Failed to inspect incomplete incremental marker: {error}"
+        ))
+    })? {
+        return Err(full_refresh_required_error(
+            root,
+            "incomplete_incremental_publication",
+            "incomplete_incremental_publication",
+        ));
+    }
+    let Some(publication) = storage.get_complete_index_publication().map_err(|error| {
+        ApiError::internal(format!(
+            "Failed to inspect complete core publication: {error}"
+        ))
+    })?
+    else {
+        return Err(full_refresh_required_error(
+            root,
+            "complete_core_publication_missing",
+            "complete_core_publication_missing",
+        ));
+    };
+    if let Err(error) = storage.validate_structural_text_unit_publication(&publication) {
+        return Err(full_refresh_required_error(
+            root,
+            "structural_publication_incompatible",
+            format!("structural_publication_incompatible:{error}"),
+        ));
+    }
+    Ok(())
+}
+
 fn run_incremental_indexing_common(
     root: &Path,
     storage_path: &Path,
@@ -16082,70 +16189,16 @@ fn run_incremental_indexing_common(
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
     source_index_policy: &SourceIndexPolicy,
 ) -> Result<IndexingRunSummary, ApiError> {
-    let live_exists = storage_path.exists();
-    let live_is_incomplete = live_exists
-        && Store::database_has_incomplete_incremental_run(storage_path).map_err(|e| {
-            ApiError::internal(format!("Failed to inspect incomplete index marker: {e}"))
-        })?;
-    if live_is_incomplete {
-        let _ = events_tx.send(AppEventPayload::StatusUpdate {
-            message: "A prior incremental index run was interrupted; rebuilding through staged full recovery."
-                .to_string(),
-        });
-        return index_full_for_runtime(
-            root,
-            storage_path,
-            events_tx,
-            cancel_token,
-            runtime,
-            source_index_policy,
-        );
-    }
+    ensure_incremental_refresh_compatible(root, storage_path)?;
     if is_indexing_cancelled(cancel_token) {
         return Err(indexing_cancelled_error());
     }
-    if live_exists {
-        let structural_live_is_verified = Store::open_read_only(storage_path)
-            .ok()
-            .and_then(|storage| {
-                storage
-                    .get_complete_index_publication()
-                    .ok()
-                    .flatten()
-                    .map(|publication| {
-                        storage
-                            .validate_structural_text_unit_publication(&publication)
-                            .is_ok()
-                    })
-            })
-            .unwrap_or(false);
-        if !structural_live_is_verified {
-            let _ = events_tx.send(AppEventPayload::StatusUpdate {
-                message: "The live index predates verified structural unit publication; rebuilding through staged full recollection."
-                    .to_string(),
-            });
-            return index_full_for_runtime(
-                root,
-                storage_path,
-                events_tx,
-                cancel_token,
-                runtime,
-                source_index_policy,
-            );
-        }
-    }
 
-    let mut staged = if live_exists {
-        SnapshotStore::clone_live_to_staged(storage_path).map_err(|e| {
-            ApiError::internal(format!(
-                "Failed to clone live storage for incremental build: {e}"
-            ))
-        })?
-    } else {
-        SnapshotStore::open_staged(storage_path).map_err(|e| {
-            ApiError::internal(format!("Failed to open staged incremental storage: {e}"))
-        })?
-    };
+    let mut staged = SnapshotStore::clone_live_to_staged(storage_path).map_err(|e| {
+        ApiError::internal(format!(
+            "Failed to clone live storage for incremental build: {e}"
+        ))
+    })?;
     let previous_publication = match staged.store_mut().get_index_publication() {
         Ok(publication) => publication,
         Err(error) => {
@@ -28383,6 +28436,14 @@ fn build_llm_symbol_doc_text() -> String {
                 storage_path.clone(),
             )
             .expect("open project");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish compatible baseline");
+        fs::write(
+            workspace.path().join("lib.rs"),
+            "pub fn value() -> i32 { 2 }\n",
+        )
+        .expect("modify source");
         let events = controller.events();
 
         controller
@@ -29338,7 +29399,7 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
-    fn incremental_request_recollects_legacy_structural_graph_without_unit_manifest() {
+    fn explicit_incremental_rejects_incompatible_structural_publication_before_source_reads() {
         let workspace = tempdir().expect("workspace dir");
         fs::write(
             workspace.path().join("Cargo.toml"),
@@ -29365,22 +29426,64 @@ fn build_llm_symbol_doc_text() -> String {
             .execute("DELETE FROM structural_text_unit_publication", [])
             .expect("remove structural manifest");
         drop(storage);
+        fs::write(
+            workspace.path().join("malformed.json"),
+            "{\"missing_value\":",
+        )
+        .expect("write source that would fail a full parse");
+        let database_before = fs::read(&storage_path).expect("read incompatible database");
+        let wal_path = storage_path.with_extension("db-wal");
+        let wal_before = fs::read(&wal_path).ok();
 
-        controller
-            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
-            .expect("repair legacy structural state");
-        let repaired = Store::database_index_publication(&storage_path)
-            .expect("read repaired publication")
-            .expect("repaired publication");
-        assert_eq!(repaired.generation, previous.generation + 1);
-        assert_eq!(repaired.mode, IndexPublicationMode::Full);
-        let repaired_store =
-            Store::open_read_only(&storage_path).expect("open repaired publication");
-        let manifest = repaired_store
-            .validate_structural_text_unit_publication(&repaired)
-            .expect("validate repaired structural manifest");
-        assert!(manifest.unit_count > 0);
-        assert_eq!(manifest.projection_count, 1);
+        for error in [
+            controller
+                .dry_run_index(IndexMode::Incremental)
+                .expect_err("dry-run must reject incompatible incremental"),
+            controller
+                .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+                .expect_err("execution must reject incompatible incremental"),
+        ] {
+            assert_eq!(error.code, FULL_REFRESH_REQUIRED_ERROR_CODE);
+            assert!(error.message.contains("requested=incremental"));
+            assert!(error.message.contains("effective=none"));
+            assert!(error.message.contains("required=full"));
+            assert_eq!(
+                error
+                    .details
+                    .as_ref()
+                    .and_then(|details| details.cause_code.as_deref()),
+                Some("structural_publication_incompatible")
+            );
+        }
+        assert_eq!(
+            fs::read(&storage_path).expect("read database after rejected requests"),
+            database_before,
+            "compatibility rejection must not mutate the live database"
+        );
+        assert_eq!(
+            fs::read(&wal_path).ok(),
+            wal_before,
+            "compatibility rejection must not mutate the live WAL"
+        );
+        assert_eq!(
+            Store::database_index_publication(&storage_path)
+                .expect("read preserved publication")
+                .expect("preserved publication"),
+            previous
+        );
+        assert!(!controller.state.lock().is_indexing);
+        assert_no_staged_publication_artifacts(&storage_path);
+
+        let full_error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect_err("explicit full refresh must reach malformed source verification");
+        assert_eq!(full_error.code, "source_malformed");
+        assert!(
+            full_error
+                .message
+                .contains("Effective refresh mode `full` could not verify"),
+            "unexpected full-refresh error: {full_error:?}"
+        );
     }
 
     #[test]
@@ -29646,7 +29749,7 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
-    fn legacy_schema_18_incomplete_marker_recovers_to_first_publication() {
+    fn legacy_schema_18_incomplete_marker_requires_explicit_full_recovery() {
         let workspace = tempdir().expect("workspace dir");
         fs::write(
             workspace.path().join("lib.rs"),
@@ -29681,9 +29784,26 @@ fn build_llm_symbol_doc_text() -> String {
                 .expect("read legacy publication")
                 .is_none()
         );
-        controller
+        let error = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
-            .expect("recover legacy marker");
+            .expect_err("explicit incremental must reject the legacy incomplete marker");
+        assert_eq!(error.code, FULL_REFRESH_REQUIRED_ERROR_CODE);
+        assert_eq!(
+            error
+                .details
+                .as_ref()
+                .and_then(|details| details.cause_code.as_deref()),
+            Some("incomplete_incremental_publication")
+        );
+        assert!(
+            Storage::database_index_publication(&storage_path)
+                .expect("read rejected legacy publication")
+                .is_none()
+        );
+
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("recover legacy marker with an explicit full refresh");
 
         assert_eq!(
             Storage::database_schema_version(&storage_path).expect("recovered schema"),
@@ -30437,16 +30557,24 @@ fn build_llm_symbol_doc_text() -> String {
                 summary.publication.is_none(),
                 "fenced generation was served"
             );
+            let dry_run_error = restarted
+                .dry_run_index(IndexMode::Incremental)
+                .expect_err("dry-run must reject implicit recovery escalation");
+            assert_eq!(dry_run_error.code, FULL_REFRESH_REQUIRED_ERROR_CODE);
             assert_eq!(
-                restarted
-                    .dry_run_index(IndexMode::Incremental)
-                    .expect("plan fenced recovery")
-                    .refresh,
-                IndexMode::Full
+                dry_run_error
+                    .details
+                    .as_ref()
+                    .and_then(|details| details.cause_code.as_deref()),
+                Some("incomplete_incremental_publication")
             );
-            restarted
+            let execution_error = restarted
                 .run_indexing_blocking(IndexMode::Incremental)
-                .expect("restart publication recovery");
+                .expect_err("execution must reject implicit recovery escalation");
+            assert_eq!(execution_error.code, FULL_REFRESH_REQUIRED_ERROR_CODE);
+            restarted
+                .run_indexing_blocking(IndexMode::Full)
+                .expect("explicit full publication recovery");
             let storage = Storage::open(storage_path).expect("open recovered storage");
             let recovered = storage
                 .get_complete_index_publication()
@@ -30874,7 +31002,7 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
-    fn cancelled_first_incremental_does_not_create_a_live_database() {
+    fn first_incremental_requires_full_before_cancellation_or_storage_creation() {
         let workspace = tempdir().expect("workspace dir");
         fs::write(
             workspace.path().join("lib.rs"),
@@ -30893,13 +31021,20 @@ fn build_llm_symbol_doc_text() -> String {
             Some(&cancel_token),
         ) {
             Err(error) => error,
-            Ok(_) => panic!("pre-cancelled first incremental must fail visibly"),
+            Ok(_) => panic!("first incremental must fail visibly"),
         };
 
-        assert_eq!(error.code, "cancelled");
+        assert_eq!(error.code, FULL_REFRESH_REQUIRED_ERROR_CODE);
+        assert_eq!(
+            error
+                .details
+                .as_ref()
+                .and_then(|details| details.cause_code.as_deref()),
+            Some("complete_core_publication_missing")
+        );
         assert!(
             !storage_path.exists(),
-            "a cancelled first run must not manufacture a live generation"
+            "a rejected first incremental must not manufacture a live generation"
         );
         let cache_dir = storage_path.parent().expect("cache parent");
         if cache_dir.exists() {
@@ -30909,7 +31044,7 @@ fn build_llm_symbol_doc_text() -> String {
                 .expect("read cache entries");
             assert!(
                 staged_artifacts.is_empty(),
-                "cancelled first run left staged debris: {staged_artifacts:?}"
+                "rejected first incremental left staged debris: {staged_artifacts:?}"
             );
         }
     }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -12585,9 +12585,23 @@ impl AppController {
         let workspace = runtime_workspace_manifest(&root, &storage_path)
             .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
         let refresh_inputs = if storage_path.exists() {
-            let store = Store::open(&storage_path)
-                .map_err(|e| ApiError::internal(format!("Failed to open storage: {e}")))?;
-            workspace_refresh_inputs(&store)?
+            let schema_version = Store::database_schema_version_observational(&storage_path)
+                .map_err(|error| {
+                    ApiError::internal(format!(
+                        "Failed to inspect dry-run storage without recovery: {error}"
+                    ))
+                })?;
+            if schema_version < CURRENT_SCHEMA_VERSION {
+                RefreshInputs::default()
+            } else {
+                let store =
+                    Store::open_freshness_observational(&storage_path).map_err(|error| {
+                        ApiError::internal(format!(
+                            "Failed to inspect dry-run storage without mutation: {error}"
+                        ))
+                    })?;
+                workspace_refresh_inputs(&store)?
+            }
         } else {
             RefreshInputs::default()
         };
@@ -16113,7 +16127,10 @@ fn full_refresh_required_error(
     reason: impl AsRef<str>,
 ) -> ApiError {
     let project = root.to_string_lossy().to_string();
-    let next_command = format!("codestory-cli index --project {:?} --refresh full", project);
+    let next_command = format!(
+        "codestory-cli index --project {} --refresh full",
+        quote_refresh_command_argument(&project)
+    );
     ApiError::with_details(
         FULL_REFRESH_REQUIRED_ERROR_CODE,
         format!(
@@ -16135,6 +16152,16 @@ fn full_refresh_required_error(
     )
 }
 
+#[cfg(windows)]
+fn quote_refresh_command_argument(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(not(windows))]
+fn quote_refresh_command_argument(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 fn ensure_incremental_refresh_compatible(root: &Path, storage_path: &Path) -> Result<(), ApiError> {
     if !storage_path.is_file() {
         return Err(full_refresh_required_error(
@@ -16142,6 +16169,29 @@ fn ensure_incremental_refresh_compatible(root: &Path, storage_path: &Path) -> Re
             "complete_core_publication_missing",
             "complete_core_publication_missing",
         ));
+    }
+    let schema_version = Store::database_schema_version_observational(storage_path).map_err(
+        |error| {
+            ApiError::internal(format!(
+                "Failed to inspect incremental refresh schema compatibility without recovery: {error}"
+            ))
+        },
+    )?;
+    if schema_version < CURRENT_SCHEMA_VERSION {
+        let (reason_code, reason) = if schema_version == 0 {
+            (
+                "complete_core_publication_missing",
+                "complete_core_publication_missing".to_string(),
+            )
+        } else {
+            (
+                "core_schema_upgrade_required",
+                format!(
+                    "core_schema_upgrade_required:observed={schema_version}:required={CURRENT_SCHEMA_VERSION}"
+                ),
+            )
+        };
+        return Err(full_refresh_required_error(root, reason_code, reason));
     }
     let storage = Store::open_freshness_observational(storage_path).map_err(|error| {
         ApiError::internal(format!(
@@ -29483,6 +29533,136 @@ fn build_llm_symbol_doc_text() -> String {
                 .message
                 .contains("Effective refresh mode `full` could not verify"),
             "unexpected full-refresh error: {full_error:?}"
+        );
+    }
+
+    #[test]
+    fn precurrent_schema_requires_typed_full_without_mutating_database_or_sidecars() {
+        let workspace = tempdir().expect("workspace dir");
+        fs::write(
+            workspace.path().join("lib.rs"),
+            "pub fn legacy_value() -> i32 { 28 }\n",
+        )
+        .expect("write source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish current baseline");
+        {
+            let storage = Storage::open(&storage_path).expect("open schema fixture");
+            storage
+                .get_connection()
+                .pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION - 1)
+                .expect("stamp supported pre-current schema");
+        }
+        let database_before = fs::read(&storage_path).expect("read old-schema database");
+        let wal_path = storage_path.with_extension("db-wal");
+        let wal_before = fs::read(&wal_path).ok();
+        let cache_path = storage_path.parent().expect("cache path");
+        let cache_entries_before = {
+            let mut entries = fs::read_dir(cache_path)
+                .expect("list cache before compatibility checks")
+                .map(|entry| {
+                    entry
+                        .expect("read cache entry")
+                        .file_name()
+                        .to_string_lossy()
+                        .to_string()
+                })
+                .collect::<Vec<_>>();
+            entries.sort();
+            entries
+        };
+
+        for error in [
+            controller
+                .dry_run_index(IndexMode::Incremental)
+                .expect_err("dry-run must reject the old schema"),
+            controller
+                .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+                .expect_err("execution must reject the old schema"),
+        ] {
+            assert_eq!(error.code, FULL_REFRESH_REQUIRED_ERROR_CODE);
+            assert_eq!(
+                error
+                    .details
+                    .as_ref()
+                    .and_then(|details| details.cause_code.as_deref()),
+                Some("core_schema_upgrade_required")
+            );
+        }
+        let auto_effective_dry_run = controller
+            .dry_run_index(IndexMode::Full)
+            .expect("auto-selected full dry-run must inspect old schema without migrating it");
+        assert_eq!(auto_effective_dry_run.refresh, IndexMode::Full);
+        assert_eq!(
+            fs::read(&storage_path).expect("read database after rejected requests"),
+            database_before,
+            "old-schema compatibility checks must preserve database bytes"
+        );
+        assert_eq!(
+            fs::read(&wal_path).ok(),
+            wal_before,
+            "old-schema compatibility checks must preserve WAL bytes"
+        );
+        let cache_entries_after = {
+            let mut entries = fs::read_dir(cache_path)
+                .expect("list cache after compatibility checks")
+                .map(|entry| {
+                    entry
+                        .expect("read cache entry")
+                        .file_name()
+                        .to_string_lossy()
+                        .to_string()
+                })
+                .collect::<Vec<_>>();
+            entries.sort();
+            entries
+        };
+        assert_eq!(cache_entries_after, cache_entries_before);
+        assert!(!controller.state.lock().is_indexing);
+        assert_no_staged_publication_artifacts(&storage_path);
+
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("explicit full refresh upgrades the supported old schema");
+        assert_eq!(
+            Storage::database_schema_version(&storage_path).expect("read upgraded schema"),
+            CURRENT_SCHEMA_VERSION
+        );
+    }
+
+    #[test]
+    fn full_refresh_required_command_quotes_shell_metacharacters() {
+        let error = full_refresh_required_error(
+            Path::new("repo/$hidden/quoted'path"),
+            "core_schema_upgrade_required",
+            "core_schema_upgrade_required",
+        );
+        let command = error
+            .details
+            .expect("typed compatibility details")
+            .next_commands
+            .into_iter()
+            .next()
+            .expect("full-refresh repair command");
+
+        #[cfg(not(windows))]
+        assert_eq!(
+            command,
+            "codestory-cli index --project 'repo/$hidden/quoted'\\''path' --refresh full"
+        );
+        #[cfg(windows)]
+        assert_eq!(
+            command,
+            "codestory-cli index --project 'repo/$hidden/quoted''path' --refresh full"
         );
     }
 

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -1539,6 +1539,19 @@ impl IndexService {
         self.controller.complete_index_publication()
     }
 
+    pub fn ensure_incremental_refresh_compatible(&self) -> Result<(), ApiError> {
+        self.controller.ensure_incremental_refresh_compatible()
+    }
+
+    pub fn ensure_incremental_refresh_compatible_at(
+        &self,
+        root: &std::path::Path,
+        storage_path: &std::path::Path,
+    ) -> Result<(), ApiError> {
+        self.controller
+            .ensure_incremental_refresh_compatible_at(root, storage_path)
+    }
+
     pub fn dry_run_index(&self, mode: IndexMode) -> Result<IndexDryRunDto, ApiError> {
         self.controller.dry_run_index(mode)
     }

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -3419,6 +3419,7 @@ pub struct SymbolSummaryRecord {
 enum NonmutatingOpenPolicy {
     StrictCurrentSchema,
     FreshnessFence,
+    SchemaVersion,
 }
 
 impl Storage {
@@ -3480,6 +3481,13 @@ impl Storage {
     /// observational entry points remain current-schema-only.
     pub fn open_freshness_observational<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
         Self::open_nonmutating(path.as_ref(), NonmutatingOpenPolicy::FreshnessFence)
+    }
+
+    /// Read the durable SQLite schema version without migrations, promotion
+    /// recovery, or sidecar creation.
+    pub fn database_schema_version_observational(path: &Path) -> Result<u32, StorageError> {
+        let storage = Self::open_nonmutating(path, NonmutatingOpenPolicy::SchemaVersion)?;
+        storage.schema_version()
     }
 
     fn open_nonmutating(path: &Path, policy: NonmutatingOpenPolicy) -> Result<Self, StorageError> {
@@ -3554,6 +3562,7 @@ impl Storage {
                     "Freshness observation requires schema version {SCHEMA_VERSION} or the fenced incomplete sentinel, found {version}"
                 )));
             }
+            NonmutatingOpenPolicy::SchemaVersion => {}
             _ => {}
         }
         Ok(Self {

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -606,6 +606,17 @@ fn observational_open_reports_old_schema_without_migration_or_sidecars() {
     let before = fs::read(&path).expect("read old-schema fixture before observation");
     assert_no_sqlite_sidecars(&path);
 
+    assert_eq!(
+        Storage::database_schema_version_observational(&path)
+            .expect("inspect old schema without migration"),
+        SCHEMA_VERSION - 1
+    );
+    assert_eq!(
+        fs::read(&path).expect("read old-schema fixture after version observation"),
+        before
+    );
+    assert_no_sqlite_sidecars(&path);
+
     let error = Storage::open_observational(&path)
         .err()
         .expect("old schema must fail closed");

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -159,9 +159,10 @@ Read commands default to `--refresh none`. Use `--refresh incremental` when a
 read should refresh an existing cache. Reserve full refresh for an empty cache,
 schema change, diagnosed corruption, or an explicit proof lane. An explicit
 incremental request never widens into a full refresh: when the live core lacks
-the required structural publication, CodeStory returns `full_refresh_required`
-before workspace discovery or parsing. Use `--refresh auto` when that bounded
-compatibility decision may select full recovery.
+the required structural publication or needs a supported schema upgrade,
+CodeStory returns `full_refresh_required` before workspace discovery or
+parsing. Use `--refresh auto` when that bounded compatibility decision may
+select full recovery.
 
 ## Full retrieval development
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -157,7 +157,11 @@ managed-release path.
 
 Read commands default to `--refresh none`. Use `--refresh incremental` when a
 read should refresh an existing cache. Reserve full refresh for an empty cache,
-schema change, diagnosed corruption, or an explicit proof lane.
+schema change, diagnosed corruption, or an explicit proof lane. An explicit
+incremental request never widens into a full refresh: when the live core lacks
+the required structural publication, CodeStory returns `full_refresh_required`
+before workspace discovery or parsing. Use `--refresh auto` when that bounded
+compatibility decision may select full recovery.
 
 ## Full retrieval development
 
@@ -208,7 +212,9 @@ Cache rules:
 
 - `--cache-dir` is an exact override; otherwise CodeStory uses the user cache
   root plus a project identity.
-- `index --refresh auto` builds an empty cache and is incremental thereafter.
+- `index --refresh auto` builds an empty or structurally incompatible cache and
+  is incremental thereafter. Dry-run output names the requested mode, effective
+  mode, and compatibility reason.
 - Cleanup acts only on current CodeStory-owned generations and tokens.
 - Tests use isolated cache and plugin roots; never clean the real user cache to
   make a test pass.

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -78,7 +78,12 @@ codestory-cli index --project <repo> --refresh auto --format json
 ```
 
 Read commands default to `--refresh none`. Use `--refresh incremental` when a
-read should refresh an existing cache first.
+read should refresh a compatible existing cache first. Explicit incremental
+refresh never escalates to full: incompatible structural publication returns
+the typed `full_refresh_required` error before workspace discovery or parsing.
+Use `--refresh auto` when CodeStory may choose full recovery for an empty or
+incompatible cache. Index dry-run output reports the requested mode, effective
+mode, and compatibility reason.
 
 Reserve `index --refresh full` or moving a cache aside for maintainer-directed
 recovery after status or `doctor` identifies that exact cache and coordinated

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -80,10 +80,10 @@ codestory-cli index --project <repo> --refresh auto --format json
 Read commands default to `--refresh none`. Use `--refresh incremental` when a
 read should refresh a compatible existing cache first. Explicit incremental
 refresh never escalates to full: incompatible structural publication returns
-the typed `full_refresh_required` error before workspace discovery or parsing.
-Use `--refresh auto` when CodeStory may choose full recovery for an empty or
-incompatible cache. Index dry-run output reports the requested mode, effective
-mode, and compatibility reason.
+the typed `full_refresh_required` error before workspace discovery or parsing,
+as does a supported pre-current schema. Use `--refresh auto` when CodeStory may
+choose full recovery for an empty or incompatible cache. Index dry-run output
+reports the requested mode, effective mode, and compatibility reason.
 
 Reserve `index --refresh full` or moving a cache aside for maintainer-directed
 recovery after status or `doctor` identifies that exact cache and coordinated

--- a/plugins/codestory/skills/codestory-grounding/references/drill.md
+++ b/plugins/codestory/skills/codestory-grounding/references/drill.md
@@ -48,6 +48,8 @@ Start with `drill-summary.json` for compact health, retrieval/freshness state, d
 
 `mechanical.drill_timings` breaks the evidence-collection runtime into setup, question search, anchor resolution, supplemental search, bridge evidence, and evidence assembly. Per-anchor `timings`, command `duration_ms`, and summary `slowest_command` fields further split anchor work into search, query resolution, consumer-summary, and artifact-command costs. Use these fields to localize slow drills before changing ranking or graph traversal logic; they are diagnostic timing, not answer-quality evidence by themselves.
 
+When `--refresh auto` must select full recovery before a safe project summary can be read, the report omits the `before_*` metrics and sets `before_unavailable_reason` to the compatibility cause. The compact summary likewise omits `mechanical.before` and `error_delta`. Do not interpret the after-refresh counts as a measured pre-refresh baseline.
+
 Consumer summaries inspect direct incoming production consumers for the selected anchor first. Related payload/API/native targets are searched only when the selected anchor has no visible graph consumers, so ordinary drills do not pay broad related-target search costs unless the direct graph evidence is missing.
 
 If `drill-summary.json` reports stale freshness, refresh the index before promoting claims. If retrieval is not full or semantic diagnostics report degraded state, wait for a complete publication or run the maintainer-directed rebuild before trusting broad natural-language recall; use symbol, trail, snippet, and source-truth files deliberately while broad retrieval is unavailable.


### PR DESCRIPTION
## Context

Explicit `--refresh incremental` could silently widen into a full refresh when the live core was incomplete, pre-current, or lacked a compatible structural publication. That changed the requested operation, read and parsed the workspace, and could replace publication state despite the caller choosing incremental.

Closes #1354
Refs #1202
Refs #1196
Refs #1179

## What changed

- add one typed `full_refresh_required` compatibility decision shared by runtime execution and dry-run
- reject explicit incremental before mutable project open, workspace reads, writer acquisition, indexing-state changes, or publication mutation when a complete compatible core is unavailable
- inspect pre-current schema versions without migrations, promotion recovery, or sidecar creation; `auto` may select full while future, corrupt, or recovery-pending states remain fail-closed
- preflight agent surfaces before their summary open so old-schema incremental requests cannot migrate before rejection, and pending promotion evidence is preserved
- retain deliberate full recovery for `auto`, while reporting the effective mode and compatibility reason
- omit unavailable drill before-metrics after compatibility-selected full recovery, carry the cause in JSON, and render the absence explicitly in Markdown instead of copying post-refresh counts
- make full-mode dry-run observational for older schemas and name requested/effective refresh state instead of generic full-refresh wording
- shell-quote the full-refresh repair command across Unix and Windows metacharacter rules
- document the changed CLI contract under `Unreleased`

## How to review

Start with `ensure_incremental_refresh_compatible` in `crates/codestory-runtime/src/lib.rs` and `database_schema_version_observational` in `crates/codestory-store/src/storage_impl/mod.rs`, then follow `RuntimeContext::resolve_refresh_decision_with_preflight` and `ensure_open_with_before` in `crates/codestory-cli/src/runtime.rs`. Runtime regressions prove compatibility rejection precedes malformed-source reads and preserves exact database/WAL/cache-sidecar state. The real `open_agent_surface` call-site tests cover old-schema incremental rejection, auto recovery, pending-promotion preservation, and the absence of a safe pre-refresh summary. Drill artifact tests cover full JSON, compact JSON, and Markdown for both available and unavailable before-metrics.

## Exact source

- Base: `81fc75b67947df0a51792235da1023b50b5af2c8`
- Head: `f4e1dfbd2eb71c01bf954a0ecb04ccc59b86ab67`
- Tree: `1e603c3bfe0bef46b55e5ef2aa3fed6cc63290d6`

## Verification

- `cargo test --locked -p codestory-store --lib` — 165 passed
- `cargo test --locked -p codestory-runtime --lib` — 823 passed
- `cargo test --locked -p codestory-cli --bin codestory-cli` — 241 passed
- focused real call-site regressions for old-schema incremental/auto, pending-promotion preservation, and unavailable drill baselines passed
- `cargo clippy --locked -p codestory-store --all-targets --all-features -- -D warnings`
- `cargo clippy --locked -p codestory-runtime --all-targets --all-features -- -D warnings`
- `cargo clippy --locked -p codestory-cli --all-targets --all-features -- -D warnings`
- `node .github/scripts/check-runtime-config-boundary.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 74 passed, 1 Windows-only skip
- `cargo fmt --all -- --check`
- `git diff --check 81fc75b67947df0a51792235da1023b50b5af2c8...HEAD`
- `node .github/scripts/check-doc-links.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- `python .github/scripts/check-codestory-release.py --version 0.16.0`

## Risk and non-claims

The main compatibility risk is changing callers that relied on explicit incremental to perform an implicit full rebuild; the typed error and safely quoted explicit full repair command make that boundary visible. Drill consumers must tolerate absent before-metrics when compatibility recovery makes a safe baseline unavailable; the explicit reason distinguishes that state from zero counts. No corpus indexing, release dispatch, installed-candidate proof, host restart, or platform proof was run for this draft.
