### PR TITLE
re-scope the windows teardown wait for the drain-time endpoint release

### DIFF
--- a/.github/scripts/packaged_agent_proof/archive_proof.py
+++ b/.github/scripts/packaged_agent_proof/archive_proof.py
@@ -153,7 +153,10 @@ def run_archive_proof(args: argparse.Namespace) -> None:
             require_frozen=require_frozen,
         )
         if args.ground_only and os.name == "nt":
-            cleanup_wait_budget = native_server_exit_wait_budget(manifest)
+            cleanup_wait_budget = native_server_exit_wait_budget(
+                manifest,
+                measurement_contract["constant_set"],
+            )
             temporary_package_directory.cleanup_retry_budget_secs = (
                 cleanup_wait_budget["timeout_ms"] / 1000
             )

--- a/.github/scripts/packaged_agent_proof/process_identity.py
+++ b/.github/scripts/packaged_agent_proof/process_identity.py
@@ -322,6 +322,14 @@ class ExactProcessExitWaiter:
             self.close()
             raise
 
+    def _windows_expired_wait_state(self, kernel) -> str:
+        exit_code = ctypes.c_uint32()
+        if not kernel.GetExitCodeProcess(self.handle, ctypes.byref(exit_code)):
+            return "in an unreadable exit state"
+        if exit_code.value == 259:
+            return "still running"
+        return f"exited with code {exit_code.value} only after the wait expired"
+
     def _wait_windows(self, timeout_ms: int, require_clean_exit: bool) -> int:
         kernel = ctypes.windll.kernel32
         kernel.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -331,14 +339,22 @@ class ExactProcessExitWaiter:
             ctypes.POINTER(ctypes.c_uint32),
         ]
         kernel.GetExitCodeProcess.restype = ctypes.c_int
+        started = time.monotonic()
         result = kernel.WaitForSingleObject(self.handle, timeout_ms)
+        if result == 258:
+            # A timed-out receipt must carry enough evidence to refute a
+            # vacuous pass: which exact process was held, how long it was
+            # actually held, and what state it was left in.
+            waited_ms = int((time.monotonic() - started) * 1000)
+            raise ProofFailure(
+                f"exact process {self.pid} (start identity"
+                f" {self.expected_start_id}) did not exit within {timeout_ms}ms:"
+                f" waited {waited_ms}ms and left it"
+                f" {self._windows_expired_wait_state(kernel)}"
+            )
         require(
             result == 0,
-            (
-                f"exact process {self.pid} did not exit within {timeout_ms}ms"
-                if result == 258
-                else f"exact process {self.pid} exit wait failed with result {result}"
-            ),
+            f"exact process {self.pid} exit wait failed with result {result}",
         )
         exit_code = ctypes.c_uint32()
         require(
@@ -353,7 +369,8 @@ class ExactProcessExitWaiter:
         return exit_code.value
 
     def _wait_unix(self, timeout_ms: int) -> None:
-        deadline = time.monotonic() + (timeout_ms / 1000)
+        started = time.monotonic()
+        deadline = started + (timeout_ms / 1000)
         while True:
             try:
                 current_identity = process_start_identity(self.pid)
@@ -369,10 +386,16 @@ class ExactProcessExitWaiter:
                 current_identity == self.expected_start_id,
                 f"process {self.pid} changed identity during exit wait",
             )
-            require(
-                time.monotonic() < deadline,
-                f"exact process {self.pid} did not exit within {timeout_ms}ms",
-            )
+            if time.monotonic() >= deadline:
+                # Match the Windows timeout evidence: exact identity, real
+                # waited duration, and the state the process was left in.
+                waited_ms = int((time.monotonic() - started) * 1000)
+                raise ProofFailure(
+                    f"exact process {self.pid} (start identity"
+                    f" {self.expected_start_id}) did not exit within"
+                    f" {timeout_ms}ms: waited {waited_ms}ms and left it still"
+                    " running with its start identity unchanged"
+                )
             time.sleep(0.01)
 
     def wait(self, timeout_ms: int, *, require_clean_exit: bool = True) -> dict:

