### PR TITLE
Keep draft calibration off full-project reactivation

### DIFF
--- a/.github/scripts/packaged_agent_proof/runtime_bootstrap_continuity.py
+++ b/.github/scripts/packaged_agent_proof/runtime_bootstrap_continuity.py
@@ -94,23 +94,25 @@ def _live_retrieval(
     cold: ColdProof,
     manifest: dict,
 ) -> dict | None:
-    run_parallel(
-        {
-            "packet-a": lambda: hosts.host_a.tool_until_ready(
-                "packet",
-                {
-                    "project": str(setup.project_a),
-                    "question": args.question,
-                    "budget": "compact",
-                },
-                "packet-a",
-            ),
-            "search-b-live": lambda: hosts.host_b.search_until_ready(
-                {"project": str(setup.project_b), "query": setup.query_b, "why": True},
-                "search-b-live",
-            ),
-        }
+    live_tasks = {}
+    # Calibration already proved both projects in the cold phase. Its draft
+    # measurements keep the resident process set live through the tiny project
+    # instead of starting another full-project activation.
+    if args.proof_tier != "calibration":
+        live_tasks["packet-a"] = lambda: hosts.host_a.tool_until_ready(
+            "packet",
+            {
+                "project": str(setup.project_a),
+                "question": args.question,
+                "budget": "compact",
+            },
+            "packet-a",
+        )
+    live_tasks["search-b-live"] = lambda: hosts.host_b.search_until_ready(
+        {"project": str(setup.project_b), "query": setup.query_b, "why": True},
+        "search-b-live",
     )
+    run_parallel(live_tasks)
     after = server_snapshot(
         hosts.host_b.engine_diagnostics(setup.project_b, "diagnostics-after-live"),
         manifest,
@@ -166,10 +168,18 @@ def _continuity_proof(
         == cold.shared_identity["server_instance_id"],
         "one client exit disrupted the surviving client or replaced the server",
     )
+    # Replacement-host continuity needs the same resident server, not a second
+    # activation of the full calibration source tree.
+    if args.proof_tier == "calibration":
+        rejoin_project = setup.project_b
+        rejoin_query = setup.query_b
+    else:
+        rejoin_project = setup.project_a
+        rejoin_query = args.query
     host_c = McpProcess(
         setup.command,
         env=setup.qualified_env,
-        cwd=setup.project_a,
+        cwd=rejoin_project,
         timeout=args.timeout_secs,
     )
     start_c = process_start_identity(host_c.process.pid)
@@ -184,10 +194,10 @@ def _continuity_proof(
         )
         host_c.initialize()
         host_c.search_until_ready(
-            {"project": str(setup.project_a), "query": args.query, "why": True},
+            {"project": str(rejoin_project), "query": rejoin_query, "why": True},
             "rejoin-search",
         )
-        diagnostics = host_c.engine_diagnostics(setup.project_a, "rejoin-diagnostics")
+        diagnostics = host_c.engine_diagnostics(rejoin_project, "rejoin-diagnostics")
         rejoin_identity = engine_identity(
             diagnostics,
             args.engine_policy,

--- a/.github/scripts/packaged_agent_proof/self_test_contracts.py
+++ b/.github/scripts/packaged_agent_proof/self_test_contracts.py
@@ -2,10 +2,14 @@
 
 from .self_test_contract_scope import run_contract_scope_self_tests
 from .self_test_resource_identity import run_resource_identity_self_tests
+from .self_test_runtime_bootstrap_scope import (
+    run_runtime_bootstrap_scope_self_tests,
+)
 from .self_test_worker_schema import run_worker_schema_self_tests
 
 
 def run_contract_self_tests() -> None:
     run_contract_scope_self_tests()
+    run_runtime_bootstrap_scope_self_tests()
     run_resource_identity_self_tests()
     run_worker_schema_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_runtime_bootstrap_scope.py
+++ b/.github/scripts/packaged_agent_proof/self_test_runtime_bootstrap_scope.py
@@ -1,0 +1,323 @@
+"""Proof-tier scope tests for the packaged runtime bootstrap."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+from . import runtime_bootstrap_continuity
+from .foundation import ProofFailure, require
+
+_PROJECT_A = Path("/self-test/large-project")
+_PROJECT_B = Path("/self-test/small-project")
+_QUESTION_A = "How does the large project activate?"
+_QUERY_A = "large_project_probe"
+_QUERY_B = "small_project_probe"
+_MANIFEST = {"asset_target": "linux-x64"}
+
+
+def _setup() -> SimpleNamespace:
+    return SimpleNamespace(
+        project_a=_PROJECT_A,
+        project_b=_PROJECT_B,
+        query_b=_QUERY_B,
+        node=Path("/self-test/node"),
+        command=["self-test-plugin-host"],
+        qualified_env={"SELF_TEST": "runtime-bootstrap"},
+    )
+
+
+def _cold() -> SimpleNamespace:
+    return SimpleNamespace(
+        snapshot_a={"engine": {"successful_encode_count": 7}},
+        shared_identity={"server_instance_id": "server-self-test"},
+        status_a={"self_test": "status-a"},
+        status_b={"self_test": "status-b"},
+        identity_a={"embedding_backend": "CPU"},
+    )
+
+
+def _args(proof_tier: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        proof_tier=proof_tier,
+        produce_qualification_evidence=True,
+        question=_QUESTION_A,
+        query=_QUERY_A,
+        timeout_secs=10,
+        engine_policy="cpu_explicit",
+        expected_backend="CPU",
+    )
+
+
+def _run_live_retrieval_case(
+    proof_tier: str,
+    *,
+    trap_project_a: bool = False,
+) -> Mock:
+    setup = _setup()
+    cold = _cold()
+    args = _args(proof_tier)
+    host_a = Mock()
+    host_b = Mock()
+    if trap_project_a:
+        host_a.tool_until_ready.side_effect = ProofFailure(
+            "calibration scheduled a second broad project-A request"
+        )
+    else:
+        host_a.tool_until_ready.return_value = ({"self_test": "packet"}, 1)
+    host_a.search_until_ready.side_effect = ProofFailure(
+        f"{proof_tier} moved its broad project-A request from packet to search"
+    )
+    host_b.search_until_ready.return_value = ({"self_test": "search"}, 1)
+    host_b.engine_diagnostics.return_value = {"self_test": "diagnostics"}
+    hosts = SimpleNamespace(
+        host_a=host_a,
+        host_b=host_b,
+        start_a="host-a-start",
+        start_b="host-b-start",
+    )
+    after = {
+        "engine": {"successful_encode_count": 8},
+        "process": {"server_instance_id": "server-self-test"},
+    }
+    memory = {"self_test": "five-process-memory"}
+    with (
+        patch.object(
+            runtime_bootstrap_continuity,
+            "server_snapshot",
+            return_value=after,
+        ) as snapshot_check,
+        patch.object(
+            runtime_bootstrap_continuity,
+            "capture_five_process_memory",
+            return_value=memory,
+        ) as memory_check,
+    ):
+        observed = runtime_bootstrap_continuity._live_retrieval(
+            args,
+            setup,
+            hosts,
+            cold,
+            _MANIFEST,
+        )
+    require(
+        observed == memory,
+        f"{proof_tier} live retrieval omitted five-process memory evidence",
+    )
+    require(
+        host_b.method_calls
+        == [
+            call.search_until_ready(
+                {
+                    "project": str(_PROJECT_B),
+                    "query": _QUERY_B,
+                    "why": True,
+                },
+                "search-b-live",
+            ),
+            call.engine_diagnostics(_PROJECT_B, "diagnostics-after-live"),
+        ],
+        f"{proof_tier} live retrieval changed the bounded project-B path",
+    )
+    snapshot_check.assert_called_once_with(
+        host_b.engine_diagnostics.return_value,
+        _MANIFEST,
+        require_resident=True,
+    )
+    memory_check.assert_called_once_with(
+        args=args,
+        node_path=setup.node,
+        host_a=host_a,
+        host_a_start=hosts.start_a,
+        host_b=host_b,
+        host_b_start=hosts.start_b,
+        status_a=cold.status_a,
+        status_b=cold.status_b,
+        snapshot=after,
+        manifest=_MANIFEST,
+        expected_backend="CPU",
+    )
+    return host_a
+
+
+def _live_retrieval_scope_tests() -> None:
+    host_a = _run_live_retrieval_case("calibration", trap_project_a=True)
+    require(
+        host_a.method_calls == [],
+        "calibration scheduled a second broad operation on project A",
+    )
+    for proof_tier in ("hosted_package", "protected_hardware", "installed_runtime"):
+        host_a = _run_live_retrieval_case(proof_tier)
+        require(
+            host_a.method_calls
+            == [
+                call.tool_until_ready(
+                    "packet",
+                    {
+                        "project": str(_PROJECT_A),
+                        "question": _QUESTION_A,
+                        "budget": "compact",
+                    },
+                    "packet-a",
+                )
+            ],
+            f"{proof_tier} no longer requires the project-A packet path",
+        )
+
+
+def _run_continuity_case(proof_tier: str, expected_project: Path) -> None:
+    setup = _setup()
+    cold = _cold()
+    args = _args(proof_tier)
+    host_a = Mock()
+    host_a.process.pid = 101
+    host_b = Mock()
+    host_b.process.pid = 202
+    host_b.search_until_ready.return_value = ({"self_test": "survivor"}, 1)
+    host_b.engine_diagnostics.return_value = {"self_test": "survivor-diagnostics"}
+    hosts = SimpleNamespace(
+        host_a=host_a,
+        host_b=host_b,
+        start_a="host-a-start",
+        start_b="host-b-start",
+    )
+    host_c = Mock()
+    host_c.process.pid = 303
+    host_c.transcript = []
+
+    def rejoin_search(arguments: dict, label: str) -> tuple[dict, int]:
+        if (
+            proof_tier == "calibration"
+            and arguments.get("project") == str(_PROJECT_A)
+        ):
+            raise ProofFailure(
+                "calibration rejoined through a broad project-A request"
+            )
+        return {"self_test": label}, 1
+
+    host_c.search_until_ready.side_effect = rejoin_search
+    host_c.engine_diagnostics.return_value = {"self_test": "rejoin-diagnostics"}
+    survivor = {
+        "engine": {"successful_encode_count": 9},
+        "process": {"server_instance_id": "server-self-test"},
+    }
+    rejoin = {
+        "engine": {"successful_encode_count": 10},
+        "process": {"server_instance_id": "server-self-test"},
+    }
+    rejoin_identity = {"embedding_materialized_reused": True}
+    with (
+        tempfile.TemporaryDirectory() as temporary,
+        patch.object(
+            runtime_bootstrap_continuity,
+            "McpProcess",
+            return_value=host_c,
+        ) as process_constructor,
+        patch.object(
+            runtime_bootstrap_continuity,
+            "process_start_identity",
+            return_value="host-c-start",
+        ) as start_identity,
+        patch.object(
+            runtime_bootstrap_continuity,
+            "server_snapshot",
+            side_effect=[survivor, rejoin],
+        ) as snapshot_check,
+        patch.object(
+            runtime_bootstrap_continuity,
+            "engine_identity",
+            return_value=rejoin_identity,
+        ) as identity_check,
+    ):
+        observed = runtime_bootstrap_continuity._continuity_proof(
+            args,
+            setup,
+            hosts,
+            cold,
+            _MANIFEST,
+            Path(temporary),
+        )
+    require(
+        observed.survivor == survivor
+        and observed.rejoin_snapshot == rejoin
+        and observed.rejoin_identity == rejoin_identity,
+        f"{proof_tier} continuity evidence changed",
+    )
+    require(
+        host_a.method_calls == [call.kill()],
+        f"{proof_tier} continuity did not replace exactly host A",
+    )
+    require(
+        host_b.method_calls
+        == [
+            call.search_until_ready(
+                {
+                    "project": str(_PROJECT_B),
+                    "query": _QUERY_B,
+                    "why": True,
+                },
+                "survivor-search",
+            ),
+            call.engine_diagnostics(_PROJECT_B, "survivor-diagnostics"),
+        ],
+        f"{proof_tier} continuity changed the surviving project-B path",
+    )
+    process_constructor.assert_called_once_with(
+        setup.command,
+        env=setup.qualified_env,
+        cwd=expected_project,
+        timeout=args.timeout_secs,
+    )
+    start_identity.assert_called_once_with(host_c.process.pid)
+    require(
+        host_c.method_calls
+        == [
+            call.initialize(),
+            call.search_until_ready(
+                {
+                    "project": str(expected_project),
+                    "query": _QUERY_B if expected_project == _PROJECT_B else _QUERY_A,
+                    "why": True,
+                },
+                "rejoin-search",
+            ),
+            call.engine_diagnostics(expected_project, "rejoin-diagnostics"),
+            call.close(),
+        ],
+        f"{proof_tier} continuity changed its replacement-host scope",
+    )
+    require(
+        snapshot_check.call_args_list
+        == [
+            call(
+                host_b.engine_diagnostics.return_value,
+                _MANIFEST,
+                require_resident=True,
+            ),
+            call(
+                host_c.engine_diagnostics.return_value,
+                _MANIFEST,
+                require_resident=True,
+            ),
+        ],
+        f"{proof_tier} continuity changed its resident snapshot checks",
+    )
+    identity_check.assert_called_once_with(
+        host_c.engine_diagnostics.return_value,
+        args.engine_policy,
+        args.expected_backend,
+    )
+
+
+def _continuity_scope_tests() -> None:
+    _run_continuity_case("calibration", _PROJECT_B)
+    for proof_tier in ("hosted_package", "protected_hardware", "installed_runtime"):
+        _run_continuity_case(proof_tier, _PROJECT_A)
+
+
+def run_runtime_bootstrap_scope_self_tests() -> None:
+    _live_retrieval_scope_tests()
+    _continuity_scope_tests()


### PR DESCRIPTION
## Context

Calibration run `30437725369` failed twice after its initial two-host cold search had already succeeded. The draft-calibration path then entered the unchanged full CodeStory checkout again: first through `packet-a`, and, if that were removed alone, later through replacement-host `rejoin-search`. The first path returned 340 preparation envelopes and expired at attempt 341 under the shared 1,800-second bound. The Linux qualification driver never started.

The declared calibration workload does not include that second full-project activation. It requires the already-proved two-host resident server and the exact five-process memory sample. The standard protected-hardware and frozen qualification tiers still own broad project-A packet/search behavior.

## What changed

- Draft calibration keeps its post-cold live retrieval on the tiny second repository, while still requiring encode-count advancement and the same resident server identity.
- Calibration replacement-host continuity also rejoins through that tiny repository.
- `hosted_package`, `protected_hardware`, and `installed_runtime` retain the existing project-A packet and project-A replacement-host paths.
- A production-function self-test traps packet-A, renamed search-A, project-B omission, memory-sample omission, and calibration rejoin-A. It also pins the broad paths for every non-calibration tier.

The underlying ready-and-unchanged activation defect is separately tracked in #1599. This PR does not declare that product behavior correct.

## How to review

Start with `_live_retrieval` and `_continuity_proof`, then read `self_test_runtime_bootstrap_scope.py` as the executable proof-tier contract. There are no workflow, release-claim, measurement-protocol, or frozen-constant changes.

## Verification

Base: `fe9532ad32d201e451b61c579536af66897ca329`
Head: `e6d102b1`

- Before the live-retrieval fix, the production self-test failed on `packet-a: calibration scheduled a second broad project-A request`.
- After that first fix but before the continuity fix, it failed on `calibration rejoined through a broad project-A request`.
- Packaged proof self-test passes.
- Workflow policy passes.
- 0.16.3 release-surface validation passes.
- Python compile check and `git diff --check` pass.
- Independent mutation pass rejected: restored calibration packet-A, renamed calibration search-A, omitted non-calibration packet-A, omitted project-B live search, omitted five-process memory capture, calibration rejoin-A, and non-calibration rejoin-B.

A fresh six-run Linux CPU plus Metal calibration is downstream acceptance. It requires this source change merged into the unfrozen #1558 tree, so this PR must land on development before that exact-source run can execute.

Closes #1598
