### PR TITLE
publish the qualification output atomically on windows

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/output.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/output.rs
@@ -4,7 +4,7 @@ use super::request::{
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use std::collections::BTreeMap;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -73,7 +73,7 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
             file.sync_all()?;
             drop(file);
             fs::rename(&temp, path)?;
-            File::open(parent)?.sync_all()?;
+            sync_published_directory(parent)?;
             Ok::<_, std::io::Error>(())
         })();
         if let Err(error) = result {
@@ -83,4 +83,95 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
         return Ok(());
     }
     bail!("embedding_qualification_temp_name_exhausted")
+}
+
+/// Make an already-published name durable.
+///
+/// The rename is what makes the publication atomic; this step only decides
+/// whether the new directory entry survives a crash, so it must never be able
+/// to fail a publication that already happened. Unix fsyncs the parent
+/// directory. Windows skips it, because `File::open` does not pass
+/// `FILE_FLAG_BACKUP_SEMANTICS` and `CreateFileW` therefore refuses a directory
+/// with `ERROR_ACCESS_DENIED` - that denial, not the rename, is what failed the
+/// publish.
+///
+/// Opening the directory properly is not the fix. Windows documents no
+/// directory-fsync contract, and the behaviour bears that out: measured on
+/// windows 11 26200 / NTFS, with and without backup-class privileges,
+/// `FlushFileBuffers` on a backup-semantics handle is denied when the handle is
+/// `GENERIC_READ` and accepted when it is `GENERIC_WRITE`, so what it would
+/// commit is an accident of access mode rather than a guarantee. Skipping the
+/// step is what every other atomic publisher here already does
+/// (`codestory_workspace::atomic_file`, `codestory_cli::native_launcher`,
+/// `native_staging`, `codestory_store::sync_promotion_parent`,
+/// `sync_qualification_directory`); these two copies did not. Windows rename
+/// durability, if it is ever wanted, comes from
+/// `MoveFileExW(.., MOVEFILE_WRITE_THROUGH)` - which `native_launcher` already
+/// uses - not from a directory fsync.
+#[cfg(not(windows))]
+fn sync_published_directory(path: &Path) -> std::io::Result<()> {
+    fs::File::open(path)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_published_directory(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_atomic_json;
+    use serde_json::{Value, json};
+
+    #[test]
+    fn publishing_an_artifact_succeeds_and_leaves_only_the_complete_file() {
+        // Regression: calibration run 30304210146, windows-x64 vulkan cell.
+        // The driver shares this publish shape with the worker
+        // (`codestory-cli/src/embedding_qualification/worker/gate.rs`), whose
+        // copy exited 1 with `publish atomic qualification output: Access is
+        // denied. (os error 5)` after its rename had already succeeded: the
+        // post-rename durability step opened the parent directory with
+        // `File::open`, which Windows refuses without
+        // FILE_FLAG_BACKUP_SEMANTICS. This asserts the publication reports its
+        // own success, that the destination holds the whole document, and that
+        // the temporary is consumed by the rename rather than left beside it.
+        //
+        // Its revert value is windows-only. On unix the reverted body is
+        // exactly the `#[cfg(not(windows))]` arm this still exercises, so a
+        // unix-only lane passes with or without the fix and gives this change
+        // no regression protection; the revert-proof was run on windows 11
+        // 26200, where it fails with the calibration error.
+        let directory = tempfile::tempdir().expect("qualification output directory");
+        // The producer publishes into a private directory; reproduce that here
+        // so the publish is exercised, not the private-directory guard.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("make the qualification output directory private");
+        }
+        let path = directory.path().join("measurements.raw.json");
+        let value = json!({"schema_version": 2, "scenario": "measurements"});
+
+        write_atomic_json(&path, &value).expect("publish qualification artifact");
+
+        let published = std::fs::read_to_string(&path).expect("read published artifact");
+        assert!(
+            published.ends_with('\n'),
+            "published artifact is truncated: {published:?}"
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&published).expect("published artifact parses"),
+            value
+        );
+        let residue = std::fs::read_dir(directory.path())
+            .expect("list qualification output directory")
+            .map(|entry| entry.expect("qualification directory entry").file_name())
+            .filter(|name| name != "measurements.raw.json")
+            .collect::<Vec<_>>();
+        assert!(
+            residue.is_empty(),
+            "publish left temporaries beside the artifact: {residue:?}"
+        );
+    }
 }

--- a/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
@@ -136,7 +136,7 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
             file.sync_all()?;
             drop(file);
             fs::rename(&temp, path)?;
-            File::open(parent)?.sync_all()?;
+            sync_published_directory(parent)?;
             Ok::<_, std::io::Error>(())
         })();
         if let Err(error) = result {
@@ -146,6 +146,39 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
         return Ok(());
     }
     bail!("embedding_qualification_temp_name_exhausted")