--- a/.github/scripts/packaged_agent_proof/runtime_contract.py
+++ b/.github/scripts/packaged_agent_proof/runtime_contract.py
@@ -90,6 +90,7 @@ def run_runtime_proof(
             env,
             server_cleanup_control,
             manifest,
+            measurement_contract["constant_set"],
             require_final_server=runtime_error is None and not args.ground_only,
         )
     except BaseException as error:

--- a/.github/scripts/packaged_agent_proof/self_test_process_exit.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process_exit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -9,7 +10,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from .foundation import ProofFailure, require
+from .foundation import SERVER_CONSTANT_SET, ProofFailure, require
 from .process_identity import ExactProcessExitWaiter, process_start_identity
 from .server_cleanup import (
     _cleanup_environment,
@@ -55,8 +56,13 @@ def _exit_budget_tests() -> dict[str, int]:
         and not native_server_exit_wait_required("macos", "installed_runtime"),
         "native server exit-wait tier selection self-test failed",
     )
+    manifest = {"server_proof": {"idle_timeout_ms": 60_000}}
     budget = native_server_exit_wait_budget(
-        {"server_proof": {"idle_timeout_ms": 60_000}}
+        manifest,
+        {
+            "status": "frozen",
+            "qualification_thresholds": {"true_idle_exit": 72_285},
+        },
     )
     require(
         budget
@@ -66,6 +72,32 @@ def _exit_budget_tests() -> dict[str, int]:
             "timeout_ms": 120_000,
         },
         "native server exit-wait budget self-test failed",
+    )
+    require(
+        native_server_exit_wait_budget(
+            manifest,
+            {"status": "draft", "qualification_thresholds": {"true_idle_exit": None}},
+        )
+        == budget,
+        "an unfrozen constant set changed the conservative exit-wait budget",
+    )
+    for hostile in (
+        {"status": "frozen"},
+        {"status": "frozen", "qualification_thresholds": {"true_idle_exit": None}},
+        {"status": "frozen", "qualification_thresholds": {"true_idle_exit": 120_001}},
+    ):
+        try:
+            native_server_exit_wait_budget(manifest, hostile)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                f"a broken frozen constant set produced an exit-wait budget: {hostile!r}"
+            )
+    checked_in = json.loads(SERVER_CONSTANT_SET.read_text(encoding="utf-8"))
+    require(
+        native_server_exit_wait_budget(manifest, checked_in) == budget,
+        "the checked-in constant set no longer clears the exit-wait floor",
     )
     require(
         remaining_native_server_exit_wait_ms(120.0, 120_000, now=0.0) == 120_000
@@ -251,18 +283,21 @@ def _windows_abnormal_exit_test(target_os: str) -> None:
 
 def _exit_timeout_test(target_os: str) -> None:
     pid = os.getpid()
-    waiter = ExactProcessExitWaiter(
-        pid,
-        process_start_identity(pid),
-        target_os,
-    )
+    start_id = process_start_identity(pid)
+    waiter = ExactProcessExitWaiter(pid, start_id, target_os)
     try:
         try:
             waiter.wait(1)
         except ProofFailure as error:
+            message = str(error)
             require(
-                "did not exit within 1ms" in str(error),
-                "exact process exit timeout reported the wrong failure",
+                f"exact process {pid}" in message
+                and start_id in message
+                and "did not exit within 1ms" in message
+                and "waited" in message
+                and "still running" in message,
+                "exact process exit timeout omitted its pid, identity, waited"
+                f" duration, or final process state: {message}",
             )
         else:
             raise ProofFailure("live process bypassed the bounded exit wait")

--- a/.github/scripts/packaged_agent_proof/server_cleanup.py
+++ b/.github/scripts/packaged_agent_proof/server_cleanup.py
@@ -81,15 +81,49 @@ def native_server_exit_wait_required(target_os: str, proof_tier: str) -> bool:
     }
 
 
