### PR TITLE
Bind every release head to its calibration source

### DIFF
--- a/.github/scripts/check-calibration-release-lineage.py
+++ b/.github/scripts/check-calibration-release-lineage.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Fail a release whose source tree was not the calibrated frozen tree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from packaged_agent_proof.calibration_lineage import (
+    verify_release_head_calibration_lineage,
+)
+from packaged_agent_proof.foundation import ProofFailure
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify that the exact release head differs from the calibrated "
+            "source only by the frozen constant-set file."
+        )
+    )
+    parser.add_argument("--repo", required=True, type=Path)
+    parser.add_argument("--expected-sha", required=True)
+    arguments = parser.parse_args()
+
+    repository_root = arguments.repo.resolve(strict=True)
+    result = verify_release_head_calibration_lineage(
+        repository_root,
+        arguments.expected_sha,
+    )
+    print(json.dumps({"status": "passed", **result}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (
+        ProofFailure,
+        subprocess.TimeoutExpired,
+        OSError,
+        json.JSONDecodeError,
+    ) as exc:
+        print(f"calibration release lineage failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -325,10 +325,25 @@ function conditionIsSatisfiable(condition, bindings, extraDomains) {
     : { satisfiable: false, reason: "no caller dispatch satisfies the condition" };
 }
 
-function requireNoCalibrationReferences(violations, file, workflow) {
+function requireNoCalibrationReferences(
+  violations,
+  file,
+  workflow,
+  allowedSteps = [],
+) {
+  const inspected = structuredClone(workflow);
+  for (const [jobName, job] of Object.entries(object(inspected.jobs))) {
+    if (!Array.isArray(job.steps)) continue;
+    job.steps = job.steps.filter(
+      step => !allowedSteps.some(
+        ([allowedJob, allowedName]) =>
+          allowedJob === jobName && allowedName === object(step).name,
+      ),
+    );
+  }
   add(
     violations,
-    !JSON.stringify(workflow).toLowerCase().includes("calibration"),
+    !JSON.stringify(inspected).toLowerCase().includes("calibration"),
     `${file} standard release path must not reference calibration`,
   );
 }
@@ -1952,7 +1967,18 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     at(release, "on", "workflow_dispatch", "inputs", "publish_release") === undefined,
     `${releaseFile} workflow_dispatch must not expose publication authority`,
   );
-  requireNoCalibrationReferences(violations, releaseFile, release);
+  const releaseLineageStepName = "Verify release-head calibration lineage";
+  add(
+    violations,
+    release.env === undefined && release.defaults === undefined,
+    `${releaseFile} release workflow must not override the release-head calibration execution environment`,
+  );
+  requireNoCalibrationReferences(
+    violations,
+    releaseFile,
+    release,
+    [["preflight", releaseLineageStepName]],
+  );
   const policy = requireJob(violations, releaseFile, release, "workflow-policy");
   // The reuse-binding contracts resolve real release commits, which a depth-1
   // clone does not carry: it answered only while the referenced commit happened
@@ -1986,6 +2012,17 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   ]);
 
   const preflight = requireJob(violations, releaseFile, release, "preflight");
+  add(
+    violations,
+    hasExactKeys(
+      preflight,
+      ["name", "needs", "runs-on", "timeout-minutes", "outputs", "steps"],
+    )
+      && preflight.name === "Release preflight"
+      && preflight["runs-on"] === "ubuntu-latest"
+      && preflight["timeout-minutes"] === 10,
+    `${releaseFile} preflight must retain the exact trusted job environment`,
+  );
   add(violations, sameMembers(needs(preflight), releaseChain.dependencies.preflight), `${releaseFile} preflight dependencies must match the release claim graph`);
   requireStepRun(violations, releaseFile, preflight, "Validate release authority", [
     'if [ "$PUBLISH_RELEASE" = "true" ]; then',
@@ -2000,6 +2037,52 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     'repos/$GITHUB_REPOSITORY/git/ref/heads/dev/codestory-next',
     "dev/codestory-next moved from proved head",
   ]);
