### PR TITLE
establish embedding-server residency before the first fault control

### DIFF
--- a/.github/scripts/packaged_agent_proof/foundation.py
+++ b/.github/scripts/packaged_agent_proof/foundation.py
@@ -38,6 +38,25 @@ QUALIFICATION_SCHEMA_VERSION = 1
 # inner EmbeddingQualificationResult contract.
 EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION = 2
 NATIVE_SERVER_TEARDOWN_GRACE_MS = 60_000
+# The product's frozen per-user embedding server idle timeout, mirrored so a
+# harness wait can be bounded by the budget that actually governs the server it
+# waits on. This is not a competing source of truth: the packaged proof marker
+# is verified to carry exactly this value in `native_contract_identity`, the
+# frozen constant set declares it, and the self-test pins this constant to that
+# declaration. It is mirrored here, never chosen here, and it must never be
+# changed to make a proof pass -- it is hashed into `constant_set_sha256` and
+# `measurement_protocol_sha256`, and `true_idle_exit` measures it.
+PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS = 60_000
+# A resident server consumes a qualification control at the top of its accept
+# loop, one 25ms poll at a time, so it answers in milliseconds. A control still
+# unanswered after the idle timeout plus this grace therefore has no resident
+# server to answer it and never will: the wait is deadlocked, not slow. Spending
+# the whole proof budget on it turns a deterministic deadlock into an anonymous
+# half-hour timeout, which is exactly what this defect cost to diagnose.
+SERVER_QUALIFICATION_CONTROL_GRACE_MS = 30_000
+SERVER_QUALIFICATION_CONTROL_TIMEOUT_SECS = (
+    PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS + SERVER_QUALIFICATION_CONTROL_GRACE_MS
+) // 1000
 PUBLICATION_FAULT_EVIDENCE_CONTRACT = "codestory-publication-lease-fault/v1"
 FAULT_RECOVERY_CONSISTENCY_CONTRACT = "codestory-fault-recovery-search-consistency/v1"
 RETRIEVAL_QUALITY_EVIDENCE_CONTRACT = "publishable-three-repeat-packet/v1"

