### PR TITLE
Inherit process policy in Windows Python setup

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2735,24 +2735,6 @@ function validateRemainingWorkflows(workflows, violations) {
     const job = requireJob(violations, vulkanFile, vulkan, "packaged-vulkan");
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Windows", "X64", "codestory-vulkan"]), `${vulkanFile} must use the protected Windows Vulkan runner`);
     add(violations, job.environment === "windows-vulkan-proof", `${vulkanFile} must use the protected Vulkan environment`);
-    const sevenZipBootstrap = namedStep(job, "Install checksum-pinned 7-Zip bootstrap");
-    add(
-      violations,
-      hasExactKeys(object(sevenZipBootstrap), ["name", "shell", "run"]),
-      `${vulkanFile} 7-Zip bootstrap must remain unconditional and fail closed`,
-    );
-    requireStepRun(
-      violations,
-      vulkanFile,
-      job,
-      "Install checksum-pinned 7-Zip bootstrap",
-      [
-        "https://www.7-zip.org/a/7zr.exe",
-        "Get-FileHash -Algorithm SHA256",
-        "56b8cc9f4971cef253644fafe54063ed7fdca551d4dee0f8c6baa81b855acd72",
-        "$env:GITHUB_PATH",
-      ],
-    );
     const pythonSetup = namedStep(job, "Install pinned Python");
     requireStepUses(
       violations,
@@ -2763,21 +2745,21 @@ function validateRemainingWorkflows(workflows, violations) {
     );
     add(
       violations,
-      hasExactKeys(object(pythonSetup), ["name", "uses", "with"])
+      hasExactKeys(object(pythonSetup), ["name", "uses", "with", "env"])
         && hasExactKeys(object(pythonSetup?.with), ["python-version"])
-        && object(pythonSetup?.with)["python-version"] === "3.13",
-      `${vulkanFile} must pin Python 3.13 unconditionally for the self-hosted proof runner`,
+        && object(pythonSetup?.with)["python-version"] === "3.13"
+        && hasExactKeys(object(pythonSetup?.env), ["PSExecutionPolicyPreference"])
+        && object(pythonSetup?.env).PSExecutionPolicyPreference === "Bypass",
+      `${vulkanFile} must pin Python 3.13 with process-scoped script policy`,
     );
     add(
       violations,
-      list(job.steps).at(1) === sevenZipBootstrap
-        && list(job.steps).at(2) === pythonSetup,
-      `${vulkanFile} proof tooling must run immediately after checkout`,
+      list(job.steps).at(1) === pythonSetup,
+      `${vulkanFile} pinned Python must run immediately after checkout`,
     );
     const windowsPowerShellShell = `powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"`;
     for (const stepName of [
       "Capture host evidence",
-      "Install checksum-pinned 7-Zip bootstrap",
       "Validate candidate-installed-only mode",
       "Capture source build tool evidence",
       "Install pinned Rust",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1205,10 +1205,6 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     workflow.jobs["packaged-vulkan"],
     "Capture host evidence",
   );
-  const protectedSevenZip = workflow => draftStep(
-    workflow.jobs["packaged-vulkan"],
-    "Install checksum-pinned 7-Zip bootstrap",
-  );
   const protectedPython = workflow => draftStep(
     workflow.jobs["packaged-vulkan"],
     "Install pinned Python",
@@ -1332,25 +1328,24 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     ["protected Python version drifts", protectedFile, workflow => {
       protectedPython(workflow).with["python-version"] = "3.14";
     }, /must pin Python 3\.13/u],
+    ["protected Python process policy is removed", protectedFile, workflow => {
+      delete protectedPython(workflow).env;
+    }, /must pin Python 3\.13 with process-scoped script policy/u],
+    ["protected Python process policy drifts", protectedFile, workflow => {
+      protectedPython(workflow).env.PSExecutionPolicyPreference = "RemoteSigned";
+    }, /must pin Python 3\.13 with process-scoped script policy/u],
     ["protected Python becomes conditional", protectedFile, workflow => {
       protectedPython(workflow).if = "false";
-    }, /must pin Python 3\.13 unconditionally/u],
+    }, /must pin Python 3\.13 with process-scoped script policy/u],
     ["protected Python becomes optional", protectedFile, workflow => {
       protectedPython(workflow)["continue-on-error"] = true;
-    }, /must pin Python 3\.13 unconditionally/u],
-    ["protected 7-Zip checksum drifts", protectedFile, workflow => {
-      protectedSevenZip(workflow).run = protectedSevenZip(workflow).run
-        .replace("56b8cc9f4971cef253644fafe54063ed7fdca551d4dee0f8c6baa81b855acd72", "wrong");
-    }, /Install checksum-pinned 7-Zip bootstrap/u],
-    ["protected 7-Zip bootstrap becomes optional", protectedFile, workflow => {
-      protectedSevenZip(workflow)["continue-on-error"] = true;
-    }, /must remain unconditional and fail closed/u],
+    }, /must pin Python 3\.13 with process-scoped script policy/u],
     ["protected Python moves after host scripts", protectedFile, workflow => {
       const steps = workflow.jobs["packaged-vulkan"].steps;
       const pythonIndex = steps.findIndex(step => step.name === "Install pinned Python");
       const [python] = steps.splice(pythonIndex, 1);
       steps.push(python);
-    }, /proof tooling must run immediately after checkout/u],
+    }, /pinned Python must run immediately after checkout/u],
   ];
 
   for (const [name, file, mutate, expectedReason] of mutations) {

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -114,27 +114,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
 
-      - name: Install checksum-pinned 7-Zip bootstrap
-        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
-        run: |
-          $ErrorActionPreference = "Stop"
-          $toolRoot = Join-Path $env:RUNNER_TEMP "codestory-setup-python-tools"
-          New-Item -ItemType Directory -Force -Path $toolRoot | Out-Null
-          $sevenZip = Join-Path $toolRoot "7z.exe"
-          Invoke-WebRequest `
-            -Uri "https://www.7-zip.org/a/7zr.exe" `
-            -OutFile $sevenZip
-          $digest = (Get-FileHash -Algorithm SHA256 -Path $sevenZip).Hash.ToLowerInvariant()
-          if ($digest -ne "56b8cc9f4971cef253644fafe54063ed7fdca551d4dee0f8c6baa81b855acd72") {
-            throw "checksum mismatch for the 7-Zip setup-python bootstrap"
-          }
-          & $sevenZip | Out-Null
-          $toolRoot | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
       - name: Install pinned Python
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.13"
+        env:
+          PSExecutionPolicyPreference: Bypass
 
       - name: Capture host evidence
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   Protected Windows qualification uses the operating system's built-in
   Windows PowerShell host with a process-scoped execution-policy bypass, and
   no longer requires a separate PowerShell 7 installation or a machine-policy
-  change on the self-hosted proof machine. The protected job also bootstraps
-  checksum-pinned 7-Zip and Python tooling inside the job instead of inheriting
-  a user-scoped host PATH that is unavailable to the runner service account.
+  change on the self-hosted proof machine. The protected job provisions pinned
+  Python with the same process-scoped script-policy bypass instead of inheriting
+  a user-scoped host PATH or changing machine policy.
   The dedicated Linux release-evidence service now provisions and verifies a
   private per-user runtime authority before measuring the shared embedding
   server, instead of failing closed when `XDG_RUNTIME_DIR` is absent.


### PR DESCRIPTION
## Context

Closes #1405
Refs #1189
Refs #1233

Exact protected job `89286445919` on release run `30029005646` proved the
remaining failure precisely:

- `actions/setup-python@v7.0.0` downloaded Python 3.13.14.
- Built-in `Expand-Archive` extracted it successfully.
- The action's child PowerShell process then failed to execute `setup.ps1`
  because machine execution policy applied; the workflow step's custom shell
  arguments do not apply inside a JavaScript action.

The same exact candidate's hosted Windows package completed its isolated
installed project-scoped `ground` proof.

## Change

- Pass `PSExecutionPolicyPreference=Bypass` only to the setup-python action so
  its child PowerShell inherits process-scoped policy.
- Remove the unnecessary checksum-pinned 7-Zip bootstrap; the exact runner log
  proved setup-python uses built-in `Expand-Archive` on this host.
- Freeze the exact action, Python line, environment, fail-closed shape, and
  order in workflow policy.
- Add controlled mutations for removed/drifted policy plus action, version,
  optional/conditional, and order drift.

This does not change product/runtime behavior, machine policy, benchmarks,
thresholds, expected answers, backends, corpus, or vector work.

## Verification

- `node .github/scripts/check-workflow-policy.mjs`
- `node --test .github/scripts/check-workflow-policy.test.mjs` — 285 passed
- `actionlint .github/workflows/windows-vulkan-proof.yml`
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- On the Windows host, setting
  `PSExecutionPolicyPreference=Bypass` in a parent process allowed a child
  `powershell.exe` launched without shell bypass arguments to execute a
  temporary `.ps1` successfully.

## Review

Review exact head `c55f6d01fc08e73ac311c746370bdc423ccf517d` against base
`b75c94707b9925f93d47d8ebb3b223906f7534d2`. Actual setup-python and installed
`ground` remain the protected job's runtime proof after integration.
