### PR TITLE
Release 0.16.1: fix first-use runtime download on slow connections

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2452,10 +2452,24 @@ function validatePostPublish(workflows, violations) {
   add(
     violations,
     pythonSetup?.uses === "actions/setup-python@v7.0.0"
+      && pythonSetup?.if === "runner.os != 'macOS'"
       && object(pythonSetup?.with)["python-version"] === "3.13"
       && object(pythonSetup?.env).PSExecutionPolicyPreference === "Bypass",
     `${file} must install pinned Python with the protected Windows execution policy`,
   );
+  const macosPythonSetup = namedStep(job, "Install pinned Python on macOS");
+  add(
+    violations,
+    macosPythonSetup?.if === "runner.os == 'macOS'"
+      && macosPythonSetup?.shell === "bash",
+    `${file} must install pinned Python through the protected macOS user toolchain`,
+  );
+  requireStepRun(violations, file, job, "Install pinned Python on macOS", [
+    "uv python install 3.13.14",
+    'python_bin="$(uv python find 3.13.14)"',
+    "platform.python_version()",
+    'echo "$shim_dir" >> "$GITHUB_PATH"',
+  ]);
   const expected = expectedPostPublishRows();
   add(
     violations,
@@ -2487,7 +2501,14 @@ function validatePostPublish(workflows, violations) {
     '--marketplace-revision "$marketplace_revision"',
     '--source-repository "$GITHUB_WORKSPACE"',
     "install-attestation-v2.json",
+    'isolated_home="$install_root/isolated-home"',
+    'HOME="$isolated_home" node',
   ]);
+  add(
+    violations,
+    namedStep(job, "Prove packaged version, help, and stdio shape")?.shell === "bash",
+    `${file} packaged Python proof must use Bash on every protected platform`,
+  );
   const resolveRun = executableRunText(String(resolveInstalled?.run ?? ""));
   for (const forbidden of [
     "git archive",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1706,6 +1706,10 @@ test("post-publish proof keeps every release asset on its protected accelerator"
     workflow.jobs.smoke,
     "Prove the catalog-resolved published runtime",
   );
+  const installStep = workflow => draftStep(
+    workflow.jobs.smoke,
+    "Resolve the published plugin through the marketplace catalog",
+  );
   const row = (workflow, assetTarget) => {
     const match = workflow.jobs.smoke.strategy.matrix.include.find(
       ({ asset_target: candidate }) => candidate === assetTarget,
@@ -1740,6 +1744,19 @@ test("post-publish proof keeps every release asset on its protected accelerator"
     ["published Python loses the protected execution policy", workflow => {
       delete draftStep(workflow.jobs.smoke, "Install pinned Python")
         .env.PSExecutionPolicyPreference;
+    }],
+    ["published Python proof falls back to PowerShell", workflow => {
+      draftStep(workflow.jobs.smoke, "Prove packaged version, help, and stdio shape").shell
+        = "powershell";
+    }],
+    ["published marketplace install inherits personal HOME", workflow => {
+      installStep(workflow).run = installStep(workflow).run
+        .replace('HOME="$isolated_home" node', "node");
+    }],
+    ["published macOS Python pin drifts", workflow => {
+      draftStep(workflow.jobs.smoke, "Install pinned Python on macOS").run
+        = draftStep(workflow.jobs.smoke, "Install pinned Python on macOS").run
+          .replaceAll("3.13.14", "3.14.6");
     }],
     ["Windows installer loses the protected execution policy", workflow => {
       draftStep(workflow.jobs.smoke, "Run Windows installer ownership self-test").shell

--- a/.github/scripts/install-codestory-marketplace-proof.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.mjs
@@ -259,11 +259,13 @@ function verifyInstallation(setup, installed) {
     fail("pinned marketplace plugin source does not match the release source tree");
   }
   const listedMarketplaces = installed.marketplaceList.marketplaces;
-  const marketplaceListEntry = listedMarketplaces?.[0];
+  const matchingMarketplaces = Array.isArray(listedMarketplaces)
+    ? listedMarketplaces.filter(({ name }) => name === setup.marketplaceName)
+    : [];
+  const marketplaceListEntry = matchingMarketplaces[0];
   if (
     !Array.isArray(listedMarketplaces)
-    || listedMarketplaces.length !== 1
-    || marketplaceListEntry?.name !== setup.marketplaceName
+    || matchingMarketplaces.length !== 1
   ) {
     fail("Codex marketplace list has an unexpected identity");
   }

--- a/.github/scripts/install-codestory-marketplace-proof.test.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.test.mjs
@@ -140,6 +140,16 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
     const marketplaceRevision = commitFixture(marketplaceRoot, "fixture", {
       init: true,
     });
+    const personalHome = path.join(root, "personal-home");
+    mkdirSync(path.join(personalHome, ".agents", "plugins"), { recursive: true });
+    writeFileSync(
+      path.join(personalHome, ".agents", "plugins", "marketplace.json"),
+      `${JSON.stringify({
+        name: "Personal",
+        interface: { displayName: "Personal" },
+        plugins: [],
+      }, null, 2)}\n`,
+    );
     const releaseSourceCommit = commitFixture(
       pluginSourceRoot,
       "release merge",
@@ -166,7 +176,12 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
       marketplaceRevision,
       expectedVersion: pluginManifest.version,
       sourceRepository: pluginSourceRoot,
-    }));
+    }), {
+      env: {
+        ...process.env,
+        HOME: personalHome,
+      },
+    });
 
     const attestation = JSON.parse(readFileSync(attestationPath));
     const expectedPluginRoot = path.join(
@@ -190,6 +205,10 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
     );
     assert.equal(attestation.marketplace.provenance.add.revision, marketplaceRevision);
     assert.equal(attestation.marketplace.provenance.list.revision, marketplaceRevision);
+    assert.deepEqual(
+      attestation.marketplace.list_result.marketplaces.map(({ name }) => name).sort(),
+      ["Fixture", "Personal"],
+    );
     assert.equal(
       attestation.marketplace.provenance.add.root,
       attestation.marketplace.provenance.list.root,

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -97,11 +97,26 @@ jobs:
           fetch-depth: 0
 
       - name: Install pinned Python
+        if: runner.os != 'macOS'
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.13"
         env:
           PSExecutionPolicyPreference: Bypass
+
+      - name: Install pinned Python on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv python install 3.13.14
+          python_bin="$(uv python find 3.13.14)"
+          test -x "$python_bin"
+          test "$("$python_bin" -c 'import platform; print(platform.python_version())')" = 3.13.14
+          shim_dir="$RUNNER_TEMP/codestory-python-3.13.14"
+          mkdir -p "$shim_dir"
+          ln -sf "$python_bin" "$shim_dir/python"
+          echo "$shim_dir" >> "$GITHUB_PATH"
 
       - name: Download accepted pre-publish closeout
         if: inputs.emit_release_cells
@@ -134,6 +149,7 @@ jobs:
           echo "checksum=$dir/SHA256SUMS.txt" >> "$GITHUB_OUTPUT"
 
       - name: Prove packaged version, help, and stdio shape
+        shell: bash
         run: >-
           python .github/scripts/check-packaged-agent-proof.py
           --archive "${{ steps.asset.outputs.archive }}"
@@ -201,15 +217,17 @@ jobs:
           set -euo pipefail
           install_root="$RUNNER_TEMP/codestory-installed-proof"
           codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
+          isolated_home="$install_root/isolated-home"
           marketplace_revision="${{ inputs.marketplace_revision }}"
           test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
           rm -rf "$install_root"
+          mkdir -p "$isolated_home"
           npm install \
             --prefix "$codex_package_root" \
             --no-audit \
             --no-fund \
             "@openai/codex@$CODEX_CLI_VERSION"
-          node .github/scripts/install-codestory-marketplace-proof.mjs \
+          HOME="$isolated_home" node .github/scripts/install-codestory-marketplace-proof.mjs \
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+## 0.16.1
+
+Fixes first use on a slow or unreliable connection.
+
+The plugin downloads the CodeStory runtime the first time you use it. That
+download was given 60 seconds in total, which a multi-hundred-megabyte archive
+cannot meet on a slow link. Every attempt was cut off mid-transfer, each retry
+threw away the bytes already downloaded and started again from zero, and after
+three rounds the whole thing reported a bare failure code.
+
+- The 60-second total budget is replaced by a stall timeout: as long as bytes
+  keep arriving, the download keeps going. A connection that goes silent for 60
+  seconds still fails fast, and an hour-long ceiling remains as a backstop.
+- Interrupted downloads resume with an HTTP range request instead of restarting.
+  Partial downloads are kept under the managed CLI directory, so progress
+  survives a retry and an MCP restart.
+- Retries are more patient (20 resumable attempts with exponential backoff) but
+  stop immediately on a permanent error such as a missing release asset, instead
+  of retrying something that cannot succeed.
+- While the runtime downloads, tools report real progress — bytes, percentage,
+  and attempt — rather than a fixed "preparing" placeholder.
+- A failed download now explains what happened and what to do about it,
+  including how much has already been downloaded and kept. The machine-readable
+  failure code stays sanitized as before.
+- New environment overrides: `CODESTORY_PLUGIN_DOWNLOAD_TIMEOUT_MS`,
+  `CODESTORY_PLUGIN_DOWNLOAD_STALL_TIMEOUT_MS`, and
+  `CODESTORY_PLUGIN_DOWNLOAD_ATTEMPTS`.
+
 ## 0.16.0
 
 CodeStory 0.16 is the release where the machinery disappears.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-bench"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-llama-sys"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "crossbeam-channel",
  "fs4",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-llama-sys"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 build = "build.rs"
 

--- a/crates/codestory-llama-sys/model-contract.json
+++ b/crates/codestory-llama-sys/model-contract.json
@@ -36,7 +36,7 @@
   },
   "producer": {
     "name": "codestory-llama-sys",
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "license": {
     "spdx_id": "MIT",

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 
 [features]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -20,16 +20,47 @@ const {
 const pluginRoot = path.dirname(__dirname);
 const launchCwd = process.cwd();
 const binaryName = process.platform === 'win32' ? 'codestory-cli.exe' : 'codestory-cli';
-const releaseDownloadTimeoutMs = 60000;
-const releaseDownloadAttempts = 3;
-const releaseDownloadRetryDelaysMs = [1000, 3000];
+function positiveDurationEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+// Release downloads are bounded by two independent limits. The stall timeout detects a dead
+// connection (no bytes at all within the window) and is the limit that should normally fire; the
+// total budget is only a backstop for a link that trickles forever. A single total deadline sized
+// for a fast link is what made first use unusable on a slow one: a multi-hundred-megabyte archive
+// simply cannot land inside it, so every attempt aborted mid-transfer no matter how healthy the
+// connection was. Budgets span all attempts of one asset because attempts resume rather than
+// restart, so retries no longer multiply the wall clock.
+const releaseDownloadStallTimeoutMs = positiveDurationEnv(
+  'CODESTORY_PLUGIN_DOWNLOAD_STALL_TIMEOUT_MS',
+  60 * 1000,
+);
+const releaseChecksumTotalTimeoutMs = positiveDurationEnv(
+  'CODESTORY_PLUGIN_DOWNLOAD_CHECKSUM_TIMEOUT_MS',
+  60 * 1000,
+);
+const releaseArchiveTotalTimeoutMs = positiveDurationEnv(
+  'CODESTORY_PLUGIN_DOWNLOAD_TIMEOUT_MS',
+  60 * 60 * 1000,
+);
+// Attempts resume from the bytes already on disk, so a high cap costs little and lets a flaky
+// link keep inching forward; the total budget above is what actually ends a hopeless download.
+const releaseDownloadAttempts = positiveDurationEnv('CODESTORY_PLUGIN_DOWNLOAD_ATTEMPTS', 20);
+const releaseDownloadRetryDelaysMs = [1000, 2000, 5000, 10000, 15000];
+const releaseDownloadRetryJitterMs = 250;
 const managedCliLockStaleMs = 10 * 60 * 1000;
 const managedCliLockMaxAgeMs = 30 * 60 * 1000;
-const releaseAssetRetryBudgetMs =
-  releaseDownloadAttempts * releaseDownloadTimeoutMs +
-  releaseDownloadRetryDelaysMs.slice(0, releaseDownloadAttempts - 1).reduce((sum, delay) => sum + delay, 0);
+const releaseAssetRetryBudgetMs = releaseArchiveTotalTimeoutMs;
 const managedCliStagingBudgetMs = 30 * 1000;
-const managedCliLockWaitMs = 2 * releaseAssetRetryBudgetMs + managedCliStagingBudgetMs;
+// A waiter blocks only the background provisioning task, never a tool call, so it can afford to
+// outlast a publisher that is legitimately downloading the archive over a slow link.
+const managedCliLockWaitMs =
+  releaseChecksumTotalTimeoutMs + releaseArchiveTotalTimeoutMs + managedCliStagingBudgetMs;
+const managedCliDownloadCacheDirName = '.download';
+const managedCliDownloadCacheMaxAgeMs = 7 * 24 * 60 * 60 * 1000;
 const managedCliPendingOwnerCleanupLimit = 64;
 const managedCliQuarantineRetention = 2;
 const managedCliArchiveMaxBytes = 256 * 1024 * 1024;
@@ -246,6 +277,77 @@ function releaseFileMaxBytes(name) {
   return name === 'SHA256SUMS.txt' ? managedCliChecksumMaxBytes : managedCliArchiveMaxBytes;
 }
 
+function releaseFileTotalTimeoutMs(name) {
+  return name === 'SHA256SUMS.txt' ? releaseChecksumTotalTimeoutMs : releaseArchiveTotalTimeoutMs;
+}
+
+// A single mutable record of what provisioning is currently doing. Tool calls answered while the
+// runtime is still preparing read this so the client sees real download progress instead of a
+// fixed "preparing" placeholder for the several minutes a large archive takes on a slow link.
+const managedCliDownloadProgress = {
+  stage: null,
+  asset: null,
+  attempt: 0,
+  receivedBytes: 0,
+  totalBytes: null,
+  startedAt: null,
+  updatedAt: null,
+};
+
+function resetManagedCliDownloadProgress(stage, asset) {
+  managedCliDownloadProgress.stage = stage;
+  managedCliDownloadProgress.asset = asset;
+  managedCliDownloadProgress.attempt = 0;
+  managedCliDownloadProgress.receivedBytes = 0;
+  managedCliDownloadProgress.totalBytes = null;
+  managedCliDownloadProgress.startedAt = Date.now();
+  managedCliDownloadProgress.updatedAt = Date.now();
+}
+
+function recordManagedCliDownloadProgress(progress) {
+  if (Number.isSafeInteger(progress.receivedBytes)) {
+    managedCliDownloadProgress.receivedBytes = progress.receivedBytes;
+  }
+  // `totalBytes` is unknown at the start of each attempt; keep the last known value rather than
+  // flickering the reported percentage back to null.
+  if (Number.isSafeInteger(progress.totalBytes)) {
+    managedCliDownloadProgress.totalBytes = progress.totalBytes;
+  }
+  if (Number.isSafeInteger(progress.attempt)) {
+    managedCliDownloadProgress.attempt = progress.attempt;
+  }
+  managedCliDownloadProgress.updatedAt = Date.now();
+}
+
+function formatByteSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return null;
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(1)} ${units[unit]}`;
+}
+
+function managedCliDownloadProgressReport() {
+  const { stage, asset, attempt, receivedBytes, totalBytes } = managedCliDownloadProgress;
+  if (!stage) return null;
+  const percent = Number.isSafeInteger(totalBytes) && totalBytes > 0
+    ? Math.min(100, Math.floor((receivedBytes / totalBytes) * 100))
+    : null;
+  return {
+    stage,
+    asset,
+    attempt: Math.max(1, attempt),
+    received_bytes: receivedBytes,
+    total_bytes: Number.isSafeInteger(totalBytes) ? totalBytes : null,
+    percent,
+  };
+}
+
 function copyLocalReleaseFile(releaseDir, name, destination, maxBytes) {
   const source = path.join(releaseDir, name);
   try {
@@ -266,19 +368,63 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Download failures carry a structured tag rather than being re-derived from their message. Error
+// text can embed untrusted or environment-specific detail, so anything that reaches a user-facing
+// surface must be built from these allow-listed enums and numbers instead.
+function downloadError(kind, message, extra = {}) {
+  const error = new Error(message);
+  error.downloadKind = kind;
+  Object.assign(error, extra);
+  return error;
+}
+
+function downloadFailureKind(error) {
+  return typeof error?.downloadKind === 'string' ? error.downloadKind : 'network';
+}
+
+// Failures that cannot improve on a later attempt. Retrying these only burns the user's time
+// before showing the same error, so the retry loop stops at the first one.
+function downloadFailurePermanent(error) {
+  const kind = downloadFailureKind(error);
+  if (['size_limit', 'content_length', 'transport'].includes(kind)) return true;
+  if (kind !== 'http_status') return false;
+  const status = Number(error?.httpStatus);
+  // 408/425/429 are explicitly "come back later"; every other 4xx is a fixed answer.
+  return Number.isInteger(status) && status >= 400 && status < 500 &&
+    ![408, 425, 429].includes(status);
+}
+
+function parseContentRangeStart(header) {
+  const match = /^bytes\s+(\d+)-(\d+)\/(\d+|\*)$/iu.exec(String(header || '').trim());
+  if (!match) return null;
+  const start = Number(match[1]);
+  const total = match[3] === '*' ? null : Number(match[3]);
+  if (!Number.isSafeInteger(start) || start < 0) return null;
+  if (total !== null && (!Number.isSafeInteger(total) || total < 0)) return null;
+  return { start, total };
+}
+
 function downloadFileOnce(url, destination, options = {}) {
-  const timeoutMs = options.timeoutMs || releaseDownloadTimeoutMs;
+  const stallTimeoutMs = options.stallTimeoutMs || releaseDownloadStallTimeoutMs;
+  const timeoutMs = options.timeoutMs || releaseArchiveTotalTimeoutMs;
   const maxBytes = options.maxBytes ?? managedCliArchiveMaxBytes;
   if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
-    return Promise.reject(new Error(`download_size_limit_invalid:${maxBytes}`));
+    return Promise.reject(downloadError('size_limit', `download_size_limit_invalid:${maxBytes}`));
   }
+  const resumeFrom = Number.isSafeInteger(options.resumeFrom) && options.resumeFrom > 0
+    ? options.resumeFrom
+    : 0;
+  if (resumeFrom > maxBytes) {
+    return Promise.reject(downloadError('size_limit', `download_size_limit_exceeded:${url}`));
+  }
+  const onProgress = typeof options.onProgress === 'function' ? options.onProgress : null;
   const deadlineMs = options.deadlineMs ?? Date.now() + timeoutMs;
   const redirectsRemaining = options.redirectsRemaining ?? 5;
   const parsedUrl = new URL(url);
   const loopbackHttp = parsedUrl.protocol === 'http:' &&
     ['127.0.0.1', '::1', '[::1]', 'localhost'].includes(parsedUrl.hostname);
   if (!options.get && parsedUrl.protocol !== 'https:' && !loopbackHttp) {
-    return Promise.reject(new Error('download transport must be HTTPS'));
+    return Promise.reject(downloadError('transport', 'download transport must be HTTPS'));
   }
   const get = options.get || (loopbackHttp ? http.get : https.get);
   return new Promise((resolve, reject) => {
@@ -287,101 +433,211 @@ function downloadFileOnce(url, destination, options = {}) {
     let activeRequest = null;
     let activeResponse = null;
     let limiter = null;
+    let stallTimer = null;
+    // Bytes already on disk from earlier attempts, plus whatever this attempt appends.
+    let downloadedBytes = resumeFrom;
     const finish = (error) => {
       if (settled) return;
       settled = true;
       clearTimeout(deadlineTimer);
+      if (stallTimer) clearTimeout(stallTimer);
       if (error) {
         if (limiter) limiter.destroy();
         if (output) output.destroy();
         if (activeResponse) activeResponse.destroy();
         if (activeRequest) activeRequest.destroy();
+        error.downloadedBytes = downloadedBytes;
         reject(error);
       } else {
-        resolve();
+        resolve({ downloadedBytes });
       }
+    };
+    const armStall = () => {
+      if (settled) return;
+      if (stallTimer) clearTimeout(stallTimer);
+      stallTimer = setTimeout(
+        () => finish(downloadError('stalled', `download stalled after ${stallTimeoutMs}ms without data: ${url}`)),
+        stallTimeoutMs,
+      );
+      // A stall timer must never hold the event loop open on its own.
+      if (typeof stallTimer.unref === 'function') stallTimer.unref();
     };
     const remainingMs = Math.max(0, deadlineMs - Date.now());
     const deadlineTimer = setTimeout(
-      () => finish(new Error(`download timed out after ${timeoutMs}ms total: ${url}`)),
+      () => finish(downloadError('timed_out', `download timed out after ${timeoutMs}ms total: ${url}`)),
       remainingMs,
     );
-    const request = get(url, (response) => {
+    const handleResponse = (response) => {
       activeResponse = response;
       if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
         response.resume();
         if (!response.headers.location || redirectsRemaining <= 0) {
-          finish(new Error(`download redirect failed: ${url}`));
+          finish(downloadError('redirect', `download redirect failed: ${url}`));
           return;
         }
         const nextUrl = new URL(response.headers.location, url).toString();
+        if (stallTimer) clearTimeout(stallTimer);
         downloadFileOnce(nextUrl, destination, {
           ...options,
           deadlineMs,
           redirectsRemaining: redirectsRemaining - 1,
-        }).then(() => finish(null), finish);
+        }).then((result) => {
+          downloadedBytes = result?.downloadedBytes ?? downloadedBytes;
+          finish(null);
+        }, finish);
         return;
       }
-      if (response.statusCode !== 200) {
+      // 416 means the partial on disk is at least as long as the asset: it is unusable, and the
+      // caller restarts from zero once the stale bytes are dropped.
+      if (resumeFrom > 0 && response.statusCode === 416) {
         response.resume();
-        finish(new Error(`download failed ${response.statusCode}: ${url}`));
+        finish(downloadError('range', `download_range_unsatisfiable:${url}`));
         return;
       }
+      if (![200, 206].includes(response.statusCode)) {
+        response.resume();
+        finish(downloadError('http_status', `download failed ${response.statusCode}: ${url}`, { httpStatus: response.statusCode }));
+        return;
+      }
+      // A server that ignores Range answers 200 with the whole body; the partial must be
+      // discarded rather than appended to, or the file would be silently corrupt.
+      let appendFrom = resumeFrom;
+      if (response.statusCode === 206) {
+        const range = parseContentRangeStart(response.headers['content-range']);
+        if (!range || range.start !== resumeFrom) {
+          response.resume();
+          finish(downloadError('range', `download_range_mismatch:${url}`));
+          return;
+        }
+      } else {
+        appendFrom = 0;
+      }
+      downloadedBytes = appendFrom;
+
       const announced = response.headers['content-length'];
+      let totalBytes = null;
       if (announced !== undefined) {
         const contentLength = Number(announced);
         if (!Number.isSafeInteger(contentLength) || contentLength < 0) {
           response.resume();
-          finish(new Error(`download_content_length_invalid:${url}`));
+          finish(downloadError('content_length', `download_content_length_invalid:${url}`));
           return;
         }
-        if (contentLength > maxBytes) {
+        totalBytes = appendFrom + contentLength;
+        if (totalBytes > maxBytes) {
           response.resume();
-          finish(new Error(`download_size_limit_exceeded:${url}`));
+          finish(downloadError('size_limit', `download_size_limit_exceeded:${url}`));
           return;
         }
       }
-      let receivedBytes = 0;
+      if (onProgress) onProgress({ receivedBytes: appendFrom, totalBytes });
+
       limiter = new Transform({
         transform(chunk, _encoding, callback) {
-          receivedBytes += chunk.length;
-          if (receivedBytes > maxBytes) {
-            callback(new Error(`download_size_limit_exceeded:${url}`));
+          downloadedBytes += chunk.length;
+          if (downloadedBytes > maxBytes) {
+            callback(downloadError('size_limit', `download_size_limit_exceeded:${url}`));
             return;
           }
+          armStall();
+          if (onProgress) onProgress({ receivedBytes: downloadedBytes, totalBytes });
           callback(null, chunk);
         },
       });
-      output = fs.createWriteStream(destination);
+      output = fs.createWriteStream(destination, appendFrom > 0 ? { flags: 'a' } : { flags: 'w' });
       pipeline(response, limiter, output, (error) => finish(error || null));
-    });
+    };
+    // Only pass a request-options object when a Range header is actually needed: the two-argument
+    // form is what injected `get` doubles in tests implement.
+    const request = resumeFrom > 0
+      ? get(url, { headers: { Range: `bytes=${resumeFrom}-` } }, handleResponse)
+      : get(url, handleResponse);
     activeRequest = request;
     request.on('error', finish);
+    armStall();
   });
 }
 
+function partialDownloadBytes(partialPath) {
+  try {
+    const metadata = fs.statSync(partialPath);
+    return metadata.isFile() ? metadata.size : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Downloads into `<destination>.part` and only publishes `destination` once the transfer
+// completes, so a failed run leaves a resumable partial instead of a truncated asset. When the
+// partial lives in a persistent cache the resume also survives an MCP restart, which is what
+// turns a repeatedly interrupted first run into forward progress.
 async function downloadFile(url, destination, options = {}) {
   const attempts = options.attempts || releaseDownloadAttempts;
   const startedAt = Date.now();
+  const totalTimeoutMs = options.timeoutMs || releaseArchiveTotalTimeoutMs;
+  const deadlineMs = startedAt + totalTimeoutMs;
+  const partialPath = options.partialPath || `${destination}.part`;
+  const onProgress = typeof options.onProgress === 'function' ? options.onProgress : null;
+  const purgePartial = () => fs.rmSync(partialPath, { force: true });
+  // `attempts` is a strict cap. Because every attempt resumes rather than restarting, attempts are
+  // cheap, so the default is generous and the real bound on a doomed download is the total
+  // deadline. `stalledAttempts` only picks the backoff delay: an attempt that moved the partial
+  // forward resets it, so a link that is working is not punished with the long waits.
   let lastError = null;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  let attempt = 0;
+  let stalledAttempts = 0;
+  while (attempt < attempts) {
+    attempt += 1;
+    const resumeFrom = partialDownloadBytes(partialPath);
+    if (onProgress) onProgress({ receivedBytes: resumeFrom, attempt });
     try {
-      await downloadFileOnce(url, destination, options);
+      await downloadFileOnce(url, partialPath, {
+        ...options,
+        resumeFrom,
+        deadlineMs,
+        onProgress: onProgress
+          ? (progress) => onProgress({ ...progress, attempt })
+          : undefined,
+      });
+      fs.rmSync(destination, { force: true });
+      fs.renameSync(partialPath, destination);
       return;
     } catch (error) {
       lastError = error;
-      fs.rmSync(destination, { force: true });
-      if (attempt < attempts) {
-        const delayMs = options.retryDelayMs
-          ? options.retryDelayMs(attempt)
-          : releaseDownloadRetryDelaysMs[attempt - 1] ||
-            releaseDownloadRetryDelaysMs[releaseDownloadRetryDelaysMs.length - 1];
-        if (delayMs > 0) await sleep(delayMs);
+      if (downloadFailurePermanent(error)) {
+        purgePartial();
+        break;
       }
+      // A partial that the server rejects or that drifted out of sync is worthless; drop it so the
+      // next attempt starts clean instead of failing the same way forever.
+      if (downloadFailureKind(error) === 'range') purgePartial();
+      const advanced = partialDownloadBytes(partialPath) > resumeFrom;
+      stalledAttempts = advanced ? 0 : stalledAttempts + 1;
+      if (Date.now() >= deadlineMs || attempt >= attempts) break;
+      const index = Math.max(0, stalledAttempts - 1);
+      const delayMs = options.retryDelayMs
+        ? options.retryDelayMs(attempt)
+        : (releaseDownloadRetryDelaysMs[index] ||
+          releaseDownloadRetryDelaysMs[releaseDownloadRetryDelaysMs.length - 1]) +
+          Math.floor(Math.random() * releaseDownloadRetryJitterMs);
+      const budgetedDelayMs = Math.max(0, Math.min(delayMs, deadlineMs - Date.now()));
+      if (budgetedDelayMs > 0) await sleep(budgetedDelayMs);
     }
   }
   const elapsedMs = Date.now() - startedAt;
-  throw new Error(`download failed after ${attempts} attempts over ${elapsedMs}ms: ${lastError?.message || 'unknown error'}`);
+  const resumableBytes = partialDownloadBytes(partialPath);
+  const resumeNote = resumableBytes > 0 ? ` resumable_bytes=${resumableBytes}` : '';
+  const failure = new Error(
+    `download failed after ${attempt} attempts over ${elapsedMs}ms:${resumeNote} ${lastError?.message || 'unknown error'}`,
+  );
+  failure.downloadFailure = {
+    kind: downloadFailureKind(lastError),
+    http_status: Number.isInteger(lastError?.httpStatus) ? lastError.httpStatus : null,
+    resumable_bytes: resumableBytes,
+    elapsed_ms: elapsedMs,
+    attempts: attempt,
+  };
+  throw failure;
 }
 
 function releaseAssetFetchFailure(name, startedAt, attempts, error) {
@@ -407,7 +663,7 @@ function redactedReleaseFileUrl(version, name) {
   return url.toString();
 }
 
-async function fetchReleaseFile(version, name, destination) {
+async function fetchReleaseFile(version, name, destination, options = {}) {
   const startedAt = Date.now();
   const maxBytes = releaseFileMaxBytes(name);
   if (process.env.CODESTORY_PLUGIN_RELEASE_DIR) {
@@ -419,10 +675,22 @@ async function fetchReleaseFile(version, name, destination) {
     return redactedReleaseFileUrl(version, name);
   }
   const url = releaseFileUrl(version, name);
+  // One stage name for the whole release fetch keeps the reported stage deterministic for clients;
+  // `asset` in the progress detail distinguishes the checksum file from the archive.
+  resetManagedCliDownloadProgress('downloading_runtime', name);
   try {
-    await downloadFile(url, destination, { maxBytes });
+    await downloadFile(url, destination, {
+      maxBytes,
+      timeoutMs: releaseFileTotalTimeoutMs(name),
+      partialPath: options.partialPath,
+      onProgress: recordManagedCliDownloadProgress,
+    });
   } catch (error) {
-    throw new Error(releaseAssetFetchFailure(name, startedAt, releaseDownloadAttempts, error));
+    const wrapped = new Error(releaseAssetFetchFailure(name, startedAt, releaseDownloadAttempts, error));
+    if (error?.downloadFailure) {
+      wrapped.downloadFailure = { ...error.downloadFailure, asset: name };
+    }
+    throw wrapped;
   }
   return redactedReleaseFileUrl(version, name);
 }
@@ -1130,9 +1398,91 @@ function managedCliFailureCode(error) {
   return probeFailure ? `${code}:${probeFailure}` : code;
 }
 
+// The machine-readable failure code is deliberately reduced to a single safe token, which left the
+// user staring at `managed_cli_asset_fetch_failed` with no idea that their download had simply been
+// cut short. The context and hint below restore that explanation without reopening the sanitization
+// hole: both are derived only from the structured `downloadFailure` tag and the already-sanitized
+// failure code, never from raw error text (which can carry untrusted child-process output).
+const managedCliProvisionFailure = { code: null, context: null, hint: null };
+
+const downloadFailureKinds = new Set([
+  'stalled',
+  'timed_out',
+  'http_status',
+  'size_limit',
+  'content_length',
+  'transport',
+  'range',
+  'redirect',
+  'network',
+]);
+
+function sanitizeDownloadFailure(failure) {
+  if (!failure || typeof failure !== 'object') return null;
+  const kind = downloadFailureKinds.has(failure.kind) ? failure.kind : 'network';
+  const safeInt = (value) => (Number.isSafeInteger(value) && value >= 0 ? value : null);
+  return {
+    kind,
+    // The asset name is one of our own fixed release filenames, never user or server supplied.
+    asset: typeof failure.asset === 'string' && /^[\w.+-]{1,128}$/u.test(failure.asset)
+      ? failure.asset
+      : null,
+    http_status: Number.isInteger(failure.http_status) &&
+      failure.http_status >= 100 && failure.http_status <= 599
+      ? failure.http_status
+      : null,
+    resumable_bytes: safeInt(failure.resumable_bytes) ?? 0,
+    elapsed_ms: safeInt(failure.elapsed_ms) ?? 0,
+    attempts: safeInt(failure.attempts) ?? 0,
+  };
+}
+
+const manualInstallHint =
+  'To skip the download, install codestory-cli yourself and point CODESTORY_CLI at it.';
+
+function managedCliDownloadHint(context, code) {
+  if (code === 'archive_checksum_mismatch') {
+    return 'The runtime archive failed checksum verification and was discarded. ' +
+      'Retry the tool to download it again.';
+  }
+  if (!context) return null;
+  const resumeNote = context.resumable_bytes > 0
+    ? ` ${formatByteSize(context.resumable_bytes)} already downloaded is kept, and retrying resumes from there.`
+    : '';
+  switch (context.kind) {
+    case 'stalled':
+    case 'timed_out':
+    case 'network':
+      return 'The CodeStory runtime download could not complete over this connection.' +
+        `${resumeNote} Retry the tool to continue downloading, or raise the budget with ` +
+        `CODESTORY_PLUGIN_DOWNLOAD_TIMEOUT_MS / CODESTORY_PLUGIN_DOWNLOAD_STALL_TIMEOUT_MS. ${manualInstallHint}`;
+    case 'http_status':
+      if (context.http_status === 404) {
+        return 'The release asset for this plugin version was not found. ' +
+          `Update the plugin, or install codestory-cli yourself and point CODESTORY_CLI at it.`;
+      }
+      return `The release download was rejected (HTTP ${context.http_status ?? 'error'}). ` +
+        `Retry later, or ${manualInstallHint.charAt(0).toLowerCase()}${manualInstallHint.slice(1)}`;
+    case 'size_limit':
+    case 'content_length':
+      return `The release asset did not match its expected size bounds. ${manualInstallHint}`;
+    case 'transport':
+      return `The release download was blocked because it was not served over HTTPS. ${manualInstallHint}`;
+    case 'range':
+    case 'redirect':
+      return 'The release download could not be resumed and was reset. Retry the tool to start it again.';
+    default:
+      return null;
+  }
+}
+
 function recordManagedCliProvisionFailure(warnings, error) {
   const code = managedCliFailureCode(error);
   const failure = `managed_cli_provision_failed:${code}`;
+  const context = sanitizeDownloadFailure(error?.downloadFailure);
+  managedCliProvisionFailure.code = code;
+  managedCliProvisionFailure.context = context;
+  managedCliProvisionFailure.hint = managedCliDownloadHint(context, code);
   warnings.push(`managed_cli_publication:terminal_failure:${code}`, failure);
   return failure;
 }
@@ -1331,6 +1681,55 @@ function trimManagedCliQuarantines(root, version, options = {}) {
   }
 }
 
+// Partial archives live under the managed root rather than an ephemeral temp dir so an interrupted
+// first run resumes after an MCP restart instead of starting the whole transfer over. The name is
+// dot-prefixed, so version enumeration and retention already skip it.
+function managedCliDownloadCacheDir(root, version) {
+  const cacheRoot = path.join(root, managedCliDownloadCacheDirName);
+  if (fs.existsSync(cacheRoot)) {
+    const metadata = fs.lstatSync(cacheRoot);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+      throw new Error('managed_cli_download_cache_not_direct');
+    }
+  }
+  const dir = path.join(cacheRoot, version);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return dir;
+}
+
+function trimManagedCliDownloadCache(root, version) {
+  const cacheRoot = path.join(root, managedCliDownloadCacheDirName);
+  let children;
+  try {
+    children = fs.readdirSync(cacheRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const child of children) {
+    const childPath = path.join(cacheRoot, child.name);
+    try {
+      // Partials for a version we are no longer provisioning can never be resumed, and even the
+      // current version's partial goes stale once the release has had time to be re-cut.
+      const expired = child.name !== version ||
+        Date.now() - fs.statSync(childPath).mtimeMs > managedCliDownloadCacheMaxAgeMs;
+      if (expired) fs.rmSync(childPath, { recursive: true, force: true });
+    } catch {
+      // Best effort: a partial we cannot inspect is simply re-downloaded.
+    }
+  }
+}
+
+function removeManagedCliDownloadCache(root, version) {
+  try {
+    fs.rmSync(path.join(root, managedCliDownloadCacheDirName, version), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // Best effort: a leftover partial is trimmed on the next provisioning run.
+  }
+}
+
 function quarantineManagedCliVersion(root, versionDir, version, reason, options = {}) {
   const renameSync = options.renameSync || fs.renameSync;
   const metadata = fs.lstatSync(versionDir);
@@ -1396,8 +1795,21 @@ async function provisionManagedCli(dataDir, version, warnings = []) {
     const sumsPath = path.join(tempRoot, 'SHA256SUMS.txt');
     const archivePath = path.join(tempRoot, asset);
     const extractDir = path.join(tempRoot, 'extract');
+    trimManagedCliDownloadCache(root, version);
+    let archivePartialPath;
+    try {
+      archivePartialPath = path.join(managedCliDownloadCacheDir(root, version), `${asset}.part`);
+    } catch (error) {
+      // A cache we cannot use costs resume, not correctness: fall back to the temp dir.
+      warnings.push(`managed_cli_publication:download_cache_unavailable:${managedCliFailureCode(error)}`);
+      archivePartialPath = `${archivePath}.part`;
+    }
+    const resumeBytes = partialDownloadBytes(archivePartialPath);
+    if (resumeBytes > 0) warnings.push(`managed_cli_publication:resume_bytes:${resumeBytes}`);
     await fetchReleaseFile(version, 'SHA256SUMS.txt', sumsPath);
-    const archiveUrl = await fetchReleaseFile(version, asset, archivePath);
+    const archiveUrl = await fetchReleaseFile(version, asset, archivePath, {
+      partialPath: archivePartialPath,
+    });
     const expected = expectedArchiveHash(fs.readFileSync(sumsPath, 'utf8'), asset);
     const actual = fileSha256(archivePath);
     if (actual !== expected) {
@@ -1443,6 +1855,8 @@ async function provisionManagedCli(dataDir, version, warnings = []) {
     if (fs.existsSync(versionDir)) throw new Error('managed_cli_publish_target_reappeared');
     fs.renameSync(stagingDir, versionDir);
     stagingDir = null;
+    removeManagedCliDownloadCache(root, version);
+    managedCliDownloadProgress.stage = null;
     return resolveManifest(path.join(versionDir, 'manifest.json'));
   } finally {
     if (stagingDir) fs.rmSync(stagingDir, { recursive: true, force: true });
@@ -2399,6 +2813,39 @@ function selectExplicitProject(value) {
   }
 }
 
+function managedProvisioningOperation() {
+  const progress = managedCliDownloadProgressReport();
+  return {
+    operation_id: 'managed-runtime-provisioning',
+    state: 'preparing',
+    stage: progress?.stage || 'downloading_runtime',
+    attempt: progress?.attempt ?? 1,
+    retry_after_ms: 1500,
+    failure: null,
+    progress: progress
+      ? {
+        asset: progress.asset,
+        received_bytes: progress.received_bytes,
+        total_bytes: progress.total_bytes,
+        percent: progress.percent,
+      }
+      : null,
+  };
+}
+
+function managedProvisioningMessage() {
+  const progress = managedCliDownloadProgressReport();
+  if (!progress || progress.asset === 'SHA256SUMS.txt') {
+    return 'CodeStory is preparing: downloading the runtime. Retry the same tool shortly.';
+  }
+  const received = formatByteSize(progress.received_bytes);
+  const total = progress.total_bytes === null ? null : formatByteSize(progress.total_bytes);
+  const measure = total
+    ? `${progress.percent}% of ${total}`
+    : `${received} so far`;
+  return `CodeStory is preparing: downloading the runtime (${measure}). Retry the same tool shortly.`;
+}
+
 function failOpenToolResult(tool, status, argumentsValue = {}) {
   const preparing = status.managed_retrieval?.state === 'preparing';
   const readiness = Array.isArray(status.readiness) ? status.readiness[0] : null;
@@ -2440,15 +2887,10 @@ function failOpenToolResult(tool, status, argumentsValue = {}) {
       state: preparing ? 'preparing' : 'unavailable',
       degraded_reason: degradedReason,
       capabilities: { local_navigation: 'unavailable', broad_search: preparing ? 'preparing' : 'unavailable' },
-      current_operation: preparing ? {
-        operation_id: 'managed-runtime-provisioning',
-        state: 'preparing',
-        stage: 'dense_preparation',
-        attempt: 1,
-        retry_after_ms: 1500,
-        failure: null,
-      } : null,
+      current_operation: preparing ? managedProvisioningOperation() : null,
       failure: preparing ? null : primaryFailure,
+      failure_context: !preparing && managedFailure ? managedCliProvisionFailure.context : null,
+      hint: !preparing && managedFailure ? managedCliProvisionFailure.hint : null,
       next_action: preparing ? 'retry_intended_tool' : 'use_source_inspection',
       retry_after_ms: preparing ? 1500 : null,
       diagnostics_uri: diagnosticsUri,
@@ -2459,30 +2901,27 @@ function failOpenToolResult(tool, status, argumentsValue = {}) {
     };
   }
   const diagnosticsUri = projectBoundResourceUri('codestory://status', project);
+  const failureHint = managedFailure ? managedCliProvisionFailure.hint : null;
   const structuredContent = preparing ? {
     code: 'codestory_preparing',
-    message: 'CodeStory is preparing. Retry the same tool shortly.',
+    message: managedProvisioningMessage(),
     tool,
     project,
     state: 'preparing',
     retry_tool: tool,
     retry_after_ms: 1500,
-    operation: {
-      operation_id: 'managed-runtime-provisioning',
-      state: 'preparing',
-      stage: 'dense_preparation',
-      attempt: 1,
-      retry_after_ms: 1500,
-      failure: null,
-    },
+    operation: managedProvisioningOperation(),
     diagnostics_uri: diagnosticsUri,
   } : {
     code: 'codestory_unavailable',
-    message: 'CodeStory is unavailable. Continue with focused source inspection.',
+    message: failureHint
+      ? `CodeStory is unavailable. ${failureHint} Meanwhile, continue with focused source inspection.`
+      : 'CodeStory is unavailable. Continue with focused source inspection.',
     tool,
     project,
     state: 'unavailable',
     failure: primaryFailure,
+    failure_context: managedFailure ? managedCliProvisionFailure.context : null,
     diagnostics_uri: diagnosticsUri,
   };
   return {
@@ -2946,6 +3385,16 @@ if (require.main === module) {
       compareManagedCliVersions,
       cleanPublicProjectPath,
       downloadFile,
+      downloadFailurePermanent,
+      managedCliDownloadHint,
+      managedCliDownloadProgress,
+      managedCliProvisionFailure,
+      managedProvisioningOperation,
+      sanitizeDownloadFailure,
+      releaseDownloadStallTimeoutMs,
+      releaseArchiveTotalTimeoutMs,
+      releaseChecksumTotalTimeoutMs,
+      trimManagedCliDownloadCache,
       extractArchive,
       failOpenToolResult,
       failOpenToolCatalog,

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1564,8 +1564,16 @@ test("managed cli pending-owner cleanup protects live and young artifacts", asyn
 });
 
 test("managed cli waiter covers both configured asset retry windows", () => {
-  assert.ok(launcherTest.releaseAssetRetryBudgetMs > 3 * 60 * 1000);
-  assert.ok(launcherTest.managedCliLockWaitMs >= 2 * launcherTest.releaseAssetRetryBudgetMs);
+  // The archive budget has to be large enough that a multi-hundred-megabyte download can finish on
+  // a slow link, and a waiter must outlast a publisher spending both asset budgets back to back.
+  assert.ok(launcherTest.releaseArchiveTotalTimeoutMs >= 30 * 60 * 1000);
+  assert.equal(launcherTest.releaseAssetRetryBudgetMs, launcherTest.releaseArchiveTotalTimeoutMs);
+  assert.ok(
+    launcherTest.managedCliLockWaitMs >=
+      launcherTest.releaseChecksumTotalTimeoutMs + launcherTest.releaseArchiveTotalTimeoutMs,
+  );
+  // The stall timeout, not the total budget, is what should cut off a dead connection.
+  assert.ok(launcherTest.releaseDownloadStallTimeoutMs < launcherTest.releaseArchiveTotalTimeoutMs);
 });
 
 test("managed cli initializing reclaim preserves a new ABA owner", async () => {
@@ -3692,14 +3700,24 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
     assert.equal(coldGround.result.structuredContent.code, "codestory_preparing");
     assert.equal(coldGround.result.structuredContent.retry_tool, "ground");
     assert.equal(coldGround.result.structuredContent.project, repoRoot);
-    assert.deepEqual(coldGround.result.structuredContent.operation, {
+    const { progress, ...operationCore } = coldGround.result.structuredContent.operation;
+    assert.deepEqual(operationCore, {
       operation_id: "managed-runtime-provisioning",
       state: "preparing",
-      stage: "dense_preparation",
+      stage: "downloading_runtime",
       attempt: 1,
       retry_after_ms: 1500,
       failure: null,
     });
+    // Progress appears once a release asset fetch is in flight; the request can land just before
+    // the background provisioner gets that far, so null is the only other legal value.
+    if (progress !== null) {
+      assert.deepEqual(
+        Object.keys(progress).sort(),
+        ["asset", "percent", "received_bytes", "total_bytes"],
+      );
+      assert.equal(typeof progress.received_bytes, "number");
+    }
     assert.doesNotMatch(coldGround.result.structuredContent.message, /status/u);
 
     releaseAssets();
@@ -4384,6 +4402,236 @@ test("release asset downloader bounds announced and streamed bytes without parti
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
+});
+
+test("release asset downloader resumes a partial transfer instead of restarting it", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-resume-"));
+  const destination = join(dataDir, "runtime.bin");
+  const body = Buffer.from("0123456789abcdefghijklmnopqrstuvwxyz");
+  const served = [];
+  let cutFirstTransfer = true;
+  const server = createServer((request, response) => {
+    const range = /^bytes=(\d+)-$/u.exec(request.headers.range || "");
+    const start = range ? Number(range[1]) : 0;
+    served.push(start);
+    if (cutFirstTransfer) {
+      cutFirstTransfer = false;
+      // Announce the full length, deliver a prefix, then drop the connection mid-transfer.
+      response.writeHead(200, { "content-length": String(body.length) });
+      response.write(body.subarray(0, 10));
+      setTimeout(() => response.destroy(), 10);
+      return;
+    }
+    if (start > 0) {
+      response.writeHead(206, {
+        "content-length": String(body.length - start),
+        "content-range": `bytes ${start}-${body.length - 1}/${body.length}`,
+      });
+      response.end(body.subarray(start));
+      return;
+    }
+    response.writeHead(200, { "content-length": String(body.length) });
+    response.end(body);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    await launcherTest.downloadFile(
+      `http://127.0.0.1:${server.address().port}/runtime`,
+      destination,
+      { attempts: 3, retryDelayMs: () => 1, timeoutMs: 5000 },
+    );
+    assert.deepEqual(await readFile(destination), body);
+    // The second attempt asked to continue from the bytes already on disk rather than from zero.
+    assert.deepEqual(served, [0, 10]);
+    assert.equal(fs.existsSync(`${destination}.part`), false);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("release asset downloader keeps a resumable partial across separate runs", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-restart-"));
+  const destination = join(dataDir, "runtime.bin");
+  const partialPath = join(dataDir, "cache", "runtime.bin.part");
+  await mkdir(join(dataDir, "cache"), { recursive: true });
+  const body = Buffer.from("the-managed-runtime-archive-payload");
+  let cutFirstTransfer = true;
+  const server = createServer((request, response) => {
+    const range = /^bytes=(\d+)-$/u.exec(request.headers.range || "");
+    const start = range ? Number(range[1]) : 0;
+    if (cutFirstTransfer) {
+      cutFirstTransfer = false;
+      response.writeHead(200, { "content-length": String(body.length) });
+      response.write(body.subarray(0, 12));
+      setTimeout(() => response.destroy(), 10);
+      return;
+    }
+    response.writeHead(start > 0 ? 206 : 200, {
+      "content-length": String(body.length - start),
+      ...(start > 0
+        ? { "content-range": `bytes ${start}-${body.length - 1}/${body.length}` }
+        : {}),
+    });
+    response.end(body.subarray(start));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const url = `http://127.0.0.1:${server.address().port}/runtime`;
+  try {
+    // First run exhausts its single attempt and fails, standing in for an MCP restart.
+    await assert.rejects(
+      launcherTest.downloadFile(url, destination, { attempts: 1, timeoutMs: 5000, partialPath }),
+      /download failed after 1 attempts/u,
+    );
+    assert.equal(fs.existsSync(destination), false);
+    assert.equal(fs.statSync(partialPath).size, 12);
+
+    // A fresh run picks the partial back up rather than re-downloading what already landed.
+    await launcherTest.downloadFile(url, destination, { attempts: 1, timeoutMs: 5000, partialPath });
+    assert.deepEqual(await readFile(destination), body);
+    assert.equal(fs.existsSync(partialPath), false);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("release asset downloader survives a transfer slower than the stall window", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-slow-"));
+  const destination = join(dataDir, "slow.bin");
+  const chunks = 8;
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-length": String(chunks) });
+    let sent = 0;
+    const interval = setInterval(() => {
+      sent += 1;
+      response.write("x");
+      if (sent === chunks) {
+        clearInterval(interval);
+        response.end();
+      }
+    }, 25);
+    response.on("close", () => clearInterval(interval));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    // Every chunk arrives well after a 40ms budget would have expired, but each one resets the
+    // stall window, so a steady trickle now completes instead of being cut off.
+    await launcherTest.downloadFile(
+      `http://127.0.0.1:${server.address().port}/slow`,
+      destination,
+      { attempts: 1, stallTimeoutMs: 400, timeoutMs: 5000 },
+    );
+    assert.equal((await readFile(destination, "utf8")).length, chunks);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("release asset downloader fails a silent connection on the stall window", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-stall-"));
+  const destination = join(dataDir, "silent.bin");
+  const server = createServer((_request, response) => {
+    response.writeHead(200);
+    // Headers only: never send a body byte.
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const started = Date.now();
+    await assert.rejects(
+      launcherTest.downloadFile(`http://127.0.0.1:${server.address().port}/silent`, destination, {
+        attempts: 1,
+        stallTimeoutMs: 80,
+        timeoutMs: 60_000,
+      }),
+      /stalled after 80ms without data/u,
+    );
+    // The stall window, not the hour-long total budget, is what ends a dead transfer.
+    assert.ok(Date.now() - started < 5000);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("release asset downloader stops immediately on a permanent status", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-permanent-"));
+  const destination = join(dataDir, "missing.bin");
+  let calls = 0;
+  const fakeGet = (_url, onResponse) => {
+    const request = new EventEmitter();
+    request.destroy = () => request;
+    calls += 1;
+    process.nextTick(() => {
+      const response = new PassThrough();
+      response.statusCode = 404;
+      response.headers = {};
+      onResponse(response);
+      response.end("");
+    });
+    return request;
+  };
+  try {
+    await assert.rejects(
+      launcherTest.downloadFile("https://example.invalid/missing", destination, {
+        attempts: 5,
+        get: fakeGet,
+        retryDelayMs: () => 1,
+        timeoutMs: 5000,
+      }),
+      /download failed 404/u,
+    );
+    // A missing release asset is a fixed answer; retrying it only delays the real error.
+    assert.equal(calls, 1);
+    assert.equal(fs.existsSync(`${destination}.part`), false);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("download failure hints stay structured and actionable", () => {
+  const stalled = launcherTest.sanitizeDownloadFailure({
+    kind: "stalled",
+    asset: "codestory-cli-v0.16.1-x86_64-apple-darwin.tar.gz",
+    resumable_bytes: 52_428_800,
+    elapsed_ms: 900_000,
+    attempts: 6,
+  });
+  assert.equal(stalled.kind, "stalled");
+  assert.equal(stalled.http_status, null);
+  const stalledHint = launcherTest.managedCliDownloadHint(stalled, "managed_cli_asset_fetch_failed");
+  assert.match(stalledHint, /50\.0 MB already downloaded is kept/u);
+  assert.match(stalledHint, /CODESTORY_PLUGIN_DOWNLOAD_TIMEOUT_MS/u);
+
+  const missing = launcherTest.sanitizeDownloadFailure({ kind: "http_status", http_status: 404 });
+  assert.match(
+    launcherTest.managedCliDownloadHint(missing, "managed_cli_asset_fetch_failed"),
+    /was not found/u,
+  );
+
+  // Anything unrecognised collapses to a safe enum rather than echoing attacker-controlled text.
+  const hostile = launcherTest.sanitizeDownloadFailure({
+    kind: "C:\\private\\candidate.exe",
+    asset: "untrusted detail\nsecond line",
+    http_status: 99_999,
+    resumable_bytes: -5,
+  });
+  assert.deepEqual(hostile, {
+    kind: "network",
+    asset: null,
+    http_status: null,
+    resumable_bytes: 0,
+    elapsed_ms: 0,
+    attempts: 0,
+  });
+
+  // A failure that is not a download failure must not be described as one.
+  assert.equal(launcherTest.managedCliDownloadHint(null, "managed_cli_probe_failed"), null);
 });
 
 test("mcp launcher keeps managed provision failures primary", async () => {


### PR DESCRIPTION
Emergency patch release. Promotes `dev/codestory-next` to `main` for **0.16.1**.

Closes #1449

## What is in this release

### First-use runtime download is fixed on slow connections (#1448)

The plugin downloads the `codestory-cli` release archive (150 MB+) on first use. That download had a **single 60 second deadline covering the entire attempt** — connect, headers and the full body — which a large archive cannot meet on a slow link. Every attempt was cut off mid-transfer, each retry deleted the partial and restarted **from byte zero**, and after three rounds the user got a bare `managed_cli_provision_failed:managed_cli_asset_fetch_failed` with the timeout detail stripped by the failure-token sanitizer. Throughout the ~3 minutes it reported a hardcoded `dense_preparation` / `attempt: 1` and no progress.

The fix:

- **Stall timeout replaces the total deadline.** The transfer continues as long as bytes keep arriving; a silent connection still fails in 60 s. An hourly per-asset ceiling remains as a backstop.
- **Downloads resume.** Transfers stream into a `.part` file and continue with `Range: bytes=N-`, validating `Content-Range`. A server that ignores `Range`, or a 416, resets the partial rather than corrupting it. Archive partials live under `<managed-root>/.download/<version>/`, so **progress survives an MCP restart**. SHA256 verification is unchanged.
- **Smarter retries.** 20 resumable attempts with exponential backoff and jitter, bounded by the total deadline — but permanent failures (4xx other than 408/425/429, size-limit, transport) fail immediately instead of being retried.
- **Real progress and actionable errors.** Preparing payloads carry the true stage, attempt, bytes and percentage; terminal failures carry a hint naming the cause, how much is already downloaded and kept, and the escape hatches.

Verified against a simulated 20 MB transfer over a link dying every 3 MB: 7 interruptions, resume offsets `0M → 3M → 6M → 9M → 12M → 15M → 18M`, **20.0 MB on the wire for a 20 MB file** (zero re-download), checksum intact. The previous code could never complete this.

Sanitization is preserved: the hint and `failure_context` are built only from allow-listed enums and bounded integers derived from a structured failure tag, never from raw error text, so untrusted child-process output still cannot reach the response. A regression test covers hostile values.

### Also included

- `isolate postpublish release proof` (#1447)

## Contract changes

- `operation.stage` is `downloading_runtime`, not `dense_preparation`; the operation gained a nullable `progress` object.
- Status and tool failure payloads gained `failure_context` and `hint`. The `failure` token is unchanged.
- New env overrides: `CODESTORY_PLUGIN_DOWNLOAD_TIMEOUT_MS`, `CODESTORY_PLUGIN_DOWNLOAD_STALL_TIMEOUT_MS`, `CODESTORY_PLUGIN_DOWNLOAD_CHECKSUM_TIMEOUT_MS`, `CODESTORY_PLUGIN_DOWNLOAD_ATTEMPTS`.

## Version

0.16.1 across 9 workspace crates, `Cargo.lock`, 3 plugin manifests, and the embedded-model `producer.version`, with a CHANGELOG entry. `check-codestory-release.py --version 0.16.1` passes.

## Tests

`plugin-static.test.mjs`: 87 pass, 0 fail (1 Windows-only skip), stable across repeated runs, and green in CI on #1448. Six new tests cover resume via `Range`, a partial surviving across separate runs, a trickling transfer the old deadline would have killed, a silent connection hitting the stall window, a 404 not being retried, and hint sanitization. Also verified `check-workflow-policy.mjs`, `check-doc-links.mjs`, and `cargo check -p codestory-cli`.

> Note: #1448 was merged at the author's direction while three Rust checks (rustdoc, linux-contracts, Ubuntu draft source checks) were still building. They run again here against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)