### PR TITLE
attribute a stalled qualification producer instead of timing out

### DIFF
--- a/.github/scripts/packaged_agent_proof/event_producer_liveness.py
+++ b/.github/scripts/packaged_agent_proof/event_producer_liveness.py
@@ -1,0 +1,203 @@
+"""Liveness attribution for the processes that append qualification events.
+
+A wait that can only report "the record never arrived" cannot tell a slow
+producer from one that exited, crashed, or never started, so every producer
+failure collapses into the same uninformative timeout. Every qualification
+wait in this harness therefore carries an explicit producer: what is expected
+to append the record, what it was doing, and how its liveness can be observed.
+
+A producer proven gone fails its wait immediately with an attributable
+termination state. A producer whose liveness genuinely cannot be observed says
+so in its own words, so even a timeout names the gap instead of hiding it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+
+from .foundation import ProofFailure
+from .process_identity import process_start_identity, terminated_process_state
+
+
+def _stream_sha256(stream: str | bytes | None) -> str:
+    if stream is None:
+        payload = b""
+    elif isinstance(stream, str):
+        payload = stream.encode("utf-8")
+    else:
+        payload = stream
+    return hashlib.sha256(payload).hexdigest()
+
+
+class EventProducer:
+    """One process expected to append the awaited qualification records."""
+
+    def __init__(self, label: str, activity: str) -> None:
+        self.label = label
+        self.activity = activity
+
+    def exited(self) -> bool:
+        """Whether the producer is provably gone.
+
+        Cheap and side-effect free: a wait calls this every poll, and must be
+        able to re-read the log before deciding that an exit lost the race with
+        a record the producer already wrote.
+        """
+        return False
+
+    def termination(self) -> str:
+        """Attributable termination state; only called once ``exited()`` holds."""
+        return "is no longer running"
+
+    def state(self) -> str:
+        """Current state, for the timeout path."""
+        return "cannot be observed from this proof host"
+
+    def describe(self) -> str:
+        return f"{self.label} ({self.activity}) {self.state()}"
+
+
+class UnobservedProducer(EventProducer):
+    """A producer this host holds no handle on, with the reason stated."""
+
+    def __init__(self, label: str, activity: str, reason: str) -> None:
+        super().__init__(label, activity)
+        self._reason = reason
+
+    def state(self) -> str:
+        return self._reason
+
+
+class ChildProcessProducer(EventProducer):
+    """A producer this harness spawned and still holds a handle on."""
+
+    def __init__(
+        self,
+        process: subprocess.Popen,
+        label: str,
+        activity: str,
+    ) -> None:
+        super().__init__(label, activity)
+        self._process = process
+
+    def exited(self) -> bool:
+        return self._process.poll() is not None
+
+    def termination(self) -> str:
+        stdout, stderr = self._process.communicate()
+        return (
+            f"exited with code {self._process.returncode}"
+            f" stdout_sha256={_stream_sha256(stdout)}"
+            f" stderr_sha256={_stream_sha256(stderr)}"
+        )
+
+    def state(self) -> str:
+        code = self._process.poll()
+        if code is None:
+            return f"is still running as pid {self._process.pid}"
+        return f"exited with code {code}"
+
+
+class NativeProcessProducer(EventProducer):
+    """A producer pinned by exact native process identity, not by pid alone."""
+
+    def __init__(
+        self,
+        pid: int,
+        process_start_id: str,
+        label: str,
+        activity: str,
+    ) -> None:
+        super().__init__(label, activity)
+        self.pid = pid
+        self.process_start_id = process_start_id
+
+    def _gone(self) -> str | None:
+        """A description of how the exact pinned process ended, or None."""
+        # Start identity alone cannot see a Linux process that exited but has
+        # not been reaped: /proc keeps answering with an unchanged start time,
+        # so the probe would report a dead producer as running for as long as
+        # the wait lasts. Ask for a terminated state first so the message this
+        # produces is never a false statement about a live process.
+        terminated = terminated_process_state(self.pid)
+        if terminated is not None:
+            return f"exited: pid {self.pid} {terminated}"
+        try:
+            observed = process_start_identity(self.pid)
+        except (FileNotFoundError, ProcessLookupError):
+            return f"exited: pid {self.pid} no longer exists"
+        except ProofFailure as error:
+            return (
+                f"exited: pid {self.pid} is no longer observable as a running"
+                f" process ({error})"
+            )
+        except OSError as error:
+            return f"exited: pid {self.pid} could not be inspected ({error})"
+        if observed != self.process_start_id:
+            return (
+                f"exited: pid {self.pid} now carries start identity {observed},"
+                f" which replaced the pinned {self.process_start_id}"
+            )
+        return None
+
+    def exited(self) -> bool:
+        return self._gone() is not None
+
+    def termination(self) -> str:
+        return self._gone() or "is still running"
+
+    def state(self) -> str:
+        return self._gone() or (
+            f"is still running as pid {self.pid}"
+            f" (start identity {self.process_start_id})"
+        )
+
+
+class ObservationalProducer(EventProducer):
+    """Report another producer's state without ever failing a wait on it.
+
+    Used for a process whose exit is expected by the scenario -- a server the
+    proof itself crashed -- where the state is still worth naming in a failure.
+    """
+
+    def __init__(self, producer: EventProducer, activity: str) -> None:
+        super().__init__(producer.label, activity)
+        self._producer = producer
+
+    def state(self) -> str:
+        return self._producer.state()
+
+
+class ProducerGroup(EventProducer):
+    """Every process whose loss would explain a missing record."""
+
+    def __init__(self, producers: list[EventProducer]) -> None:
+        if not producers:
+            raise ProofFailure("a qualification wait needs at least one producer")
+        super().__init__(
+            " and ".join(producer.label for producer in producers),
+            " and ".join(producer.activity for producer in producers),
+        )
+        self.producers = list(producers)
+
+    def _first_exited(self) -> EventProducer | None:
+        return next(
+            (producer for producer in self.producers if producer.exited()),
+            None,
+        )
+
+    def exited(self) -> bool:
+        return self._first_exited() is not None
+
+    def termination(self) -> str:
+        producer = self._first_exited()
+        if producer is None:
+            return "is still running"
+        return f"{producer.label} {producer.termination()}"
+
+    def state(self) -> str:
+        return "; ".join(producer.describe() for producer in self.producers)
+
+    def describe(self) -> str:
+        return self.state()

--- a/.github/scripts/packaged_agent_proof/process_identity.py
+++ b/.github/scripts/packaged_agent_proof/process_identity.py
@@ -112,6 +112,48 @@ def _linux_process_start_identity(pid: int) -> str:
     return f"linux:{process_fields[19]}"
 
 
+def linux_terminated_state(stat: str) -> str | None:
+    """The terminated state named in one `/proc/<pid>/stat`, or None.
+
+    A phrase, not a sentence: the caller owns naming the process it asked about.
+    """
+    fields = stat.rsplit(") ", 1)
+    if len(fields) != 2:
+        return None
+    process_fields = fields[1].split()
+    # `Z` is exited-but-unreaped; `X` and `x` are the kernel's dead states.
+    if process_fields and process_fields[0] in {"Z", "X", "x"}:
+        return (
+            f"is in state {process_fields[0]}: it has terminated and is waiting"
+            " to be reaped"
+        )
+    return None
+
+
+def terminated_process_state(pid: int) -> str | None:
+    """How ``pid`` is provably no longer running, or None if it may still be.
+
+    Only Linux needs this. A process that has exited but has not yet been reaped
+    keeps a readable ``/proc/<pid>/stat`` whose start time never changes, so a
+    liveness probe built on start identity alone calls a dead process running
+    until its parent reaps it. macOS ``proc_pidinfo`` already fails outright for
+    a zombie, and Windows ``GetExitCodeProcess`` already reports its real exit
+    code, so both answer correctly without this.
+
+    Observational only: an unreadable or unparsable ``/proc`` entry answers
+    None, because "cannot tell" must never be reported as "has exited".
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    except (FileNotFoundError, ProcessLookupError):
+        return "no longer exists"
+    except OSError:
+        return None
+    return linux_terminated_state(stat)
+
+
 def _macos_process_start_identity(pid: int) -> str:
     libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
     libproc.proc_pidinfo.argtypes = [

--- a/.github/scripts/packaged_agent_proof/publication_fault_run.py
+++ b/.github/scripts/packaged_agent_proof/publication_fault_run.py
@@ -8,6 +8,12 @@ import subprocess
 from pathlib import Path
 
 from .contract_primitives import write_private_json
+from .event_producer_liveness import (
+    ChildProcessProducer,
+    ObservationalProducer,
+    ProducerGroup,
+    UnobservedProducer,
+)
 from .foundation import require
 from .publication_fault_setup import _restore_fixture
 from .publication_fault_types import (
@@ -17,11 +23,15 @@ from .publication_fault_types import (
     PublicationFixture,
 )
 from .publication_protocol import (
+    SERVER_PRODUCER_LABEL,
     read_jsonl,
     run_publication_replacement_worker,
     send_server_qualification_control,
+    server_producer_from_control_event,
     wait_for_jsonl_event,
 )
+
+CANDIDATE_PRODUCER_LABEL = "the publication candidate process"
 
 
 def _start_fault_candidate(
@@ -83,12 +93,30 @@ def _run_fault(
     executable_sha256: str,
     timeout: int,
 ) -> PublicationFaultRun:
+    # Nothing in this harness keeps a resident server warm across the baseline
+    # publication, and no control of this run has been answered yet, so the
+    # first snapshot has no process to pin. This does not make a server that
+    # idled out attributable -- an unobserved producer can never name an exit --
+    # but it does stop the gap from being silent: a timeout here reports how far
+    # the event log actually got and states that no liveness could be observed,
+    # instead of only that a record never arrived.
     snapshot_before = send_server_qualification_control(
         private_root,
         nonce,
         sequence=1,
         action="snapshot",
         timeout=timeout,
+        producer=UnobservedProducer(
+            SERVER_PRODUCER_LABEL,
+            "answering the first control of this publication fault run",
+            "has not identified itself in this run: no control has been answered"
+            " yet, so it may never have started for this fault run or may have"
+            " already exited after the baseline publication",
+        ),
+    )
+    resident_server = server_producer_from_control_event(
+        snapshot_before,
+        "answering the publication fault controls",
     )
     candidate = _start_fault_candidate(
         env,
@@ -96,6 +124,11 @@ def _run_fault(
         nonce,
         fixture,
         commands,
+    )
+    candidate_producer = ChildProcessProducer(
+        candidate.process,
+        CANDIDATE_PRODUCER_LABEL,
+        "indexing the paused candidate publication",
     )
     stdout = ""
     stderr = ""
@@ -107,14 +140,31 @@ def _run_fault(
                 and event.get("status") == "waiting_for_resume"
             ),
             timeout=timeout,
-            process=candidate.process,
+            awaited="the publication hook pause_before_manifest_commit event",
+            producer=candidate_producer,
         )
+        # The pinned server's exit does not prove this control will go
+        # unanswered: the CLI transport starts a replacement embedding server on
+        # demand, and a replacement reads the same pinned command file. Failing
+        # the wait on that exit would reject runs the proof accepts today, so
+        # the predecessor is reported as state and only the candidate process --
+        # which nothing replaces -- can fail this wait.
         send_server_qualification_control(
             private_root,
             nonce,
             sequence=2,
             action="crash_server",
             timeout=timeout,
+            producer=ProducerGroup(
+                [
+                    ObservationalProducer(
+                        resident_server,
+                        "answering the crash control, unless it exited first and"
+                        " a replacement server answered instead",
+                    ),
+                    candidate_producer,
+                ]
+            ),
         )
         run_publication_replacement_worker(
             cli,
@@ -125,12 +175,31 @@ def _run_fault(
             executable_sha256=executable_sha256,
             timeout=timeout,
         )
+        # Sequence 2 crashed the pinned server on purpose, so its exit proves
+        # nothing here: a replacement server must start to answer this control.
+        # The crashed predecessor stays in the report as state, never as cause.
         snapshot_after = send_server_qualification_control(
             private_root,
             nonce,
             sequence=3,
             action="snapshot",
             timeout=timeout,
+            producer=ProducerGroup(
+                [
+                    UnobservedProducer(
+                        f"the replacement for {SERVER_PRODUCER_LABEL}",
+                        "answering the post-crash snapshot control",
+                        "has not identified itself: the sequence-2 server was"
+                        " crashed on purpose, so a replacement must start and"
+                        " answer before this control can complete",
+                    ),
+                    ObservationalProducer(
+                        resident_server,
+                        "the server this run crashed at sequence 2",
+                    ),
+                    candidate_producer,
+                ]
+            ),
         )
         write_private_json(
             candidate.resume_path,

--- a/.github/scripts/packaged_agent_proof/publication_protocol.py
+++ b/.github/scripts/packaged_agent_proof/publication_protocol.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import subprocess
 import time
 from pathlib import Path
 
@@ -16,12 +15,19 @@ from .contract_primitives import (
     require_sha256,
     write_private_json,
 )
+from .event_producer_liveness import (
+    EventProducer,
+    NativeProcessProducer,
+    UnobservedProducer,
+)
 from .foundation import (
     EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION,
     ProofFailure,
     require,
 )
 from .subprocess_control import json_command, run
+
+SERVER_PRODUCER_LABEL = "the per-user embedding qualification server"
 
 
 def read_jsonl(path: Path) -> list[dict]:
@@ -40,28 +46,109 @@ def read_jsonl(path: Path) -> list[dict]:
     return events
 
 
+def jsonl_log_state(path: Path) -> str:
+    """How far the awaited log actually got, in one attributable sentence.
+
+    A wait that fails must never leave open whether the log was missing, empty,
+    torn, or simply short of the awaited record: those have different causes and
+    only the log itself can tell them apart.
+    """
+    if path.is_symlink():
+        return "is a symlink and was never a trustworthy qualification log"
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return "was never created"
+    except OSError as error:
+        return f"could not be read: {error}"
+    lines = [line for line in raw.split(b"\n") if line.strip()]
+    records = read_jsonl(path)
+    trailer = "" if not raw or raw.endswith(b"\n") else "; its last line is unterminated"
+    if not records:
+        return f"holds {len(raw)} bytes and no parsed record{trailer}"
+    sequences = [
+        event["sequence"]
+        for event in records
+        if isinstance(event.get("sequence"), int)
+    ]
+    last = records[-1]
+    actions = sorted({str(event.get("action")) for event in records})
+    return (
+        f"holds {len(raw)} bytes and {len(records)} parsed record(s)"
+        f" out of {len(lines)} line(s); actions {', '.join(actions)};"
+        f" highest sequence {max(sequences) if sequences else 'none'};"
+        f" last record sequence={last.get('sequence')!r}"
+        f" action={last.get('action')!r} status={last.get('status')!r}{trailer}"
+    )
+
+
 def wait_for_jsonl_event(
     path: Path,
     predicate,
     *,
     timeout: int,
-    process: subprocess.Popen | None = None,
+    awaited: str,
+    producer: EventProducer,
 ) -> dict:
+    """Wait for one qualification record, attributing every way it can fail.
+
+    ``producer`` has no default on purpose. A wait without a liveness argument
+    turns any producer failure -- exit, crash, or a server that idled out before
+    the control was written -- into the same anonymous timeout, which is the
+    defect this signature exists to prevent. Callers with nothing to observe
+    pass an explicit ``UnobservedProducer`` that states why.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         for event in read_jsonl(path):
             if predicate(event):
                 return event
-        if process is not None and process.poll() is not None:
-            stdout, stderr = process.communicate()
+        if producer.exited():
+            # The producer may have appended the awaited record and exited
+            # between the read above and this probe, so the log decides last.
+            for event in read_jsonl(path):
+                if predicate(event):
+                    return event
             raise ProofFailure(
-                "qualification product process exited before its raw event: "
-                f"exit={process.returncode} stdout_sha256="
-                f"{hashlib.sha256(stdout.encode('utf-8')).hexdigest()} stderr_sha256="
-                f"{hashlib.sha256(stderr.encode('utf-8')).hexdigest()}"
+                f"{producer.label} ({producer.activity}) {producer.termination()}"
+                f" before {awaited} was written:"
+                f" qualification event file {path.name} {jsonl_log_state(path)}"
             )
         time.sleep(0.01)
-    raise ProofFailure(f"timed out waiting for qualification event file {path.name}")
+    raise ProofFailure(
+        f"timed out after {timeout}s waiting for {awaited}:"
+        f" qualification event file {path.name} {jsonl_log_state(path)};"
+        f" {producer.describe()}"
+    )
+
+
+def server_producer_from_control_event(event: dict, activity: str) -> EventProducer:
+    """Pin the exact server process that answered one control, when it named it."""
+    snapshot = event.get("snapshot")
+    process = snapshot.get("process") if isinstance(snapshot, dict) else None
+    pid = process.get("pid") if isinstance(process, dict) else None
+    process_start_id = (
+        process.get("process_start_id") if isinstance(process, dict) else None
+    )
+    if (
+        not isinstance(pid, int)
+        or isinstance(pid, bool)
+        or pid <= 0
+        or not isinstance(process_start_id, str)
+        or not process_start_id
+    ):
+        return UnobservedProducer(
+            SERVER_PRODUCER_LABEL,
+            activity,
+            "did not report an exact process identity in its control event,"
+            " so its liveness cannot be pinned",
+        )
+    return NativeProcessProducer(
+        pid,
+        process_start_id,
+        SERVER_PRODUCER_LABEL,
+        activity,
+    )
 
 
 def send_server_qualification_control(
@@ -71,6 +158,7 @@ def send_server_qualification_control(
     sequence: int,
     action: str,
     timeout: int,
+    producer: EventProducer,
 ) -> dict:
     nonce_sha256 = hashlib.sha256(nonce.encode("ascii")).hexdigest()
     command_path = directory / f"{nonce}.command.json"
@@ -96,6 +184,11 @@ def send_server_qualification_control(
                 and candidate.get("action") == action
             ),
             timeout=timeout,
+            awaited=(
+                f"embedding qualification control sequence={sequence}"
+                f" action={action}"
+            ),
+            producer=producer,
         )
         require(
             event.get("status") in {"completed", "accepted"},

--- a/.github/scripts/packaged_agent_proof/self_test.py
+++ b/.github/scripts/packaged_agent_proof/self_test.py
@@ -6,6 +6,7 @@ from .self_test_full_stack import run_full_stack_self_tests
 from .self_test_installation import run_installation_self_tests
 from .self_test_managed_layout import run_managed_layout_self_tests
 from .self_test_process import run_process_self_tests
+from .self_test_producer_liveness import run_producer_liveness_self_tests
 from .self_test_qualification import run_qualification_self_tests
 
 
@@ -13,6 +14,7 @@ def self_test() -> None:
     run_cli_self_tests()
     run_contract_self_tests()
     run_process_self_tests()
+    run_producer_liveness_self_tests()
     run_qualification_self_tests()
     run_installation_self_tests()
     run_managed_layout_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_producer_liveness.py
+++ b/.github/scripts/packaged_agent_proof/self_test_producer_liveness.py
@@ -1,0 +1,503 @@
+"""Self-tests for qualification producer liveness attribution.
+
+The defect these tests pin: a qualification wait without a liveness argument
+cannot tell a dead producer from a slow one, so every producer failure spends
+the whole proof budget and reports only that a record never arrived. Each test
+here fails if that behaviour comes back.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from .event_producer_liveness import (
+    ChildProcessProducer,
+    NativeProcessProducer,
+    ObservationalProducer,
+    ProducerGroup,
+    UnobservedProducer,
+)
+from .foundation import REPOSITORY_ROOT, ProofFailure, require
+from .process_identity import (
+    linux_terminated_state,
+    process_start_identity,
+    terminated_process_state,
+)
+from .publication_protocol import (
+    jsonl_log_state,
+    send_server_qualification_control,
+    server_producer_from_control_event,
+    wait_for_jsonl_event,
+)
+
+# Far longer than any of these tests may take, and far shorter than the proof
+# budget they stand in for. A wait that consults its producer fails in
+# milliseconds; a wait that ignores it burns the whole timeout, which is the
+# regression being pinned. The real harness passes a 900s budget, but pinning
+# the property does not require paying it: reproducing the defect must not cost
+# every proof workflow that runs `--self-test` a 15-minute hang before the
+# assertion can fire.
+_UNREACHED_TIMEOUT_SECS = 30
+_ATTRIBUTION_BUDGET_SECS = 8
+
+
+def _dead_process() -> subprocess.Popen:
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stderr.write('gone'); sys.exit(7)"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    process.wait(timeout=60)
+    return process
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.write_text(
+        "".join(f"{json.dumps(event, sort_keys=True)}\n" for event in events),
+        encoding="utf-8",
+    )
+
+
+def _never(_event: dict) -> bool:
+    return False
+
+
+def _dead_producer_fails_fast_instead_of_timing_out() -> None:
+    """A dead producer must surface its exit, not the 15-minute timeout."""
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-producer-liveness-self-test-"
+    ) as raw:
+        directory = Path(raw)
+        nonce = "self-test-nonce"
+        # The producer already wrote one unrelated telemetry record and then
+        # stopped, exactly like the preserved Windows evidence.
+        _write_events(
+            directory / f"{nonce}.events.jsonl",
+            [
+                {
+                    "schema_version": 1,
+                    "sequence": 0,
+                    "action": "completed_tokens",
+                    "status": "completed",
+                }
+            ],
+        )
+        process = _dead_process()
+        started = time.monotonic()
+        try:
+            send_server_qualification_control(
+                directory,
+                nonce,
+                sequence=1,
+                action="snapshot",
+                timeout=_UNREACHED_TIMEOUT_SECS,
+                producer=ChildProcessProducer(
+                    process,
+                    "the self-test producer",
+                    "answering the first control",
+                ),
+            )
+        except ProofFailure as error:
+            elapsed = time.monotonic() - started
+            message = str(error)
+            require(
+                elapsed < _ATTRIBUTION_BUDGET_SECS,
+                "a dead producer still burned the whole qualification budget"
+                f" ({elapsed:.1f}s) instead of failing fast",
+            )
+            require(
+                "the self-test producer" in message
+                and "exited with code 7" in message
+                and "stdout_sha256=" in message
+                and "stderr_sha256=" in message,
+                f"a dead producer omitted its attributable exit state: {message}",
+            )
+            require(
+                "sequence=1 action=snapshot" in message,
+                f"a dead producer's failure did not name what was awaited: {message}",
+            )
+            require(
+                "1 parsed record" in message
+                and "completed_tokens" in message,
+                "a dead producer's failure did not report how far the log got:"
+                f" {message}",
+            )
+        else:
+            raise ProofFailure("a dead producer completed a qualification control")
+        require(
+            not (directory / f"{nonce}.command.json").exists(),
+            "an attributed control failure left its command file behind",
+        )
+
+
+def _a_record_written_just_before_exit_still_completes() -> None:
+    """Exit must not beat a record the producer already appended."""
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-producer-liveness-self-test-"
+    ) as raw:
+        directory = Path(raw)
+        nonce = "self-test-nonce"
+        _write_events(
+            directory / f"{nonce}.events.jsonl",
+            [
+                {
+                    "schema_version": 1,
+                    "sequence": 1,
+                    "action": "snapshot",
+                    "status": "completed",
+                }
+            ],
+        )
+        event = send_server_qualification_control(
+            directory,
+            nonce,
+            sequence=1,
+            action="snapshot",
+            timeout=_UNREACHED_TIMEOUT_SECS,
+            producer=ChildProcessProducer(
+                _dead_process(),
+                "the self-test producer",
+                "answering the first control",
+            ),
+        )
+        require(
+            event.get("sequence") == 1 and event.get("action") == "snapshot",
+            "an exited producer lost a record it had already written",
+        )
+
+
+def _timeout_names_the_wait_the_log_and_the_producer() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-producer-liveness-self-test-"
+    ) as raw:
+        path = Path(raw) / "events.jsonl"
+        _write_events(
+            path,
+            [
+                {
+                    "schema_version": 1,
+                    "sequence": 0,
+                    "action": "completed_tokens",
+                    "status": "completed",
+                }
+            ],
+        )
+        try:
+            wait_for_jsonl_event(
+                path,
+                _never,
+                timeout=1,
+                awaited="the self-test record",
+                producer=UnobservedProducer(
+                    "the self-test producer",
+                    "doing self-test work",
+                    "has not identified itself in this run",
+                ),
+            )
+        except ProofFailure as error:
+            message = str(error)
+            require(
+                "the self-test record" in message
+                and "the self-test producer" in message
+                and "doing self-test work" in message
+                and "has not identified itself in this run" in message
+                and "1 parsed record" in message
+                and "completed_tokens" in message,
+                "a qualification timeout did not name what was awaited, how far"
+                f" the log got, and what the producer was doing: {message}",
+            )
+        else:
+            raise ProofFailure("an unreachable qualification wait completed")
+
+
+def _log_state_reports_every_shape_the_evidence_can_take() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-producer-liveness-self-test-"
+    ) as raw:
+        root = Path(raw)
+        missing = root / "missing.jsonl"
+        require(
+            jsonl_log_state(missing) == "was never created",
+            "a missing qualification log was not reported as missing",
+        )
+        empty = root / "empty.jsonl"
+        empty.write_bytes(b"")
+        require(
+            "holds 0 bytes and no parsed record" in jsonl_log_state(empty),
+            "an empty qualification log was not reported as empty",
+        )
+        torn = root / "torn.jsonl"
+        torn.write_text('{"sequence":1,"action":"snapshot"}\n{"seq', encoding="utf-8")
+        torn_state = jsonl_log_state(torn)
+        require(
+            "1 parsed record(s) out of 2 line(s)" in torn_state
+            and "its last line is unterminated" in torn_state,
+            f"a torn qualification log lost its partial-line evidence: {torn_state}",
+        )
+
+
+def _native_process_liveness_is_pinned_to_the_exact_process() -> None:
+    live = NativeProcessProducer(
+        os.getpid(),
+        process_start_identity(os.getpid()),
+        "the self-test host",
+        "running this self-test",
+    )
+    require(
+        not live.exited() and "is still running as pid" in live.state(),
+        "a live pinned process was reported as gone",
+    )
+    recycled = NativeProcessProducer(
+        os.getpid(),
+        "linux:0" if not sys.platform.startswith("win") else "windows:0",
+        "the self-test host",
+        "running this self-test",
+    )
+    require(
+        recycled.exited() and "replaced the pinned" in recycled.termination(),
+        "a pid whose start identity changed was accepted as the pinned process",
+    )
+    process = _dead_process()
+    process.communicate()
+    gone = NativeProcessProducer(
+        process.pid,
+        process_start_identity(os.getpid()),
+        "the self-test child",
+        "running this self-test",
+    )
+    require(
+        gone.exited() and "exited" in gone.termination(),
+        "an exited process was not reported as exited",
+    )
+
+
+def _an_unreaped_process_is_never_reported_as_running() -> None:
+    """A process that exited but was not reaped has exited, and must say so.
+
+    On Linux `/proc/<pid>/stat` stays readable with an unchanged start time for
+    a zombie, so a probe built on start identity alone reports a dead producer
+    as "is still running as pid N" until its parent reaps it. That window is
+    short, but the sentence it prints is false, and a proof that prints false
+    liveness is worse than one that prints none.
+
+    The stat parse is exercised from every host; the live zombie is only
+    reachable where zombies exist.
+    """
+    for state, terminated in (
+        ("Z", True),
+        ("X", True),
+        ("x", True),
+        ("R", False),
+        ("S", False),
+        ("D", False),
+        ("T", False),
+    ):
+        stat = f"4242 (a name with spaces) {state} 1 4242 4242 " + " ".join(
+            str(field) for field in range(60)
+        )
+        observed = linux_terminated_state(stat)
+        require(
+            (observed is not None) == terminated,
+            f"process state {state!r} was classified wrong: {observed!r}",
+        )
+    # Unparsable input must answer "cannot tell", never "has exited".
+    require(
+        linux_terminated_state("not a stat line") is None
+        and linux_terminated_state("") is None,
+        "an unreadable process state was reported as a termination",
+    )
+    require(
+        terminated_process_state(os.getpid()) is None,
+        "this live self-test process was reported as terminated",
+    )
+    if sys.platform != "linux":
+        return
+    # A child killed and deliberately not reaped is a zombie: /proc still has
+    # its unchanged start identity, so only the state check can see the exit.
+    zombie = subprocess.Popen([sys.executable, "-c", "raise SystemExit(0)"])
+    pinned = NativeProcessProducer(
+        zombie.pid,
+        process_start_identity(zombie.pid),
+        "the self-test zombie",
+        "already exited without being reaped",
+    )
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if terminated_process_state(zombie.pid) is not None:
+                break
+            time.sleep(0.01)
+        require(
+            pinned.exited() and "waiting to be reaped" in pinned.termination(),
+            "an exited but unreaped producer was reported as still running:"
+            f" {pinned.state()}",
+        )
+    finally:
+        zombie.wait(timeout=60)
+
+
+def _a_group_names_which_member_died() -> None:
+    survivor = UnobservedProducer(
+        "the self-test survivor",
+        "still working",
+        "cannot be observed",
+    )
+    casualty = ChildProcessProducer(
+        _dead_process(),
+        "the self-test casualty",
+        "already gone",
+    )
+    group = ProducerGroup([survivor, casualty])
+    exited = group.exited()
+    termination = group.termination()
+    require(
+        exited
+        and "the self-test casualty" in termination
+        and "exited with code 7" in termination,
+        "a producer group did not name the member that died",
+    )
+    require(
+        "the self-test survivor" in group.describe()
+        and "the self-test casualty" in group.describe(),
+        "a producer group omitted a member from its description",
+    )
+    observational = ProducerGroup(
+        [
+            survivor,
+            ObservationalProducer(
+                ChildProcessProducer(
+                    _dead_process(),
+                    "the deliberately crashed member",
+                    "crashed on purpose",
+                ),
+                "crashed on purpose",
+            ),
+        ]
+    )
+    require(
+        not observational.exited(),
+        "a deliberately crashed producer was still allowed to fail a wait",
+    )
+    require(
+        "exited with code 7" in observational.describe(),
+        "a deliberately crashed producer lost its state from the description",
+    )
+    try:
+        ProducerGroup([])
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("a qualification wait accepted an empty producer group")
+
+
+def _control_events_pin_the_server_that_answered() -> None:
+    pinned = server_producer_from_control_event(
+        {
+            "snapshot": {
+                "process": {
+                    "pid": os.getpid(),
+                    "process_start_id": process_start_identity(os.getpid()),
+                }
+            }
+        },
+        "answering self-test controls",
+    )
+    require(
+        isinstance(pinned, NativeProcessProducer)
+        and pinned.pid == os.getpid()
+        and not pinned.exited(),
+        "a control event with an exact process identity was not pinned",
+    )
+    for event in (
+        {},
+        {"snapshot": {}},
+        {"snapshot": {"process": {"pid": 0, "process_start_id": "linux:1"}}},
+        {"snapshot": {"process": {"pid": 1, "process_start_id": ""}}},
+        {"snapshot": {"process": {"pid": True, "process_start_id": "linux:1"}}},
+    ):
+        producer = server_producer_from_control_event(event, "answering controls")
+        require(
+            isinstance(producer, UnobservedProducer) and not producer.exited(),
+            f"an identity-free control event produced a pinned server: {event!r}",
+        )
+
+
+def _every_qualification_wait_carries_a_producer() -> None:
+    """Structural guard: the omission this lane fixed cannot come back.
+
+    ``wait_for_jsonl_event`` and ``send_server_qualification_control`` both take
+    ``producer`` as a keyword argument without a default, so an omission is a
+    ``TypeError``. This walks the harness anyway, because a future caller could
+    forward ``None`` or reintroduce a default and reproduce the exact defect.
+    """
+    package = REPOSITORY_ROOT / ".github" / "scripts" / "packaged_agent_proof"
+    guarded = {"wait_for_jsonl_event", "send_server_qualification_control"}
+    inspected = 0
+    for source in sorted(package.glob("*.py")):
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = (
+                node.func.id
+                if isinstance(node.func, ast.Name)
+                else getattr(node.func, "attr", None)
+            )
+            if name not in guarded:
+                continue
+            inspected += 1
+            keyword = next(
+                (
+                    entry
+                    for entry in node.keywords
+                    if entry.arg == "producer"
+                ),
+                None,
+            )
+            require(
+                keyword is not None,
+                f"{source.name}:{node.lineno} calls {name} without a producer"
+                " liveness argument, so a dead producer would degrade into an"
+                " uninformative timeout",
+            )
+            require(
+                not (
+                    isinstance(keyword.value, ast.Constant)
+                    and keyword.value.value is None
+                ),
+                f"{source.name}:{node.lineno} passes producer=None to {name}",
+            )
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name in guarded:
+                defaults = node.args.kw_defaults
+                index = [argument.arg for argument in node.args.kwonlyargs]
+                require(
+                    "producer" in index
+                    and defaults[index.index("producer")] is None,
+                    f"{node.name} gave its producer argument a default, which"
+                    " lets a caller silently omit it again",
+                )
+    require(
+        inspected >= 4,
+        f"the qualification wait audit inspected only {inspected} call sites",
+    )
+
+
+def run_producer_liveness_self_tests() -> None:
+    _dead_producer_fails_fast_instead_of_timing_out()
+    _a_record_written_just_before_exit_still_completes()
+    _timeout_names_the_wait_the_log_and_the_producer()
+    _log_state_reports_every_shape_the_evidence_can_take()
+    _native_process_liveness_is_pinned_to_the_exact_process()
+    _an_unreaped_process_is_never_reported_as_running()
+    _a_group_names_which_member_died()
+    _control_events_pin_the_server_that_answered()
+    _every_qualification_wait_carries_a_producer()

--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -73,9 +73,12 @@ pub use protocol::{
     embedding_qualification_watchdog_marker_filename, embedding_retry_state,
 };
 use qualification_control::ServerQualificationControl;
+#[cfg(all(test, windows))]
+use qualification_control::native_path_identity;
 #[cfg(test)]
 use qualification_control::{
-    ServerQualificationEvent, ServerQualificationEventClock, read_server_qualification_command,
+    CommandAbsence, MAX_DENIED_COMMAND_TICKS, ServerQualificationEvent,
+    ServerQualificationEventClock, absent_command, read_server_qualification_command,
     server_qualification_control_from_values,
 };
 #[cfg(test)]

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs
@@ -17,15 +17,18 @@ use uuid::Uuid;
 
 mod server;
 
+#[cfg(all(test, windows))]
+pub(super) use server::native_path_identity;
+#[cfg(test)]
+pub(super) use server::{
+    CommandAbsence, MAX_DENIED_COMMAND_TICKS, absent_command, read_server_qualification_command,
+    server_qualification_control_from_values,
+};
 pub(super) use server::{
     ServerQualificationControl, ServerQualificationEvent, ServerQualificationEventClock,
     poll_server_qualification_command, server_qualification_control_from_env,
     sync_qualification_directory, validate_private_qualification_file_metadata,
     write_server_qualification_event,
-};
-#[cfg(test)]
-pub(super) use server::{
-    read_server_qualification_command, server_qualification_control_from_values,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server.rs
@@ -3,7 +3,7 @@
 use configuration::PinnedQualificationDirectory;
 use event_log::ServerQualificationEventLog;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
 
 mod command_io;
 mod configuration;
@@ -12,13 +12,19 @@ mod filesystem;
 
 pub(in crate::per_user_embedding) use command_io::poll_server_qualification_command;
 #[cfg(test)]
-pub(in crate::per_user_embedding) use command_io::read_server_qualification_command;
+pub(in crate::per_user_embedding) use command_io::{
+    MAX_DENIED_COMMAND_TICKS, absent_command, read_server_qualification_command,
+};
 pub(in crate::per_user_embedding) use configuration::server_qualification_control_from_env;
 #[cfg(test)]
 pub(in crate::per_user_embedding) use configuration::server_qualification_control_from_values;
 pub(in crate::per_user_embedding) use event_log::{
     ServerQualificationEvent, ServerQualificationEventClock, write_server_qualification_event,
 };
+#[cfg(test)]
+pub(in crate::per_user_embedding) use filesystem::CommandAbsence;
+#[cfg(all(test, windows))]
+pub(in crate::per_user_embedding) use filesystem::native_path_identity;
 pub(in crate::per_user_embedding) use filesystem::{
     sync_qualification_directory, validate_private_qualification_file_metadata,
 };
@@ -33,6 +39,10 @@ pub(in crate::per_user_embedding) struct ServerQualificationControl {
     pub(in crate::per_user_embedding) processed_command_sha256: Mutex<Option<String>>,
     pub(in crate::per_user_embedding) force_incompatible: AtomicBool,
     pub(in crate::per_user_embedding) freeze_owner: AtomicBool,
+    /// Consecutive poll ticks that answered `ACCESS_DENIED` at the pinned
+    /// command path. Bounds how long a Windows delete-pending entry may be
+    /// assumed, so a permanent denial fails by name instead of hanging.
+    pub(in crate::per_user_embedding) denied_command_ticks: AtomicU32,
 }
 
 impl ServerQualificationControl {

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/command_io.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/command_io.rs
@@ -8,14 +8,30 @@ use super::event_log::{
     qualification_detail, write_server_qualification_event,
 };
 use super::filesystem::{
-    native_file_identity, native_path_identity, validate_private_qualification_file_metadata,
+    CommandAbsence, Observation, native_file_identity, optional_native_path_identity,
+    qualification_file_absence, qualification_file_lost_its_last_name,
+    validate_private_qualification_file_metadata,
 };
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use std::fs::{self, OpenOptions};
-use std::io::{self, Read};
+use std::io::Read;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
+
+/// How many consecutive ticks may answer `ACCESS_DENIED` before the server
+/// stops calling it a removal in progress.
+///
+/// A Windows delete-pending entry cannot outlive the handles that put it in
+/// that state, and this server's own handle closes inside one consume, so the
+/// real case clears within a tick or two. A denial that persists is something
+/// else -- an ACL that genuinely refuses the open -- and treating that as "no
+/// command this tick" forever recreates the unattributable multi-minute hang
+/// this whole lane exists to remove. The accept loop polls roughly every 25ms,
+/// so this bound is a few seconds: far beyond any real removal race, far short
+/// of a proof budget.
+pub(in crate::per_user_embedding) const MAX_DENIED_COMMAND_TICKS: u32 = 200;
 
 #[derive(Debug)]
 pub(in crate::per_user_embedding) struct ServerQualificationCommandFile {
@@ -39,25 +55,111 @@ struct ServerQualificationCommandParameters {
     class: Option<String>,
 }
 
+/// Observe the command file's own metadata, reporting why nothing is there.
+fn optional_command_metadata(
+    path: &Path,
+    context_message: &'static str,
+) -> Result<Observation<fs::Metadata>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if qualification_file_lost_its_last_name(&metadata) => {
+            Ok(Err(CommandAbsence::Removed))
+        }
+        Ok(metadata) => Ok(Ok(metadata)),
+        Err(error) => match qualification_file_absence(&error) {
+            Some(absence) => Ok(Err(absence)),
+            None => Err(error).context(context_message),
+        },
+    }
+}
+
+/// Record one tick that found no command, and decide whether the reason is
+/// still credible.
+///
+/// A removal is proof and resets the denial run. A denial is only ever
+/// provisional: it is tolerated while it stays inside the bound and named as a
+/// failure once it outlives it.
+pub(in crate::per_user_embedding) fn absent_command(
+    control: &ServerQualificationControl,
+    absence: CommandAbsence,
+) -> Result<Option<ServerQualificationCommandFile>> {
+    match absence {
+        CommandAbsence::Removed => {
+            control.denied_command_ticks.store(0, Ordering::Release);
+            Ok(None)
+        }
+        CommandAbsence::Denied => {
+            let denied = control
+                .denied_command_ticks
+                .fetch_add(1, Ordering::AcqRel)
+                .saturating_add(1);
+            if denied > MAX_DENIED_COMMAND_TICKS {
+                bail!("embedding_qualification_command_denied");
+            }
+            Ok(None)
+        }
+    }
+}
+
+/// Consume the pinned qualification command for one poll tick.
+///
+/// `Ok(None)` means "no command this tick", and covers both "the writer has not
+/// written one yet" and "the writer took its command back while this tick was
+/// reading it". The second case is ordinary: the proof harness removes each
+/// command once it has seen the matching event, and that removal races every
+/// tick that already opened the file. What the loser of that race observes is
+/// platform- and filesystem-dependent -- `NotFound`, a zero link count, or, on
+/// a Windows volume without POSIX delete semantics, `ACCESS_DENIED` from an
+/// entry left delete-pending -- so a poll loop that treats any of them as fatal
+/// kills the server during routine command cleanup.
+///
+/// Every other outcome stays fatal, because tolerance here must not become a
+/// blanket "ignore all IO errors" that turns real control-plane failures into
+/// silent waits: untrusted metadata, a different file substituted at the pinned
+/// path, an oversized command, a replaced pinned directory, and any other
+/// filesystem error all still stop the server. The Windows denial is bounded
+/// as well as narrow: `ACCESS_DENIED` is indistinguishable from an ACL that
+/// simply refuses the open, so it is tolerated only for as long as a real
+/// delete-pending entry could last, then fails as
+/// `embedding_qualification_command_denied` rather than waiting forever.
+///
+/// Every step of the sequence can lose that race, and each loses it
+/// differently: a `stat` fails or reports a zero link count, the native path
+/// identity fails, the open fails, and the opened handle keeps serving a file
+/// that no longer has a name. All of them are classified here, and nowhere
+/// else -- the shared metadata gate and the accept loop both stay fail-closed.
 pub(in crate::per_user_embedding) fn read_server_qualification_command(
     control: &ServerQualificationControl,
 ) -> Result<Option<ServerQualificationCommandFile>> {
+    match consume_server_qualification_command(control)? {
+        Ok(command) => {
+            control.denied_command_ticks.store(0, Ordering::Release);
+            Ok(Some(command))
+        }
+        Err(absence) => absent_command(control, absence),
+    }
+}
+
+/// One consume attempt, reporting either the command or why there was none.
+fn consume_server_qualification_command(
+    control: &ServerQualificationControl,
+) -> Result<Observation<ServerQualificationCommandFile>> {
     control.directory.revalidate()?;
     let path = control
         .directory
         .join(format!("{}.command.json", control.nonce));
-    let path_metadata = match fs::symlink_metadata(&path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => {
-            return Err(error).context("inspect embedding qualification command");
-        }
-    };
+    let path_metadata =
+        match optional_command_metadata(&path, "inspect embedding qualification command")? {
+            Ok(metadata) => metadata,
+            Err(absence) => return Ok(Err(absence)),
+        };
     validate_private_qualification_file_metadata(
         &path_metadata,
         SERVER_QUALIFICATION_MAX_COMMAND_BYTES,
     )?;
-    let identity = native_path_identity(&path)?;
+    let identity = match optional_native_path_identity(&path)? {
+        Ok(identity) => identity,
+        Err(absence) => return Ok(Err(absence)),
+    };
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -65,12 +167,19 @@ pub(in crate::per_user_embedding) fn read_server_qualification_command(
         use std::os::unix::fs::OpenOptionsExt;
         options.custom_flags(libc::O_NOFOLLOW);
     }
-    let file = options
-        .open(&path)
-        .context("open embedding qualification command")?;
+    let file = match options.open(&path) {
+        Ok(file) => file,
+        Err(error) => match qualification_file_absence(&error) {
+            Some(absence) => return Ok(Err(absence)),
+            None => return Err(error).context("open embedding qualification command"),
+        },
+    };
     let opened = file
         .metadata()
         .context("inspect opened embedding qualification command")?;
+    if qualification_file_lost_its_last_name(&opened) {
+        return Ok(Err(CommandAbsence::Removed));
+    }
     validate_private_qualification_file_metadata(&opened, SERVER_QUALIFICATION_MAX_COMMAND_BYTES)?;
     if native_file_identity(&file)? != identity {
         bail!("embedding_qualification_command_replaced");
@@ -84,16 +193,31 @@ pub(in crate::per_user_embedding) fn read_server_qualification_command(
         bail!("embedding_qualification_command_limit");
     }
     let path_metadata =
-        fs::symlink_metadata(&path).context("reinspect embedding qualification command")?;
+        match optional_command_metadata(&path, "reinspect embedding qualification command")? {
+            Ok(metadata) => metadata,
+            Err(absence) => return Ok(Err(absence)),
+        };
     validate_private_qualification_file_metadata(
         &path_metadata,
         SERVER_QUALIFICATION_MAX_COMMAND_BYTES,
     )?;
-    if native_path_identity(&path)? != identity {
+    let reobserved = match optional_native_path_identity(&path)? {
+        Ok(identity) => identity,
+        Err(absence) => return Ok(Err(absence)),
+    };
+    if reobserved != identity {
+        // A missing Unix path still yields a lexical identity, so separate "the
+        // writer removed it" from "a different file now sits at the pinned
+        // path". Only the latter is a substitution the server must refuse.
+        if let Err(absence) =
+            optional_command_metadata(&path, "reinspect embedding qualification command")?
+        {
+            return Ok(Err(absence));
+        }
         bail!("embedding_qualification_command_replaced");
     }
     control.directory.revalidate()?;
-    Ok(Some(ServerQualificationCommandFile { bytes }))
+    Ok(Ok(ServerQualificationCommandFile { bytes }))
 }
 
 pub(in crate::per_user_embedding) fn poll_server_qualification_command(

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/configuration.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/configuration.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
 
 #[derive(Debug)]
 pub(in crate::per_user_embedding) struct PinnedQualificationDirectory {
@@ -55,6 +55,7 @@ pub(in crate::per_user_embedding) fn server_qualification_control_from_values(
                 processed_command_sha256: Mutex::new(None),
                 force_incompatible: AtomicBool::new(false),
                 freeze_owner: AtomicBool::new(false),
+                denied_command_ticks: AtomicU32::new(0),
             }))
         }
         _ => bail!("embedding_qualification_gate_incomplete"),

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/filesystem.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/filesystem.rs
@@ -3,6 +3,7 @@ use codestory_workspace::{
     WorkspacePathIdentity, workspace_file_identity, workspace_path_identity,
 };
 use std::fs::{self, File};
+use std::io;
 use std::path::Path;
 
 pub(in crate::per_user_embedding) type NativeFileIdentity = WorkspacePathIdentity;
@@ -43,9 +44,102 @@ pub(in crate::per_user_embedding) fn validate_private_qualification_file_metadat
     Ok(())
 }
 
-pub(super) fn native_path_identity(path: &Path) -> Result<NativeFileIdentity> {
+pub(in crate::per_user_embedding) fn native_path_identity(
+    path: &Path,
+) -> Result<NativeFileIdentity> {
     workspace_path_identity(path)
         .context("embedding qualification filesystem path identity is unavailable")
+}
+
+/// Why one poll tick found no command to consume at the pinned path.
+///
+/// The two classes carry different certainty, and the caller bounds them
+/// differently: `Removed` is proof that the writer took its file back, while
+/// `Denied` is an observation that is *consistent with* a removal in progress
+/// but cannot rule out a file that is simply unreadable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::per_user_embedding) enum CommandAbsence {
+    /// The writer took its file back. A Unix unlink answers `NotFound`, a name
+    /// that lost its last link mid-consume reports a zero link count, and a
+    /// Windows host with POSIX delete semantics -- which is what the proof host
+    /// measured, Windows 11 build 26200 on NTFS -- also answers `NotFound`.
+    Removed,
+    /// Windows answered `ACCESS_DENIED`. A file left delete-pending answers that
+    /// way, and so does a present file whose ACL denies the open; one
+    /// observation cannot separate them, which is why this class is bounded
+    /// rather than tolerated indefinitely.
+    ///
+    /// A compatibility guard, not the measured behaviour of the current proof
+    /// host: `DeleteFileW` there unlinks the name at once. It still matters
+    /// where POSIX delete is unavailable -- older Windows, FAT/exFAT, network
+    /// filesystems, or a memory-mapped file -- because that is where a routine
+    /// command cleanup can still leave a delete-pending entry behind.
+    Denied,
+}
+
+/// One observation of the pinned command path: what was there, or why nothing
+/// was. `Err` is not a failure -- it is the attributable reason for an absence.
+pub(super) type Observation<T> = std::result::Result<T, CommandAbsence>;
+
+/// Whether one filesystem error means there is nothing to consume this tick,
+/// rather than that the qualification control plane is broken.
+///
+/// Deliberately narrow. Every other error class stays fatal so the accept loop
+/// keeps failing closed on a control plane that is genuinely broken. In
+/// particular `ERROR_SHARING_VIOLATION` does not map to `PermissionDenied` and
+/// so stays fatal.
+pub(super) fn qualification_file_absence(error: &io::Error) -> Option<CommandAbsence> {
+    classify_absence(error.kind(), cfg!(windows))
+}
+
+/// The platform argument is explicit so both answers stay testable from either
+/// host, rather than only on whichever one happens to run the suite.
+fn classify_absence(kind: io::ErrorKind, windows: bool) -> Option<CommandAbsence> {
+    match kind {
+        io::ErrorKind::NotFound => Some(CommandAbsence::Removed),
+        io::ErrorKind::PermissionDenied if windows => Some(CommandAbsence::Denied),
+        _ => None,
+    }
+}
+
+/// Whether one observation shows a file that has lost its last name.
+///
+/// Unix drops an unlinked file's link count to zero while it stays fully
+/// readable through any open handle, and a `stat` that resolves the name just
+/// as it is being removed sees the same zero. The shared private-metadata gate
+/// rejects that as an untrusted link count, which is the wrong verdict for a
+/// command the writer took back: the file is not untrusted, it is gone.
+///
+/// This never relaxes the guard that gate exists for. A hard-linked command is
+/// `nlink >= 2` and still fails closed; only the impossible-to-attack `nlink ==
+/// 0` is folded into the vanish class, and only for the command file.
+#[cfg(unix)]
+pub(super) fn qualification_file_lost_its_last_name(metadata: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    metadata.nlink() == 0
+}
+
+#[cfg(not(unix))]
+pub(super) fn qualification_file_lost_its_last_name(_metadata: &fs::Metadata) -> bool {
+    false
+}
+
+/// Native path identity that reports an absence instead of failing.
+///
+/// Only the [`qualification_file_absence`] classes become an absence. A missing
+/// Unix path yields a lexical identity rather than an error, so callers still
+/// confirm presence before treating an identity mismatch as a substitution.
+pub(super) fn optional_native_path_identity(
+    path: &Path,
+) -> Result<Observation<NativeFileIdentity>> {
+    match workspace_path_identity(path) {
+        Ok(identity) => Ok(Ok(identity)),
+        Err(error) => match qualification_file_absence(&error) {
+            Some(absence) => Ok(Err(absence)),
+            None => Err(error)
+                .context("embedding qualification filesystem path identity is unavailable"),
+        },
+    }
 }
 
 pub(super) fn native_file_identity(file: &File) -> Result<NativeFileIdentity> {
@@ -63,4 +157,41 @@ pub(in crate::per_user_embedding) fn sync_qualification_directory(path: &Path) -
 #[cfg(not(unix))]
 pub(in crate::per_user_embedding) fn sync_qualification_directory(_path: &Path) -> Result<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CommandAbsence, classify_absence};
+    use std::io;
+
+    /// The absence classes must stay exactly as narrow as they are documented,
+    /// on both platforms, from whichever host runs the suite.
+    #[test]
+    fn only_removal_and_windows_denial_read_as_an_absent_command() {
+        for windows in [false, true] {
+            assert_eq!(
+                classify_absence(io::ErrorKind::NotFound, windows),
+                Some(CommandAbsence::Removed)
+            );
+            for fatal in [
+                io::ErrorKind::InvalidData,
+                io::ErrorKind::Interrupted,
+                io::ErrorKind::IsADirectory,
+                io::ErrorKind::Other,
+                // ERROR_SHARING_VIOLATION does not map to PermissionDenied, so
+                // a genuinely locked command file stays fatal on Windows too.
+                io::ErrorKind::ResourceBusy,
+            ] {
+                assert_eq!(classify_absence(fatal, windows), None, "{fatal:?}");
+            }
+        }
+        assert_eq!(
+            classify_absence(io::ErrorKind::PermissionDenied, false),
+            None
+        );
+        assert_eq!(
+            classify_absence(io::ErrorKind::PermissionDenied, true),
+            Some(CommandAbsence::Denied)
+        );
+    }
 }

--- a/crates/codestory-retrieval/src/per_user_embedding/server/lifecycle.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/server/lifecycle.rs
@@ -80,6 +80,16 @@ pub fn run_per_user_embedding_server(config: PerUserEmbeddingServerConfig) -> Re
     let mut connections = Vec::new();
     let serve_result = (|| -> Result<()> {
         loop {
+            // Deliberately fail-stop. The transient class -- a command file the
+            // proof harness took back mid-consume, including a Windows
+            // delete-pending entry -- is classified inside the consume itself
+            // and returns "no command this tick" rather than an error. What
+            // reaches here is the fatal remainder: untrusted control metadata,
+            // a substituted command file, a replaced pinned directory, or a
+            // failed durable event append. Continuing past any of those would
+            // keep serving with a compromised or unrecordable qualification
+            // control plane, which produces an unfalsifiable proof instead of a
+            // failure -- strictly worse than stopping.
             poll_server_qualification_command(&state, config.transport.as_ref())?;
             if state
                 .qualification

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/qualification.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/qualification.rs
@@ -1,11 +1,281 @@
 use super::super::{
-    SERVER_QUALIFICATION_MAX_COMMAND_BYTES, SERVER_QUALIFICATION_MAX_EVENT_BYTES,
-    SERVER_QUALIFICATION_MAX_EVENT_RECORDS, hex_sha256, read_server_qualification_command,
+    CommandAbsence, MAX_DENIED_COMMAND_TICKS, absent_command, read_server_qualification_command,
     server_qualification_control_from_values,
+};
+// Only the platform-gated tests below use these, so importing them
+// unconditionally would warn on whichever platform is not running them.
+#[cfg(windows)]
+use super::super::native_path_identity;
+#[cfg(unix)]
+use super::super::{
+    SERVER_QUALIFICATION_MAX_COMMAND_BYTES, SERVER_QUALIFICATION_MAX_EVENT_BYTES,
+    SERVER_QUALIFICATION_MAX_EVENT_RECORDS, hex_sha256,
 };
 use super::{test_qualification_control, test_qualification_event};
 use std::fs;
-use std::sync::atomic::Ordering;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread;
+
+/// Write one command file already private, before anything can observe it.
+fn write_private_command(path: &Path, bytes: &[u8]) {
+    fs::write(path, bytes).expect("write qualification command");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .expect("private qualification command");
+    }
+}
+
+/// A command the proof harness takes back mid-consume must read as "no command
+/// this tick", never as a fatal poll error.
+///
+/// The harness removes each command once it has seen the matching event, and
+/// that removal races every poll tick that has already inspected the file.
+/// Before the vanish tolerance the consume sequence turned the loser of that
+/// race into an error, which propagates out of the accept loop and kills the
+/// server -- leaving the harness waiting out its whole budget on a producer
+/// that no longer exists.
+#[test]
+fn a_command_removed_mid_consume_never_kills_the_poll_loop() {
+    const ROUNDS: usize = 4_096;
+
+    let (_temporary, control) = test_qualification_control();
+    let command_path = control
+        .directory
+        .join(format!("{}.command.json", control.nonce));
+    let round = AtomicUsize::new(0);
+    let removed = AtomicUsize::new(0);
+    let stop = AtomicBool::new(false);
+    let consumed = AtomicUsize::new(0);
+    let absent = AtomicUsize::new(0);
+
+    thread::scope(|scope| {
+        let remover_path = command_path.clone();
+        let remover = &round;
+        let acknowledged = &removed;
+        let halt = &stop;
+        scope.spawn(move || {
+            let mut seen = 0;
+            loop {
+                let mut waited = 0_u32;
+                while remover.load(Ordering::Acquire) == seen {
+                    if halt.load(Ordering::Acquire) {
+                        return;
+                    }
+                    // Spin to keep the handshake tight enough to land inside a
+                    // consume, but yield periodically so a single-core host
+                    // still makes progress.
+                    waited = waited.wrapping_add(1);
+                    if waited.is_multiple_of(1_024) {
+                        thread::yield_now();
+                    } else {
+                        std::hint::spin_loop();
+                    }
+                }
+                seen = remover.load(Ordering::Acquire);
+                // Sweep the removal across the whole consume sequence and past
+                // its end, so across the run it lands before the first stat,
+                // between the stat and the open, while the handle is open, and
+                // after the consume has already finished.
+                for _ in 0..((seen % 512) * 64) {
+                    std::hint::spin_loop();
+                }
+                let _ = fs::remove_file(&remover_path);
+                acknowledged.store(seen, Ordering::Release);
+            }
+        });
+
+        for index in 1..=ROUNDS {
+            write_private_command(&command_path, b"{\"schema_version\":1}");
+            round.store(index, Ordering::Release);
+            match read_server_qualification_command(&control) {
+                Ok(Some(_)) => {
+                    consumed.fetch_add(1, Ordering::Release);
+                }
+                Ok(None) => {
+                    absent.fetch_add(1, Ordering::Release);
+                }
+                Err(error) => {
+                    stop.store(true, Ordering::Release);
+                    panic!("round {index} killed the poll loop: {error:#}");
+                }
+            }
+            let mut waited = 0_u32;
+            while removed.load(Ordering::Acquire) != index {
+                waited = waited.wrapping_add(1);
+                if waited.is_multiple_of(1_024) {
+                    thread::yield_now();
+                } else {
+                    std::hint::spin_loop();
+                }
+            }
+            let _ = fs::remove_file(&command_path);
+        }
+        stop.store(true, Ordering::Release);
+        round.fetch_add(1, Ordering::Release);
+    });
+
+    assert!(
+        consumed.load(Ordering::Acquire) > 0,
+        "the race never let one command through, so nothing was consumed"
+    );
+    assert!(
+        absent.load(Ordering::Acquire) > 0,
+        "the race never removed a command in time, so the tolerance was untested"
+    );
+}
+
+/// The vanish tolerance must not become "ignore every filesystem error".
+///
+/// A command that is present but unreadable is a real control-plane failure:
+/// tolerating it would convert the poll loop's genuine faults into silent
+/// waits, which is worse than the crash the tolerance removes.
+#[cfg(unix)]
+#[test]
+fn a_present_but_unreadable_command_still_stops_the_server() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if unsafe { libc::geteuid() } == 0 {
+        // Root ignores the mode, so this host cannot produce the denial.
+        return;
+    }
+    let (_temporary, control) = test_qualification_control();
+    let command_path = control
+        .directory
+        .join(format!("{}.command.json", control.nonce));
+    write_private_command(&command_path, b"{\"schema_version\":1}");
+    // Still owner-only and still exactly one link, so only the read is denied.
+    fs::set_permissions(&command_path, fs::Permissions::from_mode(0o000))
+        .expect("deny reads on a present command");
+    let error = read_server_qualification_command(&control)
+        .expect_err("an unreadable present command is not a vanished command");
+    assert!(
+        format!("{error:#}").contains("open embedding qualification command"),
+        "unexpected error: {error:#}"
+    );
+}
+
+/// A Windows `ACCESS_DENIED` is only evidence of a removal in progress for as
+/// long as a delete-pending entry could plausibly last.
+///
+/// The tolerance cannot distinguish a delete-pending entry from a file whose
+/// ACL simply refuses the open, so an unbounded tolerance would skip a genuinely
+/// unreadable command on every tick forever -- reproducing, inside the server,
+/// exactly the unattributable multi-minute hang this lane exists to remove. The
+/// bound is driven directly here because no Unix host can produce the Windows
+/// observation that feeds it.
+#[test]
+fn a_denial_that_outlives_a_delete_pending_entry_stops_the_server() {
+    let (_temporary, control) = test_qualification_control();
+    for tick in 1..=MAX_DENIED_COMMAND_TICKS {
+        assert!(
+            absent_command(&control, CommandAbsence::Denied)
+                .unwrap_or_else(|error| panic!("denied tick {tick} was not tolerated: {error:#}"))
+                .is_none(),
+            "a denied tick produced a command"
+        );
+    }
+    let error = absent_command(&control, CommandAbsence::Denied)
+        .expect_err("a denial past the bound is not a removal in progress");
+    assert!(
+        format!("{error:#}").contains("embedding_qualification_command_denied"),
+        "unexpected error: {error:#}"
+    );
+
+    // A proven removal is the ordinary case and must clear the run, so routine
+    // command cleanup can never accumulate its way into that failure however
+    // many times it races a poll tick.
+    for round in 1..=3 {
+        absent_command(&control, CommandAbsence::Removed).expect("a removal is never a failure");
+        for tick in 1..=MAX_DENIED_COMMAND_TICKS {
+            absent_command(&control, CommandAbsence::Denied).unwrap_or_else(|error| {
+                panic!("round {round} tick {tick} outlived a reset run: {error:#}")
+            });
+        }
+    }
+}
+
+/// A different file substituted at the pinned path is a substitution, not a
+/// vanish, and must still stop the server.
+#[test]
+fn a_non_file_at_the_pinned_command_path_still_stops_the_server() {
+    let (_temporary, control) = test_qualification_control();
+    let command_path = control
+        .directory
+        .join(format!("{}.command.json", control.nonce));
+    fs::create_dir(&command_path).expect("directory at the pinned command path");
+    let error = read_server_qualification_command(&control)
+        .expect_err("a directory is not a vanished command");
+    assert!(
+        format!("{error:#}").contains("embedding_qualification_file_untrusted"),
+        "unexpected error: {error:#}"
+    );
+}
+
+/// The Windows removal the proof harness actually performs must read as "no
+/// command this tick" whichever way the filesystem answers it.
+///
+/// `os.unlink` calls `DeleteFileW`, and what that leaves behind is not the same
+/// on every host. Measured on the Windows proof host (Windows 11 build
+/// 26200.8894, NTFS, `C:`): `DeleteFileW` takes POSIX delete semantics, so the
+/// name is unlinked at once and every later observation -- `symlink_metadata`,
+/// the attributes-only open native path identity performs, and a read open --
+/// answers `NotFound`. On a volume or Windows version without POSIX delete the
+/// classic behaviour applies instead: the entry stays visible and delete-pending
+/// while a handle is open, and answers those same opens with `ACCESS_DENIED`.
+///
+/// Both are the writer taking its command back, so this asserts the outcome and
+/// records the regime rather than assuming one of them. Assuming the classic
+/// regime is what an earlier version of this test did, and on the measured host
+/// that assumption is simply false.
+#[cfg(windows)]
+#[test]
+fn a_removed_command_never_kills_the_poll_loop_on_windows() {
+    use std::os::windows::ffi::OsStrExt;
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn DeleteFileW(file_name: *const u16) -> i32;
+    }
+
+    let (_temporary, control) = test_qualification_control();
+    let command_path = control
+        .directory
+        .join(format!("{}.command.json", control.nonce));
+    write_private_command(&command_path, b"{\"schema_version\":1}");
+    // Hold the command open across the removal, which is the state a poll tick
+    // that has already opened the file is in when the harness takes it back.
+    let held = fs::File::open(&command_path).expect("hold the command open");
+    let wide: Vec<u16> = command_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // Exactly the call `os.unlink` makes, not std's remove_file, so the test
+    // observes whatever the harness itself produces on this host.
+    assert_ne!(
+        unsafe { DeleteFileW(wide.as_ptr()) },
+        0,
+        "DeleteFileW failed: {}",
+        std::io::Error::last_os_error()
+    );
+    let regime = match fs::symlink_metadata(&command_path) {
+        Ok(_) => "delete-pending: the entry is still visible",
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            "posix delete: the name was unlinked at once"
+        }
+        Err(error) => panic!("unexpected observation after DeleteFileW: {error:?}"),
+    };
+    assert!(
+        read_server_qualification_command(&control)
+            .unwrap_or_else(|error| panic!("{regime} was a fatal poll error: {error:#}"))
+            .is_none(),
+        "{regime} must read as no command this tick"
+    );
+    drop(held);
+}
 
 #[cfg(unix)]
 #[test]


