### PR TITLE
drop the windows cell from the calibration matrix

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2936,13 +2936,6 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && object(calibrationMacos.with).calibration_mode === true,
     `${file} protected macOS calibration must call Metal proof in calibration mode`,
   );
-  const calibrationWindows = requireJob(violations, file, workflow, "calibration-windows");
-  add(
-    violations,
-    calibrationWindows.uses === "./.github/workflows/windows-vulkan-proof.yml"
-      && object(calibrationWindows.with).calibration_mode === true,
-    `${file} protected Windows calibration must call Vulkan proof in calibration mode`,
-  );
   add(
     violations,
     at(workflow, "jobs", "macos-source") === undefined,
@@ -2960,9 +2953,8 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       "route",
       "calibration-linux",
       "calibration-macos",
-      "calibration-windows",
     ]),
-    `${file} calibration assembly must wait for every independent calibration cell`,
+    `${file} calibration assembly must wait for both independent calibration cells`,
   );
   requireStepRun(
     violations,
@@ -2971,7 +2963,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     "Assemble frozen calibration candidate",
     [
       "--assemble-calibration-bundle",
-      'test "${#runs[@]}" = 9',
+      'test "${#runs[@]}" = 6',
       "--calibration-producer-workflow-path",
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
@@ -3572,7 +3564,6 @@ function validateRemainingWorkflows(workflows, violations) {
       "Build and package native CLI",
       "Authenticate calibration bundle producer",
       "Prove protected Windows Vulkan runtime",
-      "Collect three independent Vulkan calibration runs",
       "Stage isolated candidate-managed Windows install",
       "Prove candidate-installed Windows Vulkan runtime",
     ]) {
@@ -3591,8 +3582,6 @@ function validateRemainingWorkflows(workflows, violations) {
     requireStepRun(violations, vulkanFile, job, "Validate candidate-installed mode", [
       'if ("${{ inputs.server_behavior_only }}" -ne "true")',
       "candidate_installed_proof requires server_behavior_only",
-      'if ("${{ inputs.calibration_mode }}" -ne "false")',
-      "candidate_installed_proof cannot run in calibration mode",
     ]);
     const sourceBuildTools = namedStep(job, "Capture source build tool evidence");
     add(
@@ -3622,30 +3611,21 @@ function validateRemainingWorkflows(workflows, violations) {
     add(
       violations,
       namedStep(job, "Install pinned Rust")?.if
-        === "${{ !inputs.use_packaged_cli_artifact || inputs.calibration_mode || !inputs.server_behavior_only }}",
+        === "${{ !inputs.use_packaged_cli_artifact || !inputs.server_behavior_only }}",
       `${vulkanFile} packaged server-behavior proof must skip unused Rust installation`,
     );
     add(
       violations,
       namedStep(job, "Build qualification driver")?.if
-        === "${{ inputs.calibration_mode || !inputs.server_behavior_only }}",
+        === "${{ !inputs.server_behavior_only }}",
       `${vulkanFile} packaged server-behavior proof must skip the qualification driver`,
     );
     requireCalibrationProducerBoundary(
       violations,
       vulkanFile,
       job,
-      "${{ !inputs.calibration_mode && !inputs.server_behavior_only }}",
+      "${{ !inputs.server_behavior_only }}",
     );
-    requireStepRun(violations, vulkanFile, job, "Collect three independent Vulkan calibration runs", [
-      "(Get-Content crates/codestory-llama-sys/per-user-embedding-server-constant-set.json -Raw | ConvertFrom-Json).status",
-      '-ne "unfrozen"',
-      "--proof-tier calibration",
-      "--qualification-matrix-cell protected_windows_x64_vulkan",
-      "--calibration-run-index",
-      "--calibration-run-output",
-      "if ($LASTEXITCODE -ne 0)",
-    ]);
     const engine = namedStep(job, "Prove protected Windows Vulkan runtime");
     requireStepRun(violations, vulkanFile, job, "Prove protected Windows Vulkan runtime", [
       "--engine-policy accelerated",
@@ -3670,14 +3650,14 @@ function validateRemainingWorkflows(workflows, violations) {
     );
     add(
       violations,
-      engine?.if === "${{ !inputs.calibration_mode && !inputs.candidate_installed_proof }}",
+      engine?.if === "${{ !inputs.candidate_installed_proof }}",
       `${vulkanFile} protected Windows Vulkan proof must yield to the candidate-installed lane`,
     );
     const candidateStage = namedStep(job, "Stage isolated candidate-managed Windows install");
     add(
       violations,
-      candidateStage?.if === "${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}",
-      `${vulkanFile} candidate-managed staging must require candidate mode outside calibration`,
+      candidateStage?.if === "inputs.candidate_installed_proof",
+      `${vulkanFile} candidate-managed staging must require explicit candidate mode`,
     );
     requireStepRun(violations, vulkanFile, job, "Stage isolated candidate-managed Windows install", [
       "--prepare-candidate-installed-proof",
@@ -3701,8 +3681,8 @@ function validateRemainingWorkflows(workflows, violations) {
     const candidateProof = namedStep(job, "Prove candidate-installed Windows Vulkan runtime");
     add(
       violations,
-      candidateProof?.if === "${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}",
-      `${vulkanFile} candidate-installed Vulkan proof must require candidate mode outside calibration`,
+      candidateProof?.if === "inputs.candidate_installed_proof",
+      `${vulkanFile} candidate-installed Vulkan proof must require explicit candidate mode`,
     );
     requireStepRun(violations, vulkanFile, job, "Prove candidate-installed Windows Vulkan runtime", [
       "--proof-tier installed_runtime",
@@ -3756,8 +3736,8 @@ function validateRemainingWorkflows(workflows, violations) {
     const releaseCell = namedStep(job, "Emit authenticated Vulkan release cell");
     add(
       violations,
-      releaseCell?.if === "inputs.emit_release_cells && !inputs.calibration_mode",
-      `${vulkanFile} accelerated proof must retain the authenticated Vulkan release cell outside calibration`,
+      releaseCell?.if === "inputs.emit_release_cells",
+      `${vulkanFile} accelerated proof must retain the authenticated Vulkan release cell`,
     );
     const vulkanCellUpload = namedStep(job, "Upload authenticated Vulkan release cell");
     add(
@@ -4212,10 +4192,6 @@ function validateReleaseArtifactRerunSafety(workflows, violations) {
     ["macos-metal-proof.yml/packaged-metal/Upload Metal calibration runs", {
       name: "embedding-calibration-macos-${{ inputs.version }}",
       path: "target/calibration-runs/macos",
-    }],
-    ["windows-vulkan-proof.yml/packaged-vulkan/Upload Vulkan calibration runs", {
-      name: "embedding-calibration-windows-${{ inputs.version }}",
-      path: "target/calibration-runs/windows",
     }],
     ["release.yml/pre-publish-closeout/Upload accepted pre-publish closeout", {
       name: "release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -526,8 +526,8 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
   const packagedCoordinatorFile = "packaged-platform-pr.yml";
   const packagedProofFile = "packaged-platform-proof.yml";
   const linuxVulkanFile = "linux-vulkan-proof.yml";
-  const metalProofFile = "macos-metal-proof.yml";
   const windowsVulkanFile = "windows-vulkan-proof.yml";
+  const metalProofFile = "macos-metal-proof.yml";
   const sourceResolver = workflow => draftStep(workflow.jobs.resolve, "Resolve trusted exact head");
   const packagedResolver = workflow => draftStep(workflow.jobs.route, "Resolve trusted exact head");
 
@@ -726,59 +726,9 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
         "per-user-embedding-server-constant-set.json",
       );
     }, /Collect three independent Metal calibration runs must run test "\$\(jq -r \.status crates\/codestory-llama-sys\/per-user-embedding-server-constant-set\.json\)"/u],
-    ["Vulkan calibration reads the calibration contract from an unpinned location", windowsVulkanFile, workflow => {
-      const step = draftStep(
-        workflow.jobs["packaged-vulkan"],
-        "Collect three independent Vulkan calibration runs",
-      );
-      step.run = step.run.replaceAll(
-        "crates/codestory-llama-sys/per-user-embedding-server-constant-set.json",
-        "per-user-embedding-server-constant-set.json",
-      );
-    }, /Collect three independent Vulkan calibration runs must run \(Get-Content crates\/codestory-llama-sys\/per-user-embedding-server-constant-set\.json -Raw \| ConvertFrom-Json\)\.status/u],
-    ["Vulkan calibration accepts a frozen constant set", windowsVulkanFile, workflow => {
-      const step = draftStep(
-        workflow.jobs["packaged-vulkan"],
-        "Collect three independent Vulkan calibration runs",
-      );
-      step.run = step.run.replace('-ne "unfrozen"', '-ne "frozen"');
-    }, /Collect three independent Vulkan calibration runs must run -ne "unfrozen"/u],
-    ["Vulkan calibration masks a failed early run", windowsVulkanFile, workflow => {
-      const step = draftStep(
-        workflow.jobs["packaged-vulkan"],
-        "Collect three independent Vulkan calibration runs",
-      );
-      step.run = step.run.replace("if ($LASTEXITCODE -ne 0) {", "if ($false) {");
-    }, /Collect three independent Vulkan calibration runs must run if \(\$LASTEXITCODE -ne 0\)/u],
-    ["Vulkan release cell is emitted during calibration", windowsVulkanFile, workflow => {
-      draftStep(workflow.jobs["packaged-vulkan"], "Emit authenticated Vulkan release cell").if
-        = "inputs.emit_release_cells";
-    }, /must retain the authenticated Vulkan release cell outside calibration/u],
     ["Vulkan model preparation drops the bypass shell", windowsVulkanFile, workflow => {
       delete draftStep(workflow.jobs["packaged-vulkan"], "Prepare checksum-pinned embedded model").shell;
     }, /Prepare checksum-pinned embedded model must declare the bypass shell/u],
-    ["Vulkan candidate staging runs during calibration", windowsVulkanFile, workflow => {
-      draftStep(workflow.jobs["packaged-vulkan"], "Stage isolated candidate-managed Windows install").if
-        = "inputs.candidate_installed_proof";
-    }, /candidate-managed staging must require candidate mode outside calibration/u],
-    ["Vulkan candidate proof runs during calibration", windowsVulkanFile, workflow => {
-      draftStep(workflow.jobs["packaged-vulkan"], "Prove candidate-installed Windows Vulkan runtime").if
-        = "inputs.candidate_installed_proof";
-    }, /candidate-installed Vulkan proof must require candidate mode outside calibration/u],
-    ["protected Windows Vulkan proof runs during calibration", windowsVulkanFile, workflow => {
-      draftStep(workflow.jobs["packaged-vulkan"], "Prove protected Windows Vulkan runtime").if
-        = "${{ !inputs.candidate_installed_proof }}";
-    }, /protected Windows Vulkan proof must yield to the candidate-installed lane/u],
-    ["Vulkan qualification driver skips calibration", windowsVulkanFile, workflow => {
-      draftStep(workflow.jobs["packaged-vulkan"], "Build qualification driver").if
-        = "${{ !inputs.server_behavior_only }}";
-    }, /packaged server-behavior proof must skip the qualification driver/u],
-    ["Vulkan calibration downloads a frozen bundle", windowsVulkanFile, workflow => {
-      draftStep(workflow.jobs["packaged-vulkan"], "Authenticate calibration bundle producer").if
-        = "${{ !inputs.server_behavior_only }}";
-      draftStep(workflow.jobs["packaged-vulkan"], "Download frozen calibration bundle").if
-        = "${{ !inputs.server_behavior_only }}";
-    }, /calibration authentication and download must run only for qualification or freeze lineage/u],
   ];
 
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
@@ -1003,20 +953,6 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     ["calibration mode enables frozen Linux qualification", coordinatorFile, workflow => {
       workflow.jobs["calibration-linux"].with.hermetic_linux = true;
     }, /hosted Linux calibration must call packaged proof in calibration mode/u],
-    ["Windows calibration cell leaves calibration mode", coordinatorFile, workflow => {
-      workflow.jobs["calibration-windows"].with.calibration_mode = false;
-    }, /protected Windows calibration must call Vulkan proof in calibration mode/u],
-    ["Windows calibration cell reroutes to the package workflow", coordinatorFile, workflow => {
-      workflow.jobs["calibration-windows"].uses = "./.github/workflows/packaged-platform-proof.yml";
-    }, /protected Windows calibration must call Vulkan proof in calibration mode/u],
-    ["calibration assembly skips the Windows cell", coordinatorFile, workflow => {
-      workflow.jobs["calibration-assemble"].needs = workflow.jobs["calibration-assemble"].needs
-        .filter(name => name !== "calibration-windows");
-    }, /calibration assembly must wait for every independent calibration cell/u],
-    ["calibration assembly accepts the pre-Windows run count", coordinatorFile, workflow => {
-      const step = draftStep(workflow.jobs["calibration-assemble"], "Assemble frozen calibration candidate");
-      step.run = step.run.replace('test "${#runs[@]}" = 9', 'test "${#runs[@]}" = 6');
-    }, /Assemble frozen calibration candidate must run test "\$\{#runs\[@\]\}" = 9/u],
     ["coordinator adds a macOS source hard gate", coordinatorFile, workflow => {
       workflow.jobs["macos-source"] = {
         "runs-on": "macos-14",

--- a/.github/scripts/packaged_agent_proof/measurement_protocol_validation.py
+++ b/.github/scripts/packaged_agent_proof/measurement_protocol_validation.py
@@ -202,10 +202,8 @@ def _verify_calibration_matrix(matrix: dict, calibration_matrix: object) -> None
         == {
             "hosted_linux_x64_cpu",
             "protected_macos_arm64_metal",
-            "protected_windows_x64_vulkan",
         },
-        "measurement calibration matrix must contain the Linux CPU, macOS Metal, "
-        "and Windows Vulkan pre-publish lanes",
+        "measurement calibration matrix must contain the Linux CPU and macOS Metal pre-publish lanes",
     )
     for cell_id, cell in calibration_matrix.items():
         require(

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
@@ -127,8 +127,8 @@ def _calibration_bundle_tests(
         )
     )
     require(
-        assembled["run_count"] == 9
-        and assembled["matrix_cell_count"] == 3
+        assembled["run_count"] == 6
+        and assembled["matrix_cell_count"] == 2
         and assembled_bundle_path.is_file()
         and assembled_constant_path.is_file(),
         "calibration assembler did not produce the exact frozen artifacts",
@@ -139,8 +139,8 @@ def _calibration_bundle_tests(
         enforce_source_lineage=False,
     )
     require(
-        calibration_result["run_count"] == 9
-        and calibration_result["matrix_cell_count"] == 3,
+        calibration_result["run_count"] == 6
+        and calibration_result["matrix_cell_count"] == 2,
         "calibration bundle self-test did not verify the full matrix",
     )
     return CalibrationFixture(

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -285,30 +285,17 @@ jobs:
       use_packaged_cli_artifact: false
       calibration_mode: true
 
-  calibration-windows:
-    if: needs.route.outputs.mode == 'calibration'
-    needs: route
-    uses: ./.github/workflows/windows-vulkan-proof.yml
-    with:
-      version: ${{ needs.route.outputs.version }}
-      ref: ${{ needs.route.outputs.head_sha }}
-      proof_key: calibration-windows-${{ needs.route.outputs.head_sha }}
-      use_packaged_cli_artifact: false
-      calibration_mode: true
-
   calibration-assemble:
     if: >-
       always() &&
       needs.route.result == 'success' &&
       needs.route.outputs.mode == 'calibration' &&
       needs.calibration-linux.result == 'success' &&
-      needs.calibration-macos.result == 'success' &&
-      needs.calibration-windows.result == 'success'
+      needs.calibration-macos.result == 'success'
     needs:
       - route
       - calibration-linux
       - calibration-macos
-      - calibration-windows
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -330,12 +317,6 @@ jobs:
           name: embedding-calibration-macos-${{ needs.route.outputs.version }}
           path: target/calibration-inputs/macos
 
-      - name: Download protected Windows calibration runs
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: embedding-calibration-windows-${{ needs.route.outputs.version }}
-          path: target/calibration-inputs/windows
-
       - name: Assemble frozen calibration candidate
         shell: bash
         env:
@@ -348,7 +329,7 @@ jobs:
               \( -name 'run-1.json' -o -name 'run-2.json' -o -name 'run-3.json' \) \
               -print | sort
           )
-          test "${#runs[@]}" = 9
+          test "${#runs[@]}" = 6
           run_args=()
           for run in "${runs[@]}"; do
             run_args+=(--calibration-run "$run")
@@ -383,8 +364,8 @@ jobs:
             --arg source_head_sha "$EXPECTED_HEAD_SHA" \
             --arg producer_run_id "$GITHUB_RUN_ID" \
             '.selection_source.commit == $source_head_sha
-             and .run_count == 9
-             and .matrix_cell_count == 3
+             and .run_count == 6
+             and .matrix_cell_count == 2
              and .producer_run_id == $producer_run_id' \
             target/calibration-freeze/manifest.json >/dev/null
 

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -29,11 +29,6 @@ on:
         required: false
         default: ""
         type: string
-      calibration_mode:
-        description: Collect three independent pre-freeze Vulkan calibration runs.
-        required: false
-        default: false
-        type: boolean
       candidate_installed_proof:
         description: Install and prove the exact package through the candidate-managed launcher boundary.
         required: false
@@ -75,11 +70,6 @@ on:
         required: false
         default: ""
         type: string
-      calibration_mode:
-        description: Collect three independent pre-freeze Vulkan calibration runs.
-        required: false
-        default: false
-        type: boolean
       candidate_installed_proof:
         description: Install and prove the exact package through the candidate-managed launcher boundary.
         required: false
@@ -109,7 +99,7 @@ jobs:
     name: Packaged Windows Vulkan engine
     runs-on: [self-hosted, Windows, X64, codestory-vulkan]
     environment: windows-vulkan-proof
-    timeout-minutes: ${{ inputs.calibration_mode && 180 || 120 }}
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v5
         with:
@@ -139,9 +129,6 @@ jobs:
           if ("${{ inputs.server_behavior_only }}" -ne "true") {
             throw "candidate_installed_proof requires server_behavior_only"
           }
-          if ("${{ inputs.calibration_mode }}" -ne "false") {
-            throw "candidate_installed_proof cannot run in calibration mode"
-          }
 
       - name: Capture source build tool evidence
         if: ${{ !inputs.use_packaged_cli_artifact }}
@@ -152,7 +139,7 @@ jobs:
           ninja --version | Out-File -Append target/windows-vulkan-proof/host.txt
 
       - name: Install pinned Rust
-        if: ${{ !inputs.use_packaged_cli_artifact || inputs.calibration_mode || !inputs.server_behavior_only }}
+        if: ${{ !inputs.use_packaged_cli_artifact || !inputs.server_behavior_only }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           rustup toolchain install 1.95.0 --profile minimal
@@ -188,7 +175,7 @@ jobs:
           path: target/release-dist
 
       - name: Build qualification driver
-        if: ${{ inputs.calibration_mode || !inputs.server_behavior_only }}
+        if: ${{ !inputs.server_behavior_only }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification
 
@@ -200,7 +187,7 @@ jobs:
           path: target/release-quality-evidence
 
       - name: Authenticate calibration bundle producer
-        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only }}
+        if: ${{ !inputs.server_behavior_only }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           GH_TOKEN: ${{ github.token }}
@@ -231,7 +218,7 @@ jobs:
           }
 
       - name: Download frozen calibration bundle
-        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only }}
+        if: ${{ !inputs.server_behavior_only }}
         uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.calibration_bundle_artifact }}
@@ -240,7 +227,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Prove protected Windows Vulkan runtime
-        if: ${{ !inputs.calibration_mode && !inputs.candidate_installed_proof }}
+        if: ${{ !inputs.candidate_installed_proof }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           VERSION: ${{ inputs.version }}
@@ -297,53 +284,8 @@ jobs:
             --timeout-secs 1800 `
             --out-dir target/windows-vulkan-proof/packaged-agent
 
-      - name: Collect three independent Vulkan calibration runs
-        if: inputs.calibration_mode
-        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
-        env:
-          VERSION: ${{ inputs.version }}
-          CODESTORY_EMBED_ALLOW_CPU: "0"
-        run: |
-          $ErrorActionPreference = "Stop"
-          $constantStatus = (Get-Content crates/codestory-llama-sys/per-user-embedding-server-constant-set.json -Raw | ConvertFrom-Json).status
-          if ($constantStatus -ne "unfrozen") {
-            throw "calibration collection requires the unfrozen constant set"
-          }
-          $version = $env:VERSION.TrimStart('v')
-          $sourceSha = (git rev-parse HEAD).Trim()
-          $sourceTree = (git rev-parse 'HEAD^{tree}').Trim()
-          New-Item -ItemType Directory -Force target/calibration-runs/windows | Out-Null
-          foreach ($runIndex in 1, 2, 3) {
-            python .github/scripts/check-packaged-agent-proof.py `
-              --archive "target/release-dist/codestory-cli-v$version-windows-x64.zip" `
-              --checksum-file "target/release-dist/codestory-cli-v$version-windows-x64.zip.sha256" `
-              --expected-version $version `
-              --project "${{ github.workspace }}" `
-              --plugin-root plugins/codestory `
-              --plugin-handoff `
-              --engine-policy accelerated `
-              --expected-backend Vulkan `
-              --offline `
-              --proof-tier calibration `
-              --qualification-matrix-cell protected_windows_x64_vulkan `
-              --produce-qualification-evidence `
-              --qualification-driver target/release/codestory_embedding_qualification.exe `
-              --qualification-evidence "target/calibration-runs/windows/qualification-$runIndex.json" `
-              --calibration-run-index $runIndex `
-              --calibration-run-output "target/calibration-runs/windows/run-$runIndex.json" `
-              --expected-source-sha $sourceSha `
-              --expected-source-tree $sourceTree `
-              --timeout-secs 1800 `
-              --out-dir "target/calibration-runs/windows/proof-$runIndex"
-            # The Actions PowerShell wrapper propagates only the final exit code, so an
-            # early failed run must not be masked by a later clean one.
-            if ($LASTEXITCODE -ne 0) {
-              throw "calibration run $runIndex failed"
-            }
-          }
-
       - name: Stage isolated candidate-managed Windows install
-        if: ${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}
+        if: inputs.candidate_installed_proof
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           GH_TOKEN: ${{ github.token }}
@@ -397,7 +339,7 @@ jobs:
             --candidate-artifact-name (Split-Path -Leaf $archive)
 
       - name: Prove candidate-installed Windows Vulkan runtime
-        if: ${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}
+        if: inputs.candidate_installed_proof
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           VERSION: ${{ inputs.version }}
@@ -441,7 +383,7 @@ jobs:
             --out-dir target/candidate-installed-windows/proof
 
       - name: Upload candidate-installed Windows proof
-        if: always() && inputs.candidate_installed_proof && !inputs.calibration_mode
+        if: always() && inputs.candidate_installed_proof
         uses: actions/upload-artifact@v7.0.1
         with:
           name: candidate-installed-windows-${{ inputs.version }}-attempt-${{ github.run_attempt }}
@@ -450,7 +392,7 @@ jobs:
           retention-days: 30
 
       - name: Emit authenticated Vulkan release cell
-        if: inputs.emit_release_cells && !inputs.calibration_mode
+        if: inputs.emit_release_cells
         shell: bash
         run: |
           set -euo pipefail
@@ -475,7 +417,7 @@ jobs:
             --out target/release-cells/accelerator_execution-windows-x64-vulkan.json
 
       - name: Upload authenticated Vulkan release cell
-        if: success() && inputs.emit_release_cells && !inputs.calibration_mode
+        if: success() && inputs.emit_release_cells
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-cell-prepublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}
@@ -484,7 +426,7 @@ jobs:
           retention-days: 30
 
       - name: Emit authenticated Windows retrieval-readiness release cell
-        if: inputs.emit_release_cells && inputs.server_behavior_only && !inputs.calibration_mode
+        if: inputs.emit_release_cells && inputs.server_behavior_only
         shell: bash
         run: |
           set -euo pipefail
@@ -504,7 +446,7 @@ jobs:
             --out target/release-cells/retrieval_readiness-windows-x64.json
 
       - name: Upload authenticated Windows retrieval-readiness release cell
-        if: success() && inputs.emit_release_cells && inputs.server_behavior_only && !inputs.calibration_mode
+        if: success() && inputs.emit_release_cells && inputs.server_behavior_only
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-cell-postpublish-retrieval-windows-x64-attempt-${{ github.run_attempt }}
@@ -513,7 +455,7 @@ jobs:
           retention-days: 30
 
       - name: Emit authenticated candidate-installed Windows release cell
-        if: inputs.emit_release_cells && inputs.candidate_installed_proof && !inputs.calibration_mode
+        if: inputs.emit_release_cells && inputs.candidate_installed_proof
         shell: bash
         run: |
           set -euo pipefail
@@ -540,7 +482,7 @@ jobs:
             --out target/release-cells/candidate_installed_behavior-windows-x64.json
 
       - name: Upload authenticated candidate-installed Windows release cell
-        if: success() && inputs.emit_release_cells && inputs.candidate_installed_proof && !inputs.calibration_mode
+        if: success() && inputs.emit_release_cells && inputs.candidate_installed_proof
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-cell-prepublish-candidate-installed-windows-x64-attempt-${{ github.run_attempt }}
@@ -548,18 +490,8 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-      - name: Upload Vulkan calibration runs
-        if: always() && inputs.calibration_mode
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: embedding-calibration-windows-${{ inputs.version }}
-          path: target/calibration-runs/windows
-          if-no-files-found: error
-          retention-days: 30
-          overwrite: true
-
       - name: Upload Vulkan proof artifacts
-        if: always() && !inputs.calibration_mode
+        if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: windows-x64-vulkan-proof-${{ inputs.version }}-attempt-${{ github.run_attempt }}

--- a/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json
@@ -82,16 +82,6 @@
       "cache_state": "reused",
       "residency_state": "resident",
       "accelerator_claim": "metal"
-    },
-    "protected_windows_x64_vulkan": {
-      "asset_target": "windows-x64",
-      "proof_tier": "calibration",
-      "host_class": "protected_self_hosted_windows_x64",
-      "policy": "accelerated",
-      "backend": "vulkan",
-      "cache_state": "reused",
-      "residency_state": "resident",
-      "accelerator_claim": "vulkan"
     }
   },
   "host_package_matrix": {
@@ -565,7 +555,7 @@
       }
     },
     "post_result_formula_changes": false,
-    "slow_host_floor_rationale": "The calibration matrix is hosted Linux x64, protected macOS arm64, and protected Windows x64 only, so while Windows named-pipe hosts now contribute to the maxima these budgets scale, no host without SHA hardware acceleration does. A release executable also embeds the model, and the spawned server hashes its whole image before it binds, so the spawn budget must cover a multi-hundred-megabyte read on a cold cache. 1.50x over a CI maximum does not cover that population. The floors are the pre-freeze draft values, which were the vetted conservative behavior. Thresholds are deliberately not floored: qualification keeps measuring regressions against the calibrated maxima while users get budgets sized for the slowest supported host."
+    "slow_host_floor_rationale": "The calibration matrix is hosted Linux x64 and protected macOS arm64 only, so no Windows named-pipe host and no host without SHA hardware acceleration contributes to the maxima these budgets scale. A release executable also embeds the model, and the spawned server hashes its whole image before it binds, so the spawn budget must cover a multi-hundred-megabyte read on a cold cache. 1.50x over a CI maximum does not cover that population. The floors are the pre-freeze draft values, which were the vetted conservative behavior. Thresholds are deliberately not floored: qualification keeps measuring regressions against the calibrated maxima while users get budgets sized for the slowest supported host."
   },
   "threshold_selection": {
     "minimum_clean_calibration_runs_per_matrix_cell": 3,


### PR DESCRIPTION
Reverts the Windows calibration cell so the re-freeze can complete on the two cells that measure reliably — the matrix v0.16.1 shipped under. The bypass-shell policy pin added later is kept.

Every defect the Windows attempts surfaced is already fixed and merged and keeps its value; only the cell goes. Accepted cost, stated rather than buried: frozen budgets now derive from Linux and macOS maxima only, so an operation slowest on a named-pipe host could get a budget tighter than that host wants. That is the risk the cell existed to close and the status quo v0.16.1 already ships under.

Verified: policy checker green, 365/365 policy tests, matrix back to 6 runs across 2 cells.

Closes #1532

🤖 Generated with [Claude Code](https://claude.com/claude-code)