### PR TITLE
Promote v0.16 release secret handoff

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2476,6 +2476,11 @@ function validateRemainingWorkflows(workflows, violations) {
       `${autoFile} release caller must pass pull-request metadata access to exact source proof`,
     );
     add(violations, object(release.with).publish_release === true, `${autoFile} trusted main caller must explicitly authorize publication`);
+    add(
+      violations,
+      release.secrets === "inherit",
+      `${autoFile} release caller must inherit repository release secrets`,
+    );
   }
 
   const evidenceFile = "release-candidate-evidence.yml";

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1881,6 +1881,7 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
     ["post-publish smoke authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-smoke"].if; }],
     ["post-publish closeout authority", workflows => { delete workflows.get("release.yml").jobs["post-publish-closeout"].if; }],
     ["trusted caller opt-in", workflows => { delete workflows.get("auto-release.yml").jobs.release.with.publish_release; }],
+    ["trusted caller secret handoff", workflows => { delete workflows.get("auto-release.yml").jobs.release.secrets; }],
     ["manual release source permissions", workflows => { delete workflows.get("release.yml").permissions["pull-requests"]; }],
     ["automatic release source permissions", workflows => { delete workflows.get("auto-release.yml").jobs.release.permissions["pull-requests"]; }],
     ["rogue release caller", workflows => {

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -103,3 +103,4 @@ jobs:
       calibration_bundle_artifact: ${{ vars.CODESTORY_CALIBRATION_BUNDLE_ARTIFACT }}
       calibration_bundle_run_id: ${{ vars.CODESTORY_CALIBRATION_BUNDLE_RUN_ID }}
       publish_release: true
+    secrets: inherit


### PR DESCRIPTION
## Context

Release run `30103691755` proved that the v0.16 source and package lanes start correctly, then failed because the trusted reusable-workflow caller did not inherit the repository signing secrets. PR #1428 fixes and policy-guards that boundary.

## Change

Promote exact dev head `c3250f79b17a50ddb69d23a9b7f63e65dcc7150f` onto current main `45084e2ad40b174b437319a1d2439df07b1b437a`. The main-only detector will retry `0.16.0` because neither its tag nor release exists.

## Verification

- action syntax passes
- release version synchronization passes
- workflow policy passes
- all 298 workflow-policy tests pass
- issue-link guard and plugin static check pass on PR #1428

## Risk

This exposes the existing six repository Apple signing/notary secrets to the trusted release coordinator, which forwards only those named secrets to the protected macOS package job. Publication remains gated by every source, package, protected hardware, installed-runtime, and closeout cell.

Refs #1427
Refs #1189
Refs #1233