### PR TITLE
refuse a symlinked download partial and key retention on cli identity

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -523,6 +523,10 @@ function downloadFileOnce(url, destination, options = {}) {
     let stallTimer = null;
     // Bytes already on disk from earlier attempts, plus whatever this attempt appends.
     let downloadedBytes = resumeFrom;
+    // Device and inode of the descriptor the bytes actually went into. Publication compares the
+    // file standing at the partial path against this, so the name being swapped after the last
+    // byte cannot substitute a different file for the one this transfer wrote.
+    let partialIdentity = null;
     const finish = (error) => {
       if (settled) return;
       settled = true;
@@ -536,7 +540,7 @@ function downloadFileOnce(url, destination, options = {}) {
         error.downloadedBytes = downloadedBytes;
         reject(error);
       } else {
-        resolve({ downloadedBytes });
+        resolve({ downloadedBytes, partial: partialIdentity });
       }
     };
     const armStall = () => {
@@ -570,6 +574,7 @@ function downloadFileOnce(url, destination, options = {}) {
           redirectsRemaining: redirectsRemaining - 1,
         }).then((result) => {
           downloadedBytes = result?.downloadedBytes ?? downloadedBytes;
+          partialIdentity = result?.partial ?? partialIdentity;
           finish(null);
         }, finish);
         return;
@@ -633,14 +638,21 @@ function downloadFileOnce(url, destination, options = {}) {
       });
       // Open the partial through an explicit no-follow descriptor rather than by path. The stat that
       // chose `appendFrom` happened earlier, so a symlink planted in between would otherwise still be
-      // followed here; refusing the open keeps every provisioning byte inside the managed cache.
+      // followed here. `O_NOFOLLOW` refuses a symlink and `O_NONBLOCK` refuses to block on a fifo,
+      // but neither says anything about a *hard link*: an extra name for a file outside the cache is
+      // indistinguishable from our own partial by path. So the descriptor itself is re-checked
+      // before a byte is written, and only a lone regular file is accepted.
+      // Both flags are `0` on Windows, where the fstat below is the whole guard: it still refuses a
+      // hard link (which Windows creates without privilege) but it cannot refuse a symlink planted
+      // inside this window, so that one case stays open there.
       let partialFd;
       try {
         partialFd = fs.openSync(
           destination,
           fs.constants.O_WRONLY | fs.constants.O_CREAT |
-            (appendFrom > 0 ? fs.constants.O_APPEND : fs.constants.O_TRUNC) |
-            (fs.constants.O_NOFOLLOW || 0),
+            (appendFrom > 0 ? fs.constants.O_APPEND : 0) |
+            (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0),
+          0o600,
         );
       } catch (error) {
         response.resume();
@@ -648,6 +660,30 @@ function downloadFileOnce(url, destination, options = {}) {
           'partial_open',
           `download_partial_open_failed:${error?.code || 'unknown'}`,
         ));
+        return;
+      }
+      try {
+        const opened = fs.fstatSync(partialFd);
+        if (!opened.isFile() || opened.nlink !== 1) {
+          throw downloadError(
+            'partial_open',
+            `download_partial_open_failed:${opened.isFile() ? 'linked' : 'not_regular'}`,
+          );
+        }
+        // Truncation happens on the already-verified descriptor instead of through `O_TRUNC`, so a
+        // hard link planted at the partial path is refused above rather than emptied on the way in.
+        if (appendFrom === 0) fs.ftruncateSync(partialFd, 0);
+        partialIdentity = { dev: opened.dev, ino: opened.ino };
+      } catch (error) {
+        try {
+          fs.closeSync(partialFd);
+        } catch {
+          // The descriptor is being abandoned either way.
+        }
+        response.resume();
+        finish(downloadFailureKind(error) === 'partial_open'
+          ? error
+          : downloadError('partial_open', `download_partial_open_failed:${error?.code || 'unknown'}`));
         return;
       }
       output = fs.createWriteStream(destination, { fd: partialFd });
@@ -664,31 +700,105 @@ function downloadFileOnce(url, destination, options = {}) {
   });
 }
 
