### PR TITLE
open core store sqlite files through extended-length windows paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed semantic sidecar publication failing with `unable to open database file` on Windows under deep cache roots (service profiles, redirected homes): sidecar SQLite opens now use extended-length paths and the staged vector index no longer creates a rollback journal.
+- Windows projects whose cache root sits deep in the filesystem can index, search, and publish again. Indexing, status, and snapshot publication could fail with `unable to open database file` once the project database path approached 260 characters — reachable with a long user name, a redirected or roaming home directory, or a service account — because the database's write-ahead-log companion files were a few characters longer still. Every core database open now handles long paths, so no change to the cache location or Windows settings is needed.
 - First use completes on Linux hosts that keep `/tmp` on its own filesystem.
   Setup previously downloaded the runtime, failed to install it, and started the
   download again until it gave up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,7 @@ version = "0.16.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
+ "codestory-workspace",
  "fs4",
  "parking_lot",
  "rusqlite",

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 codestory-contracts = { workspace = true }
+codestory-workspace = { workspace = true }
 anyhow = { workspace = true }
 fs4 = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -9,6 +9,7 @@
 mod file_store;
 mod projection_store;
 mod snapshot_store;
+mod sqlite_path;
 mod storage_impl;
 
 pub use file_store::FileStore;

--- a/crates/codestory-store/src/sqlite_path.rs
+++ b/crates/codestory-store/src/sqlite_path.rs
@@ -1,0 +1,217 @@
+//! SQLite open-path normalization for the core store.
+//!
+//! The core database runs in WAL mode, so every live open materializes
+//! `-wal` and `-shm` siblings whose names SQLite derives by *appending* to
+//! the main database path. SQLite's Win32 VFS hands those names straight to
+//! `CreateFileW` without the extended-length conversion Rust's standard
+//! library performs internally, so a process without a `longPathAware`
+//! application manifest is capped at `MAX_PATH` (260 characters) no matter
+//! what the host's `LongPathsEnabled` registry key says. A main database that
+//! opens at 258 characters therefore still fails when SQLite reaches for its
+//! 262-character `-wal` sibling, and the error is a bare
+//! "unable to open database file".
+//!
+//! Every production SQLite open in this crate routes its path through
+//! [`open_path`] (or [`attach_argument`] / [`observational_uri`], which wrap
+//! it) so the extended-length prefix is present before SQLite derives any
+//! sibling name.
+//!
+//! Two invariants keep this conversion safe:
+//!
+//! * It is applied only at the moment of opening. The converted form is never
+//!   stored, hashed, or compared, so project ids, workspace ids, artifact
+//!   scope ids, cache keys, and publication digests continue to be computed
+//!   from the original path. A verbatim prefix leaking into an identity would
+//!   invalidate every existing user's store.
+//! * Diagnostics keep the caller's original path. Error messages render the
+//!   path the user configured, not `\\?\`-prefixed noise.
+
+use std::path::{Path, PathBuf};
+
+/// SQLite filenames that are not filesystem paths and must never be
+/// absolutized into a working-directory-relative file.
+const MAGIC_SQLITE_FILENAMES: [&str; 1] = [":memory:"];
+
+/// SQLite filename prefixes that select URI parsing rather than a plain path.
+const SQLITE_URI_PREFIX: &str = "file:";
+
+/// Return a form of `path` that SQLite can open regardless of `MAX_PATH`.
+///
+/// On Windows this is the extended-length (`\\?\`) form; elsewhere it is the
+/// path unchanged. Magic SQLite filenames (`:memory:`, an empty temporary
+/// name, or a `file:` URI) pass through untouched: absolutizing them would
+/// turn a private in-memory or URI-configured database into a stray file in
+/// the current working directory.
+pub(crate) fn open_path(path: &Path) -> PathBuf {
+    if is_magic_sqlite_filename(path) {
+        return path.to_path_buf();
+    }
+    codestory_workspace::paths::sqlite_open_path(path)
+}
+
+/// Return the `ATTACH DATABASE` argument for `path`.
+///
+/// An attached database gets its own `-wal`/`-shm` siblings, so it needs the
+/// same extended-length treatment as a primary open.
+pub(crate) fn attach_argument(path: &Path) -> String {
+    open_path(path).to_string_lossy().into_owned()
+}
+
+/// Build the read-only observational URI for `path`.
+///
+/// `immutable=1` is only expressible through a URI, so the observational
+/// reader cannot fall back to a plain filename. The path is converted first
+/// and then percent-encoded, which matters on Windows: the extended-length
+/// prefix must survive as literal backslashes. A forward-slash spelling
+/// (`//?/C:/...`) is *not* equivalent — Win32 disables path normalization
+/// only for the literal `\\?\` prefix — and it would additionally make SQLite
+/// parse `?` as a URI authority and reject the filename. Percent-encoding
+/// every backslash keeps the first character after `file:` off `/`, so
+/// SQLite skips authority parsing and decodes the exact verbatim path.
+pub(crate) fn observational_uri(path: &Path, immutable: bool) -> String {
+    let open_path = open_path(path);
+    let encoded = percent_encode_sqlite_uri_path(&sqlite_uri_path_bytes(&open_path));
+    format!(
+        "file:{encoded}?mode=ro{}",
+        if immutable { "&immutable=1" } else { "" }
+    )
+}
+
+/// True when `path` is a SQLite magic filename rather than a real path.
+fn is_magic_sqlite_filename(path: &Path) -> bool {
+    let Some(text) = path.to_str() else {
+        return false;
+    };
+    text.is_empty() || MAGIC_SQLITE_FILENAMES.contains(&text) || text.starts_with(SQLITE_URI_PREFIX)
+}
+
+/// Raw bytes of the filename SQLite should decode from the URI.
+#[cfg(unix)]
+fn sqlite_uri_path_bytes(path: &Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    path.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(not(unix))]
+fn sqlite_uri_path_bytes(path: &Path) -> Vec<u8> {
+    path.to_string_lossy().into_owned().into_bytes()
+}
+
+/// Percent-encode a filename for the path component of a SQLite `file:` URI.
+///
+/// Only characters SQLite can safely carry through URI parsing are left
+/// literal. Backslash is deliberately *not* literal so Windows verbatim
+/// prefixes round-trip as `%5C%5C%3F%5C`.
+fn percent_encode_sqlite_uri_path(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() + 24);
+    for byte in bytes {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b':' | b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(*byte));
+        } else {
+            use std::fmt::Write as _;
+            let _ = write!(encoded, "%{byte:02X}");
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn magic_filenames_are_never_absolutized() {
+        for magic in [":memory:", "", "file:cache?mode=memory&cache=shared"] {
+            let path = Path::new(magic);
+            assert_eq!(open_path(path), path, "{magic} must pass through unchanged");
+        }
+    }
+
+    #[test]
+    fn ordinary_relative_paths_are_not_treated_as_magic() {
+        assert!(!is_magic_sqlite_filename(Path::new("cache/codestory.db")));
+        assert!(!is_magic_sqlite_filename(Path::new("filestore.db")));
+    }
+
+    #[test]
+    fn uri_encoder_keeps_posix_paths_readable() {
+        assert_eq!(
+            percent_encode_sqlite_uri_path(b"/home/dev/.cache/codestory/core.db"),
+            "/home/dev/.cache/codestory/core.db"
+        );
+    }
+
+    #[test]
+    fn uri_encoder_escapes_uri_delimiters() {
+        assert_eq!(
+            percent_encode_sqlite_uri_path(b"/tmp/a b?c#d/core.db"),
+            "/tmp/a%20b%3Fc%23d/core.db"
+        );
+    }
+
+    /// The extended-length prefix must survive URI parsing as literal
+    /// backslashes, and the encoded form must not begin with `//` — SQLite
+    /// would then parse an authority and reject the filename.
+    #[test]
+    fn uri_encoder_preserves_a_windows_verbatim_prefix() {
+        let encoded = percent_encode_sqlite_uri_path(br"\\?\C:\cache\codestory\core.db");
+        assert_eq!(
+            encoded, "%5C%5C%3F%5CC:%5Ccache%5Ccodestory%5Ccore.db",
+            "verbatim prefix must percent-encode rather than become forward slashes"
+        );
+        let uri = format!("file:{encoded}?mode=ro");
+        assert!(
+            !uri[SQLITE_URI_PREFIX.len()..].starts_with('/'),
+            "an encoded filename starting with '/' risks SQLite authority parsing: {uri}"
+        );
+    }
+
+    #[test]
+    fn uri_encoder_preserves_a_windows_unc_verbatim_prefix() {
+        assert_eq!(
+            percent_encode_sqlite_uri_path(br"\\?\UNC\server\share\core.db"),
+            "%5C%5C%3F%5CUNC%5Cserver%5Cshare%5Ccore.db"
+        );
+    }
+
+    #[test]
+    fn observational_uri_carries_the_immutable_flag() {
+        let path = Path::new("/tmp/codestory/core.db");
+        assert!(observational_uri(path, true).ends_with("?mode=ro&immutable=1"));
+        assert!(observational_uri(path, false).ends_with("?mode=ro"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn non_windows_open_paths_are_unchanged() {
+        // Identity safety: a non-Windows store must keep byte-identical paths
+        // so nothing derived from a path can shift under this change.
+        for candidate in [
+            "/home/dev/.cache/codestory/projects/abc/core.db",
+            "/tmp/staged.sqlite",
+            "relative/core.db",
+        ] {
+            let path = Path::new(candidate);
+            assert_eq!(open_path(path), path);
+            assert_eq!(attach_argument(path), candidate);
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn non_windows_deep_paths_are_unchanged() {
+        let deep = format!("/tmp/{}/core.db", "segment".repeat(60));
+        let path = Path::new(&deep);
+        assert!(deep.len() > 260);
+        assert_eq!(open_path(path), path);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_open_paths_gain_the_extended_length_prefix() {
+        let path = Path::new(r"C:\cache\codestory\core.db");
+        let open = open_path(path);
+        assert_eq!(open, Path::new(r"\\?\C:\cache\codestory\core.db"));
+        assert_eq!(attach_argument(path), r"\\?\C:\cache\codestory\core.db");
+    }
+}

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -32,6 +32,7 @@ mod row_mapping;
 mod schema;
 mod trail;
 
+use crate::sqlite_path;
 use helpers::{
     decode_embedding_blob, deserialize_candidate_targets, encode_embedding_blob,
     numbered_placeholders, question_placeholders, serialize_candidate_targets,
@@ -235,7 +236,10 @@ fn database_logical_bytes(connection: &Connection) -> Result<u64, StorageError> 
 }
 
 fn database_logical_bytes_at_path(path: &Path) -> Result<u64, StorageError> {
-    let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let connection = Connection::open_with_flags(
+        sqlite_path::open_path(path),
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )?;
     database_logical_bytes(&connection)
 }
 
@@ -493,7 +497,10 @@ fn read_source_policy_exclusion_rollback_identity(
     if !path.exists() {
         return Ok(None);
     }
-    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let conn = Connection::open_with_flags(
+        sqlite_path::open_path(path),
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )?;
     let table_exists: i64 = conn.query_row(
         "SELECT EXISTS(
             SELECT 1 FROM sqlite_master
@@ -689,7 +696,10 @@ fn read_structural_text_unit_rollback_identity(
     if !path.exists() {
         return Ok(None);
     }
-    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let conn = Connection::open_with_flags(
+        sqlite_path::open_path(path),
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )?;
     let table_exists: i64 = conn.query_row(
         "SELECT EXISTS(
             SELECT 1 FROM sqlite_master
@@ -870,7 +880,10 @@ fn inspect_promotion_database(path: &Path) -> Result<Option<(Connection, u32)>, 
     if !path.exists() {
         return Ok(None);
     }
-    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let conn = Connection::open_with_flags(
+        sqlite_path::open_path(path),
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )?;
     let _ = conn.busy_timeout(Duration::from_millis(2_500));
     let quick_check: String = conn.query_row("PRAGMA quick_check", [], |row| row.get(0))?;
     if quick_check != "ok" {
@@ -1193,9 +1206,15 @@ fn recover_interrupted_promotion_locked(path: &Path) -> Result<(), StorageError>
 }
 
 fn restore_promotion_database(source_path: &Path, live_path: &Path) -> Result<(), StorageError> {
-    let mut live = Connection::open(live_path)?;
+    let mut live = Connection::open(sqlite_path::open_path(live_path))?;
     let _ = live.busy_timeout(Duration::from_millis(2_500));
-    live.restore(MAIN_DB, source_path, None::<fn(rusqlite::backup::Progress)>)?;
+    // `restore` opens `source_path` as a second SQLite database, so it needs
+    // the same extended-length treatment as the live connection.
+    live.restore(
+        MAIN_DB,
+        sqlite_path::open_path(source_path),
+        None::<fn(rusqlite::backup::Progress)>,
+    )?;
     Ok(())
 }
 
@@ -3657,7 +3676,10 @@ impl Storage {
     pub fn open_read_only<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
         let path = path.as_ref();
         recover_interrupted_promotion(path)?;
-        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let conn = Connection::open_with_flags(
+            sqlite_path::open_path(path),
+            OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
         conn.busy_timeout(Duration::from_millis(2_500))?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
@@ -3735,7 +3757,7 @@ impl Storage {
         // connection observes it without materializing either sidecar. SQLite
         // may update transient reader marks inside the existing SHM wal-index;
         // durable database and WAL bytes remain observationally unchanged.
-        let uri = observational_sqlite_uri(path, !wal_exists);
+        let uri = sqlite_path::observational_uri(path, !wal_exists);
         let conn = Connection::open_with_flags(
             uri,
             OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
@@ -3839,7 +3861,7 @@ impl Storage {
         if matches!(mode, StorageOpenMode::Live) {
             recover_interrupted_promotion(path)?;
         }
-        let conn = Connection::open(path)?;
+        let conn = Connection::open(sqlite_path::open_path(path))?;
         // Allow concurrent reads while indexing writes, and avoid flaky "database is locked" errors
         // in app shells when users query mid-index.
         conn.busy_timeout(Duration::from_millis(2_500))?;
@@ -3878,7 +3900,10 @@ impl Storage {
 
     pub fn database_schema_version(path: &Path) -> Result<u32, StorageError> {
         recover_interrupted_promotion(path)?;
-        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let conn = Connection::open_with_flags(
+            sqlite_path::open_path(path),
+            OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         Ok(version.max(0) as u32)
     }
@@ -3886,7 +3911,10 @@ impl Storage {
     /// Read the incomplete-run fence without migrating or otherwise mutating a live database.
     pub fn database_has_incomplete_incremental_run(path: &Path) -> Result<bool, StorageError> {
         recover_interrupted_promotion(path)?;
-        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let conn = Connection::open_with_flags(
+            sqlite_path::open_path(path),
+            OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         let version = version.max(0) as u32;
         if version != INCOMPLETE_INCREMENTAL_SCHEMA_VERSION && version > SCHEMA_VERSION {
@@ -3908,7 +3936,10 @@ impl Storage {
         path: &Path,
     ) -> Result<Option<IndexPublicationRecord>, StorageError> {
         recover_interrupted_promotion(path)?;
-        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let conn = Connection::open_with_flags(
+            sqlite_path::open_path(path),
+            OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
         read_index_publication(&conn)
     }
 
@@ -3918,7 +3949,10 @@ impl Storage {
         path: &Path,
     ) -> Result<Option<IndexPublicationRecord>, StorageError> {
         recover_interrupted_promotion(path)?;
-        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let conn = Connection::open_with_flags(
+            sqlite_path::open_path(path),
+            OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
         read_complete_index_publication(&conn)
     }
 
@@ -3935,12 +3969,23 @@ impl Storage {
                 ))
             })?;
         }
-        let source = Connection::open_with_flags(source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let source = Connection::open_with_flags(
+            sqlite_path::open_path(source_path),
+            OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
         let source_bytes = database_logical_bytes(&source)?;
         let copy_started = Instant::now();
-        source.backup(MAIN_DB, target_path, None::<fn(rusqlite::backup::Progress)>)?;
+        // `backup` opens the target as a second SQLite database.
+        source.backup(
+            MAIN_DB,
+            sqlite_path::open_path(target_path),
+            None::<fn(rusqlite::backup::Progress)>,
+        )?;
         let copy_ms = duration_ms(copy_started.elapsed());
-        let target = Connection::open_with_flags(target_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let target = Connection::open_with_flags(
+            sqlite_path::open_path(target_path),
+            OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
         let target_bytes = database_logical_bytes(&target)?;
         Ok(DatabaseSnapshotCopyStats {
             copy_ms,
@@ -3987,7 +4032,13 @@ impl Storage {
         else {
             return Ok(None);
         };
-        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        // SQLite already reports the resolved full pathname of this
+        // connection, so on Windows it is normally verbatim already and the
+        // conversion is idempotent.
+        let conn = Connection::open_with_flags(
+            sqlite_path::open_path(Path::new(path)),
+            OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
         conn.busy_timeout(Duration::from_millis(2_500))?;
         conn.pragma_update(None, "query_only", "ON")?;
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
@@ -4065,7 +4116,7 @@ impl Storage {
         if !source_path.exists() {
             return Ok(0);
         }
-        let source = source_path.to_string_lossy().to_string();
+        let source = sqlite_path::attach_argument(source_path);
         self.conn
             .execute("ATTACH DATABASE ?1 AS source_snapshot", params![source])?;
         let copy_result = self.conn.execute(
@@ -4129,7 +4180,7 @@ impl Storage {
             return Ok(0);
         }
         drop(Storage::open(source_path)?);
-        let source = source_path.to_string_lossy().to_string();
+        let source = sqlite_path::attach_argument(source_path);
         self.conn.execute(
             "ATTACH DATABASE ?1 AS structural_cache_source",
             params![source],
@@ -5252,11 +5303,11 @@ impl Storage {
         let mut rollback_backup_bytes = None;
         if previous.is_some() {
             let rollback_backup_copy_started = Instant::now();
-            let live_conn = Connection::open(live_path)?;
+            let live_conn = Connection::open(sqlite_path::open_path(live_path))?;
             let _ = live_conn.busy_timeout(Duration::from_millis(2_500));
             live_conn.backup(
                 MAIN_DB,
-                &backup_path,
+                sqlite_path::open_path(&backup_path),
                 None::<fn(rusqlite::backup::Progress)>,
             )?;
             drop(live_conn);
@@ -5313,17 +5364,19 @@ impl Storage {
         durations.prepared_journal_directory_sync = journal_write_stats.directory_sync;
 
         let staged_to_live_restore_started = Instant::now();
-        let mut live_conn = Connection::open(live_path)?;
+        let mut live_conn = Connection::open(sqlite_path::open_path(live_path))?;
         let _ = live_conn.busy_timeout(Duration::from_millis(2_500));
         live_conn.pragma_update(None, "synchronous", "FULL")?;
 
+        // `restore` opens the staged database itself, so it needs the same
+        // conversion as the live connection above.
         #[cfg(test)]
         let restore_result = if let Some(sentinel_path) =
             std::env::var_os(PROMOTION_ABORT_SENTINEL_ENV).map(PathBuf::from)
         {
             live_conn.restore(
                 MAIN_DB,
-                staged_path,
+                sqlite_path::open_path(staged_path),
                 Some(move |_progress| {
                     let mut sentinel = std::fs::File::create(&sentinel_path)
                         .expect("create promotion abort sentinel");
@@ -5335,11 +5388,18 @@ impl Storage {
                 }),
             )
         } else {
-            live_conn.restore(MAIN_DB, staged_path, None::<fn(rusqlite::backup::Progress)>)
+            live_conn.restore(
+                MAIN_DB,
+                sqlite_path::open_path(staged_path),
+                None::<fn(rusqlite::backup::Progress)>,
+            )
         };
         #[cfg(not(test))]
-        let restore_result =
-            live_conn.restore(MAIN_DB, staged_path, None::<fn(rusqlite::backup::Progress)>);
+        let restore_result = live_conn.restore(
+            MAIN_DB,
+            sqlite_path::open_path(staged_path),
+            None::<fn(rusqlite::backup::Progress)>,
+        );
 
         if let Err(err) = restore_result {
             drop(live_conn);
@@ -5893,7 +5953,7 @@ impl Storage {
             return Ok(0);
         }
         drop(Storage::open(source_path)?);
-        let source = source_path.to_string_lossy().to_string();
+        let source = sqlite_path::attach_argument(source_path);
         self.conn
             .execute("ATTACH DATABASE ?1 AS source_snapshot", params![source])?;
         let copy_result = self.conn.execute(
@@ -8237,7 +8297,7 @@ impl Storage {
             return Ok(0);
         }
         drop(Storage::open(source_path)?);
-        let source = source_path.to_string_lossy().to_string();
+        let source = sqlite_path::attach_argument(source_path);
         self.conn
             .execute("ATTACH DATABASE ?1 AS dense_anchor_source", params![source])?;
         let copy_result = self.conn.execute(
@@ -8560,7 +8620,7 @@ impl Storage {
             return Ok(0);
         }
         drop(Storage::open(source_path)?);
-        let source = source_path.to_string_lossy().to_string();
+        let source = sqlite_path::attach_argument(source_path);
         self.conn
             .execute("ATTACH DATABASE ?1 AS source_snapshot", params![source])?;
         let copy_result = self.conn.execute(
@@ -9278,7 +9338,7 @@ impl Storage {
             return Ok(0);
         }
         drop(Storage::open(source_path)?);
-        let source = source_path.to_string_lossy().to_string();
+        let source = sqlite_path::attach_argument(source_path);
         self.conn
             .execute("ATTACH DATABASE ?1 AS source_snapshot", params![source])?;
         let copy_result = self.conn.execute(
@@ -11477,34 +11537,6 @@ fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
     let mut value = path.as_os_str().to_os_string();
     value.push(suffix);
     PathBuf::from(value)
-}
-
-fn observational_sqlite_uri(path: &Path, immutable: bool) -> String {
-    #[cfg(unix)]
-    let bytes = {
-        use std::os::unix::ffi::OsStrExt;
-        path.as_os_str().as_bytes().to_vec()
-    };
-    #[cfg(not(unix))]
-    let bytes = path.to_string_lossy().replace('\\', "/").into_bytes();
-
-    let mut encoded = String::with_capacity(bytes.len() + 24);
-    for byte in bytes {
-        if byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b':' | b'-' | b'_' | b'.' | b'~') {
-            encoded.push(char::from(byte));
-        } else {
-            use std::fmt::Write as _;
-            let _ = write!(encoded, "%{byte:02X}");
-        }
-    }
-    #[cfg(windows)]
-    if encoded.len() >= 3 && encoded.as_bytes()[1] == b':' && encoded.as_bytes()[2] == b'/' {
-        encoded.insert(0, '/');
-    }
-    format!(
-        "file:{encoded}?mode=ro{}",
-        if immutable { "&immutable=1" } else { "" }
-    )
 }
 
 fn neighbor_for_direction(

--- a/crates/codestory-store/tests/long_path_open.rs
+++ b/crates/codestory-store/tests/long_path_open.rs
@@ -1,0 +1,229 @@
+//! The core store must open under cache roots longer than Windows' `MAX_PATH`.
+//!
+//! The packaged `codestory-cli.exe` carries no `longPathAware` application
+//! manifest, so `CreateFileW` stays capped at 260 characters for it no matter
+//! what `LongPathsEnabled` says on the host. Rust's standard library hides
+//! that cap by converting to extended-length form internally; SQLite's Win32
+//! VFS does not. The core store runs in WAL mode and SQLite derives `-wal`
+//! (+4) and `-shm` (+4) by appending to the main database path, so a store
+//! that opens at 258 characters still fails when SQLite reaches for its
+//! siblings — with a bare "unable to open database file".
+//!
+//! These tests exercise the real store surfaces at a padded path on every
+//! platform. On Windows they additionally assert the sibling paths cross the
+//! cap, which is the condition that actually reproduced the failure. On other
+//! platforms there is no cap, so they are regression cover proving the
+//! conversion stayed a no-op and did not disturb ordinary opens.
+
+use codestory_store::{FileInfo, FileRole, IndexArtifactCacheWrite, Store};
+use std::path::{Path, PathBuf};
+
+/// Comfortably past `MAX_PATH` once a temporary root is prefixed, while every
+/// individual component stays under the 255-character component limit.
+const PADDING_COMPONENT: &str = "codestory-long-path-padding-segment-0123456789abcdef";
+const PADDING_DEPTH: usize = 5;
+
+/// Create a database path deep enough to cross `MAX_PATH`, with its parent
+/// directories already present.
+fn deep_database_path(root: &Path, name: &str) -> PathBuf {
+    let mut directory = root.to_path_buf();
+    for index in 0..PADDING_DEPTH {
+        directory = directory.join(format!("{PADDING_COMPONENT}-{index}"));
+    }
+    std::fs::create_dir_all(&directory).expect("create the padded store directory");
+    let path = directory.join(name);
+    assert!(
+        path.as_os_str().len() > 260,
+        "the fixture must cross MAX_PATH, got {} characters",
+        path.as_os_str().len()
+    );
+    path
+}
+
+fn sibling(path: &Path, suffix: &str) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(suffix);
+    PathBuf::from(value)
+}
+
+fn seeded_file(id: i64, path: &str) -> FileInfo {
+    FileInfo {
+        id,
+        path: PathBuf::from(path),
+        language: "rust".to_string(),
+        modification_time: 1_700_000_000_000,
+        indexed: true,
+        complete: true,
+        line_count: 7,
+        file_role: FileRole::classify_path(Path::new(path)),
+    }
+}
+
+#[test]
+fn a_live_store_round_trips_under_a_path_longer_than_max_path() {
+    let root = tempfile::tempdir().expect("temporary store root");
+    let path = deep_database_path(root.path(), "codestory.db");
+
+    let mut storage = Store::open(&path).expect("open a live store beyond MAX_PATH");
+    storage
+        .insert_files_batch(&[seeded_file(1, "src/lib.rs")])
+        .expect("write through the padded store");
+
+    // WAL mode materializes both siblings while the connection is open. They
+    // are the files that actually crossed the cap in the reported failure.
+    let wal = sibling(&path, "-wal");
+    let shm = sibling(&path, "-shm");
+    assert!(wal.exists(), "WAL sidecar must exist at {}", wal.display());
+    assert!(shm.exists(), "SHM sidecar must exist at {}", shm.display());
+    assert!(
+        wal.as_os_str().len() > 260 && shm.as_os_str().len() > 260,
+        "both sidecar paths must cross MAX_PATH for this test to mean anything"
+    );
+
+    drop(storage);
+
+    let reopened = Store::open_read_only(&path).expect("reopen the padded store read-only");
+    let files = reopened.files().get_files().expect("read the padded store");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path, PathBuf::from("src/lib.rs"));
+}
+
+#[test]
+fn an_observational_store_opens_under_a_path_longer_than_max_path() {
+    let root = tempfile::tempdir().expect("temporary store root");
+    let path = deep_database_path(root.path(), "codestory.db");
+
+    let mut storage = Store::open(&path).expect("open a live store beyond MAX_PATH");
+    storage
+        .insert_files_batch(&[seeded_file(1, "src/main.rs")])
+        .expect("write through the padded store");
+    drop(storage);
+
+    // The observational reader is the one open site that must go through a
+    // SQLite `file:` URI, because `immutable=1` has no `OpenFlags` spelling.
+    // The extended-length prefix has to survive URI parsing intact.
+    let observer = Store::open_observational(&path).expect("observe the padded store");
+    let files = observer.files().get_files().expect("observe stored files");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path, PathBuf::from("src/main.rs"));
+
+    assert_eq!(
+        Store::database_schema_version(&path).expect("read the padded schema version"),
+        codestory_store::CURRENT_SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn a_database_snapshot_copies_between_paths_longer_than_max_path() {
+    let root = tempfile::tempdir().expect("temporary store root");
+    let source_path = deep_database_path(root.path(), "source.db");
+    let target_path = deep_database_path(root.path(), "target.db");
+
+    let mut source = Store::open(&source_path).expect("open the padded source store");
+    source
+        .insert_files_batch(&[seeded_file(1, "src/copied.rs")])
+        .expect("seed the padded source store");
+    drop(source);
+
+    // `copy_database_snapshot` opens the source read-only and lets SQLite's
+    // backup API open the target, so both sides need the conversion.
+    Store::copy_database_snapshot(&source_path, &target_path).expect("copy beyond MAX_PATH");
+
+    let copied = Store::open_read_only(&target_path).expect("open the padded copy");
+    let files = copied.files().get_files().expect("read the padded copy");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path, PathBuf::from("src/copied.rs"));
+}
+
+#[test]
+fn an_attached_source_database_copies_beyond_max_path() {
+    let root = tempfile::tempdir().expect("temporary store root");
+    let source_path = deep_database_path(root.path(), "cache-source.db");
+    let target_path = deep_database_path(root.path(), "cache-target.db");
+
+    let cached_file = Path::new("src/cached.rs");
+    let source = Store::open(&source_path).expect("open the padded cache source");
+    source
+        .upsert_index_artifact_cache_batch(&[IndexArtifactCacheWrite {
+            path: cached_file,
+            cache_key: "cache-key-v1",
+            artifact_blob: b"padded-artifact",
+        }])
+        .expect("seed the padded artifact cache");
+    drop(source);
+
+    // `ATTACH DATABASE` opens the attached file with its own WAL siblings.
+    let mut target = Store::open(&target_path).expect("open the padded cache target");
+    let copied = target
+        .copy_index_artifact_cache_from(&source_path)
+        .expect("attach and copy beyond MAX_PATH");
+    assert_eq!(copied, 1);
+    assert_eq!(
+        target
+            .get_index_artifact_cache(cached_file, "cache-key-v1")
+            .expect("read the copied artifact"),
+        Some(b"padded-artifact".to_vec())
+    );
+}
+
+/// Wiring guard: every SQLite open in the core store's implementation must
+/// name the conversion helper.
+///
+/// On non-Windows hosts the conversion is a no-op, so no behavioral test can
+/// notice it being removed. This reads the production source instead, which
+/// makes a reverted call site fail here rather than only on a Windows host
+/// with a deep cache root.
+#[test]
+fn every_core_store_sqlite_open_routes_through_the_conversion_helper() {
+    const SOURCE: &str = include_str!("../src/storage_impl/mod.rs");
+    /// Opening a database by one of these spellings hands SQLite a filename.
+    const OPEN_SPELLINGS: [&str; 5] = [
+        "Connection::open(",
+        "Connection::open_with_flags(",
+        "ATTACH DATABASE",
+        ".backup(",
+        ".restore(",
+    ];
+    /// Any of these in the call's immediate neighborhood proves the filename
+    /// was converted, or that no filename is involved at all.
+    const ACCEPTED: [&str; 4] = [
+        "sqlite_path::",
+        "open_in_memory",
+        "DETACH DATABASE",
+        // Opt out explicitly, next to the call, when a site genuinely does
+        // not open a filesystem path.
+        "sqlite-open-path: not required",
+    ];
+    /// How far before the opening line the conversion may appear (an
+    /// `ATTACH` binds its argument a couple of lines earlier).
+    const LINES_BEFORE: usize = 3;
+    /// How far after the opening line the conversion may appear (a multi-line
+    /// call passes it as an argument).
+    const LINES_AFTER: usize = 4;
+
+    let lines: Vec<&str> = SOURCE.lines().collect();
+    let mut unguarded = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        if !OPEN_SPELLINGS
+            .iter()
+            .any(|spelling| line.contains(spelling))
+        {
+            continue;
+        }
+        let window_start = index.saturating_sub(LINES_BEFORE);
+        let window_end = (index + LINES_AFTER + 1).min(lines.len());
+        let window = lines[window_start..window_end].join("\n");
+        if ACCEPTED.iter().any(|accepted| window.contains(accepted)) {
+            continue;
+        }
+        unguarded.push(format!("line {}: {}", index + 1, line.trim()));
+    }
+
+    assert!(
+        unguarded.is_empty(),
+        "these SQLite opens in crates/codestory-store/src/storage_impl/mod.rs do not convert \
+         their path with codestory_store::sqlite_path, so their -wal/-shm siblings will fail \
+         past MAX_PATH on Windows:\n{}",
+        unguarded.join("\n")
+    );
+}


### PR DESCRIPTION
Extends the #1506 helper to all 23 production SQLite opens in codestory-store. The core store is worse exposed than the sidecars: WAL mode means every live open materializes -wal/-shm siblings named by appending to the main path, so cache roots well under 260 chars already fail on an unmanifested binary.

The delicate site is the immutable=1 observational reader: immutable has no OpenFlags spelling so it must be a file: URI, and a raw verbatim prefix would make SQLite parse %3F as a URI authority and reject the filename. The encoder percent-encodes the backslashes, keeping the first character after "file:" off "/" so SQLite skips authority parsing. Unix encoding is byte-for-byte unchanged.

**Empirically validated on a real Windows 11 host** (the one genuinely new mechanism, flagged by review as untested): SQLite accepts file:%5C%5C%3F%5C..., decodes it to the correct file, runs WAL, and creates -wal/-shm siblings at a 356-char path; the immutable reader reads back through the same encoding. Stated plainly: that run does NOT prove plain paths fail, because the Python used to drive it is itself manifested longPathAware — the failing half was already proven by the calibration cell.

Identity safety verified by the reviewer end to end: the converted path is a call-expression temporary at every site, so no project id, cache key, or persisted bookkeeping sees a verbatim prefix. Magic paths (:memory:, file:) pass through unconverted. Revert-proofs recorded for both the wiring guard and the URI encoder.

longPathAware manifest assessed and deliberately NOT taken here: it is strictly weaker than the verbatim fix (it needs LongPathsEnabled=1, not the default), and it would change binary bytes, archive digests, and the native fingerprint — a release-boundary decision, not a path-fix drive-by.

Closes #1509

🤖 Generated with [Claude Code](https://claude.com/claude-code)