### PR TITLE
[codex] Fix Windows staged database durability sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 - Retrieval indexing now binds the selected project runtime after compatibility
   preflight and before executing an automatic incremental refresh, preventing
   exact-head repo-scale evidence runs from failing with an unopened project.
+- Disposable full-refresh storage now opens the staged SQLite database with a
+  writable handle before its durability flush, so Windows can seal and promote
+  the candidate instead of failing `sync_all` with access denied.
 - A new explicit `retrieval republish-projections` writer can adopt the current
   semantic and dense-selection policy from one complete stored core without
   source discovery, parsing, or source-file reads. It validates the pinned

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -5006,7 +5006,9 @@ impl Storage {
             )
         })?;
         let sync_started = Instant::now();
-        File::open(path)
+        OpenOptions::new()
+            .write(true)
+            .open(path)
             .and_then(|file| file.sync_all())
             .map_err(|error| {
                 promotion_path_error("sync staged database", Path::new(path), error)

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -5047,7 +5047,9 @@ fn disposable_full_build_abort_child() {
         }])
         .expect("write disposable child stage");
     fs::write(&sentinel_path, b"disposable-stage-written\n").expect("write abort sentinel");
-    File::open(&sentinel_path)
+    OpenOptions::new()
+        .write(true)
+        .open(&sentinel_path)
         .and_then(|file| file.sync_all())
         .expect("sync abort sentinel");
     std::process::abort();
@@ -6138,6 +6140,7 @@ fn staged_promotion_rejects_missing_corrupt_or_timestamp_drifted_candidate_manif
             live.get_files().expect("live files")[0].path,
             PathBuf::from("old.rs")
         );
+        drop(live);
 
         cleanup_sqlite_sidecars(&live_path).expect("clean live fixture");
         cleanup_sqlite_sidecars(&staged_path).expect("clean staged fixture");
@@ -6203,6 +6206,7 @@ fn staged_promotion_rejects_missing_corrupt_or_drifted_structural_manifest() {
             live.get_files().expect("live files")[0].path,
             PathBuf::from("old.rs")
         );
+        drop(live);
 
         cleanup_sqlite_sidecars(&live_path).expect("clean live fixture");
         cleanup_sqlite_sidecars(&staged_path).expect("clean staged fixture");
@@ -6433,6 +6437,7 @@ fn legacy_committed_journal_without_source_policy_identity_recovers_for_runtime_
         "store recovery must not synthesize policy evidence"
     );
     assert!(!committed_path.exists());
+    drop(recovered);
 
     cleanup_sqlite_sidecars(&live_path).expect("clean legacy fixture");
 }


### PR DESCRIPTION
## Context

The exact v0.16 Windows repo-scale candidate failed while sealing its disposable full-refresh SQLite database with `Access is denied. (os error 5)`. The shared seal opened the file read-only and then called `sync_all`, which requires a write-capable Windows handle.

Closes #1364
Refs #1189

## What Changed

- Open the existing staged database with write access before its durability flush; creation, truncation, checkpointing, parent sync, and promotion order are unchanged.
- Give the abort sentinel the same valid Windows sync handle so the crash proof reaches `abort()` instead of passing after an earlier panic.
- Drop three live test connections before deleting their Windows fixtures.
- Record the release-significant Windows fix in the v0.16 changelog.

## How To Review

Start at `Storage::seal_disposable_full_build`: the only production change is the access mode of the temporary durability handle. Then inspect the test-only handle and connection lifetime changes.

## Verification

- Pre-fix exact reproduction: `snapshot_store::tests::disposable_full_refresh_seals_wal_before_promotion` failed with OS error 5.
- Post-fix: all 169 `codestory-store` library tests pass on Windows.
- Exact crash/promotion regressions pass:
  - `snapshot_store::tests::disposable_full_refresh_seals_wal_before_promotion`
  - `storage_impl::tests::process_abort_during_disposable_build_never_mutates_live`
  - `storage_impl::tests::staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `node .github/scripts/check-workflow-policy.mjs`
- Independent review: no findings.

## Risk

Low. The handle opens an already-created SQLite database without create or truncate. SQLite already owns the staged database read-write; the change only lets Windows flush that file before promotion.
