### PR TITLE
open sidecar sqlite databases through extended-length paths on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed semantic sidecar publication failing with `unable to open database file` on Windows under deep cache roots (service profiles, redirected homes): sidecar SQLite opens now use extended-length paths and the staged vector index no longer creates a rollback journal.
 - First use completes on Linux hosts that keep `/tmp` on its own filesystem.
   Setup previously downloaded the runtime, failed to install it, and started the
   download again until it gave up.
@@ -52,6 +53,7 @@
   `CODESTORY_INDEX_FRESHNESS_CURRENT_FILE_CAP` raise the repository size at which
   CodeStory stops checking for changes.
 
+||||||| parent of e925d6da (note the windows deep-cache-root publication fix in the changelog)
 ## 0.16.1
 
 Fixes first use on a slow or unreliable connection.

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -12,6 +12,7 @@ use codestory_contracts::api::{
     EmbeddingVectorSemanticsDto,
 };
 use codestory_store::{FileRole, Store};
+use codestory_workspace::paths::sqlite_open_path;
 use rusqlite::{Connection, OpenFlags, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -860,10 +861,15 @@ fn write_database(
     expected_anchors: Option<&BTreeMap<String, String>>,
     produce: impl FnOnce(&mut dyn FnMut(AttestedSemanticPoint) -> Result<()>) -> Result<()>,
 ) -> Result<BTreeMap<String, String>> {
-    let mut connection = Connection::open(path)
+    let mut connection = Connection::open(sqlite_open_path(path))
         .with_context(|| format!("create embedded vector index {}", path.display()))?;
-    connection.execute_batch(
-        "PRAGMA journal_mode=DELETE;
+    // The staged file is deleted on any failure and only published after
+    // `validate_database` passes, so a rollback journal adds no durability.
+    // Keeping it off also matches the lexical shard builder and avoids the
+    // derived `-journal` sibling, the longest path SQLite would create here.
+    connection
+        .execute_batch(
+            "PRAGMA journal_mode=OFF;
          PRAGMA synchronous=FULL;
          CREATE TABLE metadata (
              singleton INTEGER PRIMARY KEY NOT NULL CHECK (singleton = 1),
@@ -886,15 +892,20 @@ fn write_database(
              dense_reason TEXT,
              vector BLOB NOT NULL
          ) WITHOUT ROWID;",
-    )?;
-    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        )
+        .with_context(|| format!("create embedded vector schema {}", path.display()))?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .with_context(|| format!("begin embedded vector write transaction {}", path.display()))?;
     let mut actual_anchors = BTreeMap::new();
     {
-        let mut insert = transaction.prepare(
-            "INSERT INTO vectors (
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO vectors (
                  node_id, document_hash, display_name, file_path, file_role, dense_reason, vector
              ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-        )?;
+            )
+            .with_context(|| format!("prepare embedded vector insert {}", path.display()))?;
         let mut visit = |attested: AttestedSemanticPoint| -> Result<()> {
             let AttestedSemanticPoint {
                 point,
@@ -923,15 +934,17 @@ fn write_database(
             {
                 bail!("duplicate embedded vector anchor {}", point.node_id);
             }
-            insert.execute(params![
-                point.node_id,
-                document_hash,
-                point.display_name,
-                point.file_path,
-                point.file_role.map(|role| role.as_str()),
-                point.dense_reason,
-                vector_bytes(&point.vector),
-            ])?;
+            insert
+                .execute(params![
+                    point.node_id,
+                    document_hash,
+                    point.display_name,
+                    point.file_path,
+                    point.file_role.map(|role| role.as_str()),
+                    point.dense_reason,
+                    vector_bytes(&point.vector),
+                ])
+                .with_context(|| format!("write embedded vector index {}", path.display()))?;
             Ok(())
         };
         produce(&mut visit)?;
@@ -952,23 +965,30 @@ fn write_database(
             missing
         );
     }
-    let vector_digest = canonical_vector_digest(&transaction, contract.embedding_dim)?;
-    transaction.execute(
-        "INSERT INTO metadata VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-        params![
-            VECTOR_INDEX_SCHEMA_VERSION,
-            generation,
-            input_hash,
-            contract.embedding_backend,
-            contract.embedding_dim as i64,
-            actual_anchors.len() as i64,
-            contract.producer_identity,
-            contract.evidence_contract_identity,
-            vector_digest,
-        ],
-    )?;
-    transaction.commit()?;
-    connection.execute_batch("PRAGMA optimize;")?;
+    let vector_digest = canonical_vector_digest(&transaction, contract.embedding_dim)
+        .with_context(|| format!("digest embedded vector index {}", path.display()))?;
+    transaction
+        .execute(
+            "INSERT INTO metadata VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                VECTOR_INDEX_SCHEMA_VERSION,
+                generation,
+                input_hash,
+                contract.embedding_backend,
+                contract.embedding_dim as i64,
+                actual_anchors.len() as i64,
+                contract.producer_identity,
+                contract.evidence_contract_identity,
+                vector_digest,
+            ],
+        )
+        .with_context(|| format!("write embedded vector metadata {}", path.display()))?;
+    transaction
+        .commit()
+        .with_context(|| format!("commit embedded vector index {}", path.display()))?;
+    connection
+        .execute_batch("PRAGMA optimize;")
+        .with_context(|| format!("optimize embedded vector index {}", path.display()))?;
     drop(connection);
     std::fs::OpenOptions::new()
         .write(true)
@@ -989,8 +1009,10 @@ fn validate_database(
 ) -> Result<VectorDatabaseAttestation> {
     contract.validate()?;
     let connection = open_read_only(path)?;
-    validate_sqlite_quick_check(&connection)?;
-    let metadata = read_metadata(&connection)?;
+    validate_sqlite_quick_check(&connection)
+        .with_context(|| format!("quick-check embedded vector index {}", path.display()))?;
+    let metadata = read_metadata(&connection)
+        .with_context(|| format!("read embedded vector metadata {}", path.display()))?;
     if metadata.schema_version != VECTOR_INDEX_SCHEMA_VERSION
         || metadata.generation != generation
         || metadata.input_hash != input_hash
@@ -1003,8 +1025,9 @@ fn validate_database(
     {
         bail!("embedded vector metadata does not match the evidence contract");
     }
-    let actual_count: i64 =
-        connection.query_row("SELECT COUNT(*) FROM vectors", [], |row| row.get(0))?;
+    let actual_count: i64 = connection
+        .query_row("SELECT COUNT(*) FROM vectors", [], |row| row.get(0))
+        .with_context(|| format!("count embedded vector rows {}", path.display()))?;
     if actual_count < 0 || actual_count as usize != expected_anchors.len() {
         bail!(
             "embedded vector count mismatch: expected {}, found {}",
@@ -1013,7 +1036,8 @@ fn validate_database(
         );
     }
     let (vector_digest, actual_anchors) =
-        validate_and_digest_vectors(&connection, contract.embedding_dim, expected_anchors)?;
+        validate_and_digest_vectors(&connection, contract.embedding_dim, expected_anchors)
+            .with_context(|| format!("validate embedded vector rows {}", path.display()))?;
     if actual_anchors != expected_anchors.len() || vector_digest != metadata.vector_digest {
         bail!("embedded vector canonical digest does not match metadata");
     }
@@ -1407,7 +1431,7 @@ fn compare_scored_hits(left: &ScoredHit, right: &ScoredHit) -> Ordering {
 
 fn open_read_only(path: &Path) -> Result<Connection> {
     Connection::open_with_flags(
-        path,
+        sqlite_open_path(path),
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
     .with_context(|| format!("open embedded vector index {}", path.display()))
@@ -1770,6 +1794,65 @@ mod tests {
             )
             .ready
         );
+    }
+
+    #[test]
+    fn vector_publication_survives_cache_roots_beyond_max_path() {
+        // Regression: NT service profiles and isolated proof harnesses resolve
+        // cache roots deep enough that the staged vector database exceeds the
+        // 260-character Windows MAX_PATH cap for non-longPathAware processes.
+        // Publication, validation, health, and search must all keep working.
+        let root = tempdir().expect("tempdir");
+        let mut deep_root = root.path().to_path_buf();
+        let segment = "max-path-regression-padding-segment".repeat(2);
+        while deep_root.as_os_str().len() < 320 {
+            deep_root.push(&segment);
+        }
+        std::fs::create_dir_all(&deep_root).expect("create deep cache root");
+        let layout = layout(&deep_root);
+        let collection = "codestory_longpath_deadbeefdeadbeef";
+        EmbeddedVectorIndex::build_with_points(
+            &layout,
+            collection,
+            "longpath-deadbeefdeadbeef",
+            "input",
+            "backend",
+            2,
+            |visit| {
+                visit(point("1", vec![1.0, 0.0]))?;
+                visit(point("2", vec![0.0, 1.0]))
+            },
+        )
+        .expect("publish embedded vector index under a deep cache root");
+
+        let path = index_path(&layout, collection);
+        assert!(
+            path.as_os_str().len() > 260,
+            "regression layout no longer exceeds MAX_PATH: {}",
+            path.display()
+        );
+        assert!(
+            EmbeddedVectorIndex::health(
+                &layout,
+                collection,
+                "longpath-deadbeefdeadbeef",
+                "input",
+                2,
+                "backend",
+                2,
+            )
+            .ready
+        );
+        let hits = search_database(
+            &path,
+            "longpath-deadbeefdeadbeef",
+            "input",
+            &[0.9, 0.1],
+            1,
+            || false,
+        )
+        .expect("search embedded vector index under a deep cache root");
+        assert_eq!(hits[0].node_id.as_deref(), Some("1"));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result, bail};
 use codestory_store::{FileRole, Store, SymbolSearchDoc};
+use codestory_workspace::paths::sqlite_open_path;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -512,7 +513,7 @@ fn write_lexical_database<F>(
 where
     F: FnOnce(&mut dyn FnMut(&LexicalDocument) -> Result<()>) -> Result<LexicalCoverage>,
 {
-    let mut connection = Connection::open(path)
+    let mut connection = Connection::open(sqlite_open_path(path))
         .with_context(|| format!("create lexical SQLite shard {}", path.display()))?;
     connection.execute_batch(
         "PRAGMA journal_mode = OFF;
@@ -813,7 +814,7 @@ fn validate_open_database_metadata(
 
 fn open_read_only(path: &Path) -> Result<Connection> {
     let connection = Connection::open_with_flags(
-        path,
+        sqlite_open_path(path),
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
     .with_context(|| format!("open lexical SQLite shard {}", path.display()))?;
@@ -1471,6 +1472,37 @@ mod tests {
                 "query={query}"
             );
         }
+    }
+
+    #[test]
+    fn lexical_shard_survives_data_dirs_beyond_max_path() {
+        // Regression companion to the embedded vector deep-root test: the
+        // lexical shard is built at the same sidecar depth, so its SQLite
+        // opens must also survive cache roots beyond the Windows MAX_PATH
+        // cap for non-longPathAware processes.
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "fn deep_handler() {}").expect("source");
+        let data = TempDir::new().expect("data");
+        let mut deep_data = data.path().to_path_buf();
+        let segment = "max-path-regression-padding-segment".repeat(2);
+        while deep_data.as_os_str().len() < 320 {
+            deep_data.push(&segment);
+        }
+        std::fs::create_dir_all(&deep_data).expect("create deep lexical data dir");
+
+        let shard = build(project.path(), &deep_data, "longpath", "input");
+        assert!(
+            shard.join(LEXICAL_INDEX_FILE).as_os_str().len() > 260,
+            "regression shard no longer exceeds MAX_PATH: {}",
+            shard.display()
+        );
+        assert_eq!(
+            search_lexical_index(&shard, "input", "deep_handler", 4)
+                .expect("search lexical shard under a deep data dir")
+                .first()
+                .map(|hit| hit.path.as_str()),
+            Some("lib.rs")
+        );
     }
 
     #[test]

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 
 pub mod atomic_file;
 pub mod owned_deletion;
+pub mod paths;
 mod repository_identity;
 pub use repository_identity::{
     PROJECT_IDENTITY_V3_SCHEMA_VERSION, ProjectIdentityV3, REPOSITORY_IDENTITY_V2_SCHEMA_VERSION,

--- a/crates/codestory-workspace/src/paths.rs
+++ b/crates/codestory-workspace/src/paths.rs
@@ -1,0 +1,150 @@
+//! Platform path identity helpers for product file access.
+//!
+//! SQLite's Windows VFS hands database paths straight to `CreateFileW`
+//! without the extended-length (`\\?\`) conversion that Rust's standard
+//! library performs internally. A process without a `longPathAware`
+//! application manifest is therefore capped at `MAX_PATH` (260 characters)
+//! for every SQLite file — including derived siblings such as `-journal`
+//! and `-wal`, which SQLite names by appending to the main database path —
+//! regardless of the `LongPathsEnabled` registry key. Deep cache roots
+//! (service profiles, redirected homes, isolated test roots) cross that cap
+//! in practice, so product SQLite opens must route through
+//! [`sqlite_open_path`].
+
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Return a form of `path` that SQLite can open regardless of `MAX_PATH`.
+///
+/// On Windows the path is absolutized with `GetFullPathNameW` semantics and
+/// converted to extended-length form (`\\?\C:\...` or `\\?\UNC\...`), which
+/// `CreateFileW` accepts at any length even without a `longPathAware`
+/// manifest or the `LongPathsEnabled` registry key. SQLite derives journal
+/// and WAL names by appending to this exact string, so those siblings
+/// inherit the prefix. Already-verbatim and device-namespace paths pass
+/// through unchanged.
+#[cfg(windows)]
+pub fn sqlite_open_path(path: &Path) -> PathBuf {
+    // `std::path::absolute` uses `GetFullPathNameW` semantics: it resolves
+    // relative paths and `.`/`..` components and rewrites `/` separators.
+    // That normalization must happen before prefixing because Win32 skips
+    // normalization entirely for `\\?\` paths.
+    let absolute = match std::path::absolute(path) {
+        Ok(absolute) => absolute,
+        // An empty or otherwise unabsolutizable path keeps today's behavior
+        // and surfaces SQLite's own open error instead.
+        Err(_) => return path.to_path_buf(),
+    };
+    match absolute.to_str().and_then(windows_extended_length_form) {
+        Some(extended) => PathBuf::from(extended),
+        // Non-UTF-8, already-verbatim, device-namespace, or otherwise
+        // unrecognized forms pass through unchanged.
+        None => absolute,
+    }
+}
+
+/// Non-Windows platforms have no `MAX_PATH` cliff; the path is returned
+/// unchanged.
+#[cfg(not(windows))]
+pub fn sqlite_open_path(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+/// Pure conversion of an absolute, already-normalized Windows path string
+/// into its extended-length form.
+///
+/// Returns `None` when the path must pass through unchanged: already
+/// verbatim (`\\?\`), a device-namespace path (`\\.\`), or not a recognized
+/// drive/UNC absolute form.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn windows_extended_length_form(path: &str) -> Option<String> {
+    if path.starts_with(r"\\?\") || path.starts_with(r"\\.\") {
+        return None;
+    }
+    if let Some(server_share) = path.strip_prefix(r"\\") {
+        return Some(format!(r"\\?\UNC\{server_share}"));
+    }
+    let bytes = path.as_bytes();
+    if bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'\\' {
+        return Some(format!(r"\\?\{path}"));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drive_paths_gain_the_extended_length_prefix() {
+        assert_eq!(
+            windows_extended_length_form(r"C:\cw\CodeStory\vectors.sqlite3").as_deref(),
+            Some(r"\\?\C:\cw\CodeStory\vectors.sqlite3")
+        );
+    }
+
+    #[test]
+    fn extended_length_form_carries_paths_beyond_max_path() {
+        let deep = format!(r"C:\{}\vectors.sqlite3", "a".repeat(300));
+        let extended = windows_extended_length_form(&deep).expect("extended-length form");
+        assert_eq!(extended, format!(r"\\?\{deep}"));
+        assert!(extended.len() > 260);
+    }
+
+    #[test]
+    fn unc_paths_use_the_unc_namespace() {
+        assert_eq!(
+            windows_extended_length_form(r"\\server\share\cache\vectors.sqlite3").as_deref(),
+            Some(r"\\?\UNC\server\share\cache\vectors.sqlite3")
+        );
+    }
+
+    #[test]
+    fn verbatim_and_device_namespace_paths_pass_through() {
+        assert_eq!(
+            windows_extended_length_form(r"\\?\C:\cw\vectors.sqlite3"),
+            None
+        );
+        assert_eq!(
+            windows_extended_length_form(r"\\?\UNC\server\share\vectors.sqlite3"),
+            None
+        );
+        assert_eq!(windows_extended_length_form(r"\\.\pipe\codestory"), None);
+    }
+
+    #[test]
+    fn relative_and_rootless_forms_are_not_prefixed() {
+        assert_eq!(windows_extended_length_form(r"cache\vectors.sqlite3"), None);
+        assert_eq!(windows_extended_length_form(r"C:vectors.sqlite3"), None);
+        assert_eq!(windows_extended_length_form(""), None);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn non_windows_paths_are_returned_unchanged() {
+        let path = Path::new("/tmp/cache/retrieval/semantic/collections/vectors.sqlite3");
+        assert_eq!(sqlite_open_path(path), path);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_open_path_round_trips_beyond_max_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let segment = "segment".repeat(12);
+        let parent = dir.path().join(&segment).join(&segment).join(&segment);
+        std::fs::create_dir_all(&parent).expect("create long parent");
+        let path = parent.join("vectors.sqlite3");
+
+        let open_path = sqlite_open_path(&path);
+        let open_text = open_path.to_str().expect("UTF-8 open path");
+        assert!(open_text.starts_with(r"\\?\"));
+        assert!(open_text.len() > 260);
+        assert_eq!(sqlite_open_path(&open_path), open_path);
+
+        std::fs::write(&open_path, b"probe").expect("write via extended-length path");
+        assert_eq!(
+            std::fs::read(&path).expect("read via original path"),
+            b"probe"
+        );
+    }
+}


### PR DESCRIPTION
The embedded-vector staging DB opened at 258 chars but its rollback journal needed 266 — past the unmanifested exe's CreateFileW cap regardless of LongPathsEnabled. Sidecar opens now go through a verbatim-path helper (journal/WAL siblings inherit the prefix), the staged vector build uses journal_mode=OFF like the lexical builder (no durability lost — the temp is discarded on failure and published atomically), and the formerly-bare error chain now names its path. Windows-gated >260-char round-trip test plus non-Windows identity test; deep-root regression factored host-runnable where possible. Reviewer notes carried: core-store WAL siblings remain a latent follow-up at ~130-char roots; the deep-root tests need a Windows CI lane to run them.

Closes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)