+// Publication reads the partial through a descriptor, not a path, because the last window in the
+// transfer is between the final byte and the rename: swap the partial for a link there and a plain
+// `rename` moves the link into place as the "archive". `identity` is the device/inode the transfer
+// actually wrote, so anything else standing at that name is refused before it can be published.
+function openVerifiedPartial(partialPath, identity) {
+  let fd;
+  try {
+    fd = fs.openSync(
+      partialPath,
+      fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0),
+    );
+  } catch (error) {
+    throw downloadError('publish', `download_publish_failed:${error?.code || 'unknown'}`);
+  }
+  try {
+    const opened = fs.fstatSync(fd);
+    const ours = opened.isFile() && opened.nlink === 1 &&
+      (!identity || (opened.dev === identity.dev && opened.ino === identity.ino));
+    if (!ours) throw downloadError('publish', 'download_publish_failed:partial_identity');
+    return { fd, metadata: opened };
+  } catch (error) {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      // The descriptor is being abandoned either way.
+    }
+    throw downloadFailureKind(error) === 'publish'
+      ? error
+      : downloadError('publish', `download_publish_failed:${error?.code || 'unknown'}`);
+  }
+}
+
+// Copies from the verified descriptor rather than re-opening the partial by name, so the
+// cross-device path publishes the same bytes the same-device path would. `O_EXCL` means the
+// destination is one this call created: a file raced into that name is a failure, not a target.
+function copyVerifiedPartial(fd, destination) {
+  const out = fs.openSync(
+    destination,
+    fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW || 0),
+    0o600,
+  );
+  try {
+    const buffer = Buffer.allocUnsafe(1024 * 1024);
+    let position = 0;
+    for (;;) {
+      const read = fs.readSync(fd, buffer, 0, buffer.length, position);
+      if (read <= 0) break;
+      fs.writeSync(out, buffer, 0, read);
+      position += read;
+    }
+  } finally {
+    fs.closeSync(out);
+  }
+}
+
 // `rename` cannot cross filesystems, and the partial deliberately lives under the managed CLI root
 // so it survives a restart while the caller's destination may sit in a temp directory on another
 // mount. Falling back to copy-then-unlink keeps publication correct wherever the two land.
