### PR TITLE
Isolate post-publish release proof hosts

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2452,10 +2452,24 @@ function validatePostPublish(workflows, violations) {
   add(
     violations,
     pythonSetup?.uses === "actions/setup-python@v7.0.0"
+      && pythonSetup?.if === "runner.os != 'macOS'"
       && object(pythonSetup?.with)["python-version"] === "3.13"
       && object(pythonSetup?.env).PSExecutionPolicyPreference === "Bypass",
     `${file} must install pinned Python with the protected Windows execution policy`,
   );
+  const macosPythonSetup = namedStep(job, "Install pinned Python on macOS");
+  add(
+    violations,
+    macosPythonSetup?.if === "runner.os == 'macOS'"
+      && macosPythonSetup?.shell === "bash",
+    `${file} must install pinned Python through the protected macOS user toolchain`,
+  );
+  requireStepRun(violations, file, job, "Install pinned Python on macOS", [
+    "uv python install 3.13.14",
+    'python_bin="$(uv python find 3.13.14)"',
+    "platform.python_version()",
+    'echo "$shim_dir" >> "$GITHUB_PATH"',
+  ]);
   const expected = expectedPostPublishRows();
   add(
     violations,
@@ -2487,7 +2501,14 @@ function validatePostPublish(workflows, violations) {
     '--marketplace-revision "$marketplace_revision"',
     '--source-repository "$GITHUB_WORKSPACE"',
     "install-attestation-v2.json",
+    'isolated_home="$install_root/isolated-home"',
+    'HOME="$isolated_home" node',
   ]);
+  add(
+    violations,
+    namedStep(job, "Prove packaged version, help, and stdio shape")?.shell === "bash",
+    `${file} packaged Python proof must use Bash on every protected platform`,
+  );
   const resolveRun = executableRunText(String(resolveInstalled?.run ?? ""));
   for (const forbidden of [
     "git archive",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1706,6 +1706,10 @@ test("post-publish proof keeps every release asset on its protected accelerator"
     workflow.jobs.smoke,
     "Prove the catalog-resolved published runtime",
   );
+  const installStep = workflow => draftStep(
+    workflow.jobs.smoke,
+    "Resolve the published plugin through the marketplace catalog",
+  );
   const row = (workflow, assetTarget) => {
     const match = workflow.jobs.smoke.strategy.matrix.include.find(
       ({ asset_target: candidate }) => candidate === assetTarget,
@@ -1740,6 +1744,19 @@ test("post-publish proof keeps every release asset on its protected accelerator"
     ["published Python loses the protected execution policy", workflow => {
       delete draftStep(workflow.jobs.smoke, "Install pinned Python")
         .env.PSExecutionPolicyPreference;
+    }],
+    ["published Python proof falls back to PowerShell", workflow => {
+      draftStep(workflow.jobs.smoke, "Prove packaged version, help, and stdio shape").shell
+        = "powershell";
+    }],
+    ["published marketplace install inherits personal HOME", workflow => {
+      installStep(workflow).run = installStep(workflow).run
+        .replace('HOME="$isolated_home" node', "node");
+    }],
+    ["published macOS Python pin drifts", workflow => {
+      draftStep(workflow.jobs.smoke, "Install pinned Python on macOS").run
+        = draftStep(workflow.jobs.smoke, "Install pinned Python on macOS").run
+          .replaceAll("3.13.14", "3.14.6");
     }],
     ["Windows installer loses the protected execution policy", workflow => {
       draftStep(workflow.jobs.smoke, "Run Windows installer ownership self-test").shell

--- a/.github/scripts/install-codestory-marketplace-proof.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.mjs
@@ -259,11 +259,13 @@ function verifyInstallation(setup, installed) {
     fail("pinned marketplace plugin source does not match the release source tree");
   }
   const listedMarketplaces = installed.marketplaceList.marketplaces;
-  const marketplaceListEntry = listedMarketplaces?.[0];
+  const matchingMarketplaces = Array.isArray(listedMarketplaces)
+    ? listedMarketplaces.filter(({ name }) => name === setup.marketplaceName)
+    : [];
+  const marketplaceListEntry = matchingMarketplaces[0];
   if (
     !Array.isArray(listedMarketplaces)
-    || listedMarketplaces.length !== 1
-    || marketplaceListEntry?.name !== setup.marketplaceName
+    || matchingMarketplaces.length !== 1
   ) {
     fail("Codex marketplace list has an unexpected identity");
   }

--- a/.github/scripts/install-codestory-marketplace-proof.test.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.test.mjs
@@ -140,6 +140,16 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
     const marketplaceRevision = commitFixture(marketplaceRoot, "fixture", {
       init: true,
     });
+    const personalHome = path.join(root, "personal-home");
+    mkdirSync(path.join(personalHome, ".agents", "plugins"), { recursive: true });
+    writeFileSync(
+      path.join(personalHome, ".agents", "plugins", "marketplace.json"),
+      `${JSON.stringify({
+        name: "Personal",
+        interface: { displayName: "Personal" },
+        plugins: [],
+      }, null, 2)}\n`,
+    );
     const releaseSourceCommit = commitFixture(
       pluginSourceRoot,
       "release merge",
@@ -166,7 +176,12 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
       marketplaceRevision,
       expectedVersion: pluginManifest.version,
       sourceRepository: pluginSourceRoot,
-    }));
+    }), {
+      env: {
+        ...process.env,
+        HOME: personalHome,
+      },
+    });
 
     const attestation = JSON.parse(readFileSync(attestationPath));
     const expectedPluginRoot = path.join(
@@ -190,6 +205,10 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
     );
     assert.equal(attestation.marketplace.provenance.add.revision, marketplaceRevision);
     assert.equal(attestation.marketplace.provenance.list.revision, marketplaceRevision);
+    assert.deepEqual(
+      attestation.marketplace.list_result.marketplaces.map(({ name }) => name).sort(),
+      ["Fixture", "Personal"],
+    );
     assert.equal(
       attestation.marketplace.provenance.add.root,
       attestation.marketplace.provenance.list.root,

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -97,11 +97,26 @@ jobs:
           fetch-depth: 0
 
       - name: Install pinned Python
+        if: runner.os != 'macOS'
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.13"
         env:
           PSExecutionPolicyPreference: Bypass
+
+      - name: Install pinned Python on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv python install 3.13.14
+          python_bin="$(uv python find 3.13.14)"
+          test -x "$python_bin"
+          test "$("$python_bin" -c 'import platform; print(platform.python_version())')" = 3.13.14
+          shim_dir="$RUNNER_TEMP/codestory-python-3.13.14"
+          mkdir -p "$shim_dir"
+          ln -sf "$python_bin" "$shim_dir/python"
+          echo "$shim_dir" >> "$GITHUB_PATH"
 
       - name: Download accepted pre-publish closeout
         if: inputs.emit_release_cells
@@ -134,6 +149,7 @@ jobs:
           echo "checksum=$dir/SHA256SUMS.txt" >> "$GITHUB_OUTPUT"
 
       - name: Prove packaged version, help, and stdio shape
+        shell: bash
         run: >-
           python .github/scripts/check-packaged-agent-proof.py
           --archive "${{ steps.asset.outputs.archive }}"
@@ -201,15 +217,17 @@ jobs:
           set -euo pipefail
           install_root="$RUNNER_TEMP/codestory-installed-proof"
           codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
+          isolated_home="$install_root/isolated-home"
           marketplace_revision="${{ inputs.marketplace_revision }}"
           test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
           rm -rf "$install_root"
+          mkdir -p "$isolated_home"
           npm install \
             --prefix "$codex_package_root" \
             --no-audit \
             --no-fund \
             "@openai/codex@$CODEX_CLI_VERSION"
-          node .github/scripts/install-codestory-marketplace-proof.mjs \
+          HOME="$isolated_home" node .github/scripts/install-codestory-marketplace-proof.mjs \
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \


### PR DESCRIPTION
Closes #1446.

The v0.16.0 release assets are published and their checksums/version smoke passed, but the protected post-publish matrix exposed host-specific proof assumptions. This runs the packaged Python proof through Bash, installs exact Python 3.13.14 in the macOS user tool cache, isolates Codex from the runner user’s personal marketplace, and permits unrelated marketplace entries while still requiring exactly one matching immutable target.

Verified:
- `git diff --check`
- workflow policy validation
- 357 workflow policy and marketplace-install tests
- exact uv Python 3.13.14 selection on the protected Mac