### PR TITLE
run the calibration freeze lineage guard where a caller reaches it

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2759,6 +2759,7 @@ function validatePackagedProof(workflows, violations, graph) {
       '--calibration-bundle "$calibration_bundle"',
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
+      "--enforce-calibration-freeze-lineage",
       'test -f "$quality_path"',
       "--engine-policy cpu_explicit",
       "--expected-backend CPU",
@@ -2775,6 +2776,31 @@ function validatePackagedProof(workflows, violations, graph) {
   const packagedProof = namedStep(
     job,
     "Packaged per-user server calibration or qualification",
+  );
+  // The calibration-to-package source-lineage guard exists only when this flag
+  // reaches the frozen invocation. Without it the packaged release can ship a
+  // constant set measured on a materially different tree, so pin the flag to
+  // the hosted_package call rather than anywhere in the step, and keep the
+  // build checkout deep enough for the ancestor and diff probes it performs.
+  const packagedProofExecutable = executableRunText(packagedProofRun);
+  const frozenInvocationIndex = packagedProofExecutable
+    .indexOf("--proof-tier hosted_package");
+  add(
+    violations,
+    frozenInvocationIndex >= 0
+      && occurrenceCount(
+        packagedProofExecutable,
+        "--enforce-calibration-freeze-lineage",
+      ) === 1
+      && packagedProofExecutable
+        .slice(frozenInvocationIndex)
+        .includes("--enforce-calibration-freeze-lineage"),
+    `${file} frozen packaged qualification must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed`,
+  );
+  add(
+    violations,
+    object(namedStep(job, "Checkout")?.with)["fetch-depth"] === 0,
+    `${file} package build must keep full history for the calibration freeze lineage probe`,
   );
   const hostedCalibrationUpload = namedStep(job, "Upload hosted Linux calibration runs");
   add(

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -116,6 +116,215 @@ function occurrenceCount(value, fragment) {
   return value.split(fragment).length - 1;
 }
 
+// A backslash-continued shell command is one logical invocation. Asserting a
+// flag appears "somewhere after" an anchor is defeatable by parking the flag on
+// a later decoy line, so every invocation-level pin below reads the single
+// logical command that carries its anchor.
+function shellInvocationsContaining(run, anchor) {
+  const commands = [];
+  let current = [];
+  for (const line of executableRunText(run).split(/\r?\n/u)) {
+    current.push(line);
+    if (!/\\\s*$/u.test(line)) {
+      commands.push(current.join("\n"));
+      current = [];
+    }
+  }
+  if (current.length > 0) commands.push(current.join("\n"));
+  return commands.filter(command => command.includes(anchor));
+}
+
+function requireFlagOnInvocation(violations, message, run, anchor, flag) {
+  const invocations = shellInvocationsContaining(run, anchor);
+  add(
+    violations,
+    invocations.length === 1
+      && invocations[0].includes(flag)
+      && occurrenceCount(executableRunText(run), flag) === 1,
+    message,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reachability of a guarded step.
+//
+// A policy that only asserts a flag is present proves nothing when the step
+// carrying it cannot run: that is exactly how the calibration freeze lineage
+// guard sat "enabled" on a branch gated behind an input every caller pinned
+// empty. The helpers below evaluate a step's own `if` against the input
+// bindings a named caller actually passes, so making the step unreachable --
+// by narrowing the condition or by stopping the caller forwarding what it
+// reads -- is a policy violation rather than a silent regression.
+const conditionTokenPattern = /^(&&|\|\||!=|==|!|\(|\)|'[^']*'|[A-Za-z_][A-Za-z0-9_.-]*)/u;
+
+function tokenizeCondition(expression) {
+  const tokens = [];
+  let rest = String(expression).replace(/\s+/gu, " ").trim();
+  while (rest.length > 0) {
+    const match = rest.match(conditionTokenPattern);
+    if (!match) {
+      throw new Error(`unsupported condition syntax near ${JSON.stringify(rest)}`);
+    }
+    tokens.push(match[1]);
+    rest = rest.slice(match[1].length).trimStart();
+  }
+  return tokens;
+}
+
+function conditionTruthy(value) {
+  return typeof value === "string" ? value !== "" : Boolean(value);
+}
+
+function evaluateCondition(expression, lookup) {
+  const tokens = tokenizeCondition(expression);
+  let position = 0;
+  const peek = () => tokens[position];
+  const take = () => tokens[position++];
+  function primary() {
+    const token = take();
+    if (token === undefined) throw new Error("condition ended early");
+    if (token === "(") {
+      const value = disjunction();
+      if (take() !== ")") throw new Error("unbalanced condition parentheses");
+      return value;
+    }
+    if (token === "!") return !conditionTruthy(primary());
+    if (token === "true") return true;
+    if (token === "false") return false;
+    if (token.startsWith("'")) return token.slice(1, -1);
+    return lookup(token);
+  }
+  function comparison() {
+    const left = primary();
+    if (peek() === "==" || peek() === "!=") {
+      const operator = take();
+      const right = primary();
+      return operator === "==" ? left === right : left !== right;
+    }
+    return left;
+  }
+  function conjunction() {
+    let value = comparison();
+    while (peek() === "&&") {
+      take();
+      const right = comparison();
+      value = conditionTruthy(value) ? right : value;
+    }
+    return value;
+  }
+  function disjunction() {
+    let value = conjunction();
+    while (peek() === "||") {
+      take();
+      const right = conjunction();
+      value = conditionTruthy(value) ? value : right;
+    }
+    return value;
+  }
+  const result = disjunction();
+  if (position !== tokens.length) throw new Error("trailing condition tokens");
+  return conditionTruthy(result);
+}
+
+function calleeInputSpecifications(workflow) {
+  const declared = object(at(workflow, "on", "workflow_call", "inputs"));
+  const specifications = new Map();
+  for (const [name, raw] of Object.entries(declared)) {
+    const specification = object(raw);
+    const boolean = specification.type === "boolean";
+    specifications.set(name, {
+      boolean,
+      default: specification.default ?? (boolean ? false : ""),
+    });
+  }
+  return specifications;
+}
+
+const dispatchForwardedPattern
+  = /^\$\{\{\s*inputs\.([A-Za-z_][A-Za-z0-9_-]*)\s*\|\|\s*''\s*\}\}$/u;
+
+// Classify what a caller can make each callee input be. A literal is fixed for
+// every run of that caller; a dispatch input forwarded verbatim is chosen by
+// whoever dispatches; anything else is treated as free so this check never
+// invents reachability the caller cannot actually deliver.
+function callerInputBindings(callerWorkflow, callerJob, specifications) {
+  const supplied = object(callerJob.with);
+  const dispatchInputs = object(at(callerWorkflow, "on", "workflow_dispatch", "inputs"));
+  const bindings = new Map();
+  for (const [name, specification] of specifications) {
+    const domain = specification.boolean ? [true, false] : ["", "supplied-by-dispatch"];
+    if (!(name in supplied)) {
+      bindings.set(name, { fixed: true, values: [specification.default] });
+      continue;
+    }
+    const value = supplied[name];
+    if (typeof value !== "string") {
+      bindings.set(name, { fixed: true, values: [value] });
+      continue;
+    }
+    if (!value.includes("${{")) {
+      bindings.set(name, { fixed: true, values: [value] });
+      continue;
+    }
+    const forwarded = value.match(dispatchForwardedPattern);
+    if (forwarded !== null && forwarded[1] in dispatchInputs) {
+      bindings.set(name, { fixed: false, values: domain });
+      continue;
+    }
+    bindings.set(name, { fixed: false, values: domain });
+  }
+  return bindings;
+}
+
+// Enumerate every value the named caller can produce for the identifiers the
+// condition reads, and report whether any of them makes the step run.
+function conditionIsSatisfiable(condition, bindings, extraDomains) {
+  let identifiers;
+  try {
+    identifiers = [...new Set(tokenizeCondition(condition).filter(token =>
+      token.includes(".")))];
+  } catch {
+    return { satisfiable: false, reason: "condition syntax is not evaluable" };
+  }
+  const domains = [];
+  for (const identifier of identifiers) {
+    if (identifier in extraDomains) {
+      domains.push([identifier, extraDomains[identifier]]);
+      continue;
+    }
+    if (!identifier.startsWith("inputs.")) {
+      return { satisfiable: false, reason: `${identifier} is not a caller-bound input` };
+    }
+    const binding = bindings.get(identifier.slice("inputs.".length));
+    if (binding === undefined) {
+      return { satisfiable: false, reason: `${identifier} is not a declared input` };
+    }
+    domains.push([identifier, binding.values]);
+  }
+  const assignment = new Map();
+  const search = (index) => {
+    if (index === domains.length) {
+      try {
+        return evaluateCondition(condition, name => {
+          if (!assignment.has(name)) throw new Error(`unbound ${name}`);
+          return assignment.get(name);
+        });
+      } catch {
+        return false;
+      }
+    }
+    const [identifier, values] = domains[index];
+    for (const value of values) {
+      assignment.set(identifier, value);
+      if (search(index + 1)) return true;
+    }
+    return false;
+  };
+  return search(0)
+    ? { satisfiable: true, reason: "" }
+    : { satisfiable: false, reason: "no caller dispatch satisfies the condition" };
+}
+
 function requireNoCalibrationReferences(violations, file, workflow) {
   add(
     violations,
@@ -2233,6 +2442,22 @@ function expectedPostPublishRows() {
   ];
 }
 
+// The asset targets the default (full) scope actually builds. A step gated on
+// matrix.asset_target is only reachable while its target survives here.
+function packageMatrixAssetTargets(expression) {
+  const match = typeof expression === "string" && expression.match(
+    /\|\| '([^']+)'\) \}\}$/u,
+  );
+  if (!match) return [];
+  try {
+    return list(object(JSON.parse(match[1])).include)
+      .map(row => object(row).asset_target)
+      .filter(target => typeof target === "string");
+  } catch {
+    return [];
+  }
+}
+
 function validatePackageMatrixExpression(violations, expression, graph) {
   const match = typeof expression === "string" && expression.match(
     /fromJSON\(inputs\.calibration_mode && '([^']+)' \|\| inputs\.scope == 'linux' && '([^']+)' \|\| inputs\.scope == 'windows' && '([^']+)' \|\| inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\)/u,
@@ -2742,11 +2967,16 @@ function validatePackagedProof(workflows, violations, graph) {
       === "matrix.asset_target == 'linux-x64' && (inputs.calibration_mode || inputs.quality_evidence_artifact != '')",
     `${file} qualification driver must skip the standard server-behavior path`,
   );
+  // The calibration bundle -- not the optional release-evidence packet -- is
+  // what these steps consume, and the frozen-candidate coordinator is forbidden
+  // to pass release evidence at all. Gating them on quality evidence made the
+  // whole frozen branch unreachable; gating them on the bundle they download is
+  // what the freeze lineage proof below needs to run.
   requireCalibrationProducerBoundary(
     violations,
     file,
     job,
-    "matrix.asset_target == 'linux-x64' && !inputs.calibration_mode && inputs.quality_evidence_artifact != ''",
+    "matrix.asset_target == 'linux-x64' && !inputs.calibration_mode && inputs.calibration_bundle_artifact != ''",
   );
   requireStepRun(
     violations,
@@ -2777,30 +3007,99 @@ function validatePackagedProof(workflows, violations, graph) {
     job,
     "Packaged per-user server calibration or qualification",
   );
-  // The calibration-to-package source-lineage guard exists only when this flag
-  // reaches the frozen invocation. Without it the packaged release can ship a
-  // constant set measured on a materially different tree, so pin the flag to
-  // the hosted_package call rather than anywhere in the step, and keep the
-  // build checkout deep enough for the ancestor and diff probes it performs.
-  const packagedProofExecutable = executableRunText(packagedProofRun);
-  const frozenInvocationIndex = packagedProofExecutable
-    .indexOf("--proof-tier hosted_package");
+  // The full frozen hosted_package qualification also carries the flag, and
+  // must keep carrying it, but it cannot run: --produce-qualification-evidence
+  // hard-requires the exact-head release-evidence packet at any non-calibration
+  // tier, and every caller of this workflow is pinned to pass no release
+  // evidence. That invocation is therefore a latent contract, not the live
+  // guard. Pin the flag to the hosted_package invocation itself -- the same
+  // logical command, so a decoy line after it does not count.
+  requireFlagOnInvocation(
+    violations,
+    `${file} frozen packaged qualification must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed`,
+    packagedProofRun,
+    "--proof-tier hosted_package",
+    "--enforce-calibration-freeze-lineage",
+  );
+  // The live guard. --version-only stops before the runtime proof, so it needs
+  // no release evidence and no qualification driver, but it still loads and
+  // verifies the authenticated calibration bundle -- and without the
+  // enforcement flag a version-only proof rejects calibration inputs outright,
+  // so removing the flag breaks this step loudly instead of disabling the
+  // guard. `check-packaged-agent-proof.py --self-test` proves both directions.
+  const lineageStepName = "Prove frozen calibration source lineage";
+  const lineageProof = namedStep(job, lineageStepName);
+  requireStepRun(violations, file, job, lineageStepName, [
+    'test "$(jq -r .status crates/codestory-llama-sys/per-user-embedding-server-constant-set.json)" = frozen',
+    "calibration-bundle.json",
+    '--calibration-bundle "$calibration_bundle"',
+    "--calibration-producer-run-id",
+    "--calibration-producer-artifact",
+    "--proof-tier hosted_package",
+    "--version-only",
+    '--expected-source-sha "$SOURCE_SHA"',
+    '--expected-source-tree "$SOURCE_TREE"',
+    "--enforce-calibration-freeze-lineage",
+  ]);
+  requireFlagOnInvocation(
+    violations,
+    `${file} ${lineageStepName} must pass --enforce-calibration-freeze-lineage on the invocation that reads the calibration bundle`,
+    stepRun(job, lineageStepName),
+    "--calibration-bundle",
+    "--enforce-calibration-freeze-lineage",
+  );
   add(
     violations,
-    frozenInvocationIndex >= 0
-      && occurrenceCount(
-        packagedProofExecutable,
-        "--enforce-calibration-freeze-lineage",
-      ) === 1
-      && packagedProofExecutable
-        .slice(frozenInvocationIndex)
-        .includes("--enforce-calibration-freeze-lineage"),
-    `${file} frozen packaged qualification must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed`,
+    lineageProof?.shell === "bash"
+      && object(lineageProof?.env).SOURCE_SHA === "${{ steps.source-identity.outputs.sha }}"
+      && object(lineageProof?.env).SOURCE_TREE === "${{ steps.source-identity.outputs.tree }}"
+      && object(lineageProof?.env).CALIBRATION_ARTIFACT
+        === "${{ inputs.calibration_bundle_artifact }}"
+      && object(lineageProof?.env).CALIBRATION_RUN_ID
+        === "${{ inputs.calibration_bundle_run_id }}",
+    `${file} ${lineageStepName} must bind the verified source identity and the authenticated producer`,
   );
   add(
     violations,
     object(namedStep(job, "Checkout")?.with)["fetch-depth"] === 0,
     `${file} package build must keep full history for the calibration freeze lineage probe`,
+  );
+  // Reachability, not presence. A flag on a step no caller can reach is the
+  // vacuous guard this check exists to prevent, so evaluate the step's own
+  // condition against the bindings the frozen-candidate coordinator passes and
+  // require some real dispatch of it to run the step.
+  const coordinatorFile = "packaged-platform-pr.yml";
+  const coordinator = workflows.get(coordinatorFile);
+  const coordinatorPackaged = object(at(coordinator, "jobs", "packaged-proof"));
+  const bindings = callerInputBindings(
+    object(coordinator),
+    coordinatorPackaged,
+    calleeInputSpecifications(workflow),
+  );
+  const fullScopeTargets = packageMatrixAssetTargets(
+    at(workflow, "jobs", "build", "strategy", "matrix"),
+  );
+  for (const [stepName, stepValue] of [
+    [lineageStepName, lineageProof],
+    ["Authenticate calibration bundle producer", namedStep(job, "Authenticate calibration bundle producer")],
+    ["Download frozen calibration bundle", namedStep(job, "Download frozen calibration bundle")],
+  ]) {
+    const reachability = conditionIsSatisfiable(
+      String(stepValue?.if ?? "false"),
+      bindings,
+      { "matrix.asset_target": fullScopeTargets },
+    );
+    add(
+      violations,
+      reachability.satisfiable,
+      `${file} step ${stepName} must be reachable from a ${coordinatorFile} frozen-candidate dispatch: ${reachability.reason}`,
+    );
+  }
+  add(
+    violations,
+    bindings.get("calibration_bundle_artifact")?.fixed === false
+      && bindings.get("calibration_bundle_run_id")?.fixed === false,
+    `${coordinatorFile} packaged proof must forward the dispatched calibration bundle identity so the freeze lineage guard can run`,
   );
   const hostedCalibrationUpload = namedStep(job, "Upload hosted Linux calibration runs");
   add(

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -760,6 +760,58 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
     ["package build loses the history the freeze lineage probe reads", packagedProofFile, workflow => {
       draftStep(workflow.jobs.build, "Checkout").with["fetch-depth"] = 1;
     }, /package build must keep full history for the calibration freeze lineage probe/u],
+    // A flag pinned only by "appears after this anchor" is defeated by parking a
+    // copy on a later decoy line while the real invocation loses it. Both freeze
+    // lineage pins read the single backslash-continued command instead.
+    ["freeze lineage flag parked on a decoy after the frozen invocation", packagedProofFile, workflow => {
+      const step = draftStep(
+        workflow.jobs.build,
+        "Packaged per-user server calibration or qualification",
+      );
+      const stripped = step.run.replace("  --enforce-calibration-freeze-lineage \\\n", "");
+      assert.notEqual(stripped, step.run, "freeze lineage flag was already absent");
+      step.run = `${stripped}echo skipping python .github/scripts/check-packaged-agent-proof.py \\\n  --enforce-calibration-freeze-lineage \\\n  --out-dir target/decoy\n`;
+    }, /must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed/u],
+    ["reachable lineage proof stops enforcing the freeze lineage", packagedProofFile, workflow => {
+      const step = draftStep(workflow.jobs.build, "Prove frozen calibration source lineage");
+      const removed = step.run.replace("  --enforce-calibration-freeze-lineage \\\n", "");
+      assert.notEqual(removed, step.run, "freeze lineage flag was already absent");
+      step.run = removed;
+    }, /must pass --enforce-calibration-freeze-lineage on the invocation that reads the calibration bundle/u],
+    ["reachable lineage proof parks the flag on a decoy", packagedProofFile, workflow => {
+      const step = draftStep(workflow.jobs.build, "Prove frozen calibration source lineage");
+      const stripped = step.run.replace("  --enforce-calibration-freeze-lineage \\\n", "");
+      assert.notEqual(stripped, step.run, "freeze lineage flag was already absent");
+      step.run = `${stripped}echo skipping python .github/scripts/check-packaged-agent-proof.py \\\n  --enforce-calibration-freeze-lineage \\\n  --out-dir target/decoy\n`;
+    }, /must pass --enforce-calibration-freeze-lineage on the invocation that reads the calibration bundle/u],
+    ["reachable lineage proof stops binding the verified source identity", packagedProofFile, workflow => {
+      delete draftStep(workflow.jobs.build, "Prove frozen calibration source lineage").env.SOURCE_SHA;
+    }, /must bind the verified source identity and the authenticated producer/u],
+    ["reachable lineage proof is removed entirely", packagedProofFile, workflow => {
+      workflow.jobs.build.steps = workflow.jobs.build.steps
+        .filter(({ name }) => name !== "Prove frozen calibration source lineage");
+    }, /must contain named step Prove frozen calibration source lineage/u],
+    // Reachability, not presence. Each of these leaves the flag exactly where it
+    // is and only makes the step impossible to reach from the frozen-candidate
+    // coordinator -- which is how the guard went dark the first time.
+    ["lineage proof re-gated on the release evidence its caller cannot pass", packagedProofFile, workflow => {
+      const step = draftStep(workflow.jobs.build, "Prove frozen calibration source lineage");
+      step.if = `${step.if} && inputs.quality_evidence_artifact != ''`;
+    }, /Prove frozen calibration source lineage must be reachable from a packaged-platform-pr\.yml frozen-candidate dispatch/u],
+    ["lineage proof re-gated onto the unfrozen calibration collection", packagedProofFile, workflow => {
+      draftStep(workflow.jobs.build, "Prove frozen calibration source lineage").if
+        = "matrix.asset_target == 'linux-x64' && inputs.calibration_mode && inputs.calibration_bundle_artifact != ''";
+    }, /Prove frozen calibration source lineage must be reachable from a packaged-platform-pr\.yml frozen-candidate dispatch/u],
+    ["lineage proof moved onto a package cell the matrix never builds", packagedProofFile, workflow => {
+      const step = draftStep(workflow.jobs.build, "Prove frozen calibration source lineage");
+      step.if = step.if.replace("linux-x64", "linux-arm64");
+    }, /Prove frozen calibration source lineage must be reachable from a packaged-platform-pr\.yml frozen-candidate dispatch/u],
+    ["frozen-candidate coordinator stops forwarding the calibration bundle", packagedCoordinatorFile, workflow => {
+      workflow.jobs["packaged-proof"].with.calibration_bundle_artifact = "";
+    }, /Prove frozen calibration source lineage must be reachable from a packaged-platform-pr\.yml frozen-candidate dispatch/u],
+    ["frozen-candidate coordinator stops forwarding the producer run", packagedCoordinatorFile, workflow => {
+      workflow.jobs["packaged-proof"].with.calibration_bundle_run_id = "";
+    }, /packaged proof must forward the dispatched calibration bundle identity so the freeze lineage guard can run/u],
     ["package evaluation downloads calibration on the standard path", packagedProofFile, workflow => {
       draftStep(workflow.jobs.build, "Authenticate calibration bundle producer").if
         = "matrix.asset_target == 'linux-x64'";

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -734,6 +734,32 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
       );
       step.if = "matrix.asset_target == 'linux-x64'";
     }, /packaged-platform-proof\.yml/u],
+    ["frozen qualification stops enforcing the calibration freeze lineage", packagedProofFile, workflow => {
+      const step = draftStep(
+        workflow.jobs.build,
+        "Packaged per-user server calibration or qualification",
+      );
+      const removed = step.run.replace("  --enforce-calibration-freeze-lineage \\\n", "");
+      assert.notEqual(removed, step.run, "freeze lineage flag was already absent");
+      step.run = removed;
+    }, /must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed/u],
+    ["freeze lineage enforcement moves onto the unfrozen calibration invocation", packagedProofFile, workflow => {
+      const step = draftStep(
+        workflow.jobs.build,
+        "Packaged per-user server calibration or qualification",
+      );
+      const moved = step.run
+        .replace("  --enforce-calibration-freeze-lineage \\\n", "")
+        .replace(
+          "      --proof-tier calibration \\\n",
+          "      --proof-tier calibration \\\n      --enforce-calibration-freeze-lineage \\\n",
+        );
+      assert.match(moved, /--proof-tier calibration \\\n\s+--enforce-calibration-freeze-lineage/u);
+      step.run = moved;
+    }, /must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed/u],
+    ["package build loses the history the freeze lineage probe reads", packagedProofFile, workflow => {
+      draftStep(workflow.jobs.build, "Checkout").with["fetch-depth"] = 1;
+    }, /package build must keep full history for the calibration freeze lineage probe/u],
     ["package evaluation downloads calibration on the standard path", packagedProofFile, workflow => {
       draftStep(workflow.jobs.build, "Authenticate calibration bundle producer").if
         = "matrix.asset_target == 'linux-x64'";

--- a/.github/scripts/packaged_agent_proof/calibration_lineage.py
+++ b/.github/scripts/packaged_agent_proof/calibration_lineage.py
@@ -9,6 +9,24 @@ from pathlib import Path
 from .contract_primitives import require_nonempty_string
 from .foundation import require
 
+# The single file a freeze commit is allowed to write between the tree that was
+# calibrated and the tree that is packaged.
+CONSTANT_SET_FREEZE_PATH = (
+    "crates/codestory-llama-sys/per-user-embedding-server-constant-set.json"
+)
+# Enforcing the freeze lineage decides the release sequencing: because the
+# freeze commit must be the only commit between calibration and the package,
+# the version bump cannot follow calibration. Every failure below repeats this
+# so a CI reader can act without opening this file.
+REQUIRED_RELEASE_ORDERING = (
+    "required release ordering is bump-then-calibrate: bump the version first "
+    "(node scripts/bump-version.mjs --version <version>), calibrate on the "
+    "bumped tree, then land the constant-set freeze commit as the only commit "
+    f"between calibration and the packaged release ({CONSTANT_SET_FREEZE_PATH} "
+    "is the only file it may write). A calibrate-then-bump ordering fails here: "
+    "move the bump ahead of calibration and recalibrate on the bumped tree"
+)
+
 
 def verify_calibration_source_lineage(
     calibration_source: dict,
@@ -43,11 +61,20 @@ def verify_calibration_source_lineage(
             capture_output=True,
             timeout=30,
         )
+        # `require`'s message argument is evaluated before the call, so the
+        # detail must not itself be a contract that a *successful* probe can
+        # violate. `git diff --name-only` legitimately prints nothing when the
+        # two trees are identical, and demanding non-empty output here replaced
+        # the actionable drift message below with "Git lineage failure must be a
+        # non-empty string".
         require(
             completed.returncode == 0,
             "calibration source-lineage probe failed: "
             + require_nonempty_string(
-                completed.stderr.strip() or completed.stdout.strip(),
+                completed.stderr.strip()
+                or completed.stdout.strip()
+                or f"git {' '.join(arguments)} exited {completed.returncode} "
+                "without output",
                 "Git lineage failure",
             ),
         )
@@ -77,7 +104,11 @@ def verify_calibration_source_lineage(
     )
     require(
         completed.returncode == 0,
-        "calibration source is not an ancestor of the frozen package source",
+        "calibration source "
+        f"{calibration_source['commit']} is not an ancestor of the frozen "
+        f"package source {frozen_source['commit']}; the packaged tree was not "
+        "grown from the calibrated tree, so the frozen constants were never "
+        f"measured on what ships. The {REQUIRED_RELEASE_ORDERING}.",
     )
     changed_paths = [
         path
@@ -89,10 +120,24 @@ def verify_calibration_source_lineage(
         ).splitlines()
         if path
     ]
+    offending_paths = [
+        path for path in changed_paths if path != CONSTANT_SET_FREEZE_PATH
+    ]
     require(
-        changed_paths
-        == ["crates/codestory-llama-sys/per-user-embedding-server-constant-set.json"],
-        "post-calibration source drift exceeded the one allowed constant-set freeze file",
+        changed_paths == [CONSTANT_SET_FREEZE_PATH],
+        "post-calibration source drift exceeded the one allowed constant-set "
+        "freeze file: "
+        + (
+            "offending changed paths between calibration "
+            f"{calibration_source['commit']} and packaged "
+            f"{frozen_source['commit']}: " + ", ".join(offending_paths)
+            if offending_paths
+            else "the packaged source did not add the required "
+            f"{CONSTANT_SET_FREEZE_PATH} freeze commit "
+            f"(no path changed between calibration {calibration_source['commit']} "
+            f"and packaged {frozen_source['commit']})"
+        )
+        + f". The {REQUIRED_RELEASE_ORDERING}.",
     )
     return {
         "selection_commit": calibration_source["commit"],

--- a/.github/scripts/packaged_agent_proof/self_test.py
+++ b/.github/scripts/packaged_agent_proof/self_test.py
@@ -1,5 +1,6 @@
 """Owner-oriented packaged-proof self-test aggregation."""
 
+from .self_test_calibration_lineage import run_calibration_lineage_self_tests
 from .self_test_cli import run_cli_self_tests
 from .self_test_contracts import run_contract_self_tests
 from .self_test_full_stack import run_full_stack_self_tests
@@ -14,6 +15,7 @@ from .self_test_server_idle import run_idle_boundary_self_tests
 
 def self_test() -> None:
     run_cli_self_tests()
+    run_calibration_lineage_self_tests()
     run_contract_self_tests()
     run_process_self_tests()
     run_producer_liveness_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_calibration_lineage.py
+++ b/.github/scripts/packaged_agent_proof/self_test_calibration_lineage.py
@@ -1,0 +1,265 @@
+"""Self-tests for the calibration-to-package source lineage guard.
+
+``verify_calibration_source_lineage`` is the strongest binding the calibration
+freeze has: the calibrated commit must be an ancestor of the packaged commit and
+the freeze file must be the only path that differs. Until the guard was turned
+on in CI nothing exercised it -- every caller in the tree passed
+``enforce_source_lineage=False`` -- so it could have been deleted, inverted, or
+quietly weakened without one test objecting. These tests build real throwaway Git
+histories and drive the guard directly, in both directions, including the
+calibrate-then-bump ordering that the enabled guard now rejects.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+
+from .calibration_lineage import (
+    CONSTANT_SET_FREEZE_PATH,
+    verify_calibration_source_lineage,
+)
+from .foundation import ProofFailure, require
+
+CARGO_MANIFEST_PATH = "crates/codestory-cli/Cargo.toml"
+_GIT_ENVIRONMENT = {
+    "GIT_AUTHOR_NAME": "CodeStory Proof",
+    "GIT_AUTHOR_EMAIL": "proof@codestory.invalid",
+    "GIT_COMMITTER_NAME": "CodeStory Proof",
+    "GIT_COMMITTER_EMAIL": "proof@codestory.invalid",
+    "GIT_AUTHOR_DATE": "2026-01-01T00:00:00+00:00",
+    "GIT_COMMITTER_DATE": "2026-01-01T00:00:00+00:00",
+    # A developer's global signing or hook configuration must not decide whether
+    # this fixture repository can commit.
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+}
+
+
+def _git(root: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", *arguments],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        timeout=60,
+        env={**os.environ, **_GIT_ENVIRONMENT},
+    )
+    require(
+        completed.returncode == 0,
+        f"calibration lineage self-test git {' '.join(arguments)} failed: "
+        + (completed.stderr.strip() or completed.stdout.strip() or "no output"),
+    )
+    return completed.stdout.strip()
+
+
+def _write(root: Path, relative: str, text: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _constant_set(status: str) -> str:
+    return json.dumps({"status": status}, indent=2) + "\n"
+
+
+def _cargo_manifest(version: str) -> str:
+    return f'[package]\nname = "codestory-cli"\nversion = "{version}"\n'
+
+
+def _commit(root: Path, message: str, *, allow_empty: bool = False) -> dict:
+    _git(root, "add", "-A")
+    arguments = ["commit", "--no-verify", "-q", "-m", message]
+    if allow_empty:
+        arguments.insert(1, "--allow-empty")
+    _git(root, *arguments)
+    return {
+        "commit": _git(root, "rev-parse", "HEAD"),
+        "tree": _git(root, "rev-parse", "HEAD^{tree}"),
+        "tracked_dirty": False,
+    }
+
+
+def _reject(
+    label: str,
+    fragments: Iterable[str],
+    calibration_source: dict,
+    frozen_source: dict,
+    root: Path,
+) -> None:
+    try:
+        verify_calibration_source_lineage(calibration_source, frozen_source, root)
+    except ProofFailure as failure:
+        message = str(failure)
+        for fragment in fragments:
+            require(
+                fragment in message,
+                f"{label} rejection message omitted {fragment!r}: {message}",
+            )
+    else:
+        raise ProofFailure(
+            f"{label} was accepted by the calibration source-lineage guard"
+        )
+
+
+def _build_calibration_history(root: Path) -> dict:
+    _git(root, "-c", "init.defaultBranch=main", "init", "-q")
+    _write(root, "README.md", "calibration lineage fixture\n")
+    _write(root, CARGO_MANIFEST_PATH, _cargo_manifest("0.16.1"))
+    _write(root, CONSTANT_SET_FREEZE_PATH, _constant_set("unfrozen"))
+    return _commit(root, "calibrated tree")
+
+
+def _accepts_the_single_freeze_commit(root: Path, calibration: dict) -> dict:
+    _write(root, CONSTANT_SET_FREEZE_PATH, _constant_set("frozen"))
+    frozen = _commit(root, "freeze the constant set")
+    lineage = verify_calibration_source_lineage(calibration, frozen, root)
+    require(
+        lineage
+        == {
+            "selection_commit": calibration["commit"],
+            "frozen_commit": frozen["commit"],
+            "allowed_changed_paths": [CONSTANT_SET_FREEZE_PATH],
+        },
+        "the one allowed constant-set freeze commit was not accepted intact",
+    )
+    return frozen
+
+
+def _rejects_identity_and_checkout_drift(
+    root: Path,
+    calibration: dict,
+    frozen: dict,
+) -> None:
+    _reject(
+        "a dirty packaged source tree",
+        ["frozen package source tree was dirty"],
+        calibration,
+        {**frozen, "tracked_dirty": True},
+        root,
+    )
+    _reject(
+        "an inexact calibration source identity",
+        ["calibration source identity is not an exact Git commit and tree"],
+        {**calibration, "commit": "not-a-commit"},
+        frozen,
+        root,
+    )
+    _reject(
+        "a package that added no freeze commit at all",
+        ["frozen package did not add the required constant-set freeze commit"],
+        frozen,
+        frozen,
+        root,
+    )
+    _reject(
+        "a packaged source the verification checkout does not hold",
+        ["verification checkout does not match the frozen package source"],
+        calibration,
+        {**frozen, "tree": calibration["tree"]},
+        root,
+    )
+    _reject(
+        "a calibration tree that its own commit does not resolve to",
+        ["calibration commit does not resolve to the recorded calibration tree"],
+        {**calibration, "tree": frozen["tree"]},
+        frozen,
+        root,
+    )
+
+
+def _rejects_calibrate_then_bump(root: Path, calibration: dict) -> None:
+    """The sequencing decision the enabled guard makes for the release runbook.
+
+    Calibrating first and bumping the version afterwards puts a second commit
+    between the calibrated tree and the packaged tree, so the frozen constants
+    were measured on a tree that is not the one shipping. The guard must reject
+    it, and the message must name the offending path and the required ordering
+    so a release operator can act from the CI log alone.
+    """
+    _git(root, "checkout", "-q", "-b", "calibrate-then-bump", calibration["commit"])
+    _write(root, CARGO_MANIFEST_PATH, _cargo_manifest("0.16.2"))
+    _commit(root, "bump the version after calibration")
+    _write(root, CONSTANT_SET_FREEZE_PATH, _constant_set("frozen"))
+    bumped_after_calibration = _commit(root, "freeze the constant set")
+    _reject(
+        "a version bump landing after calibration",
+        [
+            "post-calibration source drift exceeded the one allowed constant-set "
+            "freeze file",
+            CARGO_MANIFEST_PATH,
+            "bump-then-calibrate",
+            "recalibrate on the bumped tree",
+        ],
+        calibration,
+        bumped_after_calibration,
+        root,
+    )
+    require(
+        CONSTANT_SET_FREEZE_PATH
+        in _git(
+            root,
+            "diff",
+            "--name-only",
+            calibration["commit"],
+            bumped_after_calibration["commit"],
+        ),
+        "the calibrate-then-bump fixture did not also land the freeze file",
+    )
+
+
+def _rejects_missing_freeze_and_unrelated_history(
+    root: Path,
+    frozen: dict,
+) -> None:
+    _git(root, "checkout", "-q", "main")
+    empty_freeze = _commit(root, "package without freezing anything", allow_empty=True)
+    _reject(
+        "a packaged commit that changed no path at all",
+        [
+            "post-calibration source drift exceeded the one allowed constant-set "
+            "freeze file",
+            "did not add the required",
+            CONSTANT_SET_FREEZE_PATH,
+            "bump-then-calibrate",
+        ],
+        frozen,
+        empty_freeze,
+        root,
+    )
+    _git(root, "reset", "-q", "--hard", frozen["commit"])
+    _git(root, "checkout", "-q", "--orphan", "unrelated")
+    _write(root, "unrelated.txt", "measured somewhere else entirely\n")
+    unrelated = _commit(root, "calibrate on unrelated history")
+    _git(root, "checkout", "-q", "main")
+    require(
+        _git(root, "rev-parse", "HEAD") == frozen["commit"],
+        "the lineage fixture lost its frozen checkout",
+    )
+    _reject(
+        "calibration measured on unrelated history",
+        [
+            "is not an ancestor of the frozen package source",
+            unrelated["commit"],
+            frozen["commit"],
+            "bump-then-calibrate",
+        ],
+        unrelated,
+        frozen,
+        root,
+    )
+
+
+def run_calibration_lineage_self_tests() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw) / "calibration-lineage"
+        root.mkdir(parents=True)
+        calibration = _build_calibration_history(root)
+        frozen = _accepts_the_single_freeze_commit(root, calibration)
+        _rejects_identity_and_checkout_drift(root, calibration, frozen)
+        _rejects_calibrate_then_bump(root, calibration)
+        _rejects_missing_freeze_and_unrelated_history(root, frozen)

--- a/.github/scripts/packaged_agent_proof/self_test_calibration_lineage.py
+++ b/.github/scripts/packaged_agent_proof/self_test_calibration_lineage.py
@@ -12,6 +12,7 @@ calibrate-then-bump ordering that the enabled guard now rejects.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import subprocess
@@ -19,11 +20,12 @@ import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 
+from . import archive_proof
 from .calibration_lineage import (
     CONSTANT_SET_FREEZE_PATH,
     verify_calibration_source_lineage,
 )
-from .foundation import ProofFailure, require
+from .foundation import REPOSITORY_ROOT, ProofFailure, require
 
 CARGO_MANIFEST_PATH = "crates/codestory-cli/Cargo.toml"
 _GIT_ENVIRONMENT = {
@@ -254,6 +256,141 @@ def _rejects_missing_freeze_and_unrelated_history(
     )
 
 
+_PROBE_MANIFEST = {
+    "source": {"commit": "a" * 40, "tree": "b" * 40, "tracked_dirty": False},
+    "asset_target": "linux-x64",
+    "release_version": "0.0.0",
+}
+_PROBE_CONTRACT = {
+    "constant_set": {},
+    "protocol_sha256": "protocol",
+    "constant_set_sha256": "constants",
+    "measurement_protocol_sha256": "measurement",
+}
+
+
+def _lineage_probe_arguments(**overrides: object) -> argparse.Namespace:
+    """The exact argument shape the packaged proof lineage step dispatches."""
+    values: dict[str, object] = {
+        "archive": Path("archive.tar.gz"),
+        "checksum_file": Path("SHA256SUMS.txt"),
+        "expected_version": "0.0.0",
+        "expected_source_sha": "a" * 40,
+        "expected_source_tree": "b" * 40,
+        "measurement_protocol": Path("measurement-protocol.json"),
+        "out_dir": Path("target/packaged-calibration-lineage"),
+        "project": None,
+        "engine_policy": None,
+        "offline": False,
+        "version_only": True,
+        "proof_tier": "hosted_package",
+        "server_behavior_only": False,
+        "ground_only": False,
+        "produce_qualification_evidence": False,
+        "qualification_evidence": None,
+        "retrieval_quality_evidence": None,
+        "enforce_calibration_freeze_lineage": True,
+        "calibration_bundle": Path("calibration-bundle.json"),
+        "calibration_producer_run_id": "1234567890",
+        "calibration_producer_artifact": "embedding-calibration-bundle-" + "c" * 40,
+        "timeout_secs": 1800,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _run_lineage_probe(args: argparse.Namespace) -> dict:
+    """Run the real proof pipeline with only archive and CLI layers stubbed.
+
+    Everything the lineage step depends on -- the frozen-contract requirement,
+    the calibration bundle load, and the enforcement flag reaching
+    ``verify_calibration_bundle`` -- stays real. Unpacking a synthetic archive
+    and executing a packaged binary do not, because neither decides whether the
+    guard runs.
+    """
+    observed: dict = {}
+    originals: dict = {}
+
+    def stub(name: str, value: object) -> None:
+        originals[name] = getattr(archive_proof, name)
+        setattr(archive_proof, name, value)
+
+    def record_contracts(manifest, protocol, *, require_frozen):
+        observed["require_frozen"] = require_frozen
+        return _PROBE_CONTRACT
+
+    def record_bundle(path, contract, **kwargs):
+        observed["bundle_verification"] = {"path": path, **kwargs}
+        return {"freeze_digest": "digest", "source_lineage": {"verified": True}}
+
+    stub("unpack_archive", lambda archive, destination: None)
+    stub("find_cli", lambda root: Path("codestory-cli"))
+    stub("load_native_manifest", lambda root, cli, version: _PROBE_MANIFEST)
+    stub("verify_package_source", lambda args, manifest: None)
+    stub("verify_package_server_contracts", record_contracts)
+    stub("verify_calibration_bundle", record_bundle)
+    stub("isolated_environment", lambda root, policy, offline: {})
+    stub("package_summary", lambda *call, **keywords: {"package_contract": {}})
+    stub("write_json", lambda path, payload: None)
+    try:
+        archive_proof.run_archive_proof(args)
+        observed["outcome"] = "accepted"
+    except ProofFailure as failure:
+        observed["outcome"] = str(failure)
+    finally:
+        for name, value in originals.items():
+            setattr(archive_proof, name, value)
+    return observed
+
+
+def _version_only_invocation_enforces_the_lineage() -> None:
+    """Pin the CLI shape the reachable packaged-proof lineage step dispatches.
+
+    The full frozen ``hosted_package`` qualification cannot run without the
+    optional exact-head release-evidence packet, which the frozen-candidate
+    coordinator is forbidden to carry. ``--version-only`` stops before the
+    runtime proof but still loads and verifies the authenticated bundle, so it
+    is the shape that can actually enforce the freeze lineage in CI. If that
+    stops being true this test fails rather than the guard silently going dark.
+    """
+    enforced = _run_lineage_probe(_lineage_probe_arguments())
+    require(
+        enforced["outcome"] == "accepted",
+        f"the version-only lineage invocation was rejected: {enforced['outcome']}",
+    )
+    require(
+        enforced.get("require_frozen") is True,
+        "the version-only lineage invocation stopped requiring a frozen contract",
+    )
+    verification = enforced.get("bundle_verification")
+    require(
+        isinstance(verification, dict)
+        and verification.get("enforce_source_lineage") is True
+        and verification.get("frozen_source") == _PROBE_MANIFEST["source"]
+        and verification.get("repository_root") == REPOSITORY_ROOT
+        and verification.get("expected_producer_run_id") == "1234567890"
+        and verification.get("expected_producer_artifact")
+        == "embedding-calibration-bundle-" + "c" * 40,
+        "the version-only lineage invocation did not enforce the source lineage "
+        f"against the packaged source: {verification}",
+    )
+    # The flag is load-bearing rather than decorative here: dropping it does not
+    # quietly downgrade this step to an unchecked package smoke, it makes the
+    # bundle arguments illegal and the step fails closed.
+    unenforced = _run_lineage_probe(
+        _lineage_probe_arguments(enforce_calibration_freeze_lineage=False)
+    )
+    require(
+        unenforced["outcome"] == "qualification proof rejects calibration inputs",
+        "a version-only proof accepted calibration inputs without enforcing the "
+        f"freeze lineage: {unenforced['outcome']}",
+    )
+    require(
+        "bundle_verification" not in unenforced,
+        "an unenforced version-only proof still verified the calibration bundle",
+    )
+
+
 def run_calibration_lineage_self_tests() -> None:
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw) / "calibration-lineage"
@@ -263,3 +400,4 @@ def run_calibration_lineage_self_tests() -> None:
         _rejects_identity_and_checkout_drift(root, calibration, frozen)
         _rejects_calibrate_then_bump(root, calibration)
         _rejects_missing_freeze_and_unrelated_history(root, frozen)
+    _version_only_invocation_enforces_the_lineage()

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
@@ -143,6 +143,25 @@ def _calibration_bundle_tests(
         and calibration_result["matrix_cell_count"] == 2,
         "calibration bundle self-test did not verify the full matrix",
     )
+    require(
+        calibration_result["source_lineage"] is None,
+        "an unenforced verification reported a calibration source lineage",
+    )
+    # The flag must not be inert: with lineage enforcement on and no packaged
+    # source to bind, the freeze has to refuse rather than silently skip the
+    # guard the release workflow now depends on.
+    try:
+        verify_calibration_bundle(
+            calibration_bundle_path,
+            frozen_measurement_contract,
+            enforce_source_lineage=True,
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure(
+            "enforced calibration source lineage was skipped without a packaged source"
+        )
     return CalibrationFixture(
         bundle_path=calibration_bundle_path,
         bundle_payload=calibration_bundle_payload,

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -807,10 +807,14 @@ jobs:
           path: target/release-quality-evidence
 
       - name: Authenticate calibration bundle producer
+        # Gated on the bundle itself, not on optional release evidence. The
+        # frozen-candidate qualification lane is the only caller that names a
+        # bundle, and it is forbidden from carrying release evidence, so
+        # gating these steps on quality evidence made them unreachable.
         if: >-
           matrix.asset_target == 'linux-x64' &&
           !inputs.calibration_mode &&
-          inputs.quality_evidence_artifact != ''
+          inputs.calibration_bundle_artifact != ''
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -836,13 +840,68 @@ jobs:
         if: >-
           matrix.asset_target == 'linux-x64' &&
           !inputs.calibration_mode &&
-          inputs.quality_evidence_artifact != ''
+          inputs.calibration_bundle_artifact != ''
         uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.calibration_bundle_artifact }}
           path: target/calibration-bundle
           run-id: ${{ inputs.calibration_bundle_run_id }}
           github-token: ${{ github.token }}
+
+      - name: Prove frozen calibration source lineage
+        # This is the reachable half of the freeze proof. The full frozen
+        # hosted_package qualification below additionally requires the optional
+        # exact-head release-evidence packet, which the frozen-candidate
+        # coordinator is forbidden to pass, so that invocation never runs. The
+        # source-lineage guard needs none of that: it needs the authenticated
+        # bundle and full history, both of which the qualification lane has.
+        # --version-only stops before the runtime proof but still loads and
+        # verifies the bundle, and without --enforce-calibration-freeze-lineage
+        # a version-only proof *rejects* calibration inputs outright -- so
+        # deleting the flag breaks this step loudly instead of silently
+        # dropping the guard.
+        if: >-
+          matrix.asset_target == 'linux-x64' &&
+          !inputs.calibration_mode &&
+          inputs.calibration_bundle_artifact != ''
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
+          SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
+          CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
+          CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
+        run: |
+          set -euo pipefail
+          test "$(jq -r .status crates/codestory-llama-sys/per-user-embedding-server-constant-set.json)" = frozen
+          calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
+          test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          python .github/scripts/check-packaged-agent-proof.py \
+            --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.tar.gz" \
+            --checksum-file target/release-dist/SHA256SUMS.txt \
+            --expected-version "$INPUT_VERSION" \
+            --expected-source-sha "$SOURCE_SHA" \
+            --expected-source-tree "$SOURCE_TREE" \
+            --version-only \
+            --proof-tier hosted_package \
+            --calibration-bundle "$calibration_bundle" \
+            --calibration-producer-run-id "$CALIBRATION_RUN_ID" \
+            --calibration-producer-artifact "$CALIBRATION_ARTIFACT" \
+            --enforce-calibration-freeze-lineage \
+            --out-dir target/packaged-calibration-lineage
+
+      - name: Upload frozen calibration lineage proof
+        if: >-
+          always() &&
+          matrix.asset_target == 'linux-x64' &&
+          !inputs.calibration_mode &&
+          inputs.calibration_bundle_artifact != ''
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: packaged-calibration-lineage-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
+          path: target/packaged-calibration-lineage
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: Packaged per-user server calibration or qualification
         if: >-

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -905,6 +905,7 @@ jobs:
             --calibration-bundle "$calibration_bundle" \
             --calibration-producer-run-id "$CALIBRATION_RUN_ID" \
             --calibration-producer-artifact "$CALIBRATION_ARTIFACT" \
+            --enforce-calibration-freeze-lineage \
             --retrieval-quality-evidence "$quality_path" \
             --out-dir target/packaged-agent-proof
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,9 +218,11 @@ adapter to compensate for incorrect upstream state.
   - `plugins/codestory/.github/plugin/plugin.json`
 - Release ordering is **bump-then-calibrate**. Bump the version first,
   calibrate the per-user embedding server on the bumped tree, land the
-  constant-set freeze commit, then package and release. The frozen packaged
-  qualification enforces this: the calibration commit must be an ancestor of the
-  packaged commit and
+  constant-set freeze commit, then package and release. The frozen-candidate
+  `qualification` dispatch enforces this -- it is the only lane that carries a
+  calibration bundle, and its packaged proof runs
+  `Prove frozen calibration source lineage` whenever one arrives: the
+  calibration commit must be an ancestor of the packaged commit and
   `crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` must
   be the only file that differs between them. A calibrate-then-bump ordering
   fails the guard by name; the fix is to move the bump ahead of calibration and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,17 @@ adapter to compensate for incorrect upstream state.
   - `plugins/codestory/.codex-plugin/plugin.json`
   - `plugins/codestory/.claude-plugin/plugin.json`
   - `plugins/codestory/.github/plugin/plugin.json`
+- Release ordering is **bump-then-calibrate**. Bump the version first,
+  calibrate the per-user embedding server on the bumped tree, land the
+  constant-set freeze commit, then package and release. The frozen packaged
+  qualification enforces this: the calibration commit must be an ancestor of the
+  packaged commit and
+  `crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` must
+  be the only file that differs between them. A calibrate-then-bump ordering
+  fails the guard by name; the fix is to move the bump ahead of calibration and
+  recalibrate on the bumped tree, never to widen the allowed path set. Any other
+  commit -- a doc fix, a CI tweak, a rebase -- between calibration and the
+  package also fails, so recalibrate rather than reorder history.
 - Validate release changes with
   `python .github/scripts/check-codestory-release.py --version <version>` and
   `node .github/scripts/check-workflow-policy.mjs`.

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -218,14 +218,21 @@ claim.
 `--proof-tier calibration` may collect draft measurements, but cannot satisfy a
 package, hardware, installed, or release claim. A higher qualification tier
 requires a frozen constant set and a retained qualification record.
-`--proof-tier hosted_package` also passes
+A packaged proof handed an authenticated calibration bundle -- the manually
+dispatched `qualification` frozen-candidate lane -- runs one extra
+`--version-only --proof-tier hosted_package` invocation with
 `--enforce-calibration-freeze-lineage`, which requires the calibration commit to
 be an ancestor of the packaged commit with
 `crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` as the
 only differing path. Release ordering is therefore bump-then-calibrate: bump the
 version, calibrate on the bumped tree, then freeze and release. A
 calibrate-then-bump ordering fails the guard, which names the offending paths
-and the required ordering in its failure message.
+and the required ordering in its failure message. Dropping the flag does not
+weaken that invocation, it breaks it: a `--version-only` proof rejects
+calibration inputs unless the lineage is enforced. The heavier frozen
+`hosted_package` qualification carries the same flag but stays dark while it
+requires the optional release-evidence packet that package proof must not
+depend on.
 `--produce-qualification-evidence` requires the separate
 `codestory-embedding-qualification` driver through `--qualification-driver`.
 The harness passes the exact packaged executable to that driver through

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -218,6 +218,14 @@ claim.
 `--proof-tier calibration` may collect draft measurements, but cannot satisfy a
 package, hardware, installed, or release claim. A higher qualification tier
 requires a frozen constant set and a retained qualification record.
+`--proof-tier hosted_package` also passes
+`--enforce-calibration-freeze-lineage`, which requires the calibration commit to
+be an ancestor of the packaged commit with
+`crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` as the
+only differing path. Release ordering is therefore bump-then-calibrate: bump the
+version, calibrate on the bumped tree, then freeze and release. A
+calibrate-then-bump ordering fails the guard, which names the offending paths
+and the required ordering in its failure message.
 `--produce-qualification-evidence` requires the separate
 `codestory-embedding-qualification` driver through `--qualification-driver`.
 The harness passes the exact packaged executable to that driver through

--- a/docs/testing/per-user-embedding-server-qualification.md
+++ b/docs/testing/per-user-embedding-server-qualification.md
@@ -180,9 +180,25 @@ Frozen calibration bundles are accepted only from a successful
 `workflow_dispatch` run of `packaged-platform-pr.yml` in this repository. Every
 consumer binds the run ID, exact `embedding-calibration-bundle-<source-sha>`
 artifact name, unexpired artifact record, source commit, and bundle producer
-identity before applying the frozen thresholds. The exact
-unfrozen-to-frozen source lineage is checked once at the freeze transition; it
-is not reinterpreted as a requirement for every later package proof.
+identity before applying the frozen thresholds.
+
+The frozen `hosted_package` qualification additionally passes
+`--enforce-calibration-freeze-lineage`, so the exact calibration-to-package
+source lineage is proved rather than assumed: the calibration commit must be an
+ancestor of the packaged commit, the verification checkout must be that packaged
+commit, and
+`crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` must be
+the only path that differs between them. The packaged proof therefore checks out
+full history.
+
+That rule fixes the release ordering to **bump-then-calibrate**: bump the
+version first with `node scripts/bump-version.mjs --version <version>`,
+calibrate on the bumped tree, then land the constant-set freeze commit as the
+only commit between calibration and the packaged release. Calibrating first and
+bumping afterwards puts a second commit in that range, and the guard rejects it
+by name -- the failure lists the offending paths and repeats this ordering. The
+fix is always to move the bump ahead of calibration and recalibrate on the
+bumped tree, never to widen the allowed path set.
 
 Platform proof boundaries:
 

--- a/docs/testing/per-user-embedding-server-qualification.md
+++ b/docs/testing/per-user-embedding-server-qualification.md
@@ -182,14 +182,34 @@ consumer binds the run ID, exact `embedding-calibration-bundle-<source-sha>`
 artifact name, unexpired artifact record, source commit, and bundle producer
 identity before applying the frozen thresholds.
 
-The frozen `hosted_package` qualification additionally passes
-`--enforce-calibration-freeze-lineage`, so the exact calibration-to-package
-source lineage is proved rather than assumed: the calibration commit must be an
-ancestor of the packaged commit, the verification checkout must be that packaged
-commit, and
+The `Prove frozen calibration source lineage` step of
+`packaged-platform-proof.yml` passes `--enforce-calibration-freeze-lineage`, so
+the exact calibration-to-package source lineage is proved rather than assumed:
+the calibration commit must be an ancestor of the packaged commit, the
+verification checkout must be that packaged commit, and
 `crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` must be
 the only path that differs between them. The packaged proof therefore checks out
 full history.
+
+That step runs on every packaged proof that is handed an authenticated
+calibration bundle, which is the manually dispatched `qualification` mode of
+`packaged-platform-pr.yml` -- the frozen-candidate lane. It is a `--version-only`
+invocation: it verifies the package identity, the frozen contract, and the bundle
+with its lineage, and stops before the runtime proof. Without the enforcement
+flag a `--version-only` proof rejects calibration inputs outright, so the flag
+cannot be dropped without the step failing.
+
+The full frozen `hosted_package` qualification in the same workflow carries the
+same flag, but it cannot run today: `--produce-qualification-evidence` requires
+the exact-head release-evidence `packet-runtime-summary.json` at any
+non-calibration tier, and `packaged-platform-pr.yml` is required to pass no
+release evidence to package proof. The `protected_hardware` bundle consumers on
+the Metal, Windows Vulkan, and Linux Vulkan lanes are likewise exempt: on the
+release path they run `--server-behavior-only`, which takes their no-bundle
+branch, and on the coordinator path they carry the same release-evidence
+requirement. The lineage is proved once, on the frozen candidate, and the later
+package proofs consume the already-frozen constant set rather than re-proving how
+it was reached.
 
 That rule fixes the release ordering to **bump-then-calibrate**: bump the
 version first with `node scripts/bump-version.mjs --version <version>`,


### PR DESCRIPTION
Closes #1531

## Context

`verify_calibration_source_lineage` is the strongest binding the calibration freeze has: the calibration
commit must be an ancestor of the packaged commit, and
`crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` must be the only file that differs
between them. It runs only under `enforce_source_lineage=True`, which reaches `archive_proof.py` solely from
`--enforce-calibration-freeze-lineage`. No workflow passed that flag, and no test exercised the guard, so a
frozen constant set could ship against a materially different tree with nothing objecting.

**Correction to the first revision of this PR.** It added the flag to the frozen `hosted_package`
qualification and described the guard as enabled. That was wrong: the flag is correct there, but the step
cannot run. Its condition requires `inputs.quality_evidence_artifact != ''`, and every caller of
`packaged-platform-proof.yml` is pinned to pass none. The guard was re-created in the same vacuous shape
#1531 exists to remove. This revision fixes that.

## Caller trace

`packaged-platform-proof.yml` is `workflow_call:`-only. Two callers:

- **`release.yml:269`** passes no `quality_evidence_artifact`, no `calibration_bundle_artifact`, no
  `calibration_bundle_run_id`; `calibration_mode` defaults false. `check-workflow-policy.mjs` additionally
  *forbids* it receiving the calibration bundle inputs. The release lane deliberately carries no bundle.
- **`packaged-platform-pr.yml:400`** (`packaged-proof`) forwards `calibration_bundle_artifact` and
  `calibration_bundle_run_id` from its own `workflow_dispatch` inputs and hardcodes
  `quality_evidence_artifact: ""`, which `check-workflow-policy.mjs:~3485` requires.

So the lane that carries a calibration bundle is the manually dispatched **`qualification` mode** of
`packaged-platform-pr.yml` -- the frozen-candidate lane (`review-accepted` label, PR into
`dev/codestory-next`, `scope: full`, `hermetic_linux: true`). That is where a release candidate's packaged
proof meets its calibration bundle, and that is where the enforcement now runs.

## Why the flagged invocation cannot be the one that runs

The frozen `hosted_package` invocation passes `--produce-qualification-evidence`. At any non-calibration
tier that path hard-requires `--retrieval-quality-evidence` (`qualification_producer_setup.py:157`);
dropping the producer flag instead requires an existing retained record through `--qualification-evidence`
(`qualification_recording.py:34`). Either way it needs the exact-head release-evidence packet. Making it
reachable therefore means making package proof depend on optional release evidence, which policy explicitly
forbids. **That assertion was not weakened.** The invocation keeps the flag as a latent contract; it is not
the live guard, and the docs now say so.

## What changed

- **`packaged-platform-proof.yml`** gains `Prove frozen calibration source lineage`, gated on
  `matrix.asset_target == 'linux-x64' && !inputs.calibration_mode && inputs.calibration_bundle_artifact != ''`
  -- satisfied exactly by the frozen-candidate dispatch. It runs
  `--version-only --proof-tier hosted_package --calibration-bundle ... --enforce-calibration-freeze-lineage`.
  `--version-only` stops before the runtime proof (so no release evidence, no qualification driver, no
  30-minute run) but still loads and verifies the authenticated bundle, which is where the lineage guard
  lives. Its evidence is uploaded attempt-qualified.
- The `Authenticate calibration bundle producer` and `Download frozen calibration bundle` steps now gate on
  `inputs.calibration_bundle_artifact != ''` instead of on quality evidence -- they download a bundle, so
  the bundle is their precondition. Strictly wider than before: no case that used to run stops running.
- **The flag is load-bearing, not decorative.** Without `--enforce-calibration-freeze-lineage` a
  `--version-only` proof *rejects* calibration inputs outright ("qualification proof rejects calibration
  inputs"), so deleting the flag breaks the step loudly instead of silently disabling the guard. Verified by
  self-test in both directions.
- **`check-workflow-policy.mjs` pins reachability, not presence.** A new condition evaluator parses each
  guarded step's own `if` and enumerates every value the frozen-candidate coordinator can bind its inputs to
  (literal, forwarded dispatch input, or callee default), plus the asset targets the full-scope package
  matrix actually builds. If no dispatch satisfies the condition, that is a violation. Narrowing the `if`,
  re-gating it on release evidence the caller pins empty, moving it to a matrix cell that does not exist, or
  the coordinator ceasing to forward the bundle each fail the checker.
- Both freeze-lineage flag pins now read the single backslash-continued invocation carrying their anchor,
  closing the decoy-line bypass (a copy of the flag parked on a later `echo` line no longer satisfies the
  pin while the real command loses it).
- **`self_test_calibration_lineage.py`** additionally drives the real `archive_proof` pipeline with the
  exact argument shape the new step dispatches, asserting
  `verify_package_server_contracts(require_frozen=True)` and
  `verify_calibration_bundle(enforce_source_lineage=True, frozen_source=<packaged manifest source>,
  repository_root=REPOSITORY_ROOT, ...)`, and that the same shape without the flag fails closed.
- `calibration_lineage.py` failure messages name the offending paths, both commit SHAs, and the required
  ordering. Fixed a latent defect in its `git()` helper: `require`'s message argument is evaluated eagerly
  and demanded non-empty Git output, so a *successful* `git diff --name-only` over identical trees raised
  `"Git lineage failure must be a non-empty string"` instead of the actionable drift message. The checks are
  unchanged.
- Real-Git-history self-tests for the guard itself (accepts the single freeze commit; rejects a dirty
  packaged tree, an inexact identity, a missing freeze commit, a checkout that is not the packaged commit, a
  calibration tree its own commit does not resolve to, calibration on unrelated history, and a version bump
  landing after calibration).
- `AGENTS.md`, `docs/testing/per-user-embedding-server-qualification.md`, and
  `docs/contributors/testing-matrix.md` now say which step enforces the lineage, on which lane, and state
  plainly that the heavier frozen qualification and the three `protected_hardware` bundle consumers do not
  enforce it and why.

## Sequencing decision: bump-then-calibrate

With the rule live on the frozen-candidate lane, nothing may land between calibration and the packaged
candidate except the freeze commit itself, including the version bump. Release order: **bump the version
first, calibrate on the bumped tree, freeze, then release.**

## Still open (reported, not accommodated)

1. **The frozen `hosted_package` qualification and the three `protected_hardware` bundle consumers remain
   dark.** Closing that means deciding whether release closeout consumes the release-evidence packet -- a
   deliberate existing decision (`v0.16 release closeout does not consume that artifact`) that needs its own
   issue, not a quiet policy edit here.
2. **The release lane cannot host this guard.** It carries no calibration bundle by policy. The lineage is
   proved once on the frozen candidate; `release.yml` consumes the already-frozen constant set. Enabling it
   there would require passing a calibration bundle to `release.yml`, which `check-workflow-policy.mjs`
   forbids by name.
3. **`archive_proof.py:163` is vacuous.** `require(not args.enforce_calibration_freeze_lineage or
   require_frozen, ...)` can never fire, because `requires_calibration_bundle` returns `True` whenever the
   flag is set. Left alone here; it fails closed and fixing it is a separate change.
4. **Today's `dev/codestory-next` would fail the guard.** The frozen constant set records
   `selection_source_commit 6b0f4b2e`, and many commits and paths now sit between it and dev head. The drift
   is real -- the frozen constants were measured on a much older tree. Nothing was weakened to make it pass;
   the fix is to recalibrate under the new ordering before the next release.

## Verification

Run from a fresh worktree with `node_modules` symlinked in, on the merge of `origin/dev/codestory-next`.

| Command | Result |
| --- | --- |
| `node .github/scripts/check-workflow-policy.mjs` | pass |
| `node --test .github/scripts/check-workflow-policy.test.mjs` | 691 pass, 0 fail (dev baseline 678) |
| `node scripts/codestory-release-claims.mjs validate` | pass, graph `b21965bc...` (matches dev; unchanged by this PR) |
| `node --test scripts/tests/codestory-release-*.test.mjs` | 109 pass, 0 fail |
| `node .github/scripts/run-actionlint.mjs` | pass |
| `node --test .github/scripts/run-actionlint.test.mjs` | 3 pass, 0 fail |
| `python3 .github/scripts/check-packaged-agent-proof.py --self-test` | pass |
| `node .github/scripts/check-doc-links.mjs` | 75 files, 266 links, pass |

### Both directions

| Mutation | Result |
| --- | --- |
| Keep the new tests, revert `check-workflow-policy.mjs` and `packaged-platform-proof.yml` to dev | 677 pass, **14 fail** -- the 13 named freeze-lineage tests plus the parent suite |
| Re-gate the lineage step on `inputs.quality_evidence_artifact != ''` | policy fails: step "must be reachable from a `packaged-platform-pr.yml` frozen-candidate dispatch" |
| Re-gate the lineage step onto `inputs.calibration_mode` | policy fails, same reachability violation |
| Point the lineage step at a matrix cell that does not exist | policy fails, same reachability violation |
| Coordinator stops forwarding `calibration_bundle_artifact` | policy fails: 3 reachability violations (lineage, authenticate, download) |
| Coordinator stops forwarding `calibration_bundle_run_id` | policy fails: must forward the dispatched calibration bundle identity |
| Remove `linux-x64` from the full package matrix | policy fails: matrix scope changed + 3 reachability violations |
| Remove the flag from the lineage step | policy fails: 2 violations |
| Park the flag on a decoy line after the real invocation (either step) | policy fails -- this bypass passed before |
| Delete the lineage step | policy fails: 14 violations |
| `fetch-depth: 1` on the package build checkout | policy fails |
| `enforce_source_lineage=args....` to `False` in `archive_proof.py` | self-test fails: "the version-only lineage invocation did not enforce the source lineage against the packaged source" |
| Make `--version-only` ignore the enforcement flag in `requires_calibration_bundle` | self-test fails: "the version-only lineage invocation was rejected" (the pre-existing CLI self-test survives this one) |
| Widen the guard to `CONSTANT_SET_FREEZE_PATH in changed_paths` | self-test fails: "a version bump landing after calibration was accepted" |
| Drop the ordering sentence from the failure message | self-test fails: "rejection message omitted 'bump-then-calibrate'" |

Every mutation was reverted and the suites re-run green.

## Risk

No Rust and no job DAG change; `release-claims.json` is untouched and the graph digest matches dev exactly.
The new step runs only when a calibration bundle is supplied, which today is only the manually dispatched
frozen-candidate lane, so no scheduled or PR-triggered job changes shape. It is the same `--version-only`
invocation shape the existing `Smoke packaged release asset` step already runs on that runner, plus the
bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
