### PR TITLE
[codex] Add hosted and Linux proof scopes

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1510,7 +1510,7 @@ function expectedPackageRows(graph) {
 
 function validatePackageMatrixExpression(violations, expression, graph) {
   const match = typeof expression === "string" && expression.match(
-    /fromJSON\(inputs\.calibration_mode && '([^']+)' \|\| inputs\.scope == 'server' && '([^']+)' \|\| inputs\.scope == 'windows' && '([^']+)' \|\| inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\)/u,
+    /fromJSON\(inputs\.calibration_mode && '([^']+)' \|\| inputs\.scope == 'server' && '([^']+)' \|\| inputs\.scope == 'linux' && '([^']+)' \|\| inputs\.scope == 'windows' && '([^']+)' \|\| inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\)/u,
   );
   if (!match) {
     violations.push("packaged-platform-proof.yml matrix must select structural JSON by scope");
@@ -1524,6 +1524,7 @@ function validatePackageMatrixExpression(violations, expression, graph) {
         row => row.asset_target === "linux-x64" || row.asset_target === "macos-arm64",
       ),
     },
+    { include: full.filter(row => row.asset_target === "linux-x64") },
     { include: full.filter(row => row.asset_target === "windows-x64") },
     { include: full.filter(row => row.asset_target.startsWith("macos-")) },
     { include: full },
@@ -1772,7 +1773,7 @@ function validatePackagedProof(workflows, violations, graph) {
       '--calibration-bundle "$calibration_bundle"',
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
-      'if [ "$PROOF_SCOPE" = server ]',
+      'if [ "$PROOF_SCOPE" = server ] || [ "$PROOF_SCOPE" = linux ]',
       "--server-behavior-only",
       'test -f "$quality_path"',
       "--timeout-secs 1800",
@@ -1782,8 +1783,9 @@ function validatePackagedProof(workflows, violations, graph) {
   add(
     violations,
     String(candidateStage?.if ?? "").includes("inputs.candidate_installed_proof")
-      && String(candidateStage?.if ?? "").includes("inputs.scope == 'server'"),
-    `${file} candidate-managed Linux staging must require coordinator opt-in and remain runnable in server scope`,
+      && String(candidateStage?.if ?? "").includes("inputs.scope == 'server'")
+      && String(candidateStage?.if ?? "").includes("inputs.scope == 'linux'"),
+    `${file} candidate-managed Linux staging must require coordinator opt-in and remain runnable in server and Linux scopes`,
   );
   requireStepRun(violations, file, job, "Stage isolated candidate-managed Linux install", [
     "--prepare-candidate-installed-proof",
@@ -1800,8 +1802,9 @@ function validatePackagedProof(workflows, violations, graph) {
   add(
     violations,
     String(candidateProof?.if ?? "").includes("inputs.candidate_installed_proof")
-      && String(candidateProof?.if ?? "").includes("inputs.scope == 'server'"),
-    `${file} candidate-installed Linux proof must require coordinator opt-in and remain runnable in server scope`,
+      && String(candidateProof?.if ?? "").includes("inputs.scope == 'server'")
+      && String(candidateProof?.if ?? "").includes("inputs.scope == 'linux'"),
+    `${file} candidate-installed Linux proof must require coordinator opt-in and remain runnable in server and Linux scopes`,
   );
   requireStepRun(violations, file, job, "Prove two-host candidate-installed Linux runtime", [
     "--proof-tier installed_runtime",
@@ -2017,7 +2020,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     violations,
     sameMembers(
       at(workflow, "on", "workflow_dispatch", "inputs", "scope", "options"),
-      ["auto", "server", "windows", "macos", "full"],
+      ["auto", "none", "linux", "server", "windows", "macos", "full"],
     ),
     `${file} dispatch scopes changed`,
   );
@@ -2048,7 +2051,13 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     '.path == ".github/workflows/source-proof.yml"',
     '.name == "full-source-gate" and .conclusion == "success"',
   ]);
-  requireStepRun(violations, file, route, "Select change-aware proof scope", ["node .github/scripts/route-ci-proof.mjs --stdin"]);
+  requireStepRun(violations, file, route, "Select change-aware proof scope", [
+    'if [ "$REQUESTED_SCOPE" = none ]; then',
+    "scope=none",
+    "scope=full",
+    'elif [ "$REQUESTED_SCOPE" = "server" ]; then',
+    "node .github/scripts/route-ci-proof.mjs --stdin",
+  ]);
   requireStepRun(violations, file, route, "Read qualification constant-set state", [
     "base_frozen=false",
     "jq -r '.status == \"frozen\"'",
@@ -2193,7 +2202,22 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     `${file} must opt the accepted PR Windows package into candidate-installed proof`,
   );
   const closeout = requireJob(violations, file, workflow, "closeout");
-  requireStepRun(violations, file, closeout, "Require one coherent accepted proof", ["dev/codestory-next moved from proved head"]);
+  const evidence = requireJob(violations, file, workflow, "release-evidence");
+  add(
+    violations,
+    String(evidence.if ?? "").includes("needs.route.outputs.scope != 'none'"),
+    `${file} hosted-only integration must skip release evidence`,
+  );
+  add(
+    violations,
+    String(evidence.if ?? "").includes("needs.route.outputs.scope != 'linux'"),
+    `${file} Linux server-behavior proof must not require protected release evidence`,
+  );
+  requireStepRun(violations, file, closeout, "Require one coherent accepted proof", [
+    '[ "$SCOPE" != none ]',
+    '[ "$SCOPE" = linux ]',
+    "dev/codestory-next moved from proved head",
+  ]);
   add(violations, !scalarStrings(workflow).some(value => value === "./.github/workflows/release.yml"), `${file} must not publish releases`);
 }
 

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -475,6 +475,26 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
       packagedResolver(workflow).run = packagedResolver(workflow).run
         .replace('test "$GITHUB_SHA" = "$dev_head"', 'test -n "$GITHUB_SHA"');
     }, /GITHUB_SHA.*dev_head/u],
+    ["hosted-only integration scope removed", packagedCoordinatorFile, workflow => {
+      workflow.on.workflow_dispatch.inputs.scope.options
+        = workflow.on.workflow_dispatch.inputs.scope.options.filter(scope => scope !== "none");
+    }, /dispatch scopes changed/u],
+    ["hosted-only release evidence guard removed", packagedCoordinatorFile, workflow => {
+      workflow.jobs["release-evidence"].if
+        = workflow.jobs["release-evidence"].if.replace("needs.route.outputs.scope != 'none' &&", "");
+    }, /hosted-only integration must skip release evidence/u],
+    ["Linux release evidence guard removed", packagedCoordinatorFile, workflow => {
+      workflow.jobs["release-evidence"].if
+        = workflow.jobs["release-evidence"].if.replace("needs.route.outputs.scope != 'linux' &&", "");
+    }, /Linux server-behavior proof must not require protected release evidence/u],
+    ["Linux package matrix scope removed", packagedProofFile, workflow => {
+      workflow.jobs.build.strategy.matrix
+        = workflow.jobs.build.strategy.matrix.replace("inputs.scope == 'linux'", "inputs.scope == 'windows'");
+    }, /matrix must select structural JSON by scope/u],
+    ["Linux candidate install guard removed", packagedProofFile, workflow => {
+      const step = draftStep(workflow.jobs.build, "Stage isolated candidate-managed Linux install");
+      step.if = step.if.replace("inputs.scope == 'linux' || ", "");
+    }, /remain runnable in server and Linux scopes/u],
     ["source unversioned cache", sourceFile, workflow => {
       const restore = draftStep(workflow.jobs["full-source-gate"], "Restore Cargo inputs and output");
       restore.with.key = restore.with.key.replace("source-proof-v2", "source-proof");

--- a/.github/scripts/route-ci-proof.mjs
+++ b/.github/scripts/route-ci-proof.mjs
@@ -7,7 +7,7 @@ const scopeRank = new Map([
   ["macos", 1],
   ["full", 2],
 ]);
-const coordinatorScopes = new Set(["windows", ...scopeRank.keys()]);
+const coordinatorScopes = new Set(["linux", "windows", ...scopeRank.keys()]);
 
 const macosSurfaces = [
   /^\.github\/workflows\/macos-/u,
@@ -59,7 +59,7 @@ export function selectProofScope(paths, requested = "auto") {
   if (!coordinatorScopes.has(requested)) {
     throw new Error(`unsupported proof scope: ${requested}`);
   }
-  if (requested === "windows") return requested;
+  if (requested === "linux" || requested === "windows") return requested;
   return scopeRank.get(requested) > scopeRank.get(inferred) ? requested : inferred;
 }
 
@@ -120,6 +120,9 @@ function selfTest() {
   }
   if (selectProofScope(fixtures[2].paths, "windows") !== "windows") {
     throw new Error("coordinator Windows proof must select only Windows x64 packaging");
+  }
+  if (selectProofScope(fixtures[2].paths, "linux") !== "linux") {
+    throw new Error("coordinator Linux proof must select only Linux x64 packaging");
   }
 }
 

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -20,11 +20,11 @@ on:
         required: true
         type: string
       scope:
-        description: Auto-detect proof scope or select a coordinator package scope; server excludes Windows runtime proof.
+        description: Auto-detect proof scope or select hosted-only, Linux, or another coordinator package scope.
         required: true
         default: auto
         type: choice
-        options: [auto, server, windows, macos, full]
+        options: [auto, none, linux, server, windows, macos, full]
       source_run_id:
         description: Optional prior rejected release-evidence run to re-evaluate.
         required: false
@@ -230,7 +230,11 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ steps.resolve.outputs.mode }}" = "integration" ]; then
-            scope=full
+            if [ "$REQUESTED_SCOPE" = none ]; then
+              scope=none
+            else
+              scope=full
+            fi
           elif [ "${{ steps.resolve.outputs.mode }}" = "calibration" ]; then
             scope=none
           elif [ "${{ steps.resolve.outputs.mode }}" = "release-evidence" ]; then
@@ -453,6 +457,8 @@ jobs:
       needs.route.outputs.mode == 'release-evidence' ||
       (needs.route.outputs.mode != 'calibration' &&
        needs.route.outputs.scope != 'server' &&
+       needs.route.outputs.scope != 'linux' &&
+       needs.route.outputs.scope != 'none' &&
        needs.route.outputs.constants_frozen == 'true')
     needs: route
     uses: ./.github/workflows/release-candidate-evidence.yml
@@ -480,7 +486,8 @@ jobs:
       (needs.source-proof.result == 'success' || (needs.route.outputs.mode == 'platform' && needs.source-proof.result == 'skipped')) &&
       (needs.release-evidence.result == 'success' ||
        ((needs.route.outputs.constants_frozen != 'true' ||
-         needs.route.outputs.scope == 'server') &&
+         needs.route.outputs.scope == 'server' ||
+         needs.route.outputs.scope == 'linux') &&
         needs.release-evidence.result == 'skipped'))
     needs:
       - route
@@ -586,7 +593,7 @@ jobs:
           }
           require_result "$ROUTE_RESULT" success routing
           require_result "$STATS_RESULT" success repo-scale-stats
-          if [ "$CONSTANTS_FROZEN" = true ] && [ "$SCOPE" != server ]; then
+          if [ "$CONSTANTS_FROZEN" = true ] && [ "$SCOPE" != server ] && [ "$SCOPE" != linux ] && [ "$SCOPE" != none ]; then
             require_result "$EVIDENCE_RESULT" success release-evidence
           else
             require_result "$EVIDENCE_RESULT" skipped release-evidence
@@ -615,6 +622,9 @@ jobs:
               require_result "$VULKAN_RESULT" skipped windows-vulkan-proof
             elif [ "$SCOPE" = server ]; then
               require_result "$METAL_RESULT" success macos-metal-proof
+              require_result "$VULKAN_RESULT" skipped windows-vulkan-proof
+            elif [ "$SCOPE" = linux ]; then
+              require_result "$METAL_RESULT" skipped macos-metal-proof
               require_result "$VULKAN_RESULT" skipped windows-vulkan-proof
             else
               require_result "$METAL_RESULT" success macos-metal-proof

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       scope:
-        description: Native package matrix scope (windows, macos, or full).
+        description: Native package matrix scope (linux, windows, macos, server, or full).
         required: false
         default: full
         type: string
@@ -103,7 +103,7 @@ jobs:
       # GitHub applies matrix exclusions before includes, so an include-only
       # matrix must select the complete row set rather than trying to exclude
       # rows after the fact.
-      matrix: ${{ fromJSON(inputs.calibration_mode && '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"}]}' || inputs.scope == 'server' && '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}' || inputs.scope == 'windows' && '{"include":[{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"}]}' || inputs.scope == 'macos' && '{"include":[{"os":"macos-15-intel","rust_target":"x86_64-apple-darwin","asset_target":"macos-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}' || '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"},{"os":"ubuntu-24.04-arm","rust_target":"aarch64-unknown-linux-gnu","asset_target":"linux-arm64","exe_suffix":"","extension":"tar.gz"},{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"},{"os":"windows-11-arm","rust_target":"aarch64-pc-windows-msvc","asset_target":"windows-arm64","exe_suffix":".exe","extension":"zip"},{"os":"macos-15-intel","rust_target":"x86_64-apple-darwin","asset_target":"macos-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}') }}
+      matrix: ${{ fromJSON(inputs.calibration_mode && '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"}]}' || inputs.scope == 'server' && '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}' || inputs.scope == 'linux' && '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"}]}' || inputs.scope == 'windows' && '{"include":[{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"}]}' || inputs.scope == 'macos' && '{"include":[{"os":"macos-15-intel","rust_target":"x86_64-apple-darwin","asset_target":"macos-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}' || '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"},{"os":"ubuntu-24.04-arm","rust_target":"aarch64-unknown-linux-gnu","asset_target":"linux-arm64","exe_suffix":"","extension":"tar.gz"},{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"},{"os":"windows-11-arm","rust_target":"aarch64-pc-windows-msvc","asset_target":"windows-arm64","exe_suffix":".exe","extension":"zip"},{"os":"macos-15-intel","rust_target":"x86_64-apple-darwin","asset_target":"macos-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -586,7 +586,7 @@ jobs:
           claim_scope_args=()
           quality_path="target/release-quality-evidence/packet/packet-runtime-summary.json"
           if [ "$proof_tier" = hosted_package ]; then
-            if [ "$PROOF_SCOPE" = server ]; then
+            if [ "$PROOF_SCOPE" = server ] || [ "$PROOF_SCOPE" = linux ]; then
               claim_scope_args=(--server-behavior-only)
             else
               test -f "$quality_path"
@@ -630,7 +630,7 @@ jobs:
           matrix.asset_target == 'linux-x64' &&
           inputs.candidate_installed_proof &&
           !inputs.calibration_mode &&
-          (inputs.scope == 'server' || inputs.quality_evidence_artifact != '') &&
+          (inputs.scope == 'server' || inputs.scope == 'linux' || inputs.quality_evidence_artifact != '') &&
           inputs.calibration_bundle_artifact != '' &&
           inputs.calibration_bundle_run_id != ''
         shell: bash
@@ -668,7 +668,7 @@ jobs:
           matrix.asset_target == 'linux-x64' &&
           inputs.candidate_installed_proof &&
           !inputs.calibration_mode &&
-          (inputs.scope == 'server' || inputs.quality_evidence_artifact != '') &&
+          (inputs.scope == 'server' || inputs.scope == 'linux' || inputs.quality_evidence_artifact != '') &&
           inputs.calibration_bundle_artifact != '' &&
           inputs.calibration_bundle_run_id != ''
         env:
@@ -682,7 +682,7 @@ jobs:
           source_sha="$(git rev-parse HEAD)"
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           claim_args=()
-          if [ "${{ inputs.scope }}" = server ]; then
+          if [ "${{ inputs.scope }}" = server ] || [ "${{ inputs.scope }}" = linux ]; then
             claim_args=(--server-behavior-only)
           else
             test -f "$quality_path"
@@ -722,7 +722,7 @@ jobs:
             --out-dir target/candidate-installed-linux/proof
 
       - name: Upload candidate-installed Linux proof
-        if: always() && matrix.asset_target == 'linux-x64' && inputs.candidate_installed_proof && !inputs.calibration_mode && (inputs.scope == 'server' || inputs.quality_evidence_artifact != '')
+        if: always() && matrix.asset_target == 'linux-x64' && inputs.candidate_installed_proof && !inputs.calibration_mode && (inputs.scope == 'server' || inputs.scope == 'linux' || inputs.quality_evidence_artifact != '')
         uses: actions/upload-artifact@v7.0.1
         with:
           name: candidate-installed-linux-${{ inputs.version }}-attempt-${{ github.run_attempt }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 - Disposable full-refresh storage now opens the staged SQLite database with a
   writable handle before its durability flush, so Windows can seal and promote
   the candidate instead of failing `sync_all` with access denied.
+- The proof coordinator now supports explicit hosted-only integration and
+  Linux-only package scopes, so exact-head source, repo-scale, and Linux
+  candidate evidence do not schedule unrelated protected-platform runners.
 - A new explicit `retrieval republish-projections` writer can adopt the current
   semantic and dense-selection policy from one complete stored core without
   source discovery, parsing, or source-file reads. It validates the pinned

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -88,6 +88,9 @@ cargo test --locked -p codestory-indexer --test tictactoe_language_coverage
 The repo-scale stats lane runs once on the final merge-ready head only when
 default indexing, symbol/dense persistence, embedding reuse, or cold-start
 behavior changed. Intermediate commits do not append telemetry.
+Use the coordinator's explicit `none` scope for that final integration when
+only the hosted source and repo-scale gates are required; it deliberately skips
+package, release-evidence, and protected-hardware jobs.
 
 Semantic document allocation changes use focused runtime proof before the
 broad gate. Cover shared-file path cardinality, byte-identical and

--- a/docs/testing/per-user-embedding-server-qualification.md
+++ b/docs/testing/per-user-embedding-server-qualification.md
@@ -170,6 +170,11 @@ quality, answer quality, release readiness, or any retained qualification-tier
 claim. Every other frozen package, hardware, installed-runtime, and release
 scope still requires authenticated exact-head packet-quality evidence.
 
+The explicit `linux` coordinator scope runs the existing Linux x64 package and
+candidate-installed proof without scheduling Mac or Windows protected jobs. It
+uses the same server-behavior-only claim boundary as `server`; it does not
+assert retrieval quality or satisfy separate protected-platform cells.
+
 Frozen calibration bundles are accepted only from a successful
 `workflow_dispatch` run of `packaged-platform-pr.yml` in this repository. Every
 consumer binds the run ID, exact `embedding-calibration-bundle-<source-sha>`


### PR DESCRIPTION
## Context

The integration coordinator currently forces every exact-dev run to the full protected matrix. That prevents the required hosted source/repo-scale closeout whenever an unrelated protected runner is unavailable. The reusable package workflow already owns Linux candidate-installed proof, but no Linux-only coordinator route can reach it.

Closes #1366
Refs #1189
Refs #1233

## What Changed

- Add explicit `none` and `linux` coordinator scopes.
- Allow integration to select `none`, which runs exact-head source proof, repo-scale stats, and closeout while skipping release-evidence, package, and protected jobs.
- Route `linux` to the existing Linux x64 package and candidate-installed paths while skipping release-evidence and protected jobs.
- Keep Linux on the explicit server-behavior-only claim boundary; it does not emit retrieval-quality or protected-platform claims.
- Extend workflow policy, routing self-checks, controlled-negative tests, operator documentation, and the v0.16 changelog.

## How To Review

Review scope selection and closeout first in `packaged-platform-pr.yml`, then confirm `packaged-platform-proof.yml` treats Linux exactly like `server` for claim scope while selecting only the Linux x64 matrix row. The policy validator and negatives pin both behaviors.

## Verification

- `node .github/scripts/route-ci-proof.mjs --self-test`
- `node .github/scripts/check-workflow-policy.mjs`
- 39 focused workflow-policy positive/negative checks pass.
- `node --test .github/scripts/run-actionlint.test.mjs`
- `node .github/scripts/run-actionlint.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- Independent initial review found the Linux quality-boundary gap; the corrected exact diff was re-reviewed with no remaining findings.

## Risk

The new scopes are explicit manual coordinator choices. Existing `auto`, `server`, `windows`, `macos`, and default full behavior remain unchanged. Repository permissions remain read-only, and this coordinator still cannot call the release workflow or publish anything.
