### PR TITLE
[codex] Accept native-identical Windows resource URIs

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -29,8 +29,8 @@ import tempfile
 import threading
 import time
 import zipfile
-from pathlib import Path
-from urllib.parse import quote
+from pathlib import Path, PureWindowsPath
+from urllib.parse import quote, unquote
 
 from native_binary_contract import (
     NativeBinaryError,
@@ -76,6 +76,46 @@ def project_node_resource_uri(base_uri: str, node_id: str, project: Path) -> str
         f"{base_uri}/{quote(node_id, safe='-._~')}",
         project,
     )
+
+
+def project_resource_uri_parts(uri: str) -> tuple[str, str] | None:
+    base_uri, marker, encoded_project = uri.partition("?project=")
+    if marker == "" or base_uri == "" or encoded_project == "":
+        return None
+    try:
+        project = unquote(encoded_project, errors="strict")
+    except UnicodeDecodeError:
+        return None
+    if quote(project, safe="-._~") != encoded_project:
+        return None
+    return base_uri, project
+
+
+def resource_uri_matches(
+    expected_uri: str,
+    actual_uri: str,
+    *,
+    platform_name: str | None = None,
+    samefile=None,
+) -> bool:
+    if actual_uri == expected_uri:
+        return True
+    if (os.name if platform_name is None else platform_name) != "nt":
+        return False
+    expected = project_resource_uri_parts(expected_uri)
+    actual = project_resource_uri_parts(actual_uri)
+    if expected is None or actual is None or expected[0] != actual[0]:
+        return False
+    if not (
+        PureWindowsPath(expected[1]).is_absolute()
+        and PureWindowsPath(actual[1]).is_absolute()
+    ):
+        return False
+    identity_probe = os.path.samefile if samefile is None else samefile
+    try:
+        return identity_probe(Path(expected[1]), Path(actual[1]))
+    except (OSError, ValueError):
+        return False
 
 
 EXTERNAL_QUALIFICATION_METRICS = {
@@ -2927,11 +2967,26 @@ def assert_public_status(status: dict) -> None:
     require(not leaked, "public status leaked maintainer-only retrieval fields: " + ", ".join(leaked))
 
 
-def extract_resource(response: dict, uri: str) -> dict:
+def extract_resource(
+    response: dict,
+    uri: str,
+    *,
+    platform_name: str | None = None,
+    samefile=None,
+) -> dict:
     require("error" not in response, f"resource read failed: {response.get('error')}")
     contents = response.get("result", {}).get("contents", [])
     for item in contents:
-        if isinstance(item, dict) and item.get("uri") == uri:
+        if (
+            isinstance(item, dict)
+            and isinstance(item.get("uri"), str)
+            and resource_uri_matches(
+                uri,
+                item["uri"],
+                platform_name=platform_name,
+                samefile=samefile,
+            )
+        ):
             payload = json.loads(item.get("text", "{}"))
             require(isinstance(payload, dict), "resource emitted non-object JSON")
             return payload
@@ -9603,6 +9658,106 @@ def self_test() -> None:
         == {"node": {"id": "node/id %1"}},
         "project-bound named resource extraction failed",
     )
