### PR TITLE
Release 0.16.2 retry: marketplace preflight repaired

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1683,6 +1683,12 @@ function validateReleaseCoordinator(workflows, violations, graph) {
       "install-codestory-marketplace-proof.mjs",
       '--source-repository "$GITHUB_WORKSPACE"',
       "marketplace_revision=$marketplace_revision",
+      // Fixture mode resolves from the locally built catalog, so provenance is
+      // checked against that repository's own revision. Checking it against the
+      // live revision can never match, which is how the fixture path shipped
+      // unexercised.
+      'fixture_revision="$(git -C "$fixture_root" rev-parse HEAD)"',
+      '--marketplace-revision "$fixture_revision"',
     ],
   );
   add(

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -759,6 +759,10 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     ["release workflow policy loses its full history", releaseFile, workflow => {
       delete workflow.jobs["workflow-policy"].steps[0].with;
     }, /workflow-policy must check out full history for the reuse-binding contracts/u],
+    ["marketplace preflight proves the live revision against a fixture", releaseFile, workflow => {
+      const step = draftStep(workflow.jobs["preflight"], "Prove the public marketplace install path");
+      step.run = step.run.replace('--marketplace-revision "$fixture_revision"', '--marketplace-revision "$marketplace_revision"');
+    }, /--marketplace-revision "\$fixture_revision"/u],
     ["source compiler restore becomes exact-SHA-only", sourceFile, workflow => {
       draftStep(sourceJob(workflow), "Restore compatible compiler objects")
         .with["restore-keys"] = "${{ steps.build-cache.outputs.compiler-key }}";

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,13 +231,18 @@ jobs:
             --out "$fixture_root" \
             --source-repository "$GITHUB_WORKSPACE" \
             --commit "$GITHUB_SHA"
+          # The resolver reads the fixture, so provenance must be checked against
+          # the fixture's own revision. The live revision above is still the one
+          # the post-publish smoke consumes, so both are captured.
+          fixture_revision="$(git -C "$fixture_root" rev-parse HEAD)"
+          test "$(printf '%s' "$fixture_revision" | wc -c | tr -d ' ')" = 40
           node .github/scripts/install-codestory-marketplace-proof.mjs \
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \
             --marketplace-source "$fixture_root" \
             --marketplace-name TheGreenCedar \
-            --marketplace-revision "$marketplace_revision" \
+            --marketplace-revision "$fixture_revision" \
             --local-fixture true \
             --expected-version "$VERSION" \
             --source-repository "$GITHUB_WORKSPACE" \


### PR DESCRIPTION
Promotes dev for the 0.16.2 release retry, carrying the marketplace fixture provenance fix. The version is unchanged; the detector retries a version that has no tag or release yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)