### PR TITLE
Speed up the draft lane and source gate with sccache and pinned nextest

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -13,6 +13,8 @@ const trustedActionOwners = new Set(["actions", "github"]);
 const fullSha = /^[0-9a-f]{40}$/iu;
 const sccacheAction = "mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696";
 const sccacheVersion = "v0.16.0";
+const nextestVersion = "0.9.98";
+const nextestLinuxSha256 = "7d07712519615722b19ffe3b3d1097b7d4fa390995e3cac1f9d6dda1ba61b2a7";
 const sccacheCacheSize = "1G";
 const windowsSccacheCacheSize = "2G";
 
@@ -280,6 +282,13 @@ const draftCacheRestoreKeys = [
   `${retrievalCachePrefix}-`,
 ];
 const cacheSaveCondition = "success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''";
+const draftCompilerCachePath = "${{ runner.temp }}/codestory-draft-sccache";
+const draftCompilerCachePrefix =
+  "${{ runner.os }}-draft-sccache-v1-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}";
+const draftCompilerCachePrimary = `${draftCompilerCachePrefix}-${cacheLock}`;
+const draftCompilerSaveCondition =
+  "success() && steps.compiler-cache-restore.outputs.cache-hit != 'true' && steps.compiler-cache-restore.outputs.cache-primary-key != ''";
+const draftCompilerSaveKey = "${{ steps.compiler-cache-restore.outputs.cache-primary-key }}";
 const cacheSaveKey = "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}";
 const draftWorkflowPaths = [
   "Cargo.lock",
@@ -371,9 +380,15 @@ const draftStepSequence = [
   { uses: "actions/checkout@v5", keys: ["uses"] },
   { name: "Install Rust stable", keys: ["name", "run"] },
   { name: "Install Linux Vulkan build dependencies", keys: ["name", "run"] },
+  { name: "Install pinned sccache", keys: ["name", "uses", "with"] },
+  { name: "Configure bounded compiler cache", keys: ["name", "shell", "run"] },
   { name: "Capture Rust cache identity", keys: ["name", "id", "shell", "run"] },
   {
     name: "Restore Cargo inputs and output",
+    keys: ["name", "id", "uses", "continue-on-error", "with"],
+  },
+  {
+    name: "Restore compiler objects",
     keys: ["name", "id", "uses", "continue-on-error", "with"],
   },
   { name: "Check formatting", keys: ["name", "run"] },
@@ -386,8 +401,22 @@ const draftStepSequence = [
     name: "Save Cargo inputs and output",
     keys: ["name", "if", "uses", "continue-on-error", "with"],
   },
+  {
+    name: "Save compiler objects",
+    keys: ["name", "if", "uses", "continue-on-error", "with"],
+  },
 ];
 const draftRunCommands = new Map([
+  ["Configure bounded compiler cache", [
+    "{",
+    'echo "SCCACHE_DIR=$RUNNER_TEMP/codestory-draft-sccache"',
+    'echo "SCCACHE_CACHE_SIZE=1G"',
+    'echo "RUSTC_WRAPPER=sccache"',
+    'echo "CARGO_INCREMENTAL=0"',
+    'echo "CMAKE_C_COMPILER_LAUNCHER=sccache"',
+    'echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"',
+    '} >> "$GITHUB_ENV"',
+  ]],
   ["Install Rust stable", [
     "rustup toolchain install stable --profile minimal --component clippy --component rustfmt",
     "rustup default stable",
@@ -756,6 +785,31 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
   add(violations, sameStrings(nonCommentLines(restoreWith.path), draftCachePaths), "draft source cache restore must use only the Cargo registry, git, and default target paths");
   add(violations, restoreWith.key === draftCachePrimary, "draft source cache primary must bind the v2 platform, toolchain, target, proof topology, feature, manifest, and lock identity");
   add(violations, sameStrings(nonCommentLines(restoreWith["restore-keys"]), draftCacheRestoreKeys), "draft source cache fallbacks must keep the exact seeded retrieval, prior draft, then prior retrieval order and omit only the lock identity from prior prefixes");
+
+  const sccache = namedStep(job, "Install pinned sccache");
+  add(violations, sccache?.uses === sccacheAction, "draft source sccache must use the pinned mozilla-actions release");
+  add(
+    violations,
+    object(sccache?.with).version === sccacheVersion
+      && object(sccache?.with).disable_annotations === true,
+    "draft source sccache must pin the shared sccache version without annotations",
+  );
+
+  const compilerRestore = namedStep(job, "Restore compiler objects");
+  const compilerRestoreWith = object(compilerRestore?.with);
+  add(violations, compilerRestore?.id === "compiler-cache-restore", "draft compiler cache restore must keep its stable step id");
+  add(violations, compilerRestore?.uses === "actions/cache/restore@v5", "draft compiler cache restore must use actions/cache/restore@v5");
+  add(violations, compilerRestore?.["continue-on-error"] === true && compilerRestore?.if === undefined, "draft compiler cache restore must remain optional without conditional bypasses");
+  add(violations, compilerRestoreWith.path === draftCompilerCachePath, "draft compiler cache must live in the runner-temp sccache directory");
+  add(violations, compilerRestoreWith.key === draftCompilerCachePrimary, "draft compiler cache primary must bind platform, toolchain, target, and lock identity");
+  add(violations, sameStrings(nonCommentLines(compilerRestoreWith["restore-keys"]), [`${draftCompilerCachePrefix}-`]), "draft compiler cache fallback must omit only the lock identity");
+
+  const compilerSave = namedStep(job, "Save compiler objects");
+  const compilerSaveWith = object(compilerSave?.with);
+  add(violations, compilerSave?.uses === "actions/cache/save@v5", "draft compiler cache save must use actions/cache/save@v5");
+  add(violations, compilerSave?.["continue-on-error"] === true, "draft compiler cache save must remain non-blocking");
+  add(violations, compilerSave?.if === draftCompilerSaveCondition, "draft compiler cache must save only on a successful run that missed its primary key");
+  add(violations, compilerSaveWith.path === draftCompilerCachePath && compilerSaveWith.key === draftCompilerSaveKey, "draft compiler cache save must publish the restored primary key path");
 
   const retrievalRestore = namedStep(retrievalJob, "Restore Cargo registry, git sources, and build output");
   const retrievalRestoreWith = object(retrievalRestore?.with);
@@ -1454,7 +1508,25 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
         && lint?.if === "steps.compile-workspace.outcome == 'success'",
       `${sourceFile} compilation and lint must preserve cache state before reporting failure`,
     );
-    requireStepRun(violations, sourceFile, full, "Test the complete workspace once", ["cargo test --workspace --locked"]);
+    // nextest owns unit/integration execution; the doc pass rides along so a future doctest can
+    // never silently stop being run (nextest does not execute doctests).
+    requireStepRun(violations, sourceFile, full, "Test the complete workspace once", [
+      "cargo nextest run --workspace --locked",
+      "cargo test --workspace --doc --locked",
+    ]);
+    requireStepRun(violations, sourceFile, full, "Install pinned cargo-nextest", [
+      `cargo-nextest-${nextestVersion}-x86_64-unknown-linux-gnu.tar.gz`,
+      `${nextestLinuxSha256}  $RUNNER_TEMP/cargo-nextest.tar.gz`,
+      "sha256sum --check --strict",
+      "cargo nextest --version",
+    ]);
+    add(
+      violations,
+      stepIndex(full, "Install pinned cargo-nextest") > stepIndex(full, "Install pinned sccache")
+        && stepIndex(full, "Install pinned cargo-nextest")
+          < stepIndex(full, "Test the complete workspace once"),
+      `${sourceFile} must install the pinned test runner before the workspace test step`,
+    );
     requireStepRun(violations, sourceFile, full, "Lint every workspace target and feature once", ["cargo clippy --workspace --all-targets --all-features --locked -- -D warnings"]);
     requireStepRun(violations, sourceFile, full, "Emit authenticated source release cell", [
       "codestory-release-cell-manifest.mjs produce",

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -41,6 +41,27 @@ jobs:
       - name: Install Linux Vulkan build dependencies
         run: bash .github/scripts/install-linux-vulkan-build-deps.sh
 
+      - name: Install pinned sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: "v0.16.0"
+          disable_annotations: true
+
+      # A Cargo.lock change invalidates the whole target/ cache key, and this lane runs on every
+      # crate-touching PR. sccache's content-addressed store salvages the unchanged compilations
+      # that a key miss would otherwise redo from scratch.
+      - name: Configure bounded compiler cache
+        shell: bash
+        run: |
+          {
+            echo "SCCACHE_DIR=$RUNNER_TEMP/codestory-draft-sccache"
+            echo "SCCACHE_CACHE_SIZE=1G"
+            echo "RUSTC_WRAPPER=sccache"
+            echo "CARGO_INCREMENTAL=0"
+            echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
+            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
+          } >> "$GITHUB_ENV"
+
       - name: Capture Rust cache identity
         id: rust-cache-key
         shell: bash
@@ -62,6 +83,16 @@ jobs:
             ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
             ${{ runner.os }}-draft-v2-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-
             ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5-default-features-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-
+
+      - name: Restore compiler objects
+        id: compiler-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/codestory-draft-sccache
+          key: ${{ runner.os }}-draft-sccache-v1-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-draft-sccache-v1-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-
 
       - name: Check formatting
         run: cargo fmt --check
@@ -101,3 +132,11 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}
+
+      - name: Save compiler objects
+        if: success() && steps.compiler-cache-restore.outputs.cache-hit != 'true' && steps.compiler-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/codestory-draft-sccache
+          key: ${{ steps.compiler-cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/source-proof.yml
+++ b/.github/workflows/source-proof.yml
@@ -137,6 +137,18 @@ jobs:
           version: ${{ env.SCCACHE_VERSION }}
           disable_annotations: true
 
+      # Checksum-pinned official archive, same trust model as the actionlint gate. nextest
+      # schedules test binaries in parallel across the whole workspace, which measured 3.9x
+      # faster than `cargo test --workspace` on an identical tree with identical test parity.
+      - name: Install pinned cargo-nextest
+        shell: bash
+        run: |
+          curl -sSL -o "$RUNNER_TEMP/cargo-nextest.tar.gz" "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.98/cargo-nextest-0.9.98-x86_64-unknown-linux-gnu.tar.gz"
+          echo "7d07712519615722b19ffe3b3d1097b7d4fa390995e3cac1f9d6dda1ba61b2a7  $RUNNER_TEMP/cargo-nextest.tar.gz" | sha256sum --check --strict
+          tar -xzf "$RUNNER_TEMP/cargo-nextest.tar.gz" -C "$RUNNER_TEMP"
+          install -m 0755 "$RUNNER_TEMP/cargo-nextest" "$HOME/.cargo/bin/cargo-nextest"
+          cargo nextest --version
+
       - name: Configure bounded compiler cache
         shell: bash
         run: |
@@ -341,8 +353,12 @@ jobs:
           test "$COMPILE_OUTCOME" = success
           test "$LINT_OUTCOME" = success
 
+      # nextest does not execute doctests, so the doc pass stays: today it is empty and costs
+      # seconds, and it means a future doctest can never silently stop being run.
       - name: Test the complete workspace once
-        run: cargo test --workspace --locked
+        run: |
+          cargo nextest run --workspace --locked
+          cargo test --workspace --doc --locked
 
       - name: Emit authenticated source release cell
         if: inputs.emit_release_cells


### PR DESCRIPTION
Closes #1453
Refs #1179

## Context

The draft source lane (`rust-ci`) and the full source gate are the two hosted
lanes every change pays for. The draft lane's `target/` cache key includes
`hashFiles('Cargo.lock')`, so a lock bump rebuilds the workspace from scratch;
the gate runs `cargo test --workspace` in a single process.

## What changed

- **sccache in the draft lane**, mirroring the source gate's pinned setup
  (same action digest, same version), with its own bounded compiler-object
  cache under `runner.temp`. A lock-key miss now salvages every compilation
  the change didn't invalidate. Configuration goes through `GITHUB_ENV` so the
  job keeps its pinned no-env shape.
- **cargo-nextest in `full-source-gate`**, installed from a checksum-pinned
  official archive (the actionlint trust model). Measured side by side on an
  identical tree: **66 s vs 256 s wall for identical parity** — 2232 tests run
  either way, 29 skipped either way. A `cargo test --workspace --doc --locked`
  pass stays in the step: the workspace has zero doctests today, so it costs
  seconds, and it means a future doctest can never silently stop being run
  (nextest does not execute doctests).
- **Policy pins for every new surface**: the draft step sequence (16 steps),
  the configure step's exact lines, sccache action/version, compiler-cache
  path/key/fallback identity, the nextest archive checksum, both test
  commands, and runner-before-test ordering.

## How to review

One commit. The workflow diffs are additive steps; the policy diff is the
matching contract. `requireStepRun` matches fragments, so the old
`cargo test --workspace --locked` pin would have kept passing against the new
step text — the updated pins name both commands explicitly.

## Verification

- `node .github/scripts/check-workflow-policy.mjs` — pass
- `node --test .github/scripts/check-workflow-policy.test.mjs` — 356/356
- `node .github/scripts/run-actionlint.mjs` — pass
- Four adversarial mutations each caught by the new pins: sccache version
  drift, weakened compiler-cache key, dropped doc-test line, changed nextest
  checksum.
- Side-by-side timing and parity: `cargo test --workspace --locked` 255.9 s;
  `cargo nextest run --workspace --locked` 65.9 s, `2232 tests run: 2232
  passed, 29 skipped`.

## Risk

- The resolver contract digest is untouched (this PR doesn't edit the resolve
  step).
- Merge-order note: this branch and #1452 both edit
  `check-workflow-policy.mjs`/`source-proof.yml` in different regions;
  whichever lands second takes a trivial rebase.
- First run after merge populates the new sccache cache, so the first draft
  run sees no benefit; wins start on the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
