### PR TITLE
bound the proof tooling waits to their declared timeouts

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1250,6 +1250,9 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       "scripts/install-codestory.ps1",
       "scripts/prepare-embedded-model.mjs",
       "scripts/tests/prepare-embedded-model.test.mjs",
+      "scripts/prove-plugin-pinned-provision.mjs",
+      "scripts/lib/wait-for-managed-runtime.mjs",
+      "scripts/tests/prove-plugin-pinned-provision.test.mjs",
       "crates/codestory-llama-sys/model-contract.json",
       "crates/codestory-llama-sys/build.rs",
       "crates/codestory-llama-sys/model_staging.rs",
@@ -1272,6 +1275,11 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
     ]);
     requireStepRun(violations, pluginFile, job, "Check plugin static wiring", ["node --test plugins/codestory/tests/plugin-static.test.mjs"]);
     requireStepRun(violations, pluginFile, job, "Check embedded model preparation", ["node --test scripts/tests/prepare-embedded-model.test.mjs"]);
+    // The pinned-provision proof is the plugin lane's tag gate. Its own suite has to run
+    // somewhere, or a gate that exits 0 without proving anything reads as a pass.
+    requireStepRun(violations, pluginFile, job, "Check the pinned provision proof", [
+      "node --test scripts/tests/prove-plugin-pinned-provision.test.mjs",
+    ]);
     requireStepRun(violations, pluginFile, job, "Check release claim and evidence contracts", [
       "scripts/tests/release-evidence-runner-contract.test.mjs",
     ]);
@@ -4464,6 +4472,9 @@ export function validatePluginRelease(workflows, violations) {
   ]);
   requireStepRun(violations, file, preflight, "Refuse a changed tool surface", [
     "generated-mcp-catalog.json",
+  ]);
+  requireStepRun(violations, file, object(jobs["plugin-proof"]), "Check the pinned provision proof", [
+    "node --test scripts/tests/prove-plugin-pinned-provision.test.mjs",
   ]);
   requireStepRun(violations, file, object(jobs["plugin-proof"]), "Provision the pinned CLI end to end", [
     "scripts/prove-plugin-pinned-provision.mjs",

--- a/.github/scripts/packaged_agent_proof/self_test_installation.py
+++ b/.github/scripts/packaged_agent_proof/self_test_installation.py
@@ -15,7 +15,13 @@ class ScriptedMcpProcess(McpProcess):
         self.calls: list[tuple[str, dict, str]] = []
         self.tool_attempt_counts: dict[str, int] = {}
 
-    def tool(self, name: str, arguments: dict, request_id: str) -> dict:
+    def tool(
+        self,
+        name: str,
+        arguments: dict,
+        request_id: str,
+        deadline: float | None = None,
+    ) -> dict:
         self.calls.append((name, arguments, request_id))
         try:
             return next(self.responses)

--- a/.github/scripts/packaged_agent_proof/self_test_process.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process.py
@@ -2,6 +2,7 @@
 
 from .self_test_process_cleanup import run_process_cleanup_self_tests
 from .self_test_process_clock import run_process_clock_self_tests
+from .self_test_process_deadline import run_process_deadline_self_tests
 from .self_test_process_exit import run_process_exit_self_tests
 from .self_test_process_identity import run_process_identity_self_tests
 
@@ -9,5 +10,6 @@ from .self_test_process_identity import run_process_identity_self_tests
 def run_process_self_tests() -> None:
     run_process_identity_self_tests()
     run_process_clock_self_tests()
+    run_process_deadline_self_tests()
     run_process_exit_self_tests()
     run_process_cleanup_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_process_deadline.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process_deadline.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import queue
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from . import subprocess_control
@@ -10,6 +13,7 @@ from .subprocess_control import McpProcess
 
 _RETRY_AFTER_MS = 30_000
 _TIMEOUT_SECS = 60.0
+_NEVER = float("inf")
 
 
 class _VirtualClock:
@@ -26,39 +30,79 @@ class _VirtualClock:
 
 
 class _ScriptedHost(McpProcess):
-    """An McpProcess whose tool calls replay a script instead of a real subprocess."""
+    """An McpProcess whose stdio is scripted instead of a real subprocess.
 
-    def __init__(self, timeout: float, script: list[str]) -> None:
+    The script replaces the pipes, not the methods, so ``tool`` and ``send`` are the shipped
+    implementations. A leg that only stubbed ``tool`` could not see the transport's own
+    deadline, which is the other place a readiness wait can mint a fresh budget.
+    """
+
+    def __init__(
+        self,
+        clock: _VirtualClock,
+        timeout: float,
+        script: list[str],
+        latencies: list[float] | None = None,
+    ) -> None:
+        self.clock = clock
         self.timeout = timeout
+        # The last scripted step and latency repeat, so a leg only names its distinct steps.
         self.script = script
-        self.calls = 0
+        self.latencies = latencies or [0.0]
+        self.reads = 0
+        self.pending: dict | None = None
+        self.stderr: list[str] = []
         self.transcript: list[dict] = []
         self.tool_attempt_counts: dict[str, int] = {}
+        self.lines = self
+        self.process = SimpleNamespace(stdin=self)
 
-    def tool(self, name: str, arguments: dict, request_id: str) -> dict:
-        self.calls += 1
-        # The last scripted step repeats so a leg only has to name its distinct steps.
-        step = self.script[min(self.calls, len(self.script)) - 1]
+    # --- stdin stand-in -------------------------------------------------------------------
+    def write(self, payload: str) -> None:
+        self.pending = json.loads(payload)
+
+    def flush(self) -> None:
+        return None
+
+    # --- stdout queue stand-in ------------------------------------------------------------
+    def get(self, timeout: float | None = None):
+        self.reads += 1
+        step = self.script[min(self.reads, len(self.script)) - 1]
+        latency = self.latencies[min(self.reads, len(self.latencies)) - 1]
+        if timeout is not None and latency > timeout:
+            # The transport waited its whole remaining bound and the host never answered.
+            self.clock.now += max(0.0, timeout)
+            raise queue.Empty
+        self.clock.now += latency
+        return json.dumps(self._response(step))
+
+    def _response(self, step: str) -> dict:
+        assert self.pending is not None
+        params = self.pending.get("params", {})
         if step == "preparing":
             return {
+                "jsonrpc": "2.0",
+                "id": self.pending.get("id"),
                 "result": {
                     "isError": True,
                     "structuredContent": {
                         "code": "codestory_preparing",
                         "state": "preparing",
-                        "retry_tool": name,
+                        "retry_tool": params.get("name"),
                         "retry_after_ms": _RETRY_AFTER_MS,
                     },
-                }
+                },
             }
         return {
+            "jsonrpc": "2.0",
+            "id": self.pending.get("id"),
             "result": {
                 "structuredContent": {
-                    "query": arguments.get("query"),
+                    "query": params.get("arguments", {}).get("query"),
                     "hits": [],
                     "retrieval": {"state": step},
                 }
-            }
+            },
         }
 
 
