### PR TITLE
let each reuse binding declare what it equates

### DIFF
--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "b897679c2255b1b2278d8d5565e72617f34ac2e2c2ff830cd78ddd6e387f6498",
+    "graph_sha256": "b21965bca63639339c307fc516f682a6d1ad246534dd61b931b83a176c0bcc03",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "b897679c2255b1b2278d8d5565e72617f34ac2e2c2ff830cd78ddd6e387f6498",
+        "graph_sha256": "b21965bca63639339c307fc516f682a6d1ad246534dd61b931b83a176c0bcc03",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "b897679c2255b1b2278d8d5565e72617f34ac2e2c2ff830cd78ddd6e387f6498",
+        "graph_sha256": "b21965bca63639339c307fc516f682a6d1ad246534dd61b931b83a176c0bcc03",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "f65cf87fe997450e6434ad1c30fb735b4b9322e0609968d42500e030b81c54dd",
+  "candidate_sha256": "8a18987dd7275da0f3bca2b6199c4613a3c86667d9f950378347c91c9a2a0c22",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "b897679c2255b1b2278d8d5565e72617f34ac2e2c2ff830cd78ddd6e387f6498",
+      "graph_sha256": "b21965bca63639339c307fc516f682a6d1ad246534dd61b931b83a176c0bcc03",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "b897679c2255b1b2278d8d5565e72617f34ac2e2c2ff830cd78ddd6e387f6498",
+      "graph_sha256": "b21965bca63639339c307fc516f682a6d1ad246534dd61b931b83a176c0bcc03",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "b897679c2255b1b2278d8d5565e72617f34ac2e2c2ff830cd78ddd6e387f6498",
+    "graph_sha256": "b21965bca63639339c307fc516f682a6d1ad246534dd61b931b83a176c0bcc03",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -114,11 +114,23 @@
     },
     "native_reuse": "version_only_delta",
     "reuse": {
+      "equation": "Reuse anchors a row to the earlier run and commit it was produced by, so the commit identity is read at the release commit for every binding. Any further identity a reused row would otherwise be held to is checked as written unless the binding declares it below. A binding may declare an identity key only when the binding's own construction determines that key for the evidence being inherited, and an equated key is never dropped: the reused row must still carry the reused commit's own value for it, which the binding is what makes admissible in place of this release's.",
       "bindings": {
-        "source_tree": "Evidence from a prior run is admissible when its producing commit resolves to the identical source tree and is an ancestor of the release commit on the promotion path.",
-        "native_fingerprint": "Accelerator evidence from the previous published release is admissible when the version-normalized native fingerprint (scripts/native-fingerprint.mjs) of both commits is identical: the built inputs differ only by the embedded version string. Packaging and signing always rerun; only accelerator behavior is inherited."
+        "source_tree": {
+          "admits": "Evidence from a prior run is admissible when its producing commit resolves to the identical source tree and is an ancestor of the release commit on the promotion path.",
+          "equates": []
+        },
+        "native_fingerprint": {
+          "admits": "Accelerator evidence from the previous published release is admissible when the reused commit is an ancestor of the release commit and the version-normalized native fingerprint (scripts/native-fingerprint.mjs) of both commits is identical: the built inputs differ only by the embedded version string. Packaging and signing always rerun; only accelerator behavior is inherited.",
+          "equates": [
+            {
+              "identity": "source_tree",
+              "justification": "The fingerprint covers every input that determines the native binary -- crates/**, Cargo.lock, vendor/**, the packaging scripts and the toolchain pins, with the version stamp normalized away -- so an equal fingerprint means the accelerator this evidence exercised is built from identical inputs. The source tree is what that evidence's identity would otherwise be standing in for, and here it is the one thing the two commits are known to differ in, in non-native code the accelerator never runs. Nothing else is equated: the fingerprint says nothing about which repository, which packaged bytes, which host, or which version produced the row, so those stay checked as written."
+            }
+          ]
+        }
       },
-      "verification": "The trusted producer map verifies the binding, the reused run's job success, artifact expiry, and container digest exactly as same-run evidence, and records the reused run, commit, and binding value in the ledger."
+      "verification": "The trusted producer map verifies the binding, the reused run's job success, artifact expiry, and container digest exactly as same-run evidence, and records the reused run, commit, and binding value in the ledger. The closeout re-proves the binding against its own checkout, and re-derives the reused commit's own value for every equated identity, before it reads any reused row at the release identity."
     }
   },
   "exception_policy": {

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -172,23 +172,52 @@ export function deriveTrustedGitIdentity({ repoRoot, expectedSha }) {
   };
 }
 
