### PR TITLE
Route every dispatch input through step env, and refuse the shape generically

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -4735,6 +4735,11 @@ const launderingContexts = [
   [/\benv\b/u, "env"],
   [/\bsteps\b[\s\S]*\boutputs\b/u, "a step output"],
   [/\bneeds\b[\s\S]*\boutputs\b/u, "a job output"],
+  // For `workflow_dispatch`, `github.event` *is* the inputs container, so serialising the event
+  // carries every dispatched value into script text without the word `inputs` ever appearing --
+  // `toJSON` preserves `$(` and backticks intact. `\bevent\b` does not match inside
+  // `github.event_name`, because `_` is a word character, so the ordinary trigger read is untouched.
+  [/\bgithub\b[\s\S]*\bevent\b/u, "the event payload"],
 ];
 
 export function interpolatedDispatchInputs(run) {

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1998,7 +1998,13 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   requireStepRun(violations, releaseFile, preCloseout, "Evaluate authenticated pre-publish closeout", [
     "--trusted-producers",
     "codestory-release-closeout.mjs evaluate",
+    '--version "$RELEASE_VERSION"',
   ]);
+  // The version the ledger is filed under reaches the evaluator as a variable, so the command text
+  // alone no longer says which release it closed out.
+  requireStepEnv(violations, releaseFile, preCloseout, "Evaluate authenticated pre-publish closeout", {
+    RELEASE_VERSION: "${{ needs.preflight.outputs.version }}",
+  });
   const devRevalidation = namedStep(preCloseout, "Revalidate proof-only dev head");
   add(
     violations,
@@ -2087,6 +2093,14 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     `${releaseFile} marketplace token must be a SHA-pinned app token scoped to the marketplace repository`,
   );
   violations.push(...catalogDeliveryOutcomeViolations(releaseFile, marketplacePublish, catalogDelivery));
+  // The version the catalog is pointed at reaches the push as a variable, so the command text no
+  // longer says which release it published. Both halves are pinned, as in the plugin lane.
+  requireStepRun(violations, releaseFile, marketplacePublish, "Point the catalog at the published release", [
+    '--version "$RELEASE_VERSION"',
+  ]);
+  requireStepEnv(violations, releaseFile, marketplacePublish, "Point the catalog at the published release", {
+    RELEASE_VERSION: "${{ needs.preflight.outputs.version }}",
+  });
   requireStepRun(violations, releaseFile, preflight, "Prove the public marketplace install path", [
     "build-marketplace-fixture.mjs",
     "--local-fixture true",
@@ -2167,7 +2181,11 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     "--trusted-producers",
     "--pre-publish-ledger",
     "codestory-release-closeout.mjs evaluate",
+    '--version "$RELEASE_VERSION"',
   ]);
+  requireStepEnv(violations, releaseFile, postCloseout, "Evaluate authenticated post-publish closeout", {
+    RELEASE_VERSION: "${{ needs.preflight.outputs.version }}",
+  });
   requireStepUses(violations, releaseFile, postCloseout, "Upload accepted post-publish closeout", "actions/upload-artifact@v7.0.1");
   for (const [jobName, job] of [
     ["Metal proof", metal],
@@ -2608,21 +2626,30 @@ function validatePackagedProof(workflows, violations, graph) {
     "CARGO_TARGET_DIR=/workspace/target/glibc-2.31",
     "CXXFLAGS=-std=c++17",
   ]);
-  for (const smokeStep of [
-    "Smoke packaged release asset",
-    "Smoke packaged release asset on Windows",
+  // The identity the smoke reads is the one `source-identity` proved against the dispatched ref,
+  // and it now arrives through `env:` rather than spliced into the command. Both halves are pinned:
+  // the script names the variable, and the variable names that step's output.
+  const sourceIdentityBindings = {
+    SOURCE_SHA: "${{ steps.source-identity.outputs.sha }}",
+    SOURCE_TREE: "${{ steps.source-identity.outputs.tree }}",
+  };
+  for (const [smokeStep, sha, tree] of [
+    ["Smoke packaged release asset", '"$SOURCE_SHA"', '"$SOURCE_TREE"'],
+    ["Smoke packaged release asset on Windows", '"$env:SOURCE_SHA"', '"$env:SOURCE_TREE"'],
   ]) {
     requireStepRun(violations, file, job, smokeStep, [
-      '--expected-source-sha "${{ steps.source-identity.outputs.sha }}"',
-      '--expected-source-tree "${{ steps.source-identity.outputs.tree }}"',
+      `--expected-source-sha ${sha}`,
+      `--expected-source-tree ${tree}`,
     ]);
+    requireStepEnv(violations, file, job, smokeStep, sourceIdentityBindings);
   }
   requireStepRun(violations, file, job, "Report fresh package identity", [
     "archive_sha256=",
-    "Source SHA:",
-    "Source tree:",
+    "Source SHA: \\`$SOURCE_SHA\\`",
+    "Source tree: \\`$SOURCE_TREE\\`",
     "Archive SHA-256:",
   ]);
+  requireStepEnv(violations, file, job, "Report fresh package identity", sourceIdentityBindings);
   add(
     violations,
     stepIndex(job, "Report fresh package identity")
@@ -2929,9 +2956,15 @@ function catalogDeliveryStateViolations(file, job, delivery, handoff, installSte
     );
   }
   requireStepRun(violations, file, job, installStepName, [
-    '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
-    '--local-fixture "${{ steps.delivery.outputs.local_fixture }}"',
+    '--marketplace-source "$MARKETPLACE_SOURCE"',
+    '--local-fixture "$LOCAL_FIXTURE"',
   ]);
+  // The install arguments arrive as variables now, so the command text no longer says which
+  // delivery state they came from. This binds each variable back to that step's own output.
+  requireStepEnv(violations, file, job, installStepName, {
+    MARKETPLACE_SOURCE: "${{ steps.delivery.outputs.marketplace_source }}",
+    LOCAL_FIXTURE: "${{ steps.delivery.outputs.local_fixture }}",
+  });
   return violations;
 }
 
@@ -3030,7 +3063,9 @@ function validatePostPublish(workflows, violations, graph) {
   );
   add(
     violations,
-    identityRun.includes('--arg installer "${{ steps.delivery.outputs.installer }}"'),
+    identityRun.includes('--arg installer "$DELIVERED_INSTALLER"')
+      && object(namedStep(job, "Emit authenticated post-publish release cells")?.env)
+        .DELIVERED_INSTALLER === "${{ steps.delivery.outputs.installer }}",
     `${file} post-publish cells must record the resolved delivery installer identity`,
   );
   for (const state of catalogDelivery.states) {
@@ -3042,25 +3077,48 @@ function validatePostPublish(workflows, violations, graph) {
   }
   const resolveInstalled = namedStep(job, resolveStepName);
   requireStepRun(violations, file, job, resolveStepName, [
-    'marketplace_revision="${{ steps.delivery.outputs.marketplace_revision }}"',
+    'marketplace_revision="$MARKETPLACE_REVISION"',
     // Re-checked here as an immutable identity, not merely as 40 characters: this job is
     // dispatchable, so the published branch's revision can arrive from a human.
     `printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'`,
     '"@openai/codex@$CODEX_CLI_VERSION"',
     "install-codestory-marketplace-proof.mjs",
-    '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
+    '--marketplace-source "$MARKETPLACE_SOURCE"',
     '--marketplace-revision "$marketplace_revision"',
-    '--local-fixture "${{ steps.delivery.outputs.local_fixture }}"',
+    '--local-fixture "$LOCAL_FIXTURE"',
     '--source-repository "$GITHUB_WORKSPACE"',
     "install-attestation-v2.json",
     'isolated_home="$install_root/isolated-home"',
     'HOME="$isolated_home" node',
   ]);
+  // The install arguments arrive as variables, so the command text no longer says which delivery
+  // state produced them. Each variable is bound back to the step that resolved it.
+  requireStepEnv(violations, file, job, resolveStepName, {
+    MARKETPLACE_REVISION: "${{ steps.delivery.outputs.marketplace_revision }}",
+    MARKETPLACE_SOURCE: "${{ steps.delivery.outputs.marketplace_source }}",
+    LOCAL_FIXTURE: "${{ steps.delivery.outputs.local_fixture }}",
+  });
   add(
     violations,
     namedStep(job, "Prove packaged version, help, and stdio shape")?.shell === "bash",
     `${file} packaged Python proof must use Bash on every protected platform`,
   );
+  // The published asset this proof reads now arrives through `env:`, so the command text alone no
+  // longer says which archive or version it proved.
+  requireStepRun(violations, file, job, "Prove packaged version, help, and stdio shape", [
+    '--archive "$ASSET_ARCHIVE"',
+    '--checksum-file "$ASSET_CHECKSUM"',
+    '--expected-version "$RELEASE_VERSION"',
+  ]);
+  requireStepEnv(violations, file, job, "Prove packaged version, help, and stdio shape", {
+    ASSET_ARCHIVE: "${{ steps.asset.outputs.archive }}",
+    ASSET_CHECKSUM: "${{ steps.asset.outputs.checksum }}",
+    RELEASE_VERSION: "${{ steps.release.outputs.version }}",
+  });
+  // The macOS signing proof quarantines and unpacks the same published archive.
+  requireStepEnv(violations, file, job, "Prove published macOS signature, notarization, and quarantined execution", {
+    ASSET_ARCHIVE: "${{ steps.asset.outputs.archive }}",
+  });
   const resolveRun = executableRunText(String(resolveInstalled?.run ?? ""));
   for (const forbidden of [
     "git archive",
@@ -3082,7 +3140,8 @@ function validatePostPublish(workflows, violations, graph) {
       && resolveInstalled?.["continue-on-error"] === undefined,
     `${file} installed plugin resolution must be unconditional and fail closed`,
   );
-  const installed = namedStep(job, "Prove the catalog-resolved published runtime");
+  const installedProofName = "Prove the catalog-resolved published runtime";
+  const installed = namedStep(job, installedProofName);
   add(violations, installed !== undefined, `${file} installed runtime proof step is missing`);
   add(
     violations,
@@ -3098,7 +3157,7 @@ function validatePostPublish(workflows, violations, graph) {
   const installedRun = executableRunText(String(installed?.run ?? ""));
   for (const fragment of [
     "python .github/scripts/check-packaged-agent-proof.py",
-    '--archive "${{ steps.asset.outputs.archive }}"',
+    '--archive "$ASSET_ARCHIVE"',
     "--plugin-handoff",
     "--engine-policy accelerated",
     '--expected-backend "${{ matrix.backend }}"',
@@ -3115,6 +3174,16 @@ function validatePostPublish(workflows, violations, graph) {
       `${file} installed runtime proof must run ${fragment}`,
     );
   }
+  // The archive and the resolved installation now reach the proof as variables. Without these the
+  // command text would read the same whether it proved the published asset or something else.
+  requireStepEnv(violations, file, job, installedProofName, {
+    ASSET_ARCHIVE: "${{ steps.asset.outputs.archive }}",
+    ASSET_CHECKSUM: "${{ steps.asset.outputs.checksum }}",
+    RELEASE_VERSION: "${{ steps.release.outputs.version }}",
+    INSTALLED_PLUGIN_ROOT: "${{ steps.installed.outputs.plugin_root }}",
+    INSTALLED_ATTESTATION: "${{ steps.installed.outputs.attestation }}",
+    INSTALLED_PLUGIN_DATA: "${{ steps.installed.outputs.plugin_data }}",
+  });
   for (const fragment of ["--engine-policy cpu_explicit", "--expected-backend CPU", "--ground-only"]) {
     add(
       violations,
@@ -3256,15 +3325,20 @@ function validatePackagedCoordinator(workflows, violations, graph) {
   ]);
   requireStepRun(violations, file, route, "Select change-aware proof scope", [
     'if [ "$REQUESTED_SCOPE" = none ] || [ "$REQUESTED_SCOPE" = linux ]; then',
-    'elif [ "${{ steps.resolve.outputs.mode }}" = "package" ]; then',
+    'elif [ "$RESOLVED_MODE" = "package" ]; then',
     'test "$REQUESTED_SCOPE" != none',
     'if [ "$REQUESTED_SCOPE" = auto ]; then',
-    'elif [ "${{ steps.resolve.outputs.mode }}" = "qualification" ]; then',
+    'elif [ "$RESOLVED_MODE" = "qualification" ]; then',
     'test "$REQUESTED_SCOPE" = auto || test "$REQUESTED_SCOPE" = full',
     'scope="$REQUESTED_SCOPE"',
     "scope=full",
     "node .github/scripts/route-ci-proof.mjs --stdin",
   ]);
+  // The mode the scope selector branches on now arrives as a variable, so the branch text alone no
+  // longer says which mode it read. This binds the variable back to the resolver's own output.
+  requireStepEnv(violations, file, route, "Select change-aware proof scope", {
+    RESOLVED_MODE: "${{ steps.resolve.outputs.mode }}",
+  });
   add(
     violations,
     String(namedStep(route, "Select change-aware proof scope")?.run ?? "")
@@ -4582,9 +4656,56 @@ function validateReleaseCellUploadOwnership(workflows, violations) {
   );
 }
 
-/// Every `${{ ... }}` in a piece of text, matched up to its own first `}}` so an expression that
-/// contains a single brace (`fromJSON('{"a":1}')`) is still bounded by its real terminator.
-const interpolations = /\$\{\{[\s\S]*?\}\}/gu;
+/// Every `${{ ... }}` in a piece of text, bounded by the `}}` that actually closes it.
+///
+/// A non-greedy `/\$\{\{[\s\S]*?\}\}/` stops at the first `}}` it sees, which is not always the
+/// terminator. GitHub's expression grammar puts braces inside expressions -- `fromJSON('{"a":1}')`
+/// carries one, and `format('{{Hello {0}}}', ...)`, the brace escape from GitHub's own expression
+/// documentation, carries a run of them. Against `${{ format('{{Hello {0}}}', inputs.ref) }}` the
+/// non-greedy form returned `${{ format('{{Hello {0}}`, which names no context at all, so a rule
+/// reading these spans saw a clean file and GitHub still spliced the input. Braces are counted
+/// here and the span ends at the `}}` that closes the expression itself.
+///
+/// Single-quoted literals are skipped whole, with `''` read as GitHub's escape for one quote, so a
+/// brace inside a string cannot move the count in either direction. Text that opens an expression
+/// and never closes it yields the rest of the text rather than nothing: an unreadable expression is
+/// not evidence that it is harmless.
+export function interpolationSpans(text) {
+  const source = String(text);
+  const spans = [];
+  let cursor = 0;
+  for (;;) {
+    const start = source.indexOf("${{", cursor);
+    if (start === -1) return spans;
+    let depth = 0;
+    let quoted = false;
+    let end = -1;
+    for (let index = start + 3; index < source.length; index += 1) {
+      const character = source[index];
+      if (quoted) {
+        if (character !== "'") continue;
+        if (source[index + 1] === "'") index += 1;
+        else quoted = false;
+        continue;
+      }
+      if (character === "'") quoted = true;
+      else if (character === "{") depth += 1;
+      else if (character === "}") {
+        if (depth > 0) depth -= 1;
+        else if (source[index + 1] === "}") {
+          end = index + 2;
+          break;
+        }
+      }
+    }
+    if (end === -1) {
+      spans.push(source.slice(start));
+      return spans;
+    }
+    spans.push(source.slice(start, end));
+    cursor = end;
+  }
+}
 
 /// Any mention of the `inputs` context, however it is spelled. GitHub serves the same dispatched
 /// value under `inputs.version`, `github.event.inputs.version`, and `inputs['version']`, and an
@@ -4593,10 +4714,45 @@ const interpolations = /\$\{\{[\s\S]*?\}\}/gu;
 /// (`my_inputs`) is not the context.
 const namesADispatchInput = /\binputs\b/u;
 
+/// The contexts a dispatched value can be standing in when a script reads it one hop later. Each
+/// one is a channel, not a value: nothing at the reading site says what was put into it.
+///
+/// `env` -- a workflow-, job-, or step-level `env:` entry may be bound to `${{ inputs.x }}`, and
+///   `${{ env.NAME }}` in a script is then the input, spliced as text. This PR alone created 117
+///   step-level `env:` bindings carrying inputs, so this is the shape the next author reaches for.
+/// `steps.*.outputs.*` -- a step that receives an input can write it to `$GITHUB_OUTPUT`, and the
+///   consuming `${{ steps.x.outputs.y }}` is again text.
+/// `needs.*.outputs.*` -- a job output is a step output that crossed a job boundary.
+///
+/// The remedy is the same one #1566 applied 117 times: bind the value in `env:` and read `$NAME`.
+/// For `env` specifically it costs nothing at all -- a workflow- or job-level `env:` entry is
+/// already exported into the shell, so `$NAME` is available with no new binding.
+///
+/// Not claimed here: `github.*` can carry attacker-authored text (a pull request title), which is a
+/// different surface with a different argument. `matrix.*` can be built from an input, which is
+/// pinned where the matrix is built (`fromJSON` over a fixed set of literals) rather than here.
+const launderingContexts = [
+  [/\benv\b/u, "env"],
+  [/\bsteps\b[\s\S]*\boutputs\b/u, "a step output"],
+  [/\bneeds\b[\s\S]*\boutputs\b/u, "a job output"],
+];
+
 export function interpolatedDispatchInputs(run) {
-  return [...String(run).matchAll(interpolations)]
-    .map(match => match[0])
-    .filter(expression => namesADispatchInput.test(expression));
+  return interpolationSpans(run).filter(expression => namesADispatchInput.test(expression));
+}
+
+/// Every interpolation in `run` that reaches a dispatched value, paired with why it can.
+export function interpolatedInputChannels(run) {
+  const found = [];
+  for (const expression of interpolationSpans(run)) {
+    if (namesADispatchInput.test(expression)) {
+      found.push([expression, "a dispatch input"]);
+      continue;
+    }
+    const laundering = launderingContexts.find(([pattern]) => pattern.test(expression));
+    if (laundering !== undefined) found.push([expression, laundering[1]]);
+  }
+  return found;
 }
 
 /// Dispatched values must reach a script through `env:`, never through the script's own text.
@@ -4615,6 +4771,12 @@ export function interpolatedDispatchInputs(run) {
 ///
 /// The rule reads `run:` only. A dispatched value in an action input (`with.ref`) or an `if:` is a
 /// different surface with a different argument, pinned separately where it belongs.
+///
+/// Naming the `inputs` context alone was not enough. The context is only where the value is at the
+/// moment the rule looks: an author who binds it into `env:` and reads `${{ env.NAME }}` one line
+/// later, or writes it to `$GITHUB_OUTPUT` and reads `${{ steps.x.outputs.y }}` one step later, has
+/// rebuilt #1566 with the gate green. The channels a dispatched value can be sitting in are refused
+/// with it, so closing the surface does not depend on spotting where the value came from.
 export function dispatchInputInterpolationViolations(workflows) {
   const violations = [];
   for (const [file, workflow] of workflows) {
@@ -4623,12 +4785,118 @@ export function dispatchInputInterpolationViolations(workflows) {
         const step = object(rawStep);
         if (typeof step.run !== "string") continue;
         const named = step.name ? ` (${step.name})` : "";
-        for (const expression of new Set(interpolatedDispatchInputs(step.run))) {
+        const seen = new Set();
+        for (const [expression, channel] of interpolatedInputChannels(step.run)) {
+          if (seen.has(expression)) continue;
+          seen.add(expression);
           violations.push(
             `${file} jobs.${jobId}.steps.${index}${named} must read ${expression}`
-              + " from step env, not interpolated script text",
+              + ` from step env, not interpolated script text: it carries ${channel}`,
           );
         }
+      }
+    }
+  }
+  return violations;
+}
+
+/// Routing a value through `env:` moves the read from GitHub's interpolator into the shell, so the
+/// script stops being shell-independent the moment it does.
+///
+/// `${{ env.NAME }}` is spliced before any shell exists and reads the same everywhere. `"$NAME"` is
+/// a bash read; under pwsh -- the runner default on Windows -- it is the literal `$NAME` if it
+/// resolves to anything at all, and the correct read is `$env:NAME`. So a step that consumes a
+/// binding on a job that can land on a Windows runner has to say which shell it was written for.
+/// Every affected step in this repository declares one; this keeps that true, because the failure
+/// mode is a proof that silently compares against an empty string rather than an error.
+export function shellDependentBindingViolations(workflows) {
+  const violations = [];
+  const bashRead = name => new RegExp(`\\$\\{?${name}\\b`, "u");
+  for (const [file, workflow] of workflows) {
+    const workflowShell = at(workflow, "defaults", "run", "shell");
+    for (const [jobId, rawJob] of Object.entries(object(workflow.jobs))) {
+      const job = object(rawJob);
+      // `runs-on` is often an expression, so the platform is not always readable here. Anything
+      // that is not a literal non-Windows label is treated as reaching Windows.
+      const label = JSON.stringify(job["runs-on"] ?? "");
+      const known = /^"(ubuntu|macos)[\w.-]*"$/u.test(label);
+      if (known) continue;
+      const jobShell = at(job, "defaults", "run", "shell") ?? workflowShell;
+      for (const [index, rawStep] of list(job.steps).entries()) {
+        const step = object(rawStep);
+        if (typeof step.run !== "string") continue;
+        if ((step.shell ?? jobShell) !== undefined) continue;
+        const bound = Object.keys(object(step.env))
+          .concat(Object.keys(object(job.env)), Object.keys(object(workflow.env)))
+          .filter(name => bashRead(name).test(step.run)
+            && !new RegExp(`\\$env:${name}\\b`, "u").test(step.run));
+        if (bound.length === 0) continue;
+        const named = step.name ? ` (${step.name})` : "";
+        violations.push(
+          `${file} jobs.${jobId}.steps.${index}${named} reads ${bound.sort().join(", ")}`
+            + " as a shell variable on a job that can run on Windows and must declare its shell",
+        );
+      }
+    }
+  }
+  return violations;
+}
+
+/// A script that absorbs its own failure has to hand that failure to something that does not.
+///
+/// `continue-on-error` lives outside the script, so nothing the script's own text asserts can see
+/// it, and it turns a gate's `exit 1` into advice. Putting it on plugin-static.yml's
+/// `Check workflow policy` step would silence this file and its whole test suite while the run
+/// still reported green -- the commands that step runs are pinned, its blocking-ness was not.
+///
+/// The rule is not "gates must be blocking", because the repository has scripts that deliberately
+/// are not: source-proof compiles and lints under `continue-on-error` so a later step can save the
+/// cache before failing the job, and both release lanes push the marketplace catalog that way so a
+/// credential problem cannot strand an already-published release. What those have and a silenced
+/// gate does not is a *successor*: an `id:`, and another step that reads `steps.<id>.outcome` and
+/// fails on it. So absorbing a failure is allowed exactly when the failure is still required
+/// somewhere, and a step that absorbs its failure into nothing is refused.
+///
+/// Scoped to `run:` steps. The optional cache restores are `uses:` steps whose miss is the normal
+/// path and carries no outcome to require -- their non-blocking-ness is separately required, and
+/// this rule must not contradict that.
+export function absorbedFailureViolations(workflows) {
+  const violations = [];
+  const absorbs = value => value !== undefined && value !== false;
+  for (const [file, workflow] of workflows) {
+    for (const [jobId, rawJob] of Object.entries(object(workflow.jobs))) {
+      const job = object(rawJob);
+      // A job-level `continue-on-error` downgrades every step it contains at once, and the only
+      // thing that can still require the failure is a downstream job reading `needs.<id>.result`.
+      if (absorbs(job["continue-on-error"])) {
+        add(
+          violations,
+          scalarStrings(workflow.jobs).some(text => text.includes(`needs.${jobId}.result`)),
+          `${file} jobs.${jobId} absorbs its own failure and must have needs.${jobId}.result required`,
+        );
+      }
+      const steps = list(job.steps).map(step => object(step));
+      // Reading the outcome is not requiring it. `if: steps.x.outcome == 'success'` only decides
+      // whether the reader runs, and a skipped step is not a failed job; a reader that absorbs its
+      // own failure cannot fail the job on what it read either, so it just moves the same question
+      // one step along. A successor is therefore a blocking step that receives the outcome
+      // somewhere other than its own `if:` -- where a script can still `test` it and exit non-zero.
+      const requires = outcome => steps.some(other => {
+        if (absorbs(other["continue-on-error"])) return false;
+        const consumed = { ...other };
+        delete consumed.if;
+        return scalarStrings(consumed).some(text => text.includes(outcome));
+      });
+      for (const [index, step] of steps.entries()) {
+        if (typeof step.run !== "string") continue;
+        if (!absorbs(step["continue-on-error"])) continue;
+        const named = step.name ? ` (${step.name})` : "";
+        add(
+          violations,
+          typeof step.id === "string" && requires(`steps.${step.id}.outcome`),
+          `${file} jobs.${jobId}.steps.${index}${named} absorbs its own failure and must have`
+            + " an id whose outcome a later blocking step requires",
+        );
       }
     }
   }
@@ -5285,7 +5553,7 @@ export function validateMarketplaceSync(workflows, violations) {
   add(
     violations,
     scalarStrings(workflow)
-      .flatMap(text => [...text.matchAll(/\$\{\{[^}]*\binputs\b[^}]*\}\}/gu)].map(match => match[0]))
+      .flatMap(text => interpolatedDispatchInputs(text))
       .every(expression => Object.values(bindings).includes(expression)),
     `${file} must name a dispatch input only as ${bindings.INPUT_COMMIT} or ${bindings.INPUT_VERSION}`,
   );
@@ -5343,7 +5611,7 @@ export function validateMarketplaceSync(workflows, violations) {
       }
       add(
         violations,
-        !scalarStrings(surfaces).some(text => /\$\{\{[^}]*\binputs\b/u.test(text)),
+        !scalarStrings(surfaces).some(text => interpolatedDispatchInputs(text).length > 0),
         `${where} must not splice a dispatch input into an action input`,
       );
       for (const [name, expected] of Object.entries(bindings)) {
@@ -5417,6 +5685,8 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   validateReleaseCellUploadOwnership(workflows, violations);
   validateReleaseArtifactRerunSafety(workflows, violations);
   violations.push(...dispatchInputInterpolationViolations(workflows));
+  violations.push(...shellDependentBindingViolations(workflows));
+  violations.push(...absorbedFailureViolations(workflows));
   violations.push(...annotationScopeViolations(workflows));
   violations.push(...lostRunnerRecoveryViolations(workflows, graph));
   violations.push(...releaseWorkflowContractViolations(workflows, graph));

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -186,6 +186,22 @@ function cachePathsExcludeExactOutputs(job) {
     cachePaths(step).every(cachePath => !forbidden.test(cachePath)));
 }
 
+/// Routing a dispatched value through `env:` moves it out of the script's text, and out of reach
+/// of a fragment pin that used to name it there: `--expected-sha "$INPUT_REF"` reads the same
+/// whether `INPUT_REF` carries `inputs.ref` or the pull request head an attacker controls. The
+/// fragment pin and this binding pin are two halves of one assertion -- the script names a
+/// variable, and the variable names the value the step was reviewed with.
+function requireStepEnv(violations, file, job, name, bindings) {
+  const env = object(namedStep(job, name)?.env);
+  for (const [key, expected] of Object.entries(bindings)) {
+    add(
+      violations,
+      env[key] === expected,
+      `${file} step ${name} must bind ${key} to ${expected}`,
+    );
+  }
+}
+
 function requireStepUses(violations, file, job, name, expected) {
   add(
     violations,
@@ -1580,7 +1596,11 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       "codestory-release-cell-manifest.mjs produce",
       "--cell-id source_behavior",
       "--producer-job full-source-gate",
+      '--expected-sha "$RESOLVED_REF"',
     ]);
+    requireStepEnv(violations, sourceFile, full, "Emit authenticated source release cell", {
+      RESOLVED_REF: "${{ needs.resolve.outputs.ref }}",
+    });
     const sourceCellUpload = namedStep(full, "Upload authenticated source release cell");
     add(
       violations,
@@ -2793,7 +2813,11 @@ function validatePackagedProof(workflows, violations, graph) {
     "package_identity:${{ matrix.asset_target }}",
     "--producer-job build",
     "--archive",
+    '--expected-sha "$INPUT_REF"',
   ]);
+  requireStepEnv(violations, file, job, "Emit authenticated package release cell", {
+    INPUT_REF: "${{ inputs.ref }}",
+  });
   const packageCellUpload = namedStep(job, "Upload authenticated package release cell");
   add(
     violations,
@@ -3642,9 +3666,13 @@ function validateRemainingWorkflows(workflows, violations) {
       `${metalFile} candidate-installed validation must be an explicit Bash boundary`,
     );
     requireStepRun(violations, metalFile, job, "Validate candidate-installed mode", [
-      'test "${{ inputs.server_behavior_only }}" = true',
-      'test "${{ inputs.calibration_mode }}" = false',
+      'test "$SERVER_BEHAVIOR_ONLY" = true',
+      'test "$CALIBRATION_MODE" = false',
     ]);
+    requireStepEnv(violations, metalFile, job, "Validate candidate-installed mode", {
+      SERVER_BEHAVIOR_ONLY: "${{ inputs.server_behavior_only }}",
+      CALIBRATION_MODE: "${{ inputs.calibration_mode }}",
+    });
     requireStepRun(violations, metalFile, job, "Prepare checksum-pinned embedded model", ["node scripts/prepare-embedded-model.mjs"]);
     requireStepRun(violations, metalFile, job, "Capture host evidence", ["python3 --version", 'test "$macos_major" -ge 15']);
     add(
@@ -3779,7 +3807,20 @@ function validateRemainingWorkflows(workflows, violations) {
       "codestory-release-cell-manifest.mjs produce",
       "accelerator_execution:macos-arm64-metal",
       "--producer-job packaged-metal",
+      '--expected-sha "$INPUT_REF"',
     ]);
+    requireStepRun(violations, metalFile, job, "Emit authenticated macOS retrieval-readiness release cell", [
+      "retrieval_readiness:macos-arm64",
+      "--producer-job packaged-metal",
+      '--expected-sha "$INPUT_REF"',
+    ]);
+    for (const cell of [
+      "Emit authenticated Metal release cell",
+      "Emit authenticated macOS retrieval-readiness release cell",
+      "Emit authenticated candidate-installed macOS release cell",
+    ]) {
+      requireStepEnv(violations, metalFile, job, cell, { INPUT_REF: "${{ inputs.ref }}" });
+    }
     const metalCellUpload = namedStep(job, "Upload authenticated Metal release cell");
     add(
       violations,
@@ -3792,6 +3833,7 @@ function validateRemainingWorkflows(workflows, violations) {
       "candidate_installed_behavior:macos-arm64",
       "--producer-job packaged-metal",
       "candidate_managed_plugin",
+      '--expected-sha "$INPUT_REF"',
     ]);
     forbidStepRun(
       violations,
@@ -3926,9 +3968,12 @@ function validateRemainingWorkflows(workflows, violations) {
       `${vulkanFile} candidate-installed validation must require explicit candidate mode`,
     );
     requireStepRun(violations, vulkanFile, job, "Validate candidate-installed mode", [
-      'if ("${{ inputs.server_behavior_only }}" -ne "true")',
+      'if ($env:SERVER_BEHAVIOR_ONLY -ne "true")',
       "candidate_installed_proof requires server_behavior_only",
     ]);
+    requireStepEnv(violations, vulkanFile, job, "Validate candidate-installed mode", {
+      SERVER_BEHAVIOR_ONLY: "${{ inputs.server_behavior_only }}",
+    });
     const sourceBuildTools = namedStep(job, "Capture source build tool evidence");
     add(
       violations,
@@ -4078,7 +4123,15 @@ function validateRemainingWorkflows(workflows, violations) {
       "codestory-release-cell-manifest.mjs produce",
       "accelerator_execution:windows-x64-vulkan",
       "--producer-job packaged-vulkan",
+      '--expected-sha "$INPUT_REF"',
     ]);
+    for (const cell of [
+      "Emit authenticated Vulkan release cell",
+      "Emit authenticated Windows retrieval-readiness release cell",
+      "Emit authenticated candidate-installed Windows release cell",
+    ]) {
+      requireStepEnv(violations, vulkanFile, job, cell, { INPUT_REF: "${{ inputs.ref }}" });
+    }
     const releaseCell = namedStep(job, "Emit authenticated Vulkan release cell");
     add(
       violations,
@@ -4098,6 +4151,12 @@ function validateRemainingWorkflows(workflows, violations) {
       "candidate_installed_behavior:windows-x64",
       "--producer-job packaged-vulkan",
       "candidate_managed_plugin",
+      '--expected-sha "$INPUT_REF"',
+    ]);
+    requireStepRun(violations, vulkanFile, job, "Emit authenticated Windows retrieval-readiness release cell", [
+      "retrieval_readiness:windows-x64",
+      "--producer-job packaged-vulkan",
+      '--expected-sha "$INPUT_REF"',
     ]);
     forbidStepRun(
       violations,
@@ -4190,8 +4249,11 @@ function validateRemainingWorkflows(workflows, violations) {
       `${linuxVulkanFile} candidate-installed validation must require explicit candidate mode`,
     );
     requireStepRun(violations, linuxVulkanFile, job, "Validate candidate-installed mode", [
-      'test "${{ inputs.server_behavior_only }}" = true',
+      'test "$SERVER_BEHAVIOR_ONLY" = true',
     ]);
+    requireStepEnv(violations, linuxVulkanFile, job, "Validate candidate-installed mode", {
+      SERVER_BEHAVIOR_ONLY: "${{ inputs.server_behavior_only }}",
+    });
     const packageDownload = namedStep(job, "Download exact Linux package");
     add(
       violations,
@@ -4282,7 +4344,11 @@ function validateRemainingWorkflows(workflows, violations) {
       "retrieval_readiness:linux-x64",
       "candidate_installed_behavior:linux-x64",
       "--producer-job packaged-vulkan",
+      '--expected-sha "$INPUT_REF"',
     ]);
+    requireStepEnv(violations, linuxVulkanFile, job, "Emit authenticated Linux Vulkan release cells", {
+      INPUT_REF: "${{ inputs.ref }}",
+    });
     forbidStepRun(
       violations,
       linuxVulkanFile,
@@ -4514,6 +4580,59 @@ function validateReleaseCellUploadOwnership(workflows, violations) {
     JSON.stringify(actual.sort()) === JSON.stringify(expected.sort()),
     "release-cell Actions artifact names must have one graph-owned producer job and attempt suffix",
   );
+}
+
+/// Every `${{ ... }}` in a piece of text, matched up to its own first `}}` so an expression that
+/// contains a single brace (`fromJSON('{"a":1}')`) is still bounded by its real terminator.
+const interpolations = /\$\{\{[\s\S]*?\}\}/gu;
+
+/// Any mention of the `inputs` context, however it is spelled. GitHub serves the same dispatched
+/// value under `inputs.version`, `github.event.inputs.version`, and `inputs['version']`, and an
+/// expression can bury it in a function call, so this matches the context name itself rather than
+/// any one path through it. `outputs` does not contain `inputs`, and a word character before it
+/// (`my_inputs`) is not the context.
+const namesADispatchInput = /\binputs\b/u;
+
+export function interpolatedDispatchInputs(run) {
+  return [...String(run).matchAll(interpolations)]
+    .map(match => match[0])
+    .filter(expression => namesADispatchInput.test(expression));
+}
+
+/// Dispatched values must reach a script through `env:`, never through the script's own text.
+///
+/// Expression interpolation happens before any shell exists: GitHub splices the value into the
+/// `run:` body as characters, and the shell then parses the result. Double quotes do not stop
+/// `$(...)` or backticks, so a dispatcher who can name the value can run commands on the runner --
+/// beside whatever `GH_TOKEN`, environment secret, or self-hosted host state that step carries.
+/// `env:` is not textual: the value arrives as a variable and `"$VAR"` is inert.
+///
+/// #1554 fixed this in marketplace-sync.yml and pinned the fix with `validateMarketplaceSync`, a
+/// validator named after one file. That shape cannot fail on a second file no matter how many
+/// times the same splice is written, and eight other workflows carried it. This rule is driven by
+/// the loaded workflow set instead, so it reads whatever workflows exist at the time it runs and a
+/// workflow added tomorrow is covered without anyone editing this function.
+///
+/// The rule reads `run:` only. A dispatched value in an action input (`with.ref`) or an `if:` is a
+/// different surface with a different argument, pinned separately where it belongs.
+export function dispatchInputInterpolationViolations(workflows) {
+  const violations = [];
+  for (const [file, workflow] of workflows) {
+    for (const [jobId, job] of Object.entries(object(workflow.jobs))) {
+      for (const [index, rawStep] of list(object(job).steps).entries()) {
+        const step = object(rawStep);
+        if (typeof step.run !== "string") continue;
+        const named = step.name ? ` (${step.name})` : "";
+        for (const expression of new Set(interpolatedDispatchInputs(step.run))) {
+          violations.push(
+            `${file} jobs.${jobId}.steps.${index}${named} must read ${expression}`
+              + " from step env, not interpolated script text",
+          );
+        }
+      }
+    }
+  }
+  return violations;
 }
 
 const JOB_EVIDENCE_COLLECTOR = ".github/scripts/collect-actions-job-evidence.sh";
@@ -5069,8 +5188,11 @@ export function validatePluginRelease(workflows, violations, graph) {
   );
   requireStepRun(violations, file, marketplacePublish, "Point the catalog at the published release", [
     "publish-marketplace-catalog.mjs",
-    '--version "${{ inputs.version }}"',
+    '--version "$INPUT_VERSION"',
   ]);
+  requireStepEnv(violations, file, marketplacePublish, "Point the catalog at the published release", {
+    INPUT_VERSION: "${{ inputs.version }}",
+  });
   // Same contract as the native lane: the catalog push is delivery after an irreversible tag, so
   // it may not fail the release, and the run must record which state it ended in.
   const catalogDelivery = object(at(graph, "workflow_policy", "catalog_delivery"));
@@ -5294,6 +5416,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   validateRemainingWorkflows(workflows, violations);
   validateReleaseCellUploadOwnership(workflows, violations);
   validateReleaseArtifactRerunSafety(workflows, violations);
+  violations.push(...dispatchInputInterpolationViolations(workflows));
   violations.push(...annotationScopeViolations(workflows));
   violations.push(...lostRunnerRecoveryViolations(workflows, graph));
   violations.push(...releaseWorkflowContractViolations(workflows, graph));

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -13,6 +13,7 @@ import {
 import {
   annotationScopeViolations,
   basicWorkflowViolations,
+  dispatchInputInterpolationViolations,
   draftSourcePolicyViolations,
   draftWorkflowPolicyViolations,
   loadWorkflows,
@@ -2601,6 +2602,251 @@ test("marketplace sync keeps dispatch inputs out of script text", async (t) => {
   }
 });
 
+function firstRunStep(workflow) {
+  for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+    const steps = Array.isArray(job?.steps) ? job.steps : [];
+    for (const [index, step] of steps.entries()) {
+      if (typeof step?.run === "string") return { jobId, index, step };
+    }
+  }
+  return undefined;
+}
+
+const unwrittenWorkflow = "future-dispatch-proof.yml";
+
+function unwrittenDispatchWorkflow(run) {
+  return {
+    name: "Future dispatch proof",
+    on: { workflow_dispatch: { inputs: { ref: { required: true, type: "string" } } } },
+    permissions: { contents: "read" },
+    jobs: {
+      leak: {
+        "runs-on": "ubuntu-latest",
+        "timeout-minutes": 10,
+        steps: [{ name: "Echo the dispatched ref", shell: "bash", ...run }],
+      },
+    },
+  };
+}
+
+// #1554 fixed marketplace-sync.yml and pinned the fix with `validateMarketplaceSync`, a validator
+// that names one file. That shape cannot fail on a second file however many times the same splice
+// is written, and eight more workflows carried it (#1566). The replacement has to hold a property
+// the per-file validator could not: it reads whatever workflows exist, so it covers files nobody
+// listed -- including files that do not exist yet. Every test below is a claim about the rule's
+// reach, not about any one workflow.
+test("no workflow interpolates a dispatch input into a run: body", async (t) => {
+  await t.test("the repository as it stands has no such splice anywhere", () => {
+    assert.deepEqual(dispatchInputInterpolationViolations(loadWorkflows()), []);
+    assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  });
+
+  // The other direction, on every workflow at once. The loop names no file: it grows with the
+  // directory, so a workflow added tomorrow is mutated by this suite the day it lands.
+  for (const [file, workflow] of loadWorkflows()) {
+    const located = firstRunStep(workflow);
+    if (located === undefined) continue;
+    await t.test(`${file} cannot splice a dispatch input into ${located.step.name ?? "its first script"}`, () => {
+      const workflows = loadWorkflows();
+      const target = firstRunStep(workflows.get(file));
+      target.step.run = `${target.step.run}\necho "\${{ inputs.version }}"\n`;
+      const reported = dispatchInputInterpolationViolations(workflows);
+      assert.equal(reported.length, 1);
+      assert.equal(
+        reported[0].startsWith(`${file} jobs.${target.jobId}.steps.${target.index}`),
+        true,
+        reported[0],
+      );
+      assert.match(
+        validateWorkflows(workflows).join("\n"),
+        /must read \$\{\{ inputs\.version \}\} from step env, not interpolated script text/u,
+      );
+    });
+  }
+
+  // The claim the per-file validator could not make. Nothing here edits the rule, and the file is
+  // not on disk: the rule sees it because it iterates the set it is handed.
+  await t.test("a workflow that does not exist yet is covered without editing the rule", () => {
+    const workflows = loadWorkflows();
+    assert.equal(workflows.has(unwrittenWorkflow), false);
+    workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow({
+      run: 'echo "${{ inputs.ref }}"\n',
+    }));
+    assert.deepEqual(dispatchInputInterpolationViolations(workflows), [
+      `${unwrittenWorkflow} jobs.leak.steps.0 (Echo the dispatched ref)`
+        + " must read ${{ inputs.ref }} from step env, not interpolated script text",
+    ]);
+    assert.match(
+      validateWorkflows(workflows).join("\n"),
+      /future-dispatch-proof\.yml jobs\.leak\.steps\.0 \(Echo the dispatched ref\) must read/u,
+    );
+  });
+
+  await t.test("the same unwritten workflow reading that value from env is not a violation", () => {
+    const workflows = loadWorkflows();
+    workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow({
+      env: { INPUT_REF: "${{ inputs.ref }}" },
+      run: 'echo "$INPUT_REF"\n',
+    }));
+    assert.deepEqual(dispatchInputInterpolationViolations(workflows), []);
+  });
+
+  // GitHub serves one dispatched value under several spellings and an expression can bury the
+  // context inside a function call. A rule that only knows `inputs.name` exempts the rest.
+  for (const [name, expression] of [
+    ["the short spelling", "${{ inputs.version }}"],
+    ["the spelling GitHub serves the same value under", "${{ github.event.inputs.version }}"],
+    ["the index spelling", "${{ inputs['version'] }}"],
+    ["a fallback that reaches an input second", "${{ github.ref_name || inputs.version }}"],
+    // A single `}` inside the expression must not end the match early and hide the rest of it.
+    ["a spelling wrapped in a format call carrying a brace", "${{ format('{0}', inputs.version) }}"],
+  ]) {
+    await t.test(`${name} is refused`, () => {
+      const workflows = loadWorkflows();
+      workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow({ run: `echo "${expression}"\n` }));
+      assert.deepEqual(dispatchInputInterpolationViolations(workflows), [
+        `${unwrittenWorkflow} jobs.leak.steps.0 (Echo the dispatched ref)`
+          + ` must read ${expression} from step env, not interpolated script text`,
+      ]);
+    });
+  }
+
+  // Over-firing would make the rule unusable and force exemptions, which is how the per-file shape
+  // started. These are the expressions a run: body is allowed to carry.
+  for (const [name, run] of [
+    ["a workflow context", 'echo "${{ github.run_attempt }}"\n'],
+    ["a matrix value", 'echo "${{ matrix.asset_target }}"\n'],
+    ["a step output", 'echo "${{ steps.source-identity.outputs.sha }}"\n'],
+    ["another job's output", 'echo "${{ needs.resolve.outputs.ref }}"\n'],
+    ["a shell variable whose name merely contains the word", 'echo "$RELEASE_INPUTS_PATH"\n'],
+  ]) {
+    await t.test(`${name} is not a violation`, () => {
+      const workflows = loadWorkflows();
+      workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow({ run }));
+      assert.deepEqual(dispatchInputInterpolationViolations(workflows), []);
+    });
+  }
+
+  // #1554 established that a checkout `ref:` is not an executable surface: it is resolved by the
+  // action, not parsed by a shell, and it is pinned separately where it belongs. This rule reads
+  // `run:` only, and that boundary is asserted rather than assumed.
+  await t.test("a dispatch input in an action input is outside this rule's surface", () => {
+    const workflows = loadWorkflows();
+    workflows.set(unwrittenWorkflow, {
+      name: "Future dispatch proof",
+      on: { workflow_dispatch: { inputs: { ref: { required: true, type: "string" } } } },
+      permissions: { contents: "read" },
+      jobs: {
+        leak: {
+          "runs-on": "ubuntu-latest",
+          "timeout-minutes": 10,
+          steps: [{
+            name: "Checkout the dispatched ref",
+            uses: "actions/checkout@v5",
+            with: { ref: "${{ inputs.ref }}" },
+          }],
+        },
+      },
+    });
+    assert.deepEqual(dispatchInputInterpolationViolations(workflows), []);
+  });
+});
+
+// Routing a dispatched value through `env:` removes it from the script's text -- and from the
+// reach of the fragment pin that used to name it there. `--expected-sha "$INPUT_REF"` reads the
+// same whether `INPUT_REF` carries `inputs.ref` or a commit nobody reviewed, so the pin now has
+// two halves: the script names the variable, and the variable names the value. Both halves are
+// proven here for the trust-anchoring steps -- the release-cell producers, whose `--expected-sha`
+// is the commit every downstream claim is filed against -- and for the mode guards that decide
+// which claims a protected run is allowed to make at all.
+test("env-routed dispatch inputs stay pinned to the value they were reviewed with", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const reviewedRef = "${{ inputs.ref }}";
+  const behaviorOnly = "${{ inputs.server_behavior_only }}";
+  const sites = [
+    ["linux-vulkan-proof.yml", "packaged-vulkan", "Validate candidate-installed mode",
+      { SERVER_BEHAVIOR_ONLY: behaviorOnly },
+      'test "$SERVER_BEHAVIOR_ONLY" = true', `test "${behaviorOnly}" = true`],
+    ["windows-vulkan-proof.yml", "packaged-vulkan", "Validate candidate-installed mode",
+      { SERVER_BEHAVIOR_ONLY: behaviorOnly },
+      'if ($env:SERVER_BEHAVIOR_ONLY -ne "true")', `if ("${behaviorOnly}" -ne "true")`],
+    ["macos-metal-proof.yml", "packaged-metal", "Validate candidate-installed mode",
+      { SERVER_BEHAVIOR_ONLY: behaviorOnly, CALIBRATION_MODE: "${{ inputs.calibration_mode }}" },
+      'test "$SERVER_BEHAVIOR_ONLY" = true', `test "${behaviorOnly}" = true`],
+    ["linux-vulkan-proof.yml", "packaged-vulkan", "Emit authenticated Linux Vulkan release cells",
+      { INPUT_REF: reviewedRef },
+      '--expected-sha "$INPUT_REF"', `--expected-sha "${reviewedRef}"`],
+    ["windows-vulkan-proof.yml", "packaged-vulkan", "Emit authenticated Vulkan release cell",
+      { INPUT_REF: reviewedRef },
+      '--expected-sha "$INPUT_REF"', `--expected-sha "${reviewedRef}"`],
+    ["windows-vulkan-proof.yml", "packaged-vulkan", "Emit authenticated Windows retrieval-readiness release cell",
+      { INPUT_REF: reviewedRef },
+      '--expected-sha "$INPUT_REF"', `--expected-sha "${reviewedRef}"`],
+    ["windows-vulkan-proof.yml", "packaged-vulkan", "Emit authenticated candidate-installed Windows release cell",
+      { INPUT_REF: reviewedRef },
+      '--expected-sha "$INPUT_REF"', `--expected-sha "${reviewedRef}"`],
+    ["macos-metal-proof.yml", "packaged-metal", "Emit authenticated Metal release cell",
+      { INPUT_REF: reviewedRef },
+      '--expected-sha "$INPUT_REF"', `--expected-sha "${reviewedRef}"`],
+    ["macos-metal-proof.yml", "packaged-metal", "Emit authenticated macOS retrieval-readiness release cell",
+      { INPUT_REF: reviewedRef },
+      '--expected-sha "$INPUT_REF"', `--expected-sha "${reviewedRef}"`],
+    ["macos-metal-proof.yml", "packaged-metal", "Emit authenticated candidate-installed macOS release cell",
+      { INPUT_REF: reviewedRef },
+      '--expected-sha "$INPUT_REF"', `--expected-sha "${reviewedRef}"`],
+    ["packaged-platform-proof.yml", "build", "Emit authenticated package release cell",
+      { INPUT_REF: reviewedRef },
+      '--expected-sha "$INPUT_REF"', `--expected-sha "${reviewedRef}"`],
+    // source-proof resolves its own trusted head in an earlier job rather than taking a dispatched
+    // ref, so its anchor is that job's output. Same two halves, different source of truth.
+    ["source-proof.yml", "full-source-gate", "Emit authenticated source release cell",
+      { RESOLVED_REF: "${{ needs.resolve.outputs.ref }}" },
+      '--expected-sha "$RESOLVED_REF"', '--expected-sha "${{ needs.resolve.outputs.ref }}"'],
+  ];
+  for (const [file, jobId, stepName, bindings, needle, splice] of sites) {
+    for (const [key, expected] of Object.entries(bindings)) {
+      await t.test(`${file} ${stepName} refuses a rewired ${key}`, () => {
+        const workflows = loadWorkflows();
+        draftStep(workflows.get(file).jobs[jobId], stepName).env[key] = "${{ github.event.pull_request.head.sha }}";
+        const violations = validateWorkflows(workflows);
+        assert.ok(
+          violations.includes(`${file} step ${stepName} must bind ${key} to ${expected}`),
+          violations.join("\n"),
+        );
+      });
+      await t.test(`${file} ${stepName} refuses a dropped ${key}`, () => {
+        const workflows = loadWorkflows();
+        delete draftStep(workflows.get(file).jobs[jobId], stepName).env[key];
+        assert.ok(
+          validateWorkflows(workflows)
+            .includes(`${file} step ${stepName} must bind ${key} to ${expected}`),
+        );
+      });
+    }
+    await t.test(`${file} ${stepName} refuses the splice it was rewritten away from`, () => {
+      const workflows = loadWorkflows();
+      const step = draftStep(workflows.get(file).jobs[jobId], stepName);
+      assert.equal(step.run.includes(needle), true, `missing pinned fragment ${needle}`);
+      step.run = step.run.replace(needle, splice);
+      const violations = validateWorkflows(workflows);
+      // Both layers must see it: the fragment pin, which knows what this step should read, and
+      // the generic rule, which knows nothing about this step and refuses the shape anyway.
+      assert.ok(
+        violations.includes(`${file} step ${stepName} must run ${needle}`),
+        violations.join("\n"),
+      );
+      if (splice.includes("inputs")) {
+        assert.ok(
+          violations.some(violation =>
+            violation.startsWith(`${file} jobs.${jobId}.steps.`)
+            && violation.includes("from step env, not interpolated script text")),
+          violations.join("\n"),
+        );
+      }
+    });
+  }
+});
+
 // The guard is the layer the workflow relies on before a ref is resolved or a token is minted, so
 // it is proven by running it rather than by reading it. Every refusal below reaches the guard's own
 // `::error::` and exit 1: a bash syntax error would also be non-zero and would prove nothing.
@@ -2761,8 +3007,14 @@ test("the plugin lane publishes the catalog it then smoke-installs", async (t) =
     }, /marketplace token must be a SHA-pinned app token scoped to the marketplace repository/u],
     ["the catalog is pointed at an unbound version", workflow => {
       const step = catalogStep(workflow);
-      step.run = step.run.replace('--version "${{ inputs.version }}"', '--version "$LATEST"');
+      step.run = step.run.replace('--version "$INPUT_VERSION"', '--version "$LATEST"');
     }, /Point the catalog at the published release must run --version/u],
+    // Routing the version through `env:` moves it out of the script's text, so the script's own
+    // fragment can no longer see which value it carries. Rebinding the variable is the same
+    // substitution the mutation above makes, one layer down.
+    ["the catalog's version variable is rebound to another value", workflow => {
+      catalogStep(workflow).env.INPUT_VERSION = "${{ github.ref_name }}";
+    }, /Point the catalog at the published release must bind INPUT_VERSION/u],
     ["catalog publication hides the delivery state it recorded", workflow => {
       delete workflow.jobs["marketplace-publish"].outputs;
     }, /marketplace publication must publish the recorded delivery state/u],

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -2753,6 +2753,22 @@ test("no workflow interpolates a dispatch input into a run: body", async (t) => 
     assert.match(validateWorkflows(workflows).join("\n"), /must read \$\{\{ env\.LAUNDERED \}\}/u);
   });
 
+  // For `workflow_dispatch`, `github.event` is the container the inputs arrive in, so serialising
+  // it carries every dispatched value into script text without the word `inputs` appearing at all.
+  // `toJSON` is not an escape: it preserves `$(` and backticks verbatim.
+  await t.test("serialising the event payload does not launder an input into script text", () => {
+    const workflows = loadWorkflows();
+    workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow(
+      { run: 'echo "${{ toJSON(github.event) }}"\n' },
+    ));
+    assert.deepEqual(dispatchInputInterpolationViolations(workflows), [
+      `${unwrittenWorkflow} jobs.leak.steps.0 (Echo the dispatched ref)`
+        + " must read ${{ toJSON(github.event) }} from step env, not interpolated script text:"
+        + " it carries the event payload",
+    ]);
+    assert.match(validateWorkflows(workflows).join("\n"), /it carries the event payload/u);
+  });
+
   await t.test("a step output does not launder an input into a later script", () => {
     const workflows = loadWorkflows();
     workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow(
@@ -2797,6 +2813,9 @@ test("no workflow interpolates a dispatch input into a run: body", async (t) => 
     ["a shell variable whose name merely contains the word", 'echo "$RELEASE_INPUTS_PATH"\n'],
     ["the shell read of a job-level env entry", 'echo "$LAUNDERED"\n'],
     ["a shell variable that merely spells the env context", 'echo "$env_path/bin"\n'],
+    // `_` is a word character, so `\bevent\b` does not reach inside `github.event_name`. Reading
+    // which trigger fired says nothing about what was dispatched.
+    ["the trigger name, which is not the event payload", 'echo "${{ github.event_name }}"\n'],
   ]) {
     await t.test(`${name} is not a violation`, () => {
       const workflows = loadWorkflows();

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -11,11 +11,13 @@ import {
   MAXIMUM_RUN_ATTEMPTS,
 } from "./lost-runner-recovery.mjs";
 import {
+  absorbedFailureViolations,
   annotationScopeViolations,
   basicWorkflowViolations,
   dispatchInputInterpolationViolations,
   draftSourcePolicyViolations,
   draftWorkflowPolicyViolations,
+  interpolationSpans,
   loadWorkflows,
   lostRunnerRecoveryViolations,
   macosCliDistributionViolations,
@@ -27,6 +29,7 @@ import {
   releaseWorkflowContractViolations,
   retrievalFile,
   retrievalProducerTriggerPolicyViolations,
+  shellDependentBindingViolations,
   validateCargoTestFilters,
   validateWorkflows,
   windowsManifestProofPolicyViolations,
@@ -1058,10 +1061,7 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     }, /package jobs must checkout only the requested exact SHA/u],
     ["package smoke loses source identity", packagedFile, workflow => {
       const smoke = draftStep(packagedJob(workflow), "Smoke packaged release asset");
-      smoke.run = smoke.run.replace(
-        '--expected-source-sha "${{ steps.source-identity.outputs.sha }}" \\\n',
-        "",
-      );
+      smoke.run = smoke.run.replace('--expected-source-sha "$SOURCE_SHA" \\\n', "");
     }, /step Smoke packaged release asset must run --expected-source-sha/u],
     ["fresh package identity is reported after upload", packagedFile, workflow => {
       moveNamedStepAfter(
@@ -2614,7 +2614,7 @@ function firstRunStep(workflow) {
 
 const unwrittenWorkflow = "future-dispatch-proof.yml";
 
-function unwrittenDispatchWorkflow(run) {
+function unwrittenDispatchWorkflow(run, job = {}) {
   return {
     name: "Future dispatch proof",
     on: { workflow_dispatch: { inputs: { ref: { required: true, type: "string" } } } },
@@ -2623,7 +2623,11 @@ function unwrittenDispatchWorkflow(run) {
       leak: {
         "runs-on": "ubuntu-latest",
         "timeout-minutes": 10,
-        steps: [{ name: "Echo the dispatched ref", shell: "bash", ...run }],
+        ...job,
+        steps: [
+          ...(job.steps ?? []),
+          { name: "Echo the dispatched ref", shell: "bash", ...run },
+        ],
       },
     },
   };
@@ -2661,6 +2665,7 @@ test("no workflow interpolates a dispatch input into a run: body", async (t) => 
         validateWorkflows(workflows).join("\n"),
         /must read \$\{\{ inputs\.version \}\} from step env, not interpolated script text/u,
       );
+      assert.match(reported[0], /it carries a dispatch input$/u);
     });
   }
 
@@ -2674,7 +2679,8 @@ test("no workflow interpolates a dispatch input into a run: body", async (t) => 
     }));
     assert.deepEqual(dispatchInputInterpolationViolations(workflows), [
       `${unwrittenWorkflow} jobs.leak.steps.0 (Echo the dispatched ref)`
-        + " must read ${{ inputs.ref }} from step env, not interpolated script text",
+        + " must read ${{ inputs.ref }} from step env, not interpolated script text:"
+        + " it carries a dispatch input",
     ]);
     assert.match(
       validateWorkflows(workflows).join("\n"),
@@ -2698,31 +2704,106 @@ test("no workflow interpolates a dispatch input into a run: body", async (t) => 
     ["the spelling GitHub serves the same value under", "${{ github.event.inputs.version }}"],
     ["the index spelling", "${{ inputs['version'] }}"],
     ["a fallback that reaches an input second", "${{ github.ref_name || inputs.version }}"],
-    // A single `}` inside the expression must not end the match early and hide the rest of it.
+    // Braces inside the expression must not end the match early and hide the rest of it. The first
+    // case carries a single `}`, which the old non-greedy match survived. The rest carry `}}`
+    // sequences -- `{{` and `}}` are GitHub's own documented escapes for a literal brace inside
+    // `format()` -- and those it did not: `${{ format('{{Hello {0}}}', inputs.ref) }}` was cut to
+    // `${{ format('{{Hello {0}}`, which names no context, so the rule reported the file clean while
+    // GitHub spliced the input. Every one of these passed policy and actionlint before the fix.
     ["a spelling wrapped in a format call carrying a brace", "${{ format('{0}', inputs.version) }}"],
+    ["the documented format brace escape", "${{ format('{{Hello {0}}}', inputs.version) }}"],
+    ["the documented escape around two placeholders",
+      "${{ format('{{Hello {0} {1}}}', inputs.version, github.sha) }}"],
+    ["a brace escape whose literal looks like the terminator", "${{ format('}}{{', inputs.version) }}"],
+    ["JSON carrying a nested object", `\${{ fromJSON('{"a":{"b":1}}').a.b && inputs.version }}`],
   ]) {
     await t.test(`${name} is refused`, () => {
       const workflows = loadWorkflows();
       workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow({ run: `echo "${expression}"\n` }));
       assert.deepEqual(dispatchInputInterpolationViolations(workflows), [
         `${unwrittenWorkflow} jobs.leak.steps.0 (Echo the dispatched ref)`
-          + ` must read ${expression} from step env, not interpolated script text`,
+          + ` must read ${expression} from step env, not interpolated script text:`
+          + " it carries a dispatch input",
       ]);
+      // Reporting is not enough on its own: the span has to be the whole expression. A matcher that
+      // stops early still names `inputs` in some of these and would pass the check above on an
+      // accident rather than on the property being claimed.
+      assert.deepEqual(interpolationSpans(`echo "${expression}"`), [expression]);
     });
   }
 
+  // Naming the `inputs` context alone reads the value's *location*, not the value. One hop moves
+  // it somewhere the rule was not looking, and the launder is a legal, actionlint-clean workflow.
+  // Each of these passed both gates before the channels were refused with the context.
+  //
+  // These replace two cases that used to assert `${{ steps.*.outputs.* }}` and
+  // `${{ needs.*.outputs.* }}` are "not a violation". That claim was false, and asserting it meant
+  // a test was holding the hole open: it would have failed anyone who tried to close it.
+  await t.test("a job-level env binding does not launder an input into script text", () => {
+    const workflows = loadWorkflows();
+    workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow(
+      { run: 'echo "${{ env.LAUNDERED }}"\n' },
+      { env: { LAUNDERED: "${{ inputs.ref }}" } },
+    ));
+    assert.deepEqual(dispatchInputInterpolationViolations(workflows), [
+      `${unwrittenWorkflow} jobs.leak.steps.0 (Echo the dispatched ref)`
+        + " must read ${{ env.LAUNDERED }} from step env, not interpolated script text:"
+        + " it carries env",
+    ]);
+    assert.match(validateWorkflows(workflows).join("\n"), /must read \$\{\{ env\.LAUNDERED \}\}/u);
+  });
+
+  await t.test("a step output does not launder an input into a later script", () => {
+    const workflows = loadWorkflows();
+    workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow(
+      { run: 'echo "${{ steps.launder.outputs.ref }}"\n' },
+      {
+        steps: [{
+          name: "Write the dispatched ref to a step output",
+          id: "launder",
+          shell: "bash",
+          env: { INPUT_REF: "${{ inputs.ref }}" },
+          run: 'echo "ref=$INPUT_REF" >> "$GITHUB_OUTPUT"\n',
+        }],
+      },
+    ));
+    assert.deepEqual(dispatchInputInterpolationViolations(workflows), [
+      `${unwrittenWorkflow} jobs.leak.steps.1 (Echo the dispatched ref)`
+        + " must read ${{ steps.launder.outputs.ref }} from step env, not interpolated script text:"
+        + " it carries a step output",
+    ]);
+  });
+
+  await t.test("a job output does not launder an input into another job's script", () => {
+    const workflows = loadWorkflows();
+    workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow(
+      { run: 'echo "${{ needs.resolve.outputs.ref }}"\n' },
+    ));
+    assert.deepEqual(dispatchInputInterpolationViolations(workflows), [
+      `${unwrittenWorkflow} jobs.leak.steps.0 (Echo the dispatched ref)`
+        + " must read ${{ needs.resolve.outputs.ref }} from step env, not interpolated script text:"
+        + " it carries a job output",
+    ]);
+  });
+
   // Over-firing would make the rule unusable and force exemptions, which is how the per-file shape
-  // started. These are the expressions a run: body is allowed to carry.
+  // started. These are the expressions a run: body is still allowed to carry, and each remedy above
+  // is one `env:` line -- for `env` itself it is zero, because a workflow- or job-level `env:` entry
+  // is already exported into the shell.
   for (const [name, run] of [
     ["a workflow context", 'echo "${{ github.run_attempt }}"\n'],
     ["a matrix value", 'echo "${{ matrix.asset_target }}"\n'],
-    ["a step output", 'echo "${{ steps.source-identity.outputs.sha }}"\n'],
-    ["another job's output", 'echo "${{ needs.resolve.outputs.ref }}"\n'],
+    ["a runner context", 'echo "${{ runner.os }}"\n'],
     ["a shell variable whose name merely contains the word", 'echo "$RELEASE_INPUTS_PATH"\n'],
+    ["the shell read of a job-level env entry", 'echo "$LAUNDERED"\n'],
+    ["a shell variable that merely spells the env context", 'echo "$env_path/bin"\n'],
   ]) {
     await t.test(`${name} is not a violation`, () => {
       const workflows = loadWorkflows();
-      workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow({ run }));
+      workflows.set(unwrittenWorkflow, unwrittenDispatchWorkflow(
+        { run },
+        { env: { LAUNDERED: "${{ inputs.ref }}" } },
+      ));
       assert.deepEqual(dispatchInputInterpolationViolations(workflows), []);
     });
   }
@@ -2749,6 +2830,197 @@ test("no workflow interpolates a dispatch input into a run: body", async (t) => 
       },
     });
     assert.deepEqual(dispatchInputInterpolationViolations(workflows), []);
+  });
+});
+
+// Moving a value out of the script's text and into `env:` moves the read out of GitHub's
+// interpolator and into the shell -- and the shell is not the same everywhere. `${{ env.NAME }}`
+// read identically on every runner; `"$NAME"` is a bash read, and this repository's packaged build
+// matrix includes windows-latest, where the runner default is pwsh and the read is `$env:NAME`.
+// The failure mode is the dangerous one: not an error, but a proof comparing against an empty
+// string. Closing #1566's laundering channels forced these reads into scripts, so the property the
+// rewrite depends on is asserted rather than assumed.
+test("a binding consumed as a shell variable must say which shell it was written for", async (t) => {
+  await t.test("the repository as it stands declares a shell wherever it matters", () => {
+    assert.deepEqual(shellDependentBindingViolations(loadWorkflows()), []);
+  });
+
+  // Every step the #1566 rewrite pointed at a variable, on the one job whose matrix reaches
+  // Windows. Dropping the shell is the whole mutation; the script text is untouched.
+  for (const name of [
+    "Install pinned Rust",
+    "Smoke packaged release asset",
+    "Prove Linux x64 glibc 2.31 baseline",
+    "Report fresh package identity",
+  ]) {
+    await t.test(`${name} cannot leave its shell to the runner`, () => {
+      const workflows = loadWorkflows();
+      delete draftStep(workflows.get("packaged-platform-proof.yml").jobs.build, name).shell;
+      assert.match(
+        shellDependentBindingViolations(workflows).join("\n"),
+        new RegExp(`\\(${name}\\) reads [A-Z_, ]+ as a shell variable`, "u"),
+      );
+      assert.match(validateWorkflows(workflows).join("\n"), /must declare its shell/u);
+    });
+  }
+
+  // The Windows smoke is the counter-case: it consumes the same two bindings and is correct
+  // because it reads them the way its own shell spells them.
+  await t.test("the Windows smoke reads the same bindings the pwsh way", () => {
+    const step = draftStep(loadWorkflows().get("packaged-platform-proof.yml").jobs.build,
+      "Smoke packaged release asset on Windows");
+    assert.equal(step.shell, "pwsh");
+    assert.equal(step.env.SOURCE_SHA, "${{ steps.source-identity.outputs.sha }}");
+    assert.match(step.run, /--expected-source-sha "\$env:SOURCE_SHA"/u);
+    assert.equal(/--expected-source-sha "\$SOURCE_SHA"/u.test(step.run), false);
+  });
+
+  // A job pinned to a non-Windows label needs no declaration: bash is the runner default there,
+  // and requiring one would be noise rather than a property.
+  await t.test("a Linux-only job is not asked to declare a shell it already has", () => {
+    const workflows = loadWorkflows();
+    const job = workflows.get("release.yml").jobs["marketplace-publish"];
+    assert.equal(job["runs-on"], "ubuntu-latest");
+    assert.equal(draftStep(job, "Point the catalog at the published release").shell, undefined);
+    assert.deepEqual(shellDependentBindingViolations(workflows), []);
+  });
+});
+
+// A rule is only as blocking as the step that runs it. `continue-on-error` lives outside the
+// script, so nothing this file's own text asserts can see it, and it converts every `exit 1` the
+// step produces into advice. The commands the policy gate runs were pinned; that the gate FAILS was
+// not, so one key on plugin-static.yml would have silenced this file and its whole suite green.
+//
+// The repository has scripts that deliberately absorb their own failure, so "gates must be
+// blocking" would be false here. What those have and a silenced gate does not is a successor: an
+// `id:`, and a later step that reads `steps.<id>.outcome` and fails on it. That is the property.
+test("a script that absorbs its own failure must hand that failure to something that does not", async (t) => {
+  await t.test("the repository as it stands absorbs no failure into nothing", () => {
+    assert.deepEqual(absorbedFailureViolations(loadWorkflows()), []);
+    assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  });
+
+  // The exact key the reviewer reached for, on the exact step. It silences check-workflow-policy.mjs
+  // AND `node --test check-workflow-policy.test.mjs` at once while the job still reports success.
+  await t.test("the workflow policy gate cannot be made advisory", () => {
+    const workflows = loadWorkflows();
+    draftStep(workflows.get("plugin-static.yml").jobs["plugin-static"], "Check workflow policy")
+      ["continue-on-error"] = true;
+    assert.deepEqual(absorbedFailureViolations(workflows), [
+      "plugin-static.yml jobs.plugin-static.steps.7 (Check workflow policy) absorbs its own"
+        + " failure and must have an id whose outcome a later blocking step requires",
+    ]);
+    assert.match(validateWorkflows(workflows).join("\n"), /Check workflow policy\) absorbs its own failure/u);
+  });
+
+  // The rule names no step and no file: it reads whatever `run:` steps exist, so a gate added
+  // tomorrow is covered the day it lands. Every gate step in the repository is mutated here.
+  for (const [file, workflow] of loadWorkflows()) {
+    for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+      const steps = (Array.isArray(job?.steps) ? job.steps : [])
+        .map((step, index) => ({ step, index }))
+        .filter(({ step }) => typeof step?.run === "string"
+          && step["continue-on-error"] === undefined);
+      if (steps.length === 0) continue;
+      const { step, index } = steps[0];
+      await t.test(`${file} ${jobId} cannot silence ${step.name ?? `step ${index}`}`, () => {
+        const workflows = loadWorkflows();
+        workflows.get(file).jobs[jobId].steps[index]["continue-on-error"] = true;
+        const reported = absorbedFailureViolations(workflows);
+        // Silencing a step that was somebody else's successor reports both -- the step that stopped
+        // failing and the step whose failure it stopped requiring -- so this asserts the mutated
+        // step is named rather than that it is the only one named.
+        assert.equal(
+          reported.some(violation => violation.startsWith(`${file} jobs.${jobId}.steps.${index} `)
+            || violation.startsWith(`${file} jobs.${jobId}.steps.${index} (`)),
+          true,
+          reported.join("\n"),
+        );
+      });
+    }
+  }
+
+  // An `id:` on its own is not a successor. Naming the step is how you make its outcome readable,
+  // not how you make it required, and stopping at the id would let one line reopen the hole.
+  await t.test("naming the silenced step is not enough", () => {
+    const workflows = loadWorkflows();
+    const gate = draftStep(workflows.get("plugin-static.yml").jobs["plugin-static"], "Check workflow policy");
+    gate["continue-on-error"] = true;
+    gate.id = "workflow-policy";
+    assert.match(
+      absorbedFailureViolations(workflows).join("\n"),
+      /must have an id whose outcome a later blocking step requires/u,
+    );
+  });
+
+  // And the shape that is allowed: the failure is absorbed here and required there.
+  await t.test("a successor that requires the outcome makes absorbing it legal", () => {
+    const workflows = loadWorkflows();
+    const job = workflows.get("plugin-static.yml").jobs["plugin-static"];
+    const gate = draftStep(job, "Check workflow policy");
+    gate["continue-on-error"] = true;
+    gate.id = "workflow-policy";
+    job.steps.push({
+      name: "Require the workflow policy gate",
+      shell: "bash",
+      env: { POLICY_OUTCOME: "${{ steps.workflow-policy.outcome }}" },
+      run: 'test "$POLICY_OUTCOME" = success\n',
+    });
+    assert.deepEqual(absorbedFailureViolations(workflows), []);
+  });
+
+  // The precedent this generalises must survive it. The optional cache restores are `uses:` steps
+  // whose miss is the normal path: they carry no outcome for anything to require, and a separate
+  // rule requires them to stay non-blocking. Generalising must not put those two in conflict.
+  for (const [file, jobId, name] of [
+    ["rust-ci.yml", "linux-draft", "Restore Cargo inputs and output"],
+    ["rust-ci.yml", "linux-draft", "Restore compiler objects"],
+    ["source-proof.yml", "full-source-gate", "Restore Cargo dependency inputs"],
+    ["packaged-platform-proof.yml", "build", "Restore Cargo dependency inputs"],
+  ]) {
+    await t.test(`${file} ${name} stays deliberately optional`, () => {
+      const workflows = loadWorkflows();
+      const step = draftStep(workflows.get(file).jobs[jobId], name);
+      assert.equal(step["continue-on-error"], true);
+      assert.equal(step.run, undefined);
+      assert.deepEqual(absorbedFailureViolations(workflows), []);
+      assert.deepEqual(validateWorkflows(workflows), []);
+    });
+  }
+
+  // The two scripts that legitimately absorb their failure, and what happens when the successor
+  // that requires them is taken away. Without this the rule could be satisfied by deleting the
+  // requirement instead of the `continue-on-error`.
+  for (const [file, jobId, absorbing, successor] of [
+    ["source-proof.yml", "full-source-gate", "Compile the complete workspace test suite",
+      "Require successful source compilation"],
+    ["source-proof.yml", "full-source-gate", "Lint every workspace target and feature once",
+      "Require successful source compilation"],
+  ]) {
+    await t.test(`${file} ${absorbing} stops being required when ${successor} drops it`, () => {
+      const workflows = loadWorkflows();
+      const job = workflows.get(file).jobs[jobId];
+      const id = draftStep(job, absorbing).id;
+      const step = draftStep(job, successor);
+      step.env = Object.fromEntries(
+        Object.entries(step.env ?? {}).filter(([, value]) => !String(value).includes(`steps.${id}.outcome`)),
+      );
+      assert.match(
+        absorbedFailureViolations(workflows).join("\n"),
+        new RegExp(`\\(${absorbing}\\) absorbs its own failure`, "u"),
+      );
+    });
+  }
+
+  // A job-level key downgrades every step it contains at once, so no per-step id can answer for it.
+  // Only a downstream job reading `needs.<id>.result` can.
+  await t.test("a job cannot absorb its own failure into nothing either", () => {
+    const workflows = loadWorkflows();
+    workflows.get("plugin-static.yml").jobs["plugin-static"]["continue-on-error"] = true;
+    assert.deepEqual(absorbedFailureViolations(workflows), [
+      "plugin-static.yml jobs.plugin-static absorbs its own failure and must have"
+        + " needs.plugin-static.result required",
+    ]);
   });
 });
 
