### PR TITLE
resolve windows precise interrupt clocks from the realtime api set

### DIFF
--- a/.github/scripts/packaged_agent_proof/process_memory_sampling.py
+++ b/.github/scripts/packaged_agent_proof/process_memory_sampling.py
@@ -11,6 +11,46 @@ import time
 
 from .foundation import ProofFailure, require
 
+# QueryUnbiasedInterruptTimePrecise and QueryInterruptTimePrecise are exported
+# by the api-ms-win-core-realtime-l1-1-1 API set, hosted by KernelBase.dll.
+# Neither function is exported by kernel32.dll, so the pair must be resolved
+# from these modules in preference order.
+WINDOWS_INTERRUPT_CLOCK_MODULES = (
+    "api-ms-win-core-realtime-l1-1-1.dll",
+    "KernelBase.dll",
+)
+_WINDOWS_CLOCK_UNAVAILABLE = (
+    "Windows qualification host could not read unbiased interrupt time"
+)
+
+
+def _load_windows_module(name: str):
+    return ctypes.WinDLL(name)
+
+
+def resolve_windows_interrupt_clocks(load_module=_load_windows_module):
+    """Resolve the precise interrupt-time pair from the module exporting it.
+
+    Both clock functions must come from one module so the sampled pair shares
+    a provider. Prefer the realtime API set and fall back to KernelBase; fail
+    closed when no module provides both functions. The functions return void,
+    so genuine unavailability surfaces here rather than as a call-site status.
+    """
+    for module_name in WINDOWS_INTERRUPT_CLOCK_MODULES:
+        try:
+            module = load_module(module_name)
+        except OSError:
+            continue
+        unbiased = getattr(module, "QueryUnbiasedInterruptTimePrecise", None)
+        inclusive = getattr(module, "QueryInterruptTimePrecise", None)
+        if unbiased is None or inclusive is None:
+            continue
+        for clock in (unbiased, inclusive):
+            clock.argtypes = [ctypes.POINTER(ctypes.c_ulonglong)]
+            clock.restype = None
+        return unbiased, inclusive
+    raise ProofFailure(_WINDOWS_CLOCK_UNAVAILABLE)
+
 
 def parse_byte_quantity(value: str) -> int:
     match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([KMG])?", value.strip())
@@ -95,14 +135,15 @@ def suspend_clock_pair(target_os: str) -> tuple[int, int, str, str]:
     require(
         target_os == "windows", f"unsupported qualification clock target {target_os}"
     )
-    kernel = ctypes.windll.kernel32
+    query_unbiased, query_inclusive = resolve_windows_interrupt_clocks()
     unbiased = ctypes.c_ulonglong()
     inclusive = ctypes.c_ulonglong()
+    query_unbiased(ctypes.byref(unbiased))
+    query_inclusive(ctypes.byref(inclusive))
     require(
-        bool(kernel.QueryUnbiasedInterruptTimePrecise(ctypes.byref(unbiased))),
-        "Windows qualification host could not read unbiased interrupt time",
+        0 < unbiased.value <= inclusive.value,
+        _WINDOWS_CLOCK_UNAVAILABLE,
     )
