### PR TITLE
[codex] Scope Windows runner script policy to proof process

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2735,6 +2735,7 @@ function validateRemainingWorkflows(workflows, violations) {
     const job = requireJob(violations, vulkanFile, vulkan, "packaged-vulkan");
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
+    const windowsPowerShellShell = `powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"`;
     for (const stepName of [
       "Capture host evidence",
       "Validate candidate-installed-only mode",
@@ -2748,8 +2749,8 @@ function validateRemainingWorkflows(workflows, violations) {
     ]) {
       add(
         violations,
-        namedStep(job, stepName)?.shell === "powershell",
-        `${vulkanFile} ${stepName} must use built-in Windows PowerShell`,
+        namedStep(job, stepName)?.shell === windowsPowerShellShell,
+        `${vulkanFile} ${stepName} must use built-in Windows PowerShell with process-scoped execution-policy bypass`,
       );
     }
     const sourceBuildTools = namedStep(job, "Capture source build tool evidence");
@@ -2757,7 +2758,7 @@ function validateRemainingWorkflows(workflows, violations) {
       violations,
       hasExactKeys(object(sourceBuildTools), ["name", "if", "shell", "run"])
         && sourceBuildTools?.if === "${{ !inputs.use_packaged_cli_artifact }}"
-        && sourceBuildTools?.shell === "powershell",
+        && sourceBuildTools?.shell === windowsPowerShellShell,
       `${vulkanFile} source build tool evidence must remain source-only and fail closed`,
     );
     requireStepRun(violations, vulkanFile, job, "Capture source build tool evidence", [

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
 
       - name: Capture host evidence
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           New-Item -ItemType Directory -Force target/windows-vulkan-proof | Out-Null
           Get-ComputerInfo | Out-File target/windows-vulkan-proof/host.txt
@@ -125,7 +125,7 @@ jobs:
 
       - name: Validate candidate-installed-only mode
         if: inputs.candidate_installed_only
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           if (
             "${{ inputs.candidate_installed_proof }}" -ne "true" -or
@@ -136,7 +136,7 @@ jobs:
 
       - name: Capture source build tool evidence
         if: ${{ !inputs.use_packaged_cli_artifact }}
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           "CMAKE_GENERATOR=Ninja" | Out-File -Append target/windows-vulkan-proof/host.txt
           cmake --version | Out-File -Append target/windows-vulkan-proof/host.txt
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install pinned Rust
         if: ${{ !inputs.use_packaged_cli_artifact }}
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           rustup toolchain install 1.95.0 --profile minimal
           rustup default 1.95.0
@@ -155,7 +155,7 @@ jobs:
 
       - name: Build and package native CLI
         if: ${{ !inputs.use_packaged_cli_artifact }}
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           VERSION: ${{ inputs.version }}
           CMAKE_GENERATOR: Ninja
@@ -183,7 +183,7 @@ jobs:
           path: target/release-quality-evidence
 
       - name: Authenticate calibration bundle producer
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           GH_TOKEN: ${{ github.token }}
           CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
@@ -222,7 +222,7 @@ jobs:
 
       - name: Prove offline Vulkan and multi-repository reuse
         if: ${{ !inputs.candidate_installed_only }}
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "0"
@@ -275,7 +275,7 @@ jobs:
 
       - name: Stage isolated candidate-managed Windows install
         if: ${{ inputs.candidate_installed_proof && (inputs.server_behavior_only || inputs.quality_evidence_artifact != '') }}
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
@@ -329,7 +329,7 @@ jobs:
 
       - name: Prove two-host candidate-installed Windows runtime
         if: ${{ inputs.candidate_installed_proof && (inputs.server_behavior_only || inputs.quality_evidence_artifact != '') }}
-        shell: powershell
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   project-bound snippet links instead of rejecting a valid 8.3/long-path
   alias before reading the resource.
   Protected Windows qualification uses the operating system's built-in
-  Windows PowerShell host and no longer requires a separate PowerShell 7
-  installation on the self-hosted proof machine.
+  Windows PowerShell host with a process-scoped execution-policy bypass, and
+  no longer requires a separate PowerShell 7 installation or a machine-policy
+  change on the self-hosted proof machine.
   The dedicated Linux release-evidence service now provisions and verifies a
   private per-user runtime authority before measuring the shared embedding
   server, instead of failing closed when `XDG_RUNTIME_DIR` is absent.


### PR DESCRIPTION
## Context

Exact protected job `89255570037` on candidate `5ff907fd5b74ab8658544239498ebbefaf1de83c` proved that built-in Windows PowerShell resolves for the `NETWORK SERVICE` runner. It then failed before executing the host-evidence script because machine policy blocks Actions' temporary `.ps1` file.

## What changed

All nine protected Windows PowerShell steps use the exact custom shell:

`powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"`

The bypass is process-scoped. It installs nothing, persists no policy, and changes no product/runtime behavior. Workflow policy freezes the complete invocation. The changelog records that protected proof needs neither PowerShell 7 nor a machine-policy change.

## Review

Exact head `8405f3422ce56b4608e1aa5815fa4b9a6f2eb070`, base `5ff907fd5b74ab8658544239498ebbefaf1de83c`.

## Verification

- Actionlint accepted the custom shell syntax.
- Workflow policy passed.
- All 278 workflow-policy mutations passed.
- Release metadata, docs links, and `git diff --check` passed.

The prior run retained green exact source, Mac package-ground, and Windows package-ground receipts. It was canceled after the protected pre-runtime host failure because any later result would be stale after this source change.

Closes #1405
Refs #1189
Refs #1233
