### PR TITLE
compare every embedded producer identity against the revision

### DIFF
--- a/.github/scripts/package-codestory-release.py
+++ b/.github/scripts/package-codestory-release.py
@@ -755,7 +755,7 @@ def native_marker(
         f"backends={backends}|llama_cpp_crate=0.1.151|"
         "llama_cpp_commit=test-commit|"
         f"model_sha256={'a' * 64}|embedding_contract_sha256={embedding_contract_sha256}|"
-        f"model_embedded={model_embedded}|producer=codestory-llama-sys@0.0.0|end"
+        f"model_embedded={model_embedded}|producer=codestory-llama-sys@1.2.3|end"
     )
 
 
@@ -1035,7 +1035,19 @@ def run_self_test() -> None:
                 "tokenizer_sha256": "b" * 64,
                 "config_sha256": "c" * 64,
             },
-            "producer": {"name": "codestory-llama-sys", "version": "0.0.0"},
+            # The version and the embedding revision are deliberately different:
+            # the binary embeds the revision, so a packager that compared the
+            # version would fail here. They were equal in every real release
+            # until 0.16.2, which is why that comparison shipped unnoticed.
+            # The revision is deliberately not the version: the binary embeds
+            # the revision, so a packager comparing the version fails here. The
+            # two were equal in every release until 0.16.2, which is why that
+            # comparison shipped unnoticed.
+            "producer": {
+                "name": "codestory-llama-sys",
+                "version": "0.0.0",
+                "embedding_revision": "1.2.3",
+            },
         }
         model_contract_path = repo_root / "crates/codestory-llama-sys/model-contract.json"
         model_contract_path.parent.mkdir(parents=True, exist_ok=True)

--- a/.github/scripts/package-codestory-release.py
+++ b/.github/scripts/package-codestory-release.py
@@ -513,7 +513,10 @@ def native_release_manifest(
     embedding_descriptor = dict(embedding)
     embedding_descriptor["family"] = runtime.get("embedding_family")
     contract_sha256 = embedding_contract_digest(model, embedding_descriptor, tokenizer)
-    producer_identity = f"{producer.get('name')}@{producer.get('version')}"
+    # The binary embeds the embedding revision, not the crate version: persisted
+    # vectors are keyed by this identity, so it moves only when the embeddings do.
+    # Comparing the crate version here held only while the two were equal.
+    producer_identity = f"{producer.get('name')}@{producer.get('embedding_revision')}"
     require(fields["producer"] == producer_identity, "native engine producer does not match model contract")
     require(fields["model_sha256"] == model.get("sha256"), "embedded model digest does not match model contract")
     require(

--- a/.github/scripts/packaged_agent_proof/native_manifest.py
+++ b/.github/scripts/packaged_agent_proof/native_manifest.py
@@ -430,7 +430,11 @@ def _verify_model(
     producer = parts.model.get("producer")
     require(isinstance(producer, dict), "native manifest lacks model producer identity")
     require(
-        build_fields["producer"] == f"{producer.get('name')}@{producer.get('version')}",
+        # The binary embeds the embedding revision: persisted vectors are keyed
+        # by it, so it moves only when the embeddings do. Comparing the crate
+        # version held only while the two were equal.
+        build_fields["producer"]
+        == f"{producer.get('name')}@{producer.get('embedding_revision')}",
         "native build producer contradicts manifest",
     )
     require(

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_fixture.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_fixture.py
@@ -99,7 +99,9 @@ def _build_native_contract(
         "size_bytes": 4,
         "sha256": "a" * 64,
         "embedded": True,
-        "producer": {"name": "test", "version": "0.0.0"},
+        # Revision deliberately differs from version: the binary embeds the
+        # revision, so a check comparing the version fails here.
+        "producer": {"name": "test", "version": "0.0.0", "embedding_revision": "1.2.3"},
     }
     embedding = {
         "family": "inprocess:test",
@@ -123,7 +125,7 @@ def _build_native_contract(
         "backends=cpu,metal|llama_cpp_crate=test|"
         f"llama_cpp_commit=test|model_sha256={'a' * 64}|"
         f"embedding_contract_sha256={contract_sha256}|model_embedded=true|"
-        "producer=test@0.0.0|end"
+        "producer=test@1.2.3|end"
     )
     protocol_sha256 = sha256(protocol)
     constant_set_sha256 = sha256(constant_set)


### PR DESCRIPTION
Three consumers built the expected producer identity from `producer.version` while the binary embeds `producer.embedding_revision` — the packaging contract check, the native manifest check in the packaged proof, and both self-test fixtures. WP10b keyed that identity to the revision so a version bump does not discard persisted vectors; the comparisons held only while the two values coincided, and 0.16.2 refused all three platform artifacts.

Found by sweeping for the pattern rather than waiting for each to fail in turn: the packaging gate surfaced first, the manifest check would have failed at proof time, and the fixtures hid both because they set version and revision to the same value.

Both fixtures now use a revision that differs from their version and embed the revision in the binary marker, so reverting any consumer to the version fails the self-test rather than a release. Revert-proven; package self-test, packaged-proof self-test, and plugin-static all green.

Closes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)