### PR TITLE
[codex] Version Axios v0.16 release evidence

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2443,7 +2443,32 @@ function validateRemainingWorkflows(workflows, violations) {
       ],
       evidence,
     ));
+    const repoEvidence = namedStep(job, "Produce full-retrieval repo evidence");
     requireStepRun(violations, evidenceFile, job, "Produce full-retrieval repo evidence", ["--test-threads=1"]);
+    add(
+      violations,
+      object(repoEvidence?.env).CODESTORY_RELEASE_EVIDENCE_CORPUS_ID
+        === "codestory-release-corpus-v0.16-axios-js-ts-v2",
+      `${evidenceFile} repo evidence must bind the v0.16 Axios v2 corpus`,
+    );
+    const packetEvidence = namedStep(job, "Produce publishable packet evidence");
+    add(
+      violations,
+      object(packetEvidence?.env).CODESTORY_RELEASE_EVIDENCE_CORPUS_ID
+        === "codestory-release-corpus-v0.16-axios-js-ts-v2"
+        && object(packetEvidence?.env).CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT
+          === "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json",
+      `${evidenceFile} packet evidence must bind the v0.16 Axios v2 corpus contract`,
+    );
+    const packetRun = String(packetEvidence?.run ?? "");
+    add(
+      violations,
+      packetRun.includes("--task-manifest ")
+        && packetRun.match(/--task-manifest/gu)?.length === 1
+        && !packetRun.includes("--task-suite")
+        && !packetRun.includes("--task-ids"),
+      `${evidenceFile} packet evidence must select only the corpus-bound release task manifest`,
+    );
     requireStepRun(violations, evidenceFile, job, "Download prior rejected evidence for approval re-evaluation", ["actions/runs/$SOURCE_RUN_ID", "actions/runs/$SOURCE_RUN_ID/artifacts"]);
     requireStepRun(violations, evidenceFile, job, "Emit authenticated release-evidence cells", [
       "codestory-release-cell-manifest.mjs release-evidence",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -229,6 +229,36 @@ jobs: { check: { runs-on: ubuntu-latest, steps: [ { uses: vendor/action@${fullSh
   assert.deepEqual(block, flow);
 });
 
+test("release evidence policy pins the release-only Axios v2 task and corpus", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const file = "release-candidate-evidence.yml";
+  const mutations = [
+    ["repo corpus drifts", workflow => {
+      draftStep(workflow.jobs.measure, "Produce full-retrieval repo evidence")
+        .env.CODESTORY_RELEASE_EVIDENCE_CORPUS_ID = "codestory-release-corpus-v0.16-axios-js-ts-v1";
+    }, /repo evidence must bind the v0\.16 Axios v2 corpus/u],
+    ["packet corpus contract drifts", workflow => {
+      draftStep(workflow.jobs.measure, "Produce publishable packet evidence")
+        .env.CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT
+          = "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json";
+    }, /packet evidence must bind the v0\.16 Axios v2 corpus contract/u],
+    ["packet task falls back to the holdout suite", workflow => {
+      const step = draftStep(workflow.jobs.measure, "Produce publishable packet evidence");
+      step.run = step.run.replace(
+        /--task-manifest [^\\\n]+/u,
+        "--task-suite holdout-retrieval --task-ids axios-request-dispatch",
+      );
+    }, /must select only the corpus-bound release task manifest/u],
+  ];
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(validateWorkflows(workflows).join("\n"), expected);
+    });
+  }
+});
+
 test("release workflows retain the closeout coordinator contract test", () => {
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
   for (const [file, jobName] of [

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -96,7 +96,7 @@ jobs:
           CODESTORY_RELEASE_EVIDENCE_DRILL_OUTPUT_DIR: ${{ github.workspace }}/target/release-evidence/drill
           CODESTORY_RELEASE_EVIDENCE_STATS_PATH: ${{ github.workspace }}/target/release-evidence/stats.json
           CODESTORY_RELEASE_EVIDENCE_COMMIT: ${{ inputs.ref }}
-          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-js-ts-v1
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-js-ts-v2
           CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-inprocess-v1
           CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
           CODESTORY_REAL_REPO_DRILL_CASES: ${{ inputs.drill_manifest }}
@@ -112,8 +112,8 @@ jobs:
         env:
           CODESTORY_RELEASE_EVIDENCE_COMMIT: ${{ inputs.ref }}
           CODESTORY_RELEASE_EVIDENCE_PROFILE: ${{ inputs.profile }}
-          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-js-ts-v1
-          CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT: benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v0.16-axios-js-ts-v2
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT: benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json
           CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-inprocess-v1
           CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
           CODESTORY_EMBED_ALLOW_CPU: "1"
@@ -124,8 +124,7 @@ jobs:
           node scripts/codestory-agent-ab-benchmark.mjs \
             --packet-runtime \
             --packet-runtime-mode cold-cli \
-            --task-suite holdout-retrieval \
-            --task-ids axios-request-dispatch \
+            --task-manifest benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json \
             --materialize-repos \
             --repeats 3 \
             --publishable \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Exact indexed primary-source files outrank helper symbols when their file stem
   directly matches a required packet probe, without granting the helpers
   behavior ownership.
+- The v0.16 Axios release-evidence task is now versioned separately from the
+  general holdout suite and bound to a checksum-pinned JavaScript/TypeScript
+  project manifest. The release gate independently verifies the task, project,
+  and corpus bindings while the retained v1 evidence and approved baseline stay
+  unchanged pending a new protected measurement and baseline approval.
 - Windows-only pre-publish qualification now skips unavailable ARM64 release
   evidence and retains protected Vulkan and candidate-installed provenance under
   an explicit server-behavior-only non-claim. Full release qualification remains

--- a/benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json
+++ b/benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "corpus_id": "codestory-release-corpus-v0.16-axios-js-ts-v2",
+  "task_ids": [
+    "axios-request-dispatch-v2"
+  ],
+  "runtime_modes": [
+    "cold_cli_packet"
+  ],
+  "repeats": 3,
+  "task_manifests": {
+    "axios-request-dispatch-v2": {
+      "path": "benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json",
+      "sha256": "de6469568d6f21f697c4684e44ecedc39cac539c6152d31a7b3f1e415b20e058"
+    }
+  },
+  "project_manifests": {
+    "axios-request-dispatch-v2": {
+      "path": "benchmarks/tasks/release-evidence/axios-js-ts-codestory-project-v2.json",
+      "sha256": "25f426ab13a552be0b4b785c5733832d99ba99f01e215b11f9169c267a518e2e"
+    }
+  }
+}

--- a/benchmarks/tasks/release-evidence/axios-js-ts-codestory-project-v2.json
+++ b/benchmarks/tasks/release-evidence/axios-js-ts-codestory-project-v2.json
@@ -1,0 +1,36 @@
+{
+  "name": "axios-release-evidence-js-ts-v2",
+  "version": 1,
+  "source_groups": [
+    {
+      "id": "d338d79e-8068-5f31-9c06-1ae923e53f72",
+      "language": "JavaScript",
+      "standard": "Default",
+      "source_paths": [
+        "index.js",
+        "lib"
+      ],
+      "exclude_patterns": [
+        "**/node_modules/**"
+      ],
+      "include_paths": [],
+      "defines": {},
+      "language_specific": "Other"
+    },
+    {
+      "id": "ff6673ae-20d3-5bb9-950d-c40f99affafa",
+      "language": "TypeScript",
+      "standard": "Default",
+      "source_paths": [
+        "index.d.ts",
+        "index.d.cts"
+      ],
+      "exclude_patterns": [
+        "**/node_modules/**"
+      ],
+      "include_paths": [],
+      "defines": {},
+      "language_specific": "Other"
+    }
+  ]
+}

--- a/benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json
+++ b/benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "axios-request-dispatch-v2",
+  "version": 2,
+  "suite": "release-evidence",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "axios",
+    "url": "https://github.com/axios/axios.git",
+    "ref": "ab3f0f9a94853c821cb00f1112788ecdd3ae7ed1",
+    "workspace_root": ".",
+    "languages": [
+      "JavaScript",
+      "TypeScript"
+    ],
+    "setup": [
+      "npm install"
+    ],
+    "codestory_project_manifest": {
+      "path": "axios-js-ts-codestory-project-v2.json",
+      "sha256": "25f426ab13a552be0b4b785c5733832d99ba99f01e215b11f9169c267a518e2e"
+    }
+  },
+  "prompt": "Explain how the default axios instance is created and how an HTTP request flows through interceptors, dispatchRequest, and the transport adapter. Cite the source files that support the path.",
+  "expected_files": [
+    "lib/axios.js",
+    "lib/core/Axios.js",
+    "lib/core/dispatchRequest.js",
+    "lib/core/InterceptorManager.js",
+    "lib/adapters/adapters.js"
+  ],
+  "expected_symbols": [
+    {
+      "name": "createInstance",
+      "path": "lib/axios.js",
+      "kind": "function",
+      "why": "Factory that binds Axios methods onto the callable instance."
+    },
+    {
+      "name": "Axios",
+      "path": "lib/core/Axios.js",
+      "kind": "class",
+      "why": "Owns defaults and request/response interceptor managers."
+    },
+    {
+      "name": "Axios.prototype.request",
+      "path": "lib/core/Axios.js",
+      "kind": "method",
+      "why": "Merges config and runs the interceptor chain ending in dispatchRequest."
+    },
+    {
+      "name": "dispatchRequest",
+      "path": "lib/core/dispatchRequest.js",
+      "kind": "function",
+      "why": "Transforms data, selects an adapter, and settles the response."
+    },
+    {
+      "name": "InterceptorManager",
+      "path": "lib/core/InterceptorManager.js",
+      "kind": "class",
+      "why": "Registers fulfilled/rejected handlers for request and response chains."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "createInstance wraps an Axios context and exposes verb helpers bound to request."
+    },
+    {
+      "text": "Axios.request merges defaults, runs request interceptors, then calls dispatchRequest."
+    },
+    {
+      "text": "dispatchRequest transforms the body/headers and invokes the configured adapter."
+    },
+    {
+      "text": "InterceptorManager stores interceptor pairs used by the promise chain in request."
+    },
+    {
+      "text": "adapters.js selects xhr or http transport based on environment capabilities."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "axios sends HTTP requests directly from createInstance without an Axios request chain.",
+      "severity": "critical"
+    },
+    {
+      "text": "Interceptors run only after the transport adapter returns a response.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.7,
+    "min_expected_file_recall": 0.7,
+    "min_expected_symbol_recall": 0.65,
+    "min_expected_claim_recall": 0.75,
+    "min_citation_coverage": 0.7,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "release-evidence",
+    "javascript",
+    "typescript",
+    "http",
+    "generalization"
+  ],
+  "notes": [
+    "Versioned v0.16 release-only evidence task. Do not add it to the general holdout suite or tune product behavior against it."
+  ]
+}

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -6,17 +6,26 @@ stable between candidates. Ordinary pull requests must not target this runner.
 
 ## v0.16 corpus boundary
 
-The v0.16 profile uses
-`codestory-release-corpus-v0.16-axios-js-ts-v1`: one Axios
-JavaScript/TypeScript task with three cold CLI packet repeats. The checked
-corpus contract binds the exact task-manifest bytes and rejects missing,
-substituted, or extra task rows. Ripgrep's pinned Rust task and project template
-remain available for follow-up diagnostics, but a retained three-repeat run
+The v0.16 measurement workflow uses
+`codestory-release-corpus-v0.16-axios-js-ts-v2`: one release-only Axios
+JavaScript/TypeScript task with three cold CLI packet repeats. Its deterministic
+CodeStory project manifest schedules `index.js` and `lib/` as JavaScript plus
+`index.d.ts` and `index.d.cts` as TypeScript. That source boundary excludes
+Axios's JSON-with-comments compiler fixtures structurally; production parsing
+and malformed-source policy are unchanged. The checked corpus contract binds
+the exact task and project-manifest bytes and rejects missing, changed, escaped,
+substituted, extra, or task-inconsistent declarations. Ripgrep's pinned Rust
+task and project template remain available for follow-up diagnostics, but a
+retained three-repeat run
 did not meet its preregistered file and citation recall thresholds, so v0.16
 makes no Ripgrep or general Rust packet-quality claim. Redis/C, shell dialects,
 and general parser completeness are also outside this release-evidence claim.
-The approved baseline profile records the corpus-contract path and SHA-256, so
-candidate evidence cannot silently widen, narrow, or replace that scope.
+The retained v1 task, corpus contract, raw evidence, and approved baseline stay
+unchanged. The first protected v2 run may establish the three raw Axios rows,
+but it cannot become release evidence until those exact bytes receive a separate
+approved, release-eligible baseline. The evaluator therefore fails closed while
+the approved profile still names v1; it cannot silently widen, narrow, or
+replace that scope.
 
 Cold CLI packet provenance is taken from the packet process that actually ran.
 It binds the packet's executed semantic stage, full sidecar diagnostics, and

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -236,6 +236,27 @@ because the v2 profile did not exist yet; its always-uploaded artifact
 The approved registry derives the fixed budgets from those retained raw bytes.
 That measurement is not repeated after registration.
 
+### Axios project-bound qualification reset
+
+Qualification run `29938499816` later failed closed while refreshing the same
+pinned Axios commit because the v1 release task had no CodeStory project
+manifest. Repository-wide discovery correctly treated three JSON-with-comments
+TypeScript fixture configs as strict JSON structural sources. The release-only
+`axios-request-dispatch-v2` task keeps the v1 prompt, expected evidence, quality
+thresholds, repository, and commit, but binds an exact project manifest with
+JavaScript sources `index.js` and `lib/` and TypeScript sources `index.d.ts` and
+`index.d.cts`. It does not add an Axios, fixture, benchmark, or JSONC exception
+to production parsing.
+
+The v2 corpus and evaluator independently bind the task and project-manifest
+paths and SHA-256 values. The workflow selects that exact task with
+`--task-manifest`; it does not add the release-only task to the general
+`holdout-retrieval` suite. Preserve the v1 task, corpus, raw evidence, and
+approved baseline bytes. Run one protected exact-head v2 measurement, retain
+all three publishable Axios rows, then approve a new baseline in a separate
+reviewed change. Until that approval exists, raw v2 measurement can pass while
+candidate evaluation remains correctly blocked by the v1 baseline identity.
+
 On rejection, the workflow uploads provisioning, raw, candidate, approval (when
 provided), and report files with `if: always()`. Author an exception against the
 reported hashes and values in the short-lived repository Actions secret

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -7046,6 +7046,7 @@ export {
   isPathInside,
   isTrustedPublishableRepoUrl,
   loadTaskForResult,
+  loadReleaseEvidenceCorpusContract,
   loadTasks,
   manifestRepoMaterializationBlockers,
   materializeRepos,

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -46,6 +46,10 @@ const RELEASE_CORPUS_CONTRACTS = new Map([
     "codestory-release-corpus-v0.16-axios-js-ts-v1",
     "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v1.json",
   ],
+  [
+    "codestory-release-corpus-v0.16-axios-js-ts-v2",
+    "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json",
+  ],
 ]);
 
 function fail(message) { throw new Error(message); }
@@ -67,6 +71,11 @@ function fullSha(value, label) {
   return normalized;
 }
 function sha256(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+function sha256Digest(value, label) {
+  const digest = text(value, label);
+  if (!SHA256.test(digest)) fail(`${label} must be a lowercase SHA-256 digest`);
+  return digest;
+}
 function canonical(value) {
   if (Array.isArray(value)) return value.map(canonical);
   if (value && typeof value === "object") {
@@ -423,6 +432,41 @@ function statsContractFrom(repoRoot) {
   return contract;
 }
 
+function exactObjectKeys(value, expected, label) {
+  const actual = Object.keys(object(value, label)).sort();
+  const wanted = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    fail(`${label} must contain exactly ${wanted.join(", ")}`);
+  }
+}
+
+function containedFile(baseDir, declaredPath, label) {
+  const selected = text(declaredPath, label);
+  if (path.isAbsolute(selected) || path.posix.isAbsolute(selected) || path.win32.isAbsolute(selected)) {
+    fail(`${label} must be relative`);
+  }
+  const resolvedBase = path.resolve(baseDir);
+  const absolutePath = path.resolve(resolvedBase, selected);
+  const relativePath = path.relative(resolvedBase, absolutePath);
+  if (relativePath === "" || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    fail(`${label} escapes its allowed directory`);
+  }
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`${label} does not name a file`);
+  }
+  const realBase = realpathSync(resolvedBase);
+  const realFile = realpathSync(absolutePath);
+  const realRelative = path.relative(realBase, realFile);
+  if (realRelative === "" || realRelative.startsWith(`..${path.sep}`) || path.isAbsolute(realRelative)) {
+    fail(`${label} escapes its allowed directory`);
+  }
+  const canonicalPath = relativePath.replaceAll(path.sep, "/");
+  if (selected.replaceAll("\\", "/") !== canonicalPath) {
+    fail(`${label} must use its canonical relative path`);
+  }
+  return { absolutePath, canonicalPath };
+}
+
 function releaseCorpusContract(repoRoot, identity) {
   const relativePath = RELEASE_CORPUS_CONTRACTS.get(identity.corpus_id);
   if (!relativePath) return null;
@@ -458,20 +502,76 @@ function releaseCorpusContract(repoRoot, identity) {
     fail("release corpus contract task manifest keys must exactly match task IDs");
   }
   const taskRepositories = {};
+  const taskProjectManifests = {};
   for (const taskId of taskIds) {
     const declaration = object(contract.task_manifests[taskId], `release corpus task manifest ${taskId}`);
-    const manifestPath = path.resolve(repoRoot, text(declaration.path, `release corpus task manifest path ${taskId}`));
-    const relativeManifestPath = path.relative(repoRoot, manifestPath);
-    if (relativeManifestPath.startsWith(`..${path.sep}`) || path.isAbsolute(relativeManifestPath)) {
-      fail(`release corpus task manifest path escapes the repository for ${taskId}`);
-    }
+    exactObjectKeys(declaration, ["path", "sha256"], `release corpus task manifest ${taskId}`);
+    const { absolutePath: manifestPath } = containedFile(
+      repoRoot,
+      declaration.path,
+      `release corpus task manifest path ${taskId}`,
+    );
     const manifestBytes = readFileSync(manifestPath);
-    if (sha256(manifestBytes) !== text(declaration.sha256, `release corpus task manifest hash ${taskId}`)) {
+    if (sha256(manifestBytes) !== sha256Digest(declaration.sha256, `release corpus task manifest hash ${taskId}`)) {
       fail(`release corpus task manifest hash does not match for ${taskId}`);
     }
     const manifest = JSON.parse(manifestBytes.toString("utf8"));
     if (manifest.id !== taskId) fail(`release corpus task manifest ID does not match ${taskId}`);
     taskRepositories[taskId] = text(manifest.repo?.name, `release corpus task repository ${taskId}`);
+    const projectDeclaration = manifest.repo?.codestory_project_manifest;
+    if (projectDeclaration != null) {
+      exactObjectKeys(
+        projectDeclaration,
+        ["path", "sha256"],
+        `release task project manifest declaration ${taskId}`,
+      );
+      taskProjectManifests[taskId] = {
+        declaration: projectDeclaration,
+        taskDirectory: path.dirname(manifestPath),
+      };
+    }
+  }
+  const corpusProjectManifests = object(contract.project_manifests, "release corpus project_manifests");
+  const projectManifestIds = Object.keys(corpusProjectManifests).sort();
+  const taskProjectManifestIds = Object.keys(taskProjectManifests).sort();
+  if (JSON.stringify(projectManifestIds) !== JSON.stringify(taskProjectManifestIds)) {
+    fail("release corpus project manifest keys must exactly match task declarations");
+  }
+  for (const taskId of taskProjectManifestIds) {
+    const corpusDeclaration = object(
+      corpusProjectManifests[taskId],
+      `release corpus project manifest ${taskId}`,
+    );
+    exactObjectKeys(corpusDeclaration, ["path", "sha256"], `release corpus project manifest ${taskId}`);
+    const taskBinding = taskProjectManifests[taskId];
+    const taskDeclaration = taskBinding.declaration;
+    const taskFile = containedFile(
+      taskBinding.taskDirectory,
+      taskDeclaration.path,
+      `release task project manifest path ${taskId}`,
+    );
+    const corpusFile = containedFile(
+      repoRoot,
+      corpusDeclaration.path,
+      `release corpus project manifest path ${taskId}`,
+    );
+    if (realpathSync(taskFile.absolutePath) !== realpathSync(corpusFile.absolutePath)) {
+      fail(`release corpus project manifest path does not match task declaration for ${taskId}`);
+    }
+    const taskHash = sha256Digest(taskDeclaration.sha256, `release task project manifest hash ${taskId}`);
+    const corpusHash = sha256Digest(corpusDeclaration.sha256, `release corpus project manifest hash ${taskId}`);
+    if (taskHash !== corpusHash) {
+      fail(`release corpus project manifest hash does not match task declaration for ${taskId}`);
+    }
+    const projectBytes = readFileSync(corpusFile.absolutePath);
+    if (sha256(projectBytes) !== corpusHash) {
+      fail(`release corpus project manifest hash does not match for ${taskId}`);
+    }
+    try {
+      object(JSON.parse(projectBytes.toString("utf8")), `release corpus project manifest document ${taskId}`);
+    } catch (error) {
+      fail(`release corpus project manifest is malformed for ${taskId}: ${error.message}`);
+    }
   }
   return {
     path: relativePath,
@@ -482,7 +582,7 @@ function releaseCorpusContract(repoRoot, identity) {
     repeats: contract.repeats,
     task_manifests: contract.task_manifests,
     task_repositories: taskRepositories,
-    project_manifests: contract.project_manifests ?? {},
+    project_manifests: corpusProjectManifests,
   };
 }
 

--- a/scripts/lint-retrieval-generalization.mjs
+++ b/scripts/lint-retrieval-generalization.mjs
@@ -76,12 +76,14 @@ const corpusHarnessNonRustFiles = new Set([
   path.join(repoRoot, "scripts", "prove-drill-packet-parity.mjs"),
   path.join(repoRoot, "scripts", "score-drill-ledger.mjs"),
   path.join(repoRoot, ".github", "scripts", "test-detect-codestory-release.py"),
+  path.join(repoRoot, ".github", "scripts", "check-workflow-policy.test.mjs"),
   path.join(repoRoot, ".github", "workflows", "release-candidate-evidence.yml"),
   path.join(repoRoot, ".github", "workflows", "retrieval-engine-smoke.yml"),
 ].map((filePath) => path.resolve(filePath)));
 const corpusSupportNonRustFiles = new Set([
   path.join(repoRoot, "scripts", "lint-retrieval-generalization.mjs"),
   path.join(repoRoot, ".github", "scripts", "test-detect-codestory-release.py"),
+  path.join(repoRoot, ".github", "scripts", "check-workflow-policy.test.mjs"),
 ].map((filePath) => path.resolve(filePath)));
 const allowedHarnessReferences = [
   [

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -19,6 +19,7 @@ import {
   isTrustedPublishableRepoUrl,
   isPathInside,
   loadTaskForResult,
+  loadReleaseEvidenceCorpusContract,
   loadTasks,
   manifestRepoMaterializationBlockers,
   materializeRepos,
@@ -473,6 +474,80 @@ test("rejects manifest repo and workspace paths outside the cache", async () => 
       );
     },
   );
+});
+
+test("Axios v2 release task preserves v1 evidence while binding its exact project and corpus", async () => {
+  const v1Path = path.resolve("benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json");
+  const v2Path = path.resolve("benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json");
+  const projectPath = path.resolve("benchmarks/tasks/release-evidence/axios-js-ts-codestory-project-v2.json");
+  const v1 = JSON.parse(await readFile(v1Path, "utf8"));
+  const v2 = JSON.parse(await readFile(v2Path, "utf8"));
+  for (const field of [
+    "prompt",
+    "expected_files",
+    "expected_symbols",
+    "expected_claims",
+    "forbidden_claims",
+    "quality_thresholds",
+  ]) {
+    assert.deepEqual(v2[field], v1[field], `${field} must remain identical to the retained v1 task`);
+  }
+  assert.equal(v2.id, "axios-request-dispatch-v2");
+  assert.equal(v2.suite, "release-evidence");
+  assert.equal(v2.repo.ref, "ab3f0f9a94853c821cb00f1112788ecdd3ae7ed1");
+  assert.equal(
+    createHash("sha256").update(await readFile(projectPath)).digest("hex"),
+    v2.repo.codestory_project_manifest.sha256,
+  );
+  const project = JSON.parse(await readFile(projectPath, "utf8"));
+  assert.deepEqual(
+    project.source_groups.map(({ language, source_paths: sourcePaths }) => ({ language, sourcePaths })),
+    [
+      { language: "JavaScript", sourcePaths: ["index.js", "lib"] },
+      { language: "TypeScript", sourcePaths: ["index.d.ts", "index.d.cts"] },
+    ],
+  );
+
+  const opts = {
+    taskManifest: v2Path,
+    taskSuite: null,
+    taskIds: null,
+    repoCacheDir: path.resolve("target/agent-benchmark/test-axios-v2"),
+    materializeRepos: true,
+    publishable: true,
+    packetRuntimeMode: "cold-cli",
+    repeats: 3,
+  };
+  const tasks = await loadTasks(opts);
+  const previous = {
+    commit: process.env.CODESTORY_RELEASE_EVIDENCE_COMMIT,
+    corpusId: process.env.CODESTORY_RELEASE_EVIDENCE_CORPUS_ID,
+    corpusContract: process.env.CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT,
+  };
+  try {
+    process.env.CODESTORY_RELEASE_EVIDENCE_COMMIT = "1".repeat(40);
+    process.env.CODESTORY_RELEASE_EVIDENCE_CORPUS_ID
+      = "codestory-release-corpus-v0.16-axios-js-ts-v2";
+    process.env.CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT
+      = "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json";
+    const corpus = await loadReleaseEvidenceCorpusContract(tasks, opts);
+    assert.deepEqual(corpus.task_ids, ["axios-request-dispatch-v2"]);
+    assert.deepEqual(corpus.project_manifests, {
+      "axios-request-dispatch-v2": {
+        path: "benchmarks/tasks/release-evidence/axios-js-ts-codestory-project-v2.json",
+        sha256: v2.repo.codestory_project_manifest.sha256,
+      },
+    });
+  } finally {
+    for (const [key, value] of Object.entries({
+      CODESTORY_RELEASE_EVIDENCE_COMMIT: previous.commit,
+      CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: previous.corpusId,
+      CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT: previous.corpusContract,
+    })) {
+      if (value == null) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
 });
 
 test("materialization scrubs reusable checkouts before installing the bound project manifest", async () => {

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { copyFileSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -79,6 +79,115 @@ test("v0.16 release corpus contract rejects an omitted or substituted packet tas
     () => validatePacketCorpusContract(provenance, rows.map((row) => ({ ...row, task_id: "ripgrep-search-pipeline" })), root, identity, profile),
     /do not exactly match the checked-in release task scope/,
   );
+});
+
+function axiosV2CorpusFixture(mutate) {
+  const dir = mkdtempSync(path.join(tmpdir(), "codestory-axios-v2-corpus-"));
+  const taskRelative = "benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json";
+  const projectRelative = "benchmarks/tasks/release-evidence/axios-js-ts-codestory-project-v2.json";
+  const contractRelative = "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json";
+  for (const relative of [taskRelative, projectRelative, contractRelative]) {
+    mkdirSync(path.dirname(path.join(dir, relative)), { recursive: true });
+    copyFileSync(path.join(root, relative), path.join(dir, relative));
+  }
+  const paths = {
+    task: path.join(dir, taskRelative),
+    project: path.join(dir, projectRelative),
+    contract: path.join(dir, contractRelative),
+  };
+  mutate?.(paths);
+  return { dir, paths, contractRelative };
+}
+
+function rewriteJson(filePath, mutate) {
+  const document = JSON.parse(readFileSync(filePath));
+  mutate(document);
+  writeFileSync(filePath, `${JSON.stringify(document, null, 2)}\n`);
+}
+
+function rebindTaskHash(paths) {
+  rewriteJson(paths.contract, contract => {
+    contract.task_manifests["axios-request-dispatch-v2"].sha256 = createHash("sha256")
+      .update(readFileSync(paths.task))
+      .digest("hex");
+  });
+}
+
+function validateAxiosV2Fixture(dir, paths, contractRelative) {
+  const contractBytes = readFileSync(paths.contract);
+  const contract = JSON.parse(contractBytes);
+  const identity = {
+    corpus_id: contract.corpus_id,
+    cache_id: "cold-inprocess-v1",
+    machine_fingerprint: "fixture/fingerprint",
+  };
+  const corpusContract = {
+    path: contractRelative,
+    sha256: createHash("sha256").update(contractBytes).digest("hex"),
+    corpus_id: contract.corpus_id,
+    task_ids: contract.task_ids,
+    runtime_modes: contract.runtime_modes,
+    repeats: contract.repeats,
+    task_manifests: contract.task_manifests,
+    task_repositories: { "axios-request-dispatch-v2": "axios" },
+    project_manifests: contract.project_manifests,
+  };
+  const rows = Array.from({ length: contract.repeats }, (_, index) => ({
+    repo: "axios",
+    task_id: "axios-request-dispatch-v2",
+    mode: "cold_cli_packet",
+    repeat: index + 1,
+  }));
+  return () => validatePacketCorpusContract(
+    { corpus_contract: corpusContract },
+    rows,
+    dir,
+    identity,
+    { corpus_contract: { path: contractRelative, sha256: corpusContract.sha256 } },
+  );
+}
+
+test("Axios v2 project manifest binding fails closed", async (t) => {
+  await t.test("accepts the exact checked-in task, project, and corpus bytes", () => {
+    const fixture = axiosV2CorpusFixture();
+    assert.doesNotThrow(validateAxiosV2Fixture(fixture.dir, fixture.paths, fixture.contractRelative));
+  });
+
+  const failures = [
+    ["missing", paths => rmSync(paths.project), /does not name a file/u],
+    ["changed", paths => writeFileSync(paths.project, `${readFileSync(paths.project, "utf8")}\n`), /project manifest hash does not match/u],
+    ["escaped", paths => {
+      rewriteJson(paths.task, task => {
+        task.repo.codestory_project_manifest.path = "../../../../outside-project.json";
+      });
+      rebindTaskHash(paths);
+    }, /project manifest path .* escapes its allowed directory/u],
+    ["substituted", paths => {
+      const substitute = path.join(path.dirname(paths.project), "substitute-project.json");
+      copyFileSync(paths.project, substitute);
+      rewriteJson(paths.contract, contract => {
+        contract.project_manifests["axios-request-dispatch-v2"].path
+          = "benchmarks/tasks/release-evidence/substitute-project.json";
+      });
+    }, /path does not match task declaration/u],
+    ["extra", paths => {
+      rewriteJson(paths.contract, contract => {
+        contract.project_manifests["extra-task"] = contract.project_manifests["axios-request-dispatch-v2"];
+      });
+    }, /keys must exactly match task declarations/u],
+    ["task-inconsistent", paths => {
+      rewriteJson(paths.task, task => {
+        task.repo.codestory_project_manifest.sha256 = "0".repeat(64);
+      });
+      rebindTaskHash(paths);
+    }, /hash does not match task declaration/u],
+  ];
+  for (const [name, mutate, expected] of failures) {
+    await t.test(name, () => {
+      const fixture = axiosV2CorpusFixture(mutate);
+      assert.throws(validateAxiosV2Fixture(fixture.dir, fixture.paths, fixture.contractRelative), expected);
+    });
+  }
 });
 
 test("fingerprint prefers a validated provisioned machine identity", () => {


### PR DESCRIPTION
## Context

Axios qualification failed closed because the retained v1 release task allowed repository-wide discovery to schedule JSON-with-comments TypeScript fixtures as strict JSON. The product behavior is correct; the release-evidence project boundary was incomplete.

Closes #1398
Refs #1395
Refs #1200
Refs #1233
Refs #1189
Refs #1179

## What changed

- adds release-only `axios-request-dispatch-v2` at the same pinned Axios commit with the v1 prompt, expected evidence, and quality thresholds
- binds a deterministic CodeStory project manifest to JavaScript `index.js` plus `lib/`, and TypeScript `index.d.ts` plus `index.d.cts`
- adds `codestory-release-corpus-v0.16-axios-js-ts-v2` with exact task and project-manifest hashes
- switches only the release-candidate evidence workflow from the general holdout selector to the exact v2 task manifest
- makes the independent release gate reject missing, changed, escaped, substituted, extra, and task-inconsistent project manifests
- pins the workflow policy and updates the release-evidence runbook, performance playbook, generalization boundary, and changelog

The retained v1 task, corpus contract, and approved baseline are byte-for-byte unchanged.

## Identity

- base: `d92055a16fff165aec739b1a0a91221bc45af6db`
- head: `857baaeb9ea6ad7cf74be645537cd2a9d569ebde`
- tree: `44a76d774a7a2327162f57eff552b149c3d4f65d`
- project manifest SHA-256: `25f426ab13a552be0b4b785c5733832d99ba99f01e215b11f9169c267a518e2e`
- task manifest SHA-256: `de6469568d6f21f697c4684e44ecedc39cac539c6152d31a7b3f1e415b20e058`
- corpus contract SHA-256: `6ce90e114e1c7bf7fafd9538f58ffde0b91811c0ce5792d05740bebb0dc42fa8`

## Review order

1. `benchmarks/tasks/release-evidence/` and the v2 corpus contract
2. `scripts/codestory-release-evidence-gate.mjs` and its focused failure cases
3. `.github/workflows/release-candidate-evidence.yml` plus workflow policy
4. docs, changelog, and the generalization-boundary classification

## Verification

- `node --test scripts/tests/codestory-agent-ab-analyzer.test.mjs scripts/tests/codestory-release-evidence-gate.test.mjs` (105 pass)
- `node --test .github/scripts/run-actionlint.test.mjs .github/scripts/check-workflow-policy.test.mjs` (283 pass)
- `node .github/scripts/run-actionlint.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- `node scripts/lint-retrieval-generalization.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- exact v1 path comparison against the base and cross-check of all v2 declared hashes

## Risk and non-claims

This changes release-evidence selection and evaluation only. It does not change production parsing, add an Axios/JSONC/fixture exception, alter a retrieval backend, widen the general holdout suite, or resume corpus/vector work.

No protected measurement was run in this source lane. The retained approved baseline still binds v1, so a future exact-head v2 run may pass all three raw Axios rows while candidate evaluation remains correctly blocked until a separate reviewed baseline approval exists. This PR does not claim protected hardware, installed-runtime, package, performance, or release readiness.