### PR TITLE
pin the harness's worker wire-schema constant to the rust source of truth

### DIFF
--- a/.github/scripts/packaged_agent_proof/foundation.py
+++ b/.github/scripts/packaged_agent_proof/foundation.py
@@ -28,6 +28,15 @@ STATUS_URI = "codestory://status"
 ENGINE_DIAGNOSTICS_URI = "codestory://diagnostics/retrieval-engine"
 SERVER_PROOF_SCHEMA_VERSION = 1
 QUALIFICATION_SCHEMA_VERSION = 1
+# Outer wire contract of the packaged CLI qualification worker. This must
+# equal EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION in
+# EMBEDDING_QUALIFICATION_WORKER_CONTRACT_SOURCE below: the harness asserts
+# the version its own tree compiled, exactly like the codestory-bench driver,
+# so a stale runtime can never make a mismatch self-consistent. The packaged
+# proof self-test pins the two declarations together; bump them in the same
+# change. This is distinct from QUALIFICATION_SCHEMA_VERSION, which is the
+# inner EmbeddingQualificationResult contract.
+EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION = 2
 NATIVE_SERVER_TEARDOWN_GRACE_MS = 60_000
 PUBLICATION_FAULT_EVIDENCE_CONTRACT = "codestory-publication-lease-fault/v1"
 FAULT_RECOVERY_CONSISTENCY_CONTRACT = "codestory-fault-recovery-search-consistency/v1"
@@ -128,6 +137,14 @@ SERVER_PROTOCOL = MEASUREMENT_PROTOCOL.with_name(
 )
 SERVER_CONSTANT_SET = MEASUREMENT_PROTOCOL.with_name(
     "per-user-embedding-server-constant-set.json"
+)
+EMBEDDING_QUALIFICATION_WORKER_CONTRACT_SOURCE = (
+    REPOSITORY_ROOT
+    / "crates"
+    / "codestory-retrieval"
+    / "src"
+    / "per_user_embedding"
+    / "qualification_worker.rs"
 )
 HOLDOUT_TASK_ROOT = REPOSITORY_ROOT / "benchmarks" / "tasks" / "holdout-retrieval"
 DEFAULT_QUERY = "RuntimeContext"

--- a/.github/scripts/packaged_agent_proof/publication_protocol.py
+++ b/.github/scripts/packaged_agent_proof/publication_protocol.py
@@ -16,7 +16,11 @@ from .contract_primitives import (
     require_sha256,
     write_private_json,
 )
-from .foundation import ProofFailure, require
+from .foundation import (
+    EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION,
+    ProofFailure,
+    require,
+)
 from .subprocess_control import json_command, run
 
 
