### PR TITLE
add a windows cell to the embedding calibration matrix

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2910,6 +2910,13 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && object(calibrationMacos.with).calibration_mode === true,
     `${file} protected macOS calibration must call Metal proof in calibration mode`,
   );
+  const calibrationWindows = requireJob(violations, file, workflow, "calibration-windows");
+  add(
+    violations,
+    calibrationWindows.uses === "./.github/workflows/windows-vulkan-proof.yml"
+      && object(calibrationWindows.with).calibration_mode === true,
+    `${file} protected Windows calibration must call Vulkan proof in calibration mode`,
+  );
   add(
     violations,
     at(workflow, "jobs", "macos-source") === undefined,
@@ -2927,8 +2934,9 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       "route",
       "calibration-linux",
       "calibration-macos",
+      "calibration-windows",
     ]),
-    `${file} calibration assembly must wait for both independent calibration cells`,
+    `${file} calibration assembly must wait for every independent calibration cell`,
   );
   requireStepRun(
     violations,
@@ -2937,7 +2945,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     "Assemble frozen calibration candidate",
     [
       "--assemble-calibration-bundle",
-      'test "${#runs[@]}" = 6',
+      'test "${#runs[@]}" = 9',
       "--calibration-producer-workflow-path",
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
@@ -3538,6 +3546,7 @@ function validateRemainingWorkflows(workflows, violations) {
       "Build and package native CLI",
       "Authenticate calibration bundle producer",
       "Prove protected Windows Vulkan runtime",
+      "Collect three independent Vulkan calibration runs",
       "Stage isolated candidate-managed Windows install",
       "Prove candidate-installed Windows Vulkan runtime",
     ]) {
@@ -3556,6 +3565,8 @@ function validateRemainingWorkflows(workflows, violations) {
     requireStepRun(violations, vulkanFile, job, "Validate candidate-installed mode", [
       'if ("${{ inputs.server_behavior_only }}" -ne "true")',
       "candidate_installed_proof requires server_behavior_only",
+      'if ("${{ inputs.calibration_mode }}" -ne "false")',
+      "candidate_installed_proof cannot run in calibration mode",
     ]);
     const sourceBuildTools = namedStep(job, "Capture source build tool evidence");
     add(
@@ -3585,21 +3596,30 @@ function validateRemainingWorkflows(workflows, violations) {
     add(
       violations,
       namedStep(job, "Install pinned Rust")?.if
-        === "${{ !inputs.use_packaged_cli_artifact || !inputs.server_behavior_only }}",
+        === "${{ !inputs.use_packaged_cli_artifact || inputs.calibration_mode || !inputs.server_behavior_only }}",
       `${vulkanFile} packaged server-behavior proof must skip unused Rust installation`,
     );
     add(
       violations,
       namedStep(job, "Build qualification driver")?.if
-        === "${{ !inputs.server_behavior_only }}",
+        === "${{ inputs.calibration_mode || !inputs.server_behavior_only }}",
       `${vulkanFile} packaged server-behavior proof must skip the qualification driver`,
     );
     requireCalibrationProducerBoundary(
       violations,
       vulkanFile,
       job,
-      "${{ !inputs.server_behavior_only }}",
+      "${{ !inputs.calibration_mode && !inputs.server_behavior_only }}",
     );
+    requireStepRun(violations, vulkanFile, job, "Collect three independent Vulkan calibration runs", [
+      "(Get-Content crates/codestory-llama-sys/per-user-embedding-server-constant-set.json -Raw | ConvertFrom-Json).status",
+      '-ne "unfrozen"',
+      "--proof-tier calibration",
+      "--qualification-matrix-cell protected_windows_x64_vulkan",
+      "--calibration-run-index",
+      "--calibration-run-output",
+      "if ($LASTEXITCODE -ne 0)",
+    ]);
     const engine = namedStep(job, "Prove protected Windows Vulkan runtime");
     requireStepRun(violations, vulkanFile, job, "Prove protected Windows Vulkan runtime", [
       "--engine-policy accelerated",
@@ -3624,14 +3644,14 @@ function validateRemainingWorkflows(workflows, violations) {
     );
     add(
       violations,
-      engine?.if === "${{ !inputs.candidate_installed_proof }}",
+      engine?.if === "${{ !inputs.calibration_mode && !inputs.candidate_installed_proof }}",
       `${vulkanFile} protected Windows Vulkan proof must yield to the candidate-installed lane`,
     );
     const candidateStage = namedStep(job, "Stage isolated candidate-managed Windows install");
     add(
       violations,
-      candidateStage?.if === "inputs.candidate_installed_proof",
-      `${vulkanFile} candidate-managed staging must require explicit candidate mode`,
+      candidateStage?.if === "${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}",
+      `${vulkanFile} candidate-managed staging must require candidate mode outside calibration`,
     );
     requireStepRun(violations, vulkanFile, job, "Stage isolated candidate-managed Windows install", [
       "--prepare-candidate-installed-proof",
@@ -3655,8 +3675,8 @@ function validateRemainingWorkflows(workflows, violations) {
     const candidateProof = namedStep(job, "Prove candidate-installed Windows Vulkan runtime");
     add(
       violations,
-      candidateProof?.if === "inputs.candidate_installed_proof",
-      `${vulkanFile} candidate-installed Vulkan proof must require explicit candidate mode`,
+      candidateProof?.if === "${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}",
+      `${vulkanFile} candidate-installed Vulkan proof must require candidate mode outside calibration`,
     );
     requireStepRun(violations, vulkanFile, job, "Prove candidate-installed Windows Vulkan runtime", [
       "--proof-tier installed_runtime",
@@ -3710,8 +3730,8 @@ function validateRemainingWorkflows(workflows, violations) {
     const releaseCell = namedStep(job, "Emit authenticated Vulkan release cell");
     add(
       violations,
-      releaseCell?.if === "inputs.emit_release_cells",
-      `${vulkanFile} accelerated proof must retain the authenticated Vulkan release cell`,
+      releaseCell?.if === "inputs.emit_release_cells && !inputs.calibration_mode",
+      `${vulkanFile} accelerated proof must retain the authenticated Vulkan release cell outside calibration`,
     );
     const vulkanCellUpload = namedStep(job, "Upload authenticated Vulkan release cell");
     add(
@@ -4166,6 +4186,10 @@ function validateReleaseArtifactRerunSafety(workflows, violations) {
     ["macos-metal-proof.yml/packaged-metal/Upload Metal calibration runs", {
       name: "embedding-calibration-macos-${{ inputs.version }}",
       path: "target/calibration-runs/macos",
+    }],
+    ["windows-vulkan-proof.yml/packaged-vulkan/Upload Vulkan calibration runs", {
+      name: "embedding-calibration-windows-${{ inputs.version }}",
+      path: "target/calibration-runs/windows",
     }],
     ["release.yml/pre-publish-closeout/Upload accepted pre-publish closeout", {
       name: "release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -527,6 +527,7 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
   const packagedProofFile = "packaged-platform-proof.yml";
   const linuxVulkanFile = "linux-vulkan-proof.yml";
   const metalProofFile = "macos-metal-proof.yml";
+  const windowsVulkanFile = "windows-vulkan-proof.yml";
   const sourceResolver = workflow => draftStep(workflow.jobs.resolve, "Resolve trusted exact head");
   const packagedResolver = workflow => draftStep(workflow.jobs.route, "Resolve trusted exact head");
 
@@ -713,6 +714,56 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
         "per-user-embedding-server-constant-set.json",
       );
     }, /Collect three independent Metal calibration runs must run test "\$\(jq -r \.status crates\/codestory-llama-sys\/per-user-embedding-server-constant-set\.json\)"/u],
+    ["Vulkan calibration reads the calibration contract from an unpinned location", windowsVulkanFile, workflow => {
+      const step = draftStep(
+        workflow.jobs["packaged-vulkan"],
+        "Collect three independent Vulkan calibration runs",
+      );
+      step.run = step.run.replaceAll(
+        "crates/codestory-llama-sys/per-user-embedding-server-constant-set.json",
+        "per-user-embedding-server-constant-set.json",
+      );
+    }, /Collect three independent Vulkan calibration runs must run \(Get-Content crates\/codestory-llama-sys\/per-user-embedding-server-constant-set\.json -Raw \| ConvertFrom-Json\)\.status/u],
+    ["Vulkan calibration accepts a frozen constant set", windowsVulkanFile, workflow => {
+      const step = draftStep(
+        workflow.jobs["packaged-vulkan"],
+        "Collect three independent Vulkan calibration runs",
+      );
+      step.run = step.run.replace('-ne "unfrozen"', '-ne "frozen"');
+    }, /Collect three independent Vulkan calibration runs must run -ne "unfrozen"/u],
+    ["Vulkan calibration masks a failed early run", windowsVulkanFile, workflow => {
+      const step = draftStep(
+        workflow.jobs["packaged-vulkan"],
+        "Collect three independent Vulkan calibration runs",
+      );
+      step.run = step.run.replace("if ($LASTEXITCODE -ne 0) {", "if ($false) {");
+    }, /Collect three independent Vulkan calibration runs must run if \(\$LASTEXITCODE -ne 0\)/u],
+    ["Vulkan release cell is emitted during calibration", windowsVulkanFile, workflow => {
+      draftStep(workflow.jobs["packaged-vulkan"], "Emit authenticated Vulkan release cell").if
+        = "inputs.emit_release_cells";
+    }, /must retain the authenticated Vulkan release cell outside calibration/u],
+    ["Vulkan candidate staging runs during calibration", windowsVulkanFile, workflow => {
+      draftStep(workflow.jobs["packaged-vulkan"], "Stage isolated candidate-managed Windows install").if
+        = "inputs.candidate_installed_proof";
+    }, /candidate-managed staging must require candidate mode outside calibration/u],
+    ["Vulkan candidate proof runs during calibration", windowsVulkanFile, workflow => {
+      draftStep(workflow.jobs["packaged-vulkan"], "Prove candidate-installed Windows Vulkan runtime").if
+        = "inputs.candidate_installed_proof";
+    }, /candidate-installed Vulkan proof must require candidate mode outside calibration/u],
+    ["protected Windows Vulkan proof runs during calibration", windowsVulkanFile, workflow => {
+      draftStep(workflow.jobs["packaged-vulkan"], "Prove protected Windows Vulkan runtime").if
+        = "${{ !inputs.candidate_installed_proof }}";
+    }, /protected Windows Vulkan proof must yield to the candidate-installed lane/u],
+    ["Vulkan qualification driver skips calibration", windowsVulkanFile, workflow => {
+      draftStep(workflow.jobs["packaged-vulkan"], "Build qualification driver").if
+        = "${{ !inputs.server_behavior_only }}";
+    }, /packaged server-behavior proof must skip the qualification driver/u],
+    ["Vulkan calibration downloads a frozen bundle", windowsVulkanFile, workflow => {
+      draftStep(workflow.jobs["packaged-vulkan"], "Authenticate calibration bundle producer").if
+        = "${{ !inputs.server_behavior_only }}";
+      draftStep(workflow.jobs["packaged-vulkan"], "Download frozen calibration bundle").if
+        = "${{ !inputs.server_behavior_only }}";
+    }, /calibration authentication and download must run only for qualification or freeze lineage/u],
   ];
 
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
@@ -937,6 +988,20 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     ["calibration mode enables frozen Linux qualification", coordinatorFile, workflow => {
       workflow.jobs["calibration-linux"].with.hermetic_linux = true;
     }, /hosted Linux calibration must call packaged proof in calibration mode/u],
+    ["Windows calibration cell leaves calibration mode", coordinatorFile, workflow => {
+      workflow.jobs["calibration-windows"].with.calibration_mode = false;
+    }, /protected Windows calibration must call Vulkan proof in calibration mode/u],
+    ["Windows calibration cell reroutes to the package workflow", coordinatorFile, workflow => {
+      workflow.jobs["calibration-windows"].uses = "./.github/workflows/packaged-platform-proof.yml";
+    }, /protected Windows calibration must call Vulkan proof in calibration mode/u],
+    ["calibration assembly skips the Windows cell", coordinatorFile, workflow => {
+      workflow.jobs["calibration-assemble"].needs = workflow.jobs["calibration-assemble"].needs
+        .filter(name => name !== "calibration-windows");
+    }, /calibration assembly must wait for every independent calibration cell/u],
+    ["calibration assembly accepts the pre-Windows run count", coordinatorFile, workflow => {
+      const step = draftStep(workflow.jobs["calibration-assemble"], "Assemble frozen calibration candidate");
+      step.run = step.run.replace('test "${#runs[@]}" = 9', 'test "${#runs[@]}" = 6');
+    }, /Assemble frozen calibration candidate must run test "\$\{#runs\[@\]\}" = 9/u],
     ["coordinator adds a macOS source hard gate", coordinatorFile, workflow => {
       workflow.jobs["macos-source"] = {
         "runs-on": "macos-14",

--- a/.github/scripts/packaged_agent_proof/measurement_protocol_validation.py
+++ b/.github/scripts/packaged_agent_proof/measurement_protocol_validation.py
@@ -202,8 +202,10 @@ def _verify_calibration_matrix(matrix: dict, calibration_matrix: object) -> None
         == {
             "hosted_linux_x64_cpu",
             "protected_macos_arm64_metal",
+            "protected_windows_x64_vulkan",
         },
-        "measurement calibration matrix must contain the Linux CPU and macOS Metal pre-publish lanes",
+        "measurement calibration matrix must contain the Linux CPU, macOS Metal, "
+        "and Windows Vulkan pre-publish lanes",
     )
     for cell_id, cell in calibration_matrix.items():
         require(

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
@@ -119,8 +119,8 @@ def _calibration_bundle_tests(
         )
     )
     require(
-        assembled["run_count"] == 6
-        and assembled["matrix_cell_count"] == 2
+        assembled["run_count"] == 9
+        and assembled["matrix_cell_count"] == 3
         and assembled_bundle_path.is_file()
         and assembled_constant_path.is_file(),
         "calibration assembler did not produce the exact frozen artifacts",
@@ -131,8 +131,8 @@ def _calibration_bundle_tests(
         enforce_source_lineage=False,
     )
     require(
-        calibration_result["run_count"] == 6
-        and calibration_result["matrix_cell_count"] == 2,
+        calibration_result["run_count"] == 9
+        and calibration_result["matrix_cell_count"] == 3,
         "calibration bundle self-test did not verify the full matrix",
     )
     return CalibrationFixture(

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -285,17 +285,30 @@ jobs:
       use_packaged_cli_artifact: false
       calibration_mode: true
 
+  calibration-windows:
+    if: needs.route.outputs.mode == 'calibration'
+    needs: route
+    uses: ./.github/workflows/windows-vulkan-proof.yml
+    with:
+      version: ${{ needs.route.outputs.version }}
+      ref: ${{ needs.route.outputs.head_sha }}
+      proof_key: calibration-windows-${{ needs.route.outputs.head_sha }}
+      use_packaged_cli_artifact: false
+      calibration_mode: true
+
   calibration-assemble:
     if: >-
       always() &&
       needs.route.result == 'success' &&
       needs.route.outputs.mode == 'calibration' &&
       needs.calibration-linux.result == 'success' &&
-      needs.calibration-macos.result == 'success'
+      needs.calibration-macos.result == 'success' &&
+      needs.calibration-windows.result == 'success'
     needs:
       - route
       - calibration-linux
       - calibration-macos
+      - calibration-windows
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -317,6 +330,12 @@ jobs:
           name: embedding-calibration-macos-${{ needs.route.outputs.version }}
           path: target/calibration-inputs/macos
 
+      - name: Download protected Windows calibration runs
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: embedding-calibration-windows-${{ needs.route.outputs.version }}
+          path: target/calibration-inputs/windows
+
       - name: Assemble frozen calibration candidate
         shell: bash
         env:
@@ -329,7 +348,7 @@ jobs:
               \( -name 'run-1.json' -o -name 'run-2.json' -o -name 'run-3.json' \) \
               -print | sort
           )
-          test "${#runs[@]}" = 6
+          test "${#runs[@]}" = 9
           run_args=()
           for run in "${runs[@]}"; do
             run_args+=(--calibration-run "$run")
@@ -364,8 +383,8 @@ jobs:
             --arg source_head_sha "$EXPECTED_HEAD_SHA" \
             --arg producer_run_id "$GITHUB_RUN_ID" \
             '.selection_source.commit == $source_head_sha
-             and .run_count == 6
-             and .matrix_cell_count == 2
+             and .run_count == 9
+             and .matrix_cell_count == 3
              and .producer_run_id == $producer_run_id' \
             target/calibration-freeze/manifest.json >/dev/null
 

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -29,6 +29,11 @@ on:
         required: false
         default: ""
         type: string
+      calibration_mode:
+        description: Collect three independent pre-freeze Vulkan calibration runs.
+        required: false
+        default: false
+        type: boolean
       candidate_installed_proof:
         description: Install and prove the exact package through the candidate-managed launcher boundary.
         required: false
@@ -70,6 +75,11 @@ on:
         required: false
         default: ""
         type: string
+      calibration_mode:
+        description: Collect three independent pre-freeze Vulkan calibration runs.
+        required: false
+        default: false
+        type: boolean
       candidate_installed_proof:
         description: Install and prove the exact package through the candidate-managed launcher boundary.
         required: false
@@ -99,7 +109,7 @@ jobs:
     name: Packaged Windows Vulkan engine
     runs-on: [self-hosted, Windows, X64, codestory-vulkan]
     environment: windows-vulkan-proof
-    timeout-minutes: 120
+    timeout-minutes: ${{ inputs.calibration_mode && 180 || 120 }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -129,6 +139,9 @@ jobs:
           if ("${{ inputs.server_behavior_only }}" -ne "true") {
             throw "candidate_installed_proof requires server_behavior_only"
           }
+          if ("${{ inputs.calibration_mode }}" -ne "false") {
+            throw "candidate_installed_proof cannot run in calibration mode"
+          }
 
       - name: Capture source build tool evidence
         if: ${{ !inputs.use_packaged_cli_artifact }}
@@ -139,7 +152,7 @@ jobs:
           ninja --version | Out-File -Append target/windows-vulkan-proof/host.txt
 
       - name: Install pinned Rust
-        if: ${{ !inputs.use_packaged_cli_artifact || !inputs.server_behavior_only }}
+        if: ${{ !inputs.use_packaged_cli_artifact || inputs.calibration_mode || !inputs.server_behavior_only }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           rustup toolchain install 1.95.0 --profile minimal
@@ -172,7 +185,7 @@ jobs:
           path: target/release-dist
 
       - name: Build qualification driver
-        if: ${{ !inputs.server_behavior_only }}
+        if: ${{ inputs.calibration_mode || !inputs.server_behavior_only }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification
 
@@ -184,7 +197,7 @@ jobs:
           path: target/release-quality-evidence
 
       - name: Authenticate calibration bundle producer
-        if: ${{ !inputs.server_behavior_only }}
+        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           GH_TOKEN: ${{ github.token }}
@@ -215,7 +228,7 @@ jobs:
           }
 
       - name: Download frozen calibration bundle
-        if: ${{ !inputs.server_behavior_only }}
+        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only }}
         uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.calibration_bundle_artifact }}
@@ -224,7 +237,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Prove protected Windows Vulkan runtime
-        if: ${{ !inputs.candidate_installed_proof }}
+        if: ${{ !inputs.calibration_mode && !inputs.candidate_installed_proof }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           VERSION: ${{ inputs.version }}
@@ -281,8 +294,53 @@ jobs:
             --timeout-secs 1800 `
             --out-dir target/windows-vulkan-proof/packaged-agent
 
+      - name: Collect three independent Vulkan calibration runs
+        if: inputs.calibration_mode
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
+        env:
+          VERSION: ${{ inputs.version }}
+          CODESTORY_EMBED_ALLOW_CPU: "0"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $constantStatus = (Get-Content crates/codestory-llama-sys/per-user-embedding-server-constant-set.json -Raw | ConvertFrom-Json).status
+          if ($constantStatus -ne "unfrozen") {
+            throw "calibration collection requires the unfrozen constant set"
+          }
+          $version = $env:VERSION.TrimStart('v')
+          $sourceSha = (git rev-parse HEAD).Trim()
+          $sourceTree = (git rev-parse 'HEAD^{tree}').Trim()
+          New-Item -ItemType Directory -Force target/calibration-runs/windows | Out-Null
+          foreach ($runIndex in 1, 2, 3) {
+            python .github/scripts/check-packaged-agent-proof.py `
+              --archive "target/release-dist/codestory-cli-v$version-windows-x64.zip" `
+              --checksum-file "target/release-dist/codestory-cli-v$version-windows-x64.zip.sha256" `
+              --expected-version $version `
+              --project "${{ github.workspace }}" `
+              --plugin-root plugins/codestory `
+              --plugin-handoff `
+              --engine-policy accelerated `
+              --expected-backend Vulkan `
+              --offline `
+              --proof-tier calibration `
+              --qualification-matrix-cell protected_windows_x64_vulkan `
+              --produce-qualification-evidence `
+              --qualification-driver target/release/codestory_embedding_qualification.exe `
+              --qualification-evidence "target/calibration-runs/windows/qualification-$runIndex.json" `
+              --calibration-run-index $runIndex `
+              --calibration-run-output "target/calibration-runs/windows/run-$runIndex.json" `
+              --expected-source-sha $sourceSha `
+              --expected-source-tree $sourceTree `
+              --timeout-secs 1800 `
+              --out-dir "target/calibration-runs/windows/proof-$runIndex"
+            # The Actions PowerShell wrapper propagates only the final exit code, so an
+            # early failed run must not be masked by a later clean one.
+            if ($LASTEXITCODE -ne 0) {
+              throw "calibration run $runIndex failed"
+            }
+          }
+
       - name: Stage isolated candidate-managed Windows install
-        if: inputs.candidate_installed_proof
+        if: ${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           GH_TOKEN: ${{ github.token }}
@@ -336,7 +394,7 @@ jobs:
             --candidate-artifact-name (Split-Path -Leaf $archive)
 
       - name: Prove candidate-installed Windows Vulkan runtime
-        if: inputs.candidate_installed_proof
+        if: ${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           VERSION: ${{ inputs.version }}
@@ -380,7 +438,7 @@ jobs:
             --out-dir target/candidate-installed-windows/proof
 
       - name: Upload candidate-installed Windows proof
-        if: always() && inputs.candidate_installed_proof
+        if: always() && inputs.candidate_installed_proof && !inputs.calibration_mode
         uses: actions/upload-artifact@v7.0.1
         with:
           name: candidate-installed-windows-${{ inputs.version }}-attempt-${{ github.run_attempt }}
@@ -389,7 +447,7 @@ jobs:
           retention-days: 30
 
       - name: Emit authenticated Vulkan release cell
-        if: inputs.emit_release_cells
+        if: inputs.emit_release_cells && !inputs.calibration_mode
         shell: bash
         run: |
           set -euo pipefail
@@ -414,7 +472,7 @@ jobs:
             --out target/release-cells/accelerator_execution-windows-x64-vulkan.json
 
       - name: Upload authenticated Vulkan release cell
-        if: success() && inputs.emit_release_cells
+        if: success() && inputs.emit_release_cells && !inputs.calibration_mode
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-cell-prepublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}
@@ -423,7 +481,7 @@ jobs:
           retention-days: 30
 
       - name: Emit authenticated Windows retrieval-readiness release cell
-        if: inputs.emit_release_cells && inputs.server_behavior_only
+        if: inputs.emit_release_cells && inputs.server_behavior_only && !inputs.calibration_mode
         shell: bash
         run: |
           set -euo pipefail
@@ -443,7 +501,7 @@ jobs:
             --out target/release-cells/retrieval_readiness-windows-x64.json
 
       - name: Upload authenticated Windows retrieval-readiness release cell
-        if: success() && inputs.emit_release_cells && inputs.server_behavior_only
+        if: success() && inputs.emit_release_cells && inputs.server_behavior_only && !inputs.calibration_mode
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-cell-postpublish-retrieval-windows-x64-attempt-${{ github.run_attempt }}
@@ -452,7 +510,7 @@ jobs:
           retention-days: 30
 
       - name: Emit authenticated candidate-installed Windows release cell
-        if: inputs.emit_release_cells && inputs.candidate_installed_proof
+        if: inputs.emit_release_cells && inputs.candidate_installed_proof && !inputs.calibration_mode
         shell: bash
         run: |
           set -euo pipefail
@@ -479,7 +537,7 @@ jobs:
             --out target/release-cells/candidate_installed_behavior-windows-x64.json
 
       - name: Upload authenticated candidate-installed Windows release cell
-        if: success() && inputs.emit_release_cells && inputs.candidate_installed_proof
+        if: success() && inputs.emit_release_cells && inputs.candidate_installed_proof && !inputs.calibration_mode
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-cell-prepublish-candidate-installed-windows-x64-attempt-${{ github.run_attempt }}
@@ -487,8 +545,18 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+      - name: Upload Vulkan calibration runs
+        if: always() && inputs.calibration_mode
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: embedding-calibration-windows-${{ inputs.version }}
+          path: target/calibration-runs/windows
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
+
       - name: Upload Vulkan proof artifacts
-        if: always()
+        if: always() && !inputs.calibration_mode
         uses: actions/upload-artifact@v7.0.1
         with:
           name: windows-x64-vulkan-proof-${{ inputs.version }}-attempt-${{ github.run_attempt }}

--- a/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json
@@ -82,6 +82,16 @@
       "cache_state": "reused",
       "residency_state": "resident",
       "accelerator_claim": "metal"
+    },
+    "protected_windows_x64_vulkan": {
+      "asset_target": "windows-x64",
+      "proof_tier": "calibration",
+      "host_class": "protected_self_hosted_windows_x64",
+      "policy": "accelerated",
+      "backend": "vulkan",
+      "cache_state": "reused",
+      "residency_state": "resident",
+      "accelerator_claim": "vulkan"
     }
   },
   "host_package_matrix": {
@@ -555,7 +565,7 @@
       }
     },
     "post_result_formula_changes": false,
-    "slow_host_floor_rationale": "The calibration matrix is hosted Linux x64 and protected macOS arm64 only, so no Windows named-pipe host and no host without SHA hardware acceleration contributes to the maxima these budgets scale. A release executable also embeds the model, and the spawned server hashes its whole image before it binds, so the spawn budget must cover a multi-hundred-megabyte read on a cold cache. 1.50x over a CI maximum does not cover that population. The floors are the pre-freeze draft values, which were the vetted conservative behavior. Thresholds are deliberately not floored: qualification keeps measuring regressions against the calibrated maxima while users get budgets sized for the slowest supported host."
+    "slow_host_floor_rationale": "The calibration matrix is hosted Linux x64, protected macOS arm64, and protected Windows x64 only, so while Windows named-pipe hosts now contribute to the maxima these budgets scale, no host without SHA hardware acceleration does. A release executable also embeds the model, and the spawned server hashes its whole image before it binds, so the spawn budget must cover a multi-hundred-megabyte read on a cold cache. 1.50x over a CI maximum does not cover that population. The floors are the pre-freeze draft values, which were the vetted conservative behavior. Thresholds are deliberately not floored: qualification keeps measuring regressions against the calibrated maxima while users get budgets sized for the slowest supported host."
   },
   "threshold_selection": {
     "minimum_clean_calibration_runs_per_matrix_cell": 3,


### PR DESCRIPTION
Adds the Windows calibration cell (mirroring the existing protected Windows proof-job conventions), threads its measurements through assembly fail-closed (missing Windows run fails the freeze; the old 6-digest freeze record fails the now-9-digest check), policy checker + full test suite updated in the same change. The actual Windows calibration run happens in CI post-merge as part of the re-freeze.

Note for the re-freeze operator: collection gates on status=unfrozen, so the constant set gets unfrozen right before dispatch — the WP5-invalidated freeze record is already stale either way.

Closes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)