### PR TITLE
Preserve Windows embedding responses before pipe disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@
   requires its bounded clean idle exit before removing the unpacked archive.
   Windows named-pipe disconnects now retain their exact Win32 error and
   authenticated peer-process state while entering the existing exactly-once
-  pure-RPC recovery path.
+  pure-RPC recovery path. Successful Windows handlers now keep the one-shot
+  pipe connected for a server-capped final-response drain, preventing teardown
+  from discarding unread vector bytes while the shared server remains healthy,
+  and chunks nonblocking writes to the pipe buffer while keeping zero-progress
+  polling inside the frozen server-owned query budget even when a peer supplies
+  a longer wire deadline.
 
 ## 0.16.0
 

--- a/crates/codestory-cli/src/embedding_server_transport.rs
+++ b/crates/codestory-cli/src/embedding_server_transport.rs
@@ -328,6 +328,10 @@ impl NativeEmbeddingStream {
         self.inner.shutdown()
     }
 
+    fn finish_response_delivery(&self) -> std::io::Result<()> {
+        self.inner.finish_response_delivery()
+    }
+
     fn peer_is_alive(&self) -> std::io::Result<bool> {
         self.inner.peer_is_alive()
     }
@@ -466,6 +470,10 @@ impl codestory_retrieval::EmbeddingServerStream for NativeEmbeddingStream {
 
     fn shutdown(&self) -> std::io::Result<()> {
         NativeEmbeddingStream::shutdown(self)
+    }
+
+    fn finish_response_delivery(&self) -> std::io::Result<()> {
+        NativeEmbeddingStream::finish_response_delivery(self)
     }
 
     fn peer_is_alive(&self) -> std::io::Result<bool> {
@@ -928,6 +936,10 @@ mod platform {
 
         pub(super) fn shutdown(&self) -> std::io::Result<()> {
             self.stream.shutdown(std::net::Shutdown::Both)
+        }
+
+        pub(super) fn finish_response_delivery(&self) -> std::io::Result<()> {
+            Ok(())
         }
 
         pub(super) fn peer_is_alive(&self) -> std::io::Result<bool> {
@@ -2540,10 +2552,10 @@ mod platform {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::Duration;
     use windows_sys::Win32::Foundation::{
-        ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_INSUFFICIENT_BUFFER, ERROR_NO_DATA,
-        ERROR_PIPE_BUSY, ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, ERROR_PIPE_NOT_CONNECTED,
-        ERROR_SEM_TIMEOUT, FILETIME, GENERIC_ALL, GENERIC_READ, GENERIC_WRITE, HANDLE,
-        INVALID_HANDLE_VALUE, LocalFree, STILL_ACTIVE,
+        ERROR_ACCESS_DENIED, ERROR_BROKEN_PIPE, ERROR_FILE_NOT_FOUND, ERROR_INSUFFICIENT_BUFFER,
+        ERROR_NO_DATA, ERROR_PIPE_BUSY, ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING,
+        ERROR_PIPE_NOT_CONNECTED, ERROR_SEM_TIMEOUT, FILETIME, GENERIC_ALL, GENERIC_READ,
+        GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE, LocalFree, STILL_ACTIVE,
     };
     use windows_sys::Win32::Security::Authorization::{
         ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
@@ -2573,6 +2585,7 @@ mod platform {
     use windows_sys::Win32::System::WindowsProgramming::QueryUnbiasedInterruptTimePrecise;
 
     const NO_TIMEOUT: u64 = u64::MAX;
+    const PIPE_BUFFER_BYTES: usize = 1024 * 1024;
     const PIPE_IO_POLL: Duration = Duration::from_millis(1);
     const PIPE_CONNECT_POLL: Duration = Duration::from_millis(25);
     const SYNCHRONIZE_ACCESS: u32 = 0x0010_0000;
@@ -2718,6 +2731,47 @@ mod platform {
             Ok(())
         }
 
+        pub(super) fn finish_response_delivery(&self) -> std::io::Result<()> {
+            if !self.server_side {
+                return Ok(());
+            }
+            let started = awake_now_ns();
+            loop {
+                let mut unexpected = 0_u8;
+                let mut read = 0_u32;
+                if unsafe {
+                    ReadFile(
+                        raw(&self.handle),
+                        (&mut unexpected as *mut u8).cast(),
+                        1,
+                        &mut read,
+                        null_mut(),
+                    )
+                } != 0
+                {
+                    if read == 0 {
+                        return Ok(());
+                    }
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "embedding client wrote data after the final response",
+                    ));
+                }
+                let error = std::io::Error::last_os_error();
+                match error.raw_os_error().map(|code| code as u32) {
+                    Some(ERROR_BROKEN_PIPE) | Some(ERROR_PIPE_NOT_CONNECTED) => return Ok(()),
+                    Some(ERROR_NO_DATA) | Some(ERROR_PIPE_BUSY) | Some(ERROR_PIPE_LISTENING) => {
+                        wait_pipe_io(
+                            started,
+                            self.read_timeout_ns.load(Ordering::Acquire),
+                            "finish response delivery",
+                        )?;
+                    }
+                    _ => return Err(normalize_windows_pipe_io_error(error)),
+                }
+            }
+        }
+
         pub(super) fn peer_is_alive(&self) -> std::io::Result<bool> {
             Ok(self.peer_exit_code()?.is_none())
         }
@@ -2772,7 +2826,14 @@ mod platform {
 
     impl Write for Stream {
         fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
-            let amount = buffer.len().min(u32::MAX as usize) as u32;
+            if buffer.is_empty() {
+                return Ok(0);
+            }
+            // PIPE_NOWAIT does not promise a partial write when the request is
+            // larger than the configured pipe buffer. Bound each WriteFile
+            // call to one buffer so write_all can make progress on protocol
+            // payloads up to the larger frame limit.
+            let amount = buffer.len().min(PIPE_BUFFER_BYTES) as u32;
             let started = awake_now_ns();
             loop {
                 let mut written = 0_u32;
@@ -2786,7 +2847,19 @@ mod platform {
                     )
                 } != 0
                 {
-                    return Ok(written as usize);
+                    if written != 0 {
+                        return Ok(written as usize);
+                    }
+                    // A nonblocking byte pipe can report a successful
+                    // zero-byte write while its kernel buffer is full. Keep
+                    // the response inside the already configured finite write
+                    // deadline instead of surfacing WriteZero to write_all.
+                    wait_pipe_io(
+                        started,
+                        self.write_timeout_ns.load(Ordering::Acquire),
+                        "write",
+                    )?;
+                    continue;
                 }
                 let error = std::io::Error::last_os_error();
                 if !error
@@ -3093,8 +3166,8 @@ mod platform {
                 open_mode,
                 pipe_mode,
                 PIPE_UNLIMITED_INSTANCES,
-                1024 * 1024,
-                1024 * 1024,
+                PIPE_BUFFER_BYTES as u32,
+                PIPE_BUFFER_BYTES as u32,
                 0,
                 &security,
             )
@@ -3575,6 +3648,190 @@ mod platform {
                 ERROR_PIPE_NOT_CONNECTED,
                 error.kind()
             );
+        }
+
+        #[test]
+        fn final_response_delivery_waits_for_the_client_to_drain_before_disconnect() {
+            let current_sid = current_process_sid().expect("current process SID");
+            let sid_string = sid_string(&current_sid).expect("current SID string");
+            let security_sddl = wide(&format!(
+                "O:{sid_string}D:P(A;;GA;;;{sid_string})(A;;GA;;;SY)"
+            ));
+            let pipe_name = wide(&format!(
+                r"\\.\pipe\codestory-response-delivery-test-{}-{}",
+                unsafe { GetCurrentProcessId() },
+                awake_now_ns()
+            ));
+            let server = create_pipe_instance(&pipe_name, &security_sddl, true, true)
+                .expect("create named-pipe server");
+            let client = unsafe {
+                CreateFileW(
+                    pipe_name.as_ptr(),
+                    GENERIC_READ | GENERIC_WRITE,
+                    0,
+                    null(),
+                    OPEN_EXISTING,
+                    0,
+                    null_mut(),
+                )
+            };
+            assert_ne!(client, INVALID_HANDLE_VALUE, "connect named-pipe client");
+            let client = unsafe { OwnedHandle::from_raw_handle(client.cast()) };
+            let nonblocking = PIPE_READMODE_BYTE | PIPE_NOWAIT;
+            assert_ne!(
+                unsafe { SetNamedPipeHandleState(raw(&client), &nonblocking, null(), null()) },
+                0,
+                "set named-pipe client nonblocking"
+            );
+            if unsafe { ConnectNamedPipe(raw(&server), null_mut()) } == 0 {
+                let error = std::io::Error::last_os_error();
+                assert_eq!(
+                    error.raw_os_error().map(|code| code as u32),
+                    Some(ERROR_PIPE_CONNECTED),
+                    "client connection must be the only failed accept state"
+                );
+            }
+
+            let peer_pid = unsafe { GetCurrentProcessId() };
+            let peer_process_start_id =
+                canonical_process_start_identity(peer_pid).expect("current process start identity");
+            let identity = || TransportIdentity {
+                endpoint_namespace_id: "test-endpoint".into(),
+                lifetime_authority_id: "test-authority".into(),
+                listener_id: "test-listener".into(),
+                peer_verified: true,
+                peer_pid: Some(peer_pid),
+                peer_process_start_id: Some(peer_process_start_id.clone()),
+            };
+            let mut server_stream =
+                Stream::new(server, true, identity()).expect("retain named-pipe server stream");
+            let mut client_stream =
+                Stream::new(client, false, identity()).expect("retain named-pipe client stream");
+            let timeout = codestory_retrieval::EmbeddingClientBudgets::current().query_request;
+            server_stream
+                .set_read_timeout(Some(timeout))
+                .expect("bound response delivery wait");
+            server_stream
+                .set_write_timeout(Some(timeout))
+                .expect("bound response write");
+            client_stream
+                .set_read_timeout(Some(timeout))
+                .expect("bound response read");
+
+            let expected = (0..(2 * 1024 * 1024))
+                .map(|index| (index % 251) as u8)
+                .collect::<Vec<_>>();
+            let server_expected = expected.clone();
+            let (written_tx, written_rx) = std::sync::mpsc::channel();
+            let (finished_tx, finished_rx) = std::sync::mpsc::channel();
+            let server_thread = std::thread::spawn(move || {
+                server_stream
+                    .write_all(&server_expected)
+                    .expect("write response larger than the pipe buffer");
+                written_tx
+                    .send(())
+                    .expect("signal completed response write");
+                server_stream
+                    .finish_response_delivery()
+                    .expect("wait for client response drain");
+                finished_tx
+                    .send(())
+                    .expect("signal completed response delivery");
+            });
+
+            std::thread::sleep(Duration::from_millis(25));
+            let mut observed = vec![0_u8; expected.len()];
+            client_stream
+                .read_exact(&mut observed)
+                .expect("read the complete response before server teardown");
+            assert_eq!(observed, expected);
+            written_rx
+                .recv_timeout(timeout)
+                .expect("server completed response write");
+            assert!(
+                finished_rx.try_recv().is_err(),
+                "server must retain the pipe while the drained client handle remains open"
+            );
+
+            drop(client_stream);
+            finished_rx
+                .recv_timeout(timeout)
+                .expect("client close releases the bounded delivery wait");
+            server_thread.join().expect("join named-pipe server");
+        }
+
+        #[test]
+        fn large_response_write_times_out_when_the_client_does_not_drain() {
+            let current_sid = current_process_sid().expect("current process SID");
+            let sid_string = sid_string(&current_sid).expect("current SID string");
+            let security_sddl = wide(&format!(
+                "O:{sid_string}D:P(A;;GA;;;{sid_string})(A;;GA;;;SY)"
+            ));
+            let pipe_name = wide(&format!(
+                r"\\.\pipe\codestory-response-write-timeout-test-{}-{}",
+                unsafe { GetCurrentProcessId() },
+                awake_now_ns()
+            ));
+            let server = create_pipe_instance(&pipe_name, &security_sddl, true, true)
+                .expect("create named-pipe server");
+            let client = unsafe {
+                CreateFileW(
+                    pipe_name.as_ptr(),
+                    GENERIC_READ | GENERIC_WRITE,
+                    0,
+                    null(),
+                    OPEN_EXISTING,
+                    0,
+                    null_mut(),
+                )
+            };
+            assert_ne!(client, INVALID_HANDLE_VALUE, "connect named-pipe client");
+            let client = unsafe { OwnedHandle::from_raw_handle(client.cast()) };
+            let nonblocking = PIPE_READMODE_BYTE | PIPE_NOWAIT;
+            assert_ne!(
+                unsafe { SetNamedPipeHandleState(raw(&client), &nonblocking, null(), null()) },
+                0,
+                "set named-pipe client nonblocking"
+            );
+            if unsafe { ConnectNamedPipe(raw(&server), null_mut()) } == 0 {
+                let error = std::io::Error::last_os_error();
+                assert_eq!(
+                    error.raw_os_error().map(|code| code as u32),
+                    Some(ERROR_PIPE_CONNECTED),
+                    "client connection must be the only failed accept state"
+                );
+            }
+
+            let peer_pid = unsafe { GetCurrentProcessId() };
+            let peer_process_start_id =
+                canonical_process_start_identity(peer_pid).expect("current process start identity");
+            let identity = TransportIdentity {
+                endpoint_namespace_id: "test-endpoint".into(),
+                lifetime_authority_id: "test-authority".into(),
+                listener_id: "test-listener".into(),
+                peer_verified: true,
+                peer_pid: Some(peer_pid),
+                peer_process_start_id: Some(peer_process_start_id),
+            };
+            let mut server_stream =
+                Stream::new(server, true, identity).expect("retain named-pipe server stream");
+            let timeout = Duration::from_millis(50);
+            server_stream
+                .set_write_timeout(Some(timeout))
+                .expect("bound response write");
+
+            let response = vec![7_u8; PIPE_BUFFER_BYTES + 1];
+            let started = std::time::Instant::now();
+            let error = server_stream
+                .write_all(&response)
+                .expect_err("a non-reading client must not retain a large response writer");
+            assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+            assert!(
+                started.elapsed() < Duration::from_secs(2),
+                "the server-owned response write cap must release the handler promptly"
+            );
+
+            drop(client);
         }
     }
 }

--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -155,6 +155,12 @@ pub trait EmbeddingServerStream: Read + Write + Send {
     fn peer_exit_code(&self) -> io::Result<Option<u32>> {
         Ok(None)
     }
+    /// Completes transport-specific delivery of the final response before the
+    /// server tears the connection down. Transports whose close preserves
+    /// unread bytes need no additional work.
+    fn finish_response_delivery(&self) -> io::Result<()> {
+        Ok(())
+    }
     fn shutdown(&self) -> io::Result<()>;
 }
 
@@ -3364,21 +3370,41 @@ fn sync_qualification_directory(_path: &Path) -> Result<()> {
 
 fn serve_embedding_connection(
     state: Arc<PerUserEmbeddingServerState>,
-    stream: Box<dyn EmbeddingServerStream>,
+    mut stream: Box<dyn EmbeddingServerStream>,
 ) -> Result<()> {
-    serve_embedding_connection_inner(state, stream, false)
+    let result = serve_embedding_connection_inner(state, &mut *stream, false);
+    finish_embedding_response_delivery(&*stream, result)
 }
 
 fn serve_embedding_connection_at_handler_capacity(
     state: Arc<PerUserEmbeddingServerState>,
-    stream: Box<dyn EmbeddingServerStream>,
+    mut stream: Box<dyn EmbeddingServerStream>,
 ) -> Result<()> {
-    serve_embedding_connection_inner(state, stream, true)
+    let result = serve_embedding_connection_inner(state, &mut *stream, true);
+    finish_embedding_response_delivery(&*stream, result)
+}
+
+fn finish_embedding_response_delivery(
+    stream: &dyn EmbeddingServerStream,
+    result: Result<()>,
+) -> Result<()> {
+    result?;
+    // Do not inherit the wire deadline here: an authenticated same-user client
+    // may choose any positive value and could otherwise retain every bounded
+    // handler after receiving its response. The frozen query request deadline
+    // is the smallest server-owned product budget and physically covers a
+    // response larger than the Windows pipe buffer.
+    stream
+        .set_read_timeout(Some(EmbeddingClientBudgets::current().query_request))
+        .context("bound embedding final response delivery")?;
+    stream
+        .finish_response_delivery()
+        .context("finish embedding final response delivery")
 }
 
 fn serve_embedding_connection_inner(
     state: Arc<PerUserEmbeddingServerState>,
-    mut stream: Box<dyn EmbeddingServerStream>,
+    stream: &mut dyn EmbeddingServerStream,
     handler_capacity_limited: bool,
 ) -> Result<()> {
     let pre_request_guard = (!handler_capacity_limited)
@@ -3406,8 +3432,7 @@ fn serve_embedding_connection_inner(
         .set_write_timeout(Some(EmbeddingClientBudgets::current().connect))
         .context("bound embedding server handshake write")?;
     let connection_id = Uuid::new_v4().to_string();
-    let (hello_request, hello_payload): (EmbeddingProtocolRequest, Vec<u8>) =
-        read_frame(&mut *stream)?;
+    let (hello_request, hello_payload): (EmbeddingProtocolRequest, Vec<u8>) = read_frame(stream)?;
     if !hello_payload.is_empty() {
         bail!("embedding_server_protocol_hello_required");
     }
@@ -4492,10 +4517,17 @@ fn configure_server_operation_timeout(
     stream: &dyn EmbeddingServerStream,
     deadline_ms: u64,
 ) -> Result<()> {
-    let timeout = Duration::from_millis(deadline_ms);
-    if timeout.is_zero() {
+    let wire_timeout = Duration::from_millis(deadline_ms);
+    if wire_timeout.is_zero() {
         bail!("embedding_server_deadline_invalid");
     }
+    // The wire deadline can shorten an exchange, but it cannot lengthen a
+    // response write. In particular, Windows PIPE_NOWAIT writes must retry
+    // zero progress while the kernel buffer is full. A peer-selected timeout
+    // there would let a non-reading same-user client retain every bounded
+    // connection handler. The smallest frozen request budget is already
+    // qualified for responses larger than the Windows pipe buffer.
+    let timeout = wire_timeout.min(EmbeddingClientBudgets::current().query_request);
     stream
         .set_read_timeout(Some(timeout))
         .context("bound embedding server request read")?;
@@ -5207,22 +5239,48 @@ mod tests {
         identity: EmbeddingTransportIdentity,
         input: Cursor<Vec<u8>>,
         output: Arc<Mutex<Vec<u8>>>,
+        finished_deliveries: Arc<AtomicUsize>,
+        read_timeouts: Arc<Mutex<Vec<Option<Duration>>>>,
+        write_timeouts: Arc<Mutex<Vec<Option<Duration>>>>,
         alive: bool,
         exit_codes: Mutex<Vec<Option<u32>>>,
     }
 
     impl MemoryStream {
         fn new(input: Vec<u8>, alive: bool) -> (Self, Arc<Mutex<Vec<u8>>>) {
+            let (stream, output, _, _, _) = Self::with_delivery_tracking(input, alive);
+            (stream, output)
+        }
+
+        fn with_delivery_tracking(
+            input: Vec<u8>,
+            alive: bool,
+        ) -> (
+            Self,
+            Arc<Mutex<Vec<u8>>>,
+            Arc<AtomicUsize>,
+            Arc<Mutex<Vec<Option<Duration>>>>,
+            Arc<Mutex<Vec<Option<Duration>>>>,
+        ) {
             let output = Arc::new(Mutex::new(Vec::new()));
+            let finished_deliveries = Arc::new(AtomicUsize::new(0));
+            let read_timeouts = Arc::new(Mutex::new(Vec::new()));
+            let write_timeouts = Arc::new(Mutex::new(Vec::new()));
             (
                 Self {
                     identity: test_transport_identity(),
                     input: Cursor::new(input),
                     output: Arc::clone(&output),
+                    finished_deliveries: Arc::clone(&finished_deliveries),
+                    read_timeouts: Arc::clone(&read_timeouts),
+                    write_timeouts: Arc::clone(&write_timeouts),
                     alive,
                     exit_codes: Mutex::new(vec![None]),
                 },
                 output,
+                finished_deliveries,
+                read_timeouts,
+                write_timeouts,
             )
         }
     }
@@ -5252,11 +5310,19 @@ mod tests {
             &self.identity
         }
 
-        fn set_read_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
+        fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+            self.read_timeouts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(timeout);
             Ok(())
         }
 
-        fn set_write_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
+        fn set_write_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+            self.write_timeouts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(timeout);
             Ok(())
         }
 
@@ -5273,6 +5339,11 @@ mod tests {
                 return Ok(exit_codes.remove(0));
             }
             Ok(exit_codes.first().copied().flatten())
+        }
+
+        fn finish_response_delivery(&self) -> io::Result<()> {
+            self.finished_deliveries.fetch_add(1, Ordering::AcqRel);
+            Ok(())
         }
 
         fn shutdown(&self) -> io::Result<()> {
@@ -6414,13 +6485,19 @@ mod tests {
             EmbeddingCompatibility::current(true),
             operation,
         );
-        let (stream, _) = MemoryStream::new(encode_test_frame(&hello, &[]), true);
+        let (stream, _, finished_deliveries, _, _) =
+            MemoryStream::with_delivery_tracking(encode_test_frame(&hello, &[]), true);
         let error = serve_embedding_connection(test_server_state(), Box::new(stream))
             .expect_err("stale client identity must fail");
         assert!(
             error
                 .to_string()
                 .contains("embedding_server_peer_identity_mismatch")
+        );
+        assert_eq!(
+            finished_deliveries.load(Ordering::Acquire),
+            0,
+            "an uncorrelated protocol failure must not pretend response delivery completed"
         );
     }
 
@@ -6436,6 +6513,37 @@ mod tests {
             error
                 .to_string()
                 .contains("embedding_server_frame_too_large")
+        );
+    }
+
+    #[test]
+    fn server_response_write_timeout_cannot_exceed_the_frozen_query_budget() {
+        let (stream, _, _, read_timeouts, write_timeouts) =
+            MemoryStream::with_delivery_tracking(Vec::new(), true);
+
+        configure_server_operation_timeout(&stream, 24 * 60 * 60 * 1_000)
+            .expect("configure peer-selected exchange deadline");
+
+        let expected = Some(EmbeddingClientBudgets::current().query_request);
+        assert_eq!(
+            read_timeouts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .last()
+                .copied()
+                .flatten(),
+            expected,
+            "a peer-selected deadline must not retain a server read beyond the frozen cap"
+        );
+        assert_eq!(
+            write_timeouts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .last()
+                .copied()
+                .flatten(),
+            expected,
+            "a non-reading peer must not retain a response writer beyond the frozen cap"
         );
     }
 
@@ -6669,11 +6777,27 @@ mod tests {
         );
         let mut input = encode_test_frame(&hello, &[]);
         input.extend_from_slice(&encode_test_frame(&activate, &[]));
-        let (stream, output) = MemoryStream::new(input, true);
+        let (stream, output, finished_deliveries, read_timeouts, _) =
+            MemoryStream::with_delivery_tracking(input, true);
         let state = test_server_state();
         let idle_before = state.last_work_ended_ns.load(Ordering::Acquire);
         serve_embedding_connection(Arc::clone(&state), Box::new(stream))
             .expect("observe rejection is correlated");
+        assert_eq!(
+            finished_deliveries.load(Ordering::Acquire),
+            1,
+            "a correlated final response must finish transport delivery before teardown"
+        );
+        assert_eq!(
+            read_timeouts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .last()
+                .copied()
+                .flatten(),
+            Some(EmbeddingClientBudgets::current().query_request),
+            "final delivery must replace the peer-selected timeout with the server-owned cap"
+        );
         assert!(state.engine.lock().expect("engine state").is_none());
         assert_eq!(
             state.last_work_ended_ns.load(Ordering::Acquire),


### PR DESCRIPTION
## Context

Exact packaged-platform run `29908181023` at dev `5c1f360fc219c54a017f319c59d36db3d768ff00` left two parallel cold searches in dense preparation for 15 minutes. Both repeatedly lost the response with Win32 error 233 while the same authenticated embedding server PID and process-start identity remained live.

The server wrote each one-shot response and then immediately called `DisconnectNamedPipe` from stream teardown. Windows discards unread pipe data at that boundary, so restarting or replaying against another identical instance would reproduce the same loss.

## What changed

- add a transport final-response delivery hook after successful server handlers only;
- on Windows, retain the named-pipe instance until the client closes after reading, bounded by the server-owned frozen query-request budget rather than a client-selected wire deadline;
- chunk nonblocking writes to the configured pipe buffer and poll zero-progress results inside the frozen server-owned query budget, allowing larger protocol payloads to make progress without accepting peer-controlled handler retention;
- keep Unix close behavior unchanged;
- preserve the existing one-replay/second-loss fail-closed client path;
- add server lifecycle coverage plus Windows regressions that drain a 2 MiB response before teardown and release a writer when a non-reading client fills the 1 MiB pipe buffer;
- update `CHANGELOG.md`.

## How to review

Start at `finish_embedding_response_delivery` in `per_user_embedding.rs`, then follow `NativeEmbeddingStream::finish_response_delivery` to the Windows transport. The important boundary is that only a successful, correlated handler result enters the drain wait. Errors without a response still tear down immediately.

## Verification

Base commit: `5c1f360fc219c54a017f319c59d36db3d768ff00`

Head commit: `2d0ec2a224fbfe278a5983b456c4b959034ed64a`

Head tree: `b68afa502d4b27d3e55496bed51d023e1510775b`

Completed:

- `cargo check --locked -p codestory-retrieval -p codestory-cli`
- `cargo test --locked -p codestory-retrieval per_user_embedding --lib` (41 passed)
- `cargo test --locked -p codestory-cli embedding_server_transport --lib` (17 passed, 4 filtered)
- `cargo fmt --all -- --check`
- `git diff --check`
- physical Windows x64 at the exact head/tree: 2 MiB response-drain/close regression, non-reading >1 MiB response-write timeout regression, and raw-233 live-peer classification regression (1 passed each)
- independent exact-head re-review: no actionable findings
- hosted rustdoc run `29913836783`: passed
- hosted retrieval Linux-contracts run `29913836912`: passed
- hosted Ubuntu draft source run `29913836806`: passed

Physical Windows evidence is preserved at `C:\tmp\codestory-1385-evidence-2d0ec2a2` and mirrored at `/Users/albert/Developer/CodeStory-evidence/v016-2d0ec2a2-20260722/windows-native`. The release coordinator was not retried.

## Risk

Response writes and the delivery wait retain one bounded handler only inside the frozen query-request budget. A same-user client cannot extend either phase through its wire deadline; the physical regressions cover both a drained 2 MiB response and a non-reading client after the 1 MiB pipe buffer fills. Connection admission remains hard bounded. The calibrated 23 ms connect timeout is not substituted for response delivery. No unbounded `FlushFileBuffers`, retry, or new process authority is introduced.

## Non-claims

This PR does not prove package qualification, Vulkan execution, candidate-installed behavior, Mac/Metal, answer quality, promotion, publication, or release readiness. The exact packaged managed proof remains outside this PR and must not be inferred from source tests.

Closes #1385
Refs #1372
Refs #1221
Refs #1383
