### PR TITLE
stop treating catalog publication as a release gate

### DIFF
--- a/.github/scripts/build-marketplace-fixture.mjs
+++ b/.github/scripts/build-marketplace-fixture.mjs
@@ -15,6 +15,11 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
+import {
+  FIXTURE_MARKER_FILENAME,
+  FIXTURE_MARKER_PURPOSE,
+} from "./marketplace-delivery-identity.mjs";
+
 function fail(message) {
   console.error(`::error::${message}`);
   process.exit(1);
@@ -53,7 +58,8 @@ if (typeof manifest.version !== "string" || !manifest.version) {
   fail("pinned commit has no plugin version");
 }
 
-const catalogDirectory = path.join(path.resolve(args.out), ".agents", "plugins");
+const fixtureRoot = path.resolve(args.out);
+const catalogDirectory = path.join(fixtureRoot, ".agents", "plugins");
 mkdirSync(catalogDirectory, { recursive: true });
 // Mirrors the live catalog's shape at .agents/plugins/marketplace.json. The
 // resolver rejects a catalog missing `name`, and the live catalog carries no
@@ -87,9 +93,35 @@ writeFileSync(
   `${JSON.stringify(catalog, null, 2)}\n`,
 );
 
-// The fixture must be a git repository: the Codex resolver clones it like the live catalog.
+// A fixture catalog is a DISTINCT delivery state, not a stand-in that may pass for the live
+// catalog, so it says so in its own bytes. The installed-runtime predicate refuses to accept a
+// deferred installation unless the resolved marketplace root carries this marker naming the
+// exact commit the catalog pins -- an arbitrary local git directory, or a clone of the live
+// marketplace, cannot satisfy the deferred shape by accident.
+//
+// This file sits beside .agents/, not inside it: the resolver reads only
+// .agents/plugins/marketplace.json, so the catalog the resolver sees stays byte-identical in
+// shape to the live one.
+writeFileSync(
+  path.join(fixtureRoot, FIXTURE_MARKER_FILENAME),
+  `${JSON.stringify(
+    {
+      schema_version: 1,
+      purpose: FIXTURE_MARKER_PURPOSE,
+      pinned_commit: commit,
+      plugin_version: manifest.version,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+// The fixture must be a git repository: the Codex resolver reads it like the live catalog.
+// It deliberately has NO `origin` remote. Pointing one at the live marketplace URL would make
+// the fixture claim an identity it does not have, and the deferred predicate asserts the
+// absence positively rather than tolerating a failed probe.
 const git = (...command) =>
-  execFileSync("git", ["-C", path.resolve(args.out), ...command], { encoding: "utf8" });
+  execFileSync("git", ["-C", fixtureRoot, ...command], { encoding: "utf8" });
 git("init", "--quiet", "--initial-branch", "main");
 git("config", "user.email", "release@codestory.invalid");
 git("config", "user.name", "CodeStory release");

--- a/.github/scripts/build-marketplace-fixture.test.mjs
+++ b/.github/scripts/build-marketplace-fixture.test.mjs
@@ -4,8 +4,8 @@
 // fixture path failed at preflight.
 
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -72,6 +72,72 @@ test("the fixture states no version, because the live catalog states none", () =
   try {
     assert.equal(catalog.version, undefined);
     assert.equal(catalog.plugins[0].version, undefined);
+  } finally {
+    rmSync(out, { recursive: true, force: true });
+  }
+});
+
+// A fixture catalog is a DISTINCT delivery state, not a stand-in that may pass for the live one.
+// The installed-runtime predicate refuses a deferred install whose marketplace root does not carry
+// this marker naming the exact commit the catalog pins, so an arbitrary local git directory -- or
+// a clone of the live marketplace -- cannot satisfy the deferred shape by accident.
+test("the fixture identifies itself and the commit it pins", () => {
+  const { out, commit } = buildFixture();
+  try {
+    const marker = JSON.parse(
+      readFileSync(path.join(out, ".codestory-marketplace-fixture.json"), "utf8"),
+    );
+    assert.deepEqual(Object.keys(marker).sort(), [
+      "pinned_commit",
+      "plugin_version",
+      "purpose",
+      "schema_version",
+    ]);
+    assert.equal(marker.schema_version, 1);
+    assert.equal(marker.purpose, "codestory-candidate-pinned-marketplace-fixture");
+    assert.equal(marker.pinned_commit, commit);
+    // The marker must be committed, or a clean-tree check would pass over a fixture that had
+    // been re-marked after the fact.
+    assert.equal(
+      execFileSync("git", ["-C", out, "status", "--porcelain"], { encoding: "utf8" }).trim(),
+      "",
+    );
+  } finally {
+    rmSync(out, { recursive: true, force: true });
+  }
+});
+
+// The fixture deliberately has no `origin`. Pointing one at the live marketplace URL would make it
+// claim an identity it does not have, and the predicate asserts the absence positively rather than
+// treating a failed probe as proof of anything. The predicate's own probe used to hard-fail here,
+// which is what made the deferred path unprovable in the first place.
+test("the fixture is local-only and never claims the live marketplace as its origin", () => {
+  const { out } = buildFixture();
+  try {
+    const probe = spawnSync("git", ["-C", out, "remote", "get-url", "origin"], {
+      encoding: "utf8",
+    });
+    assert.notEqual(probe.status, 0, "a candidate-pinned fixture must have no origin remote");
+    assert.match(probe.stderr, /No such remote/u);
+    assert.equal(
+      execFileSync("git", ["-C", out, "remote"], { encoding: "utf8" }).trim(),
+      "",
+    );
+  } finally {
+    rmSync(out, { recursive: true, force: true });
+  }
+});
+
+// The resolver reads .agents/plugins/marketplace.json and nothing else, so the marker must not
+// change the catalog the resolver sees.
+test("the marker sits outside the catalog the resolver reads", () => {
+  const { out, catalog } = buildFixture();
+  try {
+    assert.equal(catalog.fixture, undefined);
+    assert.equal(
+      existsSync(path.join(out, ".agents", "plugins", ".codestory-marketplace-fixture.json")),
+      false,
+    );
   } finally {
     rmSync(out, { recursive: true, force: true });
   }

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1570,8 +1570,78 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
   }
 }
 
+// Both release lanes point the catalog at what they just published, and both do it after the tag
+// and the GitHub release already exist. Failing either lane on a credential or a rejected push
+// would turn a recoverable delivery gap into an unrecoverable one, so publication is delivery: the
+// job absorbs its own failure. That is only honest if the run then SAYS which state it ended in,
+// which is what these rules force. Every conjunct below is load-bearing; dropping any one of them
+// lets a run that never touched the catalog report that it did.
+function catalogDeliveryOutcomeViolations(file, job, delivery) {
+  const violations = [];
+  const tokenStep = namedStep(job, "Mint a scoped marketplace token");
+  add(
+    violations,
+    tokenStep?.["continue-on-error"] === true,
+    `${file} marketplace token failure must not fail an already-published release`,
+  );
+  const catalogPush = namedStep(job, "Point the catalog at the published release");
+  add(
+    violations,
+    catalogPush?.["continue-on-error"] === true
+      && catalogPush?.if === "steps.token.outcome == 'success'",
+    `${file} catalog push must run only with a minted token and must not fail the release`,
+  );
+  const deliveryOutcome = namedStep(job, "Record catalog delivery outcome");
+  add(
+    violations,
+    deliveryOutcome?.if === "always()",
+    `${file} catalog delivery outcome must be recorded whatever the catalog push did`,
+  );
+  add(
+    violations,
+    object(deliveryOutcome?.env).TOKEN_OUTCOME === "${{ steps.token.outcome }}"
+      && object(deliveryOutcome?.env).PUBLISH_OUTCOME === "${{ steps.publish.outcome }}"
+      && object(deliveryOutcome?.env).PUBLISHED_REVISION
+        === "${{ steps.publish.outputs.marketplace_revision }}",
+    `${file} catalog delivery outcome must read the real token, push, and revision results`,
+  );
+  add(
+    violations,
+    object(deliveryOutcome?.env).RECOVERY_WORKFLOW === delivery.recovery_workflow,
+    `${file} deferred catalog delivery must name ${delivery.recovery_workflow} as the recovery path`,
+  );
+  requireStepRun(violations, file, job, "Record catalog delivery outcome", [
+    "catalog_published=false",
+    '[ "$TOKEN_OUTCOME" = "success" ]',
+    '[ "$PUBLISH_OUTCOME" = "success" ]',
+    `printf '%s' "$PUBLISHED_REVISION" | grep -Eq '^[0-9a-f]{40}$'`,
+    'echo "catalog_published=$catalog_published" >> "$GITHUB_OUTPUT"',
+    'echo "marketplace_revision=$marketplace_revision" >> "$GITHUB_OUTPUT"',
+    "::warning::Catalog publication deferred",
+    "recover with $RECOVERY_WORKFLOW",
+  ]);
+  add(
+    violations,
+    object(job.outputs).catalog_published === "${{ steps.delivery.outputs.catalog_published }}"
+      && object(job.outputs).marketplace_revision === "${{ steps.delivery.outputs.marketplace_revision }}",
+    `${file} marketplace publication must publish the recorded delivery state, not the raw push result`,
+  );
+  // A retry would collapse distinguishable failures into one opaque one and could publish on a
+  // second attempt after the first was already recorded, so this job gets exactly one attempt.
+  for (const step of list(job.steps)) {
+    const run = executableRunText(String(object(step).run ?? ""));
+    add(
+      violations,
+      !/\b(?:until|while)\b|for\s+attempt|--retry\b/u.test(run),
+      `${file} marketplace publication step ${object(step).name ?? "<unnamed>"} must not retry a recorded delivery outcome`,
+    );
+  }
+  return violations;
+}
+
 function validateReleaseCoordinator(workflows, violations, graph) {
   const releaseChain = graph.workflow_policy.release_chain;
+  const catalogDelivery = graph.workflow_policy.catalog_delivery;
   const releaseFile = "release.yml";
   const release = workflows.get(releaseFile);
   if (!release) {
@@ -1932,29 +2002,59 @@ function validateReleaseCoordinator(workflows, violations, graph) {
       && object(tokenStep?.with).repositories === "AgentPluginMarketplace",
     `${releaseFile} marketplace token must be a SHA-pinned app token scoped to the marketplace repository`,
   );
-  requireStepRun(violations, releaseFile, marketplacePublish, "Point the catalog at the published release", [
-    "publish-marketplace-catalog.mjs",
-  ]);
+  violations.push(...catalogDeliveryOutcomeViolations(releaseFile, marketplacePublish, catalogDelivery));
   requireStepRun(violations, releaseFile, preflight, "Prove the public marketplace install path", [
     "build-marketplace-fixture.mjs",
     "--local-fixture true",
   ]);
 
   const post = requireJob(violations, releaseFile, release, "post-publish-smoke");
-  add(violations, post.if === "inputs.publish_release", `${releaseFile} post-publish smoke must require trusted publication authority`);
   add(violations, post.uses === "./.github/workflows/post-publish-release-smoke.yml", `${releaseFile} must call post-publish smoke`);
   add(violations, sameMembers(needs(post), releaseChain.dependencies["post-publish-smoke"]), `${releaseFile} post-publish dependencies must match the release claim graph`);
+  // The smoke still needs publication authority and a real published release, but a deferred
+  // catalog must not suppress proof of the assets that were actually published.
+  const postIf = String(post.if ?? "");
+  add(
+    violations,
+    postIf.includes("always()")
+      && postIf.includes("inputs.publish_release")
+      && postIf.includes("needs.preflight.result == 'success'")
+      && postIf.includes("needs.publish.result == 'success'"),
+    `${releaseFile} post-publish smoke must require trusted publication authority and a successful publish`,
+  );
+  add(
+    violations,
+    !postIf.includes(`needs.${catalogDelivery.publish_job}.result`),
+    `${releaseFile} post-publish smoke must not gate on ${catalogDelivery.publish_job} succeeding`,
+  );
+  // THE anti-vacuity rule: the catalog claim may only ever be the recorded delivery state. A
+  // literal, an unrelated input, or any other expression would let a release assert a catalog
+  // update that never happened.
+  add(
+    violations,
+    object(post.with).catalog_published
+      === `\${{ needs.${catalogDelivery.publish_job}.outputs.catalog_published == 'true' }}`,
+    `${releaseFile} post-publish smoke must derive catalog_published from the recorded ${catalogDelivery.publish_job} outcome`,
+  );
   add(
     violations,
     object(post.with).emit_release_cells === true
       && object(post.with).marketplace_revision
-        === "${{ needs.marketplace-publish.outputs.marketplace_revision }}"
+        === `\${{ needs.${catalogDelivery.publish_job}.outputs.marketplace_revision }}`
       && String(object(post.with).pre_publish_closeout_artifact ?? "").startsWith("release-closeout-pre-publish-"),
     `${releaseFile} post-publish smoke must consume the proved marketplace revision and accepted pre-publish ledger`,
   );
   const postCloseout = requireJob(violations, releaseFile, release, "post-publish-closeout");
   add(violations, postCloseout.if === "inputs.publish_release", `${releaseFile} post-publish closeout must require trusted publication authority`);
   add(violations, sameMembers(needs(postCloseout), releaseChain.dependencies["post-publish-closeout"]), `${releaseFile} post-publish closeout dependencies must match the release claim graph`);
+  // The closeout reached marketplace-publish only through the smoke, so removing the smoke's gate
+  // removed the closeout's too. Keep it that way rather than leaving it to be reintroduced here.
+  add(
+    violations,
+    !needs(postCloseout).includes(catalogDelivery.publish_job)
+      && !String(postCloseout.if ?? "").includes(`needs.${catalogDelivery.publish_job}`),
+    `${releaseFile} post-publish closeout must not gate on ${catalogDelivery.publish_job} succeeding`,
+  );
   requireStepRun(violations, releaseFile, postCloseout, "Authenticate post-publish Actions provenance", [
     "producer-map",
     "--phase post_publish",
@@ -2634,7 +2734,81 @@ function validatePackagedProof(workflows, violations, graph) {
   );
 }
 
-function validatePostPublish(workflows, violations) {
+// The post-publish smoke runs whether or not the catalog was updated, so the one thing it must
+// never do is let the deferred run look like the published one. Both states resolve a real Codex
+// install of the real published assets; they differ in WHICH catalog served it, and that
+// difference is carried into the release ledger as a distinct installer identity. These rules
+// prove the two states stay distinguishable and that neither can be selected by accident.
+function catalogDeliveryStateViolations(file, job, delivery, handoff, installStepName) {
+  const violations = [];
+  const published = delivery.states.find(({ id }) => id === "published");
+  const deferred = delivery.states.find(({ id }) => id === "deferred");
+  const step = namedStep(job, "Record catalog delivery state");
+  add(
+    violations,
+    step?.if === undefined && step?.["continue-on-error"] === undefined,
+    `${file} catalog delivery state must be unconditional and fail closed`,
+  );
+  add(
+    violations,
+    object(step?.env).CATALOG_PUBLISHED === handoff.published
+      && object(step?.env).INPUT_MARKETPLACE_REVISION === handoff.revision,
+    `${file} catalog delivery state must read the recorded publication handoff`,
+  );
+  requireStepRun(violations, file, job, "Record catalog delivery state", [
+    // The published branch: the live catalog, its live revision, no fixture.
+    'if [ "$CATALOG_PUBLISHED" = "true" ]; then',
+    "marketplace_source=TheGreenCedar/AgentPluginMarketplace",
+    'marketplace_revision="$INPUT_MARKETPLACE_REVISION"',
+    "local_fixture=false",
+    `installer=${published.installer}`,
+    // The deferred branch: a catalog pinned to this published commit, and a revision that cannot
+    // be a live one because the caller is required to have supplied none.
+    'elif [ "$CATALOG_PUBLISHED" = "false" ]; then',
+    'if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then',
+    "Deferred catalog publication must not carry a live catalog revision",
+    "build-marketplace-fixture.mjs",
+    'marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"',
+    "local_fixture=true",
+    `installer=${deferred.installer}`,
+    // Neither branch may fall through: an unset or unexpected handoff is a hard failure, never a
+    // silent default into the published identity.
+    "catalog_published must be true or false",
+    'test "$(printf \'%s\' "$marketplace_revision" | wc -c | tr -d \' \')" = 40',
+    'echo "installer=$installer"',
+  ]);
+  const deliveryRun = executableRunText(String(step?.run ?? ""));
+  const publishedIndex = deliveryRun.indexOf(`installer=${published.installer}`);
+  const deferredIndex = deliveryRun.indexOf(`installer=${deferred.installer}`);
+  const publishedBranch = deliveryRun.indexOf('if [ "$CATALOG_PUBLISHED" = "true" ]; then');
+  const deferredBranch = deliveryRun.indexOf('elif [ "$CATALOG_PUBLISHED" = "false" ]; then');
+  add(
+    violations,
+    published.installer !== deferred.installer
+      && publishedBranch >= 0
+      && deferredBranch > publishedBranch
+      && publishedIndex > publishedBranch
+      && publishedIndex < deferredBranch
+      && deferredIndex > deferredBranch,
+    `${file} the published installer identity must be reachable only from the published branch`,
+  );
+  // Neither state may be fabricated in a later step: the install must come from what this step
+  // resolved, and the forbidden fragments that stop a faked install apply here too.
+  for (const forbidden of ["git archive", "git clone", "git ls-remote", "--source-commit", "--source-tree"]) {
+    add(
+      violations,
+      !deliveryRun.includes(forbidden),
+      `${file} marketplace install must not fabricate installation with ${forbidden}`,
+    );
+  }
+  requireStepRun(violations, file, job, installStepName, [
+    '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
+    '--local-fixture "${{ steps.delivery.outputs.local_fixture }}"',
+  ]);
+  return violations;
+}
+
+function validatePostPublish(workflows, violations, graph) {
   const file = "post-publish-release-smoke.yml";
   const workflow = workflows.get(file);
   if (!workflow) {
@@ -2645,13 +2819,21 @@ function validatePostPublish(workflows, violations) {
   add(violations, object(workflow.permissions).actions === "read", `${file} must read the accepted pre-publish closeout`);
   requireNoCalibrationReferences(violations, file, workflow);
   for (const event of ["workflow_call", "workflow_dispatch"]) {
+    // The catalog revision is now empty exactly when publication was deferred, so the required
+    // input is the delivery state itself: the caller must state which one it is, never omit it.
+    const publishedInput = object(at(workflow, "on", event, "inputs", "catalog_published"));
+    add(
+      violations,
+      publishedInput.required === true && publishedInput.type === "boolean",
+      `${file} ${event} catalog_published must be a required boolean`,
+    );
     const marketplaceInput = object(
       at(workflow, "on", event, "inputs", "marketplace_revision"),
     );
     add(
       violations,
-      marketplaceInput.required === true && marketplaceInput.type === "string",
-      `${file} ${event} marketplace_revision must be a required string`,
+      marketplaceInput.type === "string" && marketplaceInput.default === "",
+      `${file} ${event} marketplace_revision must be a string defaulting to the deferred empty revision`,
     );
     const closeoutInput = object(at(workflow, "on", event, "inputs", "pre_publish_closeout_artifact"));
     add(violations, closeoutInput.type === "string", `${file} ${event} pre_publish_closeout_artifact must be a string`);
@@ -2701,13 +2883,43 @@ function validatePostPublish(workflows, violations) {
     object(workflow.env).CODEX_CLI_VERSION === "0.144.5",
     `${file} must pin the Codex CLI used for marketplace installation`,
   );
-  const resolveInstalled = namedStep(job, "Resolve the published plugin through the marketplace catalog");
-  requireStepRun(violations, file, job, "Resolve the published plugin through the marketplace catalog", [
-    'marketplace_revision="${{ inputs.marketplace_revision }}"',
+  const catalogDelivery = graph.workflow_policy.catalog_delivery;
+  const resolveStepName = "Resolve the published plugin through the marketplace catalog";
+  violations.push(...catalogDeliveryStateViolations(
+    file,
+    job,
+    catalogDelivery,
+    {
+      published: "${{ inputs.catalog_published }}",
+      revision: "${{ inputs.marketplace_revision }}",
+    },
+    resolveStepName,
+  ));
+  // The one place the delivery state reaches the release ledger. It must be the resolved value and
+  // never a literal, or a deferred run could sign a cell saying the public catalog served it.
+  const identityRun = executableRunText(
+    String(namedStep(job, "Emit authenticated post-publish release cells")?.run ?? ""),
+  );
+  add(
+    violations,
+    identityRun.includes('--arg installer "${{ steps.delivery.outputs.installer }}"'),
+    `${file} post-publish cells must record the resolved delivery installer identity`,
+  );
+  for (const state of catalogDelivery.states) {
+    add(
+      violations,
+      !identityRun.includes(state.installer),
+      `${file} post-publish cells must not hard-code the ${state.id} installer identity`,
+    );
+  }
+  const resolveInstalled = namedStep(job, resolveStepName);
+  requireStepRun(violations, file, job, resolveStepName, [
+    'marketplace_revision="${{ steps.delivery.outputs.marketplace_revision }}"',
     '"@openai/codex@$CODEX_CLI_VERSION"',
     "install-codestory-marketplace-proof.mjs",
-    "TheGreenCedar/AgentPluginMarketplace",
+    '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
     '--marketplace-revision "$marketplace_revision"',
+    '--local-fixture "${{ steps.delivery.outputs.local_fixture }}"',
     '--source-repository "$GITHUB_WORKSPACE"',
     "install-attestation-v2.json",
     'isolated_home="$install_root/isolated-home"',
@@ -4550,12 +4762,10 @@ export function validatePluginRelease(workflows, violations, graph) {
     "publish-marketplace-catalog.mjs",
     '--version "${{ inputs.version }}"',
   ]);
-  add(
-    violations,
-    object(marketplacePublish.outputs).marketplace_revision
-      === "${{ steps.publish.outputs.marketplace_revision }}",
-    `${file} marketplace publication must publish the revision it pushed`,
-  );
+  // Same contract as the native lane: the catalog push is delivery after an irreversible tag, so
+  // it may not fail the release, and the run must record which state it ended in.
+  const catalogDelivery = object(at(graph, "workflow_policy", "catalog_delivery"));
+  violations.push(...catalogDeliveryOutcomeViolations(file, marketplacePublish, catalogDelivery));
 
   // Preflight runs before the release exists, so a revision captured there names the *previous*
   // release. Smoke must install from the revision this run published or it proves nothing.
@@ -4565,11 +4775,31 @@ export function validatePluginRelease(workflows, violations, graph) {
     object(preflight.outputs).marketplace_revision === undefined,
     `${file} preflight must not capture a marketplace revision that predates publication`,
   );
+  const installStepName = "Prove the public marketplace install path";
   add(
     violations,
-    object(namedStep(smoke, "Prove the public marketplace install path")?.env).MARKETPLACE_REVISION
-      === "${{ needs.marketplace-publish.outputs.marketplace_revision }}",
+    object(namedStep(smoke, installStepName)?.env).MARKETPLACE_REVISION
+      === "${{ steps.delivery.outputs.marketplace_revision }}",
     `${file} post-publish smoke must install from the marketplace revision this release published`,
+  );
+  violations.push(...catalogDeliveryStateViolations(
+    file,
+    smoke,
+    catalogDelivery,
+    {
+      published: "${{ needs.marketplace-publish.outputs.catalog_published == 'true' }}",
+      revision: "${{ needs.marketplace-publish.outputs.marketplace_revision }}",
+    },
+    installStepName,
+  ));
+  const smokeIf = String(smoke.if ?? "");
+  add(
+    violations,
+    smokeIf.includes("always()")
+      && smokeIf.includes("needs.preflight.result == 'success'")
+      && smokeIf.includes("needs.publish.result == 'success'")
+      && !smokeIf.includes("needs.marketplace-publish.result"),
+    `${file} post-publish smoke must require a successful publish without gating on marketplace-publish succeeding`,
   );
 
   const auto = workflows.get("auto-release.yml");
@@ -4600,7 +4830,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   validatePluginAndDraftWorkflows(workflows, violations, graph);
   validateReleaseCoordinator(workflows, violations, graph);
   validatePackagedProof(workflows, violations, graph);
-  validatePostPublish(workflows, violations);
+  validatePostPublish(workflows, violations, graph);
   validatePackagedCoordinator(workflows, violations, graph);
   validateRemainingWorkflows(workflows, violations);
   validateReleaseCellUploadOwnership(workflows, violations);

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1591,6 +1591,15 @@ function catalogDeliveryOutcomeViolations(file, job, delivery) {
       && catalogPush?.if === "steps.token.outcome == 'success'",
     `${file} catalog push must run only with a minted token and must not fail the release`,
   );
+  // The step that mints `catalog_published` reads THIS step's outcome, so a push step that does
+  // not push would let a run claim a catalog update it never attempted. Turning the gate into
+  // delivery replaced the rule that checked this body; it belongs to both lanes, so it lives
+  // here rather than in either lane's own rules.
+  requireStepRun(violations, file, job, "Point the catalog at the published release", [
+    "publish-marketplace-catalog.mjs",
+    '--commit "$GITHUB_SHA"',
+    '--github-output "$GITHUB_OUTPUT"',
+  ]);
   const deliveryOutcome = namedStep(job, "Record catalog delivery outcome");
   add(
     violations,
@@ -1619,6 +1628,11 @@ function catalogDeliveryOutcomeViolations(file, job, delivery) {
     'echo "marketplace_revision=$marketplace_revision" >> "$GITHUB_OUTPUT"',
     "::warning::Catalog publication deferred",
     "recover with $RECOVERY_WORKFLOW",
+    // The recovery workflow mints the SAME credential from the SAME environment, so it recovers
+    // a rejected push and not a missing credential. A run that defers because the credential is
+    // absent must say that, or the ledger records an instruction nobody can follow.
+    'if [ "$TOKEN_OUTCOME" != "success" ]; then',
+    "provision the marketplace-publish credential",
   ]);
   add(
     violations,
@@ -1761,6 +1775,8 @@ function validateReleaseCoordinator(workflows, violations, graph) {
       "install-codestory-marketplace-proof.mjs",
       '--source-repository "$GITHUB_WORKSPACE"',
       "marketplace_revision=$marketplace_revision",
+      `printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'`,
+      `printf '%s' "$fixture_revision" | grep -Eq '^[0-9a-f]{40}$'`,
       // Fixture mode resolves from the locally built catalog, so provenance is
       // checked against that repository's own revision. Checking it against the
       // live revision can never match, which is how the fixture path shipped
@@ -2022,10 +2038,14 @@ function validateReleaseCoordinator(workflows, violations, graph) {
       && postIf.includes("needs.publish.result == 'success'"),
     `${releaseFile} post-publish smoke must require trusted publication authority and a successful publish`,
   );
+  // Not `.result` alone: `needs.marketplace-publish.outputs.catalog_published == 'true'` in the
+  // condition would reinstate exactly the hard catalog gate this change removed, under a
+  // different spelling. Nothing about the catalog job may appear in the condition at all; the
+  // delivery state reaches the smoke through `with:`, where it is data rather than a gate.
   add(
     violations,
-    !postIf.includes(`needs.${catalogDelivery.publish_job}.result`),
-    `${releaseFile} post-publish smoke must not gate on ${catalogDelivery.publish_job} succeeding`,
+    !postIf.includes(`needs.${catalogDelivery.publish_job}`),
+    `${releaseFile} post-publish smoke must not gate on ${catalogDelivery.publish_job} in any form`,
   );
   // THE anti-vacuity rule: the catalog claim may only ever be the recorded delivery state. A
   // literal, an unrelated input, or any other expression would let a release assert a catalog
@@ -2739,11 +2759,37 @@ function validatePackagedProof(workflows, violations, graph) {
 // install of the real published assets; they differ in WHICH catalog served it, and that
 // difference is carried into the release ledger as a distinct installer identity. These rules
 // prove the two states stay distinguishable and that neither can be selected by accident.
-function catalogDeliveryStateViolations(file, job, delivery, handoff, installStepName) {
+function catalogDeliveryStateViolations(file, job, delivery, handoff, installStepName, checkoutRef) {
   const violations = [];
   const published = delivery.states.find(({ id }) => id === "published");
   const deferred = delivery.states.find(({ id }) => id === "deferred");
+  // Whatever else the deferred branch does, it builds a catalog out of a tree and then verifies
+  // the install back against a tree. If those may be the same tree by default, the comparison is
+  // a tautology and the smoke cannot fail for any release-related reason. Both lanes therefore
+  // check out the PUBLISHED tag and make GitHub confirm it before anything is pinned.
+  const checkout = list(job.steps).find(
+    (candidate) => String(object(candidate).uses ?? "").startsWith("actions/checkout@"),
+  );
+  add(
+    violations,
+    object(object(checkout).with).ref === checkoutRef
+      && object(object(checkout).with)["fetch-depth"] === 0,
+    `${file} post-publish smoke must check out the published release tag, not the run's own head`,
+  );
+  requireStepRun(violations, file, job, "Bind this smoke to the published release", [
+    'gh release view "$TAG"',
+    "--json isDraft",
+    'published_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"',
+    `printf '%s' "$published_commit" | grep -Eq '^[0-9a-f]{40}$'`,
+    'if [ "$published_commit" != "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" ]; then',
+    'echo "commit=$published_commit" >> "$GITHUB_OUTPUT"',
+  ]);
   const step = namedStep(job, "Record catalog delivery state");
+  add(
+    violations,
+    object(step?.env).PUBLISHED_COMMIT === "${{ steps.published.outputs.commit }}",
+    `${file} catalog delivery state must pin the commit resolved from the published release`,
+  );
   add(
     violations,
     step?.if === undefined && step?.["continue-on-error"] === undefined,
@@ -2768,13 +2814,20 @@ function catalogDeliveryStateViolations(file, job, delivery, handoff, installSte
     'if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then',
     "Deferred catalog publication must not carry a live catalog revision",
     "build-marketplace-fixture.mjs",
+    // The fixture pins the PUBLISHED commit, never the workspace's own head. Building a catalog
+    // out of the tree that then verifies the install makes the source-tree comparison a
+    // tautology, which is how the plugin lane's deferred smoke became unable to fail.
+    '--commit "$published_commit"',
     'marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"',
     "local_fixture=true",
     `installer=${deferred.installer}`,
     // Neither branch may fall through: an unset or unexpected handoff is a hard failure, never a
     // silent default into the published identity.
     "catalog_published must be true or false",
-    'test "$(printf \'%s\' "$marketplace_revision" | wc -c | tr -d \' \')" = 40',
+    // Immutability, not length. A 40-character string is not a commit: the published branch
+    // takes its revision from a `workflow_dispatch`-able input, and a length-only test admits
+    // any 40 characters of anything.
+    `printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'`,
     'echo "installer=$installer"',
   ]);
   const deliveryRun = executableRunText(String(step?.run ?? ""));
@@ -2894,6 +2947,7 @@ function validatePostPublish(workflows, violations, graph) {
       revision: "${{ inputs.marketplace_revision }}",
     },
     resolveStepName,
+    "${{ steps.release.outputs.tag }}",
   ));
   // The one place the delivery state reaches the release ledger. It must be the resolved value and
   // never a literal, or a deferred run could sign a cell saying the public catalog served it.
@@ -2915,6 +2969,9 @@ function validatePostPublish(workflows, violations, graph) {
   const resolveInstalled = namedStep(job, resolveStepName);
   requireStepRun(violations, file, job, resolveStepName, [
     'marketplace_revision="${{ steps.delivery.outputs.marketplace_revision }}"',
+    // Re-checked here as an immutable identity, not merely as 40 characters: this job is
+    // dispatchable, so the published branch's revision can arrive from a human.
+    `printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'`,
     '"@openai/codex@$CODEX_CLI_VERSION"',
     "install-codestory-marketplace-proof.mjs",
     '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
@@ -4791,6 +4848,7 @@ export function validatePluginRelease(workflows, violations, graph) {
       revision: "${{ needs.marketplace-publish.outputs.marketplace_revision }}",
     },
     installStepName,
+    "v${{ inputs.version }}",
   ));
   const smokeIf = String(smoke.if ?? "");
   add(
@@ -4798,8 +4856,10 @@ export function validatePluginRelease(workflows, violations, graph) {
     smokeIf.includes("always()")
       && smokeIf.includes("needs.preflight.result == 'success'")
       && smokeIf.includes("needs.publish.result == 'success'")
-      && !smokeIf.includes("needs.marketplace-publish.result"),
-    `${file} post-publish smoke must require a successful publish without gating on marketplace-publish succeeding`,
+      // Any reference at all, not just `.result`: an `outputs.catalog_published == 'true'`
+      // conjunct here is the same hard gate wearing a different name.
+      && !smokeIf.includes("needs.marketplace-publish"),
+    `${file} post-publish smoke must require a successful publish without gating on marketplace-publish in any form`,
   );
 
   const auto = workflows.get("auto-release.yml");

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -23,6 +23,7 @@ import {
   validateWorkflows,
   windowsManifestProofPolicyViolations,
 } from "./check-workflow-policy.mjs";
+import { loadReleaseClaimGraph } from "../../scripts/codestory-release-claims.mjs";
 
 const fullSha = "0123456789abcdef0123456789abcdef01234567";
 const proofTopology = "proof5-v1-64015a841a2f69f33f7c9ce284f671ad27b3923a58db865fd4806d86230df6c5";
@@ -2369,9 +2370,9 @@ test("the plugin lane publishes the catalog it then smoke-installs", async (t) =
       const step = catalogStep(workflow);
       step.run = step.run.replace('--version "${{ inputs.version }}"', '--version "$LATEST"');
     }, /Point the catalog at the published release must run --version/u],
-    ["catalog publication hides the revision it pushed", workflow => {
+    ["catalog publication hides the delivery state it recorded", workflow => {
       delete workflow.jobs["marketplace-publish"].outputs;
-    }, /marketplace publication must publish the revision it pushed/u],
+    }, /marketplace publication must publish the recorded delivery state/u],
   ];
   for (const [name, mutate, expected] of mutations) {
     await t.test(name, () => {
@@ -2467,6 +2468,371 @@ test("the plugin lane still forbids building, signing, and forwarded secrets", a
       const violations = validateWorkflows(workflows);
       assert.notDeepEqual(violations, []);
       assert.match(violations.join("\n"), expected);
+    });
+  }
+});
+
+// Catalog publication is delivery, not a release gate. Relaxing a gate is exactly where a vacuous
+// pass gets built by accident, so these tests attack the three shapes that would produce one: a
+// claim that becomes true on its own, a smoke that passes because it stopped checking anything,
+// and a retry that hides which failure actually happened.
+function runStepBash(run, environment) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-catalog-delivery-"));
+  const output = path.join(directory, "github-output");
+  const summary = path.join(directory, "github-step-summary");
+  writeFileSync(output, "");
+  writeFileSync(summary, "");
+  const executable = process.platform === "win32" ? "wsl.exe" : "bash";
+  const args = process.platform === "win32"
+    ? ["--exec", "/bin/bash", "-c", run]
+    : ["-c", run];
+  const result = spawnSync(executable, args, {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: output,
+      GITHUB_STEP_SUMMARY: summary,
+      GITHUB_WORKSPACE: root,
+      RUNNER_TEMP: directory,
+      ...environment,
+    },
+  });
+  const outputs = Object.fromEntries(
+    readFileSync(output, "utf8")
+      .split(/\r?\n/u)
+      .filter(line => line.includes("="))
+      .map(line => [line.slice(0, line.indexOf("=")), line.slice(line.indexOf("=") + 1)]),
+  );
+  return { ...result, outputs, summary: readFileSync(summary, "utf8") };
+}
+
+// Both lanes tag irreversibly and then point the catalog at what they published, so both are
+// exercised here rather than only the one the issue named.
+const catalogOutcomeLanes = [
+  ["release.yml", "marketplace-publish"],
+  ["plugin-release.yml", "marketplace-publish"],
+];
+const catalogStateLanes = [
+  ["post-publish-release-smoke.yml", "smoke"],
+  ["plugin-release.yml", "post-publish-smoke"],
+];
+
+function runCatalogDeliveryOutcome(environment, [file, jobName] = catalogOutcomeLanes[0]) {
+  const step = draftStep(loadWorkflows().get(file).jobs[jobName], "Record catalog delivery outcome");
+  // Every GitHub expression in this step lives in env, so the body is executable bash.
+  assert.ok(!step.run.includes("${{"), "delivery outcome body must not embed workflow expressions");
+  return runStepBash(step.run, { RECOVERY_WORKFLOW: step.env.RECOVERY_WORKFLOW, ...environment });
+}
+
+function runCatalogDeliveryState(environment, [file, jobName] = catalogStateLanes[0]) {
+  const step = draftStep(loadWorkflows().get(file).jobs[jobName], "Record catalog delivery state");
+  assert.ok(!step.run.includes("${{"), "delivery state body must not embed workflow expressions");
+  return runStepBash(step.run, environment);
+}
+
+test("a release records catalog publication only when the catalog push actually landed", () => {
+  const revision = "a".repeat(40);
+
+  for (const lane of catalogOutcomeLanes) {
+    const published = runCatalogDeliveryOutcome({
+      TOKEN_OUTCOME: "success",
+      PUBLISH_OUTCOME: "success",
+      PUBLISHED_REVISION: revision,
+    }, lane);
+    assert.equal(published.status, 0, published.stderr);
+    assert.deepEqual(published.outputs, {
+      catalog_published: "true",
+      marketplace_revision: revision,
+    }, lane.join("/"));
+    assert.doesNotMatch(published.stdout, /::warning::/u, lane.join("/"));
+  }
+
+  // Each of these is a real way this job has failed or could fail. None may report published, and
+  // none may fail the release: the tag and the GitHub release already exist by this point.
+  const deferrals = [
+    ["missing credential", { TOKEN_OUTCOME: "failure", PUBLISH_OUTCOME: "", PUBLISHED_REVISION: "" }],
+    ["push rejected", { TOKEN_OUTCOME: "success", PUBLISH_OUTCOME: "failure", PUBLISHED_REVISION: "" }],
+    ["push skipped", { TOKEN_OUTCOME: "failure", PUBLISH_OUTCOME: "skipped", PUBLISHED_REVISION: "" }],
+    ["push reported success without a revision", {
+      TOKEN_OUTCOME: "success",
+      PUBLISH_OUTCOME: "success",
+      PUBLISHED_REVISION: "",
+    }],
+    ["push reported a mutable ref", {
+      TOKEN_OUTCOME: "success",
+      PUBLISH_OUTCOME: "success",
+      PUBLISHED_REVISION: "main",
+    }],
+    ["push reported a truncated revision", {
+      TOKEN_OUTCOME: "success",
+      PUBLISH_OUTCOME: "success",
+      PUBLISHED_REVISION: "a".repeat(39),
+    }],
+  ];
+  for (const lane of catalogOutcomeLanes) {
+    for (const [label, environment] of deferrals) {
+      const deferred = runCatalogDeliveryOutcome(environment, lane);
+      const where = `${lane.join("/")}: ${label}`;
+      assert.equal(deferred.status, 0, `${where}: ${deferred.stderr}`);
+      assert.deepEqual(deferred.outputs, {
+        catalog_published: "false",
+        marketplace_revision: "",
+      }, where);
+      assert.match(deferred.stdout, /::warning::Catalog publication deferred/u, where);
+      assert.match(deferred.stdout, /marketplace-sync\.yml/u, where);
+      assert.match(deferred.summary, /DEFERRED/u, where);
+    }
+  }
+});
+
+test("the post-publish smoke cannot record a public catalog install it did not perform", () => {
+  const graph = loadReleaseClaimGraph(root);
+  const { states } = graph.workflow_policy.catalog_delivery;
+  const publishedInstaller = states.find(({ id }) => id === "published").installer;
+  const deferredInstaller = states.find(({ id }) => id === "deferred").installer;
+  const liveRevision = "b".repeat(40);
+  const head = spawnSync("git", ["-C", root, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim();
+
+  for (const lane of catalogStateLanes) {
+    const where = lane.join("/");
+    const published = runCatalogDeliveryState({
+      CATALOG_PUBLISHED: "true",
+      INPUT_MARKETPLACE_REVISION: liveRevision,
+    }, lane);
+    assert.equal(published.status, 0, published.stderr);
+    assert.equal(published.outputs.state, "published", where);
+    assert.equal(published.outputs.installer, publishedInstaller, where);
+    assert.equal(published.outputs.marketplace_source, "TheGreenCedar/AgentPluginMarketplace", where);
+    assert.equal(published.outputs.marketplace_revision, liveRevision, where);
+    assert.equal(published.outputs.local_fixture, "false", where);
+
+    // Deferred still proves a real Codex install of the real published artifacts -- it changes only
+    // WHICH catalog served it -- and it says so with an installer identity that cannot be confused
+    // for the public one.
+    const deferred = runCatalogDeliveryState({
+      CATALOG_PUBLISHED: "false",
+      INPUT_MARKETPLACE_REVISION: "",
+    }, lane);
+    assert.equal(deferred.status, 0, deferred.stderr);
+    assert.equal(deferred.outputs.state, "deferred", where);
+    assert.equal(deferred.outputs.installer, deferredInstaller, where);
+    assert.notEqual(deferred.outputs.installer, publishedInstaller, where);
+    assert.notEqual(deferred.outputs.marketplace_source, "TheGreenCedar/AgentPluginMarketplace", where);
+    assert.equal(deferred.outputs.local_fixture, "true", where);
+    assert.match(deferred.outputs.marketplace_revision, /^[0-9a-f]{40}$/u, where);
+    assert.match(deferred.stdout, /::warning::Catalog publication was deferred/u, where);
+    const catalog = JSON.parse(readFileSync(
+      path.join(deferred.outputs.marketplace_source, ".agents", "plugins", "marketplace.json"),
+      "utf8",
+    ));
+    assert.equal(catalog.plugins[0].source.sha, head, `${where}: fixture must pin the released commit`);
+
+    // Refusals. A handoff that is inconsistent, absent, or merely truthy-looking must stop the
+    // smoke rather than fall through into the published identity.
+    for (const [label, environment] of [
+      ["deferred with a live revision", { CATALOG_PUBLISHED: "false", INPUT_MARKETPLACE_REVISION: liveRevision }],
+      ["absent handoff", { CATALOG_PUBLISHED: "", INPUT_MARKETPLACE_REVISION: "" }],
+      ["truthy handoff", { CATALOG_PUBLISHED: "TRUE", INPUT_MARKETPLACE_REVISION: liveRevision }],
+      ["handoff spelled yes", { CATALOG_PUBLISHED: "yes", INPUT_MARKETPLACE_REVISION: liveRevision }],
+      // Published demands an immutable revision: an empty or mutable one is not a catalog install.
+      ["published without a revision", { CATALOG_PUBLISHED: "true", INPUT_MARKETPLACE_REVISION: "" }],
+      ["published with a mutable ref", { CATALOG_PUBLISHED: "true", INPUT_MARKETPLACE_REVISION: "main" }],
+      ["published with a truncated revision", {
+        CATALOG_PUBLISHED: "true",
+        INPUT_MARKETPLACE_REVISION: "b".repeat(39),
+      }],
+    ]) {
+      const refused = runCatalogDeliveryState(environment, lane);
+      assert.notEqual(refused.status, 0, `${where}: ${label}`);
+      assert.notEqual(refused.outputs.installer, publishedInstaller, `${where}: ${label}`);
+    }
+  }
+});
+
+test("catalog publication cannot be reinstated as a gate or claimed without happening", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+
+  const releaseFile = "release.yml";
+  const smokeFile = "post-publish-release-smoke.yml";
+  const pluginFile = "plugin-release.yml";
+  const publishJob = workflows => workflows.get(releaseFile).jobs["marketplace-publish"];
+  const smokeJob = workflows => workflows.get(smokeFile).jobs.smoke;
+  const smokeCall = workflows => workflows.get(releaseFile).jobs["post-publish-smoke"];
+  const pluginPublishJob = workflows => workflows.get(pluginFile).jobs["marketplace-publish"];
+  const pluginSmokeJob = workflows => workflows.get(pluginFile).jobs["post-publish-smoke"];
+
+  const mutations = [
+    // --- The claim silently becoming true ---
+    ["release hard-codes the catalog claim", workflows => {
+      smokeCall(workflows).with.catalog_published = true;
+    }, /must derive catalog_published from the recorded marketplace-publish outcome/u],
+    ["release hard-codes the catalog claim as a string", workflows => {
+      smokeCall(workflows).with.catalog_published = "true";
+    }, /must derive catalog_published from the recorded marketplace-publish outcome/u],
+    ["catalog claim is read from an unrelated input", workflows => {
+      smokeCall(workflows).with.catalog_published = "${{ inputs.publish_release }}";
+    }, /must derive catalog_published from the recorded marketplace-publish outcome/u],
+    ["catalog claim is read from the job result instead of the recorded outcome", workflows => {
+      smokeCall(workflows).with.catalog_published
+        = "${{ needs.marketplace-publish.result == 'success' }}";
+    }, /must derive catalog_published from the recorded marketplace-publish outcome/u],
+    ["catalog claim is dropped entirely", workflows => {
+      delete smokeCall(workflows).with.catalog_published;
+    }, /must derive catalog_published from the recorded marketplace-publish outcome/u],
+    ["delivery outcome ignores whether the push ran", workflows => {
+      const step = draftStep(publishJob(workflows), "Record catalog delivery outcome");
+      step.run = step.run.replace('&& [ "$PUBLISH_OUTCOME" = "success" ] \\\n', "");
+    }, /must run \[ "\$PUBLISH_OUTCOME" = "success" \]/u],
+    ["delivery outcome accepts any revision the push printed", workflows => {
+      const step = draftStep(publishJob(workflows), "Record catalog delivery outcome");
+      step.run = step.run.replace(
+        `&& printf '%s' "$PUBLISHED_REVISION" | grep -Eq '^[0-9a-f]{40}$'`,
+        "&& true",
+      );
+    }, /grep -Eq/u],
+    ["delivery outcome defaults to published", workflows => {
+      const step = draftStep(publishJob(workflows), "Record catalog delivery outcome");
+      step.run = step.run.replace("catalog_published=false", "catalog_published=true");
+    }, /must run catalog_published=false/u],
+    ["job publishes the raw push result instead of the recorded outcome", workflows => {
+      publishJob(workflows).outputs.catalog_published = "${{ steps.publish.outcome == 'success' }}";
+    }, /must publish the recorded delivery state/u],
+    ["delivery outcome is skipped when the push failed", workflows => {
+      draftStep(publishJob(workflows), "Record catalog delivery outcome").if = "success()";
+    }, /catalog delivery outcome must be recorded whatever the catalog push did/u],
+    ["deferred publication stops naming its recovery path", workflows => {
+      delete draftStep(publishJob(workflows), "Record catalog delivery outcome").env.RECOVERY_WORKFLOW;
+    }, /must name marketplace-sync\.yml as the recovery path/u],
+
+    // --- The smoke passing because it stopped checking anything ---
+    ["deferred smoke records the public catalog installer", workflows => {
+      const step = draftStep(smokeJob(workflows), "Emit authenticated post-publish release cells");
+      step.run = step.run.replace(
+        '--arg installer "${{ steps.delivery.outputs.installer }}"',
+        "--arg installer codex_marketplace_install",
+      );
+    }, /must not hard-code the published installer identity/u],
+    ["both delivery states collapse onto one installer identity", workflows => {
+      const step = draftStep(smokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace(
+        "installer=codex_marketplace_deferred_fixture",
+        "installer=codex_marketplace_install",
+      );
+    }, /published installer identity must be reachable only from the published branch/u],
+    ["deferred branch accepts a live catalog revision", workflows => {
+      const step = draftStep(smokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace('if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then', "if false; then");
+    }, /must run if \[ -n "\$INPUT_MARKETPLACE_REVISION" \]/u],
+    ["unknown delivery states fall through instead of failing", workflows => {
+      const step = draftStep(smokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace("catalog_published must be true or false", "unreachable");
+    }, /must run catalog_published must be true or false/u],
+    ["delivery state becomes conditional", workflows => {
+      draftStep(smokeJob(workflows), "Record catalog delivery state").if = "inputs.catalog_published";
+    }, /catalog delivery state must be unconditional and fail closed/u],
+    ["delivery state stops reading the caller's handoff", workflows => {
+      delete draftStep(smokeJob(workflows), "Record catalog delivery state").env.CATALOG_PUBLISHED;
+    }, /must read the recorded publication handoff/u],
+    ["smoke resolves whatever catalog it likes", workflows => {
+      const step = draftStep(smokeJob(workflows), "Resolve the published plugin through the marketplace catalog");
+      step.run = step.run.replace(
+        '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
+        "--marketplace-source TheGreenCedar/AgentPluginMarketplace",
+      );
+    }, /must run --marketplace-source "\$\{\{ steps\.delivery\.outputs\.marketplace_source \}\}"/u],
+    ["smoke fakes the fixture catalog by cloning it", workflows => {
+      draftStep(smokeJob(workflows), "Record catalog delivery state").run
+        += "\ngit clone https://github.com/TheGreenCedar/AgentPluginMarketplace.git";
+    }, /must not fabricate installation with git clone/u],
+    ["catalog delivery state stops being a required handoff", workflows => {
+      workflows.get(smokeFile).on.workflow_call.inputs.catalog_published.required = false;
+    }, /workflow_call catalog_published must be a required boolean/u],
+
+    // --- The gate coming back, or a retry hiding which failure happened ---
+    ["token failure fails the published release again", workflows => {
+      delete draftStep(publishJob(workflows), "Mint a scoped marketplace token")["continue-on-error"];
+    }, /marketplace token failure must not fail an already-published release/u],
+    ["catalog push failure fails the published release again", workflows => {
+      delete draftStep(publishJob(workflows), "Point the catalog at the published release")["continue-on-error"];
+    }, /catalog push must run only with a minted token and must not fail the release/u],
+    ["catalog push runs without a minted token", workflows => {
+      delete draftStep(publishJob(workflows), "Point the catalog at the published release").if;
+    }, /catalog push must run only with a minted token and must not fail the release/u],
+    ["smoke waits for the catalog job to succeed", workflows => {
+      smokeCall(workflows).if
+        = "inputs.publish_release && needs.marketplace-publish.result == 'success'";
+    }, /must not gate on marketplace-publish succeeding/u],
+    ["smoke is skipped whenever the catalog job did not run cleanly", workflows => {
+      smokeCall(workflows).if = "inputs.publish_release";
+    }, /post-publish smoke must require trusted publication authority and a successful publish/u],
+    ["smoke stops requiring a real published release", workflows => {
+      smokeCall(workflows).if = "always() && inputs.publish_release && needs.preflight.result == 'success'";
+    }, /post-publish smoke must require trusted publication authority and a successful publish/u],
+    ["catalog push retries until it passes", workflows => {
+      const step = draftStep(publishJob(workflows), "Point the catalog at the published release");
+      step.run = `until node .github/scripts/publish-marketplace-catalog.mjs; do sleep 5; done\n${step.run}`;
+    }, /must not retry a recorded delivery outcome/u],
+    ["post-publish closeout reintroduces the catalog gate through its condition", workflows => {
+      workflows.get(releaseFile).jobs["post-publish-closeout"].if
+        = "inputs.publish_release && needs.marketplace-publish.result == 'success'";
+    }, /post-publish closeout must not gate on marketplace-publish succeeding/u],
+
+    // --- The plugin fast lane, which tags and publishes the same catalog ---
+    ["plugin lane token failure fails its tagged release again", workflows => {
+      delete draftStep(pluginPublishJob(workflows), "Mint a scoped marketplace token")["continue-on-error"];
+    }, /plugin-release\.yml marketplace token failure must not fail an already-published release/u],
+    ["plugin lane catalog push failure fails its tagged release again", workflows => {
+      delete draftStep(pluginPublishJob(workflows), "Point the catalog at the published release")["continue-on-error"];
+    }, /plugin-release\.yml catalog push must run only with a minted token/u],
+    ["plugin lane stops recording its delivery outcome", workflows => {
+      const job = pluginPublishJob(workflows);
+      job.steps = job.steps.filter(({ name }) => name !== "Record catalog delivery outcome");
+    }, /plugin-release\.yml must contain named step Record catalog delivery outcome/u],
+    ["plugin lane delivery outcome defaults to published", workflows => {
+      const step = draftStep(pluginPublishJob(workflows), "Record catalog delivery outcome");
+      step.run = step.run.replace("catalog_published=false", "catalog_published=true");
+    }, /plugin-release\.yml step Record catalog delivery outcome must run catalog_published=false/u],
+    ["plugin lane smoke waits for the catalog job to succeed", workflows => {
+      pluginSmokeJob(workflows).if = "needs.marketplace-publish.result == 'success'";
+    }, /plugin-release\.yml post-publish smoke must require a successful publish without gating/u],
+    ["plugin lane smoke stops requiring a real published release", workflows => {
+      delete pluginSmokeJob(workflows).if;
+    }, /plugin-release\.yml post-publish smoke must require a successful publish without gating/u],
+    ["plugin lane hard-codes its catalog claim", workflows => {
+      draftStep(pluginSmokeJob(workflows), "Record catalog delivery state").env.CATALOG_PUBLISHED = "true";
+    }, /plugin-release\.yml catalog delivery state must read the recorded publication handoff/u],
+    ["plugin lane collapses both delivery states onto one installer identity", workflows => {
+      const step = draftStep(pluginSmokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace(
+        "installer=codex_marketplace_deferred_fixture",
+        "installer=codex_marketplace_install",
+      );
+    }, /plugin-release\.yml the published installer identity must be reachable only from the published branch/u],
+    ["plugin lane deferred branch accepts a live catalog revision", workflows => {
+      const step = draftStep(pluginSmokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace('if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then', "if false; then");
+    }, /plugin-release\.yml step Record catalog delivery state must run if \[ -n "\$INPUT_MARKETPLACE_REVISION" \]/u],
+    ["plugin lane installs from a catalog the delivery state did not resolve", workflows => {
+      const step = draftStep(pluginSmokeJob(workflows), "Prove the public marketplace install path");
+      step.run = step.run.replace(
+        '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
+        "--marketplace-source TheGreenCedar/AgentPluginMarketplace",
+      );
+    }, /plugin-release\.yml step Prove the public marketplace install path must run --marketplace-source/u],
+    ["plugin lane smoke installs the revision the job failed to publish", workflows => {
+      draftStep(pluginSmokeJob(workflows), "Prove the public marketplace install path")
+        .env.MARKETPLACE_REVISION = "${{ needs.marketplace-publish.outputs.marketplace_revision }}";
+    }, /plugin-release\.yml post-publish smoke must install from the marketplace revision this release published/u],
+  ];
+
+  for (const [name, mutate, expectedReason] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows);
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, [], name);
+      assert.match(violations.join("\n"), expectedReason, name);
     });
   }
 });

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -2528,7 +2528,19 @@ function runCatalogDeliveryOutcome(environment, [file, jobName] = catalogOutcome
 function runCatalogDeliveryState(environment, [file, jobName] = catalogStateLanes[0]) {
   const step = draftStep(loadWorkflows().get(file).jobs[jobName], "Record catalog delivery state");
   assert.ok(!step.run.includes("${{"), "delivery state body must not embed workflow expressions");
+  // PUBLISHED_COMMIT is what the preceding step resolved from the published release. It is the
+  // step's own input here, exactly as it is in the workflow.
   return runStepBash(step.run, environment);
+}
+
+// Both smokes bind themselves to the published release before deciding anything, so the executable
+// body below is run with that binding present -- and, separately, with it broken.
+function runCatalogDeliveryStateBound(environment, lane) {
+  return runCatalogDeliveryState({ PUBLISHED_COMMIT: repositoryHead(), ...environment }, lane);
+}
+
+function repositoryHead() {
+  return spawnSync("git", ["-C", root, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim();
 }
 
 test("a release records catalog publication only when the catalog push actually landed", () => {
@@ -2592,11 +2604,11 @@ test("the post-publish smoke cannot record a public catalog install it did not p
   const publishedInstaller = states.find(({ id }) => id === "published").installer;
   const deferredInstaller = states.find(({ id }) => id === "deferred").installer;
   const liveRevision = "b".repeat(40);
-  const head = spawnSync("git", ["-C", root, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim();
+  const head = repositoryHead();
 
   for (const lane of catalogStateLanes) {
     const where = lane.join("/");
-    const published = runCatalogDeliveryState({
+    const published = runCatalogDeliveryStateBound({
       CATALOG_PUBLISHED: "true",
       INPUT_MARKETPLACE_REVISION: liveRevision,
     }, lane);
@@ -2610,7 +2622,7 @@ test("the post-publish smoke cannot record a public catalog install it did not p
     // Deferred still proves a real Codex install of the real published artifacts -- it changes only
     // WHICH catalog served it -- and it says so with an installer identity that cannot be confused
     // for the public one.
-    const deferred = runCatalogDeliveryState({
+    const deferred = runCatalogDeliveryStateBound({
       CATALOG_PUBLISHED: "false",
       INPUT_MARKETPLACE_REVISION: "",
     }, lane);
@@ -2635,17 +2647,47 @@ test("the post-publish smoke cannot record a public catalog install it did not p
       ["absent handoff", { CATALOG_PUBLISHED: "", INPUT_MARKETPLACE_REVISION: "" }],
       ["truthy handoff", { CATALOG_PUBLISHED: "TRUE", INPUT_MARKETPLACE_REVISION: liveRevision }],
       ["handoff spelled yes", { CATALOG_PUBLISHED: "yes", INPUT_MARKETPLACE_REVISION: liveRevision }],
-      // Published demands an immutable revision: an empty or mutable one is not a catalog install.
+      // Published demands an IMMUTABLE revision. "main" is refused by any length test at all, so
+      // it never exercised immutability; the 40-character non-hex cases below do, and they are
+      // reachable in practice because this workflow is dispatchable with an arbitrary string.
       ["published without a revision", { CATALOG_PUBLISHED: "true", INPUT_MARKETPLACE_REVISION: "" }],
       ["published with a mutable ref", { CATALOG_PUBLISHED: "true", INPUT_MARKETPLACE_REVISION: "main" }],
       ["published with a truncated revision", {
         CATALOG_PUBLISHED: "true",
         INPUT_MARKETPLACE_REVISION: "b".repeat(39),
       }],
+      ["published with forty non-hex characters", {
+        CATALOG_PUBLISHED: "true",
+        INPUT_MARKETPLACE_REVISION: "z".repeat(40),
+      }],
+      ["published with a forty-character branch name", {
+        CATALOG_PUBLISHED: "true",
+        INPUT_MARKETPLACE_REVISION: "refs/heads/some-quite-long-branch-name-xy",
+      }],
+      ["published with an uppercase revision", {
+        CATALOG_PUBLISHED: "true",
+        INPUT_MARKETPLACE_REVISION: "B".repeat(40),
+      }],
     ]) {
-      const refused = runCatalogDeliveryState(environment, lane);
+      const refused = runCatalogDeliveryStateBound(environment, lane);
       assert.notEqual(refused.status, 0, `${where}: ${label}`);
       assert.notEqual(refused.outputs.installer, publishedInstaller, `${where}: ${label}`);
+    }
+
+    // The deferred branch pins the commit the previous step resolved from the published release.
+    // A missing or non-immutable binding must stop the job rather than fall back to this tree.
+    for (const [label, publishedCommit] of [
+      ["absent published commit", ""],
+      ["mutable published ref", "main"],
+      ["forty non-hex characters", "z".repeat(40)],
+    ]) {
+      const refused = runCatalogDeliveryState({
+        CATALOG_PUBLISHED: "false",
+        INPUT_MARKETPLACE_REVISION: "",
+        PUBLISHED_COMMIT: publishedCommit,
+      }, lane);
+      assert.notEqual(refused.status, 0, `${where}: ${label}`);
+      assert.equal(refused.outputs.installer, undefined, `${where}: ${label}`);
     }
   }
 });
@@ -2762,7 +2804,7 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
     ["smoke waits for the catalog job to succeed", workflows => {
       smokeCall(workflows).if
         = "inputs.publish_release && needs.marketplace-publish.result == 'success'";
-    }, /must not gate on marketplace-publish succeeding/u],
+    }, /must not gate on marketplace-publish in any form/u],
     ["smoke is skipped whenever the catalog job did not run cleanly", workflows => {
       smokeCall(workflows).if = "inputs.publish_release";
     }, /post-publish smoke must require trusted publication authority and a successful publish/u],
@@ -2824,6 +2866,152 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
       draftStep(pluginSmokeJob(workflows), "Prove the public marketplace install path")
         .env.MARKETPLACE_REVISION = "${{ needs.marketplace-publish.outputs.marketplace_revision }}";
     }, /plugin-release\.yml post-publish smoke must install from the marketplace revision this release published/u],
+    // --- A recovery instruction that cannot be followed ---
+    // marketplace-sync.yml mints the same credential from the same environment, so it recovers a
+    // rejected push and not a missing credential. Naming it unconditionally recorded a one-click
+    // fix that does not exist for the state every release currently reaches.
+    ["deferral stops distinguishing a missing credential from a rejected push", workflows => {
+      const step = draftStep(publishJob(workflows), "Record catalog delivery outcome");
+      step.run = step.run.replace('if [ "$TOKEN_OUTCOME" != "success" ]; then', "if false; then");
+    }, /release\.yml step Record catalog delivery outcome must run if \[ "\$TOKEN_OUTCOME" != "success" \]; then/u],
+    ["plugin lane deferral stops naming the credential the recovery needs", workflows => {
+      const step = draftStep(pluginPublishJob(workflows), "Record catalog delivery outcome");
+      step.run = step.run.replace("provision the marketplace-publish credential", "try again");
+    }, /plugin-release\.yml step Record catalog delivery outcome must run provision the marketplace-publish credential/u],
+
+    // --- The push step no longer having to push ---
+    // Turning the gate into delivery deleted the rule that read this step's body, leaving a job
+    // that could mint `catalog_published=true` with the catalog untouched. Both lanes.
+    ["catalog push stops pushing anything", workflows => {
+      draftStep(publishJob(workflows), "Point the catalog at the published release").run
+        = 'echo "catalog untouched"\necho "marketplace_revision=$(printf a%.0s $(seq 40))" >> "$GITHUB_OUTPUT"';
+    }, /release\.yml step Point the catalog at the published release must run publish-marketplace-catalog\.mjs/u],
+    ["catalog push stops naming the commit it publishes", workflows => {
+      const step = draftStep(publishJob(workflows), "Point the catalog at the published release");
+      step.run = step.run.replace('--commit "$GITHUB_SHA"', "--commit HEAD");
+    }, /release\.yml step Point the catalog at the published release must run --commit "\$GITHUB_SHA"/u],
+    ["catalog push stops reporting the revision it landed", workflows => {
+      const step = draftStep(publishJob(workflows), "Point the catalog at the published release");
+      step.run = step.run.replace('--github-output "$GITHUB_OUTPUT"', "--quiet");
+    }, /release\.yml step Point the catalog at the published release must run --github-output/u],
+    ["plugin lane catalog push stops pushing anything", workflows => {
+      draftStep(pluginPublishJob(workflows), "Point the catalog at the published release").run
+        = 'echo "catalog untouched"';
+    }, /plugin-release\.yml step Point the catalog at the published release must run publish-marketplace-catalog\.mjs/u],
+
+    // --- The gate coming back under a different spelling ---
+    // `.result` was the only spelling forbidden, so the identical hard gate written as an output
+    // comparison passed. Both lanes, and the closeout that reaches the catalog through the smoke.
+    ["smoke gates on the catalog output instead of the job result", workflows => {
+      smokeCall(workflows).if
+        = "always() && inputs.publish_release && needs.preflight.result == 'success'"
+        + " && needs.publish.result == 'success'"
+        + " && needs.marketplace-publish.outputs.catalog_published == 'true'";
+    }, /must not gate on marketplace-publish in any form/u],
+    ["smoke gates on the catalog revision being present", workflows => {
+      smokeCall(workflows).if
+        = "always() && inputs.publish_release && needs.preflight.result == 'success'"
+        + " && needs.publish.result == 'success'"
+        + " && needs.marketplace-publish.outputs.marketplace_revision != ''";
+    }, /must not gate on marketplace-publish in any form/u],
+    ["plugin lane smoke gates on the catalog output instead of the job result", workflows => {
+      pluginSmokeJob(workflows).if
+        = "always() && needs.preflight.result == 'success' && needs.publish.result == 'success'"
+        + " && needs.marketplace-publish.outputs.catalog_published == 'true'";
+    }, /plugin-release\.yml post-publish smoke must require a successful publish without gating on marketplace-publish in any form/u],
+    ["post-publish closeout gates on the catalog output instead of the job result", workflows => {
+      workflows.get(releaseFile).jobs["post-publish-closeout"].if
+        = "inputs.publish_release && needs.marketplace-publish.outputs.catalog_published == 'true'";
+    }, /post-publish closeout must not gate on marketplace-publish succeeding/u],
+
+    // --- A revision test that measures length instead of immutability ---
+    ["delivery state accepts any forty characters as a revision", workflows => {
+      const step = draftStep(smokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace(
+        `printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'`,
+        `test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40`,
+      );
+    }, /must run printf '%s' "\$marketplace_revision" \| grep -Eq/u],
+    ["plugin lane delivery state accepts any forty characters as a revision", workflows => {
+      const step = draftStep(pluginSmokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace(
+        `printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'`,
+        `test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40`,
+      );
+    }, /must run printf '%s' "\$marketplace_revision" \| grep -Eq/u],
+    ["install step accepts any forty characters as a revision", workflows => {
+      const step = draftStep(smokeJob(workflows), "Resolve the published plugin through the marketplace catalog");
+      step.run = step.run.replace(
+        `printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'`,
+        `test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40`,
+      );
+    }, /must run printf '%s' "\$marketplace_revision" \| grep -Eq/u],
+    ["release preflight accepts any forty characters as a live revision", workflows => {
+      const step = draftStep(
+        workflows.get(releaseFile).jobs.preflight,
+        "Prove the public marketplace install path",
+      );
+      step.run = step.run.replace(
+        `printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'`,
+        `test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40`,
+      );
+    }, /must run printf '%s' "\$marketplace_revision" \| grep -Eq/u],
+
+    // --- The smoke verifying its own workspace against itself ---
+    ["smoke stops checking out the published tag", workflows => {
+      const checkout = smokeJob(workflows).steps
+        .find(step => String(step.uses ?? "").startsWith("actions/checkout@"));
+      delete checkout.with;
+    }, /post-publish-release-smoke\.yml post-publish smoke must check out the published release tag/u],
+    ["plugin lane smoke stops checking out the published tag", workflows => {
+      const checkout = pluginSmokeJob(workflows).steps
+        .find(step => String(step.uses ?? "").startsWith("actions/checkout@"));
+      delete checkout.with;
+    }, /plugin-release\.yml post-publish smoke must check out the published release tag/u],
+    ["plugin lane smoke checks out its own head instead of the tag", workflows => {
+      const checkout = pluginSmokeJob(workflows).steps
+        .find(step => String(step.uses ?? "").startsWith("actions/checkout@"));
+      checkout.with = { ref: "${{ github.sha }}", "fetch-depth": 0 };
+    }, /plugin-release\.yml post-publish smoke must check out the published release tag/u],
+    ["smoke stops making GitHub confirm the release is published", workflows => {
+      const job = smokeJob(workflows);
+      job.steps = job.steps.filter(({ name }) => name !== "Bind this smoke to the published release");
+    }, /post-publish-release-smoke\.yml must contain named step Bind this smoke to the published release/u],
+    ["plugin lane smoke stops making GitHub confirm the release is published", workflows => {
+      const job = pluginSmokeJob(workflows);
+      job.steps = job.steps.filter(({ name }) => name !== "Bind this smoke to the published release");
+    }, /plugin-release\.yml must contain named step Bind this smoke to the published release/u],
+    ["published binding stops comparing GitHub's commit with the checked-out tree", workflows => {
+      const step = draftStep(smokeJob(workflows), "Bind this smoke to the published release");
+      step.run = step.run.replace(
+        'if [ "$published_commit" != "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" ]; then',
+        "if false; then",
+      );
+    }, /must run if \[ "\$published_commit" != "\$\(git -C "\$GITHUB_WORKSPACE" rev-parse HEAD\)" \]; then/u],
+    ["published binding accepts a draft release", workflows => {
+      const step = draftStep(pluginSmokeJob(workflows), "Bind this smoke to the published release");
+      step.run = step.run.replace('gh release view "$TAG"', 'gh release list "$TAG"');
+    }, /plugin-release\.yml step Bind this smoke to the published release must run gh release view/u],
+    ["deferred fixture is pinned to the run's own head again", workflows => {
+      const step = draftStep(smokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace(
+        '--commit "$published_commit"',
+        '--commit "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"',
+      );
+    }, /must run --commit "\$published_commit"/u],
+    ["plugin lane deferred fixture is pinned to the run's own head again", workflows => {
+      const step = draftStep(pluginSmokeJob(workflows), "Record catalog delivery state");
+      step.run = step.run.replace(
+        '--commit "$published_commit"',
+        '--commit "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"',
+      );
+    }, /must run --commit "\$published_commit"/u],
+    ["delivery state stops reading the published commit binding", workflows => {
+      delete draftStep(smokeJob(workflows), "Record catalog delivery state").env.PUBLISHED_COMMIT;
+    }, /must pin the commit resolved from the published release/u],
+    ["plugin lane delivery state stops reading the published commit binding", workflows => {
+      delete draftStep(pluginSmokeJob(workflows), "Record catalog delivery state").env.PUBLISHED_COMMIT;
+    }, /plugin-release\.yml catalog delivery state must pin the commit resolved from the published release/u],
   ];
 
   for (const [name, mutate, expectedReason] of mutations) {

--- a/.github/scripts/install-codestory-marketplace-proof.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.mjs
@@ -15,6 +15,13 @@ import process from "node:process";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
+import {
+  DEFERRED_INSTALLATION_SOURCE,
+  DEFERRED_MARKETPLACE_REPOSITORY,
+  LIVE_INSTALLATION_SOURCE,
+  LIVE_MARKETPLACE_REPOSITORY,
+} from "./marketplace-delivery-identity.mjs";
+
 function fail(message) {
   throw new Error(message);
 }
@@ -131,6 +138,29 @@ function marketplaceRevisionAt(root) {
 
 function prepareInstallation(rawArgs) {
   const args = parseArgs(rawArgs);
+
+  // Which delivery state this install attests is decided first, before anything is touched. An
+  // unset or misspelled `--local-fixture` used to mean "live" by falling through a `!== "true"`
+  // comparison -- exactly the shape that lets a fixture resolve be attested as a public-catalog
+  // install.
+  const localFixtureRaw = args.local_fixture;
+  if (localFixtureRaw !== "true" && localFixtureRaw !== "false") {
+    fail(`--local-fixture must be true or false, not ${JSON.stringify(localFixtureRaw ?? null)}`);
+  }
+  const localFixture = localFixtureRaw === "true";
+  const installationSource = localFixture
+    ? DEFERRED_INSTALLATION_SOURCE
+    : LIVE_INSTALLATION_SOURCE;
+  const marketplaceSource = required(args, "marketplace_source");
+  if (!localFixture && marketplaceSource !== LIVE_MARKETPLACE_REPOSITORY) {
+    fail(
+      `a live marketplace install must resolve ${LIVE_MARKETPLACE_REPOSITORY}, not ${marketplaceSource}`,
+    );
+  }
+  const marketplaceRepository = localFixture
+    ? DEFERRED_MARKETPLACE_REPOSITORY
+    : marketplaceSource;
+
   const codexPackageRoot = path.resolve(required(args, "codex_package_root"));
   const codexExecutable = path.join(
     codexPackageRoot,
@@ -148,7 +178,6 @@ function prepareInstallation(rawArgs) {
   const pluginData = realpathSync(pluginDataInput);
   containedPath(codexHome, pluginData, "plugin data");
 
-  const marketplaceSource = required(args, "marketplace_source");
   const marketplaceName = required(args, "marketplace_name");
   const marketplaceRevision = required(args, "marketplace_revision");
   if (!/^[0-9a-f]{40}$/u.test(marketplaceRevision)) {
@@ -168,7 +197,10 @@ function prepareInstallation(rawArgs) {
     codexExecutable,
     codexHome,
     pluginData,
+    localFixture,
+    installationSource,
     marketplaceSource,
+    marketplaceRepository,
     marketplaceName,
     marketplaceRevision,
     expectedVersion,
@@ -183,7 +215,7 @@ function installMarketplace(setup) {
   const codex = (...command) => run(setup.codexExecutable, command, { env });
   const codexVersion = codex("--version");
   const addArguments = ["plugin", "marketplace", "add", setup.marketplaceSource];
-  if (setup.args.local_fixture !== "true") {
+  if (!setup.localFixture) {
     addArguments.push("--ref", setup.marketplaceRevision);
   }
   addArguments.push("--json");
@@ -227,7 +259,7 @@ function verifyInstallation(setup, installed) {
   const installedPlugins = installed.pluginList.installed;
   const availablePlugins = installed.pluginList.available;
   const pluginListEntry = installedPlugins?.[0];
-  const expectedSourceUrl = setup.args.local_fixture === "true"
+  const expectedSourceUrl = setup.localFixture
     ? undefined
     : "https://github.com/TheGreenCedar/CodeStory.git";
   if (
@@ -316,7 +348,7 @@ function verifyInstallation(setup, installed) {
 function attestInstallation(setup, installed, verified) {
   const attestation = {
     schema_version: 2,
-    installation_source: "codex_marketplace_install",
+    installation_source: setup.installationSource,
     installation: {
       codex_home: setup.codexHome,
       plugin_root: verified.pluginRoot,
@@ -330,7 +362,7 @@ function attestInstallation(setup, installed, verified) {
       package_sha256: verified.packageSha256,
     },
     marketplace: {
-      repository: setup.marketplaceSource,
+      repository: setup.marketplaceRepository,
       revision: setup.marketplaceRevision,
       provenance: {
         add: {

--- a/.github/scripts/install-codestory-marketplace-proof.test.mjs
+++ b/.github/scripts/install-codestory-marketplace-proof.test.mjs
@@ -193,6 +193,16 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
       pluginManifest.version,
     );
     assert.equal(attestation.schema_version, 2);
+    // A fixture resolve is a distinct delivery state end to end: it gets its own installer
+    // identity and its own attestation repository, and the Python predicate routes on exactly
+    // this value. Writing `codex_marketplace_install` here -- as the first version did -- made
+    // the live predicate refuse the release three steps after the tag was already pushed.
+    assert.equal(attestation.installation_source, "codex_marketplace_deferred_fixture");
+    assert.equal(
+      attestation.marketplace.repository,
+      "local:candidate-pinned-marketplace-fixture",
+    );
+    assert.notEqual(attestation.marketplace.repository, marketplaceRoot);
     assert.equal(attestation.marketplace.codex_cli_version, `codex-cli ${codexVersion}`);
     assert.equal(attestation.marketplace.revision, marketplaceRevision);
     assert.equal(
@@ -279,6 +289,45 @@ test("pinned Codex installs a local marketplace fixture into the attested cache"
         sourceRepository: pluginSourceRoot,
       }),
       /marketplace plugin source is not pinned to one immutable commit/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// `--local-fixture` decides which of two delivery states the attestation claims, so it may not be
+// decided by falling through a comparison. It used to be read as `!== "true"`, which made an unset
+// or misspelled value silently mean "the live public catalog served this release".
+test("the delivery state must be stated explicitly, never defaulted", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codestory-marketplace-flag-"));
+  try {
+    const base = proofArgs({
+      packageRoot: path.join(root, "codex-package"),
+      proofRoot: root,
+      marketplaceRoot: path.join(root, "marketplace"),
+      marketplaceRevision: "a".repeat(40),
+      expectedVersion: "0.0.0",
+      sourceRepository: repositoryRoot,
+    });
+    const withFlag = (value) => {
+      const args = [...base];
+      const index = args.indexOf("--local-fixture");
+      if (value === null) args.splice(index, 2);
+      else args[index + 1] = value;
+      return args;
+    };
+    for (const value of [null, "", "TRUE", "1", "yes", "tru"]) {
+      assertFailedProof(withFlag(value), /--local-fixture must be true or false/u);
+    }
+
+    // The live state may only ever name the real catalog repository. A fixture path arriving
+    // here with `--local-fixture false` would attest a public-catalog install of a local
+    // directory.
+    const live = withFlag("false");
+    live[live.indexOf("--marketplace-source") + 1] = path.join(root, "marketplace");
+    assertFailedProof(
+      live,
+      /a live marketplace install must resolve TheGreenCedar\/AgentPluginMarketplace/u,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/.github/scripts/marketplace-delivery-identity.mjs
+++ b/.github/scripts/marketplace-delivery-identity.mjs
@@ -1,0 +1,30 @@
+// The two catalog delivery states, named once.
+//
+// Catalog publication is delivery, not a release gate, so a release can be proved against
+// either the live public catalog or a catalog pinned to the exact published commit. Those are
+// DISTINCT states, and the whole risk in allowing the second one is that it quietly reads as
+// the first. So neither state is an absence: each has its own installer identity, its own
+// attestation repository name, and its own accepted shape in the Python predicate, and the
+// three names live here so the producer and the verifier cannot drift apart.
+//
+// `.github/scripts/packaged_agent_proof/marketplace_installation.py` holds the Python side of
+// the same contract; `install-codestory-marketplace-proof.test.mjs` asserts the two agree.
+
+/** Installer identity for a resolve through the live public catalog. */
+export const LIVE_INSTALLATION_SOURCE = "codex_marketplace_install";
+/** Installer identity for a resolve through a catalog pinned to the published commit. */
+export const DEFERRED_INSTALLATION_SOURCE = "codex_marketplace_deferred_fixture";
+
+/** `marketplace.repository` for the live state: the real catalog repository. */
+export const LIVE_MARKETPLACE_REPOSITORY = "TheGreenCedar/AgentPluginMarketplace";
+/**
+ * `marketplace.repository` for the deferred state. Deliberately not a filesystem path: the
+ * path is a per-run temporary directory, and writing it here made the attestation claim a
+ * "repository" that no one can resolve. This name is stable, is not a repository, and cannot
+ * be mistaken for one.
+ */
+export const DEFERRED_MARKETPLACE_REPOSITORY = "local:candidate-pinned-marketplace-fixture";
+
+/** Marker file the fixture builder writes so a fixture can identify itself to the verifier. */
+export const FIXTURE_MARKER_FILENAME = ".codestory-marketplace-fixture.json";
+export const FIXTURE_MARKER_PURPOSE = "codestory-candidate-pinned-marketplace-fixture";

--- a/.github/scripts/packaged_agent_proof/installed_identity.py
+++ b/.github/scripts/packaged_agent_proof/installed_identity.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from .contract_primitives import require_exact_keys, sha256
 from .foundation import REPOSITORY_ROOT, ProofFailure, require
 from .installation_support import directory_contract_sha256, same_existing_path
-from .marketplace_installation import marketplace_installed_plugin_identity
+from .marketplace_installation import (
+    delivery_state,
+    marketplace_installed_plugin_identity,
+)
 
 
 def _reject_source_checkout(plugin_root: Path) -> None:
@@ -157,9 +160,15 @@ def installed_plugin_identity(
     )
     _reject_source_checkout(plugin_root)
     attestation = _load_attestation(args.installed_plugin_attestation)
-    if attestation.get("installation_source") == "codex_marketplace_install":
+    # Each installer identity routes to exactly one accepted shape. A live public-catalog
+    # install and a deferred candidate-pinned fixture are different states of the world, so
+    # neither can be verified by the other's predicate -- the live check is not relaxed to
+    # admit a fixture, and the deferred check cannot mint the live repository name.
+    state = delivery_state(attestation.get("installation_source"))
+    if state is not None:
         return marketplace_installed_plugin_identity(
             attestation,
+            state,
             args.installed_plugin_data,
             plugin_root,
             manifest,

--- a/.github/scripts/packaged_agent_proof/marketplace_installation.py
+++ b/.github/scripts/packaged_agent_proof/marketplace_installation.py
@@ -1,10 +1,33 @@
-"""Marketplace checkout and installed-plugin provenance."""
+"""Marketplace checkout and installed-plugin provenance.
+
+Two delivery states resolve a released plugin through a Codex marketplace, and this module
+accepts exactly two correspondingly distinct shapes:
+
+* ``codex_marketplace_install`` -- the live public catalog. The resolver clones
+  ``TheGreenCedar/AgentPluginMarketplace`` over Git into the isolated Codex home at a pinned
+  ``ref``, so the checkout is remote-backed and carries that URL as its ``origin``.
+* ``codex_marketplace_deferred_fixture`` -- a catalog built by
+  ``.github/scripts/build-marketplace-fixture.mjs`` and pinned to the exact published commit,
+  used when catalog publication was deferred. The resolver reads it as a *local* source: the
+  marketplace root IS the fixture directory, the config records ``source_type = "local"`` with
+  no ``ref``, and the repository has no ``origin`` remote at all.
+
+Those are observed facts, not guesses: running the real pinned Codex CLI against a real fixture
+produces ``sourceType: "local"`` and a marketplace root outside the Codex home, which is why the
+live shape cannot describe a deferred install and must not be relaxed to try.
+
+Nothing about the *plugin* differs between the states. The pinned ``git-subdir`` source, the
+plugin add/list identity, the installed bytes, and the binding to the packaged release source are
+verified identically, because the deferred state is a statement about which catalog served the
+install -- never a statement that less was proved.
+"""
 
 from __future__ import annotations
 
 import json
 import re
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 import tomllib
@@ -17,6 +40,49 @@ _MARKETPLACE_NAME = "TheGreenCedar"
 _MARKETPLACE_REPOSITORY = "TheGreenCedar/AgentPluginMarketplace"
 _MARKETPLACE_URL = f"https://github.com/{_MARKETPLACE_REPOSITORY}.git"
 _PLUGIN_ID = f"codestory@{_MARKETPLACE_NAME}"
+
+LIVE_INSTALLATION_SOURCE = "codex_marketplace_install"
+DEFERRED_INSTALLATION_SOURCE = "codex_marketplace_deferred_fixture"
+# Mirrors DEFERRED_MARKETPLACE_REPOSITORY in
+# .github/scripts/marketplace-delivery-identity.mjs. Deliberately not a filesystem path and
+# deliberately not shaped like "owner/repo": it can never be confused with the live catalog.
+_DEFERRED_MARKETPLACE_REPOSITORY = "local:candidate-pinned-marketplace-fixture"
+_FIXTURE_MARKER_FILENAME = ".codestory-marketplace-fixture.json"
+_FIXTURE_MARKER_PURPOSE = "codestory-candidate-pinned-marketplace-fixture"
+
+
+@dataclass(frozen=True)
+class _DeliveryState:
+    """The parts of the accepted shape that differ between the two catalog states."""
+
+    installation_source: str
+    repository: str
+    source_type: str
+    #: ``True`` when the resolver clones the catalog into the isolated Codex home.
+    checkout_inside_codex_home: bool
+
+
+_LIVE = _DeliveryState(
+    installation_source=LIVE_INSTALLATION_SOURCE,
+    repository=_MARKETPLACE_REPOSITORY,
+    source_type="git",
+    checkout_inside_codex_home=True,
+)
+_DEFERRED = _DeliveryState(
+    installation_source=DEFERRED_INSTALLATION_SOURCE,
+    repository=_DEFERRED_MARKETPLACE_REPOSITORY,
+    source_type="local",
+    checkout_inside_codex_home=False,
+)
+
+_DELIVERY_STATES = {state.installation_source: state for state in (_LIVE, _DEFERRED)}
+
+
+def delivery_state(installation_source: object) -> _DeliveryState | None:
+    """The accepted shape for an installer identity, or ``None`` if it names no marketplace."""
+    if not isinstance(installation_source, str):
+        return None
+    return _DELIVERY_STATES.get(installation_source)
 
 
 def _git_output(repository: Path, *arguments: str) -> str:
@@ -33,6 +99,29 @@ def _git_output(repository: Path, *arguments: str) -> str:
     return completed.stdout.strip()
 
 
+def _git_origin_url(repository: Path) -> str | None:
+    """The checkout's ``origin`` URL, or ``None`` when it deliberately has no remote.
+
+    A candidate-pinned fixture is built locally and never fetched from anywhere, so
+    ``git remote get-url origin`` exits non-zero by design. Treating that as a probe failure
+    made the deferred state unprovable; the deferred shape asserts the absence positively
+    instead, and the live shape still demands the exact marketplace URL.
+    """
+    completed = subprocess.run(
+        ["git", "-C", str(repository), "remote", "get-url", "origin"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    if completed.returncode != 0:
+        require(
+            "No such remote" in completed.stderr,
+            f"Git identity probe failed: {completed.stderr.strip()}",
+        )
+        return None
+    return completed.stdout.strip()
+
+
 def _marketplace_source(source_sha: str) -> dict[str, str]:
     return {
         "source": "git-subdir",
@@ -42,8 +131,16 @@ def _marketplace_source(source_sha: str) -> dict[str, str]:
     }
 
 
+def _marketplace_origin(state: _DeliveryState, marketplace_root: Path) -> dict[str, str]:
+    return {
+        "sourceType": state.source_type,
+        "source": _MARKETPLACE_URL if state is _LIVE else str(marketplace_root),
+    }
+
+
 def _validate_attestation_paths(
     attestation: dict,
+    state: _DeliveryState,
     installed_plugin_data: Path,
     plugin_root: Path,
     manifest: dict,
@@ -83,7 +180,7 @@ def _validate_attestation_paths(
     )
     require(
         attestation["schema_version"] == 2
-        and attestation["installation_source"] == "codex_marketplace_install"
+        and attestation["installation_source"] == state.installation_source
         and codex_home.is_dir()
         and same_existing_path(Path(installation["plugin_root"]), plugin_root)
         and same_existing_path(Path(installation["plugin_data"]), installed_plugin_data)
@@ -96,6 +193,7 @@ def _validate_attestation_paths(
 
 def _validate_marketplace_results(
     marketplace: dict,
+    state: _DeliveryState,
     codex_home: Path,
     plugin_root: Path,
     manifest: dict,
@@ -117,7 +215,7 @@ def _validate_marketplace_results(
     revision = marketplace["revision"]
     marketplace_add = marketplace["add_result"]
     require(
-        marketplace["repository"] == _MARKETPLACE_REPOSITORY
+        marketplace["repository"] == state.repository
         and marketplace["codex_cli_version"] == f"codex-cli {PINNED_CODEX_CLI_VERSION}"
         and isinstance(revision, str)
         and re.fullmatch(r"[0-9a-f]{40}", revision) is not None
@@ -132,19 +230,35 @@ def _validate_marketplace_results(
         "Codex marketplace add result omitted installedRoot",
     )
     marketplace_root = Path(marketplace_root_raw).resolve()
-    expected_root = codex_home / ".tmp" / "marketplaces" / _MARKETPLACE_NAME
-    require(
-        marketplace_root.is_dir()
-        and marketplace_root.is_relative_to(codex_home)
-        and same_existing_path(marketplace_root, expected_root),
-        "Codex marketplace root is outside its isolated home",
+    if state.checkout_inside_codex_home:
+        expected_root = codex_home / ".tmp" / "marketplaces" / _MARKETPLACE_NAME
+        require(
+            marketplace_root.is_dir()
+            and marketplace_root.is_relative_to(codex_home)
+            and same_existing_path(marketplace_root, expected_root),
+            "Codex marketplace root is outside its isolated home",
+        )
+    else:
+        # A local catalog is read where it was built, so it cannot be required to live inside
+        # the Codex home. What it must not be is the CodeStory checkout itself: a catalog that
+        # is the tree under test would make the resolve prove nothing.
+        require(
+            marketplace_root.is_dir()
+            and not marketplace_root.is_relative_to(codex_home)
+            and not marketplace_root.is_relative_to(REPOSITORY_ROOT)
+            and not REPOSITORY_ROOT.is_relative_to(marketplace_root),
+            "candidate-pinned marketplace fixture is the release checkout or the Codex home",
+        )
+    _validate_marketplace_list(marketplace, state, marketplace_root)
+    plugin_source_sha = _validate_plugin_results(
+        marketplace, state, marketplace_root, plugin_root, manifest
     )
-    _validate_marketplace_list(marketplace, marketplace_root)
-    plugin_source_sha = _validate_plugin_results(marketplace, plugin_root, manifest)
     return marketplace_root, plugin_source_sha
 
 
-def _validate_marketplace_list(marketplace: dict, marketplace_root: Path) -> None:
+def _validate_marketplace_list(
+    marketplace: dict, state: _DeliveryState, marketplace_root: Path
+) -> None:
     provenance = marketplace["provenance"]
     require_exact_keys(provenance, {"add", "list"}, "marketplace provenance")
     for operation in ("add", "list"):
@@ -165,19 +279,18 @@ def _validate_marketplace_list(marketplace: dict, marketplace_root: Path) -> Non
                 {
                     "name": _MARKETPLACE_NAME,
                     "root": str(marketplace_root),
-                    "marketplaceSource": {
-                        "sourceType": "git",
-                        "source": _MARKETPLACE_URL,
-                    },
+                    "marketplaceSource": _marketplace_origin(state, marketplace_root),
                 }
             ]
         },
-        "Codex marketplace list does not match the configured Git snapshot",
+        "Codex marketplace list does not match the configured snapshot",
     )
 
 
 def _validate_plugin_results(
     marketplace: dict,
+    state: _DeliveryState,
+    marketplace_root: Path,
     plugin_root: Path,
     manifest: dict,
 ) -> str:
@@ -215,10 +328,7 @@ def _validate_plugin_results(
                     "installed": True,
                     "enabled": True,
                     "source": _marketplace_source(source_sha),
-                    "marketplaceSource": {
-                        "sourceType": "git",
-                        "source": _MARKETPLACE_URL,
-                    },
+                    "marketplaceSource": _marketplace_origin(state, marketplace_root),
                     "installPolicy": "AVAILABLE",
                     "authPolicy": "ON_INSTALL",
                 }
@@ -230,29 +340,78 @@ def _validate_plugin_results(
     return source_sha
 
 
+def _validate_fixture_identity(
+    marketplace_root: Path, plugin_source_sha: str, manifest: dict
+) -> None:
+    """A deferred install must resolve a fixture that says what it is, in its own bytes.
+
+    Without this, any local git directory carrying a plausible catalog would satisfy the
+    deferred shape. The marker is written by build-marketplace-fixture.mjs and names the commit
+    the catalog pins, so the fixture, the catalog, and the released source all have to agree.
+    """
+    marker_path = marketplace_root / _FIXTURE_MARKER_FILENAME
+    require(
+        marker_path.is_file(),
+        "deferred catalog resolve did not use a candidate-pinned marketplace fixture",
+    )
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    require_exact_keys(
+        marker,
+        {"schema_version", "purpose", "pinned_commit", "plugin_version"},
+        "marketplace fixture marker",
+    )
+    require(
+        marker["schema_version"] == 1
+        and marker["purpose"] == _FIXTURE_MARKER_PURPOSE
+        and marker["pinned_commit"] == plugin_source_sha
+        and marker["pinned_commit"] == manifest["source"]["commit"]
+        and marker["plugin_version"] == manifest["release_version"],
+        "marketplace fixture does not pin the exact released commit it served",
+    )
+
+
 def _validate_marketplace_checkout(
     codex_home: Path,
+    state: _DeliveryState,
     marketplace_root: Path,
     marketplace: dict,
     plugin_source_sha: str,
+    manifest: dict,
 ) -> str:
     config = tomllib.loads((codex_home / "config.toml").read_text(encoding="utf-8"))
     marketplace_config = config.get("marketplaces", {}).get(_MARKETPLACE_NAME)
     plugin_config = config.get("plugins", {}).get(_PLUGIN_ID)
     require(
         isinstance(marketplace_config, dict)
-        and marketplace_config.get("source_type") == "git"
-        and marketplace_config.get("source") == _MARKETPLACE_URL
-        and marketplace_config.get("ref") == marketplace["revision"]
+        and marketplace_config.get("source_type") == state.source_type
+        and marketplace_config.get("source")
+        == _marketplace_origin(state, marketplace_root)["source"]
         and plugin_config == {"enabled": True},
-        "isolated Codex config does not pin the immutable marketplace revision",
+        "isolated Codex config does not record the resolved marketplace source",
     )
+    if state is _LIVE:
+        require(
+            marketplace_config.get("ref") == marketplace["revision"],
+            "isolated Codex config does not pin the immutable marketplace revision",
+        )
+    else:
+        # A local source has no ref to pin. Recording one would be the deferred state claiming
+        # a live catalog revision, so its absence is asserted rather than merely unchecked.
+        require(
+            "ref" not in marketplace_config,
+            "deferred catalog config claims a live marketplace revision",
+        )
+    # Checked before the Git probes, not after: the marker is committed into the fixture, so a
+    # missing or altered one also dirties the tree. Ordering it first means the failure names
+    # the actual defect instead of passing for an unrelated reason.
+    if state is _DEFERRED:
+        _validate_fixture_identity(marketplace_root, plugin_source_sha, manifest)
     marketplace_commit = _git_output(marketplace_root, "rev-parse", "HEAD")
+    origin = _git_origin_url(marketplace_root)
     require(
         marketplace_commit == marketplace["revision"]
         and _git_output(marketplace_root, "status", "--porcelain") == ""
-        and _git_output(marketplace_root, "remote", "get-url", "origin")
-        == _MARKETPLACE_URL,
+        and origin == (_MARKETPLACE_URL if state is _LIVE else None),
         "Codex marketplace checkout has invalid or mutable Git identity",
     )
     catalog = json.loads(
@@ -303,27 +462,32 @@ def _validate_release_source(plugin: dict, plugin_root: Path, manifest: dict) ->
 
 def marketplace_installed_plugin_identity(
     attestation: dict,
+    state: _DeliveryState,
     installed_plugin_data: Path,
     plugin_root: Path,
     manifest: dict,
 ) -> dict:
     codex_home, plugin, marketplace = _validate_attestation_paths(
         attestation,
+        state,
         installed_plugin_data,
         plugin_root,
         manifest,
     )
     marketplace_root, plugin_source_sha = _validate_marketplace_results(
         marketplace,
+        state,
         codex_home,
         plugin_root,
         manifest,
     )
     marketplace_commit = _validate_marketplace_checkout(
         codex_home,
+        state,
         marketplace_root,
         marketplace,
         plugin_source_sha,
+        manifest,
     )
     require(
         plugin["source_commit"] == plugin_source_sha,
@@ -332,9 +496,9 @@ def marketplace_installed_plugin_identity(
     package_sha256 = _validate_release_source(plugin, plugin_root, manifest)
     return {
         "schema_version": 2,
-        "installation_source": "codex_marketplace_install",
+        "installation_source": state.installation_source,
         "codex_cli_version": PINNED_CODEX_CLI_VERSION,
-        "marketplace_repository": _MARKETPLACE_REPOSITORY,
+        "marketplace_repository": state.repository,
         "marketplace_commit": marketplace_commit,
         "plugin_id": "codestory",
         "plugin_version": manifest["release_version"],

--- a/.github/scripts/packaged_agent_proof/qualification_retained_provenance.py
+++ b/.github/scripts/packaged_agent_proof/qualification_retained_provenance.py
@@ -16,6 +16,7 @@ from .foundation import (
     PINNED_CODEX_CLI_VERSION,
     require,
 )
+from .marketplace_installation import delivery_state
 from .native_manifest import runtime_executable_sha256
 from .qualification_retained_types import (
     RetainedPackageBinding,
@@ -29,8 +30,13 @@ def _verify_marketplace_provenance(
     plugin: dict,
     runtime: dict,
 ) -> None:
+    # The two catalog delivery states carry different repository identities, and the retained
+    # evidence must name the one that matches its own installer identity. Accepting either name
+    # for either identity would let a deferred release's retained evidence read as a live one.
+    state = delivery_state(plugin.get("installation_source"))
+    require(state is not None, "installed evidence names no marketplace delivery state")
     require(
-        plugin.get("marketplace_repository") == "TheGreenCedar/AgentPluginMarketplace"
+        plugin.get("marketplace_repository") == state.repository
         and plugin.get("codex_cli_version") == PINNED_CODEX_CLI_VERSION
         and runtime.get("build_source") == "github_release"
         and runtime.get("repo_ref") == f"v{contract.manifest['release_version']}",
@@ -87,15 +93,18 @@ def _verify_installed_provenance(contract: RetainedQualificationContract) -> Non
     installation_source = plugin.get("installation_source")
     require(
         plugin.get("schema_version") == 2
-        and installation_source in {"codex_marketplace_install", "candidate_archive"}
+        and (
+            installation_source == "candidate_archive"
+            or delivery_state(installation_source) is not None
+        )
         and plugin.get("plugin_id") == "codestory"
         and plugin.get("plugin_version") == manifest["release_version"],
         "installed evidence has invalid plugin provenance",
     )
-    if installation_source == "codex_marketplace_install":
-        _verify_marketplace_provenance(contract, plugin, runtime)
-    else:
+    if installation_source == "candidate_archive":
         _verify_candidate_provenance(contract, plugin, runtime)
+    else:
+        _verify_marketplace_provenance(contract, plugin, runtime)
     require_sha256(
         plugin.get("plugin_package_sha256"),
         "installed evidence plugin_package_sha256",

--- a/.github/scripts/packaged_agent_proof/self_test.py
+++ b/.github/scripts/packaged_agent_proof/self_test.py
@@ -5,6 +5,7 @@ from .self_test_contracts import run_contract_self_tests
 from .self_test_full_stack import run_full_stack_self_tests
 from .self_test_installation import run_installation_self_tests
 from .self_test_managed_layout import run_managed_layout_self_tests
+from .self_test_marketplace_delivery import run_marketplace_delivery_self_tests
 from .self_test_process import run_process_self_tests
 from .self_test_producer_liveness import run_producer_liveness_self_tests
 from .self_test_qualification import run_qualification_self_tests
@@ -19,6 +20,7 @@ def self_test() -> None:
     run_idle_boundary_self_tests()
     run_qualification_self_tests()
     run_installation_self_tests()
+    run_marketplace_delivery_self_tests()
     run_managed_layout_self_tests()
     run_full_stack_self_tests()
     print("packaged per-user embedding server proof self-test passed")

--- a/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
+++ b/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
@@ -1,0 +1,530 @@
+"""Catalog delivery state self-tests for the installed-runtime identity predicate.
+
+Catalog publication is delivery, not a release gate, so a release can be proved against the
+live public catalog OR against a catalog pinned to the exact published commit. These are two
+distinct states and the predicate accepts two distinct shapes. What must never happen is either
+one passing as the other, or an arbitrary local directory passing as the pinned fixture -- so
+every assertion here that matters is a rejection.
+
+The first version of the deferred path shipped with none of this. It attested a fixture resolve
+as ``codex_marketplace_install``, wrote a temporary directory into
+``marketplace.repository``, and the live predicate refused it three steps after the release tag
+was already pushed. Each case below is one of the ways that failed, asserted in the
+fail-closed direction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+
+from .foundation import REPOSITORY_ROOT, ProofFailure, require
+from .installed_identity import installed_plugin_identity
+from .marketplace_installation import (
+    DEFERRED_INSTALLATION_SOURCE,
+    LIVE_INSTALLATION_SOURCE,
+)
+
+_MARKETPLACE_NAME = "TheGreenCedar"
+_LIVE_REPOSITORY = "TheGreenCedar/AgentPluginMarketplace"
+_LIVE_URL = f"https://github.com/{_LIVE_REPOSITORY}.git"
+_DEFERRED_REPOSITORY = "local:candidate-pinned-marketplace-fixture"
+_MARKER_FILENAME = ".codestory-marketplace-fixture.json"
+_MARKER_PURPOSE = "codestory-candidate-pinned-marketplace-fixture"
+_PLUGIN_ID = f"codestory@{_MARKETPLACE_NAME}"
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    require(
+        completed.returncode == 0,
+        f"marketplace delivery self-test git command failed: {completed.stderr.strip()}",
+    )
+    return completed.stdout.strip()
+
+
+def _pinned_source(commit: str) -> dict[str, str]:
+    return {
+        "source": "git-subdir",
+        "url": "https://github.com/TheGreenCedar/CodeStory.git",
+        "path": "plugins/codestory",
+        "sha": commit,
+    }
+
+
+def _manifest() -> dict:
+    version = json.loads(
+        (
+            REPOSITORY_ROOT / "plugins" / "codestory" / ".codex-plugin" / "plugin.json"
+        ).read_text(encoding="utf-8")
+    )["version"]
+    return {
+        "release_version": version,
+        "asset_target": "linux-x64",
+        "source": {
+            "commit": _git(REPOSITORY_ROOT, "rev-parse", "HEAD"),
+            "tree": _git(REPOSITORY_ROOT, "rev-parse", "HEAD^{tree}"),
+        },
+    }
+
+
+def _write_catalog(root: Path, commit: str) -> None:
+    catalog_directory = root / ".agents" / "plugins"
+    catalog_directory.mkdir(parents=True, exist_ok=True)
+    catalog = {
+        "name": _MARKETPLACE_NAME,
+        "interface": {"displayName": _MARKETPLACE_NAME},
+        "plugins": [
+            {
+                "name": "codestory",
+                "source": _pinned_source(commit),
+                "policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
+                "category": "Developer Tools",
+            }
+        ],
+    }
+    (catalog_directory / "marketplace.json").write_text(
+        f"{json.dumps(catalog, indent=2)}\n", encoding="utf-8"
+    )
+
+
+def _commit_all(root: Path, message: str) -> str:
+    _git(root, "add", "--all")
+    _git(
+        root,
+        "-c",
+        "user.email=self-test@codestory.invalid",
+        "-c",
+        "user.name=self test",
+        "commit",
+        "--quiet",
+        "--message",
+        message,
+    )
+    return _git(root, "rev-parse", "HEAD")
+
+
+def _build_world(root: Path, deferred: bool, manifest: dict) -> dict:
+    """A complete, valid installed-runtime world on disk for one delivery state."""
+    commit = manifest["source"]["commit"]
+    codex_home = (root / "codex-home").resolve()
+    plugin_data = codex_home / "plugin-data"
+    plugin_data.mkdir(parents=True)
+    plugin_root = (
+        codex_home
+        / "plugins"
+        / "cache"
+        / _MARKETPLACE_NAME
+        / "codestory"
+        / manifest["release_version"]
+    )
+    plugin_root.parent.mkdir(parents=True)
+    shutil.copytree(REPOSITORY_ROOT / "plugins" / "codestory", plugin_root)
+
+    if deferred:
+        marketplace_root = (root / "fixture").resolve()
+        marketplace_root.mkdir(parents=True)
+    else:
+        marketplace_root = (codex_home / ".tmp" / "marketplaces" / _MARKETPLACE_NAME).resolve()
+        marketplace_root.mkdir(parents=True)
+    _write_catalog(marketplace_root, commit)
+    if deferred:
+        (marketplace_root / _MARKER_FILENAME).write_text(
+            f"{json.dumps({
+                'schema_version': 1,
+                'purpose': _MARKER_PURPOSE,
+                'pinned_commit': commit,
+                'plugin_version': manifest['release_version'],
+            }, indent=2)}\n",
+            encoding="utf-8",
+        )
+    _git(marketplace_root, "init", "--quiet", "--initial-branch", "main")
+    if not deferred:
+        _git(marketplace_root, "remote", "add", "origin", _LIVE_URL)
+    revision = _commit_all(marketplace_root, "catalog")
+
+    origin = (
+        {"sourceType": "local", "source": str(marketplace_root)}
+        if deferred
+        else {"sourceType": "git", "source": _LIVE_URL}
+    )
+    config = [f"[marketplaces.{_MARKETPLACE_NAME}]"]
+    config.append(f'source_type = "{origin["sourceType"]}"')
+    config.append(f'source = "{origin["source"]}"')
+    if not deferred:
+        config.append(f'ref = "{revision}"')
+    config.append("")
+    config.append(f'[plugins."{_PLUGIN_ID}"]')
+    config.append("enabled = true")
+    (codex_home / "config.toml").write_text("\n".join(config) + "\n", encoding="utf-8")
+
+    installed_entry = {
+        "pluginId": _PLUGIN_ID,
+        "name": "codestory",
+        "marketplaceName": _MARKETPLACE_NAME,
+        "version": manifest["release_version"],
+        "installed": True,
+        "enabled": True,
+        "source": _pinned_source(commit),
+        "marketplaceSource": origin,
+        "installPolicy": "AVAILABLE",
+        "authPolicy": "ON_INSTALL",
+    }
+    attestation = {
+        "schema_version": 2,
+        "installation_source": (
+            DEFERRED_INSTALLATION_SOURCE if deferred else LIVE_INSTALLATION_SOURCE
+        ),
+        "installation": {
+            "codex_home": str(codex_home),
+            "plugin_root": str(plugin_root),
+            "plugin_data": str(plugin_data),
+        },
+        "plugin": {
+            "id": "codestory",
+            "version": manifest["release_version"],
+            "source_commit": commit,
+            "source_tree": manifest["source"]["tree"],
+            "package_sha256": "",
+        },
+        "marketplace": {
+            "repository": _DEFERRED_REPOSITORY if deferred else _LIVE_REPOSITORY,
+            "revision": revision,
+            "provenance": {
+                "add": {"root": str(marketplace_root), "revision": revision},
+                "list": {"root": str(marketplace_root), "revision": revision},
+            },
+            "codex_cli_version": f"codex-cli {_pinned_codex_cli_version()}",
+            "add_result": {
+                "marketplaceName": _MARKETPLACE_NAME,
+                "installedRoot": str(marketplace_root),
+                "alreadyAdded": False,
+            },
+            "list_result": {
+                "marketplaces": [
+                    {
+                        "name": _MARKETPLACE_NAME,
+                        "root": str(marketplace_root),
+                        "marketplaceSource": origin,
+                    }
+                ]
+            },
+            "plugin_add_result": {
+                "pluginId": _PLUGIN_ID,
+                "name": "codestory",
+                "marketplaceName": _MARKETPLACE_NAME,
+                "version": manifest["release_version"],
+                "installedPath": str(plugin_root),
+                "authPolicy": "ON_INSTALL",
+            },
+            "plugin_list_result": {"installed": [installed_entry], "available": []},
+        },
+    }
+    from .installation_support import directory_contract_sha256
+
+    attestation["plugin"]["package_sha256"] = directory_contract_sha256(plugin_root)
+    return {
+        "attestation": attestation,
+        "plugin_root": plugin_root,
+        "plugin_data": plugin_data,
+        "marketplace_root": marketplace_root,
+        "codex_home": codex_home,
+    }
+
+
+def _pinned_codex_cli_version() -> str:
+    from .foundation import PINNED_CODEX_CLI_VERSION
+
+    return PINNED_CODEX_CLI_VERSION
+
+
+def _verify(world: dict, attestation: dict, root: Path, manifest: dict) -> dict:
+    path = root / "attestation.json"
+    path.write_text(f"{json.dumps(attestation, indent=2)}\n", encoding="utf-8")
+    args = argparse.Namespace(
+        proof_tier="installed_runtime",
+        installed_plugin_attestation=path,
+        installed_plugin_data=world["plugin_data"],
+        archive=None,
+        candidate_producer_repository=None,
+        candidate_producer_workflow_path=None,
+        candidate_producer_run_id=None,
+        candidate_producer_run_attempt=None,
+        candidate_artifact_name=None,
+    )
+    return installed_plugin_identity(args, world["plugin_root"], manifest)
+
+
+def _reject(
+    world: dict,
+    root: Path,
+    manifest: dict,
+    description: str,
+    mutate: Callable[[dict], None],
+) -> None:
+    attestation = copy.deepcopy(world["attestation"])
+    mutate(attestation)
+    try:
+        _verify(world, attestation, root, manifest)
+    except ProofFailure:
+        return
+    raise ProofFailure(
+        f"installed-runtime identity accepted {description}"
+    )
+
+
+def _run_deferred_self_tests(root: Path, manifest: dict) -> None:
+    world = _build_world(root / "deferred", deferred=True, manifest=manifest)
+    identity = _verify(world, world["attestation"], root, manifest)
+    require(
+        identity["installation_source"] == DEFERRED_INSTALLATION_SOURCE
+        and identity["marketplace_repository"] == _DEFERRED_REPOSITORY,
+        "a deferred catalog resolve did not record its own installer identity",
+    )
+    require(
+        identity["plugin_source_commit"] == manifest["source"]["commit"]
+        and identity["plugin_source_tree"] == manifest["source"]["tree"],
+        "a deferred catalog resolve did not bind the released plugin source",
+    )
+
+    def relabel_as_live(attestation: dict) -> None:
+        attestation["installation_source"] = LIVE_INSTALLATION_SOURCE
+        attestation["marketplace"]["repository"] = _LIVE_REPOSITORY
+
+    _reject(
+        world,
+        root,
+        manifest,
+        "a fixture resolve relabelled as a live public-catalog install",
+        relabel_as_live,
+    )
+    _reject(
+        world,
+        root,
+        manifest,
+        "a deferred resolve claiming the live catalog repository",
+        lambda attestation: attestation["marketplace"].update(
+            repository=_LIVE_REPOSITORY
+        ),
+    )
+    _reject(
+        world,
+        root,
+        manifest,
+        "a deferred resolve claiming a git-backed marketplace source",
+        lambda attestation: attestation["marketplace"]["list_result"]["marketplaces"][
+            0
+        ].update(marketplaceSource={"sourceType": "git", "source": _LIVE_URL}),
+    )
+    _reject(
+        world,
+        root,
+        manifest,
+        "an installer identity no delivery state defines",
+        lambda attestation: attestation.update(
+            installation_source="codex_marketplace_install_v3"
+        ),
+    )
+    _reject(
+        world,
+        root,
+        manifest,
+        "a deferred resolve whose catalog is the release checkout itself",
+        lambda attestation: attestation["marketplace"]["add_result"].update(
+            installedRoot=str(REPOSITORY_ROOT)
+        ),
+    )
+
+    marker = world["marketplace_root"] / _MARKER_FILENAME
+    saved = marker.read_bytes()
+    marker.unlink()
+    _commit_all(world["marketplace_root"], "drop the fixture marker")
+    absent = copy.deepcopy(world["attestation"])
+    revision = _git(world["marketplace_root"], "rev-parse", "HEAD")
+    _restamp(absent, revision)
+    try:
+        _verify(world, absent, root, manifest)
+        raise ProofFailure(
+            "installed-runtime identity accepted a local catalog carrying no fixture marker"
+        )
+    except ProofFailure as exc:
+        require(
+            "candidate-pinned marketplace fixture" in str(exc),
+            f"a marker-less local catalog was refused for the wrong reason: {exc}",
+        )
+    marker.write_bytes(saved)
+    json_marker = json.loads(saved)
+    json_marker["pinned_commit"] = "0" * 40
+    marker.write_text(f"{json.dumps(json_marker, indent=2)}\n", encoding="utf-8")
+    _commit_all(world["marketplace_root"], "pin a different commit")
+    mismatched = copy.deepcopy(world["attestation"])
+    _restamp(mismatched, _git(world["marketplace_root"], "rev-parse", "HEAD"))
+    try:
+        _verify(world, mismatched, root, manifest)
+        raise ProofFailure(
+            "installed-runtime identity accepted a fixture pinning another commit"
+        )
+    except ProofFailure as exc:
+        require(
+            "does not pin the exact released commit" in str(exc),
+            f"a mispinned fixture was refused for the wrong reason: {exc}",
+        )
+
+    config = world["codex_home"] / "config.toml"
+    saved_config = config.read_text(encoding="utf-8")
+    config.write_text(
+        saved_config.replace(
+            "source_type =", f'ref = "{world["attestation"]["marketplace"]["revision"]}"\nsource_type ='
+        ),
+        encoding="utf-8",
+    )
+    marker.write_bytes(saved)
+    _commit_all(world["marketplace_root"], "restore the fixture marker")
+    claimed = copy.deepcopy(world["attestation"])
+    _restamp(claimed, _git(world["marketplace_root"], "rev-parse", "HEAD"))
+    try:
+        _verify(world, claimed, root, manifest)
+        raise ProofFailure(
+            "installed-runtime identity accepted a deferred config claiming a live ref"
+        )
+    except ProofFailure as exc:
+        require(
+            "claims a live marketplace revision" in str(exc),
+            f"a deferred config claiming a live ref was refused for the wrong reason: {exc}",
+        )
+    config.write_text(saved_config, encoding="utf-8")
+
+    _git(world["marketplace_root"], "remote", "add", "origin", _LIVE_URL)
+    dressed = copy.deepcopy(world["attestation"])
+    _restamp(dressed, _git(world["marketplace_root"], "rev-parse", "HEAD"))
+    try:
+        _verify(world, dressed, root, manifest)
+        raise ProofFailure(
+            "installed-runtime identity accepted a fixture wearing the live marketplace origin"
+        )
+    except ProofFailure:
+        pass
+
+
+def _restamp(attestation: dict, revision: str) -> None:
+    marketplace = attestation["marketplace"]
+    marketplace["revision"] = revision
+    for operation in ("add", "list"):
+        marketplace["provenance"][operation]["revision"] = revision
+
+
+def _run_live_self_tests(root: Path, manifest: dict) -> None:
+    world = _build_world(root / "live", deferred=False, manifest=manifest)
+    identity = _verify(world, world["attestation"], root, manifest)
+    require(
+        identity["installation_source"] == LIVE_INSTALLATION_SOURCE
+        and identity["marketplace_repository"] == _LIVE_REPOSITORY,
+        "a live catalog resolve did not record the public marketplace identity",
+    )
+    _reject(
+        world,
+        root,
+        manifest,
+        "a live install naming the deferred fixture repository",
+        lambda attestation: attestation["marketplace"].update(
+            repository=_DEFERRED_REPOSITORY
+        ),
+    )
+    _reject(
+        world,
+        root,
+        manifest,
+        "a live install relabelled as a deferred fixture resolve",
+        lambda attestation: attestation.update(
+            installation_source=DEFERRED_INSTALLATION_SOURCE
+        ),
+    )
+    # The live shape is not relaxed to admit a local source: this is the check the deferred
+    # state was originally, wrongly, expected to satisfy.
+    _reject(
+        world,
+        root,
+        manifest,
+        "a live install whose marketplace list reports a local source",
+        lambda attestation: attestation["marketplace"]["list_result"]["marketplaces"][
+            0
+        ].update(
+            marketplaceSource={
+                "sourceType": "local",
+                "source": attestation["marketplace"]["add_result"]["installedRoot"],
+            }
+        ),
+    )
+
+
+def _run_retained_provenance_self_tests() -> None:
+    """The retained evidence verifier must bind each installer identity to its own repository.
+
+    The identity predicate is only the first reader. Retained qualification evidence names the
+    marketplace repository too, and it hard-coded the live one -- so a deferred release would
+    have been refused here even after the install itself was accepted.
+    """
+    from . import qualification_retained_provenance as retained
+    from .foundation import PINNED_CODEX_CLI_VERSION
+
+    manifest = {
+        "release_version": "0.16.2",
+        "source": {"tree": "a" * 40, "commit": "b" * 40},
+    }
+    contract = SimpleNamespace(manifest=manifest)
+    runtime = {"build_source": "github_release", "repo_ref": "v0.16.2"}
+
+    def plugin(installation_source: str, repository: str) -> dict:
+        return {
+            "installation_source": installation_source,
+            "marketplace_repository": repository,
+            "codex_cli_version": PINNED_CODEX_CLI_VERSION,
+            "marketplace_commit": "c" * 40,
+            "plugin_source_commit": "b" * 40,
+            "plugin_source_tree": "a" * 40,
+        }
+
+    for source, repository in (
+        (LIVE_INSTALLATION_SOURCE, _LIVE_REPOSITORY),
+        (DEFERRED_INSTALLATION_SOURCE, _DEFERRED_REPOSITORY),
+    ):
+        retained._verify_marketplace_provenance(contract, plugin(source, repository), runtime)
+
+    # Each identity may name only its own repository, and an identity no state declares is not a
+    # delivery state at all.
+    for description, source, repository in (
+        ("a deferred fixture claiming the live catalog repository",
+         DEFERRED_INSTALLATION_SOURCE, _LIVE_REPOSITORY),
+        ("a live install claiming the fixture repository",
+         LIVE_INSTALLATION_SOURCE, _DEFERRED_REPOSITORY),
+        ("an installer identity no delivery state declares",
+         "codex_marketplace_install_v3", _LIVE_REPOSITORY),
+    ):
+        try:
+            retained._verify_marketplace_provenance(
+                contract, plugin(source, repository), runtime
+            )
+        except ProofFailure:
+            continue
+        raise ProofFailure(f"retained installed evidence accepted {description}")
+
+
+def run_marketplace_delivery_self_tests() -> None:
+    manifest = _manifest()
+    with tempfile.TemporaryDirectory(prefix="codestory-marketplace-delivery-") as raw:
+        root = Path(raw).resolve()
+        _run_deferred_self_tests(root, manifest)
+        _run_live_self_tests(root, manifest)
+    _run_retained_provenance_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
+++ b/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
@@ -521,6 +521,32 @@ def _run_retained_provenance_self_tests() -> None:
         raise ProofFailure(f"retained installed evidence accepted {description}")
 
 
+def _run_shared_identity_self_tests() -> None:
+    """The producer and the verifier must name the two states identically.
+
+    `.github/scripts/marketplace-delivery-identity.mjs` writes the installer identity and the
+    attestation repository; this module's predicate decides which shape to accept from them. If
+    the two ever drift, a real release resolves through a Codex install the predicate refuses --
+    which is precisely the failure this whole path was repaired for, and it would surface only
+    after the tag was already pushed.
+    """
+    source = (
+        REPOSITORY_ROOT / ".github" / "scripts" / "marketplace-delivery-identity.mjs"
+    ).read_text(encoding="utf-8")
+    for name, value in (
+        ("LIVE_INSTALLATION_SOURCE", LIVE_INSTALLATION_SOURCE),
+        ("DEFERRED_INSTALLATION_SOURCE", DEFERRED_INSTALLATION_SOURCE),
+        ("LIVE_MARKETPLACE_REPOSITORY", _LIVE_REPOSITORY),
+        ("DEFERRED_MARKETPLACE_REPOSITORY", _DEFERRED_REPOSITORY),
+        ("FIXTURE_MARKER_FILENAME", _MARKER_FILENAME),
+        ("FIXTURE_MARKER_PURPOSE", _MARKER_PURPOSE),
+    ):
+        require(
+            f'export const {name} = "{value}";' in source,
+            f"marketplace delivery identity {name} differs between the producer and the verifier",
+        )
+
+
 def run_marketplace_delivery_self_tests() -> None:
     manifest = _manifest()
     with tempfile.TemporaryDirectory(prefix="codestory-marketplace-delivery-") as raw:
@@ -528,3 +554,4 @@ def run_marketplace_delivery_self_tests() -> None:
         _run_deferred_self_tests(root, manifest)
         _run_live_self_tests(root, manifest)
     _run_retained_provenance_self_tests()
+    _run_shared_identity_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
+++ b/.github/scripts/packaged_agent_proof/self_test_marketplace_delivery.py
@@ -409,13 +409,21 @@ def _run_deferred_self_tests(root: Path, manifest: dict) -> None:
     _git(world["marketplace_root"], "remote", "add", "origin", _LIVE_URL)
     dressed = copy.deepcopy(world["attestation"])
     _restamp(dressed, _git(world["marketplace_root"], "rev-parse", "HEAD"))
+    # The refusal is recorded, not raised inside the `try`: a sentinel raised there is caught by
+    # this very handler, so the case would pass whether or not the predicate refused anything.
+    refusal: ProofFailure | None = None
     try:
         _verify(world, dressed, root, manifest)
-        raise ProofFailure(
-            "installed-runtime identity accepted a fixture wearing the live marketplace origin"
-        )
-    except ProofFailure:
-        pass
+    except ProofFailure as exc:
+        refusal = exc
+    require(
+        refusal is not None,
+        "installed-runtime identity accepted a fixture wearing the live marketplace origin",
+    )
+    require(
+        "invalid or mutable Git identity" in str(refusal),
+        f"a fixture wearing the live marketplace origin was refused for the wrong reason: {refusal}",
+    )
 
 
 def _restamp(attestation: dict, revision: str) -> None:

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -255,7 +255,15 @@ jobs:
             echo "Catalog delivery: published at $marketplace_revision." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          echo "::warning::Catalog publication deferred (token=$TOKEN_OUTCOME publish=$PUBLISH_OUTCOME). The release stands and the catalog still serves the previous release; recover with $RECOVERY_WORKFLOW."
+          # $RECOVERY_WORKFLOW mints the SAME credential from the SAME environment, so it recovers a
+          # rejected push, not a missing credential. Saying so here keeps the recorded recovery
+          # instruction one that can actually be followed.
+          if [ "$TOKEN_OUTCOME" != "success" ]; then
+            recovery="provision the marketplace-publish credential, then run $RECOVERY_WORKFLOW (it mints the same token, so it defers as well when that credential is absent)"
+          else
+            recovery="re-run $RECOVERY_WORKFLOW with this version and commit"
+          fi
+          echo "::warning::Catalog publication deferred (token=$TOKEN_OUTCOME publish=$PUBLISH_OUTCOME). The release stands and the catalog still serves the previous release; recover with $RECOVERY_WORKFLOW: $recovery."
           echo "Catalog delivery: DEFERRED. The release is published; the catalog still serves the previous release. Recover with $RECOVERY_WORKFLOW." >> "$GITHUB_STEP_SUMMARY"
 
   post-publish-smoke:
@@ -266,7 +274,41 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # The published release tag, not the run's own head. A bare checkout gave this job the
+      # workspace it was triggered from, and the deferred branch then built a catalog out of
+      # that workspace and verified the install back against the same tree -- a comparison that
+      # could not fail for any release-related reason. Resolving the tag makes the commit under
+      # proof the one the release actually published.
       - uses: actions/checkout@v5
+        with:
+          ref: v${{ inputs.version }}
+          fetch-depth: 0
+
+      # The tag alone is a local name; this is where it becomes the PUBLISHED identity. The
+      # published release must exist, must not be a draft, and must resolve to the commit this
+      # job checked out. Every later step pins that commit, so the fixture catalog, the Codex
+      # resolve, and the byte comparison all name a release GitHub is actually serving.
+      - name: Bind this smoke to the published release
+        id: published
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: v${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          draft="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)"
+          if [ "$draft" != "false" ]; then
+            echo "::error::Published plugin release $TAG is a draft."
+            exit 1
+          fi
+          published_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
+          printf '%s' "$published_commit" | grep -Eq '^[0-9a-f]{40}$'
+          if [ "$published_commit" != "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" ]; then
+            echo "::error::Checked-out tree is not the commit published at $TAG."
+            exit 1
+          fi
+          echo "commit=$published_commit" >> "$GITHUB_OUTPUT"
+          echo "Smoking the plugin published at $TAG ($published_commit)." >> "$GITHUB_STEP_SUMMARY"
 
       # Same two states as the native lane, decided once from the recorded publication outcome.
       # Published resolves the live catalog; deferred resolves a catalog pinned to this exact
@@ -278,8 +320,12 @@ jobs:
         env:
           CATALOG_PUBLISHED: ${{ needs.marketplace-publish.outputs.catalog_published == 'true' }}
           INPUT_MARKETPLACE_REVISION: ${{ needs.marketplace-publish.outputs.marketplace_revision }}
+          PUBLISHED_COMMIT: ${{ steps.published.outputs.commit }}
         run: |
           set -euo pipefail
+          # The commit GitHub reports for the published tag, bound in the previous step.
+          published_commit="$PUBLISHED_COMMIT"
+          printf '%s' "$published_commit" | grep -Eq '^[0-9a-f]{40}$'
           fixture_root="$RUNNER_TEMP/codestory-marketplace-delivery/fixture"
           rm -rf "$fixture_root"
           if [ "$CATALOG_PUBLISHED" = "true" ]; then
@@ -293,10 +339,14 @@ jobs:
               echo "::error::Deferred catalog publication must not carry a live catalog revision."
               exit 1
             fi
+            # Pinned to the PUBLISHED commit resolved from GitHub, not to whatever this
+            # workspace happens to be. The Codex resolver then fetches that commit from
+            # github.com, so the installed bytes come from the published release rather than
+            # from the tree performing the check.
             node .github/scripts/build-marketplace-fixture.mjs \
               --out "$fixture_root" \
               --source-repository "$GITHUB_WORKSPACE" \
-              --commit "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+              --commit "$published_commit"
             marketplace_source="$fixture_root"
             marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"
             local_fixture=true
@@ -306,7 +356,7 @@ jobs:
             echo "::error::catalog_published must be true or false, not '$CATALOG_PUBLISHED'."
             exit 1
           fi
-          test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
+          printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'
           {
             echo "marketplace_source=$marketplace_source"
             echo "marketplace_revision=$marketplace_revision"

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -188,20 +188,24 @@ jobs:
             --title "CodeStory plugin ${{ inputs.version }}" \
             --notes-file /tmp/plugin-release-notes.md
 
-  # The catalog is what a host installs from, so the plugin lane publishes it too. Without this the
-  # smoke below would resolve the previous release and fail after the tag is already irreversible.
+  # The catalog is what a host installs from, so the plugin lane publishes it too. It is DELIVERY,
+  # not a gate: the tag already exists when this job runs, so a failure here must leave the release
+  # standing with the catalog still serving the previous one -- never fail an irreversible release.
+  # The run says which of the two states it ended in, and the smoke below records that state.
   marketplace-publish:
     needs: [preflight, publish]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: marketplace-publish
     outputs:
-      marketplace_revision: ${{ steps.publish.outputs.marketplace_revision }}
+      catalog_published: ${{ steps.delivery.outputs.catalog_published }}
+      marketplace_revision: ${{ steps.delivery.outputs.marketplace_revision }}
     steps:
       - uses: actions/checkout@v5
 
       - name: Mint a scoped marketplace token
         id: token
+        continue-on-error: true
         uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1.11.3
         with:
           app-id: ${{ secrets.MARKETPLACE_APP_ID }}
@@ -211,8 +215,11 @@ jobs:
 
       # Publication already happened, so a failure here leaves the catalog serving the previous
       # release rather than a release that does not exist. marketplace-sync.yml recovers it.
+      # One attempt only: a retry loop here would hide which failure the run actually hit.
       - name: Point the catalog at the published release
         id: publish
+        if: steps.token.outcome == 'success'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
@@ -223,17 +230,99 @@ jobs:
             --version "${{ inputs.version }}" \
             --github-output "$GITHUB_OUTPUT"
 
+      # The only place this lane's "catalog was updated" claim is ever minted.
+      - name: Record catalog delivery outcome
+        id: delivery
+        if: always()
+        env:
+          TOKEN_OUTCOME: ${{ steps.token.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          PUBLISHED_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+          RECOVERY_WORKFLOW: marketplace-sync.yml
+        run: |
+          set -euo pipefail
+          catalog_published=false
+          marketplace_revision=""
+          if [ "$TOKEN_OUTCOME" = "success" ] \
+            && [ "$PUBLISH_OUTCOME" = "success" ] \
+            && printf '%s' "$PUBLISHED_REVISION" | grep -Eq '^[0-9a-f]{40}$'; then
+            catalog_published=true
+            marketplace_revision="$PUBLISHED_REVISION"
+          fi
+          echo "catalog_published=$catalog_published" >> "$GITHUB_OUTPUT"
+          echo "marketplace_revision=$marketplace_revision" >> "$GITHUB_OUTPUT"
+          if [ "$catalog_published" = "true" ]; then
+            echo "Catalog delivery: published at $marketplace_revision." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "::warning::Catalog publication deferred (token=$TOKEN_OUTCOME publish=$PUBLISH_OUTCOME). The release stands and the catalog still serves the previous release; recover with $RECOVERY_WORKFLOW."
+          echo "Catalog delivery: DEFERRED. The release is published; the catalog still serves the previous release. Recover with $RECOVERY_WORKFLOW." >> "$GITHUB_STEP_SUMMARY"
+
   post-publish-smoke:
+    # Deliberately not gated on marketplace-publish: a deferred catalog must not suppress proof of
+    # the plugin that was actually published. The delivery state is carried in, not depended on.
+    if: always() && needs.preflight.result == 'success' && needs.publish.result == 'success'
     needs: [preflight, publish, marketplace-publish]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
+      # Same two states as the native lane, decided once from the recorded publication outcome.
+      # Published resolves the live catalog; deferred resolves a catalog pinned to this exact
+      # published commit, because the live one still names the previous release. Neither may be
+      # reached by accident: an inconsistent or unrecognized handoff stops the job.
+      - name: Record catalog delivery state
+        id: delivery
+        shell: bash
+        env:
+          CATALOG_PUBLISHED: ${{ needs.marketplace-publish.outputs.catalog_published == 'true' }}
+          INPUT_MARKETPLACE_REVISION: ${{ needs.marketplace-publish.outputs.marketplace_revision }}
+        run: |
+          set -euo pipefail
+          fixture_root="$RUNNER_TEMP/codestory-marketplace-delivery/fixture"
+          rm -rf "$fixture_root"
+          if [ "$CATALOG_PUBLISHED" = "true" ]; then
+            marketplace_source=TheGreenCedar/AgentPluginMarketplace
+            marketplace_revision="$INPUT_MARKETPLACE_REVISION"
+            local_fixture=false
+            installer=codex_marketplace_install
+            state=published
+          elif [ "$CATALOG_PUBLISHED" = "false" ]; then
+            if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then
+              echo "::error::Deferred catalog publication must not carry a live catalog revision."
+              exit 1
+            fi
+            node .github/scripts/build-marketplace-fixture.mjs \
+              --out "$fixture_root" \
+              --source-repository "$GITHUB_WORKSPACE" \
+              --commit "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+            marketplace_source="$fixture_root"
+            marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"
+            local_fixture=true
+            installer=codex_marketplace_deferred_fixture
+            state=deferred
+          else
+            echo "::error::catalog_published must be true or false, not '$CATALOG_PUBLISHED'."
+            exit 1
+          fi
+          test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
+          {
+            echo "marketplace_source=$marketplace_source"
+            echo "marketplace_revision=$marketplace_revision"
+            echo "local_fixture=$local_fixture"
+            echo "installer=$installer"
+            echo "state=$state"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$state" = "deferred" ]; then
+            echo "::warning::Catalog publication was deferred for this release. This smoke proves the published plugin against a candidate-pinned catalog fixture and records installer $installer; recover the public catalog with marketplace-sync.yml."
+          fi
+          echo "Catalog delivery state: $state (installer $installer, catalog revision $marketplace_revision)." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Prove the public marketplace install path
         env:
           CODEX_CLI_VERSION: "0.144.5"
-          MARKETPLACE_REVISION: ${{ needs.marketplace-publish.outputs.marketplace_revision }}
+          MARKETPLACE_REVISION: ${{ steps.delivery.outputs.marketplace_revision }}
         run: |
           set -euo pipefail
           install_root="$RUNNER_TEMP/codestory-marketplace-postpublish"
@@ -248,9 +337,10 @@ jobs:
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \
-            --marketplace-source TheGreenCedar/AgentPluginMarketplace \
+            --marketplace-source "${{ steps.delivery.outputs.marketplace_source }}" \
             --marketplace-name TheGreenCedar \
             --marketplace-revision "$MARKETPLACE_REVISION" \
+            --local-fixture "${{ steps.delivery.outputs.local_fixture }}" \
             --expected-version "${{ inputs.version }}" \
             --source-repository "$GITHUB_WORKSPACE" \
             --attestation "$install_root/install-attestation-v2.json"

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -7,9 +7,14 @@ on:
         description: Release version to smoke, with or without a leading v.
         required: true
         type: string
-      marketplace_revision:
-        description: Immutable marketplace catalog revision proved before release.
+      catalog_published:
+        description: Whether marketplace-publish actually updated the public catalog for this release.
         required: true
+        type: boolean
+      marketplace_revision:
+        description: Immutable published catalog revision. Empty exactly when publication was deferred.
+        required: false
+        default: ""
         type: string
       pre_publish_closeout_artifact:
         description: Accepted pre-publish closeout artifact from this release run.
@@ -27,9 +32,14 @@ on:
         description: Release version to smoke, with or without a leading v.
         required: true
         type: string
-      marketplace_revision:
-        description: Immutable marketplace catalog revision proved before release.
+      catalog_published:
+        description: Whether marketplace-publish actually updated the public catalog for this release.
         required: true
+        type: boolean
+      marketplace_revision:
+        description: Immutable published catalog revision. Empty exactly when publication was deferred.
+        required: false
+        default: ""
         type: string
       pre_publish_closeout_artifact:
         description: Accepted pre-publish closeout artifact from this release run.
@@ -210,6 +220,61 @@ jobs:
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: "& scripts/install-codestory.ps1 -SelfTest"
 
+      # Catalog publication is delivery, not a gate, so this smoke must run in both states -- but it
+      # must never let the deferred state read as the published one. Each state gets its own catalog
+      # source AND its own installer identity, and the two are decided here, once, from the caller's
+      # explicit handoff. The handoff is checked both ways: published demands an immutable live
+      # revision, deferred demands the absence of one.
+      - name: Record catalog delivery state
+        id: delivery
+        shell: bash
+        env:
+          CATALOG_PUBLISHED: ${{ inputs.catalog_published }}
+          INPUT_MARKETPLACE_REVISION: ${{ inputs.marketplace_revision }}
+        run: |
+          set -euo pipefail
+          fixture_root="$RUNNER_TEMP/codestory-marketplace-delivery/fixture"
+          rm -rf "$fixture_root"
+          if [ "$CATALOG_PUBLISHED" = "true" ]; then
+            marketplace_source=TheGreenCedar/AgentPluginMarketplace
+            marketplace_revision="$INPUT_MARKETPLACE_REVISION"
+            local_fixture=false
+            installer=codex_marketplace_install
+            state=published
+          elif [ "$CATALOG_PUBLISHED" = "false" ]; then
+            # The public catalog still points at the previous release, so resolving against it would
+            # prove the PREVIOUS release. Pin a catalog to this exact published commit instead: same
+            # resolver, same pinned git-subdir source, only the catalog host differs.
+            if [ -n "$INPUT_MARKETPLACE_REVISION" ]; then
+              echo "::error::Deferred catalog publication must not carry a live catalog revision."
+              exit 1
+            fi
+            node .github/scripts/build-marketplace-fixture.mjs \
+              --out "$fixture_root" \
+              --source-repository "$GITHUB_WORKSPACE" \
+              --commit "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+            marketplace_source="$fixture_root"
+            marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"
+            local_fixture=true
+            installer=codex_marketplace_deferred_fixture
+            state=deferred
+          else
+            echo "::error::catalog_published must be true or false, not '$CATALOG_PUBLISHED'."
+            exit 1
+          fi
+          test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
+          {
+            echo "marketplace_source=$marketplace_source"
+            echo "marketplace_revision=$marketplace_revision"
+            echo "local_fixture=$local_fixture"
+            echo "installer=$installer"
+            echo "state=$state"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$state" = "deferred" ]; then
+            echo "::warning::Catalog publication was deferred for this release. This smoke proves the published assets against a candidate-pinned catalog fixture and records installer $installer; recover the public catalog with marketplace-sync.yml."
+          fi
+          echo "Catalog delivery state: $state (installer $installer, catalog revision $marketplace_revision)." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Resolve the published plugin through the marketplace catalog
         id: installed
         shell: bash
@@ -218,7 +283,7 @@ jobs:
           install_root="$RUNNER_TEMP/codestory-installed-proof"
           codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
           isolated_home="$install_root/isolated-home"
-          marketplace_revision="${{ inputs.marketplace_revision }}"
+          marketplace_revision="${{ steps.delivery.outputs.marketplace_revision }}"
           test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
           rm -rf "$install_root"
           mkdir -p "$isolated_home"
@@ -231,9 +296,10 @@ jobs:
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \
-            --marketplace-source TheGreenCedar/AgentPluginMarketplace \
+            --marketplace-source "${{ steps.delivery.outputs.marketplace_source }}" \
             --marketplace-name TheGreenCedar \
             --marketplace-revision "$marketplace_revision" \
+            --local-fixture "${{ steps.delivery.outputs.local_fixture }}" \
             --expected-version "${{ steps.release.outputs.version }}" \
             --source-repository "$GITHUB_WORKSPACE" \
             --attestation "$install_root/install-attestation-v2.json" \
@@ -275,8 +341,10 @@ jobs:
           ledger="$(find target/pre-publish-closeout -type f -name ledger.json -print)"
           test "$(printf '%s\n' "$ledger" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
           mkdir -p target/release-cells
+          # The installer identity is whatever the delivery state resolved, never a literal: a
+          # deferred run must not be able to sign a cell that says the public catalog served it.
           jq -n \
-            --arg installer codex_marketplace_install \
+            --arg installer "${{ steps.delivery.outputs.installer }}" \
             --arg native_engine coderank_q8_embedded \
             '{installer: $installer, native_engine: $native_engine}' \
             > target/release-cells/installed-identity.json

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -106,6 +106,32 @@ jobs:
           ref: ${{ steps.release.outputs.tag }}
           fetch-depth: 0
 
+      # The tag is a local name until GitHub agrees it is a published one. Every later step pins
+      # the commit resolved here, so the fixture catalog, the Codex resolve, and the byte
+      # comparison all name a release GitHub is actually serving -- never merely whatever tree
+      # this job happens to be standing in.
+      - name: Bind this smoke to the published release
+        id: published
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          draft="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)"
+          if [ "$draft" != "false" ]; then
+            echo "::error::Published release $TAG is a draft."
+            exit 1
+          fi
+          published_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
+          printf '%s' "$published_commit" | grep -Eq '^[0-9a-f]{40}$'
+          if [ "$published_commit" != "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" ]; then
+            echo "::error::Checked-out tree is not the commit published at $TAG."
+            exit 1
+          fi
+          echo "commit=$published_commit" >> "$GITHUB_OUTPUT"
+          echo "Smoking the release published at $TAG ($published_commit)." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Install pinned Python
         if: runner.os != 'macOS'
         uses: actions/setup-python@v7.0.0
@@ -231,8 +257,12 @@ jobs:
         env:
           CATALOG_PUBLISHED: ${{ inputs.catalog_published }}
           INPUT_MARKETPLACE_REVISION: ${{ inputs.marketplace_revision }}
+          PUBLISHED_COMMIT: ${{ steps.published.outputs.commit }}
         run: |
           set -euo pipefail
+          # The commit GitHub reports for the published tag, bound in the previous step.
+          published_commit="$PUBLISHED_COMMIT"
+          printf '%s' "$published_commit" | grep -Eq '^[0-9a-f]{40}$'
           fixture_root="$RUNNER_TEMP/codestory-marketplace-delivery/fixture"
           rm -rf "$fixture_root"
           if [ "$CATALOG_PUBLISHED" = "true" ]; then
@@ -252,7 +282,7 @@ jobs:
             node .github/scripts/build-marketplace-fixture.mjs \
               --out "$fixture_root" \
               --source-repository "$GITHUB_WORKSPACE" \
-              --commit "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+              --commit "$published_commit"
             marketplace_source="$fixture_root"
             marketplace_revision="$(git -C "$fixture_root" rev-parse HEAD)"
             local_fixture=true
@@ -262,7 +292,7 @@ jobs:
             echo "::error::catalog_published must be true or false, not '$CATALOG_PUBLISHED'."
             exit 1
           fi
-          test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
+          printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'
           {
             echo "marketplace_source=$marketplace_source"
             echo "marketplace_revision=$marketplace_revision"
@@ -284,7 +314,7 @@ jobs:
           codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
           isolated_home="$install_root/isolated-home"
           marketplace_revision="${{ steps.delivery.outputs.marketplace_revision }}"
-          test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
+          printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'
           rm -rf "$install_root"
           mkdir -p "$isolated_home"
           npm install \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,6 +531,12 @@ jobs:
             --title "CodeStory $TAG" \
             --notes-file target/release-assets/release-notes.md
 
+  # Catalog publication is DELIVERY, not a release gate. It runs after the tag and the GitHub
+  # release already exist, so failing the release on a missing credential or a rejected push would
+  # only turn a recoverable delivery gap into an unrecoverable one -- and the catalog keeps serving
+  # the previous release either way, so no user is ever offered a plugin that does not exist.
+  # The price is that the run must SAY which state it ended in: this job always reports one of two
+  # explicit outcomes, and post-publish-smoke records that outcome in the release ledger.
   marketplace-publish:
     name: Publish the marketplace catalog
     if: inputs.publish_release
@@ -541,7 +547,8 @@ jobs:
     timeout-minutes: 10
     environment: marketplace-publish
     outputs:
-      marketplace_revision: ${{ steps.publish.outputs.marketplace_revision }}
+      catalog_published: ${{ steps.delivery.outputs.catalog_published }}
+      marketplace_revision: ${{ steps.delivery.outputs.marketplace_revision }}
     steps:
       - name: Checkout exact release source
         uses: actions/checkout@v5
@@ -550,6 +557,7 @@ jobs:
 
       - name: Mint a scoped marketplace token
         id: token
+        continue-on-error: true
         uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1.11.3
         with:
           app-id: ${{ secrets.MARKETPLACE_APP_ID }}
@@ -559,8 +567,11 @@ jobs:
 
       # Publication already happened, so a failure here leaves the catalog serving the previous
       # release rather than a release that does not exist. marketplace-sync.yml recovers it.
+      # One attempt only: a retry loop here would hide which failure the run actually hit.
       - name: Point the catalog at the published release
         id: publish
+        if: steps.token.outcome == 'success'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
@@ -571,9 +582,41 @@ jobs:
             --version "${{ needs.preflight.outputs.version }}" \
             --github-output "$GITHUB_OUTPUT"
 
+      # The only place the "catalog was updated" claim is ever minted. It requires the token, the
+      # push, AND an immutable revision to have all landed; anything else records deferred, so an
+      # unknown or half-finished state can never read as published.
+      - name: Record catalog delivery outcome
+        id: delivery
+        if: always()
+        env:
+          TOKEN_OUTCOME: ${{ steps.token.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          PUBLISHED_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+          RECOVERY_WORKFLOW: marketplace-sync.yml
+        run: |
+          set -euo pipefail
+          catalog_published=false
+          marketplace_revision=""
+          if [ "$TOKEN_OUTCOME" = "success" ] \
+            && [ "$PUBLISH_OUTCOME" = "success" ] \
+            && printf '%s' "$PUBLISHED_REVISION" | grep -Eq '^[0-9a-f]{40}$'; then
+            catalog_published=true
+            marketplace_revision="$PUBLISHED_REVISION"
+          fi
+          echo "catalog_published=$catalog_published" >> "$GITHUB_OUTPUT"
+          echo "marketplace_revision=$marketplace_revision" >> "$GITHUB_OUTPUT"
+          if [ "$catalog_published" = "true" ]; then
+            echo "Catalog delivery: published at $marketplace_revision." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "::warning::Catalog publication deferred (token=$TOKEN_OUTCOME publish=$PUBLISH_OUTCOME). The release stands and the catalog still serves the previous release; recover with $RECOVERY_WORKFLOW."
+          echo "Catalog delivery: DEFERRED. The release is published; the catalog still serves the previous release. Recover with $RECOVERY_WORKFLOW." >> "$GITHUB_STEP_SUMMARY"
+
   post-publish-smoke:
     name: Post-publish release asset smoke
-    if: inputs.publish_release
+    # Deliberately not gated on marketplace-publish: a deferred catalog must not suppress proof of
+    # the assets that were actually published. The delivery state is carried in, not depended on.
+    if: always() && inputs.publish_release && needs.preflight.result == 'success' && needs.publish.result == 'success'
     needs:
       - preflight
       - publish
@@ -581,6 +624,7 @@ jobs:
     uses: ./.github/workflows/post-publish-release-smoke.yml
     with:
       version: ${{ needs.preflight.outputs.version }}
+      catalog_published: ${{ needs.marketplace-publish.outputs.catalog_published == 'true' }}
       marketplace_revision: ${{ needs.marketplace-publish.outputs.marketplace_revision }}
       pre_publish_closeout_artifact: release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
       emit_release_cells: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
               https://github.com/TheGreenCedar/AgentPluginMarketplace.git \
               refs/heads/main | awk '{print $1}'
           )"
-          test "$(printf '%s' "$marketplace_revision" | wc -c | tr -d ' ')" = 40
+          printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'
           echo "marketplace_revision=$marketplace_revision" >> "$GITHUB_OUTPUT"
           rm -rf "$install_root"
           npm install \
@@ -235,7 +235,7 @@ jobs:
           # the fixture's own revision. The live revision above is still the one
           # the post-publish smoke consumes, so both are captured.
           fixture_revision="$(git -C "$fixture_root" rev-parse HEAD)"
-          test "$(printf '%s' "$fixture_revision" | wc -c | tr -d ' ')" = 40
+          printf '%s' "$fixture_revision" | grep -Eq '^[0-9a-f]{40}$'
           node .github/scripts/install-codestory-marketplace-proof.mjs \
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
@@ -609,7 +609,15 @@ jobs:
             echo "Catalog delivery: published at $marketplace_revision." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          echo "::warning::Catalog publication deferred (token=$TOKEN_OUTCOME publish=$PUBLISH_OUTCOME). The release stands and the catalog still serves the previous release; recover with $RECOVERY_WORKFLOW."
+          # $RECOVERY_WORKFLOW mints the SAME credential from the SAME environment, so it recovers a
+          # rejected push, not a missing credential. Saying so here keeps the recorded recovery
+          # instruction one that can actually be followed.
+          if [ "$TOKEN_OUTCOME" != "success" ]; then
+            recovery="provision the marketplace-publish credential, then run $RECOVERY_WORKFLOW (it mints the same token, so it defers as well when that credential is absent)"
+          else
+            recovery="re-run $RECOVERY_WORKFLOW with this version and commit"
+          fi
+          echo "::warning::Catalog publication deferred (token=$TOKEN_OUTCOME publish=$PUBLISH_OUTCOME). The release stands and the catalog still serves the previous release; recover with $RECOVERY_WORKFLOW: $recovery."
           echo "Catalog delivery: DEFERRED. The release is published; the catalog still serves the previous release. Recover with $RECOVERY_WORKFLOW." >> "$GITHUB_STEP_SUMMARY"
 
   post-publish-smoke:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,10 +253,34 @@ adapter to compensate for incorrect upstream state.
   `codex_marketplace_deferred_fixture` into the release ledger. A release may say
   the catalog was updated only when the push actually landed; the honest outcome
   otherwise is "released, catalog sync deferred".
+- The two states are distinct **end to end**, not just in a log line. Each has its
+  own installer identity, its own `marketplace.repository` in the install
+  attestation (`local:candidate-pinned-marketplace-fixture` for a fixture), and
+  its own accepted shape in `marketplace_installation.py` — the resolver reports a
+  local source, a marketplace root outside the Codex home, and no pinned `ref`,
+  which the live shape cannot describe and must never be relaxed to admit. A
+  deferred install must resolve a catalog carrying the
+  `.codestory-marketplace-fixture.json` marker naming the exact released commit,
+  so an arbitrary local git directory cannot pass for one. The three names live in
+  `.github/scripts/marketplace-delivery-identity.mjs`; add a state there, in the
+  Python predicate, and in `release-claims.json` together or not at all.
+- The closeout *reads* the mark. `workflow_policy.catalog_delivery.installed_cell_group`
+  names the post-publish cells whose signed `installer` identity resolves the
+  state, and `ledger.json`/`summary.json` carry `catalog_delivery`. Every one of
+  those cells must agree on one declared identity; an undeclared installer or a
+  disagreement between targets rejects the closeout rather than passing quietly.
 - `marketplace-sync.yml` is the recovery path for a deferred catalog. Re-run it
   with the published version and commit rather than editing the catalog by hand;
   it is idempotent, so re-running it against an already-synced catalog succeeds
-  without pushing.
+  without pushing. It mints its token from the same `MARKETPLACE_APP_ID` /
+  `MARKETPLACE_APP_PRIVATE_KEY` in the same `marketplace-publish` environment the
+  release lanes use, so it recovers a push that was **rejected**, not a
+  credential that does not exist. While those secrets are absent every release
+  defers and re-running the sync defers too: the exit is to provision the
+  credential first. That is deliberate — the alternative is a second, unscoped
+  way to write another repository — but it means "deferred" persists until
+  someone with repository-settings access acts, and the ledger says so rather
+  than implying a one-click fix.
 - For a local plugin-source change Codex must observe outside a release, refresh
   the installed package and verify the managed runtime path/version plus
   project-scoped status. CodeStory repository state alone does not update an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,12 +240,23 @@ adapter to compensate for incorrect upstream state.
 - Both release lanes own marketplace publication. The `marketplace-publish` job
   in `release.yml` and in `plugin-release.yml` points
   `TheGreenCedar/AgentPluginMarketplace` at the published commit after the
-  release exists, and post-publish smoke proves that catalog. Do not
-  hand-edit the catalog before a release; preflight proves the install path
-  against a candidate-pinned fixture and no longer requires the live catalog to
-  match an unreleased commit. If the catalog push fails, the release is still
-  complete and the catalog still serves the previous release: recover with the
-  `marketplace-sync` workflow rather than editing by hand.
+  release exists. Do not hand-edit the catalog before a release; preflight proves
+  the install path against a candidate-pinned fixture and no longer requires the
+  live catalog to match an unreleased commit.
+- Catalog publication is delivery, not a release gate. It runs after an
+  irreversible tag, so a missing credential or a rejected push must not fail the
+  release; `release-claims.json` records that with
+  `workflow_policy.catalog_delivery.release_gate: false`. The job absorbs its own
+  failure and records one of two explicit states, and post-publish smoke runs
+  either way: `published` resolves the live catalog, `deferred` resolves a catalog
+  pinned to the released commit and stamps the distinct installer identity
+  `codex_marketplace_deferred_fixture` into the release ledger. A release may say
+  the catalog was updated only when the push actually landed; the honest outcome
+  otherwise is "released, catalog sync deferred".
+- `marketplace-sync.yml` is the recovery path for a deferred catalog. Re-run it
+  with the published version and commit rather than editing the catalog by hand;
+  it is idempotent, so re-running it against an already-synced catalog succeeds
+  without pushing.
 - For a local plugin-source change Codex must observe outside a release, refresh
   the installed package and verify the managed runtime path/version plus
   project-scoped status. CodeStory repository state alone does not update an

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
+    "graph_sha256": "dc16ae973ec63ecc72116f7861ff77eef8cf709ddf2002d7485665541f7fd2f6",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
+        "graph_sha256": "dc16ae973ec63ecc72116f7861ff77eef8cf709ddf2002d7485665541f7fd2f6",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
+        "graph_sha256": "dc16ae973ec63ecc72116f7861ff77eef8cf709ddf2002d7485665541f7fd2f6",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+    "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+        "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+        "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "ba277f51c4079712fd75ef1ead662198645d70074bb6b717b1bca7336968a7f1",
+  "candidate_sha256": "12906c593326f3dd9ff51f95131ff2bbd90e7865b3859bf05ac8360150ce7d5b",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+      "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+      "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+    "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "12906c593326f3dd9ff51f95131ff2bbd90e7865b3859bf05ac8360150ce7d5b",
+  "candidate_sha256": "708189e7916c88536ecbf74906bea202ed8c70c82e2cc671df5db4daaf4ebb22",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
+      "graph_sha256": "dc16ae973ec63ecc72116f7861ff77eef8cf709ddf2002d7485665541f7fd2f6",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
+      "graph_sha256": "dc16ae973ec63ecc72116f7861ff77eef8cf709ddf2002d7485665541f7fd2f6",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
+    "graph_sha256": "dc16ae973ec63ecc72116f7861ff77eef8cf709ddf2002d7485665541f7fd2f6",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1117,6 +1117,7 @@
       "publish_job": "marketplace-publish",
       "recovery_workflow": "marketplace-sync.yml",
       "release_gate": false,
+      "installed_cell_group": "installed_runtime_behavior",
       "states": [
         {
           "id": "published",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1113,6 +1113,23 @@
         ]
       }
     },
+    "catalog_delivery": {
+      "publish_job": "marketplace-publish",
+      "recovery_workflow": "marketplace-sync.yml",
+      "release_gate": false,
+      "states": [
+        {
+          "id": "published",
+          "installer": "codex_marketplace_install",
+          "live_catalog_revision": true
+        },
+        {
+          "id": "deferred",
+          "installer": "codex_marketplace_deferred_fixture",
+          "live_catalog_revision": false
+        }
+      ]
+    },
     "artifact_workflows": [
       "source-proof.yml",
       "release-candidate-evidence.yml",

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -233,7 +233,7 @@ function uniqueById(values, label) {
 // the two states it is in, so the graph names both and pins a distinct installer identity to each.
 // A run that could not publish records the deferred identity in its post-publish cells; nothing in
 // the pipeline is allowed to record the published identity without the catalog push succeeding.
-function validateCatalogDelivery(policy, dependencies) {
+function validateCatalogDelivery(policy, dependencies, cellGroups) {
   const delivery = object(policy.catalog_delivery, "workflow_policy.catalog_delivery");
   const publishJob = nonEmptyText(delivery.publish_job, "workflow_policy.catalog_delivery.publish_job");
   if (dependencies[publishJob] === undefined) {
@@ -275,6 +275,26 @@ function validateCatalogDelivery(policy, dependencies) {
   }
   if (byId.get("deferred").live_catalog_revision !== false) {
     fail("workflow_policy.catalog_delivery deferred state must not consume a live catalog revision");
+  }
+  // Naming the two states is not enough on its own: something has to read the mark, or a
+  // deferred release's closeout verdict stays indistinguishable from a published one. This
+  // names the post-publish cell family whose signed `installer` identity the closeout resolves
+  // the delivery state from, so the graph cannot declare the states without a reader.
+  const installedCellGroup = nonEmptyText(
+    delivery.installed_cell_group,
+    "workflow_policy.catalog_delivery.installed_cell_group",
+  );
+  const group = cellGroups.get(installedCellGroup);
+  if (group === undefined) {
+    fail(`workflow_policy.catalog_delivery.installed_cell_group ${installedCellGroup} must be a closeout cell group`);
+  }
+  if (group.phase !== "post_publish") {
+    fail(`workflow_policy.catalog_delivery.installed_cell_group ${installedCellGroup} must be a post-publish cell group`);
+  }
+  for (const key of ["required_identity", "singleton_identity"]) {
+    if (!(group[key] ?? []).includes("installer")) {
+      fail(`workflow_policy.catalog_delivery.installed_cell_group ${installedCellGroup} must carry installer in ${key}`);
+    }
   }
   return delivery;
 }
@@ -816,7 +836,7 @@ export function validateReleaseClaimGraph(graph) {
     }
   }
   validatePluginChain(policy.plugin_chain);
-  validateCatalogDelivery(policy, dependencies);
+  validateCatalogDelivery(policy, dependencies, cellGroups);
   stringArray(policy.artifact_workflows, "workflow_policy.artifact_workflows", { nonEmpty: true });
   const promotion = object(policy.promotion, "workflow_policy.promotion");
   nonEmptyText(promotion.source_branch, "workflow_policy.promotion.source_branch");

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -227,6 +227,58 @@ function uniqueById(values, label) {
   return found;
 }
 
+// Marketplace catalog publication is delivery, not a release gate: it happens after the tag and
+// the GitHub release already exist, so failing the release on it would only convert a recoverable
+// delivery gap into an unrecoverable one. The price of that is that the release must say which of
+// the two states it is in, so the graph names both and pins a distinct installer identity to each.
+// A run that could not publish records the deferred identity in its post-publish cells; nothing in
+// the pipeline is allowed to record the published identity without the catalog push succeeding.
+function validateCatalogDelivery(policy, dependencies) {
+  const delivery = object(policy.catalog_delivery, "workflow_policy.catalog_delivery");
+  const publishJob = nonEmptyText(delivery.publish_job, "workflow_policy.catalog_delivery.publish_job");
+  if (dependencies[publishJob] === undefined) {
+    fail(`workflow_policy.catalog_delivery.publish_job ${publishJob} must be a release chain job`);
+  }
+  nonEmptyText(delivery.recovery_workflow, "workflow_policy.catalog_delivery.recovery_workflow");
+  if (delivery.release_gate !== false) {
+    fail("workflow_policy.catalog_delivery.release_gate must be false: catalog publication is delivery, not a release gate");
+  }
+  if (!Array.isArray(delivery.states) || delivery.states.length !== 2) {
+    fail("workflow_policy.catalog_delivery.states must name exactly the published and deferred states");
+  }
+  const installers = new Set();
+  const byId = new Map();
+  for (const [index, stateValue] of delivery.states.entries()) {
+    const state = object(stateValue, `workflow_policy.catalog_delivery.states[${index}]`);
+    const id = nonEmptyText(state.id, `workflow_policy.catalog_delivery.states[${index}].id`);
+    const installer = nonEmptyText(
+      state.installer,
+      `workflow_policy.catalog_delivery.states[${index}].installer`,
+    );
+    if (!identityMatchesFormat(installer, "identifier")) {
+      fail(`workflow_policy.catalog_delivery.states[${index}].installer does not match identifier`);
+    }
+    if (typeof state.live_catalog_revision !== "boolean") {
+      fail(`workflow_policy.catalog_delivery.states[${index}].live_catalog_revision must be a boolean`);
+    }
+    if (installers.has(installer)) {
+      fail("workflow_policy.catalog_delivery states must record distinct installer identities");
+    }
+    installers.add(installer);
+    byId.set(id, state);
+  }
+  for (const id of ["published", "deferred"]) {
+    if (!byId.has(id)) fail(`workflow_policy.catalog_delivery.states must declare the ${id} state`);
+  }
+  if (byId.get("published").live_catalog_revision !== true) {
+    fail("workflow_policy.catalog_delivery published state must consume the live catalog revision");
+  }
+  if (byId.get("deferred").live_catalog_revision !== false) {
+    fail("workflow_policy.catalog_delivery deferred state must not consume a live catalog revision");
+  }
+  return delivery;
+}
+
 function validatePublicSupport(graph, packageTargets, cellGroups) {
   const publicSupport = object(
     graph.public_support,
@@ -764,6 +816,7 @@ export function validateReleaseClaimGraph(graph) {
     }
   }
   validatePluginChain(policy.plugin_chain);
+  validateCatalogDelivery(policy, dependencies);
   stringArray(policy.artifact_workflows, "workflow_policy.artifact_workflows", { nonEmpty: true });
   const promotion = object(policy.promotion, "workflow_policy.promotion");
   nonEmptyText(promotion.source_branch, "workflow_policy.promotion.source_branch");

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -141,6 +141,59 @@ export function deriveReleaseCells(graph, phase) {
   return cells;
 }
 
+// Which catalog served the release is a fact about the release, so the closeout has to READ it
+// rather than let it ride along as an unexamined string. Before this, `installer` on the
+// post-publish installed cells was free-form: a deferred release's verdict was identical in
+// shape to a published one, and nothing would have noticed a cell carrying a pre-publish
+// installer identity either. The state is resolved from the signed cells, must be one of the
+// two declared identities, must be the SAME one across every target, and lands in the ledger
+// and summary. When it cannot be resolved the closeout records that explicitly and errors --
+// it never simply omits the field.
+export function resolveCatalogDelivery({ graph, cells, manifests }) {
+  const delivery = graph.workflow_policy?.catalog_delivery;
+  const groupId = delivery?.installed_cell_group;
+  if (!delivery || typeof groupId !== "string") return { record: undefined, errors: [] };
+  const relevant = cells.filter((cell) => cell.group_id === groupId);
+  if (relevant.length === 0) return { record: undefined, errors: [] };
+  const byInstaller = new Map(delivery.states.map((state) => [state.installer, state]));
+  const errors = [];
+  const observed = new Set();
+  for (const cell of relevant) {
+    const installer = manifests.get(cell.id)?.evidence?.identity?.installer;
+    if (typeof installer !== "string" || !byInstaller.has(installer)) {
+      errors.push(
+        `${cell.id} does not record a declared catalog delivery installer identity`,
+      );
+      continue;
+    }
+    observed.add(installer);
+  }
+  if (observed.size !== 1 || errors.length > 0) {
+    if (observed.size > 1) {
+      errors.push(
+        `post-publish cells disagree on the catalog delivery state: ${[...observed].sort().join(", ")}`,
+      );
+    }
+    if (observed.size === 0 && errors.length === 0) {
+      errors.push("post-publish cells record no catalog delivery state");
+    }
+    return {
+      record: { state: "unresolved", installer: null, live_catalog_revision: null },
+      errors,
+    };
+  }
+  const [installer] = [...observed];
+  const state = byInstaller.get(installer);
+  return {
+    record: {
+      state: state.id,
+      installer,
+      live_catalog_revision: state.live_catalog_revision,
+    },
+    errors,
+  };
+}
+
 export function resolveReleaseCellConstraints(cell, producerRunAttempt) {
   const attempt = text(producerRunAttempt, "producer run attempt");
   if (!/^[1-9]\d*$/u.test(attempt)) fail("producer run attempt must be a positive integer");
@@ -1099,6 +1152,8 @@ export function evaluateReleaseCloseout({
   }
   const missingCells = ledgerCells.filter(({ status }) => status === "missing").map(({ id }) => id);
   const failedCells = ledgerCells.filter(({ status }) => status === "fail").map(({ id }) => id);
+  const catalogDelivery = resolveCatalogDelivery({ graph, cells, manifests });
+  inputErrors.push(...catalogDelivery.errors);
   inputErrors.sort();
   const decision = inputErrors.length === 0 && missingCells.length === 0 && failedCells.length === 0
     ? "accept"
@@ -1114,6 +1169,7 @@ export function evaluateReleaseCloseout({
     identity: canonicalReleaseClaimValue(gitIdentity),
     producer_provenance_sha256: digest(canonicalJson(trustedProducers)),
     trusted_exceptions_sha256: digest(canonicalJson(trustedExceptionDocument)),
+    ...(catalogDelivery.record ? { catalog_delivery: catalogDelivery.record } : {}),
     cells: ledgerCells,
     input_errors: inputErrors,
   };
@@ -1126,6 +1182,7 @@ export function evaluateReleaseCloseout({
     identity: canonicalReleaseClaimValue(gitIdentity),
     producer_provenance_sha256: ledger.producer_provenance_sha256,
     trusted_exceptions_sha256: ledger.trusted_exceptions_sha256,
+    ...(catalogDelivery.record ? { catalog_delivery: catalogDelivery.record } : {}),
     counts: {
       required: ledgerCells.length,
       passed: ledgerCells.filter(({ status }) => new Set(["pass", "pass_with_exception"]).has(status)).length,

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -363,6 +363,54 @@ test("catalog delivery declares two distinguishable states and no release gate",
   );
 });
 
+// Naming the two delivery states buys nothing on its own: the first version of this graph
+// declared both and nothing anywhere read the mark, so a deferred release's closeout verdict was
+// identical in shape to a published one. The graph must therefore also name the cell family whose
+// signed installer identity the closeout resolves the state from -- and that family has to be a
+// post-publish one that actually carries `installer`, or the reader would have nothing to read.
+test("catalog delivery names the cells whose installer identity resolves the state", () => {
+  const delivery = graph.workflow_policy.catalog_delivery;
+  const group = graph.closeout.cell_groups
+    .find(({ id }) => id === delivery.installed_cell_group);
+  assert.equal(group.phase, "post_publish");
+  assert.ok(group.required_identity.includes("installer"));
+  assert.ok(group.singleton_identity.includes("installer"));
+
+  const unread = structuredClone(graph);
+  delete unread.workflow_policy.catalog_delivery.installed_cell_group;
+  assert.throws(
+    () => validateReleaseClaimGraph(unread),
+    /workflow_policy\.catalog_delivery\.installed_cell_group/u,
+  );
+
+  const unknown = structuredClone(graph);
+  unknown.workflow_policy.catalog_delivery.installed_cell_group = "no-such-group";
+  assert.throws(
+    () => validateReleaseClaimGraph(unknown),
+    /must be a closeout cell group/u,
+  );
+
+  // A pre-publish family cannot carry the delivery state: it is produced before the catalog is
+  // ever touched, so reading it would report a state nothing had decided yet.
+  const early = structuredClone(graph);
+  early.workflow_policy.catalog_delivery.installed_cell_group = "candidate_installed_behavior";
+  assert.throws(
+    () => validateReleaseClaimGraph(early),
+    /must be a post-publish cell group/u,
+  );
+
+  // The installer must be a singleton identity, or the three targets could each report a
+  // different catalog and no single state would exist to record.
+  const nonSingleton = structuredClone(graph);
+  nonSingleton.closeout.cell_groups
+    .find(({ id }) => id === delivery.installed_cell_group)
+    .singleton_identity = ["host_os", "host_arch", "native_engine"];
+  assert.throws(
+    () => validateReleaseClaimGraph(nonSingleton),
+    /must carry installer in singleton_identity/u,
+  );
+});
+
 // check-workflow-policy.mjs asserts only that plugin-release.yml's `needs:` match this data, so a
 // chain that parses but orders nothing would let both gates pass while `gh release create` ran
 // detached from the release-authority checks and the plugin-proof matrix. Every mutation below

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -291,6 +291,78 @@ test("graph rejects ambiguous dependencies and unstructured proof lanes", () => 
   }
 });
 
+// Catalog publication is delivery rather than a release gate, which is only honest if the run
+// records which of the two states it ended in. The graph is where that vocabulary lives, so
+// deleting it, reinstating the gate, or collapsing the two installer identities onto one -- which
+// is exactly how a deferred run would come to read as a published one -- must be refusals here,
+// not merely in the workflow policy that consumes them.
+test("catalog delivery declares two distinguishable states and no release gate", () => {
+  const delivery = graph.workflow_policy.catalog_delivery;
+  assert.equal(delivery.release_gate, false);
+  assert.deepEqual(delivery.states.map(({ id }) => id).sort(), ["deferred", "published"]);
+  assert.equal(new Set(delivery.states.map(({ installer }) => installer)).size, 2);
+
+  const missing = structuredClone(graph);
+  delete missing.workflow_policy.catalog_delivery;
+  assert.throws(
+    () => validateReleaseClaimGraph(missing),
+    /workflow_policy\.catalog_delivery must be an object/u,
+  );
+
+  const gated = structuredClone(graph);
+  gated.workflow_policy.catalog_delivery.release_gate = true;
+  assert.throws(
+    () => validateReleaseClaimGraph(gated),
+    /release_gate must be false: catalog publication is delivery, not a release gate/u,
+  );
+
+  const collapsed = structuredClone(graph);
+  const [first, second] = collapsed.workflow_policy.catalog_delivery.states;
+  second.installer = first.installer;
+  assert.throws(
+    () => validateReleaseClaimGraph(collapsed),
+    /must record distinct installer identities/u,
+  );
+
+  const renamed = structuredClone(graph);
+  renamed.workflow_policy.catalog_delivery.states
+    .find(({ id }) => id === "deferred").id = "unknown";
+  assert.throws(
+    () => validateReleaseClaimGraph(renamed),
+    /must declare the deferred state/u,
+  );
+
+  const inverted = structuredClone(graph);
+  inverted.workflow_policy.catalog_delivery.states
+    .find(({ id }) => id === "deferred").live_catalog_revision = true;
+  assert.throws(
+    () => validateReleaseClaimGraph(inverted),
+    /deferred state must not consume a live catalog revision/u,
+  );
+
+  const unpublished = structuredClone(graph);
+  unpublished.workflow_policy.catalog_delivery.states
+    .find(({ id }) => id === "published").live_catalog_revision = false;
+  assert.throws(
+    () => validateReleaseClaimGraph(unpublished),
+    /published state must consume the live catalog revision/u,
+  );
+
+  const detached = structuredClone(graph);
+  detached.workflow_policy.catalog_delivery.publish_job = "no-such-job";
+  assert.throws(
+    () => validateReleaseClaimGraph(detached),
+    /publish_job no-such-job must be a release chain job/u,
+  );
+
+  const unrecoverable = structuredClone(graph);
+  delete unrecoverable.workflow_policy.catalog_delivery.recovery_workflow;
+  assert.throws(
+    () => validateReleaseClaimGraph(unrecoverable),
+    /workflow_policy\.catalog_delivery\.recovery_workflow/u,
+  );
+});
+
 // check-workflow-policy.mjs asserts only that plugin-release.yml's `needs:` match this data, so a
 // chain that parses but orders nothing would let both gates pass while `gh release create` ran
 // detached from the release-authority checks and the plugin-proof matrix. Every mutation below

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -76,7 +76,13 @@ function identityFor(cell, producerRunAttempt = "1") {
       case "host_arch": identity[key] = hostIdentity(target)[key]; break;
       case "runner": identity[key] = "hosted-runner"; break;
       case "backend": identity[key] = "CPU"; break;
-      case "installer": identity[key] = "managed_plugin"; break;
+      // The post-publish installed cells are where the closeout reads which catalog served the
+      // release, so their installer must be one of the two declared delivery identities.
+      case "installer":
+        identity[key] = cell.group_id === "installed_runtime_behavior"
+          ? "codex_marketplace_install"
+          : "managed_plugin";
+        break;
       case "profile": identity[key] = "codestory-release-evidence-linux-arm64-v2"; break;
       case "corpus_id": identity[key] = "v0.16-axios-js-ts-v1"; break;
       case "cache_id": identity[key] = "cold-full-retrieval-v1"; break;
@@ -919,4 +925,83 @@ test("native-fingerprint reuse is still refused, and refused for the tree it can
       `${cellId}: ${JSON.stringify(failures)}`,
     );
   }
+});
+
+// Catalog publication is delivery, not a release gate, so a release may legitimately end with the
+// public catalog untouched. The whole risk in allowing that is the deferred run reading as the
+// published one, and the installer identity in the post-publish cells is the only thing that
+// distinguishes them. Before these checks it was inert: a free-form string nothing read, so a
+// deferred release's verdict was identical in shape to a published one.
+test("the post-publish closeout resolves and records which catalog served the release", () => {
+  const prePublish = evaluate("pre_publish", manifestsFor("pre_publish"));
+  const published = evaluate(
+    "post_publish",
+    manifestsFor("post_publish", prePublish.ledger),
+    prePublish.ledger,
+  );
+  assert.equal(published.decision, "accept");
+  assert.deepEqual(published.ledger.catalog_delivery, {
+    state: "published",
+    installer: "codex_marketplace_install",
+    live_catalog_revision: true,
+  });
+  assert.deepEqual(published.summary.catalog_delivery, published.ledger.catalog_delivery);
+
+  // A deferred release is accepted -- it published real artifacts -- but its verdict says so.
+  const deferredManifests = manifestsFor("post_publish", prePublish.ledger);
+  for (const manifest of deferredManifests) {
+    if (manifest.cell_id.startsWith("installed_runtime_behavior:")) {
+      manifest.evidence.identity.installer = "codex_marketplace_deferred_fixture";
+    }
+  }
+  const deferred = evaluate("post_publish", deferredManifests, prePublish.ledger);
+  assert.equal(deferred.decision, "accept");
+  assert.deepEqual(deferred.ledger.catalog_delivery, {
+    state: "deferred",
+    installer: "codex_marketplace_deferred_fixture",
+    live_catalog_revision: false,
+  });
+  // The two states must be distinguishable in the signed verdict, not only to a human reading a
+  // warning in a log that expires.
+  assert.notDeepEqual(deferred.ledger.catalog_delivery, published.ledger.catalog_delivery);
+
+  // The pre-publish closeout has no post-publish installed cells, so it states nothing here
+  // rather than inventing a delivery state.
+  assert.equal(prePublish.ledger.catalog_delivery, undefined);
+});
+
+test("a post-publish closeout that cannot resolve one catalog delivery state is rejected", () => {
+  const prePublish = evaluate("pre_publish", manifestsFor("pre_publish"));
+
+  // An installer identity no delivery state declares -- including the pre-publish lane's own
+  // candidate installer, which would otherwise sail through as a plausible-looking string.
+  for (const installer of ["candidate_managed_plugin", "managed_plugin", ""]) {
+    const manifests = manifestsFor("post_publish", prePublish.ledger);
+    for (const manifest of manifests) {
+      if (manifest.cell_id.startsWith("installed_runtime_behavior:")) {
+        manifest.evidence.identity.installer = installer;
+      }
+    }
+    const rejected = evaluate("post_publish", manifests, prePublish.ledger);
+    assert.equal(rejected.decision, "reject", installer);
+    assert.equal(rejected.ledger.catalog_delivery.state, "unresolved", installer);
+    assert.ok(
+      rejected.ledger.input_errors.some((message) =>
+        message.includes("does not record a declared catalog delivery installer identity")),
+      `${installer}: ${JSON.stringify(rejected.ledger.input_errors)}`,
+    );
+  }
+
+  // Targets disagreeing about the delivery state is not a state; it is a broken release.
+  const split = manifestsFor("post_publish", prePublish.ledger);
+  split.find(({ cell_id: id }) => id === "installed_runtime_behavior:macos-arm64")
+    .evidence.identity.installer = "codex_marketplace_deferred_fixture";
+  const rejected = evaluate("post_publish", split, prePublish.ledger);
+  assert.equal(rejected.decision, "reject");
+  assert.equal(rejected.ledger.catalog_delivery.state, "unresolved");
+  assert.ok(
+    rejected.ledger.input_errors.some((message) =>
+      message.includes("disagree on the catalog delivery state")),
+    JSON.stringify(rejected.ledger.input_errors),
+  );
 });

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+      "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "8c88b13d0085393f4675e34e2d3b285d053ed5dd604117272765ee90c8b2712b",
+      "graph_sha256": "dc16ae973ec63ecc72116f7861ff77eef8cf709ddf2002d7485665541f7fd2f6",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## The bug

`marketplace-publish` runs **after** `publish` has created the tag and the GitHub release — both irreversible. Neither the `marketplace-publish` environment nor `MARKETPLACE_APP_ID` / `MARKETPLACE_APP_PRIVATE_KEY` exists in this repository (`gh api repos/TheGreenCedar/CodeStory/environments` lists six, none named `marketplace-publish`; `actions/secrets` returns `total_count: 0`). So the first release to get past pre-publish closeout would tag, publish, then die minting the token — and take `post-publish-smoke` and `post-publish-closeout` with it, because the smoke `needs:` `marketplace-publish`.

That trades a benign failure for a fatal one. When the catalog push fails, the catalog keeps serving the *previous* release: no user is ever offered a plugin that does not exist, and `marketplace-sync.yml` closes the gap idempotently. Failing the release instead leaves a tag with no proof behind it.

`plugin-release.yml` (added in #1563) had the identical shape, so it is fixed here too.

## The change

Catalog publication becomes **delivery**, not a gate.

| | before | after |
|---|---|---|
| token mint fails | job fails → release fails | recorded as `deferred`, release stands |
| catalog push rejected | job fails → release fails | recorded as `deferred`, release stands |
| post-publish smoke | skipped | runs either way |
| what the run says | nothing (it died) | one of two explicit, visible states |

## Why this is not a vacuous pass

Removing a gate is exactly where a silent truth gets built by accident. Three specific things a reviewer should hunt for, and where each is closed:

**1. A claim that silently becomes true.** The "catalog was updated" claim is minted in exactly one step, `Record catalog delivery outcome`, which requires the token outcome, the push outcome, **and** a 40-hex revision to have all landed. Every other combination records `deferred` — including a push that reported success without a revision, a mutable ref like `main`, and a truncated SHA. The smoke's `catalog_published` input is pinned by policy to exactly `${{ needs.marketplace-publish.outputs.catalog_published == 'true' }}`; a literal `true`, an unrelated input, or `needs.marketplace-publish.result` are all rejected.

**2. A smoke that passes because it now checks nothing.** The deferred path checks the *same* things. It downloads the published assets, verifies checksums, verifies macOS signing/notarization/Gatekeeper, and performs a real Codex marketplace install of the real published artifacts. Only the catalog host changes: instead of the live catalog (which still names the previous release, so resolving it would prove the *previous* release), it resolves a catalog pinned to the released commit — the same `build-marketplace-fixture.mjs` mechanics the release preflight already proves. It then stamps a **different** installer identity, `codex_marketplace_deferred_fixture`, into the `installed_runtime_behavior:<target>` post-publish release cells. The ledger records which state the release was in; policy forbids the cell-emitting step from hard-coding either identity.

**3. A retry that masks a real failure.** There is none, and policy forbids adding one (`until`/`while`/`for attempt`/`--retry` in the catalog job). A retry would collapse distinguishable failures into one opaque one and could publish on a second attempt after the outcome was already recorded.

The handoff is also checked in **both** directions, so the two states cannot be confused: `published` demands an immutable live revision, `deferred` demands the *absence* of one, and an unset or unrecognized `catalog_published` stops the job rather than defaulting into published.

## Claim graph

`release-claims.json` gains `workflow_policy.catalog_delivery`: both state ids, their two distinct installer identities, `recovery_workflow: marketplace-sync.yml`, and `release_gate: false`. `validateReleaseClaimGraph` refuses a graph that drops the block, sets `release_gate: true`, collapses the two installer identities onto one, renames a state, inverts which state carries a live revision, points `publish_job` at a job outside the release chain, or drops the recovery workflow.

The job DAG is unchanged — `marketplace-publish` stays in `post-publish-smoke`'s `needs:` so the smoke still runs *after* the catalog attempt and can observe a real catalog when one landed. What changed is that the smoke's `if:` no longer requires it to have succeeded. `post-publish-closeout` reached `marketplace-publish` only through the smoke, so it is ungated too, and a new rule keeps it that way.

## Both-directions proof

Reverted only the implementation (`release.yml`, `post-publish-release-smoke.yml`, `plugin-release.yml`, `check-workflow-policy.mjs`, `release-claims.json`, `codestory-release-claims.mjs`) with the tests left in place:

- `check-workflow-policy.test.mjs`: **390 pass, 43 fail** — every one of the 41 new/retargeted leaf tests fails, no pre-existing test fails.
- `codestory-release-claims.test.mjs`: the new `catalog delivery declares two distinguishable states and no release gate` fails.

With the implementation restored: **434 pass, 0 fail** and **33 pass, 0 fail**.

Two of the new tests are executable rather than structural — they run the actual bash of both new steps, in both lanes, against a temp `GITHUB_OUTPUT`, and assert the recorded outputs. The deferred case really builds the fixture and asserts the generated catalog pins the released commit.

## Commands run

| command | result |
|---|---|
| `node .github/scripts/check-workflow-policy.mjs` | pass |
| `node --test .github/scripts/check-workflow-policy.test.mjs` | pass (434) |
| `node scripts/codestory-release-claims.mjs validate` | pass |
| `node .github/scripts/run-actionlint.mjs` | pass |
| `node --test .github/scripts/run-actionlint.test.mjs` | pass (3) |
| `node --test scripts/tests/codestory-release-claims.test.mjs` | pass (33) |
| `node --test scripts/tests/codestory-release-{cell-manifest,closeout,evidence-gate}.test.mjs` | pass |
| `node --test .github/scripts/{build-marketplace-fixture,install-codestory-marketplace-proof}.test.mjs` | pass |
| `node --test plugins/codestory/tests/plugin-static.test.mjs` | pass |
| `node --test scripts/tests/prove-plugin-pinned-provision.test.mjs` | pass |
| `node .github/scripts/check-doc-links.mjs` | pass |

The release-evidence fixtures and `scripts/tests/fixtures/release-claims/positive.json` re-pin the claim-graph digest, which changes whenever `release-claims.json` does.

## Not done

The credential still does not exist, so the *first* release after this lands will take the deferred path and need one `marketplace-sync.yml` run. That is the point: it will be recorded as "released, catalog sync deferred" rather than failing after the tag. Provisioning the `marketplace-publish` environment and its two secrets is a repository-settings change and is out of scope for a PR.

Closes #1568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