@@ -66,7 +110,7 @@ def _run_shared_deadline_leg() -> None:
     clock = _VirtualClock()
     # A degraded poll lands mid-window, so the next poll's readiness retries are the only
     # thing that can push the wait past the shared bound.
-    host = _ScriptedHost(_TIMEOUT_SECS, ["preparing", "degraded", "preparing"])
+    host = _ScriptedHost(clock, _TIMEOUT_SECS, ["preparing", "degraded", "preparing"])
     with patch.object(subprocess_control, "time", clock):
         try:
             host.search_until_ready({"query": "self-test"}, "search")
@@ -80,21 +124,67 @@ def _run_shared_deadline_leg() -> None:
     )
 
 
+def _run_transport_deadline_leg() -> None:
+    clock = _VirtualClock()
+    # The first answer arrives late enough that a request minting its own full budget would
+    # outlive the shared bound. The host then goes silent, so the transport wait is the only
+    # thing left that can overrun.
+    host = _ScriptedHost(
+        clock,
+        _TIMEOUT_SECS,
+        ["preparing", "silent"],
+        [10.0, _NEVER],
+    )
+    with patch.object(subprocess_control, "time", clock):
+        try:
+            host.search_until_ready({"query": "self-test"}, "search")
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure("search_until_ready did not fail on a host that stopped answering")
+    require(
+        clock.now <= _TIMEOUT_SECS,
+        f"a request under search_until_ready minted its own budget: waited {clock.now}s "
+        f"against its {_TIMEOUT_SECS}s bound",
+    )
+
+
 def _run_default_deadline_leg() -> None:
     clock = _VirtualClock()
-    host = _ScriptedHost(_TIMEOUT_SECS, ["preparing", "preparing", "ready"])
+    # A host that never becomes ready pins the default bound in both directions: a default
+    # that grew past self.timeout keeps retrying past _TIMEOUT_SECS, and one that shrank gives
+    # up before it.
+    host = _ScriptedHost(clock, _TIMEOUT_SECS, ["preparing"])
     with patch.object(subprocess_control, "time", clock):
-        _, attempts = host.tool_until_ready("search", {"query": "self-test"}, "search")
+        try:
+            host.tool_until_ready("search", {"query": "self-test"}, "search")
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure("tool_until_ready did not fail on a host that never became ready")
+    attempts = host.tool_attempt_counts.get("search")
     require(
         attempts == 3 and clock.now == _TIMEOUT_SECS,
         f"tool_until_ready without a deadline changed its own bound: {attempts} attempts "
-        f"over {clock.now}s",
+        f"over {clock.now}s against {_TIMEOUT_SECS}s",
+    )
+
+
+def _run_converging_host_leg() -> None:
+    clock = _VirtualClock()
+    host = _ScriptedHost(clock, _TIMEOUT_SECS, ["preparing", "ready"])
+    with patch.object(subprocess_control, "time", clock):
+        _, attempts = host.tool_until_ready("search", {"query": "self-test"}, "search")
+    require(
+        attempts == 2 and clock.now <= _TIMEOUT_SECS,
+        f"tool_until_ready gave up on a host that converged inside the bound: {attempts} "
+        f"attempts over {clock.now}s",
     )
 
 
 def _run_threaded_deadline_leg() -> None:
     clock = _VirtualClock()
-    host = _ScriptedHost(_TIMEOUT_SECS, ["preparing"])
+    host = _ScriptedHost(clock, _TIMEOUT_SECS, ["preparing"])
     with patch.object(subprocess_control, "time", clock):
         try:
             host.tool_until_ready(
@@ -113,7 +203,32 @@ def _run_threaded_deadline_leg() -> None:
     )
 
 
+def _run_threaded_transport_deadline_leg() -> None:
+    clock = _VirtualClock()
+    # A caller-owned deadline has to reach the transport too, not only the readiness retries.
+    host = _ScriptedHost(clock, _TIMEOUT_SECS, ["silent"], [_NEVER])
+    with patch.object(subprocess_control, "time", clock):
+        try:
+            host.tool_until_ready(
+                "search",
+                {"query": "self-test"},
+                "search",
+                deadline=clock.monotonic() + 5.0,
+            )
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure("tool_until_ready ignored a caller-owned deadline")
+    require(
+        clock.now <= 5.0,
+        f"the transport ignored a caller-owned 5.0s deadline and waited {clock.now}s",
+    )
+
+
 def run_process_deadline_self_tests() -> None:
     _run_shared_deadline_leg()
+    _run_transport_deadline_leg()
     _run_default_deadline_leg()
+    _run_converging_host_leg()
     _run_threaded_deadline_leg()
+    _run_threaded_transport_deadline_leg()

--- a/.github/scripts/packaged_agent_proof/self_test_process_deadline.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process_deadline.py
@@ -1,0 +1,119 @@
+"""Readiness-wait deadline self-tests for the owned MCP transport."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from . import subprocess_control
+from .foundation import ProofFailure, require
+from .subprocess_control import McpProcess
+
+_RETRY_AFTER_MS = 30_000
+_TIMEOUT_SECS = 60.0
+
+
+class _VirtualClock:
+    """Deterministic stand-in for the module clock so the legs cost no wall time."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += max(0.0, float(seconds))
+
+
+class _ScriptedHost(McpProcess):
+    """An McpProcess whose tool calls replay a script instead of a real subprocess."""
+
+    def __init__(self, timeout: float, script: list[str]) -> None:
+        self.timeout = timeout
+        self.script = script
+        self.calls = 0
+        self.transcript: list[dict] = []
+        self.tool_attempt_counts: dict[str, int] = {}
+
+    def tool(self, name: str, arguments: dict, request_id: str) -> dict:
+        self.calls += 1
+        # The last scripted step repeats so a leg only has to name its distinct steps.
+        step = self.script[min(self.calls, len(self.script)) - 1]
+        if step == "preparing":
+            return {
+                "result": {
+                    "isError": True,
+                    "structuredContent": {
+                        "code": "codestory_preparing",
+                        "state": "preparing",
+                        "retry_tool": name,
+                        "retry_after_ms": _RETRY_AFTER_MS,
+                    },
+                }
+            }
+        return {
+            "result": {
+                "structuredContent": {
+                    "query": arguments.get("query"),
+                    "hits": [],
+                    "retrieval": {"state": step},
+                }
+            }
+        }
+
+
+def _run_shared_deadline_leg() -> None:
+    clock = _VirtualClock()
+    # A degraded poll lands mid-window, so the next poll's readiness retries are the only
+    # thing that can push the wait past the shared bound.
+    host = _ScriptedHost(_TIMEOUT_SECS, ["preparing", "degraded", "preparing"])
+    with patch.object(subprocess_control, "time", clock):
+        try:
+            host.search_until_ready({"query": "self-test"}, "search")
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure("search_until_ready did not fail on a host that never converged")
+    require(
+        clock.now <= _TIMEOUT_SECS,
+        f"search_until_ready waited {clock.now}s against its {_TIMEOUT_SECS}s bound",
+    )
+
+
+def _run_default_deadline_leg() -> None:
+    clock = _VirtualClock()
+    host = _ScriptedHost(_TIMEOUT_SECS, ["preparing", "preparing", "ready"])
+    with patch.object(subprocess_control, "time", clock):
+        _, attempts = host.tool_until_ready("search", {"query": "self-test"}, "search")
+    require(
+        attempts == 3 and clock.now == _TIMEOUT_SECS,
+        f"tool_until_ready without a deadline changed its own bound: {attempts} attempts "
+        f"over {clock.now}s",
+    )
+
+
+def _run_threaded_deadline_leg() -> None:
+    clock = _VirtualClock()
+    host = _ScriptedHost(_TIMEOUT_SECS, ["preparing"])
+    with patch.object(subprocess_control, "time", clock):
+        try:
+            host.tool_until_ready(
+                "search",
+                {"query": "self-test"},
+                "search",
+                deadline=clock.monotonic() + 5.0,
+            )
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure("tool_until_ready ignored a caller-owned deadline")
+    require(
+        clock.now <= 5.0,
+        f"tool_until_ready waited {clock.now}s against a caller-owned 5.0s deadline",
+    )
+
+
+def run_process_deadline_self_tests() -> None:
+    _run_shared_deadline_leg()
+    _run_default_deadline_leg()
+    _run_threaded_deadline_leg()

