### PR TITLE
surface the write-side windows pipe close as a classified disconnect

### DIFF
--- a/.github/scripts/packaged_agent_proof/qualification_scenario_evidence.py
+++ b/.github/scripts/packaged_agent_proof/qualification_scenario_evidence.py
@@ -84,22 +84,22 @@ class ReplayAttempt:
     submitted_ns: int
     completed_ns: int
     outcome: str
+    loss_code: str | None
 
 
 def _validated_replay_attempt(value: object, index: int) -> ReplayAttempt:
     require(isinstance(value, dict), "replay attempt is malformed")
-    require_exact_keys(
-        value,
-        {
-            "ordinal",
-            "request_id",
-            "server_instance_id",
-            "submitted_ns",
-            "completed_ns",
-            "outcome",
-        },
-        f"replay attempt {index}",
-    )
+    expected = {
+        "ordinal",
+        "request_id",
+        "server_instance_id",
+        "submitted_ns",
+        "completed_ns",
+        "outcome",
+    }
+    if "loss_code" in value:
+        expected.add("loss_code")
+    require_exact_keys(value, expected, f"replay attempt {index}")
     require(value["ordinal"] == index, "replay attempt ordinal is not exact")
     request_id = require_nonempty_string(
         value["request_id"],
@@ -122,6 +122,16 @@ def _validated_replay_attempt(value: object, index: int) -> ReplayAttempt:
         value["outcome"],
         f"replay attempt {index} outcome",
     )
+    loss_code = value.get("loss_code")
+    if loss_code is not None:
+        loss_code = require_nonempty_string(
+            loss_code,
+            f"replay attempt {index} loss_code",
+        )
+    require(
+        (outcome == "server_loss") == (loss_code is not None),
+        f"replay attempt {index} loss classification does not match its outcome",
+    )
     return ReplayAttempt(
         ordinal=index,
         request_id=request_id,
@@ -129,6 +139,7 @@ def _validated_replay_attempt(value: object, index: int) -> ReplayAttempt:
         submitted_ns=submitted_ns,
         completed_ns=completed_ns,
         outcome=outcome,
+        loss_code=loss_code,
     )
 
 
@@ -157,6 +168,14 @@ def validate_replay_attempts(
         and replay.server_instance_id == new_server_instance_id
         and replay.outcome == "completed",
         "replay attempts do not bind the old loss and exact replacement completion",
+    )
+    # These scenarios kill a live peer mid-RPC, so the original loss must be
+    # the classified transport disconnect; an unresponsive-owner timeout here
+    # is the misclassification that previously masked real Windows named-pipe
+    # disconnects.
+    require(
+        original.loss_code == "embedding_server_connection_lost",
+        "replay original loss is not the classified transport disconnect",
     )
     return attempts
 

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_external.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_external.py
@@ -214,6 +214,7 @@ def _server_crash_scenario_tests() -> None:
                             "submitted_ns": 1,
                             "completed_ns": 2,
                             "outcome": "server_loss",