+}
+
+/// Make an already-published name durable.
+///
+/// The rename is what makes the publication atomic; this step only decides
+/// whether the new directory entry survives a crash, so it must never be able
+/// to fail a publication that already happened. Unix fsyncs the parent
+/// directory. Windows skips it, because `File::open` does not pass
+/// `FILE_FLAG_BACKUP_SEMANTICS` and `CreateFileW` therefore refuses a directory
+/// with `ERROR_ACCESS_DENIED` - that denial, not the rename, is what failed the
+/// publish.
+///
+/// Opening the directory properly is not the fix. Windows documents no
+/// directory-fsync contract, and the behaviour bears that out: measured on
+/// windows 11 26200 / NTFS, with and without backup-class privileges,
+/// `FlushFileBuffers` on a backup-semantics handle is denied when the handle is
+/// `GENERIC_READ` and accepted when it is `GENERIC_WRITE`, so what it would
+/// commit is an accident of access mode rather than a guarantee. Skipping the
+/// step is what every other atomic publisher here already does
+/// (`codestory_workspace::atomic_file`, `codestory_cli::native_launcher`,
+/// `native_staging`, `codestory_store::sync_promotion_parent`,
+/// `sync_qualification_directory`); these two copies did not. Windows rename
+/// durability, if it is ever wanted, comes from
+/// `MoveFileExW(.., MOVEFILE_WRITE_THROUGH)` - which `native_launcher` already
+/// uses - not from a directory fsync.
+#[cfg(not(windows))]
+fn sync_published_directory(path: &Path) -> std::io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_published_directory(_path: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 pub(super) fn sha256_bytes(bytes: &[u8]) -> String {
@@ -267,4 +300,64 @@ pub(super) fn project_identity_sha256(runtime: &SidecarRuntimeConfig) -> String 
 
 pub(super) fn elapsed(clock: &dyn AwakeMonotonicClock, started_ns: u64) -> Duration {
     Duration::from_nanos(clock.now_ns().saturating_sub(started_ns))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_atomic_json;
+    use serde_json::{Value, json};
+
+    #[test]
+    fn publishing_an_output_succeeds_and_leaves_only_the_complete_file() {
+        // Regression: calibration run 30304210146, windows-x64 vulkan cell.
+        // The worker serialized, synced, and renamed
+        // `publication-fault-residency-1-worker-output.json` into place, and
+        // then exited 1 with `publish atomic qualification output: Access is
+        // denied. (os error 5)` because the post-rename durability step opened
+        // the parent directory with `File::open`, which Windows refuses
+        // without FILE_FLAG_BACKUP_SEMANTICS. The preserved failure evidence
+        // holds the complete published output next to the failed command, so
+        // the publication had already happened when the step reported denial.
+        // This asserts the publication reports its own success, that the
+        // destination holds the whole document, and that the temporary is
+        // consumed by the rename rather than left beside it.
+        //
+        // Its revert value is windows-only. On unix the reverted body is
+        // exactly the `#[cfg(not(windows))]` arm this still exercises, so a
+        // unix-only lane passes with or without the fix and gives this change
+        // no regression protection; the revert-proof was run on windows 11
+        // 26200, where it fails with the calibration error.
+        let directory = tempfile::tempdir().expect("qualification output directory");
+        // The producer hands the worker a private directory; reproduce that
+        // here so the publish is exercised, not the private-directory guard.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("make the qualification output directory private");
+        }
+        let path = directory.path().join("worker-output.json");
+        let value = json!({"schema_version": 2, "scenario": "query"});
+
+        write_atomic_json(&path, &value).expect("publish qualification output");
+
+        let published = std::fs::read_to_string(&path).expect("read published output");
+        assert!(
+            published.ends_with('\n'),
+            "published output is truncated: {published:?}"
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&published).expect("published output parses"),
+            value
+        );
+        let residue = std::fs::read_dir(directory.path())
+            .expect("list qualification output directory")
+            .map(|entry| entry.expect("qualification directory entry").file_name())
+            .filter(|name| name != "worker-output.json")
+            .collect::<Vec<_>>();
+        assert!(
+            residue.is_empty(),
+            "publish left temporaries beside the output: {residue:?}"
+        );
+    }
 }


### PR DESCRIPTION
The qualification-output publisher now works on Windows, where it previously failed categorically with `Access is denied. (os error 5)`. The Windows cell reached this step for the first time only after #1522 fixed the residency gap ahead of it.

**Proven on the real platform, not reasoned about.** The diagnosis and its revert-proof were executed first-hand on the Windows proof host (Windows 11 build 26200, NTFS, MSVC): the directory-handle probe was run in four privilege and location contexts, both crate suites pass at the fixed head with SHA-256-matched sources, and reverting the fix reproduces the exact calibration error. Nothing here is type-check-only. Atomicity is preserved — a partially written output is never observable at the destination on any platform — and Unix behaviour is unchanged.

No bounded retry was added, deliberately: the denial is categorical and reproduces on every attempt, so a retry would convert a hard failure into a slow one without fixing anything.

Two corrections to the record that a reviewer should keep: the classic Windows delete-pending story does **not** apply on this host (measured in an earlier lane — `DeleteFileW` takes POSIX delete semantics on Windows 11/NTFS and unlinks immediately, answering `NotFound`), and a prior claim that `MOVEFILE_WRITE_THROUGH` would "diverge from every other publisher in this tree" was wrong — `native_launcher.rs` already does exactly that. The comment now names that route as reachable rather than implying durability is unobtainable; adopting it remains a separate behaviour decision.

Scope left open and flagged rather than quietly dropped: `write_atomic_json`/`sync_published_directory` are duplicated across `codestory-cli` and `codestory-bench`, which conflicts with the AGENTS.md rule that `codestory-bench` must not own product contracts. That wants a real issue and a consolidation that preserves the current guarantees.

Closes #1525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
