### PR TITLE
[codex] Extend managed handoff timeout

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -965,6 +965,7 @@ export function managedPluginViolations(job, archiveFragment) {
     "--engine-policy cpu_explicit",
     "--expected-backend CPU",
     "--offline",
+    "--timeout-secs 1800",
   ]) {
     add(violations, run.includes(fragment), `managed plugin proof step must run ${fragment}`);
   }

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -75,8 +75,19 @@ function executableRunText(run) {
     .join("\n");
 }
 
-function argumentValues(run, flag) {
-  const tokens = run.split(/\s+/u).filter(Boolean);
+function simpleCommandTokens(run) {
+  const command = run.trim();
+  if (
+    command.length === 0
+    || /[\r\n#;&|`<>]/u.test(command)
+    || command.includes("$(")
+  ) {
+    return undefined;
+  }
+  return command.split(/\s+/u);
+}
+
+function argumentValues(tokens, flag) {
   const values = [];
   for (const [index, token] of tokens.entries()) {
     if (token === flag) {
@@ -981,7 +992,16 @@ export function managedPluginViolations(job, archiveFragment) {
   ]) {
     add(violations, run.includes(fragment), `managed plugin proof step must run ${fragment}`);
   }
-  const timeoutValues = argumentValues(run, "--timeout-secs");
+  const commandTokens = simpleCommandTokens(run);
+  add(
+    violations,
+    commandTokens?.[0] === "python"
+      && commandTokens?.[1] === ".github/scripts/check-packaged-agent-proof.py",
+    "managed plugin proof step must contain one simple checker command without comment or command-control syntax",
+  );
+  const timeoutValues = commandTokens === undefined
+    ? []
+    : argumentValues(commandTokens, "--timeout-secs");
   add(
     violations,
     timeoutValues.length === 1 && timeoutValues[0] === "1800",

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -75,6 +75,19 @@ function executableRunText(run) {
     .join("\n");
 }
 
+function argumentValues(run, flag) {
+  const tokens = run.split(/\s+/u).filter(Boolean);
+  const values = [];
+  for (const [index, token] of tokens.entries()) {
+    if (token === flag) {
+      values.push(tokens[index + 1]);
+    } else if (token.startsWith(`${flag}=`)) {
+      values.push(token.slice(flag.length + 1));
+    }
+  }
+  return values;
+}
+
 function add(violations, condition, message) {
   if (!condition) violations.push(message);
 }
@@ -965,10 +978,15 @@ export function managedPluginViolations(job, archiveFragment) {
     "--engine-policy cpu_explicit",
     "--expected-backend CPU",
     "--offline",
-    "--timeout-secs 1800",
   ]) {
     add(violations, run.includes(fragment), `managed plugin proof step must run ${fragment}`);
   }
+  const timeoutValues = argumentValues(run, "--timeout-secs");
+  add(
+    violations,
+    timeoutValues.length === 1 && timeoutValues[0] === "1800",
+    "managed plugin proof step must run exactly one --timeout-secs 1800",
+  );
   return violations;
 }
 

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -154,6 +154,7 @@ function managedJob() {
           "--engine-policy cpu_explicit",
           "--expected-backend CPU",
           "--offline",
+          "--timeout-secs 1800",
         ].join("\n"),
       },
     ],
@@ -1555,6 +1556,7 @@ test("managed proof rejects structural bypasses and decoy commands", () => {
     job => { job.steps[0].run = job.steps[0].run.replace("--engine-policy cpu_explicit", ""); },
     job => { job.steps[0].run = job.steps[0].run.replace("--expected-backend CPU", ""); },
     job => { job.steps[0].run = job.steps[0].run.replace("--offline", ""); },
+    job => { job.steps[0].run = job.steps[0].run.replace("--timeout-secs 1800", "--timeout-secs 900"); },
     job => {
       job.steps[0].run = "python .github/scripts/check-packaged-agent-proof.py\n--archive package.tar.gz\n# --plugin-handoff";
       job.steps.push({ name: "Decoy", run: "--plugin-handoff" });

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -155,7 +155,7 @@ function managedJob() {
           "--expected-backend CPU",
           "--offline",
           "--timeout-secs 1800",
-        ].join("\n"),
+        ].join(" "),
       },
     ],
   };
