### PR TITLE
stage a servable store when a fixture calls itself healthy

### DIFF
--- a/crates/codestory-cli/src/app/tests/lifecycle/packet_diagnostics.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/packet_diagnostics.rs
@@ -112,10 +112,19 @@ fn index_next_commands_use_sidecar_repair_for_missing_embedding_runtime() {
     );
 }
 
-/// Publish `manifest` for a fresh temp project and run the production
-/// readiness projection against it, exactly as `doctor` consumes it.
-fn doctor_retrieval_state_for_manifest(
+/// Publish a full sidecar manifest for a fresh temp project, let `stage`
+/// disturb the store afterwards, and run the production readiness projection
+/// against the result exactly as `doctor` consumes it.
+///
+/// The publication goes through `publish_admissible_retrieval_manifest_for_test`
+/// so the seeded symbol docs and dense anchors back the manifest's own counts.
+/// Readiness derives freshness from the same storage recount sidecar admission
+/// runs, so a fixture that upserts only the manifest row stages a publication
+/// admission *refuses*: every case below would then report stale for that one
+/// reason and none of these checks would prove anything.
+fn doctor_retrieval_state_for_publication(
     mutate: impl FnOnce(&mut codestory_retrieval::RetrievalIndexManifest),
+    stage: impl FnOnce(&Path, &Path, &codestory_retrieval::RetrievalIndexManifest),
 ) -> codestory_contracts::api::RetrievalStateDto {
     let temp = tempfile::tempdir().expect("temp dir");
     let project_root = temp.path().join("project");
@@ -128,14 +137,22 @@ fn doctor_retrieval_state_for_manifest(
     manifest.symbol_doc_count = Some(8);
     manifest.dense_projection_count = Some(2);
     mutate(&mut manifest);
-    codestory_runtime::publish_retrieval_manifest_for_test(&storage_path, &manifest)
-        .expect("publish retrieval manifest");
+    let published =
+        codestory_runtime::publish_admissible_retrieval_manifest_for_test(&storage_path, &manifest)
+            .expect("publish retrieval manifest");
+    stage(&storage_path, &project_root, &published);
     codestory_runtime::retrieval_state_from_manifest_storage_for_test(
         &storage_path,
         &project_root,
         &temp.path().join("cache"),
     )
     .expect("retrieval state")
+}
+
+fn doctor_retrieval_state_for_manifest(
+    mutate: impl FnOnce(&mut codestory_retrieval::RetrievalIndexManifest),
+) -> codestory_contracts::api::RetrievalStateDto {
+    doctor_retrieval_state_for_publication(mutate, |_, _, _| {})
 }
 
 #[test]
@@ -153,6 +170,11 @@ fn doctor_semantic_check_is_healthy_for_fresh_manifest_published_store() {
         retrieval.stored_embedding.is_some(),
         "build_doctor_output only includes the semantic check when a stored contract exists"
     );
+    assert!(
+        retrieval.semantic_ready,
+        "a servable publication must reach doctor as semantic-ready: {:?}",
+        retrieval.fallback_message
+    );
     let check = semantic_contract_check(&retrieval);
 
     assert_eq!(
@@ -162,6 +184,78 @@ fn doctor_semantic_check_is_healthy_for_fresh_manifest_published_store() {
     );
     assert!(
         check.message.contains("semantic ok"),
+        "unexpected doctor message: {}",
+        check.message
+    );
+}
+
+#[test]
+fn doctor_semantic_check_warns_after_a_core_only_refresh() {
+    // The other direction, at the surface that renders it. A core-only refresh
+    // republishes the core index without rebuilding the sidecar: the manifest
+    // and its aggregates still agree, but an indexed file is now newer than the
+    // publication, so sidecar admission refuses the very next search with
+    // `indexed_file_newer_than_retrieval_manifest`. Doctor must say so rather
+    // than call the store healthy — this is #1557's over-claim, asserted here
+    // because the runtime crate alone is not the blast radius of a readiness
+    // change that CLI surfaces consume.
+    let retrieval = doctor_retrieval_state_for_publication(
+        |_| {},
+        |storage_path, project_root, manifest| {
+            codestory_runtime::stage_core_only_refresh_for_test(
+                storage_path,
+                project_root,
+                manifest.built_at_epoch_ms + 60_000,
+            )
+            .expect("stage core-only refresh");
+        },
+    );
+
+    assert!(
+        !retrieval.semantic_ready,
+        "readiness must not promise hybrid retrieval admission refuses to serve"
+    );
+    let check = semantic_contract_check(&retrieval);
+
+    assert_eq!(
+        check.status, "warn",
+        "a core-only refresh must not be reported as healthy: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("semantic stale"),
+        "unexpected doctor message: {}",
+        check.message
+    );
+}
+
+#[test]
+fn doctor_semantic_check_warns_for_an_interrupted_incremental_run() {
+    // The second half of #1557: an interrupted incremental run leaves the
+    // manifest, symbol-doc count, dense anchors, and indexed-file mtimes all
+    // agreeing, so manifest-shape freshness sees nothing wrong, while admission
+    // refuses with `incomplete_incremental_index_run`.
+    let retrieval = doctor_retrieval_state_for_publication(
+        |_| {},
+        |storage_path, _, _| {
+            codestory_runtime::stage_incomplete_incremental_run_for_test(storage_path)
+                .expect("stage interrupted incremental run");
+        },
+    );
+
+    assert!(
+        !retrieval.semantic_ready,
+        "readiness must not promise hybrid retrieval admission refuses to serve"
+    );
+    let check = semantic_contract_check(&retrieval);
+
+    assert_eq!(
+        check.status, "warn",
+        "an interrupted incremental run must not be reported as healthy: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("semantic stale"),
         "unexpected doctor message: {}",
         check.message
     );

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -133,27 +133,77 @@ use semantic_projection::edge_digest_for_node;
 #[doc(hidden)]
 pub use semantic_projection::stored_semantic_embeddings_for_test;
 
-/// Test-support: publish a retrieval manifest fixture into the store at
-/// `storage_path`. Consumer crates (for example the CLI, whose architecture
-/// contract forbids direct `codestory_store` access) use this to stage
-/// manifest-published stores for readiness regression tests.
+/// Test-support: publish a *servable* retrieval manifest fixture into the
+/// store at `storage_path`. Consumer crates (for example the CLI, whose
+/// architecture contract forbids direct `codestory_store` access) use this to
+/// stage manifest-published stores for readiness regression tests.
+///
+/// This seeds the symbol docs and dense anchors the manifest's own counts
+/// describe, not just the manifest row, because readiness derives freshness
+/// from the same storage recount sidecar admission uses. A manifest-only
+/// fixture stages a publication admission refuses, so it cannot stand in for a
+/// healthy project — see [`search_publication::publish_admissible_retrieval_manifest`].
+/// The returned manifest is the one actually published; its
+/// `dense_reason_counts_json` matches the seeded anchors.
 #[cfg(feature = "test-support")]
 #[doc(hidden)]
-pub fn publish_retrieval_manifest_for_test(
+pub fn publish_admissible_retrieval_manifest_for_test(
     storage_path: &Path,
     manifest: &codestory_retrieval::RetrievalIndexManifest,
+) -> Result<codestory_retrieval::RetrievalIndexManifest, ApiError> {
+    let mut storage = open_storage_for_manifest_fixture(storage_path)?;
+    search_publication::publish_admissible_retrieval_manifest(&mut storage, manifest)
+}
+
+/// Test-support: leave behind the store shape a *core-only refresh* produces —
+/// an indexed file newer than the published sidecar, with the manifest and its
+/// aggregates untouched. Sidecar admission refuses that publication with
+/// `indexed_file_newer_than_retrieval_manifest`, so readiness must not promise
+/// hybrid retrieval over it.
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn stage_core_only_refresh_for_test(
+    storage_path: &Path,
+    project_root: &Path,
+    file_modification_time_epoch_ms: i64,
 ) -> Result<(), ApiError> {
-    let mut storage = Storage::open(storage_path).map_err(|error| {
+    let mut storage = open_storage_for_manifest_fixture(storage_path)?;
+    storage
+        .insert_files_batch(&[FileInfo {
+            id: 900_001,
+            path: project_root.join("core_only_refresh.rs"),
+            language: "rust".to_string(),
+            modification_time: file_modification_time_epoch_ms,
+            indexed: true,
+            complete: true,
+            line_count: 1,
+            file_role: StoreFileRole::Source,
+        }])
+        .map_err(|error| {
+            ApiError::internal(format!("Failed to seed core-only refresh file: {error}"))
+        })?;
+    Ok(())
+}
+
+/// Test-support: leave behind the marker an *interrupted incremental run*
+/// leaves. Manifest, aggregates, and mtimes all still agree; admission still
+/// refuses with `incomplete_incremental_index_run`, so readiness must too.
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn stage_incomplete_incremental_run_for_test(storage_path: &Path) -> Result<(), ApiError> {
+    let storage = open_storage_for_manifest_fixture(storage_path)?;
+    storage.begin_incremental_run().map_err(|error| {
+        ApiError::internal(format!("Failed to mark incremental run in flight: {error}"))
+    })
+}
+
+#[cfg(feature = "test-support")]
+fn open_storage_for_manifest_fixture(storage_path: &Path) -> Result<Storage, ApiError> {
+    Storage::open(storage_path).map_err(|error| {
         ApiError::internal(format!(
             "Failed to open storage for manifest fixture: {error}"
         ))
-    })?;
-    storage
-        .upsert_retrieval_index_manifest(manifest)
-        .map_err(|error| {
-            ApiError::internal(format!("Failed to publish manifest fixture: {error}"))
-        })?;
-    Ok(())
+    })
 }
 
 /// Test-support: run the production manifest-derived retrieval readiness

--- a/crates/codestory-runtime/src/search_publication.rs
+++ b/crates/codestory-runtime/src/search_publication.rs
@@ -885,6 +885,119 @@ pub(super) fn retrieval_state_from_storage_for_runtime(
     ))
 }
 
+/// Test-support: stage the store a *served* full publication actually has.
+///
+/// Readiness derives freshness from
+/// `storage_admission_refusal_reason_for_runtime`, which recounts the symbol
+/// docs, dense anchors, and dense-reason histogram in the store and refuses a
+/// manifest that disagrees with them. Upserting only the manifest row
+/// therefore stages a publication the sidecar would *refuse*: a manifest whose
+/// recorded counts nothing in the store backs is exactly the core-only-refresh
+/// shape readiness is supposed to catch, so such a fixture can never stand in
+/// for a healthy project. Seed the rows the manifest's own counts describe, so
+/// a fixture that calls itself healthy is healthy.
+///
+/// Returns the manifest as published: `dense_reason_counts_json` is rewritten
+/// to the histogram of the anchors this seeds, because admission compares the
+/// manifest's copy against a recount rather than trusting it.
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) fn publish_admissible_retrieval_manifest(
+    storage: &mut Storage,
+    manifest: &codestory_store::RetrievalIndexManifest,
+) -> Result<codestory_store::RetrievalIndexManifest, ApiError> {
+    use crate::semantic_projection::{
+        DenseAnchorReason, LLM_SYMBOL_DOC_SCHEMA_VERSION, SYMBOL_SEARCH_DOC_PROVENANCE,
+    };
+    use codestory_contracts::graph::{Node, NodeId as CoreNodeId, NodeKind};
+    use codestory_store::{DenseAnchorInput, SymbolSearchDoc};
+
+    fn storage_error(context: &str, error: impl std::fmt::Display) -> ApiError {
+        ApiError::internal(format!("{context}: {error}"))
+    }
+
+    let mut manifest = manifest.clone();
+    let symbol_doc_count = manifest.symbol_doc_count.unwrap_or(0).max(0);
+    let dense_count = manifest
+        .dense_projection_count
+        .or(manifest.projection_count)
+        .unwrap_or(0)
+        .max(0);
+    let selection_reason = DenseAnchorReason::PublicApi.as_str().to_string();
+    manifest.dense_reason_counts_json = Some(if dense_count > 0 {
+        serde_json::json!({ selection_reason.clone(): dense_count }).to_string()
+    } else {
+        "{}".to_string()
+    });
+
+    // Nodes first: symbol docs and dense anchors are keyed by node id.
+    let node_count = symbol_doc_count.max(dense_count);
+    let nodes = (1..=node_count)
+        .map(|id| Node {
+            id: CoreNodeId(id),
+            kind: NodeKind::FUNCTION,
+            serialized_name: format!("admissible_{id:02}"),
+            ..Default::default()
+        })
+        .collect::<Vec<_>>();
+    storage
+        .insert_nodes_batch(&nodes)
+        .map_err(|error| storage_error("Failed to seed admissible publication nodes", error))?;
+
+    let symbol_docs = (1..=symbol_doc_count)
+        .map(|id| SymbolSearchDoc {
+            node_id: CoreNodeId(id),
+            file_node_id: None,
+            kind: NodeKind::FUNCTION,
+            display_name: format!("admissible_{id:02}"),
+            qualified_name: None,
+            file_path: None,
+            start_line: None,
+            doc_text: format!("admissible_{id:02}"),
+            doc_version: LLM_SYMBOL_DOC_SCHEMA_VERSION,
+            doc_hash: format!("admissible-doc-{id:02}"),
+            policy_version: codestory_retrieval::SEMANTIC_POLICY_VERSION.to_string(),
+            source_provenance: SYMBOL_SEARCH_DOC_PROVENANCE.to_string(),
+            updated_at_epoch_ms: 1,
+        })
+        .collect::<Vec<_>>();
+    storage
+        .upsert_symbol_search_docs_batch(&symbol_docs)
+        .map_err(|error| {
+            storage_error("Failed to seed admissible publication symbol docs", error)
+        })?;
+
+    let dense_inputs = (1..=dense_count)
+        .map(|id| DenseAnchorInput {
+            node_id: CoreNodeId(id),
+            file_node_id: None,
+            kind: NodeKind::FUNCTION,
+            display_name: format!("admissible_{id:02}"),
+            qualified_name: None,
+            file_path: None,
+            start_line: None,
+            end_line: None,
+            file_role: codestory_store::FileRole::Source,
+            source_provenance: SYMBOL_SEARCH_DOC_PROVENANCE.to_string(),
+            text: format!("admissible_{id:02}"),
+            document_hash: format!("admissible-anchor-{id:02}"),
+            selection_reason: selection_reason.clone(),
+            policy_version: codestory_retrieval::SEMANTIC_POLICY_VERSION.to_string(),
+            source_identity: format!("core:admissible_{id:02}"),
+            updated_at_epoch_ms: 1,
+        })
+        .collect::<Vec<_>>();
+    storage
+        .upsert_dense_anchor_inputs_batch(&dense_inputs)
+        .map_err(|error| {
+            storage_error("Failed to seed admissible publication dense anchors", error)
+        })?;
+
+    storage
+        .upsert_retrieval_index_manifest(&manifest)
+        .map_err(|error| storage_error("Failed to publish admissible retrieval manifest", error))?;
+    Ok(manifest)
+}
+
 fn published_dense_projection_count(manifest: &codestory_store::RetrievalIndexManifest) -> u32 {
     match manifest.dense_projection_count {
         Some(count) if count > 0 => u32::try_from(count).unwrap_or(u32::MAX),

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -2023,74 +2023,26 @@ fn published_full_retrieval_manifest(project_root: &Path) -> RetrievalIndexManif
 /// manifest row is therefore a publication the sidecar would *not* serve, so
 /// it cannot stand in for a healthy project when asserting that readiness
 /// reports hybrid.
+///
+/// The seeding itself lives in `search_publication` so this fixture and the
+/// one consumer crates reach through
+/// `publish_admissible_retrieval_manifest_for_test` stage the same store; a
+/// second private copy here is how the CLI's doctor fixture silently fell
+/// behind this crate's in the first place.
 fn publish_admissible_full_retrieval_manifest(
     storage: &mut Storage,
     project_root: &Path,
 ) -> RetrievalIndexManifest {
-    let mut manifest = published_full_retrieval_manifest(project_root);
-    manifest.dense_reason_counts_json =
-        Some(serde_json::json!({ DenseAnchorReason::PublicApi.as_str(): 2 }).to_string());
-    let symbol_doc_count = manifest.symbol_doc_count.expect("fixture symbol doc count");
-    let dense_count = manifest
-        .dense_projection_count
-        .expect("fixture dense projection count");
-    let nodes = (1..=symbol_doc_count)
-        .map(|id| Node {
-            id: CoreNodeId(id),
-            kind: NodeKind::FUNCTION,
-            serialized_name: format!("admissible_{id:02}"),
-            ..Default::default()
-        })
-        .collect::<Vec<_>>();
-    let symbol_docs = (1..=symbol_doc_count)
-        .map(|id| SymbolSearchDoc {
-            node_id: CoreNodeId(id),
-            file_node_id: None,
-            kind: NodeKind::FUNCTION,
-            display_name: format!("admissible_{id:02}"),
-            qualified_name: None,
-            file_path: None,
-            start_line: None,
-            doc_text: format!("admissible_{id:02}"),
-            doc_version: LLM_SYMBOL_DOC_SCHEMA_VERSION,
-            doc_hash: format!("admissible-doc-{id:02}"),
-            policy_version: SEMANTIC_POLICY_VERSION.to_string(),
-            source_provenance: SYMBOL_SEARCH_DOC_PROVENANCE.to_string(),
-            updated_at_epoch_ms: 1,
-        })
-        .collect::<Vec<_>>();
-    let dense_inputs = (1..=dense_count)
-        .map(|id| DenseAnchorInput {
-            node_id: CoreNodeId(id),
-            file_node_id: None,
-            kind: NodeKind::FUNCTION,
-            display_name: format!("admissible_{id:02}"),
-            qualified_name: None,
-            file_path: None,
-            start_line: None,
-            end_line: None,
-            file_role: codestory_store::FileRole::Source,
-            source_provenance: SYMBOL_SEARCH_DOC_PROVENANCE.to_string(),
-            text: format!("admissible_{id:02}"),
-            document_hash: format!("admissible-anchor-{id:02}"),
-            selection_reason: DenseAnchorReason::PublicApi.as_str().to_string(),
-            policy_version: SEMANTIC_POLICY_VERSION.to_string(),
-            source_identity: format!("core:admissible_{id:02}"),
-            updated_at_epoch_ms: 1,
-        })
-        .collect::<Vec<_>>();
-    storage
-        .insert_nodes_batch(&nodes)
-        .expect("seed admissible publication nodes");
-    storage
-        .upsert_symbol_search_docs_batch(&symbol_docs)
-        .expect("seed admissible publication symbol docs");
-    storage
-        .upsert_dense_anchor_inputs_batch(&dense_inputs)
-        .expect("seed admissible publication dense anchors");
-    storage
-        .upsert_retrieval_index_manifest(&manifest)
-        .expect("publish retrieval manifest");
+    let manifest = published_full_retrieval_manifest(project_root);
+    let manifest =
+        crate::search_publication::publish_admissible_retrieval_manifest(storage, &manifest)
+            .expect("publish admissible retrieval manifest");
+    assert_eq!(
+        manifest.dense_reason_counts_json.as_deref(),
+        Some(serde_json::json!({ DenseAnchorReason::PublicApi.as_str(): 2 }).to_string())
+            .as_deref(),
+        "the shared fixture must publish the histogram of the anchors it seeds"
+    );
     manifest
 }
 


### PR DESCRIPTION
Closes #1572
Refs #1557

## The mechanism, confirmed

Not assumed — instrumented. An `eprintln!` on the `stale_publication` branch of `retrieval_state_from_storage_for_runtime`, run against the failing CLI fixture, printed:

```
INSTRUMENT classifies_full=true
  refusal=Some("retrieval_manifest_stale: sidecar_symbol_doc_count_changed: manifest=8 current=0")
  symbol_doc_count=Some(8) dense_projection_count=Some(2) projection_count=Some(2)
```

The manifest shape is fine (`classifies_full=true`). The refusal is `manifest_staleness_reason_for_runtime`'s symbol-doc recount — a **pre-existing admission check, unchanged by #1562** — reporting that the manifest claims 8 symbol docs over a store holding 0.

That store is genuinely stale. `doctor_retrieval_state_for_manifest` staged it by upserting the manifest row alone, then set `symbol_doc_count = Some(8)` / `dense_projection_count = Some(2)` and called the result "a healthy fresh manifest-published store". A manifest whose recorded aggregates nothing in the store backs *is* the core-only-refresh shape #1557 taught readiness to catch. Readiness was right; the fixture was describing a publication sidecar admission refuses.

#1562's author saw this and fixed it — in this crate. `publish_admissible_full_retrieval_manifest` in `crates/codestory-runtime/src/tests.rs` carries the doc comment:

> A fixture that publishes only the manifest row is therefore a publication the sidecar would *not* serve, so it cannot stand in for a healthy project when asserting that readiness reports hybrid.

But `publish_retrieval_manifest_for_test` — the entry point this crate **exports to consumers**, and the one the CLI doctor regression used — kept upserting the manifest row alone. Two fixtures for the same store, one updated, one not, in the crate that was tested and the crate that was not. That is the regression: not a wrong discrimination in the projection, but a test-support surface that could no longer express the healthy store its only consumer asked it for.

## The fix

- The seeding moves to one owner, `search_publication::publish_admissible_retrieval_manifest`, which seeds the nodes, symbol docs, and dense anchors the manifest's own counts describe and returns the manifest as published (`dense_reason_counts_json` rewritten to the histogram of the anchors it actually seeded, because admission compares that field against a recount rather than trusting it).
- `crates/codestory-runtime/src/tests.rs` and the exported `publish_admissible_retrieval_manifest_for_test` both call it, so they cannot drift apart again. The old `publish_retrieval_manifest_for_test` name is gone rather than left as a trap — a stale caller now fails to compile.
- **#1562 is untouched.** `stale_publication` still consults `storage_admission_refusal_reason_for_runtime`; not one line of the projection changed. Proof B below shows the new tests fail without it.

## Regressions, both directions, where they run

The CLI doctor surface — the consumer that broke — now asserts all three cases:

| test | store | doctor |
| --- | --- | --- |
| `doctor_semantic_check_is_healthy_for_fresh_manifest_published_store` | servable full publication | `ok` |
| `doctor_semantic_check_warns_after_a_core_only_refresh` | indexed file newer than the sidecar | `warn` / `semantic stale` |
| `doctor_semantic_check_warns_for_an_interrupted_incremental_run` | `incomplete_index_run` marker set | `warn` / `semantic stale` |

The two refusal cases are staged through `stage_core_only_refresh_for_test` and `stage_incomplete_incremental_run_for_test`. Staging them over a manifest-only store would have made them pass for the wrong reason — everything reports stale there — which is why the fixture's doc comment now says so out loud.

## Both-directions proof

**A — revert the seeding** (publish the manifest row only, as before this change):

```
cargo test -p codestory-cli --lib packet_diagnostics::doctor_semantic
  -> 4 passed; 1 failed
  FAILED doctor_semantic_check_is_healthy_for_fresh_manifest_published_store
```

The original regression, reproduced. The two refusal tests pass *vacuously* — exactly the trap documented above. This revert also now breaks the runtime crate, which it did not before:

```
cargo test -p codestory-runtime --lib retrieval_state
  -> 2 passed; 1 failed
  FAILED tests::retrieval_state_reports_hybrid_ready_from_published_manifest_without_legacy_docs
```

**B — revert #1562** (`stale_publication` back to manifest-shape only):

```
cargo test -p codestory-cli --lib packet_diagnostics::doctor_semantic
  -> 3 passed; 2 failed
  FAILED doctor_semantic_check_warns_after_a_core_only_refresh
  FAILED doctor_semantic_check_warns_for_an_interrupted_incremental_run
```

The healthy test still passes. The new tests genuinely guard #1557's fix, and they guard it at the doctor surface.

**Restored** — file byte-identical to the committed version, 5 passed; 0 failed.

## Verification

| command | result |
| --- | --- |
| `cargo test -p codestory-cli --lib doctor_semantic_check_is_healthy_for_fresh_manifest_published_store` | 1 passed (was `left: "warn"  right: "ok"`) |
| `cargo test -p codestory-cli --lib packet_diagnostics::doctor_semantic` | 5 passed; 0 failed |
| `cargo test -p codestory-cli --test architecture_contracts` | 14 passed; 0 failed |
| `cargo test --workspace --no-fail-fast` | **58 targets, 2331 passed, 0 failed, 29 ignored** |
| `cargo clippy -p codestory-runtime -p codestory-cli --all-targets` | clean |
| `cargo fmt -p codestory-runtime -p codestory-cli -- --check` | clean |

Baseline at `origin/dev/codestory-next`, same command: **2328 passed, 1 failed** — that one failure being this issue. No unrelated pre-existing failure anywhere in the workspace, so nothing to report separately.

No CHANGELOG entry: user-visible readiness behavior on dev was already correct, and this change is confined to fixtures and the test-support surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
