### PR TITLE
retry the pinned model download with bounded backoff

### DIFF
--- a/scripts/prepare-embedded-model.mjs
+++ b/scripts/prepare-embedded-model.mjs
@@ -14,7 +14,11 @@ import {
 import { constants as fsConstants } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { Readable } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+
+const downloadAttemptsPerSource = 3;
+const downloadBackoffMs = 500;
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const defaultContract = resolve(
@@ -237,6 +241,31 @@ async function download(url, destination, contract) {
   }
 }
 
+async function downloadWithRetry(url, destination, contract, failures) {
+  for (let attempt = 1; attempt <= downloadAttemptsPerSource; attempt += 1) {
+    try {
+      await download(url, destination, contract);
+      return true;
+    } catch (error) {
+      failures.push({ attempt, error, url });
+      if (attempt < downloadAttemptsPerSource) {
+        await delay(downloadBackoffMs * attempt);
+      }
+    }
+  }
+  return false;
+}
+
+function aggregatedDownloadError(failures) {
+  const details = failures
+    .map(({ attempt, error, url }) => `${url} attempt ${attempt}: ${error?.message ?? error}`)
+    .join("; ");
+  return new AggregateError(
+    failures.map(({ error }) => error),
+    `model download failed after ${failures.length} attempts: ${details}`,
+  );
+}
+
 async function destinationMetadata(path) {
   try {
     return await lstat(path);
@@ -287,17 +316,15 @@ if (!(await valid(destination, contract))) {
   } else if (process.argv.includes("--offline")) {
     throw new Error(`offline model preparation requires a valid --source or existing ${destination}`);
   } else {
-    let lastError;
+    const failures = [];
+    let published = false;
     for (const url of contract.urls) {
-      try {
-        await download(url, destination, contract);
-        lastError = undefined;
+      if (await downloadWithRetry(url, destination, contract, failures)) {
+        published = true;
         break;
-      } catch (error) {
-        lastError = error;
       }
     }
-    if (lastError) throw lastError;
+    if (!published) throw aggregatedDownloadError(failures);
   }
 }
 

--- a/scripts/tests/prepare-embedded-model.test.mjs
+++ b/scripts/tests/prepare-embedded-model.test.mjs
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const script = resolve(repositoryRoot, "scripts/prepare-embedded-model.mjs");
@@ -40,12 +40,15 @@ function contractDigest(domain, value) {
   return hash.digest("hex");
 }
 
-async function fixture(t, expected = Buffer.from("good")) {
+async function fixture(t, expected = Buffer.from("good"), sourceCount = 1) {
   const directory = await mkdtemp(resolve(tmpdir(), "codestory-model-contract-"));
   t.after(() => rm(directory, { force: true, recursive: true }));
   const contract = resolve(directory, "contract.json");
   const modelSha256 = sha256(expected);
   const revision = "0123456789abcdef0123456789abcdef01234567";
+  const urls = ["example.invalid", "mirror.example.invalid"]
+    .slice(0, sourceCount)
+    .map(host => `https://${host}/resolve/${revision}/model.gguf`);
   await writeFile(
     contract,
     JSON.stringify({
@@ -54,12 +57,7 @@ async function fixture(t, expected = Buffer.from("good")) {
         file_name: "model.gguf",
         size_bytes: expected.length,
         sha256: modelSha256,
-        sources: [
-          {
-            url: `https://example.invalid/resolve/${revision}/model.gguf`,
-            revision,
-          },
-        ],
+        sources: urls.map(url => ({ url, revision })),
       },
       runtime: {
         embedding_family: "test",
@@ -90,14 +88,79 @@ async function fixture(t, expected = Buffer.from("good")) {
       },
     }),
   );
-  return { contract, directory, expected };
+  return { contract, directory, expected, urls };
 }
 
-function run(args, cwd) {
-  return spawnSync(process.execPath, [script, ...args], {
+function run(args, cwd, options = {}) {
+  const { env, nodeArgs = [] } = options;
+  return spawnSync(process.execPath, [...nodeArgs, script, ...args], {
     cwd,
     encoding: "utf8",
+    env: env ? { ...process.env, ...env } : process.env,
   });
+}
+
+const fetchPreloadSource = `import { appendFileSync } from "node:fs";
+
+const plan = (process.env.CODESTORY_TEST_FETCH_PLAN ?? "").split(",").filter(Boolean);
+const body = Buffer.from(process.env.CODESTORY_TEST_FETCH_BODY ?? "", "base64");
+const log = process.env.CODESTORY_TEST_FETCH_LOG;
+let calls = 0;
+
+globalThis.fetch = async url => {
+  const step = plan[Math.min(calls, plan.length - 1)];
+  calls += 1;
+  if (log) appendFileSync(log, \`\${url}\\n\`);
+  if (step === "ok") {
+    return new Response(body, {
+      status: 200,
+      headers: { "content-length": String(body.length) },
+    });
+  }
+  if (step === "corrupt") {
+    const corrupt = Buffer.from(body);
+    corrupt.reverse();
+    return new Response(corrupt, {
+      status: 200,
+      headers: { "content-length": String(corrupt.length) },
+    });
+  }
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(body.subarray(0, Math.min(2, body.length)));
+        controller.error(new Error("other side closed"));
+      },
+    }),
+    { status: 200, headers: { "content-length": String(body.length) } },
+  );
+};
+`;
+
+async function transportFixture(t, plan, expected = Buffer.from("good"), sourceCount = 1) {
+  const base = await fixture(t, expected, sourceCount);
+  const preload = resolve(base.directory, "fetch-preload.mjs");
+  const log = resolve(base.directory, "fetch-calls.log");
+  await writeFile(preload, fetchPreloadSource);
+  return {
+    ...base,
+    log,
+    env: {
+      CODESTORY_TEST_FETCH_PLAN: plan,
+      CODESTORY_TEST_FETCH_BODY: expected.toString("base64"),
+      CODESTORY_TEST_FETCH_LOG: log,
+    },
+    nodeArgs: ["--import", pathToFileURL(preload).href],
+  };
+}
+
+async function fetchCalls(log) {
+  try {
+    return (await readFile(log, "utf8")).split("\n").filter(Boolean);
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
 }
 
 test("copies and verifies an explicit source while offline", async (t) => {
@@ -153,6 +216,66 @@ test("offline acquisition fails before any download", async (t) => {
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /offline model preparation requires/u);
+});
+
+test("retries a transport failure and succeeds within the attempt budget", async (t) => {
+  const { contract, directory, env, expected, log, nodeArgs, urls } = await transportFixture(
+    t,
+    "closed,ok",
+  );
+  const output = resolve(directory, "output.gguf");
+
+  const result = run(["--contract", contract, "--output", output], directory, { env, nodeArgs });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), output);
+  assert.deepEqual(await readFile(output), expected);
+  assert.deepEqual(await fetchCalls(log), [urls[0], urls[0]]);
+});
+
+test("retries a corrupt payload so the checksum gates every attempt", async (t) => {
+  const { contract, directory, env, expected, log, nodeArgs, urls } = await transportFixture(
+    t,
+    "corrupt,ok",
+  );
+  const output = resolve(directory, "output.gguf");
+
+  const result = run(["--contract", contract, "--output", output], directory, { env, nodeArgs });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(await readFile(output), expected);
+  assert.deepEqual(await fetchCalls(log), [urls[0], urls[0]]);
+});
+
+test("falls through to the next pinned source after exhausting one source", async (t) => {
+  const { contract, directory, env, expected, log, nodeArgs, urls } = await transportFixture(
+    t,
+    "closed,closed,closed,ok",
+    Buffer.from("good"),
+    2,
+  );
+  const output = resolve(directory, "output.gguf");
+
+  const result = run(["--contract", contract, "--output", output], directory, { env, nodeArgs });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(await readFile(output), expected);
+  assert.deepEqual(await fetchCalls(log), [urls[0], urls[0], urls[0], urls[1]]);
+});
+
+test("fails closed with the aggregated error after bounded attempts", async (t) => {
+  const { contract, directory, env, log, nodeArgs, urls } = await transportFixture(t, "closed");
+  const output = resolve(directory, "output.gguf");
+
+  const result = run(["--contract", contract, "--output", output], directory, { env, nodeArgs });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /model download failed after 3 attempts/u);
+  assert.match(result.stderr, /other side closed/u);
+  assert.deepEqual(await fetchCalls(log), [urls[0], urls[0], urls[0]]);
+  await assert.rejects(readFile(output), { code: "ENOENT" });
+  const leftovers = (await readdir(directory)).filter(name => name.endsWith(".partial"));
+  assert.deepEqual(leftovers, []);
 });
 
 test("rejects a symlink model destination without replacing it", async (t) => {


### PR DESCRIPTION
A transient socket close mid-download has cost two macOS calibration runs. The download is checksum-pinned, so a bounded retry cannot admit corrupted bytes — every attempt is digest-verified exactly as before, and the aggregated error still fails closed after the last one. Tests cover flaky-then-success and always-failing transports.

Deliberately not included: retry/backoff configurability (constants keep CI deterministic) and non-transient error special-casing (uniform bounded retry stays simple, at the cost of a few seconds on a permanently broken source).

Closes #1507

🤖 Generated with [Claude Code](https://claude.com/claude-code)