### PR TITLE
derive the measurement-worker kill budget from the contract deadlines

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/measurements.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/measurements.rs
@@ -6,7 +6,7 @@ use super::analysis::{
     accelerator_operands, completed_token_count, raw_server_identity,
     snapshot_has_resident_generation,
 };
-use super::process::{query_parameters, require_worker_success};
+use super::process::{measurement_worker_timeout, query_parameters, require_worker_success};
 use super::{ScenarioRunner, WorkerOutput, push_metric};
 use crate::qualification::request::REQUIRED_METRICS;
 use anyhow::{Result, bail};
@@ -154,7 +154,10 @@ impl<'a> ScenarioRunner<'a> {
         }
 
         let residency_worker = self.spawn_worker("resident_identity", query_parameters(1), None)?;
-        let residency_output = self.finish_worker(residency_worker, SNAPSHOT_TIMEOUT)?;
+        let residency_output = self.finish_worker(
+            residency_worker,
+            measurement_worker_timeout("resident_identity"),
+        )?;
         let residency_interval = measurement_interval(&residency_output)?;
         let identity = residency_output
             .engine_identity
@@ -178,7 +181,7 @@ impl<'a> ScenarioRunner<'a> {
                 snapshot.scheduler.active_request_count > 0 || snapshot.scheduler.query_depth > 0
             })?;
             self.control("release_class", Some("query"))?;
-            let output = self.finish_worker(worker, SNAPSHOT_TIMEOUT)?;
+            let output = self.finish_worker(worker, measurement_worker_timeout("query"))?;
             require_worker_success(&output, "busy_retry_usefulness")?;
             let interval = measurement_interval(&output)?;
             let snapshot = self.record_worker_snapshot("measurement_busy_complete", &output)?;
