### PR TITLE
[codex] Move Windows package target to runner root

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1716,7 +1716,9 @@ function validatePackagedProof(workflows, violations, graph) {
   );
   requireStepRun(violations, file, job, "Configure short Windows Cargo target", [
     '$workspaceTarget = Join-Path $env:GITHUB_WORKSPACE "target"',
-    'Join-Path $env:RUNNER_TEMP "ct"',
+    '$runnerRoot = [System.IO.Path]::GetPathRoot($workspaceTarget)',
+    '[string]::IsNullOrWhiteSpace($runnerRoot)',
+    'Join-Path $runnerRoot "t"',
     "New-Item -ItemType Junction -Path $shortTarget -Target $workspaceTarget",
     '"CARGO_TARGET_DIR=$shortTarget" | Out-File -FilePath $env:GITHUB_ENV',
   ]);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1194,6 +1194,10 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
       packagedShortTarget(workflow).run = packagedShortTarget(workflow).run
         .replace("New-Item -ItemType Junction", "New-Item -ItemType Directory");
     }, /Configure short Windows Cargo target/u],
+    ["packaged short Windows target stops using the runner volume root", packagedFile, workflow => {
+      packagedShortTarget(workflow).run = packagedShortTarget(workflow).run
+        .replace("$runnerRoot = [System.IO.Path]::GetPathRoot($workspaceTarget)", "$runnerRoot = $env:RUNNER_TEMP");
+    }, /Configure short Windows Cargo target/u],
     ["packaged short Windows target points at wrong storage", packagedFile, workflow => {
       packagedShortTarget(workflow).run = packagedShortTarget(workflow).run
         .replace("-Target $workspaceTarget", '-Target "wrong"');

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -141,7 +141,11 @@ jobs:
         shell: pwsh
         run: |
           $workspaceTarget = Join-Path $env:GITHUB_WORKSPACE "target"
-          $shortTarget = Join-Path $env:RUNNER_TEMP "ct"
+          $runnerRoot = [System.IO.Path]::GetPathRoot($workspaceTarget)
+          if ([string]::IsNullOrWhiteSpace($runnerRoot)) {
+            throw "workspace target has no volume root: $workspaceTarget"
+          }
+          $shortTarget = Join-Path $runnerRoot "t"
           New-Item -ItemType Directory -Force -Path $workspaceTarget | Out-Null
           if (Test-Path -LiteralPath $shortTarget) {
             throw "short Cargo target already exists: $shortTarget"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   evidence and retains protected Vulkan and candidate-installed provenance under
   an explicit server-behavior-only non-claim. Full release qualification remains
   strict and still requires exact-head quality evidence. Hosted Windows packages
-  build in a short runner-temporary Cargo target so nested Vulkan CMake and PDB
-  paths remain inside the native toolchain limit.
+  build through a Cargo target junction at the runner volume root so nested
+  Vulkan CMake, object, and PDB paths remain inside the native toolchain limit.
 
 ## 0.16.0
 


### PR DESCRIPTION
## Context

Windows-only run `29883627713` accepted exact source producer `29883208707` and proved the runner-temporary junction was used, but `D:\a\_temp\ct` still left the nested Vulkan CMake object directory at 240 characters under a 250-character limit. MSVC then failed with C1083 before package creation.

Closes #1372.

## What Changed

- Derive the short junction from the workspace volume root and use `D:\t` on the hosted runner.
- Keep the junction target at the existing workspace `target`, preserving cache storage and keys.
- Pin the root derivation, one-character path, junction, export, and ordering in workflow policy and mutation coverage.
- Correct the release changelog description.

## How To Review

1. Confirm only the Windows package matrix receives the root-level junction.
2. Confirm Cargo output still resolves physically to the workspace `target` used by cache restore/save.
3. Follow `$env:CARGO_TARGET_DIR` into Windows smoke and package steps.
4. Confirm the mutation that reverts to `$RUNNER_TEMP` fails policy.

## Verification

- `node .github/scripts/check-workflow-policy.mjs`
- Focused workflow policy mutations: 73 passed
- `node .github/scripts/run-actionlint.mjs`
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- Independent exact-diff review: no findings
- Failed-path projection: approximately 252 characters at `D:\a\_temp\ct` to 243 at `D:\t`

Fresh CodeStory grounding remained `Updating` at `CoreFreshness`; direct exact-source and failed-run inspection were used.

## Risk

The live hosted run must still prove root-directory write permission and that nested Cargo/CMake paths retain the junction spelling. This change makes no Windows package, Vulkan execution, answer-quality, release-readiness, ledger, Mac/Metal, marketplace, promotion, publication, or post-publish claim.
