### PR TITLE
[codex] fix Windows native staging flush

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1870,6 +1870,19 @@ function validatePackagedProof(workflows, violations, graph) {
   requireStepRun(violations, file, job, "Install Linux Vulkan build dependencies", [
     "bash .github/scripts/install-linux-vulkan-build-deps.sh",
   ]);
+  const windowsNativeStagingTest = namedStep(job, "Test immutable native staging on Windows");
+  add(
+    violations,
+    windowsNativeStagingTest?.if === "runner.os == 'Windows'",
+    `${file} immutable native staging regression must run on Windows`,
+  );
+  requireStepRun(violations, file, job, "Test immutable native staging on Windows", [
+    "cargo test --release --locked",
+    "-p codestory-llama-sys",
+    "--test native_staging",
+    '--target "${{ matrix.rust_target }}"',
+    "stages_complete_immutable_native_seeds",
+  ]);
   requireStepRun(violations, file, job, "Build Linux x64 at the glibc 2.31 baseline", [
     ".github/docker/linux-glibc-build.Dockerfile",
     "cargo build --release --locked -p codestory-cli",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1189,6 +1189,10 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     workflow.jobs.build,
     "Configure short Windows Cargo target",
   );
+  const packagedNativeStaging = workflow => draftStep(
+    workflow.jobs.build,
+    "Test immutable native staging on Windows",
+  );
   const protectedSourceTools = workflow => draftStep(
     workflow.jobs["packaged-vulkan"],
     "Capture source build tool evidence",
@@ -1238,6 +1242,12 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
       packagedShortTarget(workflow).run = packagedShortTarget(workflow).run
         .replace("| Out-File -FilePath $env:GITHUB_ENV", "| Write-Output");
     }, /Configure short Windows Cargo target/u],
+    ["packaged native staging regression made cross-platform", packagedFile, workflow => {
+      packagedNativeStaging(workflow).if = "runner.os != 'Windows'";
+    }, /immutable native staging regression must run on Windows/u],
+    ["packaged native staging regression removed", packagedFile, workflow => {
+      packagedNativeStaging(workflow).run = "cargo test --release --locked";
+    }, /Test immutable native staging on Windows/u],
     ["packaged identity made conditional", packagedFile, workflow => {
       packagedIdentity(workflow).if = "runner.os != 'Windows'";
     }, /native build identity must be unique, unconditional/u],

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -180,6 +180,15 @@ jobs:
         if: runner.os == 'Linux'
         run: bash .github/scripts/install-linux-vulkan-build-deps.sh
 
+      - name: Test immutable native staging on Windows
+        if: runner.os == 'Windows'
+        run: >-
+          cargo test --release --locked
+          -p codestory-llama-sys
+          --test native_staging
+          --target "${{ matrix.rust_target }}"
+          stages_complete_immutable_native_seeds
+
       - name: Build codestory-cli
         if: matrix.asset_target != 'linux-x64'
         run: cargo build --release --locked -p codestory-cli --target "${{ matrix.rust_target }}"

--- a/crates/codestory-llama-sys/native_staging.rs
+++ b/crates/codestory-llama-sys/native_staging.rs
@@ -1,7 +1,7 @@
 use fs4::fs_std::FileExt;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -201,8 +201,12 @@ fn write_runtime_file_list<'a>(
 ) -> io::Result<()> {
     let mut body = names.into_iter().collect::<Vec<_>>().join("\n");
     body.push('\n');
-    fs::write(destination, body)?;
-    File::open(destination)?.sync_all()
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)?;
+    file.write_all(body.as_bytes())?;
+    file.sync_all()
 }
 
 /// Copy one Windows runtime DLL without exposing a missing or partial destination.
