### PR TITLE
stop steering dense anchors by benchmark filenames

### DIFF
--- a/crates/codestory-runtime/src/semantic_projection.rs
+++ b/crates/codestory-runtime/src/semantic_projection.rs
@@ -2007,19 +2007,6 @@ pub(super) fn semantic_file_is_package_callable_surface(path: Option<&str>) -> b
         || normalized.contains("/controllers/")
         || normalized.contains("/middleware/")
         || normalized.contains("/sources/")
-        || matches!(
-            file_name,
-            "application.js"
-                | "context.go"
-                | "gin.go"
-                | "http.dart"
-                | "nvm.sh"
-                | "request.js"
-                | "response.js"
-                | "routergroup.go"
-                | "sessions.py"
-                | "tree.go"
-        )
 }
 
 pub(super) fn semantic_doc_is_documented_nontrivial(doc_text: &str) -> bool {

--- a/scripts/lint-retrieval-generalization.mjs
+++ b/scripts/lint-retrieval-generalization.mjs
@@ -13,6 +13,13 @@ import { fileURLToPath } from "node:url";
 import { sourcetrailQueries } from "./cross-repo-sourcetrail-queries.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/// Slugs that identify this repository as a benchmark subject. Kept explicit rather
+/// than read from a git remote so the lint is deterministic in a detached CI checkout.
+const SELF_REPOSITORY_SLUGS = new Set([
+  "thegreencedar/codestory",
+  "codestory",
+]);
 const extraScanRoots = (
   process.env.CODESTORY_RETRIEVAL_GENERALIZATION_EXTRA_SCAN_ROOTS ?? ""
 )
@@ -476,21 +483,27 @@ function benchmarkManifestDerivedPatterns() {
     for (const task of benchmarkManifestTasks(manifest)) {
       parsedTaskCount += 1;
       addSpecificMarker(markers, task.id);
-      addRepoMarkers(markers, task.repo);
       addSpecificMarker(markers, task.prompt, { allowExactPhrase: true });
-      for (const expectedFile of task.expected_files ?? []) {
-        addSpecificMarker(markers, expectedFile, { allowSpecificComposite: true });
-      }
-      for (const expectedFile of task.expected_verification_files ?? []) {
-        addSpecificMarker(markers, expectedFile, { allowSpecificComposite: true });
-      }
-      for (const symbol of task.expected_symbols ?? []) {
-        if (typeof symbol === "string") {
-          addSpecificMarker(markers, symbol);
-        } else {
-          addSpecificMarker(markers, symbol?.name);
-          addSpecificMarker(markers, symbol?.qualified_name, { allowSpecificComposite: true });
-          addSpecificMarker(markers, symbol?.path, { allowSpecificComposite: true });
+      // A task whose subject is this repository names our own symbols and paths.
+      // Banning those would forbid the product from containing itself, so only its
+      // benchmark-specific parts (id, prompt, claims) contribute markers.
+      const subjectIsSelf = taskSubjectIsThisRepository(task.repo);
+      if (!subjectIsSelf) {
+        addRepoMarkers(markers, task.repo);
+        for (const expectedFile of task.expected_files ?? []) {
+          addSpecificMarker(markers, expectedFile, { allowSpecificComposite: true });
+        }
+        for (const expectedFile of task.expected_verification_files ?? []) {
+          addSpecificMarker(markers, expectedFile, { allowSpecificComposite: true });
+        }
+        for (const symbol of task.expected_symbols ?? []) {
+          if (typeof symbol === "string") {
+            addSpecificMarker(markers, symbol);
+          } else {
+            addSpecificMarker(markers, symbol?.name);
+            addSpecificMarker(markers, symbol?.qualified_name, { allowSpecificComposite: true });
+            addSpecificMarker(markers, symbol?.path, { allowSpecificComposite: true });
+          }
         }
       }
       for (const claim of task.expected_claims ?? []) {
@@ -687,6 +700,18 @@ function benchmarkManifestTasks(manifest) {
     return [manifest];
   }
   return [];
+}
+
+/// A task manifest may name this repository as its subject: the readme-with-without
+/// suite asks CodeStory questions about CodeStory. Its expected symbols and paths are
+/// then our own product identifiers by construction, so deriving bans from them makes
+/// the product illegal to itself - `RefreshMode` is a codestory-workspace type, and
+/// `crates/.../lib.rs` is where our code lives. Only the benchmark-specific parts of
+/// such a task (its id, prompt, and claim texts) remain bannable.
+function taskSubjectIsThisRepository(repo) {
+  return repoUrlSlugs(repo?.url)
+    .concat(typeof repo?.name === "string" ? [repo.name] : [])
+    .some((slug) => SELF_REPOSITORY_SLUGS.has(slug.trim().toLowerCase()));
 }
 
 function addRepoMarkers(markers, repo) {

--- a/scripts/tests/lint-retrieval-generalization.test.mjs
+++ b/scripts/tests/lint-retrieval-generalization.test.mjs
@@ -1,0 +1,70 @@
+// The generalization lint bans benchmark identifiers from production. Its corpus is
+// derived from benchmarks/tasks/**, which includes tasks whose subject is this
+// repository - those name our own symbols, so they must not become bans. The rule
+// that excludes them can fail in two directions, and both are silent: under-firing
+// makes the product illegal to itself, over-firing disables the lint for a whole
+// holdout repository.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+/// Run the lint over one directory and return every banned pattern it reported.
+function bannedPatternsOver(scanRoot) {
+  let output;
+  try {
+    output = execFileSync(
+      process.execPath,
+      [path.join(repositoryRoot, "scripts/lint-retrieval-generalization.mjs")],
+      {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODESTORY_RETRIEVAL_GENERALIZATION_SCAN_ROOTS: scanRoot,
+        },
+      },
+    );
+  } catch (error) {
+    // A failing lint still prints its findings; the exit code is the point.
+    output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  }
+  return new Set(
+    [...output.matchAll(/Banned pattern \/(.+?)\/ in/gu)].map((match) => match[1]),
+  );
+}
+
+test("a task about this repository cannot ban this repository's own symbols", () => {
+  // RefreshMode is a codestory-workspace product type. It reaches the corpus only
+  // through readme-with-without/codestory-index-refresh-mode.task.json, whose subject
+  // is CodeStory itself, so banning it would forbid the product from naming its own
+  // API - which is what happened before the self-subject rule existed.
+  const banned = bannedPatternsOver("crates/codestory-runtime/src");
+  for (const own of ["RefreshMode", "crates"]) {
+    assert.ok(
+      ![...banned].some((pattern) => pattern.includes(own)),
+      `${own} is a CodeStory identifier and must not be banned, got: ${[...banned].join(", ")}`,
+    );
+  }
+});
+
+test("tasks about other repositories still ban their symbols", () => {
+  // The guard against over-firing: if the self-subject rule ever matched every task,
+  // the lint would report nothing and pass silently. These come from foreign holdout
+  // manifests and must survive.
+  const banned = bannedPatternsOver("crates/codestory-runtime/src");
+  assert.ok(banned.size > 0, "the lint reported no banned patterns at all");
+  for (const foreign of ["TicTacToe", "createServer"]) {
+    assert.ok(
+      [...banned].some((pattern) => pattern.includes(foreign)),
+      `${foreign} belongs to a holdout repository and must stay banned, got: ${[...banned].join(", ")}`,
+    );
+  }
+});


### PR DESCRIPTION
Deletes the ten literal holdout filenames from `semantic_file_is_package_callable_surface`; the path markers (/lib/, /src/, /pkg/, /routes/ …) stay, because they describe package layout rather than which repository is being measured. 4 lint hits in that file go to 0.

**Coverage, honestly:** nothing failed, and no coverage was lost — no test anywhere exercised those ten names against the helper. The arm was holdout tuning with nothing defending it. codestory-runtime: 855/855 lib tests pass.

Also fixes the corpus derivation the task flagged: a benchmark task whose subject is *this* repository was banning our own identifiers — `RefreshMode` (a codestory-workspace type) and our own `crates/…` paths. Such a task now contributes only its benchmark-specific parts. `index_coverage.rs` is untouched.

That rule can fail silently in two directions, so a new test covers both and is revert-proven: disabling it fails (RefreshMode banned again), forcing it always-on also fails (TicTacToe/createServer stop being banned).

**`crates/codestory-runtime/src` still cannot join `requiredScanDirs`** — beyond the `tests.rs` exclusion, 23 hits remain on ranking-lane surfaces (grounding.rs 20, search_terms.rs 2, search_scoring.rs 1), which are out of this slice.

Closes #1550

🤖 Generated with [Claude Code](https://claude.com/claude-code)