### PR TITLE
publish qualification documents through the shared atomic publisher

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/output.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/output.rs
@@ -2,12 +2,14 @@ use super::request::{
     QualificationContracts, QualificationPackage, QualificationRuntime, QualificationSource,
 };
 use anyhow::{Context, Result, bail};
+use codestory_workspace::atomic_file::{PublishNewFileError, publish_new_private_file_atomic};
 use serde::Serialize;
 use std::collections::BTreeMap;
-use std::fs::{self, OpenOptions};
-use std::io::Write;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Names the temporaries this protocol leaves beside a publication, so a
+/// half-written qualification document is recognisable as one.
+const QUALIFICATION_TEMP_PREFIX: &str = "codestory-qualification";
 
 #[derive(Debug, Serialize)]
 pub(super) struct QualificationRawOutput {
@@ -39,6 +41,15 @@ pub(super) struct QualificationScenarioSummary {
     pub(super) event_count: u64,
 }
 
+/// Publish a qualification document at `path`, which must not already exist.
+///
+/// The driver writes the same protocol the worker reads, so this states the
+/// same contract as `codestory_cli`'s `write_atomic_json` - private-directory
+/// proof, refusal to republish, pretty body with a trailing newline - and
+/// reaches the publication mechanism at the same owner,
+/// [`codestory_workspace::atomic_file`]. The two used to carry byte-identical
+/// copies of that mechanism, which is why one Windows defect had to be fixed
+/// twice.
 pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<()> {
     let parent = path
         .parent()
@@ -47,75 +58,23 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
     if path.exists() {
         bail!("embedding_qualification_output_exists");
     }
-    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
-    let bytes = serde_json::to_vec_pretty(value).context("serialize qualification output")?;
-    for _ in 0..32 {
-        let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
-        let temp = parent.join(format!(
-            ".codestory-qualification-{}-{sequence}.tmp",
-            std::process::id()
-        ));
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            options.mode(0o600);
+    let mut bytes = serde_json::to_vec_pretty(value).context("serialize qualification output")?;
+    bytes.push(b'\n');
+    match publish_new_private_file_atomic(path, QUALIFICATION_TEMP_PREFIX, &bytes) {
+        Ok(()) => Ok(()),
+        Err(PublishNewFileError::NoParent) => {
+            bail!("atomic qualification output has no parent")
         }
-        let mut file = match options.open(&temp) {
-            Ok(file) => file,
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error).context("create atomic qualification temp file"),
-        };
-        let result = (|| {
-            file.write_all(&bytes)?;
-            file.write_all(b"\n")?;
-            file.sync_all()?;
-            drop(file);
-            fs::rename(&temp, path)?;
-            sync_published_directory(parent)?;
-            Ok::<_, std::io::Error>(())
-        })();
-        if let Err(error) = result {
-            let _ = fs::remove_file(&temp);
-            return Err(error).context("publish atomic qualification output");
+        Err(PublishNewFileError::TempNamesExhausted) => {
+            bail!("embedding_qualification_temp_name_exhausted")
         }
-        return Ok(());
+        Err(PublishNewFileError::CreateTemp(error)) => {
+            Err(error).context("create atomic qualification temp file")
+        }
+        Err(PublishNewFileError::Publish(error)) => {
+            Err(error).context("publish atomic qualification output")
+        }
     }
-    bail!("embedding_qualification_temp_name_exhausted")
-}
-
-/// Make an already-published name durable.
-///
-/// The rename is what makes the publication atomic; this step only decides
-/// whether the new directory entry survives a crash, so it must never be able
-/// to fail a publication that already happened. Unix fsyncs the parent
-/// directory. Windows skips it, because `File::open` does not pass
-/// `FILE_FLAG_BACKUP_SEMANTICS` and `CreateFileW` therefore refuses a directory
-/// with `ERROR_ACCESS_DENIED` - that denial, not the rename, is what failed the
-/// publish.
-///
-/// Opening the directory properly is not the fix. Windows documents no
-/// directory-fsync contract, and the behaviour bears that out: measured on
-/// windows 11 26200 / NTFS, with and without backup-class privileges,
-/// `FlushFileBuffers` on a backup-semantics handle is denied when the handle is
-/// `GENERIC_READ` and accepted when it is `GENERIC_WRITE`, so what it would
-/// commit is an accident of access mode rather than a guarantee. Skipping the
-/// step is what every other atomic publisher here already does
-/// (`codestory_workspace::atomic_file`, `codestory_cli::native_launcher`,
-/// `native_staging`, `codestory_store::sync_promotion_parent`,
-/// `sync_qualification_directory`); these two copies did not. Windows rename
-/// durability, if it is ever wanted, comes from
-/// `MoveFileExW(.., MOVEFILE_WRITE_THROUGH)` - which `native_launcher` already
-/// uses - not from a directory fsync.
-#[cfg(not(windows))]
-fn sync_published_directory(path: &Path) -> std::io::Result<()> {
-    fs::File::open(path)?.sync_all()
-}
-
-#[cfg(windows)]
-fn sync_published_directory(_path: &Path) -> std::io::Result<()> {
-    Ok(())
 }
 
 #[cfg(test)]
@@ -126,21 +85,22 @@ mod tests {
     #[test]
     fn publishing_an_artifact_succeeds_and_leaves_only_the_complete_file() {
         // Regression: calibration run 30304210146, windows-x64 vulkan cell.
-        // The driver shares this publish shape with the worker
+        // The driver shared this publish shape with the worker
         // (`codestory-cli/src/embedding_qualification/worker/gate.rs`), whose
         // copy exited 1 with `publish atomic qualification output: Access is
         // denied. (os error 5)` after its rename had already succeeded: the
         // post-rename durability step opened the parent directory with
         // `File::open`, which Windows refuses without
-        // FILE_FLAG_BACKUP_SEMANTICS. This asserts the publication reports its
-        // own success, that the destination holds the whole document, and that
-        // the temporary is consumed by the rename rather than left beside it.
+        // FILE_FLAG_BACKUP_SEMANTICS.
         //
-        // Its revert value is windows-only. On unix the reverted body is
-        // exactly the `#[cfg(not(windows))]` arm this still exercises, so a
-        // unix-only lane passes with or without the fix and gives this change
-        // no regression protection; the revert-proof was run on windows 11
-        // 26200, where it fails with the calibration error.
+        // The step now lives once, in
+        // `codestory_workspace::atomic_file::sync_parent_directory`, and
+        // reverting it is proven there. What this covers is the wrapper: that
+        // the driver still reaches that mechanism, that the published document
+        // is whole and pretty-printed with a trailing newline, that the
+        // temporary is consumed by the rename, and that a second publication
+        // is refused with the `embedding_qualification_output_exists` code the
+        // packaged-proof scripts read.
         let directory = tempfile::tempdir().expect("qualification output directory");
         // The producer publishes into a private directory; reproduce that here
         // so the publish is exercised, not the private-directory guard.
@@ -172,6 +132,15 @@ mod tests {
         assert!(
             residue.is_empty(),
             "publish left temporaries beside the artifact: {residue:?}"
+        );
+
+        let republished = write_atomic_json(&path, &value)
+            .expect_err("a published artifact must not be republished");
+        assert!(
+            republished
+                .to_string()
+                .contains("embedding_qualification_output_exists"),
+            "unexpected refusal: {republished:?}"
         );
     }
 }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/output.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/output.rs
@@ -65,6 +65,9 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
         Err(PublishNewFileError::NoParent) => {
             bail!("atomic qualification output has no parent")
         }
+        Err(PublishNewFileError::UnsafeTempPrefix) => {
+            bail!("embedding_qualification_temp_prefix_unsafe")
+        }
         Err(PublishNewFileError::TempNamesExhausted) => {
             bail!("embedding_qualification_temp_name_exhausted")
         }

--- a/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
@@ -130,6 +130,9 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
         Err(PublishNewFileError::NoParent) => {
             bail!("atomic qualification output has no parent")
         }
+        Err(PublishNewFileError::UnsafeTempPrefix) => {
+            bail!("embedding_qualification_temp_prefix_unsafe")
+        }
         Err(PublishNewFileError::TempNamesExhausted) => {
             bail!("embedding_qualification_temp_name_exhausted")
         }

--- a/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
@@ -3,15 +3,18 @@ use codestory_retrieval::{
     AwakeMonotonicClock, EmbeddingQualificationWorkerError as WorkerError, ProcessStartProbe,
     SidecarRuntimeConfig, embedding_retry_state,
 };
+use codestory_workspace::atomic_file::{PublishNewFileError, publish_new_private_file_atomic};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::{self, File};
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 const QUALIFICATION_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
+/// Names the temporaries this protocol leaves beside a publication, so a
+/// half-written qualification document is recognisable as one.
+const QUALIFICATION_TEMP_PREFIX: &str = "codestory-qualification";
 const MAX_REQUEST_BYTES: u64 = 1024 * 1024;
 pub(super) const POLL: Duration = Duration::from_millis(25);
 
@@ -102,6 +105,16 @@ pub(super) fn canonical_existing(path: &Path) -> Result<PathBuf> {
     fs::canonicalize(path).with_context(|| format!("canonicalize {}", path.display()))
 }
 
+/// Publish a qualification document at `path`, which must not already exist.
+///
+/// This owns the qualification protocol's vocabulary - the private-directory
+/// proof, the refusal to republish, the pretty-printed body with a trailing
+/// newline, and the error codes the packaged-proof scripts read - and nothing
+/// else. The publication mechanism belongs to
+/// [`codestory_workspace::atomic_file`], which the benchmark driver's
+/// `write_atomic_json` reaches through as well: the two used to carry
+/// byte-identical copies of it, which is why one Windows defect had to be
+/// fixed twice.
 pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<()> {
     let parent = path
         .parent()
@@ -110,75 +123,23 @@ pub(super) fn write_atomic_json(path: &Path, value: &impl Serialize) -> Result<(
     if path.exists() {
         bail!("embedding_qualification_output_exists");
     }
-    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
-    let bytes = serde_json::to_vec_pretty(value).context("serialize qualification output")?;
-    for _ in 0..32 {
-        let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
-        let temp = parent.join(format!(
-            ".codestory-qualification-{}-{sequence}.tmp",
-            std::process::id()
-        ));
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            options.mode(0o600);
+    let mut bytes = serde_json::to_vec_pretty(value).context("serialize qualification output")?;
+    bytes.push(b'\n');
+    match publish_new_private_file_atomic(path, QUALIFICATION_TEMP_PREFIX, &bytes) {
+        Ok(()) => Ok(()),
+        Err(PublishNewFileError::NoParent) => {
+            bail!("atomic qualification output has no parent")
         }
-        let mut file = match options.open(&temp) {
-            Ok(file) => file,
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error).context("create atomic qualification temp file"),
-        };
-        let result = (|| {
-            file.write_all(&bytes)?;
-            file.write_all(b"\n")?;
-            file.sync_all()?;
-            drop(file);
-            fs::rename(&temp, path)?;
-            sync_published_directory(parent)?;
-            Ok::<_, std::io::Error>(())
-        })();
-        if let Err(error) = result {
-            let _ = fs::remove_file(&temp);
-            return Err(error).context("publish atomic qualification output");
+        Err(PublishNewFileError::TempNamesExhausted) => {
+            bail!("embedding_qualification_temp_name_exhausted")
         }
-        return Ok(());
+        Err(PublishNewFileError::CreateTemp(error)) => {
+            Err(error).context("create atomic qualification temp file")
+        }
+        Err(PublishNewFileError::Publish(error)) => {
+            Err(error).context("publish atomic qualification output")
+        }
     }
-    bail!("embedding_qualification_temp_name_exhausted")
-}
-
-/// Make an already-published name durable.
-///
-/// The rename is what makes the publication atomic; this step only decides
-/// whether the new directory entry survives a crash, so it must never be able
-/// to fail a publication that already happened. Unix fsyncs the parent
-/// directory. Windows skips it, because `File::open` does not pass
-/// `FILE_FLAG_BACKUP_SEMANTICS` and `CreateFileW` therefore refuses a directory
-/// with `ERROR_ACCESS_DENIED` - that denial, not the rename, is what failed the
-/// publish.
-///
-/// Opening the directory properly is not the fix. Windows documents no
-/// directory-fsync contract, and the behaviour bears that out: measured on
-/// windows 11 26200 / NTFS, with and without backup-class privileges,
-/// `FlushFileBuffers` on a backup-semantics handle is denied when the handle is
-/// `GENERIC_READ` and accepted when it is `GENERIC_WRITE`, so what it would
-/// commit is an accident of access mode rather than a guarantee. Skipping the
-/// step is what every other atomic publisher here already does (the workspace
-/// crate's `atomic_file`, this crate's `native_launcher` and `native_staging`,
-/// the store crate's promotion-parent sync, and
-/// `sync_qualification_directory`); these two copies did not. Windows rename
-/// durability, if it is ever wanted, comes from
-/// `MoveFileExW(.., MOVEFILE_WRITE_THROUGH)` - which `native_launcher` already
-/// uses - not from a directory fsync.
-#[cfg(not(windows))]
-fn sync_published_directory(path: &Path) -> std::io::Result<()> {
-    File::open(path)?.sync_all()
-}
-
-#[cfg(windows)]
-fn sync_published_directory(_path: &Path) -> std::io::Result<()> {
-    Ok(())
 }
 
 pub(super) fn sha256_bytes(bytes: &[u8]) -> String {
@@ -315,18 +276,16 @@ mod tests {
         // then exited 1 with `publish atomic qualification output: Access is
         // denied. (os error 5)` because the post-rename durability step opened
         // the parent directory with `File::open`, which Windows refuses
-        // without FILE_FLAG_BACKUP_SEMANTICS. The preserved failure evidence
-        // holds the complete published output next to the failed command, so
-        // the publication had already happened when the step reported denial.
-        // This asserts the publication reports its own success, that the
-        // destination holds the whole document, and that the temporary is
-        // consumed by the rename rather than left beside it.
+        // without FILE_FLAG_BACKUP_SEMANTICS.
         //
-        // Its revert value is windows-only. On unix the reverted body is
-        // exactly the `#[cfg(not(windows))]` arm this still exercises, so a
-        // unix-only lane passes with or without the fix and gives this change
-        // no regression protection; the revert-proof was run on windows 11
-        // 26200, where it fails with the calibration error.
+        // The step now lives once, in
+        // `codestory_workspace::atomic_file::sync_parent_directory`, and
+        // reverting it is proven there. What this covers is the wrapper: that
+        // the worker still reaches that mechanism, that the published document
+        // is whole and pretty-printed with a trailing newline, that the
+        // temporary is consumed by the rename, and that a second publication
+        // is refused with the `embedding_qualification_output_exists` code the
+        // packaged-proof scripts read.
         let directory = tempfile::tempdir().expect("qualification output directory");
         // The producer hands the worker a private directory; reproduce that
         // here so the publish is exercised, not the private-directory guard.
@@ -358,6 +317,15 @@ mod tests {
         assert!(
             residue.is_empty(),
             "publish left temporaries beside the output: {residue:?}"
+        );
+
+        let republished = write_atomic_json(&path, &value)
+            .expect_err("a published output must not be republished");
+        assert!(
+            republished
+                .to_string()
+                .contains("embedding_qualification_output_exists"),
+            "unexpected refusal: {republished:?}"
         );
     }
 }

--- a/crates/codestory-workspace/src/atomic_file.rs
+++ b/crates/codestory-workspace/src/atomic_file.rs
@@ -80,6 +80,9 @@ pub fn write_file_atomic(
 pub enum PublishNewFileError {
     /// The destination has no parent directory to publish into.
     NoParent,
+    /// The temporary prefix contained a path separator or traversal component,
+    /// so the temporary file would not have been a sibling of the destination.
+    UnsafeTempPrefix,
     /// No collision-free temporary name was available beside the destination.
     TempNamesExhausted,
     /// The temporary file could not be created.
@@ -93,6 +96,9 @@ impl std::fmt::Display for PublishNewFileError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NoParent => formatter.write_str("destination has no parent directory"),
+            Self::UnsafeTempPrefix => {
+                formatter.write_str("temporary prefix is not a plain file-name component")
+            }
             Self::TempNamesExhausted => {
                 formatter.write_str("no free temporary name beside the destination")
             }
@@ -105,7 +111,7 @@ impl std::fmt::Display for PublishNewFileError {
 impl std::error::Error for PublishNewFileError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::NoParent | Self::TempNamesExhausted => None,
+            Self::NoParent | Self::TempNamesExhausted | Self::UnsafeTempPrefix => None,
             Self::CreateTemp(error) | Self::Publish(error) => Some(error),
         }
     }
@@ -144,6 +150,19 @@ pub fn publish_new_private_file_atomic(
     content: &[u8],
 ) -> std::result::Result<(), PublishNewFileError> {
     let parent = path.parent().ok_or(PublishNewFileError::NoParent)?;
+    // The prefix reaches a filename that is joined onto the destination's
+    // parent, so a separator or traversal component in it would place the
+    // temporary file outside the directory the caller validated.
+    // `..` is a single component too, so the component must also be a normal
+    // one rather than a traversal or a root.
+    let mut components = Path::new(temp_prefix).components();
+    let plain_component = matches!(
+        (components.next(), components.next()),
+        (Some(std::path::Component::Normal(_)), None)
+    );
+    if temp_prefix.contains(['/', '\\']) || !plain_component {
+        return Err(PublishNewFileError::UnsafeTempPrefix);
+    }
     for _ in 0..PRIVATE_PUBLISH_ATTEMPTS {
         let sequence = PRIVATE_PUBLISH_COUNTER.fetch_add(1, Ordering::Relaxed);
         let temp = parent.join(format!(
@@ -546,5 +565,26 @@ mod tests {
         write_bytes_atomic(&path, "state", b"new").expect("atomic long-path write");
 
         assert_eq!(fs::read(&path).expect("read new file"), b"new");
+    }
+
+    #[test]
+    fn a_temp_prefix_that_escapes_the_directory_is_refused() {
+        // The prefix reaches a filename joined onto the destination's parent, so
+        // anything that is not a plain component could publish the temporary file
+        // outside the directory the caller validated.
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let destination = directory.path().join("published.json");
+        for prefix in ["../escape", "nested/prefix", "..", "", "a\\b"] {
+            let error = publish_new_private_file_atomic(&destination, prefix, b"{}")
+                .expect_err("an escaping prefix must be refused");
+            assert!(
+                matches!(error, PublishNewFileError::UnsafeTempPrefix),
+                "prefix {prefix:?} produced {error:?}"
+            );
+        }
+        assert!(
+            !destination.exists(),
+            "a refused publish must write nothing"
+        );
     }
 }

--- a/crates/codestory-workspace/src/atomic_file.rs
+++ b/crates/codestory-workspace/src/atomic_file.rs
@@ -73,6 +73,111 @@ pub fn write_file_atomic(
     result
 }
 
+/// The stage at which [`publish_new_private_file_atomic`] gave up, so a caller
+/// can attach its own vocabulary to each outcome without repeating the
+/// mechanism that produced it.
+#[derive(Debug)]
+pub enum PublishNewFileError {
+    /// The destination has no parent directory to publish into.
+    NoParent,
+    /// No collision-free temporary name was available beside the destination.
+    TempNamesExhausted,
+    /// The temporary file could not be created.
+    CreateTemp(std::io::Error),
+    /// Writing, syncing, renaming, or making the rename durable failed. The
+    /// temporary file has already been removed.
+    Publish(std::io::Error),
+}
+
+impl std::fmt::Display for PublishNewFileError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoParent => formatter.write_str("destination has no parent directory"),
+            Self::TempNamesExhausted => {
+                formatter.write_str("no free temporary name beside the destination")
+            }
+            Self::CreateTemp(error) => write!(formatter, "create temporary file: {error}"),
+            Self::Publish(error) => write!(formatter, "publish temporary file: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for PublishNewFileError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NoParent | Self::TempNamesExhausted => None,
+            Self::CreateTemp(error) | Self::Publish(error) => Some(error),
+        }
+    }
+}
+
+/// How many temporary names are tried before giving up, so a wedged or hostile
+/// directory cannot spin forever.
+const PRIVATE_PUBLISH_ATTEMPTS: usize = 32;
+
+/// Kept apart from [`TEMP_COUNTER`] so publications through this entry point
+/// cannot perturb the names [`atomic_temp_path`] hands out.
+static PRIVATE_PUBLISH_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Publish `content` at `path` through an owner-only temporary file beside it.
+///
+/// The caller owns the directory, and must have proven it private before
+/// calling: the content is written there in the clear before the rename, and
+/// this never creates the directory. The caller also owns the check that
+/// `path` does not already exist - the rename is what publishes, and this
+/// reports only how that publication went.
+///
+/// The order is load-bearing. The content is written, `fsync`ed, and the
+/// handle dropped *before* [`fs::rename`], so the rename can only ever expose
+/// a complete file: a reader at the destination sees the old name or the whole
+/// new one, never a partial write, on every platform. The rename stays a plain
+/// [`fs::rename`] rather than the `ReplaceFileW` path in [`write_file_atomic`],
+/// which exists to swap a destination that is already published. Afterwards
+/// `sync_parent_directory` makes the new entry durable where the platform
+/// supports it - and is the single place that decision is made, so it is not
+/// linked here: it is private, and a public doc link to it fails the
+/// deny-rustdoc-warnings gate. Any failure removes the temporary file and
+/// leaves the destination as it was.
+pub fn publish_new_private_file_atomic(
+    path: &Path,
+    temp_prefix: &str,
+    content: &[u8],
+) -> std::result::Result<(), PublishNewFileError> {
+    let parent = path.parent().ok_or(PublishNewFileError::NoParent)?;
+    for _ in 0..PRIVATE_PUBLISH_ATTEMPTS {
+        let sequence = PRIVATE_PUBLISH_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp = parent.join(format!(
+            ".{temp_prefix}-{}-{sequence}.tmp",
+            std::process::id()
+        ));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = match options.open(&temp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(PublishNewFileError::CreateTemp(error)),
+        };
+        let result = (|| {
+            file.write_all(content)?;
+            file.sync_all()?;
+            drop(file);
+            fs::rename(&temp, path)?;
+            sync_parent_directory(path)
+        })();
+        if let Err(error) = result {
+            let _ = fs::remove_file(&temp);
+            return Err(PublishNewFileError::Publish(error));
+        }
+        return Ok(());
+    }
+    Err(PublishNewFileError::TempNamesExhausted)
+}
+
 /// Reserve a collision-free temporary file beside `path` using create-new semantics.
 pub fn create_unique_temp_file(path: &Path, stem: &str) -> Result<(PathBuf, File)> {
     loop {
@@ -204,6 +309,35 @@ fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
     unreachable!("replacement attempts always return")
 }
 
+/// Make an already-published name durable.
+///
+/// The rename is what makes a publication atomic; this step only decides
+/// whether the new directory entry survives a crash, so it must never be able
+/// to fail a publication that already happened.
+///
+/// Unix fsyncs the parent directory. Windows skips it, because `File::open`
+/// does not pass `FILE_FLAG_BACKUP_SEMANTICS` and `CreateFileW` therefore
+/// refuses a directory with `ERROR_ACCESS_DENIED`. That denial, not the
+/// rename, is what failed the windows-x64 vulkan cell of calibration run
+/// 30304210146 with `publish atomic qualification output: Access is denied.
+/// (os error 5)` - in the two hand-rolled copies of this step that used to sit
+/// in the embedding-qualification worker and its benchmark driver, and that
+/// now publish through [`publish_new_private_file_atomic`] instead.
+///
+/// Opening the directory properly is not the alternative. Windows documents no
+/// directory-fsync contract, and the behaviour bears that out: measured on
+/// windows 11 26200 / NTFS, with and without backup-class privileges,
+/// `FlushFileBuffers` on a backup-semantics handle is denied when the handle
+/// is `GENERIC_READ` and accepted when it is `GENERIC_WRITE`, so what it would
+/// commit is an accident of access mode rather than a guarantee. Windows
+/// rename durability, if it is ever wanted, comes from
+/// `MoveFileExW(.., MOVEFILE_WRITE_THROUGH)` - which
+/// `codestory_cli::native_launcher` already uses - not from a directory fsync.
+///
+/// The other atomic publishers here already skip the step the same way
+/// (`codestory_cli::native_launcher`, `codestory_llama_sys::native_staging`,
+/// `codestory_store::sync_promotion_parent`,
+/// `codestory_retrieval::sync_qualification_directory`).
 #[cfg(not(windows))]
 fn sync_parent_directory(path: &Path) -> std::io::Result<()> {
     match path.parent() {
@@ -260,6 +394,103 @@ mod tests {
         assert_eq!(
             fs::read(&path).expect("read after validation error"),
             b"old"
+        );
+    }
+
+    #[test]
+    fn publishing_a_new_private_file_succeeds_and_leaves_only_the_complete_file() {
+        // Regression: calibration run 30304210146, windows-x64 vulkan cell.
+        // The embedding-qualification worker serialized, synced and renamed
+        // `publication-fault-residency-1-worker-output.json` into place and
+        // then exited 1 with `publish atomic qualification output: Access is
+        // denied. (os error 5)`, because its own copy of the post-rename
+        // durability step opened the parent directory with `File::open`, which
+        // Windows refuses without FILE_FLAG_BACKUP_SEMANTICS. The preserved
+        // failure evidence holds the complete published output next to the
+        // failed command, so the publication had already happened when the
+        // step reported denial.
+        //
+        // That copy and its twin in the benchmark driver now publish through
+        // here, so `sync_parent_directory` is the single place the decision is
+        // made. Reverting it to an unconditional `File::open(parent)?
+        // .sync_all()` fails this test with the calibration error.
+        //
+        // The revert value is windows-only. On unix the reverted body is
+        // exactly the `#[cfg(not(windows))]` arm this already exercises, so a
+        // unix-only lane passes with or without the fix; the revert-proof is
+        // run on windows.
+        let directory = tempfile::tempdir().expect("publication directory");
+        // Callers publish into a directory they have proven private; reproduce
+        // that here so the publish is exercised under its real preconditions.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700))
+                .expect("make the publication directory private");
+        }
+        let path = directory.path().join("worker-output.json");
+
+        publish_new_private_file_atomic(&path, "codestory-test", b"{\"schema_version\":2}\n")
+            .expect("publish new private file");
+
+        assert_eq!(
+            fs::read(&path).expect("read published file"),
+            b"{\"schema_version\":2}\n"
+        );
+        // The rename carries the temporary file's inode, so the published mode
+        // is the 0o600 the temporary was created with.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path)
+                    .expect("published metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        let residue = fs::read_dir(directory.path())
+            .expect("list publication directory")
+            .map(|entry| entry.expect("directory entry").file_name())
+            .filter(|name| name != "worker-output.json")
+            .collect::<Vec<_>>();
+        assert!(
+            residue.is_empty(),
+            "publish left temporaries beside the file: {residue:?}"
+        );
+    }
+
+    #[test]
+    fn failed_publication_removes_the_temporary_and_spares_the_destination() {
+        let directory = tempfile::tempdir().expect("publication directory");
+        // A non-empty directory at the destination is a rename target no
+        // platform will accept, which fails the publish after the temporary
+        // file has been written and synced.
+        let destination = directory.path().join("occupied");
+        fs::create_dir(&destination).expect("destination directory");
+        fs::write(destination.join("resident"), b"resident").expect("resident file");
+
+        let error = publish_new_private_file_atomic(&destination, "codestory-test", b"new")
+            .expect_err("publishing onto a non-empty directory must fail");
+
+        assert!(
+            matches!(error, PublishNewFileError::Publish(_)),
+            "{error:?}"
+        );
+        assert_eq!(
+            fs::read(destination.join("resident")).expect("read resident file"),
+            b"resident"
+        );
+        let residue = fs::read_dir(directory.path())
+            .expect("list publication directory")
+            .map(|entry| entry.expect("directory entry").file_name())
+            .filter(|name| name != "occupied")
+            .collect::<Vec<_>>();
+        assert!(
+            residue.is_empty(),
+            "failed publish left temporaries behind: {residue:?}"
         );
     }
 


### PR DESCRIPTION
The publish mechanism now exists once, as `codestory_workspace::atomic_file::publish_new_private_file_atomic`, reusing that module's existing directory-sync cfg-split. Both `write_atomic_json` copies become ~25-line wrappers holding only qualification vocabulary — 158 lines deleted, and both `sync_published_directory` twins are gone, so the Windows decision is made in exactly one place, shared with the sidecar publisher.

**Owning layer:** `codestory-workspace`, extended rather than replaced. Dependency direction decides it — AGENTS.md scopes `codestory-cli` to terminal adapters and `codestory-bench` to measurement that must not own product contracts (precisely what the bench copy was), and `codestory-workspace` is the only layer upstream of both. **No dependency edge was added**, and `cargo test -p codestory-cli --test architecture_contracts` passes 14/14 — run deliberately, because two contract breaks this week came from edges that compiled fine and passed every crate-scoped suite.

**There was no third copy.** `atomic_file`'s own `sync_parent_directory` has been correctly cfg-split since the commit that created it (`38804880`, verified with `git log -L`) — it was born correct and never carried the defect.

**The revert-proof is the structural payoff, and it was run on real Windows 11 26200:** reverting the cfg-split to an unconditional `File::open(parent)?.sync_all()` now fails **three** tests from one edit — the new shared-layer test, reproducing the calibration's own `Publish(Os { code: 5, kind: PermissionDenied, message: "Access is denied." })` verbatim, plus the two pre-existing sidecar publication tests. Restoring returns all seven to green. The same revert passes on macOS, exactly as expected, which is why the proof was run on Windows and is reported as a limitation rather than a claim.

**Additionally fixed here:** the new public API interpolated `temp_prefix` into a filename joined onto the destination's parent with no validation, so a separator or traversal component could place the temporary file outside the directory the caller had validated private. Today's callers pass fixed literals, but the function is public. Note `..` is a single component, so a component count is not sufficient — the one component must also be normal. Guarded, with a test over `../escape`, `nested/prefix`, `..`, `` and a backslash form.

**Known gaps, carried rather than buried:** `validate_private_directory` is still duplicated across the same two crates (same shape of problem, security-relevant, one copy in the crate that must not own it) and wants its own follow-up; the fsync-before-rename ordering — the guarantee that makes the publish atomic — has no test coverage anywhere in the repo, proven by mutation; and the Windows cli/bench qualification lane could not be run in an ad-hoc clone lacking the runner's Vulkan/cmake setup.

Closes #1529

🤖 Generated with [Claude Code](https://claude.com/claude-code)
