### PR TITLE
Automate marketplace publication and remove the pre-merge catalog chore

### DIFF
--- a/.github/scripts/build-marketplace-fixture.mjs
+++ b/.github/scripts/build-marketplace-fixture.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Build a marketplace catalog pinned to one commit of this repository.
+//
+// The release preflight proves the Codex install path works for the candidate it is about to
+// publish. The live catalog cannot serve that proof: it points at the previous release until
+// marketplace-publish updates it after publication. Requiring a live match beforehand is what
+// forced someone to hand-edit another repository before every merge to main.
+//
+// The catalog produced here is byte-identical in shape to the live one, so the proof exercises
+// the same resolver and the same pinned git-subdir source; only the commit differs.
+//
+//   node .github/scripts/build-marketplace-fixture.mjs --out DIR --source-repository DIR --commit SHA
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value == null) fail(`invalid argument: ${key}`);
+    values[key.slice(2).replaceAll("-", "_")] = value;
+  }
+  return values;
+}
+
+const args = parseArgs(process.argv.slice(2));
+for (const key of ["out", "source_repository", "commit"]) {
+  if (!args[key]) fail(`--${key.replaceAll("_", "-")} is required`);
+}
+
+const sourceRepository = path.resolve(args.source_repository);
+const commit = execFileSync("git", ["-C", sourceRepository, "rev-parse", `${args.commit}^{commit}`], {
+  encoding: "utf8",
+}).trim();
+if (!/^[0-9a-f]{40}$/u.test(commit)) fail("commit must resolve to an immutable Git identity");
+
+const manifest = JSON.parse(
+  execFileSync(
+    "git",
+    ["-C", sourceRepository, "show", `${commit}:plugins/codestory/.codex-plugin/plugin.json`],
+    { encoding: "utf8" },
+  ),
+);
+if (typeof manifest.version !== "string" || !manifest.version) {
+  fail("pinned commit has no plugin version");
+}
+
+const catalogDirectory = path.join(path.resolve(args.out), ".agents", "plugins");
+mkdirSync(catalogDirectory, { recursive: true });
+const catalog = {
+  version: 1,
+  plugins: [
+    {
+      name: "codestory",
+      version: manifest.version,
+      source: {
+        source: "git-subdir",
+        path: "plugins/codestory",
+        url: "https://github.com/TheGreenCedar/CodeStory.git",
+        sha: commit,
+      },
+    },
+  ],
+};
+writeFileSync(
+  path.join(catalogDirectory, "marketplace.json"),
+  `${JSON.stringify(catalog, null, 2)}\n`,
+);
+
+// The fixture must be a git repository: the Codex resolver clones it like the live catalog.
+const git = (...command) =>
+  execFileSync("git", ["-C", path.resolve(args.out), ...command], { encoding: "utf8" });
+git("init", "--quiet", "--initial-branch", "main");
+git("config", "user.email", "release@codestory.invalid");
+git("config", "user.name", "CodeStory release");
+git("add", "--all");
+git("commit", "--quiet", "--message", `pin codestory ${manifest.version} at ${commit}`);
+
+console.log(`Marketplace fixture pins codestory ${manifest.version} at ${commit}.`);

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1862,6 +1862,46 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   ]);
   add(violations, !scalarStrings(release).some(value => value.includes("--generate-notes")), `${releaseFile} must use curated release notes`);
 
