### PR TITLE
[codex] bridge retained source policy identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,11 @@
   cancellation, concurrent writers, and publication drift preserve the
   previous complete core, retrieval identity, and search rollback; retrieval
   stays unavailable until its existing builder publishes a generation bound
-  to the replacement core. A runtime-cache failure or late cancellation after
+  to the replacement core. The same writer can rebind the exact retained
+  `oversized-source-v1` predecessor to `bounded-source-exclusion-v2` only for
+  the schema-29 empty-structural case with byte and structural-unit caps
+  unchanged; every other policy or cap transition remains fail closed. A
+  runtime-cache failure or late cancellation after
   durable commit completes the prepared search publication, clears controller
   indexing state, and still leaves retrieval bound to the prior core.
 - Dense-anchor centrality now uses complete bounded graph relationship counts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@
   previous complete core, retrieval identity, and search rollback; retrieval
   stays unavailable until its existing builder publishes a generation bound
   to the replacement core. The same writer can rebind the exact retained
-  `oversized-source-v1` predecessor to `bounded-source-exclusion-v2` only for
-  the schema-29 empty-structural case with byte and structural-unit caps
-  unchanged; every other policy or cap transition remains fail closed. A
+  schema-1 `oversized-source-v1` publication to
+  `bounded-source-exclusion-v2` only for the schema-29 empty-structural case
+  with its v1 digest valid and byte and structural-unit caps unchanged; every
+  other policy or cap transition remains fail closed. A
   runtime-cache failure or late cancellation after
   durable commit completes the prepared search publication, clears controller
   indexing state, and still leaves retrieval bound to the prior core.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tantivy",
  "tempfile",
  "tracing",

--- a/crates/codestory-cli/tests/runtime_backed_flows.rs
+++ b/crates/codestory-cli/tests/runtime_backed_flows.rs
@@ -86,7 +86,9 @@ fn publish_schema_29_projection_fixture(workspace: &Path, cache_dir: &Path) -> P
     assert_eq!(structural_counts, (0, 0, 0));
     connection
         .execute_batch(
-            "DELETE FROM structural_text_unit_publication;
+            "UPDATE source_policy_exclusion_publication
+                SET policy_version = 'oversized-source-v1';
+             DELETE FROM structural_text_unit_publication;
              ALTER TABLE index_publication RENAME TO index_publication_v30;
              CREATE TABLE index_publication (
                 id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -614,6 +616,47 @@ fn republish_projections_cli_acquires_writer_lock_before_schema_migration() {
             .query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))
             .expect("read retained schema"),
         29
+    );
+}
+
+#[test]
+#[ignore = "builds a schema-29 indexed fixture and verifies retained policy cap drift fails closed"]
+fn republish_projections_cli_rejects_legacy_policy_cap_drift_without_mutation() {
+    let workspace = copy_tictactoe_workspace();
+    let cache = tempdir().expect("explicit cache");
+    let storage_path = publish_schema_29_projection_fixture(workspace.path(), cache.path());
+    let connection = rusqlite::Connection::open(&storage_path).expect("open retained fixture");
+    connection
+        .execute(
+            "UPDATE source_policy_exclusion_publication SET byte_cap = byte_cap + 1",
+            [],
+        )
+        .expect("drift retained byte cap");
+    connection
+        .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        .expect("checkpoint retained fixture");
+    drop(connection);
+    remove_workspace_source(workspace.path());
+    let bytes_before = fs::read(&storage_path).expect("read retained bytes");
+
+    let output = run_cli_with_cache(
+        workspace.path(),
+        cache.path(),
+        &["retrieval", "republish-projections", "--format", "json"],
+    );
+
+    assert!(!output.status.success(), "cap-drifted republish succeeded");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stderr.contains("semantic_projection_migration_required")
+            || stdout.contains("semantic_projection_migration_required"),
+        "unexpected CLI error: stderr={stderr} stdout={stdout}"
+    );
+    assert_eq!(
+        fs::read(&storage_path).expect("read retained bytes after rejection"),
+        bytes_before,
+        "CLI mutated the retained core before rejecting cap drift"
     );
 }
 

--- a/crates/codestory-cli/tests/runtime_backed_flows.rs
+++ b/crates/codestory-cli/tests/runtime_backed_flows.rs
@@ -1,8 +1,15 @@
 use fs4::fs_std::FileExt;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
