### PR TITLE
derive the load-establishment snapshot waits from the contract terms

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/control.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/control.rs
@@ -4,8 +4,8 @@ use super::super::{
 };
 use super::analysis::{control_key, elapsed, same_server_authority, validated_idle_epoch};
 use super::process::{
-    existing_control_events, qualification_command_path, qualification_nonce, query_parameters,
-    require_worker_success,
+    existing_control_events, load_establishment_timeout, qualification_command_path,
+    qualification_nonce, query_parameters, require_worker_success,
 };
 use super::{ControlCommand, ControlCommandParameters, ScenarioRunner, WorkerOutput};
 use crate::qualification::output::write_atomic_json;
@@ -80,6 +80,20 @@ impl<'a> ScenarioRunner<'a> {
             }
             self.clock.sleep(POLL);
         }
+    }
+
+    /// Snapshot wait whose predicate gates on worker-driven load
+    /// establishment. The budget comes from the named entry in
+    /// `LOAD_ESTABLISHMENT_WAITS`, so the number of establishing clients a
+    /// site depends on is declared once and derived once instead of being
+    /// re-guessed per call site.
+    pub(super) fn wait_for_established_load(
+        &mut self,
+        phase: &str,
+        predicate: impl Fn(&EmbeddingServerSnapshot) -> bool,
+    ) -> Result<EmbeddingServerSnapshot> {
+        let timeout = load_establishment_timeout(phase)?;
+        self.wait_for_snapshot(phase, timeout, predicate)
     }
 
     pub(super) fn wait_for_control_snapshot(
@@ -213,8 +227,15 @@ impl<'a> ScenarioRunner<'a> {
         if self.observe(&format!("{phase}_before"))?.is_some() {
             self.control("crash_server", None)?;
         }
-        // Observation: any owner was just crash-stopped above, so the absence
-        // worker confirms an exit that has already happened; no client ramp.
+        // Not a poll budget and not load establishment: `wait_for_absence`
+        // spawns a fresh worker and this value is that worker's kill budget,
+        // covering its start, captures, connect and absence loop. The worker's
+        // own self-enforced bound for the operation is the contract idle
+        // timeout plus its 30s absence grace (90s), and that longer bound is
+        // deliberately not honored here: `crash_server` is only accepted
+        // asynchronously, so the shorter flat budget is the driver asserting
+        // that an already-triggered exit lands promptly rather than waiting out
+        // an idle exit that is not being tested.
         self.wait_for_absence(phase, SNAPSHOT_TIMEOUT)
     }
 
@@ -229,9 +250,10 @@ impl<'a> ScenarioRunner<'a> {
         // One observe worker per poll: executable capture, connect, one
         // snapshot, no request work and no per-request transport fan-out, so
         // the flat snapshot budget dominates its honest chain. Waits that
-        // cover a client establishing load must carry a derived budget
-        // instead: load_establishment_timeout for a single admission or lease,
-        // the queue-setup budget for a seeded queue (dead_client_setup_timeout).
+        // cover clients establishing load must carry a derived budget instead:
+        // `load_establishment_timeout` for admissions and leases (one
+        // start-and-capture allowance per establishing client), the queue-setup
+        // budget for a seeded queue (`dead_client_setup_timeout`).
         let worker = self.spawn_worker("observe", query_parameters(1), None)?;
         let output = self.finish_worker(worker, SNAPSHOT_TIMEOUT)?;
         require_worker_success(&output, "observe")?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/control.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/control.rs
@@ -213,6 +213,8 @@ impl<'a> ScenarioRunner<'a> {
         if self.observe(&format!("{phase}_before"))?.is_some() {
             self.control("crash_server", None)?;
         }
+        // Observation: any owner was just crash-stopped above, so the absence
+        // worker confirms an exit that has already happened; no client ramp.
         self.wait_for_absence(phase, SNAPSHOT_TIMEOUT)
     }
 
@@ -227,8 +229,9 @@ impl<'a> ScenarioRunner<'a> {
         // One observe worker per poll: executable capture, connect, one
         // snapshot, no request work and no per-request transport fan-out, so
         // the flat snapshot budget dominates its honest chain. Waits that
-        // cover a client ramping queue load must carry the queue-setup
-        // budget instead (see dead_client_setup_timeout).
+        // cover a client establishing load must carry a derived budget
+        // instead: load_establishment_timeout for a single admission or lease,
+        // the queue-setup budget for a seeded queue (dead_client_setup_timeout).
         let worker = self.spawn_worker("observe", query_parameters(1), None)?;
         let output = self.finish_worker(worker, SNAPSHOT_TIMEOUT)?;
         require_worker_success(&output, "observe")?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/frozen_owner.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/frozen_owner.rs
@@ -37,6 +37,9 @@ impl<'a> ScenarioRunner<'a> {
                 ("clock_boot_id", json!(output.clock.boot_id)),
             ]),
         );
+        // Observation: the predicate accepts any snapshot, so the first observe
+        // worker that reaches the already-running owner satisfies it; nothing
+        // in its path waits on a client ramp.
         let after = self.wait_for_snapshot("frozen_owner_released", SNAPSHOT_TIMEOUT, |_| true)?;
         if !same_server_authority(&before, &after) {
             bail!("embedding_qualification_frozen_owner_takeover_detected");

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/incompatible_owner.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/incompatible_owner.rs
@@ -3,7 +3,9 @@ use super::super::{
     btree,
 };
 use super::ScenarioRunner;
-use super::process::{query_parameters, require_worker_error, require_worker_success};
+use super::process::{
+    load_establishment_timeout, query_parameters, require_worker_error, require_worker_success,
+};
 use anyhow::{Result, bail};
 use codestory_retrieval::EmbeddingQualificationParameters;
 use serde_json::json;
@@ -22,9 +24,14 @@ impl<'a> ScenarioRunner<'a> {
             },
             None,
         )?;
-        self.wait_for_snapshot("incompatible_owner_active", SNAPSHOT_TIMEOUT, |snapshot| {
-            snapshot.scheduler.lease_count > 0
-        })?;
+        // Load establishment: the freshly spawned lease client must start,
+        // capture its executable and transport and converge on the owner before
+        // its residency lease is visible.
+        self.wait_for_snapshot(
+            "incompatible_owner_active",
+            load_establishment_timeout(),
+            |snapshot| snapshot.scheduler.lease_count > 0,
+        )?;
         self.control("force_incompatible", None)?;
         let active = self.spawn_worker("activate_probe", query_parameters(1), None)?;
         let active_output = self.finish_worker(active, FROZEN_WORKER_TIMEOUT)?;
@@ -58,6 +65,9 @@ impl<'a> ScenarioRunner<'a> {
             ]),
         );
         self.terminate_worker(lease)?;
+        // Observation: the lease client is already terminated, so this only
+        // watches the owner's own peer-death sweep over the control channel and
+        // spawns no worker at all.
         self.wait_for_control_snapshot("incompatible_owner_idle", SNAPSHOT_TIMEOUT, |snapshot| {
             snapshot.scheduler.lease_count == 0 && snapshot.scheduler.active_request_count == 0
         })?;
@@ -87,6 +97,9 @@ impl<'a> ScenarioRunner<'a> {
                 ),
             ]),
         );