@@ -235,7 +238,7 @@ impl<'a> ScenarioRunner<'a> {
         parameters: EmbeddingQualificationParameters,
     ) -> Result<(MeasurementInterval, EmbeddingServerSnapshot, WorkerOutput)> {
         let worker = self.spawn_worker(operation, parameters, None)?;
-        let output = self.finish_worker(worker, SNAPSHOT_TIMEOUT)?;
+        let output = self.finish_worker(worker, measurement_worker_timeout(operation))?;
         require_worker_success(&output, operation)?;
         let interval = measurement_interval(&output)?;
         let snapshot = self.record_worker_snapshot("measurement_worker", &output)?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
@@ -6,8 +6,8 @@ use super::{
 use crate::qualification::request::QUALIFICATION_NONCE_ENV;
 use anyhow::{Context, Result, bail};
 use codestory_retrieval::{
-    EmbeddingQualificationAttemptResult, EmbeddingQualificationParameters, EmbeddingResult,
-    PER_USER_EMBEDDING_BULK_REQUEST_DEADLINE_MS, ProcessStartProbe,
+    EmbeddingClientBudgets, EmbeddingQualificationAttemptResult, EmbeddingQualificationParameters,
+    EmbeddingResult, PER_USER_EMBEDDING_BULK_REQUEST_DEADLINE_MS, ProcessStartProbe,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -226,4 +226,31 @@ pub(super) fn stall_worker_timeout() -> Duration {
             .saturating_add(SNAPSHOT_TIMEOUT.as_millis() as u64)
             .saturating_add(CONTROL_TIMEOUT.as_millis() as u64),
     )
+}
+
+/// Coordinator kill budget for one measurement worker. `wait_for_child` exists
+/// only as a hung-worker watchdog, so its budget must strictly dominate the
+/// worker's honest worst case, and that worst case is already defined by the
+/// constant-set deadlines the worker enforces on itself: connect to or spawn
+/// the server, then run one request bounded by its class deadline. The
+/// snapshot and control terms cover the coordinator-visible bookkeeping around
+/// the operation, matching `stall_worker_timeout`. Every term is
+/// contract-derived; a flat snapshot-wait budget killed legitimately
+/// progressing bulk workloads on the hosted 2-core calibration cell
+/// (run 30197324641: warm_bulk_64x256b needs ~24s and the 256-document
+/// throughput workload ~96s at the calibrated 2.658 docs/s, both inside the
+/// worker's own bulk deadline).
+pub(super) fn measurement_worker_timeout(operation: &str) -> Duration {
+    let budgets = EmbeddingClientBudgets::current();
+    let request_deadline = if operation == "bulk" {
+        budgets.bulk_request
+    } else {
+        budgets.query_request
+    };
+    budgets
+        .connect
+        .saturating_add(budgets.spawn)
+        .saturating_add(request_deadline)
+        .saturating_add(SNAPSHOT_TIMEOUT)
+        .saturating_add(CONTROL_TIMEOUT)
 }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
@@ -1,9 +1,47 @@
-use super::super::{ScenarioArtifact, ScenarioOrchestration};
+use super::super::{CONTROL_TIMEOUT, SNAPSHOT_TIMEOUT, ScenarioArtifact, ScenarioOrchestration};
 use super::analysis::resident_generation_is_valid;
 use super::evidence::validate_named_evidence;
+use super::process::measurement_worker_timeout;
 use super::{ScenarioEvidence, opaque_measurement_sample_id};
 use crate::qualification::request::{QualificationContracts, REQUIRED_SCENARIOS};
+use codestory_retrieval::{EmbeddingClientBudgets, PER_USER_EMBEDDING_BULK_REQUEST_DEADLINE_MS};
 use std::collections::BTreeSet;
+use std::time::Duration;
+
+#[test]
+fn measurement_worker_budgets_dominate_the_deadlines_workers_honor() {
+    // `wait_for_child` is a hung-worker watchdog: it must never kill a
+    // measurement worker that is still inside its own contract deadlines
+    // (connect or spawn convergence, then one request bounded by its class
+    // deadline), plus the coordinator's snapshot and control allowances.
+    // Regression: calibration run 30197324641 (hosted_linux_x64_cpu) was
+    // killed by a flat 20s snapshot-wait budget while the warm-bulk workload
+    // legitimately needs ~24s and the 256-document throughput workload ~96s.
+    let budgets = EmbeddingClientBudgets::current();
+    let orchestration_terms = budgets
+        .connect
+        .saturating_add(budgets.spawn)
+        .saturating_add(SNAPSHOT_TIMEOUT)
+        .saturating_add(CONTROL_TIMEOUT);
+    for operation in ["query", "observe", "resident_identity"] {
+        assert!(
+            measurement_worker_timeout(operation)
+                >= orchestration_terms.saturating_add(budgets.query_request),
+            "query-class measurement budget must dominate the worker's own query deadline chain"
+        );
+    }
+    let bulk_timeout = measurement_worker_timeout("bulk");
+    assert!(
+        bulk_timeout >= orchestration_terms.saturating_add(budgets.bulk_request),
+        "bulk measurement budget must dominate the worker's own bulk deadline chain"
+    );
+    // The exact defect: the coordinator killed bulk measurement workers below
+    // the bulk request deadline the workers themselves honor.
+    assert!(
+        bulk_timeout >= Duration::from_millis(PER_USER_EMBEDDING_BULK_REQUEST_DEADLINE_MS),
+        "bulk measurement budget must not undercut the contract bulk request deadline"
+    );
+}
 
 #[test]
 fn measurement_sample_ids_are_opaque_stable_and_unique_between_runs() {


### PR DESCRIPTION
The coordinator killed every per-sample measurement worker at a compiled-in 20s while the protocol-mandated bulk workloads legitimately need 24-96s on the hosted CPU cell (and the worker honors a ~495s bulk RPC deadline). The budget is now derived from the same contract terms the worker itself honors, following the existing stall_worker_timeout() pattern. Regression test is revert-proven. Trade-off: a truly wedged bulk worker is detected at ~542s instead of 20s — still far inside the 1800s outer python bound.

Closes #1491

🤖 Generated with [Claude Code](https://claude.com/claude-code)