+  const marketplacePublish = requireJob(violations, releaseFile, release, "marketplace-publish");
+  add(
+    violations,
+    marketplacePublish.if === "inputs.publish_release",
+    `${releaseFile} marketplace publication must require trusted publication authority`,
+  );
+  add(
+    violations,
+    sameMembers(needs(marketplacePublish), releaseChain.dependencies["marketplace-publish"]),
+    `${releaseFile} marketplace publication dependencies must match the release claim graph`,
+  );
+  add(
+    violations,
+    marketplacePublish.environment === "marketplace-publish",
+    `${releaseFile} marketplace publication must hold its cross-repository credential in its own environment`,
+  );
+  add(
+    violations,
+    marketplacePublish.permissions === undefined,
+    `${releaseFile} marketplace publication must not hold repository write permission`,
+  );
+  // The credential is minted per run and scoped to the one external repository; it must never
+  // exist in a job that also runs release code.
+  const tokenStep = namedStep(marketplacePublish, "Mint a scoped marketplace token");
+  add(
+    violations,
+    String(tokenStep?.uses ?? "").startsWith("actions/create-github-app-token@")
+      && fullSha.test(String(tokenStep?.uses ?? "").split("@")[1] ?? "")
+      && object(tokenStep?.with).owner === "TheGreenCedar"
+      && object(tokenStep?.with).repositories === "AgentPluginMarketplace",
+    `${releaseFile} marketplace token must be a SHA-pinned app token scoped to the marketplace repository`,
+  );
+  requireStepRun(violations, releaseFile, marketplacePublish, "Point the catalog at the published release", [
+    "publish-marketplace-catalog.mjs",
+  ]);
+  requireStepRun(violations, releaseFile, preflight, "Prove the public marketplace install path", [
+    "build-marketplace-fixture.mjs",
+    "--local-fixture true",
+  ]);
+
   const post = requireJob(violations, releaseFile, release, "post-publish-smoke");
   add(violations, post.if === "inputs.publish_release", `${releaseFile} post-publish smoke must require trusted publication authority`);
   add(violations, post.uses === "./.github/workflows/post-publish-release-smoke.yml", `${releaseFile} must call post-publish smoke`);
@@ -1870,7 +1910,7 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     violations,
     object(post.with).emit_release_cells === true
       && object(post.with).marketplace_revision
-        === "${{ needs.preflight.outputs.marketplace_revision }}"
+        === "${{ needs.marketplace-publish.outputs.marketplace_revision }}"
       && String(object(post.with).pre_publish_closeout_artifact ?? "").startsWith("release-closeout-pre-publish-"),
     `${releaseFile} post-publish smoke must consume the proved marketplace revision and accepted pre-publish ledger`,
   );

--- a/.github/scripts/publish-marketplace-catalog.mjs
+++ b/.github/scripts/publish-marketplace-catalog.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Point the public marketplace catalog at a published CodeStory release.
+//
+// The catalog pins codestory to an exact commit of this repository. Until now a human edited it
+// by hand in the other repository *before* merging to main, timed so the pinned commit's tree
+// would still match after the merge. This runs after publication instead: the release exists, so
+// the commit being pinned is one whose plugin sources are already downloadable.
+//
+// Idempotent: if the catalog already names this commit, it succeeds without pushing, which is
+// what makes marketplace-sync.yml a safe recovery for a failed publish.
+//
+//   node .github/scripts/publish-marketplace-catalog.mjs \
+//     --source-repository DIR --commit SHA --version X.Y.Z [--github-output FILE]
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const MARKETPLACE = "TheGreenCedar/AgentPluginMarketplace";
+const CATALOG = ".agents/plugins/marketplace.json";
+const SOURCE_URL = "https://github.com/TheGreenCedar/CodeStory.git";
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value == null) fail(`invalid argument: ${key}`);
+    values[key.slice(2).replaceAll("-", "_")] = value;
+  }
+  return values;
+}
+
+const args = parseArgs(process.argv.slice(2));
+for (const key of ["source_repository", "commit", "version"]) {
+  if (!args[key]) fail(`--${key.replaceAll("_", "-")} is required`);
+}
+const token = process.env.GH_TOKEN;
+if (!token) fail("GH_TOKEN must carry a marketplace-scoped installation token");
+
+const sourceRepository = path.resolve(args.source_repository);
+const commit = execFileSync(
+  "git",
+  ["-C", sourceRepository, "rev-parse", `${args.commit}^{commit}`],
+  { encoding: "utf8" },
+).trim();
+if (!/^[0-9a-f]{40}$/u.test(commit)) fail("commit must resolve to an immutable Git identity");
+
+// Never pin a commit whose plugin sources cannot be resolved by an installing host.
+const pluginManifest = JSON.parse(
+  execFileSync(
+    "git",
+    ["-C", sourceRepository, "show", `${commit}:plugins/codestory/.codex-plugin/plugin.json`],
+    { encoding: "utf8" },
+  ),
+);
+if (pluginManifest.version !== args.version) {
+  fail(
+    `commit ${commit} carries plugin version ${pluginManifest.version}, not the published ${args.version}`,
+  );
+}
+
+const checkout = mkdtempSync(path.join(os.tmpdir(), "codestory-marketplace-"));
+const git = (...command) =>
+  execFileSync("git", ["-C", checkout, ...command], { encoding: "utf8" }).trim();
+
+execFileSync(
+  "git",
+  ["clone", "--depth", "1", `https://x-access-token:${token}@github.com/${MARKETPLACE}.git`, checkout],
+  { stdio: ["ignore", "ignore", "inherit"] },
+);
+
+const catalogPath = path.join(checkout, CATALOG);
+const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+const entry = (catalog.plugins ?? []).find(({ name }) => name === "codestory");
+if (!entry) fail(`${CATALOG} has no codestory entry`);
+if (entry.source?.url !== SOURCE_URL || entry.source?.path !== "plugins/codestory") {
+  fail(`${CATALOG} codestory entry does not point at this repository's plugin directory`);
+}
+
+const output = (revision, published) => {
+  console.log(
+    published
+      ? `Catalog now pins codestory ${args.version} at ${commit} (${revision}).`
+      : `Catalog already pins codestory ${args.version} at ${commit} (${revision}); nothing to push.`,
+  );
+  if (args.github_output) {
+    appendFileSync(args.github_output, `marketplace_revision=${revision}\n`);
+  }
+};
+
+if (entry.source.sha === commit && entry.version === args.version) {
+  output(git("rev-parse", "HEAD"), false);
+  process.exit(0);
+}
+
+entry.version = args.version;
+entry.source.sha = commit;
+writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
+
+git("config", "user.email", "release@codestory.invalid");
+git("config", "user.name", "CodeStory release");
+git("add", CATALOG);
+git("commit", "--message", `codestory ${args.version}`);
+git("push", "origin", "HEAD:main");
+output(git("rev-parse", "HEAD"), true);