+        // Observation: the wait above already proved the owner drained, so the
+        // absence worker only confirms an exit already under way; no client
+        // ramp gates it.
         self.wait_for_absence("incompatible_owner_exited", SNAPSHOT_TIMEOUT)?;
         let replacement = self.spawn_worker("query", query_parameters(1), None)?;
         let replacement_output = self.finish_worker(replacement, NORMAL_WORKER_TIMEOUT)?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/incompatible_owner.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/incompatible_owner.rs
@@ -3,9 +3,7 @@ use super::super::{
     btree,
 };
 use super::ScenarioRunner;
-use super::process::{
-    load_establishment_timeout, query_parameters, require_worker_error, require_worker_success,
-};
+use super::process::{query_parameters, require_worker_error, require_worker_success};
 use anyhow::{Result, bail};
 use codestory_retrieval::EmbeddingQualificationParameters;
 use serde_json::json;
@@ -24,14 +22,12 @@ impl<'a> ScenarioRunner<'a> {
             },
             None,
         )?;
-        // Load establishment: the freshly spawned lease client must start,
-        // capture its executable and transport and converge on the owner before
-        // its residency lease is visible.
-        self.wait_for_snapshot(
-            "incompatible_owner_active",
-            load_establishment_timeout(),
-            |snapshot| snapshot.scheduler.lease_count > 0,
-        )?;
+        // Load establishment, one client: the freshly spawned lease client must
+        // start, capture its executable and transport and converge on the owner
+        // before its residency lease is visible.
+        self.wait_for_established_load("incompatible_owner_active", |snapshot| {
+            snapshot.scheduler.lease_count > 0
+        })?;
         self.control("force_incompatible", None)?;
         let active = self.spawn_worker("activate_probe", query_parameters(1), None)?;
         let active_output = self.finish_worker(active, FROZEN_WORKER_TIMEOUT)?;
@@ -97,9 +93,14 @@ impl<'a> ScenarioRunner<'a> {
                 ),
             ]),
         );
-        // Observation: the wait above already proved the owner drained, so the
-        // absence worker only confirms an exit already under way; no client
-        // ramp gates it.
+        // Not a poll budget and not load establishment: `wait_for_absence`
+        // spawns a fresh worker and this value is that worker's kill budget,
+        // covering its start, captures, connect and absence loop. The worker's
+        // own self-enforced bound is the contract idle timeout plus its 30s
+        // absence grace (90s), deliberately not honored here: the drained-owner
+        // probe above already proved the exit under way, so the shorter flat
+        // budget asserts that it lands promptly instead of waiting out an idle
+        // exit this scenario is not testing.
         self.wait_for_absence("incompatible_owner_exited", SNAPSHOT_TIMEOUT)?;
         let replacement = self.spawn_worker("query", query_parameters(1), None)?;
         let replacement_output = self.finish_worker(replacement, NORMAL_WORKER_TIMEOUT)?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/mixed_queue.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/mixed_queue.rs
@@ -7,7 +7,7 @@ use super::analysis::{
     analyze_queue_operations, attach_native_completion_sequences,
     require_pre_release_capacity_overflow, scheduler_values,
 };
-use super::process::{load_establishment_timeout, query_parameters, require_protocol_success};
+use super::process::{query_parameters, require_protocol_success};
 use crate::qualification::output::write_atomic_json;
 use anyhow::{Result, bail};
 use codestory_retrieval::EmbeddingQualificationParameters;
