### PR TITLE
accept binding-verified reuse rows in the pre-publish closeout

### DIFF
--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -144,6 +144,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+        with:
+          # The reuse-binding contracts verify tree identity and native
+          # fingerprints against this repository's real release history, so the
+          # default depth-1 clone cannot answer them.
+          fetch-depth: 0
 
       - name: Install workflow policy dependencies
         run: npm ci --ignore-scripts

--- a/scripts/codestory-release-cell-manifest.mjs
+++ b/scripts/codestory-release-cell-manifest.mjs
@@ -17,8 +17,6 @@ import {
   validateReleaseCellManifest,
 } from "./codestory-release-closeout.mjs";
 
-export { verifyReuseBinding };
-
 const PRODUCER_MAP_SCHEMA = "codestory.release-actions-provenance/v1";
 const ACTIONS_DIGEST = /^sha256:[0-9a-f]{64}$/u;
 

--- a/scripts/codestory-release-cell-manifest.mjs
+++ b/scripts/codestory-release-cell-manifest.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -10,12 +9,15 @@ import {
   deriveTrustedGitIdentity,
   loadReleaseClaimGraph,
   releaseClaimGraphDigest,
+  verifyReuseBinding,
 } from "./codestory-release-claims.mjs";
 import {
   deriveReleaseCells,
   resolveReleaseCellConstraints,
   validateReleaseCellManifest,
 } from "./codestory-release-closeout.mjs";
+
+export { verifyReuseBinding };
 
 const PRODUCER_MAP_SCHEMA = "codestory.release-actions-provenance/v1";
 const ACTIONS_DIGEST = /^sha256:[0-9a-f]{64}$/u;
@@ -475,45 +477,6 @@ export function buildTrustedProducerMap({
     producers,
     artifacts: [...new Map(producers.map((row) => [row.artifact.id, row.artifact])).values()],
   };
-}
-
-/// Verify a reuse binding against the local repository and return its recorded value.
-export function verifyReuseBinding({ binding, repository, releaseCommit, reusedCommit }) {
-  const run = (args) =>
-    execFileSync("git", args, { cwd: repository, encoding: "utf8" }).trim();
-  if (binding === "source_tree") {
-    const releaseTree = run(["rev-parse", `${releaseCommit}^{tree}`]);
-    const reusedTree = run(["rev-parse", `${reusedCommit}^{tree}`]);
-    if (releaseTree !== reusedTree) {
-      fail(`reused commit ${reusedCommit} tree ${reusedTree} does not match release tree ${releaseTree}`);
-    }
-    try {
-      execFileSync("git", ["merge-base", "--is-ancestor", reusedCommit, releaseCommit], {
-        cwd: repository,
-      });
-    } catch {
-      fail(`reused commit ${reusedCommit} is not an ancestor of the release commit`);
-    }
-    return releaseTree;
-  }
-  if (binding === "native_fingerprint") {
-    const script = new URL("./native-fingerprint.mjs", import.meta.url).pathname;
-    const fingerprint = (ref) =>
-      execFileSync(process.execPath, [script, "--ref", ref], {
-        cwd: repository,
-        encoding: "utf8",
-      }).trim();
-    const releasePrint = fingerprint(releaseCommit);
-    const reusedPrint = fingerprint(reusedCommit);
-    if (releasePrint !== reusedPrint) {
-      fail(
-        `native fingerprint of reused commit ${reusedCommit} (${reusedPrint}) does not match `
-          + `the release commit (${releasePrint}); accelerator evidence cannot be inherited`,
-      );
-    }
-    return releasePrint;
-  }
-  fail(`unknown reuse binding ${binding}`);
 }
 
 async function githubPages(url, token, field) {

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -172,6 +172,49 @@ export function deriveTrustedGitIdentity({ repoRoot, expectedSha }) {
   };
 }
 
