### PR TITLE
[codex] Open the project before retrieval auto refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   full refresh. Drill reports omit unavailable pre-refresh metrics and carry
   the compatibility reason instead of copying post-refresh counts into the
   before fields.
+- Retrieval indexing now binds the selected project runtime after compatibility
+  preflight and before executing an automatic incremental refresh, preventing
+  exact-head repo-scale evidence runs from failing with an unopened project.
 - A new explicit `retrieval republish-projections` writer can adopt the current
   semantic and dense-selection policy from one complete stored core without
   source discovery, parsing, or source-file reads. It validates the pinned

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -155,6 +155,7 @@ fn run_retrieval_index_refresh(
     let Some(mode) = refresh_mode else {
         return Ok(());
     };
+    runtime.open_project_summary()?;
     runtime
         .index
         .run_indexing_blocking(mode)
@@ -417,7 +418,46 @@ fn emit_retrieval_gc(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(windows))]
+    use crate::args::ProjectArgs;
     use anyhow::anyhow;
+    #[cfg(not(windows))]
+    use std::fs;
+    #[cfg(not(windows))]
+    use tempfile::tempdir;
+
+    #[cfg(not(windows))]
+    #[test]
+    fn compatible_auto_refresh_opens_the_project_before_indexing() {
+        let temp = tempdir().expect("temporary test root");
+        let project = temp.path().join("project");
+        let cache = temp.path().join("cache");
+        fs::create_dir_all(project.join("src")).expect("create source directory");
+        fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname = \"retrieval-refresh-fixture\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .expect("write manifest");
+        let source = project.join("src/lib.rs");
+        fs::write(&source, "pub fn before() {}\n").expect("write source");
+        let args = ProjectArgs {
+            project: project.clone(),
+            cache_dir: Some(cache),
+        };
+
+        let seed = RuntimeContext::new_inspect_only(&args).expect("seed runtime");
+        seed.ensure_open(RefreshMode::Full)
+            .expect("publish compatible core");
+        fs::write(&source, "pub fn after() {}\n").expect("change source");
+
+        let runtime = RuntimeContext::new_inspect_only(&args).expect("retrieval runtime");
+        let decision = runtime
+            .resolve_refresh_decision_with_preflight(RefreshMode::Auto)
+            .expect("resolve compatible auto refresh");
+        assert_eq!(decision.effective_mode, Some(IndexMode::Incremental));
+        run_retrieval_index_refresh(&runtime, RefreshMode::Auto, decision.effective_mode)
+            .expect("run compatible incremental refresh");
+    }
 
     #[test]
     fn auto_refresh_retries_full_for_semantic_doc_contract_drift() {


### PR DESCRIPTION
## Context

Exact-head integration run 29821657291 reached the mandatory repo-scale lane at dev `a88f53dc891e435925e907214afe60cf398fe2b8`, then failed when `retrieval index --refresh auto` resolved an incremental refresh and indexed before binding the new process to its project runtime.

Closes #1362.
Refs #1189.

## What Changed

- Open the selected project immediately before a resolved retrieval refresh executes.
- Preserve compatibility preflight and embedding-policy validation before mutable project open.
- Add a Linux regression that seeds a compatible core, changes source, resolves Auto to Incremental, and executes the refresh path.
- Record the release-significant correction in the v0.16 changelog.

## How To Review

Confirm the order in `run_retrieval_index`: compatibility preflight, embedding policy, then refresh. Confirm `run_retrieval_index_refresh` opens only when a refresh mode exists and before `run_indexing_blocking`.

Base: `a88f53dc891e435925e907214afe60cf398fe2b8`

Head: `1c639f05d999d046a70ddf89ffed39d3630ab0be`

Tree: `d7107c95eb6681ccf3f05b7e64b085ac089b05db`

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p codestory-cli --bin codestory-cli retrieval::tests:: -- --nocapture` (Windows: 2 passed; Linux-only exact Auto regression intentionally skipped)
- documentation links: 75 files, 265 relative links
- release version synchronization: 9 crates, lockfile, 3 plugin manifests, model producer
- workflow policy
- Independent final review: no findings
- Release CLI build and launch on Windows: `codestory-cli 0.16.0`, SHA-256 `EC78E789FAB583D9298EDAC4A38AAAAA11541741CB3BDB86C2A3A04A27663FA8`

The local Windows repo-scale reproduction reached its first full index but could not publish the staged database because this host denied `File::sync_all` (`Access is denied`, OS error 5). That is not claimed as a passing repo-scale run. Hosted Linux CI owns the exact regression proof.

## Risk

The behavior change is one project-open call on retrieval writer paths that actually execute a refresh. `--refresh none` retains its prior single open during finalization. No package, installed-runtime, protected-hardware, or release claim follows from this PR.
