### PR TITLE
Inherit binding-verified release evidence instead of re-running proven proofs

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1684,6 +1684,30 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   add(violations, source.uses === "./.github/workflows/source-proof.yml", `${releaseFile} must call exact source proof`);
   add(violations, sameMembers(needs(source), releaseChain.dependencies["source-proof"]), `${releaseFile} source proof dependencies must match the release claim graph`);
   add(violations, object(source.with).ref === "${{ github.sha }}", `${releaseFile} source proof must receive the exact release SHA`);
+  // Reuse is admissible only through the authenticated closeout binding, never by simply
+  // dropping the gate: the job may be skipped, and only when preflight resolved reusable
+  // evidence for this exact tree.
+  add(
+    violations,
+    String(source.if ?? "") === "needs.preflight.outputs.source_proof_reused != 'true'",
+    `${releaseFile} source proof may be skipped only when preflight resolved reusable evidence`,
+  );
+  requireStepRun(violations, releaseFile, requireJob(violations, releaseFile, release, "preflight"), "Resolve reusable prior evidence", [
+    'git rev-parse "$GITHUB_SHA^{tree}"',
+    "merge-base --is-ancestor",
+    "full-source-gate",
+    '.path == ".github/workflows/source-proof.yml"',
+  ]);
+  const closeout = requireJob(violations, releaseFile, release, "pre-publish-closeout");
+  requireStepRun(violations, releaseFile, closeout, "Authenticate pre-publish Actions provenance", [
+    '--reuse "$REUSE_SELECTION"',
+  ]);
+  add(
+    violations,
+    String(closeout.if ?? "").includes("needs.source-proof.result == 'skipped'")
+      && String(closeout.if ?? "").includes("needs.preflight.result == 'success'"),
+    `${releaseFile} closeout must accept a skipped source gate only alongside a successful preflight`,
+  );
   add(violations, object(source.with).version === "${{ needs.preflight.outputs.version }}" && object(source.with).emit_release_cells === true, `${releaseFile} source proof must emit its authenticated release cell`);
 
   const packaged = requireJob(violations, releaseFile, release, "packaged-proof");

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
     timeout-minutes: 10
     outputs:
       version: ${{ steps.version.outputs.version }}
+      reuse: ${{ steps.reuse.outputs.reuse }}
+      source_proof_reused: ${{ steps.reuse.outputs.source_proof_reused }}
       tag: ${{ steps.version.outputs.tag }}
       marketplace_revision: ${{ steps.marketplace.outputs.marketplace_revision }}
     steps:
@@ -152,6 +154,44 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve reusable prior evidence
+        id: reuse
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          entries=()
+
+          # The source gate proves a tree. When dev was already gated and promoted without
+          # changing the tree, re-running it for an hour cannot reach a different answer.
+          release_tree="$(git rev-parse "$GITHUB_SHA^{tree}")"
+          while IFS= read -r run_id; do
+            head_sha="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id" --jq .head_sha)"
+            git cat-file -e "$head_sha^{commit}" 2>/dev/null || continue
+            test "$(git rev-parse "$head_sha^{tree}")" = "$release_tree" || continue
+            git merge-base --is-ancestor "$head_sha" "$GITHUB_SHA" || continue
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?per_page=100" \
+              --jq '.jobs[] | select(.name | endswith("full-source-gate")) | select(.conclusion == "success") | .id' \
+              | grep -q . || continue
+            entries+=("source_behavior=$run_id:$head_sha")
+            echo "Reusing source proof from run $run_id (tree $release_tree)."
+            break
+          done < <(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/runs?status=completed&per_page=100" \
+              | jq -r --arg repo "$GITHUB_REPOSITORY" \
+                '.workflow_runs[] | select(.path == ".github/workflows/source-proof.yml" and .head_repository.full_name == $repo and .conclusion == "success") | .id'
+          )
+
+          reuse="$(IFS=,; echo "${entries[*]:-}")"
+          echo "reuse=${reuse:--}" >> "$GITHUB_OUTPUT"
+          if [ -n "$reuse" ]; then
+            echo "source_proof_reused=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "source_proof_reused=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Prove the public marketplace install path
         if: inputs.publish_release
         id: marketplace