@@ -836,6 +840,49 @@ fn sync_parent_directory(_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+mod generation_tests {
+    use super::{NATIVE_RUNTIME_FILE_LIST, NATIVE_SEEDS_DIR, stage_native_generation};
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn stages_complete_immutable_native_seeds() {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        let sources = temp.path().join("sources");
+        let profile = temp.path().join("target/debug");
+        fs::create_dir_all(&sources).expect("source directory");
+        fs::write(sources.join("libggml.so"), b"generation-one").expect("first source");
+        fs::write(sources.join("libllama.so"), b"llama").expect("second source");
+        let paths = [sources.join("libggml.so"), sources.join("libllama.so")];
+        let refs = paths.iter().map(PathBuf::as_path).collect::<Vec<_>>();
+
+        let first = stage_native_generation(&refs, &profile).expect("first generation");
+        assert_eq!(
+            fs::read_to_string(first.directory.join(NATIVE_RUNTIME_FILE_LIST))
+                .expect("generation manifest"),
+            "libggml.so\nlibllama.so\n"
+        );
+        fs::write(&paths[0], b"generation-two").expect("replace source bytes");
+        let second = stage_native_generation(&refs, &profile).expect("second generation");
+        assert_ne!(first.id, second.id);
+        assert_eq!(
+            fs::read(first.directory.join("libggml.so")).expect("immutable first bytes"),
+            b"generation-one"
+        );
+        assert_eq!(
+            fs::read(second.directory.join("libggml.so")).expect("second bytes"),
+            b"generation-two"
+        );
+        assert_eq!(
+            fs::read_dir(profile.join(NATIVE_SEEDS_DIR))
+                .expect("seed inventory")
+                .count(),
+            2
+        );
+    }
+}
+
 #[cfg(all(test, windows))]
 mod windows_tests {
     use super::{prepare_runtime_copy, publish_all_with, replace_file, stage_windows_runtime_file};
@@ -897,50 +944,13 @@ mod windows_tests {
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        NATIVE_RUNTIME_FILE_LIST, NATIVE_SEEDS_DIR, acquire_profile_staging_lock,
-        prepare_real_hard_link, publish_all, publish_all_with, stage_linux_shared_libraries,
-        stage_native_generation,
+        acquire_profile_staging_lock, prepare_real_hard_link, publish_all, publish_all_with,
+        stage_linux_shared_libraries,
     };
     use std::fs;
     use std::io;
     use std::os::unix::fs::symlink;
     use std::path::{Path, PathBuf};
-
-    #[test]
-    fn stages_complete_immutable_native_seeds() {
-        let temp = tempfile::tempdir().expect("temporary directory");
-        let sources = temp.path().join("sources");
-        let profile = temp.path().join("target/debug");
-        fs::create_dir_all(&sources).expect("source directory");
-        fs::write(sources.join("libggml.so"), b"generation-one").expect("first source");
-        fs::write(sources.join("libllama.so"), b"llama").expect("second source");
-        let paths = [sources.join("libggml.so"), sources.join("libllama.so")];
-        let refs = paths.iter().map(PathBuf::as_path).collect::<Vec<_>>();
-
-        let first = stage_native_generation(&refs, &profile).expect("first generation");
-        assert_eq!(
-            fs::read_to_string(first.directory.join(NATIVE_RUNTIME_FILE_LIST))
-                .expect("generation manifest"),
-            "libggml.so\nlibllama.so\n"
-        );
-        fs::write(&paths[0], b"generation-two").expect("replace source bytes");
-        let second = stage_native_generation(&refs, &profile).expect("second generation");
-        assert_ne!(first.id, second.id);
-        assert_eq!(
-            fs::read(first.directory.join("libggml.so")).expect("immutable first bytes"),
-            b"generation-one"
-        );
-        assert_eq!(
-            fs::read(second.directory.join("libggml.so")).expect("second bytes"),
-            b"generation-two"
-        );
-        assert_eq!(
-            fs::read_dir(profile.join(NATIVE_SEEDS_DIR))
-                .expect("seed inventory")
-                .count(),
-            2
-        );
-    }
 
     #[test]
     fn replaces_dangling_links_in_every_cargo_runtime_directory() {


### PR DESCRIPTION
## Context

Both v0.16 release attempts failed at the same Windows build-script boundary with `ERROR_ACCESS_DENIED`. The immutable-generation manifest was written and then reopened read-only before `sync_all`; Windows `FlushFileBuffers` requires a writable handle.

## What changed

- write and durably flush the manifest through one create-new writable handle
- run the portable immutable-generation test on Windows
- put that focused regression before the full Windows CLI build while reusing the same release target
- pin the workflow requirement with hostile policy mutations

## Review

The source fix is in `crates/codestory-llama-sys/native_staging.rs`. The workflow addition localizes this class of failure before the rest of the CLI build.

## Verification

Exact head: `664fe9dd`

- `cargo fmt --all -- --check`
- `cargo test --locked -p codestory-llama-sys --test native_staging stages_complete_immutable_native_seeds`
- `node .github/scripts/run-actionlint.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test .github/scripts/check-workflow-policy.test.mjs` (300 passing)
- `python .github/scripts/check-codestory-release.py --version 0.16.0`
- `git diff --check`
- Windows job `89535653447` compiled `codestory-llama-sys` through the exact
  native-generation staging path that failed twice in the release. It then
  failed later because functional tests invoked the native launcher instead of
  the runtime; that separate source-gate defect is tracked in #1433.

The original Windows `ERROR_ACCESS_DENIED` boundary is proved fixed.

Closes #1430
