### PR TITLE
[codex] Let Windows-only qualification run without Mac evidence

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1451,7 +1451,8 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(violations, object(vulkan.with).emit_release_cells === true, `${releaseFile} Vulkan proof must emit its authenticated release cell`);
   add(
     violations,
-    object(vulkan.with).candidate_installed_proof === undefined,
+    object(vulkan.with).candidate_installed_proof === undefined
+      && object(vulkan.with).server_behavior_only === undefined,
     `${releaseFile} must leave pre-merge Windows candidate-installed proof to the PR coordinator`,
   );
 
@@ -2244,6 +2245,11 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     object(packaged.with).candidate_installed_proof === true,
     `${file} must opt the accepted PR package into candidate-installed proof`,
   );
+  add(
+    violations,
+    String(packaged.if ?? "").includes("needs.route.outputs.scope == 'windows'"),
+    `${file} Windows server-behavior package proof must accept skipped protected release evidence`,
+  );
   violations.push(...packagedPrSigningViolations(workflow));
   const metal = requireJob(violations, file, workflow, "macos-metal-proof");
   add(
@@ -2275,6 +2281,18 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     object(vulkan.with).candidate_installed_proof === true,
     `${file} must opt the accepted PR Windows package into candidate-installed proof`,
   );
+  add(
+    violations,
+    object(vulkan.with).quality_evidence_artifact
+      === "${{ needs.release-evidence.result == 'success' && format('release-evidence-{0}', needs.route.outputs.head_sha) || '' }}",
+    `${file} Windows quality evidence must come only from the successful protected producer`,
+  );
+  add(
+    violations,
+    object(vulkan.with).server_behavior_only
+      === "${{ needs.route.outputs.scope == 'windows' }}",
+    `${file} must select the non-quality Windows claim only for Windows scope`,
+  );
   const closeout = requireJob(violations, file, workflow, "closeout");
   const evidence = requireJob(violations, file, workflow, "release-evidence");
   add(
@@ -2287,9 +2305,15 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     String(evidence.if ?? "").includes("needs.route.outputs.scope != 'linux'"),
     `${file} Linux server-behavior proof must not require protected release evidence`,
   );
+  add(
+    violations,
+    String(evidence.if ?? "").includes("needs.route.outputs.scope != 'windows'"),
+    `${file} Windows server-behavior proof must not require protected release evidence`,
+  );
   requireStepRun(violations, file, closeout, "Require one coherent accepted proof", [
     '[ "$SCOPE" != none ]',
     '[ "$SCOPE" = linux ]',
+    '[ "$SCOPE" != windows ]',
     "dev/codestory-next moved from proved head",
   ]);
   add(violations, !scalarStrings(workflow).some(value => value === "./.github/workflows/release.yml"), `${file} must not publish releases`);
@@ -2489,6 +2513,20 @@ function validateRemainingWorkflows(workflows, violations) {
         && candidateInput.default === false,
       `${vulkanFile} candidate-installed proof must be an explicit opt-in`,
     );
