### PR TITLE
[codex] Wait for Windows ground-proof cleanup

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -3425,9 +3425,33 @@ def add_exception_note(error: BaseException, note: str) -> None:
 
 
 class FailurePreservingTemporaryDirectory(tempfile.TemporaryDirectory):
+    def __init__(
+        self,
+        *args,
+        cleanup_retry_budget_secs: float = 0,
+        cleanup_retry_interval_secs: float = 0.5,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.cleanup_retry_budget_secs = cleanup_retry_budget_secs
+        self.cleanup_retry_interval_secs = cleanup_retry_interval_secs
+
     def __exit__(self, exc_type, exc, traceback) -> bool | None:
+        deadline = time.monotonic() + self.cleanup_retry_budget_secs
         try:
-            return super().__exit__(exc_type, exc, traceback)
+            while True:
+                try:
+                    self.cleanup()
+                    return None
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise
+                    time.sleep(
+                        min(
+                            self.cleanup_retry_interval_secs,
+                            max(0, deadline - time.monotonic()),
+                        )
+                    )
         except OSError as cleanup_error:
             if exc is None:
                 raise
@@ -10465,6 +10489,35 @@ def self_test() -> None:
         "temporary cleanup preservation self-test leaked its directory",
     )
 
+    retrying_directory = FailurePreservingTemporaryDirectory(
+        prefix="codestory-cleanup-retry-self-test-",
+        cleanup_retry_budget_secs=1,
+        cleanup_retry_interval_secs=0,
+    )
+    retrying_path = Path(retrying_directory.name)
+    original_retrying_cleanup = retrying_directory.cleanup
+    retrying_attempts = 0
+
+    def transient_temporary_cleanup() -> None:
+        nonlocal retrying_attempts
+        retrying_attempts += 1
+        if retrying_attempts < 3:
+            raise PermissionError("synthetic transient executable lock")
+        original_retrying_cleanup()
+
+    retrying_directory.cleanup = transient_temporary_cleanup
+    try:
+        with retrying_directory:
+            pass
+    finally:
+        retrying_directory.cleanup = original_retrying_cleanup
+        if retrying_path.exists():
+            original_retrying_cleanup()
+    require(
+        retrying_attempts == 3 and not retrying_path.exists(),
+        "temporary cleanup retry did not clear a transient executable lock",
+    )
+
     class ScriptedMcpProcess(McpProcess):
         def __init__(self, responses: list[dict]):
             self.timeout = 1
@@ -12288,9 +12341,10 @@ def main() -> int:
     validate_runtime_claim_scope(args)
     args.out_dir.mkdir(parents=True, exist_ok=True)
     require(sha256(args.archive) == expected_archive_digest(args.checksum_file, args.archive), "archive checksum mismatch")
-    with FailurePreservingTemporaryDirectory(
+    temporary_package_directory = FailurePreservingTemporaryDirectory(
         prefix="codestory-packaged-proof-"
-    ) as raw:
+    )
+    with temporary_package_directory as raw:
         root = Path(raw)
         unpack_archive(args.archive, root / "unpacked")
         cli = find_cli(root / "unpacked")
@@ -12315,6 +12369,11 @@ def main() -> int:
             args.measurement_protocol,
             require_frozen=require_frozen,
         )
+        if args.ground_only and os.name == "nt":
+            cleanup_wait_budget = native_server_exit_wait_budget(manifest)
+            temporary_package_directory.cleanup_retry_budget_secs = (
+                cleanup_wait_budget["timeout_ms"] / 1000
+            )
         calibration_bundle = None
         if require_frozen:
             require(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   exact installed-ground boundary. The broader two-host search, snippet,
   shared-server, lifecycle, accelerator, accuracy, and performance verifier
   remains available as separate qualification evidence and cannot be inferred
-  from the v0.16 receipt.
+  from the v0.16 receipt. Windows ground-only package cleanup uses the same
+  manifest-bound idle and native teardown window as broader qualification
+  before removing an executable that the native process may still hold open.
 - Exact indexed primary-source files outrank helper symbols when their file stem
   directly matches a required packet probe, without granting the helpers
   behavior ownership.


### PR DESCRIPTION
## Context

Exact candidate run `30012532797` passed the full source gate and Mac package/managed-ground proof. Windows built and returned a passing project-bound ground receipt, then failed with `WinError 5` while deleting the unpacked executable. The remaining `codestory-cli.exe` process was inside its declared idle-exit and native-teardown window and was killed by runner teardown.

## What changed

- Ground-only Windows proof uses the verifier's existing manifest-bound native server exit budget before treating temporary-package cleanup as failed.
- Temporary-directory cleanup retries only `OSError`; a persistent lock remains fatal.
- If proof and cleanup both fail, the proof failure remains primary with cleanup attached as secondary context.
- A deterministic self-test covers a transient executable lock.
- The v0.16 changelog records the Windows cleanup behavior.

## Review

Check exact head `a613fe1f558689c3d91a5c3bc7e6941d610d27bc` against base `1c7fee57e7e7fc17fbd83726df29321e1cd8c4db`. The intended behavior change is verifier lifecycle cleanup only; package/runtime behavior and release claims are unchanged.

## Verification

- `python -m py_compile .github/scripts/check-packaged-agent-proof.py`
- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- 62 release claim/cell/closeout/evidence tests
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

The first live Windows proof is retained as failed run `30012532797`; its public artifact contains a passing `ground` receipt but the job did not qualify because cleanup failed. One exact-head retry is required after merge.

Closes #1405
Refs #1189
Refs #1233
