### PR TITLE
tolerate an unterminated trailing line in the qualification event log

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
@@ -18,13 +18,50 @@ use std::process::{Child, ExitStatus};
 use std::time::Duration;
 
 pub(super) fn existing_control_events(directory: &Path) -> Result<Vec<ControlEvent>> {
-    let path = directory.join(format!("{}.events.jsonl", qualification_nonce()?));
-    let bytes = match fs::read(&path) {
+    published_control_events(&directory.join(format!("{}.events.jsonl", qualification_nonce()?)))
+}
+
+/// Read the records the server has finished publishing to its append-only
+/// qualification event log, treating an unterminated trailing line as a record
+/// that is not written yet rather than as corruption.
+///
+/// The writer is not at fault and needs no change: it encodes one event,
+/// appends the newline to that same buffer, issues exactly one `write_all` on
+/// an unbuffered `O_APPEND` handle, then flushes and `sync_all`s. Linux still
+/// publishes a buffered append page by page — `i_size` advances inside each
+/// per-page `write_end` while buffered readers take no `i_rwsem` — so a record
+/// that straddles a page boundary is briefly visible as its near-side prefix.
+/// Calibration run 30269041727 caught exactly that on the Linux cell: the
+/// preserved log is 90159 bytes and every one of its 248 records parses at
+/// rest, but the poll that was waiting for the 242-byte `hold_class` record at
+/// offset 89916 read only its first 196 bytes (89916 + 196 = 90112, a 4 KiB
+/// boundary to the byte), the cut landed inside `boot_id`, and the scenario
+/// died with `EOF while parsing a string at line 1 column 196`.
+///
+/// Tolerating that tail is sound because the log is append-only: whatever is
+/// visible is always a true prefix of the final content, so everything up to
+/// the last newline is a whole number of finished records and anything after
+/// it is a record still being published. Reporting it as not-yet-written is
+/// what every caller already expects — the control wait polls again inside its
+/// own `CONTROL_TIMEOUT`, and the telemetry readers only need records whose
+/// worker exited long before the concurrent tail. A line that is complete and
+/// still malformed keeps failing the whole read, so this stays fail-closed on
+/// real corruption; the same distinction the publication control poller draws
+/// in `codestory-retrieval`'s `index.rs`. The writer's own open-time check that
+/// an adopted log ends in a newline is a different question — a new producer
+/// inheriting an unterminated log means the previous producer died mid-record —
+/// and deliberately stays strict.
+pub(super) fn published_control_events(path: &Path) -> Result<Vec<ControlEvent>> {
+    let bytes = match fs::read(path) {
         Ok(bytes) => bytes,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(error) => return Err(error).context("read embedding qualification control events"),
     };
-    bytes
+    let published = match bytes.iter().rposition(|byte| *byte == b'\n') {
+        Some(newline) => &bytes[..=newline],
+        None => &bytes[..0],
+    };
+    published
         .split(|byte| *byte == b'\n')
         .filter(|line| !line.is_empty())
         .map(|line| {

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
@@ -9,6 +9,7 @@ use super::measurements::{
 use super::process::{
     LOAD_ESTABLISHMENT_WAITS, busy_retry_worker_timeout, dead_client_setup_timeout,
     load_establishment_budget, load_establishment_timeout, measurement_worker_timeout,
+    published_control_events,
 };
 use super::{ScenarioEvidence, WorkerOutput, opaque_measurement_sample_id};
 use crate::qualification::request::{QualificationContracts, REQUIRED_METRICS, REQUIRED_SCENARIOS};
@@ -629,4 +630,114 @@ fn complete_evidence(scenario: &str) -> ScenarioEvidence {
         controls: controls.iter().map(|value| (*value).into()).collect(),
         transitions: transitions.iter().map(|value| (*value).into()).collect(),
     }
+}
+
+/// The exact record that tore on the Linux calibration cell in run
+/// 30269041727: 242 bytes starting at offset 89916 of a 90159-byte log, so its
+/// first 196 bytes end at 90112 — a 4 KiB page boundary — part-way through the
+/// `boot_id` string value.
+const TORN_HOLD_CLASS_RECORD: &str = "{\"schema_version\":1,\"sequence\":28,\"action\":\"hold_class\",\"status\":\"completed\",\"server_event_sequence\":17,\"clock\":{\"domain\":\"awake_monotonic\",\"api\":\"CLOCK_MONOTONIC\",\"boot_id\":\"cb5daa6d-70bb-4839-962e-9c5c3850a68d\",\"observed_ns\":3538471174799}}";
+
+/// Bytes of that record the reader actually observed: the near-side page of
+/// the torn append, cut inside a string literal.
+const TORN_HOLD_CLASS_PREFIX_BYTES: usize = 196;
+
+fn published_event_line(sequence: u64) -> String {
+    format!(
+        "{{\"schema_version\":1,\"sequence\":{sequence},\"action\":\"snapshot\",\"status\":\"completed\",\"server_event_sequence\":{sequence},\"clock\":{{\"domain\":\"awake_monotonic\",\"api\":\"CLOCK_MONOTONIC\",\"boot_id\":\"cb5daa6d-70bb-4839-962e-9c5c3850a68d\",\"observed_ns\":{sequence}}}}}"
+    )
+}
+
+fn published_event_sequences(path: &std::path::Path) -> Vec<u64> {
+    published_control_events(path)
+        .expect("an append-only event log must read without error")
+        .into_iter()
+        .map(|event| event.sequence)
+        .collect()
+}
+
+#[test]
+fn a_half_written_event_line_reads_as_not_yet_written_instead_of_failing() {
+    // Regression: calibration run 30269041727 (hosted_linux_x64_cpu) failed
+    // `mixed_queue` with `parse embedding qualification control event: EOF
+    // while parsing a string at line 1 column 196`. The preserved log is
+    // wholly valid at rest; the control poll simply read it while the server
+    // was still publishing the very `hold_class` response the poll was waiting
+    // for, and a buffered append becomes visible page by page. The poll has to
+    // treat that prefix as "not written yet" and come back, which is what its
+    // `CONTROL_TIMEOUT` loop exists to do.
+    let torn = &TORN_HOLD_CLASS_RECORD[..TORN_HOLD_CLASS_PREFIX_BYTES];
+    let observed = serde_json::from_str::<super::super::ControlEvent>(torn)
+        .expect_err("the near-side page of the torn append is not a parsable record");
+    assert_eq!(
+        observed.to_string(),
+        "EOF while parsing a string at line 1 column 196",
+        "the fixture must reproduce the calibration failure byte for byte, or this test guards nothing"
+    );
+
+    let directory = tempfile::tempdir().expect("temporary qualification directory");
+    let path = directory.path().join("nonce.events.jsonl");
+
+    // A log whose only content is a record still being published reads as
+    // empty, not as a corrupt log.
+    std::fs::write(&path, torn).expect("write partially published log");
+    assert!(
+        published_event_sequences(&path).is_empty(),
+        "a log holding only an unfinished record has published nothing yet"
+    );
+
+    // Records completed ahead of the unfinished tail are still delivered.
+    let published = format!(
+        "{}\n{}\n",
+        published_event_line(26),
+        published_event_line(27)
+    );
+    std::fs::write(&path, format!("{published}{torn}")).expect("write torn log");
+    assert_eq!(
+        published_event_sequences(&path),
+        vec![26, 27],
+        "an unfinished trailing record must not hide the records already published"
+    );
+
+    // Once the writer finishes the record it appears, so tolerating the tail
+    // delays the observation by one poll rather than losing it.
+    std::fs::write(&path, format!("{published}{TORN_HOLD_CLASS_RECORD}\n"))
+        .expect("write completed log");
+    assert_eq!(
+        published_event_sequences(&path),
+        vec![26, 27, 28],
+        "the completed record must be observed on the next poll"
+    );
+}
+
+#[test]
+fn a_complete_but_malformed_event_line_still_fails_the_read() {
+    // The tolerance above is scoped to the one condition an append-only log
+    // makes benign: bytes after the last newline, which the writer has not
+    // finished publishing. A line the writer did terminate is a finished
+    // record, so malformed content there is real corruption and must stay a
+    // hard failure instead of silently shrinking the event history.
+    let directory = tempfile::tempdir().expect("temporary qualification directory");
+    let path = directory.path().join("nonce.events.jsonl");
+
+    let interior = format!(
+        "{}\n{{\"schema_version\":1,\"sequence\":27,\"action\":\n{}\n",
+        published_event_line(26),
+        published_event_line(28)
+    );
+    std::fs::write(&path, &interior).expect("write log with a malformed interior line");
+    assert!(
+        published_control_events(&path).is_err(),
+        "a terminated but malformed interior record must fail the read"
+    );
+
+    let trailing = format!(
+        "{}\n{{\"schema_version\":1,\"sequence\":27,\"action\":\n",
+        published_event_line(26)
+    );
+    std::fs::write(&path, &trailing).expect("write log with a malformed final line");
+    assert!(
+        published_control_events(&path).is_err(),
+        "a malformed record the writer terminated is corruption even when it is last"
+    );
 }


### PR DESCRIPTION
The scenario runner now truncates the event log at its last newline before parsing, so a record the server has not finished publishing reads as not-yet-present instead of aborting the scenario. A complete-but-malformed interior record still fails the read closed — collect::<Result<_>> is deliberately kept, and that distinction is the whole safety argument.

The tear is proven to the byte rather than inferred: the preserved log is intact at rest (248 records, newline-terminated, all parse), and the failing record straddles a 4 KiB page boundary with exactly the 196 bytes serde reported. The writer is already atomic (one write_all per record, O_APPEND, fsync); this is Linux page-granular publication, and the Python harness reader already tolerated it.

The guarding test asserts serde's exact error text so the fixture keeps reproducing the production failure byte for byte, and both directions are revert-proven.

The Windows failure in the same run is a DIFFERENT defect — the producer stopped writing entirely (log has one clean record; the awaited one never arrives) — and is deliberately out of scope here; it gets its own issue and PR.

Closes #1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)