### PR TITLE
restore protocol and retrieval contract coverage deleted in the 0.16 rewrite

### DIFF
--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -420,6 +420,33 @@ fn assert_tool_error(response: &Value, id: Value) -> &Value {
         .expect("tools/call error should include structuredContent")
 }
 
+fn assert_error_envelope(response: &Value, id: Value) -> &Value {
+    assert_eq!(response.get("jsonrpc"), Some(&json!("2.0")));
+    assert_eq!(response.get("id"), Some(&id));
+    assert!(
+        response.get("result").is_none(),
+        "error response should not include result: {response}"
+    );
+    let error = response.get("error").expect("error object");
+    assert!(
+        error.get("code").and_then(Value::as_i64).is_some(),
+        "error should include numeric code: {response}"
+    );
+    assert!(
+        error.get("message").and_then(Value::as_str).is_some(),
+        "error should include message: {response}"
+    );
+    error
+}
+
+fn assert_error_code(error: &Value, code: i64) {
+    assert_eq!(
+        error.get("code").and_then(Value::as_i64),
+        Some(code),
+        "unexpected JSON-RPC error code: {error}"
+    );
+}
+
 fn assert_search_repaired_before_terminal_model_absence(
     server: &mut StdioServer,
     error: &Value,
@@ -5573,5 +5600,162 @@ fn failed_replacement_retries_keep_identity_and_offer_retained_local_analysis() 
         false,
         "agent_packet_search",
         "unavailable",
+    );
+}
+
+#[test]
+fn unknown_method_returns_jsonrpc_error() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({"jsonrpc": "2.0", "id": 20, "method": "codestory/nope"}),
+    );
+
+    let error = assert_error_envelope(&response, json!(20));
+    assert_error_code(error, -32601);
+    let message = error["message"]
+        .as_str()
+        .expect("error message")
+        .to_ascii_lowercase();
+    assert!(
+        message.contains("method not found") || message.contains("unknown method"),
+        "unknown method message should be stable: {response}"
+    );
+}
+
+#[test]
+fn invalid_json_returns_parse_error_with_null_id() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_line(
+        &mut server,
+        r#"{"jsonrpc":"2.0","id":21,"method":"tools/list""#,
+    );
+
+    let error = assert_error_envelope(&response, Value::Null);
+    assert_error_code(error, -32700);
+    let message = error["message"]
+        .as_str()
+        .expect("error message")
+        .to_ascii_lowercase();
+    assert!(
+        message.contains("parse error") || message.contains("json"),
+        "invalid JSON message should mention parsing: {response}"
+    );
+}
+
+#[test]
+fn oversized_stdio_frame_returns_structured_protocol_error() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+    let oversized = "x".repeat(1024 * 1024 + 1);
+
+    let response = send_line(&mut server, &oversized);
+
+    let error = assert_error_envelope(&response, Value::Null);
+    assert_error_code(error, -32700);
+    assert_eq!(
+        error.pointer("/data/code").and_then(Value::as_str),
+        Some("stdio_frame_too_large"),
+        "oversized frame should use a structured protocol error: {response}"
+    );
+    assert_eq!(
+        error
+            .pointer("/data/max_frame_bytes")
+            .and_then(Value::as_u64),
+        Some(1024 * 1024),
+        "oversized frame error should report the configured byte limit: {response}"
+    );
+    assert!(
+        error
+            .pointer("/data/line_bytes")
+            .and_then(Value::as_u64)
+            .is_some_and(|bytes| bytes > 1024 * 1024),
+        "oversized frame error should report observed line bytes: {response}"
+    );
+
+    let follow_up = send_json(
+        &mut server,
+        json!({"jsonrpc": "2.0", "id": "after-oversized", "method": "initialize"}),
+    );
+    assert_success_envelope(&follow_up, json!("after-oversized"));
+}
+
+#[test]
+fn bad_tool_call_args_return_jsonrpc_error() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 22,
+            "method": "tools/call",
+            "params": {"arguments": {"query": "AppController"}}
+        }),
+    );
+
+    let error = assert_error_envelope(&response, json!(22));
+    assert_error_code(error, -32602);
+    assert!(
+        error["message"]
+            .as_str()
+            .expect("error message")
+            .contains("tool"),
+        "bad tools/call args should name the tool problem: {response}"
+    );
+}
+
+#[test]
+fn not_found_resource_returns_jsonrpc_error() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 23,
+            "method": "resources/read",
+            "params": {"uri": "codestory://missing/resource"}
+        }),
+    );
+
+    let error = assert_error_envelope(&response, json!(23));
+    assert_error_code(error, -32602);
+    let message = error["message"].as_str().expect("error message");
+    assert!(
+        message.contains("unknown resource") || message.contains("not found"),
+        "not-found resource message should be stable: {response}"
+    );
+}
+
+#[test]
+fn unknown_prompt_returns_jsonrpc_error() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 24,
+            "method": "prompts/get",
+            "params": {"name": "not_a_prompt"}
+        }),
+    );
+
+    let error = assert_error_envelope(&response, json!(24));
+    assert_error_code(error, -32602);
+    assert!(
+        error["message"]
+            .as_str()
+            .expect("error message")
+            .contains("Unknown prompt"),
+        "unknown prompt message should identify the missing prompt: {response}"
     );
 }

