### PR TITLE
cut 0.16.3 and record 0.16.2 as withdrawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.16.2
+## 0.16.3
 
 ### Fixed
 
@@ -48,6 +48,12 @@
   waits for it.
 - Windows and Linux start faster, and commands run at the same time no longer
   queue behind one another.
+
+## 0.16.2
+
+Withdrawn before distribution. The GitHub release was created and removed the same day, the
+marketplace catalog was never pointed at it, and no install path ever served it. Everything it
+contained ships in 0.16.3 above.
 
 ## 0.16.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-bench"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-llama-sys"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "crossbeam-channel",
  "fs4",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-llama-sys"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 build = "build.rs"
 

--- a/crates/codestory-llama-sys/model-contract.json
+++ b/crates/codestory-llama-sys/model-contract.json
@@ -37,7 +37,7 @@
   "producer": {
     "name": "codestory-llama-sys",
     "embedding_revision": "0.16.1",
-    "version": "0.16.2"
+    "version": "0.16.3"
   },
   "license": {
     "spdx_id": "MIT",

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 
 [features]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/cli-version.json
+++ b/plugins/codestory/cli-version.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "cli_version": "0.16.2",
-  "release_tag": "v0.16.2"
+  "cli_version": "0.16.3",
+  "release_tag": "v0.16.3"
 }


### PR DESCRIPTION
Closes #1586.

Preflight refuses any run against an existing tag, and `v0.16.2` survives the deleted release — so no 0.16.2 run, proof-only included, can execute ([30407282240](https://github.com/TheGreenCedar/CodeStory/actions/runs/30407282240)).

- `bump-version.mjs --version 0.16.3`; `producer.embedding_revision` deliberately unchanged at `0.16.1`, so the WP10b split holds and no user re-embeds.
- Changelog entries move under 0.16.3; 0.16.2 is recorded as withdrawn before distribution.

`check-codestory-release.py --version 0.16.3` passes; workflow policy, claim-graph validation, and doc links all pass.