+/// What each reuse binding's own construction determines, and may therefore equate.
+///
+/// Reuse always reads a reused row's *commit* at the release commit -- that is what anchoring to
+/// the earlier run means. Equating goes further: it lets a reused row keep an identity whose value
+/// differs from this release's, so it may only ever name a key the binding itself determines. The
+/// graph declares which of these keys each binding actually uses (`evidence_policy.reuse.bindings`)
+/// and why; this map is the ceiling, stated next to the proofs that establish it, so a graph edit
+/// alone can never grant an equation no binding proves.
+///
+///   * `source_tree` proves the reused commit resolves to this release's own tree. Nothing needs
+///     substituting: every tree-derived identity a reused row declares is still checkable directly
+///     against this release, and equating one would replace a live check with nothing. Hence [].
+///   * `native_fingerprint` proves the two commits' native build inputs -- crates/**, Cargo.lock,
+///     vendor/**, the packaging scripts, the toolchain pins, version-normalized -- hash equal. That
+///     determines the built accelerator, so accelerator execution evidence transfers across the
+///     source_tree difference the binding exists to tolerate. It determines nothing about the
+///     repository, the packaged bytes, the host, or the version, so none of those may be equated.
+const REUSE_BINDING_EQUATABLE_IDENTITY = Object.freeze({
+  source_tree: Object.freeze([]),
+  native_fingerprint: Object.freeze(["source_tree"]),
+});
+
 /// Verify a reuse binding against the local repository and return its recorded value.
 ///
 /// Both sides of the release ledger need this: the producer proves the binding before it admits
 /// cross-run evidence, and the closeout re-proves it against its own checkout before it anchors a
 /// reused row to the earlier run.
 export function verifyReuseBinding({ binding, repository, releaseCommit, reusedCommit }) {
+  if (!Object.hasOwn(REUSE_BINDING_EQUATABLE_IDENTITY, binding)) {
+    fail(`unknown reuse binding ${binding}`);
+  }
+  // Ancestry is a property of reuse itself, not of any one binding: evidence may only be inherited
+  // forward along this release's own history. Without it, a binding that compares content alone --
+  // a fingerprint, say -- would admit a run from a fork or an abandoned branch that happens to
+  // share the content, which is a different repository's proof wearing this release's clothes.
+  if (spawnSync("git", ["merge-base", "--is-ancestor", reusedCommit, releaseCommit], {
+    cwd: repository,
+    encoding: "utf8",
+  }).status !== 0) {
+    fail(`reused commit ${reusedCommit} is not an ancestor of the release commit`);
+  }
   if (binding === "source_tree") {
     const releaseTree = git(["rev-parse", `${releaseCommit}^{tree}`], repository);
     const reusedTree = git(["rev-parse", `${reusedCommit}^{tree}`], repository);
     if (releaseTree !== reusedTree) {
       fail(`reused commit ${reusedCommit} tree ${reusedTree} does not match release tree ${releaseTree}`);
-    }
-    if (spawnSync("git", ["merge-base", "--is-ancestor", reusedCommit, releaseCommit], {
-      cwd: repository,
-      encoding: "utf8",
-    }).status !== 0) {
-      fail(`reused commit ${reusedCommit} is not an ancestor of the release commit`);
     }
     return releaseTree;
   }
@@ -212,7 +241,8 @@ export function verifyReuseBinding({ binding, repository, releaseCommit, reusedC
     }
     return releasePrint;
   }
-  fail(`unknown reuse binding ${binding}`);
+  // Reachable only if a binding is added to the equation ceiling above without a proof here.
+  fail(`reuse binding ${binding} has no verification`);
 }
 
 function uniqueById(values, label) {
@@ -250,6 +280,55 @@ function cellsByProducerJobName(cellGroups) {
     }
   }
   return byJobName;
+}
+
+/// What each reuse binding is permitted to equate, declared per binding by the graph.
+///
+/// A reused row is read at the release commit; every other identity it carries is checked as
+/// written unless its binding declares that key here. That declaration is the whole authorisation:
+/// no cell group gets an exception, and no group narrows its own `required_identity` to make room
+/// for one, because narrowing would drop the check for fresh evidence too. So the equation has to
+/// survive three separate refusals before the closeout will honour it:
+///
+///   * The key must be one the binding's construction determines -- `REUSE_BINDING_EQUATABLE_IDENTITY`
+///     above is the ceiling, stated beside the proofs, so a graph edit alone cannot invent one.
+///   * The key must be part of the release identity binding (minus `commit`, which reuse anchors
+///     rather than equates), so the closeout always holds an authoritative release-side value and
+///     an authoritative reused-side value to put in its place.
+///   * The graph must say, in prose, why that particular key follows from that particular proof.
+///     An equation nobody can justify in a sentence is one nobody should be granting.
+function validateReuseBindings(evidencePolicy, identityBinding) {
+  const reuse = object(evidencePolicy.reuse, "release claim graph.evidence_policy.reuse");
+  nonEmptyText(reuse.equation, "release claim graph.evidence_policy.reuse.equation");
+  nonEmptyText(reuse.verification, "release claim graph.evidence_policy.reuse.verification");
+  const bindings = object(reuse.bindings, "release claim graph.evidence_policy.reuse.bindings");
+  const implemented = Object.keys(REUSE_BINDING_EQUATABLE_IDENTITY).sort();
+  if (JSON.stringify(Object.keys(bindings).sort()) !== JSON.stringify(implemented)) {
+    fail(`release claim graph reuse bindings must declare exactly ${implemented.join(", ")}`);
+  }
+  const equatable = new Set(identityBinding.filter((key) => key !== "commit"));
+  for (const [id, value] of Object.entries(bindings)) {
+    const binding = object(value, `release claim graph reuse binding ${id}`);
+    nonEmptyText(binding.admits, `release claim graph reuse binding ${id}.admits`);
+    if (!Array.isArray(binding.equates)) {
+      fail(`release claim graph reuse binding ${id}.equates must be an array`);
+    }
+    const determines = new Set(REUSE_BINDING_EQUATABLE_IDENTITY[id]);
+    const declared = new Set();
+    for (const [index, entryValue] of binding.equates.entries()) {
+      const entry = object(entryValue, `release claim graph reuse binding ${id}.equates[${index}]`);
+      const key = nonEmptyText(entry.identity, `release claim graph reuse binding ${id}.equates[${index}].identity`);
+      nonEmptyText(entry.justification, `release claim graph reuse binding ${id} equated identity ${key}.justification`);
+      if (declared.has(key)) fail(`release claim graph reuse binding ${id} equates ${key} twice`);
+      declared.add(key);
+      if (!equatable.has(key)) {
+        fail(`release claim graph reuse binding ${id} may not equate identity ${key} outside the release identity binding`);
+      }
+      if (!determines.has(key)) {
+        fail(`release claim graph reuse binding ${id} may not equate identity ${key}, which its construction does not determine`);
+      }
+    }
+  }
 }
 
 /// How much of a release may go unproven and still publish. Withholding exists so one dead host