--- a/.github/workflows/marketplace-sync.yml
+++ b/.github/workflows/marketplace-sync.yml
@@ -1,0 +1,75 @@
+name: Marketplace sync
+
+# Recovery for a release whose catalog push did not land.
+#
+# Publication and the catalog update are separate steps, so a failure between them leaves the
+# release published and the catalog still serving the previous one. That is the safe direction --
+# no user is offered a plugin that does not exist -- and this workflow closes the gap. It is
+# idempotent: re-running it against an already-synced catalog succeeds without pushing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Published release version to point the catalog at, without v prefix.
+        required: true
+        type: string
+      commit:
+        description: Exact published release commit on main.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: marketplace-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: marketplace-publish
+    steps:
+      - name: Checkout the published commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.commit }}
+          fetch-depth: 0
+
+      - name: Require a published release for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="v${{ inputs.version }}"
+          target="$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json targetCommitish --jq .targetCommitish)"
+          resolved="$(git rev-parse "${{ inputs.commit }}^{commit}")"
+          if [ "$target" != "$resolved" ]; then
+            echo "::error::release $tag targets $target, not $resolved. The catalog may only point at a published release commit."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$resolved" origin/main; then
+            echo "::error::$resolved is not on main."
+            exit 1
+          fi
+
+      - name: Mint a scoped marketplace token
+        id: token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1.11.3
+        with:
+          app-id: ${{ secrets.MARKETPLACE_APP_ID }}
+          private-key: ${{ secrets.MARKETPLACE_APP_PRIVATE_KEY }}
+          owner: TheGreenCedar
+          repositories: AgentPluginMarketplace
+
+      - name: Point the catalog at the published release
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/publish-marketplace-catalog.mjs \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --commit "${{ inputs.commit }}" \
+            --version "${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,13 +215,24 @@ jobs:
             --no-audit \
             --no-fund \
             "@openai/codex@$CODEX_CLI_VERSION"
+          # Fixture mode proves the install mechanics against a catalog pinned to THIS
+          # candidate. The live catalog still points at the previous release at this point --
+          # it is updated by marketplace-publish after publication -- so requiring a live
+          # tree match here is what forced a human to edit another repository before every
+          # merge to main.
+          fixture_root="$install_root/marketplace-fixture"
+          node .github/scripts/build-marketplace-fixture.mjs \
+            --out "$fixture_root" \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --commit "$GITHUB_SHA"
           node .github/scripts/install-codestory-marketplace-proof.mjs \
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \
-            --marketplace-source TheGreenCedar/AgentPluginMarketplace \
+            --marketplace-source "$fixture_root" \
             --marketplace-name TheGreenCedar \
             --marketplace-revision "$marketplace_revision" \