@@ -189,6 +229,9 @@ jobs:
 
   source-proof:
     needs: preflight
+    # A completed gate for this exact tree is already authenticated evidence; the closeout
+    # consumes it through the reuse binding instead of re-running an hour of compilation.
+    if: needs.preflight.outputs.source_proof_reused != 'true'
     uses: ./.github/workflows/source-proof.yml
     with:
       ref: ${{ github.sha }}
@@ -264,6 +307,7 @@ jobs:
 
   pre-publish-closeout:
     name: Authenticate pre-publish release cells
+    if: always() && needs.preflight.result == 'success' && (needs.source-proof.result == 'success' || needs.source-proof.result == 'skipped')
     needs:
       - preflight
       - source-proof
@@ -284,6 +328,7 @@ jobs:
         id: pre-publish-provenance
         env:
           GH_TOKEN: ${{ github.token }}
+          REUSE_SELECTION: ${{ needs.preflight.outputs.reuse }}
         shell: bash
         run: |
           set -euo pipefail
@@ -293,6 +338,7 @@ jobs:
             --phase pre_publish \
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --reuse "$REUSE_SELECTION" \
             --out target/release-closeout/trusted-pre-publish-producers.json
           artifact_ids="$(jq -r '[.artifacts[].id] | join(",")' target/release-closeout/trusted-pre-publish-producers.json)"
           test -n "$artifact_ids"

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "0e51f59a29a3b69fba16ef2e4ffde502eb5dee153449999b302f11b3f729557a",
+    "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "0e51f59a29a3b69fba16ef2e4ffde502eb5dee153449999b302f11b3f729557a",
+        "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "0e51f59a29a3b69fba16ef2e4ffde502eb5dee153449999b302f11b3f729557a",
+        "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "0e51f59a29a3b69fba16ef2e4ffde502eb5dee153449999b302f11b3f729557a",
+      "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "0e51f59a29a3b69fba16ef2e4ffde502eb5dee153449999b302f11b3f729557a",
+      "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "0e51f59a29a3b69fba16ef2e4ffde502eb5dee153449999b302f11b3f729557a",
+    "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -111,6 +111,14 @@
       "producer_artifact": "non_empty_text",
       "native_engine": "identifier",
       "pre_publish_artifact_sha256": "sha256"
+    },
+    "native_reuse": "version_only_delta",
+    "reuse": {
+      "bindings": {
+        "source_tree": "Evidence from a prior run is admissible when its producing commit resolves to the identical source tree and is an ancestor of the release commit on the promotion path.",
+        "native_fingerprint": "Accelerator evidence from the previous published release is admissible when the version-normalized native fingerprint (scripts/native-fingerprint.mjs) of both commits is identical: the built inputs differ only by the embedded version string. Packaging and signing always rerun; only accelerator behavior is inherited."
+      },
+      "verification": "The trusted producer map verifies the binding, the reused run's job success, artifact expiry, and container digest exactly as same-run evidence, and records the reused run, commit, and binding value in the ledger."
     }
   },
   "exception_policy": {
@@ -596,7 +604,8 @@
           "producer_job_name": "full-source-gate",
           "producer_artifact": "release-cell-prepublish-source-attempt-{attempt}"
         },
-        "archive_role": "none"
+        "archive_role": "none",
+        "reuse_binding": "source_tree"
       },
       {
         "id": "package_identity",
@@ -702,7 +711,8 @@
             }
           }
         ],