+    short_windows_resource = (
+        "codestory://diagnostics/retrieval-engine"
+        "?project=C%3A%2FUsers%2FRUNNER~1%2FAppData%2FLocal%2FTemp%2Fproof"
+    )
+    long_windows_resource = (
+        "codestory://diagnostics/retrieval-engine"
+        "?project=C%3A%2FUsers%2Frunneradmin%2FAppData%2FLocal%2FTemp%2Fproof"
+    )
+    identity_probes: list[tuple[Path, Path]] = []
+
+    def same_windows_resource(left: Path, right: Path) -> bool:
+        identity_probes.append((left, right))
+        return True
+
+    require(
+        extract_resource(
+            {
+                "result": {
+                    "contents": [
+                        {
+                            "uri": long_windows_resource,
+                            "text": json.dumps({"native_alias": True}),
+                        }
+                    ]
+                }
+            },
+            short_windows_resource,
+            platform_name="nt",
+            samefile=same_windows_resource,
+        )
+        == {"native_alias": True}
+        and len(identity_probes) == 1,
+        "native-identical Windows project resource URI was rejected",
+    )
+    require(
+        not resource_uri_matches(
+            short_windows_resource,
+            long_windows_resource,
+            platform_name="posix",
+            samefile=same_windows_resource,
+        )
+        and len(identity_probes) == 1,
+        "Unix project resource matching accepted a different path spelling",
+    )
+    require(
+        not resource_uri_matches(
+            short_windows_resource,
+            long_windows_resource.replace(
+                "codestory://diagnostics/retrieval-engine",
+                "codestory://status",
+            ),
+            platform_name="nt",
+            samefile=same_windows_resource,
+        )
+        and len(identity_probes) == 1,
+        "Windows project resource matching accepted a different resource base",
+    )
+    require(
+        not resource_uri_matches(
+            short_windows_resource,
+            long_windows_resource.replace("%3A", "%3a"),
+            platform_name="nt",
+            samefile=same_windows_resource,
+        )
+        and len(identity_probes) == 1,
+        "Windows project resource matching accepted noncanonical URI encoding",
+    )
+    require(
+        not resource_uri_matches(
+            short_windows_resource,
+            long_windows_resource.replace("C%3A%2F", "relative%2F"),
+            platform_name="nt",
+            samefile=same_windows_resource,
+        )
+        and len(identity_probes) == 1,
+        "Windows project resource matching accepted a relative project selector",
+    )
+    require(
+        not resource_uri_matches(
+            short_windows_resource,
+            long_windows_resource,
+            platform_name="nt",
+            samefile=lambda _left, _right: False,
+        ),
+        "Windows project resource matching accepted a different native identity",
+    )
+
+    def missing_windows_resource(_left: Path, _right: Path) -> bool:
+        raise FileNotFoundError("missing project resource")
+
+    require(
+        not resource_uri_matches(
+            short_windows_resource,
+            long_windows_resource,
+            platform_name="nt",
+            samefile=missing_windows_resource,
+        ),
+        "Windows project resource matching ignored an identity probe failure",
+    )
+
     def fail_parallel(message: str) -> None:
         raise ProofFailure(message)
 

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -9672,6 +9672,10 @@ def self_test() -> None:
         identity_probes.append((left, right))
         return True
 
+    expected_identity_probe = (
+        Path("C:/Users/RUNNER~1/AppData/Local/Temp/proof"),
+        Path("C:/Users/runneradmin/AppData/Local/Temp/proof"),
+    )
     require(
         extract_resource(
             {
@@ -9689,7 +9693,8 @@ def self_test() -> None:
             samefile=same_windows_resource,
         )
         == {"native_alias": True}
-        and len(identity_probes) == 1,
+        and identity_probes == [expected_identity_probe]
+        and expected_identity_probe[0] != expected_identity_probe[1],
         "native-identical Windows project resource URI was rejected",
     )
     require(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
   Cross-platform managed plugin handoff proof now uses the same explicit,
   bounded 1,800-second checker deadline as the other two-host qualification
   lanes instead of silently falling back to 900 seconds.
+  Windows package proof now accepts a canonical project URI returned for a
+  native-identical existing project path, while resource bases, URI encoding,
+  missing paths, and Unix project URI matching remain strict.
 
 ## 0.16.0
 


### PR DESCRIPTION
## Context

Exact Windows package run `29927022567` at `32dcafa556693da3d7bc9200ac910d754aa74c33` got past both managed-handoff searches with the corrected 1,800-second deadline, then failed host B's engine-diagnostics read because the checker looked for the literal 8.3-path URI:

`codestory://diagnostics/retrieval-engine?project=C%3A%2FUsers%2FRUNNER~1%2F...%2Fsecond-repository`

The successful `resources/read` envelope is retained, but response bodies are intentionally sanitized. Source establishes the mismatch: the checker builds its expected URI from the raw temporary path; the stdio server canonicalizes the selected existing directory and returns a content URI bound to that canonical runtime root; `extract_resource()` previously required literal URI equality.

Closes #1391.

## What changed

- Keep literal URI equality as the normal and only Unix path.
- On Windows only, parse canonically encoded project selectors, require an exact resource base, require absolute project paths, and accept differing spellings only when `os.path.samefile()` proves both existing paths are the same native object.
- Fail closed for malformed encoding, relative paths, different resources, different projects, missing paths, and identity-probe errors.
- Add verifier self-tests for the 8.3/long-path response and every rejection boundary.
- Record the package-proof correction under `Unreleased`.

## How to review

1. Confirm exact URI equality still returns immediately without platform-specific normalization.
2. Confirm Windows alias handling happens only after strict base and canonical-encoding checks.
3. Confirm `samefile` is the only acceptance path for differing spellings and every probe failure rejects.
4. Confirm no CLI/resource protocol, product runtime, or Unix path behavior changes.

## Verification

- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `python -m py_compile .github/scripts/check-packaged-agent-proof.py`
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/run-actionlint.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

## Risk and non-claims

The matcher remains fail closed and does not use lexical case folding or normalization for differing paths. This source repair does not prove a terminal managed handoff, protected Vulkan, installed-runtime behavior, performance, promotion, publication, or release readiness, and it does not authorize a qualification rerun.
