### PR TITLE
Forward release secrets into trusted publication

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2476,6 +2476,11 @@ function validateRemainingWorkflows(workflows, violations) {
       `${autoFile} release caller must pass pull-request metadata access to exact source proof`,
     );
     add(violations, object(release.with).publish_release === true, `${autoFile} trusted main caller must explicitly authorize publication`);
+    add(
+      violations,
+      release.secrets === "inherit",
+      `${autoFile} release caller must inherit repository release secrets`,
+    );
   }
 
   const evidenceFile = "release-candidate-evidence.yml";

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1881,6 +1881,7 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
     ["post-publish smoke authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-smoke"].if; }],
     ["post-publish closeout authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-closeout"].if; }],
     ["trusted caller opt-in", workflows => { delete workflows.get("auto-release.yml").jobs.release.with.publish_release; }],
+    ["trusted caller secret handoff", workflows => { delete workflows.get("auto-release.yml").jobs.release.secrets; }],
     ["manual release source permissions", workflows => { delete workflows.get("release.yml").permissions["pull-requests"]; }],
     ["automatic release source permissions", workflows => { delete workflows.get("auto-release.yml").jobs.release.permissions["pull-requests"]; }],
     ["rogue release caller", workflows => {

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -103,3 +103,4 @@ jobs:
       calibration_bundle_artifact: ${{ vars.CODESTORY_CALIBRATION_BUNDLE_ARTIFACT }}
       calibration_bundle_run_id: ${{ vars.CODESTORY_CALIBRATION_BUNDLE_RUN_ID }}
       publish_release: true
+    secrets: inherit


### PR DESCRIPTION
## Context

Auto-release run `30103691755` reached the protected macOS signing step at exact main SHA `45084e2ad40b174b437319a1d2439df07b1b437a`, but all six repository signing/notary secrets were empty inside the reusable release workflow.

## What changed

- inherit repository release secrets at the trusted `auto-release.yml` → `release.yml` boundary
- make workflow policy require that handoff
- add a mutation test that proves removing it fails policy

## Verification

- actionlint controlled fixture and workflow syntax pass
- synchronized release validation passes for `0.16.0`
- workflow policy passes
- all 298 workflow-policy tests pass
- `git diff --check` passes

## Risk

The handoff exists only on the trusted main publication caller. The reusable release workflow still forwards only the six named Apple secrets into the macOS package job, and protected platform workflows continue to reject `secrets: inherit`.

Closes #1427
Refs #1189
Refs #1233