+
+fn empty_legacy_source_policy_digest() -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"codestory-source-policy-exclusion-publication-v1\0");
+    format!("{:x}", hasher.finalize())
+}
 
 fn copy_tictactoe_workspace() -> tempfile::TempDir {
     let temp = tempdir().expect("create temp dir");
@@ -84,11 +91,24 @@ fn publish_schema_29_projection_fixture(workspace: &Path, cache_dir: &Path) -> P
         )
         .expect("read structural fixture counts");
     assert_eq!(structural_counts, (0, 0, 0));
+    let source_exclusion_count = connection
+        .query_row("SELECT COUNT(*) FROM source_policy_exclusion", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("read source exclusion count");
+    assert_eq!(source_exclusion_count, 0);
+    connection
+        .execute(
+            "UPDATE source_policy_exclusion_publication
+             SET schema_version = 1,
+                 exclusion_digest = ?1,
+                 policy_version = 'oversized-source-v1'",
+            rusqlite::params![empty_legacy_source_policy_digest()],
+        )
+        .expect("restore authentic retained v1 source-policy publication");
     connection
         .execute_batch(
-            "UPDATE source_policy_exclusion_publication
-                SET policy_version = 'oversized-source-v1';
-             DELETE FROM structural_text_unit_publication;
+            "DELETE FROM structural_text_unit_publication;
              ALTER TABLE index_publication RENAME TO index_publication_v30;
              CREATE TABLE index_publication (
                 id INTEGER PRIMARY KEY CHECK (id = 1),

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -29,4 +29,5 @@ uuid = { workspace = true }
 [dev-dependencies]
 codestory-retrieval = { workspace = true, features = ["test-support"] }
 rusqlite = { workspace = true }
+sha2 = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -6148,6 +6148,7 @@ const SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV: &str =
 const SEMANTIC_STREAM_SORT_WINDOW_BATCHES: usize = 1;
 const SEMANTIC_POLICY_VERSION: &str = codestory_retrieval::SEMANTIC_POLICY_VERSION;
 const LEGACY_SEMANTIC_PROJECTION_SCHEMA_VERSION: u32 = 29;
+const LEGACY_OVERSIZED_SOURCE_POLICY_VERSION: &str = "oversized-source-v1";
 const SYMBOL_SEARCH_DOC_PROVENANCE: &str = "extracted";
 const DENSE_CENTRAL_RELATIONSHIP_THRESHOLD: usize = 12;
 const DENSE_CENTRAL_SCORE_THRESHOLD: usize = 24;
@@ -6160,6 +6161,34 @@ enum DenseAnchorReason {
     CentralGraphNode,
     ComponentReport,
     UnstructuredDoc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SemanticProjectionSourcePolicyCompatibility {
+    Exact,
+    LegacyPredecessor,
+}
+
+fn semantic_projection_source_policy_compatibility(
+    recorded: SourcePolicyExclusionPolicyIdentity<'_>,
+    current: &SourceIndexPolicy,
+    schema_version: u32,
+    legacy_structural_empty: bool,
+) -> Option<SemanticProjectionSourcePolicyCompatibility> {
+    if recorded.byte_cap != current.byte_cap
+        || recorded.structural_unit_cap != current.structural_unit_cap
+    {
+        return None;
+    }
+    if recorded.policy_version == current.policy_version {
+        return Some(SemanticProjectionSourcePolicyCompatibility::Exact);
+    }
+    (recorded.policy_version == LEGACY_OVERSIZED_SOURCE_POLICY_VERSION
+        && current.policy_version
+            == codestory_contracts::workspace::OVERSIZED_SOURCE_POLICY_VERSION
+        && schema_version == LEGACY_SEMANTIC_PROJECTION_SCHEMA_VERSION
+        && legacy_structural_empty)
+        .then_some(SemanticProjectionSourcePolicyCompatibility::LegacyPredecessor)
 }
 
 impl DenseAnchorReason {
@@ -15760,7 +15789,7 @@ fn semantic_projection_republish_for_runtime(
                     "Pinned source-policy publication is missing.",
                 )
             })?;
-        let source_policy = SourcePolicyExclusionPolicyIdentity::new(
+        let recorded_source_policy = SourcePolicyExclusionPolicyIdentity::new(
             &source_manifest.policy_version,
             source_manifest.byte_cap,
             source_manifest.structural_unit_cap,
@@ -15774,9 +15803,13 @@ fn semantic_projection_republish_for_runtime(
                 "The selected project root does not own the cached core publication.",
             ));
         }
-        if source_manifest.policy_version != source_index_policy.policy_version
-            || source_manifest.byte_cap != source_index_policy.byte_cap
-            || source_manifest.structural_unit_cap != source_index_policy.structural_unit_cap
+        if semantic_projection_source_policy_compatibility(
+            recorded_source_policy,
+            source_index_policy,
+            expected_schema_version,
+            structural_compatibility == StructuralTextPublicationCompatibility::LegacyEmpty,
+        )
+        .is_none()
         {
             return Err(ApiError::new(
                 "semantic_projection_migration_required",
@@ -15789,7 +15822,7 @@ fn semantic_projection_republish_for_runtime(
                 &expected_publication,
                 &source_manifest.project_id,
                 &source_manifest.workspace_id,
-                source_policy,
+                recorded_source_policy,
             )
             .map_err(|error| {
                 ApiError::new(
@@ -15887,9 +15920,20 @@ fn semantic_projection_republish_for_runtime(
                     "Failed to publish semantic dense-anchor inputs: {error}"
                 ))
             })?;
+        let current_source_policy = SourcePolicyExclusionPolicyIdentity::new(
+            &source_index_policy.policy_version,
+            source_index_policy.byte_cap,
+            source_index_policy.structural_unit_cap,
+        );
         let source_candidates = source_exclusions
             .iter()
-            .map(source_policy_exclusion_candidate)
+            .map(|record| {
+                let mut candidate = source_policy_exclusion_candidate(record);
+                candidate.policy_version = source_index_policy.policy_version.clone();
+                candidate.byte_cap = source_index_policy.byte_cap;
+                candidate.structural_unit_cap = source_index_policy.structural_unit_cap;
+                candidate
+            })
             .collect::<Vec<_>>();
         staged
             .store_mut()
@@ -15897,7 +15941,7 @@ fn semantic_projection_republish_for_runtime(
                 &publication,
                 &selected_identity.project_id,
                 &selected_identity.workspace_id,
-                source_policy,
+                current_source_policy,
                 &source_candidates,
             )
             .map_err(|error| {
@@ -18017,6 +18061,96 @@ mod tests {
             DEFAULT_SOURCE_FILE_BYTE_CAP,
             codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
         )
+    }
+
+    fn legacy_source_policy_identity() -> SourcePolicyExclusionPolicyIdentity<'static> {
+        SourcePolicyExclusionPolicyIdentity::new(
+            LEGACY_OVERSIZED_SOURCE_POLICY_VERSION,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
+        )
+    }
+
+    #[test]
+    fn semantic_projection_source_policy_bridge_is_directional_and_cap_exact() {
+        let current = SourceIndexPolicy::default();
+        assert_eq!(
+            semantic_projection_source_policy_compatibility(
+                default_source_policy_identity(),
+                &current,
+                30,
+                false,
+            ),
+            Some(SemanticProjectionSourcePolicyCompatibility::Exact)
+        );
+        assert_eq!(
+            semantic_projection_source_policy_compatibility(
+                legacy_source_policy_identity(),
+                &current,
+                LEGACY_SEMANTIC_PROJECTION_SCHEMA_VERSION,
+                true,
+            ),
+            Some(SemanticProjectionSourcePolicyCompatibility::LegacyPredecessor)
+        );
+        for recorded in [
+            SourcePolicyExclusionPolicyIdentity::new(
+                "unknown-source-policy",
+                current.byte_cap,
+                current.structural_unit_cap,
+            ),
+            SourcePolicyExclusionPolicyIdentity::new(
+                LEGACY_OVERSIZED_SOURCE_POLICY_VERSION,
+                current.byte_cap + 1,
+                current.structural_unit_cap,
+            ),
+            SourcePolicyExclusionPolicyIdentity::new(
+                LEGACY_OVERSIZED_SOURCE_POLICY_VERSION,
+                current.byte_cap,
+                current.structural_unit_cap + 1,
+            ),
+        ] {
+            assert_eq!(
+                semantic_projection_source_policy_compatibility(
+                    recorded,
+                    &current,
+                    LEGACY_SEMANTIC_PROJECTION_SCHEMA_VERSION,
+                    true,
+                ),
+                None
+            );
+        }
+        assert_eq!(
+            semantic_projection_source_policy_compatibility(
+                legacy_source_policy_identity(),
+                &current,
+                30,
+                true,
+            ),
+            None
+        );
+        assert_eq!(
+            semantic_projection_source_policy_compatibility(
+                legacy_source_policy_identity(),
+                &current,
+                LEGACY_SEMANTIC_PROJECTION_SCHEMA_VERSION,
+                false,
+            ),
+            None
+        );
+        let legacy_runtime = SourceIndexPolicy {
+            policy_version: LEGACY_OVERSIZED_SOURCE_POLICY_VERSION.to_string(),
+            byte_cap: current.byte_cap,
+            structural_unit_cap: current.structural_unit_cap,
+        };
+        assert_eq!(
+            semantic_projection_source_policy_compatibility(
+                default_source_policy_identity(),
+                &legacy_runtime,
+                LEGACY_SEMANTIC_PROJECTION_SCHEMA_VERSION,
+                true,
+            ),
+            None
+        );
     }
 
     fn test_retrieval_manifest(
@@ -25969,7 +26103,7 @@ fn build_llm_symbol_doc_text() -> String {
                 content_hash: format!("{index:064x}"),
                 observed_size: DEFAULT_SOURCE_FILE_BYTE_CAP + 1 + index,
                 observed_unit_count: 0,
-                policy_version: OVERSIZED_SOURCE_POLICY_VERSION.to_string(),
+                policy_version: LEGACY_OVERSIZED_SOURCE_POLICY_VERSION.to_string(),
                 byte_cap: DEFAULT_SOURCE_FILE_BYTE_CAP,
                 structural_unit_cap: codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
             })
@@ -25979,7 +26113,7 @@ fn build_llm_symbol_doc_text() -> String {
                 &before,
                 &identity.project_id,
                 &identity.workspace_id,
-                default_source_policy_identity(),
+                legacy_source_policy_identity(),
                 &exclusions,
             )
             .expect("replace retained source-policy publication");

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -15803,33 +15803,42 @@ fn semantic_projection_republish_for_runtime(
                 "The selected project root does not own the cached core publication.",
             ));
         }
-        if semantic_projection_source_policy_compatibility(
+        let source_policy_compatibility = semantic_projection_source_policy_compatibility(
             recorded_source_policy,
             source_index_policy,
             expected_schema_version,
             structural_compatibility == StructuralTextPublicationCompatibility::LegacyEmpty,
         )
-        .is_none()
-        {
-            return Err(ApiError::new(
+        .ok_or_else(|| {
+            ApiError::new(
                 "semantic_projection_migration_required",
                 "Pinned source-policy identity differs from the current runtime policy; run a source refresh before republishing semantic projections.",
-            ));
-        }
-        staged
-            .store_mut()
-            .validate_source_policy_exclusion_publication(
-                &expected_publication,
-                &source_manifest.project_id,
-                &source_manifest.workspace_id,
-                recorded_source_policy,
             )
-            .map_err(|error| {
-                ApiError::new(
-                    "semantic_projection_migration_required",
-                    format!("Pinned source-policy publication is not complete: {error}"),
-                )
-            })?;
+        })?;
+        let source_policy_validation = match source_policy_compatibility {
+            SemanticProjectionSourcePolicyCompatibility::Exact => staged
+                .store_mut()
+                .validate_source_policy_exclusion_publication(
+                    &expected_publication,
+                    &source_manifest.project_id,
+                    &source_manifest.workspace_id,
+                    recorded_source_policy,
+                ),
+            SemanticProjectionSourcePolicyCompatibility::LegacyPredecessor => staged
+                .store_mut()
+                .validate_legacy_v1_source_policy_exclusion_publication(
+                    &expected_publication,
+                    &source_manifest.project_id,
+                    &source_manifest.workspace_id,
+                    recorded_source_policy,
+                ),
+        };
+        source_policy_validation.map_err(|error| {
+            ApiError::new(
+                "semantic_projection_migration_required",
+                format!("Pinned source-policy publication is not complete: {error}"),
+            )
+        })?;
         let source_exclusions =
             staged
                 .store_mut()
@@ -18047,6 +18056,7 @@ mod tests {
         ResolutionCertainty, SourceLocation,
     };
     use crossbeam_channel::unbounded;
+    use sha2::{Digest, Sha256};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::MutexGuard as StdMutexGuard;
@@ -18069,6 +18079,34 @@ mod tests {
             DEFAULT_SOURCE_FILE_BYTE_CAP,
             codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
         )
+    }
+
+    fn legacy_source_policy_exclusion_digest_for_test(
+        records: &[SourcePolicyExclusionRecord],
+    ) -> String {
+        fn hash_part(hasher: &mut Sha256, value: &[u8]) {
+            hasher.update((value.len() as u64).to_le_bytes());
+            hasher.update(value);
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(b"codestory-source-policy-exclusion-publication-v1\0");
+        for record in records {
+            for value in [
+                record.normalized_path.as_bytes(),
+                record.project_id.as_bytes(),
+                record.workspace_id.as_bytes(),
+                record.content_hash.as_bytes(),
+                record.policy_version.as_bytes(),
+                record.core_generation_id.as_bytes(),
+                record.core_run_id.as_bytes(),
+            ] {
+                hash_part(&mut hasher, value);
+            }
+            hash_part(&mut hasher, &record.observed_size.to_le_bytes());
+            hash_part(&mut hasher, &record.byte_cap.to_le_bytes());
+        }
+        format!("{:x}", hasher.finalize())
     }
 
     #[test]
@@ -26117,6 +26155,11 @@ fn build_llm_symbol_doc_text() -> String {
                 &exclusions,
             )
             .expect("replace retained source-policy publication");
+        let legacy_source_policy_digest = legacy_source_policy_exclusion_digest_for_test(
+            &before_storage
+                .get_source_policy_exclusions()
+                .expect("read retained source-policy exclusions"),
+        );
         let dense_before = before_storage
             .validate_dense_anchor_publication(&before)
             .expect("retained dense publication");
@@ -26140,6 +26183,13 @@ fn build_llm_symbol_doc_text() -> String {
         drop(before_storage);
 
         let legacy = rusqlite::Connection::open(&storage_path).expect("open retained v1 core");
+        legacy
+            .execute(
+                "UPDATE source_policy_exclusion_publication
+                 SET schema_version = 1, exclusion_digest = ?1",
+                rusqlite::params![legacy_source_policy_digest],
+            )
+            .expect("restore authentic retained v1 publication identity");
         legacy
             .execute_batch(
                 "DELETE FROM structural_text_unit_publication;

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -524,15 +524,42 @@ fn read_source_policy_exclusion_rollback_identity(
         && publication_columns
             .iter()
             .any(|column| column == "structural_unit_cap");
+    let manifest_schema_version = conn
+        .query_row(
+            "SELECT schema_version
+             FROM source_policy_exclusion_publication
+             WHERE id = 1 AND complete = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+    let Some(manifest_schema_version) = manifest_schema_version else {
+        return Ok(None);
+    };
+    let manifest_schema_version = u32::try_from(manifest_schema_version)
+        .map_err(|_| promotion_error("Source policy exclusion rollback schema is invalid"))?;
+    let format = match manifest_schema_version {
+        LEGACY_SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION => {
+            SourcePolicyExclusionPublicationFormat::LegacyV1
+        }
+        SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION => {
+            if !has_structural_policy_identity {
+                return Err(promotion_error(
+                    "Current source policy exclusion rollback schema is missing structural identity",
+                ));
+            }
+            SourcePolicyExclusionPublicationFormat::Current
+        }
+        _ => {
+            return Err(promotion_error(
+                "Source policy exclusion rollback schema is unsupported",
+            ));
+        }
+    };
     let structural_unit_cap_expression = if has_structural_policy_identity {
         "structural_unit_cap"
     } else {
         "2048"
-    };
-    let manifest_schema_version = if has_structural_policy_identity {
-        SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION
-    } else {
-        1
     };
     let identity_query = format!(
         "SELECT project_id, workspace_id, core_generation_id, core_run_id,
@@ -597,11 +624,7 @@ fn read_source_policy_exclusion_rollback_identity(
     } else {
         read_legacy_source_policy_exclusions(&conn)?
     };
-    let records_digest = if has_structural_policy_identity {
-        source_policy_exclusion_digest(&records)
-    } else {
-        legacy_source_policy_exclusion_digest(&records)
-    };
+    let records_digest = format.digest(&records);
     if identity.core_generation_id != publication.generation_id
         || identity.core_run_id != publication.run_id
         || identity.core_published_at_epoch_ms != publication.published_at_epoch_ms
@@ -615,6 +638,7 @@ fn read_source_policy_exclusion_rollback_identity(
                 || record.policy_version != identity.policy_version
                 || record.byte_cap != identity.byte_cap
                 || record.structural_unit_cap != identity.structural_unit_cap
+                || !format.qualifies(record)
         })
     {
         return Err(promotion_error(format!(
@@ -3189,6 +3213,7 @@ fn dense_anchor_content_summary(
 }
 
 pub const SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION: u32 = 2;
+const LEGACY_SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION: u32 = 1;
 const SOURCE_POLICY_EXCLUSION_DIGEST_DOMAIN: &[u8] =
     b"codestory-source-policy-exclusion-publication-v2\0";
 const LEGACY_SOURCE_POLICY_EXCLUSION_DIGEST_DOMAIN: &[u8] =
@@ -3287,6 +3312,41 @@ fn legacy_source_policy_exclusion_digest(records: &[SourcePolicyExclusionRecord]
         hash_dense_anchor_part(&mut hasher, &record.byte_cap.to_le_bytes());
     }
     format!("{:x}", hasher.finalize())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourcePolicyExclusionPublicationFormat {
+    Current,
+    LegacyV1,
+}
+
+impl SourcePolicyExclusionPublicationFormat {
+    fn schema_version(self) -> u32 {
+        match self {
+            Self::Current => SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION,
+            Self::LegacyV1 => LEGACY_SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION,
+        }
+    }
+
+    fn digest(self, records: &[SourcePolicyExclusionRecord]) -> String {
+        match self {
+            Self::Current => source_policy_exclusion_digest(records),
+            Self::LegacyV1 => legacy_source_policy_exclusion_digest(records),
+        }
+    }
+
+    fn qualifies(self, record: &SourcePolicyExclusionRecord) -> bool {
+        match self {
+            Self::Current => {
+                (record.observed_size > record.byte_cap && record.observed_unit_count == 0)
+                    || (record.observed_size <= record.byte_cap
+                        && record.observed_unit_count > record.structural_unit_cap)
+            }
+            Self::LegacyV1 => {
+                record.observed_size > record.byte_cap && record.observed_unit_count == 0
+            }
+        }
+    }
 }
 
 fn read_legacy_source_policy_exclusions(
@@ -7866,12 +7926,47 @@ impl Storage {
         workspace_id: &str,
         policy: SourcePolicyExclusionPolicyIdentity<'_>,
     ) -> Result<SourcePolicyExclusionManifest, StorageError> {
+        self.validate_source_policy_exclusion_publication_format(
+            publication,
+            project_id,
+            workspace_id,
+            policy,
+            SourcePolicyExclusionPublicationFormat::Current,
+        )
+    }
+
+    /// Validate an authentic schema-v1 oversized-source publication after its
+    /// database has been structurally migrated, without rewriting its identity.
+    pub fn validate_legacy_v1_source_policy_exclusion_publication(
+        &self,
+        publication: &IndexPublicationRecord,
+        project_id: &str,
+        workspace_id: &str,
+        policy: SourcePolicyExclusionPolicyIdentity<'_>,
+    ) -> Result<SourcePolicyExclusionManifest, StorageError> {
+        self.validate_source_policy_exclusion_publication_format(
+            publication,
+            project_id,
+            workspace_id,
+            policy,
+            SourcePolicyExclusionPublicationFormat::LegacyV1,
+        )
+    }
+
+    fn validate_source_policy_exclusion_publication_format(
+        &self,
+        publication: &IndexPublicationRecord,
+        project_id: &str,
+        workspace_id: &str,
+        policy: SourcePolicyExclusionPolicyIdentity<'_>,
+        format: SourcePolicyExclusionPublicationFormat,
+    ) -> Result<SourcePolicyExclusionManifest, StorageError> {
         let manifest = self
             .get_source_policy_exclusion_manifest()?
             .ok_or_else(|| {
                 StorageError::Other("source policy exclusion manifest is missing".into())
             })?;
-        if manifest.schema_version != SOURCE_POLICY_EXCLUSION_PUBLICATION_SCHEMA_VERSION
+        if manifest.schema_version != format.schema_version()
             || !manifest.complete
             || manifest.project_id != project_id
             || manifest.workspace_id != workspace_id
@@ -7889,7 +7984,7 @@ impl Storage {
         }
         let records = read_source_policy_exclusions(&self.conn)?;
         if manifest.exclusion_count != records.len() as u64
-            || manifest.exclusion_digest != source_policy_exclusion_digest(&records)
+            || manifest.exclusion_digest != format.digest(&records)
             || records.iter().any(|record| {
                 record.project_id != manifest.project_id
                     || record.workspace_id != manifest.workspace_id
@@ -7898,10 +7993,7 @@ impl Storage {
                     || record.policy_version != manifest.policy_version
                     || record.byte_cap != manifest.byte_cap
                     || record.structural_unit_cap != manifest.structural_unit_cap
-                    || !((record.observed_size > record.byte_cap
-                        && record.observed_unit_count == 0)
-                        || (record.observed_size <= record.byte_cap
-                            && record.observed_unit_count > record.structural_unit_cap))
+                    || !format.qualifies(record)
             })
         {
             return Err(StorageError::Other(

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -927,6 +927,149 @@ fn source_policy_exclusion_publication_binds_complete_rows_to_core_identity()
 }
 
 #[test]
+fn legacy_v1_source_policy_publication_validates_after_structural_column_migration()
+-> Result<(), StorageError> {
+    let path = unique_temp_db_path("legacy-v1-source-policy-validation");
+    let publication = IndexPublicationRecord {
+        generation: 4,
+        generation_id: "generation-4".into(),
+        run_id: "run-4".into(),
+        mode: IndexPublicationMode::Full,
+        published_at_epoch_ms: 44,
+    };
+    let policy = source_policy_identity(
+        "oversized-source-v1",
+        1_000_000,
+        codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
+    );
+    let candidates = vec![
+        OversizedSourceExclusionCandidate {
+            normalized_path: "src/generated/registers.h".into(),
+            content_hash: "a".repeat(64),
+            observed_size: 4_000_000,
+            observed_unit_count: 0,
+            policy_version: "oversized-source-v1".into(),
+            byte_cap: 1_000_000,
+            structural_unit_cap: codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
+        },
+        OversizedSourceExclusionCandidate {
+            normalized_path: "vendor/ordinary.rs".into(),
+            content_hash: "b".repeat(64),
+            observed_size: 1_000_001,
+            observed_unit_count: 0,
+            policy_version: "oversized-source-v1".into(),
+            byte_cap: 1_000_000,
+            structural_unit_cap: codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
+        },
+    ];
+    {
+        let mut storage = Storage::open(&path)?;
+        storage.publish_source_policy_exclusion_generation(
+            &publication,
+            "project-4",
+            "workspace-4",
+            policy,
+            &candidates,
+        )?;
+        let records = storage.get_source_policy_exclusions()?;
+        let legacy_digest = legacy_source_policy_exclusion_digest(&records);
+        storage.conn.execute(
+            "UPDATE source_policy_exclusion_publication
+             SET schema_version = 1, exclusion_digest = ?1",
+            params![legacy_digest],
+        )?;
+        let manifest = storage.validate_legacy_v1_source_policy_exclusion_publication(
+            &publication,
+            "project-4",
+            "workspace-4",
+            policy,
+        )?;
+        assert_eq!(manifest.schema_version, 1);
+        assert!(
+            storage
+                .validate_source_policy_exclusion_publication(
+                    &publication,
+                    "project-4",
+                    "workspace-4",
+                    policy,
+                )
+                .is_err(),
+            "current validator accepted a schema-v1 publication"
+        );
+    }
+    assert!(read_source_policy_exclusion_rollback_identity(&path, &publication)?.is_some());
+
+    {
+        let storage = Storage::open(&path)?;
+        let authentic_digest = storage
+            .get_source_policy_exclusion_manifest()?
+            .expect("legacy manifest")
+            .exclusion_digest;
+        storage.conn.execute(
+            "UPDATE source_policy_exclusion_publication SET exclusion_digest = ?1",
+            params!["0".repeat(64)],
+        )?;
+        assert!(
+            storage
+                .validate_legacy_v1_source_policy_exclusion_publication(
+                    &publication,
+                    "project-4",
+                    "workspace-4",
+                    policy,
+                )
+                .is_err(),
+            "legacy validator accepted digest corruption"
+        );
+        storage.conn.execute(
+            "UPDATE source_policy_exclusion_publication SET exclusion_digest = ?1",
+            params![authentic_digest],
+        )?;
+        storage.conn.execute(
+            "UPDATE source_policy_exclusion SET observed_unit_count = 1
+             WHERE normalized_path = 'vendor/ordinary.rs'",
+            [],
+        )?;
+        assert!(
+            storage
+                .validate_legacy_v1_source_policy_exclusion_publication(
+                    &publication,
+                    "project-4",
+                    "workspace-4",
+                    policy,
+                )
+                .is_err(),
+            "legacy validator accepted a nonzero migrated unit count"
+        );
+        storage.conn.execute(
+            "UPDATE source_policy_exclusion
+             SET observed_unit_count = 0, observed_size = byte_cap
+             WHERE normalized_path = 'vendor/ordinary.rs'",
+            [],
+        )?;
+        let invalid_digest =
+            legacy_source_policy_exclusion_digest(&storage.get_source_policy_exclusions()?);
+        storage.conn.execute(
+            "UPDATE source_policy_exclusion_publication SET exclusion_digest = ?1",
+            params![invalid_digest],
+        )?;
+        assert!(
+            storage
+                .validate_legacy_v1_source_policy_exclusion_publication(
+                    &publication,
+                    "project-4",
+                    "workspace-4",
+                    policy,
+                )
+                .is_err(),
+            "legacy validator accepted a non-oversized row with a valid v1 digest"
+        );
+    }
+
+    cleanup_sqlite_sidecars(&path)?;
+    Ok(())
+}
+
+#[test]
 fn source_policy_exclusion_transaction_failure_preserves_previous_manifest()
 -> Result<(), StorageError> {
     let mut storage = Storage::new_in_memory()?;


### PR DESCRIPTION
## Context

Schema-29 cores retained from v0.15 can contain a complete source-policy publication under `oversized-source-v1` with no structural publication. The current runtime requires `bounded-source-exclusion-v2`, so semantic projection republish rejected that exact predecessor before staging even when its caps and retained exclusions were otherwise valid.

Closes #1360
Refs #1202
Refs #1179

Base: `4004fff28f36574248b61f79dc0326d133fa4c0e`
Head: `ebc5ce73270f4bafa3387bb963ef4c290177b202`
Tree: `4d7d961f26861cbe981c41eb1f0bb65124a89a8f`

## What Changed

- authenticate the retained schema-1 source-policy publication against its recorded v1 digest and identity before any rebind
- permit only the directional `oversized-source-v1` to `bounded-source-exclusion-v2` transition for schema 29, the existing `LegacyEmpty` structural compatibility state, and byte/unit caps identical to current policy
- republish retained exclusion rows under the current policy identity without reading source bytes or scheduling source indexing
- preserve authentic migrated v1 source-policy identity in promotion rollback fencing by selecting digest semantics from the recorded manifest schema rather than column presence
- keep arbitrary versions, either cap drift, ownership mismatch, manifest gaps, nonempty unmanifested structural state, missing documents, and incomplete publications on existing fail-closed paths
- add runtime and real CLI coverage for the predecessor bridge and cap mismatch rejection, and document the compatibility boundary in `CHANGELOG.md`

## How To Review

1. Start at `semantic_projection_source_policy_compatibility` and verify it is directional and cap exact.
2. In `semantic_projection_republish_for_runtime`, verify ownership is checked first and the old publication is validated with `recorded_source_policy` before candidates are rewritten to `current_source_policy` in the staged database.
3. Review the runtime predecessor fixture and mismatch matrix, then the schema-29 CLI fixture and byte-identical cap-drift rejection.

## Verification

Passed on Windows at the exact head:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p codestory-store --lib source_policy_exclusion_publication_binds_complete_rows_to_core_identity`
- `cargo test --locked -p codestory-store --lib legacy_v1_source_policy_publication_validates_after_structural_column_migration`
- `cargo test --locked -p codestory-store --lib legacy_journal_recovery_runs_before_supported_schema_migration`
- `cargo test --locked -p codestory-runtime --lib semantic_projection_source_policy_bridge_is_directional_and_cap_exact`
- `cargo test --locked -p codestory-cli --test runtime_backed_flows --no-run`
- `cargo check --locked -p codestory-runtime -p codestory-cli`

Attempted but not claimed as passing locally:

- `cargo test --locked -p codestory-runtime --lib semantic_projection_republish`

All nine selected runtime tests reached the exact-base Windows staged-database durability path and failed at `File::open(path).and_then(|file| file.sync_all())` with `Access is denied. (os error 5)`. Repeating under an isolated task-owned temp directory produced the same result. This is the existing Rust 1.97 Windows build/runtime defect, not changed or hidden in this PR. Hosted CI remains required for executable behavior proof.

The first independent review of `78b04f5052f736cbe66067c55ad91264dd2c4422` found that its tests only relabelled current schema-2 publications and that the current validator would reject a genuine schema-1/v1-digest core. This head addresses that blocker with a narrowly typed legacy validator, authentic runtime/CLI fixtures, corruption negatives, and rollback identity repair. Exact-head re-review remains pending.

Packaged CodeStory grounding was invoked fresh with the exact Windows project path. Its packet preparation failed with `read embedding control length`; the later affected-path call remained `Updating at CoreFreshness` across required retries. Source review therefore used direct exact-worktree inspection, and CLI output is not represented as packaged-MCP proof.

## Risk

The bridge is confined to semantic projection-only republish. Store validation remains strict. The retained publication must validate under its old identity, and the candidate is not promoted until existing staged publication validation succeeds. This PR does not provide or replace the sealed macOS retained-corpus evidence, installed-package proof, protected-hardware proof, or release proof.