--- a/.github/scripts/packaged_agent_proof/subprocess_control.py
+++ b/.github/scripts/packaged_agent_proof/subprocess_control.py
@@ -255,8 +255,11 @@ class McpProcess:
         name: str,
         arguments: dict,
         request_id: str,
+        deadline: float | None = None,
     ) -> tuple[dict, int]:
-        deadline = time.monotonic() + self.timeout
+        # A caller that already owns a bound threads it in; otherwise this call owns its own.
+        if deadline is None:
+            deadline = time.monotonic() + self.timeout
         attempt = 0
         while True:
             attempt += 1
@@ -331,7 +334,7 @@ class McpProcess:
                 request_id if poll == 1 else f"{request_id}-degraded-{poll}"
             )
             response, attempts = self.tool_until_ready(
-                "search", arguments, poll_request_id
+                "search", arguments, poll_request_id, deadline=deadline
             )
             total_attempts += attempts
             self.tool_attempt_counts[request_id] = total_attempts

--- a/.github/scripts/packaged_agent_proof/subprocess_control.py
+++ b/.github/scripts/packaged_agent_proof/subprocess_control.py
@@ -143,11 +143,16 @@ class McpProcess:
         assert self.process.stderr
         self.stderr.extend(self.process.stderr.readlines())
 
-    def send(self, request: dict) -> dict:
+    def send(self, request: dict, deadline: float | None = None) -> dict:
         assert self.process.stdin
         self.process.stdin.write(json.dumps(request) + "\n")
         self.process.stdin.flush()
-        deadline = time.monotonic() + self.timeout
+        # A caller that already owns a bound threads it in; otherwise this call owns its own.
+        # Minting a fresh full budget underneath a caller's deadline is how a readiness loop
+        # burns several times the declared timeout: the loop only re-checks its bound between
+        # transport waits, so one late request can add another whole timeout past it.
+        if deadline is None:
+            deadline = time.monotonic() + self.timeout
         while True:
             remaining = deadline - time.monotonic()
             require(remaining > 0, f"MCP request timed out: {request.get('id')}")
@@ -238,14 +243,21 @@ class McpProcess:
             uri,
         )
 
-    def tool(self, name: str, arguments: dict, request_id: str) -> dict:
+    def tool(
+        self,
+        name: str,
+        arguments: dict,
+        request_id: str,
+        deadline: float | None = None,
+    ) -> dict:
         response = self.send(
             {
                 "jsonrpc": "2.0",
                 "id": request_id,
                 "method": "tools/call",
                 "params": {"name": name, "arguments": arguments},
-            }
+            },
+            deadline=deadline,
         )
         require("error" not in response, f"MCP {name} failed: {response.get('error')}")
         return response
@@ -258,13 +270,17 @@ class McpProcess:
         deadline: float | None = None,
     ) -> tuple[dict, int]:
         # A caller that already owns a bound threads it in; otherwise this call owns its own.
+        # The same bound has to reach the transport, or each retry's request mints a fresh
+        # budget and the readiness loop overruns whatever deadline it was handed.
         if deadline is None:
             deadline = time.monotonic() + self.timeout
         attempt = 0
         while True:
             attempt += 1
             self.tool_attempt_counts[request_id] = attempt
