### PR TITLE
[codex] correct public support matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ No Docker. No Python setup. No model download. No separate service to babysit.
 
 ### Install it and get to work
 
-CodeStory 0.16 launches on Apple Silicon Mac and Windows x64 as one
-self-contained download. The plugin starts CodeStory when you need it and gets
-out of the way when you do not.
+CodeStory 0.16 launches on Apple Silicon Mac, Windows x64 with Vulkan, and Linux
+x64 with Vulkan as self-contained downloads. The plugin starts CodeStory when
+you need it and gets out of the way when you do not.
 
 One private local model can stay warm across compatible CodeStory sessions,
 while every repository keeps its own index and state. Moving between projects
@@ -62,9 +62,14 @@ paths more accurately.
 
 ### Availability
 
-CodeStory 0.16 is available for Apple Silicon macOS and Windows x64.
-
-Linux, Intel Mac, and Windows ARM are not part of this release.
+| Platform | Release support |
+| --- | --- |
+| Apple Silicon macOS | Supported |
+| Windows x64 with Vulkan | Supported |
+| Linux x64 with Vulkan | Supported |
+| CPU-only Windows and Linux | Unsupported |
+| Intel Mac | Unsupported |
+| Windows ARM | Unsupported |
 
 ### Upgrade
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ flowchart LR
 | --- | --- | --- |
 | macOS 15+ on Apple Silicon | Yes | Metal |
 | Windows x64 | Yes | Vulkan |
+| Linux x64 | Yes | Vulkan |
 
-CodeStory 0.16 publishes only these managed package targets.
-Unshipped targets: linux-arm64, linux-x64, macos-x64, windows-arm64. Answer quality and performance are separate release non-claims.
+CPU-only Windows and Linux are unsupported. Intel Mac and Windows ARM are
+unsupported. Answer quality and performance are separate release non-claims.
 <!-- codestory-public-support:end -->
 
 ## Example prompts


### PR DESCRIPTION
## What changed

Correct the public support claim in both `README.md` and `CHANGELOG.md`:

- Apple Silicon macOS is supported.
- Windows x64 with Vulkan is supported.
- Linux x64 with Vulkan is supported.
- CPU-only Windows and Linux are unsupported.
- Intel Mac and Windows ARM are unsupported.

No test run for this docs-only correction, as requested.

Closes #1421