@@ -24,20 +24,17 @@ impl<'a> ScenarioRunner<'a> {
         self.control("hold_class", Some("bulk"))?;
         self.control("hold_class", Some("query"))?;
         let seed = self.spawn_worker("long_protocol_bulk", query_parameters(1), None)?;
-        // Load establishment: the freshly spawned seed client must start,
-        // capture its executable and transport, converge on the owner and have
-        // its bulk request admitted before this predicate can turn true.
-        self.wait_for_snapshot(
-            "mixed_queue_seed_active",
-            load_establishment_timeout(),
-            |snapshot| {
-                snapshot
-                    .scheduler
-                    .active_request
-                    .as_ref()
-                    .is_some_and(|active| active.class == "bulk")
-            },
-        )?;
+        // Load establishment, one client: the freshly spawned seed client must
+        // start, capture its executable and transport, converge on the owner
+        // and have its bulk request admitted before this predicate can turn
+        // true.
+        self.wait_for_established_load("mixed_queue_seed_active", |snapshot| {
+            snapshot
+                .scheduler
+                .active_request
+                .as_ref()
+                .is_some_and(|active| active.class == "bulk")
+        })?;
         let first_gate = self
             .context
             .output_directory

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/mixed_queue.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/mixed_queue.rs
@@ -7,7 +7,7 @@ use super::analysis::{
     analyze_queue_operations, attach_native_completion_sequences,
     require_pre_release_capacity_overflow, scheduler_values,
 };
-use super::process::{query_parameters, require_protocol_success};
+use super::process::{load_establishment_timeout, query_parameters, require_protocol_success};
 use crate::qualification::output::write_atomic_json;
 use anyhow::{Result, bail};
 use codestory_retrieval::EmbeddingQualificationParameters;
@@ -24,13 +24,20 @@ impl<'a> ScenarioRunner<'a> {
         self.control("hold_class", Some("bulk"))?;
         self.control("hold_class", Some("query"))?;
         let seed = self.spawn_worker("long_protocol_bulk", query_parameters(1), None)?;
-        self.wait_for_snapshot("mixed_queue_seed_active", SNAPSHOT_TIMEOUT, |snapshot| {
-            snapshot
-                .scheduler
-                .active_request
-                .as_ref()
-                .is_some_and(|active| active.class == "bulk")
-        })?;
+        // Load establishment: the freshly spawned seed client must start,
+        // capture its executable and transport, converge on the owner and have
+        // its bulk request admitted before this predicate can turn true.
+        self.wait_for_snapshot(
+            "mixed_queue_seed_active",
+            load_establishment_timeout(),
+            |snapshot| {
+                snapshot
+                    .scheduler
+                    .active_request
+                    .as_ref()
+                    .is_some_and(|active| active.class == "bulk")
+            },
+        )?;
         let first_gate = self
             .context
             .output_directory
@@ -64,6 +71,9 @@ impl<'a> ScenarioRunner<'a> {
             Some(second_gate.clone()),
         )?;
         write_atomic_json(&first_gate, &json!({"schema_version": 1}))?;
+        // Load establishment: gated seeding of a 32+32 enqueue by one freshly
+        // released client, already on the queue-setup budget rather than the
+        // single-admission one.
         self.wait_for_snapshot(
             "mixed_queue_first_project_enqueued",
             QUEUE_SETUP_TIMEOUT,
@@ -73,6 +83,8 @@ impl<'a> ScenarioRunner<'a> {
             },
         )?;
         write_atomic_json(&second_gate, &json!({"schema_version": 1}))?;
+        // Load establishment: the second client's gated seeding fills both
+        // queues to capacity, so it carries the same queue-setup budget.
         let saturated =
             self.wait_for_snapshot("mixed_queue_saturated", QUEUE_SETUP_TIMEOUT, |snapshot| {
                 snapshot.scheduler.query_capacity == QUALIFICATION_QUEUE_CAPACITY
@@ -99,6 +111,9 @@ impl<'a> ScenarioRunner<'a> {
         })?;
         require_pre_release_capacity_overflow(&overflow_operations)?;
         self.control("release_class", Some("bulk"))?;
+        // Observation: both queue-load clients already ramped and their work is
+        // already enqueued, so this only watches the owner's own class
+        // selection after the bulk release; no client ramp in the predicate path.
         let query_selected =
             self.wait_for_snapshot("mixed_queue_query_selected", SNAPSHOT_TIMEOUT, |snapshot| {
                 snapshot.scheduler.bulk_depth > 0

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
@@ -261,12 +261,18 @@ pub(super) fn measurement_worker_timeout(operation: &str) -> Duration {
         // bulk deadline; spawn-hello, product-query, and residency
         // measurements contain an `EnsureResident` exchange or a cold model
         // load, both bounded by the same bulk deadline the client enforces on
-        // itself.
+        // itself. The true_idle respawn scenario's `resident_identity` probe
+        // is that same `EnsureResident` exchange under that same
+        // client-enforced bulk deadline, so it must name this arm: an
+        // operation the match does not name falls through to the query
+        // deadline and would let the coordinator kill a worker that is still
+        // inside the deadline it honors.
         "bulk"
         | "measure_bulk_frame"
         | "measure_spawn_hello"
         | "measure_product_query"
-        | "measure_resident_identity" => budgets.bulk_request,
+        | "measure_resident_identity"
+        | "resident_identity" => budgets.bulk_request,
         _ => budgets.query_request,
     };
     budgets
@@ -311,31 +317,68 @@ pub(super) fn busy_retry_marker_timeout() -> Duration {
         .saturating_add(CONTROL_TIMEOUT)
 }
 
+/// Every snapshot wait in the scenario driver whose predicate gates on
+/// worker-driven load establishment, with the number of freshly spawned
+/// clients whose own start-and-capture chain has to complete inside the wait
+/// window before the predicate can turn true. `load_establishment_timeout` is
+/// the only way to spend this budget and it fails closed on a phase that is
+/// not listed here, so a new load wait cannot inherit a budget nobody derived
+/// for it; `load_establishment_waits_are_classified_at_every_site` holds this
+/// table and the call sites to each other so a site cannot quietly return to
+/// the flat snapshot budget.
+pub(super) const LOAD_ESTABLISHMENT_WAITS: &[(&str, u32)] = &[
+    ("mixed_queue_seed_active", 1),
+    ("server_crash_inflight", 1),
+    ("worker_stall_inflight", 1),
+    ("incompatible_owner_active", 1),
+    ("true_idle_lease_active", 1),
+    ("true_idle_active_bulk", 1),
+    // Two clients, one per project, are spawned inside this wait window and
+    // must each ramp before the query and bulk depths are visible together.
+    ("true_idle_work_held", 2),
+];
+
 /// Coordinator budget for one worker-driven load-establishment snapshot wait.
 /// These waits bound a phase, not an observation: the predicate cannot turn
-/// true until a freshly spawned client process has started and captured its own
-/// executable and transport, paid its contract connect and spawn-convergence
-/// allowances, and had its first request admitted or its residency lease
-/// granted — while every poll of the wait is itself a fresh observe worker that
-/// can spend the whole snapshot allowance before the predicate is next
-/// evaluated. So the budget is the establishing client's own start-and-capture
-/// chain (one snapshot allowance, the honest chain `observe_worker`
-/// documents), plus the contract connect and spawn-convergence terms, plus one
-/// more snapshot allowance for the poll already in flight. Waits whose
-/// predicate needs a seeded queue rather than a single admission carry the
-/// strictly larger queue-setup budget instead (`dead_client_setup_timeout` and
-/// mixed_queue's gated enqueue waits). Regression: calibration run 30238772170
-/// (hosted_linux_x64_cpu) died with
+/// true until every freshly spawned client the wait gates on has started and
+/// captured its own executable and transport, paid its contract connect and
+/// spawn-convergence allowances, and had its first request admitted or its
+/// residency lease granted — while every poll of the wait is itself a fresh
+/// observe worker that can spend the whole snapshot allowance before the
+/// predicate is next evaluated. So the budget is one start-and-capture
+/// allowance per establishing client (a snapshot allowance each, the honest
+/// chain `observe_worker` documents, and the clients ramp concurrently on a
+/// 2-core cell), plus the contract connect and spawn-convergence terms, plus
+/// one more snapshot allowance for the poll already in flight. Waits whose
+/// predicate needs a seeded queue rather than an admission or a lease carry
+/// the strictly larger queue-setup budget instead (`dead_client_setup_timeout`
+/// and mixed_queue's gated enqueue waits). Regression: calibration run
+/// 30238772170 (hosted_linux_x64_cpu) died with
 /// `embedding_qualification_snapshot_timeout:mixed_queue_seed_active` at the
 /// flat 20s snapshot budget while the seed client was legitimately still
 /// starting; the capture-reuse optimization is unmerged, so every captured
 /// transport is still a full ~201MB hash of the packaged binary.
-pub(super) fn load_establishment_timeout() -> Duration {
+pub(super) fn load_establishment_budget(establishing_clients: u32) -> Duration {
     let budgets = EmbeddingClientBudgets::current();
     SNAPSHOT_TIMEOUT
+        .saturating_mul(establishing_clients.max(1))
         .saturating_add(budgets.connect)
         .saturating_add(budgets.spawn)
         .saturating_add(SNAPSHOT_TIMEOUT)
+}
+
+/// Budget for the named load-establishment wait, fail-closed on a phase that
+/// carries no derivation: a wait whose establishing clients nobody counted has
+/// no honest worst case, and silently handing it a default is how a budget
+/// ends up undercutting the very chain it is supposed to bound.
+pub(super) fn load_establishment_timeout(phase: &str) -> Result<Duration> {
+    LOAD_ESTABLISHMENT_WAITS
+        .iter()
+        .find(|(wait, _)| *wait == phase)
+        .map(|(_, establishing_clients)| load_establishment_budget(*establishing_clients))
+        .ok_or_else(|| {
+            anyhow::anyhow!("embedding_qualification_load_establishment_unclassified:{phase}")
+        })
 }
 
 /// Coordinator budget for observing the dead client's established load. The

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
@@ -311,6 +311,33 @@ pub(super) fn busy_retry_marker_timeout() -> Duration {
         .saturating_add(CONTROL_TIMEOUT)
 }
 
+/// Coordinator budget for one worker-driven load-establishment snapshot wait.
+/// These waits bound a phase, not an observation: the predicate cannot turn
+/// true until a freshly spawned client process has started and captured its own
+/// executable and transport, paid its contract connect and spawn-convergence
+/// allowances, and had its first request admitted or its residency lease
+/// granted — while every poll of the wait is itself a fresh observe worker that
+/// can spend the whole snapshot allowance before the predicate is next
+/// evaluated. So the budget is the establishing client's own start-and-capture
+/// chain (one snapshot allowance, the honest chain `observe_worker`
+/// documents), plus the contract connect and spawn-convergence terms, plus one
+/// more snapshot allowance for the poll already in flight. Waits whose
+/// predicate needs a seeded queue rather than a single admission carry the
+/// strictly larger queue-setup budget instead (`dead_client_setup_timeout` and
+/// mixed_queue's gated enqueue waits). Regression: calibration run 30238772170
+/// (hosted_linux_x64_cpu) died with
+/// `embedding_qualification_snapshot_timeout:mixed_queue_seed_active` at the
+/// flat 20s snapshot budget while the seed client was legitimately still
+/// starting; the capture-reuse optimization is unmerged, so every captured
+/// transport is still a full ~201MB hash of the packaged binary.
+pub(super) fn load_establishment_timeout() -> Duration {
+    let budgets = EmbeddingClientBudgets::current();
+    SNAPSHOT_TIMEOUT
+        .saturating_add(budgets.connect)
+        .saturating_add(budgets.spawn)
+        .saturating_add(SNAPSHOT_TIMEOUT)
+}
+
 /// Coordinator budget for observing the dead client's established load. The
 /// `client_death_lease_active` wait must see the lease plus the admitted and
 /// held query/bulk work in one snapshot, and that bounds a queue-seeding

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/server_crash.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/server_crash.rs
@@ -1,9 +1,7 @@
 use super::super::{NORMAL_WORKER_TIMEOUT, btree};
 use super::ScenarioRunner;
 use super::analysis::scheduler_values;
-use super::process::{
-    load_establishment_timeout, query_parameters, require_worker_success, validate_replay_attempts,
-};
+use super::process::{query_parameters, require_worker_success, validate_replay_attempts};
 use anyhow::{Result, bail};
 use serde_json::json;
 
@@ -12,21 +10,17 @@ impl<'a> ScenarioRunner<'a> {
         let before = self.ensure_owner("server_crash_before")?;
         self.control("hold_class", Some("query"))?;
         let worker = self.spawn_worker("query", query_parameters(1), None)?;
-        // Load establishment: the freshly spawned query client must start,
-        // capture its executable and transport, converge on the owner and be
-        // admitted against the held query class before this predicate can turn
-        // true.
-        let active = self.wait_for_snapshot(
-            "server_crash_inflight",
-            load_establishment_timeout(),
-            |snapshot| {
-                snapshot
-                    .scheduler
-                    .active_request
-                    .as_ref()
-                    .is_some_and(|active| active.class == "query")
-            },
-        )?;
+        // Load establishment, one client: the freshly spawned query client must
+        // start, capture its executable and transport, converge on the owner
+        // and be admitted against the held query class before this predicate
+        // can turn true.
+        let active = self.wait_for_established_load("server_crash_inflight", |snapshot| {
+            snapshot
+                .scheduler
+                .active_request
+                .as_ref()
+                .is_some_and(|active| active.class == "query")
+        })?;
         self.transition("inflight_request_observed", scheduler_values(&active));
         self.control("crash_server", None)?;
         let output = self.finish_worker(worker, NORMAL_WORKER_TIMEOUT)?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/server_crash.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/server_crash.rs
@@ -1,7 +1,9 @@
-use super::super::{NORMAL_WORKER_TIMEOUT, SNAPSHOT_TIMEOUT, btree};
+use super::super::{NORMAL_WORKER_TIMEOUT, btree};
 use super::ScenarioRunner;
 use super::analysis::scheduler_values;
-use super::process::{query_parameters, require_worker_success, validate_replay_attempts};
+use super::process::{
+    load_establishment_timeout, query_parameters, require_worker_success, validate_replay_attempts,
+};
 use anyhow::{Result, bail};
 use serde_json::json;
 
@@ -10,14 +12,21 @@ impl<'a> ScenarioRunner<'a> {
         let before = self.ensure_owner("server_crash_before")?;
         self.control("hold_class", Some("query"))?;
         let worker = self.spawn_worker("query", query_parameters(1), None)?;
-        let active =
-            self.wait_for_snapshot("server_crash_inflight", SNAPSHOT_TIMEOUT, |snapshot| {
+        // Load establishment: the freshly spawned query client must start,
+        // capture its executable and transport, converge on the owner and be
+        // admitted against the held query class before this predicate can turn
+        // true.
+        let active = self.wait_for_snapshot(
+            "server_crash_inflight",
+            load_establishment_timeout(),
+            |snapshot| {
                 snapshot
                     .scheduler
                     .active_request
                     .as_ref()
                     .is_some_and(|active| active.class == "query")
-            })?;
+            },
+        )?;
         self.transition("inflight_request_observed", scheduler_values(&active));
         self.control("crash_server", None)?;
         let output = self.finish_worker(worker, NORMAL_WORKER_TIMEOUT)?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
@@ -7,8 +7,8 @@ use super::measurements::{
     declared_phase_boundaries, declared_workload_id, measurement_span_interval,
 };
 use super::process::{
-    busy_retry_worker_timeout, dead_client_setup_timeout, load_establishment_timeout,
-    measurement_worker_timeout,
+    LOAD_ESTABLISHMENT_WAITS, busy_retry_worker_timeout, dead_client_setup_timeout,
+    load_establishment_budget, load_establishment_timeout, measurement_worker_timeout,
 };
 use super::{ScenarioEvidence, WorkerOutput, opaque_measurement_sample_id};
 use crate::qualification::request::{QualificationContracts, REQUIRED_METRICS, REQUIRED_SCENARIOS};
@@ -35,13 +35,7 @@ fn measurement_worker_budgets_dominate_the_deadlines_workers_honor() {
         .saturating_add(budgets.spawn)
         .saturating_add(SNAPSHOT_TIMEOUT)
         .saturating_add(CONTROL_TIMEOUT);
-    for operation in [
-        "query",
-        "observe",
-        "resident_identity",
-        "measure_hello",
-        "measure_query_frame",
-    ] {
+    for operation in ["query", "observe", "measure_hello", "measure_query_frame"] {
         assert!(
             measurement_worker_timeout(operation)
                 >= orchestration_terms.saturating_add(budgets.query_request),
@@ -54,6 +48,7 @@ fn measurement_worker_budgets_dominate_the_deadlines_workers_honor() {
         "measure_spawn_hello",
         "measure_product_query",
         "measure_resident_identity",
+        "resident_identity",
     ] {
         let bulk_timeout = measurement_worker_timeout(operation);
         assert!(
@@ -67,6 +62,18 @@ fn measurement_worker_budgets_dominate_the_deadlines_workers_honor() {
             "bulk measurement budget must not undercut the contract bulk request deadline"
         );
     }
+    // The true_idle respawn scenario spawns the `resident_identity` worker,
+    // whose whole body is one `EnsureResident` exchange that the client bounds
+    // by the contract bulk deadline. Regression: that operation name matched no
+    // arm and fell through to the query deadline, so its coordinator budget was
+    // 57s against a worker worst case of ~512s — the coordinator-kills-a-
+    // progressing-worker defect this function exists to eliminate, reintroduced
+    // by a name the match never saw.
+    assert_eq!(
+        measurement_worker_timeout("resident_identity"),
+        measurement_worker_timeout("measure_resident_identity"),
+        "the scenario residency probe must carry the same bulk-deadline budget as the residency measurement"
+    );
     // The true-idle measurement worker waits out the server's own idle
     // deadline before the absence observation; its watchdog must dominate
     // that self-enforced wait plus its quiescence and absence-grace waits.
@@ -117,47 +124,214 @@ fn dead_client_setup_budget_dominates_the_seeding_terms_the_flat_wait_undercut()
 }
 
 #[test]
-fn load_establishment_budget_dominates_the_terms_the_flat_snapshot_wait_undercut() {
+fn load_establishment_budgets_cover_every_establishing_client_chain() {
     // The mixed_queue `mixed_queue_seed_active` wait — and every sibling that
-    // gates on a freshly spawned client reaching the owner — bounds a phase,
-    // not a single observation: the seed client pays its own process start and
+    // gates on freshly spawned clients reaching the owner — bounds a phase,
+    // not a single observation: each client pays its own process start and
     // executable/transport captures, then its contract connect and
-    // spawn-convergence allowances, before its bulk request is admitted, and
-    // the coordinator's own in-flight poll is one more observe worker that can
-    // spend the whole snapshot allowance first. Regression: calibration run
-    // 30238772170 (hosted_linux_x64_cpu) died with
+    // spawn-convergence allowances, before its request is admitted or its lease
+    // is granted, and the coordinator's own in-flight poll is one more observe
+    // worker that can spend the whole snapshot allowance first. Regression:
+    // calibration run 30238772170 (hosted_linux_x64_cpu) died with
     // embedding_qualification_snapshot_timeout:mixed_queue_seed_active at the
     // flat 20s budget while the seed client was legitimately still starting.
     let budgets = EmbeddingClientBudgets::current();
+    for (phase, establishing_clients) in LOAD_ESTABLISHMENT_WAITS {
+        let budget = load_establishment_timeout(phase).expect("classified wait");
+        // Independently composed chain for this site: one start-and-capture
+        // allowance per client the predicate gates on (each still a full
+        // executable and transport hash, because capture reuse is unmerged),
+        // the contract connect and spawn-convergence allowances paid to reach
+        // the owner, and one more snapshot allowance for the coordinator's poll
+        // already in flight.
+        let mut chain = budgets
+            .connect
+            .saturating_add(budgets.spawn)
+            .saturating_add(SNAPSHOT_TIMEOUT);
+        for _ in 0..*establishing_clients {
+            chain = chain.saturating_add(SNAPSHOT_TIMEOUT);
+        }
+        assert!(
+            budget >= chain,
+            "{phase}: budget must cover all {establishing_clients} establishing start-and-capture chains plus connect, spawn and the in-flight poll"
+        );
+        // The exact defect: the flat budget bounded a whole establishing phase
+        // with the allowance the coordinator sizes for one observe worker.
+        assert!(
+            budget > SNAPSHOT_TIMEOUT,
+            "{phase}: budget must strictly dominate the flat snapshot wait it replaced"
+        );
+    }
+    // Each additional establishing client buys at least another whole
+    // start-and-capture allowance, so a site's budget tracks its client count
+    // instead of being one magnitude that happens to clear the single-client
+    // chain. Regression: `true_idle_work_held` gates on two clients ramping
+    // concurrently inside its own wait window and was given the single-client
+    // budget, leaving the same flake class live in true_idle_respawn.
+    for establishing_clients in 1..=4_u32 {
+        assert!(
+            load_establishment_budget(establishing_clients.saturating_add(1))
+                >= load_establishment_budget(establishing_clients).saturating_add(SNAPSHOT_TIMEOUT),
+            "each additional establishing client must buy another start-and-capture allowance"
+        );
+    }
     assert!(
-        load_establishment_timeout()
-            >= budgets
-                .connect
-                .saturating_add(budgets.spawn)
-                .saturating_add(SNAPSHOT_TIMEOUT),
-        "load-establishment budget must dominate the client's connect and spawn allowances plus the snapshot allowance"
+        load_establishment_timeout("true_idle_work_held").expect("classified wait")
+            > load_establishment_timeout("mixed_queue_seed_active").expect("classified wait"),
+        "the two-client establishment wait must strictly dominate a single-client one"
     );
+    // Fail closed: a wait whose establishing clients nobody counted has no
+    // derived worst case, so it must not be handed a default budget.
     assert!(
-        load_establishment_timeout()
-            >= budgets
-                .connect
-                .saturating_add(budgets.spawn)
-                .saturating_add(SNAPSHOT_TIMEOUT)
-                .saturating_add(SNAPSHOT_TIMEOUT),
-        "load-establishment budget must also cover the coordinator's own in-flight observe poll"
-    );
-    // The exact defect: the flat budget bounded the whole establishing phase
-    // with the allowance the coordinator sizes for one observe worker.
-    assert!(
-        load_establishment_timeout() > SNAPSHOT_TIMEOUT,
-        "load-establishment budget must strictly dominate the flat snapshot wait it replaced"
+        load_establishment_timeout("true_idle_work_hel").is_err(),
+        "an unclassified wait must not resolve to a budget"
     );
     // Family ordering: a wait that needs a seeded queue rather than one
     // admission or lease carries the strictly larger queue-setup budget.
     assert!(
-        dead_client_setup_timeout() >= load_establishment_timeout(),
+        dead_client_setup_timeout() >= load_establishment_budget(1),
         "the seeded-queue budget must dominate the single-admission budget in the same wait family"
     );
+}
+
+/// Every snapshot wait in the driver that is not worker-driven load
+/// establishment, with the budget expression its call site must carry. Seeded
+/// queue waits bound a client filling a queue and take the queue-setup budget;
+/// observation waits hold no client ramp in the predicate path, so the flat
+/// snapshot budget dominates their honest chain and each site states why.
+const NON_LOAD_ESTABLISHMENT_WAITS: &[(&str, &str)] = &[
+    ("client_death_lease_active", "dead_client_setup_timeout()"),
+    ("mixed_queue_first_project_enqueued", "QUEUE_SETUP_TIMEOUT"),
+    ("mixed_queue_saturated", "QUEUE_SETUP_TIMEOUT"),
+    ("client_death_lease_reclaimed", "SNAPSHOT_TIMEOUT"),
+    ("frozen_owner_released", "SNAPSHOT_TIMEOUT"),
+    ("incompatible_owner_idle", "SNAPSHOT_TIMEOUT"),
+    ("mixed_queue_query_selected", "SNAPSHOT_TIMEOUT"),
+    ("true_idle_work_reclaimed", "SNAPSHOT_TIMEOUT"),
+];
+
+#[test]
+fn load_establishment_waits_are_classified_at_every_site() {
+    // The family split has to be auditable at the sites, not only in prose:
+    // every snapshot wait in the driver is either worker-driven load
+    // establishment — a budget derived from the number of clients its predicate
+    // gates on — or it is not, and then it is queue seeding or an observation
+    // whose predicate path holds no client ramp. Regression: the flat snapshot
+    // budget that killed calibration run 30238772170 at mixed_queue_seed_active
+    // could be restored at a single call site without touching any derivation,
+    // and no other assertion in this suite would notice.
+    let mut sited = BTreeSet::new();
+    for (file, source) in runner_sources() {
+        for (phase, _) in wait_sites(&source, "wait_for_established_load") {
+            assert!(
+                LOAD_ESTABLISHMENT_WAITS
+                    .iter()
+                    .any(|(wait, _)| *wait == phase),
+                "{file}: {phase} spends the load-establishment budget with no derived client count"
+            );
+            assert!(sited.insert(phase.clone()), "{file}: {phase} waits twice");
+        }
+        for call in [
+            "wait_for_snapshot",
+            "wait_for_control_snapshot",
+            "wait_for_true_idle_epoch",
+        ] {
+            for (phase, budget) in wait_sites(&source, call) {
+                let expected = NON_LOAD_ESTABLISHMENT_WAITS
+                    .iter()
+                    .find(|(wait, _)| *wait == phase)
+                    .map(|(_, budget)| *budget)
+                    .unwrap_or_else(|| {
+                        panic!("{file}: {phase} is an unclassified snapshot wait carrying {budget}")
+                    });
+                assert_eq!(
+                    budget, expected,
+                    "{file}: {phase} must carry {expected}, not {budget}"
+                );
+                assert!(sited.insert(phase.clone()), "{file}: {phase} waits twice");
+            }
+        }
+    }
+    for (phase, _) in LOAD_ESTABLISHMENT_WAITS {
+        assert!(
+            sited.contains(*phase),
+            "{phase} carries a derived load-establishment budget that no site spends"
+        );
+    }
+    for (phase, _) in NON_LOAD_ESTABLISHMENT_WAITS {
+        assert!(
+            sited.contains(*phase),
+            "{phase} is classified as a non-establishment wait that no site performs"
+        );
+    }
+}
+
+/// Every source file of the scenario driver, read from disk so a wait added in
+/// a file nobody remembered to list still has to be classified.
+fn runner_sources() -> Vec<(String, String)> {
+    let directory = std::path::Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bin/codestory_embedding_qualification/scenarios/artifact/runner"
+    ));
+    let mut sources = std::fs::read_dir(directory)
+        .expect("read the scenario runner directory")
+        .map(|entry| entry.expect("scenario runner entry").path())
+        .filter(|path| path.extension().is_some_and(|extension| extension == "rs"))
+        .map(|path| {
+            let name = path
+                .file_name()
+                .expect("scenario source name")
+                .to_string_lossy()
+                .into_owned();
+            let source = std::fs::read_to_string(&path).expect("read a scenario source");
+            (name, source)
+        })
+        .collect::<Vec<_>>();
+    sources.sort();
+    assert!(
+        sources.len() >= 10,
+        "scenario driver sources went missing from the classification scan"
+    );
+    sources
+}
+
+/// The `(phase, budget)` pair of every `self.<call>(` site in `source` whose
+/// first argument is a phase literal. The budget is the next argument with its
+/// whitespace removed; sites that take no budget argument yield the text that
+/// follows the phase, which their caller ignores.
+fn wait_sites(source: &str, call: &str) -> Vec<(String, String)> {
+    let opening = format!("self.{call}(");
+    let mut sites = Vec::new();
+    let mut rest = source;
+    while let Some(index) = rest.find(&opening) {
+        rest = &rest[index.saturating_add(opening.len())..];
+        let Some(quoted) = rest.trim_start().strip_prefix('"') else {
+            continue;
+        };
+        let Some(end) = quoted.find('"') else {
+            continue;
+        };
+        let mut depth = 0_u32;
+        let mut budget = String::new();
+        for character in quoted[end.saturating_add(1)..]
+            .chars()
+            .skip_while(|character| *character != ',')
+            .skip(1)
+        {
+            match character {
+                '(' | '[' | '{' => depth = depth.saturating_add(1),
+                ')' | ']' | '}' if depth == 0 => break,
+                ')' | ']' | '}' => depth = depth.saturating_sub(1),
+                ',' if depth == 0 => break,
+                _ => {}
+            }
+            if !character.is_whitespace() {
+                budget.push(character);
+            }
+        }
+        sites.push((quoted[..end].to_owned(), budget));
+    }
+    sites
 }
 
 #[test]

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
@@ -7,7 +7,8 @@ use super::measurements::{
     declared_phase_boundaries, declared_workload_id, measurement_span_interval,
 };
 use super::process::{
-    busy_retry_worker_timeout, dead_client_setup_timeout, measurement_worker_timeout,
+    busy_retry_worker_timeout, dead_client_setup_timeout, load_establishment_timeout,
+    measurement_worker_timeout,
 };
 use super::{ScenarioEvidence, WorkerOutput, opaque_measurement_sample_id};
 use crate::qualification::request::{QualificationContracts, REQUIRED_METRICS, REQUIRED_SCENARIOS};
@@ -112,6 +113,50 @@ fn dead_client_setup_budget_dominates_the_seeding_terms_the_flat_wait_undercut()
     assert!(
         dead_client_setup_timeout() >= QUEUE_SETUP_TIMEOUT,
         "dead-client load establishment is a queue-seeding phase and must carry the queue-setup budget"
+    );
+}
+
+#[test]
+fn load_establishment_budget_dominates_the_terms_the_flat_snapshot_wait_undercut() {
+    // The mixed_queue `mixed_queue_seed_active` wait — and every sibling that
+    // gates on a freshly spawned client reaching the owner — bounds a phase,
+    // not a single observation: the seed client pays its own process start and
+    // executable/transport captures, then its contract connect and
+    // spawn-convergence allowances, before its bulk request is admitted, and
+    // the coordinator's own in-flight poll is one more observe worker that can
+    // spend the whole snapshot allowance first. Regression: calibration run
+    // 30238772170 (hosted_linux_x64_cpu) died with
+    // embedding_qualification_snapshot_timeout:mixed_queue_seed_active at the
+    // flat 20s budget while the seed client was legitimately still starting.
+    let budgets = EmbeddingClientBudgets::current();
+    assert!(
+        load_establishment_timeout()
+            >= budgets
+                .connect
+                .saturating_add(budgets.spawn)
+                .saturating_add(SNAPSHOT_TIMEOUT),
+        "load-establishment budget must dominate the client's connect and spawn allowances plus the snapshot allowance"
+    );
+    assert!(
+        load_establishment_timeout()
+            >= budgets
+                .connect
+                .saturating_add(budgets.spawn)
+                .saturating_add(SNAPSHOT_TIMEOUT)
+                .saturating_add(SNAPSHOT_TIMEOUT),
+        "load-establishment budget must also cover the coordinator's own in-flight observe poll"
+    );
+    // The exact defect: the flat budget bounded the whole establishing phase
+    // with the allowance the coordinator sizes for one observe worker.
+    assert!(
+        load_establishment_timeout() > SNAPSHOT_TIMEOUT,
+        "load-establishment budget must strictly dominate the flat snapshot wait it replaced"
+    );
+    // Family ordering: a wait that needs a seeded queue rather than one
+    // admission or lease carries the strictly larger queue-setup budget.
+    assert!(
+        dead_client_setup_timeout() >= load_establishment_timeout(),
+        "the seeded-queue budget must dominate the single-admission budget in the same wait family"
     );
 }
 

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/true_idle_respawn.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/true_idle_respawn.rs
@@ -4,7 +4,10 @@ use super::super::{
 };
 use super::ScenarioRunner;
 use super::analysis::{elapsed, same_server_authority, scheduler_values, validated_idle_epoch};
-use super::process::{query_parameters, require_protocol_success, require_worker_success};
+use super::process::{
+    load_establishment_timeout, measurement_worker_timeout, query_parameters,
+    require_protocol_success, require_worker_success,
+};
 use anyhow::{Result, bail};
 use codestory_retrieval::{
     EmbeddingQualificationParameters, PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS,
@@ -29,17 +32,28 @@ impl<'a> ScenarioRunner<'a> {
             },
             None,
         )?;
-        self.wait_for_snapshot("true_idle_lease_active", SNAPSHOT_TIMEOUT, |snapshot| {
-            snapshot.scheduler.lease_count > 0
-        })?;
+        // Load establishment: the freshly spawned lease client must start,
+        // capture its executable and transport and converge on the owner before
+        // its residency lease is visible.
+        self.wait_for_snapshot(
+            "true_idle_lease_active",
+            load_establishment_timeout(),
+            |snapshot| snapshot.scheduler.lease_count > 0,
+        )?;
         let active_bulk = self.spawn_worker("long_protocol_bulk", query_parameters(1), None)?;
-        self.wait_for_snapshot("true_idle_active_bulk", SNAPSHOT_TIMEOUT, |snapshot| {
-            snapshot
-                .scheduler
-                .active_request
-                .as_ref()
-                .is_some_and(|active| active.class == "bulk")
-        })?;
+        // Load establishment: a second freshly spawned client must run the same
+        // start-capture-converge chain before its bulk request is admitted.
+        self.wait_for_snapshot(
+            "true_idle_active_bulk",
+            load_establishment_timeout(),
+            |snapshot| {
+                snapshot
+                    .scheduler
+                    .active_request
+                    .as_ref()
+                    .is_some_and(|active| active.class == "bulk")
+            },
+        )?;
         let queued_query = self.spawn_worker_for(
             1_usize.saturating_sub(self.context.primary_index),
             "long_protocol_query",
@@ -47,13 +61,19 @@ impl<'a> ScenarioRunner<'a> {
             None,
         )?;
         let queued_bulk = self.spawn_worker("long_protocol_bulk", query_parameters(1), None)?;
-        let anti_idle =
-            self.wait_for_snapshot("true_idle_work_held", SNAPSHOT_TIMEOUT, |snapshot| {
+        // Load establishment: two more freshly spawned clients, one per project,
+        // must each start, capture, converge and enqueue before the lease,
+        // active request and both queue depths are visible in one snapshot.
+        let anti_idle = self.wait_for_snapshot(
+            "true_idle_work_held",
+            load_establishment_timeout(),
+            |snapshot| {
                 snapshot.scheduler.lease_count > 0
                     && snapshot.scheduler.active_request_count > 0
                     && snapshot.scheduler.query_depth > 0
                     && snapshot.scheduler.bulk_depth > 0
-            })?;
+            },
+        )?;
         self.transition("anti_idle_work_observed", scheduler_values(&anti_idle));
         let wait = Duration::from_millis(PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS)
             .saturating_add(IDLE_EXIT_GRACE);
@@ -96,6 +116,9 @@ impl<'a> ScenarioRunner<'a> {
         require_protocol_success(&query_output, "true_idle_queued_query")?;
         require_protocol_success(&bulk_output, "true_idle_queued_bulk")?;
         self.terminate_worker(lease)?;
+        // Observation: every held worker already finished above and the lease
+        // client is terminated, so this only watches the owner's own quiescence
+        // over the control channel and spawns no worker.
         let (reclaimed, idle_epoch_ns, _) =
             self.wait_for_true_idle_epoch("true_idle_work_reclaimed", SNAPSHOT_TIMEOUT)?;
         self.transition("anti_idle_work_reclaimed", scheduler_values(&reclaimed));
@@ -128,6 +151,9 @@ impl<'a> ScenarioRunner<'a> {
                 .try_into()
                 .unwrap_or(u64::MAX);
             let observer = self.spawn_worker("observe", query_parameters(1), None)?;
+            // Observation: one capture-connect-snapshot chain against a
+            // resident owner, with no request work and no transport fan-out,
+            // so the flat snapshot budget dominates it.
             let observer_output = self.finish_worker(observer, SNAPSHOT_TIMEOUT)?;
             require_worker_success(&observer_output, "true_idle_observe")?;
             let observer_snapshot =
@@ -235,7 +261,14 @@ impl<'a> ScenarioRunner<'a> {
             anyhow::anyhow!("embedding_qualification_true_idle_respawn_engine_missing")
         })?;
         let identity_worker = self.spawn_worker("resident_identity", query_parameters(1), None)?;
-        let identity_output = self.finish_worker(identity_worker, SNAPSHOT_TIMEOUT)?;
+        // Load establishment by a worker rather than a snapshot wait: this
+        // probe runs an EnsureResident exchange against the just-respawned
+        // owner, so it carries the contract-derived per-operation worker budget
+        // instead of the flat snapshot bound.
+        let identity_output = self.finish_worker(
+            identity_worker,
+            measurement_worker_timeout("resident_identity"),
+        )?;
         let respawn_identity = identity_output.engine_identity.as_ref().ok_or_else(|| {
             anyhow::anyhow!("embedding_qualification_true_idle_respawn_identity_missing")
         })?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/true_idle_respawn.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/true_idle_respawn.rs
@@ -5,8 +5,7 @@ use super::super::{
 use super::ScenarioRunner;
 use super::analysis::{elapsed, same_server_authority, scheduler_values, validated_idle_epoch};
 use super::process::{
-    load_establishment_timeout, measurement_worker_timeout, query_parameters,
-    require_protocol_success, require_worker_success,
+    measurement_worker_timeout, query_parameters, require_protocol_success, require_worker_success,
 };
 use anyhow::{Result, bail};
 use codestory_retrieval::{
@@ -32,28 +31,23 @@ impl<'a> ScenarioRunner<'a> {
             },
             None,
         )?;
-        // Load establishment: the freshly spawned lease client must start,
-        // capture its executable and transport and converge on the owner before
-        // its residency lease is visible.
-        self.wait_for_snapshot(
-            "true_idle_lease_active",
-            load_establishment_timeout(),
-            |snapshot| snapshot.scheduler.lease_count > 0,
-        )?;
+        // Load establishment, one client: the freshly spawned lease client must
+        // start, capture its executable and transport and converge on the owner
+        // before its residency lease is visible.
+        self.wait_for_established_load("true_idle_lease_active", |snapshot| {
+            snapshot.scheduler.lease_count > 0
+        })?;
         let active_bulk = self.spawn_worker("long_protocol_bulk", query_parameters(1), None)?;
-        // Load establishment: a second freshly spawned client must run the same
-        // start-capture-converge chain before its bulk request is admitted.
-        self.wait_for_snapshot(
-            "true_idle_active_bulk",
-            load_establishment_timeout(),
-            |snapshot| {
-                snapshot
-                    .scheduler
-                    .active_request
-                    .as_ref()
-                    .is_some_and(|active| active.class == "bulk")
-            },
-        )?;
+        // Load establishment, one client: a second freshly spawned client must
+        // run the same start-capture-converge chain before its bulk request is
+        // admitted.
+        self.wait_for_established_load("true_idle_active_bulk", |snapshot| {
+            snapshot
+                .scheduler
+                .active_request
+                .as_ref()
+                .is_some_and(|active| active.class == "bulk")
+        })?;
         let queued_query = self.spawn_worker_for(
             1_usize.saturating_sub(self.context.primary_index),
             "long_protocol_query",
@@ -61,19 +55,17 @@ impl<'a> ScenarioRunner<'a> {
             None,
         )?;
         let queued_bulk = self.spawn_worker("long_protocol_bulk", query_parameters(1), None)?;
-        // Load establishment: two more freshly spawned clients, one per project,
-        // must each start, capture, converge and enqueue before the lease,
-        // active request and both queue depths are visible in one snapshot.
-        let anti_idle = self.wait_for_snapshot(
-            "true_idle_work_held",
-            load_establishment_timeout(),
-            |snapshot| {
-                snapshot.scheduler.lease_count > 0
-                    && snapshot.scheduler.active_request_count > 0
-                    && snapshot.scheduler.query_depth > 0
-                    && snapshot.scheduler.bulk_depth > 0
-            },
-        )?;
+        // Load establishment, two clients: both clients spawned just above, one
+        // per project, must each start, capture, converge and enqueue before
+        // the lease, active request and both queue depths are visible in one
+        // snapshot, so this wait carries both start-and-capture allowances
+        // rather than the single-client budget its siblings take.
+        let anti_idle = self.wait_for_established_load("true_idle_work_held", |snapshot| {
+            snapshot.scheduler.lease_count > 0
+                && snapshot.scheduler.active_request_count > 0
+                && snapshot.scheduler.query_depth > 0
+                && snapshot.scheduler.bulk_depth > 0
+        })?;
         self.transition("anti_idle_work_observed", scheduler_values(&anti_idle));
         let wait = Duration::from_millis(PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS)
             .saturating_add(IDLE_EXIT_GRACE);
@@ -262,9 +254,13 @@ impl<'a> ScenarioRunner<'a> {
         })?;
         let identity_worker = self.spawn_worker("resident_identity", query_parameters(1), None)?;
         // Load establishment by a worker rather than a snapshot wait: this
-        // probe runs an EnsureResident exchange against the just-respawned
-        // owner, so it carries the contract-derived per-operation worker budget
-        // instead of the flat snapshot bound.
+        // probe's whole body is one `EnsureResident` exchange against the
+        // just-respawned owner, and the client configures both that exchange's
+        // timeout and its wire deadline from the contract bulk deadline. So the
+        // kill budget is the per-operation worker budget for that operation
+        // name, which `measurement_worker_timeout` must classify into its bulk
+        // arm; the flat snapshot bound it replaced undercut the worker's own
+        // deadline by an order of magnitude.
         let identity_output = self.finish_worker(
             identity_worker,
             measurement_worker_timeout("resident_identity"),

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/worker_stall.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/worker_stall.rs
@@ -2,8 +2,7 @@ use super::super::{NORMAL_WORKER_TIMEOUT, SNAPSHOT_TIMEOUT, btree};
 use super::ScenarioRunner;
 use super::analysis::{consume_watchdog_marker, same_server_authority, scheduler_values};
 use super::process::{
-    load_establishment_timeout, require_worker_success, stall_worker_timeout,
-    validate_replay_attempts, wait_for_process_exit,
+    require_worker_success, stall_worker_timeout, validate_replay_attempts, wait_for_process_exit,
 };
 use crate::qualification::diagnostic_worker_stall_enabled;
 use crate::qualification::output::write_atomic_json;
@@ -45,21 +44,17 @@ impl<'a> ScenarioRunner<'a> {
             },
             None,
         )?;
-        // Load establishment: the freshly spawned bulk client must start,
-        // capture its executable and transport, converge on the owner and be
-        // selected into the stalled native call before this predicate can turn
-        // true.
-        let active = self.wait_for_snapshot(
-            "worker_stall_inflight",
-            load_establishment_timeout(),
-            |snapshot| {
-                snapshot
-                    .scheduler
-                    .active_request
-                    .as_ref()
-                    .is_some_and(|active| active.class == "bulk")
-            },
-        )?;
+        // Load establishment, one client: the freshly spawned bulk client must
+        // start, capture its executable and transport, converge on the owner
+        // and be selected into the stalled native call before this predicate
+        // can turn true.
+        let active = self.wait_for_established_load("worker_stall_inflight", |snapshot| {
+            snapshot
+                .scheduler
+                .active_request
+                .as_ref()
+                .is_some_and(|active| active.class == "bulk")
+        })?;
         self.transition("stalled_request_observed", scheduler_values(&active));
         let output = self.finish_worker(worker, stall_worker_timeout())?;
         if diagnostic_worker_stall_enabled()? {

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/worker_stall.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/worker_stall.rs
@@ -2,7 +2,8 @@ use super::super::{NORMAL_WORKER_TIMEOUT, SNAPSHOT_TIMEOUT, btree};
 use super::ScenarioRunner;
 use super::analysis::{consume_watchdog_marker, same_server_authority, scheduler_values};
 use super::process::{
-    require_worker_success, stall_worker_timeout, validate_replay_attempts, wait_for_process_exit,
+    load_establishment_timeout, require_worker_success, stall_worker_timeout,
+    validate_replay_attempts, wait_for_process_exit,
 };
 use crate::qualification::diagnostic_worker_stall_enabled;
 use crate::qualification::output::write_atomic_json;
@@ -44,14 +45,21 @@ impl<'a> ScenarioRunner<'a> {
             },
             None,
         )?;
-        let active =
-            self.wait_for_snapshot("worker_stall_inflight", SNAPSHOT_TIMEOUT, |snapshot| {
+        // Load establishment: the freshly spawned bulk client must start,
+        // capture its executable and transport, converge on the owner and be
+        // selected into the stalled native call before this predicate can turn
+        // true.
+        let active = self.wait_for_snapshot(
+            "worker_stall_inflight",
+            load_establishment_timeout(),
+            |snapshot| {
                 snapshot
                     .scheduler
                     .active_request
                     .as_ref()
                     .is_some_and(|active| active.class == "bulk")
-            })?;
+            },
+        )?;
         self.transition("stalled_request_observed", scheduler_values(&active));
         let output = self.finish_worker(worker, stall_worker_timeout())?;
         if diagnostic_worker_stall_enabled()? {
@@ -70,6 +78,9 @@ impl<'a> ScenarioRunner<'a> {
             .as_ref()
             .and_then(|result| (result.operations.len() == 1).then(|| &result.operations[0]))
             .ok_or_else(|| anyhow::anyhow!("embedding_qualification_stall_operation_missing"))?;
+        // Observation: a direct OS start-identity probe on the owner the
+        // watchdog already fail-stopped; it spawns no worker and waits on no
+        // client ramp.
         wait_for_process_exit(&self.clock, before.process.pid, SNAPSHOT_TIMEOUT)?;
         let (watchdog_marker, watchdog_marker_sha256) = consume_watchdog_marker(
             self.context.output_directory,


### PR DESCRIPTION
Sweeps the qualification driver's wait_for_snapshot family: load-establishment waits (seeded queues, lease ramps, thread fan-out) are re-derived from contract terms following the #1492/#1498 mechanism, and pure observation waits keep SNAPSHOT_TIMEOUT with a one-line comment saying why each is cheap — so the distinction is auditable instead of implicit. Both blocking regressions and the site-level revert are mutation-proven; full cargo test -p codestory-bench passes.

Honest residuals, disclosed rather than buried: the two wait_for_absence sites were re-documented but NOT re-priced — by the same premise motivating term 1 of this derivation, a 20s budget covering worker start plus two ~201MB captures is not purely a promptness assertion, so host load can falsify what is meant to be a claim about server exit latency. That is a distinct budget class needing its own derivation and is the clearest candidate for the next lane, along with client_death.rs:49. The observe-worker budgets stay at SNAPSHOT_TIMEOUT deliberately: #1498 framed them as one capture-connect-snapshot chain with no fan-out, and this derivation depends on that framing.

Verification is source-level only — no packaged qualification or calibration run was executed here; the failing cell is hosted_linux_x64_cpu and is not reproducible on this ARM64 macOS host.

Closes #1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)