### PR TITLE
give the release policy job the history its contracts read

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1611,6 +1611,18 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   );
   requireNoCalibrationReferences(violations, releaseFile, release);
   const policy = requireJob(violations, releaseFile, release, "workflow-policy");
+  // The reuse-binding contracts resolve real release commits, which a depth-1
+  // clone does not carry: it answered only while the referenced commit happened
+  // to be HEAD.
+  add(
+    violations,
+    list(object(policy).steps).some(
+      (step) =>
+        object(step).uses?.startsWith("actions/checkout")
+        && object(object(step).with)["fetch-depth"] === 0,
+    ),
+    `${releaseFile} workflow-policy must check out full history for the reuse-binding contracts`,
+  );
   requireStepRun(violations, releaseFile, policy, "Install workflow policy dependencies", ["npm ci --ignore-scripts"]);
   requireStepRun(violations, releaseFile, policy, "Check workflow syntax", [
     "node --test .github/scripts/run-actionlint.test.mjs",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -756,6 +756,9 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     draftStep(packagedJob(workflow), "Capture reusable build cache contract");
 
   const mutations = [
+    ["release workflow policy loses its full history", releaseFile, workflow => {
+      delete workflow.jobs["workflow-policy"].steps[0].with;
+    }, /workflow-policy must check out full history for the reuse-binding contracts/u],
     ["source compiler restore becomes exact-SHA-only", sourceFile, workflow => {
       draftStep(sourceJob(workflow), "Restore compatible compiler objects")
         .with["restore-keys"] = "${{ steps.build-cache.outputs.compiler-key }}";

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # The reuse-binding contracts verify tree identity and native
+          # fingerprints against this repository's real release history, so the
+          # default depth-1 clone cannot answer them.
+          fetch-depth: 0
 
       - name: Install workflow policy dependencies
         run: npm ci --ignore-scripts


### PR DESCRIPTION
The 0.16.2 release failed at the release-claims contracts: `git rev-parse 00121349^{tree}` cannot resolve in a depth-1 clone.

Those contracts verify reuse bindings against real release history — v0.16.0 to v0.16.1 is a pure version bump, so the trees differ (source_tree reuse must refuse) while the native fingerprints match (accelerator inheritance is what version_only_delta authorizes). The job checked out at the default depth of one, which answered those lookups only while the referenced commit happened to be HEAD. That was true at the 0.16.1 release and false 131 commits later, so the first release after it was always going to fail here.

The job now fetches full history, pinned in the policy checker with a mutation test. Verified: policy checker green, 366/366 policy tests, the cell-manifest contracts pass locally against real history.

Based on main so the release can proceed.

Closes #1537

🤖 Generated with [Claude Code](https://claude.com/claude-code)