### PR TITLE
[codex] Extend x64 candidate proof timeout

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1654,6 +1654,11 @@ function validatePackagedProof(workflows, violations, graph) {
   const job = requireJob(violations, file, workflow, "build");
   add(
     violations,
+    job["timeout-minutes"] === "${{ inputs.calibration_mode && 180 || (inputs.candidate_installed_proof && (matrix.asset_target == 'linux-x64' || matrix.asset_target == 'windows-x64') && 120 || (inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60)) }}",
+    `${file} x64 candidate-installed package qualification must retain a bounded 120-minute timeout`,
+  );
+  add(
+    violations,
     at(workflow, "concurrency", "group") === "packaged-platform-proof-${{ github.sha }}-${{ inputs.ref }}-${{ inputs.proof_key || github.ref }}",
     `${file} concurrency must bind caller SHA, exact package SHA, and proof identity`,
   );

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1312,6 +1312,19 @@ test("Windows candidate-installed proof remains distinct and provenance-bound", 
   }
 });
 
+test("candidate-installed package qualification retains enough bounded job time", () => {
+  const workflows = loadWorkflows();
+  assert.deepEqual(validateWorkflows(workflows), []);
+
+  workflows.get("packaged-platform-proof.yml").jobs.build["timeout-minutes"] =
+    "${{ inputs.calibration_mode && 180 || (inputs.candidate_installed_proof && (matrix.asset_target == 'linux-x64' || matrix.asset_target == 'windows-x64') && 60 || (inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60)) }}";
+
+  assert.match(
+    validateWorkflows(workflows).join("\n"),
+    /x64 candidate-installed package qualification must retain a bounded 120-minute timeout/u,
+  );
+});
+
 test("draft source workflow freezes its complete top-level contract", async (t) => {
   assert.deepEqual(draftWorkflowPolicyViolations(draftSourceWorkflow()), []);
   const reordered = draftSourceWorkflow();

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -97,7 +97,7 @@ jobs:
     # The six APPLE_* credentials are an environment-scoped release contract;
     # repository-only secrets are not the supported signing configuration.
     environment: ${{ inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 'macos-release-signing' || null }}
-    timeout-minutes: ${{ inputs.calibration_mode && 180 || (inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60) }}
+    timeout-minutes: ${{ inputs.calibration_mode && 180 || (inputs.candidate_installed_proof && (matrix.asset_target == 'linux-x64' || matrix.asset_target == 'windows-x64') && 120 || (inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60)) }}
     strategy:
       fail-fast: false
       # GitHub applies matrix exclusions before includes, so an include-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
 - The proof coordinator now supports explicit hosted-only integration and
   Linux-only package scopes, so exact-head source, repo-scale, and Linux
   candidate evidence do not schedule unrelated protected-platform runners.
+- Candidate-installed package qualification now has a bounded 120-minute job
+  budget, preventing exact Linux and Windows proof from being cancelled by the
+  generic 60-minute package timeout after their expensive build and lifecycle
+  checks have already passed.
 - The release workflow can now authenticate the complete pre-publish ledger on
   an exact manually selected `dev/codestory-next` head without granting publish
   authority. Only the trusted automatic `main` caller can opt into publication.


### PR DESCRIPTION
## Context

Exact Linux integration run `29852648462` at `c0655d8e76be51082c95d210c3b0a953bb429b08` completed the source gate, repo-scale stats, Linux package build/smoke, hosted server proof, and candidate-installed server proof. The reusable package job then hit its generic 60-minute timeout during the final managed plugin handoff, so GitHub cancelled the job and closeout correctly rejected it.

Closes #1370.

## What Changed

- Give Linux x64 and Windows x64 package jobs with `candidate_installed_proof=true` a bounded 120-minute timeout.
- Preserve the existing 180-minute calibration timeout, 90-minute signed-Mac timeout, and 60-minute ordinary package timeout.
- Add a workflow-policy invariant and mutation test so the candidate-installed runway cannot silently regress.
- Record the release-automation correction in the v0.16 changelog.

## How To Review

1. Confirm the timeout expression selects 180 minutes for calibration first, then 120 minutes for candidate-installed proof, then the unchanged signing/ordinary fallbacks.
2. Confirm the policy parser requires that exact bounded expression.
3. Confirm the mutation test weakens only the candidate-installed branch and is rejected.

## Verification

- `node .github/scripts/check-workflow-policy.mjs`
- `node --test --test-name-pattern "candidate-installed package qualification retains enough bounded job time" .github/scripts/check-workflow-policy.test.mjs`
- `node .github/scripts/run-actionlint.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- Full local Windows policy suite: 251/257 passed. The six unchanged resolver-harness cases fail because WSL `/bin/bash` cannot find `jq` and therefore emits no expected `--ref`; focused changed coverage passes.

No screenshot-visible UI changed.

## Risk

The larger bound applies only when the coordinator explicitly enables candidate-installed proof for Linux x64 or Windows x64. It does not lengthen ARM/macOS matrix cells, make a failed proof optional, change any proof tier or claim, grant publication permission, or alter ordinary package, calibration, or signed-Mac timeout selection. The remaining proof is an exact-head rerun through green closeout.
