### PR TITLE
Release 0.16.2 retry: marketplace preflight repaired

### DIFF
--- a/crates/codestory-llama-sys/build.rs
+++ b/crates/codestory-llama-sys/build.rs
@@ -125,6 +125,7 @@ fn main() {
              pub const MODEL_CONFIG_SHA256: &str = {:?};\n\
              pub const MODEL_PRODUCER_NAME: &str = {:?};\n\
              pub const MODEL_PRODUCER_VERSION: &str = {:?};\n\
+             pub const MODEL_PRODUCER_EMBEDDING_REVISION: &str = {:?};\n\
              pub const MODEL_LICENSE_SPDX_ID: &str = {:?};\n\
              pub const MODEL_LICENSE_SOURCE_URL: &str = {:?};\n\
              pub const NATIVE_ENGINE_BUILD_CONTRACT_SCHEMA_VERSION: u32 = 2;\n\
@@ -149,6 +150,7 @@ fn main() {
             contract.config_sha256,
             contract.producer_name,
             contract.producer_version,
+            contract.producer_embedding_revision,
             contract.license_spdx_id,
             contract.license_source_url,
         ),

--- a/crates/codestory-llama-sys/src/lib.rs
+++ b/crates/codestory-llama-sys/src/lib.rs
@@ -2441,9 +2441,23 @@ mod tests {
         ));
         assert_eq!(MODEL_PRODUCER_NAME, env!("CARGO_PKG_NAME"));
         assert_eq!(MODEL_PRODUCER_VERSION, env!("CARGO_PKG_VERSION"));
+        // The runtime id keys every persisted vector, so it carries the
+        // embedding revision rather than the crate version. Asserting the crate
+        // version here held only while the two happened to be equal, and broke
+        // on the first release that bumped one without the other - which is
+        // exactly the decoupling this identity exists to provide.
         assert!(PRODUCT_EMBEDDING_RUNTIME_ID.contains(&format!(
-            "producer-{MODEL_PRODUCER_NAME}@{MODEL_PRODUCER_VERSION}"
+            "producer-{MODEL_PRODUCER_NAME}@{MODEL_PRODUCER_EMBEDDING_REVISION}"
         )));
+        // The decoupling itself: a release may move the crate version without
+        // moving the embedding revision, and when it does the runtime id must
+        // follow the revision. Otherwise a version bump silently discards every
+        // user's persisted vectors.
+        if MODEL_PRODUCER_VERSION != MODEL_PRODUCER_EMBEDDING_REVISION {
+            assert!(!PRODUCT_EMBEDDING_RUNTIME_ID.contains(&format!(
+                "producer-{MODEL_PRODUCER_NAME}@{MODEL_PRODUCER_VERSION}"
+            )));
+        }
         assert_eq!(MODEL_LICENSE_SPDX_ID, "MIT");
         assert!(MODEL_LICENSE_SOURCE_URL.starts_with("https://"));
 


### PR DESCRIPTION
Promotes dev for the 0.16.2 release retry, carrying the marketplace fixture provenance fix. The version is unchanged; the detector retries a version that has no tag or release yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)