+/// Verify a reuse binding against the local repository and return its recorded value.
+///
+/// Both sides of the release ledger need this: the producer proves the binding before it admits
+/// cross-run evidence, and the closeout re-proves it against its own checkout before it anchors a
+/// reused row to the earlier run.
+export function verifyReuseBinding({ binding, repository, releaseCommit, reusedCommit }) {
+  if (binding === "source_tree") {
+    const releaseTree = git(["rev-parse", `${releaseCommit}^{tree}`], repository);
+    const reusedTree = git(["rev-parse", `${reusedCommit}^{tree}`], repository);
+    if (releaseTree !== reusedTree) {
+      fail(`reused commit ${reusedCommit} tree ${reusedTree} does not match release tree ${releaseTree}`);
+    }
+    if (spawnSync("git", ["merge-base", "--is-ancestor", reusedCommit, releaseCommit], {
+      cwd: repository,
+      encoding: "utf8",
+    }).status !== 0) {
+      fail(`reused commit ${reusedCommit} is not an ancestor of the release commit`);
+    }
+    return releaseTree;
+  }
+  if (binding === "native_fingerprint") {
+    const script = fileURLToPath(new URL("./native-fingerprint.mjs", import.meta.url));
+    const fingerprint = (ref) => {
+      const result = spawnSync(process.execPath, [script, "--ref", ref], {
+        cwd: repository,
+        encoding: "utf8",
+      });
+      if (result.status !== 0) fail(`native fingerprint of ${ref} failed: ${result.stderr.trim()}`);
+      return result.stdout.trim();
+    };
+    const releasePrint = fingerprint(releaseCommit);
+    const reusedPrint = fingerprint(reusedCommit);
+    if (releasePrint !== reusedPrint) {
+      fail(
+        `native fingerprint of reused commit ${reusedCommit} (${reusedPrint}) does not match `
+          + `the release commit (${releasePrint}); accelerator evidence cannot be inherited`,
+      );
+    }
+    return releasePrint;
+  }
+  fail(`unknown reuse binding ${binding}`);
+}
+
 function uniqueById(values, label) {
   if (!Array.isArray(values) || values.length === 0) fail(`${label} must be a non-empty array`);
   const found = new Map();

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -292,6 +292,14 @@ function producerAnchor({ cell, row, trustedProducers, gitIdentity, bindings, ve
     errors.push(`trusted producer map ${cell.id} reused run identity is invalid`);
     return sameRun;
   }
+  // Reuse inherits what an *earlier* run produced. A block naming the run that is publishing
+  // inherits nothing, and every binding it could name verifies vacuously -- a commit is its own
+  // ancestor and its own tree -- so treating it as reuse would hand an ordinary same-run row the
+  // reused row's freedom from the release commit. There is nothing here to reuse.
+  if (String(reused.run_id) === String(trustedProducers.run_id ?? "")) {
+    errors.push(`trusted producer map ${cell.id} reuses evidence from the publishing run`);
+    return sameRun;
+  }
   if (typeof verify !== "function") {
     errors.push(`trusted producer map ${cell.id} reuses evidence this closeout cannot verify`);
     return sameRun;
@@ -522,7 +530,7 @@ function trustedProducerIndex({
   return { byCell, reusedByCell, errors };
 }
 
-function producerAuthenticationProblems(manifest, trustedProducer) {
+function producerAuthenticationProblems(manifest, trustedProducer, reusedCommit) {
   if (!trustedProducer) return ["manifest producer is absent from the trusted producer map"];
   const identity = manifest.evidence?.identity ?? {};
   const problems = [];
@@ -537,6 +545,13 @@ function producerAuthenticationProblems(manifest, trustedProducer) {
     if (identity[key] !== trustedProducer[key]) {
       problems.push(`manifest ${key} does not match the trusted producer map`);
     }
+  }
+  // A same-run manifest is held to the release commit by the claim evaluator. A reused one is
+  // read at the release commit instead, so that comparison no longer binds it to anything --
+  // this does. The binding proof covers exactly one earlier commit, and it is the only commit
+  // this manifest may declare.
+  if (reusedCommit !== undefined && identity.commit !== reusedCommit) {
+    problems.push("manifest commit is not the reused commit the closeout proved bound to this release");
   }
   return problems;
 }
@@ -665,9 +680,14 @@ function evaluateCell({
   // closeout just re-proved against its own checkout. Reading it at the release commit applies
   // that binding; the row's own source tree is still compared against this release, so a binding
   // that does not equate the trees still fails. The ledger keeps the manifest identity untouched.
+  //
+  // The substitution is granted to exactly the commit the proof covered. A row declaring any
+  // other commit is not the evidence that was proved, so it is read as written and fails the
+  // claim evaluator's commit check -- the same check that binds every same-run row.
   const evidence = evidenceCells.map((dependency) => {
     const row = manifests.get(dependency.id).evidence;
-    if (!reusedByCell.has(dependency.id)) return row;
+    const provedCommit = reusedByCell.get(dependency.id);
+    if (provedCommit === undefined || row.identity?.commit !== provedCommit) return row;
     return { ...row, identity: { ...row.identity, commit: gitIdentity.commit } };
   });
   const requestedClaims = claims.map((claim) => ({
@@ -938,7 +958,11 @@ export function evaluateReleaseCloseout({
     if (rows.length !== 1) continue;
     const manifest = rows[0];
     const problems = manifestProblems({ manifest, cell, graph, graphSha256, version });
-    problems.push(...producerAuthenticationProblems(manifest, trusted.byCell.get(cell.id)));
+    problems.push(...producerAuthenticationProblems(
+      manifest,
+      trusted.byCell.get(cell.id),
+      trusted.reusedByCell.get(cell.id),
+    ));
     problems.push(...artifactBindingProblems(
       manifest,
       bindings.byCell.get(cell.id),

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -18,12 +18,14 @@ import {
   loadReleaseClaimGraph,
   releaseClaimGraphDigest,
   releaseClaimIdentityMatchesFormat,
+  verifyReuseBinding,
 } from "./codestory-release-claims.mjs";
 
 const MANIFEST_EVALUATION_SCHEMA = "codestory.release-cell-evaluation/v1";
 const PRODUCER_MAP_SCHEMA = "codestory.release-actions-provenance/v1";
 const TRUSTED_EXCEPTIONS_SCHEMA = "codestory.release-closeout-exceptions/v1";
 const SHA256 = /^[0-9a-f]{64}$/u;
+const FULL_SHA = /^[0-9a-f]{40}$/u;
 const ACTIONS_DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 const AGGREGATE_IDENTITY = /^(?:aggregate|all|matrix|mixed|multiple|various)$/iu;
@@ -266,10 +268,67 @@ export function validateReleaseCellManifest({ manifest, cell, graph, version }) 
   });
 }
 
-function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, phase }) {
+/// The run and commit one producer row has to be bound to.
+///
+/// Same-run rows anchor to the Actions run that is publishing. A row carrying a reuse block
+/// anchors to the reused run instead, but only once the closeout has re-proved, against its own
+/// checkout, the binding the claim graph declares for that cell's group. Every rejecting path
+/// records its reason and falls back to the same-run anchor, so unverifiable reuse also fails the
+/// run identity checks that follow.
+function producerAnchor({ cell, row, trustedProducers, gitIdentity, bindings, verify, errors }) {
+  const sameRun = { runId: trustedProducers.run_id, headSha: gitIdentity.commit, reused: false };
+  const reused = row.reused_from;
+  if (reused === undefined) return sameRun;
+  if (reused === null || typeof reused !== "object" || Array.isArray(reused)) {
+    errors.push(`trusted producer map ${cell.id} reuse record must be an object`);
+    return sameRun;
+  }
+  const binding = bindings.get(cell.group_id);
+  if (binding === undefined || reused.binding !== binding) {
+    errors.push(`trusted producer map ${cell.id} reuses evidence under an undeclared binding`);
+    return sameRun;
+  }
+  if (!/^[1-9]\d*$/u.test(String(reused.run_id ?? "")) || !FULL_SHA.test(String(reused.head_sha ?? ""))) {
+    errors.push(`trusted producer map ${cell.id} reused run identity is invalid`);
+    return sameRun;
+  }
+  if (typeof verify !== "function") {
+    errors.push(`trusted producer map ${cell.id} reuses evidence this closeout cannot verify`);
+    return sameRun;
+  }
+  let bindingValue;
+  try {
+    bindingValue = verify({
+      binding,
+      releaseCommit: gitIdentity.commit,
+      reusedCommit: reused.head_sha,
+    });
+  } catch (error) {
+    errors.push(`trusted producer map ${cell.id} ${binding} reuse is unverified: ${error.message}`);
+    return sameRun;
+  }
+  if (reused.binding_value !== bindingValue) {
+    errors.push(`trusted producer map ${cell.id} recorded ${binding} value does not bind this release`);
+    return sameRun;
+  }
+  return { runId: reused.run_id, headSha: reused.head_sha, reused: true };
+}
+
+function trustedProducerIndex({
+  trustedProducers,
+  cells,
+  gitIdentity,
+  graph,
+  phase,
+  verifyReuseBinding: verify,
+}) {
   const errors = [];
   if (trustedProducers === null || typeof trustedProducers !== "object" || Array.isArray(trustedProducers)) {
-    return { byCell: new Map(), errors: ["closeout requires a separately trusted producer map"] };
+    return {
+      byCell: new Map(),
+      reusedByCell: new Map(),
+      errors: ["closeout requires a separately trusted producer map"],
+    };
   }
   if (trustedProducers.schema !== PRODUCER_MAP_SCHEMA) {
     errors.push(`trusted producer map schema must be ${PRODUCER_MAP_SCHEMA}`);
@@ -342,6 +401,10 @@ function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, pha
   for (const cellId of byCell.keys()) {
     if (!required.has(cellId)) errors.push(`trusted producer map contains undeclared cell ${cellId}`);
   }
+  const bindings = new Map((graph.closeout.cell_groups ?? [])
+    .filter((group) => typeof group.reuse_binding === "string")
+    .map((group) => [group.id, group.reuse_binding]));
+  const reusedByCell = new Map();
   for (const cell of cells) {
     const row = byCell.get(cell.id);
     if (!row) {
@@ -369,10 +432,23 @@ function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, pha
         errors.push(`trusted producer map ${cell.id} ${key} must equal ${constrained}`);
       }
     }
-    if (row.producer_run_id !== trustedProducers.run_id) {
+    const anchor = producerAnchor({
+      cell,
+      row,
+      trustedProducers,
+      gitIdentity,
+      bindings,
+      verify,
+      errors,
+    });
+    if (anchor.reused) reusedByCell.set(cell.id, anchor.headSha);
+    if (row.producer_run_id !== anchor.runId) {
       errors.push(`trusted producer map ${cell.id} run identity differs from the Actions run`);
     }
-    if (/^[1-9]\d*$/u.test(String(row.producer_run_attempt ?? ""))
+    // An attempt is bounded by its own run's attempt counter, and the closeout knows that counter
+    // for the publishing run alone. A reuse block naming that run stays capped all the same.
+    if (row.producer_run_id === trustedProducers.run_id
+        && /^[1-9]\d*$/u.test(String(row.producer_run_attempt ?? ""))
         && /^[1-9]\d*$/u.test(String(trustedProducers.current_run_attempt ?? ""))
         && Number(row.producer_run_attempt) > Number(trustedProducers.current_run_attempt)) {
       errors.push(`trusted producer map ${cell.id} uses a future run attempt`);
@@ -405,7 +481,7 @@ function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, pha
         errors.push(`trusted producer map ${cell.id} artifact is expired`);
       }
       if (artifact.workflow_run_id !== row.producer_run_id
-          || artifact.head_sha !== gitIdentity.commit) {
+          || artifact.head_sha !== anchor.headSha) {
         errors.push(`trusted producer map ${cell.id} artifact run identity changed`);
       }
     }
@@ -416,7 +492,7 @@ function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, pha
       if (!/^[1-9]\d*$/u.test(String(job.id ?? ""))) {
         errors.push(`trusted producer map ${cell.id} job id is invalid`);
       }
-      if (job.run_id !== row.producer_run_id || job.head_sha !== gitIdentity.commit) {
+      if (job.run_id !== row.producer_run_id || job.head_sha !== anchor.headSha) {
         errors.push(`trusted producer map ${cell.id} job run identity changed`);
       }
       if (job.run_attempt !== row.producer_run_attempt
@@ -443,7 +519,7 @@ function trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, pha
       errors.push(`trusted producer map download inventory contains unused artifact ${artifactId}`);
     }
   }
-  return { byCell, errors };
+  return { byCell, reusedByCell, errors };
 }
 
 function producerAuthenticationProblems(manifest, trustedProducer) {
@@ -573,6 +649,7 @@ function evaluateCell({
   evaluatedAt,
   trustedExceptions,
   trustedExceptionIdentity,
+  reusedByCell,
 }) {
   const focal = manifests.get(cell.id);
   const claims = evaluationClaims(graph, cell, focal);
@@ -584,7 +661,15 @@ function evaluateCell({
         : dependencyCell(cells, claim.id, focal.evidence.identity.target),
     );
   }
-  const evidence = evidenceCells.map((dependency) => manifests.get(dependency.id).evidence);
+  // A reused row was produced at an earlier commit, which is the whole point of the binding the
+  // closeout just re-proved against its own checkout. Reading it at the release commit applies
+  // that binding; the row's own source tree is still compared against this release, so a binding
+  // that does not equate the trees still fails. The ledger keeps the manifest identity untouched.
+  const evidence = evidenceCells.map((dependency) => {
+    const row = manifests.get(dependency.id).evidence;
+    if (!reusedByCell.has(dependency.id)) return row;
+    return { ...row, identity: { ...row.identity, commit: gitIdentity.commit } };
+  });
   const requestedClaims = claims.map((claim) => ({
     id: claim.id,
     accepted_risks: [...claim.accepted_risks],
@@ -802,6 +887,9 @@ export function evaluateReleaseCloseout({
   trustedProducers = null,
   trustedExceptionDocument = null,
   artifactBindings = null,
+  // Re-proves a reuse binding against this closeout's own checkout. Absent, every reuse block is
+  // refused rather than trusted on the producer map's say-so.
+  verifyReuseBinding: verify = null,
 }) {
   if (!SEMVER.test(version)) fail("version must be semantic version text without a leading v");
   const evaluatedEpoch = Date.parse(evaluatedAt);
@@ -810,7 +898,14 @@ export function evaluateReleaseCloseout({
   }
   const graphSha256 = releaseClaimGraphDigest(graph);
   const cells = deriveReleaseCells(graph, phase);
-  const trusted = trustedProducerIndex({ trustedProducers, cells, gitIdentity, graph, phase });
+  const trusted = trustedProducerIndex({
+    trustedProducers,
+    cells,
+    gitIdentity,
+    graph,
+    phase,
+    verifyReuseBinding: verify,
+  });
   const performanceCell = cells.find(({ id }) => id === graph.exception_policy.eligible_evidence_type);
   const trustedException = trustedExceptionInput({
     document: trustedExceptionDocument,
@@ -945,6 +1040,7 @@ export function evaluateReleaseCloseout({
           evaluatedAt,
           trustedExceptions: trustedException.exceptions,
           trustedExceptionIdentity: trustedException.identity,
+          reusedByCell: trusted.reusedByCell,
         });
       } catch (error) {
         evaluation = {
@@ -1189,6 +1285,8 @@ function main() {
     trustedProducers,
     trustedExceptionDocument,
     artifactBindings: downloaded.artifactBindings,
+    verifyReuseBinding: ({ binding, releaseCommit, reusedCommit }) =>
+      verifyReuseBinding({ binding, repository: repoRoot, releaseCommit, reusedCommit }),
   });
   writeReleaseCloseout(text(values["out-dir"], "--out-dir"), result);
   console.log(JSON.stringify(result.summary, null, 2));

--- a/scripts/tests/codestory-release-cell-manifest.test.mjs
+++ b/scripts/tests/codestory-release-cell-manifest.test.mjs
@@ -6,7 +6,6 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   buildTrustedProducerMap,
-  verifyReuseBinding,
   produceReleaseCellManifest,
 } from "../codestory-release-cell-manifest.mjs";
 import {
@@ -394,36 +393,4 @@ test("reused evidence keeps every same-run trust requirement", () => {
   const missing = reusedRunMetadata("source_behavior");
   missing.artifacts = [];
   assert.throws(withReuse(missing), /must retain one/u);
-});
-
-test("reuse bindings verify tree identity and fingerprint equality against real history", () => {
-  // v0.16.0 -> v0.16.1 is a pure version bump in this repository's real history: different
-  // trees (so source_tree reuse must refuse) but identical native fingerprints (so
-  // accelerator inheritance is exactly what version_only_delta authorizes).
-  const releaseTag = "00121349"; // v0.16.1 release commit
-  const priorTag = "29bd4795"; // v0.16.0 release commit
-  assert.throws(
-    () => verifyReuseBinding({
-      binding: "source_tree",
-      repository: root,
-      releaseCommit: releaseTag,
-      reusedCommit: priorTag,
-    }),
-    /does not match release tree/u,
-  );
-  const fingerprint = verifyReuseBinding({
-    binding: "native_fingerprint",
-    repository: root,
-    releaseCommit: releaseTag,
-    reusedCommit: priorTag,
-  });
-  assert.match(fingerprint, /^[0-9a-f]{64}$/u);
-  // Identical commits always satisfy the tree binding.
-  const tree = verifyReuseBinding({
-    binding: "source_tree",
-    repository: root,
-    releaseCommit: releaseTag,
-    reusedCommit: releaseTag,
-  });
-  assert.match(tree, /^[0-9a-f]{40}$/u);
 });

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -16,6 +16,7 @@ import {
   renderReleasePlatformNotes,
   validatePublicSupportDocuments,
   validateReleaseClaimGraph,
+  verifyReuseBinding,
 } from "../codestory-release-claims.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -496,4 +497,50 @@ test("CLI derives repository and tree identity from repo and rejects nonexistent
   ], { encoding: "utf8" });
   assert.notEqual(nonexistent.status, 0);
   assert.match(nonexistent.stderr, /git cat-file -e/u);
+});
+
+test("reuse bindings verify tree identity and fingerprint equality against real history", () => {
+  // Both sides of the ledger prove reuse with this one function -- the producer before it admits
+  // cross-run evidence, the closeout before it anchors a row onto the earlier run -- so it is
+  // proved here, against real history, in the suite pull requests actually run.
+  //
+  // v0.16.0 -> v0.16.1 is a pure version bump in this repository's real history: different
+  // trees (so source_tree reuse must refuse) but identical native fingerprints (so
+  // accelerator inheritance is exactly what version_only_delta authorizes).
+  const releaseTag = "00121349"; // v0.16.1 release commit
+  const priorTag = "29bd4795"; // v0.16.0 release commit
+  assert.throws(
+    () => verifyReuseBinding({
+      binding: "source_tree",
+      repository: root,
+      releaseCommit: releaseTag,
+      reusedCommit: priorTag,
+    }),
+    /does not match release tree/u,
+  );
+  const fingerprint = verifyReuseBinding({
+    binding: "native_fingerprint",
+    repository: root,
+    releaseCommit: releaseTag,
+    reusedCommit: priorTag,
+  });
+  assert.match(fingerprint, /^[0-9a-f]{64}$/u);
+  // Identical commits always satisfy the tree binding.
+  const tree = verifyReuseBinding({
+    binding: "source_tree",
+    repository: root,
+    releaseCommit: releaseTag,
+    reusedCommit: releaseTag,
+  });
+  assert.match(tree, /^[0-9a-f]{40}$/u);
+  // A binding name the claim graph never declared proves nothing.
+  assert.throws(
+    () => verifyReuseBinding({
+      binding: "source_history",
+      repository: root,
+      releaseCommit: releaseTag,
+      reusedCommit: priorTag,
+    }),
+    /unknown reuse binding source_history/u,
+  );
 });

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -217,6 +217,7 @@ function evaluate(
   trustedProducers = trustedProducersFor(phase),
   trustedExceptionDocument = null,
   artifactBindings = null,
+  verifyReuseBinding = null,
 ) {
   const bindings = artifactBindings ?? manifests.map((manifest) => {
     const producer = trustedProducers?.producers?.find(({ cell_id: cellId }) =>
@@ -240,7 +241,52 @@ function evaluate(
     trustedProducers,
     trustedExceptionDocument,
     artifactBindings: bindings,
+    verifyReuseBinding,
   });
+}
+
+// ── Cross-run evidence reuse ────────────────────────────────────────────────────────────────
+
+const reusedRunId = "777";
+const reusedCommit = "3".repeat(40);
+
+/// Stands in for the git binding proof `main()` runs against the closeout's own checkout.
+function reuseVerifier({
+  // A commit is its own ancestor, so the release commit always satisfies the tree binding.
+  ancestors = [reusedCommit, gitIdentity.commit],
+  value = gitIdentity.source_tree,
+} = {}) {
+  return ({ binding, releaseCommit, reusedCommit: reused }) => {
+    assert.equal(releaseCommit, gitIdentity.commit);
+    if (binding !== "source_tree") throw new Error(`unknown reuse binding ${binding}`);
+    if (!ancestors.includes(reused)) {
+      throw new Error(`reused commit ${reused} is not an ancestor of the release commit`);
+    }
+    return value;
+  };
+}
+
+/// Re-anchor the source cell's producer row onto a prior run, exactly as the producer map does
+/// once release preflight selects source-proof reuse.
+function reuseSourceBehavior(trustedProducers, manifests, reusedFrom = {}) {
+  const row = trustedProducers.producers.find(({ cell_id: cellId }) => cellId === "source_behavior");
+  row.producer_run_id = reusedRunId;
+  row.reused_from = {
+    run_id: reusedRunId,
+    head_sha: reusedCommit,
+    binding: "source_tree",
+    binding_value: gitIdentity.source_tree,
+    ...reusedFrom,
+  };
+  row.artifact.workflow_run_id = reusedRunId;
+  row.artifact.head_sha = reusedCommit;
+  row.job.run_id = reusedRunId;
+  row.job.head_sha = reusedCommit;
+  // The reused manifest was produced by that earlier run, at the binding-equal commit.
+  const manifest = manifests.find(({ cell_id: cellId }) => cellId === "source_behavior");
+  manifest.evidence.identity.producer_run_id = reusedRunId;
+  manifest.evidence.identity.commit = reusedCommit;
+  return row;
 }
 
 test("cell inventory is derived only from the release claim graph", () => {
@@ -591,4 +637,165 @@ test("producer identity is accepted only from the separately trusted map", () =>
   assert.equal(rejectedWindow.decision, "reject");
   assert.ok(rejectedWindow.summary.input_errors.some((message) =>
     message.includes("outside its job window")));
+});
+
+test("a binding-verified reuse row is anchored to the run and commit it was produced by", () => {
+  const manifests = manifestsFor("pre_publish");
+  const trusted = trustedProducersFor("pre_publish");
+  reuseSourceBehavior(trusted, manifests);
+  const calls = [];
+  const verify = reuseVerifier();
+  const accepted = evaluate("pre_publish", manifests, null, trusted, null, null, (request) => {
+    calls.push(request);
+    return verify(request);
+  });
+  assert.equal(accepted.decision, "accept");
+  assert.deepEqual(accepted.summary.input_errors, []);
+  assert.deepEqual(accepted.summary.failed_cells, []);
+  // The closeout re-proves the binding itself rather than trusting the producer map's word.
+  assert.deepEqual(calls, [{
+    binding: "source_tree",
+    releaseCommit: gitIdentity.commit,
+    reusedCommit,
+  }]);
+  // The ledger keeps the reused run and commit rather than restating the publishing run.
+  const row = accepted.ledger.cells.find(({ id }) => id === "source_behavior");
+  assert.equal(row.identity.producer_run_id, reusedRunId);
+  assert.equal(row.identity.commit, reusedCommit);
+  // Cells that were not reused stay bound to the publishing run.
+  const packaged = accepted.ledger.cells.find(({ id }) => id === "package_identity:windows-x64");
+  assert.equal(packaged.identity.producer_run_id, "12345");
+  assert.equal(packaged.identity.commit, gitIdentity.commit);
+});
+
+test("a reuse row whose binding the closeout cannot reprove fails closed", () => {
+  const rejections = [
+    ["no binding is declared for the cell group", (trusted, manifests) => {
+      const row = trusted.producers.find(({ cell_id: cellId }) =>
+        cellId === "package_identity:windows-x64");
+      row.producer_run_id = reusedRunId;
+      row.reused_from = {
+        run_id: reusedRunId,
+        head_sha: reusedCommit,
+        binding: "source_tree",
+        binding_value: gitIdentity.source_tree,
+      };
+      row.artifact.workflow_run_id = reusedRunId;
+      row.artifact.head_sha = reusedCommit;
+      row.job.run_id = reusedRunId;
+      row.job.head_sha = reusedCommit;
+      manifests.find(({ cell_id: cellId }) => cellId === "package_identity:windows-x64")
+        .evidence.identity.producer_run_id = reusedRunId;
+    }, "package_identity:windows-x64 reuses evidence under an undeclared binding"],
+    ["the row names a binding the group did not declare", (trusted, manifests) => {
+      reuseSourceBehavior(trusted, manifests, { binding: "native_fingerprint" });
+    }, "source_behavior reuses evidence under an undeclared binding"],
+    ["the reused commit is not an ancestor of the release commit", (trusted, manifests) => {
+      reuseSourceBehavior(trusted, manifests, { head_sha: "9".repeat(40) });
+    }, "is not an ancestor of the release commit"],
+    ["the reused commit does not resolve to the release tree", (trusted, manifests) => {
+      reuseSourceBehavior(trusted, manifests);
+      // A verifier that proves the tree binding cannot prove it here.
+      trusted.producers.find(({ cell_id: cellId }) => cellId === "source_behavior")
+        .reused_from.binding_value = "e".repeat(40);
+    }, "source_behavior recorded source_tree value does not bind this release"],
+    ["the reused run identity is malformed", (trusted, manifests) => {
+      reuseSourceBehavior(trusted, manifests, { run_id: "0" });
+    }, "source_behavior reused run identity is invalid"],
+    ["the reuse record is not an object", (trusted, manifests) => {
+      reuseSourceBehavior(trusted, manifests);
+      trusted.producers.find(({ cell_id: cellId }) => cellId === "source_behavior")
+        .reused_from = reusedCommit;
+    }, "source_behavior reuse record must be an object"],
+    ["the reused artifact expired", (trusted, manifests) => {
+      reuseSourceBehavior(trusted, manifests).artifact.expired = true;
+    }, "source_behavior artifact is expired"],
+    ["the reused artifact still claims the publishing run's commit", (trusted, manifests) => {
+      reuseSourceBehavior(trusted, manifests).artifact.head_sha = gitIdentity.commit;
+    }, "source_behavior artifact run identity changed"],
+    ["the reused job still claims the publishing run's commit", (trusted, manifests) => {
+      reuseSourceBehavior(trusted, manifests).job.head_sha = gitIdentity.commit;
+    }, "source_behavior job run identity changed"],
+    ["a reuse block naming the publishing run escapes its attempt cap", (trusted, manifests) => {
+      const row = reuseSourceBehavior(trusted, manifests, {
+        run_id: trusted.run_id,
+        head_sha: gitIdentity.commit,
+      });
+      row.producer_run_id = trusted.run_id;
+      row.producer_run_attempt = "2";
+      row.artifact.workflow_run_id = trusted.run_id;
+      row.artifact.head_sha = gitIdentity.commit;
+      row.job.run_id = trusted.run_id;
+      row.job.head_sha = gitIdentity.commit;
+      row.job.run_attempt = "2";
+      const manifest = manifests.find(({ cell_id: cellId }) => cellId === "source_behavior");
+      manifest.evidence.identity.producer_run_id = trusted.run_id;
+      manifest.evidence.identity.commit = gitIdentity.commit;
+    }, "source_behavior uses a future run attempt"],
+  ];
+  for (const [label, mutate, expected] of rejections) {
+    const manifests = manifestsFor("pre_publish");
+    const trusted = trustedProducersFor("pre_publish");
+    mutate(trusted, manifests);
+    const rejected = evaluate("pre_publish", manifests, null, trusted, null, null, reuseVerifier());
+    assert.equal(rejected.decision, "reject", label);
+    assert.ok(
+      rejected.summary.input_errors.some((message) => message.includes(expected)),
+      `${label}: ${JSON.stringify(rejected.summary.input_errors)}`,
+    );
+  }
+});
+
+test("a closeout with no way to reprove a binding refuses the reuse row outright", () => {
+  const manifests = manifestsFor("pre_publish");
+  const trusted = trustedProducersFor("pre_publish");
+  reuseSourceBehavior(trusted, manifests);
+  const rejected = evaluate("pre_publish", manifests, null, trusted);
+  assert.equal(rejected.decision, "reject");
+  assert.ok(rejected.summary.input_errors.some((message) =>
+    message.includes("source_behavior reuses evidence this closeout cannot verify")));
+});
+
+test("a reused artifact container is still bound by its digest", () => {
+  const manifests = manifestsFor("pre_publish");
+  const trusted = trustedProducersFor("pre_publish");
+  reuseSourceBehavior(trusted, manifests);
+  const bindings = manifests.map((manifest) => {
+    const producer = trusted.producers.find(({ cell_id: cellId }) => cellId === manifest.cell_id);
+    return {
+      cell_id: manifest.cell_id,
+      producer_artifact: producer.producer_artifact,
+      artifact_id: producer.artifact.id,
+      artifact_digest: producer.artifact.digest,
+      manifest_sha256: canonicalManifestSha(manifest),
+    };
+  });
+  bindings.find(({ cell_id: cellId }) => cellId === "source_behavior")
+    .artifact_digest = `sha256:${"f".repeat(64)}`;
+  const rejected = evaluate(
+    "pre_publish",
+    manifests,
+    null,
+    trusted,
+    null,
+    bindings,
+    reuseVerifier(),
+  );
+  assert.equal(rejected.decision, "reject");
+  assert.ok(rejected.summary.failed_cells.includes("source_behavior"));
+  assert.ok(rejected.evaluations.get("source_behavior").value.failures.some((message) =>
+    message.includes("artifact_digest does not match Actions provenance")));
+});
+
+test("reuse never lets stale evidence through the checks that do not depend on the commit", () => {
+  // The reused commit is admissible for the commit identity the binding equates, and for nothing
+  // else: a reused manifest whose own tree is not this release's tree still fails.
+  const manifests = manifestsFor("pre_publish");
+  const trusted = trustedProducersFor("pre_publish");
+  reuseSourceBehavior(trusted, manifests);
+  manifests.find(({ cell_id: cellId }) => cellId === "source_behavior")
+    .evidence.identity.source_tree = "e".repeat(40);
+  const rejected = evaluate("pre_publish", manifests, null, trusted, null, null, reuseVerifier());
+  assert.equal(rejected.decision, "reject");
+  assert.ok(rejected.summary.failed_cells.includes("source_behavior"));
 });

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -799,3 +799,124 @@ test("reuse never lets stale evidence through the checks that do not depend on t
   assert.equal(rejected.decision, "reject");
   assert.ok(rejected.summary.failed_cells.includes("source_behavior"));
 });
+
+test("a reused manifest may declare only the commit the closeout proved bound to this release", () => {
+  // Reading a reused row at the release commit is what the binding buys, and it is the only thing
+  // that ever compared that row's declared commit to anything. So the declared commit has to be
+  // the one the binding proof covered: not an unrelated commit, and not this release's own, which
+  // the reused run could not have produced this artifact at.
+  const declarations = [
+    ["a commit the closeout never saw", "d".repeat(40)],
+    ["the publishing run's own commit", gitIdentity.commit],
+  ];
+  for (const [label, declared] of declarations) {
+    const manifests = manifestsFor("pre_publish");
+    const trusted = trustedProducersFor("pre_publish");
+    reuseSourceBehavior(trusted, manifests);
+    manifests.find(({ cell_id: cellId }) => cellId === "source_behavior")
+      .evidence.identity.commit = declared;
+    const rejected = evaluate("pre_publish", manifests, null, trusted, null, null, reuseVerifier());
+    assert.equal(rejected.decision, "reject", label);
+    assert.ok(rejected.summary.failed_cells.includes("source_behavior"), label);
+    assert.ok(
+      rejected.evaluations.get("source_behavior").value.failures.some((message) =>
+        message.includes("manifest commit is not the reused commit the closeout proved")),
+      `${label}: ${JSON.stringify(rejected.evaluations.get("source_behavior").value.failures)}`,
+    );
+    // Nothing that reads the row as evidence inherits the unproven commit either.
+    assert.ok(
+      rejected.summary.failed_cells.includes("candidate_installed_behavior:linux-x64"),
+      label,
+    );
+    // And the rejected ledger never restates the unproven commit as accepted evidence.
+    assert.equal(
+      rejected.ledger.cells.find(({ id }) => id === "source_behavior").status,
+      "fail",
+      label,
+    );
+  }
+});
+
+test("a reuse block naming the publishing run is not reuse", () => {
+  // A commit is its own ancestor and its own tree, so a reuse block pointing at the run that is
+  // publishing verifies trivially while inheriting nothing. Admitting it as a reuse anchor would
+  // let an ordinary same-run row buy the reused row's standing with a proof about nothing.
+  const manifests = manifestsFor("pre_publish");
+  const trusted = trustedProducersFor("pre_publish");
+  trusted.producers.find(({ cell_id: cellId }) => cellId === "source_behavior").reused_from = {
+    run_id: trusted.run_id,
+    head_sha: gitIdentity.commit,
+    binding: "source_tree",
+    binding_value: gitIdentity.source_tree,
+  };
+  manifests.find(({ cell_id: cellId }) => cellId === "source_behavior")
+    .evidence.identity.commit = "d".repeat(40);
+  const calls = [];
+  const verify = reuseVerifier();
+  const rejected = evaluate("pre_publish", manifests, null, trusted, null, null, (request) => {
+    calls.push(request);
+    return verify(request);
+  });
+  assert.equal(rejected.decision, "reject");
+  assert.ok(rejected.summary.input_errors.some((message) =>
+    message.includes("source_behavior reuses evidence from the publishing run")));
+  // Refused as meaningless rather than proved: there is no earlier run here to inherit from, so
+  // the closeout never asks the binding verifier to bless one.
+  assert.deepEqual(calls, []);
+  // And the row keeps the commit binding it would have had with no reuse block at all.
+  assert.ok(rejected.summary.failed_cells.includes("source_behavior"));
+});
+
+test("native-fingerprint reuse is still refused, and refused for the tree it cannot equate", () => {
+  // release-claims.json declares a second reuse binding -- accelerator_execution under
+  // native_fingerprint -- and this closeout does not yet honour it. Fingerprint reuse exists
+  // precisely because the trees differ, and accelerator_execution requires source_tree, so the
+  // claim evaluator refuses the row after the closeout anchors it. #1552 is about source-proof
+  // reuse; widening the tree identity for accelerator evidence is a separate trust decision.
+  // Pinned here so that gap stays a documented refusal and can never widen unnoticed.
+  const reusedTree = "c".repeat(40);
+  const fingerprint = "f".repeat(64);
+  const manifests = manifestsFor("pre_publish");
+  const trusted = trustedProducersFor("pre_publish");
+  const acceleratorCells = deriveReleaseCells(graph, "pre_publish")
+    .filter(({ group_id: groupId }) => groupId === "accelerator_execution")
+    .map(({ id }) => id);
+  assert.equal(acceleratorCells.length, 3);
+  for (const cellId of acceleratorCells) {
+    const row = trusted.producers.find(({ cell_id: candidate }) => candidate === cellId);
+    row.producer_run_id = reusedRunId;
+    row.reused_from = {
+      run_id: reusedRunId,
+      head_sha: reusedCommit,
+      binding: "native_fingerprint",
+      binding_value: fingerprint,
+    };
+    row.artifact.workflow_run_id = reusedRunId;
+    row.artifact.head_sha = reusedCommit;
+    row.job.run_id = reusedRunId;
+    row.job.head_sha = reusedCommit;
+    const manifest = manifests.find(({ cell_id: candidate }) => candidate === cellId);
+    manifest.evidence.identity.producer_run_id = reusedRunId;
+    manifest.evidence.identity.commit = reusedCommit;
+    manifest.evidence.identity.source_tree = reusedTree;
+  }
+  const rejected = evaluate("pre_publish", manifests, null, trusted, null, null, ({ binding }) => {
+    if (binding !== "native_fingerprint") throw new Error(`unknown reuse binding ${binding}`);
+    return fingerprint;
+  });
+  assert.equal(rejected.decision, "reject");
+  for (const cellId of acceleratorCells) {
+    assert.ok(rejected.summary.failed_cells.includes(cellId), cellId);
+    const failures = rejected.evaluations.get(cellId).value.release_claim_evaluation.failures;
+    assert.ok(
+      failures.some(({ class: failureClass, message }) =>
+        failureClass === "stale_sha" && message.includes("source tree does not match")),
+      `${cellId}: ${JSON.stringify(failures)}`,
+    );
+    // The commit the binding proof covered is admitted; only the tree it cannot equate refuses.
+    assert.ok(
+      !failures.some(({ message }) => message.includes("commit does not match")),
+      `${cellId}: ${JSON.stringify(failures)}`,
+    );
+  }
+});


### PR DESCRIPTION
`buildTrustedProducerMap` learned to inherit evidence a prior run already authenticated, but the closeout that consumes it never did. Every check anchoring a producer row — `producer_run_id`, `artifact.head_sha`, `job.head_sha` — compared against the publishing run and the release commit unconditionally, so the moment release preflight selected source-proof reuse, `pre-publish-closeout` rejected the rows the producer had just verified and publish never ran.

## What changed

`scripts/codestory-release-closeout.mjs`

- `producerAnchor` resolves the run and commit a row must be bound to. A row carrying `reused_from` anchors to the reused run only after the closeout re-proves, against its own checkout, the binding the claim graph declares for that cell's group (`reuse_binding`). Everything else anchors to the publishing run as before.
- Every rejecting path records its reason and falls back to the same-run anchor, so unverifiable reuse also fails the run identity checks that follow. Fails closed on: no binding declared for the group, a binding the group did not declare, a malformed reused run identity, a non-object reuse record, a reuse block naming the publishing run, a commit that is not an ancestor or does not resolve to the release tree, a recorded binding value that disagrees with what this checkout computes, and a closeout with no verifier at all.
- A reuse block naming the run that is publishing is refused as meaningless before any binding is proved. It inherits nothing, and it verifies vacuously under either declared binding — a commit is its own ancestor and its own tree — so admitting it would let an ordinary same-run row buy the reused row's standing with a proof about nothing.
- Expiry, container digest, job window, job success, and artifact inventory are untouched and apply to a reused artifact exactly as to a same-run one.
- The claim evaluator reads each evidence row at the release commit, and a reused row was produced at an earlier one — which is exactly what the binding equates. `evaluateCell` therefore reads a binding-verified row at the release commit. **That substitution is granted to exactly the commit the proof covered**: producer authentication compares the manifest's declared commit against the proved reused commit, and a row declaring any other commit — this release's own included — is read as written and fails the same commit check every same-run row faces. The row's own `source_tree` is still compared against this release, so a binding that does not equate the trees still fails closed, and the ledger keeps the manifest identity (and the reused run and commit) untouched.
- The attempt cap keys off the publishing run rather than off reuse, so a reuse block naming the current run cannot use it to claim an attempt that has not happened.

`scripts/codestory-release-claims.mjs` / `scripts/codestory-release-cell-manifest.mjs`

- `verifyReuseBinding` moved to the shared claim module so producer and closeout prove the binding with the same code instead of one trusting the other's word. No compatibility re-export is left behind; the one test that imported it from the manifest module moved with the function.
- The move is not byte-for-byte behaviour-preserving, and the earlier claim that it was is withdrawn. Two deliberate differences: the helper now runs git through `spawnSync` rather than `execFileSync`, which changes error text and makes a spawn failure (`status: null`) take the failure branch; and the `native-fingerprint.mjs` path is resolved with `fileURLToPath` rather than `new URL(...).pathname`. The latter is a real Windows fix — `pathname` yields `/C:/…`, which `process.execPath` cannot run. Both directions fail closed.
- The function's real-history test moved from `scripts/tests/codestory-release-cell-manifest.test.mjs` to `scripts/tests/codestory-release-claims.test.mjs` — the module that now owns it, and, unlike the manifest suite, one that PR CI actually runs (`.github/workflows/plugin-static.yml`). A security-critical function's only real-git test should not live in a file that runs at release time only.

## Tests

`scripts/tests/codestory-release-closeout.test.mjs` gains the accept path, each reject direction, and the boundary:

- a binding-verified reuse row is anchored to the run and commit it was produced by
- a reuse row whose binding the closeout cannot reprove fails closed (10 sub-cases)
- a closeout with no way to reprove a binding refuses the reuse row outright
- a reused artifact container is still bound by its digest
- reuse never lets stale evidence through the checks that do not depend on the commit
- a reused manifest may declare only the commit the closeout proved bound to this release
- a reuse block naming the publishing run is not reuse
- native-fingerprint reuse is still refused, and refused for the tree it cannot equate

Proven both directions. Against the first pass (`d3cb6038`) the two commit-binding tests fail with `decision: "accept"` where the gate must reject; with the repair they pass. Each repair isolated: reverting only the manifest-commit comparison fails `a reused manifest may declare only the commit the closeout proved bound to this release` and nothing else; reverting only the publishing-run refusal fails `a reuse block naming the publishing run is not reuse` and nothing else. Against `origin/dev/codestory-next` with `scripts/codestory-release-closeout.mjs` reverted, the new tests fail and the rest pass.

`node --test .github/scripts/build-marketplace-fixture.test.mjs scripts/tests/codestory-release-{claims,cell-manifest,closeout,evidence-gate}.test.mjs scripts/tests/release-evidence-runner-contract.test.mjs` → 78/78. `node .github/scripts/check-workflow-policy.mjs`, `node --test .github/scripts/check-workflow-policy.test.mjs` (367/367), `node --test .github/scripts/run-actionlint.test.mjs` (3/3), and `node .github/scripts/run-actionlint.mjs` all pass. No Rust, Python, or `release-claims.json` file is touched.

`.github/workflows/plugin-static.yml` gains `fetch-depth: 0` on its checkout. Moving the binding test into the PR suite surfaced why it had only ever run at release time: it proves tree identity and native fingerprints against this repository's real v0.16.0 → v0.16.1 history, which a depth-1 clone cannot resolve — it failed on the runner at `611b530b` while passing in every full checkout. `release.yml`'s contract job already fetches full history for exactly this reason (`release.yml:48-52`); the static job now matches it, so the proof runs before a change to it can merge rather than after.

## Known gap

`release-claims.json` declares a second reuse binding, `accelerator_execution` → `native_fingerprint` (`release-claims.json:715`), and this PR does not make it work. The closeout anchors a fingerprint-verified accelerator row, and `evaluateReleaseClaims` then refuses it on `identity.source_tree` — that group requires `source_tree`, and fingerprint reuse exists precisely because the trees differ. An operator can reach this today via `--reuse accelerator_execution=<run>:<sha>` and gets the same "publish never runs" outcome #1552 describes for source reuse.

This is a gap, not a design: whether an equal native fingerprint justifies evidence produced against a different tree is a separate trust decision from source-tree reuse, where nothing is substituted. It is tracked in #1567 and pinned by the `native-fingerprint reuse is still refused` test so the refusal cannot drift into silent acceptance.

## Risk

Not verifiable here: end-to-end `main()` against real Actions artifacts. `main()` supplies the real git verifier, which proves only the git relationship between two commits; what ties the reused run's manifest to that proven commit is the manifest-commit comparison added in this PR, which is covered by unit tests over the real evaluator, not by a live run.

Closes #1552
