### PR TITLE
Factor embedding delivery test observations for all-target Clippy

### DIFF
--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -5246,28 +5246,27 @@ mod tests {
         exit_codes: Mutex<Vec<Option<u32>>>,
     }
 
+    struct MemoryStreamFixture {
+        stream: MemoryStream,
+        output: Arc<Mutex<Vec<u8>>>,
+        finished_deliveries: Arc<AtomicUsize>,
+        read_timeouts: Arc<Mutex<Vec<Option<Duration>>>>,
+        write_timeouts: Arc<Mutex<Vec<Option<Duration>>>>,
+    }
+
     impl MemoryStream {
         fn new(input: Vec<u8>, alive: bool) -> (Self, Arc<Mutex<Vec<u8>>>) {
-            let (stream, output, _, _, _) = Self::with_delivery_tracking(input, alive);
-            (stream, output)
+            let fixture = Self::with_delivery_tracking(input, alive);
+            (fixture.stream, fixture.output)
         }
 
-        fn with_delivery_tracking(
-            input: Vec<u8>,
-            alive: bool,
-        ) -> (
-            Self,
-            Arc<Mutex<Vec<u8>>>,
-            Arc<AtomicUsize>,
-            Arc<Mutex<Vec<Option<Duration>>>>,
-            Arc<Mutex<Vec<Option<Duration>>>>,
-        ) {
+        fn with_delivery_tracking(input: Vec<u8>, alive: bool) -> MemoryStreamFixture {
             let output = Arc::new(Mutex::new(Vec::new()));
             let finished_deliveries = Arc::new(AtomicUsize::new(0));
             let read_timeouts = Arc::new(Mutex::new(Vec::new()));
             let write_timeouts = Arc::new(Mutex::new(Vec::new()));
-            (
-                Self {
+            MemoryStreamFixture {
+                stream: Self {
                     identity: test_transport_identity(),
                     input: Cursor::new(input),
                     output: Arc::clone(&output),
@@ -5281,7 +5280,7 @@ mod tests {
                 finished_deliveries,
                 read_timeouts,
                 write_timeouts,
-            )
+            }
         }
     }
 
@@ -6485,9 +6484,8 @@ mod tests {
             EmbeddingCompatibility::current(true),
             operation,
         );
-        let (stream, _, finished_deliveries, _, _) =
-            MemoryStream::with_delivery_tracking(encode_test_frame(&hello, &[]), true);
-        let error = serve_embedding_connection(test_server_state(), Box::new(stream))
+        let fixture = MemoryStream::with_delivery_tracking(encode_test_frame(&hello, &[]), true);
+        let error = serve_embedding_connection(test_server_state(), Box::new(fixture.stream))
             .expect_err("stale client identity must fail");
         assert!(
             error
@@ -6495,7 +6493,7 @@ mod tests {
                 .contains("embedding_server_peer_identity_mismatch")
         );
         assert_eq!(
-            finished_deliveries.load(Ordering::Acquire),
+            fixture.finished_deliveries.load(Ordering::Acquire),
             0,
             "an uncorrelated protocol failure must not pretend response delivery completed"
         );
@@ -6518,15 +6516,15 @@ mod tests {
 
     #[test]
     fn server_response_write_timeout_cannot_exceed_the_frozen_query_budget() {
-        let (stream, _, _, read_timeouts, write_timeouts) =
-            MemoryStream::with_delivery_tracking(Vec::new(), true);
+        let fixture = MemoryStream::with_delivery_tracking(Vec::new(), true);
 
-        configure_server_operation_timeout(&stream, 24 * 60 * 60 * 1_000)
+        configure_server_operation_timeout(&fixture.stream, 24 * 60 * 60 * 1_000)
             .expect("configure peer-selected exchange deadline");
 
         let expected = Some(EmbeddingClientBudgets::current().query_request);
         assert_eq!(
-            read_timeouts
+            fixture
+                .read_timeouts
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .last()
@@ -6536,7 +6534,8 @@ mod tests {
             "a peer-selected deadline must not retain a server read beyond the frozen cap"
         );
         assert_eq!(
-            write_timeouts
+            fixture
+                .write_timeouts
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .last()
@@ -6777,19 +6776,19 @@ mod tests {
         );
         let mut input = encode_test_frame(&hello, &[]);
         input.extend_from_slice(&encode_test_frame(&activate, &[]));
-        let (stream, output, finished_deliveries, read_timeouts, _) =
-            MemoryStream::with_delivery_tracking(input, true);
+        let fixture = MemoryStream::with_delivery_tracking(input, true);
         let state = test_server_state();
         let idle_before = state.last_work_ended_ns.load(Ordering::Acquire);
-        serve_embedding_connection(Arc::clone(&state), Box::new(stream))
+        serve_embedding_connection(Arc::clone(&state), Box::new(fixture.stream))
             .expect("observe rejection is correlated");
         assert_eq!(
-            finished_deliveries.load(Ordering::Acquire),
+            fixture.finished_deliveries.load(Ordering::Acquire),
             1,
             "a correlated final response must finish transport delivery before teardown"
         );
         assert_eq!(
-            read_timeouts
+            fixture
+                .read_timeouts
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .last()
@@ -6803,7 +6802,8 @@ mod tests {
             state.last_work_ended_ns.load(Ordering::Acquire),
             idle_before
         );
-        let bytes = output
+        let bytes = fixture
+            .output
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone();


### PR DESCRIPTION
## Context

Exact-dev source run `29914904224` at merge `8804ebfd0590edded3ad69b1f7bdb1cadc5fd2c8` passed all workspace tests, then failed its required Rust 1.97.1 all-target/all-feature Clippy gate. The new test helper returned a five-element tuple containing nested synchronization types, triggering `clippy::type_complexity` when the test target was linted.

The draft source workflow did not catch this because `.github/workflows/rust-ci.yml` runs Clippy with `--workspace --lib`; the exact source workflow in `.github/workflows/source-proof.yml` adds `--all-targets --all-features`, which compiles this `#[cfg(test)]` helper.

## What changed

- replace the test helper's anonymous observation tuple with a named `MemoryStreamFixture`;
- retain the same output, delivery-count, read-timeout, and write-timeout handles;
- update the three callers to use named fixture fields;
- do not suppress the lint or change product behavior.

## Verification

Base: `8804ebfd0590edded3ad69b1f7bdb1cadc5fd2c8`

Head: `53b1b0b21a527865010d56ef0543c83f14ee518f`

Tree: `9d67ffc3e83e3858cca6510765892fccb060f95c`

Completed with Rust 1.97.1:

- `cargo +stable test --locked -p codestory-retrieval per_user_embedding --lib` — 41 passed
- `cargo +stable clippy --locked -p codestory-retrieval --all-targets --all-features -- -D warnings`
- `cargo +stable clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent exact-head review: no actionable findings
- hosted Ubuntu draft source run `29916835734`: passed
- hosted rustdoc run `29916835688`: passed
- hosted retrieval Linux-contracts run `29916835723`: passed

The failed source log remains preserved at `/Users/albert/Developer/CodeStory-evidence/v016-8804ebfd0590-20260722/source-29914904224-job-88906396620.log`. The exact source workflow and release coordinator were not rerun.

## Risk

Test-only refactor in one module. The production stream, timeout, and response-delivery code is unchanged.

Closes #1387
Refs #1385
Refs #1372
