### PR TITLE
[codex] keep changelog reader-facing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,9 +176,12 @@ adapter to compensate for incorrect upstream state.
 - Keep generated comparisons, ledgers, CSVs, SVGs, and pre-release evidence in
   PR bodies, issue comments, Project updates, CI artifacts, or external
   storage unless they are intended as durable product documentation.
-- Update `CHANGELOG.md` in the same change when shipped behavior, operator or
-  contributor guidance, release automation, packaging, or version metadata
-  changes. Keep current work under `Unreleased` until release preparation.
+- Update `CHANGELOG.md` only for user- or operator-visible changes. Write for
+  release-note readers: lead with what changed for them and omit implementation,
+  refactor, CI, proof, issue, and PR mechanics. Contributor-only changes and
+  internal release automation belong in their owning PR or issue unless they
+  materially change what users or operators do or can rely on. Keep current
+  release-note work under `Unreleased` until release preparation.
 - Commit messages are short, lowercase, and imperative.
 
 ## Release Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,6 @@
 
 ## Unreleased
 
-- Publish the Windows and Linux native engine as one immutable executable-and-library generation so a starting process cannot observe a mixed llama.cpp ABI set.
-- Fail closed when runtime evidence is insufficient, capture source-index policy once at startup, and keep embedding work bounded under sustained queue pressure.
-- Bound the v0.16 package matrix, public support claims, release assets, and
-  Metal/Vulkan closeout to one validated release graph.
-- Move release qualification orchestration out of the shipped CLI into a
-  separate proof driver that exercises the exact packaged CLI through private
-  worker calls.
-- Require exact packaged retrieval readiness on protected Mac and Windows
-  release hosts without making optional performance or answer-quality evaluation
-  a shipping gate.
-- Give cold Linux retrieval contract runs enough bounded time to complete
-  instead of canceling passing protocol tests mid-suite.
-
 ## 0.16.0
 
 CodeStory 0.16 is the release where the machinery disappears.


### PR DESCRIPTION
## Context

The `Unreleased` section had become an internal implementation and proof log, burying the existing user-facing 0.16 release story.

## What changed

- removed the six internal runtime, packaging, qualification, and CI bullets from `Unreleased`
- preserved the existing 0.16 product narrative unchanged
- narrowed the repository rule so changelog entries cover user- or operator-visible effects and keep implementation/proof mechanics in PRs and issues

## Verification

- read back the changed sections
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs` (75 files, 264 links)

Closes #1421