@@ -260,7 +264,7 @@ def run_publication_replacement_worker(
     write_private_json(
         request_path,
         {
-            "schema_version": 1,
+            "schema_version": EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION,
             "nonce_sha256": hashlib.sha256(nonce.encode("ascii")).hexdigest(),
             "executable_sha256": executable_sha256,
             "project": str(project.resolve()),
@@ -299,13 +303,16 @@ def run_publication_replacement_worker(
         ) from exc
     require(
         isinstance(output, dict)
-        and output.get("schema_version") == 1
+        and output.get("schema_version")
+        == EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION
         and output.get("executable_sha256") == executable_sha256
         and output.get("error") is None,
         "publication replacement worker failed",
     )
     result = output.get("result")
     operations = result.get("operations") if isinstance(result, dict) else None
+    # The inner EmbeddingQualificationResult contract versions independently
+    # of the outer worker wire contract checked above.
     require(
         isinstance(result, dict)
         and result.get("schema_version") == 1

--- a/.github/scripts/packaged_agent_proof/self_test_contracts.py
+++ b/.github/scripts/packaged_agent_proof/self_test_contracts.py
@@ -2,8 +2,10 @@
 
 from .self_test_contract_scope import run_contract_scope_self_tests
 from .self_test_resource_identity import run_resource_identity_self_tests
+from .self_test_worker_schema import run_worker_schema_self_tests
 
 
 def run_contract_self_tests() -> None:
     run_contract_scope_self_tests()
     run_resource_identity_self_tests()
+    run_worker_schema_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_worker_schema.py
+++ b/.github/scripts/packaged_agent_proof/self_test_worker_schema.py
@@ -1,0 +1,153 @@
+"""Worker wire-contract lineage self-tests.
+
+The publication replacement worker step hand-writes the packaged CLI worker's
+wire request instead of compiling against the Rust contract, so a schema bump
+in `codestory-retrieval` cannot break it at build time. These self-tests pin
+the harness declaration to the Rust source of truth in this tree and drive the
+replacement worker step against both wire versions, so the next contract bump
+fails this PR-time lane instead of a calibration cell. The harness must keep
+asserting the version its own tree compiled — never a version echoed by the
+package or binary under test — so a stale runtime can never look
+self-consistent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from . import publication_protocol
+from .foundation import (
+    EMBEDDING_QUALIFICATION_WORKER_CONTRACT_SOURCE,
+    EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION,
+    ProofFailure,
+    require,
+)
+
+_RUST_WORKER_SCHEMA_DECLARATION = re.compile(
+    r"^pub const EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION: u32 = (\d+);$",
+    re.MULTILINE,
+)
+
+
+def compiled_worker_schema_version() -> int:
+    source = EMBEDDING_QUALIFICATION_WORKER_CONTRACT_SOURCE.read_text(
+        encoding="utf-8"
+    )
+    declarations = _RUST_WORKER_SCHEMA_DECLARATION.findall(source)
+    require(
+        len(declarations) == 1,
+        "the worker wire contract source must declare exactly one schema version",
+    )
+    return int(declarations[0])
+
+
+def _source_lineage_tests() -> None:
+    require(
+        compiled_worker_schema_version()
+        == EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION,
+        "packaged-proof worker schema version disagrees with "
+        "crates/codestory-retrieval/src/per_user_embedding/"
+        "qualification_worker.rs; bump "
+        "EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION in "
+        "packaged_agent_proof/foundation.py in the same change as the Rust "
+        "contract",
+    )
+
+
+def _worker_output(
+    executable_sha256: str,
+    schema_version: int,
+    *,
+    result_schema_version: int = 1,
+) -> dict:
+    return {
+        "schema_version": schema_version,
+        "executable_sha256": executable_sha256,
+        "error": None,
+        "result": {
+            "schema_version": result_schema_version,
+            "scenario": "query",
+            "operations": [{"status": "ok", "error_code": None}],
+        },
+    }
+
+
+def _drive_replacement_worker(output_document) -> dict:
+    executable_sha256 = "a" * 64
+    with tempfile.TemporaryDirectory() as root:
+        private_root = Path(root) / "private"
+        project = Path(root) / "project"
+        project.mkdir()
+        observed: dict = {}
+
+        def fake_run(command, *, env, cwd, timeout):
+            request_path = Path(command[command.index("--request") + 1])
+            output_path = Path(command[command.index("--output") + 1])
+            observed["request"] = json.loads(
+                request_path.read_text(encoding="utf-8")
+            )
+            output_path.write_text(
+                json.dumps(output_document(executable_sha256)) + "\n",
+                encoding="utf-8",
+            )
+            return {"exit_code": 0, "stdout": "", "stderr": ""}
+
+        with patch.object(publication_protocol, "run", fake_run):
+            publication_protocol.run_publication_replacement_worker(
+                Path(root) / "codestory-cli",
+                {},
+                project,
+                private_root,
+                "self-test-nonce",
+                executable_sha256=executable_sha256,
+                timeout=5,
+            )
+        return observed["request"]
+
+
+def _replacement_worker_wire_tests() -> None:
+    compiled = compiled_worker_schema_version()
+    request = _drive_replacement_worker(
+        lambda executable_sha256: _worker_output(executable_sha256, compiled)
+    )
+    require(
+        request.get("schema_version") == compiled,
+        "publication replacement worker request drifted from the compiled "
+        "worker wire contract",
+    )
+    for stale in (compiled - 1, compiled + 1):
+        try:
+            _drive_replacement_worker(
+                lambda executable_sha256, stale=stale: _worker_output(
+                    executable_sha256, stale
+                )
+            )
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                f"a schema_version={stale} replacement worker output was accepted"
+            )
+    wrong_inner = compiled if compiled != 1 else 2
+    try:
+        _drive_replacement_worker(
+            lambda executable_sha256: _worker_output(
+                executable_sha256, compiled, result_schema_version=wrong_inner
+            )
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure(
+            "the inner qualification result contract followed the outer "
+            "worker wire version"
+        )
+
+
+def run_worker_schema_self_tests() -> None:
+    _source_lineage_tests()
+    _replacement_worker_wire_tests()

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -8,6 +8,7 @@ on:
       - .github/scripts/test-detect-codestory-release.py
       - .github/scripts/check-codestory-release.py
       - .github/scripts/check-packaged-agent-proof.py
+      - .github/scripts/packaged_agent_proof/**
       - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
       - .github/scripts/check-workflow-policy.test.mjs
@@ -55,6 +56,7 @@ on:
       - crates/codestory-llama-sys/model_staging.rs
       - crates/codestory-llama-sys/Cargo.toml
       - crates/codestory-llama-sys/tests/model_staging.rs
+      - crates/codestory-retrieval/src/per_user_embedding/qualification_worker.rs
       - scripts/release-evidence/**
       - scripts/release-evidence/serde-json-codestory-project.json
       - scripts/tests/release-evidence-runner-contract.test.mjs
@@ -71,6 +73,7 @@ on:
       - .github/scripts/test-detect-codestory-release.py
       - .github/scripts/check-codestory-release.py
       - .github/scripts/check-packaged-agent-proof.py
+      - .github/scripts/packaged_agent_proof/**
       - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
       - .github/scripts/check-workflow-policy.test.mjs
@@ -118,6 +121,7 @@ on:
       - crates/codestory-llama-sys/model_staging.rs
       - crates/codestory-llama-sys/Cargo.toml
       - crates/codestory-llama-sys/tests/model_staging.rs
+      - crates/codestory-retrieval/src/per_user_embedding/qualification_worker.rs
       - scripts/release-evidence/**
       - scripts/release-evidence/serde-json-codestory-project.json
       - scripts/tests/release-evidence-runner-contract.test.mjs


### PR DESCRIPTION
The publication-replacement step was a third, hand-rolled participant in the worker wire contract with schema literals #1500's bump could not reach. One tree-derived constant now feeds both sites, and a static self-test parses the Rust declaration and requires equality — a future bump fails at PR time, not in a calibration cell. The fail-closed worker check is untouched (it did its job); the harness asserts the version its own tree compiled, never one read back from the binary. Revert-proven self-test legs cover v1-request rejection, stale/future output rejection, and the unchanged inner contract.

Closes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)