-            response = self.tool(name, arguments, f"{request_id}-{attempt}")
+            response = self.tool(
+                name, arguments, f"{request_id}-{attempt}", deadline=deadline
+            )
             result = response.get("result")
             require(
                 isinstance(result, dict),

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -154,6 +154,11 @@ jobs:
       - name: Run the plugin static suite
         run: node --test plugins/codestory/tests/plugin-static.test.mjs
 
+      # Prove the gate below can still fail before trusting it to pass: its wait must bound
+      # itself on readable non-managed metadata, and it must refuse to exit 0 without proving.
+      - name: Check the pinned provision proof
+        run: node --test scripts/tests/prove-plugin-pinned-provision.test.mjs
+
       # The launcher provisions the pinned, already-published CLI over the real
       # github_release path, which is the one place the pin's content addressing
       # is enforced. A digest drift between the pin and the published archive

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -62,6 +62,9 @@ on:
       - scripts/tests/release-evidence-runner-contract.test.mjs
       - scripts/codex-worktree-setup.*
       - scripts/tests/codex-worktree-setup.test.mjs
+      - scripts/prove-plugin-pinned-provision.mjs
+      - scripts/lib/wait-for-managed-runtime.mjs
+      - scripts/tests/prove-plugin-pinned-provision.test.mjs
       - .codex/environments/environment.toml
   push:
     branches:
@@ -127,6 +130,9 @@ on:
       - scripts/tests/release-evidence-runner-contract.test.mjs
       - scripts/codex-worktree-setup.*
       - scripts/tests/codex-worktree-setup.test.mjs
+      - scripts/prove-plugin-pinned-provision.mjs
+      - scripts/lib/wait-for-managed-runtime.mjs
+      - scripts/tests/prove-plugin-pinned-provision.test.mjs
       - .codex/environments/environment.toml
   workflow_dispatch:
 
@@ -153,6 +159,12 @@ jobs:
 
       - name: Check embedded model preparation
         run: node --test scripts/tests/prepare-embedded-model.test.mjs
+
+      # plugin-release.yml gates the `v*` tag on prove-plugin-pinned-provision.mjs, so its
+      # bounded wait and its refusal to run vacuously are checked here on every PR rather
+      # than discovered on the release lane.
+      - name: Check the pinned provision proof
+        run: node --test scripts/tests/prove-plugin-pinned-provision.test.mjs
 
       - name: Check workflow syntax
         run: |

--- a/scripts/lib/wait-for-managed-runtime.mjs
+++ b/scripts/lib/wait-for-managed-runtime.mjs
@@ -1,0 +1,48 @@
+// The bounded wait behind scripts/prove-plugin-pinned-provision.mjs.
+//
+// This module holds no top-level side effects so a test can import the wait without running the
+// proof. The proof itself stays an entry point that always executes its body: an entry-point
+// guard on a release gate can only fail open, and a gate that exits 0 without proving anything
+// is worse than one that fails.
+
+import fs from "node:fs";
+
+// Wait for the launcher to publish managed runtime metadata.
+//
+// Order matters. The read comes first so a launcher that published managed metadata and then
+// exited cleanly is reported as the success it is. The liveness guards then run on every tick
+// rather than only when the read throws: a launcher that resolves to a non-managed source (pin
+// or archive digest drift) keeps writing a readable file, so guards nested in the read's catch
+// would never fire again and the proof would hang until the CI job timeout.
+export function waitForManagedRuntime({ child, runtimeMetadata, timeoutMs, intervalMs = 250 }) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError(`waitForManagedRuntime needs a positive finite timeoutMs, got ${timeoutMs}.`);
+  }
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const poll = setInterval(() => {
+      let metadata;
+      try {
+        metadata = JSON.parse(fs.readFileSync(runtimeMetadata, "utf8"));
+      } catch {
+        // Not written yet, or caught mid-write. Fall through to the guards and read again.
+        metadata = undefined;
+      }
+      if (metadata !== null && typeof metadata === "object" && metadata.source === "managed") {
+        clearInterval(poll);
+        resolve(metadata);
+        return;
+      }
+      if (child.exitCode !== null) {
+        clearInterval(poll);
+        reject(new Error(`launcher exited ${child.exitCode} before provisioning finished.`));
+        return;
+      }
+      if (Date.now() > deadline) {
+        clearInterval(poll);
+        child.kill();
+        reject(new Error(`provisioning did not finish within ${timeoutMs}ms.`));
+      }
+    }, intervalMs);
+  });
+}

--- a/scripts/prove-plugin-pinned-provision.mjs
+++ b/scripts/prove-plugin-pinned-provision.mjs
@@ -7,6 +7,10 @@
 // own archive digest, and the provisioned binary must report the pinned version.
 //
 //   node scripts/prove-plugin-pinned-provision.mjs [--timeout-ms 600000]
+//
+// This file is an entry point and nothing else imports it, so its body runs unconditionally.
+// The bounded wait lives in scripts/lib/wait-for-managed-runtime.mjs, which the test imports
+// without running the proof.
 
 import { spawn, execFileSync } from "node:child_process";
 import fs from "node:fs";
@@ -14,120 +18,87 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const scriptPath = fileURLToPath(import.meta.url);
-const repositoryRoot = path.resolve(path.dirname(scriptPath), "..");
+import { waitForManagedRuntime } from "./lib/wait-for-managed-runtime.mjs";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const launcher = path.join(repositoryRoot, "plugins/codestory/scripts/codestory-mcp.cjs");
+const pin = JSON.parse(
+  fs.readFileSync(path.join(repositoryRoot, "plugins/codestory/cli-version.json"), "utf8"),
+);
 
 function fail(message) {
   console.error(`::error::${message}`);
   process.exit(1);
 }
 
