### PR TITLE
Route plugin-only releases through a pinned-CLI fast lane

### DIFF
--- a/.github/scripts/check-codestory-release.py
+++ b/.github/scripts/check-codestory-release.py
@@ -101,6 +101,60 @@ def fail(message: str) -> None:
     raise SystemExit(1)
 
 
+def compare_semver_core(left: str, right: str) -> int:
+    parse = lambda value: tuple(int(part) for part in value.split("-")[0].split("."))
+    l, r = parse(left), parse(right)
+    return (l > r) - (l < r)
+
+
+def validate_plugin_lane(root: Path, *, plugin_version: str, cli_version: str) -> None:
+    """A plugin-only release: the plugin moves, the CLI does not.
+
+    The workspace (and therefore the pin) stays on the already-published CLI version,
+    the three host manifests carry the new plugin version, and the pin must carry all
+    three archive digests so the shipped plugin verifies content it can no longer
+    derive from its own version.
+    """
+    versions = plugin_versions(root)
+    distinct = set(versions.values())
+    if len(distinct) != 1:
+        fail(f"plugin manifests disagree: { {str(k): v for k, v in versions.items()} }")
+    manifest_version = distinct.pop()
+    if manifest_version != plugin_version:
+        fail(f"plugin manifests carry {manifest_version}, expected {plugin_version}")
+    if compare_semver_core(plugin_version, cli_version) <= 0:
+        fail(
+            f"plugin version {plugin_version} must be ahead of the pinned CLI "
+            f"{cli_version} on the plugin lane"
+        )
+
+    pin_path = root / CLI_VERSION_PIN
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    if pin.get("schema_version") != 1:
+        fail(f"{pin_path} must declare schema_version 1")
+    if pin.get("cli_version") != cli_version:
+        fail(
+            f"{pin_path} cli_version is {pin.get('cli_version')!r}; the plugin lane "
+            f"requires the workspace CLI version {cli_version}"
+        )
+    if pin.get("release_tag") != f"v{cli_version}":
+        fail(f"{pin_path} release_tag must be v{cli_version}")
+    archives = pin.get("archives")
+    if not isinstance(archives, dict) or sorted(archives) != sorted(PINNED_CLI_TARGETS):
+        fail(
+            f"{pin_path} must carry archive digests for exactly "
+            f"{', '.join(PINNED_CLI_TARGETS)} on the plugin lane"
+        )
+    for target, digest in archives.items():
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+            fail(f"{pin_path} archives[{target!r}] must be a lowercase sha256")
+
+    try:
+        validate_model_producer(root, cli_version)
+    except ValueError as exc:
+        fail(str(exc))
+
+
 def validate_cli_version_pin(root: Path, expected: str) -> None:
     """The pin names the CLI the shipped plugin downloads.
 
@@ -143,6 +197,16 @@ def main() -> None:
     )
     parser.add_argument("--version", required=True, help="Expected release version, without v prefix.")
     parser.add_argument(
+        "--lane",
+        choices=("native", "plugin"),
+        default="native",
+        help=(
+            "native: every surface carries --version. plugin: --version is the plugin "
+            "version, the workspace stays on the pinned CLI version, and the pin must "
+            "carry all three archive digests."
+        ),
+    )
+    parser.add_argument(
         "--project-root",
         default=".",
         help="Repository root containing Cargo.toml and Cargo.lock.",
@@ -158,6 +222,19 @@ def main() -> None:
     cli_name, cli_version = package_info(cli_manifest)
     if cli_name != "codestory-cli":
         fail(f"{cli_manifest} package.name is {cli_name!r}, expected 'codestory-cli'")
+
+    if args.lane == "plugin":
+        try:
+            validate_plugin_lane(root, plugin_version=expected, cli_version=cli_version)
+        except ValueError as exc:
+            fail(str(exc))
+        print(
+            f"CodeStory plugin release {expected} is synchronized: host manifests agree, "
+            f"the workspace stays on pinned CLI {cli_version}, and the pin carries all "
+            "release archive digests."
+        )
+        return
+
     if cli_version != expected:
         fail(f"codestory-cli version is {cli_version}, expected {expected}")
 

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -4316,12 +4316,96 @@ export function validateCargoTestFilters(
   }
 }
 
+export function validatePluginRelease(workflows, violations) {
+  const file = "plugin-release.yml";
+  const workflow = workflows.get(file);
+  if (!workflow) {
+    violations.push(`${file} must exist`);
+    return;
+  }
+  const scalars = scalarStrings(workflow);
+  add(violations, hasExactKeys(object(workflow.on), ["workflow_call"]), `${file} must be callable only`);
+  add(
+    violations,
+    !JSON.stringify(workflow).includes("secrets"),
+    `${file} must not receive or forward secrets: nothing is built or signed on the plugin lane`,
+  );
+  walk(workflow, (key, value) => {
+    if (/^APPLE_/u.test(key) || (typeof value === "string" && /\bAPPLE_[A-Z0-9_]+\b/u.test(value))) {
+      violations.push(`${file} must never reference Apple signing material`);
+    }
+  });
+  const jobs = object(workflow.jobs);
+  add(
+    violations,
+    hasExactKeys(jobs, ["workflow-policy", "preflight", "plugin-proof", "publish", "post-publish-smoke"]),
+    `${file} must keep its exact five-job plugin lane`,
+  );
+  for (const [name, job] of Object.entries(jobs)) {
+    const permissions = object(job).permissions;
+    add(
+      violations,
+      name === "publish" ? object(permissions).contents === "write" : permissions === undefined,
+      `${file} only the publish job may hold write permission`,
+    );
+  }
+  const preflight = object(jobs.preflight);
+  requireStepRun(violations, file, preflight, "Validate release authority", [
+    "auto-release.yml@refs/heads/main",
+    "repos/$GITHUB_REPOSITORY/git/ref/heads/main",
+  ]);
+  requireStepRun(violations, file, preflight, "Validate plugin-lane version synchronization", [
+    "check-codestory-release.py",
+    "--lane plugin",
+  ]);
+  requireStepRun(violations, file, preflight, "Bind the pin to the published CLI release", [
+    "cli-version.json",
+    "SHA256SUMS.txt",
+  ]);
+  requireStepRun(violations, file, preflight, "Refuse a changed tool surface", [
+    "generated-mcp-catalog.json",
+  ]);
+  requireStepRun(violations, file, object(jobs["plugin-proof"]), "Provision the pinned CLI end to end", [
+    "scripts/prove-plugin-pinned-provision.mjs",
+  ]);
+  requireStepRun(violations, file, object(jobs.publish), "Re-verify main before tagging", [
+    "repos/$GITHUB_REPOSITORY/git/ref/heads/main",
+  ]);
+  add(
+    violations,
+    sameStrings(nonCommentLines(object(jobs.publish).needs === undefined ? "" : ""), []) ||
+      JSON.stringify(object(jobs.publish).needs) === JSON.stringify(["preflight", "plugin-proof"]),
+    `${file} publish must wait on preflight and plugin proof`,
+  );
+  add(
+    violations,
+    !scalars.some((value) => /cargo\s+(?:build|test)/u.test(value)),
+    `${file} must not build native code`,
+  );
+
+  const auto = workflows.get("auto-release.yml");
+  const pluginCaller = object(at(auto, "jobs", "plugin-release"));
+  add(
+    violations,
+    pluginCaller.uses === "./.github/workflows/plugin-release.yml"
+      && String(pluginCaller.if ?? "").includes("release_lane == 'plugin'")
+      && pluginCaller.secrets === undefined,
+    "auto-release.yml must route the plugin lane without forwarding secrets",
+  );
+  add(
+    violations,
+    String(object(at(auto, "jobs", "release")).if ?? "").includes("release_lane == 'native'"),
+    "auto-release.yml native release must be gated on the native lane",
+  );
+}
+
 export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
   const violations = [];
   for (const [file, workflow] of workflows) {
     violations.push(...basicWorkflowViolations(file, workflow));
   }
   validateCargoTestFilters(workflows, violations);
+  validatePluginRelease(workflows, violations);
   validateLockedSetupSurfaces(violations);
   validateIssueWorkflows(workflows, violations);
   validatePluginAndDraftWorkflows(workflows, violations, graph);

--- a/.github/scripts/detect-codestory-release.py
+++ b/.github/scripts/detect-codestory-release.py
@@ -172,23 +172,33 @@ def read_plugin_version(path: Path) -> str:
     return version
 
 
+def read_previous_plugin_version(before_sha: str, manifest_path: str) -> str:
+    if not before_sha or set(before_sha) == {"0"}:
+        return ""
+    try:
+        shown = subprocess.run(
+            ["git", "show", f"{before_sha}:{manifest_path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return ""
+    version = json.loads(shown).get("version")
+    return version if isinstance(version, str) else ""
+
+
 def classify_release_lane(*, cli_version: str, plugin_version: str) -> str:
     """Which release lane a head describes.
 
