### PR TITLE
name sibling publishers without their crate paths

### DIFF
--- a/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
@@ -164,9 +164,9 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
 /// `FlushFileBuffers` on a backup-semantics handle is denied when the handle is
 /// `GENERIC_READ` and accepted when it is `GENERIC_WRITE`, so what it would
 /// commit is an accident of access mode rather than a guarantee. Skipping the
-/// step is what every other atomic publisher here already does
-/// (`codestory_workspace::atomic_file`, `codestory_cli::native_launcher`,
-/// `native_staging`, `codestory_store::sync_promotion_parent`,
+/// step is what every other atomic publisher here already does (the workspace
+/// crate's `atomic_file`, this crate's `native_launcher` and `native_staging`,
+/// the store crate's promotion-parent sync, and
 /// `sync_qualification_directory`); these two copies did not. Windows rename
 /// durability, if it is ever wanted, comes from
 /// `MoveFileExW(.., MOVEFILE_WRITE_THROUGH)` - which `native_launcher` already


### PR DESCRIPTION
Repairs dev. #1526 documented the tree's other atomic publishers by fully qualified path; one spelled `codestory_store::`, and `cli_stays_thin` scans the CLI source tree textually, so a doc comment read as a direct dependency.

The comment now names each sibling in prose. The documented guarantee is unchanged and no code moved — `rg codestory_store::|codestory_indexer:: crates/codestory-cli/src` is now empty and architecture_contracts is 14/14 locally.

Follow-up worth its own review, deliberately not bundled here: `source_tree_contains` could strip comments before scanning, so documentation is free to name a symbol the crate must not depend on. That changes a guard, which should not ride along with a red-dev repair.

Closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)