### PR TITLE
shape the marketplace fixture like the catalog it stands in for

### DIFF
--- a/.github/scripts/build-marketplace-fixture.mjs
+++ b/.github/scripts/build-marketplace-fixture.mjs
@@ -55,18 +55,30 @@ if (typeof manifest.version !== "string" || !manifest.version) {
 
 const catalogDirectory = path.join(path.resolve(args.out), ".agents", "plugins");
 mkdirSync(catalogDirectory, { recursive: true });
+// Mirrors the live catalog's shape at .agents/plugins/marketplace.json. The
+// resolver rejects a catalog missing `name`, and the live catalog carries no
+// version field at either level - the pinned `sha` is what selects the plugin,
+// so inventing one here would prove an install path the real catalog cannot
+// produce.
 const catalog = {
-  version: 1,
+  name: "TheGreenCedar",
+  interface: {
+    displayName: "TheGreenCedar",
+  },
   plugins: [
     {
       name: "codestory",
-      version: manifest.version,
       source: {
         source: "git-subdir",
-        path: "plugins/codestory",
         url: "https://github.com/TheGreenCedar/CodeStory.git",
+        path: "plugins/codestory",
         sha: commit,
       },
+      policy: {
+        installation: "AVAILABLE",
+        authentication: "ON_INSTALL",
+      },
+      category: "Developer Tools",
     },
   ],
 };

--- a/.github/scripts/build-marketplace-fixture.test.mjs
+++ b/.github/scripts/build-marketplace-fixture.test.mjs
@@ -1,0 +1,78 @@
+// The fixture stands in for the live catalog during release preflight, so its
+// shape has to be the live catalog's shape. When it was not, the resolver
+// refused it with `missing field \`name\`` and the first release to exercise the
+// fixture path failed at preflight.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+/// The keys the live catalog carries, recorded here so a divergence fails at PR
+/// time instead of at the release that first depends on it.
+const CATALOG_KEYS = ["interface", "name", "plugins"];
+const PLUGIN_KEYS = ["category", "name", "policy", "source"];
+const SOURCE_KEYS = ["path", "sha", "source", "url"];
+
+function buildFixture() {
+  const out = mkdtempSync(path.join(tmpdir(), "codestory-marketplace-fixture-"));
+  const commit = execFileSync("git", ["-C", repositoryRoot, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+  }).trim();
+  execFileSync(
+    process.execPath,
+    [
+      path.join(repositoryRoot, ".github/scripts/build-marketplace-fixture.mjs"),
+      "--source-repository",
+      repositoryRoot,
+      "--out",
+      out,
+      "--commit",
+      commit,
+    ],
+    { encoding: "utf8" },
+  );
+  const catalog = JSON.parse(
+    readFileSync(path.join(out, ".agents/plugins/marketplace.json"), "utf8"),
+  );
+  return { out, catalog, commit };
+}
+
+test("the fixture catalog carries the fields the resolver requires", () => {
+  const { out, catalog, commit } = buildFixture();
+  try {
+    assert.deepEqual(Object.keys(catalog).sort(), CATALOG_KEYS);
+    assert.equal(typeof catalog.name, "string");
+    assert.ok(catalog.name.length > 0, "the resolver rejects a nameless catalog");
+
+    assert.equal(catalog.plugins.length, 1);
+    const [plugin] = catalog.plugins;
+    assert.deepEqual(Object.keys(plugin).sort(), PLUGIN_KEYS);
+    assert.equal(plugin.name, "codestory");
+    assert.deepEqual(Object.keys(plugin.source).sort(), SOURCE_KEYS);
+    assert.equal(plugin.source.sha, commit);
+    assert.equal(plugin.source.path, "plugins/codestory");
+  } finally {
+    rmSync(out, { recursive: true, force: true });
+  }
+});
+
+test("the fixture states no version, because the live catalog states none", () => {
+  // The pinned `sha` selects the plugin. A version field here would prove an
+  // install path the live catalog cannot produce.
+  const { out, catalog } = buildFixture();
+  try {
+    assert.equal(catalog.version, undefined);
+    assert.equal(catalog.plugins[0].version, undefined);
+  } finally {
+    rmSync(out, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1629,6 +1629,7 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     "node .github/scripts/run-actionlint.mjs",
   ]);
   requireStepRun(violations, releaseFile, policy, "Check release claim and evidence contracts", [
+    ".github/scripts/build-marketplace-fixture.test.mjs",
     "scripts/tests/codestory-release-claims.test.mjs",
     "scripts/tests/codestory-release-cell-manifest.test.mjs",
     "scripts/tests/codestory-release-closeout.test.mjs",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Check release claim and evidence contracts
         run: >-
           node --test
+          .github/scripts/build-marketplace-fixture.test.mjs
           scripts/tests/codestory-release-claims.test.mjs
           scripts/tests/codestory-release-cell-manifest.test.mjs
           scripts/tests/codestory-release-closeout.test.mjs


### PR DESCRIPTION
The 0.16.2 release was refused at preflight with `missing field name`: the fixture standing in for the live catalog had never been compared against it. It lacked the top-level `name` the resolver requires, along with `interface`, `policy` and `category`, and carried `version` fields at two levels that the live catalog does not have.

Invisible until now because the fixture path arrived with the zero-click marketplace work and this is the first release to exercise it — 0.16.1 proved the install path against the live catalog.

The builder now mirrors the live catalog key for key (verified by fetching it and diffing all three levels), and a new test asserts that mirror, revert-proven: deleting `name` fails it. Wired into the release policy job and pinned in the checker, so a future divergence fails at PR time instead of at a release. Policy checker green, 366/366 policy tests.

The absent version fields are deliberate and commented: the pinned `sha` selects the plugin, so a version here would prove an install path the live catalog cannot produce.

Closes #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)