### PR TITLE
derive the plugin's preparing retry hint from observed provisioning progress

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -348,6 +348,40 @@ function managedCliDownloadProgressReport() {
   };
 }
 
+// Preparing responses derive their agent retry hint from the provisioning state this launcher
+// actually observes instead of a fixed placeholder: a fixed delay makes agents busy-poll a
+// multi-minute archive download and oversleep when readiness is imminent. While a transfer is
+// measurable, the hint is the estimated remaining transfer time at the observed throughput. The
+// clamp keeps degenerate estimates sane: the floor matches the runtime's own minimum activation
+// retry delay, and the ceiling bounds how long an agent sleeps past a completion, failure, or
+// stall the estimate could not foresee.
+const provisioningRetryHintMinMs = 250;
+const provisioningRetryHintMaxMs = 10000;
+// Provisioning states carrying no measurable transfer keep the historical fixed hint.
+const provisioningRetryHintFallbackMs = 1500;
+
+function provisioningRetryHintMs(progress = managedCliDownloadProgress) {
+  const { receivedBytes, totalBytes, startedAt, updatedAt } = progress;
+  if (
+    !Number.isSafeInteger(totalBytes) || totalBytes <= 0
+    || !Number.isSafeInteger(receivedBytes) || receivedBytes <= 0
+  ) {
+    return provisioningRetryHintFallbackMs;
+  }
+  const remainingBytes = Math.max(0, totalBytes - receivedBytes);
+  // Throughput is measured over the window that actually transferred the received bytes; a
+  // wall-clock "now" would decay the rate during a stall and inflate the estimate open-endedly.
+  const observedMs = Number.isFinite(startedAt) && Number.isFinite(updatedAt)
+    ? updatedAt - startedAt
+    : 0;
+  if (remainingBytes > 0 && observedMs <= 0) return provisioningRetryHintFallbackMs;
+  const estimatedRemainingMs = remainingBytes === 0 ? 0 : remainingBytes * (observedMs / receivedBytes);
+  return Math.min(
+    provisioningRetryHintMaxMs,
+    Math.max(provisioningRetryHintMinMs, Math.round(estimatedRemainingMs)),
+  );
+}
+
 function copyLocalReleaseFile(releaseDir, name, destination, maxBytes) {
   const source = path.join(releaseDir, name);
   try {
@@ -2566,8 +2600,10 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
       automatic: true,
     },
     allowed_surfaces: Object.fromEntries(surfaces.map((surface) => [surface, blockedSurface()])),
+    // `after_ms` matches the field the CLI runtime attaches to its own preparing
+    // recommended-next-call, so agents see one timing contract across the handoff boundary.
     recommended_next_calls: preparing
-      ? [{ method: 'tools/call', instruction: 'Retry the intended CodeStory tool shortly.', retry_after_ms: 1500 }]
+      ? [{ method: 'tools/call', instruction: 'Retry the intended CodeStory tool shortly.', after_ms: provisioningRetryHintMs() }]
       : projectRoot
         ? [{
             method: 'resources/read',
@@ -2820,7 +2856,7 @@ function managedProvisioningOperation() {
     state: 'preparing',
     stage: progress?.stage || 'downloading_runtime',
     attempt: progress?.attempt ?? 1,
-    retry_after_ms: 1500,
+    retry_after_ms: provisioningRetryHintMs(),
     failure: null,
     progress: progress
       ? {
@@ -2882,17 +2918,20 @@ function failOpenToolResult(tool, status, argumentsValue = {}) {
   const project = selection.project;
   if (tool === 'status') {
     const diagnosticsUri = projectBoundResourceUri('codestory://status', project);
+    // The top-level hint repeats the operation snapshot's so one status response never carries
+    // two disagreeing delays.
+    const currentOperation = preparing ? managedProvisioningOperation() : null;
     const structuredContent = {
       project,
       state: preparing ? 'preparing' : 'unavailable',
       degraded_reason: degradedReason,
       capabilities: { local_navigation: 'unavailable', broad_search: preparing ? 'preparing' : 'unavailable' },
-      current_operation: preparing ? managedProvisioningOperation() : null,
+      current_operation: currentOperation,
       failure: preparing ? null : primaryFailure,
       failure_context: !preparing && managedFailure ? managedCliProvisionFailure.context : null,
       hint: !preparing && managedFailure ? managedCliProvisionFailure.hint : null,
       next_action: preparing ? 'retry_intended_tool' : 'use_source_inspection',
-      retry_after_ms: preparing ? 1500 : null,
+      retry_after_ms: currentOperation ? currentOperation.retry_after_ms : null,
       diagnostics_uri: diagnosticsUri,
     };
     return {
@@ -2902,6 +2941,9 @@ function failOpenToolResult(tool, status, argumentsValue = {}) {
   }
   const diagnosticsUri = projectBoundResourceUri('codestory://status', project);
   const failureHint = managedFailure ? managedCliProvisionFailure.hint : null;
+  // The top-level hint repeats the operation snapshot's so one preparing response never carries
+  // two disagreeing delays.
+  const provisioningOperation = preparing ? managedProvisioningOperation() : null;
   const structuredContent = preparing ? {
     code: 'codestory_preparing',
     message: managedProvisioningMessage(),
@@ -2909,8 +2951,8 @@ function failOpenToolResult(tool, status, argumentsValue = {}) {
     project,
     state: 'preparing',
     retry_tool: tool,
-    retry_after_ms: 1500,
-    operation: managedProvisioningOperation(),
+    retry_after_ms: provisioningOperation.retry_after_ms,
+    operation: provisioningOperation,
     diagnostics_uri: diagnosticsUri,
   } : {
     code: 'codestory_unavailable',
@@ -3151,11 +3193,18 @@ function runFailOpenMcp(status, options = {}) {
           statusValue.project_root_source = parsedResource.projectSource;
           statusValue.diagnostics_uri = parsedResource.uri;
           if (Array.isArray(statusValue.recommended_next_calls)) {
-            statusValue.recommended_next_calls = statusValue.recommended_next_calls.map((call) =>
-              call?.method === 'resources/read'
-                && call?.uri_template === 'codestory://status{?project}'
-                ? { method: call.method, uri: parsedResource.uri }
-                : call);
+            statusValue.recommended_next_calls = statusValue.recommended_next_calls.map((call) => {
+              if (call?.method === 'resources/read'
+                && call?.uri_template === 'codestory://status{?project}') {
+                return { method: call.method, uri: parsedResource.uri };
+              }
+              // The preparing diagnostic is snapshotted when provisioning starts; the retry hint
+              // must track the download progress observed at this read, not that initial instant.
+              if (call?.method === 'tools/call' && Number.isSafeInteger(call.after_ms)) {
+                return { ...call, after_ms: provisioningRetryHintMs() };
+              }
+              return call;
+            });
           }
           response = jsonrpcResult(
             request.id,
@@ -3390,6 +3439,10 @@ if (require.main === module) {
       managedCliDownloadProgress,
       managedCliProvisionFailure,
       managedProvisioningOperation,
+      provisioningRetryHintMs,
+      provisioningRetryHintMinMs,
+      provisioningRetryHintMaxMs,
+      provisioningRetryHintFallbackMs,
       sanitizeDownloadFailure,
       releaseDownloadStallTimeoutMs,
       releaseArchiveTotalTimeoutMs,

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -28,8 +28,9 @@ ceremony.
 1. Resolve the target repository root.
 2. Call the intended tool with `project=<absolute-root>`.
 3. If the result says `state=preparing`, wait for `retry_after_ms` and retry the
-   same tool with the same arguments. Do not poll status or ask the user to set
-   up CodeStory.
+   same tool with the same arguments. The delay tracks observed preparation
+   progress, so honor the reported value instead of a fixed poll interval. Do
+   not poll status or ask the user to set up CodeStory.
 4. Preserve cited anchors in source claims. Read focused source only for the
    remaining evidence gaps.
 

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -30,6 +30,14 @@ When no complete publication exists yet, `ground`, `packet`, `search`, and
 coming up. Retry that same tool. Do not ask the user to enable, repair,
 approve, or configure an internal service.
 
+While the plugin launcher is still provisioning the managed runtime itself,
+`retry_after_ms` derives from the observed runtime-download progress: the
+estimated remaining transfer time at the observed throughput, clamped between
+250 ms and 10 s. A state with no measurable transfer reports the 1500 ms
+fallback instead. Preparing responses repeat the same value inside the embedded
+`operation` snapshot, and a preparing entry in `recommended_next_calls` carries
+it as `after_ms`.
+
 `ground`, `files`, and `affected` can build or refresh the bounded local map as
 part of the call. Once a complete publication exists, local graph tools keep
 using it during refresh and never read a half-published generation.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -617,6 +617,103 @@ test("managed probe failures stay sanitized through fail-open output", () => {
   }
 });
 
+test("provisioning retry hints derive remaining transfer time within documented bounds", () => {
+  const hint = launcherTest.provisioningRetryHintMs;
+  // States carrying no measurable transfer keep the documented fallback.
+  assert.equal(launcherTest.provisioningRetryHintFallbackMs, 1500);
+  assert.equal(hint({ receivedBytes: 0, totalBytes: null, startedAt: null, updatedAt: null }), 1500);
+  assert.equal(hint({ receivedBytes: 4096, totalBytes: null, startedAt: 0, updatedAt: 1000 }), 1500);
+  assert.equal(hint({ receivedBytes: 0, totalBytes: 1024, startedAt: 0, updatedAt: 1000 }), 1500);
+  assert.equal(hint({ receivedBytes: 10, totalBytes: 100, startedAt: 500, updatedAt: 500 }), 1500);
+  // A quarter received in one second forecasts three more seconds of transfer.
+  assert.equal(hint({ receivedBytes: 25, totalBytes: 100, startedAt: 0, updatedAt: 1000 }), 3000);
+  // A slow large download clamps to the ceiling instead of parking the agent for minutes.
+  assert.equal(
+    hint({ receivedBytes: 1024, totalBytes: 1024 * 1024 * 1024, startedAt: 0, updatedAt: 1000 }),
+    launcherTest.provisioningRetryHintMaxMs,
+  );
+  // An almost-finished transfer clamps to the floor instead of oversleeping readiness.
+  assert.equal(
+    hint({ receivedBytes: 1_048_575, totalBytes: 1_048_576, startedAt: 0, updatedAt: 10 }),
+    launcherTest.provisioningRetryHintMinMs,
+  );
+  // A completed asset needs no rate to forecast: the next provisioning stage is imminent.
+  assert.equal(
+    hint({ receivedBytes: 2048, totalBytes: 2048, startedAt: 100, updatedAt: 100 }),
+    launcherTest.provisioningRetryHintMinMs,
+  );
+});
+
+test("preparing fail-open surfaces share one progress-derived retry hint", () => {
+  const original = { ...launcherTest.managedCliDownloadProgress };
+  try {
+    Object.assign(launcherTest.managedCliDownloadProgress, {
+      stage: "downloading_runtime",
+      asset: "codestory-cli-v0.0.0-test.tar.gz",
+      attempt: 2,
+      receivedBytes: 25,
+      totalBytes: 100,
+      startedAt: 0,
+      updatedAt: 1000,
+    });
+    const operation = launcherTest.managedProvisioningOperation();
+    assert.equal(operation.retry_after_ms, 3000);
+    const preparingStatus = {
+      plugin_runtime: { plugin_version: "test" },
+      managed_retrieval: { state: "preparing" },
+      degraded_reason: "managed_cli_provisioning",
+      warnings: [],
+      readiness: [],
+    };
+    const ground = launcherTest.failOpenToolResult("ground", preparingStatus, { project: repoRoot });
+    assert.equal(ground.structuredContent.retry_after_ms, 3000);
+    assert.equal(ground.structuredContent.operation.retry_after_ms, 3000);
+    const status = launcherTest.failOpenToolResult("status", preparingStatus, { project: repoRoot });
+    assert.equal(status.structuredContent.retry_after_ms, 3000);
+    assert.equal(status.structuredContent.current_operation.retry_after_ms, 3000);
+  } finally {
+    Object.assign(launcherTest.managedCliDownloadProgress, original);
+  }
+});
+
+test("fail-open status reads refresh the preparing retry hint from live download progress", { timeout: 5000 }, async () => {
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const fixture = [
+    `const launcherModule=require(${JSON.stringify(launcher)})._test;`,
+    // The diagnostic snapshot predates the transfer, so its recommended call still carries the
+    // no-signal fallback; only the read below observes the in-flight download.
+    "const status={",
+    'plugin_runtime:{plugin_version:"test"},',
+    'managed_retrieval:{state:"preparing"},',
+    'degraded_reason:"managed_cli_provisioning",',
+    "readiness:[],",
+    "recommended_next_calls:[",
+    '{method:"tools/call",instruction:"Retry the intended CodeStory tool shortly.",after_ms:launcherModule.provisioningRetryHintFallbackMs},',
+    '{method:"resources/read",uri_template:"codestory://status{?project}"}',
+    "]};",
+    'Object.assign(launcherModule.managedCliDownloadProgress,{stage:"downloading_runtime",asset:"archive.tar.gz",attempt:1,receivedBytes:25,totalBytes:100,startedAt:0,updatedAt:1000});',
+    "launcherModule.runFailOpenMcp(()=>status);",
+  ].join("");
+  const child = spawn(process.execPath, ["-e", fixture], { stdio: ["pipe", "pipe", "pipe"] });
+  const completed = once(child, "close");
+  let output = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { output += chunk; });
+  child.stdin.end(`${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "resources/read",
+    params: { uri: statusUri },
+  })}\n`);
+  assert.equal((await completed)[0], 0);
+  const responses = output.split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+  const status = JSON.parse(responses.find((response) => response.id === 1).result.contents[0].text);
+  assert.deepEqual(status.recommended_next_calls, [
+    { method: "tools/call", instruction: "Retry the intended CodeStory tool shortly.", after_ms: 3000 },
+    { method: "resources/read", uri: statusUri },
+  ]);
+});
+
 async function writeAttestedDevPluginFixture(root, version) {
   const { cp } = await import("node:fs/promises");
   const installRoot = join(
@@ -3701,14 +3798,20 @@ test("mcp launcher serves diagnostics while managed provisioning runs, then hand
     assert.equal(coldGround.result.structuredContent.retry_tool, "ground");
     assert.equal(coldGround.result.structuredContent.project, repoRoot);
     const { progress, ...operationCore } = coldGround.result.structuredContent.operation;
+    // The gated release server withholds every asset byte here, so no transfer is measurable and
+    // the retry hint must be the documented no-signal fallback.
     assert.deepEqual(operationCore, {
       operation_id: "managed-runtime-provisioning",
       state: "preparing",
       stage: "downloading_runtime",
       attempt: 1,
-      retry_after_ms: 1500,
+      retry_after_ms: launcherTest.provisioningRetryHintFallbackMs,
       failure: null,
     });
+    assert.equal(
+      coldGround.result.structuredContent.retry_after_ms,
+      coldGround.result.structuredContent.operation.retry_after_ms,
+    );
     // Progress appears once a release asset fetch is in flight; the request can land just before
     // the background provisioner gets that far, so null is the only other legal value.
     if (progress !== null) {


### PR DESCRIPTION
Replaces the four hardcoded retry_after_ms: 1500 sites in codestory-mcp.cjs with a per-site derivation from observed provisioning progress, clamped to documented bounds, with a named fallback for states carrying no progress signal. Aligns the recommended-next-call timing field with the CLI's after_ms shape (the one real schema drift found — the compact readiness projection itself is passed through unparsed). Updates SKILL.md and the status-contract reference; adds derivation tests covering both clamp bounds, the no-signal fallback, and a progress-derived case.

Verified: plugin-static suite green including the new derivation tests; no hardcoded 1500 remains at the four sites.

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)