-// Wait for the launcher to publish managed runtime metadata. The liveness guards run on every
-// tick and never sit behind the metadata read: a launcher that resolves to a non-managed source
-// (pin or archive digest drift) keeps writing a readable file, so guards nested in the read's
-// catch would never fire and the proof would hang until the CI job timeout.
-export function waitForManagedRuntime({ child, runtimeMetadata, timeoutMs, intervalMs = 250 }) {
-  const deadline = Date.now() + timeoutMs;
-  return new Promise((resolve, reject) => {
-    const poll = setInterval(() => {
-      if (child.exitCode !== null) {
-        clearInterval(poll);
-        reject(new Error(`launcher exited ${child.exitCode} before provisioning finished.`));
-        return;
-      }
-      if (Date.now() > deadline) {
-        clearInterval(poll);
-        child.kill();
-        reject(new Error(`provisioning did not finish within ${timeoutMs}ms.`));
-        return;
-      }
-      let metadata;
-      try {
-        metadata = JSON.parse(fs.readFileSync(runtimeMetadata, "utf8"));
-      } catch {
-        // Not written yet, or caught mid-write. Read again on the next tick.
-        return;
-      }
-      if (metadata.source !== "managed") return;
-      clearInterval(poll);
-      resolve(metadata);
-    }, intervalMs);
-  });
-}
-
-function verifyProvision(dataDir, pin) {
-  const versionDir = path.join(dataDir, "codestory-cli", pin.cli_version);
-  const manifest = JSON.parse(fs.readFileSync(path.join(versionDir, "manifest.json"), "utf8"));
-  const target =
-    process.platform === "darwin"
-      ? "macos-arm64"
-      : process.platform === "win32"
-        ? "windows-x64"
-        : "linux-x64";
-  if (manifest.version !== pin.cli_version) {
-    fail(`provisioned ${manifest.version}, pin names ${pin.cli_version}.`);
-  }
-  if (manifest.build_source !== "github_release") {
-    fail(`expected a github_release provision, observed ${manifest.build_source}.`);
-  }
-  if (pin.archives?.[target] && manifest.archive_sha256 !== pin.archives[target]) {
-    fail(
-      `provisioned archive digest ${manifest.archive_sha256} does not match the pin's ` +
-        `${target} digest ${pin.archives[target]}.`,
-    );
-  }
-  const binary = path.join(versionDir, manifest.path);
-  const reported = execFileSync(binary, ["--version"], { encoding: "utf8" }).trim();
-  if (!reported.includes(pin.cli_version)) {
-    fail(`provisioned binary reports "${reported}", expected ${pin.cli_version}.`);
-  }
-  console.log(
-    `Pinned provision proven: ${target} ${pin.cli_version} from github_release, ` +
-      `archive ${manifest.archive_sha256.slice(0, 12)}…, binary reports "${reported}".`,
+// A missing or non-numeric value used to yield NaN, and every `Date.now() > NaN` comparison is
+// false, so the one flag that declares the bound silently removed it. Refuse the argument
+// instead: an unbounded gate is the failure this timeout exists to prevent.
+const timeoutIndex = process.argv.indexOf("--timeout-ms");
+const timeoutMs = timeoutIndex >= 0 ? Number(process.argv[timeoutIndex + 1]) : 600_000;
+if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+  fail(
+    `--timeout-ms needs a positive number of milliseconds, got ` +
+      `${JSON.stringify(process.argv[timeoutIndex + 1] ?? null)}.`,
   );
 }
 
-async function main() {
-  const pin = JSON.parse(
-    fs.readFileSync(path.join(repositoryRoot, "plugins/codestory/cli-version.json"), "utf8"),
-  );
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-"));
+const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
 
-  const timeoutIndex = process.argv.indexOf("--timeout-ms");
-  const timeoutMs = timeoutIndex >= 0 ? Number(process.argv[timeoutIndex + 1]) : 600_000;
+const child = spawn(process.execPath, [launcher], {
+  env: { ...process.env, CODESTORY_CLI: "", PLUGIN_DATA: dataDir },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+let stderr = "";
+child.stderr.on("data", (chunk) => {
+  stderr += chunk;
+});
+child.stdout.resume();
+child.stdin.write(
+  `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "resources/read",
+    params: { uri: `codestory://status?project=${encodeURIComponent(repositoryRoot)}` },
+  })}\n`,
+);
 
-  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-"));
-  const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
-
-  const child = spawn(process.execPath, [launcher], {
-    env: { ...process.env, CODESTORY_CLI: "", PLUGIN_DATA: dataDir },
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  let stderr = "";
-  child.stderr.on("data", (chunk) => {
-    stderr += chunk;
-  });
-  child.stdout.resume();
-  child.stdin.write(
-    `${JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "resources/read",
-      params: { uri: `codestory://status?project=${encodeURIComponent(repositoryRoot)}` },
-    })}\n`,
-  );
-
-  try {
-    await waitForManagedRuntime({ child, runtimeMetadata, timeoutMs });
-  } catch (error) {
-    fail(`${error.message}\n${stderr}`);
-  }
-  child.kill();
-  verifyProvision(dataDir, pin);
-  fs.rmSync(dataDir, { recursive: true, force: true });
-  process.exit(0);
+try {
+  await waitForManagedRuntime({ child, runtimeMetadata, timeoutMs });
+} catch (error) {
+  fail(`${error.message}\n${stderr}`);
 }
+child.kill();
 
-if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
-  await main();
+const versionDir = path.join(dataDir, "codestory-cli", pin.cli_version);
+const manifest = JSON.parse(fs.readFileSync(path.join(versionDir, "manifest.json"), "utf8"));
+const target =
+  process.platform === "darwin"
+    ? "macos-arm64"
+    : process.platform === "win32"
+      ? "windows-x64"
+      : "linux-x64";
+if (manifest.version !== pin.cli_version) {
+  fail(`provisioned ${manifest.version}, pin names ${pin.cli_version}.`);
 }
+if (manifest.build_source !== "github_release") {
+  fail(`expected a github_release provision, observed ${manifest.build_source}.`);
+}
+if (pin.archives?.[target] && manifest.archive_sha256 !== pin.archives[target]) {
+  fail(
+    `provisioned archive digest ${manifest.archive_sha256} does not match the pin's ` +
+      `${target} digest ${pin.archives[target]}.`,
+  );
+}
+const binary = path.join(versionDir, manifest.path);
+const reported = execFileSync(binary, ["--version"], { encoding: "utf8" }).trim();
+if (!reported.includes(pin.cli_version)) {
+  fail(`provisioned binary reports "${reported}", expected ${pin.cli_version}.`);
+}
+console.log(
+  `Pinned provision proven: ${target} ${pin.cli_version} from github_release, ` +
+    `archive ${manifest.archive_sha256.slice(0, 12)}…, binary reports "${reported}".`,
+);
+fs.rmSync(dataDir, { recursive: true, force: true });
+process.exit(0);

--- a/scripts/prove-plugin-pinned-provision.mjs
+++ b/scripts/prove-plugin-pinned-provision.mjs
@@ -14,62 +14,49 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scriptPath = fileURLToPath(import.meta.url);
+const repositoryRoot = path.resolve(path.dirname(scriptPath), "..");
 const launcher = path.join(repositoryRoot, "plugins/codestory/scripts/codestory-mcp.cjs");
-const pin = JSON.parse(
-  fs.readFileSync(path.join(repositoryRoot, "plugins/codestory/cli-version.json"), "utf8"),
-);
 
 function fail(message) {
   console.error(`::error::${message}`);
   process.exit(1);
 }
 
