### PR TITLE
[codex] Shorten hosted Windows package build paths

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1693,19 +1693,33 @@ function validatePackagedProof(workflows, violations, graph) {
     );
   }
   const packageRestore = namedStep(job, "Restore Cargo registry, git sources, and build output");
+  const shortWindowsTarget = namedStep(job, "Configure short Windows Cargo target");
   const installRustIndex = packageSteps.findIndex(step => step.name === "Install pinned Rust");
   const nativeIdentityIndex = packageSteps.findIndex(step => step.name === "Capture Rust cache key");
+  const shortWindowsTargetIndex = packageSteps.findIndex(step => step.name === "Configure short Windows Cargo target");
   const packageRestoreIndex = packageSteps.findIndex(step => step.name === "Restore Cargo registry, git sources, and build output");
   const packageBuildIndex = packageSteps.findIndex(step => step.name === "Build codestory-cli");
   const linuxBuildIndex = packageSteps.findIndex(step => step.name === "Build Linux x64 at the glibc 2.31 baseline");
   add(
     violations,
     nativeIdentityIndex === installRustIndex + 1
-      && packageRestoreIndex === nativeIdentityIndex + 1
+      && shortWindowsTargetIndex === nativeIdentityIndex + 1
+      && packageRestoreIndex === shortWindowsTargetIndex + 1
       && nativeIdentityIndex < packageBuildIndex
       && nativeIdentityIndex < linuxBuildIndex,
     `${file} native build identity must run immediately after Rust selection and before cache restore or any native build`,
   );
+  add(
+    violations,
+    shortWindowsTarget?.if === "runner.os == 'Windows'" && shortWindowsTarget?.shell === "pwsh",
+    `${file} short Cargo target must be Windows-only PowerShell setup`,
+  );
+  requireStepRun(violations, file, job, "Configure short Windows Cargo target", [
+    '$workspaceTarget = Join-Path $env:GITHUB_WORKSPACE "target"',
+    'Join-Path $env:RUNNER_TEMP "ct"',
+    "New-Item -ItemType Junction -Path $shortTarget -Target $workspaceTarget",
+    '"CARGO_TARGET_DIR=$shortTarget" | Out-File -FilePath $env:GITHUB_ENV',
+  ]);
   const expectedPackageKey = [
     "${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-",
     "${{ matrix.rust_target }}-",
@@ -1753,6 +1767,16 @@ function validatePackagedProof(workflows, violations, graph) {
     packageBuild?.env === undefined,
     `${file} native package build must not override the selected generator`,
   );
+  requireStepRun(violations, file, job, "Smoke codestory-cli on Windows", [
+    "$env:CARGO_TARGET_DIR",
+    "${{ matrix.rust_target }}/release/codestory-cli",
+  ]);
+  requireStepRun(violations, file, job, "Package release asset on Windows", [
+    "$env:CARGO_TARGET_DIR",
+    "${{ matrix.rust_target }}/release/codestory-cli",
+    "package-codestory-release.py",
+    "--binary $bin",
+  ]);
   requireStepRun(violations, file, job, "Prepare checksum-pinned embedded model", [
     "node scripts/prepare-embedded-model.mjs",
   ]);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1161,6 +1161,10 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     "Restore Cargo registry, git sources, and build output",
   );
   const packagedBuild = workflow => draftStep(workflow.jobs.build, "Build codestory-cli");
+  const packagedShortTarget = workflow => draftStep(
+    workflow.jobs.build,
+    "Configure short Windows Cargo target",
+  );
   const protectedSourceTools = workflow => draftStep(
     workflow.jobs["packaged-vulkan"],
     "Capture source build tool evidence",
@@ -1183,6 +1187,21 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
       packagedIdentity(workflow).run = packagedIdentity(workflow).run
         .replace(/.*CMAKE_GENERATOR=Ninja.*\n/u, "");
     }, /native build identity must include CMAKE_GENERATOR=Ninja/u],
+    ["packaged short Windows target made cross-platform", packagedFile, workflow => {
+      packagedShortTarget(workflow).if = "runner.os != 'Windows'";
+    }, /short Cargo target must be Windows-only/u],
+    ["packaged short Windows target stops using a junction", packagedFile, workflow => {
+      packagedShortTarget(workflow).run = packagedShortTarget(workflow).run
+        .replace("New-Item -ItemType Junction", "New-Item -ItemType Directory");
+    }, /Configure short Windows Cargo target/u],
+    ["packaged short Windows target points at wrong storage", packagedFile, workflow => {
+      packagedShortTarget(workflow).run = packagedShortTarget(workflow).run
+        .replace("-Target $workspaceTarget", '-Target "wrong"');
+    }, /Configure short Windows Cargo target/u],
+    ["packaged short Windows target no longer exports Cargo output", packagedFile, workflow => {
+      packagedShortTarget(workflow).run = packagedShortTarget(workflow).run
+        .replace("| Out-File -FilePath $env:GITHUB_ENV", "| Write-Output");
+    }, /Configure short Windows Cargo target/u],
     ["packaged identity made conditional", packagedFile, workflow => {
       packagedIdentity(workflow).if = "runner.os != 'Windows'";
     }, /native build identity must be unique, unconditional/u],
