### PR TITLE
release 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
+## 0.16.2
+
 ### Fixed
 
-- Fixed semantic sidecar publication failing with `unable to open database file` on Windows under deep cache roots (service profiles, redirected homes): sidecar SQLite opens now use extended-length paths and the staged vector index no longer creates a rollback journal.
-- Windows projects whose cache root sits deep in the filesystem can index, search, and publish again. Indexing, status, and snapshot publication could fail with `unable to open database file` once the project database path approached 260 characters — reachable with a long user name, a redirected or roaming home directory, or a service account — because the database's write-ahead-log companion files were a few characters longer still. Every core database open now handles long paths, so no change to the cache location or Windows settings is needed.
+- Windows projects whose cache root sits deep in the filesystem can index, search, and publish again. Indexing, status, semantic publication, and snapshot publication could fail with `unable to open database file` once a database path approached 260 characters — reachable with a long user name, a redirected or roaming home directory, or a service account — because the companion files SQLite derives by appending to that path were longer still. Every database open now handles long paths, so no change to the cache location or Windows settings is needed.
 - First use completes on Linux hosts that keep `/tmp` on its own filesystem.
   Setup previously downloaded the runtime, failed to install it, and started the
   download again until it gave up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-bench"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-llama-sys"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "crossbeam-channel",
  "fs4",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-llama-sys"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 build = "build.rs"
 

--- a/crates/codestory-llama-sys/model-contract.json
+++ b/crates/codestory-llama-sys/model-contract.json
@@ -37,7 +37,7 @@
   "producer": {
     "name": "codestory-llama-sys",
     "embedding_revision": "0.16.1",
-    "version": "0.16.1"
+    "version": "0.16.2"
   },
   "license": {
     "spdx_id": "MIT",

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 
 [features]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/cli-version.json
+++ b/plugins/codestory/cli-version.json
@@ -1,10 +1,5 @@
 {
   "schema_version": 1,
-  "cli_version": "0.16.1",
-  "release_tag": "v0.16.1",
-  "archives": {
-    "macos-arm64": "0074a2a7d2fe1047230414c7ea25f3b8d53a7cbbbfbee86329903ca11e5944b4",
-    "windows-x64": "f9885831a9e61c558c19987b9e65abf49a2dbc92cb6e775832d536bec0ca59d9",
-    "linux-x64": "1ad571e594ef0d00244e307e389d0d7a6a638bf168807e3d45d38cb875cd1480"
-  }
+  "cli_version": "0.16.2",
+  "release_tag": "v0.16.2"
 }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -874,14 +874,25 @@ function semverGreater(left, right) {
 }
 
 test("the CLI version pin decides what the managed path provisions", async () => {
-  // With a valid pin, the launcher resolves the pinned version and its published digest.
-  assert.equal(launcherTest.pinnedCliVersion(), "0.16.1");
+  // Read the version out of the pin rather than restating it: a release bump
+  // rewrites the pin, and a test that hardcodes the old number fails the bump
+  // instead of the behaviour it is guarding.
   const pin = launcherTest.pinnedCliContract();
-  assert.equal(pin.release_tag, "v0.16.1");
-  assert.equal(
-    launcherTest.pinnedArchiveSha256("macos-arm64"),
-    pin.archives["macos-arm64"],
-  );
+  assert.match(pin.cli_version, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u);
+  assert.equal(launcherTest.pinnedCliVersion(), pin.cli_version);
+  assert.equal(pin.release_tag, `v${pin.cli_version}`);
+
+  // A native bump drops the digests: they cannot exist until that release
+  // publishes its archives, and the plugin lane re-adds them when it pins an
+  // already-published CLI.
+  if (pin.archives) {
+    assert.equal(
+      launcherTest.pinnedArchiveSha256("macos-arm64"),
+      pin.archives["macos-arm64"],
+    );
+  } else {
+    assert.equal(launcherTest.pinnedArchiveSha256("macos-arm64"), null);
+  }
   assert.equal(launcherTest.pinnedArchiveSha256("no-such-target"), null);
 });
 


### PR DESCRIPTION
Sets 0.16.2 across all 16 release surfaces via scripts/bump-version.mjs; the synchronization validator passes.

Also merges the two Windows long-path changelog entries into the single symptom a user experiences — they were separate fixes (semantic sidecar and core store) with one user-visible failure.

Closes #1534

🤖 Generated with [Claude Code](https://claude.com/claude-code)