### PR TITLE
Recover Windows embedding pipe disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   keeping package and archive-smoke inspection identical across processes.
   Windows package proof now pins the final exact candidate server process and
   requires its bounded clean idle exit before removing the unpacked archive.
+  Windows named-pipe disconnects now retain their exact Win32 error and
+  authenticated peer-process state while entering the existing exactly-once
+  pure-RPC recovery path.
 
 ## 0.16.0
 

--- a/crates/codestory-cli/src/embedding_server_transport.rs
+++ b/crates/codestory-cli/src/embedding_server_transport.rs
@@ -331,6 +331,17 @@ impl NativeEmbeddingStream {
     fn peer_is_alive(&self) -> std::io::Result<bool> {
         self.inner.peer_is_alive()
     }
+
+    fn peer_exit_code(&self) -> std::io::Result<Option<u32>> {
+        #[cfg(windows)]
+        {
+            return self.inner.peer_exit_code();
+        }
+        #[cfg(unix)]
+        {
+            Ok(None)
+        }
+    }
 }
 
 impl Read for NativeEmbeddingStream {
@@ -459,6 +470,10 @@ impl codestory_retrieval::EmbeddingServerStream for NativeEmbeddingStream {
 
     fn peer_is_alive(&self) -> std::io::Result<bool> {
         NativeEmbeddingStream::peer_is_alive(self)
+    }
+
+    fn peer_exit_code(&self) -> std::io::Result<Option<u32>> {
+        NativeEmbeddingStream::peer_exit_code(self)
     }
 }
 
@@ -2526,9 +2541,9 @@ mod platform {
     use std::time::Duration;
     use windows_sys::Win32::Foundation::{
         ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_INSUFFICIENT_BUFFER, ERROR_NO_DATA,
-        ERROR_PIPE_BUSY, ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, ERROR_SEM_TIMEOUT, FILETIME,
-        GENERIC_ALL, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE, LocalFree,
-        STILL_ACTIVE,
+        ERROR_PIPE_BUSY, ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, ERROR_PIPE_NOT_CONNECTED,
+        ERROR_SEM_TIMEOUT, FILETIME, GENERIC_ALL, GENERIC_READ, GENERIC_WRITE, HANDLE,
+        INVALID_HANDLE_VALUE, LocalFree, STILL_ACTIVE,
     };
     use windows_sys::Win32::Security::Authorization::{
         ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
@@ -2704,11 +2719,15 @@ mod platform {
         }
 
         pub(super) fn peer_is_alive(&self) -> std::io::Result<bool> {
+            Ok(self.peer_exit_code()?.is_none())
+        }
+
+        pub(super) fn peer_exit_code(&self) -> std::io::Result<Option<u32>> {
             let mut exit_code = 0_u32;
             if unsafe { GetExitCodeProcess(raw(&self.peer_process), &mut exit_code) } == 0 {
                 return Err(std::io::Error::last_os_error());
             }
-            Ok(exit_code == STILL_ACTIVE as u32)
+            Ok((exit_code != STILL_ACTIVE as u32).then_some(exit_code))
         }
     }
 
@@ -2740,7 +2759,7 @@ mod platform {
                             || code == ERROR_PIPE_LISTENING
                     })
                 {
-                    return Err(error);
+                    return Err(normalize_windows_pipe_io_error(error));
                 }
                 wait_pipe_io(
                     started,
@@ -2775,7 +2794,7 @@ mod platform {
                     .map(|code| code as u32)
                     .is_some_and(|code| code == ERROR_NO_DATA || code == ERROR_PIPE_BUSY)
                 {
-                    return Err(error);
+                    return Err(normalize_windows_pipe_io_error(error));
                 }
                 wait_pipe_io(
                     started,
@@ -3442,6 +3461,17 @@ mod platform {
         Ok(())
     }
 
+    fn normalize_windows_pipe_io_error(error: std::io::Error) -> std::io::Error {
+        if error.raw_os_error().map(|code| code as u32) == Some(ERROR_PIPE_NOT_CONNECTED) {
+            // DisconnectNamedPipe reports ERROR_PIPE_NOT_CONNECTED to the
+            // remote reader. Rust does not currently assign that Win32 code a
+            // portable ErrorKind, so retain the raw error as the source while
+            // exposing the precise cross-platform disconnect class.
+            return std::io::Error::new(std::io::ErrorKind::NotConnected, error);
+        }
+        error
+    }
+
     fn wide(value: &str) -> Vec<u16> {
         value.encode_utf16().chain(std::iter::once(0)).collect()
     }
@@ -3453,6 +3483,98 @@ mod platform {
             if !self.0.is_null() {
                 let _ = unsafe { LocalFree(self.0) };
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn disconnected_named_pipe_retains_raw_code_and_normalizes_the_kind() {
+            let current_sid = current_process_sid().expect("current process SID");
+            let sid_string = sid_string(&current_sid).expect("current SID string");
+            let security_sddl = wide(&format!(
+                "O:{sid_string}D:P(A;;GA;;;{sid_string})(A;;GA;;;SY)"
+            ));
+            let pipe_name = wide(&format!(
+                r"\\.\pipe\codestory-disconnect-test-{}-{}",
+                unsafe { GetCurrentProcessId() },
+                awake_now_ns()
+            ));
+            let server = create_pipe_instance(&pipe_name, &security_sddl, true, true)
+                .expect("create named-pipe server");
+            let client = unsafe {
+                CreateFileW(
+                    pipe_name.as_ptr(),
+                    GENERIC_READ | GENERIC_WRITE,
+                    0,
+                    null(),
+                    OPEN_EXISTING,
+                    0,
+                    null_mut(),
+                )
+            };
+            assert_ne!(client, INVALID_HANDLE_VALUE, "connect named-pipe client");
+            let client = unsafe { OwnedHandle::from_raw_handle(client.cast()) };
+            let nonblocking = PIPE_READMODE_BYTE | PIPE_NOWAIT;
+            assert_ne!(
+                unsafe { SetNamedPipeHandleState(raw(&client), &nonblocking, null(), null()) },
+                0,
+                "set named-pipe client nonblocking"
+            );
+            if unsafe { ConnectNamedPipe(raw(&server), null_mut()) } == 0 {
+                let error = std::io::Error::last_os_error();
+                assert_eq!(
+                    error.raw_os_error().map(|code| code as u32),
+                    Some(ERROR_PIPE_CONNECTED),
+                    "client connection must be the only failed accept state"
+                );
+            }
+
+            let peer_pid = unsafe { GetCurrentProcessId() };
+            let peer_process_start_id =
+                canonical_process_start_identity(peer_pid).expect("current process start identity");
+            let mut stream = Stream::new(
+                client,
+                false,
+                TransportIdentity {
+                    endpoint_namespace_id: "test-endpoint".into(),
+                    lifetime_authority_id: "test-authority".into(),
+                    listener_id: "test-listener".into(),
+                    peer_verified: true,
+                    peer_pid: Some(peer_pid),
+                    peer_process_start_id: Some(peer_process_start_id),
+                },
+            )
+            .expect("retain named-pipe client stream");
+            assert_ne!(
+                unsafe { DisconnectNamedPipe(raw(&server)) },
+                0,
+                "disconnect named-pipe server"
+            );
+
+            let error = stream
+                .read(&mut [0_u8; 4])
+                .expect_err("disconnected named pipe must fail");
+
+            assert_eq!(error.kind(), std::io::ErrorKind::NotConnected);
+            assert_eq!(
+                error
+                    .get_ref()
+                    .and_then(|source| source.downcast_ref::<std::io::Error>())
+                    .and_then(std::io::Error::raw_os_error)
+                    .map(|code| code as u32),
+                Some(ERROR_PIPE_NOT_CONNECTED)
+            );
+            assert!(stream.peer_is_alive().expect("probe retained peer"));
+            assert_eq!(stream.peer_exit_code().expect("probe peer exit code"), None);
+            eprintln!(
+                "named-pipe disconnect evidence: raw_os_error={} normalized_kind={:?} \
+                 peer_state=running peer_exit_code=none",
+                ERROR_PIPE_NOT_CONNECTED,
+                error.kind()
+            );
         }
     }
 }

--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -149,6 +149,12 @@ pub trait EmbeddingServerStream: Read + Write + Send {
     /// Returns false once the authenticated peer process has exited. This is
     /// deliberately process-liveness only; it never inspects project state.
     fn peer_is_alive(&self) -> io::Result<bool>;
+    /// Returns the authenticated peer process exit code when the platform can
+    /// prove that the retained process identity has exited. A live peer and a
+    /// platform without exit-code support both return `None`.
+    fn peer_exit_code(&self) -> io::Result<Option<u32>> {
+        Ok(None)
+    }
     fn shutdown(&self) -> io::Result<()>;
 }
 
@@ -705,18 +711,16 @@ pub struct EmbeddingRetryStateWire {
 }
 
 pub fn embedding_retry_state(error: &anyhow::Error) -> Option<EmbeddingRetryStateWire> {
-    error.chain().find_map(|cause| {
-        cause
-            .downcast_ref::<PerUserEmbeddingError>()
-            .map(|error| EmbeddingRetryStateWire {
-                code: error.code.clone(),
-                message: error.message.clone(),
-                retry_class: error.retry_class.clone(),
-                retry_after_ms: error.retry_after_ms,
-                retry_condition: error.retry_condition.clone(),
-                capacity: error.capacity.clone(),
-            })
-    })
+    error
+        .downcast_ref::<PerUserEmbeddingError>()
+        .map(|error| EmbeddingRetryStateWire {
+            code: error.code.clone(),
+            message: error.message.clone(),
+            retry_class: error.retry_class.clone(),
+            retry_after_ms: error.retry_after_ms,
+            retry_condition: error.retry_condition.clone(),
+            capacity: error.capacity.clone(),
+        })
 }
 
 pub fn embedding_capacity_pressure(error: &anyhow::Error) -> Option<EmbeddingCapacityPressureWire> {
@@ -4722,9 +4726,10 @@ fn exchange(
     request: EmbeddingProtocolRequest,
 ) -> Result<(EmbeddingProtocolResponse, Vec<u8>)> {
     let request_id = request.request_id.clone();
-    write_frame(stream, &request, &[]).map_err(map_bounded_exchange_error)?;
+    write_frame(stream, &request, &[])
+        .map_err(|error| map_bounded_exchange_error(error, stream))?;
     let (response, payload): (EmbeddingProtocolResponse, Vec<u8>) =
-        read_frame(stream).map_err(map_bounded_exchange_error)?;
+        read_frame(stream).map_err(|error| map_bounded_exchange_error(error, stream))?;
     if response.request_id != request_id {
         bail!("embedding_server_response_request_id_mismatch");
     }
@@ -4736,7 +4741,10 @@ fn exchange(
     Ok((response, payload))
 }
 
-fn map_bounded_exchange_error(error: anyhow::Error) -> anyhow::Error {
+fn map_bounded_exchange_error(
+    error: anyhow::Error,
+    stream: &dyn EmbeddingServerStream,
+) -> anyhow::Error {
     let io_kind = error
         .chain()
         .find_map(|cause| cause.downcast_ref::<io::Error>().map(io::Error::kind));
@@ -4744,15 +4752,14 @@ fn map_bounded_exchange_error(error: anyhow::Error) -> anyhow::Error {
         io_kind,
         Some(io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock)
     ) {
-        return PerUserEmbeddingError {
+        return error.context(PerUserEmbeddingError {
             code: "embedding_server_owner_unresponsive".into(),
             message: "the embedding server did not complete a bounded exchange".into(),
             retry_class: "after_server_change".into(),
             retry_after_ms: duration_ms(EmbeddingClientBudgets::current().retry_after),
             retry_condition: "the lifetime authority or server instance changes".into(),
             capacity: None,
-        }
-        .into();
+        });
     }
     if matches!(
         io_kind,
@@ -4764,17 +4771,59 @@ fn map_bounded_exchange_error(error: anyhow::Error) -> anyhow::Error {
                 | io::ErrorKind::UnexpectedEof
         )
     ) {
-        return PerUserEmbeddingError {
+        let raw_os_error = exchange_raw_os_error(&error);
+        let identity = stream.transport_identity();
+        let (peer_state, peer_exit_code) = match stream.peer_exit_code() {
+            Ok(Some(exit_code)) => ("exited".to_string(), Some(exit_code)),
+            Ok(None) => match stream.peer_is_alive() {
+                Ok(true) => ("running".to_string(), None),
+                Ok(false) => ("exited".to_string(), None),
+                Err(probe_error) => (format!("unknown ({probe_error})"), None),
+            },
+            Err(probe_error) => (format!("unknown ({probe_error})"), None),
+        };
+        let source_chain = format!("{error:#}");
+        let message = format!(
+            "the authenticated embedding server connection was lost; raw_os_error={}; \
+             peer_pid={}; peer_process_start_id={}; peer_state={peer_state}; \
+             peer_exit_code={}; source={source_chain}",
+            raw_os_error.map_or_else(|| "none".into(), |code| code.to_string()),
+            identity
+                .peer_pid
+                .map_or_else(|| "unknown".into(), |pid| pid.to_string()),
+            identity
+                .peer_process_start_id
+                .as_deref()
+                .unwrap_or("unknown"),
+            peer_exit_code.map_or_else(|| "none".into(), |code| code.to_string()),
+        );
+        return error.context(PerUserEmbeddingError {
             code: "embedding_server_connection_lost".into(),
-            message: "the authenticated embedding server connection was lost".into(),
+            message,
             retry_class: "same_rpc_once".into(),
             retry_after_ms: 0,
             retry_condition: "the server instance changes".into(),
             capacity: None,
-        }
-        .into();
+        });
     }
     error
+}
+
+fn exchange_raw_os_error(error: &anyhow::Error) -> Option<i32> {
+    error.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<io::Error>()
+            .and_then(nested_io_raw_os_error)
+    })
+}
+
+fn nested_io_raw_os_error(error: &io::Error) -> Option<i32> {
+    error.raw_os_error().or_else(|| {
+        error
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<io::Error>())
+            .and_then(nested_io_raw_os_error)
+    })
 }
 
 fn response_result(response: EmbeddingProtocolResponse) -> Result<EmbeddingResult> {
@@ -5077,16 +5126,14 @@ fn elapsed_since(clock: &dyn AwakeMonotonicClock, started_ns: u64) -> Duration {
 }
 
 fn is_server_loss(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| {
-        cause
-            .downcast_ref::<PerUserEmbeddingError>()
-            .is_some_and(|error| {
-                matches!(
-                    error.code.as_str(),
-                    "embedding_server_owner_unresponsive" | "embedding_server_connection_lost"
-                )
-            })
-    })
+    error
+        .downcast_ref::<PerUserEmbeddingError>()
+        .is_some_and(|error| {
+            matches!(
+                error.code.as_str(),
+                "embedding_server_owner_unresponsive" | "embedding_server_connection_lost"
+            )
+        })
 }
 
 #[cfg(test)]
@@ -6371,6 +6418,46 @@ mod tests {
                 .to_string()
                 .contains("embedding_server_frame_too_large")
         );
+    }
+
+    #[test]
+    fn bounded_exchange_maps_normalized_disconnect_and_retains_peer_evidence() {
+        let raw_error = io::Error::from_raw_os_error(233);
+        let normalized = io::Error::new(io::ErrorKind::NotConnected, raw_error);
+        let source = anyhow::Error::new(normalized).context("read embedding control length");
+        let (stream, _) = MemoryStream::new(Vec::new(), true);
+
+        let error = map_bounded_exchange_error(source, &stream);
+        let retry = embedding_retry_state(&error).expect("typed connection loss");
+
+        assert_eq!(retry.code, "embedding_server_connection_lost");
+        assert_eq!(retry.retry_class, "same_rpc_once");
+        assert!(retry.message.contains("raw_os_error=233"));
+        assert!(retry.message.contains("peer_pid=42"));
+        assert!(retry.message.contains("peer_process_start_id=server-start"));
+        assert!(retry.message.contains("peer_state=running"));
+        assert!(retry.message.contains("peer_exit_code=none"));
+        assert!(
+            retry
+                .message
+                .contains("source=read embedding control length")
+        );
+        assert_eq!(exchange_raw_os_error(&error), Some(233));
+    }
+
+    #[test]
+    fn bounded_exchange_does_not_type_unrelated_io_errors() {
+        let source = anyhow::Error::new(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "unrelated denial",
+        ))
+        .context("read embedding control length");
+        let (stream, _) = MemoryStream::new(Vec::new(), false);
+
+        let error = map_bounded_exchange_error(source, &stream);
+
+        assert!(embedding_retry_state(&error).is_none());
+        assert_eq!(error.to_string(), "read embedding control length");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -4777,7 +4777,13 @@ fn map_bounded_exchange_error(
             Ok(Some(exit_code)) => ("exited".to_string(), Some(exit_code)),
             Ok(None) => match stream.peer_is_alive() {
                 Ok(true) => ("running".to_string(), None),
-                Ok(false) => ("exited".to_string(), None),
+                Ok(false) => match stream.peer_exit_code() {
+                    Ok(exit_code) => ("exited".to_string(), exit_code),
+                    Err(probe_error) => (
+                        format!("exited (exit-code probe failed: {probe_error})"),
+                        None,
+                    ),
+                },
                 Err(probe_error) => (format!("unknown ({probe_error})"), None),
             },
             Err(probe_error) => (format!("unknown ({probe_error})"), None),
@@ -5202,6 +5208,7 @@ mod tests {
         input: Cursor<Vec<u8>>,
         output: Arc<Mutex<Vec<u8>>>,
         alive: bool,
+        exit_codes: Mutex<Vec<Option<u32>>>,
     }
 
     impl MemoryStream {
@@ -5213,6 +5220,7 @@ mod tests {
                     input: Cursor::new(input),
                     output: Arc::clone(&output),
                     alive,
+                    exit_codes: Mutex::new(vec![None]),
                 },
                 output,
             )
@@ -5254,6 +5262,17 @@ mod tests {
 
         fn peer_is_alive(&self) -> io::Result<bool> {
             Ok(self.alive)
+        }
+
+        fn peer_exit_code(&self) -> io::Result<Option<u32>> {
+            let mut exit_codes = self
+                .exit_codes
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if exit_codes.len() > 1 {
+                return Ok(exit_codes.remove(0));
+            }
+            Ok(exit_codes.first().copied().flatten())
         }
 
         fn shutdown(&self) -> io::Result<()> {
@@ -6458,6 +6477,21 @@ mod tests {
 
         assert!(embedding_retry_state(&error).is_none());
         assert_eq!(error.to_string(), "read embedding control length");
+    }
+
+    #[test]
+    fn bounded_exchange_reprobes_exit_code_after_liveness_observes_exit() {
+        let raw_error = io::Error::from_raw_os_error(233);
+        let normalized = io::Error::new(io::ErrorKind::NotConnected, raw_error);
+        let source = anyhow::Error::new(normalized).context("read embedding control length");
+        let (mut stream, _) = MemoryStream::new(Vec::new(), false);
+        stream.exit_codes = Mutex::new(vec![None, Some(0xc000_0005)]);
+
+        let error = map_bounded_exchange_error(source, &stream);
+        let retry = embedding_retry_state(&error).expect("typed connection loss");
+
+        assert!(retry.message.contains("peer_state=exited"));
+        assert!(retry.message.contains("peer_exit_code=3221225477"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Exact Windows-only coordinator runs `29894398392` and `29900992386` both terminate managed handoff at `read embedding control length`. The latter preserves that primary failure after #1381. A physical Windows probe established the missing classification boundary: `DisconnectNamedPipe` leaves the peer handle with Win32 `ERROR_PIPE_NOT_CONNECTED` (`233`), which Rust does not currently map to a portable `ErrorKind`.

Closes #1383
Refs #1372
Refs #1221

## What changed

- Normalize only raw Win32 `233` to `ErrorKind::NotConnected`, retaining the original `io::Error` as its source.
- Preserve the complete exchange error chain and expose raw OS code, authenticated peer PID/start identity, live/exited state, and Windows exit code when available.
- Reprobe the retained process handle when liveness first observes exit, so an exit racing the initial code probe does not discard the now-available code.
- Keep the existing typed `embedding_server_connection_lost` / `same_rpc_once` boundary and its one replay; unrelated I/O errors remain untyped and terminal.
- Add a physical Windows named-pipe disconnect regression plus focused mapping/non-mapping, exit-race, and replay regressions.
- Record the release-facing behavior in `CHANGELOG.md`.

## How to review

Start at `normalize_windows_pipe_io_error`, then follow `exchange` into `map_bounded_exchange_error`. The important boundaries are that only raw `233` is normalized, the original error remains in the chain, peer exit evidence survives the liveness race, and `is_server_loss` still gates a single replay in `call_pure_with_replay_controlled_and_attempts`.

## Verification

Head: `443843ae694e526230057b3fa6ac0691469ad529`
Tree: `fbb809b363cdf16422555eb094da796f5e2721c9`

Completed:

- macOS: mapping/non-mapping/exit-race tests 3/3; pure-RPC replay tests 4/4; complete retrieval suite 199 passed and 3 ignored; `cargo check --locked -p codestory-cli`; focused all-target/all-feature clippy with warnings denied; formatting and diff check.
- Physical Windows at this exact head: the named-pipe regression ran in both CLI test binaries and captured `raw_os_error=233`, `normalized_kind=NotConnected`, `peer_state=running`, `peer_exit_code=none`; mapping/exit-race 3/3, pure replay 4/4, and CLI check passed.
- Independent exact-head re-review: no P0-P3 findings; the earlier exit-code-race P3 is resolved.
- Hosted draft source run `29905355354`: passed.
- Hosted retrieval-engine run `29905355330`: passed.
- Hosted rustdoc run `29905355334`: passed.
- Windows evidence is retained at `C:\tmp\codestory-1383-evidence-443843ae` and copied to `/Users/albert/Developer/CodeStory-evidence/v016-443843ae694e-20260722/windows-native`; copied log SHA-256 `f9e0c5282f57e7360ff5c244437db8a8e7968de692cc056ae3a0aad7ce0f1cca`.

Pending:

- Merge to dev followed by exact-head integration/source proof.
- Fresh Windows coordinator rerun; until that passes, the exact run-triggering raw code and managed-handoff recovery remain non-claims.

## Risk

The cross-platform typed mapping now wraps its source instead of discarding it. Focused and full retrieval tests cover typed lookup through the retained context, exit-evidence races, cancellation, capacity, and terminal second loss. The remaining trigger question is why the server-side handler disconnected; the added peer/exit evidence will distinguish a live handler close from process exit on the next exact run.