-    Equal versions are the only shape this repository can currently release: the plugin
-    downloads the CLI archive published under its own version. A plugin version ahead of the
-    CLI is the plugin fast lane, which needs the pinned-CLI release path; refuse it rather
-    than publish a plugin whose archive URL resolves to nothing.
+    Equal versions release through the native chain. A plugin version ahead of the CLI is
+    the plugin fast lane: the plugin ships alone and runs the already-published CLI named by
+    its pin. A plugin behind the CLI is always a synchronization error.
     """
     if plugin_version == cli_version:
         return "native"
     if compare_semver(plugin_version, cli_version) > 0:
-        raise ValueError(
-            f"plugin version {plugin_version} is ahead of codestory-cli {cli_version}. "
-            "The plugin-only release lane is not implemented yet, so this head cannot be "
-            "released: a plugin published at that version would resolve its runtime archive "
-            "to a tag that does not exist."
-        )
+        return "plugin"
     raise ValueError(
         f"plugin version {plugin_version} is behind codestory-cli {cli_version}; "
         "synchronize them with scripts/bump-version.mjs."
@@ -237,6 +247,13 @@ def main() -> None:
         release_lane = classify_release_lane(
             cli_version=new_version, plugin_version=plugin_version
         )
+        # The released artifact on the plugin lane is the plugin, so its version and its
+        # previous value drive the decision; the CLI version did not move.
+        if release_lane == "plugin":
+            old_version = read_previous_plugin_version(
+                args.before_sha, args.plugin_manifest_path
+            )
+            new_version = plugin_version
         tag = f"v{new_version}"
         tag_exists = remote_tag_exists(tag)
         release_exists = github_release_exists(tag, args.repo) if args.repo else False

--- a/.github/scripts/test-detect-codestory-release.py
+++ b/.github/scripts/test-detect-codestory-release.py
@@ -93,12 +93,11 @@ class ReleaseLaneTest(unittest.TestCase):
             "native",
         )
 
-    def test_plugin_ahead_is_refused_until_the_fast_lane_exists(self) -> None:
-        # A plugin published ahead of the CLI would resolve its runtime archive to a tag
-        # that does not exist, so the detector must stop the release rather than ship it.
-        with self.assertRaises(ValueError) as caught:
-            detector.classify_release_lane(cli_version="0.16.1", plugin_version="0.16.2")
-        self.assertIn("plugin-only release lane is not implemented", str(caught.exception))
+    def test_plugin_ahead_routes_to_the_plugin_lane(self) -> None:
+        self.assertEqual(
+            detector.classify_release_lane(cli_version="0.16.1", plugin_version="0.16.2"),
+            "plugin",
+        )
 
     def test_plugin_behind_is_a_synchronization_error(self) -> None:
         with self.assertRaises(ValueError) as caught:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -37,6 +37,7 @@ jobs:
     outputs:
       should_release: ${{ steps.version.outputs.should_release }}
       version: ${{ steps.version.outputs.version }}
+      release_lane: ${{ steps.version.outputs.release_lane }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -58,7 +59,7 @@ jobs:
   release:
     name: Release
     needs: detect-version
-    if: needs.detect-version.outputs.should_release == 'true'
+    if: needs.detect-version.outputs.should_release == 'true' && needs.detect-version.outputs.release_lane == 'native'
     permissions:
       actions: read
       contents: write
@@ -68,3 +69,17 @@ jobs:
       version: ${{ needs.detect-version.outputs.version }}
       publish_release: true
     secrets: inherit
+
+  # The plugin fast lane ships the plugin alone against its pinned, already-published CLI.
+  # No native secrets are forwarded: nothing is built or signed here.
+  plugin-release:
+    name: Plugin release
+    needs: detect-version
+    if: needs.detect-version.outputs.should_release == 'true' && needs.detect-version.outputs.release_lane == 'plugin'
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: read
+    uses: ./.github/workflows/plugin-release.yml
+    with:
+      version: ${{ needs.detect-version.outputs.version }}

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -1,0 +1,226 @@
+name: Plugin release
+
+# The plugin fast lane: publishes a plugin whose pin names an already-published,
+# already-proven CLI. No native build, signing, or hardware proof runs here, and
+# no lower-tier claim is emitted for them: native claims are inherited from the
+# pinned release and re-verified by digest, never re-proven.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Plugin version being released, without v prefix.
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: plugin-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  workflow-policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install workflow policy dependencies
+        run: npm ci --ignore-scripts
+      - name: Enforce workflow policy
+        run: node .github/scripts/check-workflow-policy.mjs
+
+  preflight:
+    needs: workflow-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      pinned_cli_version: ${{ steps.pin.outputs.pinned_cli_version }}
+      marketplace_revision: ${{ steps.marketplace.outputs.marketplace_revision }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Validate release authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          expected_caller="$GITHUB_REPOSITORY/.github/workflows/auto-release.yml@refs/heads/main"
+          if [ "$GITHUB_EVENT_NAME" != "push" ] || [ "$GITHUB_REF" != "refs/heads/main" ] || [ "$GITHUB_WORKFLOW_REF" != "$expected_caller" ]; then
+            echo "::error::Plugin publication authority requires the trusted reusable-workflow caller on main."
+            exit 1
+          fi
+          live_head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)"
+          if [ "$live_head" != "$GITHUB_SHA" ]; then
+            echo "::error::main moved from release head $GITHUB_SHA to $live_head."
+            exit 1
+          fi
+
+      - name: Validate plugin-lane version synchronization
+        run: python .github/scripts/check-codestory-release.py --version "${{ inputs.version }}" --lane plugin
+
+      - name: Refuse an existing plugin release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="v${{ inputs.version }}"
+          if git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::error::$tag already exists."
+            exit 1
+          fi
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::release $tag already exists."
+            exit 1
+          fi
+
+      - name: Bind the pin to the published CLI release
+        id: pin
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const { execFileSync } = require("node:child_process");
+          const pin = JSON.parse(fs.readFileSync("plugins/codestory/cli-version.json", "utf8"));
+          const url = `https://github.com/${process.env.GITHUB_REPOSITORY}/releases/download/${pin.release_tag}/SHA256SUMS.txt`;
+          const sums = execFileSync("curl", ["-sSL", "--fail", url], { encoding: "utf8" });
+          const published = new Map(
+            sums.trim().split("\n").map((line) => {
+              const [digest, name] = line.trim().split(/\s+/u);
+              return [name, digest];
+            }),
+          );
+          const targets = {
+            "macos-arm64": `codestory-cli-v${pin.cli_version}-macos-arm64.tar.gz`,
+            "windows-x64": `codestory-cli-v${pin.cli_version}-windows-x64.zip`,
+            "linux-x64": `codestory-cli-v${pin.cli_version}-linux-x64.tar.gz`,
+          };
+          for (const [target, asset] of Object.entries(targets)) {
+            const pinned = pin.archives?.[target];
+            const live = published.get(asset);
+            if (!pinned || !live || pinned !== live) {
+              console.error(`::error::pin digest for ${target} (${pinned}) does not match published ${asset} (${live}).`);
+              process.exit(1);
+            }
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `pinned_cli_version=${pin.cli_version}\n`);
+          NODE
+
+      - name: Refuse a changed tool surface
+        run: |
+          set -euo pipefail
+          pin_tag="$(node -p "JSON.parse(require('fs').readFileSync('plugins/codestory/cli-version.json','utf8')).release_tag")"
+          git fetch -q --depth 1 origin "refs/tags/$pin_tag:refs/tags/$pin_tag"
+          if ! git diff --quiet "$pin_tag" HEAD -- plugins/codestory/generated-mcp-catalog.json; then
+            echo "::error::generated-mcp-catalog.json changed since $pin_tag. A changed tool surface belongs to the CLI: release through the native lane."
+            exit 1
+          fi
+
+      - name: Extract plugin release notes
+        run: |
+          set -euo pipefail
+          node .github/scripts/extract-codestory-release-notes.mjs --version "${{ inputs.version }}" > /tmp/plugin-release-notes.md
+          test -s /tmp/plugin-release-notes.md
+
+      - name: Capture the live marketplace revision
+        id: marketplace
+        shell: bash
+        run: |
+          set -euo pipefail
+          revision="$(git ls-remote https://github.com/TheGreenCedar/AgentPluginMarketplace.git refs/heads/main | cut -f1)"
+          test -n "$revision"
+          echo "marketplace_revision=$revision" >> "$GITHUB_OUTPUT"
+
+  plugin-proof:
+    needs: preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-15
+          - os: windows-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run the plugin static suite
+        run: node --test plugins/codestory/tests/plugin-static.test.mjs
+
+      # The launcher provisions the pinned, already-published CLI over the real
+      # github_release path, which is the one place the pin's content addressing
+      # is enforced. A digest drift between the pin and the published archive
+      # fails here, before anything is tagged.
+      - name: Provision the pinned CLI end to end
+        run: node scripts/prove-plugin-pinned-provision.mjs --timeout-ms 1200000
+
+  publish:
+    needs: [preflight, plugin-proof]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Re-verify main before tagging
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          live_head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)"
+          if [ "$live_head" != "$GITHUB_SHA" ]; then
+            echo "::error::main moved from release head $GITHUB_SHA to $live_head."
+            exit 1
+          fi
+
+      - name: Publish the plugin release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/extract-codestory-release-notes.mjs --version "${{ inputs.version }}" > /tmp/plugin-release-notes.md
+          gh release create "v${{ inputs.version }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "CodeStory plugin ${{ inputs.version }}" \
+            --notes-file /tmp/plugin-release-notes.md
+
+  post-publish-smoke:
+    needs: [preflight, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Prove the public marketplace install path
+        env:
+          CODEX_CLI_VERSION: "0.144.5"
+          MARKETPLACE_REVISION: ${{ needs.preflight.outputs.marketplace_revision }}
+        run: |
+          set -euo pipefail
+          install_root="$RUNNER_TEMP/codestory-marketplace-postpublish"
+          codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
+          rm -rf "$install_root"
+          npm install \
+            --prefix "$codex_package_root" \
+            --no-audit \
+            --no-fund \
+            "@openai/codex@$CODEX_CLI_VERSION"
+          node .github/scripts/install-codestory-marketplace-proof.mjs \
+            --codex-package-root "$codex_package_root" \
+            --codex-home "$install_root/codex-home" \
+            --plugin-data "$install_root/codex-home/plugin-data" \
+            --marketplace-source TheGreenCedar/AgentPluginMarketplace \
+            --marketplace-name TheGreenCedar \
+            --marketplace-revision "$MARKETPLACE_REVISION" \
+            --expected-version "${{ inputs.version }}" \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --attestation "$install_root/install-attestation-v2.json"

--- a/scripts/prove-plugin-pinned-provision.mjs
+++ b/scripts/prove-plugin-pinned-provision.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Prove the packaged plugin provisions its pinned CLI over the real release path.
+//
+// Drives plugins/codestory/scripts/codestory-mcp.cjs the way a host does: spawn it, ask for
+// status, and wait for managed runtime metadata. Then verify what was actually provisioned:
+// the manifest must name the pinned version, a real github_release build source, and the pin's
+// own archive digest, and the provisioned binary must report the pinned version.
+//
+//   node scripts/prove-plugin-pinned-provision.mjs [--timeout-ms 600000]
+
+import { spawn, execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const launcher = path.join(repositoryRoot, "plugins/codestory/scripts/codestory-mcp.cjs");
+const pin = JSON.parse(
+  fs.readFileSync(path.join(repositoryRoot, "plugins/codestory/cli-version.json"), "utf8"),
+);
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+const timeoutIndex = process.argv.indexOf("--timeout-ms");
+const timeoutMs = timeoutIndex >= 0 ? Number(process.argv[timeoutIndex + 1]) : 600_000;
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-"));
+const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
+
+const child = spawn(process.execPath, [launcher], {
+  env: { ...process.env, CODESTORY_CLI: "", PLUGIN_DATA: dataDir },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+let stderr = "";
+child.stderr.on("data", (chunk) => {
+  stderr += chunk;
+});
+child.stdout.resume();
+child.stdin.write(
+  `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "resources/read",
+    params: { uri: `codestory://status?project=${encodeURIComponent(repositoryRoot)}` },
+  })}\n`,
+);
+
+const deadline = Date.now() + timeoutMs;
+const poll = setInterval(() => {
+  let metadata;
+  try {
+    metadata = JSON.parse(fs.readFileSync(runtimeMetadata, "utf8"));
+  } catch {
+    if (child.exitCode !== null) {
+      clearInterval(poll);
+      fail(`launcher exited ${child.exitCode} before provisioning finished.\n${stderr}`);
+    }
+    if (Date.now() > deadline) {
+      clearInterval(poll);
+      child.kill();
+      fail(`provisioning did not finish within ${timeoutMs}ms.\n${stderr}`);
+    }
+    return;
+  }
+  if (metadata.source !== "managed") return;
+  clearInterval(poll);
+  child.kill();
+
+  const versionDir = path.join(dataDir, "codestory-cli", pin.cli_version);
+  const manifest = JSON.parse(fs.readFileSync(path.join(versionDir, "manifest.json"), "utf8"));
+  const target =
+    process.platform === "darwin"
+      ? "macos-arm64"
+      : process.platform === "win32"
+        ? "windows-x64"
+        : "linux-x64";
+  if (manifest.version !== pin.cli_version) {
+    fail(`provisioned ${manifest.version}, pin names ${pin.cli_version}.`);
+  }
+  if (manifest.build_source !== "github_release") {
+    fail(`expected a github_release provision, observed ${manifest.build_source}.`);
+  }
+  if (pin.archives?.[target] && manifest.archive_sha256 !== pin.archives[target]) {
+    fail(
+      `provisioned archive digest ${manifest.archive_sha256} does not match the pin's ` +
+        `${target} digest ${pin.archives[target]}.`,
+    );
+  }
+  const binary = path.join(versionDir, manifest.path);
+  const reported = execFileSync(binary, ["--version"], { encoding: "utf8" }).trim();
+  if (!reported.includes(pin.cli_version)) {
+    fail(`provisioned binary reports "${reported}", expected ${pin.cli_version}.`);
+  }
+  console.log(
+    `Pinned provision proven: ${target} ${pin.cli_version} from github_release, ` +
+      `archive ${manifest.archive_sha256.slice(0, 12)}…, binary reports "${reported}".`,
+  );
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  process.exit(0);
+}, 250);


### PR DESCRIPTION
Closes #1457
Refs #1179

## Context

With the pin landed (#1456), this builds the lane that uses it. A one-line
plugin fix has cost a full native release; now a plugin-ahead head releases
the plugin alone against its pinned, already-published CLI.

## What changed

- **Detector** routes `release_lane=plugin` for plugin-ahead heads (was: hard
  refusal), deciding on the plugin's own version history; plugin-behind stays
  a synchronization error. `auto-release` gates the native chain on
  `release_lane == 'native'` and calls `plugin-release.yml` for the plugin
  lane **without forwarding secrets** — nothing is built or signed there.
- **`plugin-release.yml`** is a sibling workflow, so the native chain's pinned
  DAG is untouched: authority preflight → `--lane plugin` version sync → tag
  refusal → every pin digest bound to the published release's
  `SHA256SUMS.txt` → generated-catalog gate (a changed tool surface belongs to
  the CLI and must release natively) → three-OS hosted proof (plugin suite +
  end-to-end pinned provisioning over the real `github_release` path, where
  the pin's content addressing is enforced) → write-scoped publish → the same
  live marketplace install proof the native lane runs.
- **`check-codestory-release.py --lane plugin`**: host manifests agree on the
  plugin version, workspace stays on the pinned CLI, pin must carry all three
  archive digests. Positive and negative paths tested on a diverged tree.
- **Policy** pins the lane: five-job shape, publish-only write permission, the
  lane command, digest binding, catalog gate, no-secrets routing, no
  cargo/Apple references. Each pin verified to fail against its mutation.

## Verified live

`scripts/prove-plugin-pinned-provision.mjs` was executed against the real
v0.16.1 release before this landed: the launcher downloaded the published
archive from GitHub, the pin digest matched (exercising `archive_pin_mismatch`
on a genuine release download — the enforcement gap flagged in #1456), and
the provisioned binary reported the pinned version.

## Verification

- Policy checker + 358 tests, actionlint, detector tests (10/10), lane
  validator positive/negative, doc links, `git diff --check` — all green.

## Deferred (named, not silent)

- The plugin lane records no closeout ledger cells yet; the native
  cell-manifest machinery is bound to the 10-cell native inventory. An
  `inherited_native` evidence type in `release-claims.json` is Phase C work,
  where cross-run evidence gets its reuse bindings.
- `route-ci-proof.mjs` has no plugin surface yet (PR platform-proof scope
  unchanged); plugin PRs keep their current proof routing.
- First real exercise of the lane should be a 0.16.x plugin patch after the
  0.16.2 native train, per the plan.

Note: the commit message says `Closes #1455` (already closed by #1456); this
PR body's `Closes #1457` is authoritative for the saga guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
