### PR TITLE
[codex] Authenticate the release ledger before publish

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1299,7 +1299,40 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     violations.push(`${releaseFile} must exist`);
     return;
   }
+  const releaseCallers = [...workflows.entries()]
+    .filter(([file, workflow]) => file !== releaseFile
+      && scalarStrings(workflow).some(value => value === "./.github/workflows/release.yml"))
+    .map(([file]) => file)
+    .sort();
+  add(
+    violations,
+    JSON.stringify(releaseCallers) === JSON.stringify(["auto-release.yml"]),
+    `${releaseFile} publication authority must have only the trusted auto-release.yml caller`,
+  );
   add(violations, object(release.permissions).actions === "read", `${releaseFile} must read prior-run evidence`);
+  const callExpectedHead = object(at(release, "on", "workflow_call", "inputs", "expected_head_sha"));
+  add(
+    violations,
+    callExpectedHead.required === false && callExpectedHead.type === "string" && callExpectedHead.default === "",
+    `${releaseFile} workflow_call expected_head_sha must be an optional empty string`,
+  );
+  const callPublish = object(at(release, "on", "workflow_call", "inputs", "publish_release"));
+  add(
+    violations,
+    callPublish.required === false && callPublish.type === "boolean" && callPublish.default === false,
+    `${releaseFile} workflow_call publish_release must be a fail-closed boolean`,
+  );
+  const dispatchExpectedHead = object(at(release, "on", "workflow_dispatch", "inputs", "expected_head_sha"));
+  add(
+    violations,
+    dispatchExpectedHead.required === true && dispatchExpectedHead.type === "string",
+    `${releaseFile} workflow_dispatch expected_head_sha must be a required string`,
+  );
+  add(
+    violations,
+    at(release, "on", "workflow_dispatch", "inputs", "publish_release") === undefined,
+    `${releaseFile} workflow_dispatch must not expose publication authority`,
+  );
   for (const event of ["workflow_call", "workflow_dispatch"]) {
     const input = object(at(release, "on", event, "inputs", "source_run_id"));
     add(violations, input.required === false && input.type === "string" && input.default === "", `${releaseFile} ${event} source_run_id must be an optional empty string`);
@@ -1328,6 +1361,19 @@ function validateReleaseCoordinator(workflows, violations, graph) {
 
   const preflight = requireJob(violations, releaseFile, release, "preflight");
   add(violations, sameMembers(needs(preflight), releaseChain.dependencies.preflight), `${releaseFile} preflight dependencies must match the release claim graph`);
+  requireStepRun(violations, releaseFile, preflight, "Validate release authority", [
+    'if [ "$PUBLISH_RELEASE" = "true" ]; then',
+    '"$GITHUB_EVENT_NAME" != "push"',
+    '"$GITHUB_REF" != "refs/heads/main"',
+    '$GITHUB_REPOSITORY/.github/workflows/auto-release.yml@refs/heads/main',
+    '"$GITHUB_WORKFLOW_REF" != "$expected_caller"',
+    'repos/$GITHUB_REPOSITORY/git/ref/heads/main',
+    '"$GITHUB_EVENT_NAME" != "workflow_dispatch"',
+    '"$GITHUB_REF" != "refs/heads/dev/codestory-next"',
+    '"$EXPECTED_HEAD_SHA" != "$GITHUB_SHA"',
+    'repos/$GITHUB_REPOSITORY/git/ref/heads/dev/codestory-next',
+    "dev/codestory-next moved from proved head",
+  ]);
   requireStepRun(violations, releaseFile, preflight, "Validate versioned changelog notes", [
     "node .github/scripts/extract-codestory-release-notes.mjs",
     '--version "$VERSION"',
@@ -1434,9 +1480,21 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     "--trusted-exceptions",
     "codestory-release-closeout.mjs evaluate",
   ]);
+  const devRevalidation = namedStep(preCloseout, "Revalidate proof-only dev head");
+  add(
+    violations,
+    devRevalidation?.if === "${{ !inputs.publish_release }}",
+    `${releaseFile} proof-only ledger upload must revalidate only the dev head`,
+  );
+  requireStepRun(violations, releaseFile, preCloseout, "Revalidate proof-only dev head", [
+    "repos/$GITHUB_REPOSITORY/git/ref/heads/dev/codestory-next",
+    '"$live_head" != "$GITHUB_SHA"',
+    "dev/codestory-next moved from accepted ledger head",
+  ]);
   requireStepUses(violations, releaseFile, preCloseout, "Upload accepted pre-publish closeout", "actions/upload-artifact@v7.0.1");
 
   const publish = requireJob(violations, releaseFile, release, "publish");
+  add(violations, publish.if === "inputs.publish_release", `${releaseFile} publish must require trusted publication authority`);
   add(violations, sameMembers(needs(publish), releaseChain.dependencies.publish), `${releaseFile} publish dependencies must match the release claim graph`);
   requireStepRun(violations, releaseFile, publish, "Compose versioned GitHub release notes", [
     "node .github/scripts/extract-codestory-release-notes.mjs",
@@ -1450,10 +1508,14 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   requireStepRun(violations, releaseFile, publish, "Create GitHub release", [
     "--notes-file target/release-assets/release-notes.md",
     'if [ "${#assets[@]}" -ne 7 ]; then',
+    "repos/$GITHUB_REPOSITORY/git/ref/heads/main",
+    '"$live_head" != "$GITHUB_SHA"',
+    "main moved from publishable head",
   ]);
   add(violations, !scalarStrings(release).some(value => value.includes("--generate-notes")), `${releaseFile} must use curated release notes`);
 
   const post = requireJob(violations, releaseFile, release, "post-publish-smoke");
+  add(violations, post.if === "inputs.publish_release", `${releaseFile} post-publish smoke must require trusted publication authority`);
   add(violations, post.uses === "./.github/workflows/post-publish-release-smoke.yml", `${releaseFile} must call post-publish smoke`);
   add(violations, sameMembers(needs(post), releaseChain.dependencies["post-publish-smoke"]), `${releaseFile} post-publish dependencies must match the release claim graph`);
   add(
@@ -1463,6 +1525,7 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     `${releaseFile} post-publish smoke must consume the accepted pre-publish ledger and emit authenticated cells`,
   );
   const postCloseout = requireJob(violations, releaseFile, release, "post-publish-closeout");
+  add(violations, postCloseout.if === "inputs.publish_release", `${releaseFile} post-publish closeout must require trusted publication authority`);
   add(violations, sameMembers(needs(postCloseout), releaseChain.dependencies["post-publish-closeout"]), `${releaseFile} post-publish closeout dependencies must match the release claim graph`);
   requireStepRun(violations, releaseFile, postCloseout, "Authenticate post-publish Actions provenance", [
     "producer-map",
@@ -2052,12 +2115,18 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     '.name == "full-source-gate" and .conclusion == "success"',
   ]);
   requireStepRun(violations, file, route, "Select change-aware proof scope", [
-    'if [ "$REQUESTED_SCOPE" = none ]; then',
-    "scope=none",
+    'if [ "$REQUESTED_SCOPE" = none ] || [ "$REQUESTED_SCOPE" = linux ]; then',
+    'scope="$REQUESTED_SCOPE"',
     "scope=full",
     'elif [ "$REQUESTED_SCOPE" = "server" ]; then',
     "node .github/scripts/route-ci-proof.mjs --stdin",
   ]);
+  add(
+    violations,
+    String(namedStep(route, "Select change-aware proof scope")?.run ?? "")
+      .includes('if [ "$REQUESTED_SCOPE" = none ] || [ "$REQUESTED_SCOPE" = linux ]; then'),
+    `${file} integration must preserve explicit hosted and Linux scopes`,
+  );
   requireStepRun(violations, file, route, "Read qualification constant-set state", [
     "base_frozen=false",
     "jq -r '.status == \"frozen\"'",
@@ -2255,6 +2324,7 @@ function validateRemainingWorkflows(workflows, violations) {
     add(violations, sameMembers(needs(release), ["detect-version"]), `${autoFile} release must need version detection`);
     add(violations, object(release.permissions).contents === "write", `${autoFile} release caller must grant contents write`);
     add(violations, object(release.permissions).actions === "read", `${autoFile} release caller must grant actions read`);
+    add(violations, object(release.with).publish_release === true, `${autoFile} trusted main caller must explicitly authorize publication`);
   }
 
   const evidenceFile = "release-candidate-evidence.yml";

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -109,6 +109,29 @@ esac
   });
 }
 
+function runReleaseAuthority(environment, liveSha = fullSha) {
+  const workflow = loadWorkflows().get("release.yml");
+  const run = draftStep(workflow.jobs.preflight, "Validate release authority").run;
+  const quote = value => `'${String(value).replaceAll("'", `'"'"'`)}'`;
+  const exports = Object.entries({
+    GH_TOKEN: "test-token",
+    GITHUB_REPOSITORY: "TheGreenCedar/CodeStory",
+    ...environment,
+  })
+    .map(([key, value]) => `export ${key}=${quote(value)}`)
+    .join("\n");
+  const command = `gh() { printf '%s\\n' ${quote(liveSha)}; }
+${exports}
+${run}`;
+  const executable = process.platform === "win32" ? "wsl.exe" : "bash";
+  const args = process.platform === "win32"
+    ? ["--exec", "/bin/bash", "-c", command]
+    : ["-c", command];
+  return spawnSync(executable, args, {
+    encoding: "utf8",
+  });
+}
+
 function windowsManifestJob(workflow) {
   return workflow.jobs["windows-manifest-missing"];
 }
@@ -239,6 +262,61 @@ jobs:
   const invalid = structuredClone(valid);
   invalid.jobs.check.steps[0].uses = "vendor/action@main";
   assert.match(basicWorkflowViolations("fixture.yml", invalid).join("\n"), /full-length SHA/u);
+});
+
+test("release authority accepts only exact live auto-main or manual-dev routes", async (t) => {
+  const auto = {
+    EXPECTED_HEAD_SHA: "",
+    GITHUB_EVENT_NAME: "push",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_SHA: fullSha,
+    GITHUB_WORKFLOW_REF: "TheGreenCedar/CodeStory/.github/workflows/auto-release.yml@refs/heads/main",
+    PUBLISH_RELEASE: "true",
+  };
+  const manual = {
+    EXPECTED_HEAD_SHA: fullSha,
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_REF: "refs/heads/dev/codestory-next",
+    GITHUB_SHA: fullSha,
+    GITHUB_WORKFLOW_REF: "TheGreenCedar/CodeStory/.github/workflows/release.yml@refs/heads/dev/codestory-next",
+    PUBLISH_RELEASE: "",
+  };
+
+  await t.test("trusted auto push on live main", () => {
+    const result = runReleaseAuthority(auto);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  });
+  await t.test("manual proof on exact live dev", () => {
+    const result = runReleaseAuthority(manual);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  });
+  await t.test("manual event cannot claim publication", () => {
+    const result = runReleaseAuthority({ ...manual, PUBLISH_RELEASE: "true" });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /Publication authority requires the trusted reusable-workflow caller/u);
+  });
+  await t.test("wrong automatic caller is rejected", () => {
+    const result = runReleaseAuthority({
+      ...auto,
+      GITHUB_WORKFLOW_REF: "TheGreenCedar/CodeStory/.github/workflows/rogue.yml@refs/heads/main",
+    });
+    assert.notEqual(result.status, 0);
+  });
+  await t.test("stale main is rejected", () => {
+    const result = runReleaseAuthority(auto, "2".repeat(40));
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /main moved from release head/u);
+  });
+  await t.test("wrong manual SHA is rejected", () => {
+    const result = runReleaseAuthority({ ...manual, EXPECTED_HEAD_SHA: "2".repeat(40) });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /does not match workflow head/u);
+  });
+  await t.test("stale dev is rejected", () => {
+    const result = runReleaseAuthority(manual, "2".repeat(40));
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /dev\/codestory-next moved from proved head/u);
+  });
 });
 
 test("proof resolvers reject hostile refs, SHAs, and labeled-event drift before proof work", async (t) => {
@@ -479,6 +557,10 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
       workflow.on.workflow_dispatch.inputs.scope.options
         = workflow.on.workflow_dispatch.inputs.scope.options.filter(scope => scope !== "none");
     }, /dispatch scopes changed/u],