@@ -3596,7 +3868,7 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
     ["deferred smoke records the public catalog installer", workflows => {
       const step = draftStep(smokeJob(workflows), "Emit authenticated post-publish release cells");
       step.run = step.run.replace(
-        '--arg installer "${{ steps.delivery.outputs.installer }}"',
+        '--arg installer "$DELIVERED_INSTALLER"',
         "--arg installer codex_marketplace_install",
       );
     }, /must not hard-code the published installer identity/u],
@@ -3624,10 +3896,16 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
     ["smoke resolves whatever catalog it likes", workflows => {
       const step = draftStep(smokeJob(workflows), "Resolve the published plugin through the marketplace catalog");
       step.run = step.run.replace(
-        '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
+        '--marketplace-source "$MARKETPLACE_SOURCE"',
         "--marketplace-source TheGreenCedar/AgentPluginMarketplace",
       );
-    }, /must run --marketplace-source "\$\{\{ steps\.delivery\.outputs\.marketplace_source \}\}"/u],
+    }, /must run --marketplace-source "\$MARKETPLACE_SOURCE"/u],
+    // The other half of the same claim: the variable the command names has to be bound to the
+    // delivery state's own output, or routing it through `env:` would only move the hole.
+    ["smoke rebinds the catalog source away from the delivery state", workflows => {
+      draftStep(smokeJob(workflows), "Resolve the published plugin through the marketplace catalog")
+        .env.MARKETPLACE_SOURCE = "TheGreenCedar/AgentPluginMarketplace";
+    }, /must bind MARKETPLACE_SOURCE to \$\{\{ steps\.delivery\.outputs\.marketplace_source \}\}/u],
     ["smoke fakes the fixture catalog by cloning it", workflows => {
       draftStep(smokeJob(workflows), "Record catalog delivery state").run
         += "\ngit clone https://github.com/TheGreenCedar/AgentPluginMarketplace.git";
@@ -3703,10 +3981,14 @@ test("catalog publication cannot be reinstated as a gate or claimed without happ
     ["plugin lane installs from a catalog the delivery state did not resolve", workflows => {
       const step = draftStep(pluginSmokeJob(workflows), "Prove the public marketplace install path");
       step.run = step.run.replace(
-        '--marketplace-source "${{ steps.delivery.outputs.marketplace_source }}"',
+        '--marketplace-source "$MARKETPLACE_SOURCE"',
         "--marketplace-source TheGreenCedar/AgentPluginMarketplace",
       );
     }, /plugin-release\.yml step Prove the public marketplace install path must run --marketplace-source/u],
+    ["plugin lane rebinds the catalog source away from the delivery state", workflows => {
+      draftStep(pluginSmokeJob(workflows), "Prove the public marketplace install path")
+        .env.MARKETPLACE_SOURCE = "TheGreenCedar/AgentPluginMarketplace";
+    }, /plugin-release\.yml step Prove the public marketplace install path must bind MARKETPLACE_SOURCE/u],
     ["plugin lane smoke installs the revision the job failed to publish", workflows => {
       draftStep(pluginSmokeJob(workflows), "Prove the public marketplace install path")
         .env.MARKETPLACE_REVISION = "${{ needs.marketplace-publish.outputs.marketplace_revision }}";

--- a/.github/workflows/linux-vulkan-proof.yml
+++ b/.github/workflows/linux-vulkan-proof.yml
@@ -127,7 +127,9 @@ jobs:
       - name: Validate candidate-installed mode
         if: inputs.candidate_installed_proof
         shell: bash
-        run: test "${{ inputs.server_behavior_only }}" = true
+        env:
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+        run: test "$SERVER_BEHAVIOR_ONLY" = true
 
       - name: Download exact Linux package
         uses: actions/download-artifact@v8.0.1
@@ -174,24 +176,28 @@ jobs:
         shell: bash
         env:
           CODESTORY_EMBED_ALLOW_CPU: "0"
+          INPUT_VERSION: ${{ inputs.version }}
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+          CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
+          CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
         run: |
           set -euo pipefail
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           version="${version#v}"
           archive="target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz"
           source_sha="$(git rev-parse HEAD)"
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           claim_args=()
           calibration_args=()
-          if [ "${{ inputs.server_behavior_only }}" = true ]; then
+          if [ "$SERVER_BEHAVIOR_ONLY" = true ]; then
             claim_args=(--server-behavior-only)
           else
             calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
             test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
             calibration_args=(
               --calibration-bundle "$calibration_bundle"
-              --calibration-producer-run-id "${{ inputs.calibration_bundle_run_id }}"
-              --calibration-producer-artifact "${{ inputs.calibration_bundle_artifact }}"
+              --calibration-producer-run-id "$CALIBRATION_RUN_ID"
+              --calibration-producer-artifact "$CALIBRATION_ARTIFACT"
             )
           fi
           python .github/scripts/check-packaged-agent-proof.py \
@@ -219,11 +225,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_PRODUCER_WORKFLOW_PATH: ${{ inputs.candidate_producer_workflow_path }}
+          INPUT_VERSION: ${{ inputs.version }}
+          PACKAGE_RUN_ID: ${{ inputs.package_run_id || github.run_id }}
         run: |
           set -euo pipefail
           umask 077
           test -n "$CANDIDATE_PRODUCER_WORKFLOW_PATH"
-          candidate_producer_run_id="${{ inputs.package_run_id || github.run_id }}"
+          candidate_producer_run_id="$PACKAGE_RUN_ID"
           run="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$candidate_producer_run_id")"
           test "$(jq -r '.head_repository.full_name' <<<"$run")" = "$GITHUB_REPOSITORY"
           test "$(jq -r '.path' <<<"$run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"
@@ -232,7 +240,7 @@ jobs:
           test "$candidate_producer_run_attempt" -ge 1
           echo "CODESTORY_CANDIDATE_PRODUCER_RUN_ID=$candidate_producer_run_id" >> "$GITHUB_ENV"
           echo "CODESTORY_CANDIDATE_PRODUCER_RUN_ATTEMPT=$candidate_producer_run_attempt" >> "$GITHUB_ENV"
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           version="${version#v}"
           archive="target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz"
           candidate_root="$(mktemp -d "$RUNNER_TEMP/codestory-candidate-installed-linux.XXXXXX")"
@@ -266,9 +274,10 @@ jobs:
         env:
           CODESTORY_EMBED_ALLOW_CPU: "0"
           CANDIDATE_PRODUCER_WORKFLOW_PATH: ${{ inputs.candidate_producer_workflow_path }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           version="${version#v}"
           archive="target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz"
           python .github/scripts/check-packaged-agent-proof.py \
@@ -307,9 +316,13 @@ jobs:
       - name: Emit authenticated Linux Vulkan release cells
         if: inputs.emit_release_cells
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
+          CANDIDATE_INSTALLED_PROOF: ${{ inputs.candidate_installed_proof }}
         run: |
           set -euo pipefail
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           version="${version#v}"
           archive="target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz"
           mkdir -p target/release-cells
@@ -319,7 +332,7 @@ jobs:
             > target/linux-vulkan-proof/release-cell-identity.json
           common=(
             --repo "$GITHUB_WORKSPACE"
-            --expected-sha "${{ inputs.ref }}"
+            --expected-sha "$INPUT_REF"
             --version "$version"
             --producer-workflow .github/workflows/linux-vulkan-proof.yml
             --producer-job packaged-vulkan
@@ -339,7 +352,7 @@ jobs:
             --producer-artifact "release-cell-postpublish-retrieval-linux-x64-attempt-$GITHUB_RUN_ATTEMPT" \
             --archive "$archive" \
             --out target/release-cells/retrieval_readiness-linux-x64.json
-          if [ "${{ inputs.candidate_installed_proof }}" = true ]; then
+          if [ "$CANDIDATE_INSTALLED_PROOF" = true ]; then
             jq -n \
               --arg installer candidate_managed_plugin \
               --arg runtime_version "$version" \

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -154,9 +154,12 @@ jobs:
       - name: Validate candidate-installed mode
         if: inputs.candidate_installed_proof
         shell: bash
+        env:
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+          CALIBRATION_MODE: ${{ inputs.calibration_mode }}
         run: |
-          test "${{ inputs.server_behavior_only }}" = true
-          test "${{ inputs.calibration_mode }}" = false
+          test "$SERVER_BEHAVIOR_ONLY" = true
+          test "$CALIBRATION_MODE" = false
 
       - name: Install pinned Rust
         if: ${{ !inputs.use_packaged_cli_artifact || inputs.calibration_mode || !inputs.server_behavior_only }}
@@ -314,6 +317,8 @@ jobs:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "0"
           SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+          CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
+          CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
         run: |
           set -euo pipefail
           version="${VERSION#v}"
@@ -340,8 +345,8 @@ jobs:
             )
             calibration_args=(
               --calibration-bundle "$calibration_bundle"
-              --calibration-producer-run-id "${{ inputs.calibration_bundle_run_id }}"
-              --calibration-producer-artifact "${{ inputs.calibration_bundle_artifact }}"
+              --calibration-producer-run-id "$CALIBRATION_RUN_ID"
+              --calibration-producer-artifact "$CALIBRATION_ARTIFACT"
             )
           fi
           python3 .github/scripts/check-packaged-agent-proof.py \
@@ -507,6 +512,7 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           version="${VERSION#v}"
@@ -516,7 +522,7 @@ jobs:
             > target/macos-metal-proof/release-cell-identity.json
           node scripts/codestory-release-cell-manifest.mjs produce \
             --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "${{ inputs.ref }}" \
+            --expected-sha "$INPUT_REF" \
             --version "$version" \
             --cell-id accelerator_execution:macos-arm64-metal \
             --producer-workflow .github/workflows/macos-metal-proof.yml \
@@ -542,12 +548,13 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           version="${VERSION#v}"
           node scripts/codestory-release-cell-manifest.mjs produce \
             --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "${{ inputs.ref }}" \
+            --expected-sha "$INPUT_REF" \
             --version "$version" \
             --cell-id retrieval_readiness:macos-arm64 \
             --producer-workflow .github/workflows/macos-metal-proof.yml \
@@ -572,6 +579,7 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           version="${VERSION#v}"
@@ -583,7 +591,7 @@ jobs:
             > target/candidate-installed-macos/release-cell-identity.json
           node scripts/codestory-release-cell-manifest.mjs produce \
             --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "${{ inputs.ref }}" \
+            --expected-sha "$INPUT_REF" \
             --version "$version" \
             --cell-id candidate_installed_behavior:macos-arm64 \
             --producer-workflow .github/workflows/macos-metal-proof.yml \

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -225,28 +225,29 @@ jobs:
         env:
           BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
           HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+          RESOLVED_MODE: ${{ steps.resolve.outputs.mode }}
           REQUESTED_SCOPE: ${{ inputs.scope || 'auto' }}
         run: |
           set -euo pipefail
-          if [ "${{ steps.resolve.outputs.mode }}" = "integration" ]; then
+          if [ "$RESOLVED_MODE" = "integration" ]; then
             if [ "$REQUESTED_SCOPE" = none ] || [ "$REQUESTED_SCOPE" = linux ]; then
               scope="$REQUESTED_SCOPE"
             else
               scope=full
             fi
-          elif [ "${{ steps.resolve.outputs.mode }}" = "package" ]; then
+          elif [ "$RESOLVED_MODE" = "package" ]; then
             test "$REQUESTED_SCOPE" != none
             if [ "$REQUESTED_SCOPE" = auto ]; then
               scope=full
             else
               scope="$REQUESTED_SCOPE"
             fi
-          elif [ "${{ steps.resolve.outputs.mode }}" = "qualification" ]; then
+          elif [ "$RESOLVED_MODE" = "qualification" ]; then
             test "$REQUESTED_SCOPE" = auto || test "$REQUESTED_SCOPE" = full
             scope=full
-          elif [ "${{ steps.resolve.outputs.mode }}" = "calibration" ]; then
+          elif [ "$RESOLVED_MODE" = "calibration" ]; then
             scope=none
-          elif [ "${{ steps.resolve.outputs.mode }}" = "release-evidence" ]; then
+          elif [ "$RESOLVED_MODE" = "release-evidence" ]; then
             scope=none
           else
             scope="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" | node .github/scripts/route-ci-proof.mjs --stdin --requested "$REQUESTED_SCOPE")"

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -739,16 +739,20 @@ jobs:
 
       - name: Package release asset
         if: runner.os != 'Windows'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           bin="target/${{ matrix.rust_target }}/release/codestory-cli"
           python .github/scripts/package-codestory-release.py \
-            --version "${{ inputs.version }}" \
+            --version "$INPUT_VERSION" \
             --target "${{ matrix.asset_target }}" \
             --binary "$bin" \
             --out-dir target/release-dist
 
       - name: Prove Linux x64 glibc 2.31 baseline
         if: matrix.asset_target == 'linux-x64'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           docker run --rm --platform linux/amd64 \
             --volume "$PWD:/workspace" \
@@ -758,8 +762,8 @@ jobs:
               set -euo pipefail
               bash .github/scripts/check-linux-glibc-baseline.sh "$@"
             ' bash \
-              "target/release-dist/codestory-cli-v${{ inputs.version }}-linux-x64.tar.gz" \
-              "${{ inputs.version }}" \
+              "target/release-dist/codestory-cli-v${INPUT_VERSION}-linux-x64.tar.gz" \
+              "$INPUT_VERSION" \
               target/linux-glibc-baseline \
               "glibc 2.31"
 
@@ -774,11 +778,13 @@ jobs:
 
       - name: Smoke packaged release asset
         if: runner.os != 'Windows'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           python .github/scripts/check-packaged-agent-proof.py \
-            --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.tar.gz" \
+            --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.tar.gz" \
             --checksum-file target/release-dist/SHA256SUMS.txt \
-            --expected-version "${{ inputs.version }}" \
+            --expected-version "$INPUT_VERSION" \
             --expected-source-sha "${{ steps.source-identity.outputs.sha }}" \
             --expected-source-tree "${{ steps.source-identity.outputs.tree }}" \
             --version-only \
@@ -837,14 +843,17 @@ jobs:
         env:
           CODESTORY_EMBED_ALLOW_CPU: "1"
           CALIBRATION_MODE: ${{ inputs.calibration_mode }}
+          INPUT_VERSION: ${{ inputs.version }}
+          CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
+          CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           common_args=(
-            --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.tar.gz"
+            --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.tar.gz"
             --checksum-file target/release-dist/SHA256SUMS.txt
-            --expected-version "${{ inputs.version }}"
+            --expected-version "$INPUT_VERSION"
             --project "${{ github.workspace }}"
             --plugin-root plugins/codestory
             --plugin-handoff
@@ -884,8 +893,8 @@ jobs:
             --qualification-driver target/release/codestory_embedding_qualification \
             --qualification-evidence target/packaged-agent-proof/qualification.json \
             --calibration-bundle "$calibration_bundle" \
-            --calibration-producer-run-id "${{ inputs.calibration_bundle_run_id }}" \
-            --calibration-producer-artifact "${{ inputs.calibration_bundle_artifact }}" \
+            --calibration-producer-run-id "$CALIBRATION_RUN_ID" \
+            --calibration-producer-artifact "$CALIBRATION_ARTIFACT" \
             --retrieval-quality-evidence "$quality_path" \
             --out-dir target/packaged-agent-proof
 
@@ -924,10 +933,12 @@ jobs:
       - name: Package release asset on Windows
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           $bin = Join-Path $env:CARGO_TARGET_DIR "${{ matrix.rust_target }}/release/codestory-cli${{ matrix.exe_suffix }}"
           python .github/scripts/package-codestory-release.py `
-            --version "${{ inputs.version }}" `
+            --version "$env:INPUT_VERSION" `
             --target "${{ matrix.asset_target }}" `
             --binary $bin `
             --out-dir target/release-dist
@@ -935,11 +946,13 @@ jobs:
       - name: Smoke packaged release asset on Windows
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           python .github/scripts/check-packaged-agent-proof.py `
-            --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.zip" `
+            --archive "target/release-dist/codestory-cli-v$($env:INPUT_VERSION)-${{ matrix.asset_target }}.zip" `
             --checksum-file target/release-dist/SHA256SUMS.txt `
-            --expected-version "${{ inputs.version }}" `
+            --expected-version "$env:INPUT_VERSION" `
             --expected-source-sha "${{ steps.source-identity.outputs.sha }}" `
             --expected-source-tree "${{ steps.source-identity.outputs.tree }}" `
             --version-only `
@@ -948,9 +961,11 @@ jobs:
       - name: Report fresh package identity
         id: fresh-package
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          archive="target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}"
+          archive="target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}"
           archive_sha256="$(
             python -c 'import hashlib, sys; print(hashlib.file_digest(open(sys.argv[1], "rb"), "sha256").hexdigest())' \
               "$archive"
@@ -982,19 +997,22 @@ jobs:
       - name: Emit authenticated package release cell
         if: inputs.emit_release_cells
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           node scripts/codestory-release-cell-manifest.mjs produce \
             --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "${{ inputs.ref }}" \
-            --version "${{ inputs.version }}" \
+            --expected-sha "$INPUT_REF" \
+            --version "$INPUT_VERSION" \
             --cell-id "package_identity:${{ matrix.asset_target }}" \
             --producer-workflow .github/workflows/packaged-platform-proof.yml \
             --producer-job build \
             --producer-run-id "$GITHUB_RUN_ID" \
             --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
             --producer-artifact "release-cell-prepublish-package-${{ matrix.asset_target }}-attempt-$GITHUB_RUN_ATTEMPT" \
-            --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}" \
+            --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}" \
             --out "target/release-cells/package_identity-${{ matrix.asset_target }}.json"
 
       - name: Upload authenticated package release cell
@@ -1049,9 +1067,12 @@ jobs:
 
       - name: Require exact frozen source
         shell: bash
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          test "$(git rev-parse HEAD)" = "${{ inputs.ref }}"
-          test -n "${{ inputs.version }}"
+          test "$(git rev-parse HEAD)" = "$INPUT_REF"
+          test -n "$INPUT_VERSION"
 
       - name: Install pinned Rust
         run: |

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -127,9 +127,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Install pinned Rust
+        # The toolchain is now read as a shell variable, which makes the script shell-dependent:
+        # this job's matrix includes windows-latest, where the runner default is pwsh.
+        shell: bash
         run: |
-          rustup toolchain install "${{ env.RELEASE_RUST_TOOLCHAIN }}" --profile minimal
-          rustup default "${{ env.RELEASE_RUST_TOOLCHAIN }}"
+          rustup toolchain install "$RELEASE_RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RELEASE_RUST_TOOLCHAIN"
           rustup target add "${{ matrix.rust_target }}"
 
       - name: Configure short Windows Cargo target
@@ -321,8 +324,8 @@ jobs:
         shell: bash
         run: |
           docker build --platform linux/amd64 \
-            --build-arg "BUILD_IMAGE=${{ env.LINUX_GLIBC_BUILD_IMAGE }}" \
-            --build-arg "GLSLC_IMAGE=${{ env.LINUX_GLSLC_IMAGE }}" \
+            --build-arg "BUILD_IMAGE=$LINUX_GLIBC_BUILD_IMAGE" \
+            --build-arg "GLSLC_IMAGE=$LINUX_GLSLC_IMAGE" \
             --file .github/docker/linux-glibc-build.Dockerfile \
             --tag codestory-linux-glibc-build \
             .github/docker
@@ -354,6 +357,7 @@ jobs:
       - name: Build Linux x64 at the glibc 2.31 baseline
         id: linux-build
         if: matrix.asset_target == 'linux-x64'
+        shell: bash
         run: |
           test -x "$SCCACHE_PATH"
           mkdir -p "$CARGO_HOME" "$SCCACHE_DIR"
@@ -739,6 +743,7 @@ jobs:
 
       - name: Package release asset
         if: runner.os != 'Windows'
+        shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
@@ -751,13 +756,14 @@ jobs:
 
       - name: Prove Linux x64 glibc 2.31 baseline
         if: matrix.asset_target == 'linux-x64'
+        shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           docker run --rm --platform linux/amd64 \
             --volume "$PWD:/workspace" \
             --workdir /workspace \
-            "${{ env.LINUX_GLIBC_BASELINE_IMAGE }}" \
+            "$LINUX_GLIBC_BASELINE_IMAGE" \
             bash -lc '
               set -euo pipefail
               bash .github/scripts/check-linux-glibc-baseline.sh "$@"
@@ -778,15 +784,18 @@ jobs:
 
       - name: Smoke packaged release asset
         if: runner.os != 'Windows'
+        shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
+          SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
         run: |
           python .github/scripts/check-packaged-agent-proof.py \
             --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.tar.gz" \
             --checksum-file target/release-dist/SHA256SUMS.txt \
             --expected-version "$INPUT_VERSION" \
-            --expected-source-sha "${{ steps.source-identity.outputs.sha }}" \
-            --expected-source-tree "${{ steps.source-identity.outputs.tree }}" \
+            --expected-source-sha "$SOURCE_SHA" \
+            --expected-source-tree "$SOURCE_TREE" \
             --version-only \
             --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
 
@@ -840,6 +849,7 @@ jobs:
           matrix.asset_target == 'linux-x64' &&
           (inputs.calibration_mode ||
             inputs.quality_evidence_artifact != '')
+        shell: bash
         env:
           CODESTORY_EMBED_ALLOW_CPU: "1"
           CALIBRATION_MODE: ${{ inputs.calibration_mode }}
@@ -948,13 +958,15 @@ jobs:
         shell: pwsh
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
+          SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
         run: |
           python .github/scripts/check-packaged-agent-proof.py `
             --archive "target/release-dist/codestory-cli-v$($env:INPUT_VERSION)-${{ matrix.asset_target }}.zip" `
             --checksum-file target/release-dist/SHA256SUMS.txt `
             --expected-version "$env:INPUT_VERSION" `
-            --expected-source-sha "${{ steps.source-identity.outputs.sha }}" `
-            --expected-source-tree "${{ steps.source-identity.outputs.tree }}" `
+            --expected-source-sha "$env:SOURCE_SHA" `
+            --expected-source-tree "$env:SOURCE_TREE" `
             --version-only `
             --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
 
@@ -963,6 +975,8 @@ jobs:
         shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
+          SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
         run: |
           set -euo pipefail
           archive="target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}"
@@ -973,8 +987,8 @@ jobs:
           {
             echo "### Fresh package identity"
             echo
-            echo "- Source SHA: \`${{ steps.source-identity.outputs.sha }}\`"
-            echo "- Source tree: \`${{ steps.source-identity.outputs.tree }}\`"
+            echo "- Source SHA: \`$SOURCE_SHA\`"
+            echo "- Source tree: \`$SOURCE_TREE\`"
             echo "- Archive: \`$(basename "$archive")\`"
             echo "- Archive SHA-256: \`$archive_sha256\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -1075,9 +1089,10 @@ jobs:
           test -n "$INPUT_VERSION"
 
       - name: Install pinned Rust
+        shell: bash
         run: |
-          rustup toolchain install "${{ env.RELEASE_RUST_TOOLCHAIN }}" --profile minimal
-          rustup default "${{ env.RELEASE_RUST_TOOLCHAIN }}"
+          rustup toolchain install "$RELEASE_RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RELEASE_RUST_TOOLCHAIN"
           rustup target add x86_64-unknown-linux-gnu
 
       - name: Prepare checksum-pinned embedded model
@@ -1087,8 +1102,8 @@ jobs:
         shell: bash
         run: |
           docker build --platform linux/amd64 \
-            --build-arg "BUILD_IMAGE=${{ env.LINUX_GLIBC_BUILD_IMAGE }}" \
-            --build-arg "GLSLC_IMAGE=${{ env.LINUX_GLSLC_IMAGE }}" \
+            --build-arg "BUILD_IMAGE=$LINUX_GLIBC_BUILD_IMAGE" \
+            --build-arg "GLSLC_IMAGE=$LINUX_GLSLC_IMAGE" \
             --file .github/docker/linux-glibc-build.Dockerfile \
             --tag codestory-linux-glibc-build \
             .github/docker

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -380,6 +380,8 @@ jobs:
         env:
           CODEX_CLI_VERSION: "0.144.5"
           MARKETPLACE_REVISION: ${{ steps.delivery.outputs.marketplace_revision }}
+          MARKETPLACE_SOURCE: ${{ steps.delivery.outputs.marketplace_source }}
+          LOCAL_FIXTURE: ${{ steps.delivery.outputs.local_fixture }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
@@ -395,10 +397,10 @@ jobs:
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \
-            --marketplace-source "${{ steps.delivery.outputs.marketplace_source }}" \
+            --marketplace-source "$MARKETPLACE_SOURCE" \
             --marketplace-name TheGreenCedar \
             --marketplace-revision "$MARKETPLACE_REVISION" \
-            --local-fixture "${{ steps.delivery.outputs.local_fixture }}" \
+            --local-fixture "$LOCAL_FIXTURE" \
             --expected-version "$INPUT_VERSION" \
             --source-repository "$GITHUB_WORKSPACE" \
             --attestation "$install_root/install-attestation-v2.json"

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -61,14 +61,17 @@ jobs:
           fi
 
       - name: Validate plugin-lane version synchronization
-        run: python .github/scripts/check-codestory-release.py --version "${{ inputs.version }}" --lane plugin
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: python .github/scripts/check-codestory-release.py --version "$INPUT_VERSION" --lane plugin
 
       - name: Refuse an existing plugin release
         env:
           GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          tag="v${{ inputs.version }}"
+          tag="v$INPUT_VERSION"
           if git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
             echo "::error::$tag already exists."
             exit 1
@@ -122,9 +125,11 @@ jobs:
           fi
 
       - name: Extract plugin release notes
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          node .github/scripts/extract-codestory-release-notes.mjs --version "${{ inputs.version }}" > /tmp/plugin-release-notes.md
+          node .github/scripts/extract-codestory-release-notes.mjs --version "$INPUT_VERSION" > /tmp/plugin-release-notes.md
           test -s /tmp/plugin-release-notes.md
 
   plugin-proof:
@@ -179,13 +184,14 @@ jobs:
       - name: Publish the plugin release
         env:
           GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          node .github/scripts/extract-codestory-release-notes.mjs --version "${{ inputs.version }}" > /tmp/plugin-release-notes.md
-          gh release create "v${{ inputs.version }}" \
+          node .github/scripts/extract-codestory-release-notes.mjs --version "$INPUT_VERSION" > /tmp/plugin-release-notes.md
+          gh release create "v$INPUT_VERSION" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
-            --title "CodeStory plugin ${{ inputs.version }}" \
+            --title "CodeStory plugin $INPUT_VERSION" \
             --notes-file /tmp/plugin-release-notes.md
 
   # The catalog is what a host installs from, so the plugin lane publishes it too. It is DELIVERY,
@@ -222,12 +228,13 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           node .github/scripts/publish-marketplace-catalog.mjs \
             --source-repository "$GITHUB_WORKSPACE" \
             --commit "$GITHUB_SHA" \
-            --version "${{ inputs.version }}" \
+            --version "$INPUT_VERSION" \
             --github-output "$GITHUB_OUTPUT"
 
       # The only place this lane's "catalog was updated" claim is ever minted.
@@ -373,6 +380,7 @@ jobs:
         env:
           CODEX_CLI_VERSION: "0.144.5"
           MARKETPLACE_REVISION: ${{ steps.delivery.outputs.marketplace_revision }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           install_root="$RUNNER_TEMP/codestory-marketplace-postpublish"
@@ -391,6 +399,6 @@ jobs:
             --marketplace-name TheGreenCedar \
             --marketplace-revision "$MARKETPLACE_REVISION" \
             --local-fixture "${{ steps.delivery.outputs.local_fixture }}" \
-            --expected-version "${{ inputs.version }}" \
+            --expected-version "$INPUT_VERSION" \
             --source-repository "$GITHUB_WORKSPACE" \
             --attestation "$install_root/install-attestation-v2.json"

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -188,27 +188,33 @@ jobs:
 
       - name: Prove packaged version, help, and stdio shape
         shell: bash
+        env:
+          ASSET_ARCHIVE: ${{ steps.asset.outputs.archive }}
+          ASSET_CHECKSUM: ${{ steps.asset.outputs.checksum }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: >-
           python .github/scripts/check-packaged-agent-proof.py
-          --archive "${{ steps.asset.outputs.archive }}"
-          --checksum-file "${{ steps.asset.outputs.checksum }}"
-          --expected-version "${{ steps.release.outputs.version }}"
+          --archive "$ASSET_ARCHIVE"
+          --checksum-file "$ASSET_CHECKSUM"
+          --expected-version "$RELEASE_VERSION"
           --version-only
           --out-dir "target/post-publish-version-proof/${{ matrix.asset_target }}"
 
       - name: Prove published macOS signature, notarization, and quarantined execution
         if: runner.os == 'macOS'
         shell: bash
+        env:
+          ASSET_ARCHIVE: ${{ steps.asset.outputs.archive }}
         run: |
           set -euo pipefail
           proof_dir="target/post-publish-macos-signing/${{ matrix.asset_target }}"
           unpacked="$proof_dir/unpacked"
           mkdir -p "$unpacked"
           quarantine="0083;$(date +%s);CodeStory;"
-          xattr -w com.apple.quarantine "$quarantine" "${{ steps.asset.outputs.archive }}"
-          xattr -p com.apple.quarantine "${{ steps.asset.outputs.archive }}" \
+          xattr -w com.apple.quarantine "$quarantine" "$ASSET_ARCHIVE"
+          xattr -p com.apple.quarantine "$ASSET_ARCHIVE" \
             > "$proof_dir/archive-quarantine.txt"
-          tar -xzf "${{ steps.asset.outputs.archive }}" -C "$unpacked"
+          tar -xzf "$ASSET_ARCHIVE" -C "$unpacked"
           bins="$(find "$unpacked" -type f -name codestory-cli -print)"
           count="$(printf '%s\n' "$bins" | sed '/^$/d' | wc -l | tr -d ' ')"
           if [ "$count" -ne 1 ]; then
@@ -310,12 +316,17 @@ jobs:
       - name: Resolve the published plugin through the marketplace catalog
         id: installed
         shell: bash
+        env:
+          MARKETPLACE_REVISION: ${{ steps.delivery.outputs.marketplace_revision }}
+          MARKETPLACE_SOURCE: ${{ steps.delivery.outputs.marketplace_source }}
+          LOCAL_FIXTURE: ${{ steps.delivery.outputs.local_fixture }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
           install_root="$RUNNER_TEMP/codestory-installed-proof"
           codex_package_root="$RUNNER_TEMP/codex-cli-${CODEX_CLI_VERSION}"
           isolated_home="$install_root/isolated-home"
-          marketplace_revision="${{ steps.delivery.outputs.marketplace_revision }}"
+          marketplace_revision="$MARKETPLACE_REVISION"
           printf '%s' "$marketplace_revision" | grep -Eq '^[0-9a-f]{40}$'
           rm -rf "$install_root"
           mkdir -p "$isolated_home"
@@ -328,11 +339,11 @@ jobs:
             --codex-package-root "$codex_package_root" \
             --codex-home "$install_root/codex-home" \
             --plugin-data "$install_root/codex-home/plugin-data" \
-            --marketplace-source "${{ steps.delivery.outputs.marketplace_source }}" \
+            --marketplace-source "$MARKETPLACE_SOURCE" \
             --marketplace-name TheGreenCedar \
             --marketplace-revision "$marketplace_revision" \
-            --local-fixture "${{ steps.delivery.outputs.local_fixture }}" \
-            --expected-version "${{ steps.release.outputs.version }}" \
+            --local-fixture "$LOCAL_FIXTURE" \
+            --expected-version "$RELEASE_VERSION" \
             --source-repository "$GITHUB_WORKSPACE" \
             --attestation "$install_root/install-attestation-v2.json" \
             --github-output "$GITHUB_OUTPUT"
@@ -340,24 +351,30 @@ jobs:
       - name: Prove the catalog-resolved published runtime
         env:
           CODESTORY_EMBED_ALLOW_CPU: "0"
+          ASSET_ARCHIVE: ${{ steps.asset.outputs.archive }}
+          ASSET_CHECKSUM: ${{ steps.asset.outputs.checksum }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          INSTALLED_PLUGIN_ROOT: ${{ steps.installed.outputs.plugin_root }}
+          INSTALLED_ATTESTATION: ${{ steps.installed.outputs.attestation }}
+          INSTALLED_PLUGIN_DATA: ${{ steps.installed.outputs.plugin_data }}
         shell: bash
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           python .github/scripts/check-packaged-agent-proof.py \
-            --archive "${{ steps.asset.outputs.archive }}" \
-            --checksum-file "${{ steps.asset.outputs.checksum }}" \
-            --expected-version "${{ steps.release.outputs.version }}" \
+            --archive "$ASSET_ARCHIVE" \
+            --checksum-file "$ASSET_CHECKSUM" \
+            --expected-version "$RELEASE_VERSION" \
             --project "${{ github.workspace }}" \
-            --plugin-root "${{ steps.installed.outputs.plugin_root }}" \
+            --plugin-root "$INSTALLED_PLUGIN_ROOT" \
             --plugin-handoff \
             --engine-policy accelerated \
             --expected-backend "${{ matrix.backend }}" \
             --proof-tier installed_runtime \
             --server-behavior-only \
-            --installed-plugin-attestation "${{ steps.installed.outputs.attestation }}" \
-            --installed-plugin-data "${{ steps.installed.outputs.plugin_data }}" \
+            --installed-plugin-attestation "$INSTALLED_ATTESTATION" \
+            --installed-plugin-data "$INSTALLED_PLUGIN_DATA" \
             --expected-source-sha "$source_sha" \
             --expected-source-tree "$source_tree" \
             --timeout-secs 3600 \
@@ -366,17 +383,21 @@ jobs:
       - name: Emit authenticated post-publish release cells
         if: inputs.emit_release_cells
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          ASSET_ARCHIVE: ${{ steps.asset.outputs.archive }}
+          DELIVERED_INSTALLER: ${{ steps.delivery.outputs.installer }}
         run: |
           set -euo pipefail
-          version="${{ steps.release.outputs.version }}"
-          archive="${{ steps.asset.outputs.archive }}"
+          version="$RELEASE_VERSION"
+          archive="$ASSET_ARCHIVE"
           ledger="$(find target/pre-publish-closeout -type f -name ledger.json -print)"
           test "$(printf '%s\n' "$ledger" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
           mkdir -p target/release-cells
           # The installer identity is whatever the delivery state resolved, never a literal: a
           # deferred run must not be able to sign a cell that says the public catalog served it.
           jq -n \
-            --arg installer "${{ steps.delivery.outputs.installer }}" \
+            --arg installer "$DELIVERED_INSTALLER" \
             --arg native_engine coderank_q8_embedded \
             '{installer: $installer, native_engine: $native_engine}' \
             > target/release-cells/installed-identity.json

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -89,9 +89,11 @@ jobs:
       - name: Normalize release version
         id: release
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           version="${version#v}"
           if [ -z "$version" ]; then
             echo "::error::version input is required"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -552,13 +552,15 @@ jobs:
 
       - name: Evaluate authenticated pre-publish closeout
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
           evaluated_at="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
           node scripts/codestory-release-closeout.mjs evaluate \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
-            --version "${{ needs.preflight.outputs.version }}" \
+            --version "$RELEASE_VERSION" \
             --phase pre_publish \
             --evaluated-at "$evaluated_at" \
             --trusted-producers target/release-closeout/trusted-pre-publish-producers.json \
@@ -749,12 +751,13 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
           node .github/scripts/publish-marketplace-catalog.mjs \
             --source-repository "$GITHUB_WORKSPACE" \
             --commit "$GITHUB_SHA" \
-            --version "${{ needs.preflight.outputs.version }}" \
+            --version "$RELEASE_VERSION" \
             --github-output "$GITHUB_OUTPUT"
 
       # The only place the "catalog was updated" claim is ever minted. It requires the token, the
@@ -887,6 +890,8 @@ jobs:
 
       - name: Evaluate authenticated post-publish closeout
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
           ledger="$(find target/accepted-pre-publish-closeout -type f -name ledger.json -print)"
@@ -895,7 +900,7 @@ jobs:
           node scripts/codestory-release-closeout.mjs evaluate \
             --repo "$GITHUB_WORKSPACE" \
             --expected-sha "$GITHUB_SHA" \
-            --version "${{ needs.preflight.outputs.version }}" \
+            --version "$RELEASE_VERSION" \
             --phase post_publish \
             --evaluated-at "$evaluated_at" \
             --trusted-producers target/release-closeout/trusted-post-publish-producers.json \

--- a/.github/workflows/source-proof.yml
+++ b/.github/workflows/source-proof.yml
@@ -401,12 +401,15 @@ jobs:
       - name: Emit authenticated source release cell
         if: inputs.emit_release_cells
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          RESOLVED_REF: ${{ needs.resolve.outputs.ref }}
         run: |
           set -euo pipefail
           node scripts/codestory-release-cell-manifest.mjs produce \
             --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "${{ needs.resolve.outputs.ref }}" \
-            --version "${{ inputs.version }}" \
+            --expected-sha "$RESOLVED_REF" \
+            --version "$INPUT_VERSION" \
             --cell-id source_behavior \
             --producer-workflow .github/workflows/source-proof.yml \
             --producer-job full-source-gate \

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -125,8 +125,10 @@ jobs:
       - name: Validate candidate-installed mode
         if: inputs.candidate_installed_proof
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
+        env:
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
         run: |
-          if ("${{ inputs.server_behavior_only }}" -ne "true") {
+          if ($env:SERVER_BEHAVIOR_ONLY -ne "true") {
             throw "candidate_installed_proof requires server_behavior_only"
           }
 
@@ -233,6 +235,8 @@ jobs:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "0"
           SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+          CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
+          CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
         run: |
           $ErrorActionPreference = "Stop"
           $version = $env:VERSION.TrimStart('v')
@@ -261,8 +265,8 @@ jobs:
             )
             $calibrationArgs = @(
               "--calibration-bundle", $calibrationBundles[0].FullName,
-              "--calibration-producer-run-id", "${{ inputs.calibration_bundle_run_id }}",
-              "--calibration-producer-artifact", "${{ inputs.calibration_bundle_artifact }}"
+              "--calibration-producer-run-id", "$env:CALIBRATION_RUN_ID",
+              "--calibration-producer-artifact", "$env:CALIBRATION_ARTIFACT"
             )
           }
           python .github/scripts/check-packaged-agent-proof.py `
@@ -394,9 +398,12 @@ jobs:
       - name: Emit authenticated Vulkan release cell
         if: inputs.emit_release_cells
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           version="${version#v}"
           jq -n \
             --arg native_engine coderank_q8_embedded \
@@ -404,7 +411,7 @@ jobs:
             > target/windows-vulkan-proof/release-cell-identity.json
           node scripts/codestory-release-cell-manifest.mjs produce \
             --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "${{ inputs.ref }}" \
+            --expected-sha "$INPUT_REF" \
             --version "$version" \
             --cell-id accelerator_execution:windows-x64-vulkan \
             --producer-workflow .github/workflows/windows-vulkan-proof.yml \
@@ -428,13 +435,16 @@ jobs:
       - name: Emit authenticated Windows retrieval-readiness release cell
         if: inputs.emit_release_cells && inputs.server_behavior_only
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           version="${version#v}"
           node scripts/codestory-release-cell-manifest.mjs produce \
             --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "${{ inputs.ref }}" \
+            --expected-sha "$INPUT_REF" \
             --version "$version" \
             --cell-id retrieval_readiness:windows-x64 \
             --producer-workflow .github/workflows/windows-vulkan-proof.yml \
@@ -457,9 +467,12 @@ jobs:
       - name: Emit authenticated candidate-installed Windows release cell
         if: inputs.emit_release_cells && inputs.candidate_installed_proof
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           version="${version#v}"
           jq -n \
             --arg installer candidate_managed_plugin \
@@ -469,7 +482,7 @@ jobs:
             > target/candidate-installed-windows/release-cell-identity.json
           node scripts/codestory-release-cell-manifest.mjs produce \
             --repo "$GITHUB_WORKSPACE" \
-            --expected-sha "${{ inputs.ref }}" \
+            --expected-sha "$INPUT_REF" \
             --version "$version" \
             --cell-id candidate_installed_behavior:windows-x64 \
             --producer-workflow .github/workflows/windows-vulkan-proof.yml \


### PR DESCRIPTION
Closes #1566

## The defect

GitHub expression interpolation is textual. `${{ inputs.version }}` inside a `run:` body is replaced with the value's characters *before* any shell exists, and double quotes do not stop `$(...)` or backticks. A dispatched value written into script text therefore executes on the runner — beside whatever `GH_TOKEN`, environment secret, or self-hosted host state that step carries.

#1554 fixed this in `marketplace-sync.yml` and pinned the fix with `validateMarketplaceSync`, a validator named after one file. That shape cannot fail on a second file however many times the same splice is written.

## Enumeration

Rather than trusting the issue's list, I parsed every workflow and walked `jobs.*.steps[*].run`, collecting every `${{ ... }}` expression naming the `inputs` context. **7 files, 32 steps, 55 textual occurrences** (48 distinct file/step/expression triples). The issue named 3 files; the real set was more than twice that, and `packaged-platform-proof.yml` — which the issue does not mention at all — carried the most.

| File | Steps | Occurrences | Distinct |
| --- | --- | --- | --- |
| `packaged-platform-proof.yml` | 9 | 18 | 13 |
| `linux-vulkan-proof.yml` | 5 | 11 | 11 |
| `windows-vulkan-proof.yml` | 5 | 9 | 9 |
| `plugin-release.yml` | 6 | 8 | 6 |
| `macos-metal-proof.yml` | 5 | 7 | 7 |
| `post-publish-release-smoke.yml` | 1 | 1 | 1 |
| `source-proof.yml` | 1 | 1 | 1 |
| **total** | **32** | **55** | **48** |

The issue's line numbers had drifted and its list was incomplete in both directions, so the numbers above come from re-running the parser against `origin/dev/codestory-next` rather than from reading the issue.

The highest-value sites are the nine **`Emit authenticated … release cell`** steps. Their `--expected-sha` is the commit every downstream claim in the evidence graph is filed against, and in eight of them it was `--expected-sha "${{ inputs.ref }}"` — spliced. (The ninth, in `source-proof.yml`, spliced `needs.resolve.outputs.ref`.)

## What changed

**1. Every site routed through `env:`.** Bash reads `"$INPUT_REF"`, PowerShell reads `$env:SERVER_BEHAVIOR_ONLY`. `env:` is not textual: the value arrives as a variable and the shell never reparses it.

**2. A generic rule, not another per-file validator.** `dispatchInputInterpolationViolations(workflows)` iterates the loaded workflow set and rejects any `${{ … }}` inside any `run:` body in any workflow that can carry a dispatched value. It is driven by the set it is handed, so a workflow added tomorrow is covered without editing the rule. It matches the `inputs` context by name rather than by one path through it, so `github.event.inputs.version`, `inputs['version']`, and `format('{0}', inputs.version)` are all refused.

**2a. The channels a dispatched value can hide in, refused with the context.** *(added after review — the first version of this rule was bypassable.)* Naming `inputs` reads where the value is at the moment the rule looks, not what it is. One hop moved it out of view, and both hops passed policy **and** actionlint on the earlier tree:

```yaml
jobs:
  probe:
    env:
      LAUNDERED: ${{ inputs.ref }}        # job-level env — legal, unread by the old rule
    steps:
      - run: echo "${{ env.LAUNDERED }}"  # still spliced into script text
```

and, through a step output: `env: INPUT_REF: ${{ inputs.ref }}` → `echo "ref=$INPUT_REF" >> "$GITHUB_OUTPUT"` → `echo "${{ steps.launder.outputs.ref }}"`. `env` was the likely one: this PR created 117 step-level `env:` bindings carrying inputs, so `${{ env.FOO }}` was the natural next thing to write. The rule now also refuses `env`, `steps.*.outputs.*`, and `needs.*.outputs.*` inside `run:`, and each violation says which channel it found. **44 further sites moved to `env:` bindings** — the same remedy applied 117 times already, and for `env` it costs nothing, since a workflow- or job-level `env:` entry is already exported into the shell.

**2b. The span the rule reads is brace-balanced, not non-greedy.** *(added after review — the earlier matcher was `/\$\{\{[\s\S]*?\}\}/`, non-greedy to the **first** `}}`, which is not always the terminator.)* GitHub documents `{{` / `}}` as the brace escape inside `format()`. Against `${{ format('{{Hello {0}}}', inputs.ref) }}` the non-greedy form returned `${{ format('{{Hello {0}}`, which names no context, so **policy exited 0 and actionlint exited 0** on a live splice. Braces are counted now and single-quoted literals are skipped whole (`''` read as GitHub's escape for one quote); an expression that never closes yields the rest of the text rather than nothing. `marketplace-sync.yml`'s two `[^}]*` matchers, which had the same defect, read through the same scanner.

**2c. A gate that cannot be made advisory.** *(added after review.)* `continue-on-error: true` on plugin-static.yml's `Check workflow policy` step would have silenced this file **and** its whole test suite while the run still reported green — the commands that step runs were pinned, its blocking-ness was not. Rather than a third one-off beside the existing "must be `true`" and "must not be declared" rules, the property is stated once: absorbing a failure is allowed exactly when the failure is still required — an `id:`, and a **blocking** step that reads `steps.<id>.outcome` outside its own `if:`. source-proof's compile and lint and both lanes' catalog pushes satisfy that. The deliberately-optional cache restores are `uses:` steps, outside the rule by construction, and their required non-blocking-ness is untouched.

**2d. `shell:` declared wherever a binding is read as a variable.** *(added after review.)* Routing a value into `env:` moves the read out of GitHub's interpolator and into the shell — and `"$NAME"` is a *bash* read. The packaged build matrix includes `windows-latest`, where the runner default is pwsh and the correct read is `$env:NAME`. Seven steps now declare `shell: bash`, and a rule keeps that true for any step consuming a binding on a job that can land on Windows. The failure mode this prevents is the dangerous one: not an error, but a proof comparing against an empty string.

**3. The pins that the rewrite would otherwise have loosened.** Moving a value into `env:` takes it out of reach of the `requireStepRun` fragment that used to name it: `--expected-sha "$INPUT_REF"` reads the same whether `INPUT_REF` carries `inputs.ref` or a commit nobody reviewed. A new `requireStepEnv` helper pins the second half. **Five pinned fragments across four steps were updated to the new text; none were deleted or relaxed**, and each gained a binding pin. All nine release-cell producers gained an `--expected-sha` pin they never had, and two of them (`retrieval_readiness:windows-x64`, `retrieval_readiness:macos-arm64`) gained a `requireStepRun` block where previously there was none.

## Exemption

One, and it is the boundary of the rule rather than a carve-out: **the rule reads `run:` only.** A dispatched value in an action input (`actions/checkout` `with.ref`) is not parsed by a shell, and #1554 already established it is a separately-pinned non-executable surface — `plugin-release.yml`'s post-publish checkout still resolves `v${{ inputs.version }}`, pinned by `catalogDeliveryStateViolations`. This boundary is asserted, not assumed: a test places a dispatch input in a checkout `ref:` and requires the rule to stay silent. No file, job, or step is exempted by name.

`source-proof.yml`'s release cell anchors on `needs.resolve.outputs.ref` rather than a dispatch input; it was routed through env alongside the rest since it is the same trust anchor.

## Verification

| Command | Result |
| --- | --- |
| `node .github/scripts/check-workflow-policy.mjs` | pass (exit 0) |
| `node --test .github/scripts/check-workflow-policy.test.mjs` | **676 pass, 0 fail** (was 533 before this PR, 609 before review) |
| `node .github/scripts/run-actionlint.mjs` | pass (exit 0) |
| `node scripts/codestory-release-claims.mjs validate` | pass — graph hash unchanged |
| `node --test …/lost-runner-recovery + cargo-cache-contract` | 26 pass |
| release claim/closeout/evidence-gate/runner-contract tests | 91 pass |

The job DAG is unchanged (no jobs added, removed, renamed, or re-wired), so `release-claims.json` needs no edit — confirmed by the validator reporting the same graph hash.

### Both directions

- **Rule fires:** on `origin/dev/codestory-next` (`f5c2ec54`) it produces **85 violations across 9 files** — 48 direct `inputs` splices, 26 step outputs, 7 `env`, 4 job outputs. On this branch **before** the review repair it still produced **36 across 5 files**; it now produces **0**. The per-file mutation tests are generated by iterating `loadWorkflows()` — every workflow in the directory, named by none of them.
- **Rule covers the unwritten:** a synthetic `future-dispatch-proof.yml` never on disk is refused, and the same workflow reading from `env:` is clean.
- **Rule does not over-fire:** `github.*`, `matrix.*`, `runner.*`, a shell variable merely containing the word `inputs`, and the shell read `"$NAME"` of a job-level `env:` entry are all silent. `steps.*.outputs.*` and `needs.*.outputs.*` used to be listed here as silent; **that claim was wrong and two tests were asserting it**, so they are replaced by tests that build the full launder and require the rule to report it.
- **Pins fire:** each of the 12 env-routed sites is mutated three ways — rewired binding, dropped binding, and reverting the script to the splice — and the last asserts *both* layers see it: the fragment pin that knows the step, and the generic rule that knows nothing about it.
- **Tests are load-bearing, per repair:** reverting the brace-balanced scanner to the non-greedy regex fails **4** tests (the documented `{{`/`}}` escape cases). Reverting the rule to `inputs`-only fails **3** (the env, step-output, and job-output launders). Neutering the absorbed-failure rule fails **42**. Dropping `shell: bash` from any of the four rewritten packaged-build steps fails its own test. Each was checked by making the revert and re-running the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

