### PR TITLE
Resume interrupted macOS release artifact downloads

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -3111,6 +3111,27 @@ function validateRemainingWorkflows(workflows, violations) {
         === "inputs.calibration_mode || !inputs.server_behavior_only",
       `${metalFile} packaged server-behavior proof must skip the qualification driver`,
     );
+    const packagedArtifactDownload = namedStep(job, "Download packaged CLI artifact");
+    add(
+      violations,
+      packagedArtifactDownload?.if === "inputs.use_packaged_cli_artifact"
+        && packagedArtifactDownload?.shell === "bash"
+        && object(packagedArtifactDownload?.env).GH_TOKEN === "${{ github.token }}"
+        && object(packagedArtifactDownload?.env).ARTIFACT_NAME === "codestory-cli-macos-arm64",
+      `${metalFile} packaged CLI download must be an authenticated exact-artifact Bash boundary`,
+    );
+    requireStepRun(violations, metalFile, job, "Download packaged CLI artifact", [
+      "actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100",
+      ".workflow_run.id == $run_id",
+      ".workflow_run.head_sha == $sha",
+      ".digest",
+      ".size_in_bytes",
+      "--continue-at -",
+      "--max-time 120",
+      "test \"$actual_size\" = \"$expected_size\"",
+      "test \"$actual_digest\" = \"${expected_digest#sha256:}\"",
+      "ditto -x -k",
+    ]);
     requireCalibrationProducerBoundary(
       violations,
       metalFile,

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1609,6 +1609,40 @@ test("protected candidate installs prove accelerated server behavior without CPU
   }
 });
 
+test("protected macOS package download is resumable and container-verified", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+
+  const file = "macos-metal-proof.yml";
+  const mutations = [
+    ["resume removed", step => {
+      step.run = step.run.replace("--continue-at -", "--remote-name");
+    }, /Download packaged CLI artifact/u],
+    ["container digest bypassed", step => {
+      step.run = step.run.replace(
+        'test "$actual_digest" = "${expected_digest#sha256:}"',
+        "true",
+      );
+    }, /Download packaged CLI artifact/u],
+    ["producer SHA binding removed", step => {
+      step.run = step.run.replace(".workflow_run.head_sha == $sha", "true");
+    }, /Download packaged CLI artifact/u],
+  ];
+
+  for (const [name, mutate, expectedReason] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      const step = draftStep(
+        workflows.get(file).jobs["packaged-metal"],
+        "Download packaged CLI artifact",
+      );
+      mutate(step);
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expectedReason);
+    });
+  }
+});
+
 test("post-publish proof uses an immutable real Codex marketplace install", async (t) => {
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
 

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -186,10 +186,82 @@ jobs:
 
       - name: Download packaged CLI artifact
         if: inputs.use_packaged_cli_artifact
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: codestory-cli-macos-arm64
-          path: target/release-dist
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_NAME: codestory-cli-macos-arm64
+        run: |
+          set -euo pipefail
+          artifact="$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
+              | jq \
+                --arg name "$ARTIFACT_NAME" \
+                --arg sha "$GITHUB_SHA" \
+                --argjson run_id "$GITHUB_RUN_ID" \
+                '[
+                  .artifacts[]
+                  | select(
+                      .name == $name
+                      and .expired == false
+                      and .workflow_run.id == $run_id
+                      and .workflow_run.head_sha == $sha
+                    )
+                ] | sort_by(.created_at) | last'
+          )"
+          test "$artifact" != null
+
+          artifact_id="$(jq -r '.id' <<<"$artifact")"
+          expected_size="$(jq -r '.size_in_bytes' <<<"$artifact")"
+          expected_digest="$(jq -r '.digest' <<<"$artifact")"
+          [[ "$artifact_id" =~ ^[0-9]+$ ]]
+          [[ "$expected_size" =~ ^[0-9]+$ ]]
+          [[ "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+          archive="$RUNNER_TEMP/$ARTIFACT_NAME-$artifact_id.zip"
+          download_url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip"
+          rm -f "$archive"
+          trap 'rm -f "$archive"' EXIT
+
+          complete=false
+          for attempt in $(seq 1 30); do
+            if curl \
+              --fail \
+              --location \
+              --silent \
+              --show-error \
+              --connect-timeout 30 \
+              --max-time 120 \
+              --continue-at - \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$archive" \
+              "$download_url"; then
+              complete=true
+              break
+            fi
+
+            current_size=0
+            test ! -f "$archive" || current_size="$(stat -f %z "$archive")"
+            test "$current_size" -le "$expected_size"
+            if [ "$current_size" = "$expected_size" ]; then
+              complete=true
+              break
+            fi
+            echo "::warning title=macOS artifact transfer interrupted::Resuming $ARTIFACT_NAME at byte $current_size after attempt $attempt"
+            sleep 2
+          done
+          test "$complete" = true
+
+          actual_size="$(stat -f %z "$archive")"
+          actual_digest="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          test "$actual_size" = "$expected_size"
+          test "$actual_digest" = "${expected_digest#sha256:}"
+          printf 'artifact_id=%s artifact_bytes=%s artifact_digest=%s\n' \
+            "$artifact_id" "$actual_size" "$expected_digest"
+
+          mkdir -p target/release-dist
+          ditto -x -k "$archive" target/release-dist
 
       - name: Build qualification driver
         if: inputs.calibration_mode || !inputs.server_behavior_only


### PR DESCRIPTION
Closes #1445.

The macOS protected release lane repeatedly failed before proof while downloading the 158 MB package artifact. The exact retained artifact reproduced the same connection reset locally; a byte-range retry resumed from the prior offset.

This replaces that one download boundary with an exact-run, exact-SHA artifact lookup, resumable transfer, and container size/SHA-256 verification before extraction. Workflow policy mutations freeze the producer binding, resume flag, and digest check.

Verified:
- `git diff --check`
- workflow policy validation
- 353 workflow policy tests