### PR DESCRIPTION
The Windows control wait now carries a liveness probe, so a producer that exits fails fast and attributably instead of burning 900s on an uninformative timeout. The argument is keyword-only with no default, and an AST-walking self-test asserts no call site can omit it — an *optional* liveness argument is precisely what produced this defect. Alongside it, the server's command poll tolerates a command file that vanishes mid-consume, bounded so it cannot become the hang this lane exists to remove.

**Two findings from measuring on the real hosts rather than reasoning, both contradicting the premise this lane started from:**

1. **`DeleteFileW` takes POSIX delete semantics on Windows 11 / NTFS.** The lane began from the standard claim that unlinking a held-open file leaves a delete-pending entry answering `ACCESS_DENIED`. Measured on the actual amd64 proof host: the name unlinks immediately, and `symlink_metadata`, the attributes-only identity open, and a plain read open all answer `NotFound`. The previously-written Windows test asserted the opposite and would have failed the moment it could compile. It now records which regime the host is in, asserts the property that holds in both, and passes there. The `PermissionDenied` tolerance is re-documented honestly as a compatibility guard (older Windows, FAT/exFAT, network filesystems), not as the measured behaviour of the proof host.

2. **The fourth losing step fires first, and on Unix.** Unlinking a held-open command file drops the handle's `nlink` to 0, and the metadata gate treated `nlink != 1` as `embedding_qualification_file_untrusted` — a security-flavoured verdict on a file that was merely gone. Tolerance is scoped to `nlink == 0` only, leaving the hard-link guard the gate exists for intact.

