### PR TITLE
shorten Windows installed-proof sandbox

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -3470,6 +3470,9 @@ function validateRemainingWorkflows(workflows, violations) {
       "--expected-source-sha",
       "--expected-source-tree",
       "$env:CODESTORY_CANDIDATE_WINDOWS_ROOT",
+      "$env:TEMP = $proofTemp",
+      "$env:TMP = $proofTemp",
+      "$env:TMPDIR = $proofTemp",
     ]);
     const candidateProofRun = stepRun(
       job,

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -350,6 +350,11 @@ jobs:
           $sourceTree = (git rev-parse 'HEAD^{tree}').Trim()
           $pluginRoot = Join-Path $env:CODESTORY_CANDIDATE_WINDOWS_ROOT "plugin"
           $pluginData = Join-Path $env:CODESTORY_CANDIDATE_WINDOWS_ROOT "data"
+          $proofTemp = Join-Path $env:CODESTORY_CANDIDATE_WINDOWS_ROOT "tmp"
+          New-Item -ItemType Directory -Path $proofTemp | Out-Null
+          $env:TEMP = $proofTemp
+          $env:TMP = $proofTemp
+          $env:TMPDIR = $proofTemp
           python .github/scripts/check-packaged-agent-proof.py `
             --archive $archive `
             --checksum-file "target/release-dist/codestory-cli-v$version-windows-x64.zip.sha256" `
@@ -509,6 +514,16 @@ jobs:
           ) {
             throw "refusing to clean unexpected candidate-managed root: $candidateRoot"
           }
-          if (Test-Path -LiteralPath $candidateRoot) {
-            Remove-Item -LiteralPath $candidateRoot -Recurse -Force
+          for ($attempt = 1; $attempt -le 30; $attempt++) {
+            try {
+              if (Test-Path -LiteralPath $candidateRoot) {
+                Remove-Item -LiteralPath $candidateRoot -Recurse -Force
+              }
+              break
+            } catch {
+              if ($attempt -eq 30) {
+                throw
+              }
+              Start-Sleep -Seconds 1
+            }
           }


### PR DESCRIPTION
Closes #1437

## Summary
- put the Python proof sandbox and retrieval cache under the short candidate-managed Windows root
- retry guarded candidate cleanup while the managed runtime releases its executable
- freeze the sandbox environment in workflow policy

## Direct Windows proof
- identical retained archive with runner `_work\_temp`: failed during search indexing
- identical archive with only `TEMP`, `TMP`, and `TMPDIR` moved under `C:\cs-ci-…`: passed
- ground: 6 attempts; search: 3 attempts
- Vulkan: 840 encodes across 332 execution nodes
- exact source `4fc19529af86f572d6c2597e4bdd85d691bcc6a1`, tree `99b245bfa59f57b1341bdf9209165616b2a68722`

## Verification
- `git diff --check`
- workflow policy passed
- workflow policy tests: 349 passed
- guarded cleanup passed on the Windows host after runtime exit