### PR TITLE
give every windows proof step an explicit shell

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1782,6 +1782,18 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     "--cell-id retrieval_readiness:windows-x64",
     "release-cell-postpublish-retrieval-windows-x64-attempt-$GITHUB_RUN_ATTEMPT",
   ]);
+  // The self-hosted Windows service account runs under the default Restricted execution
+  // policy, so a run step left on the default shell dies before executing anything:
+  // every step must pick bash or a powershell invocation that bypasses the policy.
+  for (const step of at(workflows.get("windows-vulkan-proof.yml"), "jobs", "packaged-vulkan", "steps") ?? []) {
+    if (typeof object(step).run !== "string") continue;
+    const shell = object(step).shell;
+    add(
+      violations,
+      typeof shell === "string" && (shell === "bash" || shell.includes("-ExecutionPolicy Bypass")),
+      `windows-vulkan-proof.yml step ${object(step).name ?? "<unnamed>"} must declare the bypass shell for the locked-down service account`,
+    );
+  }
 
   const linuxVulkan = requireJob(violations, releaseFile, release, "linux-vulkan-proof");
   add(violations, linuxVulkan.uses === "./.github/workflows/linux-vulkan-proof.yml", `${releaseFile} must call protected Linux Vulkan proof`);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -742,6 +742,9 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
       draftStep(workflow.jobs["packaged-vulkan"], "Emit authenticated Vulkan release cell").if
         = "inputs.emit_release_cells";
     }, /must retain the authenticated Vulkan release cell outside calibration/u],
+    ["Vulkan model preparation drops the bypass shell", windowsVulkanFile, workflow => {
+      delete draftStep(workflow.jobs["packaged-vulkan"], "Prepare checksum-pinned embedded model").shell;
+    }, /Prepare checksum-pinned embedded model must declare the bypass shell/u],
     ["Vulkan candidate staging runs during calibration", windowsVulkanFile, workflow => {
       draftStep(workflow.jobs["packaged-vulkan"], "Stage isolated candidate-managed Windows install").if
         = "inputs.candidate_installed_proof";

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -160,6 +160,9 @@ jobs:
 
       - name: Prepare checksum-pinned embedded model
         if: ${{ !inputs.use_packaged_cli_artifact }}
+        # The self-hosted runner service account has the default Restricted execution
+        # policy, so every run step must carry the bypass shell or die before running.
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: node scripts/prepare-embedded-model.mjs
 
       - name: Build and package native CLI


### PR DESCRIPTION
The model-prep step relied on the default PowerShell, which the NETWORK SERVICE runner account blocks (Restricted policy) — it never ran on the self-hosted box before calibration mode. Adds the bypass shell there and a policy pin requiring every run step in packaged-vulkan to declare bash or bypass-powershell, mutation-tested. The pin initially flagged the three bash release-cell steps, and was refined to accept bash — the invariant is "never the default shell".

Closes #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)