**Also fixes a pre-existing break this branch is the first to expose:** `cargo test -p codestory-retrieval --lib` does not compile on Windows at `dev` — `tests/qualification.rs` calls `native_path_identity`, which is `pub(super)` in another module and never imported. Windows-gated tests in this crate have therefore never run. Confirmed both by rustc on the Windows host and by inspection of the base commit.

**What this does NOT do, deliberately not softened:** sequence 1 — where the calibration run actually died — remains unattributable. Its producer is an `UnobservedProducer` whose `exited()` is a constant false, so the probe cannot name an exit there; it stops the gap from being silent, nothing more. No attribution claim is made for that run. Sequence 2's pinned server became an `ObservationalProducer` so its exit can no longer fail that wait — an accepted trade, because the CLI transport spawns a replacement that answers the same command file, and the stricter form would have hard-failed runs the proof accepts today.

Verified: full `codestory-retrieval` suite on macOS (224 lib + integration), 30× repeat of the qualification tests with no flakiness, clippy clean under `-D warnings`, packaged self-test green, and revert-proofs for every new behaviour — two executed on the amd64 Linux host (live zombie-process classification, impossible on macOS) and two on the amd64 Windows host.

Non-blocking follow-ups from review: `jsonl_log_state` dies with a raw `UnicodeDecodeError` on non-UTF-8 logs; the `MAX_DENIED_COMMAND_TICKS` doc converts ticks to wall-clock in a way only true for an idle server; the classifier's sharing-violation case asserts `ResourceBusy` rather than the mapped variant; the fail-closed property is still proven only through the Unix filesystem path.

Closes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