--- a/.github/scripts/packaged_agent_proof/publication_fault_run.py
+++ b/.github/scripts/packaged_agent_proof/publication_fault_run.py
@@ -118,7 +118,11 @@ def _run_fault(
         sequence=1,
         action="snapshot",
         timeout=control_timeout,
-        establish=lambda: ensure_resident_qualification_server(
+        # Each attempt writes its own worker request and output. The worker
+        # refuses to overwrite an existing output, so a shared label would make
+        # the tolerated respawn unrunnable -- the replacement would die before
+        # it started, and the run would report that instead of the lost server.
+        establish=lambda attempt: ensure_resident_qualification_server(
             cli,
             env,
             fixture.project,
@@ -127,7 +131,7 @@ def _run_fault(
             executable_sha256=executable_sha256,
             timeout=timeout,
             activity="answering the first control of this publication fault run",
-            label="fault-residency",
+            label=f"fault-residency-{attempt}",
         ),
     )
     resident_server = server_producer_from_control_event(
@@ -160,16 +164,23 @@ def _run_fault(
             producer=candidate_producer,
         )
         # This control's residency comes from the candidate itself: it embedded
-        # the mutated fixture and is now paused at the manifest fence, so the
-        # server's idle window restarted moments ago. Re-establishing residency
-        # here would put an extra admitted request inside the fault window this
-        # step exists to observe, so it is deliberately not done.
+        # the mutated fixture on its way to the manifest fence, so the server's
+        # idle window restarted during that work. Re-establishing residency here
+        # would put an extra admitted request inside the fault window this step
+        # exists to observe, so it is deliberately not done.
         #
-        # The pinned predecessor is therefore reported as state, never as cause:
-        # sequence 2's whole purpose is to end that server, and a replacement
-        # reads the same pinned command file. Only the candidate process --
-        # which nothing replaces -- can fail this wait, and the control budget
-        # bounds it either way.
+        # That is a judgement, not a bound. Nothing here measures the interval
+        # between the candidate's last embed and the fence, and on a host where
+        # one packaged CLI invocation costs the better part of a minute it is
+        # not comfortably inside the 60s budget. The residual risk is accepted
+        # rather than hidden: the control budget turns it into a fast, named
+        # timeout instead of the half hour of anonymous silence that made this
+        # class of failure so expensive to diagnose.
+        #
+        # The pinned predecessor is reported as state, never as cause: sequence
+        # 2's whole purpose is to end that server, so its exit proves nothing
+        # about this wait. Only the candidate process -- which nothing replaces
+        # -- can fail it.
         send_server_qualification_control(
             private_root,
             nonce,

--- a/.github/scripts/packaged_agent_proof/publication_fault_run.py
+++ b/.github/scripts/packaged_agent_proof/publication_fault_run.py
@@ -24,8 +24,11 @@ from .publication_fault_types import (
 )
 from .publication_protocol import (
     SERVER_PRODUCER_LABEL,
+    control_timeout_secs,
+    ensure_resident_qualification_server,
     read_jsonl,
     run_publication_replacement_worker,
+    send_control_to_resident_server,
     send_server_qualification_control,
     server_producer_from_control_event,
     wait_for_jsonl_event,
@@ -93,25 +96,38 @@ def _run_fault(
     executable_sha256: str,
     timeout: int,
 ) -> PublicationFaultRun:
-    # Nothing in this harness keeps a resident server warm across the baseline
-    # publication, and no control of this run has been answered yet, so the
-    # first snapshot has no process to pin. This does not make a server that
-    # idled out attributable -- an unobserved producer can never name an exit --
-    # but it does stop the gap from being silent: a timeout here reports how far
-    # the event log actually got and states that no liveness could be observed,
-    # instead of only that a record never arrived.
-    snapshot_before = send_server_qualification_control(
+    # The baseline publication embeds once, at its very start, and then spends
+    # the rest of its time in packaged CLI invocations that do no embedding at
+    # all. By the time this run's first control is written, that gap has already
+    # exceeded the server's frozen 60s idle budget on a slow host -- 703s on the
+    # Windows calibration cell against a 3.9s gap on Linux -- so the server that
+    # served the baseline has correctly exited, no process is left to consume
+    # the command file, and writing one starts nothing. The wait was therefore
+    # deadlocked, not slow, and burned the whole proof budget every time.
+    #
+    # The harness owes this residency, not the product: idle exit releases the
+    # resident model, is a frozen contract value, and is itself the subject of
+    # the `true_idle_exit` measurement, so extending it to survive a harness
+    # phase would corrupt the constant it measures. One admitted query
+    # establishes residency by construction on every platform, and pins the
+    # exact server that will answer.
+    control_timeout = control_timeout_secs(timeout)
+    snapshot_before = send_control_to_resident_server(
         private_root,
         nonce,
         sequence=1,
         action="snapshot",
-        timeout=timeout,
-        producer=UnobservedProducer(
-            SERVER_PRODUCER_LABEL,
-            "answering the first control of this publication fault run",
-            "has not identified itself in this run: no control has been answered"
-            " yet, so it may never have started for this fault run or may have"
-            " already exited after the baseline publication",
+        timeout=control_timeout,
+        establish=lambda: ensure_resident_qualification_server(
+            cli,
+            env,
+            fixture.project,
+            private_root,
+            nonce,
+            executable_sha256=executable_sha256,
+            timeout=timeout,
+            activity="answering the first control of this publication fault run",
+            label="fault-residency",
         ),
     )
     resident_server = server_producer_from_control_event(
@@ -143,18 +159,23 @@ def _run_fault(
             awaited="the publication hook pause_before_manifest_commit event",
             producer=candidate_producer,
         )
-        # The pinned server's exit does not prove this control will go
-        # unanswered: the CLI transport starts a replacement embedding server on
-        # demand, and a replacement reads the same pinned command file. Failing
-        # the wait on that exit would reject runs the proof accepts today, so
-        # the predecessor is reported as state and only the candidate process --
-        # which nothing replaces -- can fail this wait.
+        # This control's residency comes from the candidate itself: it embedded
+        # the mutated fixture and is now paused at the manifest fence, so the
+        # server's idle window restarted moments ago. Re-establishing residency
+        # here would put an extra admitted request inside the fault window this
+        # step exists to observe, so it is deliberately not done.
+        #
+        # The pinned predecessor is therefore reported as state, never as cause:
+        # sequence 2's whole purpose is to end that server, and a replacement
+        # reads the same pinned command file. Only the candidate process --
+        # which nothing replaces -- can fail this wait, and the control budget
+        # bounds it either way.
         send_server_qualification_control(
             private_root,
             nonce,
             sequence=2,
             action="crash_server",
-            timeout=timeout,
+            timeout=control_timeout,
             producer=ProducerGroup(
                 [
                     ObservationalProducer(
@@ -183,7 +204,7 @@ def _run_fault(
             nonce,
             sequence=3,
             action="snapshot",
-            timeout=timeout,
+            timeout=control_timeout,
             producer=ProducerGroup(
                 [
                     UnobservedProducer(

--- a/.github/scripts/packaged_agent_proof/publication_protocol.py
+++ b/.github/scripts/packaged_agent_proof/publication_protocol.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import time
 from pathlib import Path
 
@@ -22,12 +23,25 @@ from .event_producer_liveness import (
 )
 from .foundation import (
     EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION,
+    SERVER_QUALIFICATION_CONTROL_TIMEOUT_SECS,
     ProofFailure,
     require,
 )
 from .subprocess_control import json_command, run
 
 SERVER_PRODUCER_LABEL = "the per-user embedding qualification server"
+_WORKER_LABEL = re.compile(r"^[a-z][a-z0-9-]{0,31}$")
+
+
+def control_timeout_secs(timeout: int) -> int:
+    """The budget one qualification control may spend, never the proof budget.
+
+    A control is answered by a resident server in milliseconds, so the only
+    thing a longer wait can buy is a slower report of a server that is not
+    there. The proof budget is still honoured as a ceiling: a self-test or a
+    caller running on a shorter budget never gets a longer one from here.
+    """
+    return max(1, min(timeout, SERVER_QUALIFICATION_CONTROL_TIMEOUT_SECS))
 
 
 def read_jsonl(path: Path) -> list[dict]:
@@ -124,7 +138,17 @@ def wait_for_jsonl_event(
 
 def server_producer_from_control_event(event: dict, activity: str) -> EventProducer:
     """Pin the exact server process that answered one control, when it named it."""
-    snapshot = event.get("snapshot")
+    return server_producer_from_snapshot(event.get("snapshot"), activity)
+
+
+def server_producer_from_snapshot(snapshot: object, activity: str) -> EventProducer:
+    """Pin the exact server a snapshot names, from a control event or a worker.
+
+    A control event and an embedding worker's ``final_snapshot`` carry the same
+    ``EmbeddingServerSnapshot``, so both pin the same way. A snapshot without an
+    exact process identity degrades to a producer that states the gap rather
+    than to a pin that could name the wrong process.
+    """
     process = snapshot.get("process") if isinstance(snapshot, dict) else None
     pid = process.get("pid") if isinstance(process, dict) else None
     process_start_id = (
@@ -140,8 +164,8 @@ def server_producer_from_control_event(event: dict, activity: str) -> EventProdu
         return UnobservedProducer(
             SERVER_PRODUCER_LABEL,
             activity,
-            "did not report an exact process identity in its control event,"
-            " so its liveness cannot be pinned",
+            "did not report an exact process identity in the snapshot that named"
+            " it, so its liveness cannot be pinned",
         )
     return NativeProcessProducer(
         pid,
@@ -338,7 +362,7 @@ def run_quality_search(
     return rank, output_sha256
 
 
-def run_publication_replacement_worker(
+def run_embedding_qualification_query_worker(
     cli: Path,
     env: dict[str, str],
     project: Path,
@@ -347,13 +371,30 @@ def run_publication_replacement_worker(
     *,
     executable_sha256: str,
     timeout: int,
-) -> None:
+    label: str,
+) -> dict:
+    """Complete exactly one admitted embedding query, and return its result.
+
+    This is the harness's only way to make the product do real embedding work on
+    demand, and therefore its only way to establish or renew server residency:
+    an admitted request is what restarts the server's idle window. Observing a
+    server does not, and must not -- ``true_idle_respawn`` asserts that the idle
+    epoch never moves under observation, so an observer that extended the
+    observed lifetime would corrupt the very constant being measured.
+
+    ``label`` separates one caller's request and output files from another's, so
+    two callers in the same run never read each other's evidence.
+    """
+    require(
+        isinstance(label, str) and _WORKER_LABEL.fullmatch(label) is not None,
+        f"embedding qualification worker label is unusable: {label!r}",
+    )
     executable_sha256 = require_sha256(
         executable_sha256,
-        "publication replacement worker executable sha256",
+        f"publication {label} worker executable sha256",
     )
-    request_path = private_root / "publication-replacement-worker-request.json"
-    output_path = private_root / "publication-replacement-worker-output.json"
+    request_path = private_root / f"publication-{label}-worker-request.json"
+    output_path = private_root / f"publication-{label}-worker-output.json"
     write_private_json(
         request_path,
         {
@@ -386,13 +427,13 @@ def run_publication_replacement_worker(
     )
     require(
         output_path.is_file() and not output_path.is_symlink(),
-        "publication replacement worker omitted its output",
+        f"publication {label} worker omitted its output",
     )
     try:
         output = json.loads(output_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise ProofFailure(
-            f"publication replacement worker output is not valid JSON: {exc}"
+            f"publication {label} worker output is not valid JSON: {exc}"
         ) from exc
     require(
         isinstance(output, dict)
@@ -400,7 +441,7 @@ def run_publication_replacement_worker(
         == EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION
         and output.get("executable_sha256") == executable_sha256
         and output.get("error") is None,
-        "publication replacement worker failed",
+        f"publication {label} worker failed",
     )
     result = output.get("result")
     operations = result.get("operations") if isinstance(result, dict) else None
@@ -414,5 +455,132 @@ def run_publication_replacement_worker(
         and len(operations) == 1
         and operations[0].get("status") == "ok"
         and operations[0].get("error_code") is None,
-        "publication replacement worker did not complete its query",
+        f"publication {label} worker did not complete its query",
     )
+    return result
+
+
+def run_publication_replacement_worker(
+    cli: Path,
+    env: dict[str, str],
+    project: Path,
+    private_root: Path,
+    nonce: str,
+    *,
+    executable_sha256: str,
+    timeout: int,
+) -> None:
+    """Start the server that replaces the one sequence 2 crashed on purpose.
+
+    Same primitive as establishing residency -- one admitted query -- under the
+    name the post-crash step calls it by, and with its own request and output
+    files so the two never read each other's evidence.
+    """
+    run_embedding_qualification_query_worker(
+        cli,
+        env,
+        project,
+        private_root,
+        nonce,
+        executable_sha256=executable_sha256,
+        timeout=timeout,
+        label="replacement",
+    )
+
+
+def ensure_resident_qualification_server(
+    cli: Path,
+    env: dict[str, str],
+    project: Path,
+    private_root: Path,
+    nonce: str,
+    *,
+    executable_sha256: str,
+    timeout: int,
+    activity: str,
+    label: str,
+) -> EventProducer:
+    """Make a server resident for the control about to be issued, and pin it.
+
+    Residency is not something a control can ask for. The server exits on
+    ``true_idle`` after its frozen 60s budget, a control poll deliberately does
+    not restart that window, and writing a command file starts no process, so a
+    control issued into a gap longer than the budget waits for a process that
+    already exited and never returns. That is correct product behaviour: idle
+    exit releases the resident model and is itself a measured constant. The
+    harness, not the product, owes the residency it depends on.
+
+    One admitted query establishes it, and the worker's ``final_snapshot`` then
+    names the exact server that will answer, so an exit during the control is
+    attributable instead of anonymous.
+    """
+    result = run_embedding_qualification_query_worker(
+        cli,
+        env,
+        project,
+        private_root,
+        nonce,
+        executable_sha256=executable_sha256,
+        timeout=timeout,
+        label=label,
+    )
+    return server_producer_from_snapshot(result.get("final_snapshot"), activity)
+
+
+def send_control_to_resident_server(
+    directory: Path,
+    nonce: str,
+    *,
+    sequence: int,
+    action: str,
+    timeout: int,
+    establish,
+) -> dict:
+    """Issue one control against a server this harness proved resident first.
+
+    Establishing residency removes the deadlock; tolerating one respawn keeps
+    the removal honest. A server may still exit between the establishing query
+    and the control -- that is legitimate, measured product behaviour, and
+    failing the run on it would reject correct product conduct. So a pinned exit
+    costs exactly one re-establishment and one re-issued control, never an
+    unbounded retry loop and never a silent pass: a second loss fails closed and
+    names both servers.
+
+    ``establish`` returns the pinned producer for the server it made resident,
+    so the wait it guards fails in seconds with a named process instead of
+    spending its budget on anonymous silence.
+    """
+    producer = establish()
+    try:
+        return send_server_qualification_control(
+            directory,
+            nonce,
+            sequence=sequence,
+            action=action,
+            timeout=timeout,
+            producer=producer,
+        )
+    except ProofFailure as first_failure:
+        if not producer.exited():
+            # The established server is still running, so this failure is the
+            # control's own answer -- a rejected action, a stale command file, a
+            # torn log -- and re-issuing it would only hide it.
+            raise
+        lost = f"{producer.label} {producer.termination()}"
+        first = str(first_failure)
+    replacement = establish()
+    try:
+        return send_server_qualification_control(
+            directory,
+            nonce,
+            sequence=sequence,
+            action=action,
+            timeout=timeout,
+            producer=replacement,
+        )
+    except ProofFailure as second_failure:
+        raise ProofFailure(
+            f"embedding qualification control sequence={sequence} action={action}"
+            f" lost its resident server twice: {lost} ({first}); its replacement"
+            f" then failed the same control ({second_failure})"
+        ) from second_failure

--- a/.github/scripts/packaged_agent_proof/publication_protocol.py
+++ b/.github/scripts/packaged_agent_proof/publication_protocol.py
@@ -383,7 +383,13 @@ def run_embedding_qualification_query_worker(
     observed lifetime would corrupt the very constant being measured.
 
     ``label`` separates one caller's request and output files from another's, so
-    two callers in the same run never read each other's evidence.
+    two callers in the same run never read each other's evidence -- and so that
+    two invocations can both run. The worker refuses to overwrite an existing
+    output (`embedding_qualification_output_exists`), which makes a reused label
+    a one-shot: the second invocation cannot complete, whatever it was for. That
+    is checked here rather than left to the CLI so a reused label is reported as
+    the harness defect it is, at the caller that reused it, instead of as an
+    opaque non-zero exit from a command that never got to run.
     """
     require(
         isinstance(label, str) and _WORKER_LABEL.fullmatch(label) is not None,
@@ -395,6 +401,13 @@ def run_embedding_qualification_query_worker(
     )
     request_path = private_root / f"publication-{label}-worker-request.json"
     output_path = private_root / f"publication-{label}-worker-output.json"
+    require(
+        not output_path.exists() and not output_path.is_symlink(),
+        f"embedding qualification worker label {label!r} was already used in this"
+        f" run: {output_path.name} exists, and the worker refuses to overwrite an"
+        " output, so this invocation could never complete. Give each invocation"
+        " its own label instead of retrying into the previous one's evidence",
+    )
     write_private_json(
         request_path,
         {
@@ -546,11 +559,16 @@ def send_control_to_resident_server(
     unbounded retry loop and never a silent pass: a second loss fails closed and
     names both servers.
 
-    ``establish`` returns the pinned producer for the server it made resident,
-    so the wait it guards fails in seconds with a named process instead of
-    spending its budget on anonymous silence.
+    ``establish`` is called with the attempt number, 1 and then 2, and returns
+    the pinned producer for the server it made resident, so the wait it guards
+    fails in seconds with a named process instead of spending its budget on
+    anonymous silence. The attempt is not decoration: an establishing step that
+    writes evidence has to write the second attempt's evidence somewhere the
+    first attempt's does not already sit, or the tolerance this function exists
+    to provide cannot run at all. Every failure on the way is attributed to the
+    loss that started it, including a replacement that could not be established.
     """
-    producer = establish()
+    producer = establish(1)
     try:
         return send_server_qualification_control(
             directory,
@@ -568,7 +586,14 @@ def send_control_to_resident_server(
             raise
         lost = f"{producer.label} {producer.termination()}"
         first = str(first_failure)
-    replacement = establish()
+    try:
+        replacement = establish(2)
+    except ProofFailure as replacement_failure:
+        raise ProofFailure(
+            f"embedding qualification control sequence={sequence} action={action}"
+            f" lost its resident server: {lost} ({first}); no replacement server"
+            f" could be established to answer it ({replacement_failure})"
+        ) from replacement_failure
     try:
         return send_server_qualification_control(
             directory,

--- a/.github/scripts/packaged_agent_proof/self_test.py
+++ b/.github/scripts/packaged_agent_proof/self_test.py
@@ -8,6 +8,7 @@ from .self_test_managed_layout import run_managed_layout_self_tests
 from .self_test_process import run_process_self_tests
 from .self_test_producer_liveness import run_producer_liveness_self_tests
 from .self_test_qualification import run_qualification_self_tests
+from .self_test_server_idle import run_idle_boundary_self_tests
 
 
 def self_test() -> None:
@@ -15,6 +16,7 @@ def self_test() -> None:
     run_contract_self_tests()
     run_process_self_tests()
     run_producer_liveness_self_tests()
+    run_idle_boundary_self_tests()
     run_qualification_self_tests()
     run_installation_self_tests()
     run_managed_layout_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_server_idle.py
+++ b/.github/scripts/packaged_agent_proof/self_test_server_idle.py
@@ -1,10 +1,45 @@
-"""True-idle server lifecycle self-tests."""
+"""True-idle server lifecycle self-tests.
+
+Two defects live at this boundary and only one of them is the product's.
+
+The product exits on `true_idle` after its frozen 60s budget, and a control poll
+deliberately does not restart that window: `true_idle_respawn` asserts the idle
+epoch never moves under observation, and `true_idle_exit` measures the budget
+itself. Both are correct and neither may be relaxed to make a proof pass.
+
+The harness, meanwhile, used to issue the publication fault run's first control
+into a gap it never bounded -- 3.9s on Linux, 703s on Windows -- so on a slow
+host the server had correctly exited, no process was left to consume the command
+file, and writing one starts nothing. The wait was deadlocked, not slow, and
+spent the whole 1800s proof budget proving nothing. The tests below pin the
+harness side: residency is established before a control, a control is bounded by
+the budget that governs the server it waits on, and one legitimate respawn is
+tolerated while a second loss fails closed.
+"""
 
 from __future__ import annotations
 
+import ast
 import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
 
-from .foundation import ProofFailure, require
+from .event_producer_liveness import ChildProcessProducer, UnobservedProducer
+from .foundation import (
+    PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS,
+    REPOSITORY_ROOT,
+    SERVER_CONSTANT_SET,
+    SERVER_QUALIFICATION_CONTROL_TIMEOUT_SECS,
+    ProofFailure,
+    require,
+)
+from .publication_protocol import (
+    control_timeout_secs,
+    send_control_to_resident_server,
+)
 from .qualification_scenario_assertions import derive_scenario_assertions
 from .self_test_full_stack_types import ServerIdentityFixture, TrueIdleFixture
 
@@ -368,3 +403,375 @@ def run_true_idle_self_tests(server: ServerIdentityFixture) -> None:
     _materialization_binding_hostiles(fixture)
     _temporal_ordering_hostiles(fixture)
     _absence_cardinality_hostile(fixture)
+
+
+# The idle boundary the harness has to respect, as opposed to the one the
+# product measures. These budgets stand in for the real ones: the property being
+# pinned is that a control fails fast and bounded, and reproducing that must not
+# cost every `--self-test` run a real 90s wait.
+_UNREACHED_CONTROL_TIMEOUT_SECS = 30
+_ATTRIBUTION_BUDGET_SECS = 8
+# Callers whose completion proves the product did admitted embedding work, which
+# is the only thing that restarts the server's idle window. `establish` is the
+# callable `send_control_to_resident_server` is handed for exactly that purpose.
+_RESIDENCY_ESTABLISHING = {
+    "ensure_resident_qualification_server",
+    "run_embedding_qualification_query_worker",
+    "run_publication_replacement_worker",
+    "establish",
+}
+_CONTROL_SENDERS = {
+    "send_server_qualification_control",
+    "send_control_to_resident_server",
+}
+
+
+def _dead_producer(label: str) -> ChildProcessProducer:
+    process = subprocess.Popen(
+        [sys.executable, "-c", "raise SystemExit(9)"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    process.wait(timeout=60)
+    return ChildProcessProducer(process, label, "answering a self-test control")
+
+
+def _answered(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "sequence": 1,
+                "action": "snapshot",
+                "status": "completed",
+                "snapshot": {"process": {"pid": 4242, "process_start_id": "self-test"}},
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _the_control_budget_is_the_servers_own_idle_budget() -> None:
+    """A control may not outlive the server budget that decides its answer."""
+    constants = json.loads(SERVER_CONSTANT_SET.read_text(encoding="utf-8"))
+    frozen = constants.get("fixed_contract_values", {}).get("idle_timeout_ms")
+    require(
+        frozen == PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS,
+        "the harness idle timeout drifted from the frozen constant set"
+        f" ({frozen!r} vs {PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS!r}): the"
+        " harness mirrors that constant and never chooses it",
+    )
+    require(
+        SERVER_QUALIFICATION_CONTROL_TIMEOUT_SECS
+        > PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS // 1000,
+        "the control budget must outlast the idle timeout it is bounding",
+    )
+    require(
+        control_timeout_secs(1800) == SERVER_QUALIFICATION_CONTROL_TIMEOUT_SECS,
+        "a qualification control was allowed to spend the whole proof budget,"
+        " which turns a deterministic deadlock into an anonymous timeout",
+    )
+    require(
+        control_timeout_secs(5) == 5 and control_timeout_secs(0) == 1,
+        "the control budget stopped honouring a shorter proof budget",
+    )
+
+
+def _an_established_server_that_exits_is_replaced_exactly_once() -> None:
+    """A legitimate idle exit costs one respawn, never the run and never a loop."""
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-idle-boundary-self-test-"
+    ) as raw:
+        directory = Path(raw)
+        nonce = "self-test-nonce"
+        events = directory / f"{nonce}.events.jsonl"
+        attempts: list[str] = []
+
+        def establish():
+            attempts.append("established")
+            if len(attempts) == 1:
+                return _dead_producer("the self-test server that idled out")
+            _answered(events)
+            return UnobservedProducer(
+                "the self-test replacement server",
+                "answering the re-issued control",
+                "is a self-test stand-in",
+            )
+
+        started = time.monotonic()
+        event = send_control_to_resident_server(
+            directory,
+            nonce,
+            sequence=1,
+            action="snapshot",
+            timeout=_UNREACHED_CONTROL_TIMEOUT_SECS,
+            establish=establish,
+        )
+        elapsed = time.monotonic() - started
+        require(
+            event.get("sequence") == 1 and event.get("status") == "completed",
+            "a tolerated respawn lost the control it re-issued",
+        )
+        require(
+            attempts == ["established", "established"],
+            f"a lost server was re-established {len(attempts)} time(s), not once",
+        )
+        require(
+            elapsed < _ATTRIBUTION_BUDGET_SECS,
+            f"a lost server burned {elapsed:.1f}s before its replacement was"
+            " established, instead of failing its wait fast",
+        )
+        require(
+            not (directory / f"{nonce}.command.json").exists(),
+            "a re-issued control left a command file behind",
+        )
+
+
+def _a_second_lost_server_fails_closed() -> None:
+    """Tolerating a respawn must not become tolerating anything."""
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-idle-boundary-self-test-"
+    ) as raw:
+        directory = Path(raw)
+        nonce = "self-test-nonce"
+        attempts: list[str] = []
+
+        def establish():
+            attempts.append("established")
+            return _dead_producer(f"the self-test server {len(attempts)}")
+
+        started = time.monotonic()
+        try:
+            send_control_to_resident_server(
+                directory,
+                nonce,
+                sequence=1,
+                action="snapshot",
+                timeout=_UNREACHED_CONTROL_TIMEOUT_SECS,
+                establish=establish,
+            )
+        except ProofFailure as error:
+            elapsed = time.monotonic() - started
+            message = str(error)
+            require(
+                attempts == ["established", "established"],
+                f"a doomed control retried {len(attempts)} time(s) instead of"
+                " failing closed after one tolerated respawn",
+            )
+            require(
+                elapsed < _ATTRIBUTION_BUDGET_SECS,
+                f"a doomed control spent {elapsed:.1f}s before failing closed",
+            )
+            require(
+                "lost its resident server twice" in message
+                and "sequence=1 action=snapshot" in message
+                and "the self-test server 1" in message
+                and "exited with code 9" in message,
+                f"a doubly lost control did not name both servers: {message}",
+            )
+        else:
+            raise ProofFailure("a control with no server at all completed")
+
+
+def _a_live_servers_refusal_is_never_retried_away() -> None:
+    """Only a lost server earns a retry; a real answer is a real answer."""
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-idle-boundary-self-test-"
+    ) as raw:
+        directory = Path(raw)
+        nonce = "self-test-nonce"
+        (directory / f"{nonce}.events.jsonl").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "sequence": 1,
+                    "action": "snapshot",
+                    "status": "rejected",
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        attempts: list[str] = []
+
+        def establish():
+            attempts.append("established")
+            return UnobservedProducer(
+                "the self-test live server",
+                "answering the control",
+                "is a self-test stand-in that never exits",
+            )
+
+        try:
+            send_control_to_resident_server(
+                directory,
+                nonce,
+                sequence=1,
+                action="snapshot",
+                timeout=_UNREACHED_CONTROL_TIMEOUT_SECS,
+                establish=establish,
+            )
+        except ProofFailure as error:
+            require(
+                attempts == ["established"],
+                "a live server's refused control was retried, which would hide"
+                " a real product failure behind a respawn",
+            )
+            require(
+                "embedding qualification control snapshot failed" in str(error),
+                f"a refused control lost its own failure: {error}",
+            )
+        else:
+            raise ProofFailure("a refused qualification control was accepted")
+
+
+def _call_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    return getattr(node.func, "attr", None)
+
+
+def _guarded_calls(function: ast.AST) -> list[tuple[int, str, ast.Call]]:
+    """Every residency and control call in one function, in source order."""
+    marks: list[tuple[int, int, str, ast.Call]] = []
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        if name in _RESIDENCY_ESTABLISHING:
+            marks.append((node.lineno, node.col_offset, "residency", node))
+        elif name in _CONTROL_SENDERS:
+            marks.append((node.lineno, node.col_offset, "control", node))
+    return [
+        (lineno, kind, call)
+        for lineno, _column, kind, call in sorted(marks, key=lambda mark: mark[:2])
+    ]
+
+
+def _keyword(call: ast.Call, name: str) -> ast.expr | None:
+    return next(
+        (entry.value for entry in call.keywords if entry.arg == name),
+        None,
+    )
+
+
+def _establishes_its_own_residency(call: ast.Call) -> bool:
+    """A control that is handed the callable that makes a server resident.
+
+    Positional order cannot decide this one: the establishing call is written
+    inside the argument list, so it reads as "after" the control it precedes.
+    The contract is the argument itself, and the body that consumes it is
+    audited on its own terms.
+    """
+    establish = _keyword(call, "establish")
+    return establish is not None and not (
+        isinstance(establish, ast.Constant) and establish.value is None
+    )
+
+
+def _pins_a_live_producer(call: ast.Call) -> bool:
+    producer = _keyword(call, "producer")
+    if producer is None:
+        return False
+    return not any(
+        isinstance(node, ast.Name) and node.id == "UnobservedProducer"
+        for node in ast.walk(producer)
+    )
+
+
+def _every_control_is_issued_to_a_server_proven_resident() -> None:
+    """Structural guard: the assumption this lane removed cannot come back.
+
+    A control is answered only by a live server, and nothing in the control path
+    starts one -- ``send_server_qualification_control`` writes a file and polls a
+    log. So a control issued after an unbounded stretch of non-embedding work is
+    a wait on a process that may already have exited for correct reasons, and
+    the only fix available to the harness is to establish residency first.
+
+    Every control call site must therefore either follow a residency-
+    establishing call in its own function, or hold a pinned producer whose exit
+    fails the wait immediately. A site with neither is the original defect.
+    """
+    package = REPOSITORY_ROOT / ".github" / "scripts" / "packaged_agent_proof"
+    inspected = 0
+    for source in sorted(package.glob("*.py")):
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for function in ast.walk(tree):
+            if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            resident = False
+            for lineno, kind, call in _guarded_calls(function):
+                if kind == "residency":
+                    resident = True
+                    continue
+                inspected += 1
+                own = _establishes_its_own_residency(call)
+                require(
+                    resident or own or _pins_a_live_producer(call),
+                    f"{source.name}:{lineno} in {function.name} issues an"
+                    " embedding qualification control without first establishing"
+                    " server residency and without pinning a live producer, so a"
+                    " server that correctly exited on true_idle leaves the wait"
+                    " deadlocked instead of attributed",
+                )
+                resident = resident or own
+    require(
+        inspected >= 8,
+        f"the qualification control audit inspected only {inspected} call sites",
+    )
+
+
+def _the_publication_fault_run_establishes_residency_before_its_first_control() -> None:
+    """The exact site the Windows calibration cell deadlocked on."""
+    source = (
+        REPOSITORY_ROOT
+        / ".github"
+        / "scripts"
+        / "packaged_agent_proof"
+        / "publication_fault_run.py"
+    )
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    fault = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_run_fault"
+        ),
+        None,
+    )
+    require(fault is not None, "publication_fault_run lost its _run_fault owner")
+    marks = _guarded_calls(fault)
+    require(len(marks) >= 3, "the publication fault run lost its three controls")
+    first_lineno, first_kind, first_call = marks[0]
+    require(
+        first_kind == "residency" or _establishes_its_own_residency(first_call),
+        f"publication_fault_run.py:{first_lineno} issues this run's first"
+        " embedding qualification control before establishing server residency:"
+        " the baseline publication's only embedding work happens at its very"
+        " start, so on a slow host that control is written long after the"
+        " server's frozen idle budget has correctly expired, and it then waits"
+        " on a process that already exited",
+    )
+    for lineno, kind, call in marks:
+        if kind != "control":
+            continue
+        budget = _keyword(call, "timeout")
+        require(
+            isinstance(budget, ast.Name) and budget.id == "control_timeout",
+            f"publication_fault_run.py:{lineno} lets one qualification control"
+            " spend the whole proof budget instead of the budget that governs"
+            " the server answering it",
+        )
+
+
+def run_idle_boundary_self_tests() -> None:
+    _the_control_budget_is_the_servers_own_idle_budget()
+    _an_established_server_that_exits_is_replaced_exactly_once()
+    _a_second_lost_server_fails_closed()
+    _a_live_servers_refusal_is_never_retried_away()
+    _every_control_is_issued_to_a_server_proven_resident()
+    _the_publication_fault_run_establishes_residency_before_its_first_control()

--- a/.github/scripts/packaged_agent_proof/self_test_server_idle.py
+++ b/.github/scripts/packaged_agent_proof/self_test_server_idle.py
@@ -15,12 +15,20 @@ spent the whole 1800s proof budget proving nothing. The tests below pin the
 harness side: residency is established before a control, a control is bounded by
 the budget that governs the server it waits on, and one legitimate respawn is
 tolerated while a second loss fails closed.
+
+That last property is the one a stubbed test cannot see. Residency is
+established by running the embedding qualification worker, and the worker
+refuses to overwrite an existing output, so two attempts that name their
+evidence identically cannot both run -- the tolerance reads as implemented while
+being unreachable. One test therefore drives the real establishing path through
+a worker that keeps that refusal, rather than a stand-in that cannot fail on it.
 """
 
 from __future__ import annotations
 
 import ast
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -29,6 +37,7 @@ from pathlib import Path
 
 from .event_producer_liveness import ChildProcessProducer, UnobservedProducer
 from .foundation import (
+    EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION,
     PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS,
     REPOSITORY_ROOT,
     SERVER_CONSTANT_SET,
@@ -37,7 +46,9 @@ from .foundation import (
     require,
 )
 from .publication_protocol import (
+    SERVER_PRODUCER_LABEL,
     control_timeout_secs,
+    ensure_resident_qualification_server,
     send_control_to_resident_server,
 )
 from .qualification_scenario_assertions import derive_scenario_assertions
@@ -411,6 +422,7 @@ def run_true_idle_self_tests(server: ServerIdentityFixture) -> None:
 # cost every `--self-test` run a real 90s wait.
 _UNREACHED_CONTROL_TIMEOUT_SECS = 30
 _ATTRIBUTION_BUDGET_SECS = 8
+_SELF_TEST_NONCE = "self-test-nonce"
 # Callers whose completion proves the product did admitted embedding work, which
 # is the only thing that restarts the server's idle window. `establish` is the
 # callable `send_control_to_resident_server` is handed for exactly that purpose.
@@ -424,6 +436,13 @@ _CONTROL_SENDERS = {
     "send_server_qualification_control",
     "send_control_to_resident_server",
 }
+# Producers that hold a real handle on a real process, so their `exited()` can
+# fail a wait. Everything else in `event_producer_liveness` answers "not exited"
+# forever by design.
+_PINNING_PRODUCERS = {
+    "ChildProcessProducer",
+    "NativeProcessProducer",
+}
 
 
 def _dead_producer(label: str) -> ChildProcessProducer:
@@ -435,6 +454,116 @@ def _dead_producer(label: str) -> ChildProcessProducer:
     )
     process.wait(timeout=60)
     return ChildProcessProducer(process, label, "answering a self-test control")
+
+
+def _reaped_pid() -> int:
+    """A pid that is provably not a live server, on every proof platform.
+
+    ``NativeProcessProducer`` reports this pid as gone whichever way the host
+    answers: the process is reaped, so Linux has no ``/proc`` entry, macOS
+    ``proc_pidinfo`` and Windows ``OpenProcess`` both fail outright, and a
+    recycled pid answers with a start identity that cannot match the pinned
+    one. No branch of that probe can call it running.
+    """
+    process = subprocess.Popen([sys.executable, "-c", "raise SystemExit(0)"])
+    process.wait(timeout=60)
+    return process.pid
+
+
+# A stand-in for `codestory-cli internal-embedding-qualification-worker`, with
+# the one clause of the real worker that decides whether a tolerated respawn can
+# run at all: it refuses to overwrite an existing output rather than reuse it
+# (`embedding_qualification_output_exists`, worker.rs). A respawn test that
+# stubs the establishing callable instead of the worker cannot see that clause,
+# and would pass over a replacement that could never be established.
+_WORKER_STUB = '''\
+import json
+import os
+import sys
+from pathlib import Path
+
+argv = sys.argv[1:]
+if not argv or argv[0] != "internal-embedding-qualification-worker":
+    sys.stderr.write("unexpected subcommand: " + " ".join(argv) + "\\n")
+    raise SystemExit(2)
+request_path = Path(argv[argv.index("--request") + 1])
+output_path = Path(argv[argv.index("--output") + 1])
+if output_path.exists():
+    sys.stderr.write("embedding_qualification_output_exists\\n")
+    raise SystemExit(1)
+request = json.loads(request_path.read_text(encoding="utf-8"))
+counter = Path(os.environ["SELF_TEST_WORKER_INVOCATIONS"])
+invocation = 1 + (
+    json.loads(counter.read_text(encoding="utf-8")) if counter.exists() else 0
+)
+counter.write_text(json.dumps(invocation), encoding="utf-8")
+if os.environ.get("SELF_TEST_FAIL_INVOCATION") == str(invocation):
+    sys.stderr.write("self_test_worker_refused\\n")
+    raise SystemExit(3)
+if invocation == 1:
+    # The server this query made resident then exits on true_idle before the
+    # control reaches it, exactly as the frozen contract permits.
+    snapshot = {
+        "process": {
+            "pid": int(os.environ["SELF_TEST_IDLED_OUT_PID"]),
+            "process_start_id": "self-test-idled-out",
+        }
+    }
+else:
+    snapshot = {"process": None}
+    with open(os.environ["SELF_TEST_EVENTS"], "a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "sequence": 1,
+                    "action": "snapshot",
+                    "status": "completed",
+                    "snapshot": snapshot,
+                },
+                sort_keys=True,
+            )
+            + "\\n"
+        )
+output_path.write_text(
+    json.dumps(
+        {
+            "schema_version": int(os.environ["SELF_TEST_WORKER_SCHEMA_VERSION"]),
+            "executable_sha256": request["executable_sha256"],
+            "error": None,
+            "result": {
+                "schema_version": 1,
+                "scenario": "query",
+                "operations": [{"status": "ok", "error_code": None}],
+                "final_snapshot": snapshot,
+            },
+        }
+    ),
+    encoding="utf-8",
+)
+'''
+
+
+def _worker_stub_cli(directory: Path) -> Path:
+    """The stub as something the harness can invoke exactly as it invokes a CLI."""
+    script = directory / "worker-stub.py"
+    script.write_text(_WORKER_STUB, encoding="utf-8")
+    if os.name == "nt":
+        cli = directory / "worker-stub.cmd"
+        cli.write_text(
+            f'@echo off\r\n"{sys.executable}" "{script}" %*\r\n',
+            encoding="utf-8",
+        )
+        return cli
+    cli = directory / "worker-stub"
+    # `#!/bin/sh` stays inside every platform's shebang length limit; the
+    # interpreter path, which does not, lives in the body instead.
+    cli.write_text(
+        f'#!/bin/sh\nexec "{sys.executable}" "{script}" "$@"\n',
+        encoding="utf-8",
+    )
+    cli.chmod(0o700)
+    return cli
 
 
 def _answered(path: Path) -> None:
@@ -488,11 +617,11 @@ def _an_established_server_that_exits_is_replaced_exactly_once() -> None:
         directory = Path(raw)
         nonce = "self-test-nonce"
         events = directory / f"{nonce}.events.jsonl"
-        attempts: list[str] = []
+        attempts: list[int] = []
 
-        def establish():
-            attempts.append("established")
-            if len(attempts) == 1:
+        def establish(attempt: int):
+            attempts.append(attempt)
+            if attempt == 1:
                 return _dead_producer("the self-test server that idled out")
             _answered(events)
             return UnobservedProducer(
@@ -516,8 +645,9 @@ def _an_established_server_that_exits_is_replaced_exactly_once() -> None:
             "a tolerated respawn lost the control it re-issued",
         )
         require(
-            attempts == ["established", "established"],
-            f"a lost server was re-established {len(attempts)} time(s), not once",
+            attempts == [1, 2],
+            f"a lost server was re-established as {attempts}, not exactly once"
+            " under a distinguishable second attempt",
         )
         require(
             elapsed < _ATTRIBUTION_BUDGET_SECS,
@@ -537,11 +667,11 @@ def _a_second_lost_server_fails_closed() -> None:
     ) as raw:
         directory = Path(raw)
         nonce = "self-test-nonce"
-        attempts: list[str] = []
+        attempts: list[int] = []
 
-        def establish():
-            attempts.append("established")
-            return _dead_producer(f"the self-test server {len(attempts)}")
+        def establish(attempt: int):
+            attempts.append(attempt)
+            return _dead_producer(f"the self-test server {attempt}")
 
         started = time.monotonic()
         try:
@@ -557,8 +687,8 @@ def _a_second_lost_server_fails_closed() -> None:
             elapsed = time.monotonic() - started
             message = str(error)
             require(
-                attempts == ["established", "established"],
-                f"a doomed control retried {len(attempts)} time(s) instead of"
+                attempts == [1, 2],
+                f"a doomed control was established as {attempts} instead of"
                 " failing closed after one tolerated respawn",
             )
             require(
@@ -596,10 +726,10 @@ def _a_live_servers_refusal_is_never_retried_away() -> None:
             + "\n",
             encoding="utf-8",
         )
-        attempts: list[str] = []
+        attempts: list[int] = []
 
-        def establish():
-            attempts.append("established")
+        def establish(attempt: int):
+            attempts.append(attempt)
             return UnobservedProducer(
                 "the self-test live server",
                 "answering the control",
@@ -617,7 +747,7 @@ def _a_live_servers_refusal_is_never_retried_away() -> None:
             )
         except ProofFailure as error:
             require(
-                attempts == ["established"],
+                attempts == [1],
                 "a live server's refused control was retried, which would hide"
                 " a real product failure behind a respawn",
             )
@@ -629,26 +759,245 @@ def _a_live_servers_refusal_is_never_retried_away() -> None:
             raise ProofFailure("a refused qualification control was accepted")
 
 
+def _stubbed_residency(root: Path, *, fail_invocation: int | None = None):
+    """The real establishing path, wired to a worker stub instead of the CLI.
+
+    Returns the qualification directory, the stub's invocation counter, the
+    labels each attempt asked for, and the ``establish`` callable itself -- the
+    real `ensure_resident_qualification_server`, not a stand-in for it.
+    """
+    private_root = root / "qualification-suite"
+    private_root.mkdir(mode=0o700)
+    project = root / "project"
+    project.mkdir()
+    cli = _worker_stub_cli(root)
+    invocations = root / "worker-stub-invocations.json"
+    env = {
+        **os.environ,
+        "SELF_TEST_WORKER_INVOCATIONS": str(invocations),
+        "SELF_TEST_WORKER_SCHEMA_VERSION": str(
+            EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION
+        ),
+        "SELF_TEST_IDLED_OUT_PID": str(_reaped_pid()),
+        "SELF_TEST_EVENTS": str(private_root / f"{_SELF_TEST_NONCE}.events.jsonl"),
+    }
+    if fail_invocation is not None:
+        env["SELF_TEST_FAIL_INVOCATION"] = str(fail_invocation)
+    labels: list[str] = []
+
+    def establish(attempt: int):
+        labels.append(f"self-test-residency-{attempt}")
+        return ensure_resident_qualification_server(
+            cli,
+            env,
+            project,
+            private_root,
+            _SELF_TEST_NONCE,
+            executable_sha256="a" * 64,
+            timeout=_UNREACHED_CONTROL_TIMEOUT_SECS,
+            activity="answering the self-test control",
+            label=labels[-1],
+        )
+
+    return private_root, invocations, labels, establish
+
+
+def _a_respawn_runs_through_the_real_worker_primitive() -> None:
+    """The tolerated respawn has to run, not merely be written down.
+
+    The other respawn tests hand `send_control_to_resident_server` a stand-in
+    callable, which proves the control flow and nothing about the step that
+    callable stands for. Residency is established by running the embedding
+    qualification worker, and the worker refuses to overwrite an output file, so
+    a second attempt that writes where the first one wrote cannot start -- the
+    tolerance would be unreachable in production while every stubbed test still
+    passed. This drives the real `ensure_resident_qualification_server` twice,
+    through a worker that keeps that refusal, so the second attempt's evidence
+    has to land somewhere of its own for the control to complete.
+    """
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-idle-boundary-self-test-"
+    ) as raw:
+        private_root, invocations, labels, establish = _stubbed_residency(Path(raw))
+        started = time.monotonic()
+        event = send_control_to_resident_server(
+            private_root,
+            _SELF_TEST_NONCE,
+            sequence=1,
+            action="snapshot",
+            timeout=_UNREACHED_CONTROL_TIMEOUT_SECS,
+            establish=establish,
+        )
+        elapsed = time.monotonic() - started
+        require(
+            event.get("sequence") == 1 and event.get("status") == "completed",
+            "a respawn established through the real worker lost its control",
+        )
+        require(
+            labels == ["self-test-residency-1", "self-test-residency-2"],
+            f"the two residency attempts were not distinguishable: {labels}",
+        )
+        require(
+            json.loads(invocations.read_text(encoding="utf-8")) == 2,
+            "the replacement server was never actually established: the worker"
+            " that establishes residency did not run a second time",
+        )
+        for label in labels:
+            require(
+                (private_root / f"publication-{label}-worker-output.json").is_file(),
+                f"residency attempt {label} left no evidence of its own, so one"
+                " attempt overwrote or inherited the other's",
+            )
+        require(
+            elapsed < _ATTRIBUTION_BUDGET_SECS,
+            f"a lost server burned {elapsed:.1f}s before its replacement ran",
+        )
+
+
+def _a_replacement_that_cannot_be_established_names_the_loss() -> None:
+    """A replacement that never starts is still the lost server's failure.
+
+    The re-establishment happens after the first control has already failed, so
+    a failure there used to propagate as itself: an exit code from a worker,
+    with no mention of the server whose loss asked for it. The report has to
+    name what was being replaced, or it reads as an unrelated worker fault at a
+    point in the run where nobody would look for a lost server.
+    """
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-idle-boundary-self-test-"
+    ) as raw:
+        private_root, _invocations, _labels, establish = _stubbed_residency(
+            Path(raw),
+            fail_invocation=2,
+        )
+        try:
+            send_control_to_resident_server(
+                private_root,
+                _SELF_TEST_NONCE,
+                sequence=1,
+                action="snapshot",
+                timeout=_UNREACHED_CONTROL_TIMEOUT_SECS,
+                establish=establish,
+            )
+        except ProofFailure as error:
+            message = str(error)
+            require(
+                "no replacement server could be established" in message
+                and "sequence=1 action=snapshot" in message
+                and SERVER_PRODUCER_LABEL in message,
+                f"an unestablishable replacement lost its attribution: {message}",
+            )
+        else:
+            raise ProofFailure(
+                "a control whose replacement never started reported success"
+            )
+
+
+def _a_reused_worker_label_is_refused_before_the_worker_runs() -> None:
+    """The collision that would silently disarm the respawn, named at its cause."""
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-idle-boundary-self-test-"
+    ) as raw:
+        root = Path(raw)
+        private_root = root / "qualification-suite"
+        private_root.mkdir(mode=0o700)
+        (private_root / "publication-taken-worker-output.json").write_text(
+            "{}", encoding="utf-8"
+        )
+        try:
+            ensure_resident_qualification_server(
+                # Nothing here is runnable: the reuse has to be refused before
+                # the worker is invoked, so reaching the worker is the failure.
+                root / "never-invoked-cli",
+                dict(os.environ),
+                root,
+                private_root,
+                _SELF_TEST_NONCE,
+                executable_sha256="a" * 64,
+                timeout=_UNREACHED_CONTROL_TIMEOUT_SECS,
+                activity="answering a self-test control",
+                label="taken",
+            )
+        except ProofFailure as error:
+            require(
+                "was already used in this run" in str(error)
+                and "publication-taken-worker-output.json" in str(error),
+                f"a reused worker label lost its own attribution: {error}",
+            )
+        except OSError as error:
+            raise ProofFailure(
+                "a worker invocation that could never complete was allowed to"
+                f" start: the harness reached the CLI itself ({error})"
+            ) from error
+        else:
+            raise ProofFailure(
+                "a worker invocation that could never complete was allowed to start"
+            )
+
+
 def _call_name(node: ast.Call) -> str | None:
     if isinstance(node.func, ast.Name):
         return node.func.id
     return getattr(node.func, "attr", None)
 
 
-def _guarded_calls(function: ast.AST) -> list[tuple[int, str, ast.Call]]:
-    """Every residency and control call in one function, in source order."""
-    marks: list[tuple[int, int, str, ast.Call]] = []
-    for node in ast.walk(function):
-        if not isinstance(node, ast.Call):
-            continue
-        name = _call_name(node)
-        if name in _RESIDENCY_ESTABLISHING:
-            marks.append((node.lineno, node.col_offset, "residency", node))
-        elif name in _CONTROL_SENDERS:
-            marks.append((node.lineno, node.col_offset, "control", node))
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+# Fields whose contents run only on some paths through their parent. A residency
+# call inside one cannot vouch for a control outside it: an `if` that was not
+# taken, a handler that did not fire, and a loop that ran zero times all leave
+# the server exactly as absent as no call at all.
+_CONDITIONAL_FIELDS: dict[type, frozenset[str]] = {
+    ast.If: frozenset({"body", "orelse"}),
+    ast.IfExp: frozenset({"body", "orelse"}),
+    ast.While: frozenset({"body", "orelse"}),
+    ast.For: frozenset({"body", "orelse"}),
+    ast.AsyncFor: frozenset({"body", "orelse"}),
+    # `body` and `finalbody` are on every path that reaches what follows the
+    # statement; `handlers` and `orelse` are not.
+    ast.Try: frozenset({"handlers", "orelse"}),
+    ast.ExceptHandler: frozenset({"body"}),
+}
+if hasattr(ast, "TryStar"):  # pragma: no cover - version dependent
+    _CONDITIONAL_FIELDS[ast.TryStar] = frozenset({"handlers", "orelse"})
+
+
+def _guarded_calls(function: ast.AST) -> list[tuple[int, str, ast.Call, bool]]:
+    """Every residency and control call in one function body, in source order.
+
+    Each mark carries whether it is reached only on some paths. Two kinds of
+    call are excluded outright rather than marked: anything inside a nested
+    function, lambda, or class, because that body runs when its own caller runs
+    and not where it is written. The establishing callable a control is handed
+    is written exactly there, and is audited as the control's own argument.
+    """
+    marks: list[tuple[int, int, str, ast.Call, bool]] = []
+
+    def visit(node: ast.AST, *, conditional: bool) -> None:
+        if node is not function and isinstance(node, _NESTED_SCOPES):
+            return
+        if isinstance(node, ast.Call):
+            name = _call_name(node)
+            if name in _RESIDENCY_ESTABLISHING:
+                marks.append(
+                    (node.lineno, node.col_offset, "residency", node, conditional)
+                )
+            elif name in _CONTROL_SENDERS:
+                marks.append(
+                    (node.lineno, node.col_offset, "control", node, conditional)
+                )
+        branching = _CONDITIONAL_FIELDS.get(type(node), frozenset())
+        for field, value in ast.iter_fields(node):
+            children = value if isinstance(value, list) else [value]
+            for child in children:
+                if isinstance(child, ast.AST):
+                    visit(child, conditional=conditional or field in branching)
+
+    visit(function, conditional=False)
     return [
-        (lineno, kind, call)
-        for lineno, _column, kind, call in sorted(marks, key=lambda mark: mark[:2])
+        (lineno, kind, call, conditional)
+        for lineno, _column, kind, call, conditional in sorted(
+            marks, key=lambda mark: mark[:2]
+        )
     ]
 
 
@@ -666,20 +1015,64 @@ def _establishes_its_own_residency(call: ast.Call) -> bool:
     inside the argument list, so it reads as "after" the control it precedes.
     The contract is the argument itself, and the body that consumes it is
     audited on its own terms.
+
+    The argument has to name something that establishes residency. Merely being
+    present and non-``None`` would let a callable that does no embedding work --
+    ``lambda: None`` is the honest example -- satisfy the one guard standing
+    between this harness and the deadlock it just removed.
     """
     establish = _keyword(call, "establish")
-    return establish is not None and not (
-        isinstance(establish, ast.Constant) and establish.value is None
+    if establish is None:
+        return False
+    return any(
+        isinstance(node, ast.Name) and node.id in _RESIDENCY_ESTABLISHING
+        for node in ast.walk(establish)
     )
 
 
 def _pins_a_live_producer(call: ast.Call) -> bool:
+    """A producer whose exit actually fails the wait it guards.
+
+    An allowlist, not a denylist. ``UnobservedProducer`` says outright that it
+    observes nothing, and ``ObservationalProducer`` deliberately reports another
+    producer's state "without ever failing a wait on it"; both inherit
+    ``exited() -> False``, so a control holding either is exactly as deadlocked
+    as a control holding none. Naming the two producers that do pin a process
+    keeps the next non-pinning producer out by default, instead of admitting it
+    until someone remembers to exclude it here.
+    """
     producer = _keyword(call, "producer")
     if producer is None:
         return False
-    return not any(
-        isinstance(node, ast.Name) and node.id == "UnobservedProducer"
+    return any(
+        isinstance(node, ast.Name) and node.id in _PINNING_PRODUCERS
         for node in ast.walk(producer)
+    )
+
+
+def _varies_with_its_attempt(call: ast.Call) -> bool:
+    """Whether an inline establishing callable uses the attempt it is handed.
+
+    Residency is established by running the embedding qualification worker, and
+    the worker refuses to overwrite an output file. Two attempts that name their
+    evidence identically therefore cannot both run: the replacement dies on its
+    own output before it starts, and the run reports that instead of the server
+    it lost. So the attempt number has to reach the evidence, not just the
+    signature.
+
+    Only an inline lambda is decided here, which is the shape the production
+    call site uses; a named callable is a self-test stand-in that asserts the
+    same property on its own results.
+    """
+    establish = _keyword(call, "establish")
+    if not isinstance(establish, ast.Lambda):
+        return True
+    parameters = [argument.arg for argument in establish.args.args]
+    if len(parameters) != 1:
+        return False
+    return any(
+        isinstance(node, ast.Name) and node.id == parameters[0]
+        for node in ast.walk(establish.body)
     )
 
 
@@ -704,9 +1097,11 @@ def _every_control_is_issued_to_a_server_proven_resident() -> None:
             if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             resident = False
-            for lineno, kind, call in _guarded_calls(function):
+            for lineno, kind, call, conditional in _guarded_calls(function):
                 if kind == "residency":
-                    resident = True
+                    # Only a call on every path to what follows it can vouch for
+                    # a later control; a branch that may not run cannot.
+                    resident = resident or not conditional
                     continue
                 inspected += 1
                 own = _establishes_its_own_residency(call)
@@ -718,7 +1113,7 @@ def _every_control_is_issued_to_a_server_proven_resident() -> None:
                     " server that correctly exited on true_idle leaves the wait"
                     " deadlocked instead of attributed",
                 )
-                resident = resident or own
+                resident = resident or (own and not conditional)
     require(
         inspected >= 8,
         f"the qualification control audit inspected only {inspected} call sites",
@@ -746,9 +1141,10 @@ def _the_publication_fault_run_establishes_residency_before_its_first_control() 
     require(fault is not None, "publication_fault_run lost its _run_fault owner")
     marks = _guarded_calls(fault)
     require(len(marks) >= 3, "the publication fault run lost its three controls")
-    first_lineno, first_kind, first_call = marks[0]
+    first_lineno, first_kind, first_call, first_conditional = marks[0]
     require(
-        first_kind == "residency" or _establishes_its_own_residency(first_call),
+        not first_conditional
+        and (first_kind == "residency" or _establishes_its_own_residency(first_call)),
         f"publication_fault_run.py:{first_lineno} issues this run's first"
         " embedding qualification control before establishing server residency:"
         " the baseline publication's only embedding work happens at its very"
@@ -756,7 +1152,16 @@ def _the_publication_fault_run_establishes_residency_before_its_first_control() 
         " server's frozen idle budget has correctly expired, and it then waits"
         " on a process that already exited",
     )
-    for lineno, kind, call in marks:
+    require(
+        _varies_with_its_attempt(first_call),
+        f"publication_fault_run.py:{first_lineno} establishes both residency"
+        " attempts under one identity, so both would write the same worker"
+        " request and output. The worker refuses to overwrite an output, so the"
+        " replacement dies before it starts and the tolerated respawn -- a"
+        " legitimate idle exit between the establishing query and the control --"
+        " fails the run instead of surviving it",
+    )
+    for lineno, kind, call, _conditional in marks:
         if kind != "control":
             continue
         budget = _keyword(call, "timeout")
@@ -773,5 +1178,8 @@ def run_idle_boundary_self_tests() -> None:
     _an_established_server_that_exits_is_replaced_exactly_once()
     _a_second_lost_server_fails_closed()
     _a_live_servers_refusal_is_never_retried_away()
+    _a_respawn_runs_through_the_real_worker_primitive()
+    _a_replacement_that_cannot_be_established_names_the_loss()
+    _a_reused_worker_label_is_refused_before_the_worker_runs()
     _every_control_is_issued_to_a_server_proven_resident()
     _the_publication_fault_run_establishes_residency_before_its_first_control()


### PR DESCRIPTION
The publication-fault run now establishes embedding-server residency before its first control instead of assuming a server survived the baseline publication.

**Proven, not inferred.** Decoding the Windows `boot_id` maps the monotonic clock onto the job log and reproduces the failure to the second: the baseline's last embedding work ends at 17:07:57.918Z, the `sequence=1` control file appears at 17:19:41.148Z — **703.23s against a 60s idle budget**, so the server was eligible to exit 643s before the control existed. Both alternatives are refuted rather than dismissed: a server *did* start for this run (this run's nonce dir, `native_completion_sequence=1`), and no live server can ignore a control (`poll_server_qualification_command` is the accept loop's first statement and runs even in the frozen-owner branch), so 1800s of silence proves absence.

The same gap on Linux is **3.946s** — 178× smaller for identical 98-token work. Linux's own `sequence=1` snapshot self-reports `true_idle=true`: already idle, simply not for 60s yet. Linux and macOS have been passing on ~56s of margin by luck. This fix makes residency hold by construction on every platform.

**The idle timeout is deliberately untouched.** `idle_timeout_ms=60000` is hashed verbatim into the proof-marker string that generates `protocol_sha256`, `constant_set_sha256` and `measurement_protocol_sha256`; changing it would re-hash all three and invalidate every previously accepted sample — including the Linux and macOS cells that passed in the very run that exposed this. The product also refuses any other value (`embedding_server_idle_timeout_contract_mismatch`), and `true_idle_exit` is itself a measured metric (macOS measured 58857ms in the failing run). That a control poll does not reset the idle window is likewise correct and unchanged — `snapshot` *reads* `idle_epoch_ns` and must not perturb it.

Reviewer-driven repair: the first revision's respawn-tolerance branch was inoperative in production and its self-test never exercised the real path; that was rejected and rebuilt.

Residual risks stated rather than hidden: sequence 2's residency is still *asserted* rather than established (the comment now says so plainly instead of claiming a bound it does not have); the structural audit's `resident` flag is monotone with no notion of distance; the Windows branch of the worker stub still never executes in CI, on the very platform this lane is about.

Closes #1521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