+            --local-fixture true \
             --expected-version "$VERSION" \
             --source-repository "$GITHUB_WORKSPACE" \
             --attestation "$install_root/install-attestation-v2.json" \
@@ -509,16 +520,57 @@ jobs:
             --title "CodeStory $TAG" \
             --notes-file target/release-assets/release-notes.md
 
+  marketplace-publish:
+    name: Publish the marketplace catalog
+    if: inputs.publish_release
+    needs:
+      - preflight
+      - publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: marketplace-publish
+    outputs:
+      marketplace_revision: ${{ steps.publish.outputs.marketplace_revision }}
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Mint a scoped marketplace token
+        id: token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1.11.3
+        with:
+          app-id: ${{ secrets.MARKETPLACE_APP_ID }}
+          private-key: ${{ secrets.MARKETPLACE_APP_PRIVATE_KEY }}
+          owner: TheGreenCedar
+          repositories: AgentPluginMarketplace
+
+      # Publication already happened, so a failure here leaves the catalog serving the previous
+      # release rather than a release that does not exist. marketplace-sync.yml recovers it.
+      - name: Point the catalog at the published release
+        id: publish
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/publish-marketplace-catalog.mjs \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --commit "$GITHUB_SHA" \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --github-output "$GITHUB_OUTPUT"
+
   post-publish-smoke:
     name: Post-publish release asset smoke
     if: inputs.publish_release
     needs:
       - preflight
       - publish
+      - marketplace-publish
     uses: ./.github/workflows/post-publish-release-smoke.yml
     with:
       version: ${{ needs.preflight.outputs.version }}
-      marketplace_revision: ${{ needs.preflight.outputs.marketplace_revision }}
+      marketplace_revision: ${{ needs.marketplace-publish.outputs.marketplace_revision }}
       pre_publish_closeout_artifact: release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
       emit_release_cells: true
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,10 +233,18 @@ adapter to compensate for incorrect upstream state.
   hardware, post-publish, installed-runtime, and live behavior evidence for the
   claims being shipped. A merge, tag, or downloadable archive alone is not
   release completion.
-- When Codex must observe a plugin-source change, publish the corresponding
-  update to `TheGreenCedar/AgentPluginMarketplace`, refresh the marketplace,
-  and verify the installed managed runtime path/version plus project-scoped
-  status. CodeStory repository state alone does not update the marketplace.
+- The release workflow owns marketplace publication. Its `marketplace-publish`
+  job points `TheGreenCedar/AgentPluginMarketplace` at the published commit
+  after the release exists, and post-publish smoke proves that catalog. Do not
+  hand-edit the catalog before a release; preflight proves the install path
+  against a candidate-pinned fixture and no longer requires the live catalog to
+  match an unreleased commit. If the catalog push fails, the release is still
+  complete and the catalog still serves the previous release: recover with the
+  `marketplace-sync` workflow rather than editing by hand.
+- For a local plugin-source change Codex must observe outside a release, refresh
+  the installed package and verify the managed runtime path/version plus
+  project-scoped status. CodeStory repository state alone does not update an
+  already-installed host.
 
 ## Platform and Security Notes
 

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
+    "graph_sha256": "9180d4fdd0e93f730511f4bdb3824d70eb3f06a3158eb5db2ddc68c974a4dac3",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
+        "graph_sha256": "9180d4fdd0e93f730511f4bdb3824d70eb3f06a3158eb5db2ddc68c974a4dac3",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
+        "graph_sha256": "9180d4fdd0e93f730511f4bdb3824d70eb3f06a3158eb5db2ddc68c974a4dac3",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "3f5a417906888d0b5eb93e8d868629ecf03b55ab497d37695a4a67f22489d780",
+  "candidate_sha256": "98fbdaf9a97d6981aab7d61a9e3695e14bf716c5d93876cb19c4f9916531ead8",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
+      "graph_sha256": "9180d4fdd0e93f730511f4bdb3824d70eb3f06a3158eb5db2ddc68c974a4dac3",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
+      "graph_sha256": "9180d4fdd0e93f730511f4bdb3824d70eb3f06a3158eb5db2ddc68c974a4dac3",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
+    "graph_sha256": "9180d4fdd0e93f730511f4bdb3824d70eb3f06a3158eb5db2ddc68c974a4dac3",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1074,9 +1074,14 @@
           "preflight",
           "pre-publish-closeout"
         ],
