### PR TITLE
[codex] Use built-in Windows PowerShell for qualification

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2735,12 +2735,29 @@ function validateRemainingWorkflows(workflows, violations) {
     const job = requireJob(violations, vulkanFile, vulkan, "packaged-vulkan");
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
+    for (const stepName of [
+      "Capture host evidence",
+      "Validate candidate-installed-only mode",
+      "Capture source build tool evidence",
+      "Install pinned Rust",
+      "Build and package native CLI",
+      "Authenticate calibration bundle producer",
+      "Prove offline Vulkan and multi-repository reuse",
+      "Stage isolated candidate-managed Windows install",
+      "Prove two-host candidate-installed Windows runtime",
+    ]) {
+      add(
+        violations,
+        namedStep(job, stepName)?.shell === "powershell",
+        `${vulkanFile} ${stepName} must use built-in Windows PowerShell`,
+      );
+    }
     const sourceBuildTools = namedStep(job, "Capture source build tool evidence");
     add(
       violations,
       hasExactKeys(object(sourceBuildTools), ["name", "if", "shell", "run"])
         && sourceBuildTools?.if === "${{ !inputs.use_packaged_cli_artifact }}"
-        && sourceBuildTools?.shell === "pwsh",
+        && sourceBuildTools?.shell === "powershell",
       `${vulkanFile} source build tool evidence must remain source-only and fail closed`,
     );
     requireStepRun(violations, vulkanFile, job, "Capture source build tool evidence", [

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1201,6 +1201,10 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     workflow.jobs["packaged-vulkan"],
     "Capture source build tool evidence",
   );
+  const protectedHost = workflow => draftStep(
+    workflow.jobs["packaged-vulkan"],
+    "Capture host evidence",
+  );
   const protectedBuild = workflow => draftStep(
     workflow.jobs["packaged-vulkan"],
     "Build and package native CLI",
@@ -1311,6 +1315,9 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     ["protected source evidence made optional", protectedFile, workflow => {
       protectedSourceTools(workflow)["continue-on-error"] = true;
     }, /source build tool evidence must remain source-only/u],
+    ["protected host requires PowerShell 7", protectedFile, workflow => {
+      protectedHost(workflow).shell = "pwsh";
+    }, /must use built-in Windows PowerShell/u],
   ];
 
   for (const [name, file, mutate, expectedReason] of mutations) {

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
 
       - name: Capture host evidence
-        shell: pwsh
+        shell: powershell
         run: |
           New-Item -ItemType Directory -Force target/windows-vulkan-proof | Out-Null
           Get-ComputerInfo | Out-File target/windows-vulkan-proof/host.txt
@@ -125,7 +125,7 @@ jobs:
 
       - name: Validate candidate-installed-only mode
         if: inputs.candidate_installed_only
-        shell: pwsh
+        shell: powershell
         run: |
           if (
             "${{ inputs.candidate_installed_proof }}" -ne "true" -or
@@ -136,7 +136,7 @@ jobs:
 
       - name: Capture source build tool evidence
         if: ${{ !inputs.use_packaged_cli_artifact }}
-        shell: pwsh
+        shell: powershell
         run: |
           "CMAKE_GENERATOR=Ninja" | Out-File -Append target/windows-vulkan-proof/host.txt
           cmake --version | Out-File -Append target/windows-vulkan-proof/host.txt
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install pinned Rust
         if: ${{ !inputs.use_packaged_cli_artifact }}
-        shell: pwsh
+        shell: powershell
         run: |
           rustup toolchain install 1.95.0 --profile minimal
           rustup default 1.95.0
@@ -155,7 +155,7 @@ jobs:
 
       - name: Build and package native CLI
         if: ${{ !inputs.use_packaged_cli_artifact }}
-        shell: pwsh
+        shell: powershell
         env:
           VERSION: ${{ inputs.version }}
           CMAKE_GENERATOR: Ninja
@@ -183,7 +183,7 @@ jobs:
           path: target/release-quality-evidence
 
       - name: Authenticate calibration bundle producer
-        shell: pwsh
+        shell: powershell
         env:
           GH_TOKEN: ${{ github.token }}
           CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
@@ -222,7 +222,7 @@ jobs:
 
       - name: Prove offline Vulkan and multi-repository reuse
         if: ${{ !inputs.candidate_installed_only }}
-        shell: pwsh
+        shell: powershell
         env:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "0"
@@ -275,7 +275,7 @@ jobs:
 
       - name: Stage isolated candidate-managed Windows install
         if: ${{ inputs.candidate_installed_proof && (inputs.server_behavior_only || inputs.quality_evidence_artifact != '') }}
-        shell: pwsh
+        shell: powershell
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
@@ -329,7 +329,7 @@ jobs:
 
       - name: Prove two-host candidate-installed Windows runtime
         if: ${{ inputs.candidate_installed_proof && (inputs.server_behavior_only || inputs.quality_evidence_artifact != '') }}
-        shell: pwsh
+        shell: powershell
         env:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   search-link verification now applies that same native-identity rule to
   project-bound snippet links instead of rejecting a valid 8.3/long-path
   alias before reading the resource.
+  Protected Windows qualification uses the operating system's built-in
+  Windows PowerShell host and no longer requires a separate PowerShell 7
+  installation on the self-hosted proof machine.
   The dedicated Linux release-evidence service now provisions and verifies a
   private per-user runtime authority before measuring the shared embedding
   server, instead of failing closed when `XDG_RUNTIME_DIR` is absent.


### PR DESCRIPTION
## Context

Protected Windows candidate qualification in exact run `30015641725`, job `89241872746`, checked out the correct SHA and then failed at the first command with `pwsh: command not found`. The runner service is `NETWORK SERVICE`; PowerShell 7 is user-scoped, while Windows PowerShell 5.1 is machine-available. No CodeStory command ran.

## What changed

- All nine PowerShell run blocks in `windows-vulkan-proof.yml` use `shell: powershell`.
- Workflow policy now freezes those named steps to the built-in shell.
- A controlled mutation proves a reintroduced PowerShell 7 dependency fails policy.
- Changelog records the protected-runner dependency removal.

Package/runtime behavior and release claims are unchanged.

## Review

Exact head `4425b90b6255f7e563d5e5e705477d75dfe655bd`, base `e93f1043849fe27cad6a89d5961bf3be2c0bf95c`. Independent review approved all nine blocks as PowerShell 5.1-compatible with no P0-P3 findings.

## Verification

- Actionlint controlled syntax check passed.
- Workflow policy passed.
- All 278 policy mutation tests passed.
- Release metadata, docs links, and `git diff --check` passed.
- The exact “Capture host evidence” commands executed successfully under Windows PowerShell 5.1 on the protected machine.

After merge, the existing exact candidate must be superseded by one new frozen SHA. The next release proof should exercise this workflow; merge closes only this source-sized harness issue.

Closes #1405
Refs #1189
Refs #1233
