### PR TITLE
derive retrieval readiness from the publication manifest, not the dead legacy table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@
 - Search results say whether they used full retrieval. Results that fell back to
   symbolic matching reported themselves as complete, so an agent could cite
   partial evidence as if it were whole.
-- Search, ground, and index surfaces recognize the semantic index a fresh
-  install builds automatically. They previously reported retrieval as symbolic
-  with missing semantic docs forever — even right after a successful build —
-  and the suggested repair, `retrieval index --refresh full`, could never clear
-  the message. Readiness now reflects the published retrieval index itself, so
-  a healthy project reports full hybrid retrieval without any manual command.
+- Search, ground, index, and doctor surfaces recognize the semantic index a
+  fresh install builds automatically. They previously reported retrieval as
+  symbolic with missing or stale semantic docs forever — even right after a
+  successful build — and the suggested repair, `retrieval index --refresh
+  full`, could never clear the message. Readiness now reflects the published
+  retrieval index itself, so a healthy project reports full hybrid retrieval
+  and a healthy doctor semantic check without any manual command. Projects
+  small enough to publish a semantic index with zero dense entries report that
+  truthfully as ready instead of prescribing the same impossible repair.
 - CodeStory installed somewhere shared or read-only runs for people who cannot
   write to that location.
 - On Windows, ending the CodeStory process also ends the runtime it launched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - Search results say whether they used full retrieval. Results that fell back to
   symbolic matching reported themselves as complete, so an agent could cite
   partial evidence as if it were whole.
+- Search, ground, and index surfaces recognize the semantic index a fresh
+  install builds automatically. They previously reported retrieval as symbolic
+  with missing semantic docs forever — even right after a successful build —
+  and the suggested repair, `retrieval index --refresh full`, could never clear
+  the message. Readiness now reflects the published retrieval index itself, so
+  a healthy project reports full hybrid retrieval without any manual command.
 - CodeStory installed somewhere shared or read-only runs for people who cannot
   write to that location.
 - On Windows, ending the CodeStory process also ends the runtime it launched.

