### PR TITLE
share one dead-client executable capture across worker threads

### DIFF
--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
@@ -422,8 +422,8 @@ pub(super) fn load_establishment_timeout(phase: &str) -> Result<Duration> {
 /// `client_death_lease_active` wait must see the lease plus the admitted and
 /// held query/bulk work in one snapshot, and that bounds a queue-seeding
 /// phase, not a single snapshot: the freshly spawned dead client first pays
-/// its contract connect and spawn-convergence allowances, then fans out one
-/// captured transport per held request before the seeded depths become
+/// its contract connect and spawn-convergence allowances, then fans every held
+/// request out over one captured transport before the seeded depths become
 /// visible, while every poll of the wait is itself a fresh observe worker
 /// spending part of the snapshot allowance. This is the same phase shape as
 /// mixed_queue's gated seeding, which already bounds a strictly larger 64+64

--- a/crates/codestory-cli/src/embedding_qualification/worker/operations/dead_client.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/operations/dead_client.rs
@@ -1,10 +1,11 @@
-use super::super::protocol::run_raw_protocol_exchange_with_input;
+use super::super::protocol::run_raw_protocol_exchange_with_transport;
 use super::ANTI_IDLE_PROTOCOL_DEADLINE_MS;
 use anyhow::{Result, bail};
 use codestory_retrieval::{
     AwakeMonotonicClock, EmbeddingClientTransport, EmbeddingQualificationParameters,
     PerUserEmbeddingClient, SidecarRuntimeConfig,
 };
+use std::sync::Arc;
 use std::time::Duration;
 
 const CLIENT_DEATH_LEASE_HOLD_MS: u64 = 600_000;
@@ -27,51 +28,232 @@ pub(in crate::embedding_qualification::worker) fn run_dead_client_load(
     let documents = (0..parameters.documents_per_bulk)
         .map(|index| format!("{index}:{input}"))
         .collect::<Vec<_>>();
-    let mut workers = Vec::new();
-    for _ in 0..parameters.query_count {
-        workers.push(spawn_dead_client_request(
-            runtime.clone(),
-            "query",
-            input.clone(),
-        )?);
-    }
     let bulk_input = documents.join("\n");
-    for _ in 0..parameters.bulk_count {
-        workers.push(spawn_dead_client_request(
-            runtime.clone(),
-            "bulk",
-            bulk_input.clone(),
-        )?);
-    }
+    let request_runtime = runtime.clone();
+    let workers = spawn_dead_client_workers(
+        parameters.query_count,
+        parameters.bulk_count,
+        input,
+        bulk_input,
+        crate::embedding_server_transport::NativeEmbeddingClientTransport::capture,
+        move |transport, class, input| {
+            // Keep an admitted request alive until this process is terminated.
+            // Product deadlines would add cancellation retries to the pressure
+            // this worker is intended to measure.
+            let clock = EmbeddingClientTransport::clock(transport);
+            let _ = run_raw_protocol_exchange_with_transport(
+                &request_runtime,
+                transport,
+                clock.as_ref(),
+                class,
+                ANTI_IDLE_PROTOCOL_DEADLINE_MS,
+                Some(input),
+            );
+        },
+    )?;
     loop {
         std::hint::black_box(&workers);
         clock.sleep(Duration::from_secs(1));
     }
 }
 
-fn spawn_dead_client_request(
-    runtime: SidecarRuntimeConfig,
-    class: &'static str,
-    input: String,
-) -> std::io::Result<std::thread::JoinHandle<()>> {
-    std::thread::Builder::new()
-        .name(format!("codestory-dead-client-{class}"))
-        .spawn(move || {
-            // Keep an admitted request alive until this process is terminated.
-            // Product deadlines would add cancellation retries to the pressure
-            // this worker is intended to measure.
-            let transport =
-                match crate::embedding_server_transport::NativeEmbeddingClientTransport::capture() {
-                    Ok(transport) => transport,
-                    Err(_) => return,
-                };
-            let clock = EmbeddingClientTransport::clock(&transport);
-            let _ = run_raw_protocol_exchange_with_input(
-                &runtime,
-                clock.as_ref(),
-                class,
-                ANTI_IDLE_PROTOCOL_DEADLINE_MS,
-                Some(input),
+/// Capture the executable identity once, then fan every worker out over that
+/// one capture.
+///
+/// All of these workers run from the same executable by construction, so a
+/// capture inside each thread would re-hash the same file once per worker and
+/// stagger the concurrent pressure this operation exists to apply. The capture
+/// runs before the first spawn so a capture failure fails the operation instead
+/// of leaving workers that silently skip their request.
+fn spawn_dead_client_workers<Shared, Capture, Request>(
+    query_count: u32,
+    bulk_count: u32,
+    query_input: String,
+    bulk_input: String,
+    capture: Capture,
+    request: Request,
+) -> Result<Vec<std::thread::JoinHandle<()>>>
+where
+    Shared: Send + Sync + 'static,
+    Capture: FnOnce() -> Result<Shared>,
+    Request: Fn(&Shared, &'static str, String) + Send + Sync + 'static,
+{
+    let shared = Arc::new(capture()?);
+    let request = Arc::new(request);
+    let mut workers = Vec::new();
+    for (class, count, input) in [
+        ("query", query_count, query_input),
+        ("bulk", bulk_count, bulk_input),
+    ] {
+        for _ in 0..count {
+            let shared = Arc::clone(&shared);
+            let request = Arc::clone(&request);
+            let input = input.clone();
+            workers.push(
+                std::thread::Builder::new()
+                    .name(format!("codestory-dead-client-{class}"))
+                    .spawn(move || request(shared.as_ref(), class, input))?,
             );
-        })
+        }
+    }
+    Ok(workers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::spawn_dead_client_workers;
+    use anyhow::{Result, bail};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::time::Duration;
+
+    /// Stands in for the captured executable identity. Its digest names which
+    /// capture a worker read, so a second capture is visible in the record.
+    struct SharedCapture {
+        digest: String,
+    }
+
+    struct RendezvousState {
+        arrived: usize,
+        open: bool,
+    }
+
+    /// Releases a worker only once every worker has entered its request, so a
+    /// change that serialises the fan-out cannot pass. The wait carries a
+    /// timeout purely so such a change fails instead of hanging the suite; a
+    /// concurrent fan-out leaves as soon as the last worker arrives and never
+    /// approaches it.
+    struct Rendezvous {
+        expected: usize,
+        state: Mutex<RendezvousState>,
+        opened: Condvar,
+    }
+
+    impl Rendezvous {
+        fn new(expected: usize) -> Self {
+            Self {
+                expected,
+                state: Mutex::new(RendezvousState {
+                    arrived: 0,
+                    open: false,
+                }),
+                opened: Condvar::new(),
+            }
+        }
+
+        fn arrive(&self) -> bool {
+            let mut state = self.state.lock().expect("rendezvous state");
+            state.arrived += 1;
+            if state.arrived == self.expected {
+                state.open = true;
+                self.opened.notify_all();
+                return true;
+            }
+            let (_state, wait) = self
+                .opened
+                .wait_timeout_while(state, Duration::from_secs(30), |state| !state.open)
+                .expect("rendezvous wait");
+            !wait.timed_out()
+        }
+    }
+
+    #[test]
+    fn every_worker_shares_one_capture_and_applies_pressure_concurrently() {
+        const QUERY_COUNT: u32 = 3;
+        const BULK_COUNT: u32 = 2;
+        let expected_workers = (QUERY_COUNT + BULK_COUNT) as usize;
+        let captures = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let rendezvous = Arc::new(Rendezvous::new(expected_workers));
+        let capture_calls = Arc::clone(&captures);
+        let worker_observed = Arc::clone(&observed);
+        let worker_rendezvous = Arc::clone(&rendezvous);
+
+        let workers = spawn_dead_client_workers(
+            QUERY_COUNT,
+            BULK_COUNT,
+            "query-input".into(),
+            "bulk-input".into(),
+            move || {
+                let captured = capture_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(SharedCapture {
+                    digest: format!("capture-{captured}"),
+                })
+            },
+            move |shared: &SharedCapture, class, input| {
+                let concurrent = worker_rendezvous.arrive();
+                worker_observed.lock().expect("observed requests").push((
+                    class,
+                    input,
+                    shared.digest.clone(),
+                    concurrent,
+                ));
+            },
+        )
+        .expect("dead client workers spawn");
+        for worker in workers {
+            worker.join().expect("dead client worker joins");
+        }
+
+        assert_eq!(
+            captures.load(Ordering::SeqCst),
+            1,
+            "every dead-client worker must share one executable capture"
+        );
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(
+            observed.len(),
+            expected_workers,
+            "each configured worker must issue exactly one request"
+        );
+        let queries = observed
+            .iter()
+            .filter(|(class, input, _, _)| *class == "query" && input == "query-input")
+            .count();
+        let bulks = observed
+            .iter()
+            .filter(|(class, input, _, _)| *class == "bulk" && input == "bulk-input")
+            .count();
+        assert_eq!(
+            queries, QUERY_COUNT as usize,
+            "query workers keep their input"
+        );
+        assert_eq!(bulks, BULK_COUNT as usize, "bulk workers keep their input");
+        assert!(
+            observed
+                .iter()
+                .all(|(_, _, digest, _)| digest == "capture-0"),
+            "every worker must read the one captured identity"
+        );
+        assert!(
+            observed.iter().all(|(_, _, _, concurrent)| *concurrent),
+            "workers must be in flight together, not serialised behind one another"
+        );
+    }
+
+    #[test]
+    fn a_failed_capture_fails_the_operation_without_issuing_a_request() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let worker_requests = Arc::clone(&requests);
+        let error = spawn_dead_client_workers(
+            3,
+            2,
+            "query-input".into(),
+            "bulk-input".into(),
+            || -> Result<SharedCapture> { bail!("embedding_executable_changed") },
+            move |_: &SharedCapture, _, _| {
+                worker_requests.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .expect_err("a failed capture must fail the operation");
+        assert!(
+            error.to_string().contains("embedding_executable_changed"),
+            "the capture failure must reach the caller: {error}"
+        );
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            0,
+            "a failed capture must not leave workers that skip their request"
+        );
+    }
 }

--- a/crates/codestory-cli/src/embedding_qualification/worker/protocol.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/protocol.rs
@@ -138,14 +138,35 @@ pub(super) fn run_raw_protocol_exchange_with_input(
     measured_input: Option<String>,
 ) -> Result<WorkerProtocolExchange> {
     let transport = crate::embedding_server_transport::NativeEmbeddingClientTransport::capture()?;
-    let stream = connect_required_owner(&transport)?;
+    run_raw_protocol_exchange_with_transport(
+        runtime,
+        &transport,
+        clock,
+        class,
+        deadline_ms,
+        measured_input,
+    )
+}
+
+/// Run one raw exchange against an executable identity the caller already
+/// captured. Callers that fan several exchanges out of one process share a
+/// single capture instead of re-hashing the executable per exchange.
+pub(super) fn run_raw_protocol_exchange_with_transport(
+    runtime: &SidecarRuntimeConfig,
+    transport: &crate::embedding_server_transport::NativeEmbeddingClientTransport,
+    clock: &dyn AwakeMonotonicClock,
+    class: &str,
+    deadline_ms: u64,
+    measured_input: Option<String>,
+) -> Result<WorkerProtocolExchange> {
+    let stream = connect_required_owner(transport)?;
     run_protocol_exchange_on_stream(
         runtime,
         clock,
         class,
         deadline_ms,
         measured_input,
-        &transport,
+        transport,
         stream,
     )
 }


### PR DESCRIPTION
## Context

`run_dead_client_load` spawns one thread per `query_count` and one per `bulk_count`, and each thread called
`NativeEmbeddingClientTransport::capture()` itself. `capture()` resolves `current_exe()` and sha256-hashes the whole
executable, so the binary was hashed once per worker — twice, in fact, because the thread body captured a transport
for its clock and then `run_raw_protocol_exchange_with_input` captured a second one for the exchange.

The redundancy is the smaller problem. These workers deliberately skip product deadlines so cancellation retries do
not pollute the pressure they exist to measure, but a full executable hash in front of every request made that
pressure arrive late and staggered instead of concurrently — the shape of the load became an artifact of the hashing.

## What changed

- `dead_client.rs` captures once, before the first spawn, and shares that single capture with every worker through an
  `Arc`. The fan-out now lives in `spawn_dead_client_workers`, which takes the capture and the per-worker request as
  parameters so a test can pin the capture count without asserting on timing.
- `protocol.rs` gains `run_raw_protocol_exchange_with_transport`, the exchange against an identity the caller already
  captured. `run_raw_protocol_exchange_with_input` is now that function plus its own capture, so no existing caller
  changes behaviour.
- A stale sentence in the bench runner's `dead_client_setup_timeout` doc comment ("fans out one captured transport per
  held request") now describes the shared capture. The budget itself is unchanged — it is an upper bound, and this
  change only shortens the ramp it bounds.

Nothing about what `capture()` verifies changed, and no process-wide cache was added to
`embedding_server_transport.rs`; the reuse belongs to this operation, whose threads share one executable by
construction.

## How to review

Start at `spawn_dead_client_workers`. The capture runs before the loop and `?` propagates, so a capture failure fails
the operation instead of leaving threads that return early and silently skip their request — the old thread body's
`Err(_) => return`. Workers still run free: they share an `Arc`, not a lock, and nothing is held across the request.

## Verification

Both directions on the new tests:

- `cargo test -p codestory-cli --lib --locked dead_client` — 2 passed; 0 failed.
- Reverted only the source shape (capture moved back inside each thread, early return on error) with the tests
  untouched: both failed — `every_worker_shares_one_capture_and_applies_pressure_concurrently` reported
  `left: 5, right: 1` captures for 5 workers, and `a_failed_capture_fails_the_operation_without_issuing_a_request`
  reported five spawned `JoinHandle`s where the operation should have failed. Restored: 2 passed; 0 failed.

Gates:

- `cargo test -p codestory-cli --locked --test architecture_contracts` — 14 passed; 0 failed.
- `cargo test --workspace --locked` — counts in the verification comment on this PR.
- `cargo clippy -p codestory-cli --all-targets --locked` — clean.

## Risk

Low and confined to the qualification worker. The concurrency assertion is a rendezvous, not a duration: a worker
leaves only once every worker has entered its request, so a change that serialises the fan-out fails instead of merely
running slower. Its 30s wait exists solely so such a regression fails rather than hangs; a concurrent fan-out never
approaches it.

## Follow-up

None. `run_raw_protocol_exchange_with_input` still captures per call for its single-exchange callers, which is correct
for them.

Closes #1577