@@ -704,6 +783,7 @@ export function validateReleaseClaimGraph(graph) {
   for (const key of identityBinding) {
     if (!identityFormats[key]) fail(`identity ${key} must declare a format`);
   }
+  validateReuseBindings(evidencePolicy, identityBinding);
 
   const exceptionPolicy = object(graph.exception_policy, "release claim graph.exception_policy");
   if (exceptionPolicy.schema !== "codestory.model-microbenchmark-exception/v1") {
@@ -881,6 +961,15 @@ export function validateReleaseClaimGraph(graph) {
     }
     if (!new Set(["none", "pre_publish", "post_publish_compare"]).has(group.archive_role)) {
       fail(`closeout cell group ${id} has unknown archive_role ${String(group.archive_role)}`);
+    }
+    // A group admits cross-run evidence by naming a binding the reuse policy declares -- and only
+    // by that. What the binding may then equate is the binding's business, stated once beside the
+    // proof, never a per-group exception.
+    if (group.reuse_binding !== undefined) {
+      const binding = nonEmptyText(group.reuse_binding, `closeout cell group ${id}.reuse_binding`);
+      if (!Object.hasOwn(evidencePolicy.reuse.bindings, binding)) {
+        fail(`closeout cell group ${id} names undeclared reuse binding ${binding}`);
+      }
     }
     const requiredIdentity = stringArray(
       group.required_identity,

--- a/scripts/codestory-release-closeout.mjs
+++ b/scripts/codestory-release-closeout.mjs
@@ -440,7 +440,21 @@ export function validateReleaseCellManifest({ manifest, cell, graph, version }) 
 /// checkout, the binding the claim graph declares for that cell's group. Every rejecting path
 /// records its reason and falls back to the same-run anchor, so unverifiable reuse also fails the
 /// run identity checks that follow.
-function producerAnchor({ cell, row, trustedProducers, gitIdentity, bindings, verify, errors }) {
+///
+/// A verified anchor also carries the identity keys that binding is declared to equate, together
+/// with the reused commit's own value for each, re-derived here rather than taken from the row.
+/// That pair is what makes an equation honest: the release's value may stand in for the reused
+/// commit's value, but the row still has to be carrying the reused commit's value to begin with.
+function producerAnchor({
+  cell,
+  row,
+  trustedProducers,
+  gitIdentity,
+  bindings,
+  verify,
+  resolveCommitIdentity,
+  errors,
+}) {
   const sameRun = { runId: trustedProducers.run_id, headSha: gitIdentity.commit, reused: false };
   const reused = row.reused_from;
   if (reused === undefined) return sameRun;
@@ -448,7 +462,8 @@ function producerAnchor({ cell, row, trustedProducers, gitIdentity, bindings, ve
     errors.push(`trusted producer map ${cell.id} reuse record must be an object`);
     return sameRun;
   }
-  const binding = bindings.get(cell.group_id);
+  const declared = bindings.get(cell.group_id);
+  const binding = declared?.id;
   if (binding === undefined || reused.binding !== binding) {
     errors.push(`trusted producer map ${cell.id} reuses evidence under an undeclared binding`);
     return sameRun;
@@ -484,7 +499,36 @@ function producerAnchor({ cell, row, trustedProducers, gitIdentity, bindings, ve
     errors.push(`trusted producer map ${cell.id} recorded ${binding} value does not bind this release`);
     return sameRun;
   }
-  return { runId: reused.run_id, headSha: reused.head_sha, reused: true };
+  // An equated identity is the one place a reused row is allowed to differ from this release, so
+  // the value it is allowed to differ *to* is not the row's word: it is the reused commit's own,
+  // read from this checkout. With no way to read it, the equation is unproven and the reuse is
+  // refused outright rather than granted on the producer map's say-so.
+  const equated = new Map();
+  if (declared.equates.length > 0) {
+    if (typeof resolveCommitIdentity !== "function") {
+      errors.push(
+        `trusted producer map ${cell.id} equates ${declared.equates.join(", ")} `
+        + "this closeout cannot resolve",
+      );
+      return sameRun;
+    }
+    let reusedIdentity;
+    try {
+      reusedIdentity = resolveCommitIdentity(reused.head_sha);
+    } catch (error) {
+      errors.push(`trusted producer map ${cell.id} reused commit identity is unreadable: ${error.message}`);
+      return sameRun;
+    }
+    for (const key of declared.equates) {
+      const value = reusedIdentity?.[key];
+      if (typeof value !== "string" || value === "" || typeof gitIdentity[key] !== "string") {
+        errors.push(`trusted producer map ${cell.id} reused commit has no ${key} identity to equate`);
+        return sameRun;
+      }
+      equated.set(key, value);
+    }
+  }
+  return { runId: reused.run_id, headSha: reused.head_sha, reused: true, equated };
 }
 
 function trustedProducerIndex({
@@ -494,6 +538,7 @@ function trustedProducerIndex({
   graph,
   phase,
   verifyReuseBinding: verify,
+  resolveCommitIdentity,
 }) {
   const errors = [];
   if (trustedProducers === null || typeof trustedProducers !== "object" || Array.isArray(trustedProducers)) {
@@ -574,9 +619,21 @@ function trustedProducerIndex({
   for (const cellId of byCell.keys()) {
     if (!required.has(cellId)) errors.push(`trusted producer map contains undeclared cell ${cellId}`);
   }
+  // What a group's binding is, and what that binding is declared to equate. Both come from the
+  // graph: the group names a binding, the reuse policy says what that binding may substitute. A
+  // group that names a binding the policy never declared equates nothing here, and its rows are
+  // refused as undeclared -- the graph validator refuses that shape outright, and this is what
+  // makes an unvalidated graph fail closed rather than fail open.
+  const declaredBindings = graph.evidence_policy?.reuse?.bindings ?? {};
   const bindings = new Map((graph.closeout.cell_groups ?? [])
     .filter((group) => typeof group.reuse_binding === "string")
-    .map((group) => [group.id, group.reuse_binding]));
+    .filter((group) => Object.hasOwn(declaredBindings, group.reuse_binding))
+    .map((group) => [group.id, {
+      id: group.reuse_binding,
+      equates: (declaredBindings[group.reuse_binding].equates ?? [])
+        .map((entry) => entry?.identity)
+        .filter((key) => typeof key === "string" && key !== ""),
+    }]));
   const reusedByCell = new Map();
   for (const cell of cells) {
     const row = byCell.get(cell.id);
@@ -624,9 +681,12 @@ function trustedProducerIndex({
       gitIdentity,
       bindings,
       verify,
+      resolveCommitIdentity,
       errors,
     });
-    if (anchor.reused) reusedByCell.set(cell.id, anchor.headSha);
+    if (anchor.reused) {
+      reusedByCell.set(cell.id, { commit: anchor.headSha, equated: anchor.equated });
+    }
     if (row.producer_run_id !== anchor.runId) {
       errors.push(`trusted producer map ${cell.id} run identity differs from the Actions run`);
     }
@@ -707,7 +767,7 @@ function trustedProducerIndex({
   return { byCell, reusedByCell, errors };
 }
 
-function producerAuthenticationProblems(manifest, trustedProducer, reusedCommit) {
+function producerAuthenticationProblems(manifest, trustedProducer, reuse) {
   if (!trustedProducer) return ["manifest producer is absent from the trusted producer map"];
   const identity = manifest.evidence?.identity ?? {};
   const problems = [];
@@ -732,8 +792,18 @@ function producerAuthenticationProblems(manifest, trustedProducer, reusedCommit)
   // read at the release commit instead, so that comparison no longer binds it to anything --
   // this does. The binding proof covers exactly one earlier commit, and it is the only commit
   // this manifest may declare.
-  if (reusedCommit !== undefined && identity.commit !== reusedCommit) {
+  if (reuse !== undefined && identity.commit !== reuse.commit) {
     problems.push("manifest commit is not the reused commit the closeout proved bound to this release");
+  }
+  // Same argument, one step further out, for every identity the binding equates. Reading the row
+  // at this release's value for such a key removes the only check that key was performing, so the
+  // row has to be carrying the reused commit's own value for it -- re-derived from this checkout,
+  // never the producer's word. A row claiming some third tree is not the evidence the binding
+  // proved anything about.
+  for (const [key, value] of reuse?.equated ?? []) {
+    if (identity[key] !== value) {
+      problems.push(`manifest ${key} is not the reused commit's ${key} the binding equates`);
+    }
   }
   return problems;
 }
@@ -920,17 +990,30 @@ function evaluateCell({
   }
   // A reused row was produced at an earlier commit, which is the whole point of the binding the
   // closeout just re-proved against its own checkout. Reading it at the release commit applies
-  // that binding; the row's own source tree is still compared against this release, so a binding
-  // that does not equate the trees still fails. The ledger keeps the manifest identity untouched.
+  // that binding, along with each identity the graph declares that binding may equate -- and only
+  // those: `native_fingerprint` equates `source_tree` because an equal fingerprint means every
+  // input determining the native binary is identical, so accelerator execution evidence carries
+  // across a tree that differs only in code the accelerator never runs. `source_tree` equates
+  // nothing, because there the trees are identical and nothing is being substituted. Any identity
+  // outside that declaration is compared against this release exactly as it is written, so a
+  // reused row from another repository, of another version, or naming another host still fails.
+  // The ledger keeps the manifest identity untouched.
   //
-  // The substitution is granted to exactly the commit the proof covered. A row declaring any
-  // other commit is not the evidence that was proved, so it is read as written and fails the
-  // claim evaluator's commit check -- the same check that binds every same-run row.
+  // The substitution is granted to exactly the commit the proof covered, and to a row that
+  // actually carries the reused commit's own value for each equated key. A row declaring any
+  // other commit -- or some third tree -- is not the evidence that was proved, so it is read as
+  // written and fails the claim evaluator's identity checks, the same checks that bind every
+  // same-run row.
   const evidence = evidenceCells.map((dependency) => {
     const row = manifests.get(dependency.id).evidence;
-    const provedCommit = reusedByCell.get(dependency.id);
-    if (provedCommit === undefined || row.identity?.commit !== provedCommit) return row;
-    return { ...row, identity: { ...row.identity, commit: gitIdentity.commit } };
+    const reuse = reusedByCell.get(dependency.id);
+    if (reuse === undefined || row.identity?.commit !== reuse.commit) return row;
+    const identity = { ...row.identity, commit: gitIdentity.commit };
+    for (const [key, value] of reuse.equated) {
+      if (row.identity?.[key] !== value) return row;
+      identity[key] = gitIdentity[key];
+    }
+    return { ...row, identity };
   });
   const requestedClaims = claims.map((claim) => ({
     id: claim.id,
@@ -1157,6 +1240,9 @@ export function evaluateReleaseCloseout({
   // Re-proves a reuse binding against this closeout's own checkout. Absent, every reuse block is
   // refused rather than trusted on the producer map's say-so.
   verifyReuseBinding: verify = null,
+  // Reads one commit's trusted identity out of this closeout's own checkout, for the identities a
+  // binding equates. Absent, a binding that equates anything is refused the same way.
+  resolveCommitIdentity = null,
 }) {
   if (!SEMVER.test(version)) fail("version must be semantic version text without a leading v");
   const evaluatedEpoch = Date.parse(evaluatedAt);
@@ -1172,6 +1258,7 @@ export function evaluateReleaseCloseout({
     graph,
     phase,
     verifyReuseBinding: verify,
+    resolveCommitIdentity,
   });
   const performanceCell = cells.find(({ id }) => id === graph.exception_policy.eligible_evidence_type);
   const trustedException = trustedExceptionInput({
@@ -1600,6 +1687,9 @@ function main() {
     artifactBindings: downloaded.artifactBindings,
     verifyReuseBinding: ({ binding, releaseCommit, reusedCommit }) =>
       verifyReuseBinding({ binding, repository: repoRoot, releaseCommit, reusedCommit }),
+    // Same derivation the release identity itself came from, applied to the reused commit: an
+    // equated identity is only ever replaced by this checkout's reading of both ends.
+    resolveCommitIdentity: (commit) => deriveTrustedGitIdentity({ repoRoot, expectedSha: commit }),
   });
   writeReleaseCloseout(text(values["out-dir"], "--out-dir"), result);
   console.log(JSON.stringify(result.summary, null, 2));

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -800,4 +800,86 @@ test("reuse bindings verify tree identity and fingerprint equality against real 
     }),
     /unknown reuse binding source_history/u,
   );
+  // Ancestry belongs to reuse itself, not to any one binding. Read the other way round, v0.16.1
+  // is not on v0.16.0's history, and the fingerprints are equal -- content equality alone would
+  // admit a run from a fork or an abandoned branch as this release's own proof.
+  assert.throws(
+    () => verifyReuseBinding({
+      binding: "native_fingerprint",
+      repository: root,
+      releaseCommit: priorTag,
+      reusedCommit: releaseTag,
+    }),
+    /is not an ancestor of the release commit/u,
+  );
+});
+
+test("a reuse binding may equate only identities its own construction determines", () => {
+  // What a reused row is allowed to differ from this release in is declared per binding, in the
+  // graph, with a reason -- never per cell group, and never by narrowing a group's
+  // required_identity, which would drop the check for fresh evidence too (#1567).
+  const declared = graph.evidence_policy.reuse.bindings;
+  assert.deepEqual(Object.keys(declared).sort(), ["native_fingerprint", "source_tree"]);
+  assert.deepEqual(declared.source_tree.equates, []);
+  assert.deepEqual(declared.native_fingerprint.equates.map(({ identity }) => identity), ["source_tree"]);
+  assert.ok(declared.native_fingerprint.equates[0].justification.length > 0);
+
+  // The fingerprint determines the built native binary. It says nothing about which repository
+  // produced the row, so it may not equate that -- graph text alone cannot grant an equation.
+  const foreignRepository = structuredClone(graph);
+  foreignRepository.evidence_policy.reuse.bindings.native_fingerprint.equates = [
+    { identity: "repository", justification: "same organisation, surely" },
+  ];
+  assert.throws(
+    () => validateReleaseClaimGraph(foreignRepository),
+    /native_fingerprint may not equate identity repository, which its construction does not determine/u,
+  );
+
+  // The tree binding proves the reused commit resolves to this release's own tree, so there is
+  // nothing to substitute: equating the tree there would replace a live check with nothing.
+  const vacuousEquation = structuredClone(graph);
+  vacuousEquation.evidence_policy.reuse.bindings.source_tree.equates = [
+    { identity: "source_tree", justification: "the trees are equal anyway" },
+  ];
+  assert.throws(
+    () => validateReleaseClaimGraph(vacuousEquation),
+    /source_tree may not equate identity source_tree, which its construction does not determine/u,
+  );
+
+  // An identity outside the release identity binding has no authoritative release-side value the
+  // closeout could put in its place, so it can never be equated whatever a binding proves.
+  const unboundIdentity = structuredClone(graph);
+  unboundIdentity.evidence_policy.reuse.bindings.native_fingerprint.equates = [
+    { identity: "artifact_sha256", justification: "the inputs were identical" },
+  ];
+  assert.throws(
+    () => validateReleaseClaimGraph(unboundIdentity),
+    /may not equate identity artifact_sha256 outside the release identity binding/u,
+  );
+
+  // An equation nobody can justify in a sentence is one nobody should be granting.
+  const unjustified = structuredClone(graph);
+  delete unjustified.evidence_policy.reuse.bindings.native_fingerprint.equates[0].justification;
+  assert.throws(
+    () => validateReleaseClaimGraph(unjustified),
+    /equated identity source_tree.justification must be a non-empty string/u,
+  );
+
+  // Every binding the verifier implements has to say what it equates, so a new binding cannot
+  // arrive with its equations left unstated.
+  const undeclaredBinding = structuredClone(graph);
+  delete undeclaredBinding.evidence_policy.reuse.bindings.native_fingerprint;
+  assert.throws(
+    () => validateReleaseClaimGraph(undeclaredBinding),
+    /reuse bindings must declare exactly native_fingerprint, source_tree/u,
+  );
+
+  // And a cell group admits cross-run evidence only under a binding the policy declares.
+  const inventedBinding = structuredClone(graph);
+  inventedBinding.closeout.cell_groups.find(({ id }) => id === "accelerator_execution")
+    .reuse_binding = "source_history";
+  assert.throws(
+    () => validateReleaseClaimGraph(inventedBinding),
+    /accelerator_execution names undeclared reuse binding source_history/u,
+  );
 });

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -270,6 +270,7 @@ function evaluate(
   trustedExceptionDocument = null,
   artifactBindings = null,
   verifyReuseBinding = null,
+  resolveCommitIdentity = null,
 ) {
   const bindings = artifactBindings ?? manifests.map((manifest) => {
     const producer = trustedProducers?.producers?.find(({ cell_id: cellId }) =>
@@ -294,6 +295,7 @@ function evaluate(
     trustedExceptionDocument,
     artifactBindings: bindings,
     verifyReuseBinding,
+    resolveCommitIdentity,
   });
 }
 
@@ -339,6 +341,72 @@ function reuseSourceBehavior(trustedProducers, manifests, reusedFrom = {}) {
   manifest.evidence.identity.producer_run_id = reusedRunId;
   manifest.evidence.identity.commit = reusedCommit;
   return row;
+}
+
+// ── Native-fingerprint reuse ────────────────────────────────────────────────────────────────
+
+// The whole point of the native_fingerprint binding: the reused commit's tree is *not* this
+// release's tree. Version-normalized native inputs are what is equal, so the accelerator the
+// evidence exercised is the accelerator this release ships.
+const reusedTree = "c".repeat(40);
+const nativeFingerprint = "f".repeat(64);
+
+function acceleratorCellIds() {
+  return deriveReleaseCells(graph, "pre_publish")
+    .filter(({ group_id: groupId }) => groupId === "accelerator_execution")
+    .map(({ id }) => id);
+}
+
+/// Stands in for the git fingerprint proof, and for the closeout reading the reused commit's own
+/// identity out of its checkout. Both are needed before a reused row may be read at this release's
+/// tree: one says the trees may be equated, the other says which tree is being equated away.
+function fingerprintReuse({
+  ancestors = [reusedCommit],
+  fingerprint = nativeFingerprint,
+  tree = reusedTree,
+} = {}) {
+  return {
+    verify: ({ binding, releaseCommit, reusedCommit: reused }) => {
+      assert.equal(releaseCommit, gitIdentity.commit);
+      if (binding !== "native_fingerprint") throw new Error(`unknown reuse binding ${binding}`);
+      if (!ancestors.includes(reused)) {
+        throw new Error(`reused commit ${reused} is not an ancestor of the release commit`);
+      }
+      return fingerprint;
+    },
+    resolve: (commit) => {
+      if (commit !== reusedCommit) throw new Error(`git cat-file -e ${commit} failed`);
+      return { repository: gitIdentity.repository, commit, source_tree: tree };
+    },
+  };
+}
+
+/// Re-anchor all three accelerator producer rows onto a prior run, exactly as the producer map
+/// does once an operator selects `--reuse accelerator_execution=<run>:<sha>` in preflight.
+function reuseAcceleratorExecution(trustedProducers, manifests, reusedFrom = {}) {
+  const rows = [];
+  for (const cellId of acceleratorCellIds()) {
+    const row = trustedProducers.producers.find(({ cell_id: candidate }) => candidate === cellId);
+    row.producer_run_id = reusedRunId;
+    row.reused_from = {
+      run_id: reusedRunId,
+      head_sha: reusedCommit,
+      binding: "native_fingerprint",
+      binding_value: nativeFingerprint,
+      ...reusedFrom,
+    };
+    row.artifact.workflow_run_id = reusedRunId;
+    row.artifact.head_sha = reusedCommit;
+    row.job.run_id = reusedRunId;
+    row.job.head_sha = reusedCommit;
+    const manifest = manifests.find(({ cell_id: candidate }) => candidate === cellId);
+    manifest.evidence.identity.producer_run_id = reusedRunId;
+    manifest.evidence.identity.commit = reusedCommit;
+    // The reused run ran at its own tree, which is not this release's.
+    manifest.evidence.identity.source_tree = reusedTree;
+    rows.push(row);
+  }
+  return rows;
 }
 
 test("cell inventory is derived only from the release claim graph", () => {
@@ -919,58 +987,209 @@ test("a reuse block naming the publishing run is not reuse", () => {
   assert.ok(rejected.summary.failed_cells.includes("source_behavior"));
 });
 
-test("native-fingerprint reuse is still refused, and refused for the tree it cannot equate", () => {
-  // release-claims.json declares a second reuse binding -- accelerator_execution under
-  // native_fingerprint -- and this closeout does not yet honour it. Fingerprint reuse exists
-  // precisely because the trees differ, and accelerator_execution requires source_tree, so the
-  // claim evaluator refuses the row after the closeout anchors it. #1552 is about source-proof
-  // reuse; widening the tree identity for accelerator evidence is a separate trust decision.
-  // Pinned here so that gap stays a documented refusal and can never widen unnoticed.
-  const reusedTree = "c".repeat(40);
-  const fingerprint = "f".repeat(64);
+/// Every message a rejected closeout produced, wherever it recorded it: input errors, cell
+/// validation failures, and the claim evaluator's own failures all refuse in different places.
+function refusals(result) {
+  const messages = [...result.summary.input_errors];
+  for (const { value } of result.evaluations.values()) {
+    for (const failure of value.failures ?? []) messages.push(String(failure));
+    for (const failure of value.release_claim_evaluation?.failures ?? []) {
+      messages.push(String(failure.message));
+    }
+  }
+  return messages;
+}
+
+test("native-fingerprint reuse is admitted for the tree that binding equates", () => {
+  // Replaces the test that pinned this as a permanent refusal (#1567). The refusal was not a
+  // trust decision, it was a missing declaration: the closeout read every reused row at the
+  // release commit and at nothing else, so accelerator_execution -- whose required_identity
+  // includes source_tree, and whose binding exists precisely because the trees differ -- could
+  // never pass. The claim graph now says per binding which identity keys the binding may equate,
+  // and native_fingerprint equates source_tree: an equal version-normalized fingerprint means
+  // every input that determines the native binary is identical, so execution evidence carries
+  // across a tree that differs only in code the accelerator never runs.
   const manifests = manifestsFor("pre_publish");
   const trusted = trustedProducersFor("pre_publish");
-  const acceleratorCells = deriveReleaseCells(graph, "pre_publish")
-    .filter(({ group_id: groupId }) => groupId === "accelerator_execution")
-    .map(({ id }) => id);
-  assert.equal(acceleratorCells.length, 3);
-  for (const cellId of acceleratorCells) {
-    const row = trusted.producers.find(({ cell_id: candidate }) => candidate === cellId);
-    row.producer_run_id = reusedRunId;
-    row.reused_from = {
-      run_id: reusedRunId,
-      head_sha: reusedCommit,
-      binding: "native_fingerprint",
-      binding_value: fingerprint,
-    };
-    row.artifact.workflow_run_id = reusedRunId;
-    row.artifact.head_sha = reusedCommit;
-    row.job.run_id = reusedRunId;
-    row.job.head_sha = reusedCommit;
-    const manifest = manifests.find(({ cell_id: candidate }) => candidate === cellId);
-    manifest.evidence.identity.producer_run_id = reusedRunId;
-    manifest.evidence.identity.commit = reusedCommit;
-    manifest.evidence.identity.source_tree = reusedTree;
-  }
-  const rejected = evaluate("pre_publish", manifests, null, trusted, null, null, ({ binding }) => {
-    if (binding !== "native_fingerprint") throw new Error(`unknown reuse binding ${binding}`);
-    return fingerprint;
+  const cellIds = acceleratorCellIds();
+  assert.equal(cellIds.length, 3);
+  reuseAcceleratorExecution(trusted, manifests);
+  const proof = fingerprintReuse();
+  const proved = [];
+  const resolved = [];
+  const accepted = evaluate("pre_publish", manifests, null, trusted, null, null, (request) => {
+    proved.push(request);
+    return proof.verify(request);
+  }, (commit) => {
+    resolved.push(commit);
+    return proof.resolve(commit);
   });
-  assert.equal(rejected.decision, "reject");
-  for (const cellId of acceleratorCells) {
-    assert.ok(rejected.summary.failed_cells.includes(cellId), cellId);
-    const failures = rejected.evaluations.get(cellId).value.release_claim_evaluation.failures;
-    assert.ok(
-      failures.some(({ class: failureClass, message }) =>
-        failureClass === "stale_sha" && message.includes("source tree does not match")),
-      `${cellId}: ${JSON.stringify(failures)}`,
+  assert.equal(accepted.decision, "accept");
+  assert.deepEqual(accepted.summary.input_errors, []);
+  assert.deepEqual(accepted.summary.failed_cells, []);
+  assert.equal(accepted.summary.counts.passed, 10);
+  // The closeout re-proves the binding for every reused cell, against its own checkout, and reads
+  // the reused commit's own tree rather than taking the row's word for what it is equating away.
+  assert.deepEqual(proved, cellIds.map(() => ({
+    binding: "native_fingerprint",
+    releaseCommit: gitIdentity.commit,
+    reusedCommit,
+  })));
+  assert.deepEqual(resolved, cellIds.map(() => reusedCommit));
+  // The ledger states what was actually inherited: the earlier run, its commit, and its tree.
+  for (const cellId of cellIds) {
+    const row = accepted.ledger.cells.find(({ id }) => id === cellId);
+    assert.equal(row.status, "pass", cellId);
+    assert.equal(row.identity.producer_run_id, reusedRunId, cellId);
+    assert.equal(row.identity.commit, reusedCommit, cellId);
+    assert.equal(row.identity.source_tree, reusedTree, cellId);
+  }
+  // Nothing else moved: cells that were not reused stay bound to the publishing run and tree.
+  const packaged = accepted.ledger.cells.find(({ id }) => id === "package_identity:windows-x64");
+  assert.equal(packaged.identity.commit, gitIdentity.commit);
+  assert.equal(packaged.identity.source_tree, gitIdentity.source_tree);
+});
+
+test("a native-fingerprint reuse row is refused wherever the equation stops holding", () => {
+  // The accept path above buys exactly one substitution, under one proof. Each row here breaks a
+  // different part of that and must still reject -- the equated key included, because equating an
+  // identity is not dropping it: the row still has to carry the reused commit's own value for it.
+  const rejections = [
+    ["the row names a binding the group did not declare", (trusted, manifests) => {
+      reuseAcceleratorExecution(trusted, manifests, { binding: "source_tree" });
+    }, "reuses evidence under an undeclared binding", fingerprintReuse()],
+    ["the reproved fingerprint is not the one the producer recorded", (trusted, manifests) => {
+      reuseAcceleratorExecution(trusted, manifests, { binding_value: "e".repeat(64) });
+    }, "recorded native_fingerprint value does not bind this release", fingerprintReuse()],
+    ["the two commits' native fingerprints differ", (trusted, manifests) => {
+      reuseAcceleratorExecution(trusted, manifests);
+    }, "native_fingerprint reuse is unverified", {
+      verify: () => {
+        throw new Error("native fingerprint of reused commit does not match the release commit");
+      },
+      resolve: fingerprintReuse().resolve,
+    }],
+    ["the reused commit is not an ancestor of the release commit", (trusted, manifests) => {
+      reuseAcceleratorExecution(trusted, manifests);
+    }, "is not an ancestor of the release commit", fingerprintReuse({ ancestors: [] })],
+    ["the reused artifact expired", (trusted, manifests) => {
+      reuseAcceleratorExecution(trusted, manifests)[0].artifact.expired = true;
+    }, "artifact is expired", fingerprintReuse()],
+    // The equated identity, checked at its source. A reused row may be read at this release's
+    // tree only because it carries the reused commit's tree; a row naming some third tree is not
+    // the evidence the fingerprint proved anything about.
+    ["the row declares a tree that is not the reused commit's", (trusted, manifests) => {
+      reuseAcceleratorExecution(trusted, manifests);
+      manifests.find(({ cell_id: cellId }) => cellId === acceleratorCellIds()[0])
+        .evidence.identity.source_tree = "e".repeat(40);
+    }, "manifest source_tree is not the reused commit's source_tree the binding equates",
+    fingerprintReuse()],
+    ["the row declares this release's tree, which the reused run could not have produced it at",
+      (trusted, manifests) => {
+        reuseAcceleratorExecution(trusted, manifests);
+        manifests.find(({ cell_id: cellId }) => cellId === acceleratorCellIds()[0])
+          .evidence.identity.source_tree = gitIdentity.source_tree;
+      }, "manifest source_tree is not the reused commit's source_tree the binding equates",
+      fingerprintReuse()],
+    // Keys the fingerprint does not determine are not equated, and are compared as written.
+    ["the row was produced in another repository", (trusted, manifests) => {
+      reuseAcceleratorExecution(trusted, manifests);
+      manifests.find(({ cell_id: cellId }) => cellId === acceleratorCellIds()[0])
+        .evidence.identity.repository = "TheGreenCedar/NotCodeStory";
+    }, "identity repository does not match the requested release", fingerprintReuse()],
+    ["the row was produced at another version, which the fingerprint normalizes away rather than proves",
+      (trusted, manifests) => {
+        reuseAcceleratorExecution(trusted, manifests);
+        manifests.find(({ cell_id: cellId }) => cellId === acceleratorCellIds()[0])
+          .evidence.identity.producer_version = "0.15.9";
+      }, "producer_version must equal closeout version", fingerprintReuse()],
+    ["the row exercised an archive this release does not ship", (trusted, manifests) => {
+      reuseAcceleratorExecution(trusted, manifests);
+      manifests.find(({ cell_id: cellId }) => cellId === acceleratorCellIds()[0])
+        .evidence.identity.artifact_sha256 = sha("some other release archive");
+    }, "identity artifact_sha256 does not match the requested release", fingerprintReuse()],
+  ];
+  for (const [label, mutate, expected, proof] of rejections) {
+    const manifests = manifestsFor("pre_publish");
+    const trusted = trustedProducersFor("pre_publish");
+    mutate(trusted, manifests);
+    const rejected = evaluate(
+      "pre_publish",
+      manifests,
+      null,
+      trusted,
+      null,
+      null,
+      proof.verify,
+      proof.resolve,
     );
-    // The commit the binding proof covered is admitted; only the tree it cannot equate refuses.
+    assert.equal(rejected.decision, "reject", label);
+    const messages = refusals(rejected);
     assert.ok(
-      !failures.some(({ message }) => message.includes("commit does not match")),
-      `${cellId}: ${JSON.stringify(failures)}`,
+      messages.some((message) => message.includes(expected)),
+      `${label}: ${JSON.stringify(messages)}`,
     );
   }
+});
+
+test("a closeout that cannot read the reused commit refuses to equate anything", () => {
+  // The binding proof alone does not say what is being equated away. Without this checkout's own
+  // reading of the reused commit, the release's tree would be standing in for whatever the row
+  // claimed -- so reuse is refused outright rather than granted on the producer map's word.
+  const manifests = manifestsFor("pre_publish");
+  const trusted = trustedProducersFor("pre_publish");
+  reuseAcceleratorExecution(trusted, manifests);
+  const rejected = evaluate(
+    "pre_publish",
+    manifests,
+    null,
+    trusted,
+    null,
+    null,
+    fingerprintReuse().verify,
+  );
+  assert.equal(rejected.decision, "reject");
+  for (const cellId of acceleratorCellIds()) {
+    assert.ok(
+      rejected.summary.input_errors.some((message) =>
+        message.includes(`${cellId} equates source_tree this closeout cannot resolve`)),
+      `${cellId}: ${JSON.stringify(rejected.summary.input_errors)}`,
+    );
+  }
+});
+
+test("a reused accelerator container is still bound by its digest", () => {
+  const manifests = manifestsFor("pre_publish");
+  const trusted = trustedProducersFor("pre_publish");
+  reuseAcceleratorExecution(trusted, manifests);
+  const [cellId] = acceleratorCellIds();
+  const artifactBindings = manifests.map((manifest) => {
+    const producer = trusted.producers.find(({ cell_id: candidate }) => candidate === manifest.cell_id);
+    return {
+      cell_id: manifest.cell_id,
+      producer_artifact: producer.producer_artifact,
+      artifact_id: producer.artifact.id,
+      artifact_digest: producer.artifact.digest,
+      manifest_sha256: canonicalManifestSha(manifest),
+    };
+  });
+  artifactBindings.find(({ cell_id: candidate }) => candidate === cellId)
+    .artifact_digest = `sha256:${"f".repeat(64)}`;
+  const proof = fingerprintReuse();
+  const rejected = evaluate(
+    "pre_publish",
+    manifests,
+    null,
+    trusted,
+    null,
+    artifactBindings,
+    proof.verify,
+    proof.resolve,
+  );
+  assert.equal(rejected.decision, "reject");
+  assert.ok(rejected.summary.failed_cells.includes(cellId));
+  assert.ok(rejected.evaluations.get(cellId).value.failures.some((message) =>
+    message.includes("artifact_digest does not match Actions provenance")));
 });
 
 // ── Withheld accelerator claims ─────────────────────────────────────────────────────────────

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "b897679c2255b1b2278d8d5565e72617f34ac2e2c2ff830cd78ddd6e387f6498",
+      "graph_sha256": "b21965bca63639339c307fc516f682a6d1ad246534dd61b931b83a176c0bcc03",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
`release-claims.json` declared two reuse bindings and the pre-publish closeout honoured one. A
`native_fingerprint` row was anchored to its earlier run and its commit was read at the release
commit, and then `evaluateReleaseClaims` refused it on `identity.source_tree` -- the one identity
that binding exists *because* the two commits differ in. An operator selecting
`--reuse accelerator_execution=<run>:<sha>` in preflight therefore produced a producer map the
closeout could only reject, taking all three accelerator cells with it: the same "publish never
runs" outcome #1552 described.

## The declarative direction

The claim graph now states, per binding, which identity keys that binding may equate, and why:

* `native_fingerprint` equates `source_tree`. The fingerprint covers every input that determines
  the native binary -- `crates/**`, `Cargo.lock`, `vendor/**`, the packaging scripts, the toolchain
  pins, version-normalised -- so an equal fingerprint means the accelerator the evidence exercised
  is built from identical inputs, and execution evidence carries across a tree that differs only in
  non-native code the accelerator never runs.
* `source_tree` equates nothing. There the trees are identical by construction, so every
  tree-derived identity is still checkable directly against this release; equating one would
  replace a live check with nothing.

No exception for the accelerator group, and no narrowing of `accelerator_execution.required_identity`
-- narrowing would have dropped the tree check for fresh evidence too.

## The boundary

Three refusals stand between a declaration and a substitution:

* the key must be one the binding's own construction determines (`REUSE_BINDING_EQUATABLE_IDENTITY`,
  stated beside the proofs in `codestory-release-claims.mjs`, is a ceiling a graph edit cannot raise);
* it must belong to the release identity binding minus `commit`, so the closeout holds an
  authoritative value for *both* ends;
* the graph must justify it in prose.

Equating is not dropping. The closeout re-derives the reused commit's own value for each equated key
from its own checkout and requires the row to be carrying it; a row naming some third tree, or this
release's tree, is read as written and fails. Ancestry also moves out of the tree binding and applies
to every binding, since it is a property of reuse rather than of one proof -- content equality alone
would admit a fork's run wearing this release's clothes.

## Test replaced, deliberately

`native-fingerprint reuse is still refused, and refused for the tree it cannot equate` described the
old behaviour: it pinned the refusal as permanent. That refusal was a missing declaration, not a
trust decision, so the test is replaced by one asserting the accept path plus each reject direction:
undeclared binding, fingerprint mismatch, recorded-value drift, non-ancestor, expired artifact,
container digest mismatch, a tree that is not the reused commit's, and the keys the fingerprint does
not determine (`repository`, `producer_version`, `artifact_sha256`).

Proved in both directions. With the tests and the base implementation, 3 closeout tests and 2 claim
tests fail; with the change, `node --test scripts/tests/*.test.mjs` is 273/273, workflow policy
678/678, `check-workflow-policy.mjs`, `run-actionlint.mjs`, `codestory-release-claims.mjs validate`
and the Python self-tests all pass.

Still open, reported rather than widened: end-to-end accelerator reuse across a version bump now
stops at `artifact_sha256` instead, because the accelerator proof runs the packaged archive from its
own run. The fingerprint does not determine the packaged bytes and `artifact_sha256` has no locally
derivable release-side value, so equating it is a separate trust decision this PR deliberately does
not take.

Closes #1567