+    ["exact integration Linux scope removed", packagedCoordinatorFile, workflow => {
+      const step = draftStep(workflow.jobs.route, "Select change-aware proof scope");
+      step.run = step.run.replace(' || [ "$REQUESTED_SCOPE" = linux ]', "");
+    }, /integration must preserve explicit hosted and Linux scopes/u],
     ["hosted-only release evidence guard removed", packagedCoordinatorFile, workflow => {
       workflow.jobs["release-evidence"].if
         = workflow.jobs["release-evidence"].if.replace("needs.route.outputs.scope != 'none' &&", "");
@@ -1510,6 +1592,45 @@ test("controlled semantic workflow fixtures emit class-prefixed diagnostics", as
 
 test("release policy rejects manifest producer, trusted-map, and publication bypasses", () => {
   const mutations = [
+    ["call expected head", workflows => { delete workflows.get("release.yml").on.workflow_call.inputs.expected_head_sha; }],
+    ["call publication default", workflows => { workflows.get("release.yml").on.workflow_call.inputs.publish_release.default = true; }],
+    ["manual expected head", workflows => { workflows.get("release.yml").on.workflow_dispatch.inputs.expected_head_sha.required = false; }],
+    ["manual publication authority", workflows => {
+      workflows.get("release.yml").on.workflow_dispatch.inputs.publish_release = {
+        required: false,
+        type: "boolean",
+        default: false,
+      };
+    }],
+    ["release authority guard", workflows => {
+      const step = workflows.get("release.yml").jobs.preflight.steps
+        .find(({ name }) => name === "Validate release authority");
+      step.run = step.run.replace("dev/codestory-next moved from proved head", "dev head changed");
+    }],
+    ["automatic caller event", workflows => {
+      const step = workflows.get("release.yml").jobs.preflight.steps
+        .find(({ name }) => name === "Validate release authority");
+      step.run = step.run.replace('"$GITHUB_EVENT_NAME" != "push"', '"$GITHUB_EVENT_NAME" != "workflow_call"');
+    }],
+    ["accepted dev ledger revalidation", workflows => {
+      workflows.get("release.yml").jobs["pre-publish-closeout"].steps = workflows
+        .get("release.yml").jobs["pre-publish-closeout"].steps
+        .filter(({ name }) => name !== "Revalidate proof-only dev head");
+    }],
+    ["publish-time main revalidation", workflows => {
+      const step = workflows.get("release.yml").jobs.publish.steps
+        .find(({ name }) => name === "Create GitHub release");
+      step.run = step.run.replace("main moved from publishable head", "main changed");
+    }],
+    ["publish authority", workflows => { delete workflows.get("release.yml").jobs.publish.if; }],
+    ["post-publish smoke authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-smoke"].if; }],
+    ["post-publish closeout authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-closeout"].if; }],
+    ["trusted caller opt-in", workflows => { delete workflows.get("auto-release.yml").jobs.release.with.publish_release; }],
+    ["rogue release caller", workflows => {
+      workflows.get("plugin-static.yml").jobs["rogue-release"] = {
+        uses: "./.github/workflows/release.yml",
+      };
+    }],
     ["source emission", workflows => { delete workflows.get("release.yml").jobs["source-proof"].with.emit_release_cells; }],
     ["full rerun preflight guard", workflows => {
       workflows.get("release.yml").jobs.preflight.steps = workflows

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -101,3 +101,4 @@ jobs:
       version: ${{ needs.detect-version.outputs.version }}
       calibration_bundle_artifact: ${{ vars.CODESTORY_CALIBRATION_BUNDLE_ARTIFACT }}
       calibration_bundle_run_id: ${{ vars.CODESTORY_CALIBRATION_BUNDLE_RUN_ID }}
+      publish_release: true

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -230,8 +230,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ steps.resolve.outputs.mode }}" = "integration" ]; then
-            if [ "$REQUESTED_SCOPE" = none ]; then
-              scope=none
+            if [ "$REQUESTED_SCOPE" = none ] || [ "$REQUESTED_SCOPE" = linux ]; then
+              scope="$REQUESTED_SCOPE"
             else
               scope=full
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,24 @@ on:
         description: "Workflow run that produced the frozen calibration bundle artifact"
         required: true
         type: string
+      expected_head_sha:
+        description: "Optional exact head required by proof-only callers"
+        required: false
+        type: string
+        default: ""
+      publish_release:
+        description: "Trusted caller authority to publish after pre-publish closeout"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       version:
         description: "Release version from crates/codestory-cli/Cargo.toml, for example 0.7.0"
+        required: true
+        type: string
+      expected_head_sha:
+        description: "Exact dev/codestory-next head to authenticate without publishing"
         required: true
         type: string
       source_run_id:
@@ -92,11 +106,39 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Refuse non-main release
+      - name: Validate release authority
+        env:
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_RELEASE: ${{ inputs.publish_release }}
         run: |
           set -euo pipefail
-          if [ "$GITHUB_REF_NAME" != "main" ]; then
-            echo "::error::Run releases from main, not $GITHUB_REF_NAME."
+
+          if [ "$PUBLISH_RELEASE" = "true" ]; then
+            expected_caller="$GITHUB_REPOSITORY/.github/workflows/auto-release.yml@refs/heads/main"
+            if [ "$GITHUB_EVENT_NAME" != "push" ] || [ "$GITHUB_REF" != "refs/heads/main" ] || [ "$GITHUB_WORKFLOW_REF" != "$expected_caller" ]; then
+              echo "::error::Publication authority requires the trusted reusable-workflow caller on main."
+              exit 1
+            fi
+            live_head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)"
+            if [ "$live_head" != "$GITHUB_SHA" ]; then
+              echo "::error::main moved from release head $GITHUB_SHA to $live_head."
+              exit 1
+            fi
+            exit 0
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] || [ "$GITHUB_REF" != "refs/heads/dev/codestory-next" ]; then
+            echo "::error::Proof-only release runs require a manual dev/codestory-next dispatch."
+            exit 1
+          fi
+          if [ -z "$EXPECTED_HEAD_SHA" ] || [ "$EXPECTED_HEAD_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::Expected dev head $EXPECTED_HEAD_SHA does not match workflow head $GITHUB_SHA."
+            exit 1
+          fi
+          live_head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/dev/codestory-next" --jq .object.sha)"
+          if [ "$live_head" != "$GITHUB_SHA" ]; then
+            echo "::error::dev/codestory-next moved from proved head $GITHUB_SHA to $live_head."
             exit 1
           fi
 
@@ -294,6 +336,18 @@ jobs:
             --manifest-dir target/release-cell-manifests \
             --out-dir target/release-closeout/pre_publish
 
+      - name: Revalidate proof-only dev head
+        if: ${{ !inputs.publish_release }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          live_head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/dev/codestory-next" --jq .object.sha)"
+          if [ "$live_head" != "$GITHUB_SHA" ]; then
+            echo "::error::dev/codestory-next moved from accepted ledger head $GITHUB_SHA to $live_head."
+            exit 1
+          fi
+
       - name: Upload accepted pre-publish closeout
         if: success()
         uses: actions/upload-artifact@v7.0.1
@@ -308,6 +362,7 @@ jobs:
 
   publish:
     name: Publish GitHub release
+    if: inputs.publish_release
     needs:
       - preflight
       - pre-publish-closeout
@@ -392,6 +447,11 @@ jobs:
             printf '%s\n' "${assets[@]}"
             exit 1
           fi
+          live_head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)"
+          if [ "$live_head" != "$GITHUB_SHA" ]; then
+            echo "::error::main moved from publishable head $GITHUB_SHA to $live_head."
+            exit 1
+          fi
           gh release create "$TAG" "${assets[@]}" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
@@ -400,6 +460,7 @@ jobs:
 
   post-publish-smoke:
     name: Post-publish release asset smoke
+    if: inputs.publish_release
     needs:
       - preflight
       - publish
@@ -417,6 +478,7 @@ jobs:
 
   post-publish-closeout:
     name: Authenticate post-publish release cells
+    if: inputs.publish_release
     needs:
       - preflight
       - pre-publish-closeout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 - The proof coordinator now supports explicit hosted-only integration and
   Linux-only package scopes, so exact-head source, repo-scale, and Linux
   candidate evidence do not schedule unrelated protected-platform runners.
+- The release workflow can now authenticate the complete pre-publish ledger on
+  an exact manually selected `dev/codestory-next` head without granting publish
+  authority. Only the trusted automatic `main` caller can opt into publication.
 - A new explicit `retrieval republish-projections` writer can adopt the current
   semantic and dense-selection policy from one complete stored core without
   source discovery, parsing, or source-file reads. It validates the pinned

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -91,6 +91,9 @@ behavior changed. Intermediate commits do not append telemetry.
 Use the coordinator's explicit `none` scope for that final integration when
 only the hosted source and repo-scale gates are required; it deliberately skips
 package, release-evidence, and protected-hardware jobs.
+Use the explicit `linux` scope when the same exact final-dev integration should
+also build and exercise the Linux x64 candidate on its server-behavior-only
+boundary without scheduling Mac or Windows protected runners.
 
 Semantic document allocation changes use focused runtime proof before the
 broad gate. Cover shared-file path cardinality, byte-identical and
@@ -525,6 +528,23 @@ Release signing, notarization, post-publish quarantine/Gatekeeper checks,
 installed plugin readback, and live full retrieval run only from the main
 release workflow. No version bump, tag, signing, notarization, or release is
 part of ordinary remediation or embedding-engine PRs.
+
+Maintainers may manually dispatch `release.yml` from an exact
+`dev/codestory-next` SHA to authenticate the 12-cell pre-publish ledger without
+publishing. The required `expected_head_sha` must equal both the workflow SHA
+and the live dev branch head. Manual dispatch exposes no publication input;
+only the automatic reusable-workflow caller on the live `main` head passes the
+fail-closed publication authority used by publish and post-publish jobs.
+
+```text
+gh workflow run release.yml --ref dev/codestory-next \
+  -f version=<version> \
+  -f expected_head_sha=<exact-full-dev-sha> \
+  -f calibration_bundle_artifact=<artifact-name> \
+  -f calibration_bundle_run_id=<run-id>
+```
+
+There is intentionally no `publish_release` field on this manual command.
 
 ## Evidence reporting
 

--- a/docs/testing/per-user-embedding-server-qualification.md
+++ b/docs/testing/per-user-embedding-server-qualification.md
@@ -174,6 +174,8 @@ The explicit `linux` coordinator scope runs the existing Linux x64 package and
 candidate-installed proof without scheduling Mac or Windows protected jobs. It
 uses the same server-behavior-only claim boundary as `server`; it does not
 assert retrieval quality or satisfy separate protected-platform cells.
+It is valid for either an accepted platform-proof PR or an exact live
+`dev/codestory-next` integration dispatch.
 
 Frozen calibration bundles are accepted only from a successful
 `workflow_dispatch` run of `packaged-platform-pr.yml` in this repository. Every


### PR DESCRIPTION
## Context

The release workflow currently couples acceptance of the authenticated 12-cell pre-publish ledger directly to `gh release create`. That makes it impossible to prove the exact `dev/codestory-next` candidate without also granting publication authority. Promotion and publication remain explicitly unauthorized.

Closes #1367
Refs #1366
Refs #1233
Refs #1189

## What Changed

- Add a required exact-dev SHA to manual release dispatches, with no manual publication input.
- Allow the manual path only on the live `dev/codestory-next` head and revalidate that head immediately before uploading an accepted ledger.
- Add a fail-closed reusable-workflow `publish_release` input whose only checked-in caller is `auto-release.yml`.
- Require trusted publication to be the exact `auto-release.yml@refs/heads/main` push caller on the live main head, and revalidate main immediately before `gh release create`.
- Gate publish and both post-publish jobs on that trusted authority.
- Pin the authority surface with workflow policy, controlled mutations, and eight executable routing cases.
- Preserve the explicit Linux scope for exact final-dev integration, so the one frozen-head run can include Linux x64 candidate server-behavior proof without Mac, Windows, release-evidence, or publishing jobs.
- Document the non-publishing operator command and update the v0.16 changelog.

## How To Review

Start with `Validate release authority` in `release.yml`, then follow the late dev/main revalidation steps to the gated publish jobs. Confirm `workflow_dispatch` exposes no `publish_release` input and that `auto-release.yml` is the sole caller passing `true`. The policy validator and tests freeze those boundaries.

## Verification

- Eight authority behavior cases pass: trusted auto-main, exact manual-dev, manual publication rejection, rogue caller rejection, stale main rejection, wrong manual SHA rejection, and stale dev rejection.
- Publication/ledger workflow-policy mutation test passes.
- 40 exact-proof routing mutations pass, including removal of final-dev Linux integration reachability.
- CI proof routing self-tests pass.
- 56 release claim, manifest, closeout, and evidence tests pass.
- Workflow policy passes.
- actionlint harness and controlled-invalid fixture pass.
- Documentation link check passes: 75 files, 265 links.
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `git diff --check`
- Independent review found the caller-event and late-SHA revalidation gaps; corrected exact head `e4b08aa13035c0add0d73fe0bc306fce9a18dfb0` was re-reviewed against dev `1894a83f62f8627b9d4bcdef0ca880e8b31e6436` with no remaining findings. The final follow-up also received an exact-diff re-review confirming the live-dev Linux-only integration route and publication boundary.

The full local workflow-policy suite reports 249/255 because its existing five resolver cases invoke Windows `bash.exe` without propagating environment variables and lack `jq` (the parent suite is the sixth reported failure); all changed authority behavior and controlled-negative tests pass through the portable WSL/Linux harness.

## Risk

The source-level authority boundary is covered, but neither the proof-only release route nor the trusted automatic route has yet executed on GitHub-hosted infrastructure. The 12-cell ledger still requires all protected runners, secrets, and exact-head evidence; this change does not remove or weaken any claim cell. It creates no tag, release, marketplace update, or main-branch mutation.
