### PR TITLE
re-derive the stale scenario checkers against the post-#1420 driver

### DIFF
--- a/.github/scripts/packaged_agent_proof/qualification_assertions_idle.py
+++ b/.github/scripts/packaged_agent_proof/qualification_assertions_idle.py
@@ -113,20 +113,28 @@ def _true_idle_witnesses(
         absent_transition.get("observed_ns"),
         "true idle absence transition time",
     )
+    respawn_observed_ns = require_nonnegative_int(
+        respawn_observations[0].get("observed_ns"),
+        "true idle replacement witness time",
+    )
     respawn_transition_ns = require_nonnegative_int(
         respawn_transition.get("observed_ns"),
         "true idle respawn transition time",
     )
+    # The consentless-respawn proof needs exactly one product operation
+    # between the absent-owner witness and the replacement-engine witness.
+    # The proof window therefore closes at the replacement-engine witness,
+    # not at the later server_respawned transition: the driver's
+    # resident-identity re-check starts strictly after the replacement engine
+    # is witnessed, so it cannot be the operation that caused or consented
+    # the respawn and is legitimately outside the window.
     return TrueIdleWitnesses(
         absent_observed_ns=require_nonnegative_int(
             absent_observations[0].get("observed_ns"),
             "true idle absent-owner witness time",
         ),
         absent_transition_ns=absent_transition_ns,
-        respawn_observed_ns=require_nonnegative_int(
-            respawn_observations[0].get("observed_ns"),
-            "true idle replacement witness time",
-        ),
+        respawn_observed_ns=respawn_observed_ns,
         respawn_transition_ns=respawn_transition_ns,
         respawn_snapshot=respawn_observations[0]["snapshot"],
         post_absence_invocations=tuple(
@@ -136,7 +144,7 @@ def _true_idle_witnesses(
             and not isinstance(invocation.get("started_ns"), bool)
             and absent_transition_ns
             <= invocation["started_ns"]
-            <= respawn_transition_ns
+            <= respawn_observed_ns
         ),
     )
 

--- a/.github/scripts/packaged_agent_proof/self_test_server_idle.py
+++ b/.github/scripts/packaged_agent_proof/self_test_server_idle.py
@@ -140,6 +140,10 @@ def _verified_true_idle_fixture(
     true_idle_transitions, materialized_sha256 = _true_idle_transitions(
         before, respawned
     )
+    # Mirrors the driver's post-#1420 invocation shape: one plain query causes
+    # the respawn inside the proof window, and the resident-identity re-check
+    # starts only after the replacement engine is witnessed (observed_ns 400),
+    # so it must stay outside the consentless-respawn proof window.
     true_idle_invocations = [
         {
             "operation": "query",
@@ -152,6 +156,13 @@ def _verified_true_idle_fixture(
             "operation": "query",
             "started_ns": 10,
             "finished_ns": 20,
+            "exit_code": 0,
+            "termination": "exited",
+        },
+        {
+            "operation": "resident_identity",
+            "started_ns": 420,
+            "finished_ns": 440,
             "exit_code": 0,
             "termination": "exited",
         },
@@ -268,6 +279,31 @@ def _temporal_ordering_hostiles(fixture: TrueIdleFixture) -> None:
         )
     else:
         raise ProofFailure("failed first query was hidden by a later respawn success")
+    premature_identity_invocations = json.loads(json.dumps(true_idle_invocations))
+    premature_identity_invocations[2]["started_ns"] = 300
+    premature_identity_invocations[2]["finished_ns"] = 320
+    try:
+        derive_scenario_assertions(
+            "true_idle_respawn",
+            observations_by_kind=true_idle_transitions,
+            process_observations=true_idle_process_observations,
+            invocations=premature_identity_invocations,
+            same_account={},
+            materialization={
+                "sha256": materialized_sha256,
+                "reused_on_rejoin": False,
+            },
+        )
+    except ProofFailure as error:
+        require(
+            str(error)
+            == "qualification scenario true_idle_respawn raw evidence failed assertions: next_product_operation_respawns_without_consent",
+            "premature identity probe changed its exact temporal failure",
+        )
+    else:
+        raise ProofFailure(
+            "identity probe inside the consentless-respawn window was accepted"
+        )
     historical_respawn_transition = json.loads(json.dumps(true_idle_transitions))
     historical_respawn_transition["server_respawned"][0]["observed_ns"] = 150
     try:

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/client_death.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/client_death.rs
@@ -4,7 +4,7 @@ use super::super::{
 };
 use super::ScenarioRunner;
 use super::analysis::{project_identity_sha256, scheduler_values};
-use super::process::{query_parameters, require_worker_success};
+use super::process::{dead_client_setup_timeout, query_parameters, require_worker_success};
 use anyhow::{Result, bail};
 use codestory_retrieval::EmbeddingQualificationParameters;
 use serde_json::json;
@@ -25,13 +25,20 @@ impl<'a> ScenarioRunner<'a> {
             },
             None,
         )?;
-        let lease_snapshot =
-            self.wait_for_snapshot("client_death_lease_active", SNAPSHOT_TIMEOUT, |snapshot| {
+        // Load establishment is queue seeding by a freshly spawned client, so
+        // it gets the queue-setup budget; the lease-reclaim wait below stays
+        // on the flat snapshot budget because the peer-death sweep needs no
+        // new client ramp.
+        let lease_snapshot = self.wait_for_snapshot(
+            "client_death_lease_active",
+            dead_client_setup_timeout(),
+            |snapshot| {
                 snapshot.scheduler.lease_count > 0
                     && snapshot.scheduler.query_depth > 0
                     && snapshot.scheduler.bulk_depth > 0
                     && snapshot.scheduler.active_request_count > 0
-            })?;
+            },
+        )?;
         self.transition(
             "dead_client_work_observed",
             scheduler_values(&lease_snapshot),

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/control.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/control.rs
@@ -224,6 +224,11 @@ impl<'a> ScenarioRunner<'a> {
     }
 
     fn observe_worker(&mut self) -> Result<Option<EmbeddingServerSnapshot>> {
+        // One observe worker per poll: executable capture, connect, one
+        // snapshot, no request work and no per-request transport fan-out, so
+        // the flat snapshot budget dominates its honest chain. Waits that
+        // cover a client ramping queue load must carry the queue-setup
+        // budget instead (see dead_client_setup_timeout).
         let worker = self.spawn_worker("observe", query_parameters(1), None)?;
         let output = self.finish_worker(worker, SNAPSHOT_TIMEOUT)?;
         require_worker_success(&output, "observe")?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
@@ -1,4 +1,4 @@
-use super::super::{CONTROL_TIMEOUT, ControlEvent, POLL, SNAPSHOT_TIMEOUT};
+use super::super::{CONTROL_TIMEOUT, ControlEvent, POLL, QUEUE_SETUP_TIMEOUT, SNAPSHOT_TIMEOUT};
 use super::analysis::elapsed;
 use super::{
     EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION, ProcessInvocation, RunningWorker, WorkerOutput,
@@ -253,4 +253,22 @@ pub(super) fn measurement_worker_timeout(operation: &str) -> Duration {
         .saturating_add(request_deadline)
         .saturating_add(SNAPSHOT_TIMEOUT)
         .saturating_add(CONTROL_TIMEOUT)
+}
+
+/// Coordinator budget for observing the dead client's established load. The
+/// `client_death_lease_active` wait must see the lease plus the admitted and
+/// held query/bulk work in one snapshot, and that bounds a queue-seeding
+/// phase, not a single snapshot: the freshly spawned dead client first pays
+/// its contract connect and spawn-convergence allowances, then fans out one
+/// captured transport per held request before the seeded depths become
+/// visible, while every poll of the wait is itself a fresh observe worker
+/// spending part of the snapshot allowance. This is the same phase shape as
+/// mixed_queue's gated seeding, which already bounds a strictly larger 64+64
+/// enqueue with the runner's queue-setup budget, so the dead-client wait
+/// reuses that bound instead of inventing a second formula. Regression:
+/// calibration run 30200986788 (protected macOS Metal cell) timed out at the
+/// flat 20s snapshot wait while the dead client was still legitimately
+/// ramping its 16+16 held requests under host load.
+pub(super) fn dead_client_setup_timeout() -> Duration {
+    QUEUE_SETUP_TIMEOUT
 }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
@@ -1,7 +1,9 @@
-use super::super::{CONTROL_TIMEOUT, SNAPSHOT_TIMEOUT, ScenarioArtifact, ScenarioOrchestration};
+use super::super::{
+    CONTROL_TIMEOUT, QUEUE_SETUP_TIMEOUT, SNAPSHOT_TIMEOUT, ScenarioArtifact, ScenarioOrchestration,
+};
 use super::analysis::resident_generation_is_valid;
 use super::evidence::validate_named_evidence;
-use super::process::measurement_worker_timeout;
+use super::process::{dead_client_setup_timeout, measurement_worker_timeout};
 use super::{ScenarioEvidence, opaque_measurement_sample_id};
 use crate::qualification::request::{QualificationContracts, REQUIRED_SCENARIOS};
 use codestory_retrieval::{EmbeddingClientBudgets, PER_USER_EMBEDDING_BULK_REQUEST_DEADLINE_MS};
@@ -40,6 +42,33 @@ fn measurement_worker_budgets_dominate_the_deadlines_workers_honor() {
     assert!(
         bulk_timeout >= Duration::from_millis(PER_USER_EMBEDDING_BULK_REQUEST_DEADLINE_MS),
         "bulk measurement budget must not undercut the contract bulk request deadline"
+    );
+}
+
+#[test]
+fn dead_client_setup_budget_dominates_the_seeding_terms_the_flat_wait_undercut() {
+    // The `client_death_lease_active` wait bounds queue seeding by a freshly
+    // spawned client, not one snapshot: before its lease and held work are
+    // visible together the client pays its contract connect and
+    // spawn-convergence allowances and each poll of the wait spends part of
+    // the snapshot allowance. Regression: calibration run 30200986788
+    // (protected macOS Metal cell) timed out at the flat 20s snapshot wait
+    // while the dead client was legitimately still ramping its held load.
+    let budgets = EmbeddingClientBudgets::current();
+    assert!(
+        dead_client_setup_timeout()
+            >= budgets
+                .connect
+                .saturating_add(budgets.spawn)
+                .saturating_add(SNAPSHOT_TIMEOUT),
+        "dead-client setup budget must dominate the client's connect and spawn allowances plus the snapshot allowance"
+    );
+    // Load establishment is the same phase family as mixed_queue's gated
+    // seeding, which bounds a strictly larger 64+64 enqueue with the
+    // queue-setup budget; the dead-client wait must not fall back below it.
+    assert!(
+        dead_client_setup_timeout() >= QUEUE_SETUP_TIMEOUT,
+        "dead-client load establishment is a queue-seeding phase and must carry the queue-setup budget"
     );
 }
 


### PR DESCRIPTION
true_idle_respawn: the consentless-respawn proof window now ends at the replacement-engine witness instead of the server_respawned transition — the post-#1420 resident_identity probe starts strictly after that witness and cannot be the consenting operation. Falsifiability kept: a second product invocation inside the window still fails with the exact CI string (negative self-tests preserved, fixture now models the real driver shape).

client_death: the load-establishment snapshot wait derives from the contract terms (#1492 mechanism) instead of the flat 20s, whose honest cost on the Metal cell includes ~33 full 201MB executable hashes. Domination asserted in tests.

Both were diagnosed as harness defects with the product contract confirmed intact (the packaged server exits at true idle and a plain query respawns inline, identity-consistent, no consent surface). Deferred follow-up: per-thread transport captures each re-hash the packaged binary — bench-support inefficiency, not release-blocking.

Closes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)