-        "archive_role": "none"
+        "archive_role": "none",
+        "reuse_binding": "native_fingerprint"
       },
       {
         "id": "retrieval_readiness",

--- a/scripts/codestory-release-cell-manifest.mjs
+++ b/scripts/codestory-release-cell-manifest.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -259,6 +260,93 @@ function flattenJobs(jobsByAttempt) {
   });
 }
 
+/// One cell's producer taken from a prior, binding-verified run.
+///
+/// The trust requirements are the same-run ones -- named job succeeded, one matching unexpired
+/// artifact, container digest present, artifact created inside the job window -- re-anchored to
+/// the reused run and its commit, with the reuse recorded rather than implied.
+function selectReusedProducer({ cell, reused, binding }) {
+  const reusedRunId = positiveInteger(reused.runId, "reused Actions run id");
+  const reusedHeadSha = text(reused.headSha, "reused Actions head commit");
+  const jobs = flattenJobs(reused.jobsByAttempt);
+  const jobName = text(cell.identity_constraints.producer_job_name, `${cell.id} producer job name`);
+  const occurrences = jobs.filter((job) => leafJobName(job.name) === jobName);
+  if (occurrences.length === 0) fail(`reused run ${reusedRunId} has no execution of ${jobName}`);
+  const latestAttempt = Math.max(...occurrences.map(({ run_attempt: attempt }) => Number(attempt)));
+  const latestJobs = occurrences.filter(({ run_attempt: attempt }) => Number(attempt) === latestAttempt);
+  if (latestJobs.length !== 1) {
+    fail(`reused run attempt ${latestAttempt} has multiple executions of ${jobName}`);
+  }
+  const job = latestJobs[0];
+  if (job.status !== "completed" || job.conclusion !== "success") {
+    fail(`reused execution of ${jobName} did not succeed`);
+  }
+  if (String(job.run_id) !== reusedRunId || job.head_sha !== reusedHeadSha) {
+    fail(`reused Actions job ${jobName} is not bound to the reused run and commit`);
+  }
+  const constraints = resolveReleaseCellConstraints(cell, String(latestAttempt));
+  const matching = (reused.artifacts ?? []).filter(({ name }) => name === constraints.producer_artifact);
+  if (matching.length !== 1) {
+    fail(`reused run must retain one ${constraints.producer_artifact} artifact`);
+  }
+  const artifact = matching[0];
+  if (artifact.expired !== false
+      || String(artifact.workflow_run?.id) !== reusedRunId
+      || artifact.workflow_run?.head_sha !== reusedHeadSha) {
+    fail(`reused artifact ${constraints.producer_artifact} has stale run provenance`);
+  }
+  if (!ACTIONS_DIGEST.test(String(artifact.digest ?? ""))) {
+    fail(`reused artifact ${constraints.producer_artifact} has no SHA-256 container digest`);
+  }
+  if (!Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes <= 0) {
+    fail(`reused artifact ${constraints.producer_artifact} has invalid size`);
+  }
+  const createdAt = actionsTimestamp(artifact.created_at, "reused artifact created_at");
+  const startedAt = actionsTimestamp(job.started_at, "reused job started_at");
+  const completedAt = actionsTimestamp(job.completed_at, "reused job completed_at");
+  if (Date.parse(createdAt) < Date.parse(startedAt)
+      || Date.parse(createdAt) > Date.parse(completedAt)) {
+    fail(`reused artifact ${constraints.producer_artifact} was not created by its job window`);
+  }
+  return {
+    cell_id: cell.id,
+    producer_workflow: constraints.producer_workflow,
+    producer_job: constraints.producer_job,
+    producer_job_name: constraints.producer_job_name,
+    producer_run_id: reusedRunId,
+    producer_run_attempt: String(latestAttempt),
+    producer_artifact: constraints.producer_artifact,
+    reused_from: {
+      run_id: reusedRunId,
+      head_sha: reusedHeadSha,
+      binding,
+      binding_value: text(reused.bindingValue, "reused binding value"),
+    },
+    artifact: {
+      id: positiveInteger(artifact.id, "reused artifact id"),
+      name: artifact.name,
+      digest: artifact.digest,
+      size_in_bytes: artifact.size_in_bytes,
+      expired: false,
+      created_at: createdAt,
+      expires_at: actionsTimestamp(artifact.expires_at, "reused artifact expires_at"),
+      workflow_run_id: reusedRunId,
+      head_sha: reusedHeadSha,
+    },
+    job: {
+      id: positiveInteger(job.id, "reused job id"),
+      run_id: reusedRunId,
+      head_sha: reusedHeadSha,
+      name: job.name,
+      status: job.status,
+      conclusion: job.conclusion,
+      run_attempt: String(latestAttempt),
+      started_at: startedAt,
+      completed_at: completedAt,
+    },
+  };
+}
+
 export function buildTrustedProducerMap({
   graph,
   gitIdentity,
@@ -267,13 +355,31 @@ export function buildTrustedProducerMap({
   currentRunAttempt,
   artifacts,
   jobsByAttempt,
+  // Cross-run evidence, keyed by cell-group id. Admissible only for groups that declare a
+  // reuse_binding in the claim graph; the caller is responsible for having verified the binding
+  // (tree equality and ancestry, or native-fingerprint equality) before supplying an entry.
+  reuse = {},
 }) {
   const selectedRunId = positiveInteger(runId, "Actions run id");
   const selectedCurrentAttempt = positiveInteger(currentRunAttempt, "Actions current run attempt");
   if (!Array.isArray(artifacts)) fail("Actions artifacts must be an array");
   const jobs = flattenJobs(jobsByAttempt);
+  const groupBindings = new Map(
+    (graph.closeout.cell_groups ?? [])
+      .filter((group) => typeof group.reuse_binding === "string")
+      .map((group) => [group.id, group.reuse_binding]),
+  );
+  for (const groupId of Object.keys(reuse)) {
+    if (!groupBindings.has(groupId)) {
+      fail(`cell group ${groupId} does not admit cross-run evidence`);
+    }
+  }
   const selectionCache = new Map();
   const producers = deriveReleaseCells(graph, phase).map((cell) => {
+    const reused = reuse[cell.group_id];
+    if (reused) {
+      return selectReusedProducer({ cell, reused, binding: groupBindings.get(cell.group_id) });
+    }
     const jobName = text(cell.identity_constraints.producer_job_name, `${cell.id} producer job name`);
     const cacheKey = `${jobName}\0${cell.identity_constraints.producer_artifact}`;
     let selected = selectionCache.get(cacheKey);
@@ -371,6 +477,45 @@ export function buildTrustedProducerMap({
   };
 }
 
+/// Verify a reuse binding against the local repository and return its recorded value.
+export function verifyReuseBinding({ binding, repository, releaseCommit, reusedCommit }) {
+  const run = (args) =>
+    execFileSync("git", args, { cwd: repository, encoding: "utf8" }).trim();
+  if (binding === "source_tree") {
+    const releaseTree = run(["rev-parse", `${releaseCommit}^{tree}`]);
+    const reusedTree = run(["rev-parse", `${reusedCommit}^{tree}`]);
+    if (releaseTree !== reusedTree) {
+      fail(`reused commit ${reusedCommit} tree ${reusedTree} does not match release tree ${releaseTree}`);
+    }
+    try {
+      execFileSync("git", ["merge-base", "--is-ancestor", reusedCommit, releaseCommit], {
+        cwd: repository,
+      });
+    } catch {
+      fail(`reused commit ${reusedCommit} is not an ancestor of the release commit`);
+    }
+    return releaseTree;
+  }
+  if (binding === "native_fingerprint") {
+    const script = new URL("./native-fingerprint.mjs", import.meta.url).pathname;
+    const fingerprint = (ref) =>
+      execFileSync(process.execPath, [script, "--ref", ref], {
+        cwd: repository,
+        encoding: "utf8",
+      }).trim();
+    const releasePrint = fingerprint(releaseCommit);
+    const reusedPrint = fingerprint(reusedCommit);
+    if (releasePrint !== reusedPrint) {
+      fail(
+        `native fingerprint of reused commit ${reusedCommit} (${reusedPrint}) does not match `
+          + `the release commit (${releasePrint}); accelerator evidence cannot be inherited`,
+      );
+    }
+    return releasePrint;
+  }
+  fail(`unknown reuse binding ${binding}`);
+}
+
 async function githubPages(url, token, field) {
   const values = [];
   for (let page = 1; ; page += 1) {
@@ -416,6 +561,33 @@ async function produceMap(values) {
       "jobs",
     )).map((job) => ({ ...job, run_attempt: String(attempt) }));
   }
+  // --reuse source_behavior=<runId>:<headSha>[,<group>=<runId>:<headSha>...]
+  // Each entry admits cross-run evidence for one reuse-bound cell group, after this process
+  // itself verifies the binding against the local repository.
+  const reuse = {};
+  for (const entry of text(values.reuse ?? "-", "--reuse").split(",")) {
+    if (entry === "-" || entry === "") continue;
+    const match = /^([a-z_]+)=(\d+):([0-9a-f]{40})$/u.exec(entry);
+    if (!match) fail(`--reuse entry ${entry} must be group=runId:headSha`);
+    const [, groupId, reusedRunId, reusedHeadSha] = match;
+    const binding = (graph.closeout.cell_groups ?? []).find((group) => group.id === groupId)
+      ?.reuse_binding;
+    if (!binding) fail(`cell group ${groupId} does not admit cross-run evidence`);
+    const bindingValue = verifyReuseBinding({
+      binding,
+      repository: text(values.repo, "--repo"),
+      releaseCommit: gitIdentity.commit,
+      reusedCommit: reusedHeadSha,
+    });
+    const reusedUrl = `${apiRoot}/repos/${repositoryPath}/actions/runs/${reusedRunId}`;
+    reuse[groupId] = {
+      runId: reusedRunId,
+      headSha: reusedHeadSha,
+      bindingValue,
+      artifacts: await githubPages(`${reusedUrl}/artifacts`, token, "artifacts"),
+      jobsByAttempt: await githubPages(`${reusedUrl}/jobs?filter=all`, token, "jobs"),
+    };
+  }
   const map = buildTrustedProducerMap({
     graph,
     gitIdentity,
@@ -424,6 +596,7 @@ async function produceMap(values) {
     currentRunAttempt: runAttempt,
     artifacts,
     jobsByAttempt,
+    reuse,
   });
   writeJson(text(values.out, "--out"), map);
 }

--- a/scripts/native-fingerprint.mjs
+++ b/scripts/native-fingerprint.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// The native fingerprint: what the shipped binaries are built from, minus the version stamp.
+//
+// A release bump edits version lines in every crate manifest, Cargo.lock, and the model
+// contract, so a naive tree hash always changes and could never justify inheriting evidence.
+// This hash covers the native-relevant paths with the known version-bump lines normalized
+// away: when two commits share a fingerprint, their native build inputs differ only by the
+// version string embedded in the binaries. Accelerator behavior is invariant under that
+// delta, which is exactly the claim `evidence_policy.native_reuse = "version_only_delta"`
+// authorizes inheriting; packaging and signing still rerun because the bytes differ.
+//
+//   node scripts/native-fingerprint.mjs [--ref HEAD]
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/// Everything that shapes the built native artifacts.
+const NATIVE_PATHS = [
+  "crates",
+  "vendor",
+  "Cargo.toml",
+  "Cargo.lock",
+  ".cargo",
+  "rust-toolchain.toml",
+  ".github/scripts/package-codestory-release.py",
+  ".github/scripts/install-linux-vulkan-build-deps.sh",
+  ".github/scripts/install-windows-vulkan-sdk.ps1",
+];
+
+/// Files whose version-bump lines are normalized rather than hashed raw.
+const VERSION_STAMPED = new Set([
+  "Cargo.lock",
+  "crates/codestory-llama-sys/model-contract.json",
+  ...[
+    "codestory-llama-sys",
+    "codestory-contracts",
+    "codestory-workspace",
+    "codestory-store",
+    "codestory-indexer",
+    "codestory-retrieval",
+    "codestory-runtime",
+    "codestory-cli",
+    "codestory-bench",
+  ].map((crate) => `crates/${crate}/Cargo.toml`),
+]);
+
+function git(args) {
+  return execFileSync("git", args, { cwd: repositoryRoot, encoding: "utf8", maxBuffer: 1 << 28 });
+}
+
+/// Strip exactly the lines the version bump rewrites; everything else stays byte-exact.
+function normalizeVersionStamp(relative, content) {
+  if (relative === "Cargo.lock") {
+    // Only codestory-* package versions move on a bump; foreign versions must stay significant.
+    return content.replace(
+      /(name = "codestory-[a-z-]+"\nversion = ")[^"]+(")/gu,
+      "$1<bump>$2",
+    );
+  }
+  if (relative.endsWith("model-contract.json")) {
+    return content.replace(/("version"\s*:\s*")\d+\.\d+\.\d+[^"]*(")/u, "$1<bump>$2");
+  }
+  // Crate manifests: the [package] version line only.
+  return content.replace(/(^\[package\][\s\S]*?^version\s*=\s*")[^"]+(")/mu, "$1<bump>$2");
+}
+
+function main() {
+  const refIndex = process.argv.indexOf("--ref");
+  const ref = refIndex >= 0 ? process.argv[refIndex + 1] : "HEAD";
+
+  const listing = git(["ls-tree", "-r", ref, "--", ...NATIVE_PATHS])
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [meta, relative] = line.split("\t");
+      const [mode, , objectId] = meta.split(/\s+/u);
+      return { mode, objectId, relative };
+    })
+    .sort((left, right) => (left.relative < right.relative ? -1 : 1));
+
+  if (listing.length === 0) {
+    console.error("::error::native fingerprint saw no tracked native paths");
+    process.exit(1);
+  }
+
+  const hash = createHash("sha256");
+  hash.update("codestory-native-fingerprint-v1\0");
+  for (const { mode, objectId, relative } of listing) {
+    if (VERSION_STAMPED.has(relative)) {
+      const content = git(["cat-file", "blob", objectId]);
+      hash.update(`${mode} ${relative}\0`);
+      hash.update(normalizeVersionStamp(relative, content));
+      hash.update("\0");
+    } else {
+      // Unstamped files contribute their git object id, which already binds content.
+      hash.update(`${mode} ${relative} ${objectId}\0`);
+    }
+  }
+  console.log(hash.digest("hex"));
+}
+
+main();

--- a/scripts/tests/codestory-release-cell-manifest.test.mjs
+++ b/scripts/tests/codestory-release-cell-manifest.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   buildTrustedProducerMap,
+  verifyReuseBinding,
   produceReleaseCellManifest,
 } from "../codestory-release-cell-manifest.mjs";
 import {
@@ -285,4 +286,144 @@ test("Actions provenance rejects missing, expired, malformed, stale, and future 
     currentRunAttempt: "1",
     ...future,
   }), /no execution/u);
+});
+
+// ── Cross-run evidence reuse ────────────────────────────────────────────────────────────────
+
+/// Metadata for a prior, binding-verified run that produced the reused cells.
+function reusedRunMetadata(groupId, { runId = 777, headSha = "b".repeat(40), conclusion = "success", expired = false } = {}) {
+  const artifacts = [];
+  const jobs = [];
+  let nextId = 5000;
+  for (const selected of deriveReleaseCells(graph, "pre_publish")) {
+    if (selected.group_id !== groupId) continue;
+    const constraints = resolveReleaseCellConstraints(selected, "1");
+    if (!jobs.some((job) => job.name.endsWith(constraints.producer_job_name))) {
+      jobs.push({
+        id: nextId++,
+        run_id: runId,
+        run_attempt: "1",
+        head_sha: headSha,
+        name: `Release / ${constraints.producer_job_name}`,
+        status: "completed",
+        conclusion,
+        started_at: "2026-07-10T12:00:00.000Z",
+        completed_at: "2026-07-10T12:10:00.000Z",
+      });
+    }
+    if (conclusion === "success" && !artifacts.some(({ name }) => name === constraints.producer_artifact)) {
+      artifacts.push({
+        id: nextId++,
+        name: constraints.producer_artifact,
+        digest: `sha256:${String(nextId).padStart(64, "0")}`,
+        size_in_bytes: 2048,
+        expired,
+        created_at: "2026-07-10T12:05:00.000Z",
+        expires_at: "2026-08-09T12:05:00.000Z",
+        workflow_run: { id: runId, head_sha: headSha },
+      });
+    }
+  }
+  return { runId: String(runId), headSha, bindingValue: "t".repeat(64), artifacts, jobsByAttempt: jobs };
+}
+
+test("a reuse-bound group accepts binding-verified evidence from a prior run", () => {
+  const metadata = actionsMetadata("pre_publish");
+  // The current run did not execute the source gate at all.
+  metadata.jobsByAttempt["1"] = metadata.jobsByAttempt["1"].filter(
+    (job) => !job.name.endsWith("full-source-gate"),
+  );
+  metadata.artifacts = metadata.artifacts.filter(
+    ({ name }) => !name.startsWith("release-cell-prepublish-source"),
+  );
+  const map = buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: "1",
+    ...metadata,
+    reuse: { source_behavior: reusedRunMetadata("source_behavior") },
+  });
+  const row = map.producers.find(({ cell_id: cellId }) => cellId === "source_behavior");
+  assert.equal(row.producer_run_id, "777");
+  assert.equal(row.reused_from.binding, "source_tree");
+  assert.equal(row.reused_from.head_sha, "b".repeat(40));
+  assert.equal(row.artifact.workflow_run_id, "777");
+  // Non-reused cells stay bound to the current run.
+  const packaged = map.producers.find(({ cell_id: cellId }) => cellId.startsWith("package_identity"));
+  assert.equal(packaged.producer_run_id, "12345");
+});
+
+test("cross-run evidence is refused for groups without a reuse binding", () => {
+  const metadata = actionsMetadata("pre_publish");
+  assert.throws(() => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: "1",
+    ...metadata,
+    reuse: { package_identity: reusedRunMetadata("package_identity") },
+  }), /package_identity does not admit cross-run evidence/u);
+});
+
+test("reused evidence keeps every same-run trust requirement", () => {
+  const base = actionsMetadata("pre_publish");
+  const withReuse = (reused) => () => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: "1",
+    ...base,
+    reuse: { source_behavior: reused },
+  });
+
+  assert.throws(
+    withReuse(reusedRunMetadata("source_behavior", { conclusion: "failure" })),
+    /did not succeed/u,
+  );
+  assert.throws(
+    withReuse(reusedRunMetadata("source_behavior", { expired: true })),
+    /stale run provenance/u,
+  );
+  const wrongRun = reusedRunMetadata("source_behavior");
+  for (const artifact of wrongRun.artifacts) artifact.workflow_run.id = 999;
+  assert.throws(withReuse(wrongRun), /stale run provenance/u);
+  const missing = reusedRunMetadata("source_behavior");
+  missing.artifacts = [];
+  assert.throws(withReuse(missing), /must retain one/u);
+});
+
+test("reuse bindings verify tree identity and fingerprint equality against real history", () => {
+  // v0.16.0 -> v0.16.1 is a pure version bump in this repository's real history: different
+  // trees (so source_tree reuse must refuse) but identical native fingerprints (so
+  // accelerator inheritance is exactly what version_only_delta authorizes).
+  const releaseTag = "00121349"; // v0.16.1 release commit
+  const priorTag = "29bd4795"; // v0.16.0 release commit
+  assert.throws(
+    () => verifyReuseBinding({
+      binding: "source_tree",
+      repository: root,
+      releaseCommit: releaseTag,
+      reusedCommit: priorTag,
+    }),
+    /does not match release tree/u,
+  );
+  const fingerprint = verifyReuseBinding({
+    binding: "native_fingerprint",
+    repository: root,
+    releaseCommit: releaseTag,
+    reusedCommit: priorTag,
+  });
+  assert.match(fingerprint, /^[0-9a-f]{64}$/u);
+  // Identical commits always satisfy the tree binding.
+  const tree = verifyReuseBinding({
+    binding: "source_tree",
+    repository: root,
+    releaseCommit: releaseTag,
+    reusedCommit: releaseTag,
+  });
+  assert.match(tree, /^[0-9a-f]{40}$/u);
 });

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "0e51f59a29a3b69fba16ef2e4ffde502eb5dee153449999b302f11b3f729557a",
+      "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
Closes #1459
Refs #1233, #1189, #1179