+    const serverBehaviorInput = object(at(
+      vulkan,
+      "on",
+      "workflow_call",
+      "inputs",
+      "server_behavior_only",
+    ));
+    add(
+      violations,
+      serverBehaviorInput.required === false
+        && serverBehaviorInput.type === "boolean"
+        && serverBehaviorInput.default === false,
+      `${vulkanFile} server-behavior-only claim scope must be an explicit opt-in`,
+    );
     const job = requireJob(violations, vulkanFile, vulkan, "packaged-vulkan");
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
@@ -2525,14 +2563,17 @@ function validateRemainingWorkflows(workflows, violations) {
       "--offline",
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
+      "--server-behavior-only",
+      "Test-Path $qualityPath",
     ]);
     add(violations, object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${vulkanFile} engine proof must reject CPU fallback`);
     const candidateStage = namedStep(job, "Stage isolated candidate-managed Windows install");
     add(
       violations,
       String(candidateStage?.if ?? "").includes("inputs.candidate_installed_proof")
+        && String(candidateStage?.if ?? "").includes("inputs.server_behavior_only")
         && String(candidateStage?.if ?? "").includes("inputs.quality_evidence_artifact"),
-      `${vulkanFile} candidate-managed staging must require coordinator opt-in and exact-head quality evidence`,
+      `${vulkanFile} candidate-managed staging must require coordinator opt-in and remain runnable in Windows server scope`,
     );
     requireStepRun(violations, vulkanFile, job, "Stage isolated candidate-managed Windows install", [
       "--prepare-candidate-installed-proof",
@@ -2550,8 +2591,9 @@ function validateRemainingWorkflows(workflows, violations) {
     add(
       violations,
       String(candidateProof?.if ?? "").includes("inputs.candidate_installed_proof")
+        && String(candidateProof?.if ?? "").includes("inputs.server_behavior_only")
         && String(candidateProof?.if ?? "").includes("inputs.quality_evidence_artifact"),
-      `${vulkanFile} candidate-installed proof must require coordinator opt-in and exact-head quality evidence`,
+      `${vulkanFile} candidate-installed proof must require coordinator opt-in and remain runnable in Windows server scope`,
     );
     requireStepRun(violations, vulkanFile, job, "Prove two-host candidate-installed Windows runtime", [
       "--proof-tier installed_runtime",
@@ -2565,6 +2607,8 @@ function validateRemainingWorkflows(workflows, violations) {
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
       "--retrieval-quality-evidence",
+      "--server-behavior-only",
+      "Test-Path $qualityPath",
       "--expected-source-sha",
       "--expected-source-tree",
       "$env:CODESTORY_CANDIDATE_WINDOWS_ROOT",
@@ -2580,6 +2624,7 @@ function validateRemainingWorkflows(workflows, violations) {
       candidateUpload?.uses === "actions/upload-artifact@v7.0.1"
         && String(candidateUpload?.if ?? "").includes("always()")
         && String(candidateUpload?.if ?? "").includes("inputs.candidate_installed_proof")
+        && String(candidateUpload?.if ?? "").includes("inputs.server_behavior_only")
         && object(candidateUpload?.with).name
           === "candidate-installed-windows-${{ inputs.version }}-attempt-${{ github.run_attempt }}"
         && object(candidateUpload?.with).path === "target/candidate-installed-windows"
@@ -2591,12 +2636,19 @@ function validateRemainingWorkflows(workflows, violations) {
       "accelerator_execution:windows-x64-vulkan",
       "--producer-job packaged-vulkan",
     ]);
+    const releaseCell = namedStep(job, "Emit authenticated Vulkan release cell");
+    add(
+      violations,
+      releaseCell?.if === "inputs.emit_release_cells && !inputs.server_behavior_only",
+      `${vulkanFile} server-behavior-only proof must never emit a release cell`,
+    );
     const vulkanCellUpload = namedStep(job, "Upload authenticated Vulkan release cell");
     add(
       violations,
       vulkanCellUpload?.uses === "actions/upload-artifact@v7.0.1"
         && String(vulkanCellUpload?.if ?? "").includes("success()")
-        && String(vulkanCellUpload?.if ?? "").includes("inputs.emit_release_cells"),
+        && String(vulkanCellUpload?.if ?? "").includes("inputs.emit_release_cells")
+        && String(vulkanCellUpload?.if ?? "").includes("!inputs.server_behavior_only"),
       `${vulkanFile} Vulkan release cell must be a success-only retained artifact`,
     );
   }

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -569,6 +569,18 @@ test("exact proof policy rejects trigger, identity, and cache downgrades", async
       workflow.jobs["release-evidence"].if
         = workflow.jobs["release-evidence"].if.replace("needs.route.outputs.scope != 'linux' &&", "");
     }, /Linux server-behavior proof must not require protected release evidence/u],
+    ["Windows release evidence guard removed", packagedCoordinatorFile, workflow => {
+      workflow.jobs["release-evidence"].if
+        = workflow.jobs["release-evidence"].if.replace("needs.route.outputs.scope != 'windows' &&", "");
+    }, /Windows server-behavior proof must not require protected release evidence/u],
+    ["Windows package remains blocked on release evidence", packagedCoordinatorFile, workflow => {
+      workflow.jobs["packaged-proof"].if
+        = workflow.jobs["packaged-proof"].if.replace("needs.route.outputs.scope == 'windows'", "needs.route.outputs.scope == 'full'");
+    }, /Windows server-behavior package proof must accept skipped protected release evidence/u],
+    ["Windows closeout still requires release evidence", packagedCoordinatorFile, workflow => {
+      const step = draftStep(workflow.jobs.closeout, "Require one coherent accepted proof");
+      step.run = step.run.replace(' && [ "$SCOPE" != windows ]', "");
+    }, /Require one coherent accepted proof/u],
     ["Linux package matrix scope removed", packagedProofFile, workflow => {
       workflow.jobs.build.strategy.matrix
         = workflow.jobs.build.strategy.matrix.replace("inputs.scope == 'linux'", "inputs.scope == 'windows'");
@@ -1268,12 +1280,29 @@ test("Windows candidate-installed proof remains distinct and provenance-bound", 
     ["coordinator opt-in removed", coordinatorFile, workflow => {
       delete workflow.jobs["windows-vulkan-proof"].with.candidate_installed_proof;
     }, /accepted PR Windows package into candidate-installed proof/u],
+    ["coordinator server-only scope removed", coordinatorFile, workflow => {
+      delete workflow.jobs["windows-vulkan-proof"].with.server_behavior_only;
+    }, /non-quality Windows claim only for Windows scope/u],
+    ["coordinator quality artifact bypasses producer result", coordinatorFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].with.quality_evidence_artifact
+        = "${{ needs.route.outputs.constants_frozen == 'true' && format('release-evidence-{0}', needs.route.outputs.head_sha) || '' }}";
+    }, /Windows quality evidence must come only from the successful protected producer/u],
     ["release enables pre-merge proof", releaseFile, workflow => {
       workflow.jobs["windows-vulkan-proof"].with.candidate_installed_proof = true;
+    }, /leave pre-merge Windows candidate-installed proof/u],
+    ["release enables server-only proof", releaseFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].with.server_behavior_only = true;
     }, /leave pre-merge Windows candidate-installed proof/u],
     ["explicit opt-in removed", protectedFile, workflow => {
       delete workflow.on.workflow_call.inputs.candidate_installed_proof;
     }, /candidate-installed proof must be an explicit opt-in/u],
+    ["server-only opt-in removed", protectedFile, workflow => {
+      delete workflow.on.workflow_call.inputs.server_behavior_only;
+    }, /server-behavior-only claim scope must be an explicit opt-in/u],
+    ["candidate staging loses server-only route", protectedFile, workflow => {
+      candidateStage(workflow).if = candidateStage(workflow).if
+        .replace("inputs.server_behavior_only || ", "");
+    }, /candidate-managed staging must require coordinator opt-in and remain runnable in Windows server scope/u],
     ["candidate staging bypassed", protectedFile, workflow => {
       candidateStage(workflow).run = candidateStage(workflow).run
         .replace("--prepare-candidate-installed-proof", "--version-only");
@@ -1281,6 +1310,14 @@ test("Windows candidate-installed proof remains distinct and provenance-bound", 
     ["candidate tier weakened", protectedFile, workflow => {
       candidateProof(workflow).run = candidateProof(workflow).run
         .replace("--proof-tier installed_runtime", "--proof-tier protected_hardware");
+    }, /Prove two-host candidate-installed Windows runtime/u],
+    ["candidate proof loses server-only route", protectedFile, workflow => {
+      candidateProof(workflow).if = candidateProof(workflow).if
+        .replace("inputs.server_behavior_only || ", "");
+    }, /candidate-installed proof must require coordinator opt-in and remain runnable in Windows server scope/u],
+    ["candidate server-only claim removed", protectedFile, workflow => {
+      candidateProof(workflow).run = candidateProof(workflow).run
+        .replace("--server-behavior-only", "--version-only");
     }, /Prove two-host candidate-installed Windows runtime/u],
     ["candidate cell relabeled", protectedFile, workflow => {
       candidateProof(workflow).run = candidateProof(workflow).run
@@ -1299,6 +1336,10 @@ test("Windows candidate-installed proof remains distinct and provenance-bound", 
     ["candidate artifact loses attempt identity", protectedFile, workflow => {
       candidateUpload(workflow).with.name = "candidate-installed-windows-${{ inputs.version }}";
     }, /attempt-scoped artifact/u],
+    ["server-only proof emits release cell", protectedFile, workflow => {
+      draftStep(workflow.jobs["packaged-vulkan"], "Emit authenticated Vulkan release cell").if
+        = "inputs.emit_release_cells";
+    }, /server-behavior-only proof must never emit a release cell/u],
   ];
 
   for (const [name, file, mutate, expectedReason] of mutations) {

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -458,6 +458,7 @@ jobs:
       (needs.route.outputs.mode != 'calibration' &&
        needs.route.outputs.scope != 'server' &&
        needs.route.outputs.scope != 'linux' &&
+       needs.route.outputs.scope != 'windows' &&
        needs.route.outputs.scope != 'none' &&
        needs.route.outputs.constants_frozen == 'true')
     needs: route
@@ -487,7 +488,8 @@ jobs:
       (needs.release-evidence.result == 'success' ||
        ((needs.route.outputs.constants_frozen != 'true' ||
          needs.route.outputs.scope == 'server' ||
-         needs.route.outputs.scope == 'linux') &&
+         needs.route.outputs.scope == 'linux' ||
+         needs.route.outputs.scope == 'windows') &&
         needs.release-evidence.result == 'skipped'))
     needs:
       - route
@@ -545,10 +547,11 @@ jobs:
       ref: ${{ needs.route.outputs.head_sha }}
       proof_key: ${{ needs.route.outputs.proof_key }}
       use_packaged_cli_artifact: true
-      quality_evidence_artifact: ${{ needs.route.outputs.constants_frozen == 'true' && format('release-evidence-{0}', needs.route.outputs.head_sha) || '' }}
+      quality_evidence_artifact: ${{ needs.release-evidence.result == 'success' && format('release-evidence-{0}', needs.route.outputs.head_sha) || '' }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact || '' }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id || '' }}
       candidate_installed_proof: true
+      server_behavior_only: ${{ needs.route.outputs.scope == 'windows' }}
 
   closeout:
     if: >-
@@ -593,7 +596,7 @@ jobs:
           }
           require_result "$ROUTE_RESULT" success routing
           require_result "$STATS_RESULT" success repo-scale-stats
-          if [ "$CONSTANTS_FROZEN" = true ] && [ "$SCOPE" != server ] && [ "$SCOPE" != linux ] && [ "$SCOPE" != none ]; then
+          if [ "$CONSTANTS_FROZEN" = true ] && [ "$SCOPE" != server ] && [ "$SCOPE" != linux ] && [ "$SCOPE" != windows ] && [ "$SCOPE" != none ]; then
             require_result "$EVIDENCE_RESULT" success release-evidence
           else
             require_result "$EVIDENCE_RESULT" skipped release-evidence

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -34,6 +34,11 @@ on:
         required: false
         default: false
         type: boolean
+      server_behavior_only:
+        description: Prove bounded server behavior without making packet-quality or release-readiness claims.
+        required: false
+        default: false
+        type: boolean
       emit_release_cells:
         required: false
         default: false
@@ -60,6 +65,11 @@ on:
         type: string
       candidate_installed_proof:
         description: Stage and qualify the exact package through the private candidate-managed launcher boundary.
+        required: false
+        default: false
+        type: boolean
+      server_behavior_only:
+        description: Prove bounded server behavior without making packet-quality or release-readiness claims.
         required: false
         default: false
         type: boolean
@@ -184,7 +194,9 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "0"
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
         run: |
+          $ErrorActionPreference = "Stop"
           $version = $env:VERSION.TrimStart('v')
           $sourceSha = (git rev-parse HEAD).Trim()
           $sourceTree = (git rev-parse 'HEAD^{tree}').Trim()
@@ -194,10 +206,19 @@ jobs:
           if ($calibrationBundles.Count -ne 1) {
             throw "expected exactly one frozen calibration-bundle.json"
           }
-          $qualityArgs = @()
+          $claimArgs = @()
           $qualityPath = "target/release-quality-evidence/packet/packet-runtime-summary.json"
-          if (Test-Path $qualityPath) {
-            $qualityArgs = @("--retrieval-quality-evidence", $qualityPath)
+          if ($env:SERVER_BEHAVIOR_ONLY -eq "true") {
+            $claimArgs = @("--server-behavior-only")
+          } else {
+            if (-not (Test-Path $qualityPath)) {
+              throw "protected Windows proof requires exact-head quality evidence"
+            }
+            $claimArgs = @(
+              "--produce-qualification-evidence",
+              "--qualification-evidence", "target/windows-vulkan-proof/qualification.json",
+              "--retrieval-quality-evidence", $qualityPath
+            )
           }
           python .github/scripts/check-packaged-agent-proof.py `
             --archive "target/release-dist/codestory-cli-v$version-windows-x64.zip" `
@@ -211,19 +232,17 @@ jobs:
             --offline `
             --proof-tier protected_hardware `
             --qualification-matrix-cell protected_windows_x64_vulkan `
-            --produce-qualification-evidence `
-            --qualification-evidence target/windows-vulkan-proof/qualification.json `
+            @claimArgs `
             --calibration-bundle $calibrationBundles[0].FullName `
             --calibration-producer-run-id "${{ inputs.calibration_bundle_run_id }}" `
             --calibration-producer-artifact "${{ inputs.calibration_bundle_artifact }}" `
             --expected-source-sha $sourceSha `
             --expected-source-tree $sourceTree `
-            @qualityArgs `
             --timeout-secs 1800 `
             --out-dir target/windows-vulkan-proof/packaged-agent
 
       - name: Stage isolated candidate-managed Windows install
-        if: ${{ inputs.candidate_installed_proof && inputs.quality_evidence_artifact != '' }}
+        if: ${{ inputs.candidate_installed_proof && (inputs.server_behavior_only || inputs.quality_evidence_artifact != '') }}
         shell: pwsh
         env:
           VERSION: ${{ inputs.version }}
@@ -262,7 +281,7 @@ jobs:
             --candidate-artifact-name (Split-Path -Leaf $archive)
 
       - name: Prove two-host candidate-installed Windows runtime
-        if: ${{ inputs.candidate_installed_proof && inputs.quality_evidence_artifact != '' }}
+        if: ${{ inputs.candidate_installed_proof && (inputs.server_behavior_only || inputs.quality_evidence_artifact != '') }}
         shell: pwsh
         env:
           VERSION: ${{ inputs.version }}
@@ -280,8 +299,18 @@ jobs:
             throw "expected exactly one frozen calibration-bundle.json"
           }
           $qualityPath = "target/release-quality-evidence/packet/packet-runtime-summary.json"
