### PR TITLE
prove fixture provenance against the fixture's own revision

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1683,6 +1683,12 @@ function validateReleaseCoordinator(workflows, violations, graph) {
       "install-codestory-marketplace-proof.mjs",
       '--source-repository "$GITHUB_WORKSPACE"',
       "marketplace_revision=$marketplace_revision",
+      // Fixture mode resolves from the locally built catalog, so provenance is
+      // checked against that repository's own revision. Checking it against the
+      // live revision can never match, which is how the fixture path shipped
+      // unexercised.
+      'fixture_revision="$(git -C "$fixture_root" rev-parse HEAD)"',
+      '--marketplace-revision "$fixture_revision"',
     ],
   );
   add(

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -759,6 +759,10 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     ["release workflow policy loses its full history", releaseFile, workflow => {
       delete workflow.jobs["workflow-policy"].steps[0].with;
     }, /workflow-policy must check out full history for the reuse-binding contracts/u],
+    ["marketplace preflight proves the live revision against a fixture", releaseFile, workflow => {
+      const step = draftStep(workflow.jobs["preflight"], "Prove the public marketplace install path");
+      step.run = step.run.replace('--marketplace-revision "$fixture_revision"', '--marketplace-revision "$marketplace_revision"');
+    }, /--marketplace-revision "\$fixture_revision"/u],
     ["source compiler restore becomes exact-SHA-only", sourceFile, workflow => {
       draftStep(sourceJob(workflow), "Restore compatible compiler objects")
         .with["restore-keys"] = "${{ steps.build-cache.outputs.compiler-key }}";

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,13 +231,18 @@ jobs:
             --out "$fixture_root" \
             --source-repository "$GITHUB_WORKSPACE" \
             --commit "$GITHUB_SHA"
+          # The resolver reads the fixture, so provenance must be checked against
+          # the fixture's own revision. The live revision above is still the one
+          # the post-publish smoke consumes, so both are captured.
+          fixture_revision="$(git -C "$fixture_root" rev-parse HEAD)"
+          test "$(printf '%s' "$fixture_revision" | wc -c | tr -d ' ')" = 40
           node .github/scripts/install-codestory-marketplace-proof.mjs \
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \
             --marketplace-source "$fixture_root" \
             --marketplace-name TheGreenCedar \
-            --marketplace-revision "$marketplace_revision" \
+            --marketplace-revision "$fixture_revision" \
             --local-fixture true \
             --expected-version "$VERSION" \
             --source-repository "$GITHUB_WORKSPACE" \


### PR DESCRIPTION
The preflight resolves the plugin from a locally built fixture catalog but asserted the resolved revision equalled the **live** marketplace HEAD. Two different repositories, so the check could never pass — it failed the first time a release exercised fixture mode.

The proof now receives the fixture repository revision; the live revision is still captured because the post-publish smoke consumes it against the real catalog. Pinned in the policy checker with a mutation test that reverts the argument and expects the failure.

Third defect in this path today with a single cause: fixture mode shipped with the zero-click marketplace work and 0.16.2 is the first release to run it. Policy checker green, 366/366 policy tests.

Closes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)