### PR TITLE
[codex] normalize release-contract line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,10 @@
 *.scm text eol=lf
 
+# Release contract digests must be identical on every package builder.
+docs/testing/per-user-embedding-server-constant-set.json text eol=lf
+docs/testing/per-user-embedding-server-measurement-protocol.json text eol=lf
+docs/testing/per-user-embedding-server-protocol.json text eol=lf
+
 # Codex Autoresearch ledger files
 autoresearch.jsonl text eol=lf
 autoresearch.md text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,9 @@ CodeStory 0.16 makes repository search more accurate and reduces duplicate model
   no longer requires a separate PowerShell 7 installation or a machine-policy
   change on the self-hosted proof machine. The protected job provisions pinned
   Python with the same process-scoped script-policy bypass instead of inheriting
-  a user-scoped host PATH or changing machine policy.
+  a user-scoped host PATH or changing machine policy. Byte-hashed release
+  contracts use LF checkouts on every platform so Windows packages, protected
+  qualification, and the frozen calibration receipt share one identity.
   The dedicated Linux release-evidence service now provisions and verifies a
   private per-user runtime authority before measuring the shared embedding
   server, instead of failing closed when `XDG_RUNTIME_DIR` is absent.


### PR DESCRIPTION
## Context

Windows package builders and the protected Windows qualification runner applied
different line endings to three byte-hashed release contracts. Run
`30033990902` proved both sides independently: the hosted package manifest used
the CRLF digests, while the frozen calibration bundle and protected checkout
used the LF digests. That made exact installed-package closeout impossible even
though the JSON documents were semantically identical.

## What changed

- force the measurement protocol, server protocol, and frozen constant-set JSON
  files to LF through `.gitattributes`;
- change no product, runtime, benchmark, threshold, backend, corpus, vector, or
  machine-policy behavior.

## How to review

Confirm the three paths are the complete set compared byte-for-byte by
`check-packaged-agent-proof.py` and embedded by
`package-codestory-release.py`.

## Verification

- fresh Windows clone with `core.autocrlf=true` at
  `ac4a15c7fb651e62b5c0328e2756eac88aab21cb`:
  - measurement:
    `9b3a883f11d7e33522a74150d45d8a34f4e9b57759a5e55b980b470aed07ee22`
  - protocol:
    `f4a3fa4afb4d5bcd8e707a5e21b687cdd023dc3398b28ff6891a2318e89c5ec7`
  - constant set:
    `feb1be30450f5546ce447bc7237ea0a8ab91596ae408d35999b709ae6aa0121b`
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- both package/proof scripts load their command interfaces
- `node .github/scripts/check-workflow-policy.mjs`
- 285 workflow-policy mutation tests
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

## Risk

Low and limited to checkout normalization. Existing Git blobs already contain
LF; non-Windows checkouts are unchanged. Windows builders will now package the
same authenticated contract bytes as the frozen calibration producer.

Closes #1405
Refs #1189
Refs #1233