-    kernel.QueryInterruptTimePrecise(ctypes.byref(inclusive))
     return (
         int(unbiased.value) * 100,
         int(inclusive.value) * 100,

--- a/.github/scripts/packaged_agent_proof/self_test_process.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process.py
@@ -1,11 +1,13 @@
 """Process-level packaged proof self-test coordinator."""
 
 from .self_test_process_cleanup import run_process_cleanup_self_tests
+from .self_test_process_clock import run_process_clock_self_tests
 from .self_test_process_exit import run_process_exit_self_tests
 from .self_test_process_identity import run_process_identity_self_tests
 
 
 def run_process_self_tests() -> None:
     run_process_identity_self_tests()
+    run_process_clock_self_tests()
     run_process_exit_self_tests()
     run_process_cleanup_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_process_clock.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process_clock.py
@@ -1,0 +1,157 @@
+"""Suspend-inclusive clock sampling proof self-tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from .foundation import ProofFailure, require
+from .process_memory_sampling import (
+    WINDOWS_INTERRUPT_CLOCK_MODULES,
+    resolve_windows_interrupt_clocks,
+    suspend_clock_pair,
+)
+
+_CLOCK_EXPORTS = ("QueryUnbiasedInterruptTimePrecise", "QueryInterruptTimePrecise")
+_EXPECTED_CLOCK_APIS = {
+    "linux": ("CLOCK_MONOTONIC", "CLOCK_BOOTTIME"),
+    "macos": ("mach_absolute_time", "mach_continuous_time"),
+    "windows": _CLOCK_EXPORTS,
+}
+
+
+def _target_os() -> str:
+    if os.name == "nt":
+        return "windows"
+    return "macos" if sys.platform == "darwin" else "linux"
+
+
+class _FakeClockFunction:
+    def __init__(self, module_name: str, export: str) -> None:
+        self.module_name = module_name
+        self.export = export
+
+
+class _FakeRealtimeModule:
+    def __init__(self, name: str, exports: tuple[str, ...]) -> None:
+        for export in exports:
+            setattr(self, export, _FakeClockFunction(name, export))
+
+
+def _require_resolved_pair(pair, module_name: str, label: str) -> None:
+    unbiased, inclusive = pair
+    require(
+        (unbiased.module_name, unbiased.export)
+        == (module_name, "QueryUnbiasedInterruptTimePrecise")
+        and (inclusive.module_name, inclusive.export)
+        == (module_name, "QueryInterruptTimePrecise"),
+        f"{label} resolved the clock pair from the wrong module",
+    )
+    for clock in (unbiased, inclusive):
+        require(
+            getattr(clock, "restype", 0) is None
+            and len(getattr(clock, "argtypes", ())) == 1,
+            f"{label} left the clock pair without void/out-parameter prototypes",
+        )
+
+
+def _run_host_clock_gate_leg() -> None:
+    target_os = _target_os()
+    first = suspend_clock_pair(target_os)
+    second = suspend_clock_pair(target_os)
+    require(
+        first[2:] == _EXPECTED_CLOCK_APIS[target_os],
+        f"{target_os} suspend clock pair reported unexpected APIs {first[2:]}",
+    )
+    require(
+        second[2:] == first[2:],
+        "suspend clock APIs changed between consecutive samples",
+    )
+    require(
+        second[0] >= first[0] > 0 and second[1] >= first[1] > 0,
+        "suspend clock pair moved backwards between consecutive samples",
+    )
+    try:
+        suspend_clock_pair("freebsd")
+    except ProofFailure as failure:
+        require(
+            "unsupported qualification clock target" in str(failure),
+            "unsupported clock target failed with an unexpected error",
+        )
+    else:
+        raise ProofFailure("unsupported clock target was not rejected")
+
+
+def _run_resolver_preference_leg() -> None:
+    requested: list[str] = []
+
+    def load_module(name: str) -> _FakeRealtimeModule:
+        requested.append(name)
+        return _FakeRealtimeModule(name, _CLOCK_EXPORTS)
+
+    pair = resolve_windows_interrupt_clocks(load_module)
+    require(
+        requested == [WINDOWS_INTERRUPT_CLOCK_MODULES[0]],
+        "clock resolver did not prefer the realtime API set module",
+    )
+    _require_resolved_pair(pair, WINDOWS_INTERRUPT_CLOCK_MODULES[0], "clock resolver")
+
+
+def _run_resolver_fallback_leg() -> None:
+    requested: list[str] = []
+
+    def load_module(name: str) -> _FakeRealtimeModule:
+        requested.append(name)
+        if name == WINDOWS_INTERRUPT_CLOCK_MODULES[0]:
+            raise OSError(f"cannot load {name}")
+        return _FakeRealtimeModule(name, _CLOCK_EXPORTS)
+
+    pair = resolve_windows_interrupt_clocks(load_module)
+    require(
+        requested == list(WINDOWS_INTERRUPT_CLOCK_MODULES),
+        "clock resolver skipped the API set before falling back",
+    )
+    _require_resolved_pair(
+        pair, WINDOWS_INTERRUPT_CLOCK_MODULES[1], "clock resolver fallback"
+    )
+
+    def load_partial(name: str) -> _FakeRealtimeModule:
+        if name == WINDOWS_INTERRUPT_CLOCK_MODULES[0]:
+            return _FakeRealtimeModule(name, _CLOCK_EXPORTS[:1])
+        return _FakeRealtimeModule(name, _CLOCK_EXPORTS)
+
+    _require_resolved_pair(
+        resolve_windows_interrupt_clocks(load_partial),
+        WINDOWS_INTERRUPT_CLOCK_MODULES[1],
+        "clock resolver with a partial API set export",
+    )
+
+
+def _run_resolver_fail_closed_leg() -> None:
+    def load_nothing(name: str):
+        raise OSError(f"cannot load {name}")
+
+    def load_empty(name: str) -> _FakeRealtimeModule:
+        return _FakeRealtimeModule(name, ())
+
+    for label, load_module in (
+        ("unloadable modules", load_nothing),
+        ("modules without the exports", load_empty),
+    ):
+        try:
+            resolve_windows_interrupt_clocks(load_module)
+        except ProofFailure as failure:
+            require(
+                str(failure)
+                == "Windows qualification host could not read unbiased interrupt time",
+                f"clock resolver changed its fail-closed error for {label}",
+            )
+        else:
+            raise ProofFailure(f"clock resolver did not fail closed for {label}")
+
+
+def run_process_clock_self_tests() -> None:
+    _run_host_clock_gate_leg()
+    _run_resolver_preference_leg()
+    _run_resolver_fallback_leg()
+    _run_resolver_fail_closed_leg()


### PR DESCRIPTION
QueryUnbiasedInterruptTimePrecise lives in KernelBase / api-ms-win-core-realtime-l1-1-1, not kernel32, so the packaged-proof memory sampler raised AttributeError on the first Windows host to reach that line. Resolution now prefers the API set with a KernelBase fallback and fails closed with the existing error when neither exports it; every other lookup in the file was audited in the same pass.

Second, smaller correctness fix: both Precise functions return void, so the old truth-test of their return value was asserting on undefined register contents. Correct void/PULONGLONG prototypes replace it, and the call site keeps a fail-closed sanity gate (0 < unbiased <= inclusive) under the same message.

Proof boundary stated plainly: the Windows branch cannot execute on the macOS host, so live proof is the next Windows calibration cell; the self-test exercises the resolver shape cross-platform through a seam rather than calling real Win32.

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)