### PR TITLE
[codex] stabilize native manifest ordering

### DIFF
--- a/.github/scripts/native_binary_contract.py
+++ b/.github/scripts/native_binary_contract.py
@@ -27,6 +27,11 @@ def _cstring(data: bytes, offset: int, limit: int | None = None) -> str:
         raise NativeBinaryError("native dependency name is not UTF-8") from exc
 
 
+def _sorted_unique_dependencies(names: list[str]) -> list[str]:
+    """Return exact dependency spellings in a deterministic total order."""
+    return sorted(set(names), key=lambda name: (name.lower(), name))
+
+
 def inspect_binary(path: Path) -> dict[str, object]:
     data = path.read_bytes()
     if data.startswith(b"\x7fELF"):
@@ -194,7 +199,7 @@ def _inspect_elf(data: bytes) -> dict[str, object]:
         end = strtab_offset + (strtab_size or len(data) - strtab_offset)
         _require(end <= len(data), "ELF string table is truncated")
         needed = [_cstring(data, strtab_offset + value, end) for value in needed_offsets]
-    return {"format": "elf", "arch": arch, "needed": sorted(set(needed), key=str.lower)}
+    return {"format": "elf", "arch": arch, "needed": _sorted_unique_dependencies(needed)}
 
 
 def _inspect_pe(data: bytes) -> dict[str, object]:
@@ -269,7 +274,7 @@ def _inspect_pe(data: bytes) -> dict[str, object]:
                 name_rva -= image_base
             needed.append(_cstring(data, rva_to_offset(name_rva)))
             cursor += 32
-    return {"format": "pe", "arch": arch, "needed": sorted(set(needed), key=str.lower)}
+    return {"format": "pe", "arch": arch, "needed": _sorted_unique_dependencies(needed)}
 
 
 def _inspect_macho(data: bytes) -> dict[str, object]:
@@ -292,4 +297,4 @@ def _inspect_macho(data: bytes) -> dict[str, object]:
             _require(0 < name_offset < size, "Mach-O dylib name offset is invalid")
             needed.append(_cstring(data, cursor + name_offset, cursor + size))
         cursor += size
-    return {"format": "mach-o", "arch": arch, "needed": sorted(set(needed), key=str.lower)}
+    return {"format": "mach-o", "arch": arch, "needed": _sorted_unique_dependencies(needed)}

--- a/.github/scripts/package-codestory-release.py
+++ b/.github/scripts/package-codestory-release.py
@@ -5,10 +5,12 @@ import argparse
 import gzip
 import hashlib
 import json
+import os
 import shutil
 import stat
 import struct
 import subprocess
+import sys
 import tarfile
 import tempfile
 import zipfile
@@ -16,6 +18,7 @@ from pathlib import Path
 
 from native_binary_contract import (
     NativeBinaryError,
+    inspect_binary,
     inspect_runtime_layout,
     runtime_artifact_role,
 )
@@ -891,6 +894,44 @@ def write_synthetic_runtime(
 def run_self_test() -> None:
     with tempfile.TemporaryDirectory(prefix="codestory-package-self-test-") as temp_dir:
         temp_root = Path(temp_dir)
+        dependency_names = ("kernel32.dll", "KERNEL32.dll", "User32.dll")
+        expected_dependencies = ["KERNEL32.dll", "kernel32.dll", "User32.dll"]
+        inspector_dir = str(Path(__file__).resolve().parent)
+        inspect_command = (
+            "import json, sys; "
+            "from pathlib import Path; "
+            "sys.path.insert(0, sys.argv[2]); "
+            "from native_binary_contract import inspect_binary; "
+            "print(json.dumps(inspect_binary(Path(sys.argv[1]))['needed']))"
+        )
+        for binary_format, arch in [
+            ("elf", "x86_64"),
+            ("pe", "x86_64"),
+            ("mach-o", "aarch64"),
+        ]:
+            dependency_binary = temp_root / f"dependency-order-{binary_format}"
+            dependency_binary.write_bytes(
+                synthetic_binary(binary_format, arch, "", dependency_names)
+            )
+            if inspect_binary(dependency_binary)["needed"] != expected_dependencies:
+                raise AssertionError(
+                    f"{binary_format} dependency spelling or total ordering is unstable"
+                )
+            seeded_results = []
+            for hash_seed in ("0", "1", "42"):
+                seeded = subprocess.run(
+                    [sys.executable, "-c", inspect_command, str(dependency_binary), inspector_dir],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env={**os.environ, "PYTHONHASHSEED": hash_seed},
+                )
+                seeded_results.append(json.loads(seeded.stdout))
+            if any(result != expected_dependencies for result in seeded_results):
+                raise AssertionError(
+                    f"{binary_format} dependency ordering changes across Python hash seeds"
+                )
+
         repo_root = temp_root / "repo"
         (repo_root / "docs/users").mkdir(parents=True)
         (repo_root / "plugins/codestory/skills/codestory-grounding").mkdir(parents=True)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   strict and still requires exact-head quality evidence. Hosted Windows packages
   build through a Cargo target junction at the runner volume root so nested
   Vulkan CMake, object, and PDB paths remain inside the native toolchain limit.
+  Native dependency manifests now use a deterministic case-sensitive tie-break
+  after case-insensitive ordering, preserving exact import spellings while
+  keeping package and archive-smoke inspection identical across processes.
 
 ## 0.16.0
 


### PR DESCRIPTION
## Context

Windows qualification built and archived one exact executable, then archive smoke rejected its native manifest because package and checker processes could order the case-colliding imports `kernel32.dll` and `KERNEL32.dll` differently. The binary bytes were unchanged; the shared inspector's set iteration leaked through a case-insensitive sort key.

Base: `f0062e7bef7c40a1e16b7638826c0663c6dbcb3d`
Head: `529ad3b48ffe2ab13025495495879daa7936b232`

## What changed

- give native dependency names a deterministic total order: case-insensitive key first, exact spelling as the tie-break
- retain both exact spellings instead of folding case
- exercise ELF, PE, and Mach-O inspection through independent `PYTHONHASHSEED` processes with case-colliding imports
- record the package correctness change under `Unreleased`

## How to review

Start with `.github/scripts/native_binary_contract.py`; the behavior change is the shared dependency-order helper used by all three format parsers. The package self-test creates synthetic images and proves identical exact output under seeds `0`, `1`, and `42`.

## Verification

- `python -m py_compile .github/scripts/native_binary_contract.py .github/scripts/package-codestory-release.py .github/scripts/check-packaged-agent-proof.py`
- `python .github/scripts/package-codestory-release.py --self-test`
- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test .github/scripts/check-workflow-policy.test.mjs` — 276 passed
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 74 passed, 1 Windows-only skip
- `git diff --check`

## Risk and non-claims

This changes only canonical dependency descriptor ordering. Digest, architecture, linkage, backend, runtime-artifact, and hardware checks are unchanged. It does not prove Windows archive smoke, Vulkan execution, installed-candidate behavior, Mac/Metal, promotion, publication, or release readiness; those remain live exact-head qualification work after merge.

Closes #1376
Refs #1372