-        "post-publish-smoke": [
+        "marketplace-publish": [
           "preflight",
           "publish"
+        ],
+        "post-publish-smoke": [
+          "preflight",
+          "publish",
+          "marketplace-publish"
         ],
         "post-publish-closeout": [
           "preflight",

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "8a86bda8ae0ef72ed1c57ed1a83120a31e5193068187f0806ce9acdc0c1efc4b",
+      "graph_sha256": "9180d4fdd0e93f730511f4bdb3824d70eb3f06a3158eb5db2ddc68c974a4dac3",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
Closes #1461
Refs #1189, #1179

## Context

Phase D of the release-DevX plan. Two manual steps remained in every release,
both outside this repository: hand-editing the marketplace catalog before
merging to main, and up to seven environment-approval clicks.

## The ordering problem

Preflight required the live catalog's pinned commit to have a whole-repo tree
identical to the release commit. At preflight time the catalog can only point
at the *previous* release — the one being released does not exist yet. The only
way to satisfy it was to hand-edit another repository beforehand with a SHA
chosen to still tree-match after the merge.

**Inverted**: preflight proves install mechanics against a candidate-pinned
fixture (same resolver, same pinned git-subdir source, only the commit
differs); `marketplace-publish` points the live catalog at the published commit
*after* publication; post-publish smoke proves that catalog rather than the one
preflight happened to observe.

## What changed

- **`build-marketplace-fixture.mjs`** — a real git catalog repo pinned to the
  candidate, byte-shape-identical to the live one. Verified locally.
- **`marketplace-publish` job** — GitHub App token scoped to
  `AgentPluginMarketplace` alone, minted per run, in its own environment, in a
  job with **no** repository write permission that runs no release code.
  `publish-marketplace-catalog.mjs` refuses to pin a commit whose plugin
  version ≠ the published release, and is idempotent.
- **`marketplace-sync.yml`** — dispatch-only recovery. Requires the target to
  be a published release commit on main before touching the catalog. Safe
  failure direction: a failed push leaves the catalog serving the previous
  release, never one that doesn't exist.
- **Policy** pins the new job's environment, absence of write permission,
  SHA-pinned token scoped to the one repo, fixture-mode preflight, and smoke's
  consumption of the *published* revision. All four verified against their
  mutations.
- **AGENTS.md** — the workflow owns marketplace publication; the manual path is
  now documented as recovery only.

## Fixes a regression I introduced in #1460

The release-evidence fixtures attest their own bytes: re-pinning the
claim-graph digest inside `candidate.json` changed its digest without updating
the `candidate_sha256` that `report.json` pins. That left
`codestory-release-evidence-gate` **red on `dev/codestory-next`**. Bisected
(green at `5c3cd866`, red at the #1460 merge `7f7e4630`) and fixed here; the
suite is 20/20 again.

## Verification

Policy checker + 358 tests, actionlint, claims validate, evidence-gate 20/20,
closeout/cell-manifest/claims 67/67 combined, doc links, `git diff --check`.

## Your action required (not in this PR)

Zero-click needs GitHub settings changes only you can make:

1. Create the marketplace GitHub App (contents: write on
   `AgentPluginMarketplace` only); add `MARKETPLACE_APP_ID` /
   `MARKETPLACE_APP_PRIVATE_KEY` to a new `marketplace-publish` environment,
   deployment branch `main`, no reviewers.
2. Remove required reviewers from `macos-release-signing`,
   `macos-metal-release`, `windows-vulkan-proof`, `linux-vulkan-proof`.
3. Compensating controls: deployment branch policies (`main`,
   `dev/codestory-next`, `codex/*`) on those four; self-hosted runner group
   restricted to this repo, ephemeral/non-privileged; confirm `main` branch
   protection requires the source-guard check and forbids force-push.
4. Since the signing gate's human check is gone, add audit alerting on
   `macos-release-signing` access and document credential rotation.

Until step 1 is done, `marketplace-publish` will fail on a missing secret —
which is why it runs **after** publish: the release still completes and
`marketplace-sync` recovers the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
