### PR TITLE
preserve qualification evidence when the packaged proof fails

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2540,6 +2540,20 @@ function validatePackagedProof(workflows, violations, graph) {
         === "success() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode",
     `${file} hosted calibration artifact must remain calibration-only`,
   );
+  const hostedCalibrationFailureUpload = namedStep(
+    job,
+    "Upload hosted Linux calibration failure evidence",
+  );
+  add(
+    violations,
+    hostedCalibrationFailureUpload?.uses === "actions/upload-artifact@v7.0.1"
+      && hostedCalibrationFailureUpload?.if
+        === "failure() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode"
+      && object(hostedCalibrationFailureUpload?.with).path
+        === "target/calibration-runs/linux"
+      && object(hostedCalibrationFailureUpload?.with)["if-no-files-found"] === "warn",
+    `${file} hosted calibration failure evidence must stay a failure-only best-effort upload`,
+  );
   const hostedEvaluationUpload = namedStep(job, "Upload packaged agent proof artifacts");
   add(
     violations,

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -681,6 +681,18 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
       draftStep(workflow.jobs.build, "Upload hosted Linux calibration runs").if
         = "success() && matrix.asset_target == 'linux-x64'";
     }, /hosted calibration artifact must remain calibration-only/u],
+    ["package calibration failure evidence removed", packagedProofFile, workflow => {
+      workflow.jobs.build.steps = workflow.jobs.build.steps
+        .filter(({ name }) => name !== "Upload hosted Linux calibration failure evidence");
+    }, /hosted calibration failure evidence must stay a failure-only best-effort upload/u],
+    ["package calibration failure evidence becomes success-gated", packagedProofFile, workflow => {
+      draftStep(workflow.jobs.build, "Upload hosted Linux calibration failure evidence").if
+        = "success() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode";
+    }, /hosted calibration failure evidence must stay a failure-only best-effort upload/u],
+    ["package calibration failure evidence fails closed", packagedProofFile, workflow => {
+      draftStep(workflow.jobs.build, "Upload hosted Linux calibration failure evidence")
+        .with["if-no-files-found"] = "error";
+    }, /hosted calibration failure evidence must stay a failure-only best-effort upload/u],
     ["package evaluation becomes a standard server-behavior proof", packagedProofFile, workflow => {
       draftStep(
         workflow.jobs.build,

--- a/.github/scripts/packaged_agent_proof/archive_proof.py
+++ b/.github/scripts/packaged_agent_proof/archive_proof.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from .archive_io import find_cli, unpack_archive
 from .calibration_verification import verify_calibration_bundle
 from .contract_primitives import write_json
+from .failure_evidence import preserve_failure_evidence
 from .foundation import LEGACY_HELP_TOKENS, REPOSITORY_ROOT, require
 from .installation_support import isolated_environment
 from .native_manifest import load_native_manifest
@@ -134,72 +135,87 @@ def run_archive_proof(args: argparse.Namespace) -> None:
     )
     with temporary_package_directory as raw:
         root = Path(raw)
-        unpack_archive(args.archive, root / "unpacked")
-        cli = find_cli(root / "unpacked")
-        manifest = load_native_manifest(
-            root / "unpacked",
-            cli,
-            args.expected_version,
+        try:
+            _run_proof_phases(args, temporary_package_directory, root)
+        except BaseException as error:
+            # The temporary package root is destroyed on exit; copy the
+            # qualification evidence it holds into the workflow-uploaded
+            # output directory before that happens.
+            preserve_failure_evidence(root, args.out_dir, error)
+            raise
+
+
+def _run_proof_phases(
+    args: argparse.Namespace,
+    temporary_package_directory: FailurePreservingTemporaryDirectory,
+    root: Path,
+) -> None:
+    unpack_archive(args.archive, root / "unpacked")
+    cli = find_cli(root / "unpacked")
+    manifest = load_native_manifest(
+        root / "unpacked",
+        cli,
+        args.expected_version,
+    )
+    verify_package_source(args, manifest)
+    require_frozen = requires_calibration_bundle(args)
+    require(
+        not args.enforce_calibration_freeze_lineage or require_frozen,
+        "calibration freeze lineage is valid only for the immediate frozen proof",
+    )
+    measurement_contract = verify_package_server_contracts(
+        manifest,
+        args.measurement_protocol,
+        require_frozen=require_frozen,
+    )
+    if args.ground_only and os.name == "nt":
+        cleanup_wait_budget = native_server_exit_wait_budget(
+            manifest,
+            measurement_contract["constant_set"],
         )
-        verify_package_source(args, manifest)
-        require_frozen = requires_calibration_bundle(args)
+        temporary_package_directory.cleanup_retry_budget_secs = (
+            cleanup_wait_budget["timeout_ms"] / 1000
+        )
+    calibration_bundle = load_calibration_bundle(
+        args,
+        manifest,
+        measurement_contract,
+        required=require_frozen,
+    )
+    env = isolated_environment(root, args.engine_policy, args.offline)
+    summary = package_summary(
+        args,
+        cli,
+        root,
+        env,
+        manifest,
+        measurement_contract,
+        calibration_bundle,
+    )
+    if not args.version_only:
         require(
-            not args.enforce_calibration_freeze_lineage or require_frozen,
-            "calibration freeze lineage is valid only for the immediate frozen proof",
+            args.project is not None,
+            "--project is required for the runtime proof",
         )
-        measurement_contract = verify_package_server_contracts(
-            manifest,
-            args.measurement_protocol,
-            require_frozen=require_frozen,
+        require(
+            args.engine_policy is not None,
+            "--engine-policy is required for the runtime proof",
         )
-        if args.ground_only and os.name == "nt":
-            cleanup_wait_budget = native_server_exit_wait_budget(
-                manifest,
-                measurement_contract["constant_set"],
-            )
-            temporary_package_directory.cleanup_retry_budget_secs = (
-                cleanup_wait_budget["timeout_ms"] / 1000
-            )
-        calibration_bundle = load_calibration_bundle(
-            args,
-            manifest,
-            measurement_contract,
-            required=require_frozen,
-        )
-        env = isolated_environment(root, args.engine_policy, args.offline)
-        summary = package_summary(
+        runtime = run_runtime_proof(
             args,
             cli,
-            root,
             env,
+            root,
             manifest,
             measurement_contract,
-            calibration_bundle,
         )
-        if not args.version_only:
-            require(
-                args.project is not None,
-                "--project is required for the runtime proof",
-            )
-            require(
-                args.engine_policy is not None,
-                "--engine-policy is required for the runtime proof",
-            )
-            runtime = run_runtime_proof(
-                args,
-                cli,
-                env,
-                root,
-                manifest,
-                measurement_contract,
-            )
-            summary["runtime"] = runtime
-            record_runtime_contract(args, summary, manifest, runtime)
-            record_qualification_contract(
-                args,
-                summary,
-                manifest,
-                runtime,
-                measurement_contract,
-            )
-        write_json(args.out_dir / "summary.json", summary)
+        summary["runtime"] = runtime
+        record_runtime_contract(args, summary, manifest, runtime)
+        record_qualification_contract(
+            args,
+            summary,
+            manifest,
+            runtime,
+            measurement_contract,
+        )
+    write_json(args.out_dir / "summary.json", summary)

--- a/.github/scripts/packaged_agent_proof/failure_evidence.py
+++ b/.github/scripts/packaged_agent_proof/failure_evidence.py
@@ -1,0 +1,144 @@
+"""Best-effort preservation of qualification evidence for failed proof runs.
+
+The packaged proof executes inside a temporary package root that is destroyed
+when the run ends. ``FailurePreservingTemporaryDirectory`` preserves the
+primary *exception* when cleanup itself fails, but the evidence written under
+the temporary root (``qualification-suite/artifacts/request.json``, driver
+output, worker logs, partial measurement samples) is still deleted with the
+process. This module copies that evidence into the workflow-uploaded output
+directory on the failure path, so a post-mortem never requires a re-run.
+
+Preservation is diagnostic and best-effort: it never masks the primary proof
+failure, it adds nothing on green runs, and per-run secrets registered by the
+producing phases (the qualification nonces) are redacted from every preserved
+byte before it can reach an uploaded artifact.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .subprocess_control import add_exception_note
+
+EVIDENCE_DIRECTORY_NAMES = ("qualification-suite", "qualification")
+FAILURE_EVIDENCE_DIRECTORY_NAME = "failure-evidence"
+REDACTION_MARKER = "[redacted-qualification-secret]"
+PRESERVATION_BYTE_BUDGET = 64 * 1024 * 1024
+
+_registered_secrets: list[str] = []
+
+
+def register_failure_evidence_secret(value: str) -> None:
+    """Record a per-run secret so preserved evidence never contains it."""
+    if isinstance(value, str) and value and value not in _registered_secrets:
+        _registered_secrets.append(value)
+
+
+def reset_failure_evidence_secrets() -> None:
+    """Clear registered secrets; self-test isolation only."""
+    _registered_secrets.clear()
+
+
+def _redacted(payload: bytes) -> bytes:
+    marker = REDACTION_MARKER.encode("utf-8")
+    for secret in _registered_secrets:
+        payload = payload.replace(secret.encode("utf-8"), marker)
+    return payload
+
+
+def _preserve_directory(
+    source: Path,
+    destination: Path,
+    remaining_budget: int,
+    skipped: list[str],
+) -> int:
+    for path in sorted(source.rglob("*")):
+        relative = path.relative_to(source).as_posix()
+        try:
+            if path.is_symlink():
+                skipped.append(f"{relative} (symlink)")
+                continue
+            if path.is_dir():
+                (destination / relative).mkdir(parents=True, exist_ok=True)
+                continue
+            if not path.is_file():
+                skipped.append(f"{relative} (special file)")
+                continue
+            size = path.stat().st_size
+            if size > remaining_budget:
+                skipped.append(f"{relative} (over evidence budget: {size} bytes)")
+                continue
+            payload = _redacted(path.read_bytes())
+            target = destination / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(payload)
+            remaining_budget -= size
+        except OSError as copy_error:
+            skipped.append(f"{relative} (unreadable: {copy_error})")
+    return remaining_budget
+
+
+def preserve_failure_evidence(
+    root: Path,
+    out_dir: Path,
+    error: BaseException,
+) -> None:
+    """Copy qualification evidence from ``root`` into ``out_dir`` on failure.
+
+    ``root`` is the temporary package root that is about to be destroyed;
+    ``out_dir`` is the ``--out-dir`` upload root that consuming workflows
+    already upload. Nothing is written when no qualification evidence exists
+    yet, so failures before the qualification suite stays artifact-free and
+    green runs are untouched. Preservation never raises past this function.
+    """
+    try:
+        sources = [
+            root / name
+            for name in EVIDENCE_DIRECTORY_NAMES
+            if (root / name).is_dir() and not (root / name).is_symlink()
+        ]
+        if not sources:
+            return
+        destination = out_dir / FAILURE_EVIDENCE_DIRECTORY_NAME
+        skipped: list[str] = []
+        remaining_budget = PRESERVATION_BYTE_BUDGET
+        for source in sources:
+            remaining_budget = _preserve_directory(
+                source,
+                destination / source.name,
+                remaining_budget,
+                skipped,
+            )
+        manifest = {
+            "schema_version": 1,
+            "reason": (
+                "packaged proof failed after qualification evidence existed; "
+                "the temporary package root is destroyed, so its evidence is "
+                "copied here for post-mortems"
+            ),
+            "error": _redacted(
+                f"{type(error).__name__}: {error}".encode("utf-8", "replace")
+            ).decode("utf-8", "replace"),
+            "preserved_directories": [source.name for source in sources],
+            "skipped_entries": skipped,
+            "redaction_marker": REDACTION_MARKER,
+            "redacted_secret_count": len(_registered_secrets),
+        }
+        destination.mkdir(parents=True, exist_ok=True)
+        (destination / "failure.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        add_exception_note(
+            error,
+            f"qualification failure evidence preserved under {destination}",
+        )
+    except BaseException as preservation_error:  # never mask the proof failure
+        try:
+            add_exception_note(
+                error,
+                f"failure evidence preservation also failed: {preservation_error}",
+            )
+        except BaseException:
+            pass

--- a/.github/scripts/packaged_agent_proof/installation_support.py
+++ b/.github/scripts/packaged_agent_proof/installation_support.py
@@ -9,6 +9,7 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 
+from .failure_evidence import register_failure_evidence_secret
 from .foundation import (
     LEGACY_TOKENS,
     QUALIFICATION_SCHEMA_VERSION,
@@ -119,6 +120,7 @@ def qualification_environment(
     proof_root.mkdir(parents=True, exist_ok=True)
     proof_root.chmod(0o700)
     nonce = secrets.token_hex(32)
+    register_failure_evidence_secret(nonce)
     qualified = dict(env)
     qualified["CODESTORY_EMBED_QUALIFICATION_DIR"] = str(proof_root)
     qualified["CODESTORY_EMBED_QUALIFICATION_NONCE"] = nonce

--- a/.github/scripts/packaged_agent_proof/qualification_producer_setup.py
+++ b/.github/scripts/packaged_agent_proof/qualification_producer_setup.py
@@ -8,6 +8,7 @@ import secrets
 from pathlib import Path
 
 from .contract_primitives import sha256
+from .failure_evidence import register_failure_evidence_secret
 from .foundation import RETRIEVAL_QUALITY_EVIDENCE_CONTRACT, ProofFailure, require
 from .native_manifest import runtime_executable_sha256
 from .publication_consistency_verifier import (
@@ -55,6 +56,7 @@ def prepare_qualification_producer(
     private_root.mkdir(mode=0o700)
     artifact_root.mkdir(mode=0o700)
     nonce = secrets.token_hex(32)
+    register_failure_evidence_secret(nonce)
     projects = runtime.get("_qualification_projects")
     require(
         isinstance(projects, list)

--- a/.github/scripts/packaged_agent_proof/self_test_failure_evidence.py
+++ b/.github/scripts/packaged_agent_proof/self_test_failure_evidence.py
@@ -1,0 +1,229 @@
+"""Self-tests proving failed proof runs preserve qualification evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from . import archive_proof
+from .failure_evidence import (
+    FAILURE_EVIDENCE_DIRECTORY_NAME,
+    REDACTION_MARKER,
+    preserve_failure_evidence,
+    register_failure_evidence_secret,
+    reset_failure_evidence_secrets,
+)
+from .foundation import ProofFailure, require
+from .self_test_full_stack_types import FullStackFixture
+
+_UNIT_SECRET = "e" * 64
+_SCRIPTED_SECRET = "f" * 64
+_SCRIPTED_FAILURE = "scripted qualification driver failure"
+
+
+def _read(path: Path) -> bytes:
+    require(
+        path.is_file() and not path.is_symlink(),
+        f"preserved evidence is missing: {path}",
+    )
+    return path.read_bytes()
+
+
+def _require_redacted(payload: bytes, secret: str, context: str) -> None:
+    require(
+        secret.encode("utf-8") not in payload,
+        f"{context} leaked a registered qualification secret",
+    )
+    require(
+        REDACTION_MARKER.encode("utf-8") in payload,
+        f"{context} lost its redaction marker",
+    )
+
+
+def _preservation_unit_tests() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        root = base / "root"
+        out_dir = base / "out"
+        artifact_root = root / "qualification-suite" / "artifacts"
+        artifact_root.mkdir(parents=True)
+        out_dir.mkdir()
+        register_failure_evidence_secret(_UNIT_SECRET)
+        (artifact_root / "request.json").write_text(
+            json.dumps({"schema_version": 1, "qualification_nonce": _UNIT_SECRET}),
+            encoding="utf-8",
+        )
+        (root / "qualification-suite" / "worker.log").write_text(
+            f"worker crashed after handshake nonce={_UNIT_SECRET}\n",
+            encoding="utf-8",
+        )
+        (root / "qualification").mkdir()
+        (root / "qualification" / "gate.json").write_text(
+            '{"state": "open"}\n', encoding="utf-8"
+        )
+        symlink_supported = True
+        try:
+            os.symlink(base, root / "qualification-suite" / "escape")
+        except (OSError, NotImplementedError):
+            symlink_supported = False
+        error = ProofFailure(f"unit failure carrying {_UNIT_SECRET}")
+        preserve_failure_evidence(root, out_dir, error)
+        evidence = out_dir / FAILURE_EVIDENCE_DIRECTORY_NAME
+        _require_redacted(
+            _read(evidence / "qualification-suite" / "artifacts" / "request.json"),
+            _UNIT_SECRET,
+            "preserved request.json",
+        )
+        _require_redacted(
+            _read(evidence / "qualification-suite" / "worker.log"),
+            _UNIT_SECRET,
+            "preserved worker log",
+        )
+        require(
+            _read(evidence / "qualification" / "gate.json")
+            == b'{"state": "open"}\n',
+            "preserved server-identity qualification evidence changed",
+        )
+        if symlink_supported:
+            require(
+                not (evidence / "qualification-suite" / "escape").exists(),
+                "preservation followed a symlink out of the evidence root",
+            )
+        manifest = json.loads(_read(evidence / "failure.json"))
+        require(
+            "unit failure" in manifest["error"]
+            and _UNIT_SECRET not in manifest["error"],
+            "failure manifest lost or leaked the primary error",
+        )
+        require(
+            manifest["preserved_directories"]
+            == ["qualification-suite", "qualification"],
+            "failure manifest changed its preserved directory contract",
+        )
+
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        root = base / "root"
+        out_dir = base / "out"
+        root.mkdir()
+        out_dir.mkdir()
+        preserve_failure_evidence(root, out_dir, ProofFailure("early failure"))
+        require(
+            not any(out_dir.iterdir()),
+            "preservation created artifacts before qualification evidence existed",
+        )
+
+
+def _scripted_proof_arguments(fixture: FullStackFixture, out_dir: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        archive=fixture.root / "artifact.zip",
+        expected_version="0.0.0",
+        expected_source_sha=None,
+        expected_source_tree=None,
+        measurement_protocol=fixture.measurement_protocol,
+        out_dir=out_dir,
+        project=fixture.root,
+        engine_policy="cpu_explicit",
+        offline=True,
+        version_only=False,
+        proof_tier="calibration",
+        server_behavior_only=False,
+        ground_only=False,
+        enforce_calibration_freeze_lineage=False,
+        calibration_bundle=None,
+        calibration_producer_run_id=None,
+        calibration_producer_artifact=None,
+        timeout_secs=60,
+    )
+
+
+def _scripted_driver_failure_tests(fixture: FullStackFixture) -> None:
+    observed: dict[str, Path] = {}
+
+    def failing_runtime_proof(args, cli, env, root, manifest, measurement_contract):
+        observed["root"] = root
+        register_failure_evidence_secret(_SCRIPTED_SECRET)
+        artifact_root = root / "qualification-suite" / "artifacts"
+        artifact_root.mkdir(parents=True)
+        (artifact_root / "request.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "qualification_nonce": _SCRIPTED_SECRET,
+                    "output_directory": str(artifact_root),
+                }
+            ),
+            encoding="utf-8",
+        )
+        (artifact_root / "measurement-samples.partial.jsonl").write_text(
+            '{"sample_index": 0}\n', encoding="utf-8"
+        )
+        raise ProofFailure(_SCRIPTED_FAILURE)
+
+    def stub_package_summary(*call_args, **call_kwargs):
+        return {"package_contract": {}}
+
+    original_runtime_proof = archive_proof.run_runtime_proof
+    original_package_summary = archive_proof.package_summary
+    archive_proof.run_runtime_proof = failing_runtime_proof
+    archive_proof.package_summary = stub_package_summary
+    try:
+        with tempfile.TemporaryDirectory() as raw:
+            out_dir = Path(raw) / "packaged-agent-proof"
+            out_dir.mkdir(parents=True)
+            args = _scripted_proof_arguments(fixture, out_dir)
+            try:
+                archive_proof.run_archive_proof(args)
+            except ProofFailure as error:
+                require(
+                    _SCRIPTED_FAILURE in str(error),
+                    "scripted driver failure changed its primary error",
+                )
+            else:
+                raise ProofFailure("scripted driver failure did not propagate")
+            root = observed.get("root")
+            require(
+                root is not None and not root.exists(),
+                "temporary package root survived the failed proof",
+            )
+            evidence = out_dir / FAILURE_EVIDENCE_DIRECTORY_NAME
+            _require_redacted(
+                _read(
+                    evidence / "qualification-suite" / "artifacts" / "request.json"
+                ),
+                _SCRIPTED_SECRET,
+                "upload-root request.json",
+            )
+            require(
+                _read(
+                    evidence
+                    / "qualification-suite"
+                    / "artifacts"
+                    / "measurement-samples.partial.jsonl"
+                )
+                == b'{"sample_index": 0}\n',
+                "upload-root partial measurement samples changed",
+            )
+            manifest = json.loads(_read(evidence / "failure.json"))
+            require(
+                _SCRIPTED_FAILURE in manifest["error"],
+                "upload-root failure manifest lost the driver failure",
+            )
+            require(
+                not (out_dir / "summary.json").exists(),
+                "failed proof still wrote a passing summary",
+            )
+    finally:
+        archive_proof.run_runtime_proof = original_runtime_proof
+        archive_proof.package_summary = original_package_summary
+
+
+def run_failure_evidence_self_tests(fixture: FullStackFixture) -> None:
+    try:
+        _preservation_unit_tests()
+        _scripted_driver_failure_tests(fixture)
+    finally:
+        reset_failure_evidence_secrets()

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+from .self_test_failure_evidence import run_failure_evidence_self_tests
 from .self_test_full_stack_calibration import run_calibration_self_tests
 from .self_test_full_stack_external import run_external_evidence_self_tests
 from .self_test_full_stack_fixture import build_full_stack_fixture
@@ -22,6 +23,7 @@ def run_full_stack_self_tests() -> None:
         server = run_server_identity_self_tests(fixture)
         run_true_idle_self_tests(server)
         measurement_contract = run_calibration_self_tests(fixture)
+        run_failure_evidence_self_tests(fixture)
         external = run_external_evidence_self_tests(fixture)
         run_retained_qualification_self_tests(
             fixture,

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -899,6 +899,15 @@ jobs:
           retention-days: 30
           overwrite: true
 
+      - name: Upload hosted Linux calibration failure evidence
+        if: failure() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: embedding-calibration-linux-failure-evidence-attempt-${{ github.run_attempt }}
+          path: target/calibration-runs/linux
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Upload packaged agent proof artifacts
         if: >-
           always() &&


### PR DESCRIPTION
On any packaged-proof failure the harness now copies the qualification-suite (and server-identity) directories from the doomed temp root into the uploaded out-dir under failure-evidence/, with per-run qualification nonces redacted from every preserved byte and a failure.json manifest carrying the primary error. All proof lanes benefit through their existing always()-uploaded paths; the hosted Linux calibration lane (success-only out-dir uploads) gains a failure()-gated evidence upload, policy-pinned with mutation tests. Preservation is best-effort and budgeted (64 MiB), never masks the primary error, and produces nothing on green runs. Revert-proven self-test drives a scripted driver failure end to end.

Reviewer notes carried as future follow-ups (non-blocking): pin the failure-artifact name prefix in policy; the pre-existing assert-after-write privacy pattern in retained artifacts; failure() vs always() for cancelled-run evidence.

Closes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)