### PR TITLE
recover a release from a lost self-hosted runner

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -5,6 +5,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { LineCounter, parseDocument } from "yaml";
 import { loadReleaseClaimGraph } from "../../scripts/codestory-release-claims.mjs";
+import {
+  LOST_RUNNER_ANNOTATION,
+  MAXIMUM_RUN_ATTEMPTS,
+} from "./lost-runner-recovery.mjs";
 
 const workflowRoot = path.join(".github", "workflows");
 const retrievalFile = "retrieval-engine-smoke.yml";
@@ -1643,7 +1647,12 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     "scripts/tests/codestory-release-closeout.test.mjs",
     "scripts/tests/codestory-release-evidence-gate.test.mjs",
   ]);
-  requireStepRun(violations, releaseFile, policy, "Enforce workflow policy", ["node .github/scripts/check-workflow-policy.mjs"]);
+  requireStepRun(violations, releaseFile, policy, "Enforce workflow policy", [
+    "node .github/scripts/check-workflow-policy.mjs",
+    // The recovery contract decides whether a lost host may withhold a claim, so the release's own
+    // policy gate must execute its tests before any proof runs.
+    "node --test .github/scripts/lost-runner-recovery.test.mjs",
+  ]);
 
   const preflight = requireJob(violations, releaseFile, release, "preflight");
   add(violations, sameMembers(needs(preflight), releaseChain.dependencies.preflight), `${releaseFile} preflight dependencies must match the release claim graph`);
@@ -1840,10 +1849,14 @@ function validateReleaseCoordinator(workflows, violations, graph) {
 
   const preCloseout = requireJob(violations, releaseFile, release, "pre-publish-closeout");
   add(violations, sameMembers(needs(preCloseout), releaseChain.dependencies["pre-publish-closeout"]), `${releaseFile} pre-publish closeout dependencies must match the release claim graph`);
+  // The producer map is the trust boundary between a real proof and a non-claim, so the closeout
+  // collects the lost-runner evidence itself instead of inheriting the non-claim producer's verdict.
   requireStepRun(violations, releaseFile, preCloseout, "Authenticate pre-publish Actions provenance", [
     "producer-map",
     "--phase pre_publish",
     "artifact_ids",
+    "bash .github/scripts/collect-actions-job-evidence.sh",
+    "--job-evidence target/release-closeout/job-evidence.json",
   ]);
   const preDownload = namedStep(preCloseout, "Download selected pre-publish release cells");
   add(
@@ -1878,10 +1891,27 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   const publish = requireJob(violations, releaseFile, release, "publish");
   add(violations, publish.if === "inputs.publish_release", `${releaseFile} publish must require trusted publication authority`);
   add(violations, sameMembers(needs(publish), releaseChain.dependencies.publish), `${releaseFile} publish dependencies must match the release claim graph`);
+  // The published platform table is a claim about this release, so it is rendered from the accepted
+  // ledger. Rendering it from the static graph is how a release whose accelerator proof was
+  // withheld still announced that accelerator as supported.
+  requireStepUses(
+    violations,
+    releaseFile,
+    publish,
+    "Download the accepted pre-publish closeout",
+    "actions/download-artifact@v8.0.1",
+  );
   requireStepRun(violations, releaseFile, publish, "Compose versioned GitHub release notes", [
     "node .github/scripts/extract-codestory-release-notes.mjs",
     "--output target/release-assets/release-notes.md",
     "node scripts/codestory-release-claims.mjs release-platform-notes",
+    "--ledger target/release-closeout/pre_publish/ledger.json",
+  ]);
+  // The ledger the README tells readers to consult has to be reachable from the release itself.
+  requireStepRun(violations, releaseFile, publish, "Ship the accepted closeout summary with the release", [
+    "target/release-closeout/pre_publish/summary.json",
+    '"$(jq -r .decision "$summary")" = accept',
+    "target/release-assets/release-closeout-summary.json",
   ]);
   requireStepRun(violations, releaseFile, publish, "Refuse existing tag or release", [
     'git ls-remote --exit-code --tags origin "refs/tags/$TAG"',
@@ -1959,6 +1989,8 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     "producer-map",
     "--phase post_publish",
     "artifact_ids",
+    "bash .github/scripts/collect-actions-job-evidence.sh",
+    "--job-evidence target/release-closeout/job-evidence.json",
   ]);
   const postDownload = namedStep(postCloseout, "Download selected release cells without flattening");
   add(
@@ -4181,12 +4213,214 @@ function validateReleaseCellUploadOwnership(workflows, violations) {
     "linux-vulkan-proof.yml/packaged-vulkan/release-cell-postpublish-retrieval-linux-x64-attempt-${{ github.run_attempt }}",
     "linux-vulkan-proof.yml/packaged-vulkan/release-cell-prepublish-candidate-installed-linux-x64-attempt-${{ github.run_attempt }}",
     "post-publish-release-smoke.yml/smoke/release-cell-postpublish-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}",
+    // The withheld-claim producer is the one job allowed to write a cell it did not prove, and it
+    // owns exactly one attempt-qualified artifact per protected host and closeout phase.
+    "release.yml/accelerator-non-claim/release-cell-nonclaim-prepublish-macos-arm64-metal-attempt-${{ github.run_attempt }}",
+    "release.yml/accelerator-non-claim/release-cell-nonclaim-postpublish-macos-arm64-metal-attempt-${{ github.run_attempt }}",
+    "release.yml/accelerator-non-claim/release-cell-nonclaim-prepublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}",
+    "release.yml/accelerator-non-claim/release-cell-nonclaim-postpublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}",
+    "release.yml/accelerator-non-claim/release-cell-nonclaim-prepublish-linux-x64-vulkan-attempt-${{ github.run_attempt }}",
+    "release.yml/accelerator-non-claim/release-cell-nonclaim-postpublish-linux-x64-vulkan-attempt-${{ github.run_attempt }}",
   ];
   add(
     violations,
     JSON.stringify(actual.sort()) === JSON.stringify(expected.sort()),
     "release-cell Actions artifact names must have one graph-owned producer job and attempt suffix",
   );
+}
+
+const JOB_EVIDENCE_COLLECTOR = ".github/scripts/collect-actions-job-evidence.sh";
+
+/// `checks: read` is the token scope that makes the lost-runner signature readable at all.
+///
+/// The signature's first part is a job annotation, and GET /repos/{o}/{r}/check-runs/{id}/annotations
+/// is gated on that scope. A workflow that runs the collector without it gets a 403, which the
+/// collector now refuses rather than reporting as "no annotations" -- so the missing scope stops a
+/// release instead of quietly making recovery impossible. This rule catches it before the release,
+/// in every workflow that reaches the collector, including the reusable-workflow callers whose own
+/// grant is the ceiling for everything they call.
+export function annotationScopeViolations(workflows) {
+  const violations = [];
+  const grantsChecksRead = permissions => object(permissions).checks === "read";
+  const collectorWorkflows = new Set();
+  for (const [file, workflow] of workflows) {
+    for (const [jobId, job] of Object.entries(object(workflow.jobs))) {
+      const runsCollector = list(object(job).steps)
+        .some(step => String(object(step).run ?? "").includes(JOB_EVIDENCE_COLLECTOR));
+      if (!runsCollector) continue;
+      collectorWorkflows.add(file);
+      // A job-level `permissions:` block replaces the workflow-level one outright, so the effective
+      // grant is whichever of the two the job actually has.
+      const effective = object(job).permissions !== undefined
+        ? object(job).permissions
+        : object(workflow).permissions;
+      add(
+        violations,
+        grantsChecksRead(effective),
+        `${file} job ${jobId} reads Actions job annotations and must grant checks: read`,
+      );
+    }
+  }
+  for (const [file, workflow] of workflows) {
+    for (const [jobId, job] of Object.entries(object(workflow.jobs))) {
+      const uses = String(object(job).uses ?? "");
+      if (!uses.startsWith("./.github/workflows/")) continue;
+      if (!collectorWorkflows.has(uses.slice(uses.lastIndexOf("/") + 1))) continue;
+      add(
+        violations,
+        grantsChecksRead(object(job).permissions),
+        `${file} job ${jobId} calls a workflow that reads job annotations and must pass checks: read`,
+      );
+    }
+  }
+  add(
+    violations,
+    collectorWorkflows.size > 0,
+    `no workflow runs ${JOB_EVIDENCE_COLLECTOR}, so the lost-runner signature is never collected`,
+  );
+  return violations;
+}
+
+/// The two halves of the lost-runner contract: a bounded automatic re-dispatch, and a withheld
+/// claim once that bound is spent.
+///
+/// Both are places where a gate is being relaxed, so the policy pins the shapes that keep the
+/// relaxation honest: the rerun names individual lost jobs instead of asking Actions to rerun every
+/// failure, the recovery never waits on a human, and the withheld-claim producer decides from the
+/// shared classifier rather than from "the proof job went red".
+export function lostRunnerRecoveryViolations(workflows, graph) {
+  const violations = [];
+  const policy = graph.non_claim_policy;
+  const rerunFile = "lost-runner-rerun.yml";
+  const rerun = workflows.get(rerunFile);
+  add(
+    violations,
+    MAXIMUM_RUN_ATTEMPTS === policy.maximum_run_attempts,
+    `${rerunFile} recovery bound must equal the release claim graph maximum_run_attempts`,
+  );
+  add(
+    violations,
+    LOST_RUNNER_ANNOTATION === policy.annotation,
+    `${rerunFile} recovery contract must key on the annotation the release claim graph records`,
+  );
+  if (!rerun) {
+    violations.push(`${rerunFile} must exist`);
+  } else {
+    const trigger = object(at(rerun, "on", "workflow_run"));
+    add(
+      violations,
+      includesAll(trigger.workflows, ["Auto Release", "Release"])
+        && includesAll(trigger.types, ["completed"]),
+      `${rerunFile} must observe completed release runs`,
+    );
+    add(
+      violations,
+      JSON.stringify(Object.entries(object(rerun.permissions)).sort())
+        === JSON.stringify([["actions", "write"], ["checks", "read"], ["contents", "read"]]),
+      `${rerunFile} must hold only the Actions write and annotation read scopes its recovery needs`,
+    );
+    const job = requireJob(violations, rerunFile, rerun, "rerun-lost-jobs");
+    // The repository requires machine recovery: an environment on this job would put a human click
+    // between a dropped connection and the retry, which is the failure this workflow exists to fix.
+    add(
+      violations,
+      object(job).environment === undefined,
+      `${rerunFile} recovery must not wait on an approval environment`,
+    );
+    add(
+      violations,
+      String(object(job).if ?? "").includes("github.event.workflow_run.conclusion == 'failure'"),
+      `${rerunFile} must act only on a failed release run`,
+    );
+    requireStepRun(violations, rerunFile, job, "Collect Actions failure evidence", [
+      "bash .github/scripts/collect-actions-job-evidence.sh",
+    ]);
+    requireStepRun(violations, rerunFile, job, "Plan the bounded rerun", [
+      "node .github/scripts/lost-runner-recovery.mjs plan-rerun",
+    ]);
+    const dispatch = namedStep(job, "Re-dispatch only the lost jobs");
+    add(
+      violations,
+      dispatch?.if === "steps.plan.outputs.rerun == 'true'",
+      `${rerunFile} re-dispatch must be gated on the classified recovery plan`,
+    );
+    requireStepRun(violations, rerunFile, job, "Re-dispatch only the lost jobs", [
+      "actions/jobs/$job_id/rerun",
+    ]);
+    // Re-running every failed job would sweep an assertion failure back into the queue alongside
+    // the lost one; the plan names ids, so the API call must be the per-job endpoint.
+    add(
+      violations,
+      !scalarStrings(rerun).some(value => value.includes("rerun-failed-jobs")),
+      `${rerunFile} must re-dispatch named lost jobs, never every failed job`,
+    );
+  }
+
+  const releaseFile = "release.yml";
+  const release = workflows.get(releaseFile);
+  if (!release) return violations;
+  const job = requireJob(violations, releaseFile, release, "accelerator-non-claim");
+  add(
+    violations,
+    sameMembers(needs(job), graph.workflow_policy.release_chain.dependencies["accelerator-non-claim"]),
+    `${releaseFile} non-claim dependencies must match the release claim graph`,
+  );
+  add(
+    violations,
+    job.name === policy.producer_job_name,
+    `${releaseFile} non-claim job name must equal the release claim graph producer_job_name`,
+  );
+  add(
+    violations,
+    object(job).environment === undefined,
+    `${releaseFile} non-claim producer must not wait on an approval environment`,
+  );
+  add(
+    violations,
+    String(object(job).if ?? "").startsWith("always()"),
+    `${releaseFile} non-claim producer must observe every accelerator outcome`,
+  );
+  requireStepRun(violations, releaseFile, job, "Collect protected accelerator job evidence", [
+    "bash .github/scripts/collect-actions-job-evidence.sh",
+    "non_claim_policy.hosts",
+  ]);
+  requireStepRun(violations, releaseFile, job, "Decide withheld accelerator hosts", [
+    "node .github/scripts/lost-runner-recovery.mjs plan-non-claim",
+  ]);
+  const record = namedStep(job, "Record populated accelerator non-claims");
+  add(
+    violations,
+    record?.if === "steps.non-claim.outputs.withheld_hosts != ''",
+    `${releaseFile} non-claim cells must be written only for hosts the classifier withheld`,
+  );
+  requireStepRun(violations, releaseFile, job, "Record populated accelerator non-claims", [
+    "scripts/codestory-release-cell-manifest.mjs withhold",
+    '--producer-run-attempt "$GITHUB_RUN_ATTEMPT"',
+  ]);
+  // A non-claim producer that emitted evidence for a host that reported would overwrite a real
+  // proof, so every upload is bound to the classifier's own withheld list. Each closeout phase gets
+  // its own container: a phase authorizes every manifest inside the container it downloads, so a
+  // container mixing phases would carry a manifest that phase's producer map never selected.
+  for (const host of policy.hosts) {
+    for (const [phase, artifact] of Object.entries(host.producer_artifacts)) {
+      const prefix = artifact.replace("-attempt-{attempt}", "");
+      const upload = [...list(job.steps)].find(step =>
+        String(object(object(step).with).name ?? "").startsWith(prefix));
+      add(
+        violations,
+        upload?.if === `contains(steps.non-claim.outputs.withheld_hosts, '${host.id}')`
+          && String(object(object(upload).with).path ?? "").endsWith(`/${host.id}/${phase}`),
+        `${releaseFile} withheld ${host.id} ${phase} cells must upload only that phase for a withheld host`,
+      );
+    }
+  }
+  const closeout = requireJob(violations, releaseFile, release, "pre-publish-closeout");
+  add(
+    violations,
+    String(object(closeout).if ?? "").includes("needs.accelerator-non-claim.result == 'success'"),
+    `${releaseFile} pre-publish closeout must require a decided non-claim outcome`,
+  );
+  return violations;
 }
 
 function validateReleaseArtifactRerunSafety(workflows, violations) {
@@ -4605,6 +4839,8 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   validateRemainingWorkflows(workflows, violations);
   validateReleaseCellUploadOwnership(workflows, violations);
   validateReleaseArtifactRerunSafety(workflows, violations);
+  violations.push(...annotationScopeViolations(workflows));
+  violations.push(...lostRunnerRecoveryViolations(workflows, graph));
   violations.push(...releaseWorkflowContractViolations(workflows, graph));
   return violations;
 }

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -5,11 +5,18 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { loadReleaseClaimGraph } from "../../scripts/codestory-release-claims.mjs";
 import {
+  LOST_RUNNER_ANNOTATION,
+  MAXIMUM_RUN_ATTEMPTS,
+} from "./lost-runner-recovery.mjs";
+import {
+  annotationScopeViolations,
   basicWorkflowViolations,
   draftSourcePolicyViolations,
   draftWorkflowPolicyViolations,
   loadWorkflows,
+  lostRunnerRecoveryViolations,
   macosCliDistributionViolations,
   notaryStepViolations,
   packagedPrSigningViolations,
@@ -2469,4 +2476,204 @@ test("the plugin lane still forbids building, signing, and forwarded secrets", a
       assert.match(violations.join("\n"), expected);
     });
   }
+});
+
+test("every lane that reads job annotations holds the checks: read scope", async (t) => {
+  // The recovery path was inert in production because none of the three permission blocks that
+  // govern the annotations call granted `checks: read`. The live repository now does, in all three
+  // -- including auto-release.yml, the lane that actually publishes.
+  const workflows = loadWorkflows();
+  assert.deepEqual(annotationScopeViolations(workflows), []);
+  assert.equal(workflows.get("release.yml").permissions.checks, "read");
+  assert.equal(workflows.get("lost-runner-rerun.yml").permissions.checks, "read");
+  assert.equal(workflows.get("auto-release.yml").jobs.release.permissions.checks, "read");
+
+  const mutations = [
+    ["release.yml loses the scope", live => {
+      delete live.get("release.yml").permissions.checks;
+    }, /release\.yml job accelerator-non-claim .*checks: read/u],
+    ["auto-release.yml loses the scope", live => {
+      delete live.get("auto-release.yml").jobs.release.permissions.checks;
+    }, /auto-release\.yml job release .*checks: read/u],
+    ["lost-runner-rerun.yml loses the scope", live => {
+      delete live.get("lost-runner-rerun.yml").permissions.checks;
+    }, /lost-runner-rerun\.yml job rerun-lost-jobs .*checks: read/u],
+    // A job-level block replaces the workflow-level one, so a narrower job grant is a real loss.
+    ["a job-level block drops the scope", live => {
+      live.get("release.yml").jobs["accelerator-non-claim"].permissions = {
+        actions: "read",
+        contents: "read",
+      };
+    }, /release\.yml job accelerator-non-claim .*checks: read/u],
+    ["write is not read", live => {
+      live.get("release.yml").permissions.checks = "write";
+    }, /release\.yml job accelerator-non-claim .*checks: read/u],
+  ];
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const live = loadWorkflows();
+      mutate(live);
+      const violations = annotationScopeViolations(live);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expected);
+      // The whole gate must refuse too, not only the isolated predicate.
+      assert.notDeepEqual(validateWorkflows(live), []);
+    });
+  }
+});
+
+test("the closeout collects the lost-runner evidence itself and publishes from the ledger", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const mutations = [
+    // The trust boundary that decides proof-versus-non-claim must not inherit the producer's
+    // verdict, so the closeout's own producer-map call carries evidence it collected.
+    ["pre-publish closeout stops collecting its own evidence", live => {
+      const step = live.get("release.yml").jobs["pre-publish-closeout"].steps
+        .find(({ name }) => name === "Authenticate pre-publish Actions provenance");
+      step.run = step.run
+        .replace(/\s*bash \.github\/scripts\/collect-actions-job-evidence\.sh[^\n]*\n[^\n]*\n/u, "\n")
+        .replace(/\s*--job-evidence [^\n]*\n/u, "\n");
+    }, /must contain --job-evidence|collect-actions-job-evidence/u],
+    ["post-publish closeout stops collecting its own evidence", live => {
+      const step = live.get("release.yml").jobs["post-publish-closeout"].steps
+        .find(({ name }) => name === "Authenticate post-publish Actions provenance");
+      step.run = step.run.replace(/\s*--job-evidence [^\n]*\n/u, "\n");
+    }, /--job-evidence/u],
+    // Release notes rendered from the static graph are how a withheld accelerator was still
+    // announced as supported.
+    ["release notes rendered without the ledger", live => {
+      const step = live.get("release.yml").jobs.publish.steps
+        .find(({ name }) => name === "Compose versioned GitHub release notes");
+      step.run = step.run.replace(/ \\\n\s*--ledger [^\n]*/u, "");
+    }, /--ledger target\/release-closeout\/pre_publish\/ledger\.json/u],
+    ["the accepted ledger is never downloaded", live => {
+      const job = live.get("release.yml").jobs.publish;
+      job.steps = job.steps.filter(({ name }) => name !== "Download the accepted pre-publish closeout");
+    }, /Download the accepted pre-publish closeout/u],
+    // The ledger the README points readers at has to reach a release consumer.
+    ["the closeout summary stops shipping", live => {
+      const job = live.get("release.yml").jobs.publish;
+      job.steps = job.steps
+        .filter(({ name }) => name !== "Ship the accepted closeout summary with the release");
+    }, /Ship the accepted closeout summary with the release/u],
+    ["a rejected closeout is shipped anyway", live => {
+      const step = live.get("release.yml").jobs.publish.steps
+        .find(({ name }) => name === "Ship the accepted closeout summary with the release");
+      step.run = step.run.replace(/\s*test "\$\(jq -r \.decision "\$summary"\)" = accept\n/u, "\n");
+    }, /= accept/u],
+  ];
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const live = loadWorkflows();
+      mutate(live);
+      const violations = validateWorkflows(live);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expected);
+    });
+  }
+});
+
+test("lost-runner recovery stays automatic, bounded, and blind to job names", () => {
+  const graph = loadReleaseClaimGraph(root);
+  const rerunFile = "lost-runner-rerun.yml";
+
+  // Both halves agree on the same live repository shape today.
+  assert.deepEqual(lostRunnerRecoveryViolations(loadWorkflows(), graph), []);
+  assert.equal(MAXIMUM_RUN_ATTEMPTS, graph.non_claim_policy.maximum_run_attempts);
+  assert.equal(LOST_RUNNER_ANNOTATION, graph.non_claim_policy.annotation);
+
+  const mutations = [
+    // Recovery that waits on a human is the failure this workflow exists to remove.
+    ["approval-gated rerun", workflows => {
+      workflows.get(rerunFile).jobs["rerun-lost-jobs"].environment = "release-recovery";
+    }],
+    ["approval-gated non-claim", workflows => {
+      workflows.get("release.yml").jobs["accelerator-non-claim"].environment = "release-recovery";
+    }],
+    // Re-running every failed job would sweep an assertion failure along with the lost one.
+    ["blanket failed-job rerun", workflows => {
+      const step = workflows.get(rerunFile).jobs["rerun-lost-jobs"].steps
+        .find(({ name }) => name === "Re-dispatch only the lost jobs");
+      step.run = step.run.replace(
+        "actions/jobs/$job_id/rerun",
+        "actions/runs/$FAILED_RUN_ID/rerun-failed-jobs",
+      );
+    }],
+    ["ungated re-dispatch", workflows => {
+      delete workflows.get(rerunFile).jobs["rerun-lost-jobs"].steps
+        .find(({ name }) => name === "Re-dispatch only the lost jobs").if;
+    }],
+    ["unclassified re-dispatch", workflows => {
+      const job = workflows.get(rerunFile).jobs["rerun-lost-jobs"];
+      job.steps = job.steps.filter(({ name }) => name !== "Plan the bounded rerun");
+    }],
+    ["rerun on every conclusion", workflows => {
+      delete workflows.get(rerunFile).jobs["rerun-lost-jobs"].if;
+    }],
+    ["missing release observation", workflows => {
+      workflows.get(rerunFile).on.workflow_run.workflows = ["Auto Release"];
+    }],
+    ["broadened recovery permissions", workflows => {
+      workflows.get(rerunFile).permissions.contents = "write";
+    }],
+    // The withheld-claim producer must decide from the classifier, not from a red proof job.
+    ["unclassified non-claim", workflows => {
+      const job = workflows.get("release.yml").jobs["accelerator-non-claim"];
+      job.steps = job.steps.filter(({ name }) => name !== "Decide withheld accelerator hosts");
+    }],
+    ["unconditional non-claim cells", workflows => {
+      delete workflows.get("release.yml").jobs["accelerator-non-claim"].steps
+        .find(({ name }) => name === "Record populated accelerator non-claims").if;
+    }],
+    ["non-claim upload for a host that reported", workflows => {
+      workflows.get("release.yml").jobs["accelerator-non-claim"].steps
+        .find(({ with: options }) => String(options?.name ?? "")
+          .startsWith("release-cell-nonclaim-prepublish-linux-x64-vulkan")).if = "always()";
+    }],
+    // One container per closeout phase: a phase's producer map authorizes only the manifests it
+    // selected, so a container carrying another phase's cell is rejected at download time.
+    ["phase-mixed non-claim container", workflows => {
+      workflows.get("release.yml").jobs["accelerator-non-claim"].steps
+        .find(({ with: options }) => String(options?.name ?? "")
+          .startsWith("release-cell-nonclaim-postpublish-linux-x64-vulkan"))
+        .with.path = "target/release-non-claim/cells/linux-x64-vulkan";
+    }],
+    ["closeout ignores the non-claim outcome", workflows => {
+      const job = workflows.get("release.yml").jobs["pre-publish-closeout"];
+      job.if = job.if.replace(
+        " && (needs.accelerator-non-claim.result == 'success' || needs.accelerator-non-claim.result == 'skipped')",
+        "",
+      );
+    }],
+    ["non-claim skips the accelerator hosts", workflows => {
+      workflows.get("release.yml").jobs["accelerator-non-claim"].needs = ["preflight", "packaged-proof"];
+    }],
+    ["non-claim producer job renamed away from the graph", workflows => {
+      workflows.get("release.yml").jobs["accelerator-non-claim"].name = "Skip accelerator proof";
+    }],
+    ["forged withheld cell producer", workflows => {
+      workflows.get("release.yml").jobs.publish.steps.push({
+        name: "Upload forged withheld cell",
+        uses: "actions/upload-artifact@v7.0.1",
+        with: {
+          name: "release-cell-nonclaim-prepublish-linux-x64-vulkan-attempt-${{ github.run_attempt }}",
+          path: "forged.json",
+        },
+      });
+    }],
+  ];
+  for (const [label, mutate] of mutations) {
+    const workflows = loadWorkflows();
+    mutate(workflows);
+    assert.notDeepEqual(validateWorkflows(workflows), [], label);
+  }
+
+  // A recovery bound that drifts from the release claim graph is caught even when the workflows
+  // are untouched: the two numbers are the same fact.
+  const drifted = structuredClone(graph);
+  drifted.non_claim_policy.maximum_run_attempts = 5;
+  assert.notDeepEqual(lostRunnerRecoveryViolations(loadWorkflows(), drifted), []);
+  const rephrased = structuredClone(graph);
+  rephrased.non_claim_policy.annotation = "The runner went away.";
+  assert.notDeepEqual(lostRunnerRecoveryViolations(loadWorkflows(), rephrased), []);
 });

