### PR TITLE
[codex] serialize retrieval lint fixtures across nextest processes

### DIFF
--- a/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
+++ b/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
@@ -1,24 +1,68 @@
 //! Ensures the retrieval generalization lint script stays runnable from the workspace root.
 
-use std::fs;
+use fs4::fs_std::FileExt;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 static LINT_SCRIPT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+const LINT_SCRIPT_LOCK_HELPER_PATH: &str = "CODESTORY_LINT_SCRIPT_LOCK_HELPER_PATH";
+const LINT_SCRIPT_LOCK_HELPER_READY: &str = "CODESTORY_LINT_SCRIPT_LOCK_HELPER_READY";
+const LINT_SCRIPT_LOCK_HELPER_RELEASE: &str = "CODESTORY_LINT_SCRIPT_LOCK_HELPER_RELEASE";
 
-/// Serialises the lint subprocesses. The lock guards no shared state -- only the
-/// cost of running many `node` processes at once -- so a test that panics while
-/// holding it has corrupted nothing. Recovering from the poison rather than
-/// propagating it keeps one real failure reported as one failure: without this,
-/// the first genuine assertion turns every later test into a `PoisonError`
-/// panic, and the failure list says nothing about how much is actually broken.
-fn lint_script_lock() -> MutexGuard<'static, ()> {
-    LINT_SCRIPT_LOCK
+struct LintScriptGuard {
+    _thread_guard: MutexGuard<'static, ()>,
+    process_lock: File,
+}
+
+impl Drop for LintScriptGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.process_lock);
+    }
+}
+
+/// Serialises lint subprocesses in this test binary and across independent test
+/// processes. Cargo-nextest gives each test its own process, so the Rust mutex
+/// alone cannot protect a clean default-root scan from another test temporarily
+/// planting a hostile source file in the checkout.
+///
+/// Neither lock protects product state. Recovering a poisoned thread lock is
+/// therefore safe and keeps one real assertion failure from turning every later
+/// guard test into a `PoisonError` panic.
+fn lint_script_lock() -> LintScriptGuard {
+    lint_script_lock_at(&lint_script_lock_path(&workspace_root()))
+}
+
+fn lint_script_lock_at(lock_path: &Path) -> LintScriptGuard {
+    let thread_guard = LINT_SCRIPT_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent).expect("create lint script lock directory");
+    }
+    let process_lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(lock_path)
+        .expect("open lint script process lock");
+    FileExt::lock_exclusive(&process_lock).expect("lock lint script across test processes");
+    LintScriptGuard {
+        _thread_guard: thread_guard,
+        process_lock,
+    }
+}
+
+fn lint_script_lock_path(repo_root: &Path) -> PathBuf {
+    repo_root
+        .join("target")
+        .join("retrieval-generalization-guard.lock")
 }
 
 fn production_source(contents: &str) -> &str {
@@ -212,6 +256,109 @@ fn retrieval_generalization_lint_script_exits_clean_with_extra_fixture_root() {
     assert!(
         production_file_count > 0,
         "extra fixture root should not replace the real production scan roots, stdout={stdout}"
+    );
+}
+
+#[test]
+#[ignore = "spawned by lint_script_lock_serializes_independent_test_processes"]
+fn lint_script_lock_process_helper() {
+    let Some(lock_path) = std::env::var_os(LINT_SCRIPT_LOCK_HELPER_PATH) else {
+        return;
+    };
+    let ready_path =
+        PathBuf::from(std::env::var_os(LINT_SCRIPT_LOCK_HELPER_READY).expect("helper ready path"));
+    let release_path = PathBuf::from(
+        std::env::var_os(LINT_SCRIPT_LOCK_HELPER_RELEASE).expect("helper release path"),
+    );
+
+    let _guard = lint_script_lock_at(Path::new(&lock_path));
+    fs::write(&ready_path, b"ready").expect("mark lint script lock helper ready");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !release_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "parent never released lint script lock helper"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn lint_script_lock_serializes_independent_test_processes() {
+    let fixture = TempDir::new().expect("create process lock fixture");
+    let lock_path = fixture.path().join("lint-script.lock");
+    let ready_path = fixture.path().join("helper-ready");
+    let release_path = fixture.path().join("helper-release");
+    let mut helper = Command::new(std::env::current_exe().expect("current guard test executable"))
+        .arg("--exact")
+        .arg("lint_script_lock_process_helper")
+        .arg("--ignored")
+        .arg("--nocapture")
+        .env(LINT_SCRIPT_LOCK_HELPER_PATH, &lock_path)
+        .env(LINT_SCRIPT_LOCK_HELPER_READY, &ready_path)
+        .env(LINT_SCRIPT_LOCK_HELPER_RELEASE, &release_path)
+        .spawn()
+        .expect("spawn lint script lock helper process");
+
+    let ready_deadline = Instant::now() + Duration::from_secs(10);
+    let mut early_exit = None;
+    while !ready_path.exists() && Instant::now() < ready_deadline {
+        if let Some(status) = helper.try_wait().expect("inspect lint script lock helper") {
+            early_exit = Some(status);
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    if !ready_path.exists() {
+        if early_exit.is_none() {
+            let _ = helper.kill();
+            early_exit = helper.wait().ok();
+        }
+        panic!("lint script lock helper did not acquire its lock; status={early_exit:?}");
+    }
+
+    let contender = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .expect("open lint script lock contender");
+    let acquired_while_helper_held =
+        FileExt::try_lock_exclusive(&contender).expect("contend for held lint script lock");
+    if acquired_while_helper_held {
+        FileExt::unlock(&contender).expect("release unexpectedly acquired contender lock");
+    }
+
+    fs::write(&release_path, b"release").expect("release lint script lock helper");
+    let exit_deadline = Instant::now() + Duration::from_secs(5);
+    let helper_status = loop {
+        if let Some(status) = helper.try_wait().expect("inspect released lock helper") {
+            break status;
+        }
+        if Instant::now() >= exit_deadline {
+            let _ = helper.kill();
+            break helper.wait().expect("reap stalled lint script lock helper");
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    let acquired_after_release =
+        FileExt::try_lock_exclusive(&contender).expect("acquire released lint script lock");
+    if acquired_after_release {
+        FileExt::unlock(&contender).expect("release lint script lock contender");
+    }
+
+    assert!(
+        !acquired_while_helper_held,
+        "a second process acquired the lint script lock before the holder released it"
+    );
+    assert!(
+        helper_status.success(),
+        "lint script lock helper failed: {helper_status}"
+    );
+    assert!(
+        acquired_after_release,
+        "process lock contender did not acquire after the holder released it"
     );
 }
 

--- a/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
+++ b/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
@@ -13,6 +13,13 @@ static LINT_SCRIPT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 const LINT_SCRIPT_LOCK_HELPER_PATH: &str = "CODESTORY_LINT_SCRIPT_LOCK_HELPER_PATH";
 const LINT_SCRIPT_LOCK_HELPER_READY: &str = "CODESTORY_LINT_SCRIPT_LOCK_HELPER_READY";
 const LINT_SCRIPT_LOCK_HELPER_RELEASE: &str = "CODESTORY_LINT_SCRIPT_LOCK_HELPER_RELEASE";
+const LINT_SCRIPT_CRASH_HELPER_ROOT: &str = "CODESTORY_LINT_SCRIPT_CRASH_HELPER_ROOT";
+const PLANTED_SOURCE_OWNERSHIP_MARKER: &str =
+    "// CODESTORY_TEST_OWNED: retrieval-generalization-guard\n";
+const PLANTED_SOURCE_PATHS: [&str; 2] = [
+    "crates/codestory-runtime/src/ranking_scope_probe_generated.rs",
+    "crates/codestory-runtime/src/ranking_probe/tests.rs",
+];
 
 struct LintScriptGuard {
     _thread_guard: MutexGuard<'static, ()>,
@@ -34,7 +41,14 @@ impl Drop for LintScriptGuard {
 /// therefore safe and keeps one real assertion failure from turning every later
 /// guard test into a `PoisonError` panic.
 fn lint_script_lock() -> LintScriptGuard {
-    lint_script_lock_at(&lint_script_lock_path(&workspace_root()))
+    let repo_root = workspace_root();
+    lint_script_lock_for(&repo_root, &lint_script_lock_path(&repo_root))
+}
+
+fn lint_script_lock_for(repo_root: &Path, lock_path: &Path) -> LintScriptGuard {
+    let guard = lint_script_lock_at(lock_path);
+    recover_stale_planted_sources(repo_root);
+    guard
 }
 
 fn lint_script_lock_at(lock_path: &Path) -> LintScriptGuard {
@@ -63,6 +77,29 @@ fn lint_script_lock_path(repo_root: &Path) -> PathBuf {
     repo_root
         .join("target")
         .join("retrieval-generalization-guard.lock")
+}
+
+fn recover_stale_planted_sources(repo_root: &Path) {
+    for relative_path in PLANTED_SOURCE_PATHS {
+        let path = repo_root.join(relative_path);
+        let contents = match fs::read(&path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => panic!(
+                "read possible stale planted source {}: {error}",
+                path.display()
+            ),
+        };
+        if !contents.starts_with(PLANTED_SOURCE_OWNERSHIP_MARKER.as_bytes()) {
+            continue;
+        }
+        fs::remove_file(&path).unwrap_or_else(|error| {
+            panic!("remove stale planted source {}: {error}", path.display())
+        });
+        if relative_path == PLANTED_SOURCE_PATHS[1] {
+            let _ = fs::remove_dir(path.parent().expect("stale planted source parent"));
+        }
+    }
 }
 
 fn production_source(contents: &str) -> &str {
@@ -284,6 +321,32 @@ fn lint_script_lock_process_helper() {
 }
 
 #[test]
+#[ignore = "spawned by lint_script_lock_recovers_a_fixture_after_process_exit"]
+fn lint_script_crash_recovery_helper() {
+    let Some(repo_root) = std::env::var_os(LINT_SCRIPT_CRASH_HELPER_ROOT) else {
+        return;
+    };
+    let lock_path =
+        PathBuf::from(std::env::var_os(LINT_SCRIPT_LOCK_HELPER_PATH).expect("helper lock path"));
+    let repo_root = PathBuf::from(repo_root);
+    let _guard = lint_script_lock_for(&repo_root, &lock_path);
+    let _planted = PlantedSource::write(
+        repo_root.join(PLANTED_SOURCE_PATHS[1]),
+        concat!(
+            "pub fn ranking_probe_entry_points() -> [&'static str; 2] {\n",
+            "    [\"createApplication\", \"benchmarks/tasks\"]\n",
+            "}\n"
+        ),
+    );
+
+    // Model a killed nextest process: `process::exit` skips both the planted
+    // source destructor and the lock guard destructor. The operating system
+    // releases the file lock, while the next holder has to recover the
+    // proof-marked source before it scans the checkout.
+    std::process::exit(0);
+}
+
+#[test]
 fn lint_script_lock_serializes_independent_test_processes() {
     let fixture = TempDir::new().expect("create process lock fixture");
     let lock_path = fixture.path().join("lint-script.lock");
@@ -360,6 +423,68 @@ fn lint_script_lock_serializes_independent_test_processes() {
         acquired_after_release,
         "process lock contender did not acquire after the holder released it"
     );
+}
+
+#[test]
+fn lint_script_lock_recovers_a_fixture_after_process_exit() {
+    let fixture = TempDir::new().expect("create crash recovery fixture");
+    let lock_path = fixture.path().join("target/lint-script.lock");
+    let status = Command::new(std::env::current_exe().expect("current guard test executable"))
+        .arg("--exact")
+        .arg("lint_script_crash_recovery_helper")
+        .arg("--ignored")
+        .arg("--nocapture")
+        .env(LINT_SCRIPT_CRASH_HELPER_ROOT, fixture.path())
+        .env(LINT_SCRIPT_LOCK_HELPER_PATH, &lock_path)
+        .status()
+        .expect("spawn lint script crash recovery helper");
+    assert!(status.success(), "crash recovery helper failed: {status}");
+
+    let stale_path = fixture.path().join(PLANTED_SOURCE_PATHS[1]);
+    let stale_contents = fs::read(&stale_path).expect("crashed helper should leave planted source");
+    assert!(
+        stale_contents.starts_with(PLANTED_SOURCE_OWNERSHIP_MARKER.as_bytes()),
+        "crashed helper should leave an explicitly owned source fixture"
+    );
+
+    {
+        let _guard = lint_script_lock_for(fixture.path(), &lock_path);
+        assert!(
+            !stale_path.exists(),
+            "the next lock holder should recover the crashed process fixture before scanning"
+        );
+    }
+}
+
+#[test]
+fn lint_script_lock_preserves_unowned_and_unknown_sources() {
+    let fixture = TempDir::new().expect("create recovery ownership fixture");
+    let lock_path = fixture.path().join("target/lint-script.lock");
+    let unowned_path = fixture.path().join(PLANTED_SOURCE_PATHS[0]);
+    let unknown_path = fixture
+        .path()
+        .join("crates/codestory-runtime/src/unknown_probe.rs");
+    let unowned_contents = b"pub fn user_owned_source() {}\n";
+    let unknown_contents =
+        format!("{PLANTED_SOURCE_OWNERSHIP_MARKER}pub fn unknown_test_source() {{}}\n");
+    fs::create_dir_all(unowned_path.parent().expect("unowned source parent"))
+        .expect("create unowned source parent");
+    fs::write(&unowned_path, unowned_contents).expect("write unowned source");
+    fs::write(&unknown_path, &unknown_contents).expect("write unknown marked source");
+
+    {
+        let _guard = lint_script_lock_for(fixture.path(), &lock_path);
+        assert_eq!(
+            fs::read(&unowned_path).expect("unowned source should remain"),
+            unowned_contents,
+            "a known path without the ownership marker must not be removed"
+        );
+        assert_eq!(
+            fs::read_to_string(&unknown_path).expect("unknown marked source should remain"),
+            unknown_contents,
+            "the ownership marker must not authorize cleanup outside the known path set"
+        );
+    }
 }
 
 #[test]
@@ -2514,7 +2639,9 @@ fn linter_excludes_only_module_bodies_their_parent_declares_cfg_test() {
 
 /// Writes `contents` at `relative_path` inside the repository, runs the lint
 /// with its real default scan roots before and after, and removes the planted
-/// file (and any directory created for it) again, including on panic.
+/// file (and any directory created for it) again. The source carries a test
+/// ownership marker so the next lock holder can recover it if this process
+/// exits before `Drop` runs.
 fn run_default_lint_with_planted_source(
     repo_root: &Path,
     relative_path: &Path,
@@ -2534,7 +2661,9 @@ fn run_default_lint_with_planted_source(
 
 /// A source file planted in the real tree for the duration of one assertion.
 /// `Drop` runs while a failing assertion unwinds, so a red test cannot leave a
-/// stray module behind for the next `cargo build` to trip over.
+/// stray module behind for the next `cargo build` to trip over. Forced process
+/// exit skips `Drop`; `lint_script_lock` removes only the known paths carrying
+/// `PLANTED_SOURCE_OWNERSHIP_MARKER` before the next scan.
 struct PlantedSource {
     path: PathBuf,
     created_directory: Option<PathBuf>,
@@ -2554,7 +2683,8 @@ impl PlantedSource {
             fs::create_dir_all(&parent).expect("create planted probe directory");
             Some(parent)
         };
-        fs::write(&path, contents).expect("plant probe source file");
+        let marked_contents = format!("{PLANTED_SOURCE_OWNERSHIP_MARKER}{contents}");
+        fs::write(&path, marked_contents).expect("plant probe source file");
         Self {
             path,
             created_directory,


### PR DESCRIPTION
## Context

Closes #1591
Refs #1179

CodeStory blocks benchmark-shaped retrieval steering with a lint that scans the real production roots. Two guard tests temporarily plant hostile Rust files in those roots to prove an unlisted runtime file and an orphan `tests.rs` module cannot escape the scan.

The guard serialized lint subprocesses with a Rust `Mutex`. That works under the standard test harness, but the 0.16.3 source proof uses cargo-nextest, which runs each test in its own process. Release run 30411881352 failed when a clean default-root scan observed `crates/codestory-runtime/src/ranking_probe/tests.rs` while another process had planted it.

## Outcome

Default-root lint reads and temporary source plants now share one checkout-scoped advisory file lock in addition to the existing thread lock. Parallel cargo-nextest processes cannot observe each other's fixture state. If a planter is killed before its destructor runs, the next lock holder removes only a known fixture path carrying the exact test-ownership marker before scanning.

## What changed

- Hold the existing thread guard and an `fs4` exclusive lock at `target/retrieval-generalization-guard.lock` around every lint subprocess.
- Keep the lock across the complete baseline, plant, hostile scan, and normal cleanup sequence.
- Mark the two real-tree fixtures as test-owned and recover only those exact paths after abnormal process exit.
- Add real process regressions for lock exclusion, crash recovery, and the non-deletion boundary.
- Keep poison recovery for the thread mutex so one assertion still reports as one failure.

No production source, lint rule, workflow, or release claim changed.

## How to review

1. `lint_script_lock_for`: confirm recovery occurs only after acquiring the checkout-scoped process lock.
2. `recover_stale_planted_sources`: confirm both the exact known path and exact ownership marker are required.
3. `run_default_lint_with_planted_source`: confirm the guard covers baseline through fixture cleanup.
4. The process regressions: remove the exclusive lock or recovery call, and try widening cleanup beyond either ownership proof.

## Verification

Head `ef028057d16768e230a3f169cff19e34bda532e7`, base `2292cff92144935e3592027ab41195e3644b0de0`.

- Pre-fix hostile reproduction at the base: staggered cargo-nextest processes made the planter pass in 22.643s and the clean scan fail in 11.399s on the exact planted `createApplication` / `benchmarks/tasks` payload.
- Lock mutation: removing `FileExt::lock_exclusive` makes `lint_script_lock_serializes_independent_test_processes` fail because a second process acquires the lock early.
- Crash mutation: removing the recovery call makes `lint_script_lock_recovers_a_fixture_after_process_exit` fail with the planted source still present.
- Real SIGKILL reproduction: after the actual planter created `ranking_probe/tests.rs`, killing its Rust process returned 137; the next clean process removed the marker-owned file and passed.
- Independent exact-head refutation repeated that process and confirmed no orphan process, file, or directory remained.
- Independent cleanup mutations proved the boundaries are live: adding an unknown path or removing the marker gate makes the preservation regression fail.
- `cargo nextest run --locked -p codestory-runtime --test retrieval_generalization_guard --no-fail-fast` — 46 passed, 2 skipped; independently repeated with the same result.
- `cargo test --workspace --locked` — every workspace test binary and doctest passed, including the full 46-test standard guard.
- `cargo test --locked -p codestory-cli --test architecture_contracts` — 14 passed.
- Focused clippy with `-D warnings`, per-crate formatting, and `git diff --check` — clean.
- Remote saga guard, draft source checks, rustdoc, and retrieval contracts — green.

## Risk or follow-up

The lock and recovery are test-only. Recovery is intentionally narrower than a general stale-file cleanup: it ignores every unknown path and every known path without the exact ownership marker. The empty lock file may remain under ignored `target/` output.
