### PR TITLE
Key persisted vectors by an embedding revision, not the release version

### DIFF
--- a/.github/scripts/check-codestory-release.py
+++ b/.github/scripts/check-codestory-release.py
@@ -94,6 +94,14 @@ def validate_model_producer(root: Path, expected: str) -> None:
         raise ValueError(
             f"{MODEL_CONTRACT} producer.version is {version!r}, expected {expected}"
         )
+    # Deliberately not compared with the release version. This keys persisted vectors, so it
+    # must be free to stay still across releases; bumping it discards every user's dense
+    # sidecars. It moves only when the embeddings themselves change.
+    revision = producer.get("embedding_revision")
+    if not isinstance(revision, str) or not SEMVER_RE.fullmatch(revision):
+        raise ValueError(
+            f"{MODEL_CONTRACT} producer.embedding_revision must be a semver string"
+        )
 
 
 def fail(message: str) -> None:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,10 @@ adapter to compensate for incorrect upstream state.
   `codestory-*` workspace crate, `Cargo.lock`, the `producer.version` in
   `crates/codestory-llama-sys/model-contract.json`, the CLI version pin in
   `plugins/codestory/cli-version.json`, and these plugin manifests:
+  (`producer.embedding_revision` is deliberately not a release surface: it keys
+  persisted vectors, so bumping it discards every user's dense sidecars. Move it
+  only when the embeddings themselves change -- model, llama.cpp commit,
+  pooling, normalization, dimension, prefixes, or vector schema.)
   - `plugins/codestory/.codex-plugin/plugin.json`
   - `plugins/codestory/.claude-plugin/plugin.json`
   - `plugins/codestory/.github/plugin/plugin.json`

--- a/crates/codestory-llama-sys/build.rs
+++ b/crates/codestory-llama-sys/build.rs
@@ -38,6 +38,7 @@ struct ModelContract {
     config_sha256: String,
     producer_name: String,
     producer_version: String,
+    producer_embedding_revision: String,
     license_spdx_id: String,
     license_source_url: String,
 }
@@ -94,15 +95,18 @@ fn main() {
         contract.llama_cpp_source_commit,
         contract.sha256,
         contract.producer_name,
-        contract.producer_version,
+        contract.producer_embedding_revision,
     );
+    // The embedding revision, not the crate version. Persisted vectors are keyed by this id, so
+    // using the release version discarded every user's dense sidecars on a bugfix that touched
+    // nothing about embeddings. The revision moves only when the embeddings themselves change.
     let product_embedding_runtime_id = format!(
         "{}:sha256-{}:llama.cpp-{}:producer-{}@{}",
         contract.embedding_family,
         contract.sha256,
         contract.llama_cpp_source_commit,
         contract.producer_name,
-        contract.producer_version
+        contract.producer_embedding_revision
     );
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR"));
@@ -609,6 +613,16 @@ fn load_model_contract() -> ModelContract {
         env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION"),
         "producer.version must match the crate version"
     );
+    // Deliberately not tied to the crate version: it must be free to stay still across releases.
+    let producer_embedding_revision = required_string(producer, "embedding_revision");
+    assert!(
+        producer_embedding_revision
+            .split('.')
+            .filter(|part| !part.is_empty())
+            .all(|part| part.bytes().all(|byte| byte.is_ascii_digit()))
+            && producer_embedding_revision.split('.').count() == 3,
+        "producer.embedding_revision must be a dotted numeric revision"
+    );
     let license_spdx_id = required_string(license, "spdx_id");
     assert_eq!(license_spdx_id, "MIT", "unsupported model license");
     let license_source_url = required_string(license, "source_url");
@@ -635,6 +649,7 @@ fn load_model_contract() -> ModelContract {
         config_sha256,
         producer_name,
         producer_version,
+        producer_embedding_revision,
         license_spdx_id,
         license_source_url,
     }

--- a/crates/codestory-llama-sys/model-contract.json
+++ b/crates/codestory-llama-sys/model-contract.json
@@ -36,6 +36,7 @@
   },
   "producer": {
     "name": "codestory-llama-sys",
+    "embedding_revision": "0.16.1",
     "version": "0.16.1"
   },
   "license": {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -153,6 +153,9 @@ function main() {
       check,
     });
   }
+  // producer.version only. producer.embedding_revision keys persisted vectors and is left
+  // alone on purpose: bumping it would discard every user's dense sidecars on a release that
+  // changed nothing about embeddings.
   rewrite(
     MODEL_CONTRACT,
     (source) => setJsonVersion(source, version, ["producer", "version"]),


### PR DESCRIPTION
Closes #1463
Refs #1179

Splits the vector-identity key from the release version so a version-only
release no longer discards every user's dense sidecars. Full rationale and
proof in the commit message; highlights:

- `producer.embedding_revision` (starts at 0.16.1 = today's vectors stay valid)
  keys `PRODUCT_EMBEDDING_RUNTIME_ID` and the native engine's producer stamp.
- Proven both directions: identity byte-identical across a version bump with
  the revision fixed; identity follows the revision when it alone moves.
- `bump-version.mjs` proven on a real bump in a cloned tree: `producer.version`
  0.16.1→0.16.2 while the revision stayed. Release validator requires the
  revision as semver but never compares it to the release version.
- One deliberate acceptance: this change itself alters nothing about the
  identity (revision == current version), so **no re-embed happens at all** —
  the plan's "one final re-embed" turned out to be avoidable by seeding the
  revision at the current value.

Verification: llama-sys 22/22, workspace 2252/0, bump tests 4/4, detector
10/10, release validator, doc links — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