@@ -1560,6 +1560,9 @@ test("managed proof rejects structural bypasses and decoy commands", () => {
     job => { job.steps[0].run = job.steps[0].run.replace("--timeout-secs 1800", "--timeout-secs 18000"); },
     job => { job.steps[0].run += "\n--timeout-secs 900"; },
     job => { job.steps[0].run += "\n--timeout-secs=900"; },
+    job => { job.steps[0].run = job.steps[0].run.replace("--timeout-secs 1800", "# --timeout-secs 1800"); },
+    job => { job.steps[0].run = job.steps[0].run.replace("--timeout-secs 1800", "; echo --timeout-secs 1800"); },
+    job => { job.steps[0].run += "\necho --timeout-secs 1800"; },
     job => {
       job.steps[0].run = "python .github/scripts/check-packaged-agent-proof.py\n--archive package.tar.gz\n# --plugin-handoff";
       job.steps.push({ name: "Decoy", run: "--plugin-handoff" });

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1557,6 +1557,9 @@ test("managed proof rejects structural bypasses and decoy commands", () => {
     job => { job.steps[0].run = job.steps[0].run.replace("--expected-backend CPU", ""); },
     job => { job.steps[0].run = job.steps[0].run.replace("--offline", ""); },
     job => { job.steps[0].run = job.steps[0].run.replace("--timeout-secs 1800", "--timeout-secs 900"); },
+    job => { job.steps[0].run = job.steps[0].run.replace("--timeout-secs 1800", "--timeout-secs 18000"); },
+    job => { job.steps[0].run += "\n--timeout-secs 900"; },
+    job => { job.steps[0].run += "\n--timeout-secs=900"; },
     job => {
       job.steps[0].run = "python .github/scripts/check-packaged-agent-proof.py\n--archive package.tar.gz\n# --plugin-handoff";
       job.steps.push({ name: "Decoy", run: "--plugin-handoff" });

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -823,6 +823,7 @@ jobs:
           --expected-backend CPU
           --offline
           --proof-tier calibration
+          --timeout-secs 1800
           --out-dir target/packaged-managed-proof
 
       - name: Upload managed plugin proof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   and chunks nonblocking writes to the pipe buffer while keeping zero-progress
   polling inside the frozen server-owned query budget even when a peer supplies
   a longer wire deadline.
+  Cross-platform managed plugin handoff proof now uses the same explicit,
+  bounded 1,800-second checker deadline as the other two-host qualification
+  lanes instead of silently falling back to 900 seconds.
 
 ## 0.16.0
 


### PR DESCRIPTION
## Context

Exact Windows package run `29919524350` at `a4fd5ecc2a1c6d2def11475c2a2ea526b7e9454b` reached the final managed plugin handoff without the earlier raw Windows pipe-disconnect failure. Host B completed its tiny second-repository search, while project A remained in the coarse `Publication` activation stage until the checker stopped after 132 attempts.

The cross-platform managed handoff did not pass `--timeout-secs`, so it used the checker's 900-second default. The other two-host hosted, protected-hardware, and candidate-installed lanes explicitly use the intended bounded 1,800-second deadline. This is an internal proof-process cutoff, distinct from the GitHub job timeout fixed by #1370.

Closes #1389.

## What changed

- Pass `--timeout-secs 1800` to the cross-platform managed plugin handoff.
- Require that exact bounded deadline in the managed-proof workflow policy.
- Add a mutation case that rejects shortening it back to 900 seconds.
- Record the release-automation correction under `Unreleased`.

## How to review

1. Confirm the managed handoff receives the same 1,800-second checker deadline as the other two-host qualification lanes.
2. Confirm policy validation rejects both removing and shortening the deadline.
3. Confirm no proof tier, claim, retry, or product runtime behavior changes.

## Verification

- `node --test .github/scripts/check-workflow-policy.test.mjs` — 276 passed
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/run-actionlint.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

## Risk and non-claims

The larger deadline remains bounded and changes only the final managed handoff checker. It does not prove project A was making progress at the prior cutoff, change fail-closed activation behavior, weaken any readiness check, add performance or acceleration claims, authorize a qualification rerun, or grant promotion, publication, or release authority.