--- a/.github/scripts/collect-actions-job-evidence.sh
+++ b/.github/scripts/collect-actions-job-evidence.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Collect the Actions job evidence that .github/scripts/lost-runner-recovery.mjs classifies.
+#
+# Both halves of the lost-runner contract -- the bounded automatic rerun and the withheld-claim
+# fallback -- read the same three facts about a failed job, so they read them through one collector
+# rather than two copies of the same jq. Successful jobs are recorded without annotation or log
+# lookups because the classifier only ever inspects failures.
+#
+# Every lookup here fails closed. "This job had no annotations" and "this token may not read
+# annotations" are different facts about the world that an earlier version of this script both
+# reported as `[]`; the second one is a repository misconfiguration and has to stop the run rather
+# than quietly re-describe a lost runner as an ordinary assertion failure. The same goes for the
+# log blob: only a 404 means "the runner never uploaded one", and every other outcome -- 403, a
+# rate limit, a transport error -- is an error, never the permissive answer.
+#
+# The annotations endpoint needs the `checks: read` token scope. Any job that runs this script must
+# declare it; .github/scripts/check-workflow-policy.mjs refuses a workflow that does not.
+#
+# usage: collect-actions-job-evidence.sh <run_id> <run_attempt> <output.json>
+set -euo pipefail
+
+run_id="$1"
+run_attempt="$2"
+output="$3"
+mkdir -p "$(dirname "$output")"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Ask one Actions endpoint for its HTTP status without letting a transport failure impersonate an
+# answer. Prints the final status code of the redirect chain, or nothing at all when gh never got
+# a response -- callers treat "nothing" as an error, never as a verdict.
+http_status() {
+  local target="$1" response
+  response="$(gh api --include --silent "$target" 2>/dev/null || true)"
+  printf '%s\n' "$response" |
+    awk 'toupper($1) ~ /^HTTP\// { code = $2 } END { if (code != "") print code }'
+}
+
+# Every attempt, not just the current one. The recovery bound counts how many times *this job* was
+# lost to its runner, which is a different number from how many times the run was re-run: a release
+# re-run for an unrelated reason must not consume a host's one automatic retry before it is owed.
+: > "$work/jobs.ndjson"
+attempt=1
+while [ "$attempt" -le "$run_attempt" ]; do
+  gh api --paginate \
+    "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/attempts/$attempt/jobs?per_page=100" \
+    --jq '.jobs[]' >> "$work/jobs.ndjson"
+  attempt=$((attempt + 1))
+done
+jq -s '.' "$work/jobs.ndjson" > "$work/jobs.json"
+
+# One row per execution: a job Actions carried forward unchanged is listed under the same id by
+# every later attempt, and counting it twice would spend a recovery that never happened.
+jq -c '[.[] | {id, name, status, conclusion, run_attempt, steps}]
+       | group_by(.id) | map(max_by(.run_attempt)) | sort_by(.id) | .[]' \
+  "$work/jobs.json" > "$work/selected.json"
+
+: > "$work/rows.json"
+# Read from a file rather than a pipe so the loop runs in this shell: a `exit 1` below has to stop
+# the collector, not just a subshell that the pipeline would then report as success.
+while IFS= read -r job; do
+  job_id="$(jq -r '.id' <<<"$job")"
+  if [ "$(jq -r '.conclusion' <<<"$job")" = failure ]; then
+    if ! annotations="$(gh api "repos/$GITHUB_REPOSITORY/check-runs/$job_id/annotations" 2>"$work/annotations.err")"; then
+      echo "::error::Cannot read annotations for job $job_id: $(tr -d '\n' < "$work/annotations.err")." >&2
+      echo "::error::The lost-runner signature is unreadable without the checks: read token scope." >&2
+      exit 1
+    fi
+    if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$annotations"; then
+      echo "::error::Annotations for job $job_id are not a JSON array." >&2
+      exit 1
+    fi
+    # A runner that lost communication never uploaded its log blob, so this endpoint 404s. That is
+    # one of the three parts of the signature and is not inferable from the job record alone.
+    log_status="$(http_status "repos/$GITHUB_REPOSITORY/actions/jobs/$job_id/logs")"
+    case "$log_status" in
+      2??) log_uploaded=true ;;
+      404|410) log_uploaded=false ;;
+      *)
+        echo "::error::Log blob probe for job $job_id answered ${log_status:-no HTTP status}." >&2
+        echo "::error::Only 404 means the runner uploaded no log; every other answer is an error." >&2
+        exit 1
+        ;;
+    esac
+    # Recorded state, so a reader of the evidence can see which answer produced the verdict rather
+    # than having to assume one.
+    probe="$(jq -nc \
+      --arg log_http_status "$log_status" \
+      '{annotations_read: true, log_http_status: ($log_http_status | tonumber)}')"
+  else
+    annotations='[]'
+    log_uploaded=true
+    probe='{"annotations_read":false,"log_http_status":null,"skipped":"conclusion_not_failure"}'
+  fi
+  jq -c \
+    --argjson annotations "$annotations" \
+    --argjson log_uploaded "$log_uploaded" \
+    --argjson probe "$probe" \
+    '. + {annotations: $annotations, log_uploaded: $log_uploaded, evidence_probe: $probe}' <<<"$job" \
+    >> "$work/rows.json"
+done < "$work/selected.json"
+
+jq -s '.' "$work/rows.json" > "$output"

