### PR TITLE
Provision Python for protected Windows proof

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2735,9 +2735,49 @@ function validateRemainingWorkflows(workflows, violations) {
     const job = requireJob(violations, vulkanFile, vulkan, "packaged-vulkan");
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
+    const sevenZipBootstrap = namedStep(job, "Install checksum-pinned 7-Zip bootstrap");
+    add(
+      violations,
+      hasExactKeys(object(sevenZipBootstrap), ["name", "shell", "run"]),
+      `${vulkanFile} 7-Zip bootstrap must remain unconditional and fail closed`,
+    );
+    requireStepRun(
+      violations,
+      vulkanFile,
+      job,
+      "Install checksum-pinned 7-Zip bootstrap",
+      [
+        "https://www.7-zip.org/a/7zr.exe",
+        "Get-FileHash -Algorithm SHA256",
+        "56b8cc9f4971cef253644fafe54063ed7fdca551d4dee0f8c6baa81b855acd72",
+        "$env:GITHUB_PATH",
+      ],
+    );
+    const pythonSetup = namedStep(job, "Install pinned Python");
+    requireStepUses(
+      violations,
+      vulkanFile,
+      job,
+      "Install pinned Python",
+      "actions/setup-python@v7.0.0",
+    );
+    add(
+      violations,
+      hasExactKeys(object(pythonSetup), ["name", "uses", "with"])
+        && hasExactKeys(object(pythonSetup?.with), ["python-version"])
+        && object(pythonSetup?.with)["python-version"] === "3.13",
+      `${vulkanFile} must pin Python 3.13 unconditionally for the self-hosted proof runner`,
+    );
+    add(
+      violations,
+      list(job.steps).at(1) === sevenZipBootstrap
+        && list(job.steps).at(2) === pythonSetup,
+      `${vulkanFile} proof tooling must run immediately after checkout`,
+    );
     const windowsPowerShellShell = `powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"`;
     for (const stepName of [
       "Capture host evidence",
+      "Install checksum-pinned 7-Zip bootstrap",
       "Validate candidate-installed-only mode",
       "Capture source build tool evidence",
       "Install pinned Rust",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1205,6 +1205,14 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     workflow.jobs["packaged-vulkan"],
     "Capture host evidence",
   );
+  const protectedSevenZip = workflow => draftStep(
+    workflow.jobs["packaged-vulkan"],
+    "Install checksum-pinned 7-Zip bootstrap",
+  );
+  const protectedPython = workflow => draftStep(
+    workflow.jobs["packaged-vulkan"],
+    "Install pinned Python",
+  );
   const protectedBuild = workflow => draftStep(
     workflow.jobs["packaged-vulkan"],
     "Build and package native CLI",
@@ -1318,6 +1326,31 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     ["protected host requires PowerShell 7", protectedFile, workflow => {
       protectedHost(workflow).shell = "pwsh";
     }, /must use built-in Windows PowerShell/u],
+    ["protected Python action drifts", protectedFile, workflow => {
+      protectedPython(workflow).uses = "actions/setup-python@v6";
+    }, /must use actions\/setup-python@v7\.0\.0/u],
+    ["protected Python version drifts", protectedFile, workflow => {
+      protectedPython(workflow).with["python-version"] = "3.14";
+    }, /must pin Python 3\.13/u],
+    ["protected Python becomes conditional", protectedFile, workflow => {
+      protectedPython(workflow).if = "false";
+    }, /must pin Python 3\.13 unconditionally/u],
+    ["protected Python becomes optional", protectedFile, workflow => {
+      protectedPython(workflow)["continue-on-error"] = true;
+    }, /must pin Python 3\.13 unconditionally/u],
+    ["protected 7-Zip checksum drifts", protectedFile, workflow => {
+      protectedSevenZip(workflow).run = protectedSevenZip(workflow).run
+        .replace("56b8cc9f4971cef253644fafe54063ed7fdca551d4dee0f8c6baa81b855acd72", "wrong");
+    }, /Install checksum-pinned 7-Zip bootstrap/u],
+    ["protected 7-Zip bootstrap becomes optional", protectedFile, workflow => {
+      protectedSevenZip(workflow)["continue-on-error"] = true;
+    }, /must remain unconditional and fail closed/u],
+    ["protected Python moves after host scripts", protectedFile, workflow => {
+      const steps = workflow.jobs["packaged-vulkan"].steps;
+      const pythonIndex = steps.findIndex(step => step.name === "Install pinned Python");
+      const [python] = steps.splice(pythonIndex, 1);
+      steps.push(python);
+    }, /proof tooling must run immediately after checkout/u],
   ];
 
   for (const [name, file, mutate, expectedReason] of mutations) {

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -114,6 +114,28 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
 
+      - name: Install checksum-pinned 7-Zip bootstrap
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $toolRoot = Join-Path $env:RUNNER_TEMP "codestory-setup-python-tools"
+          New-Item -ItemType Directory -Force -Path $toolRoot | Out-Null
+          $sevenZip = Join-Path $toolRoot "7z.exe"
+          Invoke-WebRequest `
+            -Uri "https://www.7-zip.org/a/7zr.exe" `
+            -OutFile $sevenZip
+          $digest = (Get-FileHash -Algorithm SHA256 -Path $sevenZip).Hash.ToLowerInvariant()
+          if ($digest -ne "56b8cc9f4971cef253644fafe54063ed7fdca551d4dee0f8c6baa81b855acd72") {
+            throw "checksum mismatch for the 7-Zip setup-python bootstrap"
+          }
+          & $sevenZip | Out-Null
+          $toolRoot | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install pinned Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.13"
+
       - name: Capture host evidence
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   Protected Windows qualification uses the operating system's built-in
   Windows PowerShell host with a process-scoped execution-policy bypass, and
   no longer requires a separate PowerShell 7 installation or a machine-policy
-  change on the self-hosted proof machine.
+  change on the self-hosted proof machine. The protected job also bootstraps
+  checksum-pinned 7-Zip and Python tooling inside the job instead of inheriting
+  a user-scoped host PATH that is unavailable to the runner service account.
   The dedicated Linux release-evidence service now provisions and verifies a
   private per-user runtime authority before measuring the shared embedding
   server, instead of failing closed when `XDG_RUNTIME_DIR` is absent.


### PR DESCRIPTION
## Context

Closes #1405
Refs #1189
Refs #1233

Exact proof-only release run `30023191604` reached protected Windows job
`89267489554` under the `NETWORK SERVICE` runner. The process-scoped
PowerShell bypass worked: host capture, exact checkout, package download, and
calibration authentication passed. Candidate staging then failed before product
execution because `python` was not available on the service account's PATH.

The same exact candidate's hosted Windows package already completed its
isolated installed project-scoped `ground` proof.

## Change

- Bootstrap the official standalone 7-Zip extractor with a frozen SHA-256 using
  built-in Windows PowerShell.
- Install Python 3.13 with `actions/setup-python@v7.0.0` immediately afterward.
- Freeze both steps, their fail-closed shape, versions/checksum, PowerShell
  host, and ordering in workflow policy.
- Add controlled mutations for action, version, checksum, optional/conditional,
  and order drift.
- Record the runner-only provisioning change in the v0.16 changelog.

This does not change product/runtime behavior, machine-wide policy, benchmark
thresholds, expected answers, backends, corpus, or vector work.

## Verification

- `node .github/scripts/check-workflow-policy.mjs`
- `node --test .github/scripts/check-workflow-policy.test.mjs` — 285 passed
- `actionlint .github/workflows/windows-vulkan-proof.yml`
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- Exact PowerShell 5.1 bootstrap command passed on the Windows host; downloaded
  7-Zip 26.02 reported SHA-256
  `56b8cc9f4971cef253644fafe54063ed7fdca551d4dee0f8c6baa81b855acd72`.

## Review

Review exact head `8f899c4c3dd125e36871ff1a55acc9f78aef64ac` against base
`842049903ae9941e201fb7c057bfafd6d05ba70f`. The first independent review found
the missing 7-Zip prerequisite and permissive setup-step shape; both are
addressed at this head. The remaining live proof is one protected Windows
candidate-installed `ground` receipt after integration.