--- a/crates/codestory-retrieval/tests/full_stack_integration.rs
+++ b/crates/codestory-retrieval/tests/full_stack_integration.rs
@@ -1,0 +1,229 @@
+#![cfg(feature = "test-support")]
+//! A supported local project reaches full retrieval through the embedded store
+//! and its pinned publication evidence, and fails closed before a retrieval
+//! generation is published.
+
+use codestory_contracts::graph::{Node, NodeId, NodeKind};
+use codestory_retrieval::test_support::publish_zero_dense_pinned_query_fixture;
+use codestory_retrieval::{
+    QueryRequest, RetrievalCache, RetrievalStageKind, SidecarProcessDefaults, SidecarProfile,
+    SidecarRuntimeConfig, SidecarRuntimeDefaults, SidecarRuntimeOverrides, StageCompletionStatus,
+    execute_retrieval_query_with_cache_for_runtime,
+};
+use codestory_store::{
+    FileInfo, FileRole, IndexPublicationMode, IndexPublicationRecord, SearchSymbolProjection,
+    Store, SymbolSearchDoc,
+};
+use std::path::Path;
+use tempfile::TempDir;
+
+fn runtime(project_root: &Path, cache_root: &Path) -> SidecarRuntimeConfig {
+    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        Some(project_root),
+        SidecarProfile::Local,
+        None,
+        &SidecarProcessDefaults::new(cache_root.to_path_buf(), SidecarRuntimeDefaults::default()),
+        &SidecarRuntimeOverrides::default(),
+    )
+}
+
+fn seed_fixture_graph(storage: &mut Store, project_root: &Path) -> NodeId {
+    let file_node_id = 1_001_i64;
+    storage
+        .insert_file(&FileInfo {
+            id: file_node_id,
+            path: project_root.join("lib.rs"),
+            language: "rust".to_string(),
+            modification_time: 1,
+            indexed: true,
+            complete: true,
+            line_count: 3,
+            file_role: FileRole::Entrypoint,
+        })
+        .expect("insert file");
+    storage
+        .insert_nodes_batch(&[Node {
+            id: NodeId(file_node_id),
+            kind: NodeKind::FILE,
+            serialized_name: "lib.rs".to_string(),
+            start_line: Some(1),
+            start_col: Some(0),
+            end_line: Some(3),
+            end_col: Some(0),
+            ..Default::default()
+        }])
+        .expect("file node");
+    let function = Node {
+        id: NodeId(2_001),
+        kind: NodeKind::FUNCTION,
+        serialized_name: "extension_service".to_string(),
+        qualified_name: Some("extension_service".to_string()),
+        file_node_id: Some(NodeId(file_node_id)),
+        start_line: Some(1),
+        start_col: Some(0),
+        end_line: Some(1),
+        end_col: Some(30),
+        ..Default::default()
+    };
+    storage
+        .insert_nodes_batch(std::slice::from_ref(&function))
+        .expect("function node");
+    storage
+        .upsert_search_symbol_projection_batch(&[SearchSymbolProjection {
+            node_id: function.id,
+            display_name: function.serialized_name.clone(),
+        }])
+        .expect("search projection");
+    // A symbol search doc keeps the graph identity visible through the lexical
+    // shard without producing dense anchors, so the fixture publication stays
+    // strictly zero-dense.
+    storage
+        .upsert_symbol_search_docs_batch(&[SymbolSearchDoc {
+            node_id: function.id,
+            file_node_id: Some(NodeId(file_node_id)),
+            kind: NodeKind::FUNCTION,
+            display_name: function.serialized_name.clone(),
+            qualified_name: function.qualified_name.clone(),
+            file_path: Some("lib.rs".into()),
+            start_line: Some(1),
+            doc_text: "symbol_kind: FUNCTION\nname: extension_service".into(),
+            doc_version: 1,
+            doc_hash: "extension-service-doc".into(),
+            policy_version: codestory_retrieval::SEMANTIC_POLICY_VERSION.into(),
+            source_provenance: "graph".into(),
+            updated_at_epoch_ms: 1,
+        }])
+        .expect("symbol search doc");
+    storage
+        .put_index_publication(&IndexPublicationRecord {
+            generation: 1,
+            generation_id: "11111111-1111-4111-8111-111111111111".into(),
+            run_id: "core-run-1".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        })
+        .expect("core publication");
+    function.id
+}
+
+fn seeded_project() -> (TempDir, TempDir, TempDir, std::path::PathBuf) {
+    let project = TempDir::new().expect("project");
+    std::fs::write(
+        project.path().join("lib.rs"),
+        "pub fn extension_service() {}\n",
+    )
+    .expect("write source");
+    let cache = TempDir::new().expect("cache");
+    let database = TempDir::new().expect("database");
+    let storage_path = database.path().join("codestory.db");
+    {
+        let mut storage = Store::open(&storage_path).expect("open store");
+        seed_fixture_graph(&mut storage, project.path());
+    }
+    (project, cache, database, storage_path)
+}
+
+#[test]
+fn published_generation_reaches_full_mode_and_returns_graph_backed_hits() {
+    let (project, cache, _database, storage_path) = seeded_project();
+    let runtime = runtime(project.path(), cache.path());
+
+    publish_zero_dense_pinned_query_fixture(project.path(), &storage_path, &runtime)
+        .expect("publish strict zero-dense generation");
+
+    let result = execute_retrieval_query_with_cache_for_runtime(
+        QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "extension_service",
+            budget_ms: Some(2_000),
+            cancelled: None,
+        },
+        &mut RetrievalCache::new(),
+        &runtime,
+    )
+    .expect("query embedded retrieval");
+
+    assert_eq!(result.trace.retrieval_mode, "full");
+    assert!(
+        result.trace.degraded_reason.is_none(),
+        "full mode must not carry a degraded reason: {:?}",
+        result.trace
+    );
+    assert!(
+        result
+            .hits
+            .iter()
+            .any(|hit| { hit.file_path == "lib.rs" && hit.node_id.as_deref() == Some("2001") }),
+        "expected a graph-backed lexical hit, got {:?}",
+        result.hits
+    );
+}
+
+#[test]
+fn natural_language_query_skips_semantic_stage_for_zero_dense_publication() {
+    let (project, cache, _database, storage_path) = seeded_project();
+    let runtime = runtime(project.path(), cache.path());
+
+    publish_zero_dense_pinned_query_fixture(project.path(), &storage_path, &runtime)
+        .expect("publish strict zero-dense generation");
+
+    let result = execute_retrieval_query_with_cache_for_runtime(
+        QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "how the extension service is implemented",
+            budget_ms: Some(2_000),
+            cancelled: None,
+        },
+        &mut RetrievalCache::new(),
+        &runtime,
+    )
+    .expect("query embedded retrieval");
+
+    assert_eq!(result.trace.retrieval_mode, "full");
+    let semantic_stage = result
+        .trace
+        .stages
+        .iter()
+        .find(|stage| stage.stage == RetrievalStageKind::Stage1bSemantic)
+        .expect("semantic stage trace");
+    assert_eq!(
+        semantic_stage.completion_status,
+        StageCompletionStatus::Skipped,
+        "zero-dense publications must skip the semantic stage instead of degrading"
+    );
+    assert_eq!(
+        semantic_stage.cancel_reason.as_deref(),
+        Some("zero_dense_anchors"),
+        "the skip must be attributed to the zero-dense publication: {semantic_stage:?}"
+    );
+    assert!(
+        !semantic_stage.degraded,
+        "a planned zero-dense skip is not a degraded stage: {semantic_stage:?}"
+    );
+}
+
+#[test]
+fn query_fails_closed_before_a_retrieval_generation_is_published() {
+    let (project, cache, _database, storage_path) = seeded_project();
+    let runtime = runtime(project.path(), cache.path());
+
+    let error = execute_retrieval_query_with_cache_for_runtime(
+        QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "extension_service",
+            budget_ms: Some(2_000),
+            cancelled: None,
+        },
+        &mut RetrievalCache::new(),
+        &runtime,
+    )
+    .expect_err("queries must fail closed without a published retrieval generation");
+
+    assert!(
+        format!("{error:#}").contains("retrieval sidecar manifest is missing"),
+        "fail-closed error should name the missing retrieval generation: {error:#}"
+    );
+}

