### PR TITLE
[codex] accept native-identical Windows qualification paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   strict and still requires exact-head quality evidence. Hosted Windows packages
   build through a Cargo target junction at the runner volume root so nested
   Vulkan CMake, object, and PDB paths remain inside the native toolchain limit.
+  Private Windows qualification directories accept ordinary and canonical path
+  spellings only when both resolve to the same native volume and file identity.
   Native dependency manifests now use a deterministic case-sensitive tie-break
   after case-insensitive ordering, preserving exact import spellings while
   keeping package and archive-smoke inspection identical across processes.

--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -2502,6 +2502,7 @@ impl PinnedQualificationDirectory {
                 path.display()
             )
         })?;
+        #[cfg(not(windows))]
         if canonical != path {
             bail!("embedding_qualification_directory_untrusted");
         }
@@ -2509,6 +2510,15 @@ impl PinnedQualificationDirectory {
             .context("reinspect canonical embedding qualification directory")?;
         validate_private_qualification_directory_metadata(&metadata)?;
         let identity = native_path_identity(&canonical)?;
+        #[cfg(windows)]
+        {
+            let caller = fs::symlink_metadata(path)
+                .context("reinspect caller embedding qualification directory")?;
+            validate_private_qualification_directory_metadata(&caller)?;
+            if native_path_identity(path)? != identity {
+                bail!("embedding_qualification_directory_untrusted");
+            }
+        }
         #[cfg(unix)]
         let handle = {
             use std::os::unix::fs::OpenOptionsExt;
@@ -7058,6 +7068,36 @@ mod tests {
                 .to_string()
                 .contains("embedding_qualification_event_log_replaced")
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn qualification_gate_accepts_native_identical_windows_path_spellings() {
+        let temporary = tempfile::tempdir().expect("temporary qualification root");
+        let directory = temporary.path().join("qualification");
+        fs::create_dir(&directory).expect("qualification directory");
+        let canonical = fs::canonicalize(&directory).expect("canonical qualification directory");
+        assert_ne!(
+            directory, canonical,
+            "Windows canonicalization should expose the verbatim spelling mismatch"
+        );
+        assert_eq!(
+            native_path_identity(&directory).expect("caller directory identity"),
+            native_path_identity(&canonical).expect("canonical directory identity")
+        );
+
+        let control = server_qualification_control_from_values(
+            Some(directory.into_os_string()),
+            Some("test-nonce".into()),
+        )
+        .expect("native-identical Windows spellings are trusted")
+        .expect("qualification control is enabled");
+
+        assert_eq!(control.directory.path, canonical);
+        control
+            .directory
+            .revalidate()
+            .expect("canonical directory remains pinned");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Context

Exact Windows-only qualification run `29890020286` passed the real x64 archive smoke, then failed packaged managed handoff because the checker supplied an ordinary absolute `C:\Users\...` qualification path while Rust canonicalization returned the same directory with a different Windows spelling.

Base: `5bccd680c33a2f21d2ecddcb4ceab14d5fdd5f24`

Head: `e762afadd01540dbf62f99c335d046ee86d51d43`

## What changed

- Keep the existing absolute-path and final-component symlink/type checks.
- Keep Unix's exact canonical spelling, owner, `0700`, no-link, and open-handle checks unchanged.
- On Windows, reinspect the caller path and accept its spelling only when it identifies the same existing native volume/file object as the canonical path.
- Continue storing the canonical path and revalidating its pinned native identity before qualification I/O.
- Add a Windows regression that proves an ordinary path and its verbatim canonical spelling are distinct strings, share native identity, and open successfully.
- Record the behavior under `Unreleased`.

## How to review

The trust-boundary change is isolated to `PinnedQualificationDirectory::open`. The key property is that only Windows replaces lexical path equality with existing filesystem identity; missing paths and identity errors still fail closed.

## Verification

- Physical Windows 11, exact head, isolated worktree and target:
  - `cargo test -p codestory-retrieval qualification_gate_accepts_native_identical_windows_path_spellings --locked`
  - 1 passed, 0 failed
- macOS:
  - `cargo test -p codestory-retrieval qualification_gate --locked`
  - 2 passed, 0 failed; covers broad permissions, linked directories/files, bounded command/event handling, and replacement rejection
  - `cargo check -p codestory-retrieval --all-targets --all-features --locked`
  - `cargo fmt --all -- --check`
  - `git diff --check`
  - `node .github/scripts/check-workflow-policy.mjs`
  - `node --test plugins/codestory/tests/plugin-static.test.mjs` (74 passed, 1 Windows-only skip)

The macOS-to-Windows cross-target attempt stopped in native dependencies because the Mac has no Windows C/C++ SDK; the physical Windows result above is the platform proof.

## Risk and follow-up

The change deliberately does not relax Unix behavior or accept missing/case-folded lexical paths. Replacement protection on Windows remains native path-identity revalidation, as before. This PR does not claim Vulkan, installed-candidate, Mac/Metal, promotion, publication, or release readiness; the exact-head Windows coordinator lane remains required after merge.

Closes #1378

Refs #1372

Refs #1221