-          if (-not (Test-Path $qualityPath)) {
-            throw "candidate-installed Windows proof requires exact-head quality evidence"
+          $claimArgs = @()
+          if ("${{ inputs.server_behavior_only }}" -eq "true") {
+            $claimArgs = @("--server-behavior-only")
+          } else {
+            if (-not (Test-Path $qualityPath)) {
+              throw "candidate-installed Windows proof requires exact-head quality evidence"
+            }
+            $claimArgs = @(
+              "--produce-qualification-evidence",
+              "--qualification-evidence", "target/candidate-installed-windows/qualification.json",
+              "--retrieval-quality-evidence", $qualityPath
+            )
           }
           $pluginRoot = Join-Path $env:CODESTORY_CANDIDATE_WINDOWS_ROOT "plugin"
           $pluginData = Join-Path $env:CODESTORY_CANDIDATE_WINDOWS_ROOT "data"
@@ -297,12 +326,10 @@ jobs:
             --offline `
             --proof-tier installed_runtime `
             --qualification-matrix-cell candidate_installed_windows_x64_cpu `
-            --produce-qualification-evidence `
-            --qualification-evidence target/candidate-installed-windows/qualification.json `
+            @claimArgs `
             --calibration-bundle $calibrationBundles[0].FullName `
             --calibration-producer-run-id "${{ inputs.calibration_bundle_run_id }}" `
             --calibration-producer-artifact "${{ inputs.calibration_bundle_artifact }}" `
-            --retrieval-quality-evidence $qualityPath `
             --installed-plugin-source candidate `
             --installed-plugin-provenance target/candidate-installed-windows/provenance.json `
             --installed-plugin-data $pluginData `
@@ -317,7 +344,7 @@ jobs:
             --out-dir target/candidate-installed-windows/proof
 
       - name: Upload candidate-installed Windows proof
-        if: always() && inputs.candidate_installed_proof && inputs.quality_evidence_artifact != ''
+        if: always() && inputs.candidate_installed_proof && (inputs.server_behavior_only || inputs.quality_evidence_artifact != '')
         uses: actions/upload-artifact@v7.0.1
         with:
           name: candidate-installed-windows-${{ inputs.version }}-attempt-${{ github.run_attempt }}
@@ -326,7 +353,7 @@ jobs:
           retention-days: 30
 
       - name: Emit authenticated Vulkan release cell
-        if: inputs.emit_release_cells
+        if: inputs.emit_release_cells && !inputs.server_behavior_only
         shell: bash
         run: |
           set -euo pipefail
@@ -354,7 +381,7 @@ jobs:
             --out target/release-cells/accelerator_execution-windows-x64-vulkan.json
 
       - name: Upload authenticated Vulkan release cell
-        if: success() && inputs.emit_release_cells
+        if: success() && inputs.emit_release_cells && !inputs.server_behavior_only
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-cell-prepublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Release
+
+- Windows-only pre-publish qualification now skips unavailable ARM64 release
+  evidence and retains protected Vulkan and candidate-installed provenance under
+  an explicit server-behavior-only non-claim. Full release qualification remains
+  strict and still requires exact-head quality evidence.
+
 ## 0.16.0
 
 CodeStory 0.16 makes repository search more accurate and reduces duplicate model memory across agents and projects. The model and embedding engine ship inside CodeStory, compatible processes share one private local server, and startup, readiness, and idle shutdown happen automatically.


### PR DESCRIPTION
## Context

Exact Windows-only run `29866189303` accepted the frozen source and calibration producers at `d81bba4d49df9582b94e24a38f48e7a6284c9a65`, then blocked on the offline Mac-hosted Linux ARM64 release-evidence runner before scheduling the online protected Windows/Vulkan runner.

Closes #1372.

## What Changed

- Treat explicit `scope=windows` as a bounded server-behavior lane that skips the protected ARM64 quality producer.
- Pass no quality artifact unless the release-evidence producer actually succeeded.
- Run protected Vulkan and candidate-installed Windows proof with `--server-behavior-only`, while retaining calibration, exact-source, package, and candidate provenance.
- Prevent server-behavior-only proof from emitting an authenticated release cell.
- Keep full coordinator and `release.yml` callers strict: they still require exact-head quality evidence and do not opt into the bounded claim.
- Add workflow policy and mutation coverage for every routing and non-claim boundary.

## How To Review

1. Follow `scope=windows` through `packaged-platform-pr.yml`: release evidence must skip, package and Vulkan must run, and closeout must require the skipped/success results.
2. Review `windows-vulkan-proof.yml`: server behavior rejects quality/qualification inputs; normal full-release behavior still requires them.
3. Confirm `release.yml` supplies neither candidate-installed nor server-behavior-only inputs and still emits authenticated release cells.
4. Review the mutation tests that remove each boundary and must fail policy validation.

## Verification

- `node .github/scripts/check-workflow-policy.mjs`
- `node --test --test-name-pattern "exact proof policy|Windows candidate-installed|candidate-installed package" .github/scripts/check-workflow-policy.test.mjs` (62 passed)
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `git diff --check`
- Live exact-head Windows-only proof required after review and merge.

The unfiltered policy test command also ran. Its policy and mutation cases passed; six pre-existing resolver harness cases failed because the Windows host's Bash environment has no `jq`. Those harness failures do not exercise this diff.

## Risk

The first live Windows-only coordinator run remains the decisive proof. This change deliberately makes no answer-quality, release-readiness, authenticated-ledger, Mac/Metal, marketplace, post-publish, promotion, or publication claim. Full release qualification remains unchanged and strict.