--- a/.github/scripts/lost-runner-recovery.mjs
+++ b/.github/scripts/lost-runner-recovery.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+
+// A self-hosted runner that drops its connection mid-job is reported by Actions as an ordinary job
+// failure, which is indistinguishable from a proof that ran and refused to pass unless the run is
+// inspected. GitHub does leave a precise, machine-readable signature behind:
+//
+//   1. a job annotation whose text is exactly LOST_RUNNER_ANNOTATION,
+//   2. at least one step that completed with an EMPTY conclusion -- the steps queued behind the
+//      point where the connection died were never resolved, and
+//   3. no log blob: the runner never uploaded one, so the logs endpoint has nothing to serve.
+//
+// A proof that executed and failed its own assertions has none of those: it has a real conclusion
+// on every step and a log blob. This module keys on the signature, never on job names, so that a
+// renamed or newly added proof job cannot silently become retryable.
+
+import { readFileSync, writeFileSync, appendFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const LOST_RUNNER_ANNOTATION =
+  "The self-hosted runner lost communication with the server. "
+  + "Verify the machine is running and has a healthy network connection.";
+
+/// Total executions of one job permitted for a release run, counting the original. Two means one
+/// automatic recovery attempt: the bound exists so a permanently sick host cannot loop forever, and
+/// it is the same bound the withheld-claim fallback waits for before it stops expecting a proof.
+export const MAXIMUM_RUN_ATTEMPTS = 2;
+
+export const RUNNER_COMMUNICATION_LOSS = "runner_communication_loss";
+export const JOB_ASSERTION_FAILURE = "job_assertion_failure";
+export const RERUN_PLAN_SCHEMA = "codestory.lost-runner-rerun-plan/v1";
+export const NON_CLAIM_PLAN_SCHEMA = "codestory.accelerator-non-claim-plan/v1";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function text(value, label) {
+  if (typeof value !== "string" || value === "") fail(`${label} must be non-empty text`);
+  return value;
+}
+
+function positiveInteger(value, label) {
+  const selected = String(value ?? "");
+  if (!/^[1-9]\d*$/u.test(selected)) fail(`${label} must be a positive integer`);
+  return Number(selected);
+}
+
+function list(value, label) {
+  if (!Array.isArray(value)) fail(`${label} must be an array`);
+  return value;
+}
+
+/// Actions renders a reusable workflow's job as "<caller job> / <called job>"; the leaf is the name
+/// the release claim graph binds its producers to.
+export function leafJobName(name) {
+  return text(name, "Actions job name").split(" / ").at(-1);
+}
+
+function emptyConclusionSteps(job) {
+  return list(job.steps ?? [], "job steps")
+    .filter((step) => step?.conclusion === null || step?.conclusion === "")
+    .map((step) => String(step?.name ?? ""));
+}
+
+function annotationMatches(job) {
+  if (!Array.isArray(job.annotations)) fail("job annotations must be an array");
+  return job.annotations
+    .some((annotation) => String(annotation?.message ?? "").trim() === LOST_RUNNER_ANNOTATION);
+}
+
+/// Whether the runner uploaded a log blob. This must be a fact the collector actually established,
+/// not a field that happens to be absent: an absent field used to read as `false`, which is the
+/// half of the signature a lost runner needs, so a collector that silently stopped probing would
+/// have made every failure look lost. Absence is an error here and nowhere near a verdict.
+function logUploaded(job) {
+  if (typeof job.log_uploaded !== "boolean") {
+    fail("job log_uploaded must be a boolean established by the evidence collector");
+  }
+  return job.log_uploaded;
+}
+
+/// Classify one *failed* job. The lost-runner verdict requires all three signature parts at once:
+/// any one of them alone is reachable by an ordinary failure (a cancelled step leaves an empty
+/// conclusion, a log can be expired), so partial matches stay assertion failures and are never
+/// retried and never converted into a withheld claim.
+export function classifyJobFailure(job) {
+  const name = leafJobName(job?.name);
+  const conclusion = job?.conclusion === null || job?.conclusion === undefined
+    ? null
+    : String(job.conclusion);
+  const emptySteps = emptyConclusionSteps(job ?? {});
+  const evidence = {
+    annotation_matched: annotationMatches(job ?? {}),
+    empty_conclusion_steps: emptySteps,
+    log_uploaded: logUploaded(job ?? {}),
+  };
+  const lost = conclusion === "failure"
+    && evidence.annotation_matched
+    && emptySteps.length > 0
+    && evidence.log_uploaded === false;
+  return {
+    id: positiveInteger(job?.id, "Actions job id"),
+    name,
+    conclusion,
+    run_attempt: String(positiveInteger(job?.run_attempt, "Actions job run attempt")),
+    signature: lost ? RUNNER_COMMUNICATION_LOSS : JOB_ASSERTION_FAILURE,
+    evidence,
+  };
+}
+
+/// One row per *execution*. The collector reads every attempt of a run, so a job that Actions
+/// carried forward unchanged appears once per attempt listing under the same id; those are the same
+/// execution and must be counted once.
+function distinctExecutions(jobs) {
+  const byId = new Map();
+  for (const job of list(jobs, "Actions jobs")) {
+    const id = positiveInteger(job?.id, "Actions job id");
+    const attempt = positiveInteger(job?.run_attempt, "Actions job run attempt");
+    const previous = byId.get(id);
+    // Keep the richest sighting of an execution: a later attempt's listing carries the same facts,
+    // but only the listing taken from the attempt the job ran in has its evidence probed.
+    if (previous === undefined || positiveInteger(previous.run_attempt, "run attempt") < attempt) {
+      byId.set(id, job);
+    }
+  }
+  return [...byId.values()];
+}
+
+function failedJobs(jobs) {
+  return distinctExecutions(jobs).filter((job) => String(job?.conclusion ?? "") === "failure");
+}
+
+/// How many *executions* of one job name were lost to their runner, across every attempt collected.
+///
+/// This is the recovery counter, and it is deliberately not `GITHUB_RUN_ATTEMPT`. A release run
+/// reaches attempt 2 for any reason a maintainer likes -- a flaky unrelated job, a re-run to pick
+/// up a secret -- and the run-attempt number cannot tell that apart from "the automatic recovery
+/// for this host has already been spent". Counting lost executions of the job itself can: a host
+/// that has been lost once is owed a re-dispatch no matter what attempt the run is on, and a host
+/// that has been lost twice has had its one automatic recovery and gets no more.
+export function countLostExecutions(jobs, jobName) {
+  return distinctExecutions(jobs)
+    .filter((job) => leafJobName(job?.name) === jobName)
+    .filter((job) => String(job?.conclusion ?? "") === "failure")
+    .filter((job) => classifyJobFailure(job).signature === RUNNER_COMMUNICATION_LOSS)
+    .length;
+}
+
+/// Decide which individual jobs to re-dispatch. Only jobs carrying the lost-runner signature are
+/// ever re-dispatched -- the plan names them one by one instead of asking Actions to rerun every
+/// failed job, so a proof that failed its own assertions is left exactly as it is and keeps the run
+/// red. No approval gate is consulted: recovery is a machine decision or it does not happen.
+///
+/// The bound is per job, not per run: see `countLostExecutions`.
+export function planLostRunnerRerun({ runAttempt, runConclusion, jobs }) {
+  const attempt = positiveInteger(runAttempt, "run attempt");
+  const classified = failedJobs(jobs).map(classifyJobFailure);
+  const withRecoveries = classified.map((job) => ({
+    ...job,
+    lost_executions: countLostExecutions(jobs, job.name),
+  }));
+  const lost = withRecoveries.filter(({ signature }) => signature === RUNNER_COMMUNICATION_LOSS);
+  const notRetried = withRecoveries.filter(({ signature }) => signature !== RUNNER_COMMUNICATION_LOSS);
+  const retryable = lost.filter(({ lost_executions: spent }) => spent < MAXIMUM_RUN_ATTEMPTS);
+  const reason = String(runConclusion ?? "") !== "failure"
+    ? "run_did_not_fail"
+    : lost.length === 0
+      ? "no_runner_communication_loss"
+      : retryable.length === 0
+        ? "recovery_bound_reached"
+        : "runner_communication_loss";
+  return {
+    schema: RERUN_PLAN_SCHEMA,
+    rerun: reason === "runner_communication_loss",
+    reason,
+    run_attempt: attempt,
+    maximum_run_attempts: MAXIMUM_RUN_ATTEMPTS,
+    rerun_job_ids: reason === "runner_communication_loss" ? retryable.map(({ id }) => id) : [],
+    lost_jobs: lost,
+    not_retried_jobs: notRetried,
+  };
+}
+
+export const HOST_PROVEN = "proven";
+export const HOST_WITHHELD = "withheld";
+export const HOST_RETRY_PENDING = "retry_pending";
+export const HOST_BLOCKED = "blocked";
+
+/// Decide, per protected accelerator host, whether this run may record a populated non-claim.
+///
+/// `withheld` is reachable only from the lost-runner signature *after* the retry bound is spent.
+/// Every other shape -- a proof that failed its own assertions, a cancelled job, a job that never
+/// appeared in the run -- is `blocked`, which the CLI turns into a non-zero exit. Withholding is
+/// therefore never the fallback for "something went wrong": it is the fallback for exactly one
+/// machine-checkable fact.
+export function planAcceleratorNonClaim({ runAttempt, hosts, jobs }) {
+  const attempt = positiveInteger(runAttempt, "run attempt");
+  const inspected = distinctExecutions(jobs);
+  const rows = list(hosts, "protected hosts").map((host) => {
+    const hostId = text(host?.id, "protected host id");
+    const jobName = text(host?.job_name, `${hostId} producer job name`);
+    const occurrences = inspected.filter((job) => leafJobName(job?.name) === jobName);
+    if (occurrences.length === 0) {
+      return { host: hostId, job_name: jobName, state: HOST_BLOCKED, detail: "job_absent_from_run" };
+    }
+    const latestAttempt = Math.max(
+      ...occurrences.map((job) => positiveInteger(job?.run_attempt, `${jobName} run attempt`)),
+    );
+    const latest = occurrences.filter((job) => Number(job.run_attempt) === latestAttempt);
+    if (latest.length !== 1) {
+      return { host: hostId, job_name: jobName, state: HOST_BLOCKED, detail: "job_is_ambiguous" };
+    }
+    const job = latest[0];
+    if (String(job.status ?? "") === "completed" && String(job.conclusion ?? "") === "success") {
+      return { host: hostId, job_name: jobName, state: HOST_PROVEN, detail: "proof_succeeded" };
+    }
+    if (String(job.conclusion ?? "") !== "failure") {
+      return {
+        host: hostId,
+        job_name: jobName,
+        state: HOST_BLOCKED,
+        detail: `job_conclusion_${String(job.conclusion ?? "none")}`,
+      };
+    }
+    const classified = classifyJobFailure(job);
+    if (classified.signature !== RUNNER_COMMUNICATION_LOSS) {
+      return {
+        host: hostId,
+        job_name: jobName,
+        state: HOST_BLOCKED,
+        detail: JOB_ASSERTION_FAILURE,
+        job: classified,
+      };
+    }
+    // The bound that has to be spent is this host's own recovery, counted in lost executions of
+    // its job. A release run sitting at attempt 2 for an unrelated reason has still never
+    // re-dispatched this host, and the first loss of a runner is owed its one automatic retry.
+    const spent = countLostExecutions(jobs, jobName);
+    if (spent < MAXIMUM_RUN_ATTEMPTS || attempt < MAXIMUM_RUN_ATTEMPTS) {
+      return {
+        host: hostId,
+        job_name: jobName,
+        state: HOST_RETRY_PENDING,
+        detail: "automatic_rerun_still_owed",
+        lost_executions: spent,
+        job: classified,
+      };
+    }
+    return {
+      host: hostId,
+      job_name: jobName,
+      state: HOST_WITHHELD,
+      detail: RUNNER_COMMUNICATION_LOSS,
+      lost_executions: spent,
+      job: classified,
+    };
+  });
+  return {
+    schema: NON_CLAIM_PLAN_SCHEMA,
+    run_attempt: attempt,
+    maximum_run_attempts: MAXIMUM_RUN_ATTEMPTS,
+    hosts: rows,
+    withheld_hosts: rows.filter(({ state }) => state === HOST_WITHHELD).map(({ host }) => host),
+    blocked_hosts: rows
+      .filter(({ state }) => state === HOST_BLOCKED || state === HOST_RETRY_PENDING)
+      .map(({ host }) => host),
+  };
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(path.resolve(text(filePath, "input path")), "utf8"));
+}
+
+function writeJson(filePath, value) {
+  const absolute = path.resolve(text(filePath, "output path"));
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function emitOutputs(entries) {
+  const target = process.env.GITHUB_OUTPUT;
+  if (!target) return;
+  for (const [key, value] of Object.entries(entries)) {
+    appendFileSync(target, `${key}=${value}\n`);
+  }
+}
+
+function parseArgs(argv) {
+  const command = argv.shift();
+  const values = {};
+  while (argv.length > 0) {
+    const key = argv.shift();
+    const value = argv.shift();
+    if (!key?.startsWith("--") || value === undefined) fail("arguments must be --key value pairs");
+    values[key.slice(2)] = value;
+  }
+  return { command, values };
+}
+
+function main() {
+  const { command, values } = parseArgs(process.argv.slice(2));
+  if (command === "plan-rerun") {
+    const input = readJson(values.input);
+    const plan = planLostRunnerRerun({
+      runAttempt: input.run_attempt,
+      runConclusion: input.conclusion,
+      jobs: input.jobs,
+    });
+    writeJson(values.out ?? "target/lost-runner/rerun-plan.json", plan);
+    emitOutputs({ rerun: String(plan.rerun), job_ids: plan.rerun_job_ids.join(" ") });
+    console.log(JSON.stringify(plan, null, 2));
+    return;
+  }
+  if (command === "plan-non-claim") {
+    const input = readJson(values.input);
+    const plan = planAcceleratorNonClaim({
+      runAttempt: input.run_attempt,
+      hosts: input.hosts,
+      jobs: input.jobs,
+    });
+    writeJson(values.out ?? "target/lost-runner/non-claim-plan.json", plan);
+    emitOutputs({ withheld_hosts: plan.withheld_hosts.join(" ") });
+    console.log(JSON.stringify(plan, null, 2));
+    if (plan.blocked_hosts.length > 0) {
+      const blocked = plan.hosts.filter(({ state }) => state !== HOST_PROVEN && state !== HOST_WITHHELD);
+      for (const row of blocked) {
+        console.error(`::error::${row.host} cannot record a non-claim: ${row.detail}`);
+      }
+      process.exitCode = 1;
+    }
+    return;
+  }
+  fail(`unknown command ${String(command)}`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/.github/scripts/lost-runner-recovery.test.mjs
+++ b/.github/scripts/lost-runner-recovery.test.mjs
@@ -1,0 +1,600 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  JOB_ASSERTION_FAILURE,
+  LOST_RUNNER_ANNOTATION,
+  MAXIMUM_RUN_ATTEMPTS,
+  RUNNER_COMMUNICATION_LOSS,
+  classifyJobFailure,
+  countLostExecutions,
+  planAcceleratorNonClaim,
+  planLostRunnerRerun,
+} from "./lost-runner-recovery.mjs";
+
+const script = fileURLToPath(new URL("./lost-runner-recovery.mjs", import.meta.url));
+
+function lostJob(overrides = {}) {
+  return {
+    id: 41,
+    name: "linux-vulkan-proof / Packaged Linux Vulkan engine",
+    status: "completed",
+    conclusion: "failure",
+    run_attempt: "1",
+    log_uploaded: false,
+    annotations: [{ level: "failure", message: LOST_RUNNER_ANNOTATION }],
+    steps: [
+      { name: "Checkout exact source", status: "completed", conclusion: "success" },
+      { name: "Prove offline Linux Vulkan retrieval", status: "completed", conclusion: null },
+      { name: "Upload Linux Vulkan proof artifacts", status: "completed", conclusion: null },
+    ],
+    ...overrides,
+  };
+}
+
+function assertionJob(overrides = {}) {
+  return {
+    id: 42,
+    name: "linux-vulkan-proof / Packaged Linux Vulkan engine",
+    status: "completed",
+    conclusion: "failure",
+    run_attempt: "1",
+    log_uploaded: true,
+    annotations: [{ level: "failure", message: "Process completed with exit code 1." }],
+    steps: [
+      { name: "Checkout exact source", status: "completed", conclusion: "success" },
+      { name: "Prove offline Linux Vulkan retrieval", status: "completed", conclusion: "failure" },
+    ],
+    ...overrides,
+  };
+}
+
+const linuxHost = { id: "linux-x64-vulkan", job_name: "Packaged Linux Vulkan engine" };
+
+function runCli(command, input) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-lost-runner-"));
+  const inputPath = path.join(directory, "input.json");
+  const outPath = path.join(directory, "plan.json");
+  const outputsPath = path.join(directory, "outputs.txt");
+  writeFileSync(inputPath, JSON.stringify(input));
+  writeFileSync(outputsPath, "");
+  const result = spawnSync(
+    process.execPath,
+    [script, command, "--input", inputPath, "--out", outPath],
+    { encoding: "utf8", env: { ...process.env, GITHUB_OUTPUT: outputsPath } },
+  );
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    plan: JSON.parse(readFileSync(outPath, "utf8")),
+    outputs: readFileSync(outputsPath, "utf8"),
+  };
+}
+
+test("the lost-runner verdict needs the whole signature, not any one part of it", () => {
+  assert.equal(classifyJobFailure(lostJob()).signature, RUNNER_COMMUNICATION_LOSS);
+
+  // Each single-part removal must fall back to an assertion failure. Any one of these alone is
+  // reachable without a lost runner, so a partial match must never unlock a retry.
+  assert.equal(
+    classifyJobFailure(lostJob({ annotations: [{ message: "Process completed with exit code 1." }] })).signature,
+    JOB_ASSERTION_FAILURE,
+  );
+  assert.equal(
+    classifyJobFailure(lostJob({
+      steps: [{ name: "Prove offline Linux Vulkan retrieval", status: "completed", conclusion: "failure" }],
+    })).signature,
+    JOB_ASSERTION_FAILURE,
+  );
+  assert.equal(classifyJobFailure(lostJob({ log_uploaded: true })).signature, JOB_ASSERTION_FAILURE);
+
+  // A near-miss annotation is not the annotation.
+  assert.equal(
+    classifyJobFailure(lostJob({
+      annotations: [{ message: `${LOST_RUNNER_ANNOTATION} Retrying.` }],
+    })).signature,
+    JOB_ASSERTION_FAILURE,
+  );
+  // Surrounding whitespace in the Actions payload is not meaningful.
+  assert.equal(
+    classifyJobFailure(lostJob({ annotations: [{ message: `\n${LOST_RUNNER_ANNOTATION}\n` }] })).signature,
+    RUNNER_COMMUNICATION_LOSS,
+  );
+
+  // The verdict is reached without ever reading the job name.
+  assert.equal(
+    classifyJobFailure(lostJob({ name: "some-unrelated-job / Brand new proof" })).signature,
+    RUNNER_COMMUNICATION_LOSS,
+  );
+  assert.equal(
+    classifyJobFailure(assertionJob({ name: "linux-vulkan-proof / Packaged Linux Vulkan engine" })).signature,
+    JOB_ASSERTION_FAILURE,
+  );
+});
+
+/// The same host lost again on a later attempt: a *second* execution of the same job name, which is
+/// what actually spends the one automatic recovery.
+function lostAgain(attempt = MAXIMUM_RUN_ATTEMPTS) {
+  return lostJob({ id: 40 + attempt, run_attempt: String(attempt) });
+}
+
+test("only lost jobs are re-dispatched and the recovery bound counts recoveries", () => {
+  const lost = planLostRunnerRerun({
+    runAttempt: 1,
+    runConclusion: "failure",
+    jobs: [lostJob(), { id: 9, name: "Release / Workflow policy", conclusion: "success", run_attempt: "1" }],
+  });
+  assert.equal(lost.rerun, true);
+  assert.equal(lost.reason, "runner_communication_loss");
+  assert.deepEqual(lost.rerun_job_ids, [41]);
+  assert.equal(lost.maximum_run_attempts, MAXIMUM_RUN_ATTEMPTS);
+  assert.deepEqual(lost.lost_jobs.map(({ lost_executions: spent }) => spent), [1]);
+
+  // An assertion failure alongside a lost runner is reported and left untouched: it is not in the
+  // re-dispatch list, so the rerun cannot turn it green.
+  const mixed = planLostRunnerRerun({
+    runAttempt: 1,
+    runConclusion: "failure",
+    jobs: [lostJob(), assertionJob({ id: 77, name: "windows-vulkan-proof / Packaged Windows Vulkan engine" })],
+  });
+  assert.deepEqual(mixed.rerun_job_ids, [41]);
+  assert.deepEqual(mixed.not_retried_jobs.map(({ id }) => id), [77]);
+
+  // A run whose only failure is an assertion failure is never re-dispatched.
+  const assertionOnly = planLostRunnerRerun({
+    runAttempt: 1,
+    runConclusion: "failure",
+    jobs: [assertionJob()],
+  });
+  assert.equal(assertionOnly.rerun, false);
+  assert.equal(assertionOnly.reason, "no_runner_communication_loss");
+  assert.deepEqual(assertionOnly.rerun_job_ids, []);
+
+  // The bound is two lost executions of the same job: the second loss gets no third try.
+  const bounded = planLostRunnerRerun({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    runConclusion: "failure",
+    jobs: [lostJob(), lostAgain()],
+  });
+  assert.equal(bounded.rerun, false);
+  assert.equal(bounded.reason, "recovery_bound_reached");
+  assert.deepEqual(bounded.lost_jobs.map(({ lost_executions: spent }) => spent), [2, 2]);
+
+  // A run that reached attempt 2 for an unrelated reason has still never re-dispatched this host,
+  // and the first loss of its runner is owed its one automatic recovery. Reading the run-attempt
+  // number as a recovery counter refused the retry here and withheld the claim with zero recoveries.
+  const rerunForOtherReasons = planLostRunnerRerun({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    runConclusion: "failure",
+    jobs: [
+      { id: 9, name: "Release / Workflow policy", conclusion: "success", run_attempt: "1" },
+      lostJob({ run_attempt: String(MAXIMUM_RUN_ATTEMPTS) }),
+    ],
+  });
+  assert.equal(rerunForOtherReasons.rerun, true);
+  assert.equal(rerunForOtherReasons.reason, "runner_communication_loss");
+  assert.deepEqual(rerunForOtherReasons.rerun_job_ids, [41]);
+  assert.deepEqual(rerunForOtherReasons.lost_jobs.map(({ lost_executions: spent }) => spent), [1]);
+
+  // A job Actions carried forward unchanged is listed by every later attempt under the same id.
+  // Counting those listings would spend a recovery that never happened.
+  const carriedForward = planLostRunnerRerun({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    runConclusion: "failure",
+    jobs: [lostJob(), lostJob()],
+  });
+  assert.equal(carriedForward.rerun, true);
+  assert.deepEqual(carriedForward.lost_jobs.map(({ lost_executions: spent }) => spent), [1]);
+
+  // A green run is never re-dispatched even if a prior attempt left failure rows behind.
+  const green = planLostRunnerRerun({ runAttempt: 1, runConclusion: "success", jobs: [lostJob()] });
+  assert.equal(green.rerun, false);
+  assert.equal(green.reason, "run_did_not_fail");
+});
+
+test("a non-claim is reachable only from a spent retry bound on a lost runner", () => {
+  const proven = planAcceleratorNonClaim({
+    runAttempt: 1,
+    hosts: [linuxHost],
+    jobs: [lostJob({ conclusion: "success", steps: [], annotations: [], log_uploaded: true })],
+  });
+  assert.deepEqual(proven.hosts.map(({ state }) => state), ["proven"]);
+  assert.deepEqual(proven.withheld_hosts, []);
+  assert.deepEqual(proven.blocked_hosts, []);
+
+  // Attempts still owed: the run must be re-dispatched before anything may be withheld.
+  const pending = planAcceleratorNonClaim({ runAttempt: 1, hosts: [linuxHost], jobs: [lostJob()] });
+  assert.deepEqual(pending.hosts.map(({ state }) => state), ["retry_pending"]);
+  assert.deepEqual(pending.withheld_hosts, []);
+  assert.deepEqual(pending.blocked_hosts, ["linux-x64-vulkan"]);
+
+  const withheld = planAcceleratorNonClaim({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: [lostJob(), lostAgain()],
+  });
+  assert.deepEqual(withheld.hosts.map(({ state }) => state), ["withheld"]);
+  assert.deepEqual(withheld.withheld_hosts, ["linux-x64-vulkan"]);
+  assert.deepEqual(withheld.blocked_hosts, []);
+  assert.equal(withheld.hosts[0].lost_executions, MAXIMUM_RUN_ATTEMPTS);
+
+  // Withholding is the end of the bounded recovery path, never a shortcut around it. A release
+  // sitting at attempt 2 for an unrelated reason has spent no recovery on this host, so its first
+  // lost runner is owed one -- the earlier code withheld the claim here with zero recoveries.
+  const firstLossOnAReRunRelease = planAcceleratorNonClaim({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: [lostJob({ run_attempt: String(MAXIMUM_RUN_ATTEMPTS) })],
+  });
+  assert.deepEqual(firstLossOnAReRunRelease.hosts.map(({ state }) => state), ["retry_pending"]);
+  assert.equal(firstLossOnAReRunRelease.hosts[0].lost_executions, 1);
+  assert.deepEqual(firstLossOnAReRunRelease.withheld_hosts, []);
+  assert.deepEqual(firstLossOnAReRunRelease.blocked_hosts, ["linux-x64-vulkan"]);
+  // The two halves agree: what the non-claim refuses to withhold, the rerun plan agrees to retry.
+  assert.equal(
+    planLostRunnerRerun({
+      runAttempt: MAXIMUM_RUN_ATTEMPTS,
+      runConclusion: "failure",
+      jobs: [lostJob({ run_attempt: String(MAXIMUM_RUN_ATTEMPTS) })],
+    }).rerun,
+    true,
+  );
+
+  // The proof ran and refused to pass: exhausting attempts must not convert that into a non-claim.
+  const assertionFailure = planAcceleratorNonClaim({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: [assertionJob({ run_attempt: String(MAXIMUM_RUN_ATTEMPTS) })],
+  });
+  assert.deepEqual(assertionFailure.hosts.map(({ state }) => state), ["blocked"]);
+  assert.equal(assertionFailure.hosts[0].detail, JOB_ASSERTION_FAILURE);
+  assert.deepEqual(assertionFailure.withheld_hosts, []);
+
+  // A cancelled proof and a proof that never ran are both blocked, never withheld.
+  for (const jobs of [
+    [lostJob({ conclusion: "cancelled", run_attempt: String(MAXIMUM_RUN_ATTEMPTS) })],
+    [],
+  ]) {
+    const blocked = planAcceleratorNonClaim({
+      runAttempt: MAXIMUM_RUN_ATTEMPTS,
+      hosts: [linuxHost],
+      jobs,
+    });
+    assert.deepEqual(blocked.withheld_hosts, []);
+    assert.deepEqual(blocked.blocked_hosts, ["linux-x64-vulkan"]);
+  }
+});
+
+// ── The shell collector ─────────────────────────────────────────────────────────────────────
+
+const collector = fileURLToPath(new URL("./collect-actions-job-evidence.sh", import.meta.url));
+
+const collectorJobs = {
+  jobs: [
+    {
+      id: 41,
+      name: "linux-vulkan-proof / Packaged Linux Vulkan engine",
+      status: "completed",
+      conclusion: "failure",
+      run_attempt: 1,
+      steps: [
+        { name: "Checkout exact source", status: "completed", conclusion: "success" },
+        { name: "Prove offline Linux Vulkan retrieval", status: "completed", conclusion: null },
+      ],
+    },
+    {
+      id: 42,
+      name: "Release / Workflow policy",
+      status: "completed",
+      conclusion: "success",
+      run_attempt: 1,
+      steps: [{ name: "Enforce workflow policy", status: "completed", conclusion: "success" }],
+    },
+  ],
+};
+
+/// A `gh api` stand-in faithful enough to answer the three questions the collector asks, including
+/// the ones it must refuse to answer. `annotations` and `logs` each take an HTTP status; the stub
+/// reproduces gh's real behaviour for it -- a non-2xx exits 1 and prints the status line only when
+/// `--include` was passed, which is exactly how the collector distinguishes "no log" from "no
+/// answer".
+function runCollector({
+  annotationsStatus = 200,
+  logsStatus = 404,
+  runAttempt = 1,
+  jobsByAttempt = { 1: collectorJobs },
+} = {}) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-collect-"));
+  const bin = path.join(directory, "bin");
+  mkdirSync(bin);
+  for (const [attempt, listing] of Object.entries(jobsByAttempt)) {
+    writeFileSync(path.join(directory, `jobs-${attempt}.json`), JSON.stringify(listing));
+  }
+  const annotations = JSON.stringify([
+    { annotation_level: "failure", message: LOST_RUNNER_ANNOTATION },
+  ]);
+  writeFileSync(path.join(bin, "gh"), `#!/bin/sh
+include=0
+for arg in "$@"; do
+  case "$arg" in --include|-i) include=1 ;; esac
+done
+answer() {
+  status="$1"
+  body="$2"
+  case "$status" in
+    2*) [ "$include" = 1 ] && printf 'HTTP/2.0 %s OK\\r\\n\\r\\n' "$status"
+        [ -n "$body" ] && printf '%s\\n' "$body"
+        exit 0 ;;
+    *)  [ "$include" = 1 ] && printf 'HTTP/2.0 %s Refused\\r\\n\\r\\n' "$status"
+        echo "gh: HTTP $status" >&2
+        exit 1 ;;
+  esac
+}
+requested_attempt() {
+  for arg in "$@"; do
+    case "$arg" in
+      *"/attempts/"*"/jobs"*)
+        printf '%s' "$arg" | sed -e 's|.*/attempts/||' -e 's|/jobs.*||'
+        return ;;
+    esac
+  done
+}
+case "$*" in
+  *"/actions/runs/"*"/jobs"*)
+    listing='${directory}/jobs-'"$(requested_attempt "$@")"'.json'
+    [ -f "$listing" ] || { echo "gh: no such attempt" >&2; exit 1; }
+    jq -c '.jobs[]' "$listing" ;;
+  *"/check-runs/"*"/annotations"*) answer '${annotationsStatus}' '${annotations}' ;;
+  *"/actions/jobs/"*"/logs"*) answer '${logsStatus}' '' ;;
+  *) printf '[]\\n' ;;
+esac
+`, { mode: 0o755 });
+  const output = path.join(directory, "evidence.json");
+  const collected = spawnSync("bash", [collector, "7", String(runAttempt), output], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      GITHUB_REPOSITORY: "TheGreenCedar/CodeStory",
+    },
+  });
+  return {
+    status: collected.status,
+    stderr: collected.stderr,
+    rows: existsSync(output) ? JSON.parse(readFileSync(output, "utf8")) : null,
+  };
+}
+
+test("the shell collector hands the classifier the whole signature", () => {
+  // The three signature parts live in three different Actions endpoints, so the collector is the
+  // only place they are joined. A collector that dropped one of them would silently turn every
+  // lost job into an assertion failure, which no unit test of the classifier can catch.
+  const collected = runCollector();
+  assert.equal(collected.status, 0, collected.stderr);
+  assert.equal(collected.rows.length, 2);
+  const plan = planLostRunnerRerun({ runAttempt: 1, runConclusion: "failure", jobs: collected.rows });
+  assert.equal(plan.rerun, true);
+  assert.deepEqual(plan.rerun_job_ids, [41]);
+  assert.equal(plan.lost_jobs[0].evidence.log_uploaded, false);
+  assert.equal(plan.lost_jobs[0].evidence.annotation_matched, true);
+  assert.deepEqual(plan.lost_jobs[0].evidence.empty_conclusion_steps, [
+    "Prove offline Linux Vulkan retrieval",
+  ]);
+  // The probe result is recorded, so a reader can see which answer produced the verdict.
+  const failed = collected.rows.find(({ id }) => id === 41);
+  assert.deepEqual(failed.evidence_probe, { annotations_read: true, log_http_status: 404 });
+});
+
+test("a failed job that did upload its log is an assertion failure, not a lost runner", () => {
+  // The permissive direction of the log probe. Everything else about job 41 matches the lost-runner
+  // signature exactly; only the uploaded log separates it from one, so this is the branch that
+  // keeps an ordinary red proof out of the retry-and-withhold lane.
+  const collected = runCollector({ logsStatus: 200 });
+  assert.equal(collected.status, 0, collected.stderr);
+  const failed = collected.rows.find(({ id }) => id === 41);
+  assert.equal(failed.log_uploaded, true);
+  assert.deepEqual(failed.evidence_probe, { annotations_read: true, log_http_status: 200 });
+
+  const plan = planLostRunnerRerun({ runAttempt: 1, runConclusion: "failure", jobs: collected.rows });
+  assert.equal(plan.rerun, false);
+  assert.equal(plan.reason, "no_runner_communication_loss");
+  assert.deepEqual(plan.rerun_job_ids, []);
+  assert.deepEqual(plan.not_retried_jobs.map(({ signature }) => signature), [JOB_ASSERTION_FAILURE]);
+
+  // And it can never become a withheld claim, however many attempts are spent on it.
+  const nonClaim = planAcceleratorNonClaim({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: collected.rows,
+  });
+  assert.deepEqual(nonClaim.withheld_hosts, []);
+  assert.deepEqual(nonClaim.blocked_hosts, ["linux-x64-vulkan"]);
+  assert.equal(nonClaim.hosts[0].detail, JOB_ASSERTION_FAILURE);
+});
+
+test("the collector reads every attempt so the recovery bound counts recoveries", () => {
+  // The recovery counter needs history the current attempt alone does not have. Attempt 1 lost the
+  // Linux host; attempt 2 re-executed it (a new job id) and lost it again, and also lists the
+  // policy job Actions carried forward unchanged under its original id.
+  const lostAt = (id, attempt) => ({
+    id,
+    name: "linux-vulkan-proof / Packaged Linux Vulkan engine",
+    status: "completed",
+    conclusion: "failure",
+    run_attempt: attempt,
+    steps: [
+      { name: "Checkout exact source", status: "completed", conclusion: "success" },
+      { name: "Prove offline Linux Vulkan retrieval", status: "completed", conclusion: null },
+    ],
+  });
+  const carriedForward = {
+    id: 42,
+    name: "Release / Workflow policy",
+    status: "completed",
+    conclusion: "success",
+    run_attempt: 1,
+    steps: [{ name: "Enforce workflow policy", status: "completed", conclusion: "success" }],
+  };
+  const collected = runCollector({
+    runAttempt: 2,
+    jobsByAttempt: {
+      1: { jobs: [lostAt(41, 1), carriedForward] },
+      2: { jobs: [lostAt(43, 2), carriedForward] },
+    },
+  });
+  assert.equal(collected.status, 0, collected.stderr);
+  // Three executions, not four: the carried-forward job is listed by both attempts under one id.
+  assert.deepEqual(collected.rows.map(({ id }) => id), [41, 42, 43]);
+
+  assert.equal(countLostExecutions(collected.rows, "Packaged Linux Vulkan engine"), 2);
+  const plan = planLostRunnerRerun({ runAttempt: 2, runConclusion: "failure", jobs: collected.rows });
+  assert.equal(plan.rerun, false);
+  assert.equal(plan.reason, "recovery_bound_reached");
+  const nonClaim = planAcceleratorNonClaim({
+    runAttempt: 2,
+    hosts: [linuxHost],
+    jobs: collected.rows,
+  });
+  assert.deepEqual(nonClaim.withheld_hosts, ["linux-x64-vulkan"]);
+  assert.equal(nonClaim.hosts[0].lost_executions, 2);
+
+  // A host that succeeded on attempt 1 and was not re-executed is still `proven`, whether or not
+  // Actions carries it into the attempt-2 listing. Reading only the current attempt would report
+  // `job_absent_from_run` for every healthy host and block the recovery a second way.
+  const macos = {
+    id: 44,
+    name: "macos-metal-proof / Packaged Apple Silicon Metal engine",
+    status: "completed",
+    conclusion: "success",
+    run_attempt: 1,
+    steps: [{ name: "Prove Metal retrieval", status: "completed", conclusion: "success" }],
+  };
+  const onlyTheLostJobRetried = runCollector({
+    runAttempt: 2,
+    jobsByAttempt: {
+      1: { jobs: [lostAt(41, 1), macos, carriedForward] },
+      2: { jobs: [lostAt(43, 2)] },
+    },
+  });
+  assert.equal(onlyTheLostJobRetried.status, 0, onlyTheLostJobRetried.stderr);
+  assert.deepEqual(
+    planAcceleratorNonClaim({
+      runAttempt: 2,
+      hosts: [linuxHost, { id: "macos-arm64-metal", job_name: "Packaged Apple Silicon Metal engine" }],
+      jobs: onlyTheLostJobRetried.rows,
+    }).hosts.map(({ host, state }) => [host, state]),
+    [["linux-x64-vulkan", "withheld"], ["macos-arm64-metal", "proven"]],
+  );
+
+  // The same run with only one loss so far still owes a recovery, and is refused a non-claim.
+  const onlyOnce = runCollector({
+    runAttempt: 2,
+    jobsByAttempt: {
+      1: { jobs: [carriedForward] },
+      2: { jobs: [lostAt(43, 2), carriedForward] },
+    },
+  });
+  assert.equal(onlyOnce.status, 0, onlyOnce.stderr);
+  assert.equal(countLostExecutions(onlyOnce.rows, "Packaged Linux Vulkan engine"), 1);
+  assert.equal(
+    planAcceleratorNonClaim({ runAttempt: 2, hosts: [linuxHost], jobs: onlyOnce.rows })
+      .hosts[0].state,
+    "retry_pending",
+  );
+  assert.equal(
+    planLostRunnerRerun({ runAttempt: 2, runConclusion: "failure", jobs: onlyOnce.rows }).rerun,
+    true,
+  );
+});
+
+test("the collector refuses an answer it did not get, rather than reporting an absence", () => {
+  // A 403 on the annotations endpoint is what a token without `checks: read` produces. Reporting
+  // it as "this job had no annotations" is the fail-open that made the whole recovery path inert:
+  // the signature can never match, so a genuinely lost runner reads as an assertion failure.
+  const forbidden = runCollector({ annotationsStatus: 403 });
+  assert.equal(forbidden.status, 1);
+  assert.equal(forbidden.rows, null);
+  assert.match(forbidden.stderr, /Cannot read annotations for job 41/u);
+  assert.match(forbidden.stderr, /checks: read/u);
+
+  // The same rule for the log blob: only 404 means "no log was uploaded".
+  for (const logsStatus of [403, 429, 500]) {
+    const refused = runCollector({ logsStatus });
+    assert.equal(refused.status, 1, `logs ${logsStatus}`);
+    assert.equal(refused.rows, null, `logs ${logsStatus}`);
+    assert.match(refused.stderr, /Log blob probe for job 41 answered/u);
+  }
+});
+
+test("an evidence row without an established log_uploaded fact is refused", () => {
+  // The collector is the only thing that can know this, so the classifier must not invent it. An
+  // absent field used to read as `false` -- the half of the signature a lost runner needs.
+  const { log_uploaded: _dropped, ...withoutProbe } = lostJob();
+  assert.throws(() => classifyJobFailure(withoutProbe), /log_uploaded must be a boolean/u);
+  assert.throws(() => classifyJobFailure(lostJob({ log_uploaded: "false" })), /must be a boolean/u);
+  assert.throws(
+    () => planAcceleratorNonClaim({
+      runAttempt: MAXIMUM_RUN_ATTEMPTS,
+      hosts: [linuxHost],
+      jobs: [withoutProbe],
+    }),
+    /log_uploaded must be a boolean/u,
+  );
+  // Annotations are the same: an absent list is an unread endpoint, not an empty one.
+  const { annotations: _dropped2, ...withoutAnnotations } = lostJob();
+  assert.throws(() => classifyJobFailure(withoutAnnotations), /annotations must be an array/u);
+});
+
+test("the CLI fails closed for every host it cannot decide", () => {
+  const rerun = runCli("plan-rerun", {
+    run_attempt: 1,
+    conclusion: "failure",
+    jobs: [lostJob()],
+  });
+  assert.equal(rerun.status, 0);
+  assert.equal(rerun.plan.rerun, true);
+  assert.match(rerun.outputs, /^rerun=true$/mu);
+  assert.match(rerun.outputs, /^job_ids=41$/mu);
+
+  const refused = runCli("plan-rerun", {
+    run_attempt: 1,
+    conclusion: "failure",
+    jobs: [assertionJob()],
+  });
+  assert.equal(refused.status, 0);
+  assert.equal(refused.plan.rerun, false);
+  assert.match(refused.outputs, /^rerun=false$/mu);
+  assert.match(refused.outputs, /^job_ids=$/mu);
+
+  const withheld = runCli("plan-non-claim", {
+    run_attempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: [lostJob(), lostAgain()],
+  });
+  assert.equal(withheld.status, 0);
+  assert.match(withheld.outputs, /^withheld_hosts=linux-x64-vulkan$/mu);
+
+  // One loss on a run that reached attempt 2 for its own reasons is still owed a recovery, so the
+  // CLI refuses to withhold and exits non-zero rather than recording an unearned non-claim.
+  const owed = runCli("plan-non-claim", {
+    run_attempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: [lostJob({ run_attempt: String(MAXIMUM_RUN_ATTEMPTS) })],
+  });
+  assert.equal(owed.status, 1);
+  assert.match(owed.stderr, /automatic_rerun_still_owed/u);
+  assert.match(owed.outputs, /^withheld_hosts=$/mu);
+
+  const blocked = runCli("plan-non-claim", {
+    run_attempt: MAXIMUM_RUN_ATTEMPTS,
+    hosts: [linuxHost],
+    jobs: [assertionJob({ run_attempt: String(MAXIMUM_RUN_ATTEMPTS) })],
+  });
+  assert.equal(blocked.status, 1);
+  assert.match(blocked.stderr, /job_assertion_failure/u);
+  assert.match(blocked.outputs, /^withheld_hosts=$/mu);
+});

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -62,6 +62,9 @@ jobs:
     if: needs.detect-version.outputs.should_release == 'true' && needs.detect-version.outputs.release_lane == 'native'
     permissions:
       actions: read