-function publishDownloadedFile(partialPath, destination) {
+function publishDownloadedFile(partialPath, destination, identity = null) {
+  const { fd, metadata } = openVerifiedPartial(partialPath, identity);
   try {
-    fs.rmSync(destination, { force: true });
-    fs.renameSync(partialPath, destination);
-    return;
-  } catch (error) {
-    if (error?.code !== 'EXDEV') {
-      throw downloadError('publish', `download_publish_failed:${error?.code || 'unknown'}`);
+    try {
+      fs.rmSync(destination, { force: true });
+      fs.renameSync(partialPath, destination);
+    } catch (error) {
+      if (error?.code !== 'EXDEV') {
+        throw downloadError('publish', `download_publish_failed:${error?.code || 'unknown'}`);
+      }
+      try {
+        copyVerifiedPartial(fd, destination);
+        fs.rmSync(partialPath, { force: true });
+      } catch (copyError) {
+        throw downloadError('publish', `download_publish_failed:${copyError?.code || 'unknown'}`);
+      }
+      return;
     }
-  }
-  try {
-    fs.copyFileSync(partialPath, destination);
-    fs.rmSync(partialPath, { force: true });
-  } catch (error) {
-    throw downloadError('publish', `download_publish_failed:${error?.code || 'unknown'}`);
+    // A rename keeps the inode, so the published name must still be the verified file. If it is
+    // not, something replaced the partial between the check and the rename: drop what landed
+    // instead of handing a foreign file to the checksum step as this release's archive.
+    const published = fs.lstatSync(destination);
+    if (!published.isFile() || published.dev !== metadata.dev || published.ino !== metadata.ino) {
+      fs.rmSync(destination, { force: true });
+      throw downloadError('publish', 'download_publish_failed:published_identity');
+    }
+  } finally {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      // Closing a descriptor whose file is already published or discarded changes nothing.
+    }
   }
 }
 
 // The partial is the one attacker-reachable name in the provisioning path, so it is measured with
 // `lstat`: a symlink planted there would otherwise report the target's size and make the transfer
-// resume *through* the link into a file outside the managed cache. Anything that is not a regular
-// file can never be resumed, so it is dropped and the transfer restarts from zero.
+// resume *through* the link into a file outside the managed cache. A hard link passes `isFile()`
+// and is just as available to a same-user attacker, so a partial with more than one name is
+// refused too. Anything but a lone regular file is unlinked here and the transfer restarts from
+// zero; a directory cannot be unlinked this way and instead fails the no-follow open below.
 function partialDownloadBytes(partialPath) {
   let metadata = null;
   try {
@@ -696,11 +806,12 @@ function partialDownloadBytes(partialPath) {
   } catch {
     return 0;
   }
-  if (metadata.isFile()) return metadata.size;
+  if (metadata.isFile() && metadata.nlink === 1) return metadata.size;
   try {
     fs.rmSync(partialPath, { force: true });
   } catch {
-    // Best effort. The no-follow open below is what actually refuses to write through the link.
+    // Best effort. The no-follow open and its fstat are what actually refuse to write through a
+    // link that survives here.
   }
   return 0;
 }
@@ -729,7 +840,7 @@ async function downloadFile(url, destination, options = {}) {
     const resumeFrom = partialDownloadBytes(partialPath);
     if (onProgress) onProgress({ receivedBytes: resumeFrom, attempt });
     try {
-      await downloadFileOnce(url, partialPath, {
+      const transferred = await downloadFileOnce(url, partialPath, {
         ...options,
         resumeFrom,
         deadlineMs,
@@ -737,7 +848,7 @@ async function downloadFile(url, destination, options = {}) {
           ? (progress) => onProgress({ ...progress, attempt })
           : undefined,
       });
-      publishDownloadedFile(partialPath, destination);
+      publishDownloadedFile(partialPath, destination, transferred?.partial || null);
       return;
     } catch (error) {
       lastError = error;
@@ -1837,10 +1948,28 @@ function managedCliDownloadCacheRoot(root) {
   return cacheRoot;
 }
 
+// The per-version directory needs the same guard as the cache root, and needs it after the mkdir:
+// `mkdirSync({ recursive: true })` on an existing symlink-to-directory succeeds silently, and the
+// no-follow open that protects the partial only constrains the final path component. A symlinked
+// version entry would therefore route every provisioning byte outside the cache with no race at
+// all. Provisioning treats a throw here as "no cache" and falls back to its temp directory, so
+// refusing costs resume rather than correctness.
 function managedCliDownloadCacheDir(root, version) {
-  const dir = path.join(managedCliDownloadCacheRoot(root), version);
+  const cacheRoot = managedCliDownloadCacheRoot(root);
+  const dir = path.join(cacheRoot, version);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  return dir;
+  const metadata = fs.lstatSync(dir);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error('managed_cli_download_cache_not_direct');
+  }
+  // The lstat above covers the entry itself; resolving both ends also catches a link deeper in the
+  // version name and pins the answer to a path that really sits inside the cache.
+  const resolved = fs.realpathSync(dir);
+  const resolvedRoot = fs.realpathSync(cacheRoot);
+  if (resolved !== resolvedRoot && !resolved.startsWith(resolvedRoot + path.sep)) {
+    throw new Error('managed_cli_download_cache_not_direct');
+  }
+  return resolved;
 }
 
 function trimManagedCliDownloadCache(root, version) {
@@ -3597,6 +3726,7 @@ if (require.main === module) {
       pinnedCliVersion,
       pinnedArchiveSha256,
       publishDownloadedFile,
+      managedCliDownloadCacheDir,
       removeManagedCliDownloadCache,
       managedCliDownloadHint,
       managedCliDownloadProgress,

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -631,7 +631,26 @@ function downloadFileOnce(url, destination, options = {}) {
           callback(null, chunk);
         },
       });
-      output = fs.createWriteStream(destination, appendFrom > 0 ? { flags: 'a' } : { flags: 'w' });
+      // Open the partial through an explicit no-follow descriptor rather than by path. The stat that
+      // chose `appendFrom` happened earlier, so a symlink planted in between would otherwise still be
+      // followed here; refusing the open keeps every provisioning byte inside the managed cache.
+      let partialFd;
+      try {
+        partialFd = fs.openSync(
+          destination,
+          fs.constants.O_WRONLY | fs.constants.O_CREAT |
+            (appendFrom > 0 ? fs.constants.O_APPEND : fs.constants.O_TRUNC) |
+            (fs.constants.O_NOFOLLOW || 0),
+        );
+      } catch (error) {
+        response.resume();
+        finish(downloadError(
+          'partial_open',
+          `download_partial_open_failed:${error?.code || 'unknown'}`,
+        ));
+        return;
+      }
+      output = fs.createWriteStream(destination, { fd: partialFd });
       pipeline(response, limiter, output, (error) => finish(error || null));
     };
     // Only pass a request-options object when a Range header is actually needed: the two-argument
@@ -666,13 +685,24 @@ function publishDownloadedFile(partialPath, destination) {
   }
 }
 
+// The partial is the one attacker-reachable name in the provisioning path, so it is measured with
+// `lstat`: a symlink planted there would otherwise report the target's size and make the transfer
+// resume *through* the link into a file outside the managed cache. Anything that is not a regular
+// file can never be resumed, so it is dropped and the transfer restarts from zero.
 function partialDownloadBytes(partialPath) {
+  let metadata = null;
   try {
-    const metadata = fs.statSync(partialPath);
-    return metadata.isFile() ? metadata.size : 0;
+    metadata = fs.lstatSync(partialPath);
   } catch {
     return 0;
   }
+  if (metadata.isFile()) return metadata.size;
+  try {
+    fs.rmSync(partialPath, { force: true });
+  } catch {
+    // Best effort. The no-follow open below is what actually refuses to write through the link.
+  }
+  return 0;
 }
 
 // Downloads into `<destination>.part` and only publishes `destination` once the transfer
@@ -1521,6 +1551,7 @@ const downloadFailureKinds = new Set([
   'transport',
   'range',
   'redirect',
+  'partial_open',
   'network',
 ]);
 
@@ -1577,6 +1608,7 @@ function managedCliDownloadHint(context, code) {
       return `The release download was blocked because it was not served over HTTPS. ${manualInstallHint}`;
     case 'range':
     case 'redirect':
+    case 'partial_open':
       return 'The release download could not be resumed and was reset. Retry the tool to start it again.';
     default:
       return null;
@@ -2462,13 +2494,18 @@ function managedCliRetentionReportUnlocked(resolved, probe, options = {}) {
     reportUnverifiedManagedCliInventory(report, inventory.entries, 'active_unverified');
     return report;
   }
-  if (probe.version !== resolved.version) {
+  // Retention is keyed on CLI identity, not plugin identity. The probe reports the CLI's own version
+  // and the cache is laid out by CLI version, so comparing either against `resolved.version` (the
+  // plugin's version) disables retention outright on every plugin-only release, where the plugin
+  // moves ahead of the pinned CLI.
+  const activeCliVersion = resolved.cliVersion || resolved.version;
+  if (probe.version !== activeCliVersion) {
     report.warnings.push('managed_cli_retention_active_version_mismatch');
     reportUnverifiedManagedCliInventory(report, inventory.entries, 'active_version_mismatch');
     return report;
   }
 
-  const active = inventory.entries.find((entry) => entry.version === resolved.version);
+  const active = inventory.entries.find((entry) => entry.version === activeCliVersion);
   if (!active) {
     report.warnings.push('managed_cli_retention_active_directory_missing');
     reportUnverifiedManagedCliInventory(report, inventory.entries, 'active_directory_missing');

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -4873,6 +4873,219 @@ test("release asset downloader refuses a partial swapped for a symlink after it 
   }
 });
 
+// `O_NOFOLLOW` constrains the last path component only, and a hard link is not a symlink at all:
+// `lstat().isFile()` is true for one, so a hard link planted at the partial path was sized, resumed
+// and appended through into the file it shares an inode with. A partial with a second name is
+// never one this process created.
+test("release asset downloader refuses to resume through a hard-linked partial", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-partial-hardlink-"));
+  const destination = join(dataDir, "runtime.bin");
+  const partialPath = join(dataDir, "cache", "runtime.bin.part");
+  const outside = join(dataDir, "outside.txt");
+  await mkdir(join(dataDir, "cache"), { recursive: true });
+  await writeFile(outside, "precious", "utf8");
+  await link(outside, partialPath);
+  const body = Buffer.from("the-managed-runtime-archive-payload");
+  const server = createServer((request, response) => {
+    const start = Number(/^bytes=(\d+)-$/u.exec(request.headers.range || "")?.[1] ?? 0);
+    response.writeHead(start > 0 ? 206 : 200, {
+      "content-length": String(body.length - start),
+      ...(start > 0
+        ? { "content-range": `bytes ${start}-${body.length - 1}/${body.length}` }
+        : {}),
+    });
+    response.end(body.subarray(start));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    await launcherTest.downloadFile(
+      `http://127.0.0.1:${server.address().port}/runtime`,
+      destination,
+      { attempts: 3, retryDelayMs: () => 1, timeoutMs: 5000, partialPath },
+    );
+    // The extra name is dropped rather than resumed, so the linked file keeps its own bytes and the
+    // published archive is a different inode entirely — not a second name for the attacker's file.
+    assert.equal(await readFile(outside, "utf8"), "precious");
+    assert.deepEqual(await readFile(destination), body);
+    assert.notEqual(fs.statSync(destination).ino, fs.statSync(outside).ino);
+    assert.equal(fs.statSync(destination).nlink, 1);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+// The same window the symlink swap uses is open to a hard link, and there `O_NOFOLLOW` does
+// nothing. The descriptor itself has to be refused: the transfer fstats what it opened and writes
+// only into a lone regular file.
+test("release asset downloader refuses a partial hard-linked after it is sized", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-partial-linkswap-"));
+  const destination = join(dataDir, "runtime.bin");
+  const partialPath = join(dataDir, "cache", "runtime.bin.part");
+  const outside = join(dataDir, "outside.txt");
+  await mkdir(join(dataDir, "cache"), { recursive: true });
+  await writeFile(outside, "precious", "utf8");
+  const body = Buffer.from("the-managed-runtime-archive-payload");
+  const server = createServer((request, response) => {
+    const start = Number(/^bytes=(\d+)-$/u.exec(request.headers.range || "")?.[1] ?? 0);
+    response.writeHead(start > 0 ? 206 : 200, {
+      "content-length": String(body.length - start),
+      ...(start > 0
+        ? { "content-range": `bytes ${start}-${body.length - 1}/${body.length}` }
+        : {}),
+    });
+    response.end(body.subarray(start));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  let planted = false;
+  try {
+    await launcherTest.downloadFile(
+      `http://127.0.0.1:${server.address().port}/runtime`,
+      destination,
+      {
+        attempts: 3,
+        retryDelayMs: () => 1,
+        timeoutMs: 5000,
+        partialPath,
+        // The first callback of the first attempt sits between the sizing lstat and the open.
+        onProgress() {
+          if (planted) return;
+          planted = true;
+          fs.linkSync(outside, partialPath);
+        },
+      },
+    );
+    assert.equal(planted, true);
+    // The attempt that opened the planted link wrote nothing: neither the release bytes nor a
+    // truncation reached it, and the next attempt started from a partial of its own.
+    assert.equal(await readFile(outside, "utf8"), "precious");
+    assert.deepEqual(await readFile(destination), body);
+    assert.notEqual(fs.statSync(destination).ino, fs.statSync(outside).ino);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+// Between the last byte and the rename the partial is still just a name. Publication therefore
+// works from a no-follow descriptor and compares it against the device/inode the transfer wrote,
+// so a link swapped in at that point is refused instead of renamed into place as the "archive".
+test("release asset publication refuses a partial swapped for a symlink before the rename", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-publish-symlink-"));
+  const destination = join(dataDir, "runtime.bin");
+  const partialPath = join(dataDir, "cache", "runtime.bin.part");
+  const outside = join(dataDir, "outside.txt");
+  await mkdir(join(dataDir, "cache"), { recursive: true });
+  await writeFile(outside, "precious", "utf8");
+  const body = Buffer.from("the-managed-runtime-archive-payload");
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-length": String(body.length) });
+    response.end(body);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  let planted = false;
+  try {
+    await assert.rejects(
+      launcherTest.downloadFile(
+        `http://127.0.0.1:${server.address().port}/runtime`,
+        destination,
+        {
+          attempts: 1,
+          retryDelayMs: () => 1,
+          timeoutMs: 5000,
+          partialPath,
+          onProgress(progress) {
+            if (planted || progress.receivedBytes !== body.length) return;
+            planted = true;
+            fs.rmSync(partialPath, { force: true });
+            fs.symlinkSync(outside, partialPath, "file");
+          },
+        },
+      ),
+      /download_publish_failed/u,
+    );
+    assert.equal(planted, true);
+    assert.equal(fs.existsSync(destination), false);
+    assert.equal(await readFile(outside, "utf8"), "precious");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+// A plain regular file swapped in at the partial path passes every type check there is, so type is
+// not the question publication asks: it asks whether this is the file the transfer wrote. Without
+// the identity comparison the foreign bytes are published as this release's archive.
+test("release asset publication refuses a partial replaced by another regular file", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-publish-swap-"));
+  const destination = join(dataDir, "runtime.bin");
+  const partialPath = join(dataDir, "cache", "runtime.bin.part");
+  await mkdir(join(dataDir, "cache"), { recursive: true });
+  const body = Buffer.from("the-managed-runtime-archive-payload");
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-length": String(body.length) });
+    response.end(body);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  let planted = false;
+  try {
+    await assert.rejects(
+      launcherTest.downloadFile(
+        `http://127.0.0.1:${server.address().port}/runtime`,
+        destination,
+        {
+          attempts: 1,
+          retryDelayMs: () => 1,
+          timeoutMs: 5000,
+          partialPath,
+          onProgress(progress) {
+            if (planted || progress.receivedBytes !== body.length) return;
+            planted = true;
+            fs.rmSync(partialPath, { force: true });
+            fs.writeFileSync(partialPath, "substituted-archive-payload");
+          },
+        },
+      ),
+      /download_publish_failed:partial_identity/u,
+    );
+    assert.equal(planted, true);
+    assert.equal(fs.existsSync(destination), false);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+// `mkdirSync({ recursive: true })` succeeds silently on an existing symlink-to-directory, and the
+// no-follow open protecting the partial only constrains the final component. A symlinked version
+// entry therefore needed no race at all to put every provisioning byte outside the cache.
+test("download cache refuses a symlinked per-version directory", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-cache-version-symlink-"));
+  const root = join(dataDir, "codestory-cli");
+  const outside = join(dataDir, "outside");
+  await mkdir(join(root, ".download"), { recursive: true });
+  await mkdir(outside, { recursive: true });
+  await symlink(outside, join(root, ".download", "0.16.1"), "dir");
+  try {
+    assert.throws(
+      () => launcherTest.managedCliDownloadCacheDir(root, "0.16.1"),
+      /managed_cli_download_cache_not_direct/u,
+    );
+    // Nothing was handed back, so no partial path can be built through the link.
+    assert.deepEqual(await readdir(outside), []);
+    // A real directory is still accepted, and lands inside the cache root.
+    const usable = launcherTest.managedCliDownloadCacheDir(root, "0.16.2");
+    assert.equal(usable, join(await realpath(join(root, ".download")), "0.16.2"));
+    assert.equal(fs.lstatSync(usable).isDirectory(), true);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("download cache trimming refuses to delete through a symlinked cache root", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-symlink-"));
   const root = join(dataDir, "codestory-cli");

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1476,6 +1476,49 @@ test("managed cli retention keeps active plus a verified adjacent version", asyn
   }
 });
 
+// A plugin-only release moves the plugin version without moving the pinned CLI version, which is the
+// normal state of the plugin lane. Retention must key on CLI identity: comparing the running CLI's
+// probe against the plugin version made every such release look like an active-version mismatch and
+// silently switched managed-CLI pruning off for the whole release.
+test("managed cli retention keeps pruning when the plugin version leads the cli version", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-skew-"));
+  try {
+    const stale = await writeManagedCliFixture(dataDir, "0.15.9");
+    const rollback = await writeManagedCliFixture(dataDir, "0.16.0");
+    const active = await writeManagedCliFixture(dataDir, "0.16.1");
+    const probeVersion = (candidate) => ({
+      status: 0,
+      error: null,
+      version: candidate.cliVersion || candidate.version,
+      stdout: "",
+      stderr: "",
+    });
+    const resolved = {
+      source: "managed",
+      version: "0.16.4",
+      cliVersion: "0.16.1",
+      path: active.cliPath,
+      warnings: [],
+    };
+
+    const report = launcherTest.managedCliRetentionReport(resolved, probeVersion(resolved), {
+      dataDir,
+      probeVersion,
+    });
+
+    assert.deepEqual(report.warnings, []);
+    assert.deepEqual(report.retained.map((entry) => entry.version), ["0.16.1", "0.16.0"]);
+    assert.equal(report.retained.find((entry) => entry.version === "0.16.1").reason, "active");
+    assert.deepEqual(report.removed.map((entry) => entry.version), ["0.15.9"]);
+    assert.equal(report.removed_bytes > 0, true);
+    await assert.rejects(access(stale.versionDir));
+    await access(rollback.versionDir);
+    await access(active.versionDir);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("managed cli retention reports a locked Windows executable without pruning it", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-lock-"));
   try {
@@ -4732,6 +4775,100 @@ test("a publication failure is permanent instead of restarting the transfer", as
       true,
     );
   } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+// The `.part` name is the one attacker-reachable file in the provisioning path. Sizing it with
+// `stat` reported the symlink target's length, so the transfer resumed by appending release bytes
+// straight into whatever the link pointed at, outside the managed cache.
+test("release asset downloader refuses to resume through a symlinked partial", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-partial-symlink-"));
+  const destination = join(dataDir, "runtime.bin");
+  const partialPath = join(dataDir, "cache", "runtime.bin.part");
+  const outside = join(dataDir, "outside.txt");
+  await mkdir(join(dataDir, "cache"), { recursive: true });
+  await writeFile(outside, "precious", "utf8");
+  await symlink(outside, partialPath, "file");
+  const body = Buffer.from("the-managed-runtime-archive-payload");
+  const server = createServer((request, response) => {
+    const start = Number(/^bytes=(\d+)-$/u.exec(request.headers.range || "")?.[1] ?? 0);
+    response.writeHead(start > 0 ? 206 : 200, {
+      "content-length": String(body.length - start),
+      ...(start > 0
+        ? { "content-range": `bytes ${start}-${body.length - 1}/${body.length}` }
+        : {}),
+    });
+    response.end(body.subarray(start));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    await launcherTest.downloadFile(
+      `http://127.0.0.1:${server.address().port}/runtime`,
+      destination,
+      { attempts: 3, retryDelayMs: () => 1, timeoutMs: 5000, partialPath },
+    );
+    // The planted link is dropped rather than measured or written through, so provisioning still
+    // completes and the file it pointed at is untouched.
+    assert.deepEqual(await readFile(destination), body);
+    assert.equal(await readFile(outside, "utf8"), "precious");
+    assert.equal(fs.existsSync(partialPath), false);
+    assert.equal(fs.lstatSync(destination).isFile(), true);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+// The stat that sizes the partial and the open that writes it are separate syscalls, so dropping a
+// non-regular partial is not on its own enough: the link can be planted in between. The write must
+// be refused at the descriptor.
+test("release asset downloader refuses a partial swapped for a symlink after it is sized", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-partial-swap-"));
+  const destination = join(dataDir, "runtime.bin");
+  const partialPath = join(dataDir, "cache", "runtime.bin.part");
+  const outside = join(dataDir, "outside.txt");
+  await mkdir(join(dataDir, "cache"), { recursive: true });
+  await writeFile(outside, "precious", "utf8");
+  const body = Buffer.from("the-managed-runtime-archive-payload");
+  const server = createServer((request, response) => {
+    const start = Number(/^bytes=(\d+)-$/u.exec(request.headers.range || "")?.[1] ?? 0);
+    response.writeHead(start > 0 ? 206 : 200, {
+      "content-length": String(body.length - start),
+      ...(start > 0
+        ? { "content-range": `bytes ${start}-${body.length - 1}/${body.length}` }
+        : {}),
+    });
+    response.end(body.subarray(start));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  let planted = false;
+  try {
+    await launcherTest.downloadFile(
+      `http://127.0.0.1:${server.address().port}/runtime`,
+      destination,
+      {
+        attempts: 3,
+        retryDelayMs: () => 1,
+        timeoutMs: 5000,
+        partialPath,
+        // The first progress callback fires after the partial has been sized and before the transfer
+        // opens it: exactly the window a planted link would exploit.
+        onProgress() {
+          if (planted) return;
+          planted = true;
+          fs.symlinkSync(outside, partialPath, "file");
+        },
+      },
+    );
+    assert.equal(planted, true);
+    assert.equal(await readFile(outside, "utf8"), "precious");
+    assert.deepEqual(await readFile(destination), body);
+    assert.equal(fs.lstatSync(destination).isFile(), true);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
     await rm(dataDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Closes #1555

Base `dev/codestory-next` 6c8db903. Head a1122108 (6d4dcc2f, then a1122108 answering review).
Two files: `plugins/codestory/scripts/codestory-mcp.cjs` and `plugins/codestory/tests/plugin-static.test.mjs`.

## The provisioning partial is an attacker-reachable name

`partialDownloadBytes` sized `<destination>.part` with `fs.statSync`, which resolves symlinks. A symlink planted at the partial path reported its *target's* size, the transfer issued `Range: bytes=<target size>-`, and `fs.createWriteStream(partialPath, { flags: 'a' })` appended the release bytes through the link into a file outside the managed cache. `publishDownloadedFile` then renamed the symlink itself into place, so the published "archive" was a link to the attacker's file.

The threat model in #1555 is a same-user process or a writable ancestor. That makes every name in the provisioning path suspect, not just the final component of one of them, and it makes hard links as available as symlinks. Five changes, because each syscall is separately reachable:

- **Sizing.** `partialDownloadBytes` uses `lstat`, and accepts only a *lone* regular file. A symlink is not a regular file; a hard link is one, but a partial this process created has exactly one name. Anything else is unlinked and the transfer restarts from zero.
- **Opening.** The transfer opens the partial through `O_NOFOLLOW | O_NONBLOCK` and hands the fd to `createWriteStream`, so a symlink planted in the window between the sizing and the open is refused at the descriptor, and a fifo cannot block the process.
- **Verifying the descriptor.** `O_NOFOLLOW` says nothing about hard links, so the opened fd is `fstat`ed before a byte is written and rejected unless it is a regular file with `nlink === 1`. Truncation moved from `O_TRUNC` onto that verified descriptor, so a planted link is refused rather than emptied on the way in.
- **The per-version cache directory.** `managedCliDownloadCacheDir` created `<cacheRoot>/<version>` with `mkdirSync({ recursive: true })`, which returns quietly when that name is already a symlink to a directory — and a no-follow open of the *final* component is no protection when the *parent* is the link. It now carries the same `lstat` guard as `managedCliDownloadCacheRoot`, plus a realpath containment check so a version name cannot climb out of the cache. Provisioning already treats a throw here as "no cache" and falls back to its temp directory, so refusing costs resume, not correctness.
- **Publishing.** The window between the last byte and the rename was untouched: `renameSync` moved whatever stood at the partial path. The transfer now records the device/inode of the descriptor it actually wrote; publication opens the partial no-follow, refuses anything that is not that file, re-checks the published name after the rename, and removes it on a mismatch. The cross-device fallback copies from the same verified descriptor instead of re-opening by name.

An open refusal is reported as a new `partial_open` failure kind. It is retryable: the next attempt's `lstat` drops the poisoned partial, so provisioning recovers rather than wedging.

## Managed-CLI retention disabled on every plugin-only release

`managedCliRetentionReportUnlocked` compared `probe.version` — the running CLI's own version — against `resolved.version`, which is the **plugin** version, and used the same value to find the active version directory. Those two strings agree only on a release that moves both. On any plugin-only release the comparison fails, retention reports `managed_cli_retention_active_version_mismatch`, and pruning is silently off for that entire release while stale CLI versions accumulate. Both sites now compare `resolved.cliVersion || resolved.version`, the same CLI-identity expression the launcher already uses for `CODESTORY_PLUGIN_CLI_VERSION`.

## What this does **not** close

Stated explicitly because the first round of this PR claimed more than it delivered.

- **Windows loses the symlink half.** `fs.constants.O_NOFOLLOW` and `O_NONBLOCK` are `undefined` there and degrade to `0`. The `lstat`, `fstat` and publish-identity checks all hold on Windows and *do* refuse a hard link (`mklink /H` needs no privilege), but a symlink planted inside the stat/open window is followed. Creating one on Windows needs privilege or developer mode. The lane runs `ubuntu-latest` and both symlink tests call `fs.symlink`, so there is no Windows evidence in either direction; the comment at the open now says this at the code.
- **The cache directory can still be swapped after it is checked.** The guard `lstat`s `<cacheRoot>/<version>` and the partial is opened by path afterwards. Node exposes no `openat`, so a directory swapped in that instant cannot be refused from here. What is closed is the case that needs no race at all — a symlinked version entry sitting there before provisioning starts — which is what the probe in review exploited.
- **A directory left at the partial path still wedges provisioning.** `fs.rmSync(partialPath, { force: true })` cannot remove one without `recursive: true`, so every attempt dies at the no-follow open with `download_partial_open_failed:EISDIR` until a human clears it. Not a regression — `createWriteStream` failed the same way — and left out of this round deliberately. The comment that advertised a self-heal it does not have has been corrected to describe what actually happens.
- **The `partial_open` hint text is wrong for most `partial_open` causes.** `managedCliDownloadHint` says "could not be resumed and was reset", but only `kind === 'range'` triggers `purgePartial()`. True for the symlink case, false for `EACCES`/`EISDIR`/`EPERM`. Untouched here.
- **Checksums remain the backstop, not the boundary.** `provisionManagedCli` verifies the archive against `SHA256SUMS.txt` and the shipped pin, so a substituted archive was never executable content. These changes are about where the bytes are written and which file is published, not about trusting the archive.

## Tests

`plugins/codestory/tests/plugin-static.test.mjs`, 103 tests. Every new test was run with its own fix reverted and the rest of the change intact.

| test | revert | result without the fix |
| --- | --- | --- |
| refuses to resume through a symlinked partial | `lstat` → `statSync` | `ELOOP` after 3 attempts |
| refuses a partial swapped for a symlink after it is sized | drop `O_NOFOLLOW` | outside file overwritten with the payload |
| refuses to resume through a hard-linked partial | drop the `nlink === 1` check in `partialDownloadBytes` | `download_partial_open_failed:linked`, `resumable_bytes=8` — the link is measured and never dropped |
| refuses a partial hard-linked after it is sized | drop the `fstat` check, restore `O_TRUNC` | fails: the planted link is opened and written through |
| publication refuses a partial swapped for a symlink before the rename | original path-based `publishDownloadedFile` | `Missing expected rejection` — the link is renamed into place |
| publication refuses a partial replaced by another regular file | drop only the device/inode comparison | `Missing expected rejection` — foreign bytes published as the archive |
| download cache refuses a symlinked per-version directory | drop the per-version guard | `Missing expected exception` — the symlinked directory is returned and used |
| keeps pruning when the plugin version leads the cli version | `resolved.cliVersion \|\| resolved.version` → `resolved.version` | reports `managed_cli_retention_active_version_mismatch`, prunes nothing |

The three publication/hard-link tests assert the gate *fails closed*, not merely that the happy path survives: the file outside the cache keeps its own bytes, the published archive is a different inode with `nlink === 1`, and the swapped-in cases reject with `download_publish_failed` and leave no destination behind.

Commands run in the worktree at head a1122108:

- `node --test plugins/codestory/tests/plugin-static.test.mjs` → 103 tests, 102 pass, 0 fail, 1 pre-existing platform skip (Windows executable locking).
- `node .github/scripts/check-workflow-policy.mjs` → pass (no workflow files touched; run as a sanity check).
- `node --check plugins/codestory/scripts/codestory-mcp.cjs` → pass.

No workflow, Rust, or Python surfaces touched; `plugins/codestory/**` already triggers the plugin-static lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
