### PR TITLE
[codex] Provision Linux release-evidence runtime authority

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1177,7 +1177,9 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       "crates/codestory-llama-sys/model_staging.rs",
       "crates/codestory-llama-sys/Cargo.toml",
       "crates/codestory-llama-sys/tests/model_staging.rs",
+      "scripts/release-evidence/**",
       "scripts/release-evidence/serde-json-codestory-project.json",
+      "scripts/tests/release-evidence-runner-contract.test.mjs",
     ];
     for (const event of ["pull_request", "push"]) {
       add(violations, includesAll(at(plugin, "on", event, "paths"), requiredPaths), `${pluginFile} ${event} paths must cover policy and release surfaces`);
@@ -1191,6 +1193,9 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
     ]);
     requireStepRun(violations, pluginFile, job, "Check plugin static wiring", ["node --test plugins/codestory/tests/plugin-static.test.mjs"]);
     requireStepRun(violations, pluginFile, job, "Check embedded model preparation", ["node --test scripts/tests/prepare-embedded-model.test.mjs"]);
+    requireStepRun(violations, pluginFile, job, "Check release claim and evidence contracts", [
+      "scripts/tests/release-evidence-runner-contract.test.mjs",
+    ]);
     requireStepRun(violations, pluginFile, job, "Check workflow syntax", [
       "node --test .github/scripts/run-actionlint.test.mjs",
       "node .github/scripts/run-actionlint.mjs",

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -52,8 +52,9 @@ on:
       - crates/codestory-llama-sys/model_staging.rs
       - crates/codestory-llama-sys/Cargo.toml
       - crates/codestory-llama-sys/tests/model_staging.rs
-      - scripts/release-evidence/machine-contract.json
+      - scripts/release-evidence/**
       - scripts/release-evidence/serde-json-codestory-project.json
+      - scripts/tests/release-evidence-runner-contract.test.mjs
       - scripts/codex-worktree-setup.*
       - scripts/tests/codex-worktree-setup.test.mjs
       - .codex/environments/environment.toml
@@ -111,8 +112,9 @@ on:
       - crates/codestory-llama-sys/model_staging.rs
       - crates/codestory-llama-sys/Cargo.toml
       - crates/codestory-llama-sys/tests/model_staging.rs
-      - scripts/release-evidence/machine-contract.json
+      - scripts/release-evidence/**
       - scripts/release-evidence/serde-json-codestory-project.json
+      - scripts/tests/release-evidence-runner-contract.test.mjs
       - scripts/codex-worktree-setup.*
       - scripts/tests/codex-worktree-setup.test.mjs
       - .codex/environments/environment.toml
@@ -153,6 +155,7 @@ jobs:
           scripts/tests/codestory-release-claims.test.mjs
           scripts/tests/codestory-release-closeout.test.mjs
           scripts/tests/codestory-release-evidence-gate.test.mjs
+          scripts/tests/release-evidence-runner-contract.test.mjs
 
       - name: Check workflow policy
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
   Windows package proof now accepts a canonical project URI returned for a
   native-identical existing project path, while resource bases, URI encoding,
   missing paths, and Unix project URI matching remain strict.
+  The dedicated Linux release-evidence service now provisions and verifies a
+  private per-user runtime authority before measuring the shared embedding
+  server, instead of failing closed when `XDG_RUNTIME_DIR` is absent.
 
 ## 0.16.0
 

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -88,7 +88,9 @@ Provisioning is idempotent. It:
   compiler UI fixtures from the valid-source corpus;
 - registers the runner only with `TheGreenCedar/CodeStory`; and
 - keeps Cargo, Rust, temp, XDG, CodeStory, drill, work, and artifact state
-  under the proof-owned volume.
+  under the proof-owned volume. The Actions service receives a dedicated
+  runner-owned `XDG_RUNTIME_DIR` with mode `0700`; verification rejects a
+  missing, linked, broadly accessible, or differently owned runtime authority.
 
 The runner workspace is mounted by the owned host lifecycle instead of guest
 `fstab`; this avoids boot-order races between the root disk and Colima's data

--- a/scripts/release-evidence/guest-provision.sh
+++ b/scripts/release-evidence/guest-provision.sh
@@ -27,6 +27,7 @@ sudo apt-get install -y --no-install-recommends \
 
 get() { jq -er "$1" "$contract"; }
 runner_root=$(get '.runner.root')
+runtime_dir="$runner_root/runtime"
 data_root=$(get '.runner.data_root')
 runner_version=$(get '.runner.version')
 runner_sha=$(get '.runner.sha256')
@@ -66,6 +67,7 @@ fi
 sudo usermod -d "$runner_root/home" codestory-runner
 sudo install -d -m 0750 -o root -g codestory-runner "$data_root"
 sudo install -d -m 0755 "$runner_root"
+test "$runtime_dir" = "$runner_root/runtime"
 if ! mountpoint -q "$runner_root"; then
   sudo mount --bind "$data_root" "$runner_root"
 fi
@@ -74,6 +76,7 @@ sudo install -d -o codestory-runner -g codestory-runner -m 0750 \
   "$runner_root/cargo" "$runner_root/rustup" "$runner_root/sccache" \
   "$runner_root/home" "$runner_root/tmp" \
   "$runner_root/drills" "$runner_root/artifacts" "$runner_root/validation"
+sudo install -d -o codestory-runner -g codestory-runner -m 0700 "$runtime_dir"
 sudo rm -rf "$runner_root/validation/codestory"
 sudo install -d -o codestory-runner -g codestory-runner -m 0750 \
   "$runner_root/validation/codestory"

--- a/scripts/release-evidence/guest-runner.sh
+++ b/scripts/release-evidence/guest-runner.sh
@@ -10,6 +10,7 @@ runner_name=$(get '.runner.name')
 runner_version=$(get '.runner.version')
 profile_id=$(get '.profile_id')
 runner_root=$(get '.runner.root')
+runtime_dir="$runner_root/runtime"
 runner="$runner_root/actions-runner"
 registration="$runner/.runner"
 
@@ -62,6 +63,11 @@ inspect() {
 
 install_service() {
   test "$binary_version" = "$runner_version"
+  test "$runtime_dir" = "$runner_root/runtime"
+  test -d "$runtime_dir"
+  test ! -L "$runtime_dir"
+  test "$(stat -c '%u:%g:%a' "$runtime_dir")" = \
+    "$(id -u codestory-runner):$(id -g codestory-runner):700"
   if test "$configured" != true; then
     IFS= read -r token
     test -n "$token"
@@ -92,6 +98,7 @@ install_service() {
     "Environment=RUSTUP_HOME=$runner_root/rustup" \
     "Environment=SCCACHE_DIR=$runner_root/sccache" \
     "Environment=TMPDIR=$runner_root/tmp" \
+    "Environment=XDG_RUNTIME_DIR=$runtime_dir" \
     "Environment=XDG_CACHE_HOME=$runner_root/cache/xdg" \
     "Environment=CODESTORY_CACHE_DIR=$runner_root/cache/codestory" \
     "Environment=CODESTORY_EMBED_ALLOW_CPU=1" \

--- a/scripts/release-evidence/guest-verify.sh
+++ b/scripts/release-evidence/guest-verify.sh
@@ -10,6 +10,7 @@ repository=$(get '.repository')
 runner_name=$(get '.runner.name')
 runner_version=$(get '.runner.version')
 runner_root=$(get '.runner.root')
+runtime_dir="$runner_root/runtime"
 data_root=$(get '.runner.data_root')
 drill_commit=$(get '.drill.commit')
 drill_project_manifest_sha=$(get '.drill.project_manifest_sha256')
@@ -129,6 +130,16 @@ jq -e '.cases[0].anchors == ["from_reader", "Deserializer::from_reader", "Value"
   "$runner_root/drills/real-repo-drill-cases.json" >/dev/null
 test -f "$runner_root/validation/source-sha"
 test ! -e "$runner_root/validation/codestory/.git"
+test "$runtime_dir" = "$runner_root/runtime"
+test -d "$runtime_dir"
+test ! -L "$runtime_dir"
+test "$(stat -c '%u:%g:%a' "$runtime_dir")" = \
+  "$(id -u codestory-runner):$(id -g codestory-runner):700"
+test -f "$runner_root/actions-runner/.service"
+service=$(sed -n '1p' "$runner_root/actions-runner/.service")
+test -n "$service"
+systemctl show "$service" --property=Environment --value \
+  | tr ' ' '\n' | grep -qxF "XDG_RUNTIME_DIR=$runtime_dir"
 source_sha=$(sed -n '1p' "$runner_root/validation/source-sha")
 printf '%s\n' "$source_sha" | grep -Eq '^[0-9a-f]{40}$'
 
@@ -166,13 +177,15 @@ jq -n --slurpfile observed "$observed_identity" \
   --arg drill_commit "$drill_commit" --arg manifest_sha "$manifest_sha" \
   --arg project_manifest_sha "$project_manifest_sha" \
   --arg source_sha "$source_sha" --argjson memory_bytes "$memory_bytes" \
-  --argjson workspace_free_bytes "$workspace_free_bytes" '
+  --argjson workspace_free_bytes "$workspace_free_bytes" \
+  --arg xdg_runtime_dir "$runtime_dir" '
   {
     schema_version:2, verified_at:$verified_at, profile_id:$profile_id,
     contract_sha256:$contract_sha, fingerprint:$fingerprint,
     observed_identity:$observed[0], observed_identity_sha256:$observed_identity_sha,
     runner:{repository:$repository,name:$runner_name,id:$runner_id,version:$runner_version,
       labels:["self-hosted","Linux","ARM64","codestory-release-evidence"],automatic_updates:false},
+    runtime:{xdg_runtime_dir:$xdg_runtime_dir,owner:"codestory-runner",mode:"0700"},
     capacity:{observed_memory_bytes:$memory_bytes,observed_workspace_free_bytes:$workspace_free_bytes},
     drill:{repository:"https://github.com/serde-rs/json.git",commit:$drill_commit,
       manifest:"/srv/codestory-release-evidence/drills/real-repo-drill-cases.json",

--- a/scripts/tests/release-evidence-runner-contract.test.mjs
+++ b/scripts/tests/release-evidence-runner-contract.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const root = new URL("../../", import.meta.url);
+
+async function source(path) {
+  return readFile(new URL(path, root), "utf8");
+}
+
+test("release-evidence runner provisions and verifies its XDG runtime authority", async () => {
+  const [contractSource, baselineSource, provision, runner, verify] = await Promise.all([
+    source("scripts/release-evidence/machine-contract.json"),
+    source("benchmarks/release-evidence/approved-baselines.json"),
+    source("scripts/release-evidence/guest-provision.sh"),
+    source("scripts/release-evidence/guest-runner.sh"),
+    source("scripts/release-evidence/guest-verify.sh"),
+  ]);
+  const contract = JSON.parse(contractSource);
+  const baselines = JSON.parse(baselineSource);
+  const runtimeDir = `${contract.runner.root}/runtime`;
+  const contractSha = createHash("sha256").update(contractSource).digest("hex");
+
+  assert.match(provision, /runtime_dir="\$runner_root\/runtime"/);
+  assert.match(runner, /runtime_dir="\$runner_root\/runtime"/);
+  assert.match(verify, /runtime_dir="\$runner_root\/runtime"/);
+  assert.equal(
+    baselines.profiles[contract.profile_id].identity.machine_fingerprint,
+    `${contract.profile_id}/${contractSha}`,
+  );
+  assert.match(provision, /install -d -o codestory-runner -g codestory-runner -m 0700 "\$runtime_dir"/);
+  assert.match(runner, /Environment=XDG_RUNTIME_DIR=\$runtime_dir/);
+  assert.match(verify, /stat -c '%u:%g:%a' "\$runtime_dir"/);
+  assert.match(verify, /grep -qxF "XDG_RUNTIME_DIR=\$runtime_dir"/);
+});


### PR DESCRIPTION
## Context

Exact-head qualification run `29932876305` reached the dedicated Linux ARM64 release-evidence runner, then failed before package, Metal, or Vulkan proof because the service did not provide the Linux runtime authority required by the shared embedding server.

## What changed

- derive a dedicated `runtime` directory from the checked runner root;
- provision it as `codestory-runner:codestory-runner` with mode `0700`;
- export it as the service's `XDG_RUNTIME_DIR`;
- reject missing, linked, broadly accessible, differently owned, or differently configured runtime authority during guest verification;
- record the runtime authority in provisioning evidence;
- keep the static runner contract and CI path coverage aligned;
- document the operator-visible contract and changelog entry.

## How to review

Start with the checked runner root, then follow its derived `runtime` directory through guest provisioning, service configuration, and guest verification. The new static test binds those surfaces so a partial future edit fails CI.

## Verification

Exact PR head: `d5ec8d8cadc0e756b7a5d8f63c37364a85717b57`

- `bash -n` on the three guest scripts
- static release-evidence runner contract test
- workflow policy and 276 policy regression tests
- actionlint wrapper tests and full workflow lint
- documentation link check
- `git diff --check`

The superseded qualification failure remains negative evidence. This PR makes no package, Metal, Vulkan, installed-runtime, performance, release-readiness, or publication claim; those require a fresh exact-head qualification after merge.

## Risk

The dedicated guest must be reprovisioned from the merged exact head so its service receives the new environment. The approved machine-contract checksum and baseline fingerprint remain unchanged: this completes the runner-root contract rather than changing the host, VM, toolchain, or measurement profile. The runtime directory remains inside the proof-owned volume and is not host-mounted. It persists across VM boots rather than using systemd's ephemeral `RuntimeDirectory`; the dedicated account has no login session, and stale endpoints still fail closed through held directory identity, lifetime locking, peer identity, and executable provenance checks.

Closes #1393
Refs #1372
Refs #1221
Refs #1233
Refs #1179