+      # This is the lane that actually publishes releases, so it is the lane whose token has to be
+      # able to read the lost-runner annotation. A called workflow cannot widen the caller's grant.
+      checks: read
       contents: write
       pull-requests: read
     uses: ./.github/workflows/release.yml

--- a/.github/workflows/lost-runner-rerun.yml
+++ b/.github/workflows/lost-runner-rerun.yml
@@ -1,0 +1,86 @@
+name: Lost runner rerun
+
+# The repository owns exactly one GPU Linux host, so a single dropped connection used to cost a
+# whole release. This companion re-dispatches the individual jobs that carry the lost-runner
+# signature -- and only those -- with no approval step anywhere: recovery is a machine decision or
+# it does not happen. A job that ran and failed its own assertions is never named in the rerun
+# request, so it stays red and keeps the run red.
+
+on:
+  workflow_run:
+    workflows:
+      - Auto Release
+      - Release
+    types:
+      - completed
+
+permissions:
+  actions: write
+  # The lost-runner signature includes the job annotation Actions leaves behind, and
+  # GET /repos/{owner}/{repo}/check-runs/{id}/annotations is gated on `checks: read`. Without it
+  # the collector cannot read the signature at all, so the recovery path is dead.
+  checks: read
+  contents: read
+
+concurrency:
+  group: lost-runner-rerun-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun-lost-jobs:
+    name: Re-dispatch jobs lost by their runner
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout recovery policy
+        uses: actions/checkout@v5
+
+      - name: Collect Actions failure evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
+          FAILED_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          FAILED_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .github/scripts/collect-actions-job-evidence.sh \
+            "$FAILED_RUN_ID" "$FAILED_RUN_ATTEMPT" target/lost-runner/jobs.json
+          jq -n \
+            --arg run_attempt "$FAILED_RUN_ATTEMPT" \
+            --arg conclusion "$FAILED_RUN_CONCLUSION" \
+            --slurpfile jobs target/lost-runner/jobs.json \
+            '{run_attempt: $run_attempt, conclusion: $conclusion, jobs: $jobs[0]}' \
+            > target/lost-runner/rerun-input.json
+
+      - name: Plan the bounded rerun
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          node .github/scripts/lost-runner-recovery.mjs plan-rerun \
+            --input target/lost-runner/rerun-input.json \
+            --out target/lost-runner/rerun-plan.json
+
+      - name: Re-dispatch only the lost jobs
+        if: steps.plan.outputs.rerun == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_IDS: ${{ steps.plan.outputs.job_ids }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$JOB_IDS"
+          for job_id in $JOB_IDS; do
+            gh api --method POST "repos/$GITHUB_REPOSITORY/actions/jobs/$job_id/rerun"
+          done
+
+      - name: Upload the recovery decision
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: lost-runner-rerun-${{ github.event.workflow_run.id }}-attempt-${{ github.event.workflow_run.run_attempt }}
+          path: target/lost-runner
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -12,6 +12,9 @@ on:
       - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
       - .github/scripts/check-workflow-policy.test.mjs
+      - .github/scripts/collect-actions-job-evidence.sh
+      - .github/scripts/lost-runner-recovery.mjs
+      - .github/scripts/lost-runner-recovery.test.mjs
       - .github/scripts/cargo-cache-contract.mjs
       - .github/scripts/cargo-cache-contract.test.mjs
       - .github/scripts/install-codestory-marketplace-proof.mjs
@@ -80,6 +83,9 @@ on:
       - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
       - .github/scripts/check-workflow-policy.test.mjs
+      - .github/scripts/collect-actions-job-evidence.sh
+      - .github/scripts/lost-runner-recovery.mjs
+      - .github/scripts/lost-runner-recovery.test.mjs
       - .github/scripts/cargo-cache-contract.mjs
       - .github/scripts/cargo-cache-contract.test.mjs
       - .github/scripts/install-codestory-marketplace-proof.mjs
@@ -188,6 +194,7 @@ jobs:
         run: |
           node .github/scripts/check-workflow-policy.mjs
           node --test .github/scripts/check-workflow-policy.test.mjs
+          node --test .github/scripts/lost-runner-recovery.test.mjs
           node --test .github/scripts/cargo-cache-contract.test.mjs
 
       - name: Check real Codex marketplace installation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ on:
 
 permissions:
   actions: read
+  # accelerator-non-claim reads the job annotation that identifies a lost runner, which the Actions
+  # annotations endpoint gates on `checks: read`. Without it the collector fails closed and this
+  # workflow stops rather than mistaking an unreadable signature for an ordinary failure.
+  checks: read
   contents: read
   pull-requests: read
 
@@ -72,6 +76,7 @@ jobs:
         run: |
           node .github/scripts/check-workflow-policy.mjs
           node --test .github/scripts/check-workflow-policy.test.mjs
+          node --test .github/scripts/lost-runner-recovery.test.mjs
 
   preflight:
     name: Release preflight
@@ -327,9 +332,155 @@ jobs:
       candidate_producer_workflow_path: ${{ inputs.publish_release && '.github/workflows/auto-release.yml' || '.github/workflows/release.yml' }}
       emit_release_cells: true
 
+  # The repository owns one host per accelerator. When a host drops its connection instead of
+  # reporting, .github/scripts/lost-runner-rerun.yml re-dispatches it once; if the second attempt is
+  # lost the same way, this job records a populated non-claim for that host so the closeout has a
+  # visible withheld claim to accept instead of an unexplained gap. It refuses -- and fails the run
+  # -- for every other shape of failure, so a proof that ran and disagreed can never be withheld.
+  accelerator-non-claim:
+    name: Withhold unproven accelerator claims
+    if: always() && needs.preflight.result == 'success' && needs.packaged-proof.result == 'success'
+    needs:
+      - preflight
+      - packaged-proof
+      - macos-metal-proof
+      - windows-vulkan-proof
+      - linux-vulkan-proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Collect protected accelerator job evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .github/scripts/collect-actions-job-evidence.sh \
+            "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" target/release-non-claim/jobs.json
+          jq -n \
+            --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --slurpfile graph release-claims.json \
+            --slurpfile jobs target/release-non-claim/jobs.json \
+            '{
+               run_attempt: $run_attempt,
+               hosts: [$graph[0].non_claim_policy.hosts[]
+                 | {id: .id, job_name: .unavailable_producer_job_name}],
+               jobs: $jobs[0]
+             }' > target/release-non-claim/plan-input.json
+
+      - name: Decide withheld accelerator hosts
+        id: non-claim
+        shell: bash
+        run: |
+          set -euo pipefail
+          node .github/scripts/lost-runner-recovery.mjs plan-non-claim \
+            --input target/release-non-claim/plan-input.json \
+            --out target/release-non-claim/plan.json
+
+      - name: Download release packages for withheld identity
+        if: steps.non-claim.outputs.withheld_hosts != ''
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: codestory-cli-*
+          path: target/release-dist
+          merge-multiple: false
+
+      - name: Record populated accelerator non-claims
+        if: steps.non-claim.outputs.withheld_hosts != ''
+        env:
+          WITHHELD_HOSTS: ${{ steps.non-claim.outputs.withheld_hosts }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          jq -n \
+            --arg installer candidate_managed_plugin \
+            --arg native_engine coderank_q8_embedded \
+            '{installer: $installer, native_engine: $native_engine}' \
+            > target/release-non-claim/identity.json
+          for host in $WITHHELD_HOSTS; do
+            case "$host" in
+              macos-arm64-metal) target=macos-arm64; extension=tar.gz ;;
+              windows-x64-vulkan) target=windows-x64; extension=zip ;;
+              linux-x64-vulkan) target=linux-x64; extension=tar.gz ;;
+              *) echo "::error::unknown non-claim host $host"; exit 1 ;;
+            esac
+            node scripts/codestory-release-cell-manifest.mjs withhold \
+              --repo "$GITHUB_WORKSPACE" \
+              --expected-sha "$GITHUB_SHA" \
+              --version "$version" \
+              --host "$host" \
+              --producer-run-id "$GITHUB_RUN_ID" \
+              --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+              --identity target/release-non-claim/identity.json \
+              --archive "target/release-dist/codestory-cli-$target/codestory-cli-v$version-$target.$extension" \
+              --out-dir "target/release-non-claim/cells/$host"
+          done
+
+      - name: Upload withheld pre-publish macOS accelerator cells
+        if: contains(steps.non-claim.outputs.withheld_hosts, 'macos-arm64-metal')
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-nonclaim-prepublish-macos-arm64-metal-attempt-${{ github.run_attempt }}
+          path: target/release-non-claim/cells/macos-arm64-metal/pre_publish
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload withheld post-publish macOS accelerator cells
+        if: contains(steps.non-claim.outputs.withheld_hosts, 'macos-arm64-metal')
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-nonclaim-postpublish-macos-arm64-metal-attempt-${{ github.run_attempt }}
+          path: target/release-non-claim/cells/macos-arm64-metal/post_publish
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload withheld pre-publish Windows accelerator cells
+        if: contains(steps.non-claim.outputs.withheld_hosts, 'windows-x64-vulkan')
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-nonclaim-prepublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}
+          path: target/release-non-claim/cells/windows-x64-vulkan/pre_publish
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload withheld post-publish Windows accelerator cells
+        if: contains(steps.non-claim.outputs.withheld_hosts, 'windows-x64-vulkan')
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-nonclaim-postpublish-windows-x64-vulkan-attempt-${{ github.run_attempt }}
+          path: target/release-non-claim/cells/windows-x64-vulkan/post_publish
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload withheld pre-publish Linux accelerator cells
+        if: contains(steps.non-claim.outputs.withheld_hosts, 'linux-x64-vulkan')
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-nonclaim-prepublish-linux-x64-vulkan-attempt-${{ github.run_attempt }}
+          path: target/release-non-claim/cells/linux-x64-vulkan/pre_publish
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload withheld post-publish Linux accelerator cells
+        if: contains(steps.non-claim.outputs.withheld_hosts, 'linux-x64-vulkan')
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-cell-nonclaim-postpublish-linux-x64-vulkan-attempt-${{ github.run_attempt }}
+          path: target/release-non-claim/cells/linux-x64-vulkan/post_publish
+          if-no-files-found: error
+          retention-days: 30
+
   pre-publish-closeout:
     name: Authenticate pre-publish release cells
-    if: always() && needs.preflight.result == 'success' && (needs.source-proof.result == 'success' || needs.source-proof.result == 'skipped')
+    if: always() && needs.preflight.result == 'success' && (needs.source-proof.result == 'success' || needs.source-proof.result == 'skipped') && (needs.accelerator-non-claim.result == 'success' || needs.accelerator-non-claim.result == 'skipped')
     needs:
       - preflight
       - source-proof
@@ -337,6 +488,7 @@ jobs:
       - macos-metal-proof
       - windows-vulkan-proof
       - linux-vulkan-proof
+      - accelerator-non-claim
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -354,6 +506,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # The closeout reads the lost-runner signature itself rather than trusting the non-claim
+          # producer's verdict, so it collects the same Actions evidence independently.
+          bash .github/scripts/collect-actions-job-evidence.sh \
+            "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" target/release-closeout/job-evidence.json
           node scripts/codestory-release-cell-manifest.mjs producer-map \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
@@ -361,6 +517,7 @@ jobs:
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
             --reuse "$REUSE_SELECTION" \
+            --job-evidence target/release-closeout/job-evidence.json \
             --out target/release-closeout/trusted-pre-publish-producers.json
           artifact_ids="$(jq -r '[.artifacts[].id] | join(",")' target/release-closeout/trusted-pre-publish-producers.json)"
           test -n "$artifact_ids"
@@ -455,12 +612,28 @@ jobs:
           pattern: codestory-cli-*
           merge-multiple: true
 
+      # The published notes and the shipped summary both have to say what this release proved, so
+      # they are rendered from the accepted ledger rather than from the static claim graph.
+      - name: Download the accepted pre-publish closeout
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}
+          path: target/release-closeout
+
       - name: Combine and verify checksums
         run: |
           set -euo pipefail
           find target/release-assets -name '*.sha256' -print0 | sort -z | xargs -0 cat > target/release-assets/SHA256SUMS.txt
           test -s target/release-assets/SHA256SUMS.txt
           (cd target/release-assets && sha256sum -c SHA256SUMS.txt)
+
+      - name: Ship the accepted closeout summary with the release
+        run: |
+          set -euo pipefail
+          summary=target/release-closeout/pre_publish/summary.json
+          test -f "$summary"
+          test "$(jq -r .decision "$summary")" = accept
+          cp "$summary" target/release-assets/release-closeout-summary.json
 
       - name: Compose versioned GitHub release notes
         env:
@@ -472,7 +645,8 @@ jobs:
             --output target/release-assets/release-notes.md
           {
             printf '\n'
-            node scripts/codestory-release-claims.mjs release-platform-notes
+            node scripts/codestory-release-claims.mjs release-platform-notes \
+              --ledger target/release-closeout/pre_publish/ledger.json
             printf '\n'
           } >> target/release-assets/release-notes.md
 
@@ -514,7 +688,8 @@ jobs:
           actual_file="$(mktemp)"
           printf '%s\n' "${expected_names[@]}" | sort > "$expected_file"
           find target/release-assets -maxdepth 1 -type f \
-            \( -name 'codestory-cli-v*.tar.gz' -o -name 'codestory-cli-v*.zip' -o -name 'SHA256SUMS.txt' \) \
+            \( -name 'codestory-cli-v*.tar.gz' -o -name 'codestory-cli-v*.zip' \
+               -o -name 'SHA256SUMS.txt' -o -name 'release-closeout-summary.json' \) \
             -exec basename {} \; | sort > "$actual_file"
           if ! diff -u "$expected_file" "$actual_file"; then
             echo "::error::Release assets differ from the release claim graph."
@@ -611,12 +786,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          bash .github/scripts/collect-actions-job-evidence.sh \
+            "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" target/release-closeout/job-evidence.json
           node scripts/codestory-release-cell-manifest.mjs producer-map \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
             --phase post_publish \
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --job-evidence target/release-closeout/job-evidence.json \
             --out target/release-closeout/trusted-post-publish-producers.json
           artifact_ids="$(jq -r '[.artifacts[].id] | join(",")' target/release-closeout/trusted-post-publish-producers.json)"
           test -n "$artifact_ids"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ flowchart LR
 | Windows ARM | Unsupported |
 <!-- codestory-public-support:end -->
 
+"Supported with Metal" and "Supported with Vulkan" describe what the release
+line ships and intends to prove. Each individual release proves it on the
+protected hardware for that platform, and a release whose accelerator host was
+unreachable ships with that platform's accelerator claim **withheld** rather
+than assumed: the accelerator ran on that host in earlier releases, but this
+release did not observe it.
+
+You do not have to take the table's word for any single release. Every release
+ships `release-closeout-summary.json` as a release asset, and its platform
+section in the GitHub release notes is rendered from that release's ledger, so
+a platform whose accelerator was withheld says so in the notes instead of being
+listed as supported. In the summary, `withheld_cells` names every cell that did
+not run, `withheld_claims` names the claims nothing in that release proved, and
+`partially_withheld_claims` names the ones another host still proved. At most
+one platform's accelerator may be withheld
+(`non_claim_policy.withhold_policy.maximum_withheld_hosts`); a release that
+proved no accelerator anywhere is refused rather than published. See
+[the testing matrix](docs/contributors/testing-matrix.md) for how a claim
+becomes withheld.
+
 ## Example prompts
 
 Use your project's symbols and paths:

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+    "graph_sha256": "79ad7c2b9b2c22c23d6e4d26e0bfcd2b484afd89fb0a3143b7a887955c9619a8",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+        "graph_sha256": "79ad7c2b9b2c22c23d6e4d26e0bfcd2b484afd89fb0a3143b7a887955c9619a8",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+        "graph_sha256": "79ad7c2b9b2c22c23d6e4d26e0bfcd2b484afd89fb0a3143b7a887955c9619a8",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+      "graph_sha256": "79ad7c2b9b2c22c23d6e4d26e0bfcd2b484afd89fb0a3143b7a887955c9619a8",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+      "graph_sha256": "79ad7c2b9b2c22c23d6e4d26e0bfcd2b484afd89fb0a3143b7a887955c9619a8",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+    "graph_sha256": "79ad7c2b9b2c22c23d6e4d26e0bfcd2b484afd89fb0a3143b7a887955c9619a8",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "ba277f51c4079712fd75ef1ead662198645d70074bb6b717b1bca7336968a7f1",
+  "candidate_sha256": "627932380729447ad3fdb1e08f8f76c83b966d2dd8cb4e44614f6593b3f3c03d",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -494,6 +494,88 @@ The v0.16 closeout consumes physical Metal and Vulkan execution evidence and
 makes those accelerator claims for the released targets. Accuracy, latency,
 and throughput remain independent evaluator lanes and release non-claims.
 
+### Withheld accelerator claims
+
+The repository owns one host per accelerator, so a host that loses its
+connection mid-proof used to cost the whole release. Recovery is automatic and
+bounded, and it never waits on a human click.
+
+`.github/scripts/lost-runner-recovery.mjs` classifies a failed job as a runner
+communication loss only when all three parts of the Actions signature are
+present at once: the exact `The self-hosted runner lost communication with the
+server.` annotation, at least one step that completed with an empty conclusion,
+and no uploaded log blob. A proof that ran and failed its own assertions has a
+real conclusion on every step and a log, so it is classified as an assertion
+failure and is never re-dispatched and never withheld. The classifier never
+reads job names.
+
+All three parts are read by `.github/scripts/collect-actions-job-evidence.sh`,
+which fails closed on every one of them. The annotation endpoint needs the
+`checks: read` token scope; without it the call 403s, and a 403 reported as "no
+annotations" would make the signature unmatchable and the whole recovery path
+inert. The collector treats any answer other than a successful read as an
+error, and only a `404` from the log-blob endpoint counts as "the runner
+uploaded no log". `.github/scripts/check-workflow-policy.mjs` refuses any
+workflow that runs the collector without `checks: read`, including the
+reusable-workflow callers whose grant is the ceiling for what they call.
+
+`.github/workflows/lost-runner-rerun.yml` watches completed release runs and
+re-dispatches the individual lost jobs by id. The bound is
+`non_claim_policy.maximum_run_attempts` (2, meaning one automatic recovery
+attempt) and it counts **lost executions of that job**, not run attempts: a
+release re-run for an unrelated reason has spent no recovery on any host, so
+the first loss of a runner is still owed its one retry. The collector reads
+every attempt of the run to make that count possible, and counts a job Actions
+carried forward unchanged once. Jobs that failed on their own assertions are
+not named in the rerun request and stay red.
+
+If a host is lost twice, `release.yml`'s `accelerator-non-claim` job records a
+**populated non-claim** for that host in place of the cells that host would
+have produced. It mirrors the package manifest's own shape:
+`runtime_execution: not_proven_by_package` with a `non_claim_reason`. Every
+cell that host owns -- accelerator execution, candidate-installed behavior, and
+retrieval readiness -- is written with evidence status `withheld`, naming the
+target, backend, runner, the unavailable producer job, the exact annotation,
+and every claim the missing proof would have carried.
+
+The closeout does not take the producer's word for any of that. Its own job
+runs the same collector and `buildTrustedProducerMap` re-derives the signature
+before it will authenticate a cell against the non-claim producer, so a red
+accelerator job cannot become an accepted withheld claim through a bug or a
+future edit in the producer alone.
+
+A withheld cell is recorded as `withheld` in `ledger.json` and in
+`summary.json`'s `withheld_cells`, `withheld_hosts`, and `counts.withheld`, and
+is never counted as passed. Any cell that still claims a pass while something
+it rests on was withheld fails closeout validation, so a withheld accelerator
+claim cannot be inherited as a silent pass by retrieval readiness.
+
+**How much may be withheld** is `non_claim_policy.withhold_policy` in
+`release-claims.json`, and the closeout enforces it:
+
+- `maximum_withheld_hosts` (1) bounds how many protected hosts may be silent at
+  once. The graph refuses a cap that does not leave at least one host proven, so
+  "no accelerator was proven anywhere" is unrepresentable rather than merely
+  discouraged.
+- `claims_requiring_proof` names the claims that must keep at least one
+  *passing* cell in any phase that closes them. A withheld cell records a
+  non-claim and can never satisfy one.
+
+Breaking either records a named `input_errors` entry and the closeout decision
+becomes `reject`, so `pre-publish-closeout` fails and `publish` is skipped.
+
+The two claim lists in the ledger are literal in both directions:
+`withheld_claims` is what nothing in that phase proved, and
+`partially_withheld_claims` is what a withheld cell rested on but another host
+still proved. Their union is every claim a withheld cell touched.
+
+The published surfaces say the same thing. The GitHub release notes' platform
+section is rendered from the accepted ledger --
+`codestory-release-claims.mjs release-platform-notes` requires `--ledger` and
+has no graph-only mode -- and `release-closeout-summary.json` ships as a
+release asset, so a consumer can read what a specific release proved without
+reaching into a 30-day Actions artifact.
+
 Run the coordinator only with retained producer manifests and a fresh output
 directory:
 