+                            "loss_code": "embedding_server_connection_lost",
                         },
                         {
                             "ordinal": 2,
@@ -261,6 +262,25 @@ def _server_crash_scenario_tests() -> None:
         pass
     else:
         raise ProofFailure("named scenario transitions with false values were accepted")
+    misclassified_scenario = json.loads(json.dumps(scenario_observations))
+    misclassified_scenario["query_replayed"][0]["values"]["wire_attempts"][0][
+        "loss_code"
+    ] = "embedding_server_owner_unresponsive"
+    try:
+        derive_scenario_assertions(
+            "server_crash",
+            observations_by_kind=misclassified_scenario,
+            process_observations=[],
+            invocations=[],
+            same_account={},
+            materialization={},
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure(
+            "a crash loss misclassified as an unresponsive owner was accepted"
+        )
 
 
 def _fault_consistency_tests(fixture: FullStackFixture) -> dict:

--- a/.github/scripts/packaged_agent_proof/self_test_qualification.py
+++ b/.github/scripts/packaged_agent_proof/self_test_qualification.py
@@ -13,8 +13,9 @@ def _replay_attempt(
     request_id: str,
     server_instance_id: str,
     outcome: str,
+    loss_code: str | None = None,
 ) -> dict[str, object]:
-    return {
+    attempt: dict[str, object] = {
         "ordinal": ordinal,
         "request_id": request_id,
         "server_instance_id": server_instance_id,
@@ -22,6 +23,9 @@ def _replay_attempt(
         "completed_ns": ordinal * 10 + 1,
         "outcome": outcome,
     }
+    if loss_code is not None:
+        attempt["loss_code"] = loss_code
+    return attempt
 
 
 def run_qualification_self_tests() -> None:
@@ -57,7 +61,13 @@ def run_qualification_self_tests() -> None:
     replay = {
         "wire_attempt_count": 2,
         "wire_attempts": [
-            _replay_attempt(1, "request-1", "server-old", "server_loss"),
+            _replay_attempt(
+                1,
+                "request-1",
+                "server-old",
+                "server_loss",
+                loss_code="embedding_server_connection_lost",
+            ),
             _replay_attempt(2, "request-2", "server-new", "completed"),
         ],
     }
@@ -67,7 +77,10 @@ def run_qualification_self_tests() -> None:
         new_server_instance_id="server-new",
     )
     require(
-        attempts[0].outcome == "server_loss" and attempts[1].outcome == "completed",
+        attempts[0].outcome == "server_loss"
+        and attempts[0].loss_code == "embedding_server_connection_lost"
+        and attempts[1].outcome == "completed"
+        and attempts[1].loss_code is None,
         "typed replay validation changed",
     )
     stale_replay = copy.deepcopy(replay)
@@ -82,3 +95,45 @@ def run_qualification_self_tests() -> None:
         pass
     else:
         raise ProofFailure("replay against the stale server was accepted")
+    misclassified_replay = copy.deepcopy(replay)
+    misclassified_replay["wire_attempts"][0]["loss_code"] = (
+        "embedding_server_owner_unresponsive"
+    )
+    try:
+        validate_replay_attempts(
+            misclassified_replay,
+            old_server_instance_id="server-old",
+            new_server_instance_id="server-new",
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure(
+            "an unresponsive-owner timeout was accepted as the disconnect loss"
+        )
+    unclassified_replay = copy.deepcopy(replay)
+    del unclassified_replay["wire_attempts"][0]["loss_code"]
+    try:
+        validate_replay_attempts(
+            unclassified_replay,
+            old_server_instance_id="server-old",
+            new_server_instance_id="server-new",
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("a loss without a typed classification was accepted")
+    mislabeled_replay = copy.deepcopy(replay)
+    mislabeled_replay["wire_attempts"][1]["loss_code"] = (
+        "embedding_server_connection_lost"
+    )
+    try:
+        validate_replay_attempts(
+            mislabeled_replay,
+            old_server_instance_id="server-old",
+            new_server_instance_id="server-new",
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("a completed attempt carrying a loss code was accepted")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
   the background. The model keeps running between commands as before, so later
   commands do not reload it. A runtime crash now also reports the raw Windows
   exit code instead of a bare failure.
+- On Windows, losing the connection to the embedding runtime while sending it a
+  request is recognized as a disconnect and retried once against the
+  replacement, instead of waiting out the full request deadline and failing as
+  an unresponsive runtime. The recorded failure keeps the raw Windows error
+  code and whether the runtime exited, so a crash can be told apart from an
+  external kill.
 
 ### Faster
 

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
@@ -159,14 +159,20 @@ pub(super) fn validate_replay_attempts(
     new_server_instance_id: &str,
     phase: &str,
 ) -> Result<()> {
+    // Crash and stall scenarios kill a live peer mid-RPC, so the original
+    // loss must be the classified transport disconnect; an
+    // unresponsive-owner timeout here means the platform transport
+    // misclassified a real disconnect again.
     if attempts.len() != 2
         || attempts[0].ordinal != 1
         || attempts[1].ordinal != 2
         || attempts[0].request_id == attempts[1].request_id
         || attempts[0].server_instance_id != old_server_instance_id
         || attempts[0].outcome != "server_loss"
+        || attempts[0].loss_code.as_deref() != Some("embedding_server_connection_lost")
         || attempts[1].server_instance_id != new_server_instance_id
         || attempts[1].outcome != "completed"
+        || attempts[1].loss_code.is_some()
         || attempts.iter().any(|attempt| {
             attempt.request_id.trim().is_empty() || attempt.submitted_ns > attempt.completed_ns
         })

--- a/crates/codestory-cli/src/embedding_server_transport.rs
+++ b/crates/codestory-cli/src/embedding_server_transport.rs
@@ -864,6 +864,41 @@ fn classify_windows_data_pipe_open_error(
     })
 }
 
+#[cfg(any(windows, test))]
+const WINDOWS_ERROR_PIPE_BUSY_CODE: u32 = 231;
+
+#[cfg(any(windows, test))]
+const WINDOWS_ERROR_NO_DATA_CODE: u32 = 232;
+
+#[cfg(any(windows, test))]
+const WINDOWS_ERROR_PIPE_LISTENING_CODE: u32 = 536;
+
+/// Whether a failed nonblocking named-pipe ReadFile may keep polling inside
+/// its configured deadline. ERROR_NO_DATA on a read only reports an empty
+/// pipe; a peer that closed its end surfaces as ERROR_BROKEN_PIPE or
+/// ERROR_PIPE_NOT_CONNECTED, which must escape the poll loop.
+#[cfg(any(windows, test))]
+fn windows_pipe_read_failure_is_pollable(error_code: u32) -> bool {
+    matches!(
+        error_code,
+        WINDOWS_ERROR_PIPE_BUSY_CODE
+            | WINDOWS_ERROR_NO_DATA_CODE
+            | WINDOWS_ERROR_PIPE_LISTENING_CODE
+    )
+}
+
+/// Whether a failed nonblocking named-pipe WriteFile may keep polling inside
+/// its configured deadline. ERROR_NO_DATA is deliberately not pollable on a
+/// write: a full kernel buffer surfaces as a successful zero-byte write, so
+/// a failing write with this code means the peer end of the pipe is gone.
+/// Polling it would burn the whole write deadline and then misreport a real
+/// disconnect as an unresponsive owner instead of a connection loss carrying
+/// its raw code and peer-exit evidence.
+#[cfg(any(windows, test))]
+fn windows_pipe_write_failure_is_pollable(error_code: u32) -> bool {
+    error_code == WINDOWS_ERROR_PIPE_BUSY_CODE
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ExecutableFileIdentity {
     native_identity: codestory_workspace::WorkspacePathIdentity,
@@ -2922,6 +2957,7 @@ mod platform {
         ENDPOINT_NAMESPACE, ExecutableAttestationStore, NativeConnectOutcome,
         QUALIFICATION_DIR_ENV, QUALIFICATION_NONCE_ENV, RetainedWindowsAuthorityState,
         TransportIdentity, awake_deadline_ns, classify_windows_data_pipe_open_error, sha256_fields,
+        windows_pipe_read_failure_is_pollable, windows_pipe_write_failure_is_pollable,
     };
     use anyhow::{Context, Result, bail};
     use std::ffi::c_void;
@@ -2965,6 +3001,14 @@ mod platform {
         PROCESS_QUERY_LIMITED_INFORMATION,
     };
     use windows_sys::Win32::System::WindowsProgramming::QueryUnbiasedInterruptTimePrecise;
+
+    // The host-testable poll classification must decide on the exact Win32
+    // values the platform calls below observe.
+    const _: () = {
+        assert!(super::WINDOWS_ERROR_PIPE_BUSY_CODE == ERROR_PIPE_BUSY);
+        assert!(super::WINDOWS_ERROR_NO_DATA_CODE == ERROR_NO_DATA);
+        assert!(super::WINDOWS_ERROR_PIPE_LISTENING_CODE == ERROR_PIPE_LISTENING);
+    };
 
     const NO_TIMEOUT: u64 = u64::MAX;
     const PIPE_BUFFER_BYTES: usize = 1024 * 1024;
@@ -3179,7 +3223,7 @@ mod platform {
                 let error = std::io::Error::last_os_error();
                 match error.raw_os_error().map(|code| code as u32) {
                     Some(ERROR_BROKEN_PIPE) | Some(ERROR_PIPE_NOT_CONNECTED) => return Ok(()),
-                    Some(ERROR_NO_DATA) | Some(ERROR_PIPE_BUSY) | Some(ERROR_PIPE_LISTENING) => {
+                    Some(code) if windows_pipe_read_failure_is_pollable(code) => {
                         wait_pipe_io(
                             started,
                             self.read_timeout_ns.load(Ordering::Acquire),
@@ -3226,11 +3270,7 @@ mod platform {
                 if !error
                     .raw_os_error()
                     .map(|code| code as u32)
-                    .is_some_and(|code| {
-                        code == ERROR_NO_DATA
-                            || code == ERROR_PIPE_BUSY
-                            || code == ERROR_PIPE_LISTENING
-                    })
+                    .is_some_and(windows_pipe_read_failure_is_pollable)
                 {
                     return Err(normalize_windows_pipe_io_error(error));
                 }
@@ -3284,7 +3324,7 @@ mod platform {
                 if !error
                     .raw_os_error()
                     .map(|code| code as u32)
-                    .is_some_and(|code| code == ERROR_NO_DATA || code == ERROR_PIPE_BUSY)
+                    .is_some_and(windows_pipe_write_failure_is_pollable)
                 {
                     return Err(normalize_windows_pipe_io_error(error));
                 }
@@ -4087,6 +4127,99 @@ mod platform {
         }
 
         #[test]
+        fn write_to_a_closed_named_pipe_surfaces_the_pipe_closing_code_immediately() {
+            let current_sid = current_process_sid().expect("current process SID");
+            let sid_string = sid_string(&current_sid).expect("current SID string");
+            let security_sddl = wide(&format!(
+                "O:{sid_string}D:P(A;;GA;;;{sid_string})(A;;GA;;;SY)"
+            ));
+            let pipe_name = wide(&format!(
+                r"\\.\pipe\codestory-write-disconnect-test-{}-{}",
+                unsafe { GetCurrentProcessId() },
+                awake_now_ns()
+            ));
+            let server = create_pipe_instance(&pipe_name, &security_sddl, true, true)
+                .expect("create named-pipe server");
+            let client = unsafe {
+                CreateFileW(
+                    pipe_name.as_ptr(),
+                    GENERIC_READ | GENERIC_WRITE,
+                    0,
+                    null(),
+                    OPEN_EXISTING,
+                    0,
+                    null_mut(),
+                )
+            };
+            assert_ne!(client, INVALID_HANDLE_VALUE, "connect named-pipe client");
+            let client = unsafe { OwnedHandle::from_raw_handle(client.cast()) };
+            let nonblocking = PIPE_READMODE_BYTE | PIPE_NOWAIT;
+            assert_ne!(
+                unsafe { SetNamedPipeHandleState(raw(&client), &nonblocking, null(), null()) },
+                0,
+                "set named-pipe client nonblocking"
+            );
+            if unsafe { ConnectNamedPipe(raw(&server), null_mut()) } == 0 {
+                let error = std::io::Error::last_os_error();
+                assert_eq!(
+                    error.raw_os_error().map(|code| code as u32),
+                    Some(ERROR_PIPE_CONNECTED),
+                    "client connection must be the only failed accept state"
+                );
+            }
+
+            let peer_pid = unsafe { GetCurrentProcessId() };
+            let peer_process_start_id =
+                canonical_process_start_identity(peer_pid).expect("current process start identity");
+            let mut stream = Stream::new(
+                client,
+                false,
+                TransportIdentity {
+                    endpoint_namespace_id: "test-endpoint".into(),
+                    lifetime_authority_id: "test-authority".into(),
+                    listener_id: "test-listener".into(),
+                    peer_verified: true,
+                    peer_pid: Some(peer_pid),
+                    peer_process_start_id: Some(peer_process_start_id),
+                },
+            )
+            .expect("retain named-pipe client stream");
+            stream
+                .set_write_timeout(Some(
+                    codestory_retrieval::EmbeddingClientBudgets::current().query_request,
+                ))
+                .expect("bound request write");
+            // Close the raw server handle without DisconnectNamedPipe so the
+            // writer observes the peer-close code rather than the explicit
+            // disconnect code already covered above.
+            drop(server);
+
+            let started = std::time::Instant::now();
+            let error = stream
+                .write(&[7_u8; 8])
+                .expect_err("a write to a closed named pipe must fail");
+
+            assert!(
+                started.elapsed() < Duration::from_secs(2),
+                "a real disconnect must escape the write poll loop instead of \
+                 burning the configured write deadline"
+            );
+            assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+            assert_eq!(
+                error.raw_os_error().map(|code| code as u32),
+                Some(ERROR_NO_DATA)
+            );
+            assert!(stream.peer_is_alive().expect("probe retained peer"));
+            eprintln!(
+                "named-pipe write disconnect evidence: raw_os_error={} normalized_kind={:?} \
+                 elapsed_ms={} peer_state=running",
+                ERROR_NO_DATA,
+                error.kind(),
+                started.elapsed().as_millis()
+            );
+        }
+
+        #[test]
         fn final_response_delivery_waits_for_the_client_to_drain_before_disconnect() {
             let current_sid = current_process_sid().expect("current process SID");
             let sid_string = sid_string(&current_sid).expect("current SID string");
@@ -4666,6 +4799,38 @@ mod tests {
         )
         .expect("missing data pipe is classified");
         assert!(matches!(outcome, NativeConnectOutcome::NoOwner));
+    }
+
+    #[test]
+    fn windows_pipe_closing_write_code_escapes_the_poll_loop_while_empty_reads_wait() {
+        // ERROR_NO_DATA reports an empty pipe to a nonblocking reader but a
+        // vanished peer to a writer, so only the read side may keep polling.
+        assert!(windows_pipe_read_failure_is_pollable(
+            WINDOWS_ERROR_NO_DATA_CODE
+        ));
+        assert!(!windows_pipe_write_failure_is_pollable(
+            WINDOWS_ERROR_NO_DATA_CODE
+        ));
+
+        assert!(windows_pipe_read_failure_is_pollable(
+            WINDOWS_ERROR_PIPE_BUSY_CODE
+        ));
+        assert!(windows_pipe_write_failure_is_pollable(
+            WINDOWS_ERROR_PIPE_BUSY_CODE
+        ));
+        assert!(windows_pipe_read_failure_is_pollable(
+            WINDOWS_ERROR_PIPE_LISTENING_CODE
+        ));
+        assert!(!windows_pipe_write_failure_is_pollable(
+            WINDOWS_ERROR_PIPE_LISTENING_CODE
+        ));
+
+        // ERROR_BROKEN_PIPE and ERROR_PIPE_NOT_CONNECTED are disconnects on
+        // both directions and must surface with their raw code retained.
+        for disconnect_code in [109, 233] {
+            assert!(!windows_pipe_read_failure_is_pollable(disconnect_code));
+            assert!(!windows_pipe_write_failure_is_pollable(disconnect_code));
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/per_user_embedding/client.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/client.rs
@@ -520,10 +520,15 @@ impl PerUserEmbeddingClient {
                 Ok::<_, anyhow::Error>((result, payload))
             })();
             let completed_ns = clock.now_ns();
-            let outcome = match &call {
-                Ok(_) => "completed",
-                Err(error) if is_server_loss(error) => "server_loss",
-                Err(_) => "failed",
+            let (outcome, loss_code) = match &call {
+                Ok(_) => ("completed", None),
+                Err(error) if is_server_loss(error) => (
+                    "server_loss",
+                    error
+                        .downcast_ref::<PerUserEmbeddingError>()
+                        .map(|typed| typed.code.clone()),
+                ),
+                Err(_) => ("failed", None),
             };
             attempts.push(EmbeddingQualificationAttemptResult {
                 ordinal: attempts.len() as u32 + 1,
@@ -532,6 +537,7 @@ impl PerUserEmbeddingClient {
                 submitted_ns,
                 completed_ns,
                 outcome: outcome.into(),
+                loss_code,
             });
             match call {
                 Ok(result) => return Ok((result, attempts)),

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs
@@ -74,6 +74,11 @@ pub struct EmbeddingQualificationAttemptResult {
     pub submitted_ns: u64,
     pub completed_ns: u64,
     pub outcome: String,
+    /// The typed code behind a `server_loss` outcome, so retained replay
+    /// evidence can distinguish a classified transport disconnect from an
+    /// unresponsive-owner timeout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loss_code: Option<String>,
 }
 
 pub(super) type EmbeddingQualificationAttemptExchange = (

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/client_replay.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/client_replay.rs
@@ -59,6 +59,37 @@ fn pure_rpc_replays_once_and_only_once_on_typed_loss() {
 }
 
 #[test]
+fn windows_pipe_closing_write_loss_is_classified_and_replayed_exactly_once() {
+    let transport = BootstrapTestTransport::new(
+        [BootstrapConnectOutcome::WriteDisconnect],
+        BootstrapConnectOutcome::Connected,
+        Duration::from_millis(5),
+    );
+    let client = PerUserEmbeddingClient {
+        transport: transport.clone(),
+        compatibility: EmbeddingCompatibility::current(true),
+        scope_id: "test-scope".into(),
+    };
+
+    let (vector, attempts) = client
+        .embed_query_with_qualification_attempts("x")
+        .expect("a classified pipe-closing write loss earns exactly one replay");
+
+    assert_eq!(vector.len(), RETRIEVAL_EMBEDDING_DIM);
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(attempts[0].outcome, "server_loss");
+    assert_eq!(
+        attempts[0].loss_code.as_deref(),
+        Some("embedding_server_connection_lost"),
+        "the recorded loss must be the classified transport disconnect, \
+         not an unresponsive-owner timeout"
+    );
+    assert_eq!(attempts[1].outcome, "completed");
+    assert_eq!(attempts[1].loss_code, None);
+    assert_ne!(attempts[0].request_id, attempts[1].request_id);
+}
+
+#[test]
 fn pure_rpc_replay_waits_for_a_fail_stopped_owner_to_release_authority() {
     let transport = BootstrapTestTransport::new(
         [

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/client_transports.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/client_transports.rs
@@ -140,6 +140,7 @@ impl EmbeddingClientTransport for ControlledCancelTestTransport {
 pub(super) enum BootstrapConnectOutcome {
     Connected,
     Loss,
+    WriteDisconnect,
     HelloLoss,
     NoOwner,
     OwnerUnresponsive,
@@ -344,6 +345,12 @@ impl EmbeddingClientTransport for BootstrapTestTransport {
             BootstrapConnectOutcome::Loss => EmbeddingConnectOutcome::Connected(Box::new(
                 ScriptStream::new(ScriptOutcome::Loss, self.compatibility.clone()),
             )),
+            BootstrapConnectOutcome::WriteDisconnect => {
+                EmbeddingConnectOutcome::Connected(Box::new(ScriptStream::new(
+                    ScriptOutcome::WriteDisconnect,
+                    self.compatibility.clone(),
+                )))
+            }
             BootstrapConnectOutcome::HelloLoss => EmbeddingConnectOutcome::Connected(Box::new(
                 ScriptStream::new(ScriptOutcome::HelloLoss, self.compatibility.clone()),
             )),

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/protocol_transport.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/protocol_transport.rs
@@ -188,6 +188,35 @@ fn bounded_exchange_maps_normalized_disconnect_and_retains_peer_evidence() {
 }
 
 #[test]
+fn bounded_exchange_maps_the_write_side_pipe_closing_code_and_retains_exit_evidence() {
+    // ERROR_NO_DATA (232) is the only signal a Windows named-pipe writer
+    // receives when the peer end is gone; the platform surfaces it with the
+    // portable BrokenPipe kind and the raw code retained.
+    let raw_error = io::Error::from_raw_os_error(232);
+    let normalized = io::Error::new(io::ErrorKind::BrokenPipe, raw_error);
+    let source = anyhow::Error::new(normalized).context("write embedding control length");
+    let (mut stream, _) = MemoryStream::new(Vec::new(), false);
+    stream.exit_codes = Mutex::new(vec![Some(1)]);
+
+    let error = map_bounded_exchange_error(source, &stream);
+    let retry = embedding_retry_state(&error).expect("typed connection loss");
+
+    assert_eq!(retry.code, "embedding_server_connection_lost");
+    assert_eq!(retry.retry_class, "same_rpc_once");
+    assert!(retry.message.contains("raw_os_error=232"));
+    assert!(retry.message.contains("peer_pid=42"));
+    assert!(retry.message.contains("peer_process_start_id=server-start"));
+    assert!(retry.message.contains("peer_state=exited"));
+    assert!(retry.message.contains("peer_exit_code=1"));
+    assert!(
+        retry
+            .message
+            .contains("source=write embedding control length")
+    );
+    assert_eq!(exchange_raw_os_error(&error), Some(232));
+}
+
+#[test]
 fn bounded_exchange_does_not_type_unrelated_io_errors() {
     let source = anyhow::Error::new(io::Error::new(
         io::ErrorKind::PermissionDenied,

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/transport_fixtures.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/transport_fixtures.rs
@@ -165,10 +165,15 @@ impl EmbeddingServerStream for MemoryStream {
     }
 }
 
+/// The raw Win32 code a named-pipe writer observes when the peer end closed:
+/// ERROR_NO_DATA, "the pipe is being closed".
+pub(super) const WINDOWS_PIPE_CLOSING_RAW_CODE: i32 = 232;
+
 #[derive(Clone)]
 pub(super) enum ScriptOutcome {
     Success,
     Loss,
+    WriteDisconnect,
     HelloLoss,
     Capacity,
     TimedBulk {
@@ -189,6 +194,7 @@ pub(super) struct ScriptStream {
     pub(super) outcome: ScriptOutcome,
     pub(super) compatibility: EmbeddingCompatibility,
     pub(super) read_gate: Option<Arc<AtomicBool>>,
+    pub(super) hello_completed: bool,
 }
 
 impl ScriptStream {
@@ -200,6 +206,7 @@ impl ScriptStream {
             outcome,
             compatibility,
             read_gate: None,
+            hello_completed: false,
         }
     }
 
@@ -221,7 +228,11 @@ impl ScriptStream {
     ) -> io::Result<Option<(EmbeddingProtocolResponse, Vec<u8>)>> {
         let request_id = request.request_id;
         match request.operation {
-            EmbeddingOperation::Hello { .. } => self.hello_response(&request_id),
+            EmbeddingOperation::Hello { .. } => {
+                let response = self.hello_response(&request_id);
+                self.hello_completed = true;
+                response
+            }
             EmbeddingOperation::EmbedQuery { .. } => self.query_response(&request_id),
             EmbeddingOperation::EmbedDocuments { inputs, .. } => {
                 self.documents_response(&request_id, inputs.len())
@@ -328,6 +339,9 @@ impl ScriptStream {
                 )))
             }
             ScriptOutcome::HelloLoss => Err(io::Error::other("query reached hello-loss stream")),
+            ScriptOutcome::WriteDisconnect => Err(io::Error::other(
+                "query write must fail before a response is produced",
+            )),
             ScriptOutcome::TimedBulk { .. } => {
                 Err(io::Error::other("query reached timed bulk stream"))
             }
@@ -402,6 +416,15 @@ impl Read for ScriptStream {
 
 impl Write for ScriptStream {
     fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self.hello_completed && matches!(self.outcome, ScriptOutcome::WriteDisconnect) {
+            // The exact shape the Windows transport surfaces when the peer
+            // closed the pipe during a request write: the portable
+            // BrokenPipe kind with the raw pipe-closing code retained.
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                io::Error::from_raw_os_error(WINDOWS_PIPE_CLOSING_RAW_CODE),
+            ));
+        }
         self.writes.extend_from_slice(buffer);
         Ok(buffer.len())
     }


### PR DESCRIPTION
Closes the remaining write-side gap from #1383 (read-side 109/233 landed in #1384): ERROR_NO_DATA (232) on a write to a closed named pipe now classifies as embedding_server_connection_lost with the raw OS code preserved and exit evidence retained; the receipt checker now insists crash/stall loss carries the classified disconnect, so the old misclassification fails the receipt.

Proof boundary: the classifier and replay boundary are pure over error shape — host tests exercise the identical code paths; the windows module is type-checked verbatim for x86_64-pc-windows-msvc via the scratch-crate technique. Physical named-pipe execution stays owned by the Windows platform proof lane; #1383 remains open for it.

Closes #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)