--- a/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
+++ b/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
@@ -1,0 +1,301 @@
+//! Read-only browser surface contracts: graph reads serve from the complete
+//! core publication while product search and ask fail closed without full
+//! retrieval.
+
+use codestory_contracts::api::{
+    AgentAskRequest, AgentResponseModeDto, AgentRetrievalPresetDto,
+    AgentRetrievalProfileSelectionDto, ApiError, IndexMode, LayoutDirection,
+    ListRootSymbolsRequest, NodeDetailsRequest, NodeId, SearchRepoTextMode, SearchRequest,
+    TrailCallerScope, TrailConfigDto, TrailDirection, TrailMode,
+};
+use codestory_contracts::workspace::SourceIndexPolicy;
+use codestory_retrieval::{
+    SidecarProcessDefaults, SidecarProfile, SidecarRuntimeConfig, SidecarRuntimeDefaults,
+    SidecarRuntimeOverrides,
+};
+use codestory_runtime::{ReadOnlyBrowserService, Runtime, RuntimeProcessConfig};
+use std::fs;
+use std::path::Path;
+use tempfile::{TempDir, tempdir};
+
+fn write_browser_fixture(root: &Path) {
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src dir");
+    fs::write(
+        src.join("lib.rs"),
+        r#"
+pub mod browser;
+pub mod ingest;
+pub mod routing;
+
+pub use browser::{build_snapshot_digest, exact_symbol_anchor, expand_browser_context};
+pub use ingest::{BrowserEvent, parse_event as parse_ingest_event};
+pub use routing::{RouteDecision, parse_event as parse_route_event, route_browser_request};
+
+pub fn orchestrate_browser_session(payload: &str) -> RouteDecision {
+    let event = ingest::parse_event(payload);
+    let route = routing::parse_event(&event);
+    browser::expand_browser_context();
+    route
+}
+"#,
+    )
+    .expect("write lib fixture");
+    fs::write(
+        src.join("browser.rs"),
+        r#"
+use crate::routing;
+
+/// Exact anchor for symbol lookup in the browser golden fixture.
+pub fn exact_symbol_anchor() -> &'static str {
+    "exact-symbol-anchor"
+}
+
+/// Build the deterministic digest used by natural-language browser questions.
+pub fn build_snapshot_digest() -> &'static str {
+    "browser retrieval integrates ingest parsing with route decisions"
+}
+
+pub fn expand_browser_context() -> String {
+    let anchor = exact_symbol_anchor();
+    let digest = build_snapshot_digest();
+    let plan = routing::route_browser_request();
+    format!("{anchor}:{digest}:{plan}")
+}
+"#,
+    )
+    .expect("write browser fixture");
+    fs::write(
+        src.join("ingest.rs"),
+        r#"
+pub const ROUTE_LITERAL: &str = "CODESTORY_BROWSER_LITERAL";
+
+#[derive(Clone, Debug)]
+pub struct BrowserEvent {
+    pub raw: String,
+    pub marker: &'static str,
+}
+
+pub fn parse_event(input: &str) -> BrowserEvent {
+    BrowserEvent {
+        raw: input.to_string(),
+        marker: ROUTE_LITERAL,
+    }
+}
+"#,
+    )
+    .expect("write ingest fixture");
+    fs::write(
+        src.join("routing.rs"),
+        r#"
+use crate::ingest::BrowserEvent;
+
+#[derive(Clone, Debug)]
+pub struct RouteDecision {
+    pub target: &'static str,
+}
+
+pub fn parse_event(event: &BrowserEvent) -> RouteDecision {
+    let _literal = event.marker;
+    RouteDecision { target: "browser-route" }
+}
+
+pub fn route_browser_request() -> &'static str {
+    "route browser requests through ingest parse_event and build_snapshot_digest"
+}
+"#,
+    )
+    .expect("write routing fixture");
+}
+
+fn indexed_runtime() -> (Runtime, TempDir, TempDir, TempDir) {
+    let workspace = tempdir().expect("workspace dir");
+    write_browser_fixture(workspace.path());
+
+    let storage = tempdir().expect("storage dir");
+    let cache = tempdir().expect("cache dir");
+    let sidecar = SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        Some(workspace.path()),
+        SidecarProfile::Local,
+        None,
+        &SidecarProcessDefaults::new(
+            cache.path().to_path_buf(),
+            SidecarRuntimeDefaults::default(),
+        ),
+        &SidecarRuntimeOverrides::default(),
+    );
+    let runtime = Runtime::new_with_process_config(RuntimeProcessConfig::new(
+        sidecar,
+        SourceIndexPolicy::default(),
+    ));
+    let project = runtime.project_service();
+    project
+        .open_project_with_storage_path(
+            workspace.path().to_path_buf(),
+            storage.path().join("codestory.db"),
+        )
+        .expect("open project");
+    // Core-only indexing keeps the fixture without retrieval sidecars so the
+    // fail-closed contracts observe exactly the missing-full-retrieval state.
+    project
+        .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+        .expect("index workspace");
+
+    (runtime, workspace, storage, cache)
+}
+
+fn assert_mandatory_retrieval_unavailable(error: &ApiError) {
+    assert_eq!(error.code, "retrieval_unavailable");
+    assert!(
+        error
+            .message
+            .contains("retrieval is unavailable or degraded"),
+        "error should name mandatory retrieval unavailability: {error:?}"
+    );
+    assert!(
+        error.message.contains("expected profile=agent mode=full"),
+        "error should name the agent full-mode requirement: {error:?}"
+    );
+    let details = error.details.as_ref().expect("retrieval error details");
+    assert_eq!(details.failed_layer.as_deref(), Some("retrieval_engine"));
+    assert!(
+        details.next_commands.first().is_some_and(|command| {
+            command.contains("codestory-cli retrieval index --profile agent")
+                && command.contains("--format json")
+        }),
+        "retrieval error should start with the canonical retrieval repair command: {error:?}"
+    );
+    assert!(
+        details
+            .next_commands
+            .iter()
+            .any(|command| command.contains("codestory-cli retrieval status")
+                && command.contains("--format json")),
+        "retrieval error should include the retrieval status proof command: {error:?}"
+    );
+    assert!(
+        details
+            .next_commands
+            .iter()
+            .all(|command| !command.contains("codestory-cli index")),
+        "retrieval errors should not repeat core index repair commands: {error:?}"
+    );
+}
+
+fn root_symbol_id(browser: &ReadOnlyBrowserService, needle: &str, file: &str) -> NodeId {
+    // The fixture re-exports the browser symbols from lib.rs, so the defining
+    // file disambiguates the definition node from its alias.
+    browser
+        .list_root_symbols(ListRootSymbolsRequest { limit: Some(200) })
+        .expect("list root symbols")
+        .into_iter()
+        .find(|symbol| {
+            symbol.label.contains(needle)
+                && symbol
+                    .file_path
+                    .as_deref()
+                    .is_some_and(|path| path.ends_with(file))
+        })
+        .unwrap_or_else(|| panic!("expected root symbol {needle} in {file}"))
+        .id
+}
+
+#[test]
+fn exact_literal_product_search_fails_closed_without_full_retrieval() {
+    let (runtime, _workspace, _storage, _cache) = indexed_runtime();
+
+    let error = runtime
+        .browser_service()
+        .search_results(SearchRequest {
+            query: "CODESTORY_BROWSER_LITERAL".to_string(),
+            repo_text: SearchRepoTextMode::On,
+            limit_per_source: 8,
+            expand_search_plan: false,
+            hybrid_weights: None,
+            hybrid_limits: None,
+        })
+        .expect_err("mandatory product search should fail closed without full retrieval");
+
+    assert_mandatory_retrieval_unavailable(&error);
+}
+
+#[test]
+fn exact_file_literal_investigate_ask_fails_closed_without_full_retrieval() {
+    let (runtime, _workspace, _storage, _cache) = indexed_runtime();
+
+    let error = runtime
+        .browser_service()
+        .ask(AgentAskRequest {
+            prompt: "Where is CODESTORY_BROWSER_LITERAL defined?".to_string(),
+            retrieval_profile: AgentRetrievalProfileSelectionDto::Preset {
+                preset: AgentRetrievalPresetDto::Investigate,
+            },
+            focus_node_id: None,
+            max_results: Some(8),
+            response_mode: AgentResponseModeDto::Structured,
+            latency_budget_ms: Some(30_000),
+            include_evidence: true,
+            hybrid_weights: None,
+        })
+        .expect_err("investigate ask should fail closed instead of citing repo-text fallback");
+
+    assert_mandatory_retrieval_unavailable(&error);
+}
+
+#[test]
+fn graph_and_snippet_expansion_preserve_neighbor_and_source_evidence() {
+    let (runtime, _workspace, _storage, _cache) = indexed_runtime();
+    let browser = runtime.browser_service();
+
+    let focus = root_symbol_id(&browser, "expand_browser_context", "browser.rs");
+    let trail = browser
+        .trail_context(TrailConfigDto {
+            root_id: focus.clone(),
+            mode: TrailMode::Neighborhood,
+            target_id: None,
+            depth: 1,
+            direction: TrailDirection::Outgoing,
+            caller_scope: TrailCallerScope::ProductionOnly,
+            edge_filter: Vec::new(),
+            show_utility_calls: true,
+            hide_speculative: false,
+            story: false,
+            node_filter: Vec::new(),
+            max_nodes: 20,
+            layout_direction: LayoutDirection::Horizontal,
+        })
+        .expect("trail context");
+    let labels = trail
+        .trail
+        .nodes
+        .iter()
+        .map(|node| node.label.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        labels
+            .iter()
+            .any(|label| label.contains("expand_browser_context")),
+        "trail should keep the focus node: {labels:?}"
+    );
+    assert!(
+        labels
+            .iter()
+            .any(|label| label.contains("exact_symbol_anchor")),
+        "trail should preserve callee neighbor evidence: {labels:?}"
+    );
+    assert!(
+        labels
+            .iter()
+            .any(|label| label.contains("build_snapshot_digest")),
+        "trail should preserve callee neighbor evidence: {labels:?}"
+    );
+    assert!(!trail.trail.truncated);
+
+    let details = browser
+        .node_details(NodeDetailsRequest { id: focus.clone() })
+        .expect("node details");
+    assert_eq!(details.display_name, "expand_browser_context");
+    let snippet = browser.snippet_context(focus, 4).expect("snippet context");
+    assert!(snippet.snippet.contains("routing::route_browser_request"));
+}


### PR DESCRIPTION
Restores the coverage deleted rather than migrated in the 0.16 rewrite, adapted to current APIs: stdio JSON-RPC protocol contracts, the retrieval browser read-only surface contracts, and a full-mode retrieval e2e lane (gated on the crate's test-support feature, the established pattern for publication-fixture tests: cargo test -p codestory-retrieval --features test-support --test full_stack_integration).

Deliberately not resurrected, with the deleting commit as evidence of intentional contract removal: qdrant backend contracts (6865c608), docker bootstrap surface (c119e688), sidecar CLI alias and readiness-broker tests (e33bee81), and the permanently-ignored live-sidecar stubs that depended on the removed hash embed test mode.

Verified: every restored suite green; full cargo test for codestory-cli and codestory-retrieval green.

Closes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)