--- a/release-claims.json
+++ b/release-claims.json
@@ -1,6 +1,6 @@
 {
   "schema": "codestory.release-claims/v1",
-  "graph_version": 7,
+  "graph_version": 8,
   "graph_id": "codestory-release-claims",
   "standard_release_claims": [
     "source_behavior",
@@ -957,6 +957,70 @@
       }
     ]
   },
+  "non_claim_policy": {
+    "schema": "codestory.release-non-claim/v1",
+    "runtime_execution": "not_proven_by_package",
+    "reason": "accelerator_host_unavailable",
+    "annotation": "The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection.",
+    "maximum_run_attempts": 2,
+    "recovery_contract": ".github/scripts/lost-runner-recovery.mjs",
+    "producer_workflow": ".github/workflows/release.yml",
+    "producer_job": "accelerator-non-claim",
+    "producer_job_name": "Withhold unproven accelerator claims",
+    "withhold_policy": {
+      "maximum_withheld_hosts": 1,
+      "claims_requiring_proof": [
+        "accelerator_execution",
+        "installed_runtime_behavior",
+        "platform_support",
+        "retrieval_readiness"
+      ]
+    },
+    "hosts": [
+      {
+        "id": "macos-arm64-metal",
+        "unavailable_producer_workflow": ".github/workflows/macos-metal-proof.yml",
+        "unavailable_producer_job_name": "Packaged Apple Silicon Metal engine",
+        "producer_artifacts": {
+          "pre_publish": "release-cell-nonclaim-prepublish-macos-arm64-metal-attempt-{attempt}",
+          "post_publish": "release-cell-nonclaim-postpublish-macos-arm64-metal-attempt-{attempt}"
+        },
+        "withheld_cells": [
+          "accelerator_execution:macos-arm64-metal",
+          "candidate_installed_behavior:macos-arm64",
+          "retrieval_readiness:macos-arm64"
+        ]
+      },
+      {
+        "id": "windows-x64-vulkan",
+        "unavailable_producer_workflow": ".github/workflows/windows-vulkan-proof.yml",
+        "unavailable_producer_job_name": "Packaged Windows Vulkan engine",
+        "producer_artifacts": {
+          "pre_publish": "release-cell-nonclaim-prepublish-windows-x64-vulkan-attempt-{attempt}",
+          "post_publish": "release-cell-nonclaim-postpublish-windows-x64-vulkan-attempt-{attempt}"
+        },
+        "withheld_cells": [
+          "accelerator_execution:windows-x64-vulkan",
+          "candidate_installed_behavior:windows-x64",
+          "retrieval_readiness:windows-x64"
+        ]
+      },
+      {
+        "id": "linux-x64-vulkan",
+        "unavailable_producer_workflow": ".github/workflows/linux-vulkan-proof.yml",
+        "unavailable_producer_job_name": "Packaged Linux Vulkan engine",
+        "producer_artifacts": {
+          "pre_publish": "release-cell-nonclaim-prepublish-linux-x64-vulkan-attempt-{attempt}",
+          "post_publish": "release-cell-nonclaim-postpublish-linux-x64-vulkan-attempt-{attempt}"
+        },
+        "withheld_cells": [
+          "accelerator_execution:linux-x64-vulkan",
+          "candidate_installed_behavior:linux-x64",
+          "retrieval_readiness:linux-x64"
+        ]
+      }
+    ]
+  },
   "workflow_policy": {
     "artifact_retention_days": 30,
     "package_matrix": [
@@ -1062,13 +1126,21 @@
           "preflight",
           "packaged-proof"
         ],
+        "accelerator-non-claim": [
+          "preflight",
+          "packaged-proof",
+          "macos-metal-proof",
+          "windows-vulkan-proof",
+          "linux-vulkan-proof"
+        ],
         "pre-publish-closeout": [
           "preflight",
           "source-proof",
           "packaged-proof",
           "macos-metal-proof",
           "windows-vulkan-proof",
-          "linux-vulkan-proof"
+          "linux-vulkan-proof",
+          "accelerator-non-claim"
         ],
         "publish": [
           "preflight",

--- a/scripts/codestory-release-cell-manifest.mjs
+++ b/scripts/codestory-release-cell-manifest.mjs
@@ -13,9 +13,16 @@ import {
 } from "./codestory-release-claims.mjs";
 import {
   deriveReleaseCells,
+  releaseCellWithheldClaims,
   resolveReleaseCellConstraints,
+  resolveReleaseCellNonClaimConstraints,
   validateReleaseCellManifest,
 } from "./codestory-release-closeout.mjs";
+import {
+  RUNNER_COMMUNICATION_LOSS,
+  classifyJobFailure,
+  countLostExecutions,
+} from "../.github/scripts/lost-runner-recovery.mjs";
 
 const PRODUCER_MAP_SCHEMA = "codestory.release-actions-provenance/v1";
 const ACTIONS_DIGEST = /^sha256:[0-9a-f]{64}$/u;
@@ -136,6 +143,7 @@ export function produceReleaseCellManifest({
   archivePath = null,
   prePublishLedger = null,
   evidence = null,
+  nonClaim = null,
 }) {
   const graphSha256 = releaseClaimGraphDigest(graph);
   const type = evidenceType(graph, cell.evidence_type);
@@ -148,6 +156,7 @@ export function produceReleaseCellManifest({
     ...(suppliedIdentity ?? {}),
     ...gitIdentity,
     ...resolveReleaseCellConstraints(cell, producer.producer_run_attempt),
+    ...(nonClaim ? resolveReleaseCellNonClaimConstraints(cell, producer.producer_run_attempt) : {}),
     ...producer,
   };
   if (cell.required_identity.includes("producer_version")) identity.producer_version = version;
@@ -168,13 +177,14 @@ export function produceReleaseCellManifest({
       id: evidence?.id ?? `${cell.id}:${producer.producer_run_id}:${producer.producer_run_attempt}`,
       type: cell.evidence_type,
       tier: type.tier,
-      status: evidence?.status ?? "pass",
+      status: evidence?.status ?? (nonClaim ? "withheld" : "pass"),
       graph_sha256: graphSha256,
       observed_at: observed,
       expires_at: expires,
       identity,
     },
   };
+  if (nonClaim) manifest.non_claim = nonClaim;
   if (cell.archive_role === "pre_publish") {
     if (!artifact || !archivePath) fail(`${cell.id} requires --archive`);
     manifest.archive = { name: artifact.name, sha256: artifact.sha256, bytes: artifact.bytes };
@@ -233,6 +243,62 @@ function produceOne(values) {
   writeJson(text(values.out, "--out"), manifest);
 }
 
+/// Record the populated non-claim for one protected host that never reported.
+///
+/// This is the only writer of a withheld release cell. It refuses to invent one for a host the
+/// graph does not declare, and it stamps the recovery bound into every manifest it writes, so a
+/// withheld cell always carries the evidence that the automatic reruns were spent first.
+function withholdHost(values) {
+  const { graph, gitIdentity } = common(values);
+  const version = text(values.version, "--version").replace(/^v/u, "");
+  const policy = graph.non_claim_policy;
+  const hostId = text(values.host, "--host");
+  const host = (policy?.hosts ?? []).find(({ id }) => id === hostId);
+  if (!host) fail(`release claim graph declares no non-claim host ${hostId}`);
+  const attempt = positiveInteger(values["producer-run-attempt"], "--producer-run-attempt");
+  if (Number(attempt) < policy.maximum_run_attempts) {
+    fail(`a non-claim may be recorded only after ${policy.maximum_run_attempts} run attempts`);
+  }
+  const identity = values.identity ? JSON.parse(readFileSync(values.identity, "utf8")) : {};
+  const outDir = text(values["out-dir"], "--out-dir");
+  for (const cellId of host.withheld_cells) {
+    const cell = selectedCell(graph, cellId);
+    // Each closeout phase downloads and authorizes its own container, so the manifests are written
+    // into one directory per phase and uploaded as one artifact per phase.
+    const producer = authenticatedProducer({
+      "producer-workflow": policy.producer_workflow,
+      "producer-job": policy.producer_job,
+      "producer-run-id": values["producer-run-id"],
+      "producer-run-attempt": attempt,
+      "producer-artifact": host.producer_artifacts[cell.phase].replaceAll("{attempt}", attempt),
+    }, gitIdentity);
+    const manifest = produceReleaseCellManifest({
+      graph,
+      gitIdentity,
+      version,
+      cell,
+      identity,
+      producer,
+      observedAt: values["observed-at"],
+      archivePath: values.archive,
+      nonClaim: {
+        host: host.id,
+        runtime_execution: policy.runtime_execution,
+        non_claim_reason: policy.reason,
+        annotation: policy.annotation,
+        unavailable_producer_workflow: host.unavailable_producer_workflow,
+        unavailable_producer_job_name: host.unavailable_producer_job_name,
+        withheld_claims: releaseCellWithheldClaims(graph, cell),
+        run_attempt: attempt,
+      },
+    });
+    writeJson(
+      path.join(outDir, cell.phase, `${cellId.replaceAll(/[^A-Za-z0-9._-]/gu, "_")}.json`),
+      manifest,
+    );
+  }
+}
+
 function positiveInteger(value, label) {
   const selected = text(String(value ?? ""), label);
   if (!/^[1-9]\d*$/u.test(selected)) fail(`${label} must be a positive integer`);
@@ -247,6 +313,22 @@ function actionsTimestamp(value, label) {
 
 function leafJobName(value) {
   return text(value, "Actions job name").split(" / ").at(-1);
+}
+
+/// The one execution of `jobName` at the highest attempt at or below the current one. `absent` and
+/// `ambiguous` are reported distinctly and are never treated as "the host went away": only a single
+/// resolved execution that ran and did not succeed may hand a cell to its non-claim producer, so a
+/// missing or duplicated job still fails through the strict selection below.
+function latestExecution(jobs, jobName, currentAttempt) {
+  const occurrences = jobs.filter((job) =>
+    leafJobName(job.name) === jobName
+    && Number(positiveInteger(job.run_attempt, `${jobName} run attempt`)) <= Number(currentAttempt));
+  if (occurrences.length === 0) return { state: "absent", job: null };
+  const latestAttempt = Math.max(...occurrences.map(({ run_attempt: attempt }) => Number(attempt)));
+  const latest = occurrences.filter(({ run_attempt: attempt }) => Number(attempt) === latestAttempt);
+  return latest.length === 1
+    ? { state: "resolved", job: latest[0] }
+    : { state: "ambiguous", job: null };
 }
 
 function flattenJobs(jobsByAttempt) {
@@ -347,6 +429,38 @@ function selectReusedProducer({ cell, reused, binding }) {
   };
 }
 
+/// The closeout's own reading of the lost-runner signature.
+///
+/// This deliberately repeats work the non-claim producer already did. The producer decides whether
+/// to *write* a non-claim; this decides whether the closeout will *authenticate a cell against*
+/// one, and a single shared verdict would mean any bug or future edit in the producer silently
+/// converts every red accelerator job into an accepted withheld claim with nothing to object. The
+/// evidence is collected by the closeout job itself, so the producer is not consulted at all.
+function confirmsWithholding({ graph, jobEvidence, jobName, cellId }) {
+  if (jobEvidence === null) {
+    fail(`closeout cannot route ${cellId} to a non-claim without its own Actions job evidence`);
+  }
+  const executions = jobEvidence.filter((job) =>
+    leafJobName(String(job?.name ?? "")) === jobName
+    && String(job?.conclusion ?? "") === "failure");
+  if (executions.length === 0) {
+    fail(`Actions job evidence has no failed execution of ${jobName} to withhold ${cellId} for`);
+  }
+  for (const job of executions) {
+    if (classifyJobFailure(job).signature !== RUNNER_COMMUNICATION_LOSS) {
+      fail(`${jobName} failed its own assertions, so ${cellId} may not be withheld`);
+    }
+  }
+  const spent = countLostExecutions(jobEvidence, jobName);
+  if (spent < graph.non_claim_policy.maximum_run_attempts) {
+    fail(
+      `${jobName} has been lost ${spent} time(s); ${cellId} may not be withheld before the `
+      + `${graph.non_claim_policy.maximum_run_attempts}-execution recovery bound is spent`,
+    );
+  }
+  return true;
+}
+
 export function buildTrustedProducerMap({
   graph,
   gitIdentity,
@@ -355,6 +469,9 @@ export function buildTrustedProducerMap({
   currentRunAttempt,
   artifacts,
   jobsByAttempt,
+  // The closeout's own collected Actions job evidence -- annotations, step conclusions and the log
+  // blob probe -- for confirming a withheld routing without asking the non-claim producer.
+  jobEvidence = null,
   // Cross-run evidence, keyed by cell-group id. Admissible only for groups that declare a
   // reuse_binding in the claim graph; the caller is responsible for having verified the binding
   // (tree equality and ancestry, or native-fingerprint equality) before supplying an entry.
@@ -380,8 +497,32 @@ export function buildTrustedProducerMap({
     if (reused) {
       return selectReusedProducer({ cell, reused, binding: groupBindings.get(cell.group_id) });
     }
-    const jobName = text(cell.identity_constraints.producer_job_name, `${cell.id} producer job name`);
-    const cacheKey = `${jobName}\0${cell.identity_constraints.producer_artifact}`;
+    const primaryJobName = text(
+      cell.identity_constraints.producer_job_name,
+      `${cell.id} producer job name`,
+    );
+    // A protected host that never reported cannot sign its own absence. When -- and only when --
+    // its latest attempt did not succeed, the cell's producer becomes the hosted job that recorded
+    // the populated non-claim, and the row is stamped so the closeout knows to expect a withheld
+    // manifest rather than a proof.
+    //
+    // "Did not succeed" is necessary but nowhere near sufficient: on its own it routes every red
+    // accelerator job into the withheld lane, and the only thing keeping an assertion failure out
+    // would be the non-claim producer's own refusal to upload for it. This map is what decides
+    // whether a cell is authenticated against the real proof or against the non-claim producer, so
+    // it checks the lost-runner signature itself, from evidence it collected, rather than
+    // inheriting the producer's verdict.
+    const primaryLatest = latestExecution(jobs, primaryJobName, selectedCurrentAttempt);
+    const notGreen = cell.non_claim !== undefined
+      && primaryLatest.state === "resolved"
+      && (primaryLatest.job.status !== "completed" || primaryLatest.job.conclusion !== "success");
+    const withheld = notGreen
+      && confirmsWithholding({ graph, jobEvidence, jobName: primaryJobName, cellId: cell.id });
+    const jobName = withheld ? cell.non_claim.producer_job_name : primaryJobName;
+    const artifactTemplate = withheld
+      ? cell.non_claim.producer_artifact
+      : cell.identity_constraints.producer_artifact;
+    const cacheKey = `${jobName}\0${artifactTemplate}`;
     let selected = selectionCache.get(cacheKey);
     if (!selected) {
       const occurrences = jobs.filter((job) =>
@@ -401,7 +542,12 @@ export function buildTrustedProducerMap({
       if (String(job.run_id) !== selectedRunId || job.head_sha !== gitIdentity.commit) {
         fail(`Actions job ${jobName} is not bound to the selected run and commit`);
       }
-      const constraints = resolveReleaseCellConstraints(cell, String(latestAttempt));
+      const constraints = withheld
+        ? {
+          ...resolveReleaseCellConstraints(cell, String(latestAttempt)),
+          ...resolveReleaseCellNonClaimConstraints(cell, String(latestAttempt)),
+        }
+        : resolveReleaseCellConstraints(cell, String(latestAttempt));
       const matchingArtifacts = artifacts.filter(({ name }) => name === constraints.producer_artifact);
       if (matchingArtifacts.length !== 1) {
         fail(`Actions run must retain one ${constraints.producer_artifact} artifact`);
@@ -450,10 +596,12 @@ export function buildTrustedProducerMap({
           completed_at: completedAt,
         },
       };
+      selected.non_claim = withheld;
       selectionCache.set(cacheKey, selected);
     }
     return {
       cell_id: cell.id,
+      ...(selected.non_claim ? { non_claim: true } : {}),
       producer_workflow: selected.constraints.producer_workflow,
       producer_job: selected.constraints.producer_job,
       producer_job_name: selected.constraints.producer_job_name,
@@ -549,6 +697,10 @@ async function produceMap(values) {
       jobsByAttempt: await githubPages(`${reusedUrl}/jobs?filter=all`, token, "jobs"),
     };
   }
+  // Collected by the closeout job itself, never handed over by the non-claim producer.
+  const jobEvidence = values["job-evidence"]
+    ? JSON.parse(readFileSync(text(values["job-evidence"], "--job-evidence"), "utf8"))
+    : null;
   const map = buildTrustedProducerMap({
     graph,
     gitIdentity,
@@ -557,6 +709,7 @@ async function produceMap(values) {
     currentRunAttempt: runAttempt,
     artifacts,
     jobsByAttempt,
+    jobEvidence,
     reuse,
   });
   writeJson(text(values.out, "--out"), map);
@@ -565,8 +718,9 @@ async function produceMap(values) {
 async function main() {
   const { command, values } = parseArgs(process.argv.slice(2));
   if (command === "produce") produceOne(values);
+  else if (command === "withhold") withholdHost(values);
   else if (command === "producer-map") await produceMap(values);
-  else fail("command must be produce or producer-map");
+  else fail("command must be produce, withhold, or producer-map");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const GRAPH_SCHEMA = "codestory.release-claims/v1";
-const GRAPH_VERSION = 7;
+const GRAPH_VERSION = 8;
 const KNOWN_PACKAGE_TARGETS = new Set([
   "linux-arm64",
   "linux-x64",
@@ -225,6 +225,156 @@ function uniqueById(values, label) {
     found.set(id, row);
   }
   return found;
+}
+
+/// Every closeout cell one protected job produces, keyed by the leaf Actions job name that produces
+/// it. A host that goes missing takes its whole column with it, so the withheld set is derived from
+/// the graph instead of listed by hand: adding a cell to a protected job cannot leave a stale
+/// non-claim behind that quietly keeps claiming something.
+function cellsByProducerJobName(cellGroups) {
+  const byJobName = new Map();
+  const record = (jobName, cellId) => {
+    if (typeof jobName !== "string" || jobName === "") return;
+    if (!byJobName.has(jobName)) byJobName.set(jobName, []);
+    byJobName.get(jobName).push(cellId);
+  };
+  for (const [groupId, group] of cellGroups) {
+    if (group.expansion === "instances") {
+      for (const instance of group.instances) {
+        record(
+          instance.identity_constraints?.producer_job_name
+            ?? group.identity_constraints?.producer_job_name,
+          `${groupId}:${instance.id}`,
+        );
+      }
+    }
+  }
+  return byJobName;
+}
+
+/// How much of a release may go unproven and still publish. Withholding exists so one dead host
+/// cannot cost a release its other nine cells -- it is not a way to publish a release nothing
+/// vouched for. The two numbers below are the whole policy and they live in the graph rather than
+/// in the closeout, because a reader deciding whether to trust a release reads the graph:
+///
+///   * `maximum_withheld_hosts` bounds how many of the protected hosts may be silent at once. It
+///     must stay strictly below the number of hosts, so "every accelerator was withheld" is
+///     unrepresentable rather than merely discouraged.
+///   * `claims_requiring_proof` names the claims that must retain at least one *passing* cell in
+///     any phase that requires them. A withheld cell records a non-claim, so it can never be the
+///     thing that satisfies one of these.
+function validateWithholdPolicy(policy, hosts, cellGroups) {
+  const withhold = object(
+    policy.withhold_policy,
+    "release claim graph.non_claim_policy.withhold_policy",
+  );
+  const maximum = withhold.maximum_withheld_hosts;
+  if (!Number.isInteger(maximum) || maximum < 1) {
+    fail("non_claim_policy.withhold_policy.maximum_withheld_hosts must be a positive integer");
+  }
+  if (maximum >= hosts.size) {
+    fail(
+      "non_claim_policy.withhold_policy.maximum_withheld_hosts must leave at least one protected "
+      + `host proven (${hosts.size} hosts are declared)`,
+    );
+  }
+  const required = stringArray(
+    withhold.claims_requiring_proof,
+    "non_claim_policy.withhold_policy.claims_requiring_proof",
+    { nonEmpty: true },
+  );
+  if (JSON.stringify(required) !== JSON.stringify([...required].sort())) {
+    fail("non_claim_policy.withhold_policy.claims_requiring_proof must be sorted");
+  }
+  const claimOfCellGroup = new Map(
+    [...cellGroups].map(([groupId, group]) => [groupId, group.claim]),
+  );
+  const closeoutClaims = new Set(claimOfCellGroup.values());
+  for (const claimId of required) {
+    if (!closeoutClaims.has(claimId)) {
+      fail(`non_claim_policy.withhold_policy.claims_requiring_proof names unclosed claim ${claimId}`);
+    }
+  }
+  const withheldClaims = new Set();
+  for (const host of hosts.values()) {
+    for (const cellId of host.withheld_cells ?? []) {
+      const claimId = claimOfCellGroup.get(String(cellId).split(":")[0]);
+      if (claimId !== undefined) withheldClaims.add(claimId);
+    }
+  }
+  // Every claim a host can withhold has to be one the policy insists stays proven somewhere,
+  // otherwise the cap would be silent about exactly the claims withholding can erase.
+  for (const claimId of [...withheldClaims].sort()) {
+    if (!required.includes(claimId)) {
+      fail(
+        `non_claim_policy.withhold_policy.claims_requiring_proof must include ${claimId}, `
+        + "which a withheld host can erase",
+      );
+    }
+  }
+}
+
+function validateNonClaimPolicy(graph, cellGroups) {
+  const policy = object(graph.non_claim_policy, "release claim graph.non_claim_policy");
+  if (policy.schema !== "codestory.release-non-claim/v1") {
+    fail("release claim graph.non_claim_policy.schema must be codestory.release-non-claim/v1");
+  }
+  // The recorded state mirrors the package manifest's own accelerator non-claim, so a reader who
+  // already understands `not_proven_by_package` reads a withheld release cell the same way.
+  if (policy.runtime_execution !== "not_proven_by_package") {
+    fail("release claim graph.non_claim_policy.runtime_execution must be not_proven_by_package");
+  }
+  nonEmptyText(policy.reason, "release claim graph.non_claim_policy.reason");
+  nonEmptyText(policy.annotation, "release claim graph.non_claim_policy.annotation");
+  nonEmptyText(policy.recovery_contract, "release claim graph.non_claim_policy.recovery_contract");
+  if (policy.maximum_run_attempts !== 2) {
+    fail("release claim graph.non_claim_policy.maximum_run_attempts must be 2");
+  }
+  for (const key of ["producer_workflow", "producer_job", "producer_job_name"]) {
+    nonEmptyText(policy[key], `release claim graph.non_claim_policy.${key}`);
+  }
+  const producedCells = cellsByProducerJobName(cellGroups);
+  const hosts = uniqueById(policy.hosts, "release claim graph.non_claim_policy.hosts");
+  validateWithholdPolicy(policy, hosts, cellGroups);
+  const artifacts = new Set();
+  const accelerator = cellGroups.get("accelerator_execution");
+  const acceleratorInstances = (accelerator?.instances ?? []).map(({ id }) => id).sort();
+  if (JSON.stringify([...hosts.keys()].sort()) !== JSON.stringify(acceleratorInstances)) {
+    fail("non_claim_policy.hosts must name exactly the protected accelerator instances");
+  }
+  for (const [hostId, host] of hosts) {
+    nonEmptyText(host.unavailable_producer_workflow, `non_claim_policy.hosts ${hostId}.unavailable_producer_workflow`);
+    const jobName = nonEmptyText(
+      host.unavailable_producer_job_name,
+      `non_claim_policy.hosts ${hostId}.unavailable_producer_job_name`,
+    );
+    // One artifact container may only hold cells of a single closeout phase, because the phase's
+    // trusted producer map is what authorizes every manifest inside the container it downloads.
+    const hostArtifacts = object(
+      host.producer_artifacts,
+      `non_claim_policy.hosts ${hostId}.producer_artifacts`,
+    );
+    if (JSON.stringify(Object.keys(hostArtifacts).sort()) !== JSON.stringify(["post_publish", "pre_publish"])) {
+      fail(`non_claim_policy.hosts ${hostId}.producer_artifacts must name one artifact per closeout phase`);
+    }
+    for (const [phase, artifact] of Object.entries(hostArtifacts)) {
+      nonEmptyText(artifact, `non_claim_policy.hosts ${hostId}.producer_artifacts.${phase}`);
+      if (!artifact.includes("{attempt}")) {
+        fail(`non_claim_policy.hosts ${hostId}.producer_artifacts.${phase} must be attempt-qualified`);
+      }
+      if (artifacts.has(artifact)) fail(`non_claim_policy.hosts duplicates artifact ${artifact}`);
+      artifacts.add(artifact);
+    }
+    const declared = stringArray(
+      host.withheld_cells,
+      `non_claim_policy.hosts ${hostId}.withheld_cells`,
+      { nonEmpty: true },
+    );
+    const derived = producedCells.get(jobName) ?? [];
+    if (JSON.stringify([...declared].sort()) !== JSON.stringify([...derived].sort())) {
+      fail(`non_claim_policy host ${hostId} must withhold exactly the cells ${jobName} produces`);
+    }
+  }
 }
 
 function validatePublicSupport(graph, packageTargets, cellGroups) {
@@ -707,6 +857,8 @@ export function validateReleaseClaimGraph(graph) {
     }
   }
 
+  validateNonClaimPolicy(graph, cellGroups);
+
   const policy = object(graph.workflow_policy, "release claim graph.workflow_policy");
   if (!Number.isInteger(policy.artifact_retention_days) || policy.artifact_retention_days <= 0) {
     fail("workflow_policy.artifact_retention_days must be a positive integer");
@@ -889,6 +1041,8 @@ export function validatePlatformNarrativeDocuments(graph, repoRoot) {
   }
 }
 
+export const RELEASE_CLOSEOUT_SUMMARY_ASSET = "release-closeout-summary.json";
+
 export function releaseAssetNames(graph, version) {
   validateReleaseClaimGraph(graph);
   if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u.test(version)) {
@@ -900,23 +1054,66 @@ export function releaseAssetNames(graph, version) {
         `codestory-cli-v${version}-${target}.${extension}`,
     ),
     "SHA256SUMS.txt",
+    // The one machine-readable statement of what this release did and did not prove. It ships with
+    // the release because the README tells readers to consult the ledger rather than the platform
+    // table, and an Actions artifact with a 30-day retention is not something a release consumer
+    // can reach.
+    RELEASE_CLOSEOUT_SUMMARY_ASSET,
   ];
 }
 
-export function renderReleasePlatformNotes(graph) {
+/// Which package target each protected accelerator host speaks for, derived from the cells the host
+/// withholds rather than from a second copy of the mapping.
+function acceleratorHostByTarget(graph) {
+  const byTarget = new Map();
+  for (const host of graph.non_claim_policy.hosts) {
+    for (const cellId of host.withheld_cells) {
+      const [group, instance] = cellId.split(":");
+      if (group === "candidate_installed_behavior") byTarget.set(instance, host);
+    }
+  }
+  return byTarget;
+}
+
+/// The platform table that goes into the published GitHub release notes.
+///
+/// This is the surface a release consumer actually reads, so it is rendered from the accepted
+/// closeout ledger, never from the static graph alone. Rendering it from the graph is how a release
+/// whose Vulkan proof was withheld still announced "supported with Vulkan": the graph says what the
+/// repository intends to support, and only the ledger says what this release proved. A withheld
+/// accelerator is stated in the notes, in the same words the ledger recorded it in.
+export function renderReleasePlatformNotes(graph, ledger) {
   validateReleaseClaimGraph(graph);
-  const packages = graph.public_support.packages.map(
-    ({ label, accelerator_claim: claim }) =>
-      `- ${label}: supported with ${claim === "metal" ? "Metal" : "Vulkan"}`,
-  );
+  const closeout = object(ledger, "closeout ledger");
+  const withheldCells = new Set(stringArray(closeout.withheld_cells, "closeout ledger.withheld_cells"));
+  const hostByTarget = acceleratorHostByTarget(graph);
+  const reason = graph.non_claim_policy.reason;
+  const packages = graph.public_support.packages.map(({ label, target, accelerator_claim: claim }) => {
+    const accelerator = claim === "metal" ? "Metal" : "Vulkan";
+    const host = hostByTarget.get(target);
+    const withheld = host !== undefined
+      && host.withheld_cells.some((cellId) =>
+        cellId.startsWith("accelerator_execution:") && withheldCells.has(cellId));
+    return withheld
+      ? `- ${label}: ${accelerator} not proven for this release (${reason})`
+      : `- ${label}: supported with ${accelerator}`;
+  });
   const unsupported = graph.public_support.unsupported.map(
     ({ label }) => `- ${label}: unsupported`,
   );
+  const withheldNote = withheldCells.size === 0
+    ? []
+    : [
+      "",
+      `This release withheld ${withheldCells.size} evidence cell(s); `
+      + "release-closeout-summary.json names every one of them.",
+    ];
   return [
     "## Platform support",
     "",
     ...packages,
     ...unsupported,
+    ...withheldNote,
   ].join("\n");
 }
 
@@ -1403,7 +1600,10 @@ function main() {
     return;
   }
   if (command === "release-platform-notes") {
-    console.log(renderReleasePlatformNotes(graph));
+    // The ledger is required, not optional: an optional ledger would mean the published notes can
+    // still be produced from the graph alone, which is the exact fail-open this command had.
+    const ledgerPath = nonEmptyText(values.ledger, "--ledger");
+    console.log(renderReleasePlatformNotes(graph, JSON.parse(readFileSync(ledgerPath, "utf8"))));
     return;
   }
   if (command === "evaluate") {

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -138,6 +138,30 @@ export function deriveReleaseCells(graph, phase) {
   cells.sort((left, right) => left.id.localeCompare(right.id));
   const ids = cells.map(({ id }) => id);
   if (new Set(ids).size !== ids.length) fail("release claim graph derives duplicate closeout cell ids");
+  const nonClaimHostByCell = new Map();
+  const nonClaimPolicy = graph.non_claim_policy;
+  for (const host of nonClaimPolicy?.hosts ?? []) {
+    for (const cellId of host.withheld_cells ?? []) nonClaimHostByCell.set(cellId, host);
+  }
+  for (const cell of cells) {
+    const host = nonClaimHostByCell.get(cell.id);
+    if (!host) continue;
+    cell.non_claim = {
+      host: host.id,
+      reason: nonClaimPolicy.reason,
+      runtime_execution: nonClaimPolicy.runtime_execution,
+      annotation: nonClaimPolicy.annotation,
+      maximum_run_attempts: nonClaimPolicy.maximum_run_attempts,
+      unavailable_producer_workflow: host.unavailable_producer_workflow,
+      unavailable_producer_job_name: host.unavailable_producer_job_name,
+      producer_workflow: nonClaimPolicy.producer_workflow,
+      producer_job: nonClaimPolicy.producer_job,
+      producer_job_name: nonClaimPolicy.producer_job_name,
+      // One container per phase: a phase's trusted producer map authorizes every manifest in the
+      // container it downloads, so a cross-phase container would carry an unowned manifest.
+      producer_artifact: host.producer_artifacts[cell.phase],
+    };
+  }
   return cells;
 }
 
@@ -148,6 +172,86 @@ export function resolveReleaseCellConstraints(cell, producerRunAttempt) {
     key,
     typeof value === "string" ? value.replaceAll("{attempt}", attempt) : value,
   ]));
+}
+
+/// The producer identity a withheld cell is authenticated against. A dead host cannot sign its own
+/// absence, so the recorded non-claim is produced by a separate hosted job with its own artifact
+/// name; everything else about the cell's identity -- target, backend, runner, host -- still has to
+/// describe the proof that did not happen.
+export function resolveReleaseCellNonClaimConstraints(cell, producerRunAttempt) {
+  const attempt = text(producerRunAttempt, "producer run attempt");
+  if (!/^[1-9]\d*$/u.test(attempt)) fail("producer run attempt must be a positive integer");
+  if (!cell.non_claim) fail(`closeout cell ${cell.id} does not admit a withheld non-claim`);
+  return {
+    producer_workflow: cell.non_claim.producer_workflow,
+    producer_job: cell.non_claim.producer_job,
+    producer_job_name: cell.non_claim.producer_job_name,
+    producer_artifact: cell.non_claim.producer_artifact.replaceAll("{attempt}", attempt),
+  };
+}
+
+export function isWithheldManifest(manifest) {
+  return manifest?.evidence?.status === "withheld";
+}
+
+/// A withheld cell has to *say* what it is not claiming. The recorded non-claim names the host that
+/// never reported, quotes the exact Actions annotation the recovery contract keyed on, and lists
+/// every claim the missing proof would have carried. A cell that omits any of that, or that carries
+/// a non-claim while still asserting a pass, is a validation failure rather than a quiet downgrade.
+function nonClaimProblems({ manifest, cell, graph, withheld }) {
+  const problems = [];
+  if (!withheld) {
+    if (manifest.non_claim !== undefined) {
+      problems.push("only a withheld cell may carry a non-claim");
+    }
+    return problems;
+  }
+  if (!cell.non_claim) {
+    problems.push(`closeout cell ${cell.id} does not admit a withheld non-claim`);
+    return problems;
+  }
+  let nonClaim;
+  try {
+    nonClaim = object(manifest.non_claim, `${cell.id}.non_claim`);
+  } catch (error) {
+    problems.push(error.message);
+    return problems;
+  }
+  const expected = {
+    host: cell.non_claim.host,
+    runtime_execution: cell.non_claim.runtime_execution,
+    non_claim_reason: cell.non_claim.reason,
+    annotation: cell.non_claim.annotation,
+    unavailable_producer_workflow: cell.non_claim.unavailable_producer_workflow,
+    unavailable_producer_job_name: cell.non_claim.unavailable_producer_job_name,
+  };
+  for (const [key, value] of Object.entries(expected)) {
+    if (nonClaim[key] !== value) problems.push(`non-claim ${key} must equal ${String(value)}`);
+  }
+  let withheldClaims = [];
+  try {
+    withheldClaims = transitiveClaims(graph, cell.claim).map(({ id }) => id).sort();
+  } catch (error) {
+    problems.push(error.message);
+  }
+  const declared = Array.isArray(nonClaim.withheld_claims)
+    ? [...nonClaim.withheld_claims].map(String).sort()
+    : null;
+  if (declared === null || JSON.stringify(declared) !== JSON.stringify(withheldClaims)) {
+    problems.push(`non-claim withheld_claims must name ${withheldClaims.join(", ")}`);
+  }
+  // Withholding is the end of the bounded recovery path, never a shortcut around it: a non-claim
+  // recorded before the automatic reruns are spent would let one flaky minute drop a claim.
+  const attempt = String(nonClaim.run_attempt ?? "");
+  if (!/^[1-9]\d*$/u.test(attempt) || Number(attempt) < cell.non_claim.maximum_run_attempts) {
+    problems.push(
+      `non-claim run_attempt must reach the ${cell.non_claim.maximum_run_attempts} attempt recovery bound`,
+    );
+  }
+  if (manifest.evidence?.identity?.producer_run_attempt !== attempt) {
+    problems.push("non-claim run_attempt must match the producing run attempt");
+  }
+  return problems;
 }
 
 function manifestProblems({ manifest, cell, graph, graphSha256, version }) {
@@ -181,12 +285,20 @@ function manifestProblems({ manifest, cell, graph, graphSha256, version }) {
       problems.push(`manifest identity ${key} does not match ${formats[key]}`);
     }
   }
+  const withheld = isWithheldManifest(manifest);
   let resolvedConstraints = cell.identity_constraints;
   try {
     resolvedConstraints = resolveReleaseCellConstraints(cell, identity.producer_run_attempt);
+    if (withheld) {
+      resolvedConstraints = {
+        ...resolvedConstraints,
+        ...resolveReleaseCellNonClaimConstraints(cell, identity.producer_run_attempt),
+      };
+    }
   } catch (error) {
     problems.push(error.message);
   }
+  problems.push(...nonClaimProblems({ manifest, cell, graph, withheld }));
   for (const [key, expected] of Object.entries(resolvedConstraints)) {
     if (identity[key] !== expected) {
       problems.push(`manifest identity ${key} must equal ${expected}`);
@@ -419,6 +531,13 @@ function trustedProducerIndex({
       errors.push(`trusted producer map is missing ${cell.id}`);
       continue;
     }
+    const nonClaimRow = row.non_claim === true;
+    if (row.non_claim !== undefined && typeof row.non_claim !== "boolean") {
+      errors.push(`trusted producer map ${cell.id} non_claim must be a boolean`);
+    }
+    if (nonClaimRow && !cell.non_claim) {
+      errors.push(`trusted producer map ${cell.id} does not admit a withheld non-claim`);
+    }
     for (const key of [
       "producer_workflow",
       "producer_job",
@@ -432,7 +551,12 @@ function trustedProducerIndex({
       }
       let constrained;
       try {
-        constrained = resolveReleaseCellConstraints(cell, row.producer_run_attempt)[key];
+        constrained = nonClaimRow && cell.non_claim
+          ? {
+            ...resolveReleaseCellConstraints(cell, row.producer_run_attempt),
+            ...resolveReleaseCellNonClaimConstraints(cell, row.producer_run_attempt),
+          }[key]
+          : resolveReleaseCellConstraints(cell, row.producer_run_attempt)[key];
       } catch (error) {
         errors.push(`trusted producer map ${cell.id} ${error.message}`);
       }
@@ -534,6 +658,11 @@ function producerAuthenticationProblems(manifest, trustedProducer, reusedCommit)
   if (!trustedProducer) return ["manifest producer is absent from the trusted producer map"];
   const identity = manifest.evidence?.identity ?? {};
   const problems = [];
+  // The producer map and the manifest have to agree about which one of the two is being recorded.
+  // Disagreement is how a real proof's producer could otherwise be paired with a withheld manifest.
+  if ((trustedProducer.non_claim === true) !== isWithheldManifest(manifest)) {
+    problems.push("manifest withheld state does not match the trusted producer map");
+  }
   for (const key of [
     "producer_workflow",
     "producer_job",
@@ -609,6 +738,66 @@ function trustedExceptionInput({ document, graph, graphSha256, gitIdentity, vers
     exceptions: canonicalReleaseClaimValue(exceptions),
     identity: canonicalReleaseClaimValue(trustedIdentity ?? {}),
     errors,
+  };
+}
+
+/// Every claim a cell carries, including the ones it only inherits. Withholding one accelerator
+/// proof therefore withholds the whole chain that rested on it, spelled out by name in the ledger.
+export function releaseCellWithheldClaims(graph, cell) {
+  return transitiveClaims(graph, cell.claim).map(({ id }) => id).sort();
+}
+
+const PASSING_CELL_STATUSES = new Set(["pass", "pass_with_exception"]);
+
+/// How much of a release may be unproven and still publish.
+///
+/// A single withheld host is a bounded, recorded loss: the other hosts still prove the claim, and
+/// the ledger says which one did not. Withholding *most* of a release is a different thing
+/// entirely -- a release nothing vouched for -- and the earlier shape of this closeout could not
+/// tell the two apart, because it only ever consulted missing and failed cells. Both bounds below
+/// come from `non_claim_policy.withhold_policy` in release-claims.json, so the threshold is data a
+/// reader can check against the ledger rather than a constant buried here.
+///
+/// The return value also splits the claims a withheld cell rests on into the ones nothing else
+/// proves and the ones another host still proves, because a single unioned list is false in one
+/// direction or the other for every release that withholds anything.
+function assessWithheldClaims({ graph, cells, ledgerCells, withheldHosts }) {
+  const policy = graph.non_claim_policy.withhold_policy;
+  const problems = [];
+  // A withheld row that names no host would not be counted against the cap at all, which is the
+  // one way a capped policy could still be evaded by an absence.
+  for (const row of ledgerCells.filter(({ status }) => status === "withheld")) {
+    const host = row.non_claim?.host;
+    if (typeof host !== "string" || host === "") {
+      problems.push(`withheld cell ${row.id} names no host to count against the withhold cap`);
+    }
+  }
+  const maximum = policy.maximum_withheld_hosts;
+  if (withheldHosts.length > maximum) {
+    problems.push(
+      `withheld hosts ${withheldHosts.join(", ")} exceed the ${maximum}-host withhold cap`,
+    );
+  }
+  const claimOfCell = new Map(cells.map(({ id, claim }) => [id, claim]));
+  const provenClaims = new Set(ledgerCells
+    .filter(({ status }) => PASSING_CELL_STATUSES.has(status))
+    .map(({ id }) => claimOfCell.get(id))
+    .filter((claim) => claim !== undefined));
+  const phaseClaims = new Set(cells.map(({ claim }) => claim));
+  for (const claimId of policy.claims_requiring_proof) {
+    // A claim this phase never closes cannot be withheld here either, so it is not this phase's
+    // business. Every claim the phase does close has to keep at least one cell that actually ran.
+    if (!phaseClaims.has(claimId)) continue;
+    if (provenClaims.has(claimId)) continue;
+    problems.push(`claim ${claimId} requires proof but no cell proved it`);
+  }
+  const touched = [...new Set(ledgerCells
+    .filter(({ status }) => status === "withheld")
+    .flatMap(({ withheld_claims: rows }) => rows ?? []))];
+  return {
+    problems,
+    withheld_claims: touched.filter((claimId) => !provenClaims.has(claimId)).sort(),
+    partially_withheld_claims: touched.filter((claimId) => provenClaims.has(claimId)).sort(),
   };
 }
 
@@ -728,6 +917,11 @@ function dependencyValidationProblems({ cell, cells, manifests, graph, problemsB
     const dependency = dependencyCell(cells, claim.id, focal.evidence.identity.target);
     if ((problemsByCell.get(dependency.id) ?? []).length > 0) {
       problems.push(`dependency cell ${dependency.id} failed closeout validation`);
+    }
+    // A withheld dependency is the whole point of the rule: a cell that still wants to pass while
+    // something it rests on was never proven has to fail loudly, not inherit a quiet pass.
+    if (isWithheldManifest(manifests.get(dependency.id)) && !isWithheldManifest(focal)) {
+      problems.push(`dependency cell ${dependency.id} is withheld`);
     }
   }
   return problems;
@@ -1053,6 +1247,17 @@ export function evaluateReleaseCloseout({
         status: "fail",
         failures: [...new Set(problems)].sort(),
       };
+    } else if (isWithheldManifest(manifest)) {
+      // A withheld cell is never handed to the claim evaluator: that evaluator only knows how to
+      // answer "is this claim proven", and the honest answer here is "nobody asked it".
+      evaluation = {
+        schema: MANIFEST_EVALUATION_SCHEMA,
+        cell_id: cell.id,
+        evidence_cells: [cell.id],
+        status: "withheld",
+        withheld_claims: transitiveClaims(graph, cell.claim).map(({ id }) => id).sort(),
+        non_claim: canonicalReleaseClaimValue(manifest.non_claim),
+      };
     } else {
       try {
         evaluation = evaluateCell({
@@ -1095,10 +1300,24 @@ export function evaluateReleaseCloseout({
       evaluation: evaluationRecord,
       ...(manifest.archive ? { archive: canonicalReleaseClaimValue(manifest.archive) } : {}),
       ...(manifest.comparison ? { comparison: canonicalReleaseClaimValue(manifest.comparison) } : {}),
+      ...(evaluation.status === "withheld"
+        ? {
+          non_claim: canonicalReleaseClaimValue(manifest.non_claim),
+          withheld_claims: [...evaluation.withheld_claims],
+        }
+        : {}),
     });
   }
   const missingCells = ledgerCells.filter(({ status }) => status === "missing").map(({ id }) => id);
   const failedCells = ledgerCells.filter(({ status }) => status === "fail").map(({ id }) => id);
+  const withheldRows = ledgerCells.filter(({ status }) => status === "withheld");
+  const withheldCells = withheldRows.map(({ id }) => id);
+  const withheldHosts = [...new Set(withheldRows.map(({ non_claim: nonClaim }) => nonClaim?.host)
+    .filter((host) => typeof host === "string" && host !== ""))].sort();
+  const withheld = assessWithheldClaims({ graph, cells, ledgerCells, withheldHosts });
+  const withheldClaims = withheld.withheld_claims;
+  const partiallyWithheldClaims = withheld.partially_withheld_claims;
+  inputErrors.push(...withheld.problems);
   inputErrors.sort();
   const decision = inputErrors.length === 0 && missingCells.length === 0 && failedCells.length === 0
     ? "accept"
@@ -1115,6 +1334,13 @@ export function evaluateReleaseCloseout({
     producer_provenance_sha256: digest(canonicalJson(trustedProducers)),
     trusted_exceptions_sha256: digest(canonicalJson(trustedExceptionDocument)),
     cells: ledgerCells,
+    withheld_cells: withheldCells,
+    withheld_hosts: withheldHosts,
+    // Literal in both directions: `withheld_claims` is what nothing in this phase proved, and
+    // `partially_withheld_claims` is what a withheld cell rested on but another cell still proved.
+    withheld_claims: withheldClaims,
+    partially_withheld_claims: partiallyWithheldClaims,
+    withhold_policy: canonicalReleaseClaimValue(graph.non_claim_policy.withhold_policy),
     input_errors: inputErrors,
   };
   const summary = {
@@ -1131,9 +1357,15 @@ export function evaluateReleaseCloseout({
       passed: ledgerCells.filter(({ status }) => new Set(["pass", "pass_with_exception"]).has(status)).length,
       failed: failedCells.length,
       missing: missingCells.length,
+      withheld: withheldCells.length,
     },
     failed_cells: failedCells,
     missing_cells: missingCells,
+    withheld_cells: withheldCells,
+    withheld_hosts: withheldHosts,
+    withheld_claims: withheldClaims,
+    partially_withheld_claims: partiallyWithheldClaims,
+    withhold_policy: canonicalReleaseClaimValue(graph.non_claim_policy.withhold_policy),
     input_errors: inputErrors,
   };
   return {

--- a/scripts/tests/codestory-release-cell-manifest.test.mjs
+++ b/scripts/tests/codestory-release-cell-manifest.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -393,4 +394,268 @@ test("reused evidence keeps every same-run trust requirement", () => {
   const missing = reusedRunMetadata("source_behavior");
   missing.artifacts = [];
   assert.throws(withReuse(missing), /must retain one/u);
+});
+
+// ── Withheld accelerator claims ─────────────────────────────────────────────────────────────
+
+const nonClaimPolicy = graph.non_claim_policy;
+const linuxHost = nonClaimPolicy.hosts.find(({ id }) => id === "linux-x64-vulkan");
+
+const withheldAttempt = String(nonClaimPolicy.maximum_run_attempts);
+
+/// The Actions job evidence the closeout collects for itself: the annotation, the empty step
+/// conclusions, and the log-blob probe. `signature` picks which of the two shapes a failed Linux
+/// proof has, and only one of them may route a cell into the withheld lane.
+function lostHostEvidence({ signature = "lost", executions = nonClaimPolicy.maximum_run_attempts } = {}) {
+  const rows = [];
+  for (let attempt = 1; attempt <= executions; attempt += 1) {
+    rows.push({
+      id: 8000 + attempt,
+      name: `linux-vulkan-proof / ${linuxHost.unavailable_producer_job_name}`,
+      status: "completed",
+      conclusion: "failure",
+      run_attempt: String(attempt),
+      log_uploaded: signature !== "lost",
+      annotations: signature === "lost"
+        ? [{ message: nonClaimPolicy.annotation }]
+        : [{ message: "Process completed with exit code 1." }],
+      steps: signature === "lost"
+        ? [
+          { name: "Checkout exact source", status: "completed", conclusion: "success" },
+          { name: "Prove offline Linux Vulkan retrieval", status: "completed", conclusion: null },
+        ]
+        : [{ name: "Prove offline Linux Vulkan retrieval", status: "completed", conclusion: "failure" }],
+    });
+  }
+  return rows;
+}
+
+/// Actions metadata for a run whose Linux proof did not succeed and whose hosted non-claim job did.
+/// The run is at the recovery bound, because a cell may only be withheld once that bound is spent.
+function withheldRunMetadata(phase, {
+  hostConclusion = "failure",
+  withNonClaimArtifact = true,
+  jobEvidence = lostHostEvidence(),
+} = {}) {
+  const metadata = actionsMetadata(phase);
+  for (const jobs of Object.values(metadata.jobsByAttempt)) {
+    for (const job of jobs) {
+      if (job.name.endsWith(linuxHost.unavailable_producer_job_name)) job.conclusion = hostConclusion;
+    }
+  }
+  if (hostConclusion !== "success") {
+    const lostArtifacts = new Set(linuxHost.withheld_cells.map((id) =>
+      resolveReleaseCellConstraints(cell(id), "1").producer_artifact));
+    metadata.artifacts = metadata.artifacts.filter(({ name }) => !lostArtifacts.has(name));
+  }
+  metadata.jobsByAttempt[withheldAttempt].push({
+    id: 9001,
+    run_id: 12345,
+    run_attempt: withheldAttempt,
+    head_sha: gitIdentity.commit,
+    name: `Release / ${nonClaimPolicy.producer_job_name}`,
+    status: "completed",
+    conclusion: "success",
+    started_at: "2026-07-19T13:00:00.000Z",
+    completed_at: "2026-07-19T13:10:00.000Z",
+  });
+  if (withNonClaimArtifact) {
+    metadata.artifacts.push({
+      id: 9002,
+      name: linuxHost.producer_artifacts.pre_publish.replaceAll("{attempt}", withheldAttempt),
+      digest: `sha256:${"9".repeat(64)}`,
+      size_in_bytes: 1024,
+      expired: false,
+      created_at: "2026-07-19T13:05:00.000Z",
+      expires_at: "2026-08-18T12:05:00.000Z",
+      workflow_run: { id: 12345, head_sha: gitIdentity.commit },
+    });
+  }
+  return { ...metadata, jobEvidence };
+}
+
+test("a lost protected host routes only its own cells to the non-claim producer", () => {
+  const map = buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: withheldAttempt,
+    ...withheldRunMetadata("pre_publish"),
+  });
+  const byCell = new Map(map.producers.map((row) => [row.cell_id, row]));
+  for (const cellId of ["accelerator_execution:linux-x64-vulkan", "candidate_installed_behavior:linux-x64"]) {
+    assert.equal(byCell.get(cellId).non_claim, true, cellId);
+    assert.equal(byCell.get(cellId).producer_job, nonClaimPolicy.producer_job);
+    assert.equal(
+      byCell.get(cellId).producer_artifact,
+      linuxHost.producer_artifacts.pre_publish.replaceAll("{attempt}", withheldAttempt),
+    );
+  }
+  // Every host that did report keeps its real proof producer, and nothing else is marked withheld.
+  assert.deepEqual(
+    map.producers.filter(({ non_claim: withheld }) => withheld === true)
+      .map(({ cell_id: id }) => id).sort(),
+    ["accelerator_execution:linux-x64-vulkan", "candidate_installed_behavior:linux-x64"],
+  );
+  assert.equal(byCell.get("accelerator_execution:windows-x64-vulkan").non_claim, undefined);
+  assert.equal(byCell.get("package_identity:linux-x64").non_claim, undefined);
+});
+
+test("the non-claim producer is never substituted for a host that reported", () => {
+  // Success on the protected host keeps the proof producer even when a non-claim artifact exists.
+  const proven = buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: withheldAttempt,
+    ...withheldRunMetadata("pre_publish", { hostConclusion: "success", jobEvidence: [] }),
+  });
+  assert.deepEqual(proven.producers.filter(({ non_claim: withheld }) => withheld === true), []);
+
+  // Without a recorded non-claim there is nothing to fall back to, and the run stays broken.
+  assert.throws(() => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: withheldAttempt,
+    ...withheldRunMetadata("pre_publish", { withNonClaimArtifact: false }),
+  }), /must retain one release-cell-nonclaim-prepublish-linux-x64-vulkan-attempt-2 artifact/u);
+});
+
+test("the closeout reads the lost-runner signature itself before it trusts a non-claim", () => {
+  // The trust boundary decides whether a cell is authenticated against the real proof or against
+  // the non-claim producer. Routing on "the host job is not green" made the producer's own refusal
+  // to upload the single point of failure; the map now refuses the routing on its own evidence.
+  const withEvidence = (jobEvidence) => () => buildTrustedProducerMap({
+    graph,
+    gitIdentity,
+    phase: "pre_publish",
+    runId: "12345",
+    currentRunAttempt: withheldAttempt,
+    ...withheldRunMetadata("pre_publish", { jobEvidence }),
+  });
+
+  // A proof that ran and failed its own assertions is red, and stays red.
+  assert.throws(
+    withEvidence(lostHostEvidence({ signature: "assertion" })),
+    /failed its own assertions, so accelerator_execution:linux-x64-vulkan may not be withheld/u,
+  );
+  // One loss is not a spent recovery bound, however many attempts the run has had.
+  assert.throws(
+    withEvidence(lostHostEvidence({ executions: 1 })),
+    /has been lost 1 time\(s\).*recovery bound is spent/su,
+  );
+  // No evidence at all is refused outright rather than defaulting to the permissive route.
+  assert.throws(withEvidence(null), /cannot route .* to a non-claim without its own Actions job evidence/u);
+  assert.throws(withEvidence([]), /has no failed execution of Packaged Linux Vulkan engine/u);
+
+  // And the honest shape still routes.
+  const routed = withEvidence(lostHostEvidence())();
+  assert.deepEqual(
+    routed.producers.filter(({ non_claim: withheld }) => withheld === true)
+      .map(({ cell_id: id }) => id).sort(),
+    ["accelerator_execution:linux-x64-vulkan", "candidate_installed_behavior:linux-x64"],
+  );
+});
+
+test("withheld manifests carry the populated non-claim and refuse an unspent retry bound", () => {
+  const bound = String(nonClaimPolicy.maximum_run_attempts);
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-release-nonclaim-"));
+  const archive = path.join(directory, "codestory-cli-v0.16.0-linux-x64.tar.gz");
+  writeFileSync(archive, "release archive bytes");
+  const selected = cell("accelerator_execution:linux-x64-vulkan");
+  const build = (attempt) => produceReleaseCellManifest({
+    graph,
+    gitIdentity,
+    version,
+    cell: selected,
+    identity: { native_engine: "coderank_q8_embedded" },
+    producer: {
+      producer_workflow: nonClaimPolicy.producer_workflow,
+      producer_job: nonClaimPolicy.producer_job,
+      producer_job_name: nonClaimPolicy.producer_job_name,
+      producer_run_id: "12345",
+      producer_run_attempt: attempt,
+      producer_artifact: linuxHost.producer_artifacts.pre_publish.replaceAll("{attempt}", attempt),
+    },
+    observedAt,
+    archivePath: archive,
+    nonClaim: {
+      host: linuxHost.id,
+      runtime_execution: nonClaimPolicy.runtime_execution,
+      non_claim_reason: nonClaimPolicy.reason,
+      annotation: nonClaimPolicy.annotation,
+      unavailable_producer_workflow: linuxHost.unavailable_producer_workflow,
+      unavailable_producer_job_name: linuxHost.unavailable_producer_job_name,
+      withheld_claims: ["accelerator_execution", "package_identity", "source_behavior"],
+      run_attempt: attempt,
+    },
+  });
+
+  const manifest = build(bound);
+  assert.equal(manifest.evidence.status, "withheld");
+  assert.equal(manifest.non_claim.runtime_execution, "not_proven_by_package");
+  assert.equal(manifest.non_claim.non_claim_reason, "accelerator_host_unavailable");
+  // The identity still describes the proof that did not happen, so the ledger names the host.
+  assert.equal(manifest.evidence.identity.backend, "Vulkan");
+  assert.equal(manifest.evidence.identity.runner, "codestory-linux-vulkan");
+  assert.equal(manifest.evidence.identity.producer_job, nonClaimPolicy.producer_job);
+
+  assert.throws(() => build("1"), /recovery bound/u);
+});
+
+test("withhold writes one container per closeout phase, never a phase-mixed one", () => {
+  // Each phase's trusted producer map authorizes only the manifests it selected, so a container
+  // holding another phase's cell is rejected at download time and the release is lost anyway.
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-release-withhold-"));
+  const archive = path.join(directory, "codestory-cli-v0.16.0-linux-x64.tar.gz");
+  writeFileSync(archive, "release archive bytes");
+  const identityPath = path.join(directory, "identity.json");
+  writeFileSync(identityPath, JSON.stringify({
+    installer: "candidate_managed_plugin",
+    native_engine: "coderank_q8_embedded",
+  }));
+  const outDir = path.join(directory, "cells");
+  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  const result = spawnSync(process.execPath, [
+    path.join(root, "scripts/codestory-release-cell-manifest.mjs"), "withhold",
+    "--repo", root,
+    "--expected-sha", head,
+    "--version", version,
+    "--host", "linux-x64-vulkan",
+    "--producer-run-id", "12345",
+    "--producer-run-attempt", String(nonClaimPolicy.maximum_run_attempts),
+    "--identity", identityPath,
+    "--archive", archive,
+    "--out-dir", outDir,
+  ], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+
+  const expected = {
+    pre_publish: {
+      artifact: linuxHost.producer_artifacts.pre_publish,
+      cells: ["accelerator_execution:linux-x64-vulkan", "candidate_installed_behavior:linux-x64"],
+    },
+    post_publish: {
+      artifact: linuxHost.producer_artifacts.post_publish,
+      cells: ["retrieval_readiness:linux-x64"],
+    },
+  };
+  assert.deepEqual(readdirSync(outDir).sort(), ["post_publish", "pre_publish"]);
+  for (const [phase, { artifact, cells }] of Object.entries(expected)) {
+    const written = readdirSync(path.join(outDir, phase))
+      .map((name) => JSON.parse(readFileSync(path.join(outDir, phase, name), "utf8")));
+    assert.deepEqual(written.map(({ cell_id: id }) => id).sort(), [...cells].sort(), phase);
+    for (const manifest of written) {
+      assert.equal(manifest.phase, phase);
+      assert.equal(manifest.evidence.status, "withheld");
+      assert.equal(
+        manifest.evidence.identity.producer_artifact,
+        artifact.replaceAll("{attempt}", String(nonClaimPolicy.maximum_run_attempts)),
+      );
+    }
+  }
 });

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -103,7 +103,7 @@ test("versioned claim graph has one deterministic digest and all declared contro
   assert.match(releaseClaimGraphDigest(graph), /^[0-9a-f]{64}$/u);
   assert.equal(positiveFixture().evidence[0].graph_sha256, releaseClaimGraphDigest(graph));
   assert.equal(graph.claims.length, 8);
-  assert.equal(graph.graph_version, 7);
+  assert.equal(graph.graph_version, 8);
   assert.deepEqual(
     [...graph.standard_release_claims].sort(),
     [
@@ -177,15 +177,37 @@ test("public support, assets, and release notes derive from the package and clos
       "codestory-cli-v0.16.0-macos-arm64.tar.gz",
       "codestory-cli-v0.16.0-linux-x64.tar.gz",
       "SHA256SUMS.txt",
+      // The README tells a reader to consult the ledger rather than the platform table, so the
+      // machine-readable closeout summary has to ship with the release itself.
+      "release-closeout-summary.json",
     ],
   );
-  assert.match(renderPublicSupport(graph), /Apple Silicon \\| Supported with Metal/u);
-  assert.match(renderPublicSupport(graph), /Windows x64 \\| Supported with Vulkan/u);
-  assert.match(renderPublicSupport(graph), /Linux x64 \\| Supported with Vulkan/u);
-  assert.match(renderPublicSupport(graph), /CPU-only Windows and Linux \\| Unsupported/u);
-  assert.match(renderReleasePlatformNotes(graph), /macOS 15\+ on Apple Silicon: supported with Metal/u);
-  assert.match(renderReleasePlatformNotes(graph), /Windows x64: supported with Vulkan/u);
-  assert.match(renderReleasePlatformNotes(graph), /Linux x64: supported with Vulkan/u);
+  assert.match(renderPublicSupport(graph), /Apple Silicon \| Supported with Metal/u);
+  assert.match(renderPublicSupport(graph), /Windows x64 \| Supported with Vulkan/u);
+  assert.match(renderPublicSupport(graph), /Linux x64 \| Supported with Vulkan/u);
+  assert.match(renderPublicSupport(graph), /CPU-only Windows and Linux \| Unsupported/u);
+
+  // The release notes are a claim about one release, so they are rendered from that release's
+  // ledger. The graph alone can no longer produce them.
+  const proven = renderReleasePlatformNotes(graph, { withheld_cells: [] });
+  assert.match(proven, /macOS 15\+ on Apple Silicon: supported with Metal/u);
+  assert.match(proven, /Windows x64: supported with Vulkan/u);
+  assert.match(proven, /Linux x64: supported with Vulkan/u);
+  assert.throws(() => renderReleasePlatformNotes(graph), /closeout ledger/u);
+  assert.throws(() => renderReleasePlatformNotes(graph, {}), /withheld_cells/u);
+
+  const withheld = renderReleasePlatformNotes(graph, {
+    withheld_cells: [
+      "accelerator_execution:linux-x64-vulkan",
+      "candidate_installed_behavior:linux-x64",
+    ],
+  });
+  assert.match(
+    withheld,
+    /Linux x64: Vulkan not proven for this release \(accelerator_host_unavailable\)/u,
+  );
+  assert.equal(/Linux x64: supported with Vulkan/u.test(withheld), false);
+  assert.match(withheld, /Windows x64: supported with Vulkan/u);
 });
 
 test("positive fixture evaluates deterministically", () => {
@@ -244,6 +266,70 @@ test("graph rejects ambiguous dependencies and unstructured proof lanes", () => 
   assert.throws(
     () => validateReleaseClaimGraph(aggregateCell),
     /identity undeclared_identity must declare a format/u,
+  );
+
+  // A non-claim that withholds less than the lost host actually produced would leave a live claim
+  // resting on a proof that never ran, so the withheld set is checked against the graph itself.
+  const partialNonClaim = structuredClone(graph);
+  partialNonClaim.non_claim_policy.hosts.find(({ id }) => id === "linux-x64-vulkan")
+    .withheld_cells = ["accelerator_execution:linux-x64-vulkan"];
+  assert.throws(
+    () => validateReleaseClaimGraph(partialNonClaim),
+    /must withhold exactly the cells Packaged Linux Vulkan engine produces/u,
+  );
+
+  const unboundedRecovery = structuredClone(graph);
+  unboundedRecovery.non_claim_policy.maximum_run_attempts = 12;
+  assert.throws(
+    () => validateReleaseClaimGraph(unboundedRecovery),
+    /maximum_run_attempts must be 2/u,
+  );
+
+  const softenedNonClaim = structuredClone(graph);
+  softenedNonClaim.non_claim_policy.runtime_execution = "assumed_from_prior_release";
+  assert.throws(
+    () => validateReleaseClaimGraph(softenedNonClaim),
+    /runtime_execution must be not_proven_by_package/u,
+  );
+
+  // The withhold cap is data, and the graph refuses a cap that could leave nothing proven. A cap
+  // equal to the number of protected hosts makes "no accelerator was proven anywhere" a legal
+  // release, which is the whole thing the cap exists to make unrepresentable.
+  const uncappedWithholding = structuredClone(graph);
+  uncappedWithholding.non_claim_policy.withhold_policy.maximum_withheld_hosts =
+    uncappedWithholding.non_claim_policy.hosts.length;
+  assert.throws(
+    () => validateReleaseClaimGraph(uncappedWithholding),
+    /must leave at least one protected host proven/u,
+  );
+
+  const noCap = structuredClone(graph);
+  delete noCap.non_claim_policy.withhold_policy;
+  assert.throws(() => validateReleaseClaimGraph(noCap), /withhold_policy must be an object/u);
+
+  const zeroCap = structuredClone(graph);
+  zeroCap.non_claim_policy.withhold_policy.maximum_withheld_hosts = 0;
+  assert.throws(
+    () => validateReleaseClaimGraph(zeroCap),
+    /maximum_withheld_hosts must be a positive integer/u,
+  );
+
+  // Dropping a claim a lost host can erase would make the cap silent about exactly that claim.
+  const unguardedClaim = structuredClone(graph);
+  unguardedClaim.non_claim_policy.withhold_policy.claims_requiring_proof =
+    unguardedClaim.non_claim_policy.withhold_policy.claims_requiring_proof
+      .filter((claimId) => claimId !== "accelerator_execution");
+  assert.throws(
+    () => validateReleaseClaimGraph(unguardedClaim),
+    /claims_requiring_proof must include accelerator_execution/u,
+  );
+
+  const unmatchedHosts = structuredClone(graph);
+  unmatchedHosts.non_claim_policy.hosts = unmatchedHosts.non_claim_policy.hosts
+    .filter(({ id }) => id !== "linux-x64-vulkan");
+  assert.throws(
+    () => validateReleaseClaimGraph(unmatchedHosts),
+    /must name exactly the protected accelerator instances/u,
   );
 
   const mismatchedSupport = structuredClone(graph);

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import os from "node:os";
@@ -9,7 +10,9 @@ import {
   deriveReleaseCells,
   evaluateReleaseCloseout,
   readReleaseCellArtifacts,
+  releaseCellWithheldClaims,
   resolveReleaseCellConstraints,
+  resolveReleaseCellNonClaimConstraints,
   writeReleaseCloseout,
 } from "../codestory-release-closeout.mjs";
 import {
@@ -94,10 +97,42 @@ function identityFor(cell, producerRunAttempt = "1") {
   return identity;
 }
 
-function manifestsFor(phase, prePublishLedger = null) {
+const nonClaimPolicy = graph.non_claim_policy;
+const linuxHost = nonClaimPolicy.hosts.find(({ id }) => id === "linux-x64-vulkan");
+
+function nonClaimFor(cell, host, attempt) {
+  return {
+    host: host.id,
+    runtime_execution: nonClaimPolicy.runtime_execution,
+    non_claim_reason: nonClaimPolicy.reason,
+    annotation: nonClaimPolicy.annotation,
+    unavailable_producer_workflow: host.unavailable_producer_workflow,
+    unavailable_producer_job_name: host.unavailable_producer_job_name,
+    withheld_claims: releaseCellWithheldClaims(graph, cell),
+    run_attempt: attempt,
+  };
+}
+
+/// Withholding is declared per host, so every helper takes the set of hosts a scenario lost. One
+/// host is the ordinary outage; the multi-host forms exist because the withhold cap is only
+/// observable when more than one host is gone at once.
+function withheldHostList(withheldHost) {
+  if (withheldHost === null || withheldHost === undefined) return [];
+  return Array.isArray(withheldHost) ? withheldHost : [withheldHost];
+}
+
+function withheldHostOf(withheldHost, cellId) {
+  return withheldHostList(withheldHost).find((host) => host.withheld_cells.includes(cellId)) ?? null;
+}
+
+function manifestsFor(phase, prePublishLedger = null, { attempt = "1", withheldHost = null } = {}) {
   const graphSha256 = releaseClaimGraphDigest(graph);
   return deriveReleaseCells(graph, phase).map((cell) => {
-    const identity = identityFor(cell);
+    const host = withheldHostOf(withheldHost, cell.id);
+    const withheld = host !== null;
+    const identity = withheld
+      ? { ...identityFor(cell, attempt), ...resolveReleaseCellNonClaimConstraints(cell, attempt) }
+      : identityFor(cell, attempt);
     const evidenceType = graph.evidence_types.find(({ id }) => id === cell.evidence_type);
     const manifest = {
       schema: graph.closeout.manifest_schema,
@@ -109,13 +144,14 @@ function manifestsFor(phase, prePublishLedger = null) {
         id: `${cell.id}-evidence`,
         type: cell.evidence_type,
         tier: evidenceType.tier,
-        status: "pass",
+        status: withheld ? "withheld" : "pass",
         graph_sha256: graphSha256,
         observed_at: observedAt,
         expires_at: expiresAt,
         identity,
       },
     };
+    if (withheld) manifest.non_claim = nonClaimFor(cell, host, attempt);
     if (cell.archive_role === "pre_publish") {
       manifest.archive = {
         name: archiveName(identity.target),
@@ -139,11 +175,20 @@ function manifestsFor(phase, prePublishLedger = null) {
   });
 }
 
-function trustedProducersFor(phase) {
+function trustedProducersFor(phase, withheldHost = null) {
   const artifactByName = new Map();
+  const attempt = withheldHostList(withheldHost).length > 0
+    ? String(nonClaimPolicy.maximum_run_attempts)
+    : "1";
   let nextId = 1000;
   const producers = deriveReleaseCells(graph, phase).map((cell) => {
-    const constraints = resolveReleaseCellConstraints(cell, "1");
+    const withheld = withheldHostOf(withheldHost, cell.id) !== null;
+    const constraints = withheld
+      ? {
+        ...resolveReleaseCellConstraints(cell, attempt),
+        ...resolveReleaseCellNonClaimConstraints(cell, attempt),
+      }
+      : resolveReleaseCellConstraints(cell, attempt);
     let artifact = artifactByName.get(constraints.producer_artifact);
     if (!artifact) {
       artifact = {
@@ -161,11 +206,12 @@ function trustedProducersFor(phase) {
     }
     return {
       cell_id: cell.id,
+      ...(withheld ? { non_claim: true } : {}),
       producer_workflow: constraints.producer_workflow,
       producer_job: constraints.producer_job,
       producer_job_name: constraints.producer_job_name,
       producer_run_id: "12345",
-      producer_run_attempt: "1",
+      producer_run_attempt: attempt,
       producer_artifact: constraints.producer_artifact,
       artifact,
       job: {
@@ -175,7 +221,7 @@ function trustedProducersFor(phase) {
         name: `Release / ${constraints.producer_job_name}`,
         status: "completed",
         conclusion: "success",
-        run_attempt: "1",
+        run_attempt: attempt,
         started_at: "2026-07-18T11:00:00.000Z",
         completed_at: "2026-07-18T11:10:00.000Z",
       },
@@ -188,7 +234,7 @@ function trustedProducersFor(phase) {
     graph_sha256: releaseClaimGraphDigest(graph),
     identity: gitIdentity,
     run_id: "12345",
-    current_run_attempt: "1",
+    current_run_attempt: attempt,
     producers,
     artifacts: [...artifactByName.values()],
   };
@@ -919,4 +965,331 @@ test("native-fingerprint reuse is still refused, and refused for the tree it can
       `${cellId}: ${JSON.stringify(failures)}`,
     );
   }
+});
+
+// ── Withheld accelerator claims ─────────────────────────────────────────────────────────────
+
+const withheldAttempt = String(nonClaimPolicy.maximum_run_attempts);
+
+function withheldPrePublish() {
+  return {
+    manifests: manifestsFor("pre_publish", null, { attempt: withheldAttempt, withheldHost: linuxHost }),
+    trustedProducers: trustedProducersFor("pre_publish", linuxHost),
+  };
+}
+
+function cellOf(id) {
+  return deriveReleaseCells(graph, "post_publish").find(({ id: candidate }) => candidate === id);
+}
+
+test("a lost host is recorded as an explicit withheld claim, never as a pass and never as a gap", () => {
+  const { manifests, trustedProducers } = withheldPrePublish();
+  const result = evaluate("pre_publish", manifests, null, trustedProducers);
+
+  // The release is not lost, but the accepted ledger says out loud what it did not prove.
+  assert.equal(result.decision, "accept");
+  assert.deepEqual(result.summary.missing_cells, []);
+  assert.deepEqual(result.summary.failed_cells, []);
+  assert.deepEqual(
+    result.summary.withheld_cells,
+    ["accelerator_execution:linux-x64-vulkan", "candidate_installed_behavior:linux-x64"],
+  );
+  assert.equal(result.summary.counts.withheld, 2);
+  // A withheld cell is never counted as proven.
+  assert.equal(
+    result.summary.counts.passed,
+    result.summary.counts.required - result.summary.counts.withheld,
+  );
+  // Linux stopped proving the accelerator, but macOS and Windows did not, so the claim is named as
+  // partially withheld. `withheld_claims` stays literal: it is what nothing in the phase proved.
+  assert.ok(result.summary.partially_withheld_claims.includes("accelerator_execution"));
+  assert.deepEqual(result.summary.withheld_hosts, ["linux-x64-vulkan"]);
+  assert.equal(result.summary.withheld_claims.includes("accelerator_execution"), false);
+
+  const row = result.ledger.cells.find(({ id }) => id === "accelerator_execution:linux-x64-vulkan");
+  assert.equal(row.status, "withheld");
+  assert.equal(row.non_claim.runtime_execution, "not_proven_by_package");
+  assert.equal(row.non_claim.non_claim_reason, "accelerator_host_unavailable");
+  assert.equal(row.non_claim.unavailable_producer_job_name, "Packaged Linux Vulkan engine");
+  assert.deepEqual(row.withheld_claims, ["accelerator_execution", "package_identity", "source_behavior"]);
+  // The withheld row still names the host, backend, and target the missing proof would have used.
+  assert.equal(row.identity.backend, "Vulkan");
+  assert.equal(row.identity.target, "linux-x64");
+  assert.equal(row.identity.producer_job, nonClaimPolicy.producer_job);
+
+  const evaluation = result.evaluations.get("accelerator_execution:linux-x64-vulkan").value;
+  assert.equal(evaluation.status, "withheld");
+  assert.equal(evaluation.release_claim_evaluation, undefined);
+
+  // Every host that did report is untouched and still passes on its own proof.
+  const windows = result.ledger.cells.find(({ id }) => id === "accelerator_execution:windows-x64-vulkan");
+  assert.equal(windows.status, "pass");
+  assert.equal(windows.non_claim, undefined);
+});
+
+test("nothing may pass on top of a withheld claim, and nothing else may be withheld", () => {
+  // Withhold only the accelerator cell and let everything the Linux host produces keep claiming a
+  // pass. Retrieval readiness rests on proven accelerator execution, so it must fail rather than
+  // inherit an unexamined pass.
+  const acceleratorOnly = {
+    ...linuxHost,
+    withheld_cells: ["accelerator_execution:linux-x64-vulkan"],
+  };
+  const prePublish = evaluate(
+    "pre_publish",
+    manifestsFor("pre_publish", null, { attempt: withheldAttempt, withheldHost: acceleratorOnly }),
+    null,
+    trustedProducersFor("pre_publish", acceleratorOnly),
+  );
+  const postManifests = manifestsFor("post_publish", prePublish.ledger, {
+    attempt: withheldAttempt,
+    withheldHost: acceleratorOnly,
+  });
+  const cascaded = evaluate(
+    "post_publish",
+    postManifests,
+    prePublish.ledger,
+    trustedProducersFor("post_publish", acceleratorOnly),
+  );
+  assert.equal(
+    cascaded.ledger.cells.find(({ id }) => id === "retrieval_readiness:linux-x64").status,
+    "fail",
+  );
+  assert.ok(cascaded.evaluations.get("retrieval_readiness:linux-x64").value.failures.some((message) =>
+    message.includes("is withheld")));
+  assert.equal(cascaded.decision, "reject");
+
+  // A cell the graph never declared withholdable cannot be withheld into an accepted ledger.
+  const ineligible = withheldPrePublish();
+  const source = ineligible.manifests.find(({ cell_id: id }) => id === "source_behavior");
+  source.evidence.status = "withheld";
+  source.non_claim = nonClaimFor(cellOf("source_behavior"), linuxHost, withheldAttempt);
+  const rejectedSource = evaluate("pre_publish", ineligible.manifests, null, ineligible.trustedProducers);
+  assert.equal(rejectedSource.decision, "reject");
+  assert.ok(rejectedSource.evaluations.get("source_behavior").value.failures.some((message) =>
+    message.includes("does not admit a withheld non-claim")));
+
+  // A withheld manifest paired with a real proof producer, or the reverse, is a mismatch.
+  const mismatch = withheldPrePublish();
+  delete mismatch.trustedProducers.producers
+    .find(({ cell_id: id }) => id === "accelerator_execution:linux-x64-vulkan").non_claim;
+  const rejectedMismatch = evaluate("pre_publish", mismatch.manifests, null, mismatch.trustedProducers);
+  assert.equal(rejectedMismatch.decision, "reject");
+
+  const forged = withheldPrePublish();
+  const proven = forged.manifests
+    .find(({ cell_id: id }) => id === "accelerator_execution:windows-x64-vulkan");
+  proven.non_claim = nonClaimFor(
+    cellOf("accelerator_execution:windows-x64-vulkan"),
+    linuxHost,
+    withheldAttempt,
+  );
+  const rejectedForged = evaluate("pre_publish", forged.manifests, null, forged.trustedProducers);
+  assert.equal(rejectedForged.decision, "reject");
+  assert.ok(rejectedForged.evaluations.get("accelerator_execution:windows-x64-vulkan").value.failures
+    .some((message) => message.includes("only a withheld cell may carry a non-claim")));
+});
+
+test("a withheld cell must carry a complete, unspent-bound, honest non-claim", () => {
+  const cellId = "accelerator_execution:linux-x64-vulkan";
+  const cases = [
+    ["absent non-claim", (manifest) => {
+      delete manifest.non_claim;
+    }, /non_claim must be an object/u],
+    ["downgraded runtime execution", (manifest) => {
+      manifest.non_claim.runtime_execution = "proven_by_package";
+    }, /runtime_execution must equal not_proven_by_package/u],
+    ["invented reason", (manifest) => {
+      manifest.non_claim.non_claim_reason = "we_were_in_a_hurry";
+    }, /non_claim_reason must equal accelerator_host_unavailable/u],
+    ["mis-quoted annotation", (manifest) => {
+      manifest.non_claim.annotation = "Process completed with exit code 1.";
+    }, /annotation must equal/u],
+    ["shrunken withheld claim list", (manifest) => {
+      manifest.non_claim.withheld_claims = ["accelerator_execution"];
+    }, /withheld_claims must name/u],
+    ["unspent retry bound", (manifest) => {
+      manifest.non_claim.run_attempt = "1";
+    }, /recovery bound/u],
+    ["wrong unavailable host", (manifest) => {
+      manifest.non_claim.unavailable_producer_job_name = "Packaged Windows Vulkan engine";
+    }, /unavailable_producer_job_name must equal/u],
+  ];
+  for (const [label, mutate, pattern] of cases) {
+    const { manifests, trustedProducers } = withheldPrePublish();
+    mutate(manifests.find(({ cell_id: id }) => id === cellId));
+    const result = evaluate("pre_publish", manifests, null, trustedProducers);
+    assert.equal(result.decision, "reject", label);
+    assert.equal(result.ledger.cells.find(({ id }) => id === cellId).status, "fail", label);
+    assert.ok(
+      result.evaluations.get(cellId).value.failures.some((message) => pattern.test(message)),
+      `${label}: ${JSON.stringify(result.evaluations.get(cellId).value.failures)}`,
+    );
+  }
+});
+
+// ── The withhold cap ────────────────────────────────────────────────────────────────────────
+
+const withholdPolicy = nonClaimPolicy.withhold_policy;
+
+function withheldPrePublishHosts(hosts) {
+  return {
+    manifests: manifestsFor("pre_publish", null, { attempt: withheldAttempt, withheldHost: hosts }),
+    trustedProducers: trustedProducersFor("pre_publish", hosts),
+  };
+}
+
+test("the withhold cap is graph data and leaves at least one protected host proven", () => {
+  assert.equal(withholdPolicy.maximum_withheld_hosts, 1);
+  assert.ok(withholdPolicy.maximum_withheld_hosts < nonClaimPolicy.hosts.length);
+  assert.ok(withholdPolicy.claims_requiring_proof.includes("accelerator_execution"));
+});
+
+test("a release that withholds every accelerator host is refused, not published", () => {
+  const { manifests, trustedProducers } = withheldPrePublishHosts(nonClaimPolicy.hosts);
+  const result = evaluate("pre_publish", manifests, null, trustedProducers);
+
+  // The exact shape the reviewer published: six of ten required cells withheld and accepted.
+  assert.equal(result.summary.counts.withheld, 6);
+  assert.equal(result.summary.counts.failed, 0);
+  assert.equal(result.summary.counts.missing, 0);
+  assert.equal(result.decision, "reject");
+  assert.deepEqual(
+    result.summary.withheld_hosts,
+    ["linux-x64-vulkan", "macos-arm64-metal", "windows-x64-vulkan"],
+  );
+  // Refusal is a recorded state naming the cap it broke, never a silent absence.
+  assert.ok(
+    result.summary.input_errors.some((message) => /exceed the 1-host withhold cap/u.test(message)),
+    JSON.stringify(result.summary.input_errors),
+  );
+  assert.ok(
+    result.summary.input_errors.some((message) =>
+      message === "claim accelerator_execution requires proof but no cell proved it"),
+    JSON.stringify(result.summary.input_errors),
+  );
+  assert.ok(
+    result.summary.input_errors.some((message) =>
+      message === "claim installed_runtime_behavior requires proof but no cell proved it"),
+    JSON.stringify(result.summary.input_errors),
+  );
+  assert.deepEqual(result.ledger.withhold_policy, {
+    claims_requiring_proof: [...withholdPolicy.claims_requiring_proof],
+    maximum_withheld_hosts: withholdPolicy.maximum_withheld_hosts,
+  });
+});
+
+test("two withheld hosts already break the cap even though a third still proves the claim", () => {
+  const two = nonClaimPolicy.hosts.filter(({ id }) => id !== "windows-x64-vulkan");
+  const { manifests, trustedProducers } = withheldPrePublishHosts(two);
+  const result = evaluate("pre_publish", manifests, null, trustedProducers);
+  assert.equal(result.summary.counts.withheld, 4);
+  assert.equal(result.decision, "reject");
+  assert.deepEqual(result.summary.withheld_hosts, ["linux-x64-vulkan", "macos-arm64-metal"]);
+  assert.ok(
+    result.summary.input_errors.some((message) =>
+      message === "withheld hosts linux-x64-vulkan, macos-arm64-metal exceed the 1-host withhold cap"),
+    JSON.stringify(result.summary.input_errors),
+  );
+  // Windows still proved the accelerator, so the per-claim rule alone would not have caught this.
+  assert.ok(
+    !result.summary.input_errors.some((message) => /requires proof/u.test(message)),
+    JSON.stringify(result.summary.input_errors),
+  );
+});
+
+test("a withheld cell never satisfies a claim the policy requires proof for", () => {
+  // One host is inside the cap, so only the per-claim rule can speak here: strip the two proving
+  // accelerator cells to missing and the withheld third must not stand in for them.
+  const { manifests, trustedProducers } = withheldPrePublish();
+  const surviving = new Set([
+    "accelerator_execution:macos-arm64-metal",
+    "accelerator_execution:windows-x64-vulkan",
+  ]);
+  const thinned = manifests.filter(({ cell_id: id }) => !surviving.has(id));
+  const result = evaluate("pre_publish", thinned, null, trustedProducers);
+  assert.equal(result.decision, "reject");
+  assert.deepEqual(result.summary.withheld_hosts, ["linux-x64-vulkan"]);
+  assert.ok(
+    result.summary.input_errors.some((message) =>
+      message === "claim accelerator_execution requires proof but no cell proved it"),
+    JSON.stringify(result.summary.input_errors),
+  );
+});
+
+test("the published platform notes state a withheld accelerator instead of asserting it", () => {
+  // End to end through the real programs: the real closeout writes a real ledger, and the real
+  // release-notes command reads it. The graph still says Linux is a Vulkan platform; only the
+  // ledger knows this release did not prove it, which is why the notes may not be rendered from
+  // the graph alone.
+  const { manifests, trustedProducers } = withheldPrePublish();
+  const accepted = evaluate("pre_publish", manifests, null, trustedProducers);
+  assert.equal(accepted.decision, "accept");
+  const out = mkdtempSync(path.join(os.tmpdir(), "codestory-withheld-notes-"));
+  writeReleaseCloseout(out, accepted);
+
+  const render = (ledgerPath) => spawnSync(
+    process.execPath,
+    [
+      path.join(root, "scripts/codestory-release-claims.mjs"),
+      "release-platform-notes",
+      "--ledger",
+      ledgerPath,
+    ],
+    { encoding: "utf8" },
+  );
+  const withheldNotes = render(path.join(out, "ledger.json"));
+  assert.equal(withheldNotes.status, 0, withheldNotes.stderr);
+  assert.match(
+    withheldNotes.stdout,
+    /^- Linux x64: Vulkan not proven for this release \(accelerator_host_unavailable\)$/mu,
+  );
+  assert.equal(/^- Linux x64: supported with Vulkan$/mu.test(withheldNotes.stdout), false);
+  // The hosts that did prove their accelerator still say so.
+  assert.match(withheldNotes.stdout, /^- Windows x64: supported with Vulkan$/mu);
+  assert.match(withheldNotes.stdout, /^- macOS 15\+ on Apple Silicon: supported with Metal$/mu);
+  assert.match(withheldNotes.stdout, /release-closeout-summary\.json/u);
+
+  // A fully proven release is unchanged, so the honest wording costs nothing when nothing was lost.
+  const provenOut = mkdtempSync(path.join(os.tmpdir(), "codestory-proven-notes-"));
+  writeReleaseCloseout(provenOut, evaluate("pre_publish", manifestsFor("pre_publish")));
+  const provenNotes = render(path.join(provenOut, "ledger.json"));
+  assert.equal(provenNotes.status, 0, provenNotes.stderr);
+  assert.match(provenNotes.stdout, /^- Linux x64: supported with Vulkan$/mu);
+  assert.equal(/not proven for this release/u.test(provenNotes.stdout), false);
+
+  // Without a ledger the command refuses outright: the graph alone can never publish a claim.
+  const ungrounded = spawnSync(
+    process.execPath,
+    [path.join(root, "scripts/codestory-release-claims.mjs"), "release-platform-notes"],
+    { encoding: "utf8" },
+  );
+  assert.notEqual(ungrounded.status, 0);
+  assert.match(ungrounded.stderr, /--ledger/u);
+});
+
+test("withheld_claims names only what nothing proved, and says so separately for the rest", () => {
+  const { manifests, trustedProducers } = withheldPrePublish();
+  const result = evaluate("pre_publish", manifests, null, trustedProducers);
+  assert.equal(result.decision, "accept");
+
+  // package_identity:linux-x64 and source_behavior passed in this very ledger, so reporting their
+  // claims as withheld was the thing a reader could not take literally.
+  assert.deepEqual(result.summary.withheld_claims, []);
+  assert.deepEqual(
+    result.summary.partially_withheld_claims,
+    ["accelerator_execution", "installed_runtime_behavior", "package_identity", "source_behavior"],
+  );
+  for (const claimId of result.summary.partially_withheld_claims) {
+    const proven = result.ledger.cells.filter(({ claim, status }) =>
+      claim === claimId && new Set(["pass", "pass_with_exception"]).has(status));
+    assert.ok(proven.length > 0, `${claimId} is reported partial but nothing proved it`);
+  }
+  // Together the two lists still name every claim a withheld cell rested on: nothing is dropped.
+  assert.deepEqual(
+    [...result.summary.withheld_claims, ...result.summary.partially_withheld_claims].sort(),
+    [...new Set(result.ledger.cells
+      .filter(({ status }) => status === "withheld")
+      .flatMap(({ withheld_claims: rows }) => rows))].sort(),
+  );
 });

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "5e61e808ffb6edad30699c701b3f8c4182ddfeb3f7d83ba49bb41b1ce948aacb",
+      "graph_sha256": "79ad7c2b9b2c22c23d6e4d26e0bfcd2b484afd89fb0a3143b7a887955c9619a8",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
Release run 30357489443 was lost entirely because `codestory-linux-vulkan-wsl-rx7900xt` lost communication with GitHub mid-proof. `pre-publish-closeout` then failed as a pure cascade. There is exactly one GPU Linux host, so one flaky host cost a whole release.

## The signature, not the job name

`.github/scripts/lost-runner-recovery.mjs` classifies a failed job as a runner communication loss only when **all three** parts of the Actions signature hold at once:

1. an annotation whose text is exactly `The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection.`
2. at least one step that completed with an **empty** conclusion
3. **no** uploaded log blob — the runner never uploaded one

A proof that ran and failed its own assertions has a real conclusion on every step and a log, so it is classified `job_assertion_failure`. Job names are never read: a renamed or newly added proof job cannot become retryable by accident.

`.github/scripts/collect-actions-job-evidence.sh` is the single place those three facts (three different endpoints) are joined, shared by both halves.

## (1) Automatic retry — no human in the loop

`.github/workflows/lost-runner-rerun.yml` fires on `workflow_run` completion of Auto Release / Release, and re-dispatches the **individual** lost jobs via `POST /actions/jobs/{id}/rerun`. It deliberately does **not** use `rerun-failed-jobs`, which would sweep an assertion failure back into the queue alongside the lost one; policy forbids that string in the workflow. The bound is `MAXIMUM_RUN_ATTEMPTS = 2` (one automatic recovery attempt), cross-checked against `non_claim_policy.maximum_run_attempts` in `release-claims.json`. The job carries no `environment:`, and policy rejects adding one.

## (2) Explicit non-claim instead of hard failure

If the second attempt is lost the same way, `release.yml`'s new `accelerator-non-claim` job records a **populated non-claim** for that host, mirroring the package manifest's shape: `runtime_execution: not_proven_by_package` plus `non_claim_reason`. Every cell that host owns — accelerator execution, candidate-installed behavior, retrieval readiness — is written with evidence status `withheld`, naming the target, backend, runner, the unavailable producer job, the exact annotation, and every claim the missing proof would have carried.

The closeout accepts a withheld cell and records it as `withheld` in `ledger.json` and in `summary.json`'s `withheld_cells`, `withheld_claims`, and `counts.withheld`.

## Not a vacuous pass

- **A claim cannot silently become true.** A withheld cell is never handed to the claim evaluator; its ledger status is `withheld` and `counts.passed` excludes it. `counts.passed == counts.required - counts.withheld` is asserted directly.
- **Nothing can inherit an unproven claim.** Any cell that still claims a pass while a cell it depends on is withheld fails closeout validation (`dependency cell X is withheld`). Proven with retrieval readiness resting on a withheld accelerator.
- **Withholding cannot substitute for a real failure.** `planAcceleratorNonClaim` reaches `withheld` only from the full lost-runner signature *after* the retry bound is spent. An assertion failure, a cancelled job, an absent job, or an unspent bound are all `blocked` → non-zero exit → the run stays red.
- **A non-claim cannot be forged or hollowed out.** Missing `non_claim`, a downgraded `runtime_execution`, an invented reason, a mis-quoted annotation, a shrunken `withheld_claims` list, an unspent `run_attempt`, or the wrong unavailable host each make the cell `fail`.
- **The producer map and the manifest must agree.** A withheld manifest paired with a real proof producer (or the reverse) is a mismatch, and a non-claim attached to a cell that passed is rejected.
- **The fallback only fires for a host that actually didn't report.** A host whose proof succeeded keeps its proof producer even when a non-claim artifact exists; ambiguous or absent jobs never route to the fallback.
- **The graph owns what gets withheld.** `non_claim_policy.hosts[].withheld_cells` must equal exactly the cells that host's job produces, checked against the cell groups themselves, so adding a cell to a protected job cannot leave a stale non-claim behind.

`release-claims.json` bumps to `graph_version: 8`, adds `non_claim_policy`, and adds `accelerator-non-claim` to the release chain DAG. `check-workflow-policy.mjs` gains `lostRunnerRecoveryViolations`, and the withheld-cell artifact names join the graph-owned upload ownership list.

## Docs

README notes that a "Supported with Metal/Vulkan" row describes the release line's intent, and that a release whose accelerator host was unreachable ships with that claim **withheld** — read the ledger, not the platform table. `docs/contributors/testing-matrix.md` gains a "Withheld accelerator claims" section describing the signature, the bound, and the ledger surface.

## Both-directions proof

Every guard was removed or weakened and the corresponding test was watched to fail, then restored and watched to pass:

| Guard removed | Test that failed |
| --- | --- |
| classifier's empty-step + missing-log requirements | `the lost-runner verdict needs the whole signature...` |
| collector's log-blob probe | `the shell collector hands the classifier the whole signature` |
| `dependency cell X is withheld` cascade rule | `nothing may pass on top of a withheld claim...` |
| `nonClaimProblems` validation | `a withheld cell must carry a complete, unspent-bound, honest non-claim` + cascade test |
| `withheld` ledger status branch | `a lost host is recorded as an explicit withheld claim...` |
| guard on the non-claim producer fallback | `the non-claim producer is never substituted for a host that reported` + 7 existing provenance tests |
| `validateNonClaimPolicy` graph check | `graph rejects ambiguous dependencies and unstructured proof lanes` |
| `lostRunnerRecoveryViolations` hookup | `lost-runner recovery stays automatic, bounded, and blind to job names` |
| one withheld artifact from the upload-ownership list | `check-workflow-policy.mjs` reported a violation |

## Commands run

| Command | Result |
| --- | --- |
| `node .github/scripts/check-workflow-policy.mjs` | pass |
| `node --test .github/scripts/check-workflow-policy.test.mjs` | pass (369) |
| `node --test .github/scripts/lost-runner-recovery.test.mjs` | pass (5) |
| `node scripts/codestory-release-claims.mjs validate` | pass |
| `node .github/scripts/run-actionlint.mjs` | pass |
| `node .github/scripts/check-doc-links.mjs` | pass |
| `node --test scripts/tests/codestory-release-{claims,cell-manifest,closeout,evidence-gate}.test.mjs` | pass (74) |
| `node --test .github/scripts/*.test.mjs` (all touched lanes) | pass (399) |
| `shellcheck .github/scripts/collect-actions-job-evidence.sh` | pass |

Closes #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)