### PR TITLE
stage the candidate proof install through the shared flat managed layout

### DIFF
--- a/.github/scripts/packaged_agent_proof/candidate_installation.py
+++ b/.github/scripts/packaged_agent_proof/candidate_installation.py
@@ -17,6 +17,12 @@ from .archive_io import (
 from .contract_primitives import sha256, write_json
 from .foundation import CANDIDATE_PRODUCER_WORKFLOW_PATHS, REPOSITORY_ROOT, require
 from .installation_support import directory_contract_sha256, same_existing_path
+from .managed_layout import (
+    managed_archive_name,
+    managed_binary_name,
+    require_provisioner_package_root,
+    stage_flat_managed_install,
+)
 from .native_manifest import load_native_manifest
 
 
@@ -73,20 +79,14 @@ def _verify_candidate_checkout(source_plugin: Path, manifest: dict) -> None:
     )
 
 
-def _expected_archive_name(version: str, asset_target: str) -> str:
-    suffix = "zip" if asset_target.startswith("windows-") else "tar.gz"
-    return f"codestory-cli-v{version}-{asset_target}.{suffix}"
-
-
 def _managed_manifest(
     archive: Path,
     manifest: dict,
-    relative_cli: str,
     version: str,
 ) -> dict:
     archive_sha256 = sha256(archive)
     return {
-        "path": relative_cli,
+        "path": managed_binary_name(manifest["asset_target"]),
         "sha256": manifest["binary"]["sha256"],
         "version": version,
         "build_source": "candidate_archive",
@@ -114,25 +114,25 @@ def _stage_candidate_installation(
         manifest = load_native_manifest(unpacked, cli, version)
         _verify_candidate_checkout(source_plugin, manifest)
         require(
-            archive.name == _expected_archive_name(version, manifest["asset_target"]),
+            archive.name == managed_archive_name(version, manifest["asset_target"]),
             "candidate install archive name does not match its package target",
         )
-        package_root = cli.parent
+        package_root = require_provisioner_package_root(
+            unpacked,
+            archive.name,
+            manifest["asset_target"],
+        )
         require(
-            package_root.parent == unpacked,
-            "candidate install archive must contain one package root",
+            cli == package_root / managed_binary_name(manifest["asset_target"]),
+            "candidate install launcher is not the package root launcher",
         )
         shutil.copytree(source_plugin, plugin_output)
-        version_root = data_output / "codestory-cli" / version
-        shutil.copytree(package_root, version_root)
-        write_json(
-            version_root / "manifest.json",
-            _managed_manifest(
-                archive,
-                manifest,
-                cli.relative_to(package_root).as_posix(),
-                version,
-            ),
+        stage_flat_managed_install(
+            package_root,
+            data_output,
+            version,
+            manifest["asset_target"],
+            _managed_manifest(archive, manifest, version),
         )
         return manifest
 

--- a/.github/scripts/packaged_agent_proof/ground_proof.py
+++ b/.github/scripts/packaged_agent_proof/ground_proof.py
@@ -17,8 +17,13 @@ from .contract_primitives import (
     write_private_json,
 )
 from .foundation import LOWER_TIER_NONCLAIMS, require
-from .installation_support import assert_no_legacy_state, qualification_environment
+from .installation_support import (
+    assert_no_legacy_state,
+    qualification_environment,
+    same_existing_path,
+)
 from .installed_identity import installed_plugin_identity
+from .managed_layout import verify_flat_managed_layout
 from .managed_runtime import verify_managed_runtime_status
 from .server_engine_identity import engine_identity
 from .server_identity import server_snapshot
@@ -97,6 +102,15 @@ def _managed_ground_runtime(
     require(
         managed_binary.is_relative_to(args.installed_plugin_data.resolve()),
         "installed managed executable is outside the installed plugin data root",
+    )
+    staged_launcher = verify_flat_managed_layout(
+        args.installed_plugin_data.resolve(),
+        manifest["release_version"],
+        manifest["asset_target"],
+    )
+    require(
+        same_existing_path(managed_binary, staged_launcher),
+        "installed managed executable is not the flat provisioned launcher",
     )
     require(
         managed_binary != cli.resolve(),

--- a/.github/scripts/packaged_agent_proof/managed_layout.py
+++ b/.github/scripts/packaged_agent_proof/managed_layout.py
@@ -1,0 +1,158 @@
+"""Flat managed-CLI install layout shared by staging and verification.
+
+The plugin provisioner (provisionManagedCli in
+plugins/codestory/scripts/codestory-mcp.cjs) publishes a release by copying
+the archive's single package root directly into
+<plugin data>/codestory-cli/<version>/ and writing manifest.json beside the
+launcher, keeping the executable path one flat segment on every platform.
+Staging and every checker derive that layout from this module so the proof
+fails whenever either side drifts from what managed provisioning installs.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from .contract_primitives import sha256, write_json
+from .foundation import HEX_SHA256, TARGET_CONTRACTS, ProofFailure, require
+
+MANAGED_CLI_DIR_NAME = "codestory-cli"
+MANAGED_MANIFEST_NAME = "manifest.json"
+# The provisioner owns these names inside the version root, so a package that
+# shipped them would collide with provisioner state instead of installing.
+RESERVED_PACKAGE_PATHS = ("manifest.json", ".provisioning")
+_ARCHIVE_SUFFIXES = (".zip", ".tar.gz")
+
+
+def managed_binary_name(asset_target: str) -> str:
+    require(
+        asset_target in TARGET_CONTRACTS,
+        f"unsupported managed install target: {asset_target}",
+    )
+    return TARGET_CONTRACTS[asset_target]["binary_name"]
+
+
+def managed_archive_name(version: str, asset_target: str) -> str:
+    require(
+        asset_target in TARGET_CONTRACTS,
+        f"unsupported managed install target: {asset_target}",
+    )
+    suffix = "zip" if asset_target.startswith("windows-") else "tar.gz"
+    return f"codestory-cli-v{version}-{asset_target}.{suffix}"
+
+
+def package_root_name(archive_name: str) -> str:
+    for suffix in _ARCHIVE_SUFFIXES:
+        if archive_name.endswith(suffix) and len(archive_name) > len(suffix):
+            return archive_name[: -len(suffix)]
+    raise ProofFailure(
+        f"managed install archive name is not a release asset: {archive_name}"
+    )
+
+
+def managed_version_root(plugin_data: Path, version: str) -> Path:
+    return plugin_data / MANAGED_CLI_DIR_NAME / version
+
+
+def managed_launcher_path(plugin_data: Path, version: str, asset_target: str) -> Path:
+    return managed_version_root(plugin_data, version) / managed_binary_name(
+        asset_target
+    )
+
+
+def require_provisioner_package_root(
+    unpacked: Path,
+    archive_name: str,
+    asset_target: str,
+) -> Path:
+    root_name = package_root_name(archive_name)
+    entries = sorted(entry.name for entry in unpacked.iterdir())
+    require(
+        entries == [root_name],
+        f"managed install archive must contain exactly one package root named {root_name}",
+    )
+    package_root = unpacked / root_name
+    require(
+        package_root.is_dir() and not package_root.is_symlink(),
+        "managed install package root must be a direct directory",
+    )
+    for reserved in RESERVED_PACKAGE_PATHS:
+        require(
+            not (package_root / reserved).exists(),
+            f"managed install package root must not ship provisioner-owned {reserved}",
+        )
+    launcher = package_root / managed_binary_name(asset_target)
+    require(
+        launcher.is_file() and not launcher.is_symlink(),
+        "managed install package root does not contain the launcher at its top level",
+    )
+    return package_root
+
+
+def stage_flat_managed_install(
+    package_root: Path,
+    plugin_data: Path,
+    version: str,
+    asset_target: str,
+    managed_manifest: dict,
+) -> Path:
+    version_root = managed_version_root(plugin_data, version)
+    shutil.copytree(package_root, version_root)
+    write_json(version_root / MANAGED_MANIFEST_NAME, managed_manifest)
+    return verify_flat_managed_layout(plugin_data, version, asset_target)
+
+
+def _managed_manifest_contents(version_root: Path) -> dict:
+    manifest_path = version_root / MANAGED_MANIFEST_NAME
+    require(
+        manifest_path.is_file(),
+        f"managed install manifest is missing: {manifest_path}",
+    )
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ProofFailure(
+            f"managed install manifest is not valid JSON: {exc}"
+        ) from exc
+    require(isinstance(manifest, dict), "managed install manifest is not an object")
+    return manifest
+
+
+def verify_flat_managed_layout(
+    plugin_data: Path,
+    version: str,
+    asset_target: str,
+) -> Path:
+    version_root = managed_version_root(plugin_data, version)
+    manifest = _managed_manifest_contents(version_root)
+    archive_name = managed_archive_name(version, asset_target)
+    require(
+        manifest.get("version") == version
+        and manifest.get("target") == asset_target
+        and manifest.get("archive") == archive_name
+        and manifest.get("stdio_initialize_verified") is True
+        and HEX_SHA256.fullmatch(str(manifest.get("archive_sha256") or "")) is not None,
+        "managed install manifest does not describe this staged version",
+    )
+    launcher_name = managed_binary_name(asset_target)
+    require(
+        manifest.get("path") == launcher_name,
+        "managed install manifest must point at the flat launcher beside it",
+    )
+    launcher = version_root / launcher_name
+    require(
+        launcher.is_file() and not launcher.is_symlink(),
+        f"managed install launcher is missing from the flat version root: {launcher}",
+    )
+    require(
+        HEX_SHA256.fullmatch(str(manifest.get("sha256") or "")) is not None
+        and sha256(launcher) == manifest["sha256"],
+        "managed install manifest digest does not match the staged launcher",
+    )
+    require(
+        not (version_root / package_root_name(archive_name)).exists(),
+        "managed install version root still nests the extracted archive root",
+    )
+    return launcher

--- a/.github/scripts/packaged_agent_proof/runtime_bootstrap_continuity.py
+++ b/.github/scripts/packaged_agent_proof/runtime_bootstrap_continuity.py
@@ -12,7 +12,8 @@ from .contract_primitives import (
     write_json,
 )
 from .foundation import require
-from .installation_support import run_parallel
+from .installation_support import run_parallel, same_existing_path
+from .managed_layout import verify_flat_managed_layout
 from .managed_runtime import verify_managed_runtime_status
 from .memory_observation import capture_five_process_memory
 from .process_identity import process_start_identity
@@ -69,6 +70,15 @@ def _managed_runtime(
     require(
         managed_binary.is_relative_to(args.installed_plugin_data.resolve()),
         "installed managed executable is outside the installed plugin data root",
+    )
+    staged_launcher = verify_flat_managed_layout(
+        args.installed_plugin_data.resolve(),
+        manifest["release_version"],
+        manifest["asset_target"],
+    )
+    require(
+        same_existing_path(managed_binary, staged_launcher),
+        "installed managed executable is not the flat provisioned launcher",
     )
     require(
         managed_binary != cli.resolve(),

--- a/.github/scripts/packaged_agent_proof/self_test.py
+++ b/.github/scripts/packaged_agent_proof/self_test.py
@@ -4,6 +4,7 @@ from .self_test_cli import run_cli_self_tests
 from .self_test_contracts import run_contract_self_tests
 from .self_test_full_stack import run_full_stack_self_tests
 from .self_test_installation import run_installation_self_tests
+from .self_test_managed_layout import run_managed_layout_self_tests
 from .self_test_process import run_process_self_tests
 from .self_test_qualification import run_qualification_self_tests
 
@@ -14,5 +15,6 @@ def self_test() -> None:
     run_process_self_tests()
     run_qualification_self_tests()
     run_installation_self_tests()
+    run_managed_layout_self_tests()
     run_full_stack_self_tests()
     print("packaged per-user embedding server proof self-test passed")

--- a/.github/scripts/packaged_agent_proof/self_test_managed_layout.py
+++ b/.github/scripts/packaged_agent_proof/self_test_managed_layout.py
@@ -1,0 +1,186 @@
+"""Flat managed-install layout staging and divergence self-tests."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+from .contract_primitives import sha256, write_json
+from .foundation import ProofFailure, require
+from .managed_layout import (
+    MANAGED_MANIFEST_NAME,
+    managed_archive_name,
+    managed_binary_name,
+    managed_launcher_path,
+    managed_version_root,
+    package_root_name,
+    require_provisioner_package_root,
+    stage_flat_managed_install,
+    verify_flat_managed_layout,
+)
+
+_VERSION = "0.0.0"
+_TARGET = "windows-x64"
+
+
+def _archive_name() -> str:
+    return managed_archive_name(_VERSION, _TARGET)
+
+
+def _fixture_unpacked(root: Path, name: str) -> tuple[Path, Path]:
+    unpacked = root / name
+    package_root = unpacked / package_root_name(_archive_name())
+    package_root.mkdir(parents=True)
+    (package_root / managed_binary_name(_TARGET)).write_bytes(b"launcher-bytes")
+    generation = package_root / "native-generations" / "generation-1"
+    generation.mkdir(parents=True)
+    (generation / "runtime-module.dll").write_bytes(b"runtime-bytes")
+    return unpacked, package_root
+
+
+def _managed_manifest(package_root: Path) -> dict:
+    return {
+        "path": managed_binary_name(_TARGET),
+        "sha256": sha256(package_root / managed_binary_name(_TARGET)),
+        "version": _VERSION,
+        "build_source": "candidate_archive",
+        "repo_ref": "1" * 40,
+        "archive": _archive_name(),
+        "archive_url": f"candidate-archive:{'d' * 64}",
+        "archive_sha256": "d" * 64,
+        "target": _TARGET,
+        "stdio_initialize_verified": True,
+        "provisioned_at": f"candidate-proof:{'1' * 40}",
+    }
+
+
+def _flat_staging_test(root: Path) -> None:
+    unpacked, package_root = _fixture_unpacked(root, "flat-unpacked")
+    resolved_root = require_provisioner_package_root(
+        unpacked, _archive_name(), _TARGET
+    )
+    require(
+        resolved_root == package_root,
+        "package root resolution did not return the archive root",
+    )
+    plugin_data = root / "flat-data"
+    launcher = stage_flat_managed_install(
+        package_root,
+        plugin_data,
+        _VERSION,
+        _TARGET,
+        _managed_manifest(package_root),
+    )
+    require(
+        launcher == managed_launcher_path(plugin_data, _VERSION, _TARGET),
+        "staged launcher is not at the flat managed launcher path",
+    )
+    version_root = managed_version_root(plugin_data, _VERSION)
+    require(
+        launcher.parent == version_root,
+        "staged launcher is not a direct child of the managed version root",
+    )
+    require(
+        (
+            version_root / "native-generations" / "generation-1" / "runtime-module.dll"
+        ).is_file(),
+        "staging did not copy the package root contents into the version root",
+    )
+    require(
+        verify_flat_managed_layout(plugin_data, _VERSION, _TARGET) == launcher,
+        "flat layout verification did not resolve the staged launcher",
+    )
+
+
+def _nested_staging_rejection_test(root: Path) -> None:
+    unpacked, package_root = _fixture_unpacked(root, "nested-unpacked")
+    plugin_data = root / "nested-data"
+    version_root = managed_version_root(plugin_data, _VERSION)
+    # Reproduce the shipped regression: the whole extraction directory lands in
+    # the version root, pushing the launcher one archive-root segment deeper.
+    shutil.copytree(unpacked, version_root)
+    nested_manifest = _managed_manifest(package_root)
+    nested_manifest["path"] = (
+        f"{package_root.name}/{managed_binary_name(_TARGET)}"
+    )
+    write_json(version_root / MANAGED_MANIFEST_NAME, nested_manifest)
+    try:
+        verify_flat_managed_layout(plugin_data, _VERSION, _TARGET)
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("nested managed install staging was accepted")
+
+
+def _package_root_hostiles_test(root: Path) -> None:
+    flat = root / "rootless-unpacked"
+    flat.mkdir()
+    (flat / managed_binary_name(_TARGET)).write_bytes(b"launcher-bytes")
+    hostile_extractions = [("archive without a package root", flat)]
+    crowded, _package_root = _fixture_unpacked(root, "crowded-unpacked")
+    (crowded / "second-root").mkdir()
+    hostile_extractions.append(("archive with a second extraction root", crowded))
+    misnamed = root / "misnamed-unpacked"
+    misnamed_root = misnamed / "codestory-cli-v9.9.9-windows-x64"
+    misnamed_root.mkdir(parents=True)
+    (misnamed_root / managed_binary_name(_TARGET)).write_bytes(b"launcher-bytes")
+    hostile_extractions.append(("archive with a misnamed package root", misnamed))
+    reserved, reserved_root = _fixture_unpacked(root, "reserved-unpacked")
+    (reserved_root / MANAGED_MANIFEST_NAME).write_text("{}", encoding="utf-8")
+    hostile_extractions.append(("package root shipping manifest.json", reserved))
+    for label, unpacked in hostile_extractions:
+        try:
+            require_provisioner_package_root(unpacked, _archive_name(), _TARGET)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(f"{label} was accepted as a provisioner package root")
+
+
+def _manifest_divergence_rejection_test(root: Path) -> None:
+    unpacked, package_root = _fixture_unpacked(root, "divergence-unpacked")
+    plugin_data = root / "divergence-data"
+    valid_manifest = _managed_manifest(package_root)
+    launcher = stage_flat_managed_install(
+        package_root,
+        plugin_data,
+        _VERSION,
+        _TARGET,
+        valid_manifest,
+    )
+    version_root = managed_version_root(plugin_data, _VERSION)
+    manifest_path = version_root / MANAGED_MANIFEST_NAME
+    hostile_manifests = [
+        ("launcher digest mismatch", {"sha256": "e" * 64}),
+        ("nested launcher path", {"path": f"{package_root.name}/{launcher.name}"}),
+        ("foreign archive name", {"archive": managed_archive_name("9.9.9", _TARGET)}),
+        ("foreign target", {"target": "linux-x64"}),
+        ("unverified stdio handshake", {"stdio_initialize_verified": False}),
+    ]
+    for label, overrides in hostile_manifests:
+        write_json(manifest_path, {**json.loads(json.dumps(valid_manifest)), **overrides})
+        try:
+            verify_flat_managed_layout(plugin_data, _VERSION, _TARGET)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(f"managed manifest with {label} was accepted")
+    write_json(manifest_path, valid_manifest)
+    launcher.unlink()
+    try:
+        verify_flat_managed_layout(plugin_data, _VERSION, _TARGET)
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("managed manifest without its staged launcher was accepted")
+
+
+def run_managed_layout_self_tests() -> None:
+    with tempfile.TemporaryDirectory(prefix="codestory-managed-layout-") as raw:
+        root = Path(raw)
+        _flat_staging_test(root)
+        _nested_staging_rejection_test(root)
+        _package_root_hostiles_test(root)
+        _manifest_divergence_rejection_test(root)


### PR DESCRIPTION
The candidate proof staged a nested layout while provisionManagedCli installs flat, so the proof never exercised what users actually get. The proof now stages exactly the flat managed layout, with path expectations derived from a shared source so any future divergence fails the proof instead of drifting silently. Host-verifiable half proven via the plugin's own verifyPublishedManagedCli accepting the Python-staged layout plus a nested-regression rejection probe; the protected Windows candidate-installed run stays owned by the platform proof lane — #1437 remains open for it.

Closes #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)