@@ -1214,6 +1233,18 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     ["packaged build overrides generator", packagedFile, workflow => {
       packagedBuild(workflow).env = { CMAKE_GENERATOR: "Visual Studio 18 2026" };
     }, /native package build must not override the selected generator/u],
+    ["packaged Windows smoke ignores short target", packagedFile, workflow => {
+      draftStep(workflow.jobs.build, "Smoke codestory-cli on Windows").run
+        = '$bin = "target/codestory-cli.exe"';
+    }, /Smoke codestory-cli on Windows/u],
+    ["packaged Windows asset ignores short target", packagedFile, workflow => {
+      draftStep(workflow.jobs.build, "Package release asset on Windows").run
+        = 'python .github/scripts/package-codestory-release.py --binary "target/codestory-cli.exe"';
+    }, /Package release asset on Windows/u],
+    ["packaged Windows asset reroutes the short-target binary", packagedFile, workflow => {
+      const step = draftStep(workflow.jobs.build, "Package release asset on Windows");
+      step.run = step.run.replace("--binary $bin", "--binary target/wrong.exe");
+    }, /Package release asset on Windows/u],
     ["protected generator removed", protectedFile, workflow => {
       delete protectedBuild(workflow).env.CMAKE_GENERATOR;
     }, /source package build must use the Ninja native generator/u],

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -136,6 +136,19 @@ jobs:
             echo "ninja=not-applicable" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Configure short Windows Cargo target
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $workspaceTarget = Join-Path $env:GITHUB_WORKSPACE "target"
+          $shortTarget = Join-Path $env:RUNNER_TEMP "ct"
+          New-Item -ItemType Directory -Force -Path $workspaceTarget | Out-Null
+          if (Test-Path -LiteralPath $shortTarget) {
+            throw "short Cargo target already exists: $shortTarget"
+          }
+          New-Item -ItemType Junction -Path $shortTarget -Target $workspaceTarget | Out-Null
+          "CARGO_TARGET_DIR=$shortTarget" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
@@ -433,7 +446,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $bin = Join-Path "target/${{ matrix.rust_target }}/release" "codestory-cli${{ matrix.exe_suffix }}"
+          $bin = Join-Path $env:CARGO_TARGET_DIR "${{ matrix.rust_target }}/release/codestory-cli${{ matrix.exe_suffix }}"
           & $bin --version
           & $bin --help
 
@@ -734,7 +747,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $bin = Join-Path "target/${{ matrix.rust_target }}/release" "codestory-cli${{ matrix.exe_suffix }}"
+          $bin = Join-Path $env:CARGO_TARGET_DIR "${{ matrix.rust_target }}/release/codestory-cli${{ matrix.exe_suffix }}"
           python .github/scripts/package-codestory-release.py `
             --version "${{ inputs.version }}" `
             --target "${{ matrix.asset_target }}" `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Windows-only pre-publish qualification now skips unavailable ARM64 release
   evidence and retains protected Vulkan and candidate-installed provenance under
   an explicit server-behavior-only non-claim. Full release qualification remains
-  strict and still requires exact-head quality evidence.
+  strict and still requires exact-head quality evidence. Hosted Windows packages
+  build in a short runner-temporary Cargo target so nested Vulkan CMake and PDB
+  paths remain inside the native toolchain limit.
 
 ## 0.16.0
 


### PR DESCRIPTION
## Context

Windows-only run `29875293305` proved the Mac/ARM64 dependency was removed, but hosted package job `88784436001` then failed before producing an archive. Nested llama/Vulkan CMake output exceeded the Windows object-path limit and MSVC failed with C1041 opening `vc140.pdb`.

This is the same path-length class already reproduced locally: the exact build succeeds when Cargo uses a short target path.

Closes #1372.

## What Changed

- Add a Windows-only setup step that creates `$RUNNER_TEMP\ct` as a junction to the existing workspace `target` directory.
- Export that short junction as `CARGO_TARGET_DIR` before cache restore and all Cargo work.
- Route Windows binary smoke and release packaging to the exact short-target output.
- Preserve the existing target-only cache path list, key, and non-Windows behavior.
- Pin the junction target, environment-file export, ordering, and downstream `--binary` dataflow in workflow policy and mutation tests.

## How To Review

1. Confirm the junction aliases `$RUNNER_TEMP\ct` to `$GITHUB_WORKSPACE\target` and is Windows-only.
2. Follow Cargo's explicit target layout through the Windows smoke and package steps.
3. Confirm Linux/macOS cache path lists and native build paths are unchanged.
4. Review the wrong-target, missing-export, rerouted-binary, ordering, and Windows-scope mutations.

## Verification

- `node .github/scripts/check-workflow-policy.mjs`
- `node --test --test-name-pattern "Windows source package builds|exact proof policy|candidate-installed package" .github/scripts/check-workflow-policy.test.mjs` (72 passed)
- `node .github/scripts/run-actionlint.mjs`
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- Two independent reviews: no findings.
- Live hosted Windows package rerun remains the decisive proof.

The unfiltered policy test file still has six pre-existing resolver-fixture failures because local Bash cannot find `jq`; the workflow policy and all relevant mutations pass.

## Risk

The junction uses standard Windows filesystem behavior and keeps cached storage in the original workspace `target`, but the current hosted runner image must still prove the nested Vulkan build live. This change makes no answer-quality, release-readiness, authenticated-ledger, Mac/Metal, marketplace, promotion, publication, or post-publish claim.