-def native_server_exit_wait_budget(manifest: dict) -> dict:
+def native_server_exit_wait_budget(manifest: dict, constant_set: dict) -> dict:
     product_idle_timeout_ms = require_positive_int(
         manifest["server_proof"].get("idle_timeout_ms"),
         "native server product idle timeout",
     )
+    # Re-derived for the drain-time endpoint release (PR #1452). The exit tail
+    # after the unchanged 60s idle deadline used to hold the endpoint until
+    # process exit behind an uninterruptible watchdog cadence (frozen at
+    # 19,271ms) plus native engine teardown; the endpoint is now released the
+    # moment draining starts and the watchdog wakes within a 100ms slice, so
+    # the grace funds exactly one remaining phase: Windows-native engine
+    # teardown, the span that held the AMD Vulkan pipeline cache open past
+    # candidate cleanup (WinError 32). No frozen contract measures that phase
+    # -- the calibration matrix has no Windows cell, and since the drain-time
+    # release the calibrated true_idle_exit threshold ends at owner absence
+    # rather than process exit -- so the conservative grace frozen by #1397
+    # stays. The frozen threshold still binds this budget as a floor: the
+    # receipt must never hold the exact process to a bound tighter than the
+    # whole-idle-exit claim the release itself makes.
+    timeout_ms = product_idle_timeout_ms + NATIVE_SERVER_TEARDOWN_GRACE_MS
+    require(
+        isinstance(constant_set, dict),
+        "native server exit-wait budget requires the verified constant set",
+    )
+    if constant_set.get("status") == "frozen":
+        thresholds = constant_set.get("qualification_thresholds")
+        require(
+            isinstance(thresholds, dict),
+            "frozen embedding server constants omit qualification thresholds",
+        )
+        true_idle_exit_ms = require_positive_int(
+            thresholds.get("true_idle_exit"),
+            "frozen true-idle exit qualification threshold",
+        )
+        require(
+            timeout_ms >= true_idle_exit_ms,
+            f"native server exit-wait bound {timeout_ms}ms is tighter than the"
+            f" frozen {true_idle_exit_ms}ms true-idle exit claim",
+        )
     return {
         "product_idle_timeout_ms": product_idle_timeout_ms,
         "native_teardown_grace_ms": NATIVE_SERVER_TEARDOWN_GRACE_MS,
-        "timeout_ms": product_idle_timeout_ms + NATIVE_SERVER_TEARDOWN_GRACE_MS,
+        "timeout_ms": timeout_ms,
     }
 
 
@@ -275,10 +309,11 @@ def _wait_for_pinned_servers(
     entries: list,
     final_entry: dict | None,
     manifest: dict,
+    constant_set: dict,
     *,
     require_final_server: bool,
 ) -> tuple[dict, dict, int, list[str]]:
-    wait_budget = native_server_exit_wait_budget(manifest)
+    wait_budget = native_server_exit_wait_budget(manifest, constant_set)
     timeout_ms = wait_budget["timeout_ms"]
     final_identity = final_entry.get("identity") if final_entry is not None else None
     entries.sort(
@@ -326,6 +361,7 @@ def wait_for_final_temporary_package_server(
     env: dict[str, str],
     control: dict,
     manifest: dict,
+    constant_set: dict,
     *,
     require_final_server: bool,
 ) -> dict | None:
@@ -368,6 +404,7 @@ def wait_for_final_temporary_package_server(
         entries,
         final_entry,
         manifest,
+        constant_set,
         require_final_server=require_final_server,
     )
     failures = []


### PR DESCRIPTION
The receipt checker now waits on the exact server process it launched (pid + identity evidence, not name scans), with a bound re-derived from WP6 drain-time endpoint-release semantics; timeout fails the receipt with evidence (pid, waited duration, final process state). Runtime evidence on real Windows stays owned by the platform proof lane — #1397 remains open for it.

Closes #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)