--- a/crates/codestory-cli/src/app/diagnostics/doctor.rs
+++ b/crates/codestory-cli/src/app/diagnostics/doctor.rs
@@ -235,17 +235,26 @@ pub(in crate::app) fn semantic_contract_check(
     }
 
     if let Some(current) = retrieval.current_embedding.as_ref() {
-        compare_contract_field(
+        // The stored contract is projected from the publication pointer (the
+        // retrieval manifest), which records one opaque embedding runtime id
+        // — the same identity space as the current contract's cache key —
+        // plus a dimension. Per-doc profile/backend-label/doc-shape metadata
+        // is not carried by the publication pointer: it is validated when the
+        // generation is staged and folded into the sidecar input hash, so an
+        // absent optional field is not evidence of drift. The cache key and
+        // dimension are required publication evidence and keep failing closed
+        // when they are absent.
+        compare_carried_contract_field(
             &mut gaps,
             "embedding profile",
             stored.embedding_profile.as_deref(),
-            Some(current.profile.as_str()),
+            current.profile.as_str(),
         );
-        compare_contract_field(
+        compare_carried_contract_field(
             &mut gaps,
             "embedding backend",
             stored.embedding_backend.as_deref(),
-            Some(current.backend.as_str()),
+            current.backend.as_str(),
         );
         compare_contract_field(
             &mut gaps,
@@ -253,21 +262,38 @@ pub(in crate::app) fn semantic_contract_check(
             stored.cache_key.as_deref(),
             Some(current.cache_key.as_str()),
         );
-        compare_contract_field(
+        compare_carried_contract_field(
             &mut gaps,
             "semantic doc shape",
             stored.doc_shape.as_deref(),
-            Some(current.doc_shape.as_str()),
+            current.doc_shape.as_str(),
         );
-        if let (Some(stored_dim), Some(current_dim)) = (stored.dimension, current.dimension)
-            && stored_dim != current_dim
-        {
-            gaps.push(format!(
-                "embedding dimension mismatch: stored={stored_dim} current={current_dim}"
-            ));
+        match (stored.dimension, current.dimension) {
+            (Some(stored_dim), Some(current_dim)) if stored_dim != current_dim => {
+                gaps.push(format!(
+                    "embedding dimension mismatch: stored={stored_dim} current={current_dim}"
+                ));
+            }
+            (None, Some(current_dim)) => {
+                gaps.push(format!(
+                    "embedding dimension missing from stored docs; current={current_dim}"
+                ));
+            }
+            _ => {}
         }
     } else {
         gaps.push("current embedding config could not be resolved".to_string());
+    }
+    // The readiness projection already judged this publication against the
+    // full manifest contract (schema, generation, degraded modes, policy
+    // version). Honor its degraded verdict even when every field the
+    // publication carries matches, so doctor never calls a stale or degraded
+    // publication healthy.
+    if retrieval.fallback_reason == Some(RetrievalFallbackReasonDto::DegradedRuntime) {
+        gaps.push(
+            "the published retrieval index is stale or degraded for the current contract"
+                .to_string(),
+        );
     }
 
     if gaps.is_empty() {
@@ -299,6 +325,26 @@ pub(in crate::app) fn semantic_contract_check(
                 gaps.join("; ")
             ),
         )
+    }
+}
+
+/// Flag a mismatch only when the stored contract actually carries the field.
+///
+/// Publication-pointer contracts legitimately omit per-doc metadata (profile,
+/// backend label, doc shape); treating those omissions as gaps made doctor
+/// report `semantic stale` forever on healthy manifest-published stores.
+pub(in crate::app::diagnostics) fn compare_carried_contract_field(
+    gaps: &mut Vec<String>,
+    label: &str,
+    stored: Option<&str>,
+    current: &str,
+) {
+    if let Some(stored) = stored
+        && stored != current
+    {
+        gaps.push(format!(
+            "{label} mismatch: stored={stored} current={current}"
+        ));
     }
 }
 

--- a/crates/codestory-cli/src/app/tests/lifecycle/packet_diagnostics.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/packet_diagnostics.rs
@@ -122,10 +122,8 @@ fn doctor_retrieval_state_for_manifest(
     std::fs::create_dir_all(&project_root).expect("project root");
     let storage_path = temp.path().join("codestory.db");
     let project_id = codestory_retrieval::sidecar_project_id_for_root(&project_root);
-    let mut manifest = codestory_retrieval::test_support::retrieval_manifest_fixture(
-        &project_id,
-        &"a".repeat(64),
-    );
+    let mut manifest =
+        codestory_retrieval::test_support::retrieval_manifest_fixture(&project_id, &"a".repeat(64));
     manifest.projection_count = Some(2);
     manifest.symbol_doc_count = Some(8);
     manifest.dense_projection_count = Some(2);

--- a/crates/codestory-cli/src/app/tests/lifecycle/packet_diagnostics.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/packet_diagnostics.rs
@@ -112,6 +112,98 @@ fn index_next_commands_use_sidecar_repair_for_missing_embedding_runtime() {
     );
 }
 
+/// Publish `manifest` for a fresh temp project and run the production
+/// readiness projection against it, exactly as `doctor` consumes it.
+fn doctor_retrieval_state_for_manifest(
+    mutate: impl FnOnce(&mut codestory_retrieval::RetrievalIndexManifest),
+) -> codestory_contracts::api::RetrievalStateDto {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let project_root = temp.path().join("project");
+    std::fs::create_dir_all(&project_root).expect("project root");
+    let storage_path = temp.path().join("codestory.db");
+    let project_id = codestory_retrieval::sidecar_project_id_for_root(&project_root);
+    let mut manifest = codestory_retrieval::test_support::retrieval_manifest_fixture(
+        &project_id,
+        &"a".repeat(64),
+    );
+    manifest.projection_count = Some(2);
+    manifest.symbol_doc_count = Some(8);
+    manifest.dense_projection_count = Some(2);
+    mutate(&mut manifest);
+    codestory_runtime::publish_retrieval_manifest_for_test(&storage_path, &manifest)
+        .expect("publish retrieval manifest");
+    codestory_runtime::retrieval_state_from_manifest_storage_for_test(
+        &storage_path,
+        &project_root,
+        &temp.path().join("cache"),
+    )
+    .expect("retrieval state")
+}
+
+#[test]
+fn doctor_semantic_check_is_healthy_for_fresh_manifest_published_store() {
+    // Regression: a healthy fresh install publishes semantic readiness through
+    // the retrieval manifest. The manifest records one opaque embedding
+    // runtime id plus a dimension; projecting that id into the stored
+    // contract's `embedding_backend`/leaving profile and doc-shape `None` made
+    // this doctor check report "semantic stale" with `retrieval index
+    // --refresh full` advice forever, even though a refresh republishes the
+    // identical manifest.
+    let retrieval = doctor_retrieval_state_for_manifest(|_| {});
+
+    assert!(
+        retrieval.stored_embedding.is_some(),
+        "build_doctor_output only includes the semantic check when a stored contract exists"
+    );
+    let check = semantic_contract_check(&retrieval);
+
+    assert_eq!(
+        check.status, "ok",
+        "a healthy manifest-published store must not report semantic stale: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("semantic ok"),
+        "unexpected doctor message: {}",
+        check.message
+    );
+}
+
+#[test]
+fn doctor_semantic_check_stays_warn_for_mismatched_manifest_backend() {
+    let retrieval = doctor_retrieval_state_for_manifest(|manifest| {
+        manifest.embedding_backend = Some("legacy-backend".to_string());
+    });
+
+    let check = semantic_contract_check(&retrieval);
+
+    assert_eq!(check.status, "warn", "{}", check.message);
+    assert!(
+        check.message.contains("semantic stale"),
+        "a mismatched publication must keep failing closed: {}",
+        check.message
+    );
+}
+
+#[test]
+fn doctor_semantic_check_stays_warn_for_degraded_manifest_with_matching_contract() {
+    // The degraded manifest still carries the current embedding runtime id and
+    // dimension, so field comparison alone would call it healthy. The doctor
+    // must honor the readiness projection's degraded verdict instead.
+    let retrieval = doctor_retrieval_state_for_manifest(|manifest| {
+        manifest.degraded_modes_json = r#"["embedded_vector_index_unavailable"]"#.to_string();
+    });
+
+    let check = semantic_contract_check(&retrieval);
+
+    assert_eq!(check.status, "warn", "{}", check.message);
+    assert!(
+        check.message.contains("semantic stale"),
+        "a degraded publication must keep failing closed: {}",
+        check.message
+    );
+}
+
 #[test]
 fn semantic_contract_check_uses_sidecar_repair_for_missing_embedding_runtime() {
     let mut retrieval = sample_retrieval();

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -501,6 +501,12 @@ impl EmbeddingVectorProducerEvidenceDto {
 ///
 /// `mixed_*` flags are diagnostic evidence that the cache was built from more
 /// than one profile/model/backend/dimension/doc-shape and may need repair.
+///
+/// Producers that project this contract from a publication pointer (the
+/// retrieval index manifest) carry only the fields that pointer records — the
+/// embedding runtime id as `cache_key`, the dimension, and the semantic
+/// policy version. Optional fields the publication contract does not carry
+/// stay `None`; consumers must not read an absent optional field as drift.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 pub struct StoredSemanticDocsContractDto {
     pub doc_count: u32,

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -207,7 +207,14 @@ fn parse_degraded_modes(manifest: &codestory_store::RetrievalIndexManifest) -> V
         .unwrap_or_else(|_| vec!["degraded_modes_json_invalid".into()])
 }
 
-fn manifest_classifies_full(manifest: &codestory_store::RetrievalIndexManifest) -> bool {
+/// Whether a published manifest classifies as a current, non-degraded full
+/// sidecar publication.
+///
+/// This is the manifest-only admission check: it validates the sidecar
+/// generation contract and requires an empty degraded-mode list without
+/// probing artifacts or the embedding runtime. Readiness projections use it
+/// so observational reads stay a single indexed manifest-row lookup.
+pub fn manifest_classifies_full(manifest: &codestory_store::RetrievalIndexManifest) -> bool {
     manifest_has_current_sidecar_contract(&manifest.project_id, manifest)
         && parse_degraded_modes(manifest).is_empty()
 }

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -79,8 +79,8 @@ pub use generation::{
 };
 pub use health::{
     ComponentHealth, ComponentStatus, InfrastructureHealth, RetrievalManifestContractReport,
-    RetrievalManifestLaneProvenance, RetrievalStatusReport, probe_infrastructure_health,
-    probe_sidecar_health,
+    RetrievalManifestLaneProvenance, RetrievalStatusReport, manifest_classifies_full,
+    probe_infrastructure_health, probe_sidecar_health,
 };
 pub use index::{
     FinalizeIndexOutcome, RetrievalIndexCancelled, SidecarInputChanged, finalize_index,

--- a/crates/codestory-runtime/src/controller_core.rs
+++ b/crates/codestory-runtime/src/controller_core.rs
@@ -342,7 +342,8 @@ impl AppController {
     }
 
     pub fn retrieval_state(&self) -> Result<RetrievalStateDto, ApiError> {
+        let project_root = self.require_project_root()?;
         let storage = self.open_storage_read_only()?;
-        retrieval_state_from_storage_for_runtime(&storage, &self.runtime_config)
+        retrieval_state_from_storage_for_runtime(&storage, &project_root, &self.runtime_config)
     }
 }

--- a/crates/codestory-runtime/src/controller_indexing.rs
+++ b/crates/codestory-runtime/src/controller_indexing.rs
@@ -90,6 +90,7 @@ impl AppController {
             members,
             retrieval: Some(retrieval_state_from_storage_for_runtime(
                 storage,
+                root,
                 &self.runtime_config,
             )?),
             freshness: Some(freshness),
@@ -157,6 +158,7 @@ impl AppController {
         let mut summary = self.project_summary_from_storage(&root, &storage_path, &storage)?;
         summary.retrieval = Some(retrieval_state_from_storage_for_runtime(
             &storage,
+            &root,
             &self.runtime_config,
         )?);
 

--- a/crates/codestory-runtime/src/grounding.rs
+++ b/crates/codestory-runtime/src/grounding.rs
@@ -1446,7 +1446,7 @@ impl AppController {
 
         let total_file_count = dto_stats.file_count;
         let retrieval =
-            retrieval_state_from_storage_for_runtime(&storage, &self.runtime_config).ok();
+            retrieval_state_from_storage_for_runtime(&storage, &root, &self.runtime_config).ok();
         if let Some(state) = retrieval.as_ref() {
             let mode = match state.mode {
                 codestory_contracts::api::RetrievalModeDto::Hybrid => "hybrid",

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -144,7 +144,9 @@ pub fn publish_retrieval_manifest_for_test(
     manifest: &codestory_retrieval::RetrievalIndexManifest,
 ) -> Result<(), ApiError> {
     let mut storage = Storage::open(storage_path).map_err(|error| {
-        ApiError::internal(format!("Failed to open storage for manifest fixture: {error}"))
+        ApiError::internal(format!(
+            "Failed to open storage for manifest fixture: {error}"
+        ))
     })?;
     storage
         .upsert_retrieval_index_manifest(manifest)

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -132,6 +132,62 @@ use semantic_projection::edge_digest_for_node;
 #[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub use semantic_projection::stored_semantic_embeddings_for_test;
+
+/// Test-support: publish a retrieval manifest fixture into the store at
+/// `storage_path`. Consumer crates (for example the CLI, whose architecture
+/// contract forbids direct `codestory_store` access) use this to stage
+/// manifest-published stores for readiness regression tests.
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn publish_retrieval_manifest_for_test(
+    storage_path: &Path,
+    manifest: &codestory_retrieval::RetrievalIndexManifest,
+) -> Result<(), ApiError> {
+    let mut storage = Storage::open(storage_path).map_err(|error| {
+        ApiError::internal(format!("Failed to open storage for manifest fixture: {error}"))
+    })?;
+    storage
+        .upsert_retrieval_index_manifest(manifest)
+        .map_err(|error| {
+            ApiError::internal(format!("Failed to publish manifest fixture: {error}"))
+        })?;
+    Ok(())
+}
+
+/// Test-support: run the production manifest-derived retrieval readiness
+/// projection against a storage path, exactly as the search/ground/index
+/// surfaces do. Consumer-side regression tests (for example the CLI doctor)
+/// use this so their fixtures cannot drift from the real producer vocabulary.
+///
+/// The projection runs under a deterministic Local-profile sidecar runtime:
+/// empty process defaults (no ambient environment reads) with hybrid
+/// retrieval explicitly enabled and `cache_root` as the isolated cache root.
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn retrieval_state_from_manifest_storage_for_test(
+    storage_path: &Path,
+    project_root: &Path,
+    cache_root: &Path,
+) -> Result<RetrievalStateDto, ApiError> {
+    let process_defaults = codestory_retrieval::SidecarProcessDefaults::new(
+        cache_root.to_path_buf(),
+        codestory_retrieval::SidecarRuntimeDefaults::default(),
+    );
+    let overrides = codestory_retrieval::SidecarRuntimeOverrides {
+        hybrid_retrieval_enabled: Some(true),
+        ..Default::default()
+    };
+    let runtime =
+        codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+            None,
+            codestory_retrieval::SidecarProfile::Local,
+            None,
+            &process_defaults,
+            &overrides,
+        );
+    let storage = open_storage_for_read(storage_path)?;
+    search_publication::retrieval_state_from_storage_for_runtime(&storage, project_root, &runtime)
+}
 #[cfg(test)]
 use semantic_projection::{
     DENSE_CENTRAL_RELATIONSHIP_THRESHOLD, DENSE_CENTRAL_SCORE_THRESHOLD, DenseAnchorCentrality,

--- a/crates/codestory-runtime/src/search_plan.rs
+++ b/crates/codestory-runtime/src/search_plan.rs
@@ -1614,20 +1614,18 @@ impl AppController {
         apply_search_intent_filters(&mut indexed_symbol_hits, &intent_query.filters);
         let project_root = self.require_project_root()?;
         indexed_symbol_hits.sort_by(|left, right| {
-            compare_search_hits_with_project_root(
-                Some(project_root.as_path()),
-                &query,
-                left,
-                right,
-            )
+            compare_search_hits_with_project_root(Some(project_root.as_path()), &query, left, right)
         });
         dedupe_inexact_search_hits_by_display_key(&query, &mut indexed_symbol_hits);
         indexed_symbol_hits.truncate(limit_per_source);
         annotate_search_hit_match_quality(&query, &mut indexed_symbol_hits);
 
         let storage = self.open_storage_read_only()?;
-        let retrieval =
-            retrieval_state_from_storage_for_runtime(&storage, &project_root, &self.runtime_config)?;
+        let retrieval = retrieval_state_from_storage_for_runtime(
+            &storage,
+            &project_root,
+            &self.runtime_config,
+        )?;
         let freshness = self.index_freshness().ok();
         let mut repo_text_hits = Vec::new();
         let mut suggestions = Vec::new();

--- a/crates/codestory-runtime/src/search_plan.rs
+++ b/crates/codestory-runtime/src/search_plan.rs
@@ -1612,16 +1612,22 @@ impl AppController {
         let initial_sidecar_hits = indexed_symbol_hits.clone();
 
         apply_search_intent_filters(&mut indexed_symbol_hits, &intent_query.filters);
-        let project_root = self.require_project_root().ok();
+        let project_root = self.require_project_root()?;
         indexed_symbol_hits.sort_by(|left, right| {
-            compare_search_hits_with_project_root(project_root.as_deref(), &query, left, right)
+            compare_search_hits_with_project_root(
+                Some(project_root.as_path()),
+                &query,
+                left,
+                right,
+            )
         });
         dedupe_inexact_search_hits_by_display_key(&query, &mut indexed_symbol_hits);
         indexed_symbol_hits.truncate(limit_per_source);
         annotate_search_hit_match_quality(&query, &mut indexed_symbol_hits);
 
         let storage = self.open_storage_read_only()?;
-        let retrieval = retrieval_state_from_storage_for_runtime(&storage, &self.runtime_config)?;
+        let retrieval =
+            retrieval_state_from_storage_for_runtime(&storage, &project_root, &self.runtime_config)?;
         let freshness = self.index_freshness().ok();
         let mut repo_text_hits = Vec::new();
         let mut suggestions = Vec::new();
@@ -1689,7 +1695,12 @@ impl AppController {
                 (None, None) => std::cmp::Ordering::Equal,
             };
             anchor_order.then_with(|| {
-                compare_search_hits_with_project_root(project_root.as_deref(), &query, left, right)
+                compare_search_hits_with_project_root(
+                    Some(project_root.as_path()),
+                    &query,
+                    left,
+                    right,
+                )
             })
         });
         dedupe_inexact_search_hits_by_display_key(&query, &mut indexed_symbol_hits);
@@ -1706,12 +1717,12 @@ impl AppController {
         annotate_search_hit_match_quality(&query, &mut indexed_symbol_hits);
         crate::search_evidence::attach_pinned_search_evidence(
             &storage,
-            project_root.as_deref(),
+            Some(project_root.as_path()),
             &mut indexed_symbol_hits,
         );
         crate::search_evidence::attach_pinned_search_evidence(
             &storage,
-            project_root.as_deref(),
+            Some(project_root.as_path()),
             &mut suggestions,
         );
         let hits = indexed_symbol_hits.clone();

--- a/crates/codestory-runtime/src/search_publication.rs
+++ b/crates/codestory-runtime/src/search_publication.rs
@@ -18,8 +18,7 @@ use crate::semantic_projection::{
 };
 use crate::semantic_projection::{
     SEARCH_SYMBOL_STREAM_BATCH_SIZE, SearchStateBuildStats, current_embedding_contract_for_runtime,
-    load_persisted_semantic_docs_for_runtime, semantic_doc_stats_match_contract,
-    stored_semantic_docs_contract_from_stats,
+    load_persisted_semantic_docs_for_runtime,
 };
 use serde::{Deserialize, Serialize};
 
@@ -723,36 +722,73 @@ pub(super) fn retrieval_state_from_engine_with_storage_contract(
 #[cfg(test)]
 pub(super) fn retrieval_state_from_storage(
     storage: &Storage,
+    project_root: &Path,
 ) -> Result<RetrievalStateDto, ApiError> {
-    retrieval_state_from_storage_for_runtime(storage, &test_sidecar_runtime_from_env())
+    retrieval_state_from_storage_for_runtime(
+        storage,
+        project_root,
+        &test_sidecar_runtime_from_env(),
+    )
 }
 
+/// Derive agent-visible retrieval readiness from the published retrieval manifest.
+///
+/// Semantic readiness must come from the same publication pointer that admits
+/// sidecar-primary retrieval: the `retrieval_index_manifest` row for this
+/// project. The legacy `llm_symbol_doc` table is intentionally cleared on
+/// every semantic publication, so counting it reported `missing_semantic_docs`
+/// forever on stores whose sidecar vectors were fully published — including
+/// every fresh auto-bootstrap. This read stays observational: one indexed
+/// manifest-row lookup plus pure contract checks, with no probing, repair, or
+/// refresh.
 pub(super) fn retrieval_state_from_storage_for_runtime(
     storage: &Storage,
+    project_root: &Path,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<RetrievalStateDto, ApiError> {
-    let stats = storage
-        .get_llm_symbol_doc_stats()
-        .map_err(|e| ApiError::internal(format!("Failed to query LLM symbol doc stats: {e}")))?;
+    let project_id = codestory_retrieval::sidecar_project_id_for_root(project_root);
+    let manifest = storage.get_retrieval_index_manifest(&project_id).map_err(|e| {
+        ApiError::internal(format!("Failed to query retrieval index manifest: {e}"))
+    })?;
     let probe = embedding_runtime_availability_from_config(runtime);
     let current_embedding = current_embedding_contract_for_runtime(runtime);
-    let stored_embedding = stored_semantic_docs_contract_from_stats(&stats);
-    let contract_mismatch = stats.doc_count > 0
-        && probe.available
-        && !current_embedding
-            .as_ref()
-            .is_some_and(|contract| semantic_doc_stats_match_contract(&stats, contract));
+    let stored_embedding = manifest
+        .as_ref()
+        .map(stored_semantic_docs_contract_from_manifest);
+    let semantic_doc_count = manifest
+        .as_ref()
+        .map(published_dense_projection_count)
+        .unwrap_or(0);
+    // Fail closed: published vectors count as semantic readiness only while the
+    // manifest still classifies as a current, non-degraded full publication.
+    let stale_publication = manifest
+        .as_ref()
+        .is_some_and(|manifest| !codestory_retrieval::manifest_classifies_full(manifest));
+    let contract_mismatch = manifest
+        .as_ref()
+        .is_some_and(|manifest| !manifest_matches_current_embedding_contract(manifest, runtime));
+    let runtime_degraded =
+        semantic_doc_count > 0 && probe.available && (stale_publication || contract_mismatch);
     let fallback_message = probe.fallback_message.or_else(|| {
-        contract_mismatch.then(|| {
-            "Stored semantic docs do not match the current embedding contract. Run `retrieval index --refresh full` before trusting hybrid retrieval."
-                .to_string()
-        })
+        if !runtime_degraded {
+            None
+        } else if contract_mismatch {
+            Some(
+                "Stored semantic docs do not match the current embedding contract. Run `retrieval index --refresh full` before trusting hybrid retrieval."
+                    .to_string(),
+            )
+        } else {
+            Some(
+                "The published retrieval sidecar is stale or degraded for the current contract. Run `retrieval index --refresh full` to repair full sidecar readiness."
+                    .to_string(),
+            )
+        }
     });
     Ok(retrieval_state_from_parts_with_hybrid(
-        stats.doc_count,
-        stats
-            .embedding_model
-            .clone()
+        semantic_doc_count,
+        manifest
+            .as_ref()
+            .and_then(|manifest| manifest.embedding_backend.clone())
             .or_else(|| {
                 current_embedding
                     .as_ref()
@@ -762,8 +798,52 @@ pub(super) fn retrieval_state_from_storage_for_runtime(
         probe.available,
         fallback_message,
         current_embedding,
-        Some(stored_embedding),
-        contract_mismatch,
+        stored_embedding,
+        runtime_degraded,
         runtime.retrieval.hybrid_enabled,
     ))
+}
+
+fn published_dense_projection_count(manifest: &codestory_store::RetrievalIndexManifest) -> u32 {
+    match manifest.dense_projection_count {
+        Some(count) if count > 0 => u32::try_from(count).unwrap_or(u32::MAX),
+        _ => 0,
+    }
+}
+
+/// Manifest-only check that the published vectors were produced under the
+/// embedding contract this runtime queries with.
+fn manifest_matches_current_embedding_contract(
+    manifest: &codestory_store::RetrievalIndexManifest,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+) -> bool {
+    let expected_backend = codestory_retrieval::embedding_runtime_id_for_runtime(runtime);
+    let expected_dim = i32::try_from(codestory_retrieval::semantic_vector_dim())
+        .unwrap_or(codestory_retrieval::RETRIEVAL_EMBEDDING_DIM as i32);
+    manifest.embedding_backend.as_deref() == Some(expected_backend.as_str())
+        && manifest.embedding_dim == Some(expected_dim)
+}
+
+fn stored_semantic_docs_contract_from_manifest(
+    manifest: &codestory_store::RetrievalIndexManifest,
+) -> StoredSemanticDocsContractDto {
+    StoredSemanticDocsContractDto {
+        doc_count: published_dense_projection_count(manifest),
+        embedding_profile: None,
+        embedding_backend: manifest.embedding_backend.clone(),
+        cache_key: manifest.embedding_backend.clone(),
+        dimension: manifest
+            .embedding_dim
+            .and_then(|dimension| u32::try_from(dimension).ok()),
+        doc_version: None,
+        mixed_embedding_profiles: false,
+        mixed_embedding_models: false,
+        mixed_embedding_backends: false,
+        mixed_dimensions: false,
+        mixed_doc_versions: false,
+        mixed_doc_shapes: false,
+        doc_shape: None,
+        semantic_policy_version: manifest.semantic_policy_version.clone(),
+        mixed_semantic_policy_versions: false,
+    }
 }

--- a/crates/codestory-runtime/src/search_publication.rs
+++ b/crates/codestory-runtime/src/search_publication.rs
@@ -614,6 +614,7 @@ pub(super) fn retrieval_state_from_parts(
         current_embedding,
         stored_embedding,
         runtime_degraded,
+        false,
         hybrid_retrieval_enabled(),
     )
 }
@@ -627,22 +628,28 @@ pub(super) fn retrieval_state_from_parts_with_hybrid(
     current_embedding: Option<EmbeddingProfileContractDto>,
     stored_embedding: Option<StoredSemanticDocsContractDto>,
     runtime_degraded: bool,
+    zero_dense_published: bool,
     hybrid_configured: bool,
 ) -> RetrievalStateDto {
+    // `zero_dense_published` distinguishes a current, contract-matched full
+    // publication that truthfully selected zero dense anchors from a semantic
+    // lane that was never built. Only the latter is repairable by
+    // `retrieval index --refresh full`.
+    let semantic_lane_unbuilt = semantic_doc_count == 0 && !zero_dense_published;
     let fallback_reason = if !hybrid_configured {
         Some(RetrievalFallbackReasonDto::DisabledByConfig)
     } else if runtime_degraded {
         Some(RetrievalFallbackReasonDto::DegradedRuntime)
     } else if !embedding_runtime_available {
         Some(RetrievalFallbackReasonDto::MissingEmbeddingRuntime)
-    } else if semantic_doc_count == 0 {
+    } else if semantic_lane_unbuilt {
         Some(RetrievalFallbackReasonDto::MissingSemanticDocs)
     } else {
         None
     };
     let semantic_mode = if !hybrid_configured {
         SemanticModeDto::DisabledByConfig
-    } else if runtime_degraded || !embedding_runtime_available || semantic_doc_count == 0 {
+    } else if runtime_degraded || !embedding_runtime_available || semantic_lane_unbuilt {
         SemanticModeDto::DegradedRuntime
     } else {
         SemanticModeDto::Enabled
@@ -738,9 +745,18 @@ pub(super) fn retrieval_state_from_storage(
 /// project. The legacy `llm_symbol_doc` table is intentionally cleared on
 /// every semantic publication, so counting it reported `missing_semantic_docs`
 /// forever on stores whose sidecar vectors were fully published — including
-/// every fresh auto-bootstrap. This read stays observational: one indexed
-/// manifest-row lookup plus pure contract checks, with no probing, repair, or
-/// refresh.
+/// every fresh auto-bootstrap.
+///
+/// Cost and parity: resolving the manifest key goes through
+/// `sidecar_project_id_for_root`, which re-observes project identity with
+/// three git subprocesses per call (`config --get remote.origin.url`,
+/// `rev-parse HEAD^{tree}`, and a workload-dependent `status --porcelain`)
+/// before the single indexed manifest-row lookup and pure contract checks.
+/// That is deliberately the same uncached helper per-search sidecar admission
+/// uses (`retrieval_primary::retrieval_manifest_exists`), so this projection
+/// and admission can never disagree about which manifest row is current. Do
+/// not substitute a cached identity here without proving admission reads the
+/// same cache. The read stays observational: no probing, repair, or refresh.
 pub(super) fn retrieval_state_from_storage_for_runtime(
     storage: &Storage,
     project_root: &Path,
@@ -769,6 +785,15 @@ pub(super) fn retrieval_state_from_storage_for_runtime(
         .is_some_and(|manifest| !manifest_matches_current_embedding_contract(manifest, runtime));
     let runtime_degraded =
         semantic_doc_count > 0 && probe.available && (stale_publication || contract_mismatch);
+    // A current, contract-matched full publication may legitimately select
+    // zero dense anchors (generation only requires the dense count to equal
+    // the projection count). Admission serves that sidecar as full, so the
+    // semantic lane is published-and-empty, not unbuilt: reporting
+    // `missing_semantic_docs` here would prescribe a refresh that republishes
+    // the identical zero-anchor manifest and can never clear the message.
+    let zero_dense_published = manifest.as_ref().is_some_and(|manifest| {
+        manifest.dense_projection_count == Some(0) && !stale_publication && !contract_mismatch
+    });
     let fallback_message = probe.fallback_message.or_else(|| {
         if !runtime_degraded {
             None
@@ -800,6 +825,7 @@ pub(super) fn retrieval_state_from_storage_for_runtime(
         current_embedding,
         stored_embedding,
         runtime_degraded,
+        zero_dense_published,
         runtime.retrieval.hybrid_enabled,
     ))
 }
@@ -824,13 +850,24 @@ fn manifest_matches_current_embedding_contract(
         && manifest.embedding_dim == Some(expected_dim)
 }
 
+/// Project the manifest's producer evidence into the consumer vocabulary of
+/// [`StoredSemanticDocsContractDto`].
+///
+/// The manifest records the embedding identity as one opaque runtime id (its
+/// `embedding_backend` column) plus a dimension and the semantic policy
+/// version. That runtime id lives in the same identity space as the current
+/// contract's `cache_key` (`embedding_runtime_id()`), so it maps to
+/// `cache_key`. The manifest does not carry a per-doc backend label, profile,
+/// doc shape, or doc version: those inputs are validated at publication time
+/// and folded into the sidecar input hash, so they stay `None` here instead
+/// of being fabricated in a vocabulary the doctor would flag forever.
 fn stored_semantic_docs_contract_from_manifest(
     manifest: &codestory_store::RetrievalIndexManifest,
 ) -> StoredSemanticDocsContractDto {
     StoredSemanticDocsContractDto {
         doc_count: published_dense_projection_count(manifest),
         embedding_profile: None,
-        embedding_backend: manifest.embedding_backend.clone(),
+        embedding_backend: None,
         cache_key: manifest.embedding_backend.clone(),
         dimension: manifest
             .embedding_dim

--- a/crates/codestory-runtime/src/search_publication.rs
+++ b/crates/codestory-runtime/src/search_publication.rs
@@ -763,9 +763,11 @@ pub(super) fn retrieval_state_from_storage_for_runtime(
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<RetrievalStateDto, ApiError> {
     let project_id = codestory_retrieval::sidecar_project_id_for_root(project_root);
-    let manifest = storage.get_retrieval_index_manifest(&project_id).map_err(|e| {
-        ApiError::internal(format!("Failed to query retrieval index manifest: {e}"))
-    })?;
+    let manifest = storage
+        .get_retrieval_index_manifest(&project_id)
+        .map_err(|e| {
+            ApiError::internal(format!("Failed to query retrieval index manifest: {e}"))
+        })?;
     let probe = embedding_runtime_availability_from_config(runtime);
     let current_embedding = current_embedding_contract_for_runtime(runtime);
     let stored_embedding = manifest

--- a/crates/codestory-runtime/src/search_scoring.rs
+++ b/crates/codestory-runtime/src/search_scoring.rs
@@ -1267,7 +1267,10 @@ impl AppController {
         let storage_retrieval = if semantic_disabled {
             None
         } else {
-            Some(retrieval_state_from_storage(&storage)?)
+            Some(retrieval_state_from_storage(
+                &storage,
+                &self.require_project_root()?,
+            )?)
         };
         let mut graph_boosts = HashMap::<codestory_contracts::graph::NodeId, f32>::new();
         let requested_max_results = max_results.clamp(1, 50);

--- a/crates/codestory-runtime/src/semantic_projection.rs
+++ b/crates/codestory-runtime/src/semantic_projection.rs
@@ -5,10 +5,10 @@ use super::{
     IndexingPhaseTimings, Instant, LlmSymbolDoc, LlmSymbolDocStats, Path, RetrievalFileRole,
     SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES, SEMANTIC_FILE_TEXT_MAX_BYTES, SearchEngine,
     SourceIndexPolicy, SourcePolicyExclusionPolicyIdentity, Storage, StoreFileRole,
-    SymbolSearchDoc, clamp_u128_to_u32, clamp_usize_to_u32,
-    current_epoch_ms, indexing_cancelled_error, is_indexing_cancelled, node_display_name,
-    read_file_text_limited, retrieval_file_role_from_path, semantic_doc_language_from_path,
-    semantic_path_aliases, semantic_symbol_aliases, semantic_symbol_role_aliases,
+    SymbolSearchDoc, clamp_u128_to_u32, clamp_usize_to_u32, current_epoch_ms,
+    indexing_cancelled_error, is_indexing_cancelled, node_display_name, read_file_text_limited,
+    retrieval_file_role_from_path, semantic_doc_language_from_path, semantic_path_aliases,
+    semantic_symbol_aliases, semantic_symbol_role_aliases,
 };
 #[cfg(test)]
 use super::{embedding_profile_contract_from_env, test_sidecar_runtime_from_env};

--- a/crates/codestory-runtime/src/semantic_projection.rs
+++ b/crates/codestory-runtime/src/semantic_projection.rs
@@ -5,7 +5,7 @@ use super::{
     IndexingPhaseTimings, Instant, LlmSymbolDoc, LlmSymbolDocStats, Path, RetrievalFileRole,
     SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES, SEMANTIC_FILE_TEXT_MAX_BYTES, SearchEngine,
     SourceIndexPolicy, SourcePolicyExclusionPolicyIdentity, Storage, StoreFileRole,
-    StoredSemanticDocsContractDto, SymbolSearchDoc, clamp_u128_to_u32, clamp_usize_to_u32,
+    SymbolSearchDoc, clamp_u128_to_u32, clamp_usize_to_u32,
     current_epoch_ms, indexing_cancelled_error, is_indexing_cancelled, node_display_name,
     read_file_text_limited, retrieval_file_role_from_path, semantic_doc_language_from_path,
     semantic_path_aliases, semantic_symbol_aliases, semantic_symbol_role_aliases,
@@ -555,28 +555,6 @@ pub(super) fn semantic_doc_stats_match_contract(
         && stats.doc_version == Some(LLM_SYMBOL_DOC_SCHEMA_VERSION)
         && stats.doc_shape.as_deref() == Some(contract.doc_shape.as_str())
         && stats.semantic_policy_version.as_deref() == Some(SEMANTIC_POLICY_VERSION)
-}
-
-pub(super) fn stored_semantic_docs_contract_from_stats(
-    stats: &LlmSymbolDocStats,
-) -> StoredSemanticDocsContractDto {
-    StoredSemanticDocsContractDto {
-        doc_count: stats.doc_count,
-        embedding_profile: stats.embedding_profile.clone(),
-        embedding_backend: stats.embedding_backend.clone(),
-        cache_key: stats.embedding_model.clone(),
-        dimension: stats.embedding_dim,
-        doc_version: stats.doc_version,
-        mixed_embedding_profiles: stats.mixed_embedding_profiles,
-        mixed_embedding_models: stats.mixed_embedding_models,
-        mixed_embedding_backends: stats.mixed_embedding_backends,
-        mixed_dimensions: stats.mixed_dimensions,
-        mixed_doc_versions: stats.mixed_doc_versions,
-        mixed_doc_shapes: stats.mixed_doc_shapes,
-        doc_shape: stats.doc_shape.clone(),
-        semantic_policy_version: stats.semantic_policy_version.clone(),
-        mixed_semantic_policy_versions: stats.mixed_semantic_policy_versions,
-    }
 }
 
 #[cfg(test)]

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -10,16 +10,15 @@ use super::{
     LLM_SYMBOL_DOC_SCHEMA_VERSION, NodeId, OVERSIZED_SOURCE_POLICY_VERSION, PUBLICATION_TEST_FAULT,
     PendingLlmSymbolDoc, PublicationTestAction, PublicationTestBoundary, RefreshExecutionPlan,
     RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalIndexManifest, RetrievalModeDto,
-    RetrievalStateDto,
-    SEMANTIC_DOC_ALIAS_MODE_ENV, SEMANTIC_DOC_DEFAULT_MAX_TOKENS, SEMANTIC_DOC_MAX_TOKENS_ENV,
-    SEMANTIC_DOC_SCOPE_ENV, SEMANTIC_EDGE_STREAM_BATCH_SIZE, SEMANTIC_STREAM_PENDING_DOCS_ENV,
-    SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV, SYMBOL_SEARCH_DOC_PROVENANCE, SearchEngine,
-    SearchGenerationCompletion, SearchHit, SearchHitOrigin, SearchHybridLimitsDto,
-    SearchPlanAnchorGroupDto, SearchPlanChannelDto, SearchPlanPromotionStatusDto,
-    SearchRepoTextMode, SearchRequest, SearchSymbolProjection, SemanticDocAliasMode,
-    SemanticDocGraphContext, SemanticDocScope, SemanticModeDto, SourceIndexPolicy,
-    SourcePolicyExclusionPolicyIdentity, Storage, Store, SymbolSearchDoc, TrailConfigDto,
-    WorkspaceManifest, apply_hybrid_limits, architecture_query_intents,
+    RetrievalStateDto, SEMANTIC_DOC_ALIAS_MODE_ENV, SEMANTIC_DOC_DEFAULT_MAX_TOKENS,
+    SEMANTIC_DOC_MAX_TOKENS_ENV, SEMANTIC_DOC_SCOPE_ENV, SEMANTIC_EDGE_STREAM_BATCH_SIZE,
+    SEMANTIC_STREAM_PENDING_DOCS_ENV, SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV,
+    SYMBOL_SEARCH_DOC_PROVENANCE, SearchEngine, SearchGenerationCompletion, SearchHit,
+    SearchHitOrigin, SearchHybridLimitsDto, SearchPlanAnchorGroupDto, SearchPlanChannelDto,
+    SearchPlanPromotionStatusDto, SearchRepoTextMode, SearchRequest, SearchSymbolProjection,
+    SemanticDocAliasMode, SemanticDocGraphContext, SemanticDocScope, SemanticModeDto,
+    SourceIndexPolicy, SourcePolicyExclusionPolicyIdentity, Storage, Store, SymbolSearchDoc,
+    TrailConfigDto, WorkspaceManifest, apply_hybrid_limits, architecture_query_intents,
     arm_full_refresh_staged_store_hook, arm_incremental_staged_store_hook,
     arm_publication_test_fault, arm_semantic_projection_before_revalidate_hook,
     arm_source_policy_after_plan_hook, arm_source_policy_before_revalidate_hook,
@@ -2007,10 +2006,8 @@ fn core_dense_anchor_publication_succeeds_when_embedding_backend_is_unavailable(
 /// publication for `project_root` under the current sidecar contract.
 fn published_full_retrieval_manifest(project_root: &Path) -> RetrievalIndexManifest {
     let project_id = codestory_retrieval::sidecar_project_id_for_root(project_root);
-    let mut manifest = codestory_retrieval::test_support::retrieval_manifest_fixture(
-        &project_id,
-        &"a".repeat(64),
-    );
+    let mut manifest =
+        codestory_retrieval::test_support::retrieval_manifest_fixture(&project_id, &"a".repeat(64));
     manifest.projection_count = Some(2);
     manifest.symbol_doc_count = Some(8);
     manifest.dense_projection_count = Some(2);
@@ -2063,7 +2060,10 @@ fn retrieval_state_reports_hybrid_ready_from_published_manifest_without_legacy_d
         Some(2),
         "the stored contract reports the published dense projection count"
     );
-    let stored = retrieval.stored_embedding.as_ref().expect("stored contract");
+    let stored = retrieval
+        .stored_embedding
+        .as_ref()
+        .expect("stored contract");
     let current = retrieval
         .current_embedding
         .as_ref()

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -9,7 +9,8 @@ use super::{
     LEGACY_OVERSIZED_SOURCE_POLICY_VERSION, LLM_DOC_EMBED_BATCH_SIZE_ENV,
     LLM_SYMBOL_DOC_SCHEMA_VERSION, NodeId, OVERSIZED_SOURCE_POLICY_VERSION, PUBLICATION_TEST_FAULT,
     PendingLlmSymbolDoc, PublicationTestAction, PublicationTestBoundary, RefreshExecutionPlan,
-    RepoTextScanStatsDto, RetrievalIndexManifest, RetrievalModeDto, RetrievalStateDto,
+    RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalIndexManifest, RetrievalModeDto,
+    RetrievalStateDto,
     SEMANTIC_DOC_ALIAS_MODE_ENV, SEMANTIC_DOC_DEFAULT_MAX_TOKENS, SEMANTIC_DOC_MAX_TOKENS_ENV,
     SEMANTIC_DOC_SCOPE_ENV, SEMANTIC_EDGE_STREAM_BATCH_SIZE, SEMANTIC_STREAM_PENDING_DOCS_ENV,
     SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV, SYMBOL_SEARCH_DOC_PROVENANCE, SearchEngine,
@@ -1999,6 +2000,161 @@ fn core_dense_anchor_publication_succeeds_when_embedding_backend_is_unavailable(
             .get_all_llm_symbol_docs()
             .expect("legacy vectors")
             .is_empty()
+    );
+}
+
+/// A retrieval manifest that classifies as a current, non-degraded full
+/// publication for `project_root` under the current sidecar contract.
+fn published_full_retrieval_manifest(project_root: &Path) -> RetrievalIndexManifest {
+    let project_id = codestory_retrieval::sidecar_project_id_for_root(project_root);
+    let mut manifest = codestory_retrieval::test_support::retrieval_manifest_fixture(
+        &project_id,
+        &"a".repeat(64),
+    );
+    manifest.projection_count = Some(2);
+    manifest.symbol_doc_count = Some(8);
+    manifest.dense_projection_count = Some(2);
+    manifest
+}
+
+#[test]
+fn retrieval_state_reports_hybrid_ready_from_published_manifest_without_legacy_docs() {
+    // Regression: a fresh auto-bootstrap publishes semantic vectors through the
+    // retrieval manifest while intentionally clearing the legacy
+    // `llm_symbol_doc` table. Deriving `semantic_doc_count` from that legacy
+    // table pinned every honest projection at missing_semantic_docs even
+    // though sidecar-primary retrieval was fully live.
+    let _env = hybrid_test_env();
+    let temp = tempdir().expect("temp dir");
+    let project_root = temp.path().join("project");
+    fs::create_dir_all(&project_root).expect("project root");
+    let storage_path = temp.path().join("codestory.db");
+    let mut storage = Storage::open(&storage_path).expect("open storage");
+    storage
+        .upsert_retrieval_index_manifest(&published_full_retrieval_manifest(&project_root))
+        .expect("publish retrieval manifest");
+    assert_eq!(
+        storage
+            .get_llm_symbol_doc_stats()
+            .expect("legacy stats")
+            .doc_count,
+        0,
+        "modern publications keep the legacy core-vector table empty"
+    );
+
+    let retrieval = crate::search_publication::retrieval_state_from_storage_for_runtime(
+        &storage,
+        &project_root,
+        &test_sidecar_runtime_from_env(),
+    )
+    .expect("retrieval state");
+
+    assert_eq!(retrieval.mode, RetrievalModeDto::Hybrid);
+    assert!(retrieval.semantic_ready);
+    assert_eq!(retrieval.semantic_mode, SemanticModeDto::Enabled);
+    assert_eq!(retrieval.semantic_doc_count, 2);
+    assert_eq!(retrieval.fallback_reason, None);
+    assert_eq!(retrieval.fallback_message, None);
+    assert_eq!(
+        retrieval
+            .stored_embedding
+            .as_ref()
+            .map(|stored| stored.doc_count),
+        Some(2),
+        "the stored contract reports the published dense projection count"
+    );
+
+    // The stdio host compaction projects {"state":"ready"} from exactly these
+    // wire fields: mode == "hybrid" with no stated fallback.
+    let wire = serde_json::to_value(&retrieval).expect("serialize retrieval state");
+    assert_eq!(wire["mode"], serde_json::json!("hybrid"));
+    assert_eq!(wire["semantic_ready"], serde_json::json!(true));
+    assert!(wire.get("fallback_reason").is_none());
+}
+
+#[test]
+fn retrieval_state_without_manifest_reports_missing_semantic_docs() {
+    let _env = hybrid_test_env();
+    let temp = tempdir().expect("temp dir");
+    let project_root = temp.path().join("project");
+    fs::create_dir_all(&project_root).expect("project root");
+    let storage_path = temp.path().join("codestory.db");
+    let storage = Storage::open(&storage_path).expect("open storage");
+
+    let retrieval = crate::search_publication::retrieval_state_from_storage_for_runtime(
+        &storage,
+        &project_root,
+        &test_sidecar_runtime_from_env(),
+    )
+    .expect("retrieval state");
+
+    assert_eq!(retrieval.mode, RetrievalModeDto::Symbolic);
+    assert!(!retrieval.semantic_ready);
+    assert_eq!(retrieval.semantic_doc_count, 0);
+    assert_eq!(
+        retrieval.fallback_reason,
+        Some(RetrievalFallbackReasonDto::MissingSemanticDocs)
+    );
+    assert!(
+        retrieval
+            .fallback_message
+            .as_deref()
+            .is_some_and(|message| message.contains("retrieval index --refresh full")),
+        "the genuinely-unbuilt case is where the CLI repair advice is truthful"
+    );
+    assert!(retrieval.stored_embedding.is_none());
+}
+
+#[test]
+fn degraded_or_mismatched_manifest_does_not_report_hybrid_ready() {
+    let _env = hybrid_test_env();
+    let temp = tempdir().expect("temp dir");
+    let project_root = temp.path().join("project");
+    fs::create_dir_all(&project_root).expect("project root");
+    let storage_path = temp.path().join("codestory.db");
+    let mut storage = Storage::open(&storage_path).expect("open storage");
+    let runtime = test_sidecar_runtime_from_env();
+
+    let mut degraded = published_full_retrieval_manifest(&project_root);
+    degraded.degraded_modes_json = r#"["embedded_vector_index_unavailable"]"#.to_string();
+    storage
+        .upsert_retrieval_index_manifest(&degraded)
+        .expect("publish degraded manifest");
+    let state = crate::search_publication::retrieval_state_from_storage_for_runtime(
+        &storage,
+        &project_root,
+        &runtime,
+    )
+    .expect("degraded retrieval state");
+    assert_eq!(state.mode, RetrievalModeDto::Symbolic);
+    assert!(!state.semantic_ready);
+    assert_eq!(
+        state.fallback_reason,
+        Some(RetrievalFallbackReasonDto::DegradedRuntime)
+    );
+
+    let mut mismatched = published_full_retrieval_manifest(&project_root);
+    mismatched.embedding_backend = Some("legacy-backend".to_string());
+    storage
+        .upsert_retrieval_index_manifest(&mismatched)
+        .expect("publish mismatched manifest");
+    let state = crate::search_publication::retrieval_state_from_storage_for_runtime(
+        &storage,
+        &project_root,
+        &runtime,
+    )
+    .expect("mismatched retrieval state");
+    assert_eq!(state.mode, RetrievalModeDto::Symbolic);
+    assert!(!state.semantic_ready);
+    assert_eq!(
+        state.fallback_reason,
+        Some(RetrievalFallbackReasonDto::DegradedRuntime)
+    );
+    assert!(
+        state
+            .fallback_message
+            .as_deref()
+            .is_some_and(|message| message.contains("embedding contract"))
     );
 }
 

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -2063,6 +2063,24 @@ fn retrieval_state_reports_hybrid_ready_from_published_manifest_without_legacy_d
         Some(2),
         "the stored contract reports the published dense projection count"
     );
+    let stored = retrieval.stored_embedding.as_ref().expect("stored contract");
+    let current = retrieval
+        .current_embedding
+        .as_ref()
+        .expect("current contract");
+    assert_eq!(
+        stored.cache_key.as_deref(),
+        Some(current.cache_key.as_str()),
+        "the manifest's embedding runtime id must project into the current \
+         contract's cache-key identity space so consumers (doctor) can compare it"
+    );
+    assert_eq!(
+        stored.embedding_backend, None,
+        "the manifest carries no per-doc backend label; projecting the runtime \
+         id into that field made doctor report semantic stale forever"
+    );
+    assert_eq!(stored.embedding_profile, None);
+    assert_eq!(stored.doc_shape, None);
 
     // The stdio host compaction projects {"state":"ready"} from exactly these
     // wire fields: mode == "hybrid" with no stated fallback.
@@ -2070,6 +2088,73 @@ fn retrieval_state_reports_hybrid_ready_from_published_manifest_without_legacy_d
     assert_eq!(wire["mode"], serde_json::json!("hybrid"));
     assert_eq!(wire["semantic_ready"], serde_json::json!(true));
     assert!(wire.get("fallback_reason").is_none());
+}
+
+#[test]
+fn zero_dense_full_publication_reports_ready_without_missing_docs() {
+    // A tiny project can legally publish a current, non-degraded full sidecar
+    // with zero dense anchors (generation only requires the dense projection
+    // count to equal the projection count). Admission serves that sidecar as
+    // full, so readiness must report the lane as published-and-empty rather
+    // than unbuilt: `retrieval index --refresh full` would republish the
+    // identical zero-anchor manifest and could never clear the message.
+    let _env = hybrid_test_env();
+    let temp = tempdir().expect("temp dir");
+    let project_root = temp.path().join("project");
+    fs::create_dir_all(&project_root).expect("project root");
+    let storage_path = temp.path().join("codestory.db");
+    let mut storage = Storage::open(&storage_path).expect("open storage");
+    let mut manifest = published_full_retrieval_manifest(&project_root);
+    manifest.projection_count = Some(0);
+    manifest.symbol_doc_count = Some(0);
+    manifest.dense_projection_count = Some(0);
+    storage
+        .upsert_retrieval_index_manifest(&manifest)
+        .expect("publish zero-dense manifest");
+    let runtime = test_sidecar_runtime_from_env();
+
+    let retrieval = crate::search_publication::retrieval_state_from_storage_for_runtime(
+        &storage,
+        &project_root,
+        &runtime,
+    )
+    .expect("retrieval state");
+
+    assert_eq!(retrieval.mode, RetrievalModeDto::Hybrid);
+    assert!(retrieval.semantic_ready);
+    assert_eq!(retrieval.semantic_mode, SemanticModeDto::Enabled);
+    assert_eq!(retrieval.semantic_doc_count, 0);
+    assert_eq!(retrieval.fallback_reason, None);
+    assert_eq!(retrieval.fallback_message, None);
+    assert_eq!(
+        retrieval
+            .stored_embedding
+            .as_ref()
+            .map(|stored| stored.doc_count),
+        Some(0),
+        "the truthful published state remains visible as a zero dense count"
+    );
+
+    // A zero-dense manifest that is stale or mismatched keeps the unbuilt
+    // classification: there a refresh genuinely rebuilds the publication, so
+    // the repair advice stays truthful and the state stays fail-closed.
+    let mut mismatched = manifest.clone();
+    mismatched.embedding_backend = Some("legacy-backend".to_string());
+    storage
+        .upsert_retrieval_index_manifest(&mismatched)
+        .expect("publish mismatched zero-dense manifest");
+    let state = crate::search_publication::retrieval_state_from_storage_for_runtime(
+        &storage,
+        &project_root,
+        &runtime,
+    )
+    .expect("mismatched zero-dense retrieval state");
+    assert_eq!(state.mode, RetrievalModeDto::Symbolic);
+    assert!(!state.semantic_ready);
+    assert_eq!(
+        state.fallback_reason,
+        Some(RetrievalFallbackReasonDto::MissingSemanticDocs)
+    );
 }
 
 #[test]


### PR DESCRIPTION
The readiness projection sourced semantic_doc_count from llm_symbol_doc — the legacy v0.15 core-vector table nothing has written since f39c7158 and that every modern publication actively clears — so every search/ground/index surface permanently reported symbolic/missing_semantic_docs with repair advice that can never succeed, and plan-expanded searches consumed the false semantic_ready=false. The pre-WP8a stdio projection masked this by lying ready; the calibration lane caught it the moment the projection became honest.

The projection now derives from the retrieval_index_manifest publication pointer with the same classification sidecar-primary admission performs (fail-closed: manifest exists, classifies full, contract-matched, runtime not degraded). The doctor's stored-contract comparison speaks the consumer vocabulary — fields the manifest cannot carry stay absent instead of lying in the wrong field, cache_key/dimension stay required, and a DegradedRuntime verdict is a gap so doctor can never contradict the projection. A current zero-dense-anchor full publication truthfully reports ready with count 0 instead of impossible advice.

Regression tests are revert-proven at both layers (doctor: three-gap WARN on the unrepaired commit → ok; projection: Symbolic → Hybrid), plus fail-closed companions (mismatched backend, degraded-but-field-matching manifest still WARN). Full suites green: codestory-runtime, codestory-cli (19 suites), codestory-retrieval. Adversarially reviewed twice; first revision rejected for relocating the impossible-advice pathology into doctor, repaired and re-approved.

Closes #1489

🤖 Generated with [Claude Code](https://claude.com/claude-code)