-const timeoutIndex = process.argv.indexOf("--timeout-ms");
-const timeoutMs = timeoutIndex >= 0 ? Number(process.argv[timeoutIndex + 1]) : 600_000;
-
-const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-"));
-const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
-
-const child = spawn(process.execPath, [launcher], {
-  env: { ...process.env, CODESTORY_CLI: "", PLUGIN_DATA: dataDir },
-  stdio: ["pipe", "pipe", "pipe"],
-});
-let stderr = "";
-child.stderr.on("data", (chunk) => {
-  stderr += chunk;
-});
-child.stdout.resume();
-child.stdin.write(
-  `${JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "resources/read",
-    params: { uri: `codestory://status?project=${encodeURIComponent(repositoryRoot)}` },
-  })}\n`,
-);
-
-const deadline = Date.now() + timeoutMs;
-const poll = setInterval(() => {
-  let metadata;
-  try {
-    metadata = JSON.parse(fs.readFileSync(runtimeMetadata, "utf8"));
-  } catch {
-    if (child.exitCode !== null) {
+// Wait for the launcher to publish managed runtime metadata. The liveness guards run on every
+// tick and never sit behind the metadata read: a launcher that resolves to a non-managed source
+// (pin or archive digest drift) keeps writing a readable file, so guards nested in the read's
+// catch would never fire and the proof would hang until the CI job timeout.
+export function waitForManagedRuntime({ child, runtimeMetadata, timeoutMs, intervalMs = 250 }) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const poll = setInterval(() => {
+      if (child.exitCode !== null) {
+        clearInterval(poll);
+        reject(new Error(`launcher exited ${child.exitCode} before provisioning finished.`));
+        return;
+      }
+      if (Date.now() > deadline) {
+        clearInterval(poll);
+        child.kill();
+        reject(new Error(`provisioning did not finish within ${timeoutMs}ms.`));
+        return;
+      }
+      let metadata;
+      try {
+        metadata = JSON.parse(fs.readFileSync(runtimeMetadata, "utf8"));
+      } catch {
+        // Not written yet, or caught mid-write. Read again on the next tick.
+        return;
+      }
+      if (metadata.source !== "managed") return;
       clearInterval(poll);
-      fail(`launcher exited ${child.exitCode} before provisioning finished.\n${stderr}`);
-    }
-    if (Date.now() > deadline) {
-      clearInterval(poll);
-      child.kill();
-      fail(`provisioning did not finish within ${timeoutMs}ms.\n${stderr}`);
-    }
-    return;
-  }
-  if (metadata.source !== "managed") return;
-  clearInterval(poll);
-  child.kill();
+      resolve(metadata);
+    }, intervalMs);
+  });
+}
 
+function verifyProvision(dataDir, pin) {
   const versionDir = path.join(dataDir, "codestory-cli", pin.cli_version);
   const manifest = JSON.parse(fs.readFileSync(path.join(versionDir, "manifest.json"), "utf8"));
   const target =
@@ -99,6 +86,48 @@ const poll = setInterval(() => {
     `Pinned provision proven: ${target} ${pin.cli_version} from github_release, ` +
       `archive ${manifest.archive_sha256.slice(0, 12)}…, binary reports "${reported}".`,
   );
+}
+
+async function main() {
+  const pin = JSON.parse(
+    fs.readFileSync(path.join(repositoryRoot, "plugins/codestory/cli-version.json"), "utf8"),
+  );
+
+  const timeoutIndex = process.argv.indexOf("--timeout-ms");
+  const timeoutMs = timeoutIndex >= 0 ? Number(process.argv[timeoutIndex + 1]) : 600_000;
+
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-"));
+  const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
+
+  const child = spawn(process.execPath, [launcher], {
+    env: { ...process.env, CODESTORY_CLI: "", PLUGIN_DATA: dataDir },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  child.stdout.resume();
+  child.stdin.write(
+    `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/read",
+      params: { uri: `codestory://status?project=${encodeURIComponent(repositoryRoot)}` },
+    })}\n`,
+  );
+
+  try {
+    await waitForManagedRuntime({ child, runtimeMetadata, timeoutMs });
+  } catch (error) {
+    fail(`${error.message}\n${stderr}`);
+  }
+  child.kill();
+  verifyProvision(dataDir, pin);
   fs.rmSync(dataDir, { recursive: true, force: true });
   process.exit(0);
-}, 250);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  await main();
+}

--- a/scripts/tests/prove-plugin-pinned-provision.test.mjs
+++ b/scripts/tests/prove-plugin-pinned-provision.test.mjs
@@ -6,40 +6,18 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-const scriptUrl = pathToFileURL(
-  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../prove-plugin-pinned-provision.mjs"),
-).href;
+const scriptsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const proofScript = path.join(scriptsDir, "prove-plugin-pinned-provision.mjs");
+const waitModuleUrl = pathToFileURL(path.join(scriptsDir, "lib/wait-for-managed-runtime.mjs")).href;
 
 // The wait must bound itself even when the launcher keeps a readable non-managed metadata file
 // on disk, so drive it in its own process and kill it if it outlives the bound. A hang here is a
 // reported failure, not a wedged test run.
 const KILL_AFTER_MS = 5_000;
 
-function driveWait({ runtimeMetadata, timeoutMs, exitCode }) {
-  const source = `
-    import { waitForManagedRuntime } from ${JSON.stringify(scriptUrl)};
-    const exitCode = ${JSON.stringify(exitCode)};
-    let killed = false;
-    const child = { exitCode, kill() { killed = true; } };
-    const started = Date.now();
-    let outcome;
-    try {
-      await waitForManagedRuntime({
-        child,
-        runtimeMetadata: ${JSON.stringify(runtimeMetadata)},
-        timeoutMs: ${JSON.stringify(timeoutMs)},
-        intervalMs: 10,
-      });
-      outcome = { settled: "resolved" };
-    } catch (error) {
-      outcome = { settled: "rejected", message: error.message };
-    }
-    console.log(JSON.stringify({ ...outcome, killed, elapsedMs: Date.now() - started }));
-  `;
+function runNode(args, options = {}) {
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, ["--input-type=module", "-e", source], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawn(process.execPath, args, { stdio: ["ignore", "pipe", "pipe"], ...options });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk) => {
@@ -51,24 +29,58 @@ function driveWait({ runtimeMetadata, timeoutMs, exitCode }) {
     const killer = setTimeout(() => child.kill("SIGKILL"), KILL_AFTER_MS);
     child.on("close", (code, signal) => {
       clearTimeout(killer);
-      if (signal || stdout.trim() === "") {
-        resolve({ settled: "hung", code, signal, stderr });
-        return;
-      }
-      resolve(JSON.parse(stdout.trim()));
+      resolve({ code, signal, stdout, stderr });
     });
   });
 }
 
+function driveWait({ runtimeMetadata, timeoutMs, exitCode }) {
+  const source = `
+    import { waitForManagedRuntime } from ${JSON.stringify(waitModuleUrl)};
+    const exitCode = ${JSON.stringify(exitCode)};
+    let killed = false;
+    const child = { exitCode, kill() { killed = true; } };
+    const started = Date.now();
+    let outcome;
+    try {
+      const metadata = await waitForManagedRuntime({
+        child,
+        runtimeMetadata: ${JSON.stringify(runtimeMetadata)},
+        timeoutMs: ${JSON.stringify(timeoutMs)},
+        intervalMs: 10,
+      });
+      outcome = { settled: "resolved", metadata };
+    } catch (error) {
+      outcome = { settled: "rejected", message: error.message };
+    }
+    console.log(JSON.stringify({ ...outcome, killed, elapsedMs: Date.now() - started }));
+  `;
+  return runNode(["--input-type=module", "-e", source]).then((result) => {
+    if (result.signal || result.stdout.trim() === "") {
+      return { settled: "hung", code: result.code, signal: result.signal, stderr: result.stderr };
+    }
+    return JSON.parse(result.stdout.trim());
+  });
+}
+
+function scratchDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-test-"));
+}
+
 function driftedRuntimeMetadata() {
-  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-test-"));
-  const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
+  const runtimeMetadata = path.join(scratchDir(), ".codestory-mcp-runtime.json");
   // What the launcher writes when the pin's archive digest no longer resolves: readable
   // metadata that never reaches the managed source the proof is waiting for.
   fs.writeFileSync(
     runtimeMetadata,
     JSON.stringify({ source: "managed_unavailable", path: null, cliVersion: null }),
   );
+  return runtimeMetadata;
+}
+
+function managedRuntimeMetadata() {
+  const runtimeMetadata = path.join(scratchDir(), ".codestory-mcp-runtime.json");
+  fs.writeFileSync(runtimeMetadata, JSON.stringify({ source: "managed", cliVersion: "9.9.9" }));
   return runtimeMetadata;
 }
 
@@ -96,10 +108,70 @@ test("a launcher that exits while runtime metadata stays readable fails fast", a
 });
 
 test("managed runtime metadata resolves the wait with the published metadata", async () => {
-  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-test-"));
-  const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
-  fs.writeFileSync(runtimeMetadata, JSON.stringify({ source: "managed", cliVersion: "9.9.9" }));
-  const outcome = await driveWait({ runtimeMetadata, timeoutMs: 600_000, exitCode: null });
+  const outcome = await driveWait({
+    runtimeMetadata: managedRuntimeMetadata(),
+    timeoutMs: 600_000,
+    exitCode: null,
+  });
   assert.equal(outcome.settled, "resolved", JSON.stringify(outcome));
+  assert.equal(outcome.metadata.cliVersion, "9.9.9");
   assert.equal(outcome.killed, false, "a successful wait must not kill the launcher itself");
+});
+
+// The launcher hands off and exits 0 once it has published its manifest, so the exit guard must
+// never outrank a completed provision: the metadata read has to settle the tick first.
+test("a launcher that published managed metadata and then exited 0 is a success", async () => {
+  const outcome = await driveWait({
+    runtimeMetadata: managedRuntimeMetadata(),
+    timeoutMs: 600_000,
+    exitCode: 0,
+  });
+  assert.equal(
+    outcome.settled,
+    "resolved",
+    `a completed provision was reported as a failure: ${JSON.stringify(outcome)}`,
+  );
+  assert.equal(outcome.metadata.source, "managed");
+});
+
+test("the wait refuses a timeout that is not a positive number instead of never expiring", async () => {
+  const outcome = await driveWait({
+    runtimeMetadata: driftedRuntimeMetadata(),
+    timeoutMs: null,
+    exitCode: null,
+  });
+  assert.equal(outcome.settled, "rejected", `an unbounded wait was accepted: ${JSON.stringify(outcome)}`);
+  assert.match(outcome.message, /positive finite timeoutMs/u);
+});
+
+// plugin-release.yml gates the `v*` tag on this script, so every way of invoking it has to reach
+// the proof. A wrong entry-point comparison used to exit 0 with no output when the path reached
+// the file through a symlink, which is a vacuous pass on the release gate.
+for (const invocation of ["direct", "symlinked"]) {
+  test(`the gate refuses an unusable --timeout-ms when invoked ${invocation}`, async (t) => {
+    let entry = proofScript;
+    if (invocation === "symlinked") {
+      const link = path.join(scratchDir(), "scripts");
+      try {
+        fs.symlinkSync(scriptsDir, link, "dir");
+      } catch (error) {
+        t.skip(`this platform refuses directory symlinks: ${error.code}`);
+        return;
+      }
+      entry = path.join(link, "prove-plugin-pinned-provision.mjs");
+    }
+    const outcome = await runNode([entry, "--timeout-ms", "not-a-number"]);
+    assert.equal(
+      outcome.code,
+      1,
+      `the gate did not fail closed: ${JSON.stringify({ ...outcome, entry })}`,
+    );
+    assert.match(outcome.stderr, /::error::--timeout-ms needs a positive number/u);
+  });
+}
+
+test("the gate refuses --timeout-ms with no value at all", async () => {
+  const outcome = await runNode([proofScript, "--timeout-ms"]);
+  assert.equal(outcome.code, 1, `the gate did not fail closed: ${JSON.stringify(outcome)}`);
+  assert.match(outcome.stderr, /::error::--timeout-ms needs a positive number/u);
 });

--- a/scripts/tests/prove-plugin-pinned-provision.test.mjs
+++ b/scripts/tests/prove-plugin-pinned-provision.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptUrl = pathToFileURL(
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../prove-plugin-pinned-provision.mjs"),
+).href;
+
+// The wait must bound itself even when the launcher keeps a readable non-managed metadata file
+// on disk, so drive it in its own process and kill it if it outlives the bound. A hang here is a
+// reported failure, not a wedged test run.
+const KILL_AFTER_MS = 5_000;
+
+function driveWait({ runtimeMetadata, timeoutMs, exitCode }) {
+  const source = `
+    import { waitForManagedRuntime } from ${JSON.stringify(scriptUrl)};
+    const exitCode = ${JSON.stringify(exitCode)};
+    let killed = false;
+    const child = { exitCode, kill() { killed = true; } };
+    const started = Date.now();
+    let outcome;
+    try {
+      await waitForManagedRuntime({
+        child,
+        runtimeMetadata: ${JSON.stringify(runtimeMetadata)},
+        timeoutMs: ${JSON.stringify(timeoutMs)},
+        intervalMs: 10,
+      });
+      outcome = { settled: "resolved" };
+    } catch (error) {
+      outcome = { settled: "rejected", message: error.message };
+    }
+    console.log(JSON.stringify({ ...outcome, killed, elapsedMs: Date.now() - started }));
+  `;
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", source], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    const killer = setTimeout(() => child.kill("SIGKILL"), KILL_AFTER_MS);
+    child.on("close", (code, signal) => {
+      clearTimeout(killer);
+      if (signal || stdout.trim() === "") {
+        resolve({ settled: "hung", code, signal, stderr });
+        return;
+      }
+      resolve(JSON.parse(stdout.trim()));
+    });
+  });
+}
+
+function driftedRuntimeMetadata() {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-test-"));
+  const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
+  // What the launcher writes when the pin's archive digest no longer resolves: readable
+  // metadata that never reaches the managed source the proof is waiting for.
+  fs.writeFileSync(
+    runtimeMetadata,
+    JSON.stringify({ source: "managed_unavailable", path: null, cliVersion: null }),
+  );
+  return runtimeMetadata;
+}
+
+test("pin drift that keeps runtime metadata readable still times out within the bound", async () => {
+  const outcome = await driveWait({
+    runtimeMetadata: driftedRuntimeMetadata(),
+    timeoutMs: 300,
+    exitCode: null,
+  });
+  assert.equal(outcome.settled, "rejected", `wait did not bound itself: ${JSON.stringify(outcome)}`);
+  assert.match(outcome.message, /provisioning did not finish within 300ms/u);
+  assert.equal(outcome.killed, true, "the timed-out wait must kill the launcher");
+  assert.ok(outcome.elapsedMs < KILL_AFTER_MS, `waited ${outcome.elapsedMs}ms`);
+});
+
+test("a launcher that exits while runtime metadata stays readable fails fast", async () => {
+  const outcome = await driveWait({
+    runtimeMetadata: driftedRuntimeMetadata(),
+    timeoutMs: 600_000,
+    exitCode: 3,
+  });
+  assert.equal(outcome.settled, "rejected", `wait did not notice the exit: ${JSON.stringify(outcome)}`);
+  assert.match(outcome.message, /launcher exited 3 before provisioning finished/u);
+  assert.ok(outcome.elapsedMs < KILL_AFTER_MS, `waited ${outcome.elapsedMs}ms`);
+});
+
+test("managed runtime metadata resolves the wait with the published metadata", async () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-test-"));
+  const runtimeMetadata = path.join(dataDir, ".codestory-mcp-runtime.json");
+  fs.writeFileSync(runtimeMetadata, JSON.stringify({ source: "managed", cliVersion: "9.9.9" }));
+  const outcome = await driveWait({ runtimeMetadata, timeoutMs: 600_000, exitCode: null });
+  assert.equal(outcome.settled, "resolved", JSON.stringify(outcome));
+  assert.equal(outcome.killed, false, "a successful wait must not kill the launcher itself");
+});


### PR DESCRIPTION
Closes #1556

Two proof-tooling waits declared a timeout that could not actually bound them.
The first commit fixed both and introduced two new defects of its own on the
`plugin-release.yml` tag gate. The second commit repairs those and closes the
gaps a review found in the tests.

## `scripts/prove-plugin-pinned-provision.mjs`

**The original bug.** The `--timeout-ms` deadline check and the child-exit check
both sat inside the `catch` of the runtime metadata read. That catch only runs
while the file is missing or half-written. The moment the launcher published
readable *non-managed* metadata — `managed_unavailable`, which is what pin or
archive digest drift produces — the read stopped throwing, neither guard ran
again, and the proof polled forever until the CI job timeout. The gate hung on
precisely the drift it exists to catch.

**What the tick does now:** read → resolve if the source is `managed` → then the
liveness guards, every tick. Guards-first, which commit 1 shipped, turned a
launcher that published its manifest and then exited 0 — the launcher's real
clean-exit path at `codestory-mcp.cjs:3218` — into a reported failure.
Read-first keeps the drift fix without inventing that spurious failure on the
tag path.

**No entry-point guard.** Commit 1 wrapped the body in
`if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath)`.
`path.resolve` is lexical; Node realpath-resolves the ESM main entry it reports
through `import.meta.url`. Any symlink on the invocation path made the two
differ, so `main()` never ran and the release gate exited **0 with no output** —
a vacuous pass on the job that `publish` (the one holding `contents: write`)
depends on. The repair is not a better comparison. This file is an entry point,
its body runs unconditionally again as it did before the PR, and the bounded
wait moved to `scripts/lib/wait-for-managed-runtime.mjs`, which has no top-level
side effects. The test imports the wait without running the proof, and nothing
has to guess whether it is the entry.

**`--timeout-ms` can no longer disable the bound.** A missing or non-numeric
value produced `NaN`, and `Date.now() > NaN` is always false, so the one flag
that declares the bound silently removed it. Both the script and the wait now
refuse it. Pre-existing, but it is the class this PR is named after.

`verifyProvision` is no longer extracted: the verification block is the pre-PR
code, unchanged.

## `.github/scripts/packaged_agent_proof/subprocess_control.py`

`search_until_ready` computes a shared deadline, but each poll called
`tool_until_ready`, which minted its own `time.monotonic() + self.timeout`.
Commit 1 threaded the shared deadline into the readiness *retries* and stopped
there. Every `self.tool(...)` inside that loop still went through `send()`,
which minted its own full budget again, so the worst case stayed
≈ 2 × `self.timeout`. Measured against the branch's own code: **100.0s spent
under a 60.0s bound.**

The deadline now reaches the transport. `send()` and `tool()` take an optional
`deadline`, `tool_until_ready` threads its own into every request, and each
mints its own only when none is supplied, so existing callers keep today's
behaviour. Same probe after the change: **60.0s.**

## Tests

`scripts/tests/prove-plugin-pinned-provision.test.mjs` — 8 legs. The wait runs
in its own process and is killed if it outlives the bound, so a regression is a
reported failure rather than a wedged run. Drift metadata times out within the
declared bound and kills the launcher; a launcher exit is noticed while metadata
stays readable; managed metadata resolves; **managed metadata together with
`exitCode: 0` resolves** — the combination commit 1 broke and its test avoided;
a non-numeric `timeoutMs` is refused instead of never expiring; and the gate
itself, invoked **directly and through a symlinked path**, exits 1 with a
diagnostic instead of exiting 0 in silence.

`.github/scripts/packaged_agent_proof/self_test_process_deadline.py` — 6 legs
under a virtual clock, no wall time. The scripted host now replaces the
**pipes**, not the methods, so `tool()` and `send()` are the shipped
implementations; the previous version stubbed `tool()` and was structurally
blind to the transport half. The default-bound leg drives a host that never
becomes ready, so it fails if the default grows *or* shrinks — the old leg used
a converging host whose two retries happened to sum to the timeout, and would
have passed a default loosened to `2 * self.timeout`.

## CI wiring

`scripts/tests/prove-plugin-pinned-provision.test.mjs` ran in **no workflow**.
It is now a step in `plugin-static.yml` (every PR) and in `plugin-release.yml`'s
`plugin-proof` job, ahead of the gate it checks. Both steps and the new path
triggers are paired in `check-workflow-policy.mjs`.

## Verification

Both directions, per repo rules.

| command | result |
| --- | --- |
| `node --test scripts/tests/prove-plugin-pinned-provision.test.mjs` | 8/8 pass |
| the same suite against commit 1's script | **3 fail** — the symlinked invocation exited 0 in 21ms; the two `--timeout-ms` legs hung 5004ms to the kill bound |
| the same suite with the tick reordered guards-first | **1 fail** — "a launcher that published managed metadata and then exited 0 is a success" |
| the same suite with the wait's `timeoutMs` validation removed | **1 fail** — the unbounded wait hangs to the kill bound |
| `python3 .github/scripts/check-packaged-agent-proof.py --self-test` | pass |
| the same, with `deadline=deadline` removed from `tool_until_ready`'s request | **fail** — `minted its own budget: waited 100.0s against its 60.0s bound` |
| the same, with the default loosened to `2 * self.timeout` | **fail** — `5 attempts over 120.0s against 60.0s` |
| commit 1's self-test against that same loosened default | **passes** — which is the blindness this commit removes |
| `node .github/scripts/check-workflow-policy.mjs` | pass |
| the same, with the two new CI steps deleted | **fail** — 4 violations naming both workflows |
| `node --test .github/scripts/check-workflow-policy.test.mjs` | 367/367 pass |
| `node .github/scripts/run-actionlint.mjs` | pass |
| `node .github/scripts/route-ci-proof.mjs --self-test` | pass |
| `node --test plugins/codestory/tests/plugin-static.test.mjs` | 94 pass, 0 fail |
| `node --test scripts/tests/prove-drill-packet-parity.test.mjs` | 4/4 pass |
| `node scripts/prove-plugin-pinned-provision.mjs --timeout-ms 1`, direct **and** through a symlink | both exit 1 with `provisioning did not finish within 1ms`; the symlinked form exited 0 in silence before |

`.github/workflows/**` is touched now, so the policy-pairing rule applies and is
satisfied: every workflow edit has a matching assertion in
`check-workflow-policy.mjs`, demonstrated failing above. No Rust changed, so
`cargo test -p codestory-cli --test architecture_contracts` is N/A.

Known limit: the symlink leg skips itself on a platform that refuses directory
symlinks, which is Windows without developer mode. The rest of the suite still
runs there, and the leg runs on the Linux and macOS legs of `plugin-proof`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
