### PR TITLE
[codex] Repair final desktop qualification control plane

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -4507,7 +4507,8 @@ def prove_runtime(
             None,
         )
         require(
-            linked_snippet_uri == expected_snippet_uri,
+            isinstance(linked_snippet_uri, str)
+            and resource_uri_matches(expected_snippet_uri, linked_snippet_uri),
             "packaged search returned a missing or noncanonical project-bound snippet link",
         )
         snippet_resource = host_b.resource(
@@ -9804,6 +9805,30 @@ def self_test() -> None:
         and identity_probes == [expected_identity_probe]
         and expected_identity_probe[0] != expected_identity_probe[1],
         "native-identical Windows project resource URI was rejected",
+    )
+    short_windows_snippet = short_windows_resource.replace(
+        "codestory://diagnostics/retrieval-engine",
+        "codestory://snippet/node%2Fid",
+    )
+    long_windows_snippet = long_windows_resource.replace(
+        "codestory://diagnostics/retrieval-engine",
+        "codestory://snippet/node%2Fid",
+    )
+    snippet_identity_probes: list[tuple[Path, Path]] = []
+
+    def same_windows_snippet(left: Path, right: Path) -> bool:
+        snippet_identity_probes.append((left, right))
+        return True
+
+    require(
+        resource_uri_matches(
+            short_windows_snippet,
+            long_windows_snippet,
+            platform_name="nt",
+            samefile=same_windows_snippet,
+        )
+        and snippet_identity_probes == [expected_identity_probe],
+        "native-identical Windows snippet link URI was rejected",
     )
     require(
         not resource_uri_matches(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   lanes instead of silently falling back to 900 seconds.
   Windows package proof now accepts a canonical project URI returned for a
   native-identical existing project path, while resource bases, URI encoding,
-  missing paths, and Unix project URI matching remain strict.
+  missing paths, and Unix project URI matching remain strict. Managed-handoff
+  search-link verification now applies that same native-identity rule to
+  project-bound snippet links instead of rejecting a valid 8.3/long-path
+  alias before reading the resource.
   The dedicated Linux release-evidence service now provisions and verifies a
   private per-user runtime authority before measuring the shared embedding
   server, instead of failing closed when `XDG_RUNTIME_DIR` is absent.


### PR DESCRIPTION
## Context

Closes #1405
Refs #1189
Refs #1233

Exact v0.16 pre-publication run `29980536203` proved the source cell and Windows package structure, then stopped on two control-plane defects. The macOS signing environment rejected `dev/codestory-next` before the package job began, and the Windows verifier rejected a native-identical 8.3/long-path snippet link before reading it.

The environment now allows exactly `main` and `dev/codestory-next` while retaining its required reviewer. This PR owns the remaining source change only.

## Outcome

Apply the established fail-closed Windows native-identity rule to the final project-bound snippet-link assertion so the next exact two-platform candidate run measures the packaged runtime instead of a verifier spelling mismatch.

## What changed

- Validate the returned snippet URI with `resource_uri_matches`, preserving literal equality everywhere and permitting a Windows alias only after canonical encoding, exact resource base, absolute path, and `samefile` identity checks.
- Add a self-test covering the same 8.3/long-path alias on a node-specific snippet URI.
- Record the release-proof correction in the v0.16 changelog.

## How to review

1. Confirm the search-link assertion uses the same matcher already used by resource extraction.
2. Confirm the matcher still rejects Unix aliases, malformed encoding, relative paths, different resource bases, missing paths, and different native identities.
3. Confirm no retrieval behavior, expected answer, threshold, backend, corpus, or vector implementation changed.

## Verification

- `python3 .github/scripts/check-packaged-agent-proof.py --self-test` — passed.
- `python3 -m py_compile .github/scripts/check-packaged-agent-proof.py` — passed.
- `node .github/scripts/check-workflow-policy.mjs` — passed after installing the one worktree-local package from the lockfile.
- `node .github/scripts/run-actionlint.mjs` — passed.
- `node .github/scripts/check-doc-links.mjs` — passed.
- `git diff --check` — passed.

## Risk or follow-up

This is verifier-only. It does not prove either candidate install, publication, marketplace behavior, accuracy, performance, accelerator execution, Linux, Intel Mac, or Windows ARM. One exact Mac-and-Windows candidate run follows only after independent review, exact-head CI, and merge into `dev/codestory-next`.
