### PR TITLE
[codex] Grant release source-proof permissions

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1354,6 +1354,11 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     `${releaseFile} publication authority must have only the trusted auto-release.yml caller`,
   );
   add(violations, object(release.permissions).actions === "read", `${releaseFile} must read prior-run evidence`);
+  add(
+    violations,
+    object(release.permissions)["pull-requests"] === "read",
+    `${releaseFile} must grant the exact source resolver pull-request metadata access`,
+  );
   const callExpectedHead = object(at(release, "on", "workflow_call", "inputs", "expected_head_sha"));
   add(
     violations,
@@ -2443,6 +2448,11 @@ function validateRemainingWorkflows(workflows, violations) {
     add(violations, sameMembers(needs(release), ["detect-version"]), `${autoFile} release must need version detection`);
     add(violations, object(release.permissions).contents === "write", `${autoFile} release caller must grant contents write`);
     add(violations, object(release.permissions).actions === "read", `${autoFile} release caller must grant actions read`);
+    add(
+      violations,
+      object(release.permissions)["pull-requests"] === "read",
+      `${autoFile} release caller must pass pull-request metadata access to exact source proof`,
+    );
     add(violations, object(release.with).publish_release === true, `${autoFile} trusted main caller must explicitly authorize publication`);
   }
 

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1753,6 +1753,8 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
     ["post-publish smoke authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-smoke"].if; }],
     ["post-publish closeout authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-closeout"].if; }],
     ["trusted caller opt-in", workflows => { delete workflows.get("auto-release.yml").jobs.release.with.publish_release; }],
+    ["manual release source permissions", workflows => { delete workflows.get("release.yml").permissions["pull-requests"]; }],
+    ["automatic release source permissions", workflows => { delete workflows.get("auto-release.yml").jobs.release.permissions["pull-requests"]; }],
     ["rogue release caller", workflows => {
       workflows.get("plugin-static.yml").jobs["rogue-release"] = {
         uses: "./.github/workflows/release.yml",

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -96,6 +96,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      pull-requests: read
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ needs.detect-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 concurrency:
   group: release-${{ inputs.version }}


### PR DESCRIPTION
## Context

Proof-only release run [29978788799](https://github.com/TheGreenCedar/CodeStory/actions/runs/29978788799) failed before any job started. GitHub rejected `release.yml` because its reusable `source-proof.yml` requests `pull-requests: read`, while the manual release workflow and trusted auto-release caller passed `pull-requests: none`.

Closes #1405
Refs #1233

## Change

- grant `pull-requests: read` at the reusable release workflow boundary
- pass the same permission from the trusted `auto-release.yml` caller
- make workflow policy and mutation tests reject either permission being removed

This does not change product behavior, package contents, claim scope, or publication authority.

Base: `35cf3ed02cde932068b2bc1944f590f033568205`

Head: `f0128680`

## Verification

- workflow policy
- 277 workflow mutation tests
- actionlint
- `git diff --check`

The failed run did not start a job or consume the Mac/Windows package qualification attempt. After merge, the proof-only release workflow gets one retry on the new exact `dev` head.
