### PR TITLE
[codex] handle indexer resolution cancellation cooperatively

### DIFF
--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1480,6 +1480,8 @@ pub struct WorkspaceIndexer {
     artifact_cache_policies: ArtifactCachePolicies,
     #[cfg(test)]
     pipeline_test_hooks: FullRefreshPipelineTestHooks,
+    #[cfg(test)]
+    before_resolution_test_hook: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 
 impl WorkspaceIndexer {
@@ -1517,6 +1519,8 @@ impl WorkspaceIndexer {
             artifact_cache_policies: ArtifactCachePolicies::default(),
             #[cfg(test)]
             pipeline_test_hooks: FullRefreshPipelineTestHooks::default(),
+            #[cfg(test)]
+            before_resolution_test_hook: None,
         }
     }
 
@@ -1558,6 +1562,12 @@ impl WorkspaceIndexer {
     #[cfg(test)]
     fn with_pipeline_test_hooks(mut self, hooks: FullRefreshPipelineTestHooks) -> Self {
         self.pipeline_test_hooks = hooks;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_before_resolution_test_hook(mut self, hook: Arc<dyn Fn() + Send + Sync>) -> Self {
+        self.before_resolution_test_hook = Some(hook);
         self
     }
 
@@ -1842,10 +1852,26 @@ impl WorkspaceIndexer {
                     "Resolution pass starting with {unresolved_calls_start} unresolved CALL edges, {unresolved_imports_start} unresolved IMPORT edges, and {unresolved_overrides_start} unresolved OVERRIDE edges{scope_suffix}."
                 ),
             });
+            #[cfg(test)]
+            if let Some(hook) = &self.before_resolution_test_hook {
+                hook();
+            }
             let resolution_started = Instant::now();
-            let resolution_stats = resolver
-                .run_with_scope_with_cancel(storage, resolution_scope, cancel_token)
-                .map_err(|e| anyhow!("Resolution error: {:?}", e))?;
+            let resolution_stats = match resolver.run_with_scope_with_cancel(
+                storage,
+                resolution_scope,
+                cancel_token,
+            ) {
+                Ok(resolution_stats) => resolution_stats,
+                Err(error) if resolution::is_resolution_cancelled(&error) => {
+                    event_bus.publish(Event::IndexingComplete { duration_ms: 0 });
+                    return Ok(WorkspaceIndexingOutcome {
+                        stats,
+                        policy_exclusions,
+                    });
+                }
+                Err(error) => return Err(anyhow!("Resolution error: {:?}", error)),
+            };
             stats.edge_resolution_ms = stats
                 .edge_resolution_ms
                 .saturating_add(duration_ms_u64(resolution_started.elapsed()));
@@ -24691,6 +24717,72 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
         assert!(
             !storage.get_edges()?.is_empty(),
             "indexing should flush edges"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolution_cancellation_after_outer_check_returns_completed_indexing_work() -> Result<()>
+    {
+        use codestory_store::Store as Storage;
+        use codestory_workspace::RefreshInfo;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let path = dir.path().join("module.rs");
+        std::fs::write(&path, "fn caller() { callee(); }\nfn callee() {}\n")?;
+
+        let mut storage = Storage::new_in_memory()?;
+        let cancel_token = CancellationToken::new();
+        let cancel_before_resolution = cancel_token.clone();
+        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf())
+            .with_batch_config(IncrementalIndexingConfig {
+                file_batch_size: 1,
+                node_batch_size: usize::MAX,
+                edge_batch_size: usize::MAX,
+                occurrence_batch_size: usize::MAX,
+                error_batch_size: usize::MAX,
+            })
+            .with_before_resolution_test_hook(Arc::new(move || {
+                cancel_before_resolution.cancel();
+            }));
+        let refresh_info = RefreshInfo {
+            mode: codestory_workspace::BuildMode::Incremental,
+            files_to_index: vec![path],
+            files_to_remove: vec![],
+            existing_file_ids: HashMap::new(),
+        };
+
+        let stats = indexer.run_incremental(
+            &mut storage,
+            &refresh_info,
+            &EventBus::new(),
+            Some(&cancel_token),
+        )?;
+
+        assert!(cancel_token.is_cancelled());
+        assert!(
+            !stats.resolution_ran,
+            "rolled-back resolution is not completed work"
+        );
+        assert_eq!(stats.artifact_cache_writes, 1);
+        assert_eq!(stats.artifact_cache_write_transactions, 1);
+        let edges = storage.get_edges()?;
+        assert!(!edges.is_empty(), "completed indexing work should remain");
+        let call_edges = edges
+            .iter()
+            .filter(|edge| edge.kind == EdgeKind::CALL)
+            .collect::<Vec<_>>();
+        assert!(
+            !call_edges.is_empty(),
+            "fixture must produce a resolvable call"
+        );
+        assert!(
+            call_edges
+                .into_iter()
+                .all(|edge| edge.resolved_target.is_none()),
+            "cancelled resolution must not publish partial target updates"
         );
 
         Ok(())

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -715,6 +715,14 @@ pub struct ResolutionPass {
     semantic_resolvers: SemanticResolverRegistry,
 }
 
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("resolution cancelled")]
+struct ResolutionCancelled;
+
+pub(crate) fn is_resolution_cancelled(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<ResolutionCancelled>().is_some()
+}
+
 impl Default for ResolutionPass {
     fn default() -> Self {
         Self::new()
@@ -836,7 +844,7 @@ impl ResolutionPass {
 
     fn check_cancelled(cancel_token: Option<&CancellationToken>) -> Result<()> {
         if cancel_token.is_some_and(CancellationToken::is_cancelled) {
-            anyhow::bail!("resolution cancelled");
+            return Err(ResolutionCancelled.into());
         }
         Ok(())
     }
@@ -3398,6 +3406,22 @@ mod tests {
     use std::collections::HashSet;
     use std::time::Instant;
     use tempfile::tempdir;
+
+    #[test]
+    fn resolution_cancellation_signal_is_typed() {
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let cancellation = ResolutionPass::check_cancelled(Some(&cancel_token))
+            .expect_err("cancelled resolution should return its typed signal");
+        assert!(is_resolution_cancelled(&cancellation));
+
+        let unrelated = anyhow::anyhow!("resolution cancelled");
+        assert!(
+            !is_resolution_cancelled(&unrelated),
+            "matching text must not reclassify an unrelated resolution failure"
+        );
+    }
 
     fn create_node_table(conn: &Connection) -> Result<()> {
         conn.execute_batch(


### PR DESCRIPTION
## Context

The exact 0.16.3 proof candidate failed its full source gate when asynchronous progress handling cancelled indexing after the outer token check and inside `ResolutionPass`. The resolution transaction rolled back, but `WorkspaceIndexer` surfaced that cooperative stop as a generic failure. Under 256 isolated test processes at concurrency 64, the pre-fix head failed 41 times with the same Actions error.

Closes #1593

## What changed

- Replaced the untyped `resolution cancelled` error with an internal typed signal.
- Converted only that typed signal at the indexer boundary into successful completion with the already-finished indexing stats.
- Kept unrelated resolution errors fatal and left runtime cancellation mapping unchanged.
- Added a deterministic regression at the post-check boundary and a type-identity regression that rejects same-text unrelated errors.

## How to review

Start at `ResolutionCancelled` and `check_cancelled` in `crates/codestory-indexer/src/resolution/mod.rs`. Then inspect the result match around `run_with_scope_with_cancel` in `crates/codestory-indexer/src/lib.rs`. The deterministic test proves completed indexing writes remain while cancelled resolution updates do not publish.

## Verification

Completed on exact head `d2c7b8511b457dc40f64cfeb5b5c5755a9eb8541`:

- Release-source command `cargo nextest run --workspace --locked`: 2,388 passed, 31 skipped, zero failed.
- Full `codestory-indexer` package: 245 library tests plus every integration binary passed.
- Architecture contracts: 14/14 passed.
- Runtime cancellation-state integration test passed.
- Original 256-process, concurrency-64 contention shape: 256/256 passed; pre-fix was 215/256.
- Independent adversarial verification passed:
  - same-text SQLite failure remained fatal;
  - cancellation after resolver apply rolled back source and target mutations;
  - typed cancellation survived `anyhow` context;
  - all production propagation sites preserved the typed error.
- `git diff --check` passed.
- PR checks passed: Ubuntu draft source checks, Linux retrieval contracts, rustdoc warnings, and closing-issue guard.

The ordinary in-process `cargo test --workspace --locked` crossed the changed paths and most of the workspace, then was stopped after unrelated activation fixtures formed a process-wide SQLite mutex convoy. The release-source isolated-process command above completed the full workspace cleanly.

## Risk

Classification is type-based, never text-based. A cancelled resolution transaction still rolls back through the existing transaction wrapper; successful resolution and no-token behavior are unchanged. This repairs an internal indexer contract, so it has no changelog entry.