## Context

A native release re-runs the 60-minute source gate on a tree dev already
gated, and re-runs 6 hours of hardware proofs even when only the version
string moved. Phase C of the release-DevX plan: inherit authenticated
evidence through the closeout's own trust machinery.

## What changed

- **`scripts/native-fingerprint.mjs`** — version-normalized hash of the
  native-relevant tree (crates/**, vendor/**, Cargo.{toml,lock}, .cargo,
  packaging scripts), with exactly the version-bump lines normalized.
  **Proven against real history**: v0.16.0 ≡ v0.16.1 (pure bump), HEAD
  differs (real native changes).
- **Claim graph** — `evidence_policy.reuse` bindings (`source_tree`,
  `native_fingerprint`), `native_reuse: "version_only_delta"` (per the
  approved plan decision: enabled immediately), `reuse_binding` on the
  `source_behavior` and `accelerator_execution` cell groups. The graph digest
  moved; all bound fixtures re-pinned.
- **Trusted producer map** — accepts a prior run's producer for a reuse-bound
  group only: binding verified in-process (tree equality + ancestry via git,
  or fingerprint equality), then every same-run trust check re-applied
  against the reused run (job success, single unexpired artifact, container
  digest, creation window), and `reused_from {run, commit, binding, value}`
  recorded in the ledger. Groups without a binding are refused outright.
- **`release.yml`** — preflight resolves reusable source evidence for the
  exact tree (same-tree + ancestor + successful gate); the source-proof job
  is skipped only then; closeout tolerates exactly that skip and passes the
  reuse selection to the producer map.
- **Policy** — pins the skip condition, the resolve-step fragments, the
  `--reuse` plumbing, and the closeout condition; each verified to fail
  against its mutation.

## Verification

- Cell-manifest tests: 11/11, including cross-run acceptance, refusal for
  unbound groups, failed/expired/wrong-run/missing reused evidence, and
  binding verification against real repository history.
- Policy checker + 358 tests, actionlint, claims validate, closeout tests,
  detector tests — all green.

## Deferred (named)

- Hardware-proof inheritance is authorized by the graph and enforced by the
  same producer-map path, but `release.yml` does not yet auto-resolve a prior
  release run for the accelerator groups — that resolve step needs the prior
  release's run id lookup plus skip-gating on three hardware jobs, and lands
  with the 0.16.2 train where it will first be exercised for real. The
  mechanism (binding + cross-run acceptance + ledger recording) is complete
  and tested.
- The plugin lane's `inherited_native` ledger cells ride the same mechanism
  once the closeout runs on that lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