+  const releaseLineage = namedStep(preflight, releaseLineageStepName);
+  add(
+    violations,
+    preflight.if === undefined
+      && preflight["continue-on-error"] === undefined
+      && hasExactKeys(
+        releaseLineage,
+        ["name", "env", "shell", "working-directory", "run"],
+      )
+      && hasExactKeys(object(releaseLineage?.env), ["BASH_ENV"])
+      && object(releaseLineage?.env).BASH_ENV === "/dev/null"
+      && releaseLineage?.shell === "/bin/bash --noprofile --norc -e -o pipefail {0}"
+      && releaseLineage?.["working-directory"] === "${{ github.workspace }}",
+    `${releaseFile} release-head calibration lineage must be unconditional and fail closed`,
+  );
+  add(
+    violations,
+    sameStrings(
+      nonCommentLines(releaseLineage?.run),
+      [
+        "/usr/bin/python3 -E -s "
+          + '"$GITHUB_WORKSPACE/.github/scripts/check-calibration-release-lineage.py" '
+          + '--repo "$GITHUB_WORKSPACE" --expected-sha "$GITHUB_SHA"',
+      ],
+    ),
+    `${releaseFile} release-head calibration lineage must use the pinned interpreter on the exact release checkout`,
+  );
+  const preflightCheckout = namedStep(preflight, "Checkout");
+  add(
+    violations,
+    hasExactKeys(preflightCheckout, ["name", "uses", "with"])
+      && preflightCheckout?.uses === "actions/checkout@v5"
+      && hasExactKeys(object(preflightCheckout?.with), ["fetch-depth"])
+      && object(preflightCheckout?.with)["fetch-depth"] === 0,
+    `${releaseFile} preflight checkout must retain the exact trusted shape`,
+  );
+  add(
+    violations,
+    stepIndex(preflight, "Checkout") === 0
+      && stepIndex(preflight, releaseLineageStepName) === 1
+      && stepIndex(preflight, releaseLineageStepName)
+        < stepIndex(preflight, "Validate release authority")
+      && stepIndex(preflight, releaseLineageStepName)
+        < stepIndex(preflight, "Verify release version"),
+    `${releaseFile} release-head calibration lineage must run immediately after checkout and before other release work`,
+  );
   requireStepRun(violations, releaseFile, preflight, "Validate versioned changelog notes", [
     "node .github/scripts/extract-codestory-release-notes.mjs",
     '--version "$VERSION"',

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -132,6 +139,74 @@ ${run}`;
   return spawnSync(executable, args, {
     encoding: "utf8",
   });
+}
+
+const calibrationReleaseChecker = path.join(
+  root,
+  ".github/scripts/check-calibration-release-lineage.py",
+);
+const calibrationConstantSet =
+  "crates/codestory-llama-sys/per-user-embedding-server-constant-set.json";
+const calibrationGitEnvironment = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "CodeStory Proof",
+  GIT_AUTHOR_EMAIL: "proof@codestory.invalid",
+  GIT_COMMITTER_NAME: "CodeStory Proof",
+  GIT_COMMITTER_EMAIL: "proof@codestory.invalid",
+  GIT_AUTHOR_DATE: "2026-01-01T00:00:00+00:00",
+  GIT_COMMITTER_DATE: "2026-01-01T00:00:00+00:00",
+  GIT_CONFIG_GLOBAL: os.devNull,
+  GIT_CONFIG_SYSTEM: os.devNull,
+};
+
+function calibrationGit(repository, ...gitArguments) {
+  const result = spawnSync(
+    "git",
+    ["-c", "commit.gpgsign=false", ...gitArguments],
+    {
+      cwd: repository,
+      encoding: "utf8",
+      env: calibrationGitEnvironment,
+    },
+  );
+  assert.equal(
+    result.status,
+    0,
+    result.stderr || result.stdout || `git ${gitArguments.join(" ")} failed`,
+  );
+  return result.stdout.trim();
+}
+
+function writeCalibrationFixture(repository, relative, contents) {
+  const target = path.join(repository, relative);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, contents);
+}
+
+function commitCalibrationFixture(repository, message) {
+  calibrationGit(repository, "add", "-A");
+  calibrationGit(repository, "commit", "--no-verify", "-q", "-m", message);
+  return {
+    commit: calibrationGit(repository, "rev-parse", "HEAD"),
+    tree: calibrationGit(repository, "rev-parse", "HEAD^{tree}"),
+  };
+}
+
+function runCalibrationReleaseCheck(repository, expectedSha) {
+  return spawnSync(
+    "python",
+    [
+      calibrationReleaseChecker,
+      "--repo",
+      repository,
+      "--expected-sha",
+      expectedSha,
+    ],
+    {
+      cwd: root,
+      encoding: "utf8",
+    },
+  );
 }
 
 const marketplaceGuardName = "Validate the dispatched release coordinates";
@@ -449,6 +524,189 @@ test("release authority accepts only exact live auto-main or manual-dev routes",
     assert.notEqual(result.status, 0);
     assert.match(result.stdout, /dev\/codestory-next moved from proved head/u);
   });
+});
+
+test("release-head calibration lineage rejects identities and source shapes around the freeze", async (t) => {
+  const fixtureRoot = mkdtempSync(
+    path.join(os.tmpdir(), "codestory-release-lineage-"),
+  );
+  t.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+  const repository = path.join(fixtureRoot, "repository");
+  mkdirSync(repository, { recursive: true });
+  calibrationGit(repository, "-c", "init.defaultBranch=main", "init", "-q");
+  writeCalibrationFixture(repository, "README.md", "release lineage fixture\n");
+  writeCalibrationFixture(
+    repository,
+    calibrationConstantSet,
+    `${JSON.stringify({ status: "unfrozen", freeze_record: null }, null, 2)}\n`,
+  );
+  const calibrated = commitCalibrationFixture(repository, "calibrate");
+  const frozenContract = {
+    status: "frozen",
+    freeze_record: {
+      selection_source_commit: calibrated.commit,
+      selection_source_tree: calibrated.tree,
+    },
+  };
+  writeCalibrationFixture(
+    repository,
+    calibrationConstantSet,
+    `${JSON.stringify(frozenContract, null, 2)}\n`,
+  );
+  const frozen = commitCalibrationFixture(repository, "freeze constants");
+
+  await t.test("the one-file freeze is accepted", () => {
+    const result = runCalibrationReleaseCheck(repository, frozen.commit);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const receipt = JSON.parse(result.stdout);
+    assert.equal(receipt.status, "passed");
+    assert.equal(receipt.selection_commit, calibrated.commit);
+    assert.equal(receipt.frozen_commit, frozen.commit);
+    assert.deepEqual(receipt.allowed_changed_paths, [calibrationConstantSet]);
+  });
+
+  await t.test("a caller-supplied SHA that is not the checkout is rejected", () => {
+    const result = runCalibrationReleaseCheck(repository, calibrated.commit);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /release checkout does not match the expected release source/u);
+  });
+
+  await t.test("a tree-preserving promotion commit stays bound", () => {
+    calibrationGit(
+      repository,
+      "commit",
+      "--allow-empty",
+      "--no-verify",
+      "-q",
+      "-m",
+      "promote frozen tree",
+    );
+    const promoted = calibrationGit(repository, "rev-parse", "HEAD");
+    const result = runCalibrationReleaseCheck(repository, promoted);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    calibrationGit(repository, "reset", "--hard", frozen.commit);
+  });
+
+  await t.test("a freeze record carrying the wrong calibration tree is rejected", () => {
+    writeCalibrationFixture(
+      repository,
+      calibrationConstantSet,
+      `${JSON.stringify({
+        ...frozenContract,
+        freeze_record: {
+          ...frozenContract.freeze_record,
+          selection_source_tree: "f".repeat(40),
+        },
+      }, null, 2)}\n`,
+    );
+    const wrongTree = commitCalibrationFixture(repository, "forge calibration tree");
+    const result = runCalibrationReleaseCheck(repository, wrongTree.commit);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /calibration commit does not resolve to the recorded calibration tree/u);
+    calibrationGit(repository, "reset", "--hard", frozen.commit);
+  });
+
+  await t.test("source drift after the freeze is rejected and named", () => {
+    writeCalibrationFixture(repository, "README.md", "post-freeze source drift\n");
+    const drifted = commitCalibrationFixture(repository, "change source after freeze");
+    const result = runCalibrationReleaseCheck(repository, drifted.commit);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /post-calibration source drift exceeded/u);
+    assert.match(result.stderr, /README\.md/u);
+  });
+});
+
+test("release policy keeps the release-head lineage check mandatory and exact", async (t) => {
+  const stepName = "Verify release-head calibration lineage";
+  const cases = [
+    ["missing step", workflows => {
+      const steps = workflows.get("release.yml").jobs.preflight.steps;
+      workflows.get("release.yml").jobs.preflight.steps = steps
+        .filter(step => step.name !== stepName);
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["conditional publishing-only step", workflows => {
+      draftStep(workflows.get("release.yml").jobs.preflight, stepName).if
+        = "inputs.publish_release";
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["advisory continue-on-error step", workflows => {
+      draftStep(workflows.get("release.yml").jobs.preflight, stepName)["continue-on-error"]
+        = true;
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["advisory preflight job", workflows => {
+      workflows.get("release.yml").jobs.preflight["continue-on-error"] = true;
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["conditional preflight job", workflows => {
+      workflows.get("release.yml").jobs.preflight.if = "inputs.publish_release";
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["job PATH shadows the lineage interpreter", workflows => {
+      workflows.get("release.yml").jobs.preflight.env = {
+        PATH: "${{ github.workspace }}/scripts/fake-bin:${{ env.PATH }}",
+      };
+    }, /preflight must retain the exact trusted job environment/u],
+    ["job BASH_ENV changes lineage execution", workflows => {
+      workflows.get("release.yml").jobs.preflight.env = {
+        BASH_ENV: "${{ github.workspace }}/scripts/fake-bin/bash-env",
+      };
+    }, /preflight must retain the exact trusted job environment/u],
+    ["job shell defaults change lineage execution", workflows => {
+      workflows.get("release.yml").jobs.preflight.defaults = {
+        run: { shell: "bash --noprofile --norc -e {0}" },
+      };
+    }, /preflight must retain the exact trusted job environment/u],
+    ["workflow PATH shadows the lineage interpreter", workflows => {
+      workflows.get("release.yml").env = {
+        PATH: "${{ github.workspace }}/scripts/fake-bin:${{ env.PATH }}",
+      };
+    }, /release workflow must not override the release-head calibration execution environment/u],
+    ["workflow BASH_ENV changes lineage execution", workflows => {
+      workflows.get("release.yml").env = {
+        BASH_ENV: "${{ github.workspace }}/scripts/fake-bin/bash-env",
+      };
+    }, /release workflow must not override the release-head calibration execution environment/u],
+    ["workflow shell defaults change lineage execution", workflows => {
+      workflows.get("release.yml").defaults = {
+        run: { shell: "bash --noprofile --norc -e {0}" },
+      };
+    }, /release workflow must not override the release-head calibration execution environment/u],
+    ["interpreter uses PATH lookup", workflows => {
+      const step = draftStep(workflows.get("release.yml").jobs.preflight, stepName);
+      step.run = step.run.replace("/usr/bin/python3 -E -s", "python");
+    }, /must use the pinned interpreter on the exact release checkout/u],
+    ["lineage shell uses PATH lookup", workflows => {
+      const step = draftStep(workflows.get("release.yml").jobs.preflight, stepName);
+      step.shell = "bash -e {0}";
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["lineage step sources a hostile BASH_ENV", workflows => {
+      const step = draftStep(workflows.get("release.yml").jobs.preflight, stepName);
+      step.env.BASH_ENV = "${{ github.workspace }}/scripts/fake-bin/bash-env";
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["lineage step changes working directory", workflows => {
+      const step = draftStep(workflows.get("release.yml").jobs.preflight, stepName);
+      step["working-directory"] = "${{ runner.temp }}";
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["lineage step injects another environment variable", workflows => {
+      const step = draftStep(workflows.get("release.yml").jobs.preflight, stepName);
+      step.env.PYTHONPATH = "${{ github.workspace }}/scripts/fake-python";
+    }, /release-head calibration lineage must be unconditional and fail closed/u],
+    ["step inserted before lineage", workflows => {
+      workflows.get("release.yml").jobs.preflight.steps.splice(1, 0, {
+        name: "Rewrite execution environment",
+        run: 'echo "$GITHUB_WORKSPACE/scripts/fake-bin" >> "$GITHUB_PATH"',
+      });
+    }, /must run immediately after checkout and before other release work/u],
+    ["wrong release SHA", workflows => {
+      const step = draftStep(workflows.get("release.yml").jobs.preflight, stepName);
+      step.run = step.run.replace("$GITHUB_SHA", "$EXPECTED_HEAD_SHA");
+    }, /must use the pinned interpreter on the exact release checkout/u],
+  ];
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  for (const [name, mutate, expected] of cases) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows);
+      assert.match(validateWorkflows(workflows).join("\n"), expected);
+    });
+  }
 });
 
 test("proof resolvers reject hostile refs, SHAs, and labeled-event drift before proof work", async (t) => {
@@ -1179,6 +1437,12 @@ test("standard release paths reject calibration plumbing", async (t) => {
     ["release forwards calibration to package proof", workflows => {
       workflows.get("release.yml").jobs["packaged-proof"].with.calibration_bundle_run_id
         = "${{ inputs.calibration_bundle_run_id }}";
+    }, /release\.yml standard release path must not reference calibration/u],
+    ["release hides calibration plumbing in a same-named decoy step", workflows => {
+      workflows.get("release.yml").jobs["workflow-policy"].steps.push({
+        name: "Verify release-head calibration lineage",
+        run: "echo calibration_bundle_artifact",
+      });
     }, /release\.yml standard release path must not reference calibration/u],
     ["post-publish proof receives calibration", workflows => {
       const step = draftStep(

--- a/.github/scripts/packaged_agent_proof/calibration_lineage.py
+++ b/.github/scripts/packaged_agent_proof/calibration_lineage.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 from pathlib import Path
 
 from .contract_primitives import require_nonempty_string
-from .foundation import require
+from .foundation import ProofFailure, require
 
 # The single file a freeze commit is allowed to write between the tree that was
 # calibrated and the tree that is packaged.
@@ -26,6 +27,125 @@ REQUIRED_RELEASE_ORDERING = (
     "is the only file it may write). A calibrate-then-bump ordering fails here: "
     "move the bump ahead of calibration and recalibrate on the bumped tree"
 )
+
+
+def _git(repository_root: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=repository_root,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    require(
+        completed.returncode == 0,
+        "calibration source-lineage probe failed: "
+        + require_nonempty_string(
+            completed.stderr.strip()
+            or completed.stdout.strip()
+            or f"git {' '.join(arguments)} exited {completed.returncode} "
+            "without output",
+            "Git lineage failure",
+        ),
+    )
+    return completed.stdout.strip()
+
+
+def _tracked_source_dirty(repository_root: Path) -> bool:
+    dirty = False
+    for arguments in (
+        ("diff", "--quiet", "--ignore-submodules", "--"),
+        ("diff", "--cached", "--quiet", "--ignore-submodules", "--"),
+    ):
+        completed = subprocess.run(
+            ["git", *arguments],
+            cwd=repository_root,
+            capture_output=True,
+            timeout=30,
+        )
+        require(
+            completed.returncode in (0, 1),
+            "calibration source-lineage dirty-tree probe failed: "
+            + require_nonempty_string(
+                completed.stderr.decode(errors="replace").strip()
+                or completed.stdout.decode(errors="replace").strip()
+                or f"git {' '.join(arguments)} exited {completed.returncode} "
+                "without output",
+                "Git dirty-tree failure",
+            ),
+        )
+        dirty = dirty or completed.returncode == 1
+    return dirty
+
+
+def verify_release_head_calibration_lineage(
+    repository_root: Path,
+    expected_release_commit: str,
+) -> dict:
+    """Bind a release checkout to the calibration source in its freeze record.
+
+    Package qualification can authenticate the original calibration bundle,
+    but the publishing lane deliberately does not receive that optional
+    evidence. The checked-in freeze record is therefore the release lane's
+    durable source binding: the actual release head must descend from the
+    recorded calibration commit and differ from it only by the constant-set
+    freeze file.
+    """
+
+    require(
+        isinstance(expected_release_commit, str)
+        and re.fullmatch(r"[0-9a-f]{40}", expected_release_commit) is not None,
+        "expected release source is not an exact lowercase Git commit",
+    )
+    constant_set_path = repository_root / CONSTANT_SET_FREEZE_PATH
+    require(
+        constant_set_path.is_file() and not constant_set_path.is_symlink(),
+        f"release calibration freeze record is missing or unsafe: "
+        f"{constant_set_path}",
+    )
+    try:
+        constant_set = json.loads(constant_set_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ProofFailure(
+            f"release calibration constant set is not valid JSON: {exc}"
+        ) from exc
+    require(
+        isinstance(constant_set, dict) and constant_set.get("status") == "frozen",
+        "release calibration constant set is not frozen",
+    )
+    freeze_record = constant_set.get("freeze_record")
+    require(
+        isinstance(freeze_record, dict),
+        "release calibration constant set omits its freeze record",
+    )
+
+    release_commit = _git(repository_root, "rev-parse", "HEAD")
+    release_tree = _git(repository_root, "rev-parse", "HEAD^{tree}")
+    require(
+        release_commit == expected_release_commit,
+        "release checkout does not match the expected release source: "
+        f"expected {expected_release_commit}, got {release_commit}",
+    )
+    calibration_source = {
+        "commit": freeze_record.get("selection_source_commit"),
+        "tree": freeze_record.get("selection_source_tree"),
+        "tracked_dirty": False,
+    }
+    release_source = {
+        "commit": release_commit,
+        "tree": release_tree,
+        "tracked_dirty": _tracked_source_dirty(repository_root),
+    }
+    lineage = verify_calibration_source_lineage(
+        calibration_source,
+        release_source,
+        repository_root,
+    )
+    return {
+        **lineage,
+        "selection_tree": calibration_source["tree"],
+        "release_tree": release_tree,
+    }
 
 
 def verify_calibration_source_lineage(
@@ -53,40 +173,18 @@ def verify_calibration_source_lineage(
         "frozen package did not add the required constant-set freeze commit",
     )
 
-    def git(*arguments: str) -> str:
-        completed = subprocess.run(
-            ["git", *arguments],
-            cwd=repository_root,
-            text=True,
-            capture_output=True,
-            timeout=30,
-        )
-        # `require`'s message argument is evaluated before the call, so the
-        # detail must not itself be a contract that a *successful* probe can
-        # violate. `git diff --name-only` legitimately prints nothing when the
-        # two trees are identical, and demanding non-empty output here replaced
-        # the actionable drift message below with "Git lineage failure must be a
-        # non-empty string".
-        require(
-            completed.returncode == 0,
-            "calibration source-lineage probe failed: "
-            + require_nonempty_string(
-                completed.stderr.strip()
-                or completed.stdout.strip()
-                or f"git {' '.join(arguments)} exited {completed.returncode} "
-                "without output",
-                "Git lineage failure",
-            ),
-        )
-        return completed.stdout.strip()
-
     require(
-        git("rev-parse", "HEAD") == frozen_source["commit"]
-        and git("rev-parse", "HEAD^{tree}") == frozen_source["tree"],
+        _git(repository_root, "rev-parse", "HEAD") == frozen_source["commit"]
+        and _git(repository_root, "rev-parse", "HEAD^{tree}")
+        == frozen_source["tree"],
         "verification checkout does not match the frozen package source",
     )
     require(
-        git("rev-parse", f"{calibration_source['commit']}^{{tree}}")
+        _git(
+            repository_root,
+            "rev-parse",
+            f"{calibration_source['commit']}^{{tree}}",
+        )
         == calibration_source["tree"],
         "calibration commit does not resolve to the recorded calibration tree",
     )
@@ -112,7 +210,8 @@ def verify_calibration_source_lineage(
     )
     changed_paths = [
         path
-        for path in git(
+        for path in _git(
+            repository_root,
             "diff",
             "--name-only",
             calibration_source["commit"],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify release-head calibration lineage
+        env:
+          BASH_ENV: /dev/null
+        shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+        working-directory: ${{ github.workspace }}
+        run: >-
+          /usr/bin/python3 -E -s
+          "$GITHUB_WORKSPACE/.github/scripts/check-calibration-release-lineage.py"
+          --repo "$GITHUB_WORKSPACE"
+          --expected-sha "$GITHUB_SHA"
+
       - name: Validate release authority
         env:
           EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,12 +219,14 @@ adapter to compensate for incorrect upstream state.
 - Release ordering is **bump-then-calibrate**. Bump the version first,
   calibrate the per-user embedding server on the bumped tree, land the
   constant-set freeze commit, then package and release. The frozen-candidate
-  `qualification` dispatch enforces this -- it is the only lane that carries a
-  calibration bundle, and its packaged proof runs
-  `Prove frozen calibration source lineage` whenever one arrives: the
-  calibration commit must be an ancestor of the packaged commit and
-  `crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` must
-  be the only file that differs between them. A calibrate-then-bump ordering
+  `qualification` dispatch authenticates the calibration bundle and runs
+  `Prove frozen calibration source lineage`. Every proof-only or publishing
+  release preflight separately runs
+  `.github/scripts/check-calibration-release-lineage.py` against its actual
+  checked-out head, even when no bundle is supplied. Both bindings require the
+  calibration commit to be an ancestor of the release commit and require
+  `crates/codestory-llama-sys/per-user-embedding-server-constant-set.json` to be
+  the only file that differs between them. A calibrate-then-bump ordering
   fails the guard by name; the fix is to move the bump ahead of calibration and
   recalibrate on the bumped tree, never to widen the allowed path set. Any other
   commit -- a doc fix, a CI tweak, a rebase -- between calibration and the

--- a/docs/testing/per-user-embedding-server-qualification.md
+++ b/docs/testing/per-user-embedding-server-qualification.md
@@ -199,6 +199,16 @@ with its lineage, and stops before the runtime proof. Without the enforcement
 flag a `--version-only` proof rejects calibration inputs outright, so the flag
 cannot be dropped without the step failing.
 
+The release workflow has a second, unconditional binding. Before reusing source
+proof or building a package, `release.yml` runs
+`.github/scripts/check-calibration-release-lineage.py` against its exact
+checked-out `GITHUB_SHA`. The check reads the calibration commit and tree from
+the checked-in freeze record, derives the release tree from Git, and applies the
+same ancestor and one-file-difference rule. It runs for both a proof-only
+`dev/codestory-next` dispatch and the publishing `main` caller, so qualifying one
+head cannot authorize a later source tree. This check does not replace bundle
+authentication or turn package proof into a release-evidence consumer.
+
 The full frozen `hosted_package` qualification in the same workflow carries the
 same flag, but it cannot run today: `--produce-qualification-evidence` requires
 the exact-head release-evidence `packet-runtime-summary.json` at any
@@ -207,9 +217,10 @@ release evidence to package proof. The `protected_hardware` bundle consumers on
 the Metal, Windows Vulkan, and Linux Vulkan lanes are likewise exempt: on the
 release path they run `--server-behavior-only`, which takes their no-bundle
 branch, and on the coordinator path they carry the same release-evidence
-requirement. The lineage is proved once, on the frozen candidate, and the later
-package proofs consume the already-frozen constant set rather than re-proving how
-it was reached.
+requirement. Those package and hardware invocations consume the already-frozen
+constant set without re-authenticating its bundle; the mandatory release
+preflight independently proves that the frozen source binding still covers the
+tree being released.
 
 That rule fixes the release ordering to **bump-then-calibrate**: bump the
 version first with `node scripts/bump-version.mjs --version <version>`,


### PR DESCRIPTION
## Context

The calibration-lineage verifier existed, but the standard proof and publishing release path supplied no calibration bundle. That let a later source head package frozen timing constants without proving that the constants were measured on the tree being released.

## What changed

- Release preflight now reads the calibration commit and tree from the checked-in freeze record and applies the existing ancestor plus constants-only-diff verifier to the actual `GITHUB_SHA`.
- The check is the first executable step after an exact full-history checkout. Its runner, shell, interpreter, environment, working directory, command, and job shape are pinned by workflow policy.
- The authenticated calibration-bundle proof remains separate and unchanged.
- The contributor and qualification contracts now describe both bindings.

The release job graph and `release-claims.json` are unchanged.

## How to review

Start with `.github/scripts/check-calibration-release-lineage.py` and `verify_release_head_calibration_lineage`, then the preflight step and its workflow-policy assertions. The important failure boundary is any source change after calibration other than the generated constant-set freeze.

## Verification

- workflow policy: 705/705 before the execution-boundary amendment; focused amended policy suite 19/19; current validator clean
- release contract tests: 109/109
- actionlint tests: 3/3; live actionlint clean
- release claim graph, 0.16.3 surface validation, route self-test, docs links, packaged-proof self-test, and `git diff --check` clean
- independent configuration matrix: 17/17 execution-override variants rejected
- exact checker against the current stale 0.16.3 candidate: failed and named the post-calibration source drift

The current development head is expected to remain unreleasable until issue #1558's corrected measurement is recalibrated and the generated constant set is the sole post-calibration file change.

Closes #1590
