### PR TITLE
Remove CPU calibration and freeze runtime constants only

### DIFF
--- a/.github/scripts/check-linux-glibc-baseline.sh
+++ b/.github/scripts/check-linux-glibc-baseline.sh
@@ -44,7 +44,7 @@ grep -Eiq 'usage:' "$out_dir/help.stdout.txt"
 initialize='{"jsonrpc":"2.0","id":"initialize","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"glibc-baseline-proof","version":"1.0.0"}}}'
 set +e
 printf '%s\n' "$initialize" | CODESTORY_CACHE_ROOT="$out_dir/cache" \
-  CODESTORY_EMBED_ALLOW_CPU=1 timeout 30s \
+  CODESTORY_EMBED_ALLOW_CPU=0 timeout 30s \
   "$cli" serve --stdio --refresh none --project /workspace \
   > "$out_dir/stdio-initialize.stdout.txt" 2> "$out_dir/stdio-initialize.stderr.txt"
 stdio_status=${PIPESTATUS[1]}

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -85,6 +85,26 @@ function executableRunText(run) {
     .join("\n");
 }
 
+// Shell concatenates adjacent quoted and unquoted literal fragments before it
+// dispatches a command: `cpu_"explicit"` is the exact `cpu_explicit` argument
+// and `"c"pu` is `cpu`. Policy checks must inspect that executable spelling,
+// not the source-level quote placement an evasion chose.
+function shellLiteralNormalizedText(run) {
+  return executableRunText(String(run ?? "")).replaceAll(/['"]/gu, "");
+}
+
+function hasNonLiteralCpuAssignment(value) {
+  const normalized = shellLiteralNormalizedText(value);
+  return [...normalized.matchAll(
+    /\bCODESTORY_EMBED_ALLOW_CPU\s*=\s*([^\s;&|]+)/giu,
+  )].some(([, assigned]) => assigned !== "0");
+}
+
+function hasShellLoop(run) {
+  return /(?:^|[;\n])\s*(?:for|select|until|while)\b/imu
+    .test(shellLiteralNormalizedText(run));
+}
+
 function add(violations, condition, message) {
   if (!condition) violations.push(message);
 }
@@ -132,6 +152,14 @@ function shellInvocationsContaining(run, anchor) {
   }
   if (current.length > 0) commands.push(current.join("\n"));
   return commands.filter(command => command.includes(anchor));
+}
+
+function jobShellInvocationsContaining(job, anchor) {
+  return list(job?.steps).flatMap(step =>
+    shellInvocationsContaining(
+      shellLiteralNormalizedText(object(step).run),
+      shellLiteralNormalizedText(anchor),
+    ));
 }
 
 function requireFlagOnInvocation(violations, message, run, anchor, flag) {
@@ -488,10 +516,16 @@ const draftCachePaths = [
   "target",
 ];
 const sourceResolverContractDigest = "2fe869b675010f5db29259aff38d83456c01dbc9885989afbf7c92a2826791af";
-const platformResolverContractDigest = "12f5e887eb236625eec5e9718edd305ba625ab06f9a1467ed1146a8a80db0f74";
+const platformResolverContractDigest = "cb8eb03393f8e24bf9e083004be658c5d2f22fa118d3c43b8bc6b388f19ecddd";
 // check-workflow-policy.test.mjs runs this exact script against hostile dispatch values and proves
 // it exits non-zero, so the digest stands for a rejection that was measured, not merely read.
 const marketplaceGuardDigest = "6380c916a1b3566b4b9d6545b63fbc9c7db12b54fb328b5c89316daae0162d84";
+// This closeout is a small shell control-flow program. Substring checks can be
+// satisfied by parking the accepted qualification branch in dead code while
+// the live branch blocks on optional Linux hardware, so pin its reviewed
+// executable text as well as its reader-facing invariants.
+const packagedPlatformCloseoutDigest =
+  "ce7a7f5aa99f5fcbc037d4c1f06de5d841e4a4d114208820592a84c41c797b1a";
 const draftProofCommands = [
   "cargo test --locked -p codestory-llama-sys --test native_staging",
   "cargo test --locked -p codestory-llama-sys --test model_staging",
@@ -814,6 +848,12 @@ export function windowsManifestProofPolicyViolations(workflowValue) {
     hasExactKeys(workflow.jobs, ["linux-contracts", "windows-manifest-missing"]),
     "Windows manifest proof workflow must contain exactly linux-contracts and windows-manifest-missing jobs",
   );
+  add(
+    violations,
+    hasExactKeys(linux.env, ["CODESTORY_TEST_EMBED_ALLOW_CPU"])
+      && linux.env.CODESTORY_TEST_EMBED_ALLOW_CPU === "1",
+    "retrieval source tests must opt into the CPU test seam explicitly",
+  );
   const nodeSetup = list(linux.steps).map(object)
     .find((step) => step.uses === "actions/setup-node@v5");
   add(
@@ -887,10 +927,10 @@ export function windowsManifestProofPolicyViolations(workflowValue) {
   add(violations, job["timeout-minutes"] === 30, "Windows manifest proof timeout must remain 30 minutes");
   add(
     violations,
-    hasExactKeys(job.env, ["CODESTORY_EMBED_ALLOW_CPU", "CMAKE_GENERATOR"])
-      && job.env.CODESTORY_EMBED_ALLOW_CPU === "1"
+    hasExactKeys(job.env, ["CODESTORY_TEST_EMBED_ALLOW_CPU", "CMAKE_GENERATOR"])
+      && job.env.CODESTORY_TEST_EMBED_ALLOW_CPU === "1"
       && job.env.CMAKE_GENERATOR === windowsNativeGenerator,
-    "Windows manifest proof must explicitly permit CPU runtime execution and use the Ninja native generator",
+    "Windows manifest proof source test must explicitly use the CPU test seam and Ninja native generator",
   );
   add(
     violations,
@@ -2659,7 +2699,7 @@ function packageMatrixAssetTargets(expression) {
 
 function validatePackageMatrixExpression(violations, expression, graph) {
   const match = typeof expression === "string" && expression.match(
-    /fromJSON\(inputs\.calibration_mode && '([^']+)' \|\| inputs\.scope == 'linux' && '([^']+)' \|\| inputs\.scope == 'windows' && '([^']+)' \|\| inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\)/u,
+    /fromJSON\(inputs\.scope == 'linux' && '([^']+)' \|\| inputs\.scope == 'windows' && '([^']+)' \|\| inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\)/u,
   );
   if (!match) {
     violations.push("packaged-platform-proof.yml matrix must select structural JSON by scope");
@@ -2672,7 +2712,6 @@ function validatePackageMatrixExpression(violations, expression, graph) {
   const macosArm64 = graph.workflow_policy.package_matrix.find(({ asset_target: target }) =>
     target === "macos-arm64");
   const expected = [
-    { include: [linuxX64] },
     { include: [linuxX64] },
     { include: [windowsX64] },
     { include: [macosArm64] },
@@ -2707,6 +2746,8 @@ function validatePackagedProof(workflows, violations, graph) {
     requireOptionalStringInput(violations, file, workflow, "workflow_call", key);
   }
   for (const key of [
+    "calibration_mode",
+    "quality_evidence_artifact",
     "candidate_installed_proof",
     "candidate_installed_only",
     "server_behavior_only",
@@ -2733,8 +2774,8 @@ function validatePackagedProof(workflows, violations, graph) {
   const job = requireJob(violations, file, workflow, "build");
   add(
     violations,
-    job["timeout-minutes"] === "${{ inputs.calibration_mode && 180 || (inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60) }}",
-    `${file} package build timeout must cover only calibration or signed macOS packaging`,
+    job["timeout-minutes"] === "${{ inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60 }}",
+    `${file} package build timeout must cover only signed macOS packaging`,
   );
   add(
     violations,
@@ -2813,9 +2854,8 @@ function validatePackagedProof(workflows, violations, graph) {
     violations,
     nativeIdentity?.id === "build-cache"
       && nativeIdentity?.shell === "bash"
-      && object(nativeIdentity?.env).CALIBRATION_MODE === "${{ inputs.calibration_mode }}"
-      && object(nativeIdentity?.env).QUALITY_EVIDENCE_ARTIFACT
-        === "${{ inputs.quality_evidence_artifact }}"
+      && object(nativeIdentity?.env).CALIBRATION_MODE === undefined
+      && object(nativeIdentity?.env).QUALITY_EVIDENCE_ARTIFACT === undefined
       && nativeIdentityRun.includes(`--namespace ${graph.workflow_policy.promotion.packaged_cache_namespace}`)
       && nativeIdentityRun.includes('--exact-sha "$EXACT_SHA"')
       && nativeIdentityRun.includes('--os "$RUNNER_OS"')
@@ -2831,8 +2871,7 @@ function validatePackagedProof(workflows, violations, graph) {
       && nativeIdentityRun.includes("--cargo-config .cargo/config.toml")
       && nativeIdentityRun.includes("--identity cargo_incremental=0")
       && nativeIdentityRun.includes("qualification_driver=disabled")
-      && nativeIdentityRun.includes("qualification_driver=enabled")
-      && nativeIdentityRun.includes('--identity "qualification_driver=$qualification_driver"')
+      && !nativeIdentityRun.includes("qualification_driver=enabled")
       && nativeIdentityRun.includes(".cargo/llama-dynamic-backends.cmake")
       && nativeIdentityRun.includes("git ls-files '*Cargo.toml'")
       && nativeIdentityRun.includes("model-contract.json")
@@ -2963,16 +3002,13 @@ function validatePackagedProof(workflows, violations, graph) {
     String(finalizeCompilerObjects?.if ?? "")
       .includes("steps.linux-build.outcome == 'success'")
       && String(finalizeCompilerObjects?.if ?? "")
-        .includes("steps.qualification-driver.outcome != 'skipped'")
-      && String(finalizeCompilerObjects?.if ?? "")
         .includes("steps.package-build.outcome == 'success'"),
     `${file} must stop the compiler server that performed each selected build`,
   );
   add(
     violations,
     compilerSaveIndex > stepIndex(job, "Build codestory-cli")
-      && compilerSaveIndex > stepIndex(job, "Build Linux x64 at the glibc 2.31 baseline")
-      && compilerSaveIndex > stepIndex(job, "Build qualification driver"),
+      && compilerSaveIndex > stepIndex(job, "Build Linux x64 at the glibc 2.31 baseline"),
     `${file} compiler cache must save after every selected compilation step`,
   );
   add(
@@ -3159,66 +3195,20 @@ function validatePackagedProof(workflows, violations, graph) {
     !executableRunText(String(linuxBaseline?.run ?? "")).includes("libvulkan"),
     `${file} Linux glibc baseline must not install a Vulkan loader`,
   );
-  const qualificationDriver = namedStep(job, "Build qualification driver");
   add(
     violations,
-    qualificationDriver?.if
-      === "matrix.asset_target == 'linux-x64' && (inputs.calibration_mode || inputs.quality_evidence_artifact != '')",
-    `${file} qualification driver must skip the standard server-behavior path`,
+    namedStep(job, "Build qualification driver") === undefined
+      && namedStep(job, "Packaged per-user server calibration or qualification") === undefined
+      && namedStep(job, "Upload hosted Linux calibration runs") === undefined
+      && namedStep(job, "Upload hosted Linux calibration failure evidence") === undefined
+      && namedStep(job, "Upload packaged agent proof artifacts") === undefined,
+    `${file} package-only workflow must not collect calibration or run hosted qualification`,
   );
-  // The calibration bundle -- not the optional release-evidence packet -- is
-  // what these steps consume, and the frozen-candidate coordinator is forbidden
-  // to pass release evidence at all. Gating them on quality evidence made the
-  // whole frozen branch unreachable; gating them on the bundle they download is
-  // what the freeze lineage proof below needs to run.
   requireCalibrationProducerBoundary(
     violations,
     file,
     job,
-    "matrix.asset_target == 'linux-x64' && !inputs.calibration_mode && inputs.calibration_bundle_artifact != ''",
-  );
-  requireStepRun(
-    violations,
-    file,
-    job,
-    "Packaged per-user server calibration or qualification",
-    [
-      "--proof-tier hosted_package",
-      "calibration-bundle.json",
-      '--calibration-bundle "$calibration_bundle"',
-      "--calibration-producer-run-id",
-      "--calibration-producer-artifact",
-      "--enforce-calibration-freeze-lineage",
-      'test -f "$quality_path"',
-      "--engine-policy cpu_explicit",
-      "--expected-backend CPU",
-      "--produce-qualification-evidence",
-      "--timeout-secs 1800",
-      'test "$(jq -r .status crates/codestory-llama-sys/per-user-embedding-server-constant-set.json)" = unfrozen',
-      'test "$(jq -r .status crates/codestory-llama-sys/per-user-embedding-server-constant-set.json)" = frozen',
-    ],
-  );
-  const packagedProofRun = stepRun(
-    job,
-    "Packaged per-user server calibration or qualification",
-  );
-  const packagedProof = namedStep(
-    job,
-    "Packaged per-user server calibration or qualification",
-  );
-  // The full frozen hosted_package qualification also carries the flag, and
-  // must keep carrying it, but it cannot run: --produce-qualification-evidence
-  // hard-requires the exact-head release-evidence packet at any non-calibration
-  // tier, and every caller of this workflow is pinned to pass no release
-  // evidence. That invocation is therefore a latent contract, not the live
-  // guard. Pin the flag to the hosted_package invocation itself -- the same
-  // logical command, so a decoy line after it does not count.
-  requireFlagOnInvocation(
-    violations,
-    `${file} frozen packaged qualification must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed`,
-    packagedProofRun,
-    "--proof-tier hosted_package",
-    "--enforce-calibration-freeze-lineage",
+    "matrix.asset_target == 'linux-x64' && inputs.calibration_bundle_artifact != ''",
   );
   // The live guard. --version-only stops before the runtime proof, so it needs
   // no release evidence and no qualification driver, but it still loads and
@@ -3299,53 +3289,6 @@ function validatePackagedProof(workflows, violations, graph) {
     bindings.get("calibration_bundle_artifact")?.fixed === false
       && bindings.get("calibration_bundle_run_id")?.fixed === false,
     `${coordinatorFile} packaged proof must forward the dispatched calibration bundle identity so the freeze lineage guard can run`,
-  );
-  const hostedCalibrationUpload = namedStep(job, "Upload hosted Linux calibration runs");
-  add(
-    violations,
-    hostedCalibrationUpload?.uses === "actions/upload-artifact@v7.0.1"
-      && hostedCalibrationUpload?.if
-        === "success() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode",
-    `${file} hosted calibration artifact must remain calibration-only`,
-  );
-  const hostedCalibrationFailureUpload = namedStep(
-    job,
-    "Upload hosted Linux calibration failure evidence",
-  );
-  add(
-    violations,
-    hostedCalibrationFailureUpload?.uses === "actions/upload-artifact@v7.0.1"
-      && hostedCalibrationFailureUpload?.if
-        === "failure() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode"
-      && object(hostedCalibrationFailureUpload?.with).path
-        === "target/calibration-runs/linux"
-      && object(hostedCalibrationFailureUpload?.with)["if-no-files-found"] === "warn",
-    `${file} hosted calibration failure evidence must stay a failure-only best-effort upload`,
-  );
-  const hostedEvaluationUpload = namedStep(job, "Upload packaged agent proof artifacts");
-  add(
-    violations,
-    hostedEvaluationUpload?.uses === "actions/upload-artifact@v7.0.1"
-      && String(hostedEvaluationUpload?.if ?? "").replace(/\s+/gu, " ")
-        === "always() && matrix.asset_target == 'linux-x64' && (inputs.calibration_mode || inputs.quality_evidence_artifact != '')",
-    `${file} hosted evaluation artifact must require explicit calibration or quality evidence`,
-  );
-  add(
-    violations,
-    String(packagedProof?.if ?? "").replace(/\s+/gu, " ")
-      === "matrix.asset_target == 'linux-x64' && (inputs.calibration_mode || inputs.quality_evidence_artifact != '')",
-    `${file} hosted CPU evaluation must require explicit calibration or quality evidence`,
-  );
-  add(
-    violations,
-    packagedProofRun.includes('if [ "$CALIBRATION_MODE" = true ]')
-      && packagedProofRun.includes("--proof-tier calibration")
-      && packagedProofRun.includes("--proof-tier hosted_package")
-      && occurrenceCount(packagedProofRun, "--calibration-bundle") === 1
-      && !packagedProofRun.includes("--server-behavior-only")
-      && !packagedProofRun.includes("--ground-only")
-      && !packagedProofRun.includes("--proof-tier installed_runtime"),
-    `${file} optional hosted CPU lane must remain evaluation-only`,
   );
   add(
     violations,
@@ -3782,6 +3725,114 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     return;
   }
   const promotion = graph.workflow_policy.promotion;
+  const calibrationPolicy = object(graph.workflow_policy.calibration);
+  const qualificationPolicy = object(graph.workflow_policy.qualification);
+  add(
+    violations,
+    sameMembers(Object.keys(object(workflow.jobs)), [
+      "route",
+      "calibration-macos",
+      "calibration-assemble",
+      "release-evidence",
+      "source-proof",
+      "packaged-proof",
+      "macos-metal-proof",
+      "windows-vulkan-proof",
+      "linux-vulkan-proof",
+      "closeout",
+    ]),
+    `${file} must retain the reviewed exact job set so no hidden hardware job can block calibration or qualification`,
+  );
+  add(
+    violations,
+    calibrationPolicy.coordinator_workflow === file
+      && calibrationPolicy.mode === "calibration"
+      && calibrationPolicy.assembly_job === "calibration-assemble"
+      && calibrationPolicy.runs_per_required_cell === 3
+      && calibrationPolicy.samples_per_metric_per_run === 1
+      && list(calibrationPolicy.required_cells).length === 1
+      && object(list(calibrationPolicy.required_cells)[0]).id
+        === "protected_macos_arm64_metal"
+      && list(calibrationPolicy.optional_cells).length === 1
+      && object(list(calibrationPolicy.optional_cells)[0]).id
+        === "protected_linux_x64_vulkan"
+      && object(list(calibrationPolicy.optional_cells)[0]).assembly_dependency === false
+      && object(list(calibrationPolicy.optional_cells)[0]).feeds_constant_selection === false,
+    `${file} must implement the release claim graph calibration contract`,
+  );
+  add(
+    violations,
+    qualificationPolicy.coordinator_workflow === file
+      && qualificationPolicy.mode === "qualification"
+      && qualificationPolicy.runs_per_available_cell === 1
+      && JSON.stringify(list(qualificationPolicy.required_cells))
+        === JSON.stringify([
+          {
+            id: "protected_macos_arm64_metal",
+            workflow: "macos-metal-proof.yml",
+            job: "packaged-metal",
+            policy: "accelerated",
+            backend: "metal",
+            produces_quality: true,
+          },
+          {
+            id: "protected_windows_x64_vulkan",
+            workflow: "windows-vulkan-proof.yml",
+            job: "packaged-vulkan",
+            policy: "accelerated",
+            backend: "vulkan",
+            produces_quality: false,
+          },
+        ])
+      && JSON.stringify(list(qualificationPolicy.optional_cells))
+        === JSON.stringify([
+          {
+            id: "protected_linux_x64_vulkan",
+            workflow: "linux-vulkan-proof.yml",
+            job: "packaged-vulkan",
+            trigger: "workflow_dispatch",
+            policy: "accelerated",
+            backend: "vulkan",
+            closeout_dependency: false,
+            blocking: false,
+          },
+        ])
+      && JSON.stringify(object(qualificationPolicy.quality_contract))
+        === JSON.stringify({
+          producer_cell: "protected_macos_arm64_metal",
+          corpus_id: "codestory-release-corpus-v1",
+          evaluation_contract: "publishable-three-repeat-packet/v1",
+          task_count: 3,
+          repeats_per_task: 3,
+          row_count: 9,
+        })
+      && sameMembers(list(qualificationPolicy.required_evidence), [
+        "qualification_scenarios",
+        "true_idle_exit",
+        "total_codestory_process_memory",
+        "retrieval_quality",
+        "backend_observed_accelerator_residency",
+      ])
+      && sameMembers(list(qualificationPolicy.required_scenarios), [
+        "client_death",
+        "cold_race",
+        "frozen_owner",
+        "incompatible_owner",
+        "mixed_queue",
+        "server_crash",
+        "true_idle_respawn",
+        "worker_stall",
+      ])
+      && qualificationPolicy.true_idle_timeout_ms === 60_000
+      && qualificationPolicy.true_idle_observation_grace_ms === 2_500
+      && sameMembers(list(qualificationPolicy.forbidden_policies), ["cpu_explicit"])
+      && sameMembers(list(qualificationPolicy.forbidden_backends), ["cpu"])
+      && sameMembers(
+        list(qualificationPolicy.forbidden_environment),
+        ["CODESTORY_EMBED_ALLOW_CPU=1"],
+      ),
+    `${file} must implement the release claim graph qualification contract`,
+  );
   const expectedConcurrency = [
     "proof-",
     promotion.proof_run_sha_expression,
@@ -3839,8 +3890,17 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     'test "$INPUT_HEAD_SHA" = "$dev_head"',
     'test "$GITHUB_REF" = "refs/heads/dev/codestory-next"',
     'test "$GITHUB_SHA" = "$dev_head"',
+    'elif [ "$mode" = "qualification" ]; then',
+    'test -z "$INPUT_SOURCE_RUN_ID"',
+    'test -n "$INPUT_CALIBRATION_ARTIFACT"',
+    'test -n "$INPUT_CALIBRATION_RUN_ID"',
     "--ref $head_ref",
   ]);
+  requireStepEnv(violations, file, route, "Resolve trusted exact head", {
+    INPUT_SOURCE_RUN_ID: "${{ inputs.source_run_id }}",
+    INPUT_CALIBRATION_ARTIFACT: "${{ inputs.calibration_bundle_artifact }}",
+    INPUT_CALIBRATION_RUN_ID: "${{ inputs.calibration_bundle_run_id }}",
+  });
   requireExactResolverContract(violations, file, route, platformResolverContractDigest);
   requireStepRun(violations, file, route, "Require successful exact-head source proof", [
     "actions/runs?head_sha=$HEAD_SHA",
@@ -3890,13 +3950,10 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && routeSteps.findIndex(step => step.uses === "actions/checkout@v5") > 0,
     `${file} must resolve exact workflow/ref identity before checkout`,
   );
-  const calibrationLinux = requireJob(violations, file, workflow, "calibration-linux");
   add(
     violations,
-    calibrationLinux.uses === "./.github/workflows/packaged-platform-proof.yml"
-      && object(calibrationLinux.with).calibration_mode === true
-      && object(calibrationLinux.with).hermetic_linux === undefined,
-    `${file} hosted Linux calibration must call packaged proof in calibration mode`,
+    at(workflow, "jobs", "calibration-linux") === undefined,
+    `${file} calibration must not schedule hosted Linux CPU or wait for optional Linux Vulkan evidence`,
   );
   const calibrationMacos = requireJob(violations, file, workflow, "calibration-macos");
   add(
@@ -3918,12 +3975,65 @@ function validatePackagedCoordinator(workflows, violations, graph) {
   );
   add(
     violations,
-    sameMembers(needs(calibrationAssemble), [
-      "route",
-      "calibration-linux",
-      "calibration-macos",
-    ]),
-    `${file} calibration assembly must wait for both independent calibration cells`,
+    sameMembers(needs(calibrationAssemble), ["route", "calibration-macos"])
+      && String(calibrationAssemble.if ?? "")
+        === "always() && needs.route.result == 'success' && needs.route.outputs.mode == 'calibration' && needs.calibration-macos.result == 'success'",
+    `${file} calibration assembly must wait only for required protected macOS Metal evidence`,
+  );
+  const calibrationAssemblySteps = list(calibrationAssemble.steps).map(object);
+  const calibrationCheckout = namedStep(
+    calibrationAssemble,
+    "Checkout exact calibration head",
+  );
+  const calibrationDownload = namedStep(
+    calibrationAssemble,
+    "Download protected macOS calibration runs",
+  );
+  const calibrationAssembly = namedStep(
+    calibrationAssemble,
+    "Assemble frozen calibration candidate",
+  );
+  const calibrationUpload = namedStep(
+    calibrationAssemble,
+    "Upload calibration bundle and frozen constant candidate",
+  );
+  add(
+    violations,
+    JSON.stringify(calibrationAssemblySteps.map(step => step.name))
+      === JSON.stringify([
+        "Checkout exact calibration head",
+        "Download protected macOS calibration runs",
+        "Assemble frozen calibration candidate",
+        "Upload calibration bundle and frozen constant candidate",
+      ])
+      && calibrationCheckout?.uses === "actions/checkout@v5"
+      && hasExactKeys(calibrationCheckout?.with, ["ref", "fetch-depth"])
+      && object(calibrationCheckout?.with).ref === "${{ needs.route.outputs.head_sha }}"
+      && object(calibrationCheckout?.with)["fetch-depth"] === 0
+      && calibrationDownload?.uses === "actions/download-artifact@v8.0.1"
+      && hasExactKeys(calibrationDownload?.with, ["name", "path"])
+      && object(calibrationDownload?.with).name
+        === "embedding-calibration-macos-${{ needs.route.outputs.version }}"
+      && object(calibrationDownload?.with).path === "target/calibration-inputs/macos"
+      && calibrationAssembly?.shell === "bash"
+      && hasExactKeys(calibrationAssembly?.env, ["EXPECTED_HEAD_SHA"])
+      && object(calibrationAssembly?.env).EXPECTED_HEAD_SHA
+        === "${{ needs.route.outputs.head_sha }}"
+      && calibrationUpload?.uses === "actions/upload-artifact@v7.0.1"
+      && hasExactKeys(
+        calibrationUpload?.with,
+        ["name", "path", "if-no-files-found", "retention-days"],
+      )
+      && object(calibrationUpload?.with).name
+        === "embedding-calibration-bundle-${{ needs.route.outputs.head_sha }}"
+      && object(calibrationUpload?.with).path === "target/calibration-freeze"
+      && object(calibrationUpload?.with)["if-no-files-found"] === "error"
+      && object(calibrationUpload?.with)["retention-days"] === 30,
+    `${file} calibration assembly must keep the exact protected macOS-only step boundary`,
+  );
+  const calibrationAssemblyRun = stepRun(
+    calibrationAssemble,
+    "Assemble frozen calibration candidate",
   );
   requireStepRun(
     violations,
@@ -3932,11 +4042,20 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     "Assemble frozen calibration candidate",
     [
       "--assemble-calibration-bundle",
-      'test "${#runs[@]}" = 6',
+      "find target/calibration-inputs/macos",
+      'test "${#runs[@]}" = 3',
+      ".run_count == 3",
+      ".matrix_cell_count == 1",
       "--calibration-producer-workflow-path",
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
     ],
+  );
+  add(
+    violations,
+    !scalarStrings(calibrationAssemble).some(value => value.toLowerCase().includes("linux"))
+      && !calibrationAssemblyRun.includes("find target/calibration-inputs -type"),
+    `${file} calibration assembly must not select, discover, or gate on Linux evidence`,
   );
   requireStepUses(
     violations,
@@ -3981,7 +4100,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     violations,
     !String(packaged.if ?? "").includes("release-evidence")
       && !needs(packaged).includes("release-evidence")
-      && object(packaged.with).quality_evidence_artifact === "",
+      && object(packaged.with).quality_evidence_artifact === undefined,
     `${file} package proof must not depend on optional release evidence`,
   );
   violations.push(...packagedPrSigningViolations(workflow));
@@ -3999,41 +4118,49 @@ function validatePackagedCoordinator(workflows, violations, graph) {
   add(violations, object(metal.with).use_packaged_cli_artifact === true, `${file} Metal proof must use the packaged CLI`);
   add(
     violations,
-    object(metal.with).candidate_installed_proof === true,
-    `${file} must opt the accepted PR Metal package into candidate-installed proof`,
+    object(metal.with).candidate_installed_proof
+      === "${{ needs.route.outputs.mode != 'qualification' }}",
+    `${file} qualification must run full Metal proof rather than candidate-installed proof`,
   );
   add(
     violations,
-    object(metal.with).server_behavior_only === true
+    object(metal.with).server_behavior_only
+        === "${{ needs.route.outputs.mode != 'qualification' }}"
       && object(metal.with).quality_evidence_artifact === "",
-    `${file} Metal proof must use bounded readiness without optional quality evidence`,
+    `${file} qualification must run full Metal quality and lifecycle proof`,
   );
   const vulkan = requireJob(violations, file, workflow, "windows-vulkan-proof");
   add(
     violations,
-    sameMembers(needs(vulkan), ["route", "packaged-proof"]),
-    `${file} Vulkan proof must wait only for routing and package proof`,
+    sameMembers(needs(vulkan), ["route", "packaged-proof", "macos-metal-proof"]),
+    `${file} Windows qualification must wait for successful protected Metal quality`,
   );
   add(
     violations,
-    String(vulkan.if ?? "").includes("needs.route.outputs.mode != 'package'"),
-    `${file} package-only mode must skip protected Windows proof`,
+    String(vulkan.if ?? "").includes("needs.route.outputs.mode != 'package'")
+      && String(vulkan.if ?? "").includes(
+        "(needs.route.outputs.mode != 'qualification' || needs.macos-metal-proof.result == 'success')",
+      ),
+    `${file} package-only mode must skip Windows while qualification requires successful Metal`,
   );
   add(violations, object(vulkan.with).use_packaged_cli_artifact === true, `${file} Vulkan proof must use the packaged CLI`);
   add(
     violations,
-    object(vulkan.with).candidate_installed_proof === true,
-    `${file} must opt the accepted PR Windows package into candidate-installed proof`,
+    object(vulkan.with).candidate_installed_proof
+      === "${{ needs.route.outputs.mode != 'qualification' }}",
+    `${file} qualification must run full Windows proof rather than candidate-installed proof`,
   );
   add(
     violations,
-    object(vulkan.with).quality_evidence_artifact === "",
-    `${file} Windows proof must not consume optional quality evidence`,
+    object(vulkan.with).quality_evidence_artifact
+      === "${{ needs.route.outputs.mode == 'qualification' && format('frozen-candidate-quality-{0}', needs.route.outputs.head_sha) || '' }}",
+    `${file} Windows qualification must consume the exact protected Metal quality artifact`,
   );
   add(
     violations,
-    object(vulkan.with).server_behavior_only === true,
-    `${file} Windows proof must use bounded retrieval readiness`,
+    object(vulkan.with).server_behavior_only
+      === "${{ needs.route.outputs.mode != 'qualification' }}",
+    `${file} qualification must run full Windows lifecycle and fault proof`,
   );
   const linuxVulkan = requireJob(violations, file, workflow, "linux-vulkan-proof");
   add(
@@ -4043,8 +4170,11 @@ function validatePackagedCoordinator(workflows, violations, graph) {
   );
   add(
     violations,
-    String(linuxVulkan.if ?? "").includes("needs.route.outputs.mode != 'package'"),
-    `${file} package-only mode must skip protected Linux proof`,
+    String(linuxVulkan.if ?? "").includes("needs.route.outputs.mode != 'package'")
+      && String(linuxVulkan.if ?? "").includes(
+        "needs.route.outputs.mode != 'qualification'",
+      ),
+    `${file} package-only and qualification modes must skip coordinator Linux proof`,
   );
   add(
     violations,
@@ -4072,6 +4202,15 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     ]),
     `${file} closeout must wait for every selected platform proof`,
   );
+  add(
+    violations,
+    closeout.if
+      === "always() && needs.route.result != 'skipped' && needs.route.outputs.mode != 'release-evidence' && needs.route.outputs.mode != 'calibration'"
+      && closeout["runs-on"] === "ubuntu-latest"
+      && closeout["timeout-minutes"] === 20
+      && closeout["continue-on-error"] === undefined,
+    `${file} closeout job must retain its reviewed unconditional result-checking activation`,
+  );
   const evidence = requireJob(violations, file, workflow, "release-evidence");
   add(
     violations,
@@ -4084,6 +4223,39 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && !scalarStrings(closeout).some(value => value.includes("EVIDENCE_RESULT")),
     `${file} normal closeout must not depend on optional release evidence`,
   );
+  const closeoutProofName = "Require one coherent accepted proof";
+  const closeoutProof = namedStep(closeout, closeoutProofName);
+  const closeoutRun = executableRunText(stepRun(closeout, closeoutProofName));
+  add(
+    violations,
+    list(closeout.steps).length === 1
+      && closeoutProof?.if === undefined
+      && closeoutProof?.["continue-on-error"] === undefined
+      && closeoutProof?.shell === "bash"
+      && closeoutProof?.["working-directory"] === undefined,
+    `${file} closeout must run one unconditional proof step under the reviewed Bash interpreter`,
+  );
+  const expectedCloseoutEnv = {
+    GH_TOKEN: "${{ github.token }}",
+    HEAD_SHA: "${{ needs.route.outputs.head_sha }}",
+    MODE: "${{ needs.route.outputs.mode }}",
+    SCOPE: "${{ needs.route.outputs.scope }}",
+    ROUTE_RESULT: "${{ needs.route.result }}",
+    SOURCE_RESULT: "${{ needs.source-proof.result }}",
+    PACKAGE_RESULT: "${{ needs.packaged-proof.result }}",
+    METAL_RESULT: "${{ needs.macos-metal-proof.result }}",
+    WINDOWS_VULKAN_RESULT: "${{ needs.windows-vulkan-proof.result }}",
+    LINUX_VULKAN_RESULT: "${{ needs.linux-vulkan-proof.result }}",
+  };
+  const closeoutEnv = object(closeoutProof?.env);
+  add(
+    violations,
+    hasExactKeys(closeoutEnv, Object.keys(expectedCloseoutEnv))
+      && Object.entries(expectedCloseoutEnv).every(
+        ([key, value]) => closeoutEnv[key] === value,
+      ),
+    `${file} closeout proof must bind every route and platform result from the reviewed jobs exactly`,
+  );
   requireStepRun(violations, file, closeout, "Require one coherent accepted proof", [
     'if [ "$MODE" = package ]',
     'require_result "$PACKAGE_RESULT" success packaged-proof',
@@ -4092,9 +4264,25 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     '[ "$SCOPE" = linux ]',
     "WINDOWS_VULKAN_RESULT",
     "LINUX_VULKAN_RESULT",
+    'if [ "$MODE" = qualification ]; then',
+    'require_result "$LINUX_VULKAN_RESULT" skipped linux-vulkan-proof',
     'require_result "$LINUX_VULKAN_RESULT" success linux-vulkan-proof',
     "dev/codestory-next moved from proved head",
   ]);
+  requireExactStepScript(
+    violations,
+    file,
+    closeout,
+    "Require one coherent accepted proof",
+    packagedPlatformCloseoutDigest,
+    "coordinator closeout",
+  );
+  add(
+    violations,
+    /if\s+\[\s*"\$MODE"\s*=\s*qualification\s*\];\s*then\s+require_result\s+"\$LINUX_VULKAN_RESULT"\s+skipped\s+linux-vulkan-proof\s+else\s+require_result\s+"\$LINUX_VULKAN_RESULT"\s+success\s+linux-vulkan-proof\s+fi/um
+      .test(closeoutRun),
+    `${file} qualification closeout must accept skipped optional Linux proof without blocking`,
+  );
   add(violations, !scalarStrings(workflow).some(value => value === "./.github/workflows/release.yml"), `${file} must not publish releases`);
 }
 
@@ -4170,7 +4358,8 @@ function validateRemainingWorkflows(workflows, violations) {
     add(
       violations,
       object(repoEvidence?.env).CODESTORY_RELEASE_EVIDENCE_CORPUS_ID
-        === "codestory-release-corpus-v0.16-axios-js-ts-v2",
+        === "codestory-release-corpus-v0.16-axios-js-ts-v2"
+        && object(repoEvidence?.env).CODESTORY_EMBED_ALLOW_CPU === "0",
       `${evidenceFile} repo evidence must bind the v0.16 Axios v2 corpus`,
     );
     const packetEvidence = namedStep(job, "Produce publishable packet evidence");
@@ -4178,8 +4367,9 @@ function validateRemainingWorkflows(workflows, violations) {
       violations,
       object(packetEvidence?.env).CODESTORY_RELEASE_EVIDENCE_CORPUS_ID
         === "codestory-release-corpus-v0.16-axios-js-ts-v2"
-        && object(packetEvidence?.env).CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT
-          === "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json",
+      && object(packetEvidence?.env).CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT
+          === "benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json"
+      && object(packetEvidence?.env).CODESTORY_EMBED_ALLOW_CPU === "0",
       `${evidenceFile} packet evidence must bind the v0.16 Axios v2 corpus contract`,
     );
     const packetRun = String(packetEvidence?.run ?? "");
@@ -4274,6 +4464,34 @@ function validateRemainingWorkflows(workflows, violations) {
     });
     requireStepRun(violations, metalFile, job, "Prepare checksum-pinned embedded model", ["node scripts/prepare-embedded-model.mjs"]);
     requireStepRun(violations, metalFile, job, "Capture host evidence", ["python3 --version", 'test "$macos_major" -ge 15']);
+    const calibrationClock = namedStep(
+      job,
+      "Start Metal constant calibration clock",
+    );
+    const modelPreparation = namedStep(job, "Prepare checksum-pinned embedded model");
+    add(
+      violations,
+      calibrationClock?.if === "inputs.calibration_mode"
+        && calibrationClock?.id === "calibration-clock"
+        && calibrationClock?.shell === "bash"
+        && occurrenceCount(String(calibrationClock?.run ?? ""), "time.monotonic_ns()") === 1
+        && String(calibrationClock?.run ?? "").includes(
+          'echo "started-ns=',
+        )
+        && String(calibrationClock?.run ?? "").includes(">> \"$GITHUB_OUTPUT\"")
+        && modelPreparation?.id === "model-prepare"
+        && modelPreparation?.if === "${{ !inputs.use_packaged_cli_artifact }}"
+        && modelPreparation?.shell === "bash"
+        && occurrenceCount(
+          String(modelPreparation?.run ?? ""),
+          "time.monotonic_ns()",
+        ) === 2
+        && String(modelPreparation?.run ?? "").includes("duration-ms=")
+        && String(modelPreparation?.run ?? "").includes(">> \"$GITHUB_OUTPUT\"")
+        && stepIndex(job, "Start Metal constant calibration clock")
+          < stepIndex(job, "Prepare checksum-pinned embedded model"),
+      `${metalFile} calibration must time model preparation and total wall time from one explicit clock`,
+    );
     add(
       violations,
       namedStep(job, "Install pinned Rust")?.if
@@ -4283,8 +4501,43 @@ function validateRemainingWorkflows(workflows, violations) {
     add(
       violations,
       namedStep(job, "Build qualification driver")?.if
-        === "inputs.calibration_mode || !inputs.server_behavior_only",
-      `${metalFile} packaged server-behavior proof must skip the qualification driver`,
+        === "${{ !inputs.calibration_mode && !inputs.server_behavior_only }}",
+      `${metalFile} calibration and packaged server-behavior proof must skip the qualification driver`,
+    );
+    const nativeBuild = namedStep(job, "Build and package native CLI");
+    const nativeBuildRun = executableRunText(String(nativeBuild?.run ?? ""));
+    const normalizedNativeBuildRun = shellLiteralNormalizedText(nativeBuildRun);
+    add(
+      violations,
+      object(nativeBuild?.env).CALIBRATION_MODE === "${{ inputs.calibration_mode }}"
+        && nativeBuild?.id === "native-build-package"
+        && shellInvocationsContaining(normalizedNativeBuildRun, "cargo build").length === 1
+        && normalizedNativeBuildRun.includes("-p codestory-cli")
+        && normalizedNativeBuildRun.includes("-p codestory-bench")
+        && normalizedNativeBuildRun.includes("--bin codestory-cli")
+        && normalizedNativeBuildRun.includes("--bin codestory-cli-runtime")
+        && normalizedNativeBuildRun.includes("--bin codestory_embedding_constant_calibration")
+        && shellInvocationsContaining(
+          normalizedNativeBuildRun,
+          "python3 .github/scripts/package-codestory-release.py",
+        ).length === 1
+        && jobShellInvocationsContaining(job, "cargo build").length === 2
+        && jobShellInvocationsContaining(
+          job,
+          ".github/scripts/package-codestory-release.py",
+        ).length === 1
+        && jobShellInvocationsContaining(
+          job,
+          "node scripts/prepare-embedded-model.mjs",
+        ).length === 1
+        && jobShellInvocationsContaining(
+          job,
+          ".github/scripts/check-packaged-agent-proof.py",
+        ).length === 4
+        && occurrenceCount(normalizedNativeBuildRun, "time.monotonic_ns()") === 2
+        && normalizedNativeBuildRun.includes("duration-ms=")
+        && normalizedNativeBuildRun.includes(">> $GITHUB_OUTPUT"),
+      `${metalFile} calibration must build CLI and constant collector once through one shared Cargo invocation and package once`,
     );
     const packagedArtifactDownload = namedStep(job, "Download packaged CLI artifact");
     add(
@@ -4307,15 +4560,177 @@ function validateRemainingWorkflows(workflows, violations) {
       "test \"$actual_digest\" = \"${expected_digest#sha256:}\"",
       "ditto -x -k",
     ]);
+    const qualityDownload = namedStep(
+      job,
+      "Download exact-head publishable packet quality evidence",
+    );
+    add(
+      violations,
+      qualityDownload?.if === "inputs.quality_evidence_artifact != ''"
+        && qualityDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(qualityDownload?.with, ["name", "path"])
+        && object(qualityDownload?.with).name
+          === "${{ inputs.quality_evidence_artifact }}"
+        && object(qualityDownload?.with).path === "target/release-quality-evidence",
+      `${metalFile} imported quality evidence must bind the caller-selected exact artifact`,
+    );
+    const qualityProducerName = "Produce exact-head holdout quality on protected Metal";
+    const qualityProducer = namedStep(job, qualityProducerName);
+    const qualityProducerRun = shellLiteralNormalizedText(
+      stepRun(job, qualityProducerName),
+    );
+    add(
+      violations,
+      qualityProducer?.if
+        === "${{ !inputs.calibration_mode && !inputs.server_behavior_only && inputs.quality_evidence_artifact == '' }}"
+        && qualityProducer?.shell === "bash"
+        && hasExactKeys(qualityProducer?.env, ["VERSION", "CODESTORY_EMBED_ALLOW_CPU"])
+        && object(qualityProducer?.env).VERSION === "${{ inputs.version }}"
+        && object(qualityProducer?.env).CODESTORY_EMBED_ALLOW_CPU === "0"
+        && qualityProducerRun.includes(
+          "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz",
+        )
+        && qualityProducerRun.includes("mktemp -d $RUNNER_TEMP/codestory-quality-cli.")
+        && qualityProducerRun.includes("mktemp -d $RUNNER_TEMP/codestory-quality-cache.")
+        && qualityProducerRun.includes("mktemp -d $RUNNER_TEMP/codestory-quality-stdio.")
+        && qualityProducerRun.includes(
+          "CODESTORY_RELEASE_EVIDENCE_PROFILE=protected-macos-arm64-metal",
+        )
+        && qualityProducerRun.includes(
+          "CODESTORY_RELEASE_EVIDENCE_CORPUS_ID=codestory-release-corpus-v1",
+        )
+        && qualityProducerRun.includes(
+          "CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT=benchmarks/release-evidence/corpus-contracts/holdout-retrieval-v1.json",
+        )
+        && qualityProducerRun.includes(
+          "CODESTORY_RELEASE_EVIDENCE_CACHE_ID=frozen-candidate-holdout-v1",
+        )
+        && shellInvocationsContaining(
+          qualityProducerRun,
+          "node scripts/codestory-agent-ab-benchmark.mjs",
+        ).length === 1
+        && qualityProducerRun.includes("--packet-runtime")
+        && qualityProducerRun.includes("--packet-runtime-mode cold-cli")
+        && qualityProducerRun.includes("--task-suite holdout-retrieval")
+        && qualityProducerRun.includes("--materialize-repos")
+        && qualityProducerRun.includes("--repeats 3")
+        && qualityProducerRun.includes("--publishable")
+        && qualityProducerRun.includes("--max-source-reads-after-packet 0")
+        && qualityProducerRun.includes("--codestory-cli $packaged_cli")
+        && qualityProducerRun.includes("--timeout-ms 180000")
+        && qualityProducerRun.includes("--out-dir $quality_root/packet"),
+      `${metalFile} protected Metal must generate one exact-head three-repeat holdout quality artifact for qualification`,
+    );
+    const qualityUploadName = "Upload exact-head protected Metal quality evidence";
+    const qualityUpload = namedStep(job, qualityUploadName);
+    add(
+      violations,
+      qualityUpload?.if
+        === "${{ !inputs.calibration_mode && !inputs.server_behavior_only && inputs.quality_evidence_artifact == '' }}"
+        && qualityUpload?.uses === "actions/upload-artifact@v7.0.1"
+        && hasExactKeys(
+          qualityUpload?.with,
+          ["name", "path", "if-no-files-found", "retention-days", "overwrite"],
+        )
+        && object(qualityUpload?.with).name
+          === "frozen-candidate-quality-${{ inputs.ref || github.sha }}"
+        && object(qualityUpload?.with).path === "target/release-quality-evidence"
+        && object(qualityUpload?.with)["if-no-files-found"] === "error"
+        && object(qualityUpload?.with)["retention-days"] === 30
+        && object(qualityUpload?.with).overwrite === true
+        && stepIndex(job, qualityUploadName) > stepIndex(job, qualityProducerName)
+        && stepIndex(job, "Prove protected Metal runtime")
+          > stepIndex(job, qualityUploadName),
+      `${metalFile} protected Metal quality must upload one exact-head stable handoff before qualification`,
+    );
     requireCalibrationProducerBoundary(
       violations,
       metalFile,
       job,
       "${{ !inputs.calibration_mode && !inputs.server_behavior_only }}",
     );
-    requireStepRun(violations, metalFile, job, "Collect three independent Metal calibration runs", [
+    const calibrationStepName = "Collect three independent Metal constant calibration runs";
+    requireStepRun(violations, metalFile, job, calibrationStepName, [
       'test "$(jq -r .status crates/codestory-llama-sys/per-user-embedding-server-constant-set.json)" = unfrozen',
+      "--proof-tier calibration",
+      "--engine-policy accelerated",
+      "--expected-backend Metal",
+      "--qualification-matrix-cell protected_macos_arm64_metal",
+      "--collect-constant-calibration",
+      "--constant-calibration-output-dir target/calibration-runs/macos",
+      "--qualification-driver target/release/codestory_embedding_constant_calibration",
+      "--out-dir target/calibration-proof/macos",
     ]);
+    const calibrationRun = shellLiteralNormalizedText(
+      stepRun(job, calibrationStepName),
+    );
+    add(
+      violations,
+      shellInvocationsContaining(
+        calibrationRun,
+        "python3 .github/scripts/check-packaged-agent-proof.py",
+      ).length === 1
+        && occurrenceCount(calibrationRun, "--collect-constant-calibration") === 1
+        && !hasShellLoop(calibrationRun)
+        && !calibrationRun.includes("--produce-qualification-evidence")
+        && !calibrationRun.includes("--qualification-evidence")
+        && !calibrationRun.includes("--calibration-run-index")
+        && !calibrationRun.includes("--calibration-run-output")
+        && !calibrationRun.includes("--retrieval-quality-evidence")
+        && !calibrationRun.includes("--publication-fault-evidence")
+        && !calibrationRun.includes("--qualification-scenario")
+        && !calibrationRun.includes("--samples-per-metric")
+        && !calibrationRun.includes("true_idle_exit")
+        && !calibrationRun.includes("total_codestory_process_memory")
+        && !calibrationRun.includes("backend_observed_accelerator_residency")
+        && !calibrationRun.includes("--project")
+        && !calibrationRun.includes("--plugin-root")
+        && !calibrationRun.includes("--plugin-handoff"),
+      `${metalFile} calibration must use one three-run synthetic-project constant collector without full qualification or nested sampling`,
+    );
+    const calibrationTimingName = "Publish Metal constant calibration timing";
+    const calibrationTiming = namedStep(job, calibrationTimingName);
+    const calibrationTimingRun = stepRun(job, calibrationTimingName);
+    add(
+      violations,
+      calibrationTiming?.if === "inputs.calibration_mode"
+        && calibrationTiming?.shell === "bash"
+        && hasExactKeys(calibrationTiming?.env, [
+          "CALIBRATION_STARTED_NS",
+          "MODEL_PREPARATION_DURATION_MS",
+          "BUILD_PACKAGE_DURATION_MS",
+        ])
+        && object(calibrationTiming?.env).CALIBRATION_STARTED_NS
+          === "${{ steps.calibration-clock.outputs.started-ns }}"
+        && object(calibrationTiming?.env).MODEL_PREPARATION_DURATION_MS
+          === "${{ steps.model-prepare.outputs.duration-ms }}"
+        && object(calibrationTiming?.env).BUILD_PACKAGE_DURATION_MS
+          === "${{ steps.native-build-package.outputs.duration-ms }}"
+        && calibrationTimingRun.includes("timing_path=target/calibration-runs/macos/timing.json")
+        && calibrationTimingRun.includes(
+          "calibration_finished_ns=\"$(python3 -c 'import time; print(time.monotonic_ns())')\"",
+        )
+        && calibrationTimingRun.includes(
+          "calibration_total_ms=$(((calibration_finished_ns - CALIBRATION_STARTED_NS) / 1000000))",
+        )
+        && calibrationTimingRun.includes(
+          'test "$calibration_total_ms" -lt 600000',
+        )
+        && calibrationTimingRun.includes(
+          '[[ "$MODEL_PREPARATION_DURATION_MS" =~ ^[0-9]+$ ]]',
+        )
+        && calibrationTimingRun.includes("test \"$BUILD_PACKAGE_DURATION_MS\" -ge 0")
+        && calibrationTimingRun.includes("archive_authentication_unpack_ms")
+        && calibrationTimingRun.includes("project_and_request_setup_ms")
+        && calibrationTimingRun.includes("measurement_ms")
+        && calibrationTimingRun.includes("retention_validation_ms")
+        && calibrationTimingRun.includes("end_to_end_ms")
+        && calibrationTimingRun.includes("Model preparation")
+        && calibrationTimingRun.includes("Shared CLI build and package")
+        && calibrationTimingRun.includes("Total calibration wall time")
+        && calibrationTimingRun.includes(">> \"$GITHUB_STEP_SUMMARY\""),
+      `${metalFile} calibration must publish shared build/package and five-phase collector timing, including model preparation and an under-ten-minute total`,
+    );
     const engine = namedStep(job, "Prove protected Metal runtime");
     requireStepRun(violations, metalFile, job, "Prove protected Metal runtime", [
       "--engine-policy accelerated",
@@ -4467,6 +4882,20 @@ function validateRemainingWorkflows(workflows, violations) {
       for (const key of ["calibration_bundle_artifact", "calibration_bundle_run_id"]) {
         requireOptionalStringInput(violations, vulkanFile, vulkan, event, key);
       }
+      const qualityInput = object(at(
+        vulkan,
+        "on",
+        event,
+        "inputs",
+        "quality_evidence_artifact",
+      ));
+      add(
+        violations,
+        qualityInput.required === false
+          && qualityInput.type === "string"
+          && (qualityInput.default === "" || qualityInput.default === undefined),
+        `${vulkanFile} ${event} quality_evidence_artifact must be an optional empty string`,
+      );
     }
     const candidateInput = object(at(
       vulkan,
@@ -4610,6 +5039,20 @@ function validateRemainingWorkflows(workflows, violations) {
         === "${{ !inputs.server_behavior_only }}",
       `${vulkanFile} packaged server-behavior proof must skip the qualification driver`,
     );
+    const qualityDownload = namedStep(
+      job,
+      "Download exact-head publishable packet quality evidence",
+    );
+    add(
+      violations,
+      qualityDownload?.if === "inputs.quality_evidence_artifact != ''"
+        && qualityDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(qualityDownload?.with, ["name", "path"])
+        && object(qualityDownload?.with).name
+          === "${{ inputs.quality_evidence_artifact }}"
+        && object(qualityDownload?.with).path === "target/release-quality-evidence",
+      `${vulkanFile} qualification must download the exact protected Metal quality handoff`,
+    );
     requireCalibrationProducerBoundary(
       violations,
       vulkanFile,
@@ -4635,8 +5078,18 @@ function validateRemainingWorkflows(workflows, violations) {
       engineRun.includes("$calibrationArgs = @()")
         && engineRun.includes("@calibrationArgs")
         && engineRun.includes('$claimArgs = @("--server-behavior-only")')
-        && occurrenceCount(engineRun, "--calibration-bundle") === 1,
-      `${vulkanFile} server-behavior proof must omit calibration while qualification retains it`,
+        && engineRun.includes('"--produce-qualification-evidence"')
+        && engineRun.includes(
+          '"--qualification-driver", "target/release/codestory_embedding_qualification.exe"',
+        )
+        && engineRun.includes(
+          '"--qualification-evidence", "target/windows-vulkan-proof/qualification.json"',
+        )
+        && engineRun.includes('"--retrieval-quality-evidence", $qualityPath')
+        && occurrenceCount(engineRun, "--produce-qualification-evidence") === 1
+        && occurrenceCount(engineRun, "--calibration-bundle") === 1
+        && occurrenceCount(engineRun, "check-packaged-agent-proof.py") === 1,
+      `${vulkanFile} server-behavior proof must omit calibration while qualification runs one full lifecycle and quality proof`,
     );
     add(
       violations,
@@ -4795,6 +5248,16 @@ function validateRemainingWorkflows(workflows, violations) {
       for (const key of ["calibration_bundle_artifact", "calibration_bundle_run_id"]) {
         requireOptionalStringInput(violations, linuxVulkanFile, linuxVulkan, event, key);
       }
+      for (const key of ["quality_evidence_artifact", "quality_evidence_run_id"]) {
+        const input = object(at(linuxVulkan, "on", event, "inputs", key));
+        add(
+          violations,
+          input.required === false
+            && input.type === "string"
+            && (input.default === "" || input.default === undefined),
+          `${linuxVulkanFile} ${event} ${key} must be an optional empty string`,
+        );
+      }
       add(
         violations,
         at(linuxVulkan, "on", event, "inputs", "candidate_installed_only") === undefined,
@@ -4815,6 +5278,36 @@ function validateRemainingWorkflows(workflows, violations) {
         && candidateInput.default === false,
       `${linuxVulkanFile} reusable candidate-installed proof must be an explicit opt-in`,
     );
+    const optionalCalibrationInput = object(at(
+      linuxVulkan,
+      "on",
+      "workflow_dispatch",
+      "inputs",
+      "constant_calibration_mode",
+    ));
+    add(
+      violations,
+      at(linuxVulkan, "on", "workflow_call", "inputs", "constant_calibration_mode")
+        === undefined
+        && optionalCalibrationInput.required === false
+        && optionalCalibrationInput.type === "boolean"
+        && optionalCalibrationInput.default === false,
+      `${linuxVulkanFile} optional constant calibration must be manual-only and off by default`,
+    );
+    const manualPackageRunInput = object(at(
+      linuxVulkan,
+      "on",
+      "workflow_dispatch",
+      "inputs",
+      "package_run_id",
+    ));
+    add(
+      violations,
+      manualPackageRunInput.required === false
+        && manualPackageRunInput.type === "string"
+        && manualPackageRunInput.default === "",
+      `${linuxVulkanFile} standalone constant calibration must not require an upstream package run`,
+    );
     add(
       violations,
       at(
@@ -4827,7 +5320,41 @@ function validateRemainingWorkflows(workflows, violations) {
       ) === ".github/workflows/packaged-platform-pr.yml",
       `${linuxVulkanFile} manual candidate proof must trust the package-producing workflow`,
     );
+    const route = requireJob(violations, linuxVulkanFile, linuxVulkan, "route");
+    add(
+      violations,
+      JSON.stringify(route["runs-on"]) === JSON.stringify("ubuntu-latest")
+        && route["timeout-minutes"] === 5,
+      `${linuxVulkanFile} standalone dispatch validation must stay on a bounded hosted route job`,
+    );
+    requireStepRun(
+      violations,
+      linuxVulkanFile,
+      route,
+      "Require an upstream package for standalone protected proof",
+      [
+        'if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$CONSTANT_CALIBRATION_MODE" != true ]; then',
+        'test -n "$PACKAGE_RUN_ID"',
+      ],
+    );
+    requireStepEnv(
+      violations,
+      linuxVulkanFile,
+      route,
+      "Require an upstream package for standalone protected proof",
+      {
+        EVENT_NAME: "${{ github.event_name }}",
+        CONSTANT_CALIBRATION_MODE: "${{ inputs.constant_calibration_mode }}",
+        PACKAGE_RUN_ID: "${{ inputs.package_run_id }}",
+      },
+    );
     const job = requireJob(violations, linuxVulkanFile, linuxVulkan, "packaged-vulkan");
+    add(
+      violations,
+      job.if === "${{ !inputs.constant_calibration_mode }}"
+        && sameMembers(needs(job), ["route"]),
+      `${linuxVulkanFile} release proof job must not run during standalone optional calibration`,
+    );
     requireStepUses(
       violations,
       linuxVulkanFile,
@@ -4866,6 +5393,91 @@ function validateRemainingWorkflows(workflows, violations) {
       job,
       "${{ !inputs.server_behavior_only }}",
     );
+    const qualificationRust = namedStep(
+      job,
+      "Install pinned Rust for frozen-candidate qualification",
+    );
+    const qualificationDriver = namedStep(job, "Build qualification driver");
+    add(
+      violations,
+      qualificationRust?.if === "${{ !inputs.server_behavior_only }}"
+        && qualificationRust?.shell === "bash"
+        && String(qualificationRust?.run ?? "").includes(
+          "rustup toolchain install 1.95.0 --profile minimal",
+        )
+        && qualificationDriver?.if === "${{ !inputs.server_behavior_only }}"
+        && qualificationDriver?.shell === "bash"
+        && String(qualificationDriver?.run ?? "")
+          === "cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification",
+      `${linuxVulkanFile} standalone qualification must build its pinned full qualification driver exactly once`,
+    );
+    const qualityAuthentication = namedStep(
+      job,
+      "Authenticate protected Metal quality producer",
+    );
+    const qualityAuthenticationRun = stepRun(
+      job,
+      "Authenticate protected Metal quality producer",
+    );
+    add(
+      violations,
+      qualityAuthentication?.if === "${{ !inputs.server_behavior_only }}"
+        && qualityAuthentication?.shell === "bash"
+        && hasExactKeys(qualityAuthentication?.env, [
+          "GH_TOKEN",
+          "QUALITY_ARTIFACT",
+          "QUALITY_RUN_ID",
+        ])
+        && object(qualityAuthentication?.env).GH_TOKEN === "${{ github.token }}"
+        && object(qualityAuthentication?.env).QUALITY_ARTIFACT
+          === "${{ inputs.quality_evidence_artifact }}"
+        && object(qualityAuthentication?.env).QUALITY_RUN_ID
+          === "${{ inputs.quality_evidence_run_id }}"
+        && qualityAuthenticationRun.includes('test -n "$QUALITY_ARTIFACT"')
+        && qualityAuthenticationRun.includes('test -n "$QUALITY_RUN_ID"')
+        && qualityAuthenticationRun.includes(
+          'test "$(jq -r \'.head_repository.full_name\' <<<"$run")" = "$GITHUB_REPOSITORY"',
+        )
+        && qualityAuthenticationRun.includes(
+          'test "$(jq -r \'.path\' <<<"$run")" = ".github/workflows/packaged-platform-pr.yml"',
+        )
+        && qualityAuthenticationRun.includes(
+          'test "$(jq -r \'.event\' <<<"$run")" = workflow_dispatch',
+        )
+        && qualityAuthenticationRun.includes(
+          'test "$(jq -r \'.conclusion\' <<<"$run")" = success',
+        )
+        && qualityAuthenticationRun.includes(
+          'test "$producer_sha" = "$(git rev-parse HEAD)"',
+        )
+        && qualityAuthenticationRun.includes(
+          'test "$QUALITY_ARTIFACT" = "frozen-candidate-quality-$producer_sha"',
+        )
+        && qualityAuthenticationRun.includes('test "$artifact_count" = 1'),
+      `${linuxVulkanFile} standalone qualification must authenticate exact-head protected Metal quality`,
+    );
+    const qualityDownload = namedStep(
+      job,
+      "Download exact-head protected Metal quality evidence",
+    );
+    add(
+      violations,
+      qualityDownload?.if === "${{ !inputs.server_behavior_only }}"
+        && qualityDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(
+          qualityDownload?.with,
+          ["name", "path", "run-id", "github-token"],
+        )
+        && object(qualityDownload?.with).name
+          === "${{ inputs.quality_evidence_artifact }}"
+        && object(qualityDownload?.with).path === "target/release-quality-evidence"
+        && object(qualityDownload?.with)["run-id"]
+          === "${{ inputs.quality_evidence_run_id }}"
+        && object(qualityDownload?.with)["github-token"] === "${{ github.token }}"
+        && stepIndex(job, "Download exact-head protected Metal quality evidence")
+          > stepIndex(job, "Authenticate protected Metal quality producer"),
+      `${linuxVulkanFile} standalone qualification must consume the authenticated protected Metal quality artifact`,
+    );
     const engine = namedStep(job, "Prove offline Linux Vulkan retrieval");
     requireStepRun(violations, linuxVulkanFile, job, "Prove offline Linux Vulkan retrieval", [
       "--engine-policy accelerated",
@@ -4883,6 +5495,7 @@ function validateRemainingWorkflows(workflows, violations) {
       `${linuxVulkanFile} protected proof must reject CPU fallback`,
     );
     const engineRun = stepRun(job, "Prove offline Linux Vulkan retrieval");
+    const normalizedEngineRun = shellLiteralNormalizedText(engineRun);
     add(
       violations,
       engine?.if === "${{ !inputs.candidate_installed_proof }}",
@@ -4893,8 +5506,22 @@ function validateRemainingWorkflows(workflows, violations) {
       engineRun.includes("calibration_args=()")
         && engineRun.includes('"${calibration_args[@]}"')
         && engineRun.includes('claim_args=(--server-behavior-only)')
-        && occurrenceCount(engineRun, "--calibration-bundle") === 1,
-      `${linuxVulkanFile} server-behavior proof must omit calibration while qualification retains it`,
+        && engineRun.includes("quality_args=()")
+        && engineRun.includes("qualification_args=()")
+        && normalizedEngineRun.includes(
+          "quality_args=(--retrieval-quality-evidence $quality_path)",
+        )
+        && normalizedEngineRun.includes("--produce-qualification-evidence")
+        && normalizedEngineRun.includes(
+          "--qualification-driver target/release/codestory_embedding_qualification",
+        )
+        && normalizedEngineRun.includes(
+          "--qualification-evidence target/linux-vulkan-proof/qualification.json",
+        )
+        && occurrenceCount(engineRun, "--produce-qualification-evidence") === 1
+        && occurrenceCount(engineRun, "--calibration-bundle") === 1
+        && occurrenceCount(engineRun, "check-packaged-agent-proof.py") === 1,
+      `${linuxVulkanFile} server-behavior proof must omit calibration while standalone qualification runs one full lifecycle and quality proof`,
     );
     requireStepRun(violations, linuxVulkanFile, job, "Stage isolated candidate-managed Linux install", [
       "--prepare-candidate-installed-proof",
@@ -4955,6 +5582,109 @@ function validateRemainingWorkflows(workflows, violations) {
       "Emit authenticated Linux Vulkan release cells",
       ["calibration"],
     );
+    const optionalCalibration = requireJob(
+      violations,
+      linuxVulkanFile,
+      linuxVulkan,
+      "optional-constant-calibration",
+    );
+    add(
+      violations,
+      optionalCalibration.if
+        === "${{ github.event_name == 'workflow_dispatch' && inputs.constant_calibration_mode }}"
+        && JSON.stringify(optionalCalibration["runs-on"])
+          === JSON.stringify(["self-hosted", "Linux", "X64", "codestory-linux-vulkan"])
+        && optionalCalibration.environment === "linux-vulkan-proof",
+      `${linuxVulkanFile} optional calibration must be a standalone protected manual Vulkan job`,
+    );
+    const optionalCollectorName = "Collect optional Linux Vulkan constant calibration";
+    requireStepRun(violations, linuxVulkanFile, optionalCalibration, optionalCollectorName, [
+      'test "$GITHUB_EVENT_NAME" = workflow_dispatch',
+      "--engine-policy accelerated",
+      "--expected-backend Vulkan",
+      "--proof-tier calibration",
+      "--qualification-matrix-cell protected_linux_x64_vulkan",
+      "--collect-constant-calibration",
+      "--constant-calibration-output-dir target/calibration-runs/linux-vulkan",
+      "--qualification-driver target/release/codestory_embedding_constant_calibration",
+      "--out-dir target/calibration-proof/linux-vulkan",
+    ]);
+    const optionalCollector = namedStep(optionalCalibration, optionalCollectorName);
+    const optionalCollectorRun = shellLiteralNormalizedText(
+      stepRun(optionalCalibration, optionalCollectorName),
+    );
+    add(
+      violations,
+      object(optionalCollector?.env).CODESTORY_EMBED_ALLOW_CPU === "0"
+        && shellInvocationsContaining(
+          optionalCollectorRun,
+          "python .github/scripts/check-packaged-agent-proof.py",
+        ).length === 1
+        && !optionalCollectorRun.includes("--produce-qualification-evidence")
+        && !optionalCollectorRun.includes("--qualification-evidence")
+        && !optionalCollectorRun.includes("--retrieval-quality-evidence")
+        && !optionalCollectorRun.includes("--publication-fault-evidence")
+        && !optionalCollectorRun.includes("--qualification-scenario")
+        && !optionalCollectorRun.includes("--samples-per-metric")
+        && !hasShellLoop(optionalCollectorRun)
+        && !optionalCollectorRun.includes("--project")
+        && !optionalCollectorRun.includes("--plugin-root")
+        && !optionalCollectorRun.includes("--plugin-handoff"),
+      `${linuxVulkanFile} optional calibration must collect accelerated constants once from a synthetic project without qualification`,
+    );
+    const optionalNativeBuild = namedStep(
+      optionalCalibration,
+      "Build and package native CLI and constant driver",
+    );
+    const optionalNativeBuildRun = shellLiteralNormalizedText(
+      String(optionalNativeBuild?.run ?? ""),
+    );
+    add(
+      violations,
+      object(optionalNativeBuild?.env).VERSION === "${{ inputs.version }}"
+        && shellInvocationsContaining(optionalNativeBuildRun, "cargo build").length === 1
+        && optionalNativeBuildRun.includes("-p codestory-cli")
+        && optionalNativeBuildRun.includes("--bin codestory-cli")
+        && optionalNativeBuildRun.includes("--bin codestory-cli-runtime")
+        && optionalNativeBuildRun.includes("-p codestory-bench")
+        && optionalNativeBuildRun.includes("--bin codestory_embedding_constant_calibration")
+        && shellInvocationsContaining(
+          optionalNativeBuildRun,
+          "python .github/scripts/package-codestory-release.py",
+        ).length === 1
+        && jobShellInvocationsContaining(optionalCalibration, "cargo build").length === 1
+        && jobShellInvocationsContaining(
+          optionalCalibration,
+          ".github/scripts/package-codestory-release.py",
+        ).length === 1
+        && jobShellInvocationsContaining(
+          optionalCalibration,
+          ".github/scripts/check-packaged-agent-proof.py",
+        ).length === 1
+        && optionalNativeBuildRun.includes("--target linux-x64")
+        && optionalNativeBuildRun.includes("--binary target/release/codestory-cli")
+        && jobShellInvocationsContaining(
+          optionalCalibration,
+          "node scripts/prepare-embedded-model.mjs",
+        ).length === 1
+        && namedStep(optionalCalibration, "Download exact Linux package") === undefined
+        && namedStep(optionalCalibration, "Build constant calibration driver") === undefined
+        && !scalarStrings(optionalCalibration).some(value =>
+          value.includes("inputs.package_run_id")),
+      `${linuxVulkanFile} optional calibration must prepare once, build CLI and collector once, and package that exact CLI once`,
+    );
+    const optionalUpload = namedStep(
+      optionalCalibration,
+      "Upload optional Linux Vulkan calibration evidence",
+    );
+    add(
+      violations,
+      optionalUpload?.uses === "actions/upload-artifact@v7.0.1"
+        && String(object(optionalUpload?.with).name).includes("${{ github.run_attempt }}")
+        && String(object(optionalUpload?.with).path).includes("target/calibration-runs/linux-vulkan")
+        && String(object(optionalUpload?.with).path).includes("target/calibration-proof/linux-vulkan"),
+      `${linuxVulkanFile} optional calibration must upload attempt-scoped non-selecting evidence`,
+    );
     for (const name of [
       "Upload authenticated Linux accelerator release cell",
       "Upload authenticated Linux retrieval release cell",
@@ -5005,6 +5735,215 @@ function findNamedStep(workflow, name) {
     if (found) return found;
   }
   return undefined;
+}
+
+function releaseProofWorkflowFiles(workflows, graph) {
+  const files = new Set([
+    "auto-release.yml",
+    "packaged-platform-pr.yml",
+    object(graph.workflow_policy.calibration).coordinator_workflow,
+  ].filter(Boolean));
+  for (const evidenceType of list(graph.evidence_types)) {
+    for (const lane of list(object(evidenceType).proof_lanes)) {
+      files.add(path.basename(String(lane)));
+    }
+  }
+  for (const file of list(graph.workflow_policy.artifact_workflows)) {
+    files.add(path.basename(String(file)));
+  }
+  for (const contract of list(graph.workflow_policy.protected_jobs)) {
+    files.add(path.basename(String(object(contract).workflow)));
+  }
+  for (const cell of [
+    ...list(object(graph.workflow_policy.calibration).required_cells),
+    ...list(object(graph.workflow_policy.calibration).optional_cells),
+    ...list(object(graph.workflow_policy.qualification).required_cells),
+    ...list(object(graph.workflow_policy.qualification).optional_cells),
+  ]) {
+    files.add(path.basename(String(object(cell).workflow)));
+  }
+  files.add(path.basename(
+    String(object(graph.workflow_policy.qualification).coordinator_workflow ?? ""),
+  ));
+  files.delete("");
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const file of [...files]) {
+      for (const job of Object.values(object(workflows.get(file)?.jobs))) {
+        const reusable = String(object(job).uses ?? "");
+        const match = reusable.match(/^\.\/\.github\/workflows\/([^/]+\.yml)$/u);
+        if (match && !files.has(match[1])) {
+          files.add(match[1]);
+          changed = true;
+        }
+      }
+    }
+  }
+  return files;
+}
+
+function workflowCpuSelectorViolations(file, value) {
+  const violations = [];
+  function visit(current, location, key = "") {
+    if (Array.isArray(current)) {
+      current.forEach((item, index) => visit(item, `${location}[${index}]`));
+      return;
+    }
+    if (current !== null && typeof current === "object") {
+      for (const [childKey, childValue] of Object.entries(current)) {
+        visit(childValue, `${location}.${childKey}`, childKey);
+      }
+      return;
+    }
+    const text = String(current ?? "");
+    const normalizedKey = key.toLowerCase().replaceAll("-", "_");
+    const normalizedText = text.trim().toLowerCase();
+    if (
+      normalizedKey === "codestory_embed_allow_cpu"
+      && text !== "0"
+    ) {
+      violations.push(
+        `[cpu_selector] ${file} ${location} must set CODESTORY_EMBED_ALLOW_CPU to literal 0`,
+      );
+    }
+    if (
+      ["policy", "engine_policy", "execution_policy"].includes(normalizedKey)
+      && normalizedText === "cpu_explicit"
+    ) {
+      violations.push(`[cpu_selector] ${file} ${location} selects cpu_explicit`);
+    }
+    if (
+      ["backend", "expected_backend"].includes(normalizedKey)
+      && normalizedText === "cpu"
+    ) {
+      violations.push(`[cpu_selector] ${file} ${location} selects CPU backend`);
+    }
+    const executable = shellLiteralNormalizedText(text);
+    if (
+      hasNonLiteralCpuAssignment(executable)
+      || /\bcpu_explicit\b/iu.test(executable)
+      || /--expected-backend(?:\s+|=)cpu\b/iu.test(executable)
+      || /(?:expected_backend|backend)\s*=\s*cpu\b/iu.test(executable)
+    ) {
+      violations.push(`[cpu_selector] ${file} ${location} contains a CPU proof selector`);
+    }
+  }
+  visit(value, file);
+  return violations;
+}
+
+const cpuTestSeamAllowedJobs = new Map([
+  [
+    "retrieval-engine-smoke.yml",
+    new Set(["linux-contracts", "windows-manifest-missing"]),
+  ],
+]);
+
+function workflowCpuTestSeamViolations(file, value, releaseProofFiles) {
+  const violations = [];
+  function visit(current, location, pathParts, jobName) {
+    if (Array.isArray(current)) {
+      current.forEach((item, index) =>
+        visit(item, `${location}[${index}]`, [...pathParts, String(index)], jobName));
+      return;
+    }
+    if (current !== null && typeof current === "object") {
+      for (const [childKey, childValue] of Object.entries(current)) {
+        const childPath = [...pathParts, childKey];
+        const childLocation = `${location}.${childKey}`;
+        const childJob = pathParts.length === 1 && pathParts[0] === "jobs"
+          ? childKey
+          : jobName;
+        if (
+          childKey.toLowerCase().replaceAll("-", "_")
+            === "codestory_test_embed_allow_cpu"
+        ) {
+          const allowed = !releaseProofFiles.has(file)
+            && cpuTestSeamAllowedJobs.get(file)?.has(childJob) === true
+            && childPath.length === 4
+            && childPath[0] === "jobs"
+            && childPath[1] === childJob
+            && childPath[2] === "env"
+            && String(childValue) === "1";
+          add(
+            violations,
+            allowed,
+            `[cpu_test_seam] ${file} ${childLocation} may enable CPU only through the exact source-test job seam`,
+          );
+          continue;
+        }
+        visit(childValue, childLocation, childPath, childJob);
+      }
+      return;
+    }
+    if (
+      /\bCODESTORY_TEST_EMBED_ALLOW_CPU\b/iu.test(
+        shellLiteralNormalizedText(String(current ?? "")),
+      )
+    ) {
+      violations.push(
+        `[cpu_test_seam] ${file} ${location} may not reference the CPU test seam outside an allowlisted source-test job env`,
+      );
+    }
+  }
+  visit(value, file, [], "");
+  return violations;
+}
+
+export function releaseProofCpuSelectorViolations(
+  workflows,
+  graph = loadReleaseClaimGraph(repositoryRoot),
+  supportSources,
+) {
+  const violations = [];
+  const releaseProofFiles = releaseProofWorkflowFiles(workflows, graph);
+  for (const [file, workflow] of workflows) {
+    // The product selector is never legal in a workflow. Source tests that
+    // exercise CPU behavior use the separately named, policy-owned test seam.
+    violations.push(...workflowCpuSelectorViolations(file, workflow));
+    violations.push(...workflowCpuTestSeamViolations(
+      file,
+      workflow,
+      releaseProofFiles,
+    ));
+  }
+  const sources = supportSources ?? new Map([
+    [
+      "scripts/release-evidence/guest-runner.sh",
+      fs.readFileSync(path.join(repositoryRoot, "scripts/release-evidence/guest-runner.sh"), "utf8"),
+    ],
+    [
+      ".github/scripts/check-linux-glibc-baseline.sh",
+      fs.readFileSync(path.join(repositoryRoot, ".github/scripts/check-linux-glibc-baseline.sh"), "utf8"),
+    ],
+    [
+      "scripts/release-evidence/guest-verify.sh",
+      fs.readFileSync(path.join(repositoryRoot, "scripts/release-evidence/guest-verify.sh"), "utf8"),
+    ],
+  ]);
+  for (const [file, source] of sources) {
+    if (
+      file.endsWith("guest-verify.sh")
+    ) {
+      add(
+        violations,
+        source.includes('grep -qxF "CODESTORY_EMBED_ALLOW_CPU=0"')
+          && source.includes('grep -qxF "CODESTORY_EMBED_ALLOW_CPU=1"'),
+        `[cpu_selector] ${file} must prove CPU is disabled in the runner service`,
+      );
+      continue;
+    }
+    const executable = shellLiteralNormalizedText(source);
+    if (
+      hasNonLiteralCpuAssignment(executable)
+      || /\bcpu_explicit\b/iu.test(executable)
+      || /--expected-backend(?:\s+|=)cpu\b/iu.test(executable)
+    ) {
+      violations.push(`[cpu_selector] ${file} contains a CPU proof selector`);
+    }
+  }
+  return violations;
 }
 
 export function releaseWorkflowContractViolations(
@@ -5646,10 +6585,6 @@ function validateReleaseArtifactRerunSafety(workflows, violations) {
       name: "release-evidence-${{ inputs.ref }}",
       path: "target/release-evidence",
     }],
-    ["packaged-platform-proof.yml/build/Upload hosted Linux calibration runs", {
-      name: "embedding-calibration-linux-${{ inputs.version }}",
-      path: "target/calibration-runs/linux",
-    }],
     ["packaged-platform-proof.yml/build/Upload release asset", {
       name: "codestory-cli-${{ matrix.asset_target }}",
       path: "target/release-dist/*.tar.gz\ntarget/release-dist/*.zip\ntarget/release-dist/*.sha256\ntarget/release-dist/SHA256SUMS.txt\n",
@@ -5657,6 +6592,10 @@ function validateReleaseArtifactRerunSafety(workflows, violations) {
     ["macos-metal-proof.yml/packaged-metal/Upload Metal calibration runs", {
       name: "embedding-calibration-macos-${{ inputs.version }}",
       path: "target/calibration-runs/macos",
+    }],
+    ["macos-metal-proof.yml/packaged-metal/Upload exact-head protected Metal quality evidence", {
+      name: "frozen-candidate-quality-${{ inputs.ref || github.sha }}",
+      path: "target/release-quality-evidence",
     }],
     ["release.yml/pre-publish-closeout/Upload accepted pre-publish closeout", {
       name: "release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}",
@@ -6212,6 +7151,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   validatePostPublish(workflows, violations, graph);
   validatePackagedCoordinator(workflows, violations, graph);
   validateRemainingWorkflows(workflows, violations);
+  violations.push(...releaseProofCpuSelectorViolations(workflows, graph));
   validateReleaseCellUploadOwnership(workflows, violations);
   validateReleaseArtifactRerunSafety(workflows, violations);
   violations.push(...dispatchInputInterpolationViolations(workflows));

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -32,6 +32,7 @@ import {
   packagedPrSigningViolations,
   parseWorkflow,
   releaseEvidenceApprovalViolations,
+  releaseProofCpuSelectorViolations,
   releaseEvidenceWorkflowRef,
   releaseWorkflowContractViolations,
   retrievalFile,
@@ -367,6 +368,768 @@ test("release evidence policy pins the release-only Axios v2 task and corpus", a
       const workflows = loadWorkflows();
       mutate(workflows.get(file));
       assert.match(validateWorkflows(workflows).join("\n"), expected);
+    });
+  }
+});
+
+test("every release-proof workflow rejects CPU selectors at every structural level", async (t) => {
+  const graph = loadReleaseClaimGraph(root);
+  const releaseProofFiles = [
+    "auto-release.yml",
+    "packaged-platform-pr.yml",
+    ...new Set([
+      ...graph.evidence_types.flatMap(({ proof_lanes: lanes }) => lanes),
+      ...graph.workflow_policy.artifact_workflows,
+      ...graph.workflow_policy.protected_jobs.map(({ workflow }) => workflow),
+      graph.workflow_policy.calibration.coordinator_workflow,
+      ...graph.workflow_policy.calibration.required_cells.map(({ workflow }) => workflow),
+      ...graph.workflow_policy.calibration.optional_cells.map(({ workflow }) => workflow),
+      graph.workflow_policy.qualification.coordinator_workflow,
+      ...graph.workflow_policy.qualification.required_cells.map(({ workflow }) => workflow),
+      ...graph.workflow_policy.qualification.optional_cells.map(({ workflow }) => workflow),
+    ].map(file => path.basename(file))),
+  ];
+  assert.deepEqual(releaseProofCpuSelectorViolations(loadWorkflows(), graph), []);
+
+  const mutations = [
+    ["workflow environment", workflow => {
+      workflow.env = { ...workflow.env, CODESTORY_EMBED_ALLOW_CPU: "1" };
+    }],
+    ["job environment", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.env = { ...job.env, CODESTORY_EMBED_ALLOW_CPU: 1 };
+    }],
+    ["step environment", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [{ name: "Injected CPU selector", run: "true" }];
+      job.steps[0].env = {
+        ...job.steps[0].env,
+        CODESTORY_EMBED_ALLOW_CPU: "1",
+      };
+    }],
+    ["inline environment assignment", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected CPU selector",
+        run: "CODESTORY_EMBED_ALLOW_CPU=1 true",
+      });
+    }],
+    ["inline arithmetic environment assignment", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected CPU selector",
+        run: "CODESTORY_EMBED_ALLOW_CPU=$((1)) true",
+      });
+    }],
+    ["inline command-substitution environment assignment", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected CPU selector",
+        run: "CODESTORY_EMBED_ALLOW_CPU=$(printf 1) true",
+      });
+    }],
+    ["equal-form engine policy", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected CPU selector",
+        run: "codestory-proof --engine-policy=cpu_explicit",
+      });
+    }],
+    ["shell-concatenated engine policy", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected CPU selector",
+        run: 'codestory-proof --engine-policy cpu_"explicit"',
+      });
+    }],
+    ["spaced backend flag", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected CPU selector",
+        run: "codestory-proof --expected-backend CPU",
+      });
+    }],
+    ["shell-concatenated backend flag", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected CPU selector",
+        run: 'codestory-proof --expected-backend "c"pu',
+      });
+    }],
+    ["matrix semantic key", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.strategy = { matrix: { include: [{ engine_policy: "cpu_explicit" }] } };
+    }],
+    ["whitespace-wrapped matrix policy", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.strategy = { matrix: { include: [{ engine_policy: " CPU_EXPLICIT " }] } };
+    }],
+    ["whitespace-wrapped matrix backend", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.strategy = { matrix: { include: [{ backend: " CPU " }] } };
+    }],
+  ];
+
+  for (const file of releaseProofFiles) {
+    for (const [shape, mutate] of mutations) {
+      await t.test(`${file}: ${shape}`, () => {
+        const workflows = loadWorkflows();
+        mutate(workflows.get(file));
+        assert.match(
+          releaseProofCpuSelectorViolations(workflows, graph).join("\n"),
+          new RegExp(`\\[cpu_selector\\] ${file.replaceAll(".", "\\.")}`, "u"),
+        );
+      });
+    }
+  }
+
+  await t.test("non-release source workflow cannot enable the product CPU selector", () => {
+    const workflows = loadWorkflows();
+    workflows.get("rust-ci.yml").jobs["linux-draft"].env = {
+      CODESTORY_EMBED_ALLOW_CPU: "1",
+    };
+    assert.match(
+      releaseProofCpuSelectorViolations(workflows, graph).join("\n"),
+      /\[cpu_selector\] rust-ci\.yml/u,
+    );
+  });
+  await t.test("release proof cannot use the CPU test seam", () => {
+    const workflows = loadWorkflows();
+    workflows.get("macos-metal-proof.yml").jobs["packaged-metal"].env = {
+      CODESTORY_TEST_EMBED_ALLOW_CPU: "1",
+    };
+    assert.match(
+      releaseProofCpuSelectorViolations(workflows, graph).join("\n"),
+      /\[cpu_test_seam\] macos-metal-proof\.yml/u,
+    );
+  });
+  await t.test("unrelated source job cannot claim the CPU test seam", () => {
+    const workflows = loadWorkflows();
+    workflows.get("rust-ci.yml").jobs["linux-draft"].env = {
+      CODESTORY_TEST_EMBED_ALLOW_CPU: "1",
+    };
+    assert.match(
+      releaseProofCpuSelectorViolations(workflows, graph).join("\n"),
+      /\[cpu_test_seam\] rust-ci\.yml/u,
+    );
+  });
+  await t.test("allowlisted source test cannot move the seam to a step", () => {
+    const workflows = loadWorkflows();
+    const workflow = workflows.get("retrieval-engine-smoke.yml");
+    delete workflow.jobs["linux-contracts"].env.CODESTORY_TEST_EMBED_ALLOW_CPU;
+    workflow.jobs["linux-contracts"].steps[0].env = {
+      CODESTORY_TEST_EMBED_ALLOW_CPU: "1",
+    };
+    assert.match(
+      releaseProofCpuSelectorViolations(workflows, graph).join("\n"),
+      /\[cpu_test_seam\] retrieval-engine-smoke\.yml/u,
+    );
+  });
+
+  const supportSources = new Map([
+    [
+      "scripts/release-evidence/guest-runner.sh",
+      readFileSync(path.join(root, "scripts/release-evidence/guest-runner.sh"), "utf8"),
+    ],
+    [
+      ".github/scripts/check-linux-glibc-baseline.sh",
+      readFileSync(path.join(root, ".github/scripts/check-linux-glibc-baseline.sh"), "utf8"),
+    ],
+    [
+      "scripts/release-evidence/guest-verify.sh",
+      readFileSync(path.join(root, "scripts/release-evidence/guest-verify.sh"), "utf8"),
+    ],
+  ]);
+  await t.test("runner service re-enables CPU", () => {
+    const mutated = new Map(supportSources);
+    mutated.set(
+      "scripts/release-evidence/guest-runner.sh",
+      mutated.get("scripts/release-evidence/guest-runner.sh")
+        .replace("CODESTORY_EMBED_ALLOW_CPU=0", "CODESTORY_EMBED_ALLOW_CPU=1"),
+    );
+    assert.match(
+      releaseProofCpuSelectorViolations(loadWorkflows(), graph, mutated).join("\n"),
+      /guest-runner\.sh contains a CPU proof selector/u,
+    );
+  });
+  for (const [shape, assignment] of [
+    ["arithmetic", "CODESTORY_EMBED_ALLOW_CPU=$((1))"],
+    ["command substitution", "CODESTORY_EMBED_ALLOW_CPU=$(printf 1)"],
+  ]) {
+    await t.test(`runner service re-enables CPU through ${shape}`, () => {
+      const mutated = new Map(supportSources);
+      mutated.set(
+        "scripts/release-evidence/guest-runner.sh",
+        mutated.get("scripts/release-evidence/guest-runner.sh")
+          .replace("CODESTORY_EMBED_ALLOW_CPU=0", assignment),
+      );
+      assert.match(
+        releaseProofCpuSelectorViolations(loadWorkflows(), graph, mutated).join("\n"),
+        /guest-runner\.sh contains a CPU proof selector/u,
+      );
+    });
+  }
+  await t.test("glibc smoke re-enables CPU", () => {
+    const mutated = new Map(supportSources);
+    mutated.set(
+      ".github/scripts/check-linux-glibc-baseline.sh",
+      mutated.get(".github/scripts/check-linux-glibc-baseline.sh")
+        .replace("CODESTORY_EMBED_ALLOW_CPU=0", "CODESTORY_EMBED_ALLOW_CPU=1"),
+    );
+    assert.match(
+      releaseProofCpuSelectorViolations(loadWorkflows(), graph, mutated).join("\n"),
+      /check-linux-glibc-baseline\.sh contains a CPU proof selector/u,
+    );
+  });
+  await t.test("runner verification stops proving CPU disabled", () => {
+    const mutated = new Map(supportSources);
+    mutated.set(
+      "scripts/release-evidence/guest-verify.sh",
+      mutated.get("scripts/release-evidence/guest-verify.sh")
+        .replace('grep -qxF "CODESTORY_EMBED_ALLOW_CPU=0"', "grep -qxF ignored"),
+    );
+    assert.match(
+      releaseProofCpuSelectorViolations(loadWorkflows(), graph, mutated).join("\n"),
+      /guest-verify\.sh must prove CPU is disabled/u,
+    );
+  });
+});
+
+test("constant calibration structure rejects qualification, 3x3 sampling, repeated setup, and Linux gating", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const metalFile = "macos-metal-proof.yml";
+  const coordinatorFile = "packaged-platform-pr.yml";
+  const collector = workflow => draftStep(
+    workflow.jobs["packaged-metal"],
+    "Collect three independent Metal constant calibration runs",
+  );
+  const nativeBuild = workflow => draftStep(
+    workflow.jobs["packaged-metal"],
+    "Build and package native CLI",
+  );
+  const metalTiming = workflow => draftStep(
+    workflow.jobs["packaged-metal"],
+    "Publish Metal constant calibration timing",
+  );
+  const linuxCollector = workflow => draftStep(
+    workflow.jobs["optional-constant-calibration"],
+    "Collect optional Linux Vulkan constant calibration",
+  );
+  const linuxNativeBuild = workflow => draftStep(
+    workflow.jobs["optional-constant-calibration"],
+    "Build and package native CLI and constant driver",
+  );
+  const assembly = workflow => workflow.jobs["calibration-assemble"];
+  const assemblyStep = workflow => draftStep(
+    assembly(workflow),
+    "Assemble frozen calibration candidate",
+  );
+
+  const mutations = [
+    ["qualification scenario enters calibration", metalFile, workflow => {
+      collector(workflow).run += "\n--qualification-scenario lifecycle";
+    }, /without full qualification or nested sampling/u],
+    ["fault evidence enters calibration", metalFile, workflow => {
+      collector(workflow).run += "\n--publication-fault-evidence target/fault.json";
+    }, /without full qualification or nested sampling/u],
+    ["quality evidence enters calibration", metalFile, workflow => {
+      collector(workflow).run += "\n--retrieval-quality-evidence target/quality.json";
+    }, /without full qualification or nested sampling/u],
+    ["full qualification producer enters calibration", metalFile, workflow => {
+      collector(workflow).run += "\n--produce-qualification-evidence";
+    }, /without full qualification or nested sampling/u],
+    ["shell-concatenated qualification producer enters calibration", metalFile, workflow => {
+      collector(workflow).run = collector(workflow).run.replace(
+        "--out-dir target/calibration-proof/macos",
+        '--produce-"qualification-evidence" \\\n  --out-dir target/calibration-proof/macos',
+      );
+    }, /without full qualification or nested sampling/u],
+    ["shell-concatenated qualification evidence enters calibration", metalFile, workflow => {
+      collector(workflow).run = collector(workflow).run.replace(
+        "--out-dir target/calibration-proof/macos",
+        '--qualification-"evidence" target/qualification.json \\\n  --out-dir target/calibration-proof/macos',
+      );
+    }, /without full qualification or nested sampling/u],
+    ["shell-concatenated fault evidence enters calibration", metalFile, workflow => {
+      collector(workflow).run = collector(workflow).run.replace(
+        "--out-dir target/calibration-proof/macos",
+        '--publication-"fault-evidence" target/fault.json \\\n  --out-dir target/calibration-proof/macos',
+      );
+    }, /without full qualification or nested sampling/u],
+    ["3x3 sampling is requested", metalFile, workflow => {
+      collector(workflow).run += "\n--samples-per-metric 3";
+    }, /without full qualification or nested sampling/u],
+    ["outer run loop returns", metalFile, workflow => {
+      collector(workflow).run = `for run_index in 1 2 3; do\n${collector(workflow).run}\ndone`;
+    }, /without full qualification or nested sampling/u],
+    ["renamed outer run loop returns", metalFile, workflow => {
+      collector(workflow).run = `for attempt in 1 2 3; do\n${collector(workflow).run}\ndone`;
+    }, /without full qualification or nested sampling/u],
+    ["brace-expanded outer run loop returns", metalFile, workflow => {
+      collector(workflow).run = `for attempt in {1..3}; do\n${collector(workflow).run}\ndone`;
+    }, /without full qualification or nested sampling/u],
+    ["collector is invoked twice", metalFile, workflow => {
+      collector(workflow).run += `\n${collector(workflow).run}`;
+    }, /without full qualification or nested sampling/u],
+    ["Metal collector accepts a checkout project", metalFile, workflow => {
+      collector(workflow).run += "\n--project \"$GITHUB_WORKSPACE\"";
+    }, /synthetic-project constant collector/u],
+    ["Metal collector accepts a plugin root", metalFile, workflow => {
+      collector(workflow).run += "\n--plugin-root plugins\/codestory";
+    }, /synthetic-project constant collector/u],
+    ["Metal collector accepts a plugin handoff", metalFile, workflow => {
+      collector(workflow).run += "\n--plugin-handoff";
+    }, /synthetic-project constant collector/u],
+    ["Metal proof output enters retained calibration root", metalFile, workflow => {
+      collector(workflow).run = collector(workflow).run.replace(
+        "--out-dir target/calibration-proof/macos",
+        "--out-dir target/calibration-runs/macos/proof",
+      );
+    }, /must run --out-dir target\/calibration-proof\/macos/u],
+    ["Cargo build repeats", metalFile, workflow => {
+      nativeBuild(workflow).run += '\ncargo build --release --locked "${cargo_args[@]}"';
+    }, /one shared Cargo invocation and package once/u],
+    ["package repeats", metalFile, workflow => {
+      nativeBuild(workflow).run += "\npython3 .github/scripts/package-codestory-release.py --version 0.0.0";
+    }, /one shared Cargo invocation and package once/u],
+    ["model preparation repeats", metalFile, workflow => {
+      workflow.jobs["packaged-metal"].steps.push({
+        name: "Prepare model again",
+        run: "node scripts/prepare-embedded-model.mjs",
+      });
+    }, /one shared Cargo invocation and package once/u],
+    ["Cargo build repeats in a separate step", metalFile, workflow => {
+      workflow.jobs["packaged-metal"].steps.push({
+        name: "Build native CLI again",
+        shell: "bash",
+        run: "cargo build --release --locked -p codestory-cli",
+      });
+    }, /one shared Cargo invocation and package once/u],
+    ["packaging repeats in a separate step", metalFile, workflow => {
+      workflow.jobs["packaged-metal"].steps.push({
+        name: "Package native CLI again",
+        shell: "bash",
+        run: "python3 .github/scripts/package-codestory-release.py --version 0.16.3",
+      });
+    }, /one shared Cargo invocation and package once/u],
+    ["shell-concatenated model preparation repeats", metalFile, workflow => {
+      workflow.jobs["packaged-metal"].steps.push({
+        name: "Prepare model material again",
+        shell: "bash",
+        run: 'node scripts/prepare-"embedded-model".mjs',
+      });
+    }, /one shared Cargo invocation and package once/u],
+    ["complete packaged calibration harness repeats", metalFile, workflow => {
+      const repeated = collector(workflow).run
+        .replaceAll("target/calibration-runs/macos", "target/calibration-runs/macos-again")
+        .replaceAll("target/calibration-proof/macos", "target/calibration-proof/macos-again");
+      workflow.jobs["packaged-metal"].steps.push({
+        name: "Collect constant calibration again",
+        shell: "bash",
+        run: repeated,
+      });
+    }, /one shared Cargo invocation and package once/u],
+    ["shared build and package timing loses its output identity", metalFile, workflow => {
+      delete nativeBuild(workflow).id;
+    }, /one shared Cargo invocation and package once/u],
+    ["shared build and package timing is not measured once", metalFile, workflow => {
+      nativeBuild(workflow).run = nativeBuild(workflow).run.replace(
+        "build_package_finished_ns=\"$(python3 -c 'import time; print(time.monotonic_ns())')\"",
+        "build_package_finished_ns=\"$build_package_started_ns\"",
+      );
+    }, /one shared Cargo invocation and package once/u],
+    ["calibration total clock loses its output identity", metalFile, workflow => {
+      delete draftStep(
+        workflow.jobs["packaged-metal"],
+        "Start Metal constant calibration clock",
+      ).id;
+    }, /time model preparation and total wall time/u],
+    ["model preparation loses measured duration", metalFile, workflow => {
+      const model = draftStep(
+        workflow.jobs["packaged-metal"],
+        "Prepare checksum-pinned embedded model",
+      );
+      model.run = model.run.replace(
+        "model_prepare_finished_ns=\"$(python3 -c 'import time; print(time.monotonic_ns())')\"",
+        "model_prepare_finished_ns=\"$model_prepare_started_ns\"",
+      );
+    }, /time model preparation and total wall time/u],
+    ["timing summary loses shared build and package duration", metalFile, workflow => {
+      metalTiming(workflow).env.BUILD_PACKAGE_DURATION_MS = "0";
+    }, /shared build\/package and five-phase collector timing/u],
+    ["timing summary loses model preparation duration", metalFile, workflow => {
+      metalTiming(workflow).env.MODEL_PREPARATION_DURATION_MS = "0";
+    }, /shared build\/package and five-phase collector timing/u],
+    ["timing summary weakens the ten-minute target", metalFile, workflow => {
+      metalTiming(workflow).run = metalTiming(workflow).run.replace(
+        'test "$calibration_total_ms" -lt 600000',
+        'test "$calibration_total_ms" -lt 900000',
+      );
+    }, /shared build\/package and five-phase collector timing/u],
+    ["timing summary is not published", metalFile, workflow => {
+      metalTiming(workflow).run = metalTiming(workflow).run.replace(
+        "$GITHUB_STEP_SUMMARY",
+        "$IGNORED_SUMMARY",
+      );
+    }, /shared build\/package and five-phase collector timing/u],
+    ...[
+      "archive_authentication_unpack_ms",
+      "project_and_request_setup_ms",
+      "measurement_ms",
+      "retention_validation_ms",
+      "end_to_end_ms",
+    ].map(field => [
+      `timing summary drops ${field}`,
+      metalFile,
+      workflow => {
+        metalTiming(workflow).run = metalTiming(workflow).run.replaceAll(
+          field,
+          "omitted_timing_value",
+        );
+      },
+      /shared build\/package and five-phase collector timing/u,
+    ]),
+    ["Linux collector accepts a checkout project", "linux-vulkan-proof.yml", workflow => {
+      linuxCollector(workflow).run += "\n--project \"$GITHUB_WORKSPACE\"";
+    }, /synthetic project without qualification/u],
+    ["Linux collector accepts a plugin root", "linux-vulkan-proof.yml", workflow => {
+      linuxCollector(workflow).run += "\n--plugin-root plugins\/codestory";
+    }, /synthetic project without qualification/u],
+    ["Linux collector accepts a plugin handoff", "linux-vulkan-proof.yml", workflow => {
+      linuxCollector(workflow).run += "\n--plugin-handoff";
+    }, /synthetic project without qualification/u],
+    ["Linux proof output enters retained calibration root", "linux-vulkan-proof.yml", workflow => {
+      linuxCollector(workflow).run = linuxCollector(workflow).run.replace(
+        "--out-dir target/calibration-proof/linux-vulkan",
+        "--out-dir target/calibration-runs/linux-vulkan/proof",
+      );
+    }, /must run --out-dir target\/calibration-proof\/linux-vulkan/u],
+    ["Linux diagnostic upload drops disjoint proof output", "linux-vulkan-proof.yml", workflow => {
+      const upload = draftStep(
+        workflow.jobs["optional-constant-calibration"],
+        "Upload optional Linux Vulkan calibration evidence",
+      );
+      upload.with.path = upload.with.path.replace(
+        "target/calibration-proof/linux-vulkan",
+        "",
+      );
+    }, /must upload attempt-scoped non-selecting evidence/u],
+    ["Linux calibration requires an upstream package run", "linux-vulkan-proof.yml", workflow => {
+      workflow.on.workflow_dispatch.inputs.package_run_id.required = true;
+      delete workflow.on.workflow_dispatch.inputs.package_run_id.default;
+    }, /must not require an upstream package run/u],
+    ["Linux calibration downloads an independently built package", "linux-vulkan-proof.yml", workflow => {
+      workflow.jobs["optional-constant-calibration"].steps.splice(5, 0, {
+        name: "Download exact Linux package",
+        uses: "actions/download-artifact@v8.0.1",
+        with: {
+          name: "codestory-cli-linux-x64",
+          "run-id": "${{ inputs.package_run_id }}",
+        },
+      });
+    }, /prepare once, build CLI and collector once, and package that exact CLI once/u],
+    ["Linux calibration reads package_run_id", "linux-vulkan-proof.yml", workflow => {
+      linuxNativeBuild(workflow).env.PACKAGE_RUN_ID = "${{ inputs.package_run_id }}";
+    }, /prepare once, build CLI and collector once, and package that exact CLI once/u],
+    ["Linux calibration repeats Cargo build", "linux-vulkan-proof.yml", workflow => {
+      linuxNativeBuild(workflow).run += "\ncargo build --release --locked -p codestory-bench";
+    }, /prepare once, build CLI and collector once, and package that exact CLI once/u],
+    ["Linux calibration repeats packaging", "linux-vulkan-proof.yml", workflow => {
+      linuxNativeBuild(workflow).run += "\npython .github/scripts/package-codestory-release.py --version 0.0.0";
+    }, /prepare once, build CLI and collector once, and package that exact CLI once/u],
+    ["Linux calibration omits the runtime binary", "linux-vulkan-proof.yml", workflow => {
+      linuxNativeBuild(workflow).run = linuxNativeBuild(workflow).run.replace(
+        "--bin codestory-cli-runtime",
+        "",
+      );
+    }, /prepare once, build CLI and collector once, and package that exact CLI once/u],
+    ["Linux calibration repeats model preparation", "linux-vulkan-proof.yml", workflow => {
+      workflow.jobs["optional-constant-calibration"].steps.push({
+        name: "Prepare model again",
+        run: "node scripts/prepare-embedded-model.mjs",
+      });
+    }, /prepare once, build CLI and collector once, and package that exact CLI once/u],
+    ["assembly waits for Linux", coordinatorFile, workflow => {
+      assembly(workflow).needs.push("calibration-linux");
+    }, /wait only for required protected macOS Metal evidence/u],
+    ["assembly condition waits for Linux", coordinatorFile, workflow => {
+      assembly(workflow).if += " && needs.calibration-linux.result == 'success'";
+    }, /wait only for required protected macOS Metal evidence/u],
+    ["assembly condition waits on an optional Vulkan variable", coordinatorFile, workflow => {
+      assembly(workflow).if += " && vars.OPTIONAL_VULKAN_READY == 'true'";
+    }, /wait only for required protected macOS Metal evidence/u],
+    ["assembly downloads Linux evidence", coordinatorFile, workflow => {
+      assembly(workflow).steps.splice(1, 0, {
+        name: "Download optional Linux evidence",
+        uses: "actions/download-artifact@v8.0.1",
+        with: {
+          name: "optional-embedding-calibration-linux-vulkan",
+          path: "target/calibration-inputs/linux",
+        },
+      });
+    }, /must not select, discover, or gate on Linux evidence/u],
+    ["assembly requires wildcard optional evidence", coordinatorFile, workflow => {
+      assembly(workflow).steps.splice(2, 0, {
+        name: "Download auxiliary calibration evidence",
+        uses: "actions/download-artifact@v8.0.1",
+        with: {
+          pattern: "optional-embedding-calibration-*",
+          path: "target/auxiliary-calibration",
+        },
+      }, {
+        name: "Require auxiliary calibration evidence",
+        shell: "bash",
+        run: 'test "$(find target/auxiliary-calibration -type f | wc -l | tr -d " ")" -gt 0',
+      });
+    }, /exact protected macOS-only step boundary/u],
+    ["assembly can overwrite required runs with wildcard evidence", coordinatorFile, workflow => {
+      assembly(workflow).steps.splice(2, 0, {
+        name: "Download auxiliary calibration evidence",
+        uses: "actions/download-artifact@v8.0.1",
+        with: {
+          pattern: "optional-embedding-calibration-*",
+          path: "target/auxiliary-calibration",
+        },
+      }, {
+        name: "Select auxiliary calibration evidence",
+        shell: "bash",
+        run: [
+          'test "$(find target/auxiliary-calibration -name "run-*.json" | wc -l | tr -d " ")" = 3',
+          'find target/auxiliary-calibration -name "run-*.json" -exec cp {} target/calibration-inputs/macos/ \\;',
+        ].join("\n"),
+      });
+    }, /exact protected macOS-only step boundary/u],
+    ["assembly broadens artifact discovery", coordinatorFile, workflow => {
+      assemblyStep(workflow).run = assemblyStep(workflow).run
+        .replace("find target/calibration-inputs/macos", "find target/calibration-inputs");
+    }, /must not select, discover, or gate on Linux evidence/u],
+    ["assembly accepts six records", coordinatorFile, workflow => {
+      assemblyStep(workflow).run = assemblyStep(workflow).run
+        .replace('test "${#runs[@]}" = 3', 'test "${#runs[@]}" = 6');
+    }, /step Assemble frozen calibration candidate must run test "\$\{#runs\[@\]\}" = 3/u],
+    ["assembly accepts two matrix cells", coordinatorFile, workflow => {
+      assemblyStep(workflow).run = assemblyStep(workflow).run
+        .replace(".matrix_cell_count == 1", ".matrix_cell_count == 2");
+    }, /step Assemble frozen calibration candidate must run \.matrix_cell_count == 1/u],
+    ["an extra Linux hardware job can keep calibration from completing", coordinatorFile, workflow => {
+      workflow.jobs["hidden-linux-calibration-wait"] = {
+        needs: "route",
+        if: "needs.route.outputs.mode == 'calibration'",
+        "runs-on": ["self-hosted", "Linux", "X64", "codestory-vulkan"],
+        "timeout-minutes": 360,
+        steps: [{ name: "Wait on optional Linux", run: "true" }],
+      };
+    }, /must retain the reviewed exact job set so no hidden hardware job can block calibration/u],
+  ];
+  for (const [name, file, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(validateWorkflows(workflows).join("\n"), expected);
+    });
+  }
+});
+
+test("frozen-candidate qualification keeps the Metal quality handoff and optional Linux topology", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const coordinatorFile = "packaged-platform-pr.yml";
+  const metalFile = "macos-metal-proof.yml";
+  const windowsFile = "windows-vulkan-proof.yml";
+  const linuxFile = "linux-vulkan-proof.yml";
+
+  const mutations = [
+    ["qualification route accepts no calibration artifact", coordinatorFile, workflow => {
+      const resolver = draftStep(workflow.jobs.route, "Resolve trusted exact head");
+      resolver.run = resolver.run.replace(
+        'test -n "$INPUT_CALIBRATION_ARTIFACT"',
+        'true "$INPUT_CALIBRATION_ARTIFACT"',
+      );
+    }, /Resolve trusted exact head must run test -n "\$INPUT_CALIBRATION_ARTIFACT"|exact normalized trusted resolver/u],
+    ["Metal qualification becomes candidate-installed only", coordinatorFile, workflow => {
+      workflow.jobs["macos-metal-proof"].with.candidate_installed_proof = true;
+    }, /qualification must run full Metal proof rather than candidate-installed proof/u],
+    ["Metal qualification becomes server-behavior only", coordinatorFile, workflow => {
+      workflow.jobs["macos-metal-proof"].with.server_behavior_only = true;
+    }, /qualification must run full Metal quality and lifecycle proof/u],
+    ["Windows no longer waits for Metal", coordinatorFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].needs
+        = workflow.jobs["windows-vulkan-proof"].needs
+          .filter(name => name !== "macos-metal-proof");
+    }, /Windows qualification must wait for successful protected Metal quality/u],
+    ["Windows ignores failed Metal qualification", coordinatorFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].if
+        = workflow.jobs["windows-vulkan-proof"].if.replace(
+          "(needs.route.outputs.mode != 'qualification' || needs.macos-metal-proof.result == 'success') &&",
+          "",
+        );
+    }, /qualification requires successful Metal/u],
+    ["Windows qualification loses exact quality artifact", coordinatorFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].with.quality_evidence_artifact = "";
+    }, /must consume the exact protected Metal quality artifact/u],
+    ["Windows qualification becomes candidate-installed only", coordinatorFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].with.candidate_installed_proof = true;
+    }, /qualification must run full Windows proof rather than candidate-installed proof/u],
+    ["Windows qualification becomes server-behavior only", coordinatorFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].with.server_behavior_only = true;
+    }, /qualification must run full Windows lifecycle and fault proof/u],
+    ["coordinator schedules Linux during qualification", coordinatorFile, workflow => {
+      workflow.jobs["linux-vulkan-proof"].if
+        = workflow.jobs["linux-vulkan-proof"].if.replace(
+          "needs.route.outputs.mode != 'qualification' &&",
+          "",
+        );
+    }, /qualification modes must skip coordinator Linux proof/u],
+    ["qualification closeout blocks on Linux", coordinatorFile, workflow => {
+      const closeout = draftStep(
+        workflow.jobs.closeout,
+        "Require one coherent accepted proof",
+      );
+      closeout.run = closeout.run.replace(
+        `if [ "$MODE" = qualification ]; then
+      require_result "$LINUX_VULKAN_RESULT" skipped linux-vulkan-proof
+    else`,
+        `if [ "$MODE" = qualification ]; then
+      require_result "$LINUX_VULKAN_RESULT" success linux-vulkan-proof
+    else`,
+      );
+    }, /qualification closeout must accept skipped optional Linux proof without blocking/u],
+    ["qualification closeout hides the accepted Linux branch in dead code", coordinatorFile, workflow => {
+      const closeout = draftStep(
+        workflow.jobs.closeout,
+        "Require one coherent accepted proof",
+      );
+      const accepted = `if [ "$MODE" = qualification ]; then
+      require_result "$LINUX_VULKAN_RESULT" skipped linux-vulkan-proof
+    else
+      require_result "$LINUX_VULKAN_RESULT" success linux-vulkan-proof
+    fi`;
+      closeout.run = closeout.run.replace(
+        accepted,
+        accepted.replace(
+          'require_result "$LINUX_VULKAN_RESULT" skipped linux-vulkan-proof',
+          'require_result "$LINUX_VULKAN_RESULT" success linux-vulkan-proof',
+        ),
+      );
+      closeout.run += `\nif false; then\n${accepted}\nfi\n`;
+    }, /must match the reviewed coordinator closeout script exactly/u],
+    ["qualification closeout job is disabled", coordinatorFile, workflow => {
+      workflow.jobs.closeout.if = "${{ always() && false }}";
+    }, /closeout job must retain its reviewed unconditional result-checking activation/u],
+    ["qualification closeout proof step is disabled", coordinatorFile, workflow => {
+      draftStep(
+        workflow.jobs.closeout,
+        "Require one coherent accepted proof",
+      ).if = "${{ false }}";
+    }, /closeout must run one unconditional proof step under the reviewed Bash interpreter/u],
+    ["qualification closeout shell ignores the reviewed script", coordinatorFile, workflow => {
+      draftStep(
+        workflow.jobs.closeout,
+        "Require one coherent accepted proof",
+      ).shell = "bash -c 'true' {0}";
+    }, /closeout must run one unconditional proof step under the reviewed Bash interpreter/u],
+    ["qualification closeout mode is rebound away from the route", coordinatorFile, workflow => {
+      draftStep(
+        workflow.jobs.closeout,
+        "Require one coherent accepted proof",
+      ).env.MODE = "qualification ";
+    }, /closeout proof must bind every route and platform result from the reviewed jobs exactly/u],
+    ["Metal quality producer runs during calibration", metalFile, workflow => {
+      draftStep(
+        workflow.jobs["packaged-metal"],
+        "Produce exact-head holdout quality on protected Metal",
+      ).if = "${{ !inputs.server_behavior_only }}";
+    }, /must generate one exact-head three-repeat holdout quality artifact/u],
+    ["Metal quality producer weakens repeat contract", metalFile, workflow => {
+      const producer = draftStep(
+        workflow.jobs["packaged-metal"],
+        "Produce exact-head holdout quality on protected Metal",
+      );
+      producer.run = producer.run.replace("--repeats 3", "--repeats 1");
+    }, /must generate one exact-head three-repeat holdout quality artifact/u],
+    ["Metal quality upload loses exact-head name", metalFile, workflow => {
+      draftStep(
+        workflow.jobs["packaged-metal"],
+        "Upload exact-head protected Metal quality evidence",
+      ).with.name = "frozen-candidate-quality";
+    }, /must upload one exact-head stable handoff/u],
+    ["Metal quality upload loses safe overwrite", metalFile, workflow => {
+      draftStep(
+        workflow.jobs["packaged-metal"],
+        "Upload exact-head protected Metal quality evidence",
+      ).with.overwrite = false;
+    }, /must upload one exact-head stable handoff/u],
+    ["Windows downloads an unrelated quality artifact", windowsFile, workflow => {
+      draftStep(
+        workflow.jobs["packaged-vulkan"],
+        "Download exact-head publishable packet quality evidence",
+      ).with.name = "latest-quality";
+    }, /must download the exact protected Metal quality handoff/u],
+    ["Linux full qualification skips driver build", linuxFile, workflow => {
+      draftStep(
+        workflow.jobs["packaged-vulkan"],
+        "Build qualification driver",
+      ).if = "${{ inputs.server_behavior_only }}";
+    }, /must build its pinned full qualification driver exactly once/u],
+    ["Linux trusts quality from another workflow", linuxFile, workflow => {
+      const authenticate = draftStep(
+        workflow.jobs["packaged-vulkan"],
+        "Authenticate protected Metal quality producer",
+      );
+      authenticate.run = authenticate.run.replace(
+        ".github/workflows/packaged-platform-pr.yml",
+        ".github/workflows/release.yml",
+      );
+    }, /must authenticate exact-head protected Metal quality/u],
+    ["Linux quality download loses producer run identity", linuxFile, workflow => {
+      draftStep(
+        workflow.jobs["packaged-vulkan"],
+        "Download exact-head protected Metal quality evidence",
+      ).with["run-id"] = "${{ github.run_id }}";
+    }, /must consume the authenticated protected Metal quality artifact/u],
+    ["Linux standalone path removes lifecycle qualification", linuxFile, workflow => {
+      const proof = draftStep(
+        workflow.jobs["packaged-vulkan"],
+        "Prove offline Linux Vulkan retrieval",
+      );
+      proof.run = proof.run.replace("--produce-qualification-evidence", "--server-behavior-only");
+    }, /standalone qualification runs one full lifecycle and quality proof/u],
+  ];
+
+  for (const [name, file, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(validateWorkflows(workflows).join("\n"), expected);
+    });
+  }
+
+  for (const [name, mutate] of [
+    ["required Windows qualification cell becomes optional", graph => {
+      graph.workflow_policy.qualification.required_cells
+        = graph.workflow_policy.qualification.required_cells.slice(0, 1);
+    }],
+    ["quality producer moves off protected Metal", graph => {
+      graph.workflow_policy.qualification.quality_contract.producer_cell
+        = "protected_windows_x64_vulkan";
+    }],
+    ["true-idle grace replaces the product timeout", graph => {
+      graph.workflow_policy.qualification.true_idle_timeout_ms = 2_500;
+    }],
+  ]) {
+    await t.test(`claim graph: ${name}`, () => {
+      const graph = structuredClone(loadReleaseClaimGraph(root));
+      mutate(graph);
+      assert.match(
+        validateWorkflows(loadWorkflows(), graph).join("\n"),
+        /must implement the release claim graph qualification contract/u,
+      );
     });
   }
 });
@@ -981,55 +1744,9 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
       workflow.jobs.build.strategy.matrix
         = workflow.jobs.build.strategy.matrix.replace("inputs.scope == 'linux'", "inputs.scope == 'windows'");
     }, /matrix must select structural JSON by scope/u],
-    ["package evaluation driver reaches the standard path", packagedProofFile, workflow => {
-      draftStep(workflow.jobs.build, "Build qualification driver").if
-        = "matrix.asset_target == 'linux-x64'";
-    }, /packaged-platform-proof\.yml/u],
-    ["package evaluation reaches the standard path", packagedProofFile, workflow => {
-      const step = draftStep(
-        workflow.jobs.build,
-        "Packaged per-user server calibration or qualification",
-      );
-      step.if = "matrix.asset_target == 'linux-x64'";
-    }, /packaged-platform-proof\.yml/u],
-    ["frozen qualification stops enforcing the calibration freeze lineage", packagedProofFile, workflow => {
-      const step = draftStep(
-        workflow.jobs.build,
-        "Packaged per-user server calibration or qualification",
-      );
-      const removed = step.run.replace("  --enforce-calibration-freeze-lineage \\\n", "");
-      assert.notEqual(removed, step.run, "freeze lineage flag was already absent");
-      step.run = removed;
-    }, /must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed/u],
-    ["freeze lineage enforcement moves onto the unfrozen calibration invocation", packagedProofFile, workflow => {
-      const step = draftStep(
-        workflow.jobs.build,
-        "Packaged per-user server calibration or qualification",
-      );
-      const moved = step.run
-        .replace("  --enforce-calibration-freeze-lineage \\\n", "")
-        .replace(
-          "      --proof-tier calibration \\\n",
-          "      --proof-tier calibration \\\n      --enforce-calibration-freeze-lineage \\\n",
-        );
-      assert.match(moved, /--proof-tier calibration \\\n\s+--enforce-calibration-freeze-lineage/u);
-      step.run = moved;
-    }, /must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed/u],
     ["package build loses the history the freeze lineage probe reads", packagedProofFile, workflow => {
       draftStep(workflow.jobs.build, "Checkout").with["fetch-depth"] = 1;
     }, /package build must keep full history for the calibration freeze lineage probe/u],
-    // A flag pinned only by "appears after this anchor" is defeated by parking a
-    // copy on a later decoy line while the real invocation loses it. Both freeze
-    // lineage pins read the single backslash-continued command instead.
-    ["freeze lineage flag parked on a decoy after the frozen invocation", packagedProofFile, workflow => {
-      const step = draftStep(
-        workflow.jobs.build,
-        "Packaged per-user server calibration or qualification",
-      );
-      const stripped = step.run.replace("  --enforce-calibration-freeze-lineage \\\n", "");
-      assert.notEqual(stripped, step.run, "freeze lineage flag was already absent");
-      step.run = `${stripped}echo skipping python .github/scripts/check-packaged-agent-proof.py \\\n  --enforce-calibration-freeze-lineage \\\n  --out-dir target/decoy\n`;
-    }, /must pass --enforce-calibration-freeze-lineage so the calibration-to-package source lineage is proved, not assumed/u],
     ["reachable lineage proof stops enforcing the freeze lineage", packagedProofFile, workflow => {
       const step = draftStep(workflow.jobs.build, "Prove frozen calibration source lineage");
       const removed = step.run.replace("  --enforce-calibration-freeze-lineage \\\n", "");
@@ -1076,32 +1793,6 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
       draftStep(workflow.jobs.build, "Download frozen calibration bundle").if
         = "matrix.asset_target == 'linux-x64'";
     }, /packaged-platform-proof\.yml/u],
-    ["package evaluation artifact upload reaches the standard path", packagedProofFile, workflow => {
-      draftStep(workflow.jobs.build, "Upload packaged agent proof artifacts").if
-        = "always() && matrix.asset_target == 'linux-x64'";
-    }, /packaged-platform-proof\.yml/u],
-    ["package calibration artifact escapes into quality evaluation", packagedProofFile, workflow => {
-      draftStep(workflow.jobs.build, "Upload hosted Linux calibration runs").if
-        = "success() && matrix.asset_target == 'linux-x64'";
-    }, /hosted calibration artifact must remain calibration-only/u],
-    ["package calibration failure evidence removed", packagedProofFile, workflow => {
-      workflow.jobs.build.steps = workflow.jobs.build.steps
-        .filter(({ name }) => name !== "Upload hosted Linux calibration failure evidence");
-    }, /hosted calibration failure evidence must stay a failure-only best-effort upload/u],
-    ["package calibration failure evidence becomes success-gated", packagedProofFile, workflow => {
-      draftStep(workflow.jobs.build, "Upload hosted Linux calibration failure evidence").if
-        = "success() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode";
-    }, /hosted calibration failure evidence must stay a failure-only best-effort upload/u],
-    ["package calibration failure evidence fails closed", packagedProofFile, workflow => {
-      draftStep(workflow.jobs.build, "Upload hosted Linux calibration failure evidence")
-        .with["if-no-files-found"] = "error";
-    }, /hosted calibration failure evidence must stay a failure-only best-effort upload/u],
-    ["package evaluation becomes a standard server-behavior proof", packagedProofFile, workflow => {
-      draftStep(
-        workflow.jobs.build,
-        "Packaged per-user server calibration or qualification",
-      ).run += "\n--server-behavior-only";
-    }, /optional hosted CPU lane must remain evaluation-only/u],
     ["package workflow reclaims candidate-installed proof", packagedProofFile, workflow => {
       workflow.on.workflow_call.inputs.candidate_installed_proof = {
         required: false,
@@ -1109,26 +1800,16 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
         type: "boolean",
       };
     }, /package-only workflow must not define candidate_installed_proof/u],
-    ["package evaluation reads the calibration contract from an unpinned location", packagedProofFile, workflow => {
-      const step = draftStep(
-        workflow.jobs.build,
-        "Packaged per-user server calibration or qualification",
-      );
-      step.run = step.run.replaceAll(
-        "crates/codestory-llama-sys/per-user-embedding-server-constant-set.json",
-        "per-user-embedding-server-constant-set.json",
-      );
-    }, /must run test "\$\(jq -r \.status crates\/codestory-llama-sys\/per-user-embedding-server-constant-set\.json\)"/u],
     ["Metal calibration reads the calibration contract from an unpinned location", metalProofFile, workflow => {
       const step = draftStep(
         workflow.jobs["packaged-metal"],
-        "Collect three independent Metal calibration runs",
+        "Collect three independent Metal constant calibration runs",
       );
       step.run = step.run.replaceAll(
         "crates/codestory-llama-sys/per-user-embedding-server-constant-set.json",
         "per-user-embedding-server-constant-set.json",
       );
-    }, /Collect three independent Metal calibration runs must run test "\$\(jq -r \.status crates\/codestory-llama-sys\/per-user-embedding-server-constant-set\.json\)"/u],
+    }, /Collect three independent Metal constant calibration runs must run test "\$\(jq -r \.status crates\/codestory-llama-sys\/per-user-embedding-server-constant-set\.json\)"/u],
     ["Vulkan model preparation drops the bypass shell", windowsVulkanFile, workflow => {
       delete draftStep(workflow.jobs["packaged-vulkan"], "Prepare checksum-pinned embedded model").shell;
     }, /Prepare checksum-pinned embedded model must declare the bypass shell/u],
@@ -1368,7 +2049,7 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     }, /packaged-platform-proof\.yml must compute one complete reusable compiler compatibility contract/u],
     ["packaged workload variants collide", packagedFile, workflow => {
       packagedIdentity(workflow).run = packagedIdentity(workflow).run
-        .replace('--identity "qualification_driver=$qualification_driver"', "--workload ignored");
+        .replace("--identity qualification_driver=disabled", "--workload ignored");
     }, /packaged-platform-proof\.yml must compute one complete reusable compiler compatibility contract/u],
     ["source compiler cache waits for tests", sourceFile, workflow => {
       moveNamedStepAfter(
@@ -1450,14 +2131,23 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     ["package mode enables protected Windows proof", coordinatorFile, workflow => {
       workflow.jobs["windows-vulkan-proof"].if = workflow.jobs["windows-vulkan-proof"].if
         .replace("needs.route.outputs.mode != 'package' &&", "");
-    }, /package-only mode must skip protected Windows proof/u],
+    }, /package-only mode must skip Windows while qualification requires successful Metal/u],
     ["package mode enables protected Linux proof", coordinatorFile, workflow => {
       workflow.jobs["linux-vulkan-proof"].if = workflow.jobs["linux-vulkan-proof"].if
         .replace("needs.route.outputs.mode != 'package' &&", "");
-    }, /package-only mode must skip protected Linux proof/u],
-    ["calibration mode enables frozen Linux qualification", coordinatorFile, workflow => {
-      workflow.jobs["calibration-linux"].with.hermetic_linux = true;
-    }, /hosted Linux calibration must call packaged proof in calibration mode/u],
+    }, /package-only and qualification modes must skip coordinator Linux proof/u],
+    ["calibration mode restores hosted Linux CPU calibration", coordinatorFile, workflow => {
+      workflow.jobs["calibration-linux"] = {
+        if: "needs.route.outputs.mode == 'calibration'",
+        needs: "route",
+        uses: "./.github/workflows/packaged-platform-proof.yml",
+        with: {
+          version: "${{ needs.route.outputs.version }}",
+          ref: "${{ needs.route.outputs.head_sha }}",
+          calibration_mode: true,
+        },
+      };
+    }, /calibration must not schedule hosted Linux CPU/u],
     ["coordinator adds a macOS source hard gate", coordinatorFile, workflow => {
       workflow.jobs["macos-source"] = {
         "runs-on": "macos-14",
@@ -1899,10 +2589,10 @@ test("Windows manifest-missing proof freezes routing, native topology, and exact
       windowsManifestJob(workflow)["timeout-minutes"] = 60;
     }],
     ["CPU permission removed", workflow => {
-      delete windowsManifestJob(workflow).env.CODESTORY_EMBED_ALLOW_CPU;
+      delete windowsManifestJob(workflow).env.CODESTORY_TEST_EMBED_ALLOW_CPU;
     }],
     ["CPU permission disabled", workflow => {
-      windowsManifestJob(workflow).env.CODESTORY_EMBED_ALLOW_CPU = "0";
+      windowsManifestJob(workflow).env.CODESTORY_TEST_EMBED_ALLOW_CPU = "0";
     }],
     ["native generator removed", workflow => {
       delete windowsManifestJob(workflow).env.CMAKE_GENERATOR;
@@ -2452,7 +3142,7 @@ test("package workflow keeps a packaging-only timeout", () => {
 
   assert.match(
     validateWorkflows(workflows).join("\n"),
-    /package build timeout must cover only calibration or signed macOS packaging/u,
+    /package build timeout must cover only signed macOS packaging/u,
   );
 });
 
@@ -2829,18 +3519,17 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
       delete step.with.overwrite;
     }],
     ["overwriteable terminal evidence", workflows => {
-      const step = workflows.get("packaged-platform-proof.yml").jobs.build.steps
-        .find(({ name }) => name === "Upload packaged agent proof artifacts");
-      step.name = "Upload hosted Linux calibration runs";
-      step.with.name = "embedding-calibration-linux-${{ inputs.version }}";
-      step.with.path = "target/calibration-runs/linux";
+      const step = workflows.get("linux-vulkan-proof.yml")
+        .jobs["optional-constant-calibration"].steps
+        .find(({ name }) => name === "Upload optional Linux Vulkan calibration evidence");
+      step.with.name = "optional-embedding-calibration-linux-vulkan-${{ inputs.version }}";
       step.with.overwrite = true;
     }],
     ["attempt-qualified duplicate stable key", workflows => {
-      const steps = workflows.get("packaged-platform-proof.yml").jobs.build.steps;
-      const index = steps.findIndex(({ name }) => name === "Upload hosted Linux calibration runs");
+      const steps = workflows.get("macos-metal-proof.yml").jobs["packaged-metal"].steps;
+      const index = steps.findIndex(({ name }) => name === "Upload Metal calibration runs");
       steps.splice(index + 1, 0, {
-        name: "Upload hosted Linux calibration runs",
+        name: "Upload Metal calibration runs",
         uses: "actions/upload-artifact@v7.0.1",
         with: {
           name: "diagnostic-attempt-${{ github.run_attempt }}",

--- a/.github/scripts/package-codestory-release.py
+++ b/.github/scripts/package-codestory-release.py
@@ -585,7 +585,7 @@ def native_release_manifest(
         "embedding": embedding_descriptor,
         "tokenizer_config": tokenizer,
         "accelerator": {
-            "cpu_fallback": "explicit_only",
+            "cpu_fallback": "unsupported",
             "package_claim": "compiled_capability_only",
             "runtime_execution": "not_proven_by_package",
             "expected_protected_backend": target_contract["expected_protected_backend"],

--- a/.github/scripts/packaged_agent_proof/archive_proof.py
+++ b/.github/scripts/packaged_agent_proof/archive_proof.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import argparse
 import os
+import time
 from pathlib import Path
 
 from .archive_io import find_cli, unpack_archive
 from .calibration_verification import verify_calibration_bundle
-from .contract_primitives import write_json
+from .constant_calibration import collect_constant_calibration
+from .contract_primitives import sha256, write_json
 from .failure_evidence import preserve_failure_evidence
 from .foundation import LEGACY_HELP_TOKENS, REPOSITORY_ROOT, require
 from .installation_support import isolated_environment
@@ -81,6 +83,8 @@ def requires_calibration_bundle(args: argparse.Namespace) -> bool:
 
 
 def claim_scope(args: argparse.Namespace) -> str:
+    if getattr(args, "collect_constant_calibration", False):
+        return "constant_calibration"
     if args.ground_only:
         return (
             "installed_ground"
@@ -150,6 +154,7 @@ def _run_proof_phases(
     temporary_package_directory: FailurePreservingTemporaryDirectory,
     root: Path,
 ) -> None:
+    package_phase_started = time.perf_counter()
     unpack_archive(args.archive, root / "unpacked")
     cli = find_cli(root / "unpacked")
     manifest = load_native_manifest(
@@ -192,6 +197,20 @@ def _run_proof_phases(
         measurement_contract,
         calibration_bundle,
     )
+    if getattr(args, "collect_constant_calibration", False):
+        summary["constant_calibration"] = collect_constant_calibration(
+            args,
+            root=root,
+            unpacked_root=root / "unpacked",
+            cli=cli,
+            manifest=manifest,
+            measurement_contract=measurement_contract,
+            env=env,
+            archive_sha256=sha256(args.archive),
+            package_phase_started=package_phase_started,
+        )
+        write_json(args.out_dir / "summary.json", summary)
+        return
     if not args.version_only:
         require(
             args.project is not None,

--- a/.github/scripts/packaged_agent_proof/calibration_assembly.py
+++ b/.github/scripts/packaged_agent_proof/calibration_assembly.py
@@ -96,7 +96,6 @@ def _frozen_calibration_constant_set(
     frozen = json.loads(json.dumps(constant_set))
     frozen["status"] = "frozen"
     frozen["calibration_required_values"] = selection["calibration_required_values"]
-    frozen["qualification_thresholds"] = selection["qualification_thresholds"]
     frozen["freeze_record"] = {
         "selection_source_commit": source["commit"],
         "selection_source_tree": source["tree"],
@@ -107,7 +106,7 @@ def _frozen_calibration_constant_set(
         "calibration_freeze_digest": selection["freeze_digest"],
         "run_artifact_sha256s": selection["run_artifact_sha256s"],
         "selection_rule": (
-            "all_preregistered_clean_runs_no_outlier_removal+slow_host_floors_v1"
+            "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2"
         ),
         "selected_at": require_nonempty_string(
             selected_at,

--- a/.github/scripts/packaged_agent_proof/calibration_freeze.py
+++ b/.github/scripts/packaged_agent_proof/calibration_freeze.py
@@ -14,7 +14,6 @@ def _calibration_freeze(
     bundle: CalibrationBundle,
     accumulator: CalibrationAccumulator,
     selected_constants: dict,
-    thresholds: dict,
     *,
     compare_frozen_constant_set: bool,
     frozen_source: dict | None,
@@ -26,10 +25,6 @@ def _calibration_freeze(
             bundle.constant_set["calibration_required_values"] == selected_constants,
             "frozen compiled constants do not match the preregistered calibration formulas",
         )
-        require(
-            bundle.constant_set["qualification_thresholds"] == thresholds,
-            "frozen qualification thresholds do not match the preregistered calibration formulas",
-        )
     digests = sorted(accumulator.artifact_digests)
     freeze_digest = canonical_sha256(
         {
@@ -39,7 +34,6 @@ def _calibration_freeze(
             "contracts": bundle.contracts,
             "run_artifact_sha256s": digests,
             "calibration_required_values": selected_constants,
-            "qualification_thresholds": thresholds,
         }
     )
     lineage = None
@@ -84,6 +78,6 @@ def _verify_calibration_freeze_record(
         and record["calibration_freeze_digest"] == freeze_digest
         and sorted(record["run_artifact_sha256s"]) == digests
         and record["selection_rule"]
-        == "all_preregistered_clean_runs_no_outlier_removal+slow_host_floors_v1",
+        == "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
         "constant-set freeze record does not bind the exact recomputed calibration bundle",
     )

--- a/.github/scripts/packaged_agent_proof/calibration_metrics.py
+++ b/.github/scripts/packaged_agent_proof/calibration_metrics.py
@@ -13,29 +13,8 @@ from .calibration_records import (
     _calibration_sample,
     _record_calibration_durations,
 )
-from .contract_primitives import (
-    require_exact_keys,
-    require_nonnegative_int,
-    require_positive_int,
-)
+from .contract_primitives import require_exact_keys, require_nonnegative_int, require_positive_int
 from .foundation import require
-
-
-def _aggregate_calibration_values(
-    aggregation: str,
-    values: list[float | int],
-) -> float | int:
-    if aggregation == "maximum":
-        return max(values)
-    if aggregation == "minimum":
-        return min(values)
-    if aggregation == "exact":
-        return values[0]
-    require(
-        aggregation == "all_rows_pass_rate",
-        f"unknown calibration aggregation {aggregation}",
-    )
-    return sum(values) / len(values)
 
 
 def _calibration_metric_value(
@@ -55,9 +34,10 @@ def _calibration_metric_value(
         f"{field} used the wrong unit",
     )
     samples = record["samples"]
-    policy = bundle.protocol["metric_sampling"][metric]
+    policy = bundle.protocol["calibration_metric_sampling"][metric]
     require(
-        isinstance(samples, list) and len(samples) == policy["sample_count"],
+        isinstance(samples, list)
+        and len(samples) == policy["sample_count_per_run"] == 1,
         f"{field} sample count changed",
     )
     normalized = [
@@ -72,14 +52,6 @@ def _calibration_metric_value(
         )
         for index, sample in enumerate(samples)
     ]
-    identities = [sample.identity for sample in normalized]
-    if policy.get("independence") == "distinct_server_instance_per_sample":
-        require(
-            len({identity[:2] for identity in identities}) == len(normalized),
-            f"{field} samples are not independent",
-        )
-    else:
-        require(len(set(identities)) == 1, f"{field} changed server identity")
     for sample in normalized:
         _record_calibration_durations(
             metric,
@@ -87,10 +59,7 @@ def _calibration_metric_value(
             field=field,
             accumulator=accumulator,
         )
-    return _aggregate_calibration_values(
-        policy["aggregation"],
-        [sample.value for sample in normalized],
-    )
+    return normalized[0].value
 
 
 def _verified_calibration_runs(
@@ -123,6 +92,24 @@ def _verified_calibration_runs(
     require(
         accumulator.observed_run_cells == accumulator.expected_run_cells,
         "calibration bundle does not exactly cover every matrix cell three times",
+    )
+    require(
+        set(accumulator.server_identities_by_run) == accumulator.expected_run_cells
+        and set(accumulator.materialization_reused_by_run)
+        == accumulator.expected_run_cells
+        and all(
+            len(identities) == 1
+            for identities in accumulator.server_identities_by_run.values()
+        ),
+        "each calibration run must use exactly one fresh server generation",
+    )
+    run_identities = [
+        next(iter(accumulator.server_identities_by_run[run_cell]))
+        for run_cell in sorted(accumulator.expected_run_cells)
+    ]
+    require(
+        len(set(run_identities)) == len(run_identities),
+        "calibration clean runs reused a server generation",
     )
     packages = accumulator.packages_by_cell.values()
     require(
@@ -168,16 +155,55 @@ def _selected_calibration_constants(
         query_floor,
         math.ceil(max(durations["query_request_duration"]) * 1.50),
     )
-    replay = max(query, math.ceil(max(durations["bulk_request_duration"]) * 1.50))
-    retry = max(1, math.floor(min(durations["capacity_condition_duration"]) * 0.50))
+    replay_floor = require_positive_int(
+        formulas["request_deadlines_ms"]["bulk_request_deadline_ms"][
+            "replay_success_budget_slow_host_floor_ms"
+        ],
+        "bulk replay success slow-host floor",
+    )
+    retry_floor = require_positive_int(
+        formulas["capacity_retry_policy"]["retry_after_slow_host_floor_ms"],
+        "capacity retry slow-host floor",
+    )
+    initial_floor = require_positive_int(
+        formulas["election_backoff_policy"]["initial_backoff_slow_host_floor_ms"],
+        "election initial-backoff slow-host floor",
+    )
+    maximum_floor = require_positive_int(
+        formulas["election_backoff_policy"]["maximum_backoff_slow_host_floor_ms"],
+        "election maximum-backoff slow-host floor",
+    )
+    hard_floor = require_positive_int(
+        formulas["hard_native_no_progress_ms"]["slow_host_floor_ms"],
+        "native no-progress slow-host floor",
+    )
+    cadence_floor = require_positive_int(
+        formulas["watchdog_cadence_ms"]["slow_host_floor_ms"],
+        "watchdog cadence slow-host floor",
+    )
+    replay = max(
+        replay_floor,
+        query,
+        math.ceil(max(durations["bulk_request_duration"]) * 1.50),
+    )
+    retry = max(
+        retry_floor,
+        math.floor(min(durations["capacity_condition_duration"]) * 0.50),
+    )
     initial = max(
-        1, math.ceil(max(durations["existing_owner_connect_duration"]) * 0.50)
+        initial_floor,
+        math.ceil(max(durations["existing_owner_connect_duration"]) * 0.50),
     )
     maximum = max(
-        initial, math.ceil(max(durations["spawn_convergence_duration"]) * 0.25)
+        maximum_floor,
+        initial,
+        math.ceil(max(durations["spawn_convergence_duration"]) * 0.25),
     )
-    hard = max(1, math.ceil(max(durations["successful_operation_duration"]) * 4.00))
-    cadence = max(1, math.floor(hard / 20))
+    hard = max(
+        hard_floor,
+        math.ceil(max(durations["successful_operation_duration"]) * 4.00),
+    )
+    cadence = max(cadence_floor, math.floor(hard / 20))
     return {
         "connect_timeout_ms": connect,
         "spawn_convergence_timeout_ms": spawn,
@@ -202,25 +228,3 @@ def _selected_calibration_constants(
         "hard_native_no_progress_ms": hard,
         "watchdog_cadence_ms": cadence,
     }
-
-
-def _selected_calibration_thresholds(
-    values_by_metric: dict[str, list[float | int]],
-    metric_contracts: dict,
-) -> dict[str, float | int]:
-    thresholds: dict[str, float | int] = {}
-    for metric, values in values_by_metric.items():
-        comparison = metric_contracts[metric]["comparison"]
-        if comparison == "less_than_or_equal":
-            threshold: float | int = math.ceil(max(values) * 1.20)
-        elif comparison == "greater_than_or_equal":
-            threshold = math.floor(min(values) * 0.80)
-        else:
-            require(
-                len(set(values)) == 1,
-                f"calibration equal metric {metric} did not have one exact observed value",
-            )
-            threshold = values[0]
-        thresholds[metric] = threshold
-    thresholds["retrieval_quality"] = 1.0
-    return thresholds

--- a/.github/scripts/packaged_agent_proof/calibration_records.py
+++ b/.github/scripts/packaged_agent_proof/calibration_records.py
@@ -42,6 +42,8 @@ class CalibrationAccumulator:
     artifact_digests: set[str]
     packages_by_cell: dict[str, dict]
     sample_ids: set[str]
+    server_identities_by_run: dict[tuple[str, int], set[tuple[str, str, int]]]
+    materialization_reused_by_run: dict[tuple[str, int], bool]
     metric_values: dict[str, list[float | int]]
     duration_values_ms: dict[str, list[float]]
 
@@ -50,6 +52,7 @@ class CalibrationAccumulator:
 class CalibrationRun:
     position: int
     matrix_cell_id: str
+    run_index: int
     matrix_cell: dict
     package: dict
     metrics: dict
@@ -203,7 +206,7 @@ def _calibration_bundle(
 
 
 def _calibration_accumulator(bundle: CalibrationBundle) -> CalibrationAccumulator:
-    metrics = set(bundle.protocol["required_metrics"]) - {"retrieval_quality"}
+    metrics = set(bundle.protocol["calibration_required_metrics"])
     return CalibrationAccumulator(
         expected_run_cells={
             (cell_id, run_index)
@@ -215,6 +218,8 @@ def _calibration_accumulator(bundle: CalibrationBundle) -> CalibrationAccumulato
         artifact_digests=set(),
         packages_by_cell={},
         sample_ids=set(),
+        server_identities_by_run={},
+        materialization_reused_by_run={},
         metric_values={metric: [] for metric in metrics},
         duration_values_ms={
             "existing_owner_connect_duration": [],
@@ -281,7 +286,8 @@ def _calibration_raw_payload(
     require(isinstance(value, dict), f"{field} is malformed")
     require_exact_keys(value, {"name", "sha256", "payload"}, field)
     require(
-        value["name"] == "measurements.raw.json",
+        value["name"]
+        == f"constant-calibration-run-{expected_identity['run_index']}.raw.json",
         f"calibration run {position} raw artifact has the wrong name",
     )
     digest = require_sha256(value["sha256"], f"{field} sha256")
@@ -310,6 +316,7 @@ def _calibration_raw_payload(
             "source",
             "contracts",
             "package",
+            "materialized_reused",
             "clean",
             "unplanned_suspend",
             "metrics",
@@ -347,6 +354,7 @@ def _calibration_run(
             "source",
             "contracts",
             "package",
+            "materialized_reused",
             "raw_artifact",
         },
         field,
@@ -373,6 +381,13 @@ def _calibration_run(
         raw_run["clean"] is True and raw_run["unplanned_suspend"] is False,
         f"calibration run {position} was not a clean awake run",
     )
+    materialized_reused = raw_run["materialized_reused"]
+    require(
+        isinstance(materialized_reused, bool)
+        and materialized_reused is (run_index > 1),
+        f"calibration run {position} repeated or skipped model materialization",
+    )
+    accumulator.materialization_reused_by_run[run_cell] = materialized_reused
     require(
         raw_run["source"] == bundle.source and raw_run["contracts"] == bundle.contracts,
         f"calibration run {position} changed source, tree, or protocol identity",
@@ -396,6 +411,7 @@ def _calibration_run(
             "source": bundle.source,
             "contracts": bundle.contracts,
             "package": package,
+            "materialized_reused": materialized_reused,
         },
         accumulator=accumulator,
     )
@@ -404,7 +420,7 @@ def _calibration_run(
         isinstance(metrics, dict) and set(metrics) == set(accumulator.metric_values),
         f"calibration run {position} omitted a required metric",
     )
-    return CalibrationRun(position, cell_id, matrix_cell, package, metrics)
+    return CalibrationRun(position, cell_id, run_index, matrix_cell, package, metrics)
 
 
 _CALIBRATION_SAMPLE_FIELDS = {
@@ -470,13 +486,17 @@ def _calibration_sample(
         ),
         require_positive_int(server["load_generation"], f"{field} load_generation"),
     )
+    accumulator.server_identities_by_run.setdefault(
+        (run.matrix_cell_id, run.run_index),
+        set(),
+    ).add(identity)
     target_os = TARGET_CONTRACTS[run.matrix_cell["asset_target"]]["target_os"]
     clock_policy = bundle.protocol["clock_policy"]
     value = qualification_measurement_sample_value(
         metric,
         sample,
         contracts=bundle.contracts,
-        phase_boundaries=bundle.protocol["phase_boundaries"],
+        phase_boundaries=bundle.protocol["calibration_phase_boundaries"],
         allowed_awake_apis=set(clock_policy["platform_apis"][target_os]),
         inclusive_api=clock_policy["suspend_detection"]["platform_apis"][target_os],
         maximum_suspend_ns=maximum_suspend_ns,

--- a/.github/scripts/packaged_agent_proof/calibration_self_test.py
+++ b/.github/scripts/packaged_agent_proof/calibration_self_test.py
@@ -10,14 +10,6 @@ from pathlib import Path
 from .contract_primitives import canonical_sha256, sha256, write_json
 from .foundation import TARGET_CONTRACTS
 
-_MEMORY_ROLES = (
-    "plugin_host_a",
-    "plugin_cli_a",
-    "plugin_host_b",
-    "plugin_cli_b",
-    "embedding_server",
-)
-
 _SUCCESSFUL_METRICS = {
     "cold_first_vector",
     "first_product_ready",
@@ -59,29 +51,6 @@ def _self_test_operands(
         operands["completed_documents"] = 1
     elif metric == "bulk_tokens_per_second":
         operands["completed_tokens"] = 1
-    elif metric == "total_codestory_process_memory":
-        operands["processes"] = [
-            {
-                "role": role,
-                "pid": pid + index + 1,
-                "process_start_id": f"boot:{pid + index + 1}",
-                "executable_sha256": hashlib.sha256(f"exe:{role}".encode()).hexdigest(),
-                "resident_bytes": 1,
-                "measurement_api": "self_test",
-            }
-            for index, role in enumerate(_MEMORY_ROLES)
-        ]
-    elif metric == "backend_observed_accelerator_residency":
-        accelerated = cell["policy"] == "accelerated"
-        operands = {
-            "policy": cell["policy"],
-            "backend": cell["backend"],
-            "accelerator_execution_verified": accelerated,
-            "resident_accelerator_tensor_count": 1 if accelerated else 0,
-            "resident_accelerator_tensor_bytes": 1 if accelerated else 0,
-            "offloaded_layer_count": 1 if accelerated else 0,
-            "model_layer_count": 1,
-        }
     return operands
 
 
@@ -91,7 +60,6 @@ def _self_test_sample(
     metric_position: int,
     repeat: int,
 ) -> dict:
-    policy = context.protocol["metric_sampling"][metric]
     pid = (
         10_000
         + context.cell_position * 1_000
@@ -99,19 +67,11 @@ def _self_test_sample(
         + metric_position * 10
         + repeat
     )
-    independent = policy.get("independence") == "distinct_server_instance_per_sample"
-    identity_seed = (
-        f"{context.seed}:{metric}:{repeat}"
-        if independent
-        else f"{context.seed}:{metric}"
-    )
+    identity_seed = context.seed
     server_id = "server:" + hashlib.sha256(identity_seed.encode()).hexdigest()
-    server_start = (
-        f"boot:{pid}"
-        if independent
-        else "boot:"
-        + hashlib.sha256(f"server-start:{context.seed}:{metric}".encode()).hexdigest()
-    )
+    server_start = "boot:" + hashlib.sha256(
+        f"server-start:{context.seed}".encode()
+    ).hexdigest()
     started_ns = repeat * 2_000_000
     finished_ns = started_ns + 1_000_000
     boot_id = f"boot-{context.cell_position}"
@@ -136,11 +96,11 @@ def _self_test_sample(
             "resolution_ns": 1,
         },
         "start": {
-            "phase": context.protocol["phase_boundaries"][metric][0],
+            "phase": context.protocol["calibration_phase_boundaries"][metric][0],
             "observed_ns": started_ns,
         },
         "end": {
-            "phase": context.protocol["phase_boundaries"][metric][1],
+            "phase": context.protocol["calibration_phase_boundaries"][metric][1],
             "observed_ns": finished_ns,
         },
         "operands": _self_test_operands(
@@ -163,14 +123,14 @@ def _self_test_sample(
 
 def _self_test_metrics(context: SelfTestRunContext) -> dict:
     metrics = {}
-    names = sorted(set(context.protocol["required_metrics"]) - {"retrieval_quality"})
+    names = sorted(context.protocol["calibration_required_metrics"])
     for position, metric in enumerate(names):
-        policy = context.protocol["metric_sampling"][metric]
+        policy = context.protocol["calibration_metric_sampling"][metric]
         metrics[metric] = {
             "unit": context.protocol["metric_contracts"][metric]["unit"],
             "samples": [
                 _self_test_sample(context, metric, position, repeat)
-                for repeat in range(1, policy["sample_count"] + 1)
+                for repeat in range(1, policy["sample_count_per_run"] + 1)
             ],
         }
     return metrics
@@ -201,6 +161,7 @@ def _self_test_run(context: SelfTestRunContext) -> tuple[dict, str]:
         "source": context.source,
         "contracts": context.contracts,
         "package": package,
+        "materialized_reused": context.run_index > 1,
         "clean": True,
         "unplanned_suspend": False,
         "metrics": _self_test_metrics(context),
@@ -217,8 +178,11 @@ def _self_test_run(context: SelfTestRunContext) -> tuple[dict, str]:
             "source": context.source,
             "contracts": context.contracts,
             "package": package,
+            "materialized_reused": context.run_index > 1,
             "raw_artifact": {
-                "name": "measurements.raw.json",
+                "name": (
+                    f"constant-calibration-run-{context.run_index}.raw.json"
+                ),
                 "sha256": digest,
                 "payload": payload,
             },
@@ -258,46 +222,31 @@ def _self_test_runs(
     return runs, digests
 
 
-def _self_test_selection(protocol: dict) -> tuple[dict, dict]:
-    constants = {
+def _self_test_selection() -> dict:
+    return {
         "connect_timeout_ms": 2000,
         "spawn_convergence_timeout_ms": 15000,
         "request_deadlines_ms": {
             "query_request_deadline_ms": 10000,
-            "bulk_replay_success_budget_ms": 10000,
-            "bulk_request_deadline_ms": 25005,
+            "bulk_replay_success_budget_ms": 144537,
+            "bulk_request_deadline_ms": 564239,
         },
         "capacity_retry_policy": {
-            "retry_after_ms": 1,
+            "retry_after_ms": 40,
             "retry_class": "after_capacity_change",
             "retry_condition_source": "named_condition_from_typed_capacity_response",
         },
         "election_backoff_policy": {
-            "initial_backoff_ms": 1,
-            "maximum_backoff_ms": 1,
+            "initial_backoff_ms": 7,
+            "maximum_backoff_ms": 102,
             "jitter": (
                 "sha256(process_start_id||attempt) modulo inclusive "
                 "[initial_backoff_ms,maximum_backoff_ms]"
             ),
         },
-        "hard_native_no_progress_ms": 4,
-        "watchdog_cadence_ms": 1,
+        "hard_native_no_progress_ms": 385431,
+        "watchdog_cadence_ms": 19271,
     }
-    thresholds = {
-        metric: (
-            1.0
-            if metric == "retrieval_quality"
-            else 1
-            if metric == "backend_observed_accelerator_residency"
-            else 800
-            if metric in {"bulk_documents_per_second", "bulk_tokens_per_second"}
-            else 6
-            if metric == "total_codestory_process_memory"
-            else 2
-        )
-        for metric in protocol["required_metrics"]
-    }
-    return constants, thresholds
 
 
 def _frozen_self_test_contract(
@@ -326,7 +275,7 @@ def _frozen_self_test_contract(
         "calibration_freeze_digest": bundle["freeze_digest"],
         "run_artifact_sha256s": sorted(digests),
         "selection_rule": (
-            "all_preregistered_clean_runs_no_outlier_removal+slow_host_floors_v1"
+            "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2"
         ),
         "selected_at": "self-test",
     }
@@ -348,7 +297,10 @@ def build_calibration_self_test_bundle(
         "input_constant_set_sha256": measurement_contract["constant_set_sha256"],
     }
     runs, digests = _self_test_runs(protocol, contracts, source)
-    constants, thresholds = _self_test_selection(protocol)
+    constants = _self_test_selection()
+    thresholds = json.loads(
+        json.dumps(measurement_contract["constant_set"]["qualification_thresholds"])
+    )
     producer = {
         "repository": "TheGreenCedar/CodeStory",
         "workflow_path": ".github/workflows/packaged-platform-pr.yml",
@@ -366,7 +318,6 @@ def build_calibration_self_test_bundle(
         "contracts": contracts,
         "run_artifact_sha256s": sorted(digests),
         "calibration_required_values": constants,
-        "qualification_thresholds": thresholds,
     }
     bundle = {
         "schema_version": 1,

--- a/.github/scripts/packaged_agent_proof/calibration_verification.py
+++ b/.github/scripts/packaged_agent_proof/calibration_verification.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from .calibration_freeze import _calibration_freeze
 from .calibration_metrics import (
     _selected_calibration_constants,
-    _selected_calibration_thresholds,
     _verified_calibration_runs,
 )
 from .calibration_records import _calibration_bundle
@@ -36,15 +35,10 @@ def verify_calibration_bundle(
         accumulator.duration_values_ms,
         bundle.protocol["constant_selection"],
     )
-    thresholds = _selected_calibration_thresholds(
-        accumulator.metric_values,
-        bundle.protocol["metric_contracts"],
-    )
     freeze_digest, source_lineage = _calibration_freeze(
         bundle,
         accumulator,
         selected_constants,
-        thresholds,
         compare_frozen_constant_set=compare_frozen_constant_set,
         frozen_source=frozen_source,
         repository_root=repository_root,
@@ -59,7 +53,6 @@ def verify_calibration_bundle(
         "run_count": len(bundle.runs),
         "freeze_digest": freeze_digest,
         "calibration_required_values": selected_constants,
-        "qualification_thresholds": thresholds,
         "run_artifact_sha256s": sorted(accumulator.artifact_digests),
         "source_lineage": source_lineage,
     }

--- a/.github/scripts/packaged_agent_proof/cli.py
+++ b/.github/scripts/packaged_agent_proof/cli.py
@@ -44,7 +44,7 @@ def parse_args() -> argparse.Namespace:
         default="hosted_package",
     )
     parser.add_argument("--plugin-handoff", action="store_true")
-    parser.add_argument("--engine-policy", choices=("accelerated", "cpu_explicit"))
+    parser.add_argument("--engine-policy", choices=("accelerated",))
     parser.add_argument("--expected-backend")
     parser.add_argument("--qualification-matrix-cell")
     parser.add_argument("--offline", action="store_true")
@@ -57,8 +57,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--retrieval-quality-evidence", type=Path)
     parser.add_argument("--calibration-bundle", type=Path)
     parser.add_argument("--enforce-calibration-freeze-lineage", action="store_true")
-    parser.add_argument("--calibration-run-index", type=int)
-    parser.add_argument("--calibration-run-output", type=Path)
+    parser.add_argument("--collect-constant-calibration", action="store_true")
+    parser.add_argument("--constant-calibration-output-dir", type=Path)
     parser.add_argument("--assemble-calibration-bundle", action="store_true")
     parser.add_argument("--calibration-run", type=Path, action="append", default=[])
     parser.add_argument("--calibration-bundle-output", type=Path)
@@ -100,13 +100,53 @@ def _resolve_optional_paths(args: argparse.Namespace) -> None:
         "publication_fault_evidence",
         "retrieval_quality_evidence",
         "calibration_bundle",
-        "calibration_run_output",
         "installed_plugin_attestation",
         "installed_plugin_data",
     ):
         value = getattr(args, field)
         if value is not None:
             setattr(args, field, value.resolve())
+    if args.constant_calibration_output_dir is not None:
+        args.constant_calibration_output_dir = (
+            args.constant_calibration_output_dir.resolve()
+        )
+
+
+def _validate_calibration_mode(args: argparse.Namespace) -> None:
+    if args.collect_constant_calibration:
+        require(
+            args.proof_tier == "calibration"
+            and not args.version_only
+            and args.constant_calibration_output_dir is not None
+            and args.qualification_driver is not None
+            and args.engine_policy == "accelerated"
+            and args.offline
+            and args.project is None
+            and args.plugin_root is None
+            and not args.plugin_handoff
+            and not args.additional_project
+            and not args.additional_query
+            and not args.produce_qualification_evidence
+            and args.qualification_evidence is None
+            and args.publication_fault_evidence is None
+            and args.retrieval_quality_evidence is None
+            and args.calibration_bundle is None,
+            "constant calibration requires its isolated GPU-only collector and rejects project, plugin, or qualification inputs",
+        )
+        retained_root = args.constant_calibration_output_dir.resolve()
+        proof_root = args.out_dir.resolve()
+        require(
+            retained_root != proof_root
+            and not retained_root.is_relative_to(proof_root)
+            and not proof_root.is_relative_to(retained_root),
+            "constant-calibration retained runs and package proof output must use disjoint directories",
+        )
+    else:
+        require(
+            args.proof_tier != "calibration"
+            and args.constant_calibration_output_dir is None,
+            "the calibration proof tier is valid only for constant-only collection",
+        )
 
 
 def _prepare_proof_arguments(args: argparse.Namespace) -> None:
@@ -118,14 +158,7 @@ def _prepare_proof_arguments(args: argparse.Namespace) -> None:
     args.checksum_file = args.checksum_file.resolve()
     args.out_dir = args.out_dir.resolve()
     _resolve_optional_paths(args)
-    require(
-        (args.calibration_run_output is None) == (args.calibration_run_index is None),
-        "--calibration-run-output and --calibration-run-index must be supplied together",
-    )
-    require(
-        args.calibration_run_output is None or args.proof_tier == "calibration",
-        "calibration run output is valid only for the calibration proof tier",
-    )
+    _validate_calibration_mode(args)
     validate_runtime_claim_scope(args)
     args.out_dir.mkdir(parents=True, exist_ok=True)
     require(

--- a/.github/scripts/packaged_agent_proof/constant_calibration.py
+++ b/.github/scripts/packaged_agent_proof/constant_calibration.py
@@ -1,0 +1,563 @@
+"""Constant-only calibration collection from one authenticated package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import secrets
+import time
+from pathlib import Path
+
+from .contract_primitives import (
+    canonical_sha256,
+    normalized_backend,
+    require_exact_keys,
+    require_nonempty_string,
+    require_positive_int,
+    require_sha256,
+    sha256,
+    write_json,
+    write_private_json,
+)
+from .failure_evidence import register_failure_evidence_secret
+from .foundation import NATIVE_MANIFEST_FILE, ProofFailure, TARGET_CONTRACTS, require
+from .measurement_samples import qualification_measurement_sample_value
+from .native_manifest import runtime_executable_path, runtime_executable_sha256
+from .subprocess_control import run
+
+_RUN_COUNT = 3
+_METRIC_COUNT = 9
+_SAMPLE_FIELDS = {
+    "sample_id",
+    "repeat",
+    "matrix_cell_id",
+    "workload_id",
+    "cache_state",
+    "residency_state",
+    "process",
+    "server_identity",
+    "clock",
+    "start",
+    "end",
+    "operands",
+    "suspend_witness",
+}
+
+
+def _constant_calibration_matrix_cell(args, protocol: dict, manifest: dict) -> dict:
+    cell_id = require_nonempty_string(
+        args.qualification_matrix_cell,
+        "--collect-constant-calibration requires --qualification-matrix-cell",
+    )
+    required = protocol["calibration_matrix"]
+    optional = protocol["optional_calibration_evidence_matrix"]
+    require(
+        not (cell_id in required and cell_id in optional),
+        f"constant-calibration matrix cell {cell_id} is duplicated",
+    )
+    cell = required.get(cell_id) or optional.get(cell_id)
+    require(cell is not None, f"unknown constant-calibration matrix cell {cell_id!r}")
+    require(
+        cell["asset_target"] == manifest["asset_target"]
+        and cell["proof_tier"] == "calibration"
+        and cell["policy"] == "accelerated"
+        and normalized_backend(cell["backend"]) in {"metal", "vulkan"}
+        and cell["cache_state"] == "reused"
+        and cell["residency_state"] == "resident",
+        "constant-calibration matrix cell is not an accelerated GPU lane",
+    )
+    require(
+        args.engine_policy == "accelerated"
+        and args.offline
+        and normalized_backend(args.expected_backend)
+        == normalized_backend(cell["backend"]),
+        "constant calibration requires offline accelerated execution on its declared GPU backend",
+    )
+    return cell
+
+
+def _prepare_synthetic_project(private_root: Path) -> Path:
+    project = private_root / "synthetic-project"
+    project.mkdir(mode=0o700)
+    (project / "README.md").write_text(
+        "# Constant calibration fixture\n\nOne project prepared once per package cell.\n",
+        encoding="utf-8",
+    )
+    (project / "lib.rs").write_text(
+        'pub fn constant_calibration_probe() -> &\'static str { "gpu" }\n',
+        encoding="utf-8",
+    )
+    return project.resolve()
+
+
+def _native_manifest_path(unpacked_root: Path) -> Path:
+    matches = [
+        path
+        for path in unpacked_root.rglob(NATIVE_MANIFEST_FILE)
+        if path.is_file() and not path.is_symlink()
+    ]
+    require(
+        len(matches) == 1,
+        "constant calibration requires exactly one authenticated native manifest",
+    )
+    return matches[0].resolve()
+
+
+def _load_json(path: Path, field: str) -> dict:
+    require(
+        path.is_file() and not path.is_symlink(),
+        f"{field} is missing or unsafe: {path}",
+    )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ProofFailure(f"{field} is not valid JSON: {exc}") from exc
+    require(isinstance(value, dict), f"{field} must be an object")
+    return value
+
+
+def _validate_driver_output(
+    output: dict,
+    *,
+    request: dict,
+    request_path: Path,
+    private_root: Path,
+    protocol: dict,
+    matrix_cell: dict,
+) -> list[tuple[dict, dict, str]]:
+    require_exact_keys(
+        output,
+        {
+            "schema_version",
+            "source",
+            "package",
+            "contracts",
+            "runtime",
+            "request_sha256",
+            "calibration_runs",
+        },
+        "constant-calibration driver output",
+    )
+    require(
+        output["schema_version"] == 1
+        and output["source"] == request["source"]
+        and output["package"] == request["package"]
+        and output["contracts"] == request["contracts"]
+        and output["runtime"] == request["runtime"]
+        and output["request_sha256"] == sha256(request_path),
+        "constant-calibration driver output changed its authenticated request identity",
+    )
+    summaries = output["calibration_runs"]
+    require(
+        isinstance(summaries, list) and len(summaries) == _RUN_COUNT,
+        "constant-calibration driver must return exactly three clean runs",
+    )
+    target_os = TARGET_CONTRACTS[matrix_cell["asset_target"]]["target_os"]
+    allowed_awake_apis = set(protocol["clock_policy"]["platform_apis"][target_os])
+    inclusive_api = protocol["clock_policy"]["suspend_detection"]["platform_apis"][
+        target_os
+    ]
+    maximum_suspend_ns = protocol["clock_policy"]["suspend_detection"][
+        "maximum_inclusive_minus_awake_ns"
+    ]
+    expected_metrics = set(protocol["calibration_required_metrics"])
+    retained = []
+    observed_generations: set[tuple[str, str, int]] = set()
+    for expected_index, summary in enumerate(summaries, start=1):
+        field = f"constant-calibration run {expected_index}"
+        require(isinstance(summary, dict), f"{field} summary is malformed")
+        require_exact_keys(
+            summary,
+            {
+                "run_index",
+                "measurements",
+                "server_identities",
+                "backend",
+                "policy",
+                "model_sha256",
+                "materialized_reused",
+            },
+            f"{field} summary",
+        )
+        require(
+            summary["run_index"] == expected_index
+            and summary["policy"] == "accelerated"
+            and normalized_backend(summary["backend"])
+            == normalized_backend(matrix_cell["backend"])
+            and summary["model_sha256"] == request["package"]["model_sha256"]
+            and summary["materialized_reused"] is (expected_index > 1),
+            f"{field} changed backend, model, or materialization identity",
+        )
+        measurements = summary["measurements"]
+        require(
+            isinstance(measurements, dict)
+            and measurements
+            == {
+                "artifact": f"constant-calibration-run-{expected_index}.raw.json",
+                "metric_count": _METRIC_COUNT,
+                "sample_count": _METRIC_COUNT,
+            },
+            f"{field} did not retain one sample for each constant-source metric",
+        )
+        artifact_path = private_root / measurements["artifact"]
+        raw = _load_json(artifact_path, f"{field} raw artifact")
+        require_exact_keys(
+            raw,
+            {
+                "schema_version",
+                "run_index",
+                "contracts",
+                "metrics",
+                "server_identities",
+                "backend",
+                "policy",
+                "model_sha256",
+                "materialized_reused",
+            },
+            f"{field} raw artifact",
+        )
+        require(
+            raw["schema_version"] == 1
+            and raw["run_index"] == expected_index
+            and raw["contracts"] == request["contracts"]
+            and raw["backend"] == summary["backend"]
+            and raw["policy"] == summary["policy"]
+            and raw["model_sha256"] == summary["model_sha256"]
+            and raw["materialized_reused"] == summary["materialized_reused"]
+            and raw["server_identities"] == summary["server_identities"],
+            f"{field} summary does not bind its raw artifact",
+        )
+        identities = raw["server_identities"]
+        require(
+            isinstance(identities, list) and len(identities) == 1,
+            f"{field} must use one fresh server generation",
+        )
+        identity = identities[0]
+        require(isinstance(identity, dict), f"{field} server identity is malformed")
+        require_exact_keys(
+            identity,
+            {"server_instance_id", "process_start_id", "load_generation"},
+            f"{field} server identity",
+        )
+        generation = (
+            require_nonempty_string(
+                identity["server_instance_id"],
+                f"{field} server_instance_id",
+            ),
+            require_nonempty_string(
+                identity["process_start_id"],
+                f"{field} process_start_id",
+            ),
+            require_positive_int(
+                identity["load_generation"],
+                f"{field} load_generation",
+            ),
+        )
+        require(
+            generation not in observed_generations,
+            "constant calibration reused a server generation across clean runs",
+        )
+        observed_generations.add(generation)
+        metrics = raw["metrics"]
+        require(
+            isinstance(metrics, dict) and set(metrics) == expected_metrics,
+            f"{field} included qualification-only or omitted constant-source metrics",
+        )
+        for metric, record in metrics.items():
+            require(isinstance(record, dict), f"{field} metric {metric} is malformed")
+            require_exact_keys(record, {"unit", "samples"}, f"{field} metric {metric}")
+            require(
+                record["unit"] == protocol["metric_contracts"][metric]["unit"]
+                and isinstance(record["samples"], list)
+                and len(record["samples"]) == 1,
+                f"{field} metric {metric} must retain exactly one declared sample",
+            )
+            sample = record["samples"][0]
+            require(
+                isinstance(sample, dict),
+                f"{field} metric {metric} sample is malformed",
+            )
+            require_exact_keys(
+                sample,
+                _SAMPLE_FIELDS,
+                f"{field} metric {metric} sample",
+            )
+            require(
+                sample["repeat"] == 1
+                and sample["matrix_cell_id"] == request["runtime"]["matrix_cell_id"]
+                and sample["workload_id"] == protocol["workloads"][metric]["workload_id"]
+                and sample["cache_state"] == matrix_cell["cache_state"]
+                and sample["residency_state"] == matrix_cell["residency_state"]
+                and sample["server_identity"] == identity,
+                f"{field} metric {metric} escaped its declared workload or server generation",
+            )
+            qualification_measurement_sample_value(
+                metric,
+                sample,
+                contracts=request["contracts"],
+                phase_boundaries=protocol["calibration_phase_boundaries"],
+                allowed_awake_apis=allowed_awake_apis,
+                inclusive_api=inclusive_api,
+                maximum_suspend_ns=maximum_suspend_ns,
+                expected_policy="accelerated",
+                expected_backend=matrix_cell["backend"],
+            )
+        retained.append((summary, raw, sha256(artifact_path)))
+    return retained
+
+
+def _host_fingerprint() -> str:
+    identity = "|".join(
+        (
+            platform.system(),
+            platform.machine(),
+            platform.release(),
+            platform.node(),
+        )
+    )
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
+
+
+def _retained_run(
+    *,
+    summary: dict,
+    raw: dict,
+    physical_artifact_sha256: str,
+    manifest: dict,
+    measurement_contract: dict,
+    matrix_cell_id: str,
+    matrix_cell: dict,
+    archive_sha256: str,
+    host_fingerprint: str,
+    request_sha256: str,
+) -> dict:
+    run_index = summary["run_index"]
+    contracts = {
+        "protocol_sha256": measurement_contract["protocol_sha256"],
+        "measurement_protocol_sha256": measurement_contract[
+            "measurement_protocol_sha256"
+        ],
+        "input_constant_set_sha256": measurement_contract["constant_set_sha256"],
+    }
+    package = {
+        "archive_sha256": require_sha256(
+            archive_sha256,
+            "constant-calibration archive sha256",
+        ),
+        "executable_sha256": runtime_executable_sha256(manifest),
+        "asset_target": manifest["asset_target"],
+        "release_version": manifest["release_version"],
+        "model_sha256": summary["model_sha256"],
+        "policy": "accelerated",
+        "backend": normalized_backend(matrix_cell["backend"]),
+    }
+    run_id = canonical_sha256(
+        {
+            "source": manifest["source"],
+            "package": package,
+            "matrix_cell_id": matrix_cell_id,
+            "run_index": run_index,
+            "host_fingerprint": host_fingerprint,
+            "request_sha256": request_sha256,
+            "driver_artifact_sha256": physical_artifact_sha256,
+        }
+    )
+    payload = {
+        "schema_version": 1,
+        "run_id_sha256": run_id,
+        "matrix_cell_id": matrix_cell_id,
+        "run_index": run_index,
+        "host_fingerprint": host_fingerprint,
+        "source": manifest["source"],
+        "contracts": contracts,
+        "package": package,
+        "materialized_reused": summary["materialized_reused"],
+        "clean": True,
+        "unplanned_suspend": False,
+        "metrics": raw["metrics"],
+    }
+    return {
+        "run_id_sha256": run_id,
+        "matrix_cell_id": matrix_cell_id,
+        "run_index": run_index,
+        "host_fingerprint": host_fingerprint,
+        "clean": True,
+        "unplanned_suspend": False,
+        "source": manifest["source"],
+        "contracts": contracts,
+        "package": package,
+        "materialized_reused": summary["materialized_reused"],
+        "raw_artifact": {
+            "name": summary["measurements"]["artifact"],
+            "sha256": canonical_sha256(payload),
+            "payload": payload,
+        },
+    }
+
+
+def collect_constant_calibration(
+    args,
+    *,
+    root: Path,
+    unpacked_root: Path,
+    cli: Path,
+    manifest: dict,
+    measurement_contract: dict,
+    env: dict[str, str],
+    archive_sha256: str,
+    package_phase_started: float,
+) -> dict:
+    protocol = measurement_contract["measurement_protocol"]
+    matrix_cell = _constant_calibration_matrix_cell(args, protocol, manifest)
+    matrix_cell_id = args.qualification_matrix_cell
+    require(
+        args.qualification_driver is not None
+        and args.qualification_driver.is_file()
+        and not args.qualification_driver.is_symlink(),
+        "--collect-constant-calibration requires the exact shared calibration driver",
+    )
+    retained_root = args.constant_calibration_output_dir
+    require(
+        retained_root is not None,
+        "--collect-constant-calibration requires --constant-calibration-output-dir",
+    )
+    retained_root.mkdir(parents=True, exist_ok=True)
+    require(
+        retained_root.is_dir()
+        and not retained_root.is_symlink()
+        and not any(retained_root.iterdir()),
+        "constant-calibration output directory must be a new empty directory",
+    )
+    setup_started = time.perf_counter()
+    private_root = root / "constant-calibration"
+    private_root.mkdir(mode=0o700)
+    project = _prepare_synthetic_project(private_root)
+    nonce = secrets.token_hex(32)
+    register_failure_evidence_secret(nonce)
+    nonce_sha256 = hashlib.sha256(nonce.encode("ascii")).hexdigest()
+    executable = runtime_executable_path(cli, manifest)
+    driver_contracts = {
+        "protocol_sha256": measurement_contract["protocol_sha256"],
+        "constant_set_sha256": measurement_contract["constant_set_sha256"],
+        "measurement_protocol_sha256": measurement_contract[
+            "measurement_protocol_sha256"
+        ],
+    }
+    request = {
+        "schema_version": 1,
+        "calibration_nonce": nonce,
+        "calibration_nonce_sha256": nonce_sha256,
+        "source": manifest["source"],
+        "package": {
+            "archive_sha256": archive_sha256,
+            "executable_sha256": runtime_executable_sha256(manifest),
+            "asset_target": manifest["asset_target"],
+            "release_version": manifest["release_version"],
+            "model_sha256": manifest["model"]["sha256"],
+        },
+        "contracts": driver_contracts,
+        "runtime": {
+            "engine_policy": "accelerated",
+            "expected_backend": normalized_backend(matrix_cell["backend"]),
+            "offline": True,
+            "matrix_cell_id": matrix_cell_id,
+            "cache_state": matrix_cell["cache_state"],
+            "residency_state": matrix_cell["residency_state"],
+        },
+        "project": str(project),
+        "required_runs": _RUN_COUNT,
+        "output_directory": str(private_root.resolve()),
+    }
+    request_path = private_root / "request.json"
+    output_path = private_root / "output.json"
+    write_private_json(request_path, request)
+    calibration_env = dict(env)
+    require(
+        calibration_env.get("CODESTORY_EMBED_ALLOW_CPU") == "0",
+        "constant calibration must disable CPU fallback",
+    )
+    calibration_env["CODESTORY_EMBED_CONSTANT_CALIBRATION_DIR"] = str(
+        private_root.resolve()
+    )
+    calibration_env["CODESTORY_EMBED_CONSTANT_CALIBRATION_NONCE"] = nonce
+    calibration_env["CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256"] = archive_sha256
+    calibration_env["CODESTORY_PLUGIN_CLI_MANIFEST_PATH"] = str(
+        _native_manifest_path(unpacked_root)
+    )
+    setup_finished = time.perf_counter()
+    measurement = run(
+        [
+            str(args.qualification_driver.resolve()),
+            "--cli",
+            str(executable),
+            "--request",
+            str(request_path),
+            "--output",
+            str(output_path),
+        ],
+        env=calibration_env,
+        cwd=root,
+        timeout=args.timeout_secs,
+    )
+    validation_started = time.perf_counter()
+    output = _load_json(output_path, "constant-calibration driver output")
+    retained = _validate_driver_output(
+        output,
+        request=request,
+        request_path=request_path,
+        private_root=private_root,
+        protocol=protocol,
+        matrix_cell=matrix_cell,
+    )
+    fingerprint = _host_fingerprint()
+    run_artifacts = []
+    for summary, raw, physical_digest in retained:
+        document = _retained_run(
+            summary=summary,
+            raw=raw,
+            physical_artifact_sha256=physical_digest,
+            manifest=manifest,
+            measurement_contract=measurement_contract,
+            matrix_cell_id=matrix_cell_id,
+            matrix_cell=matrix_cell,
+            archive_sha256=archive_sha256,
+            host_fingerprint=fingerprint,
+            request_sha256=output["request_sha256"],
+        )
+        destination = retained_root / f"run-{summary['run_index']}.json"
+        write_json(destination, document)
+        run_artifacts.append(
+            {
+                "name": destination.name,
+                "sha256": sha256(destination),
+                "raw_artifact_sha256": physical_digest,
+            }
+        )
+    finished = time.perf_counter()
+    timing = {
+        "schema_version": 1,
+        "archive_authentication_unpack_ms": round(
+            (setup_started - package_phase_started) * 1000,
+            3,
+        ),
+        "project_and_request_setup_ms": round(
+            (setup_finished - setup_started) * 1000,
+            3,
+        ),
+        "measurement_ms": measurement["wall_ms"],
+        "retention_validation_ms": round((finished - validation_started) * 1000, 3),
+        "end_to_end_ms": round((finished - package_phase_started) * 1000, 3),
+    }
+    write_json(retained_root / "timing.json", timing)
+    return {
+        "schema_version": 1,
+        "status": "constant_calibration",
+        "matrix_cell_id": matrix_cell_id,
+        "required_for_assembly": matrix_cell_id in protocol["calibration_matrix"],
+        "run_count": len(run_artifacts),
+        "metric_count_per_run": _METRIC_COUNT,
+        "sample_count_per_metric_per_run": 1,
+        "run_artifacts": run_artifacts,
+        "timing": timing,
+    }

--- a/.github/scripts/packaged_agent_proof/installation_support.py
+++ b/.github/scripts/packaged_agent_proof/installation_support.py
@@ -94,7 +94,7 @@ def isolated_environment(
             "TEMP": str(temp),
             "TMP": str(temp),
             "XDG_RUNTIME_DIR": str(runtime),
-            "CODESTORY_EMBED_ALLOW_CPU": "1" if policy == "cpu_explicit" else "0",
+            "CODESTORY_EMBED_ALLOW_CPU": "0",
         }
     )
     if offline:

--- a/.github/scripts/packaged_agent_proof/measurement_constant_selection.py
+++ b/.github/scripts/packaged_agent_proof/measurement_constant_selection.py
@@ -35,7 +35,7 @@ def _verify_constant_sources(constant_selection: dict) -> None:
         }
         and all(
             isinstance(cell, dict)
-            and cell.get("artifact") == "measurements.raw.json"
+            and cell.get("artifact") == "constant-calibration-run-*.raw.json"
             and isinstance(cell.get("operand"), str)
             and bool(cell["operand"])
             and (
@@ -50,9 +50,10 @@ def _verify_constant_sources(constant_selection: dict) -> None:
         constant_selection["clean_run_requirements"]
         == {
             "minimum_runs_per_matrix_cell": 3,
-            "matrix_coverage": "every_calibration_matrix_cell",
+            "matrix_coverage": "every_required_calibration_matrix_cell",
             "source_identity": "one_exact_candidate_commit_and_tree",
             "artifact_selection": "all_preregistered_clean_runs",
+            "fresh_server_identity": "disjoint_across_clean_runs",
             "unplanned_suspend": False,
             "outlier_removal": "none",
         },
@@ -100,7 +101,11 @@ def _verify_constant_formulas(constant_selection: dict) -> None:
         and formulas["request_deadlines_ms"]
         .get("bulk_request_deadline_ms", {})
         .get("replay_success_budget_formula")
-        == "max(query_request_deadline_ms,ceiling(maximum_raw_value_ms_across_all_selected_samples*1.50))"
+        == "max(144537,query_request_deadline_ms,ceiling(maximum_raw_value_ms_across_all_selected_samples*1.50))"
+        and formulas["request_deadlines_ms"]
+        .get("bulk_request_deadline_ms", {})
+        .get("replay_success_budget_slow_host_floor_ms")
+        == 144537
         and formulas["request_deadlines_ms"]
         .get("bulk_request_deadline_ms", {})
         .get("formula")
@@ -109,7 +114,9 @@ def _verify_constant_formulas(constant_selection: dict) -> None:
     )
     require(
         formulas["capacity_retry_policy"].get("retry_after_ms_formula")
-        == "max(1,floor(minimum_raw_value_ms_across_all_selected_samples*0.50))"
+        == "max(40,floor(minimum_raw_value_ms_across_all_selected_samples*0.50))"
+        and formulas["capacity_retry_policy"].get("retry_after_slow_host_floor_ms")
+        == 40
         and formulas["capacity_retry_policy"].get("retry_class")
         == "after_capacity_change"
         and formulas["capacity_retry_policy"].get("retry_condition_source")
@@ -118,12 +125,25 @@ def _verify_constant_formulas(constant_selection: dict) -> None:
     )
     require(
         formulas["election_backoff_policy"].get("initial_backoff_ms_formula")
-        == "max(1,ceiling(maximum_existing_owner_connect_duration_ms_across_all_selected_samples*0.50))"
+        == "max(7,ceiling(maximum_existing_owner_connect_duration_ms_across_all_selected_samples*0.50))"
+        and formulas["election_backoff_policy"].get("initial_backoff_slow_host_floor_ms")
+        == 7
         and formulas["election_backoff_policy"].get("maximum_backoff_ms_formula")
-        == "max(initial_backoff_ms,ceiling(maximum_spawn_convergence_duration_ms_across_all_selected_samples*0.25))"
+        == "max(102,initial_backoff_ms,ceiling(maximum_spawn_convergence_duration_ms_across_all_selected_samples*0.25))"
+        and formulas["election_backoff_policy"].get("maximum_backoff_slow_host_floor_ms")
+        == 102
         and formulas["election_backoff_policy"].get("jitter")
         == "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
         "election backoff selection formula changed",
+    )
+    require(
+        formulas["hard_native_no_progress_ms"].get("formula")
+        == "max(385431,ceiling(maximum_complete_successful_operation_duration_ms_across_all_selected_samples*4.00))"
+        and formulas["hard_native_no_progress_ms"].get("slow_host_floor_ms") == 385431
+        and formulas["watchdog_cadence_ms"].get("formula")
+        == "max(19271,floor(hard_native_no_progress_ms/20))"
+        and formulas["watchdog_cadence_ms"].get("slow_host_floor_ms") == 19271,
+        "native no-progress or watchdog slow-host floor changed",
     )
     require(
         constant_selection["post_result_formula_changes"] is False,
@@ -159,30 +179,23 @@ def _verify_constant_selection(protocol: dict) -> None:
 
 
 def _verify_thresholds_and_clock(protocol: dict) -> None:
-    threshold_selection = protocol.get("threshold_selection")
+    threshold_contract = protocol.get("qualification_threshold_contract")
     require(
-        isinstance(threshold_selection, dict)
-        and threshold_selection
+        isinstance(threshold_contract, dict)
+        and threshold_contract
         == {
-            "minimum_clean_calibration_runs_per_matrix_cell": 3,
-            "matrix_coverage": "every_calibration_matrix_cell",
-            "source_identity": "one_exact_candidate_commit_and_tree",
-            "producer_identity": (
-                "trusted_packaged_platform_pr_workflow_run_and_exact_artifact"
-            ),
-            "artifact_selection": "all_preregistered_clean_runs",
-            "less_than_or_equal": (
-                "ceiling(maximum_cell_aggregate_across_all_runs*1.20)"
-            ),
-            "greater_than_or_equal": (
-                "floor(minimum_cell_aggregate_across_all_runs*0.80)"
-            ),
-            "equal": "exact_observed_contract_value",
-            "retrieval_quality": 1.0,
-            "outlier_removal": "none",
-            "post_result_threshold_changes": False,
+            "source": "checked_in_frozen_candidate_contract",
+            "selected_by_calibration": False,
+            "omitted_measurements": "preserve_checked_in_thresholds",
+            "true_idle_exit": {
+                "idle_timeout_ms": 60_000,
+                "observation_grace_ms": 2_500,
+                "formula": "idle_timeout_ms+observation_grace_ms",
+                "required_threshold_ms": 62_500,
+                "qualification_runs_per_available_gpu_platform": 1,
+            },
         },
-        "measurement threshold-selection formula is incomplete or mutable",
+        "qualification-threshold contract is incomplete or mutable",
     )
     require(
         protocol.get("calibration_bundle_contract")
@@ -191,6 +204,7 @@ def _verify_thresholds_and_clock(protocol: dict) -> None:
             "required_for_frozen_qualification": True,
             "matrix_cells": "exactly_every_calibration_matrix_cell",
             "independent_clean_runs_per_matrix_cell": 3,
+            "samples_per_metric_per_run": 1,
             "source_identity": "one_exact_candidate_commit_and_tree",
             "producer_identity": (
                 "trusted_packaged_platform_pr_workflow_run_and_exact_artifact"
@@ -199,9 +213,7 @@ def _verify_thresholds_and_clock(protocol: dict) -> None:
                 "protocol_sha256",
                 "measurement_protocol_sha256",
             ],
-            "raw_artifact": (
-                "embedded_product_and_five_process_measurements_with_canonical_sha256"
-            ),
+            "raw_artifact": "nine_constant_source_metrics_with_canonical_sha256",
             "clock_witnesses": "awake_monotonic_plus_suspend_inclusive_per_sample",
             "successful_operation_operand": "successful_operation_duration_ns",
             "freeze_digest_inputs": [
@@ -211,16 +223,24 @@ def _verify_thresholds_and_clock(protocol: dict) -> None:
                 "contracts",
                 "run_artifact_sha256s",
                 "calibration_required_values",
-                "qualification_thresholds",
             ],
-            "constant_set_comparison": (
-                "exact_recomputed_values_thresholds_and_freeze_record"
-            ),
+            "constant_set_comparison": "exact_recomputed_runtime_constants_and_freeze_record",
             "qualification_boundary": (
-                "installed_runtime_cells_are_post_freeze_qualification_only"
+                "lifecycle_fault_idle_memory_quality_accelerator_and_performance_are_frozen_candidate_qualification_only"
             ),
         },
         "measurement calibration-bundle contract is incomplete or mutable",
+    )
+    rules = protocol.get("measurement_rules")
+    require(
+        isinstance(rules, dict)
+        and rules.get("calibration_and_qualification_are_distinct") is True
+        and rules.get("constants_frozen_before_qualification") is True
+        and rules.get("missing_required_cell_fails") is True
+        and rules.get("calibration_runs_full_qualification") is False
+        and rules.get("qualification_runs_once_per_available_gpu_platform") is True
+        and rules.get("threshold_movement_after_results") is False,
+        "calibration and qualification boundary is incomplete or mutable",
     )
     clock_policy = protocol.get("clock_policy")
     suspend = (

--- a/.github/scripts/packaged_agent_proof/measurement_protocol.py
+++ b/.github/scripts/packaged_agent_proof/measurement_protocol.py
@@ -22,6 +22,7 @@ from .measurement_constant_selection import (
 )
 from .measurement_protocol_validation import (
     _measurement_document,
+    _verify_calibration_sampling,
     _verify_measurement_matrices,
     _verify_measurement_sampling,
     _verify_scenario_and_metric_contracts,
@@ -33,6 +34,7 @@ def load_measurement_protocol(path: Path) -> tuple[dict, str]:
     required_metrics, metric_contracts = _verify_scenario_and_metric_contracts(protocol)
     _verify_measurement_matrices(protocol)
     _verify_measurement_sampling(protocol, required_metrics, metric_contracts)
+    _verify_calibration_sampling(protocol, required_metrics)
     _verify_constant_selection(protocol)
     _verify_thresholds_and_clock(protocol)
     return protocol, sha256(path)

--- a/.github/scripts/packaged_agent_proof/measurement_protocol_validation.py
+++ b/.github/scripts/packaged_agent_proof/measurement_protocol_validation.py
@@ -118,14 +118,6 @@ def _verify_scenario_and_metric_contracts(protocol: dict) -> tuple[set[str], dic
 
 def _verify_host_package_matrix(matrix: dict) -> None:
     expected_cells = {
-        "hosted_linux_x64_cpu": (
-            "linux-x64",
-            "hosted_package",
-            "github_hosted_linux_x64",
-            "cpu_explicit",
-            "cpu",
-            "none",
-        ),
         "protected_macos_arm64_metal": (
             "macos-arm64",
             "protected_hardware",
@@ -195,15 +187,15 @@ def _verify_host_package_matrix(matrix: dict) -> None:
         )
 
 
-def _verify_calibration_matrix(matrix: dict, calibration_matrix: object) -> None:
+def _verify_calibration_matrix(
+    matrix: dict,
+    calibration_matrix: object,
+    optional_evidence_matrix: object,
+) -> None:
     require(
         isinstance(calibration_matrix, dict)
-        and set(calibration_matrix)
-        == {
-            "hosted_linux_x64_cpu",
-            "protected_macos_arm64_metal",
-        },
-        "measurement calibration matrix must contain the Linux CPU and macOS Metal pre-publish lanes",
+        and set(calibration_matrix) == {"protected_macos_arm64_metal"},
+        "measurement calibration matrix must contain only protected macOS Metal",
     )
     for cell_id, cell in calibration_matrix.items():
         require(
@@ -240,6 +232,48 @@ def _verify_calibration_matrix(matrix: dict, calibration_matrix: object) -> None
             ),
             f"measurement calibration matrix cell {cell_id} does not use its exact qualification path",
         )
+    require(
+        isinstance(optional_evidence_matrix, dict)
+        and set(optional_evidence_matrix) == {"protected_linux_x64_vulkan"},
+        "optional calibration evidence must contain only protected Linux Vulkan",
+    )
+    for cell_id, cell in optional_evidence_matrix.items():
+        require(
+            isinstance(cell, dict)
+            and set(cell)
+            == {
+                "asset_target",
+                "proof_tier",
+                "host_class",
+                "policy",
+                "backend",
+                "cache_state",
+                "residency_state",
+                "accelerator_claim",
+                "feeds_constant_selection",
+            }
+            and cell["proof_tier"] == "calibration"
+            and cell["cache_state"] == "reused"
+            and cell["residency_state"] == "resident"
+            and cell["feeds_constant_selection"] is False,
+            f"optional calibration evidence cell {cell_id} is malformed",
+        )
+        qualification_cell = matrix[cell_id]
+        require(
+            all(
+                cell[field] == qualification_cell[field]
+                for field in (
+                    "asset_target",
+                    "host_class",
+                    "policy",
+                    "backend",
+                    "cache_state",
+                    "residency_state",
+                    "accelerator_claim",
+                )
+            ),
+            f"optional calibration evidence cell {cell_id} does not use its exact qualification path",
+        )
 
 
 def _verify_measurement_matrices(protocol: dict) -> None:
@@ -248,7 +282,74 @@ def _verify_measurement_matrices(protocol: dict) -> None:
         isinstance(matrix, dict), "measurement protocol omitted its host/package matrix"
     )
     _verify_host_package_matrix(matrix)
-    _verify_calibration_matrix(matrix, protocol.get("calibration_matrix"))
+    _verify_calibration_matrix(
+        matrix,
+        protocol.get("calibration_matrix"),
+        protocol.get("optional_calibration_evidence_matrix"),
+    )
+
+
+def _verify_calibration_sampling(
+    protocol: dict,
+    required_metrics: set[str],
+) -> None:
+    expected_metrics = {
+        "existing_owner_connect",
+        "spawn_convergence",
+        "cold_first_vector",
+        "first_product_ready",
+        "warm_query_ipc",
+        "warm_bulk_ipc",
+        "bulk_documents_per_second",
+        "bulk_tokens_per_second",
+        "busy_retry_usefulness",
+    }
+    calibration_metrics = protocol.get("calibration_required_metrics")
+    require(
+        isinstance(calibration_metrics, list)
+        and len(calibration_metrics) == len(set(calibration_metrics))
+        and set(calibration_metrics) == expected_metrics
+        and set(calibration_metrics).issubset(required_metrics),
+        "constant calibration must name exactly the nine runtime-constant source metrics",
+    )
+    sampling = protocol.get("calibration_metric_sampling")
+    require(
+        isinstance(sampling, dict) and set(sampling) == expected_metrics,
+        "constant-calibration sample policy does not match its required metrics",
+    )
+    for metric, policy in sampling.items():
+        require(
+            isinstance(policy, dict)
+            and policy == {"sample_count_per_run": 1},
+            f"constant-calibration metric {metric} must take one sample per clean run",
+        )
+    boundaries = protocol.get("calibration_phase_boundaries")
+    require(
+        isinstance(boundaries, dict) and set(boundaries) == expected_metrics,
+        "constant calibration must declare phase boundaries for exactly its nine metrics",
+    )
+    for metric, points in boundaries.items():
+        require(
+            isinstance(points, list)
+            and len(points) == 2
+            and all(isinstance(point, str) and point for point in points),
+            f"constant-calibration metric {metric} has malformed phase boundaries",
+        )
+        if metric != "cold_first_vector":
+            require(
+                points == protocol["phase_boundaries"][metric],
+                f"constant-calibration metric {metric} changed its shared phase boundary",
+            )
+    require(
+        boundaries["cold_first_vector"]
+        == [
+            "product_request_started_with_fresh_owner_model_absent",
+            "first_vector_and_engine_evidence_validated",
+        ]
+        and protocol.get("calibration_workload_state_overrides")
+        == {"cold_first_vector": "fresh_owner_model_absent"},
+        "constant calibration must measure cold-first-vector on the fresh owner before model materialization",
+    )
 
 
 def _verify_measurement_sampling(

--- a/.github/scripts/packaged_agent_proof/measurement_samples.py
+++ b/.github/scripts/packaged_agent_proof/measurement_samples.py
@@ -375,12 +375,6 @@ def _accelerator_residency_value(
         and tensor_count > 0
         and tensor_bytes > 0
         and offloaded == model_layers
-    ) or (
-        expected_policy == "cpu_explicit"
-        and operands["accelerator_execution_verified"] is False
-        and tensor_count == 0
-        and tensor_bytes == 0
-        and offloaded == 0
     )
     require(
         valid,

--- a/.github/scripts/packaged_agent_proof/native_contract_identity.py
+++ b/.github/scripts/packaged_agent_proof/native_contract_identity.py
@@ -291,31 +291,18 @@ def verify_engine_identities_against_manifest(
         policy == expected_policy,
         "runtime policy does not match the requested proof lane",
     )
-    if policy == "accelerated":
-        expected_backend = accelerator.get("expected_protected_backend")
-        require(
-            isinstance(expected_backend, str) and bool(expected_backend),
-            "this package target has no protected accelerator execution claim",
-        )
-        require(
-            observed_backend == expected_backend,
-            "runtime accelerator backend does not match the protected package contract",
-        )
-        execution = "proven_by_live_runtime"
-        non_claim_reason = None
-    else:
-        require(
-            policy == "cpu_explicit",
-            "runtime used neither protected acceleration nor explicit CPU",
-        )
-        require(
-            observed_backend == "cpu", "explicit CPU proof selected a non-CPU backend"
-        )
-        execution = "explicit_cpu_execution"
-        non_claim_reason = (
-            accelerator.get("non_claim_reason")
-            or "explicit_cpu_execution_does_not_prove_acceleration"
-        )
+    require(policy == "accelerated", "runtime proof requires accelerated embeddings")
+    expected_backend = accelerator.get("expected_protected_backend")
+    require(
+        isinstance(expected_backend, str) and bool(expected_backend),
+        "this package target has no protected accelerator execution claim",
+    )
+    require(
+        observed_backend == expected_backend,
+        "runtime accelerator backend does not match the protected package contract",
+    )
+    execution = "proven_by_live_runtime"
+    non_claim_reason = None
 
     return {
         "build_identity": engine["build_identity"],

--- a/.github/scripts/packaged_agent_proof/native_manifest.py
+++ b/.github/scripts/packaged_agent_proof/native_manifest.py
@@ -446,8 +446,8 @@ def _verify_model(
 def _verify_accelerator(parts: ManifestParts, target_contract: dict) -> None:
     accelerator = parts.accelerator
     require(
-        accelerator.get("cpu_fallback") == "explicit_only",
-        "native manifest permits implicit CPU fallback",
+        accelerator.get("cpu_fallback") == "unsupported",
+        "native manifest permits CPU fallback",
     )
     require(
         accelerator.get("package_claim") == "compiled_capability_only",

--- a/.github/scripts/packaged_agent_proof/package_contracts.py
+++ b/.github/scripts/packaged_agent_proof/package_contracts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from .contract_primitives import (
     require_exact_keys,
     require_nonempty_string,
+    require_positive_int,
     require_sha256,
 )
 from .foundation import SERVER_LIFECYCLES, require
@@ -131,6 +132,31 @@ def verify_package_server_contracts(
     require(
         isinstance(thresholds, dict) and set(thresholds) == required_metrics,
         "embedding server qualification thresholds do not match the measurement metrics",
+    )
+    fixed = constant_set.get("fixed_contract_values")
+    threshold_contract = measurement.get("qualification_threshold_contract", {}).get(
+        "true_idle_exit"
+    )
+    require(
+        isinstance(fixed, dict)
+        and isinstance(threshold_contract, dict)
+        and require_positive_int(
+            fixed.get("idle_timeout_ms"),
+            "fixed per-user embedding idle timeout",
+        )
+        == threshold_contract["idle_timeout_ms"]
+        and require_positive_int(
+            fixed.get("true_idle_observation_grace_ms"),
+            "fixed true-idle observation grace",
+        )
+        == threshold_contract["observation_grace_ms"]
+        and thresholds.get("true_idle_exit")
+        == threshold_contract["required_threshold_ms"]
+        == (
+            threshold_contract["idle_timeout_ms"]
+            + threshold_contract["observation_grace_ms"]
+        ),
+        "true-idle qualification threshold must be the fixed product timeout plus observation grace",
     )
     if require_frozen:
         _verify_frozen_constant_set(measurement, constant_set)

--- a/.github/scripts/packaged_agent_proof/qualification_output.py
+++ b/.github/scripts/packaged_agent_proof/qualification_output.py
@@ -1,17 +1,12 @@
-"""Retained and calibration-run outputs for qualification production."""
+"""Retained outputs for frozen-candidate qualification production."""
 
 from __future__ import annotations
 
-import json
-
 from .contract_primitives import (
     assert_retained_json_privacy,
-    canonical_sha256,
-    require_positive_int,
     write_private_json,
 )
-from .foundation import LOWER_TIER_NONCLAIMS, require
-from .native_manifest import runtime_executable_sha256
+from .foundation import LOWER_TIER_NONCLAIMS
 from .qualification_metrics import QualificationMeasurementEvidence
 from .qualification_production_types import (
     QualificationProducerContext,
@@ -66,93 +61,6 @@ def retained_qualification_output(
     return retained
 
 
-def _calibration_memory_samples(memory: dict) -> list[dict]:
-    samples = []
-    for sample in memory["payload"]["samples"]:
-        normalized = json.loads(json.dumps(sample))
-        normalized["process"] = normalized.pop("producer_process")
-        samples.append(normalized)
-    return samples
-
-
-def calibration_run_output(
-    context: QualificationProducerContext,
-    runner: QualificationRunnerEvidence,
-    measurements: QualificationMeasurementEvidence,
-) -> dict:
-    run_index = require_positive_int(
-        context.args.calibration_run_index,
-        "--calibration-run-index",
-    )
-    require(
-        run_index <= 3,
-        "--calibration-run-index must be in the preregistered range 1..3",
-    )
-    identity = context.runtime["identity"]
-    package = {
-        "archive_sha256": context.archive_sha256,
-        "executable_sha256": runtime_executable_sha256(context.manifest),
-        "asset_target": context.manifest["asset_target"],
-        "release_version": context.manifest["release_version"],
-        "model_sha256": identity["embedding_model_sha256"],
-        "policy": context.args.engine_policy,
-        "backend": runner.expected_backend,
-    }
-    contracts = {
-        "protocol_sha256": context.measurement_contract["protocol_sha256"],
-        "measurement_protocol_sha256": context.measurement_contract[
-            "measurement_protocol_sha256"
-        ],
-        "input_constant_set_sha256": context.measurement_contract[
-            "constant_set_sha256"
-        ],
-    }
-    metrics = json.loads(json.dumps(measurements.measurement["payload"]["metrics"]))
-    metrics["total_codestory_process_memory"] = {
-        "unit": "bytes",
-        "samples": _calibration_memory_samples(measurements.memory),
-    }
-    identity_seed = {
-        "source": context.manifest["source"],
-        "package": package,
-        "matrix_cell_id": runner.matrix_cell_id,
-        "run_index": run_index,
-        "host_fingerprint": measurements.host["fingerprint"],
-        "measurement_artifact_sha256": measurements.measurement["artifact"]["sha256"],
-        "memory_artifact_sha256": measurements.memory["artifact"]["sha256"],
-    }
-    run_id = canonical_sha256(identity_seed)
-    raw_payload = {
-        "schema_version": 1,
-        "run_id_sha256": run_id,
-        "matrix_cell_id": runner.matrix_cell_id,
-        "run_index": run_index,
-        "host_fingerprint": measurements.host["fingerprint"],
-        "source": context.manifest["source"],
-        "contracts": contracts,
-        "package": package,
-        "clean": context.manifest["source"]["tracked_dirty"] is False,
-        "unplanned_suspend": measurements.measurement["unplanned_suspend"],
-        "metrics": metrics,
-    }
-    return {
-        "run_id_sha256": run_id,
-        "matrix_cell_id": runner.matrix_cell_id,
-        "run_index": run_index,
-        "host_fingerprint": measurements.host["fingerprint"],
-        "clean": raw_payload["clean"],
-        "unplanned_suspend": raw_payload["unplanned_suspend"],
-        "source": context.manifest["source"],
-        "contracts": contracts,
-        "package": package,
-        "raw_artifact": {
-            "name": "measurements.raw.json",
-            "sha256": canonical_sha256(raw_payload),
-            "payload": raw_payload,
-        },
-    }
-
-
 def write_qualification_outputs(
     context: QualificationProducerContext,
     runner: QualificationRunnerEvidence,
@@ -173,12 +81,4 @@ def write_qualification_outputs(
             *context.runtime.get("_qualification_forbidden_values", []),
         ],
     )
-    if (
-        context.args.proof_tier == "calibration"
-        and context.args.calibration_run_output is not None
-    ):
-        write_private_json(
-            context.args.calibration_run_output,
-            calibration_run_output(context, runner, measurements),
-        )
     return retained

--- a/.github/scripts/packaged_agent_proof/qualification_recording.py
+++ b/.github/scripts/packaged_agent_proof/qualification_recording.py
@@ -67,25 +67,6 @@ def record_retained_qualification(
     summary["package_contract"]["highest_proof_tier"] = args.proof_tier
 
 
-def record_calibration_qualification(
-    args: argparse.Namespace,
-    summary: dict[str, object],
-) -> None:
-    if args.qualification_evidence is None or not args.qualification_evidence.is_file():
-        return
-    calibration = load_evidence(
-        args.qualification_evidence,
-        "calibration evidence",
-    )
-    require(
-        calibration.get("schema_version") == 1
-        and calibration.get("status") == "calibration"
-        and calibration.get("tier") == "calibration",
-        "calibration evidence has the wrong schema, status, or tier",
-    )
-    summary["qualification"] = calibration
-
-
 def record_qualification_contract(
     args: argparse.Namespace,
     summary: dict[str, object],
@@ -121,9 +102,11 @@ def record_qualification_contract(
         }
         summary["package_contract"]["release_readiness_claim"] = True
         summary["package_contract"]["highest_proof_tier"] = args.proof_tier
-    elif args.proof_tier == "calibration":
-        record_calibration_qualification(args, summary)
     else:
+        require(
+            args.proof_tier != "calibration",
+            "constant calibration cannot enter frozen-candidate qualification recording",
+        )
         record_retained_qualification(
             args,
             summary,

--- a/.github/scripts/packaged_agent_proof/qualification_retained_provenance.py
+++ b/.github/scripts/packaged_agent_proof/qualification_retained_provenance.py
@@ -205,7 +205,7 @@ def _verify_host(contract: RetainedQualificationContract) -> None:
     )
     require(
         package.get("policy") == host.get("policy")
-        and host.get("policy") in {"accelerated", "cpu_explicit"},
+        and host.get("policy") == "accelerated",
         "retained qualification package and host policy identities disagree",
     )
     require(

--- a/.github/scripts/packaged_agent_proof/runtime_retrieval_quality.py
+++ b/.github/scripts/packaged_agent_proof/runtime_retrieval_quality.py
@@ -211,7 +211,7 @@ def _verify_cache_provenance(row: dict, index: int) -> None:
         and bool(cache.get("semantic_generation"))
         and bool(cache.get("manifest_embedding_backend"))
         and bool(cache.get("embedding_engine_instance_id"))
-        and cache.get("embedding_policy") in {"accelerated", "cpu_explicit"}
+        and cache.get("embedding_policy") == "accelerated"
         and cache.get("semantic_backend") is not None
         and cache.get("local_only") is True
         and cache.get("indexed") is True

--- a/.github/scripts/packaged_agent_proof/self_test_cli.py
+++ b/.github/scripts/packaged_agent_proof/self_test_cli.py
@@ -7,10 +7,9 @@ import tempfile
 from pathlib import Path
 
 from .archive_proof import claim_scope, load_calibration_bundle, requires_calibration_bundle
-from .cli import _resolve_optional_paths
+from .cli import _resolve_optional_paths, _validate_calibration_mode
 from .contract_primitives import write_json
 from .foundation import ProofFailure, require
-from .qualification_recording import record_calibration_qualification
 
 
 def run_cli_self_tests() -> None:
@@ -27,10 +26,21 @@ def run_cli_self_tests() -> None:
             publication_fault_evidence=None,
             retrieval_quality_evidence=None,
             calibration_bundle=None,
-            calibration_run_output=None,
+            collect_constant_calibration=False,
+            constant_calibration_output_dir=None,
             installed_plugin_attestation=attestation,
             installed_plugin_data=None,
+            out_dir=root / "proof",
             proof_tier="installed_runtime",
+            engine_policy="accelerated",
+            expected_backend="metal",
+            offline=True,
+            project=None,
+            plugin_root=None,
+            plugin_handoff=False,
+            additional_project=[],
+            additional_query=[],
+            produce_qualification_evidence=False,
             ground_only=True,
             server_behavior_only=False,
             version_only=False,
@@ -92,19 +102,57 @@ def run_cli_self_tests() -> None:
         args.enforce_calibration_freeze_lineage = False
         args.server_behavior_only = False
 
-        calibration = root / "calibration.json"
-        write_json(
-            calibration,
-            {
-                "schema_version": 1,
-                "status": "calibration",
-                "tier": "calibration",
-            },
-        )
-        args.qualification_evidence = calibration
-        summary: dict[str, object] = {}
-        record_calibration_qualification(args, summary)
-        require(
-            summary["qualification"]["status"] == "calibration",
-            "calibration qualification was not recorded",
-        )
+        calibration_args = argparse.Namespace(**vars(args))
+        calibration_args.proof_tier = "calibration"
+        calibration_args.ground_only = False
+        calibration_args.server_behavior_only = False
+        try:
+            _validate_calibration_mode(calibration_args)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                "calibration tier reached the full qualification path without its collector"
+            )
+        calibration_args.collect_constant_calibration = True
+        calibration_args.constant_calibration_output_dir = root / "constant-runs"
+        calibration_args.qualification_driver = attestation
+        _validate_calibration_mode(calibration_args)
+        calibration_args.produce_qualification_evidence = True
+        try:
+            _validate_calibration_mode(calibration_args)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                "constant calibration accepted a full qualification producer"
+            )
+        calibration_args.produce_qualification_evidence = False
+        calibration_args.plugin_handoff = True
+        try:
+            _validate_calibration_mode(calibration_args)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                "constant calibration accepted packaged plugin handoff"
+            )
+        calibration_args.plugin_handoff = False
+        calibration_args.plugin_root = attestation
+        try:
+            _validate_calibration_mode(calibration_args)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                "constant calibration accepted a packaged plugin root"
+            )
+        calibration_args.plugin_root = None
+        calibration_args.engine_policy = "cpu_explicit"
+        calibration_args.expected_backend = "cpu"
+        try:
+            _validate_calibration_mode(calibration_args)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure("constant calibration accepted CPU execution")

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
@@ -12,7 +12,8 @@ from .calibration_self_test import (
     build_calibration_self_test_bundle,
 )
 from .calibration_verification import verify_calibration_bundle
-from .contract_primitives import canonical_sha256, write_json
+from .constant_calibration import _validate_driver_output
+from .contract_primitives import canonical_sha256, sha256, write_json
 from .foundation import TARGET_CONTRACTS, ProofFailure, require
 from .measurement_samples import selected_qualification_matrix_cell
 from .package_contracts import verify_package_server_contracts
@@ -127,8 +128,8 @@ def _calibration_bundle_tests(
         )
     )
     require(
-        assembled["run_count"] == 6
-        and assembled["matrix_cell_count"] == 2
+        assembled["run_count"] == 3
+        and assembled["matrix_cell_count"] == 1
         and assembled_bundle_path.is_file()
         and assembled_constant_path.is_file(),
         "calibration assembler did not produce the exact frozen artifacts",
@@ -139,8 +140,8 @@ def _calibration_bundle_tests(
         enforce_source_lineage=False,
     )
     require(
-        calibration_result["run_count"] == 6
-        and calibration_result["matrix_cell_count"] == 2,
+        calibration_result["run_count"] == 3
+        and calibration_result["matrix_cell_count"] == 1,
         "calibration bundle self-test did not verify the full matrix",
     )
     require(
@@ -192,15 +193,12 @@ def _measurement_window_semantics_tests(
     inclusive_api = protocol["clock_policy"]["suspend_detection"]["platform_apis"][
         target_os
     ]
-    raw_metric_names = frozenset(
-        set(protocol["required_metrics"])
-        - {"retrieval_quality", "total_codestory_process_memory"}
-    )
+    raw_metric_names = frozenset(protocol["calibration_required_metrics"])
     validation = MeasurementValidationContract(
         contracts={},
         protocol=protocol,
         metric_contracts=protocol["metric_contracts"],
-        phase_boundaries=protocol["phase_boundaries"],
+        phase_boundaries=protocol["calibration_phase_boundaries"],
         matrix_cell_id=cell_id,
         matrix_cell=cell,
         expected_policy=cell["policy"],
@@ -336,20 +334,253 @@ def _calibration_hostile_tests(
         pass
     else:
         raise ProofFailure("duplicate calibration sample identity was accepted")
-    hostile_frozen_contract = json.loads(json.dumps(frozen_measurement_contract))
-    hostile_frozen_contract["constant_set"]["qualification_thresholds"][
+
+    hostile_calibration = json.loads(json.dumps(calibration_bundle_payload))
+    hostile_run = hostile_calibration["runs"][0]
+    hostile_metric = hostile_run["raw_artifact"]["payload"]["metrics"][
         "warm_query_ipc"
-    ] += 1
+    ]
+    duplicate_sample = json.loads(json.dumps(hostile_metric["samples"][0]))
+    duplicate_sample["repeat"] = 2
+    duplicate_sample["sample_id"] += "-repeat"
+    hostile_metric["samples"].append(duplicate_sample)
+    hostile_run["raw_artifact"]["sha256"] = canonical_sha256(
+        hostile_run["raw_artifact"]["payload"]
+    )
+    write_json(hostile_calibration_path, hostile_calibration)
     try:
         verify_calibration_bundle(
-            calibration_bundle_path,
-            hostile_frozen_contract,
+            hostile_calibration_path,
+            frozen_measurement_contract,
             enforce_source_lineage=False,
         )
     except ProofFailure:
         pass
     else:
-        raise ProofFailure("post-result calibration threshold change was accepted")
+        raise ProofFailure("three-by-three calibration sampling was accepted")
+
+    hostile_calibration = json.loads(json.dumps(calibration_bundle_payload))
+    hostile_run = hostile_calibration["runs"][0]
+    source_sample = hostile_run["raw_artifact"]["payload"]["metrics"][
+        "warm_query_ipc"
+    ]["samples"][0]
+    qualification_metric = json.loads(json.dumps(source_sample))
+    qualification_metric["sample_id"] += "-true-idle"
+    qualification_metric["workload_id"] = "true-idle-qualification"
+    hostile_run["raw_artifact"]["payload"]["metrics"]["true_idle_exit"] = {
+        "unit": "milliseconds",
+        "samples": [qualification_metric],
+    }
+    hostile_run["raw_artifact"]["sha256"] = canonical_sha256(
+        hostile_run["raw_artifact"]["payload"]
+    )
+    write_json(hostile_calibration_path, hostile_calibration)
+    try:
+        verify_calibration_bundle(
+            hostile_calibration_path,
+            frozen_measurement_contract,
+            enforce_source_lineage=False,
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("qualification-only metric was accepted in calibration")
+
+    hostile_calibration = json.loads(json.dumps(calibration_bundle_payload))
+    first_run = hostile_calibration["runs"][0]
+    second_run = hostile_calibration["runs"][1]
+    first_metrics = first_run["raw_artifact"]["payload"]["metrics"]
+    second_metrics = second_run["raw_artifact"]["payload"]["metrics"]
+    for metric in second_metrics:
+        second_metrics[metric]["samples"][0]["server_identity"] = json.loads(
+            json.dumps(first_metrics[metric]["samples"][0]["server_identity"])
+        )
+    second_run["raw_artifact"]["sha256"] = canonical_sha256(
+        second_run["raw_artifact"]["payload"]
+    )
+    write_json(hostile_calibration_path, hostile_calibration)
+    try:
+        verify_calibration_bundle(
+            hostile_calibration_path,
+            frozen_measurement_contract,
+            enforce_source_lineage=False,
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("calibration reused a server generation across clean runs")
+
+    hostile_calibration = json.loads(json.dumps(calibration_bundle_payload))
+    hostile_run = hostile_calibration["runs"][1]
+    hostile_run["materialized_reused"] = False
+    hostile_run["raw_artifact"]["payload"]["materialized_reused"] = False
+    hostile_run["raw_artifact"]["sha256"] = canonical_sha256(
+        hostile_run["raw_artifact"]["payload"]
+    )
+    write_json(hostile_calibration_path, hostile_calibration)
+    try:
+        verify_calibration_bundle(
+            hostile_calibration_path,
+            frozen_measurement_contract,
+            enforce_source_lineage=False,
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("calibration repeated model materialization after run one")
+
+    hostile_calibration = json.loads(json.dumps(calibration_bundle_payload))
+    hostile_calibration["qualification_thresholds"] = {
+        "warm_query_ipc": 1,
+    }
+    write_json(hostile_calibration_path, hostile_calibration)
+    try:
+        verify_calibration_bundle(
+            hostile_calibration_path,
+            frozen_measurement_contract,
+            enforce_source_lineage=False,
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("calibration bundle was allowed to select thresholds")
+
+
+def _constant_collector_driver_tests(
+    fixture: FullStackFixture,
+    calibration: CalibrationFixture,
+) -> None:
+    protocol = calibration.frozen_measurement_contract["measurement_protocol"]
+    measurement_contract = calibration.frozen_measurement_contract
+    cell_id, cell = next(iter(protocol["calibration_matrix"].items()))
+    private_root = fixture.root / "constant-driver"
+    private_root.mkdir()
+    package = calibration.bundle_payload["runs"][0]["package"]
+    driver_package = {
+        key: package[key]
+        for key in (
+            "archive_sha256",
+            "executable_sha256",
+            "asset_target",
+            "release_version",
+            "model_sha256",
+        )
+    }
+    driver_contracts = {
+        "protocol_sha256": measurement_contract["protocol_sha256"],
+        "constant_set_sha256": measurement_contract["constant_set_sha256"],
+        "measurement_protocol_sha256": measurement_contract[
+            "measurement_protocol_sha256"
+        ],
+    }
+    request = {
+        "schema_version": 1,
+        "source": fixture.manifest["source"],
+        "package": driver_package,
+        "contracts": driver_contracts,
+        "runtime": {
+            "engine_policy": "accelerated",
+            "expected_backend": cell["backend"],
+            "offline": True,
+            "matrix_cell_id": cell_id,
+            "cache_state": cell["cache_state"],
+            "residency_state": cell["residency_state"],
+        },
+    }
+    request_path = private_root / "request.json"
+    write_json(request_path, request)
+    summaries = []
+    for run in calibration.bundle_payload["runs"]:
+        run_index = run["run_index"]
+        metrics = run["raw_artifact"]["payload"]["metrics"]
+        identity = next(iter(metrics.values()))["samples"][0]["server_identity"]
+        artifact_name = f"constant-calibration-run-{run_index}.raw.json"
+        raw = {
+            "schema_version": 1,
+            "run_index": run_index,
+            "contracts": driver_contracts,
+            "metrics": metrics,
+            "server_identities": [identity],
+            "backend": cell["backend"],
+            "policy": "accelerated",
+            "model_sha256": package["model_sha256"],
+            "materialized_reused": run_index > 1,
+        }
+        write_json(private_root / artifact_name, raw)
+        summaries.append(
+            {
+                "run_index": run_index,
+                "measurements": {
+                    "artifact": artifact_name,
+                    "metric_count": 9,
+                    "sample_count": 9,
+                },
+                "server_identities": [identity],
+                "backend": cell["backend"],
+                "policy": "accelerated",
+                "model_sha256": package["model_sha256"],
+                "materialized_reused": run_index > 1,
+            }
+        )
+    output = {
+        "schema_version": 1,
+        "source": request["source"],
+        "package": driver_package,
+        "contracts": driver_contracts,
+        "runtime": request["runtime"],
+        "request_sha256": sha256(request_path),
+        "calibration_runs": summaries,
+    }
+    validated = _validate_driver_output(
+        output,
+        request=request,
+        request_path=request_path,
+        private_root=private_root,
+        protocol=protocol,
+        matrix_cell=cell,
+    )
+    require(
+        len(validated) == 3,
+        "constant-calibration driver output did not retain three clean runs",
+    )
+
+    hostile = json.loads(json.dumps(output))
+    hostile["calibration_runs"][0]["backend"] = "cpu"
+    try:
+        _validate_driver_output(
+            hostile,
+            request=request,
+            request_path=request_path,
+            private_root=private_root,
+            protocol=protocol,
+            matrix_cell=cell,
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("constant-calibration driver output accepted CPU")
+
+    raw_path = private_root / "constant-calibration-run-1.raw.json"
+    raw = json.loads(raw_path.read_text(encoding="utf-8"))
+    raw["metrics"]["true_idle_exit"] = json.loads(
+        json.dumps(raw["metrics"]["warm_query_ipc"])
+    )
+    write_json(raw_path, raw)
+    try:
+        _validate_driver_output(
+            output,
+            request=request,
+            request_path=request_path,
+            private_root=private_root,
+            protocol=protocol,
+            matrix_cell=cell,
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure(
+            "constant-calibration driver output accepted a qualification-only metric"
+        )
 
 
 def run_calibration_self_tests(fixture: FullStackFixture) -> dict:
@@ -357,4 +588,5 @@ def run_calibration_self_tests(fixture: FullStackFixture) -> dict:
     calibration = _calibration_bundle_tests(fixture, measurement_contract)
     _measurement_window_semantics_tests(fixture, calibration)
     _calibration_hostile_tests(fixture, calibration)
+    _constant_collector_driver_tests(fixture, calibration)
     return measurement_contract

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_external.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_external.py
@@ -529,6 +529,20 @@ def _quality_hostiles(
         pass
     else:
         raise ProofFailure("stale retrieval quality source tree was accepted")
+    hostile_quality = json.loads(json.dumps(quality_payload))
+    hostile_quality["release_evidence"]["rows"][0][
+        "codestory_cache_provenance"
+    ]["embedding_policy"] = "cpu_explicit"
+    write_json(quality_path, hostile_quality)
+    try:
+        verify_retrieval_quality_raw_evidence(
+            quality_path,
+            source=manifest["source"],
+        )
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure("CPU-backed retrieval quality evidence was accepted")
     write_json(quality_path, quality_payload)
     try:
         verify_package_server_contracts(

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_fixture.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_fixture.py
@@ -58,9 +58,6 @@ def _prepare_contract_files(root: Path) -> tuple[Path, Path, Path]:
     unfrozen_constant_set["calibration_required_values"] = {
         field: None for field in unfrozen_constant_set["calibration_required_values"]
     }
-    unfrozen_constant_set["qualification_thresholds"] = {
-        field: None for field in unfrozen_constant_set["qualification_thresholds"]
-    }
     unfrozen_constant_set["freeze_record"] = None
     write_json(self_constant_set, unfrozen_constant_set)
     self_measurement_protocol = root / MEASUREMENT_PROTOCOL.name
@@ -205,7 +202,7 @@ def _native_manifest(contract: NativeContractFixture) -> dict:
         "embedding": contract.embedding,
         "tokenizer_config": contract.tokenizer,
         "accelerator": {
-            "cpu_fallback": "explicit_only",
+            "cpu_fallback": "unsupported",
             "package_claim": "compiled_capability_only",
             "runtime_execution": "not_proven_by_package",
             "expected_protected_backend": "metal",

--- a/.github/scripts/packaged_agent_proof/self_test_process_exit.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process_exit.py
@@ -61,7 +61,10 @@ def _exit_budget_tests() -> dict[str, int]:
         manifest,
         {
             "status": "frozen",
-            "qualification_thresholds": {"true_idle_exit": 72_285},
+            "fixed_contract_values": {
+                "idle_timeout_ms": 60_000,
+                "true_idle_observation_grace_ms": 2_500,
+            },
         },
     )
     require(
@@ -83,8 +86,21 @@ def _exit_budget_tests() -> dict[str, int]:
     )
     for hostile in (
         {"status": "frozen"},
-        {"status": "frozen", "qualification_thresholds": {"true_idle_exit": None}},
-        {"status": "frozen", "qualification_thresholds": {"true_idle_exit": 120_001}},
+        {"status": "frozen", "fixed_contract_values": {}},
+        {
+            "status": "frozen",
+            "fixed_contract_values": {
+                "idle_timeout_ms": 60_000,
+                "true_idle_observation_grace_ms": None,
+            },
+        },
+        {
+            "status": "frozen",
+            "fixed_contract_values": {
+                "idle_timeout_ms": 60_000,
+                "true_idle_observation_grace_ms": 60_001,
+            },
+        },
     ):
         try:
             native_server_exit_wait_budget(manifest, hostile)

--- a/.github/scripts/packaged_agent_proof/server_cleanup.py
+++ b/.github/scripts/packaged_agent_proof/server_cleanup.py
@@ -97,28 +97,34 @@ def native_server_exit_wait_budget(manifest: dict, constant_set: dict) -> dict:
     # -- the calibration matrix has no Windows cell, and since the drain-time
     # release the calibrated true_idle_exit threshold ends at owner absence
     # rather than process exit -- so the conservative grace frozen by #1397
-    # stays. The frozen threshold still binds this budget as a floor: the
-    # receipt must never hold the exact process to a bound tighter than the
-    # whole-idle-exit claim the release itself makes.
+    # stays. The fixed product timeout plus its explicit observation grace
+    # binds this budget as a floor: calibration never selects this threshold.
     timeout_ms = product_idle_timeout_ms + NATIVE_SERVER_TEARDOWN_GRACE_MS
     require(
         isinstance(constant_set, dict),
         "native server exit-wait budget requires the verified constant set",
     )
     if constant_set.get("status") == "frozen":
-        thresholds = constant_set.get("qualification_thresholds")
+        fixed = constant_set.get("fixed_contract_values")
         require(
-            isinstance(thresholds, dict),
-            "frozen embedding server constants omit qualification thresholds",
+            isinstance(fixed, dict),
+            "frozen embedding server constants omit fixed contract values",
         )
-        true_idle_exit_ms = require_positive_int(
-            thresholds.get("true_idle_exit"),
-            "frozen true-idle exit qualification threshold",
+        fixed_idle_timeout_ms = require_positive_int(
+            fixed.get("idle_timeout_ms"),
+            "fixed true-idle product timeout",
+        )
+        true_idle_observation_grace_ms = require_positive_int(
+            fixed.get("true_idle_observation_grace_ms"),
+            "fixed true-idle observation grace",
+        )
+        true_idle_exit_ms = (
+            fixed_idle_timeout_ms + true_idle_observation_grace_ms
         )
         require(
             timeout_ms >= true_idle_exit_ms,
             f"native server exit-wait bound {timeout_ms}ms is tighter than the"
-            f" frozen {true_idle_exit_ms}ms true-idle exit claim",
+            f" fixed {true_idle_exit_ms}ms true-idle exit contract",
         )
     return {
         "product_idle_timeout_ms": product_idle_timeout_ms,

--- a/.github/scripts/packaged_agent_proof/server_engine_identity.py
+++ b/.github/scripts/packaged_agent_proof/server_engine_identity.py
@@ -67,8 +67,8 @@ def _verify_engine_core(
         f"software adapter is not allowed: {adapter}",
     )
     require(
-        fields["embedding_policy"] in {"accelerated", "cpu_explicit"},
-        "status lacks an explicit embedding policy",
+        fields["embedding_policy"] == "accelerated",
+        "status lacks the required accelerated embedding policy",
     )
     require(
         bool(fields["embedding_engine_instance_id"]),

--- a/.github/workflows/linux-vulkan-proof.yml
+++ b/.github/workflows/linux-vulkan-proof.yml
@@ -18,6 +18,16 @@ on:
         required: false
         default: ""
         type: string
+      quality_evidence_artifact:
+        description: Exact-head protected Metal quality artifact.
+        required: false
+        default: ""
+        type: string
+      quality_evidence_run_id:
+        description: Workflow run that produced the protected Metal quality artifact.
+        required: false
+        default: ""
+        type: string
       calibration_bundle_artifact:
         required: false
         default: ""
@@ -57,8 +67,19 @@ on:
         required: false
         type: string
       package_run_id:
-        description: Upstream packaged-platform run containing codestory-cli-linux-x64.
-        required: true
+        description: Upstream packaged-platform run containing codestory-cli-linux-x64; omitted for standalone constant calibration.
+        required: false
+        default: ""
+        type: string
+      quality_evidence_artifact:
+        description: Exact-head protected Metal quality artifact.
+        required: false
+        default: ""
+        type: string
+      quality_evidence_run_id:
+        description: Workflow run that produced the protected Metal quality artifact.
+        required: false
+        default: ""
         type: string
       calibration_bundle_artifact:
         required: false
@@ -83,6 +104,11 @@ on:
         required: false
         default: true
         type: boolean
+      constant_calibration_mode:
+        description: Collect optional Linux Vulkan constant-calibration evidence without feeding the frozen bundle.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -93,7 +119,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  route:
+    name: Validate Linux proof dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require an upstream package for standalone protected proof
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CONSTANT_CALIBRATION_MODE: ${{ inputs.constant_calibration_mode }}
+          PACKAGE_RUN_ID: ${{ inputs.package_run_id }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$CONSTANT_CALIBRATION_MODE" != true ]; then
+            test -n "$PACKAGE_RUN_ID"
+          fi
+
   packaged-vulkan:
+    if: ${{ !inputs.constant_calibration_mode }}
+    needs: route
     name: Packaged Linux Vulkan engine
     runs-on: [self-hosted, Linux, X64, codestory-linux-vulkan]
     environment: linux-vulkan-proof
@@ -109,6 +154,13 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.13"
+
+      - name: Install pinned Rust for frozen-candidate qualification
+        if: ${{ !inputs.server_behavior_only }}
+        shell: bash
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
 
       - name: Capture Linux Vulkan host evidence
         shell: bash
@@ -171,6 +223,46 @@ jobs:
           run-id: ${{ inputs.calibration_bundle_run_id }}
           github-token: ${{ github.token }}
 
+      - name: Build qualification driver
+        if: ${{ !inputs.server_behavior_only }}
+        shell: bash
+        run: cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification
+
+      - name: Authenticate protected Metal quality producer
+        if: ${{ !inputs.server_behavior_only }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          QUALITY_ARTIFACT: ${{ inputs.quality_evidence_artifact }}
+          QUALITY_RUN_ID: ${{ inputs.quality_evidence_run_id }}
+        run: |
+          set -euo pipefail
+          test -n "$QUALITY_ARTIFACT"
+          test -n "$QUALITY_RUN_ID"
+          run="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$QUALITY_RUN_ID")"
+          producer_sha="$(jq -r '.head_sha' <<<"$run")"
+          test "$(jq -r '.head_repository.full_name' <<<"$run")" = "$GITHUB_REPOSITORY"
+          test "$(jq -r '.path' <<<"$run")" = ".github/workflows/packaged-platform-pr.yml"
+          test "$(jq -r '.event' <<<"$run")" = workflow_dispatch
+          test "$(jq -r '.conclusion' <<<"$run")" = success
+          test "$producer_sha" = "$(git rev-parse HEAD)"
+          test "$QUALITY_ARTIFACT" = "frozen-candidate-quality-$producer_sha"
+          artifact_count="$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$QUALITY_RUN_ID/artifacts?per_page=100" \
+              | jq --arg name "$QUALITY_ARTIFACT" \
+                '[.artifacts[] | select(.name == $name and .expired == false)] | length'
+          )"
+          test "$artifact_count" = 1
+
+      - name: Download exact-head protected Metal quality evidence
+        if: ${{ !inputs.server_behavior_only }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ inputs.quality_evidence_artifact }}
+          path: target/release-quality-evidence
+          run-id: ${{ inputs.quality_evidence_run_id }}
+          github-token: ${{ github.token }}
+
       - name: Prove offline Linux Vulkan retrieval
         if: ${{ !inputs.candidate_installed_proof }}
         shell: bash
@@ -188,12 +280,22 @@ jobs:
           source_sha="$(git rev-parse HEAD)"
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           claim_args=()
+          quality_args=()
+          qualification_args=()
           calibration_args=()
           if [ "$SERVER_BEHAVIOR_ONLY" = true ]; then
             claim_args=(--server-behavior-only)
           else
             calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
             test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+            quality_path=target/release-quality-evidence/packet/packet-runtime-summary.json
+            test -f "$quality_path"
+            quality_args=(--retrieval-quality-evidence "$quality_path")
+            qualification_args=(
+              --produce-qualification-evidence
+              --qualification-driver target/release/codestory_embedding_qualification
+              --qualification-evidence target/linux-vulkan-proof/qualification.json
+            )
             calibration_args=(
               --calibration-bundle "$calibration_bundle"
               --calibration-producer-run-id "$CALIBRATION_RUN_ID"
@@ -213,9 +315,11 @@ jobs:
             --proof-tier protected_hardware \
             --qualification-matrix-cell protected_linux_x64_vulkan \
             "${claim_args[@]}" \
+            "${qualification_args[@]}" \
             "${calibration_args[@]}" \
             --expected-source-sha "$source_sha" \
             --expected-source-tree "$source_tree" \
+            "${quality_args[@]}" \
             --timeout-secs 1800 \
             --out-dir target/linux-vulkan-proof/packaged-agent
 
@@ -402,4 +506,107 @@ jobs:
           name: linux-x64-vulkan-proof-${{ inputs.version }}-attempt-${{ github.run_attempt }}
           path: target/linux-vulkan-proof
           if-no-files-found: error
+          retention-days: 30
+
+  optional-constant-calibration:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.constant_calibration_mode }}
+    needs: route
+    name: Optional Linux Vulkan constant calibration
+    runs-on: [self-hosted, Linux, X64, codestory-linux-vulkan]
+    environment: linux-vulkan-proof
+    timeout-minutes: 180
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Install pinned Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install pinned Rust
+        shell: bash
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Capture optional Linux Vulkan calibration host evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/linux-vulkan-calibration
+          {
+            uname -a
+            uname -m
+            lscpu
+            command -v vulkaninfo
+            vulkaninfo --summary
+          } > target/linux-vulkan-calibration/host.txt 2>&1
+          test "$(uname -m)" = x86_64
+
+      - name: Prepare checksum-pinned embedded model
+        run: node scripts/prepare-embedded-model.mjs
+
+      - name: Build and package native CLI and constant driver
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          cargo build --release --locked \
+            -p codestory-cli \
+            --bin codestory-cli \
+            --bin codestory-cli-runtime \
+            -p codestory-bench \
+            --bin codestory_embedding_constant_calibration
+          python .github/scripts/package-codestory-release.py \
+            --version "$version" \
+            --target linux-x64 \
+            --binary target/release/codestory-cli \
+            --out-dir target/release-dist
+
+      - name: Collect optional Linux Vulkan constant calibration
+        shell: bash
+        env:
+          CODESTORY_EMBED_ALLOW_CPU: "0"
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = workflow_dispatch
+          test "$(jq -r .status crates/codestory-llama-sys/per-user-embedding-server-constant-set.json)" = unfrozen
+          version="${INPUT_VERSION#v}"
+          source_sha="$(git rev-parse HEAD)"
+          source_tree="$(git rev-parse 'HEAD^{tree}')"
+          mkdir -p target/calibration-runs/linux-vulkan
+          python .github/scripts/check-packaged-agent-proof.py \
+            --archive "target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz" \
+            --checksum-file target/release-dist/SHA256SUMS.txt \
+            --expected-version "$version" \
+            --engine-policy accelerated \
+            --expected-backend Vulkan \
+            --offline \
+            --proof-tier calibration \
+            --qualification-matrix-cell protected_linux_x64_vulkan \
+            --collect-constant-calibration \
+            --constant-calibration-output-dir target/calibration-runs/linux-vulkan \
+            --qualification-driver target/release/codestory_embedding_constant_calibration \
+            --expected-source-sha "$source_sha" \
+            --expected-source-tree "$source_tree" \
+            --timeout-secs 1800 \
+            --out-dir target/calibration-proof/linux-vulkan
+
+      - name: Upload optional Linux Vulkan calibration evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: optional-embedding-calibration-linux-vulkan-${{ inputs.version }}-attempt-${{ github.run_attempt }}
+          path: |
+            target/calibration-runs/linux-vulkan
+            target/calibration-proof/linux-vulkan
+            target/linux-vulkan-calibration
+          if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -168,24 +168,55 @@ jobs:
           rustup toolchain install 1.95.0 --profile minimal
           rustup default 1.95.0
 
+      - name: Start Metal constant calibration clock
+        if: inputs.calibration_mode
+        id: calibration-clock
+        shell: bash
+        run: echo "started-ns=$(python3 -c 'import time; print(time.monotonic_ns())')" >> "$GITHUB_OUTPUT"
+
       - name: Prepare checksum-pinned embedded model
+        id: model-prepare
         if: ${{ !inputs.use_packaged_cli_artifact }}
-        run: node scripts/prepare-embedded-model.mjs
+        shell: bash
+        run: |
+          set -euo pipefail
+          model_prepare_started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          node scripts/prepare-embedded-model.mjs
+          model_prepare_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          echo "duration-ms=$(((model_prepare_finished_ns - model_prepare_started_ns) / 1000000))" \
+            >> "$GITHUB_OUTPUT"
 
       - name: Build and package native CLI
+        id: native-build-package
         if: ${{ !inputs.use_packaged_cli_artifact }}
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
+          CALIBRATION_MODE: ${{ inputs.calibration_mode }}
         run: |
           set -euo pipefail
+          build_package_started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
           version="${VERSION#v}"
-          cargo build --release -p codestory-cli --locked
+          cargo_args=(
+            -p codestory-cli
+            --bin codestory-cli
+            --bin codestory-cli-runtime
+          )
+          if [ "$CALIBRATION_MODE" = true ]; then
+            cargo_args+=(
+              -p codestory-bench
+              --bin codestory_embedding_constant_calibration
+            )
+          fi
+          cargo build --release --locked "${cargo_args[@]}"
           python3 .github/scripts/package-codestory-release.py \
             --version "$version" \
             --target macos-arm64 \
             --binary target/release/codestory-cli \
             --out-dir target/release-dist
+          build_package_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          echo "duration-ms=$(((build_package_finished_ns - build_package_started_ns) / 1000000))" \
+            >> "$GITHUB_OUTPUT"
 
       - name: Download packaged CLI artifact
         if: inputs.use_packaged_cli_artifact
@@ -267,7 +298,7 @@ jobs:
           ditto -x -k "$archive" target/release-dist
 
       - name: Build qualification driver
-        if: inputs.calibration_mode || !inputs.server_behavior_only
+        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only }}
         shell: bash
         run: cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification
 
@@ -277,6 +308,64 @@ jobs:
         with:
           name: ${{ inputs.quality_evidence_artifact }}
           path: target/release-quality-evidence
+
+      - name: Produce exact-head holdout quality on protected Metal
+        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only && inputs.quality_evidence_artifact == '' }}
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          CODESTORY_EMBED_ALLOW_CPU: "0"
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          archive="target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz"
+          quality_root=target/release-quality-evidence
+          packaged_root="$(mktemp -d "$RUNNER_TEMP/codestory-quality-cli.XXXXXX")"
+          export CODESTORY_CACHE_ROOT
+          CODESTORY_CACHE_ROOT="$(mktemp -d "$RUNNER_TEMP/codestory-quality-cache.XXXXXX")"
+          export CODESTORY_STDIO_CACHE_ROOT
+          CODESTORY_STDIO_CACHE_ROOT="$(mktemp -d "$RUNNER_TEMP/codestory-quality-stdio.XXXXXX")"
+          rm -rf "$quality_root"
+          mkdir -p "$quality_root"
+          tar -xzf "$archive" -C "$packaged_root"
+          packaged_cli="$(
+            find "$packaged_root" -type f -name codestory-cli -print
+          )"
+          test "$(printf '%s\n' "$packaged_cli" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          test -x "$packaged_cli"
+          export CODESTORY_RELEASE_EVIDENCE_COMMIT
+          CODESTORY_RELEASE_EVIDENCE_COMMIT="$(git rev-parse HEAD)"
+          export CODESTORY_RELEASE_EVIDENCE_TREE
+          CODESTORY_RELEASE_EVIDENCE_TREE="$(git rev-parse 'HEAD^{tree}')"
+          export CODESTORY_RELEASE_EVIDENCE_PROFILE=protected-macos-arm64-metal
+          export CODESTORY_RELEASE_EVIDENCE_CORPUS_ID=codestory-release-corpus-v1
+          export CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT=benchmarks/release-evidence/corpus-contracts/holdout-retrieval-v1.json
+          export CODESTORY_RELEASE_EVIDENCE_CACHE_ID=frozen-candidate-holdout-v1
+          export CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT
+          CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT="$(
+            shasum -a 256 target/macos-metal-proof/host.txt | awk '{print $1}'
+          )"
+          node scripts/codestory-agent-ab-benchmark.mjs \
+            --packet-runtime \
+            --packet-runtime-mode cold-cli \
+            --task-suite holdout-retrieval \
+            --materialize-repos \
+            --repeats 3 \
+            --publishable \
+            --max-source-reads-after-packet 0 \
+            --codestory-cli "$packaged_cli" \
+            --timeout-ms 180000 \
+            --out-dir "$quality_root/packet"
+
+      - name: Upload exact-head protected Metal quality evidence
+        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only && inputs.quality_evidence_artifact == '' }}
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: frozen-candidate-quality-${{ inputs.ref || github.sha }}
+          path: target/release-quality-evidence
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
 
       - name: Authenticate calibration bundle producer
         if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only }}
@@ -370,7 +459,7 @@ jobs:
             --timeout-secs 1800 \
             --out-dir target/macos-metal-proof/packaged-agent
 
-      - name: Collect three independent Metal calibration runs
+      - name: Collect three independent Metal constant calibration runs
         if: inputs.calibration_mode
         shell: bash
         env:
@@ -384,29 +473,73 @@ jobs:
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           export TMPDIR="${RUNNER_TEMP}/codestory metal calibration ü"
           mkdir -p "$TMPDIR" target/calibration-runs/macos
-          for run_index in 1 2 3; do
-            python3 .github/scripts/check-packaged-agent-proof.py \
-              --archive "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz" \
-              --checksum-file "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz.sha256" \
-              --expected-version "$version" \
-              --project "${{ github.workspace }}" \
-              --plugin-root plugins/codestory \
-              --plugin-handoff \
-              --engine-policy accelerated \
-              --expected-backend Metal \
-              --offline \
-              --proof-tier calibration \
-              --qualification-matrix-cell protected_macos_arm64_metal \
-              --produce-qualification-evidence \
-              --qualification-driver target/release/codestory_embedding_qualification \
-              --qualification-evidence "target/calibration-runs/macos/qualification-${run_index}.json" \
-              --calibration-run-index "$run_index" \
-              --calibration-run-output "target/calibration-runs/macos/run-${run_index}.json" \
-              --expected-source-sha "$source_sha" \
-              --expected-source-tree "$source_tree" \
-              --timeout-secs 1800 \
-              --out-dir "target/calibration-runs/macos/proof-${run_index}"
-          done
+          python3 .github/scripts/check-packaged-agent-proof.py \
+            --archive "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz" \
+            --checksum-file "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz.sha256" \
+            --expected-version "$version" \
+            --engine-policy accelerated \
+            --expected-backend Metal \
+            --offline \
+            --proof-tier calibration \
+            --qualification-matrix-cell protected_macos_arm64_metal \
+            --collect-constant-calibration \
+            --constant-calibration-output-dir target/calibration-runs/macos \
+            --qualification-driver target/release/codestory_embedding_constant_calibration \
+            --expected-source-sha "$source_sha" \
+            --expected-source-tree "$source_tree" \
+            --timeout-secs 1800 \
+            --out-dir target/calibration-proof/macos
+
+      - name: Publish Metal constant calibration timing
+        if: inputs.calibration_mode
+        shell: bash
+        env:
+          CALIBRATION_STARTED_NS: ${{ steps.calibration-clock.outputs.started-ns }}
+          MODEL_PREPARATION_DURATION_MS: ${{ steps.model-prepare.outputs.duration-ms }}
+          BUILD_PACKAGE_DURATION_MS: ${{ steps.native-build-package.outputs.duration-ms }}
+        run: |
+          set -euo pipefail
+          timing_path=target/calibration-runs/macos/timing.json
+          calibration_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          [[ "$CALIBRATION_STARTED_NS" =~ ^[0-9]+$ ]]
+          [[ "$MODEL_PREPARATION_DURATION_MS" =~ ^[0-9]+$ ]]
+          [[ "$BUILD_PACKAGE_DURATION_MS" =~ ^[0-9]+$ ]]
+          calibration_total_ms=$(((calibration_finished_ns - CALIBRATION_STARTED_NS) / 1000000))
+          test "$calibration_total_ms" -ge 0
+          test "$calibration_total_ms" -lt 600000
+          test "$BUILD_PACKAGE_DURATION_MS" -ge 0
+          jq -e '
+            .schema_version == 1
+            and all(
+              [
+                .archive_authentication_unpack_ms,
+                .project_and_request_setup_ms,
+                .measurement_ms,
+                .retention_validation_ms,
+                .end_to_end_ms
+              ][];
+              type == "number" and . >= 0
+            )
+          ' "$timing_path" >/dev/null
+          {
+            echo "### Metal constant calibration timing"
+            echo
+            echo "| Phase | Duration |"
+            echo "|---|---:|"
+            printf '| Model preparation | %s ms |\n' "$MODEL_PREPARATION_DURATION_MS"
+            printf '| Shared CLI build and package | %s ms |\n' "$BUILD_PACKAGE_DURATION_MS"
+            jq -r '
+              [
+                ["Archive authentication and unpack", .archive_authentication_unpack_ms],
+                ["Project and request setup", .project_and_request_setup_ms],
+                ["Measurement", .measurement_ms],
+                ["Retention validation", .retention_validation_ms],
+                ["Archive through retained evidence", .end_to_end_ms]
+              ][]
+              | "| \(.[0]) | \(.[1]) ms |"
+            ' "$timing_path"
+            printf '| Total calibration wall time | %s ms |\n' "$calibration_total_ms"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Stage isolated candidate-managed macOS install
         if: ${{ inputs.candidate_installed_proof && !inputs.calibration_mode }}

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -153,6 +153,10 @@ jobs:
               echo "::error::Calibration collection does not consume prior proof artifacts."
               exit 1
             fi
+          elif [ "$mode" = "qualification" ]; then
+            test -z "$INPUT_SOURCE_RUN_ID"
+            test -n "$INPUT_CALIBRATION_ARTIFACT"
+            test -n "$INPUT_CALIBRATION_RUN_ID"
           fi
           {
             echo "head_sha=$current_head"
@@ -264,17 +268,6 @@ jobs:
           python .github/scripts/check-codestory-release.py --version "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  calibration-linux:
-    if: needs.route.outputs.mode == 'calibration'
-    needs: route
-    uses: ./.github/workflows/packaged-platform-proof.yml
-    with:
-      version: ${{ needs.route.outputs.version }}
-      ref: ${{ needs.route.outputs.head_sha }}
-      scope: full
-      proof_key: calibration-linux-${{ needs.route.outputs.head_sha }}
-      calibration_mode: true
-
   calibration-macos:
     if: needs.route.outputs.mode == 'calibration'
     needs: route
@@ -291,11 +284,9 @@ jobs:
       always() &&
       needs.route.result == 'success' &&
       needs.route.outputs.mode == 'calibration' &&
-      needs.calibration-linux.result == 'success' &&
       needs.calibration-macos.result == 'success'
     needs:
       - route
-      - calibration-linux
       - calibration-macos
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -305,12 +296,6 @@ jobs:
         with:
           ref: ${{ needs.route.outputs.head_sha }}
           fetch-depth: 0
-
-      - name: Download hosted Linux calibration runs
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: embedding-calibration-linux-${{ needs.route.outputs.version }}
-          path: target/calibration-inputs/linux
 
       - name: Download protected macOS calibration runs
         uses: actions/download-artifact@v8.0.1
@@ -326,11 +311,11 @@ jobs:
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
           mapfile -t runs < <(
-            find target/calibration-inputs -type f \
+            find target/calibration-inputs/macos -type f \
               \( -name 'run-1.json' -o -name 'run-2.json' -o -name 'run-3.json' \) \
               -print | sort
           )
-          test "${#runs[@]}" = 6
+          test "${#runs[@]}" = 3
           run_args=()
           for run in "${runs[@]}"; do
             run_args+=(--calibration-run "$run")
@@ -365,8 +350,8 @@ jobs:
             --arg source_head_sha "$EXPECTED_HEAD_SHA" \
             --arg producer_run_id "$GITHUB_RUN_ID" \
             '.selection_source.commit == $source_head_sha
-             and .run_count == 6
-             and .matrix_cell_count == 2
+             and .run_count == 3
+             and .matrix_cell_count == 1
              and .producer_run_id == $producer_run_id' \
             target/calibration-freeze/manifest.json >/dev/null
 
@@ -417,7 +402,6 @@ jobs:
       proof_key: ${{ needs.route.outputs.proof_key }}
       sign_macos: false
       hermetic_linux: ${{ needs.route.outputs.mode == 'qualification' }}
-      quality_evidence_artifact: ""
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact || '' }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id || '' }}
 
@@ -440,9 +424,9 @@ jobs:
       quality_evidence_artifact: ""
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact || '' }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id || '' }}
-      candidate_installed_proof: true
+      candidate_installed_proof: ${{ needs.route.outputs.mode != 'qualification' }}
       candidate_producer_workflow_path: .github/workflows/packaged-platform-pr.yml
-      server_behavior_only: true
+      server_behavior_only: ${{ needs.route.outputs.mode != 'qualification' }}
 
   windows-vulkan-proof:
     if: >-
@@ -450,22 +434,24 @@ jobs:
       needs.route.result == 'success' &&
       needs.packaged-proof.result == 'success' &&
       needs.route.outputs.mode != 'package' &&
+      (needs.route.outputs.mode != 'qualification' || needs.macos-metal-proof.result == 'success') &&
       (needs.route.outputs.scope == 'windows' || needs.route.outputs.scope == 'full')
     needs:
       - route
       - packaged-proof
+      - macos-metal-proof
     uses: ./.github/workflows/windows-vulkan-proof.yml
     with:
       version: ${{ needs.route.outputs.version }}
       ref: ${{ needs.route.outputs.head_sha }}
       proof_key: ${{ needs.route.outputs.proof_key }}
       use_packaged_cli_artifact: true
-      quality_evidence_artifact: ""
+      quality_evidence_artifact: ${{ needs.route.outputs.mode == 'qualification' && format('frozen-candidate-quality-{0}', needs.route.outputs.head_sha) || '' }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact || '' }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id || '' }}
-      candidate_installed_proof: true
+      candidate_installed_proof: ${{ needs.route.outputs.mode != 'qualification' }}
       candidate_producer_workflow_path: .github/workflows/packaged-platform-pr.yml
-      server_behavior_only: true
+      server_behavior_only: ${{ needs.route.outputs.mode != 'qualification' }}
 
   linux-vulkan-proof:
     if: >-
@@ -473,6 +459,7 @@ jobs:
       needs.route.result == 'success' &&
       needs.packaged-proof.result == 'success' &&
       needs.route.outputs.mode != 'package' &&
+      needs.route.outputs.mode != 'qualification' &&
       (needs.route.outputs.scope == 'linux' || needs.route.outputs.scope == 'full')
     needs:
       - route
@@ -556,7 +543,11 @@ jobs:
             else
               require_result "$METAL_RESULT" success macos-metal-proof
               require_result "$WINDOWS_VULKAN_RESULT" success windows-vulkan-proof
-              require_result "$LINUX_VULKAN_RESULT" success linux-vulkan-proof
+              if [ "$MODE" = qualification ]; then
+                require_result "$LINUX_VULKAN_RESULT" skipped linux-vulkan-proof
+              else
+                require_result "$LINUX_VULKAN_RESULT" success linux-vulkan-proof
+              fi
             fi
           fi
           if [ "$MODE" = integration ]; then

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -26,11 +26,6 @@ on:
         required: false
         default: false
         type: boolean
-      quality_evidence_artifact:
-        description: Exact-head release-evidence artifact containing packet/packet-runtime-summary.json.
-        required: false
-        default: ""
-        type: string
       calibration_bundle_artifact:
         description: Frozen calibration bundle artifact name.
         required: false
@@ -41,11 +36,6 @@ on:
         required: false
         default: ""
         type: string
-      calibration_mode:
-        description: Collect the three independent hosted Linux calibration runs only.
-        required: false
-        default: false
-        type: boolean
       emit_release_cells:
         description: Emit authenticated package cells for the production release coordinator.
         required: false
@@ -96,13 +86,13 @@ jobs:
     # The six APPLE_* credentials are an environment-scoped release contract;
     # repository-only secrets are not the supported signing configuration.
     environment: ${{ inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 'macos-release-signing' || null }}
-    timeout-minutes: ${{ inputs.calibration_mode && 180 || (inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60) }}
+    timeout-minutes: ${{ inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60 }}
     strategy:
       fail-fast: false
       # GitHub applies matrix exclusions before includes, so an include-only
       # matrix must select the complete row set rather than trying to exclude
       # rows after the fact.
-      matrix: ${{ fromJSON(inputs.calibration_mode && '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"}]}' || inputs.scope == 'linux' && '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"}]}' || inputs.scope == 'windows' && '{"include":[{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"}]}' || inputs.scope == 'macos' && '{"include":[{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}' || '{"include":[{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"},{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"}]}') }}
+      matrix: ${{ fromJSON(inputs.scope == 'linux' && '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"}]}' || inputs.scope == 'windows' && '{"include":[{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"}]}' || inputs.scope == 'macos' && '{"include":[{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}' || '{"include":[{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"},{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"}]}') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -195,8 +185,6 @@ jobs:
         shell: bash
         env:
           EXACT_SHA: ${{ inputs.ref }}
-          CALIBRATION_MODE: ${{ inputs.calibration_mode }}
-          QUALITY_EVIDENCE_ARTIFACT: ${{ inputs.quality_evidence_artifact }}
         run: |
           set -euo pipefail
           rust_version="$(rustc -Vv | sed -n 's/^release: //p')"
@@ -209,13 +197,9 @@ jobs:
             --relevant-input crates/codestory-llama-sys/model-contract.json
             --relevant-input scripts/prepare-embedded-model.mjs
           )
-          qualification_driver=disabled
-          if [ "$CALIBRATION_MODE" = true ] || [ -n "$QUALITY_EVIDENCE_ARTIFACT" ]; then
-            qualification_driver=enabled
-          fi
           extra_identity=(
             --identity cargo_incremental=0
-            --identity "qualification_driver=$qualification_driver"
+            --identity qualification_driver=disabled
           )
           while IFS= read -r manifest; do
             relevant_inputs+=(--relevant-input "$manifest")
@@ -402,11 +386,6 @@ jobs:
           cp "target/glibc-2.31/${{ matrix.rust_target }}/release/codestory-native-runtime-files-v1.txt" \
             "target/${{ matrix.rust_target }}/release/codestory-native-runtime-files-v1.txt"
 
-      - name: Build qualification driver
-        id: qualification-driver
-        if: matrix.asset_target == 'linux-x64' && (inputs.calibration_mode || inputs.quality_evidence_artifact != '')
-        run: cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification
-
       - name: Stop compilation clock
         id: compile-clock-stop
         if: >-
@@ -421,11 +400,7 @@ jobs:
         if: >-
           always() &&
           (
-            (
-              matrix.asset_target == 'linux-x64' &&
-              steps.linux-build.outcome == 'success' &&
-              steps.qualification-driver.outcome != 'skipped'
-            ) ||
+            (matrix.asset_target == 'linux-x64' && steps.linux-build.outcome == 'success') ||
             (matrix.asset_target != 'linux-x64' && steps.package-build.outcome == 'success')
           )
         shell: bash
@@ -799,21 +774,9 @@ jobs:
             --version-only \
             --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
 
-      - name: Download exact-head publishable packet quality evidence
-        if: matrix.asset_target == 'linux-x64' && inputs.quality_evidence_artifact != ''
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: ${{ inputs.quality_evidence_artifact }}
-          path: target/release-quality-evidence
-
       - name: Authenticate calibration bundle producer
-        # Gated on the bundle itself, not on optional release evidence. The
-        # frozen-candidate qualification lane is the only caller that names a
-        # bundle, and it is forbidden from carrying release evidence, so
-        # gating these steps on quality evidence made them unreachable.
         if: >-
           matrix.asset_target == 'linux-x64' &&
-          !inputs.calibration_mode &&
           inputs.calibration_bundle_artifact != ''
         shell: bash
         env:
@@ -839,7 +802,6 @@ jobs:
       - name: Download frozen calibration bundle
         if: >-
           matrix.asset_target == 'linux-x64' &&
-          !inputs.calibration_mode &&
           inputs.calibration_bundle_artifact != ''
         uses: actions/download-artifact@v8.0.1
         with:
@@ -849,12 +811,8 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Prove frozen calibration source lineage
-        # This is the reachable half of the freeze proof. The full frozen
-        # hosted_package qualification below additionally requires the optional
-        # exact-head release-evidence packet, which the frozen-candidate
-        # coordinator is forbidden to pass, so that invocation never runs. The
-        # source-lineage guard needs none of that: it needs the authenticated
-        # bundle and full history, both of which the qualification lane has.
+        # The source-lineage guard needs the authenticated bundle and full
+        # history from the frozen-candidate qualification lane.
         # --version-only stops before the runtime proof but still loads and
         # verifies the bundle, and without --enforce-calibration-freeze-lineage
         # a version-only proof *rejects* calibration inputs outright -- so
@@ -862,7 +820,6 @@ jobs:
         # dropping the guard.
         if: >-
           matrix.asset_target == 'linux-x64' &&
-          !inputs.calibration_mode &&
           inputs.calibration_bundle_artifact != ''
         shell: bash
         env:
@@ -894,109 +851,11 @@ jobs:
         if: >-
           always() &&
           matrix.asset_target == 'linux-x64' &&
-          !inputs.calibration_mode &&
           inputs.calibration_bundle_artifact != ''
         uses: actions/upload-artifact@v7.0.1
         with:
           name: packaged-calibration-lineage-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
           path: target/packaged-calibration-lineage
-          if-no-files-found: warn
-          retention-days: 30
-
-      - name: Packaged per-user server calibration or qualification
-        if: >-
-          matrix.asset_target == 'linux-x64' &&
-          (inputs.calibration_mode ||
-            inputs.quality_evidence_artifact != '')
-        shell: bash
-        env:
-          CODESTORY_EMBED_ALLOW_CPU: "1"
-          CALIBRATION_MODE: ${{ inputs.calibration_mode }}
-          INPUT_VERSION: ${{ inputs.version }}
-          CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
-          CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
-        run: |
-          set -euo pipefail
-          source_sha="$(git rev-parse HEAD)"
-          source_tree="$(git rev-parse 'HEAD^{tree}')"
-          common_args=(
-            --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.tar.gz"
-            --checksum-file target/release-dist/SHA256SUMS.txt
-            --expected-version "$INPUT_VERSION"
-            --project "${{ github.workspace }}"
-            --plugin-root plugins/codestory
-            --plugin-handoff
-            --engine-policy cpu_explicit
-            --expected-backend CPU
-            --offline
-            --qualification-matrix-cell hosted_linux_x64_cpu
-            --expected-source-sha "$source_sha"
-            --expected-source-tree "$source_tree"
-            --timeout-secs 1800
-          )
-          if [ "$CALIBRATION_MODE" = true ]; then
-            test "$(jq -r .status crates/codestory-llama-sys/per-user-embedding-server-constant-set.json)" = unfrozen
-            mkdir -p target/calibration-runs/linux
-            for run_index in 1 2 3; do
-              python .github/scripts/check-packaged-agent-proof.py \
-                "${common_args[@]}" \
-                --proof-tier calibration \
-                --produce-qualification-evidence \
-                --qualification-driver target/release/codestory_embedding_qualification \
-                --calibration-run-index "$run_index" \
-                --calibration-run-output "target/calibration-runs/linux/run-${run_index}.json" \
-                --qualification-evidence "target/calibration-runs/linux/qualification-${run_index}.json" \
-                --out-dir "target/calibration-runs/linux/proof-${run_index}"
-            done
-            exit 0
-          fi
-          test "$(jq -r .status crates/codestory-llama-sys/per-user-embedding-server-constant-set.json)" = frozen
-          calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
-          test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
-          quality_path="target/release-quality-evidence/packet/packet-runtime-summary.json"
-          test -f "$quality_path"
-          python .github/scripts/check-packaged-agent-proof.py \
-            "${common_args[@]}" \
-            --proof-tier hosted_package \
-            --produce-qualification-evidence \
-            --qualification-driver target/release/codestory_embedding_qualification \
-            --qualification-evidence target/packaged-agent-proof/qualification.json \
-            --calibration-bundle "$calibration_bundle" \
-            --calibration-producer-run-id "$CALIBRATION_RUN_ID" \
-            --calibration-producer-artifact "$CALIBRATION_ARTIFACT" \
-            --enforce-calibration-freeze-lineage \
-            --retrieval-quality-evidence "$quality_path" \
-            --out-dir target/packaged-agent-proof
-
-      - name: Upload hosted Linux calibration runs
-        if: success() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: embedding-calibration-linux-${{ inputs.version }}
-          path: target/calibration-runs/linux
-          if-no-files-found: error
-          retention-days: 30
-          overwrite: true
-
-      - name: Upload hosted Linux calibration failure evidence
-        if: failure() && matrix.asset_target == 'linux-x64' && inputs.calibration_mode
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: embedding-calibration-linux-failure-evidence-attempt-${{ github.run_attempt }}
-          path: target/calibration-runs/linux
-          if-no-files-found: warn
-          retention-days: 30
-
-      - name: Upload packaged agent proof artifacts
-        if: >-
-          always() &&
-          matrix.asset_target == 'linux-x64' &&
-          (inputs.calibration_mode ||
-            inputs.quality_evidence_artifact != '')
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: packaged-agent-proof-${{ matrix.asset_target }}-attempt-${{ github.run_attempt }}
-          path: target/packaged-agent-proof
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -92,7 +92,7 @@ jobs:
           CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-inprocess-v1
           CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
           CODESTORY_REAL_REPO_DRILL_CASES: ${{ inputs.drill_manifest }}
-          CODESTORY_EMBED_ALLOW_CPU: "1"
+          CODESTORY_EMBED_ALLOW_CPU: "0"
         run: |
           set -euo pipefail
           cargo test --locked -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture --test-threads=1 \
@@ -108,7 +108,7 @@ jobs:
           CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT: benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json
           CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-inprocess-v1
           CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
-          CODESTORY_EMBED_ALLOW_CPU: "1"
+          CODESTORY_EMBED_ALLOW_CPU: "0"
         run: |
           set -euo pipefail
           CODESTORY_RELEASE_EVIDENCE_TREE="$(git rev-parse 'HEAD^{tree}')"

--- a/.github/workflows/retrieval-engine-smoke.yml
+++ b/.github/workflows/retrieval-engine-smoke.yml
@@ -1,5 +1,6 @@
-# Retrieval smoke: hosted jobs use the explicit CPU policy. Hardware workflows
-# own Metal and Vulkan claims.
+# Retrieval smoke: hosted jobs may use the test-only CPU fixture seam to
+# exercise CPU-shaped failure boundaries. It is not a product CPU mode and
+# makes no hardware claim; protected workflows own Metal and Vulkan proof.
 # Contract: docs/ops/retrieval-engine.md#proof-boundary
 
 name: retrieval-engine-smoke
@@ -105,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      CODESTORY_EMBED_ALLOW_CPU: "1"
+      CODESTORY_TEST_EMBED_ALLOW_CPU: "1"
     steps:
       - uses: actions/checkout@v5
 
@@ -194,7 +195,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     env:
-      CODESTORY_EMBED_ALLOW_CPU: "1"
+      CODESTORY_TEST_EMBED_ALLOW_CPU: "1"
       CMAKE_GENERATOR: Ninja
     steps:
       - uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,14 @@ adapter to compensate for incorrect upstream state.
   recalibrate on the bumped tree, never to widen the allowed path set. Any other
   commit -- a doc fix, a CI tweak, a rebase -- between calibration and the
   package also fails, so recalibrate rather than reorder history.
+- CPU embeddings are unsupported. Calibration and release-proof execution must
+  use `accelerated` policy with CPU fallback disabled. Runtime-constant
+  calibration requires exactly three fresh protected Apple Silicon Metal runs
+  with one sample per metric per run. Optional Linux Vulkan calibration is a
+  standalone, non-selecting diagnostic; it never joins or blocks calibration
+  assembly. Calibration freezes runtime constants only. Lifecycle, fault,
+  true-idle, memory, retrieval-quality, and accelerator qualification run later
+  against the frozen candidate.
 - Validate release changes with
   `python .github/scripts/check-codestory-release.py --version <version>` and
   `node .github/scripts/check-workflow-policy.mjs`.

--- a/benchmarks/release-evidence/corpus-contracts/holdout-retrieval-v1.json
+++ b/benchmarks/release-evidence/corpus-contracts/holdout-retrieval-v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "corpus_id": "codestory-release-corpus-v1",
+  "task_ids": [
+    "axios-request-dispatch",
+    "redis-server-event-loop",
+    "ripgrep-search-pipeline"
+  ],
+  "runtime_modes": [
+    "cold_cli_packet"
+  ],
+  "repeats": 3,
+  "task_manifests": {
+    "axios-request-dispatch": {
+      "path": "benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json",
+      "sha256": "3dfb002f0dd0b0683c8bca2314a405dc0d728aeeb8533247a6b17e316aed81c0"
+    },
+    "redis-server-event-loop": {
+      "path": "benchmarks/tasks/holdout-retrieval/redis-server-event-loop.task.json",
+      "sha256": "b8f928d796d1094ac3bc7c4e9ba21ff048d85f15dd69bd9153a574503dc54d5e"
+    },
+    "ripgrep-search-pipeline": {
+      "path": "benchmarks/tasks/holdout-retrieval/ripgrep-search-pipeline.task.json",
+      "sha256": "3b3f1c803a062c7aa532c4152eaa16279c77cb920bf42134e495273b1ac94422"
+    }
+  },
+  "project_manifests": {
+    "ripgrep-search-pipeline": {
+      "path": "benchmarks/tasks/holdout-retrieval/ripgrep-rust-codestory-project.json",
+      "sha256": "85b8ade56e2907ba78366a231cb11970f2b18830725771d9f435d3109bb1972a"
+    }
+  }
+}

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "6e3a706449d3fd82c7b63634c14f1cd56b86cf1daf50e6ee9c696a5b2f05e1f2",
+    "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "6e3a706449d3fd82c7b63634c14f1cd56b86cf1daf50e6ee9c696a5b2f05e1f2",
+        "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "6e3a706449d3fd82c7b63634c14f1cd56b86cf1daf50e6ee9c696a5b2f05e1f2",
+        "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "a6dd742ea981eba53669f4d39bc174364c24bed859b9821e620f165d9f8e3d3b",
+  "candidate_sha256": "6925404522d26cdd90b63ccf6322394a8a1b6ba5cb9e64207a0fb65c03a642f0",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "6e3a706449d3fd82c7b63634c14f1cd56b86cf1daf50e6ee9c696a5b2f05e1f2",
+      "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "6e3a706449d3fd82c7b63634c14f1cd56b86cf1daf50e6ee9c696a5b2f05e1f2",
+      "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "6e3a706449d3fd82c7b63634c14f1cd56b86cf1daf50e6ee9c696a5b2f05e1f2",
+    "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/crates/codestory-bench/src/bin/codestory_embedding_constant_calibration.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_constant_calibration.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
-#[command(name = "codestory-embedding-qualification")]
+#[command(name = "codestory-embedding-constant-calibration")]
 struct Arguments {
     #[arg(long, value_name = "CODESTORY_CLI")]
     cli: PathBuf,
@@ -15,5 +15,9 @@ struct Arguments {
 
 fn main() -> Result<()> {
     let arguments = Arguments::parse();
-    codestory_bench::qualification::run(arguments.cli, arguments.request, arguments.output)
+    codestory_bench::qualification::run_constant_calibration(
+        arguments.cli,
+        arguments.request,
+        arguments.output,
+    )
 }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/constant_calibration.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/constant_calibration.rs
@@ -1,0 +1,82 @@
+//! Private, package-bound producer for the runtime constants' measurement data.
+//!
+//! This lane deliberately shares only the qualification driver's low-level
+//! worker protocol. It has its own request and output schemas and never enters
+//! the lifecycle-scenario or external-evidence paths.
+
+use anyhow::{Context, Result, bail};
+use codestory_retrieval::SidecarRuntimeConfig;
+use output::{ConstantCalibrationRawOutput, ConstantCalibrationRunSummary};
+use request::REQUIRED_RUNS;
+use scenarios::artifact::{ScenarioContext, run_constant_calibration};
+use std::path::PathBuf;
+
+use super::{output as qualification_output, scenarios};
+
+mod output;
+mod request;
+
+pub fn run(cli: PathBuf, request_path: PathBuf, output_path: PathBuf) -> Result<()> {
+    let validated = request::load(cli, &request_path, &output_path)?;
+    let request::ValidatedRequest {
+        request,
+        executable,
+        output_directory,
+        output_path,
+        nonce_sha256,
+        request_sha256,
+    } = validated;
+    let runtime = SidecarRuntimeConfig::for_project_auto(&request.project);
+    if runtime.embedding.allow_cpu {
+        bail!("embedding_constant_calibration_cpu_fallback_enabled");
+    }
+    let runtimes = [runtime];
+    let projects = [request.project.clone()];
+    let artifacts = run_constant_calibration(
+        ScenarioContext {
+            scenario: "constant_calibration",
+            runtimes: &runtimes,
+            projects: &projects,
+            primary_index: 0,
+            contracts: &request.contracts,
+            qualification_runtime: &request.runtime,
+            output_directory: &output_directory,
+            nonce_sha256: &nonce_sha256,
+            worker_nonce: Some(&request.calibration_nonce),
+            executable: &executable,
+        },
+        request.required_runs,
+        &request.package.model_sha256,
+    )
+    .context("run embedding constant calibration")?;
+    if artifacts.len() != REQUIRED_RUNS as usize {
+        bail!("embedding_constant_calibration_run_count_invalid");
+    }
+
+    let mut calibration_runs = Vec::with_capacity(artifacts.len());
+    for artifact in artifacts {
+        let artifact_name = format!("constant-calibration-run-{}.raw.json", artifact.run_index());
+        qualification_output::write_atomic_json(&output_directory.join(&artifact_name), &artifact)
+            .with_context(|| {
+                format!("write raw embedding constant calibration artifact {artifact_name}")
+            })?;
+        calibration_runs.push(ConstantCalibrationRunSummary::from_artifact(
+            &artifact,
+            artifact_name,
+        ));
+    }
+
+    qualification_output::write_atomic_json(
+        &output_path,
+        &ConstantCalibrationRawOutput {
+            schema_version: 1,
+            source: request.source,
+            package: request.package,
+            contracts: request.contracts,
+            runtime: request.runtime,
+            request_sha256,
+            calibration_runs,
+        },
+    )
+    .context("write raw embedding constant calibration output")
+}

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/constant_calibration/output.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/constant_calibration/output.rs
@@ -1,0 +1,151 @@
+use super::request::ConstantCalibrationPackage;
+use crate::qualification::request::{
+    QualificationContracts, QualificationRuntime, QualificationSource,
+};
+use crate::qualification::scenarios::artifact::{
+    ConstantCalibrationRunArtifact, RawServerIdentity,
+};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(super) struct ConstantCalibrationRawOutput {
+    pub(super) schema_version: u32,
+    pub(super) source: QualificationSource,
+    pub(super) package: ConstantCalibrationPackage,
+    pub(super) contracts: QualificationContracts,
+    pub(super) runtime: QualificationRuntime,
+    pub(super) request_sha256: String,
+    pub(super) calibration_runs: Vec<ConstantCalibrationRunSummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct ConstantCalibrationRunSummary {
+    pub(super) run_index: u32,
+    pub(super) measurements: ConstantCalibrationMeasurementsSummary,
+    pub(super) server_identities: Vec<RawServerIdentity>,
+    pub(super) backend: String,
+    pub(super) policy: String,
+    pub(super) model_sha256: String,
+    pub(super) materialized_reused: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct ConstantCalibrationMeasurementsSummary {
+    pub(super) artifact: String,
+    pub(super) metric_count: u64,
+    pub(super) sample_count: u64,
+}
+
+impl ConstantCalibrationRunSummary {
+    pub(super) fn from_artifact(
+        artifact: &ConstantCalibrationRunArtifact,
+        artifact_name: String,
+    ) -> Self {
+        Self {
+            run_index: artifact.run_index(),
+            measurements: ConstantCalibrationMeasurementsSummary {
+                artifact: artifact_name,
+                metric_count: artifact.metric_count(),
+                sample_count: artifact.sample_count(),
+            },
+            server_identities: artifact.server_identities().to_vec(),
+            backend: artifact.backend().into(),
+            policy: artifact.policy().into(),
+            model_sha256: artifact.model_sha256().into(),
+            materialized_reused: artifact.materialized_reused(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ConstantCalibrationMeasurementsSummary, ConstantCalibrationRawOutput,
+        ConstantCalibrationRunSummary,
+    };
+    use crate::qualification::constant_calibration::request::ConstantCalibrationPackage;
+    use crate::qualification::request::{
+        QualificationContracts, QualificationRuntime, QualificationSource,
+    };
+    use crate::qualification::scenarios::artifact::RawServerIdentity;
+
+    #[test]
+    fn output_schema_contains_three_constant_runs_and_no_qualification_surfaces() {
+        let run = |run_index| ConstantCalibrationRunSummary {
+            run_index,
+            measurements: ConstantCalibrationMeasurementsSummary {
+                artifact: format!("constant-calibration-run-{run_index}.raw.json"),
+                metric_count: 9,
+                sample_count: 9,
+            },
+            server_identities: vec![RawServerIdentity {
+                server_instance_id: format!("server-{run_index}"),
+                process_start_id: format!("boot:{run_index}"),
+                load_generation: 1,
+            }],
+            backend: "metal".into(),
+            policy: "accelerated".into(),
+            model_sha256: "a".repeat(64),
+            materialized_reused: run_index > 1,
+        };
+        let output = ConstantCalibrationRawOutput {
+            schema_version: 1,
+            source: QualificationSource {
+                commit: "b".repeat(40),
+                tree: "c".repeat(40),
+                tracked_dirty: false,
+            },
+            package: ConstantCalibrationPackage {
+                archive_sha256: "d".repeat(64),
+                executable_sha256: "e".repeat(64),
+                asset_target: "macos-arm64".into(),
+                release_version: "0.16.3".into(),
+                model_sha256: "a".repeat(64),
+            },
+            contracts: QualificationContracts {
+                protocol_sha256: "1".repeat(64),
+                constant_set_sha256: "2".repeat(64),
+                measurement_protocol_sha256: "3".repeat(64),
+            },
+            runtime: QualificationRuntime {
+                engine_policy: "accelerated".into(),
+                expected_backend: "metal".into(),
+                offline: true,
+                matrix_cell_id: "protected_macos_arm64_metal".into(),
+                cache_state: "reused".into(),
+                residency_state: "resident".into(),
+            },
+            request_sha256: "f".repeat(64),
+            calibration_runs: vec![run(1), run(2), run(3)],
+        };
+        let value = serde_json::to_value(output).expect("serialize output");
+        assert_eq!(
+            value
+                .as_object()
+                .expect("output object")
+                .keys()
+                .map(String::as_str)
+                .collect::<std::collections::BTreeSet<_>>(),
+            [
+                "calibration_runs",
+                "contracts",
+                "package",
+                "request_sha256",
+                "runtime",
+                "schema_version",
+                "source",
+            ]
+            .into_iter()
+            .collect()
+        );
+        assert_eq!(
+            value["calibration_runs"]
+                .as_array()
+                .expect("calibration runs")
+                .len(),
+            3
+        );
+        assert!(value.get("scenarios").is_none());
+        assert!(value.get("qualification_thresholds").is_none());
+    }
+}

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/constant_calibration/request.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/constant_calibration/request.rs
@@ -1,0 +1,335 @@
+use crate::qualification::request::{
+    QualificationContracts, QualificationExecutable, QualificationRuntime, QualificationSource,
+    canonical_existing, compiled_asset_target, is_lower_hex, qualification_executable,
+    read_private_request, required_absolute_directory, sha256_bytes, validate_direct_child,
+    validate_private_directory, validate_project, validate_runtime, validate_source,
+};
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CALIBRATION_DIR_ENV: &str = "CODESTORY_EMBED_CONSTANT_CALIBRATION_DIR";
+const CALIBRATION_NONCE_ENV: &str = "CODESTORY_EMBED_CONSTANT_CALIBRATION_NONCE";
+const ARCHIVE_SHA256_ENV: &str = "CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256";
+const MANIFEST_PATH_ENV: &str = "CODESTORY_PLUGIN_CLI_MANIFEST_PATH";
+const NATIVE_MANIFEST_FILE: &str = "codestory-native-manifest.json";
+pub(super) const REQUIRED_RUNS: u32 = 3;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ConstantCalibrationRequest {
+    pub(super) schema_version: u32,
+    pub(super) calibration_nonce: String,
+    pub(super) calibration_nonce_sha256: String,
+    pub(super) source: QualificationSource,
+    pub(super) package: ConstantCalibrationPackage,
+    pub(super) contracts: QualificationContracts,
+    pub(super) runtime: QualificationRuntime,
+    pub(super) project: PathBuf,
+    pub(super) required_runs: u32,
+    pub(super) output_directory: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ConstantCalibrationPackage {
+    pub(super) archive_sha256: String,
+    pub(super) executable_sha256: String,
+    pub(super) asset_target: String,
+    pub(super) release_version: String,
+    pub(super) model_sha256: String,
+}
+
+pub(super) struct ValidatedRequest {
+    pub(super) request: ConstantCalibrationRequest,
+    pub(super) executable: QualificationExecutable,
+    pub(super) output_directory: PathBuf,
+    pub(super) output_path: PathBuf,
+    pub(super) nonce_sha256: String,
+    pub(super) request_sha256: String,
+}
+
+pub(super) fn load(
+    cli: PathBuf,
+    request_path: &Path,
+    output_path: &Path,
+) -> Result<ValidatedRequest> {
+    let executable = qualification_executable(cli)?;
+    let request_bytes = read_private_request(request_path)?;
+    let request: ConstantCalibrationRequest = serde_json::from_slice(&request_bytes)
+        .context("parse embedding constant calibration request")?;
+    validate_request(
+        request,
+        &request_bytes,
+        request_path,
+        output_path,
+        executable,
+    )
+}
+
+fn validate_request(
+    request: ConstantCalibrationRequest,
+    request_bytes: &[u8],
+    request_path: &Path,
+    output_path: &Path,
+    executable: QualificationExecutable,
+) -> Result<ValidatedRequest> {
+    validate_request_shape(&request)?;
+    let calibration_directory = required_absolute_directory(CALIBRATION_DIR_ENV)?;
+    validate_private_directory(&calibration_directory)?;
+    let nonce = std::env::var(CALIBRATION_NONCE_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("embedding_constant_calibration_gate_closed"))?;
+    if request.calibration_nonce != nonce {
+        bail!("embedding_constant_calibration_nonce_mismatch");
+    }
+    let nonce_sha256 = sha256_bytes(nonce.as_bytes());
+    if request.calibration_nonce_sha256 != nonce_sha256 {
+        bail!("embedding_constant_calibration_nonce_hash_mismatch");
+    }
+    if canonical_existing(&request.output_directory)? != calibration_directory {
+        bail!("embedding_constant_calibration_output_directory_mismatch");
+    }
+    validate_direct_child(request_path, &calibration_directory, true)?;
+    let output_path = validate_direct_child(output_path, &calibration_directory, false)?;
+    if output_path.exists() {
+        bail!("embedding_constant_calibration_output_exists");
+    }
+    validate_source(&request.source)?;
+    validate_package_and_contracts(&request, &executable)?;
+    validate_runtime(&request.runtime)?;
+    validate_accelerated_runtime(&request.runtime)?;
+    let project = validate_project(&request.project)?;
+    let mut request = request;
+    request.project = project;
+    Ok(ValidatedRequest {
+        request,
+        executable,
+        output_directory: calibration_directory,
+        output_path,
+        nonce_sha256,
+        request_sha256: sha256_bytes(request_bytes),
+    })
+}
+
+fn validate_request_shape(request: &ConstantCalibrationRequest) -> Result<()> {
+    if request.schema_version != 1 || request.required_runs != REQUIRED_RUNS {
+        bail!("embedding_constant_calibration_schema_invalid");
+    }
+    Ok(())
+}
+
+fn validate_accelerated_runtime(runtime: &QualificationRuntime) -> Result<()> {
+    if runtime.engine_policy != "accelerated"
+        || !runtime.offline
+        || !matches!(
+            runtime.expected_backend.to_ascii_lowercase().as_str(),
+            "metal" | "vulkan"
+        )
+    {
+        bail!("embedding_constant_calibration_runtime_invalid");
+    }
+    Ok(())
+}
+
+fn validate_package_and_contracts(
+    request: &ConstantCalibrationRequest,
+    executable: &QualificationExecutable,
+) -> Result<()> {
+    for value in [
+        request.package.archive_sha256.as_str(),
+        request.package.executable_sha256.as_str(),
+        request.package.model_sha256.as_str(),
+        request.contracts.protocol_sha256.as_str(),
+        request.contracts.constant_set_sha256.as_str(),
+        request.contracts.measurement_protocol_sha256.as_str(),
+    ] {
+        if !is_lower_hex(value, 64) {
+            bail!("embedding_constant_calibration_hash_invalid");
+        }
+    }
+    if request.package.executable_sha256 != executable.sha256
+        || request.package.release_version != executable.version
+        || request.package.asset_target != compiled_asset_target()
+    {
+        bail!("embedding_constant_calibration_package_mismatch");
+    }
+    let archive_sha256 = std::env::var(ARCHIVE_SHA256_ENV)
+        .ok()
+        .filter(|value| is_lower_hex(value, 64))
+        .ok_or_else(|| {
+            anyhow::anyhow!("embedding_constant_calibration_archive_identity_unavailable")
+        })?;
+    if request.package.archive_sha256 != archive_sha256 {
+        bail!("embedding_constant_calibration_archive_mismatch");
+    }
+    if request.contracts.protocol_sha256 != codestory_retrieval::PER_USER_EMBEDDING_PROTOCOL_SHA256
+        || request.contracts.constant_set_sha256
+            != codestory_retrieval::PER_USER_EMBEDDING_CONSTANT_SET_SHA256
+        || request.contracts.measurement_protocol_sha256
+            != codestory_retrieval::PER_USER_EMBEDDING_MEASUREMENT_PROTOCOL_SHA256
+    {
+        bail!("embedding_constant_calibration_contract_mismatch");
+    }
+    validate_manifest(request, executable)
+}
+
+fn validate_manifest(
+    request: &ConstantCalibrationRequest,
+    executable: &QualificationExecutable,
+) -> Result<()> {
+    let manifest_path = std::env::var_os(MANIFEST_PATH_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            executable
+                .path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(NATIVE_MANIFEST_FILE)
+        });
+    let manifest_bytes = fs::read(&manifest_path)
+        .with_context(|| format!("read native manifest {}", manifest_path.display()))?;
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&manifest_bytes).context("parse native package manifest")?;
+    if manifest.get("source") != Some(&serde_json::to_value(&request.source)?)
+        || manifest.pointer("/runtime_executable/sha256")
+            != Some(&serde_json::Value::String(
+                request.package.executable_sha256.clone(),
+            ))
+        || manifest.get("asset_target")
+            != Some(&serde_json::Value::String(
+                request.package.asset_target.clone(),
+            ))
+        || manifest.get("release_version")
+            != Some(&serde_json::Value::String(
+                request.package.release_version.clone(),
+            ))
+        || manifest.pointer("/model/sha256")
+            != Some(&serde_json::Value::String(
+                request.package.model_sha256.clone(),
+            ))
+        || manifest.pointer("/server_proof/protocol_sha256")
+            != Some(&serde_json::Value::String(
+                request.contracts.protocol_sha256.clone(),
+            ))
+        || manifest.pointer("/server_proof/constant_set_sha256")
+            != Some(&serde_json::Value::String(
+                request.contracts.constant_set_sha256.clone(),
+            ))
+        || manifest.pointer("/server_proof/measurement_protocol_sha256")
+            != Some(&serde_json::Value::String(
+                request.contracts.measurement_protocol_sha256.clone(),
+            ))
+        || manifest.pointer("/accelerator/cpu_fallback")
+            != Some(&serde_json::Value::String("unsupported".into()))
+        || manifest.pointer("/accelerator/expected_protected_backend")
+            != Some(&serde_json::Value::String(
+                request.runtime.expected_backend.clone(),
+            ))
+    {
+        bail!("embedding_constant_calibration_manifest_mismatch");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ConstantCalibrationPackage, ConstantCalibrationRequest, REQUIRED_RUNS,
+        validate_accelerated_runtime, validate_request_shape,
+    };
+    use crate::qualification::request::{
+        QualificationContracts, QualificationRuntime, QualificationSource,
+    };
+    use std::path::PathBuf;
+
+    fn request() -> ConstantCalibrationRequest {
+        ConstantCalibrationRequest {
+            schema_version: 1,
+            calibration_nonce: "nonce".into(),
+            calibration_nonce_sha256: "a".repeat(64),
+            source: QualificationSource {
+                commit: "b".repeat(40),
+                tree: "c".repeat(40),
+                tracked_dirty: false,
+            },
+            package: ConstantCalibrationPackage {
+                archive_sha256: "d".repeat(64),
+                executable_sha256: "e".repeat(64),
+                asset_target: "macos-arm64".into(),
+                release_version: "0.16.3".into(),
+                model_sha256: "f".repeat(64),
+            },
+            contracts: QualificationContracts {
+                protocol_sha256: "1".repeat(64),
+                constant_set_sha256: "2".repeat(64),
+                measurement_protocol_sha256: "3".repeat(64),
+            },
+            runtime: QualificationRuntime {
+                engine_policy: "accelerated".into(),
+                expected_backend: "metal".into(),
+                offline: true,
+                matrix_cell_id: "protected_macos_arm64_metal".into(),
+                cache_state: "reused".into(),
+                residency_state: "resident".into(),
+            },
+            project: PathBuf::from("/private/synthetic"),
+            required_runs: REQUIRED_RUNS,
+            output_directory: PathBuf::from("/private/calibration"),
+        }
+    }
+
+    #[test]
+    fn request_shape_requires_exactly_three_runs() {
+        let mut value = request();
+        validate_request_shape(&value).expect("three-run request");
+        for count in [0, 1, 2, 4] {
+            value.required_runs = count;
+            assert!(
+                validate_request_shape(&value).is_err(),
+                "{count} runs must fail"
+            );
+        }
+    }
+
+    #[test]
+    fn request_schema_cannot_reintroduce_qualification_scenarios_or_metrics() {
+        for (field, value) in [
+            ("required_scenarios", serde_json::json!([])),
+            ("required_metrics", serde_json::json!([])),
+            ("proof_tier", serde_json::json!("calibration")),
+        ] {
+            let mut encoded = serde_json::to_value(request()).expect("serialize request");
+            encoded
+                .as_object_mut()
+                .expect("request object")
+                .insert(field.into(), value);
+            assert!(
+                serde_json::from_value::<ConstantCalibrationRequest>(encoded).is_err(),
+                "{field} must remain outside the constant-only request schema"
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_accepts_only_offline_accelerated_metal_or_vulkan() {
+        let mut runtime = request().runtime;
+        validate_accelerated_runtime(&runtime).expect("Metal runtime");
+        runtime.expected_backend = "vulkan".into();
+        validate_accelerated_runtime(&runtime).expect("Vulkan runtime");
+        for (policy, backend, offline) in [
+            ("cpu_explicit", "cpu", true),
+            ("accelerated", "cpu", true),
+            ("accelerated", "cuda", true),
+            ("accelerated", "metal", false),
+        ] {
+            runtime.engine_policy = policy.into();
+            runtime.expected_backend = backend.into();
+            runtime.offline = offline;
+            assert!(validate_accelerated_runtime(&runtime).is_err());
+        }
+    }
+}

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/mod.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/mod.rs
@@ -12,13 +12,16 @@ use scenarios::artifact::{ScenarioContext, run_measurements, run_scenario};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+mod constant_calibration;
 mod output;
 mod request;
 mod scenarios;
 
 const DIAGNOSTIC_SCENARIO_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIAGNOSTIC_SCENARIO";
 
-pub(super) fn run(cli: PathBuf, request_path: PathBuf, output_path: PathBuf) -> Result<()> {
+pub use constant_calibration::run as run_constant_calibration;
+
+pub fn run(cli: PathBuf, request_path: PathBuf, output_path: PathBuf) -> Result<()> {
     let validated = request::load(cli, &request_path, &output_path)?;
     let request::ValidatedRequest {
         request,
@@ -44,6 +47,7 @@ pub(super) fn run(cli: PathBuf, request_path: PathBuf, output_path: PathBuf) -> 
             qualification_runtime: &request.runtime,
             output_directory: &output_directory,
             nonce_sha256: &nonce_sha256,
+            worker_nonce: None,
             executable: &executable,
         })
         .context("run diagnostic embedding qualification scenario worker_stall")?;
@@ -61,6 +65,7 @@ pub(super) fn run(cli: PathBuf, request_path: PathBuf, output_path: PathBuf) -> 
         qualification_runtime: &request.runtime,
         output_directory: &output_directory,
         nonce_sha256: &nonce_sha256,
+        worker_nonce: None,
         executable: &executable,
     })
     .context("run embedding qualification measurements")?;
@@ -82,6 +87,7 @@ pub(super) fn run(cli: PathBuf, request_path: PathBuf, output_path: PathBuf) -> 
             qualification_runtime: &request.runtime,
             output_directory: &output_directory,
             nonce_sha256: &nonce_sha256,
+            worker_nonce: None,
             executable: &executable,
         })
         .with_context(|| format!("run named embedding qualification scenario {scenario}"))?;

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/request.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/request.rs
@@ -10,7 +10,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const QUALIFICATION_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
+pub(super) const QUALIFICATION_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
 pub(super) const QUALIFICATION_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
 const ARCHIVE_SHA256_ENV: &str = "CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256";
 const MANIFEST_PATH_ENV: &str = "CODESTORY_PLUGIN_CLI_MANIFEST_PATH";
@@ -195,7 +195,7 @@ fn validate_gate_and_paths(
     Ok((qualification_directory, output_path, nonce_sha256))
 }
 
-fn validate_source(source: &QualificationSource) -> Result<()> {
+pub(super) fn validate_source(source: &QualificationSource) -> Result<()> {
     if !is_lower_hex(&source.commit, 40) || !is_lower_hex(&source.tree, 40) || source.tracked_dirty
     {
         bail!("embedding_qualification_source_invalid");
@@ -299,7 +299,7 @@ fn validate_manifest(
     Ok(())
 }
 
-fn qualification_executable(path: PathBuf) -> Result<QualificationExecutable> {
+pub(super) fn qualification_executable(path: PathBuf) -> Result<QualificationExecutable> {
     if !path.is_absolute() || !path.is_file() {
         bail!("embedding_qualification_executable_invalid");
     }
@@ -330,7 +330,7 @@ fn qualification_executable(path: PathBuf) -> Result<QualificationExecutable> {
     })
 }
 
-fn validate_runtime(runtime: &QualificationRuntime) -> Result<()> {
+pub(super) fn validate_runtime(runtime: &QualificationRuntime) -> Result<()> {
     if runtime.expected_backend.trim().is_empty()
         || runtime.matrix_cell_id.is_empty()
         || !runtime
@@ -339,25 +339,15 @@ fn validate_runtime(runtime: &QualificationRuntime) -> Result<()> {
             .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
         || runtime.cache_state != "reused"
         || runtime.residency_state != "resident"
-        || !matches!(
-            runtime.engine_policy.as_str(),
-            "accelerated" | "cpu_explicit"
-        )
+        || runtime.engine_policy != "accelerated"
     {
         bail!("embedding_qualification_runtime_invalid");
     }
     let allow_cpu = codestory_retrieval::sidecar_process_defaults().embedding_allow_cpu();
-    if (runtime.engine_policy == "cpu_explicit") != allow_cpu {
+    if allow_cpu {
         bail!("embedding_qualification_policy_mismatch");
     }
-    if runtime.engine_policy == "cpu_explicit"
-        && !runtime.expected_backend.eq_ignore_ascii_case("cpu")
-    {
-        bail!("embedding_qualification_backend_mismatch");
-    }
-    if runtime.engine_policy == "accelerated"
-        && runtime.expected_backend.eq_ignore_ascii_case("cpu")
-    {
+    if runtime.expected_backend.eq_ignore_ascii_case("cpu") {
         bail!("embedding_qualification_backend_mismatch");
     }
     Ok(())
@@ -385,6 +375,22 @@ fn validate_projects(projects: &[PathBuf]) -> Result<()> {
         bail!("embedding_qualification_projects_not_distinct");
     }
     Ok(())
+}
+
+pub(super) fn validate_project(project: &Path) -> Result<PathBuf> {
+    if !project.is_absolute() {
+        bail!("embedding_constant_calibration_project_not_absolute");
+    }
+    let metadata = fs::symlink_metadata(project).with_context(|| {
+        format!(
+            "inspect embedding constant calibration project {}",
+            project.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!("embedding_constant_calibration_project_untrusted");
+    }
+    canonical_existing(project)
 }
 
 fn validate_exact_string_list(actual: &[String], expected: &[&str], field: &str) -> Result<()> {
@@ -471,7 +477,7 @@ pub(super) fn validate_private_directory(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn validate_private_file_metadata(metadata: &fs::Metadata) -> Result<()> {
+pub(super) fn validate_private_file_metadata(metadata: &fs::Metadata) -> Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
@@ -490,14 +496,14 @@ pub(super) fn sha256_bytes(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
-fn is_lower_hex(value: &str, length: usize) -> bool {
+pub(super) fn is_lower_hex(value: &str, length: usize) -> bool {
     value.len() == length
         && value
             .bytes()
             .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
-fn compiled_asset_target() -> &'static str {
+pub(super) fn compiled_asset_target() -> &'static str {
     match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "x86_64") => "linux-x64",
         ("linux", "aarch64") => "linux-arm64",
@@ -506,5 +512,58 @@ fn compiled_asset_target() -> &'static str {
         ("windows", "x86_64") => "windows-x64",
         ("windows", "aarch64") => "windows-arm64",
         _ => "unsupported",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        QualificationRuntime, REQUIRED_METRICS, REQUIRED_SCENARIOS, validate_exact_string_list,
+        validate_runtime,
+    };
+
+    #[test]
+    fn full_qualification_keeps_exact_scenario_and_metric_lists() {
+        let scenarios = REQUIRED_SCENARIOS
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect::<Vec<_>>();
+        let metrics = REQUIRED_METRICS
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect::<Vec<_>>();
+        validate_exact_string_list(&scenarios, REQUIRED_SCENARIOS, "scenarios")
+            .expect("exact scenarios");
+        validate_exact_string_list(&metrics, REQUIRED_METRICS, "metrics").expect("exact metrics");
+
+        let mut missing = scenarios;
+        missing.pop();
+        assert!(validate_exact_string_list(&missing, REQUIRED_SCENARIOS, "scenarios").is_err());
+        let mut reordered = metrics.clone();
+        reordered.swap(0, 1);
+        assert!(validate_exact_string_list(&reordered, REQUIRED_METRICS, "metrics").is_err());
+        let mut extra = metrics;
+        extra.push("constant_only_escape".into());
+        assert!(validate_exact_string_list(&extra, REQUIRED_METRICS, "metrics").is_err());
+    }
+
+    #[test]
+    fn full_qualification_rejects_removed_cpu_backend_and_policy() {
+        let accelerated = QualificationRuntime {
+            engine_policy: "accelerated".into(),
+            expected_backend: "metal".into(),
+            offline: true,
+            matrix_cell_id: "macos-metal".into(),
+            cache_state: "reused".into(),
+            residency_state: "resident".into(),
+        };
+
+        let mut cpu_backend = accelerated.clone();
+        cpu_backend.expected_backend = "cpu".into();
+        assert!(validate_runtime(&cpu_backend).is_err());
+
+        let mut cpu_policy = accelerated;
+        cpu_policy.engine_policy = "cpu_explicit".into();
+        assert!(validate_runtime(&cpu_policy).is_err());
     }
 }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact.rs
@@ -214,29 +214,6 @@ pub(in crate::qualification) struct ConstantCalibrationRunArtifact {
 }
 
 impl ConstantCalibrationRunArtifact {
-    fn new(
-        run_index: u32,
-        contracts: QualificationContracts,
-        metrics: BTreeMap<String, RawMetric>,
-        server_identities: Vec<RawServerIdentity>,
-        backend: String,
-        policy: String,
-        model_sha256: String,
-        materialized_reused: bool,
-    ) -> Self {
-        Self {
-            schema_version: 1,
-            run_index,
-            contracts,
-            metrics,
-            server_identities,
-            backend,
-            policy,
-            model_sha256,
-            materialized_reused,
-        }
-    }
-
     pub(in crate::qualification) fn run_index(&self) -> u32 {
         self.run_index
     }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact.rs
@@ -13,7 +13,9 @@ use std::time::Duration;
 
 mod runner;
 
-pub(in crate::qualification) use runner::{run_measurements, run_scenario};
+pub(in crate::qualification) use runner::{
+    run_constant_calibration, run_measurements, run_scenario,
+};
 
 const WORKER_COMMAND: &str = "internal-embedding-qualification-worker";
 const POLL: Duration = Duration::from_millis(25);
@@ -39,6 +41,7 @@ pub(in crate::qualification) struct ScenarioContext<'a> {
     pub(in crate::qualification) qualification_runtime: &'a QualificationRuntime,
     pub(in crate::qualification) output_directory: &'a Path,
     pub(in crate::qualification) nonce_sha256: &'a str,
+    pub(in crate::qualification) worker_nonce: Option<&'a str>,
     pub(in crate::qualification) executable: &'a QualificationExecutable,
 }
 
@@ -197,6 +200,79 @@ pub(in crate::qualification) struct MeasurementArtifact {
     metrics: BTreeMap<String, RawMetric>,
 }
 
+#[derive(Debug, Serialize)]
+pub(in crate::qualification) struct ConstantCalibrationRunArtifact {
+    schema_version: u32,
+    run_index: u32,
+    contracts: QualificationContracts,
+    metrics: BTreeMap<String, RawMetric>,
+    server_identities: Vec<RawServerIdentity>,
+    backend: String,
+    policy: String,
+    model_sha256: String,
+    materialized_reused: bool,
+}
+
+impl ConstantCalibrationRunArtifact {
+    fn new(
+        run_index: u32,
+        contracts: QualificationContracts,
+        metrics: BTreeMap<String, RawMetric>,
+        server_identities: Vec<RawServerIdentity>,
+        backend: String,
+        policy: String,
+        model_sha256: String,
+        materialized_reused: bool,
+    ) -> Self {
+        Self {
+            schema_version: 1,
+            run_index,
+            contracts,
+            metrics,
+            server_identities,
+            backend,
+            policy,
+            model_sha256,
+            materialized_reused,
+        }
+    }
+
+    pub(in crate::qualification) fn run_index(&self) -> u32 {
+        self.run_index
+    }
+
+    pub(in crate::qualification) fn metric_count(&self) -> u64 {
+        self.metrics.len() as u64
+    }
+
+    pub(in crate::qualification) fn sample_count(&self) -> u64 {
+        self.metrics
+            .values()
+            .map(|metric| metric.samples.len() as u64)
+            .sum()
+    }
+
+    pub(in crate::qualification) fn server_identities(&self) -> &[RawServerIdentity] {
+        &self.server_identities
+    }
+
+    pub(in crate::qualification) fn backend(&self) -> &str {
+        &self.backend
+    }
+
+    pub(in crate::qualification) fn policy(&self) -> &str {
+        &self.policy
+    }
+
+    pub(in crate::qualification) fn model_sha256(&self) -> &str {
+        &self.model_sha256
+    }
+
+    pub(in crate::qualification) fn materialized_reused(&self) -> bool {
+        self.materialized_reused
+    }
+}
+
 impl MeasurementArtifact {
     pub(in crate::qualification) fn summary(
         &self,
@@ -243,11 +319,11 @@ struct RawMetricProcess {
     process_start_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-struct RawServerIdentity {
-    server_instance_id: String,
-    process_start_id: String,
-    load_generation: u64,
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub(in crate::qualification) struct RawServerIdentity {
+    pub(in crate::qualification) server_instance_id: String,
+    pub(in crate::qualification) process_start_id: String,
+    pub(in crate::qualification) load_generation: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner.rs
@@ -1,6 +1,6 @@
 use super::{
-    ControlEvent, MeasurementArtifact, ProcessInvocation, RawMetric, RawMetricSample,
-    ScenarioArtifact, ScenarioContext, ScenarioOrchestration,
+    ConstantCalibrationRunArtifact, ControlEvent, MeasurementArtifact, ProcessInvocation,
+    RawMetric, RawMetricSample, ScenarioArtifact, ScenarioContext, ScenarioOrchestration,
 };
 use crate::qualification::request::{QualificationExecutable, sha256_bytes};
 use anyhow::{Result, bail};
@@ -35,7 +35,8 @@ mod worker_stall;
 use analysis::project_identity_sha256;
 use evidence::validate_named_evidence;
 use process::{
-    cleanup_worker_files, existing_control_events, qualification_command_path, qualification_nonce,
+    cleanup_worker_files, existing_control_events_for_nonce, qualification_command_path,
+    qualification_nonce,
 };
 
 #[derive(Debug, Default)]
@@ -84,6 +85,7 @@ struct ScenarioRunner<'a> {
     evidence: ScenarioEvidence,
     active_controls: BTreeSet<String>,
     active_gates: BTreeSet<PathBuf>,
+    qualification_nonce: String,
     next_sequence: u64,
     next_worker: u64,
 }
@@ -150,6 +152,24 @@ pub(in crate::qualification) fn run_measurements(
     result
 }
 
+pub(in crate::qualification) fn run_constant_calibration(
+    context: ScenarioContext<'_>,
+    required_runs: u32,
+    model_sha256: &str,
+) -> Result<Vec<ConstantCalibrationRunArtifact>> {
+    let mut runner = ScenarioRunner::new_constant_calibration(context)?;
+    let mut result = runner.constant_calibration_runs(required_runs, model_sha256);
+    if result.is_ok() && !runner.active_controls.is_empty() {
+        result = Err(anyhow::anyhow!(
+            "embedding_constant_calibration_controls_not_released"
+        ));
+    }
+    if result.is_err() {
+        runner.cleanup_after_failure();
+    }
+    result
+}
+
 fn push_metric(
     metrics: &mut BTreeMap<String, RawMetric>,
     metric: &str,
@@ -187,6 +207,20 @@ fn opaque_measurement_sample_id(
     )
 }
 
+fn opaque_constant_calibration_sample_id(
+    nonce_sha256: &str,
+    matrix_cell_id: &str,
+    run_index: u32,
+    metric: &str,
+) -> String {
+    sha256_bytes(
+        format!(
+            "codestory-embedding-constant-calibration-sample-v1|{nonce_sha256}|{matrix_cell_id}|{run_index}|{metric}"
+        )
+        .as_bytes(),
+    )
+}
+
 impl<'a> ScenarioRunner<'a> {
     fn new(context: ScenarioContext<'a>) -> Result<Self> {
         if context.runtimes.len() != 2
@@ -197,11 +231,28 @@ impl<'a> ScenarioRunner<'a> {
         {
             bail!("embedding_qualification_scenario_projects_invalid");
         }
+        Self::build(context)
+    }
+
+    fn new_constant_calibration(context: ScenarioContext<'a>) -> Result<Self> {
+        if context.runtimes.len() != 1 || context.projects.len() != 1 || context.primary_index != 0
+        {
+            bail!("embedding_constant_calibration_project_invalid");
+        }
+        Self::build(context)
+    }
+
+    fn build(context: ScenarioContext<'a>) -> Result<Self> {
         let clock = CoordinatorClock::capture();
         let started_ns = clock.now_ns();
-        let next_sequence = existing_control_events(context.output_directory)?
-            .iter()
-            .fold(0, |maximum, event| maximum.max(event.sequence));
+        let qualification_nonce = match context.worker_nonce {
+            Some(nonce) => nonce.to_owned(),
+            None => qualification_nonce()?,
+        };
+        let next_sequence =
+            existing_control_events_for_nonce(context.output_directory, &qualification_nonce)?
+                .iter()
+                .fold(0, |maximum, event| maximum.max(event.sequence));
         Ok(Self {
             executable: context.executable.clone(),
             clock,
@@ -223,6 +274,7 @@ impl<'a> ScenarioRunner<'a> {
             evidence: ScenarioEvidence::default(),
             active_controls: BTreeSet::new(),
             active_gates: BTreeSet::new(),
+            qualification_nonce,
             next_sequence,
             next_worker: 0,
         })
@@ -250,12 +302,10 @@ impl<'a> ScenarioRunner<'a> {
             let _ = self.control("crash_server", None);
             self.active_controls.clear();
         }
-        if let Ok(nonce) = qualification_nonce() {
-            let _ = fs::remove_file(qualification_command_path(
-                self.context.output_directory,
-                &nonce,
-            ));
-        }
+        let _ = fs::remove_file(qualification_command_path(
+            self.context.output_directory,
+            &self.qualification_nonce,
+        ));
         for gate in std::mem::take(&mut self.active_gates) {
             let _ = fs::remove_file(gate);
         }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/analysis.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/analysis.rs
@@ -42,7 +42,19 @@ pub(super) fn scheduler_values(snapshot: &EmbeddingServerSnapshot) -> BTreeMap<S
 }
 
 pub(super) fn completed_token_count(directory: &Path, request_id: &str) -> Result<u64> {
-    existing_control_events(directory)?
+    completed_token_count_for_nonce(
+        directory,
+        request_id,
+        &super::process::qualification_nonce()?,
+    )
+}
+
+pub(super) fn completed_token_count_for_nonce(
+    directory: &Path,
+    request_id: &str,
+    nonce: &str,
+) -> Result<u64> {
+    super::process::existing_control_events_for_nonce(directory, nonce)?
         .into_iter()
         .rev()
         .find_map(|event| {

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/control.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/control.rs
@@ -4,8 +4,8 @@ use super::super::{
 };
 use super::analysis::{control_key, elapsed, same_server_authority, validated_idle_epoch};
 use super::process::{
-    existing_control_events, load_establishment_timeout, qualification_command_path,
-    qualification_nonce, query_parameters, require_worker_success,
+    existing_control_events_for_nonce, load_establishment_timeout, qualification_command_path,
+    query_parameters, require_worker_success,
 };
 use super::{ControlCommand, ControlCommandParameters, ScenarioRunner, WorkerOutput};
 use crate::qualification::output::write_atomic_json;
@@ -265,7 +265,7 @@ impl<'a> ScenarioRunner<'a> {
 
     pub(super) fn control(&mut self, action: &str, class: Option<&str>) -> Result<ControlEvent> {
         let command_path =
-            qualification_command_path(self.context.output_directory, &qualification_nonce()?);
+            qualification_command_path(self.context.output_directory, &self.qualification_nonce);
         let wait_started = self.clock.now_ns();
         while command_path.exists() {
             if elapsed(&self.clock, wait_started) >= CONTROL_TIMEOUT {
@@ -287,9 +287,12 @@ impl<'a> ScenarioRunner<'a> {
         let event_result = (|| -> Result<ControlEvent> {
             let started = self.clock.now_ns();
             loop {
-                if let Some(event) = existing_control_events(self.context.output_directory)?
-                    .into_iter()
-                    .find(|event| event.sequence == self.next_sequence)
+                if let Some(event) = existing_control_events_for_nonce(
+                    self.context.output_directory,
+                    &self.qualification_nonce,
+                )?
+                .into_iter()
+                .find(|event| event.sequence == self.next_sequence)
                 {
                     return Ok(event);
                 }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/measurements.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/measurements.rs
@@ -1,17 +1,20 @@
 use super::super::{
-    MeasurementArtifact, MeasurementInterval, POLL, ProcessObservation,
-    QUALIFICATION_QUEUE_CAPACITY, RawMetric, RawMetricClock, RawMetricProcess,
-    RawMetricSampleInput, successful_operation_duration_ns, successful_operation_operands,
+    ConstantCalibrationRunArtifact, MeasurementArtifact, MeasurementInterval, POLL,
+    ProcessObservation, QUALIFICATION_QUEUE_CAPACITY, RawMetric, RawMetricClock, RawMetricProcess,
+    RawMetricSampleInput, RawServerIdentity, successful_operation_duration_ns,
+    successful_operation_operands,
 };
 use super::analysis::{
-    accelerator_operands, completed_token_count, elapsed, raw_server_identity,
-    snapshot_has_resident_generation,
+    accelerator_operands, completed_token_count, completed_token_count_for_nonce, elapsed,
+    raw_server_identity, snapshot_has_resident_generation,
 };
 use super::process::{
     busy_retry_marker_timeout, busy_retry_worker_timeout, measurement_worker_timeout,
     query_parameters, require_worker_success,
 };
-use super::{RunningWorker, ScenarioRunner, WorkerOutput, push_metric};
+use super::{
+    RunningWorker, ScenarioRunner, WorkerOutput, opaque_constant_calibration_sample_id, push_metric,
+};
 use crate::qualification::request::REQUIRED_METRICS;
 use anyhow::{Context, Result, bail};
 use codestory_retrieval::{
@@ -19,10 +22,22 @@ use codestory_retrieval::{
     EmbeddingQualificationWorkerMeasurementSpan as WorkerMeasurementSpan, EmbeddingServerSnapshot,
 };
 use serde_json::json;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
+
+pub(super) const CONSTANT_CALIBRATION_METRICS: &[&str] = &[
+    "spawn_convergence",
+    "existing_owner_connect",
+    "cold_first_vector",
+    "first_product_ready",
+    "warm_query_ipc",
+    "warm_bulk_ipc",
+    "bulk_documents_per_second",
+    "bulk_tokens_per_second",
+    "busy_retry_usefulness",
+];
 
 /// The measurement protocol's declared `phase_boundaries` for every metric the
 /// driver records. The WP5-floored frozen constants derive their meaning from
@@ -97,6 +112,252 @@ pub(super) struct MeasuredWorker {
 }
 
 impl<'a> ScenarioRunner<'a> {
+    pub(super) fn constant_calibration_runs(
+        &mut self,
+        required_runs: u32,
+        model_sha256: &str,
+    ) -> Result<Vec<ConstantCalibrationRunArtifact>> {
+        if required_runs != 3 {
+            bail!("embedding_constant_calibration_run_count_invalid");
+        }
+        let mut observed_identities = BTreeSet::new();
+        let mut runs = Vec::with_capacity(required_runs as usize);
+        for run_index in 1..=required_runs {
+            let run = self.constant_calibration_run(run_index, model_sha256)?;
+            retain_fresh_server_identities(&mut observed_identities, run.server_identities())?;
+            runs.push(run);
+        }
+        self.reset_owner("constant_calibration_finish")?;
+        Ok(runs)
+    }
+
+    fn constant_calibration_run(
+        &mut self,
+        run_index: u32,
+        model_sha256: &str,
+    ) -> Result<ConstantCalibrationRunArtifact> {
+        let mut metrics = BTreeMap::new();
+        let mut sampled_identities = BTreeSet::new();
+        let expected_materialized_reused = expected_materialization_reuse(run_index)?;
+
+        self.reset_owner(&format!("constant_calibration_run_{run_index}_start"))?;
+        let spawn = self.run_measure_worker(
+            "measure_constant_spawn_hello",
+            "spawn_convergence",
+            1,
+            query_parameters(1),
+        )?;
+        let cold = self.run_measure_worker(
+            "measure_constant_cold_query",
+            "cold_first_vector",
+            1,
+            measurement_parameters(1, 0, 0, 256),
+        )?;
+        let cold_identity = raw_server_identity(&cold.snapshot)?;
+
+        let first_ready = self.run_measure_worker(
+            "measure_product_query",
+            "first_product_ready",
+            1,
+            measurement_parameters(1, 0, 0, 256),
+        )?;
+        let first_ready_identity = raw_server_identity(&first_ready.snapshot)?;
+
+        let warm_query = self.run_measure_worker(
+            "measure_query_frame",
+            "warm_query_ipc",
+            1,
+            measurement_parameters(1, 0, 0, 256),
+        )?;
+        require_completed_documents(&warm_query, 1)?;
+        let warm_query_identity = frame_server_identity(&warm_query)?;
+        let engine = require_constant_engine_identity(
+            &warm_query,
+            &warm_query_identity,
+            self.context.qualification_runtime.expected_backend.as_str(),
+            model_sha256,
+            expected_materialized_reused,
+        )?;
+        let engine_backend = engine.backend.clone();
+        let engine_policy = engine.policy.clone();
+        let engine_model_sha256 = engine.model_digest.clone();
+        let engine_materialized_reused = engine.materialized_reused;
+        if spawn.snapshot.process.server_instance_id != warm_query_identity.server_instance_id
+            || spawn.snapshot.process.process_start_id != warm_query_identity.process_start_id
+            || cold_identity != warm_query_identity
+            || first_ready_identity != warm_query_identity
+        {
+            bail!("embedding_constant_calibration_generation_changed");
+        }
+
+        sampled_identities.insert(warm_query_identity.clone());
+        self.record_constant_metric(
+            &mut metrics,
+            "spawn_convergence",
+            run_index,
+            &spawn.interval,
+            warm_query_identity.clone(),
+            BTreeMap::new(),
+        )?;
+        sampled_identities.insert(cold_identity.clone());
+        self.record_constant_metric(
+            &mut metrics,
+            "cold_first_vector",
+            run_index,
+            &cold.interval,
+            cold_identity,
+            successful_operation_operands(&cold.interval),
+        )?;
+        sampled_identities.insert(first_ready_identity.clone());
+        self.record_constant_metric(
+            &mut metrics,
+            "first_product_ready",
+            run_index,
+            &first_ready.interval,
+            first_ready_identity,
+            successful_operation_operands(&first_ready.interval),
+        )?;
+        self.record_constant_metric(
+            &mut metrics,
+            "warm_query_ipc",
+            run_index,
+            &warm_query.interval,
+            warm_query_identity.clone(),
+            successful_operation_operands(&warm_query.interval),
+        )?;
+
+        let existing = self.run_measure_worker(
+            "measure_hello",
+            "existing_owner_connect",
+            1,
+            query_parameters(1),
+        )?;
+        let existing_identity = raw_server_identity(&existing.snapshot)?;
+        sampled_identities.insert(existing_identity.clone());
+        self.record_constant_metric(
+            &mut metrics,
+            "existing_owner_connect",
+            run_index,
+            &existing.interval,
+            existing_identity,
+            BTreeMap::new(),
+        )?;
+
+        let warm_bulk = self.run_measure_worker(
+            "measure_bulk_frame",
+            "warm_bulk_ipc",
+            1,
+            measurement_parameters(0, 1, 64, 256),
+        )?;
+        require_completed_documents(&warm_bulk, 64)?;
+        let warm_bulk_identity = frame_server_identity(&warm_bulk)?;
+        require_constant_engine_identity(
+            &warm_bulk,
+            &warm_bulk_identity,
+            self.context.qualification_runtime.expected_backend.as_str(),
+            model_sha256,
+            expected_materialized_reused,
+        )?;
+        sampled_identities.insert(warm_bulk_identity.clone());
+        self.record_constant_metric(
+            &mut metrics,
+            "warm_bulk_ipc",
+            run_index,
+            &warm_bulk.interval,
+            warm_bulk_identity,
+            successful_operation_operands(&warm_bulk.interval),
+        )?;
+
+        let throughput = self.run_measure_worker(
+            "measure_bulk_frame",
+            "bulk_documents_per_second",
+            1,
+            measurement_parameters(0, 1, 256, 256),
+        )?;
+        require_completed_documents(&throughput, 256)?;
+        let throughput_identity = frame_server_identity(&throughput)?;
+        require_constant_engine_identity(
+            &throughput,
+            &throughput_identity,
+            self.context.qualification_runtime.expected_backend.as_str(),
+            model_sha256,
+            expected_materialized_reused,
+        )?;
+        let request_id = throughput.request_id.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("embedding_constant_calibration_bulk_request_id_missing")
+        })?;
+        let completed_tokens = completed_token_count_for_nonce(
+            self.context.output_directory,
+            request_id,
+            &self.qualification_nonce,
+        )?;
+        let duration_ns = successful_operation_duration_ns(&throughput.interval);
+        sampled_identities.insert(throughput_identity.clone());
+        self.record_constant_metric(
+            &mut metrics,
+            "bulk_documents_per_second",
+            run_index,
+            &throughput.interval,
+            throughput_identity.clone(),
+            BTreeMap::from([
+                ("completed_documents".into(), json!(256)),
+                (
+                    "successful_operation_duration_ns".into(),
+                    json!(duration_ns),
+                ),
+            ]),
+        )?;
+        self.record_constant_metric(
+            &mut metrics,
+            "bulk_tokens_per_second",
+            run_index,
+            &throughput.interval,
+            throughput_identity,
+            BTreeMap::from([
+                ("completed_tokens".into(), json!(completed_tokens)),
+                (
+                    "successful_operation_duration_ns".into(),
+                    json!(duration_ns),
+                ),
+            ]),
+        )?;
+
+        let busy = self.measure_busy_retry(1)?;
+        let busy_identity = raw_server_identity(&busy.snapshot)?;
+        sampled_identities.insert(busy_identity.clone());
+        self.record_constant_metric(
+            &mut metrics,
+            "busy_retry_usefulness",
+            run_index,
+            &busy.interval,
+            busy_identity,
+            BTreeMap::new(),
+        )?;
+
+        if metrics.len() != CONSTANT_CALIBRATION_METRICS.len()
+            || metrics.keys().map(String::as_str).collect::<BTreeSet<_>>()
+                != CONSTANT_CALIBRATION_METRICS
+                    .iter()
+                    .copied()
+                    .collect::<BTreeSet<_>>()
+            || metrics.values().any(|metric| metric.samples.len() != 1)
+        {
+            bail!("embedding_constant_calibration_measurement_set_invalid");
+        }
+        require_one_run_server_identity(&sampled_identities, &warm_query_identity)?;
+
+        Ok(ConstantCalibrationRunArtifact::new(
+            run_index,
+            self.context.contracts.clone(),
+            metrics,
+            sampled_identities.into_iter().collect(),
+            engine_backend,
+            engine_policy,
+            engine_model_sha256,
+            engine_materialized_reused,
+        ))
+    }
+
     pub(super) fn measurements(&mut self) -> Result<MeasurementArtifact> {
         let mut metrics = BTreeMap::new();
 
@@ -492,6 +753,35 @@ impl<'a> ScenarioRunner<'a> {
         push_metric(metrics, metric, metric_unit(metric), sample)
     }
 
+    fn record_constant_metric(
+        &self,
+        metrics: &mut BTreeMap<String, RawMetric>,
+        metric: &str,
+        run_index: u32,
+        interval: &MeasurementInterval,
+        server_identity: RawServerIdentity,
+        operands: BTreeMap<String, serde_json::Value>,
+    ) -> Result<()> {
+        let [start_phase, end_phase] = declared_constant_phase_boundaries(metric)?;
+        let sample_id = opaque_constant_calibration_sample_id(
+            self.context.nonce_sha256,
+            &self.context.qualification_runtime.matrix_cell_id,
+            run_index,
+            metric,
+        );
+        let sample = interval.sample(RawMetricSampleInput {
+            sample_id: &sample_id,
+            repeat: 1,
+            runtime: self.context.qualification_runtime,
+            workload_id: declared_workload_id(metric)?,
+            server_identity,
+            start_phase,
+            end_phase,
+            operands,
+        });
+        push_metric(metrics, metric, metric_unit(metric), sample)
+    }
+
     pub(super) fn measurement_sample_id(&self, metric: &str, repeat: u32) -> String {
         super::opaque_measurement_sample_id(
             self.context.nonce_sha256,
@@ -500,6 +790,106 @@ impl<'a> ScenarioRunner<'a> {
             repeat,
         )
     }
+}
+
+fn declared_constant_phase_boundaries(metric: &str) -> Result<[&'static str; 2]> {
+    if metric == "cold_first_vector" {
+        return Ok([
+            "product_request_started_with_fresh_owner_model_absent",
+            "first_vector_and_engine_evidence_validated",
+        ]);
+    }
+    declared_phase_boundaries(metric)
+}
+
+fn require_constant_engine_identity<'a>(
+    measured: &'a MeasuredWorker,
+    server_identity: &RawServerIdentity,
+    expected_backend: &str,
+    expected_model_sha256: &str,
+    expected_materialized_reused: bool,
+) -> Result<&'a EmbeddingEngineIdentity> {
+    let identity = measured
+        .engine_identity
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("embedding_constant_calibration_engine_identity_missing"))?;
+    validate_constant_engine_evidence(
+        identity,
+        server_identity,
+        expected_backend,
+        expected_model_sha256,
+        expected_materialized_reused,
+    )?;
+    if measured.snapshot.process.server_instance_id != identity.server_instance_id
+        || measured
+            .snapshot
+            .engine
+            .as_ref()
+            .is_none_or(|engine| engine.load_generation != identity.load_generation)
+    {
+        bail!("embedding_constant_calibration_engine_identity_invalid");
+    }
+    Ok(identity)
+}
+
+fn validate_constant_engine_evidence(
+    identity: &EmbeddingEngineIdentity,
+    server_identity: &RawServerIdentity,
+    expected_backend: &str,
+    expected_model_sha256: &str,
+    expected_materialized_reused: bool,
+) -> Result<()> {
+    if identity.server_instance_id != server_identity.server_instance_id
+        || identity.load_generation != server_identity.load_generation
+        || identity.load_generation == 0
+        || identity.model_load_count == 0
+        || identity.residency != "resident"
+        || !identity.worker_alive
+        || identity.load_error.is_some()
+        || identity.policy != "accelerated"
+        || identity.backend.eq_ignore_ascii_case("cpu")
+        || !identity.backend.eq_ignore_ascii_case(expected_backend)
+        || identity.model_digest != expected_model_sha256
+        || identity.materialized_model_sha256 != expected_model_sha256
+        || !identity.embedded_model
+        || identity.materialized_reused != expected_materialized_reused
+    {
+        bail!("embedding_constant_calibration_engine_identity_invalid");
+    }
+    Ok(())
+}
+
+fn expected_materialization_reuse(run_index: u32) -> Result<bool> {
+    match run_index {
+        1 => Ok(false),
+        2 | 3 => Ok(true),
+        _ => bail!("embedding_constant_calibration_run_index_invalid"),
+    }
+}
+
+fn retain_fresh_server_identities(
+    observed: &mut BTreeSet<RawServerIdentity>,
+    current: &[RawServerIdentity],
+) -> Result<()> {
+    if current.is_empty() {
+        bail!("embedding_constant_calibration_server_identity_missing");
+    }
+    for identity in current {
+        if !observed.insert(identity.clone()) {
+            bail!("embedding_constant_calibration_server_identity_reused");
+        }
+    }
+    Ok(())
+}
+
+fn require_one_run_server_identity(
+    sampled: &BTreeSet<RawServerIdentity>,
+    expected: &RawServerIdentity,
+) -> Result<()> {
+    if sampled != &BTreeSet::from([expected.clone()]) {
+        bail!("embedding_constant_calibration_generation_changed");
+    }
+    Ok(())
 }
 
 /// Build the recorded interval from the worker's declared-instant span. The
@@ -588,5 +978,237 @@ fn metric_unit(metric: &str) -> &'static str {
         "bulk_tokens_per_second" => "tokens_per_second",
         "backend_observed_accelerator_residency" => "boolean",
         _ => "milliseconds",
+    }
+}
+
+#[cfg(test)]
+mod constant_calibration_tests {
+    use super::{
+        CONSTANT_CALIBRATION_METRICS, RawServerIdentity, declared_constant_phase_boundaries,
+        declared_phase_boundaries, expected_materialization_reuse,
+        opaque_constant_calibration_sample_id, require_one_run_server_identity,
+        retain_fresh_server_identities, validate_constant_engine_evidence,
+    };
+    use codestory_retrieval::EmbeddingEngineIdentity;
+    use std::collections::BTreeSet;
+
+    fn server_identity(name: &str) -> RawServerIdentity {
+        RawServerIdentity {
+            server_instance_id: name.into(),
+            process_start_id: format!("boot:{name}"),
+            load_generation: 1,
+        }
+    }
+
+    fn engine_identity(name: &str, backend: &str, reused: bool) -> EmbeddingEngineIdentity {
+        EmbeddingEngineIdentity {
+            server_instance_id: name.into(),
+            load_generation: 1,
+            model_load_count: 1,
+            residency: "resident".into(),
+            worker_alive: true,
+            load_error: None,
+            model_digest: "a".repeat(64),
+            ggml_build_identity: "ggml-test".into(),
+            backend: backend.into(),
+            adapter_name: backend.into(),
+            adapter_description: "test".into(),
+            policy: "accelerated".into(),
+            embedded_model: true,
+            materialized_model_sha256: "a".repeat(64),
+            materialized_reused: reused,
+            initialization_ms: 1,
+            smoke_ms: 1,
+            adapter_memory_total: 0,
+            adapter_memory_used_by_load: 0,
+            execution_device_names: Vec::new(),
+            execution_backend_names: Vec::new(),
+            execution_observation_source: "test".into(),
+            encode_count: 0,
+            execution_node_count: 0,
+            resident_accelerator_tensor_count: 0,
+            resident_accelerator_tensor_bytes: 0,
+            model_layer_count: 0,
+            offloaded_layer_count: 0,
+            accelerator_execution_verified: false,
+        }
+    }
+
+    #[test]
+    fn constant_plan_is_exactly_the_nine_runtime_constant_metrics() {
+        assert_eq!(
+            CONSTANT_CALIBRATION_METRICS,
+            [
+                "spawn_convergence",
+                "existing_owner_connect",
+                "cold_first_vector",
+                "first_product_ready",
+                "warm_query_ipc",
+                "warm_bulk_ipc",
+                "bulk_documents_per_second",
+                "bulk_tokens_per_second",
+                "busy_retry_usefulness",
+            ]
+        );
+        for forbidden in [
+            "true_idle_exit",
+            "total_codestory_process_memory",
+            "backend_observed_accelerator_residency",
+            "retrieval_quality",
+        ] {
+            assert!(!CONSTANT_CALIBRATION_METRICS.contains(&forbidden));
+        }
+        assert_eq!(
+            declared_constant_phase_boundaries("cold_first_vector")
+                .expect("constant cold boundary")[0],
+            "product_request_started_with_fresh_owner_model_absent"
+        );
+        assert_eq!(
+            declared_phase_boundaries("cold_first_vector").expect("qualification cold boundary")[0],
+            "product_request_started_with_owner_absent",
+            "the full qualification protocol must remain unchanged"
+        );
+    }
+
+    #[test]
+    fn constant_sample_identity_is_unique_per_logical_run() {
+        let first = opaque_constant_calibration_sample_id("nonce", "metal", 1, "warm_query_ipc");
+        let second = opaque_constant_calibration_sample_id("nonce", "metal", 2, "warm_query_ipc");
+        assert_ne!(first, second);
+        assert_eq!(
+            first,
+            opaque_constant_calibration_sample_id("nonce", "metal", 1, "warm_query_ipc")
+        );
+    }
+
+    #[test]
+    fn materialized_model_is_new_once_then_reused_twice() {
+        assert!(!expected_materialization_reuse(1).expect("run one"));
+        assert!(expected_materialization_reuse(2).expect("run two"));
+        assert!(expected_materialization_reuse(3).expect("run three"));
+        for invalid in [0, 4] {
+            assert!(expected_materialization_reuse(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn engine_precondition_binds_accelerated_backend_model_and_reuse_only() {
+        let server = server_identity("server-a");
+        let metal = engine_identity("server-a", "Metal", false);
+        validate_constant_engine_evidence(&metal, &server, "metal", &"a".repeat(64), false)
+            .expect("Metal identity");
+        let vulkan = engine_identity("server-a", "Vulkan", false);
+        validate_constant_engine_evidence(&vulkan, &server, "vulkan", &"a".repeat(64), false)
+            .expect("Vulkan identity");
+
+        let mut invalid = metal.clone();
+        invalid.policy = "cpu_explicit".into();
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.backend = "CPU".into();
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        assert!(
+            validate_constant_engine_evidence(&metal, &server, "vulkan", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.load_generation = 2;
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.model_load_count = 0;
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.residency = "absent".into();
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.worker_alive = false;
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.load_error = Some("model load failed".into());
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.model_digest = "b".repeat(64);
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.materialized_model_sha256 = "b".repeat(64);
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.materialized_reused = true;
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal.clone();
+        invalid.embedded_model = false;
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+        invalid = metal;
+        invalid.server_instance_id = "server-b".into();
+        assert!(
+            validate_constant_engine_evidence(&invalid, &server, "metal", &"a".repeat(64), false)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn server_identities_must_be_disjoint_across_records() {
+        let first = server_identity("server-a");
+        let second = server_identity("server-b");
+        let third = server_identity("server-c");
+        let mut observed = BTreeSet::new();
+        retain_fresh_server_identities(&mut observed, std::slice::from_ref(&first))
+            .expect("first run");
+        retain_fresh_server_identities(&mut observed, std::slice::from_ref(&second))
+            .expect("second run");
+        assert!(
+            retain_fresh_server_identities(&mut observed, std::slice::from_ref(&first)).is_err()
+        );
+        retain_fresh_server_identities(&mut observed, std::slice::from_ref(&third))
+            .expect("third fresh run");
+        assert!(retain_fresh_server_identities(&mut observed, &[]).is_err());
+    }
+
+    #[test]
+    fn every_metric_in_one_record_must_share_one_generation() {
+        let expected = server_identity("server-a");
+        require_one_run_server_identity(&BTreeSet::from([expected.clone()]), &expected)
+            .expect("one generation");
+        assert!(
+            require_one_run_server_identity(
+                &BTreeSet::from([expected.clone(), server_identity("server-b")]),
+                &expected,
+            )
+            .is_err()
+        );
+        assert!(require_one_run_server_identity(&BTreeSet::new(), &expected).is_err());
     }
 }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/measurements.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/measurements.rs
@@ -346,16 +346,17 @@ impl<'a> ScenarioRunner<'a> {
         }
         require_one_run_server_identity(&sampled_identities, &warm_query_identity)?;
 
-        Ok(ConstantCalibrationRunArtifact::new(
+        Ok(ConstantCalibrationRunArtifact {
+            schema_version: 1,
             run_index,
-            self.context.contracts.clone(),
+            contracts: self.context.contracts.clone(),
             metrics,
-            sampled_identities.into_iter().collect(),
-            engine_backend,
-            engine_policy,
-            engine_model_sha256,
-            engine_materialized_reused,
-        ))
+            server_identities: sampled_identities.into_iter().collect(),
+            backend: engine_backend,
+            policy: engine_policy,
+            model_sha256: engine_model_sha256,
+            materialized_reused: engine_materialized_reused,
+        })
     }
 
     pub(super) fn measurements(&mut self) -> Result<MeasurementArtifact> {

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/process.rs
@@ -18,7 +18,14 @@ use std::process::{Child, ExitStatus};
 use std::time::Duration;
 
 pub(super) fn existing_control_events(directory: &Path) -> Result<Vec<ControlEvent>> {
-    published_control_events(&directory.join(format!("{}.events.jsonl", qualification_nonce()?)))
+    existing_control_events_for_nonce(directory, &qualification_nonce()?)
+}
+
+pub(super) fn existing_control_events_for_nonce(
+    directory: &Path,
+    nonce: &str,
+) -> Result<Vec<ControlEvent>> {
+    published_control_events(&directory.join(format!("{nonce}.events.jsonl")))
 }
 
 /// Read the records the server has finished publishing to its append-only
@@ -307,6 +314,7 @@ pub(super) fn measurement_worker_timeout(operation: &str) -> Duration {
         "bulk"
         | "measure_bulk_frame"
         | "measure_spawn_hello"
+        | "measure_constant_cold_query"
         | "measure_product_query"
         | "measure_resident_identity"
         | "resident_identity" => budgets.bulk_request,

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
@@ -47,6 +47,7 @@ fn measurement_worker_budgets_dominate_the_deadlines_workers_honor() {
         "bulk",
         "measure_bulk_frame",
         "measure_spawn_hello",
+        "measure_constant_cold_query",
         "measure_product_query",
         "measure_resident_identity",
         "resident_identity",

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/worker_process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/worker_process.rs
@@ -329,7 +329,6 @@ mod tests {
         );
         let constant_env = constant
             .get_envs()
-            .map(|(name, value)| (name, value))
             .collect::<std::collections::BTreeMap<_, _>>();
         assert_eq!(
             constant_env.get(OsStr::new(QUALIFICATION_DIR_ENV)),

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/worker_process.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/worker_process.rs
@@ -11,7 +11,9 @@ use super::{
     WorkerRequest,
 };
 use crate::qualification::output::write_atomic_json;
-use crate::qualification::request::read_private_request;
+use crate::qualification::request::{
+    QUALIFICATION_DIR_ENV, QUALIFICATION_NONCE_ENV, read_private_request,
+};
 use anyhow::{Context, Result, bail};
 use codestory_retrieval::{EmbeddingQualificationParameters, EmbeddingServerSnapshot};
 use serde_json::{Value, json};
@@ -142,7 +144,8 @@ impl<'a> ScenarioRunner<'a> {
         }
         write_atomic_json(&request_path, &request)?;
         let started_ns = self.clock.now_ns();
-        let child = Command::new(&self.executable.path)
+        let mut command = Command::new(&self.executable.path);
+        command
             .arg(WORKER_COMMAND)
             .arg("--request")
             .arg(&request_path)
@@ -150,7 +153,15 @@ impl<'a> ScenarioRunner<'a> {
             .arg(&output_path)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::null());
+        bridge_constant_worker_gate(
+            &mut command,
+            self.context.output_directory,
+            self.context
+                .worker_nonce
+                .map(|_| self.qualification_nonce.as_str()),
+        );
+        let child = command
             .spawn()
             .with_context(|| format!("spawn qualification worker {invocation_id}"))?;
         let pid = child.id();
@@ -290,5 +301,54 @@ impl<'a> ScenarioRunner<'a> {
                 Some(snapshot.clone()),
             ));
         Ok(snapshot)
+    }
+}
+
+fn bridge_constant_worker_gate(command: &mut Command, directory: &Path, nonce: Option<&str>) {
+    if let Some(nonce) = nonce {
+        command
+            .env(QUALIFICATION_DIR_ENV, directory)
+            .env(QUALIFICATION_NONCE_ENV, nonce);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bridge_constant_worker_gate;
+    use crate::qualification::request::{QUALIFICATION_DIR_ENV, QUALIFICATION_NONCE_ENV};
+    use std::ffi::OsStr;
+    use std::process::Command;
+
+    #[test]
+    fn constant_worker_gate_is_child_local_and_full_qualification_still_inherits() {
+        let mut constant = Command::new("unused");
+        bridge_constant_worker_gate(
+            &mut constant,
+            std::path::Path::new("/private/calibration"),
+            Some("constant-nonce"),
+        );
+        let constant_env = constant
+            .get_envs()
+            .map(|(name, value)| (name, value))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(
+            constant_env.get(OsStr::new(QUALIFICATION_DIR_ENV)),
+            Some(&Some(OsStr::new("/private/calibration")))
+        );
+        assert_eq!(
+            constant_env.get(OsStr::new(QUALIFICATION_NONCE_ENV)),
+            Some(&Some(OsStr::new("constant-nonce")))
+        );
+
+        let mut qualification = Command::new("unused");
+        bridge_constant_worker_gate(
+            &mut qualification,
+            std::path::Path::new("/private/qualification"),
+            None,
+        );
+        assert!(
+            qualification.get_envs().next().is_none(),
+            "the full qualification path must continue inheriting its existing gate"
+        );
     }
 }

--- a/crates/codestory-bench/src/lib.rs
+++ b/crates/codestory-bench/src/lib.rs
@@ -1,2 +1,6 @@
 // Main library for benchmarks
+#[doc(hidden)]
+#[path = "bin/codestory_embedding_qualification/mod.rs"]
+pub mod qualification;
+
 pub mod util;

--- a/crates/codestory-cli/src/app.rs
+++ b/crates/codestory-cli/src/app.rs
@@ -120,6 +120,22 @@ use runtime::map_api_error;
 pub async fn run() -> ExitCode {
     let raw_args = std::env::args_os().collect::<Vec<_>>();
     let json = json_output_requested(&raw_args);
+    if std::env::var_os("CODESTORY_EMBED_ALLOW_CPU")
+        .is_some_and(|value| !value.is_empty() && value != "0")
+    {
+        let envelope = command_failure_envelope(
+            "unsupported_embedding_policy",
+            "embedding_backend",
+            "CPU embeddings are unsupported; CodeStory requires Metal or Vulkan acceleration",
+            serde_json::json!({"environment": "CODESTORY_EMBED_ALLOW_CPU"}),
+        );
+        if json {
+            emit_command_failure(&envelope, requested_output_file(&raw_args));
+        } else {
+            eprintln!("Error: {}", envelope.error.message);
+        }
+        return ExitCode::FAILURE;
+    }
     let cli = match Cli::try_parse_from(&raw_args) {
         Ok(cli) => cli,
         Err(error) => {

--- a/crates/codestory-cli/src/embedding_qualification/worker.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker.rs
@@ -6,9 +6,10 @@ use self::gate::{
 };
 use self::operations::{
     run_activate_probe, run_cold_race_protocol_exchange, run_dead_client_load,
-    run_measure_busy_retry, run_measure_hello, run_measure_product_query,
-    run_measure_resident_identity, run_measure_spawn_hello, run_measure_true_idle,
-    run_measure_vector_frame, run_queue_load, wait_for_owner_absence,
+    run_measure_busy_retry, run_measure_constant_cold_query, run_measure_constant_spawn_hello,
+    run_measure_hello, run_measure_product_query, run_measure_resident_identity,
+    run_measure_spawn_hello, run_measure_true_idle, run_measure_vector_frame, run_queue_load,
+    wait_for_owner_absence,
 };
 use self::protocol::run_raw_protocol_exchange;
 use crate::args::InternalEmbeddingQualificationCommand;
@@ -204,6 +205,14 @@ fn run_measure_operation(
     match request.operation.as_str() {
         "measure_hello" => run_measure_hello(runtime, clock.as_ref()),
         "measure_spawn_hello" => run_measure_spawn_hello(runtime, clock.as_ref()),
+        "measure_constant_spawn_hello" => run_measure_constant_spawn_hello(runtime, clock.as_ref()),
+        "measure_constant_cold_query" => run_measure_constant_cold_query(
+            runtime,
+            clock.as_ref(),
+            workload_id,
+            repeat,
+            request.parameters.input_bytes,
+        ),
         "measure_product_query" => run_measure_product_query(
             runtime,
             clock.as_ref(),

--- a/crates/codestory-cli/src/embedding_qualification/worker/operations.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/operations.rs
@@ -9,9 +9,9 @@ pub(super) use absence::wait_for_owner_absence;
 pub(super) use activation::{run_activate_probe, run_cold_race_protocol_exchange};
 pub(super) use dead_client::run_dead_client_load;
 pub(super) use measure::{
-    run_measure_busy_retry, run_measure_hello, run_measure_product_query,
-    run_measure_resident_identity, run_measure_spawn_hello, run_measure_true_idle,
-    run_measure_vector_frame,
+    run_measure_busy_retry, run_measure_constant_cold_query, run_measure_constant_spawn_hello,
+    run_measure_hello, run_measure_product_query, run_measure_resident_identity,
+    run_measure_spawn_hello, run_measure_true_idle, run_measure_vector_frame,
 };
 pub(super) use queue::run_queue_load;
 

--- a/crates/codestory-cli/src/embedding_qualification/worker/operations/measure.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/operations/measure.rs
@@ -212,6 +212,37 @@ pub(in crate::embedding_qualification::worker) fn run_measure_spawn_hello(
     Ok(measurement(span, resident))
 }
 
+/// Constant calibration's spawn sample stops after the compatible hello. It
+/// deliberately leaves the fresh owner without a resident model so the next
+/// product request can measure first-vector latency on this same generation.
+pub(in crate::embedding_qualification::worker) fn run_measure_constant_spawn_hello(
+    runtime: &SidecarRuntimeConfig,
+    clock: &dyn AwakeMonotonicClock,
+) -> Result<WorkerMeasurement> {
+    let transport = crate::embedding_server_transport::NativeEmbeddingClientTransport::capture()?;
+    let client = PerUserEmbeddingClient::for_runtime(runtime)?;
+    if client.observe()?.is_some() {
+        bail!("embedding_constant_calibration_spawn_owner_present");
+    }
+    let start = begin_span(clock)?;
+    let spawn_attempt = transport.spawn_exact_current_exe()?;
+    let mut stream = connect_until(
+        &transport,
+        clock,
+        SPAWN_CONVERGENCE_BUDGET,
+        Some(&spawn_attempt),
+    )?;
+    let hello = validated_hello(&mut stream, &transport, runtime, clock)?;
+    let span = finish_span(clock, start)?;
+    if hello.process.server_instance_id.is_empty()
+        || hello.process.process_start_id.is_empty()
+        || hello.engine.is_some()
+    {
+        bail!("embedding_constant_calibration_spawn_not_cold");
+    }
+    Ok(measurement(span, hello))
+}
+
 /// `cold_first_vector` and `first_product_ready`: span
 /// [`product_request_started(...)` -> `..._validated`] around client
 /// construction plus one `embed_query`; the client validates identity,
@@ -236,6 +267,41 @@ pub(in crate::embedding_qualification::worker) fn run_measure_product_query(
         .observe()?
         .filter(resident_engine_generation)
         .ok_or_else(|| anyhow::anyhow!("embedding_qualification_product_owner_missing"))?;
+    Ok(measurement(span, snapshot))
+}
+
+/// Constant calibration decomposes process spawn from first model use. The
+/// fresh owner must still have no resident generation when this interval
+/// starts, and the first product query must load the model on that same server
+/// generation.
+pub(in crate::embedding_qualification::worker) fn run_measure_constant_cold_query(
+    runtime: &SidecarRuntimeConfig,
+    clock: &dyn AwakeMonotonicClock,
+    workload_id: &str,
+    repeat: u32,
+    input_bytes: u32,
+) -> Result<WorkerMeasurement> {
+    let client = PerUserEmbeddingClient::for_runtime(runtime)?;
+    let cold_owner = client
+        .observe()?
+        .filter(|snapshot| snapshot.engine.is_none())
+        .ok_or_else(|| anyhow::anyhow!("embedding_constant_calibration_owner_not_cold"))?;
+    let input = workload_input(workload_id, repeat, 0, input_bytes.max(1) as usize);
+    let start = begin_span(clock)?;
+    let vector = client.embed_query(&input)?;
+    let span = finish_span(clock, start)?;
+    if vector.is_empty() {
+        bail!("embedding_constant_calibration_product_vector_missing");
+    }
+    let snapshot = client
+        .observe()?
+        .filter(resident_engine_generation)
+        .ok_or_else(|| anyhow::anyhow!("embedding_constant_calibration_product_owner_missing"))?;
+    if snapshot.process.server_instance_id != cold_owner.process.server_instance_id
+        || snapshot.process.process_start_id != cold_owner.process.process_start_id
+    {
+        bail!("embedding_constant_calibration_generation_changed");
+    }
     Ok(measurement(span, snapshot))
 }
 

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -1519,7 +1519,7 @@ mod tests {
         let _managed_env = EnvSnapshot::clear(MANAGED_ENV_VARS);
         let _home_env = EnvSnapshot::clear(HOME_ENV_VARS);
         unsafe {
-            env::set_var("CODESTORY_EMBED_ALLOW_CPU", "1");
+            env::set_var("CODESTORY_TEST_EMBED_ALLOW_CPU", "1");
         }
         let temp = tempdir().expect("temp dir");
         let project = temp.path().join("project");
@@ -1583,7 +1583,7 @@ mod tests {
         let _managed_env = EnvSnapshot::clear(MANAGED_ENV_VARS);
         let _home_env = EnvSnapshot::clear(HOME_ENV_VARS);
         unsafe {
-            env::set_var("CODESTORY_EMBED_ALLOW_CPU", "1");
+            env::set_var("CODESTORY_TEST_EMBED_ALLOW_CPU", "1");
         }
         let temp = tempdir().expect("temp dir");
         let project = temp.path().join("project");
@@ -1690,7 +1690,7 @@ mod tests {
         let _managed_env = EnvSnapshot::clear(MANAGED_ENV_VARS);
         let _home_env = EnvSnapshot::clear(HOME_ENV_VARS);
         unsafe {
-            env::set_var("CODESTORY_EMBED_ALLOW_CPU", "1");
+            env::set_var("CODESTORY_TEST_EMBED_ALLOW_CPU", "1");
         }
         let temp = tempdir().expect("temp dir");
         let project = temp.path().join("project");

--- a/crates/codestory-cli/tests/cli_error_contracts.rs
+++ b/crates/codestory-cli/tests/cli_error_contracts.rs
@@ -184,7 +184,7 @@ fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> std::process::O
         .arg(workspace)
         .arg("--cache-dir")
         .arg(cache_dir)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1");
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1");
     command.output().expect("run codestory-cli")
 }
 
@@ -298,6 +298,25 @@ fn top_level_help_names_command_purposes() {
             "top-level help should show {command:?} purpose {purpose:?}, not only command names:\n{help_text}"
         );
     }
+}
+
+#[test]
+fn product_cli_rejects_the_removed_cpu_embedding_selector() {
+    let output = test_support::cli_command()
+        .args(["doctor", "--format", "json"])
+        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .output()
+        .expect("run removed CPU selector");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("CPU embeddings are unsupported"));
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["error"]["code"], "unsupported_embedding_policy");
+    assert_eq!(
+        json["error"]["details"]["failed_layer"],
+        "embedding_backend"
+    );
+    assert_eq!(json["context"]["environment"], "CODESTORY_EMBED_ALLOW_CPU");
 }
 
 #[test]

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -92,7 +92,7 @@ fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> std::process::O
         .arg(workspace)
         .arg("--cache-dir")
         .arg(cache_dir)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1");
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1");
     command.output().expect("run codestory-cli")
 }
 
@@ -108,7 +108,7 @@ fn run_cli_with_stdin(
         .arg(workspace)
         .arg("--cache-dir")
         .arg(cache_dir)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -136,7 +136,7 @@ fn run_cli_with_embedding_env(
         .arg(workspace)
         .arg("--cache-dir")
         .arg(cache_dir)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1");
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1");
     for (name, value) in envs {
         command.env(name, value);
     }
@@ -201,7 +201,7 @@ fn run_stdio_request(workspace: &Path, cache_dir: &Path, request: &str) -> Value
         .arg(workspace)
         .arg("--cache-dir")
         .arg(cache_dir)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -937,7 +937,7 @@ pub fn schedule_index(project_path: &str) -> usize {
         cache_dir.path(),
         &["agent", "preflight", "--format", "json"],
         &[
-            ("CODESTORY_EMBED_ALLOW_CPU", "1"),
+            ("CODESTORY_TEST_EMBED_ALLOW_CPU", "1"),
             ("CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS", "0"),
         ],
     );

--- a/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
+++ b/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
@@ -858,7 +858,7 @@ fn run_cli_output_with_sidecar_cache_root(
         .arg(cache_dir)
         .env_remove("CODESTORY_STDIO_CACHE_ROOT")
         .env("CODESTORY_CACHE_ROOT", sidecar_cache_root)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .output()
         .expect("run codestory-cli");
     let seconds = started.elapsed().as_secs_f64();

--- a/crates/codestory-cli/tests/http_transport_contracts.rs
+++ b/crates/codestory-cli/tests/http_transport_contracts.rs
@@ -150,7 +150,7 @@ fn indexed_fixture() -> HttpFixture {
         .arg(workspace.path())
         .arg("--cache-dir")
         .arg(cache_dir.path())
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .output()
         .expect("run index");
     assert!(
@@ -185,7 +185,7 @@ fn indexed_zero_dense_fixture() -> HttpFixture {
         .arg(workspace.path())
         .arg("--cache-dir")
         .arg(cache_dir.path())
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .output()
         .expect("run zero-dense index");
     assert!(
@@ -245,7 +245,7 @@ fn http_serve_rejects_non_loopback_addr_before_opening_runtime_state() {
         .arg(cache_dir.path())
         .arg("--addr")
         .arg("0.0.0.0:0")
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .output()
         .expect("run serve");
     assert!(
@@ -273,7 +273,7 @@ fn spawn_http_server(fixture: &HttpFixture) -> (HttpServer, String) {
         .arg(fixture.cache_dir.path())
         .arg("--addr")
         .arg(&addr)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -274,7 +274,7 @@ fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> String {
         .arg(workspace)
         .arg("--cache-dir")
         .arg(cache_dir)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .output()
         .expect("run codestory-cli");
     assert!(

--- a/crates/codestory-cli/tests/report_export.rs
+++ b/crates/codestory-cli/tests/report_export.rs
@@ -77,7 +77,7 @@ fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> String {
         .arg(workspace)
         .arg("--cache-dir")
         .arg(cache_dir)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .output()
         .expect("run codestory-cli");
     assert!(

--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -100,7 +100,7 @@ fn run_cli(workspace: &Path, args: &[&str]) -> std::process::Output {
     command.args(args);
     command.arg("--project").arg(workspace);
     command.env("CODESTORY_HYBRID_RETRIEVAL_ENABLED", "true");
-    command.env("CODESTORY_EMBED_ALLOW_CPU", "1");
+    command.env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1");
     command.output().expect("run codestory-cli")
 }
 

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -300,7 +300,7 @@ fn write_managed_cli_fixture(plugin_data: &Path, version: &str) -> PathBuf {
 }
 
 fn allow_explicit_cpu_embeddings(command: &mut Command) {
-    command.env("CODESTORY_EMBED_ALLOW_CPU", "1");
+    command.env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1");
 }
 
 fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
@@ -370,7 +370,7 @@ fn spawn_multi_project_stdio_server(cache_root: &Path) -> StdioServer {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .env("CODESTORY_STDIO_CACHE_ROOT", cache_root)
         .env("CODESTORY_PLUGIN_MULTI_PROJECT", "1")
         .spawn()

--- a/crates/codestory-cli/tests/stdio_warm_loop_stats.rs
+++ b/crates/codestory-cli/tests/stdio_warm_loop_stats.rs
@@ -219,7 +219,7 @@ fn run_cli_json(binary: &Path, workspace: &Path, cache_dir: &Path, args: &[Strin
         .arg(workspace)
         .arg("--cache-dir")
         .arg(cache_dir)
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .output()
         .expect("run codestory-cli");
     let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
@@ -247,7 +247,7 @@ fn spawn_stdio_server(binary: &Path, fixture: &WarmLoopFixture) -> StdioServer {
         .arg(fixture.workspace.path())
         .arg("--cache-dir")
         .arg(fixture.cache_dir.path())
-        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -40,27 +40,10 @@
     "maximum_payload_bytes": 16777216,
     "protocol_schema_version": 1,
     "pure_embedding_rpc_replay_limit": 1,
-    "query_queue_capacity": 64
+    "query_queue_capacity": 64,
+    "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "bdaf0d80a19af41cb1acdcc4d0ee7dbca4b90481d4e5616f72416b65923f5b0e",
-    "calibration_freeze_digest": "67e0af9456ddc1afc7ba2298b546024f36b1f92034b9b9e7363936ffbedae0b1",
-    "input_constant_set_sha256": "fb0326d180cc5e2e6cae46d70e5a7706d5ed423c30fb95b4b983ed61dcdc2e2c",
-    "measurement_protocol_sha256": "6d29a6a92dc6f9552d004806f0bb0785c040e57a9de25e3877d26bb76e78f04b",
-    "protocol_sha256": "f4a3fa4afb4d5bcd8e707a5e21b687cdd023dc3398b28ff6891a2318e89c5ec7",
-    "run_artifact_sha256s": [
-      "184d5aa079369f8057acb71576a6a1e4dfd2f4e2f56ec20d17a9aab147c9f8dc",
-      "2fd6767d1195f9852ca56dfffb8511eb3c001e7f65450aed33c77e27a5b60d44",
-      "5ef180010acdcb6f518fefc9dac00a9da8277b4c4d397c0006efd9e1424d2c42",
-      "6e5e26f19b6028d87bd19ffca8d4dbec5d3ebaa0fd2037003723f7eef9d9f557",
-      "943449b5c7c187c397f2530011d08d5f56b9f41509bd182fbd7b03f970678116",
-      "fcad9b4c59792c1493ccc4ae96c9d3377efced89460b561cd1c4a2c7017377d7"
-    ],
-    "selected_at": "github-actions-run:30329118684:1",
-    "selection_rule": "all_preregistered_clean_runs_no_outlier_removal+slow_host_floors_v1",
-    "selection_source_commit": "6b0f4b2edb7d99fe43b63cfb0bd3a85ca9d0032c",
-    "selection_source_tree": "c759c770b6de9b0b5051a145d5862444052d5cdd"
-  },
+  "freeze_record": null,
   "qualification_thresholds": {
     "backend_observed_accelerator_residency": 1,
     "bulk_documents_per_second": 2,
@@ -72,11 +55,11 @@
     "retrieval_quality": 1.0,
     "spawn_convergence": 486,
     "total_codestory_process_memory": 3366597428,
-    "true_idle_exit": 71374,
+    "true_idle_exit": 62500,
     "warm_bulk_ipc": 29119,
     "warm_query_ipc": 577
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json
@@ -63,16 +63,6 @@
     "rationale": "the incumbent in-process runtime does not expose the same server phase hooks or ownership semantics, so a paired delta would conflate IPC with runtime, cache, model-load, and lifecycle changes"
   },
   "calibration_matrix": {
-    "hosted_linux_x64_cpu": {
-      "asset_target": "linux-x64",
-      "proof_tier": "calibration",
-      "host_class": "github_hosted_linux_x64",
-      "policy": "cpu_explicit",
-      "backend": "cpu",
-      "cache_state": "reused",
-      "residency_state": "resident",
-      "accelerator_claim": "none"
-    },
     "protected_macos_arm64_metal": {
       "asset_target": "macos-arm64",
       "proof_tier": "calibration",
@@ -84,17 +74,20 @@
       "accelerator_claim": "metal"
     }
   },
-  "host_package_matrix": {
-    "hosted_linux_x64_cpu": {
+  "optional_calibration_evidence_matrix": {
+    "protected_linux_x64_vulkan": {
       "asset_target": "linux-x64",
-      "proof_tier": "hosted_package",
-      "host_class": "github_hosted_linux_x64",
-      "policy": "cpu_explicit",
-      "backend": "cpu",
+      "proof_tier": "calibration",
+      "host_class": "protected_self_hosted_linux_x64",
+      "policy": "accelerated",
+      "backend": "vulkan",
       "cache_state": "reused",
       "residency_state": "resident",
-      "accelerator_claim": "none"
-    },
+      "accelerator_claim": "vulkan",
+      "feeds_constant_selection": false
+    }
+  },
+  "host_package_matrix": {
     "protected_macos_arm64_metal": {
       "asset_target": "macos-arm64",
       "proof_tier": "protected_hardware",
@@ -179,6 +172,47 @@
       "publishable_packet_candidate_fixed",
       "publishable_packet_pass_rate_scored"
     ]
+  },
+  "calibration_phase_boundaries": {
+    "existing_owner_connect": [
+      "client_connect_started",
+      "compatible_hello_validated"
+    ],
+    "spawn_convergence": [
+      "owner_absence_proven",
+      "compatible_hello_validated"
+    ],
+    "cold_first_vector": [
+      "product_request_started_with_fresh_owner_model_absent",
+      "first_vector_and_engine_evidence_validated"
+    ],
+    "first_product_ready": [
+      "product_request_started",
+      "product_result_validated"
+    ],
+    "warm_query_ipc": [
+      "client_frame_started",
+      "query_response_identity_and_vector_validated"
+    ],
+    "warm_bulk_ipc": [
+      "client_frame_started",
+      "bulk_response_identity_and_vectors_validated"
+    ],
+    "bulk_documents_per_second": [
+      "bulk_measurement_window_started",
+      "bulk_document_results_validated"
+    ],
+    "bulk_tokens_per_second": [
+      "bulk_measurement_window_started",
+      "bulk_token_results_validated"
+    ],
+    "busy_retry_usefulness": [
+      "typed_retry_emitted",
+      "named_retry_condition_became_true"
+    ]
+  },
+  "calibration_workload_state_overrides": {
+    "cold_first_vector": "fresh_owner_model_absent"
   },
   "workloads": {
     "existing_owner_connect": {
@@ -428,6 +462,46 @@
       "external_contract": "publishable-three-repeat-packet/v1"
     }
   },
+  "calibration_required_metrics": [
+    "existing_owner_connect",
+    "spawn_convergence",
+    "cold_first_vector",
+    "first_product_ready",
+    "warm_query_ipc",
+    "warm_bulk_ipc",
+    "bulk_documents_per_second",
+    "bulk_tokens_per_second",
+    "busy_retry_usefulness"
+  ],
+  "calibration_metric_sampling": {
+    "existing_owner_connect": {
+      "sample_count_per_run": 1
+    },
+    "spawn_convergence": {
+      "sample_count_per_run": 1
+    },
+    "cold_first_vector": {
+      "sample_count_per_run": 1
+    },
+    "first_product_ready": {
+      "sample_count_per_run": 1
+    },
+    "warm_query_ipc": {
+      "sample_count_per_run": 1
+    },
+    "warm_bulk_ipc": {
+      "sample_count_per_run": 1
+    },
+    "bulk_documents_per_second": {
+      "sample_count_per_run": 1
+    },
+    "bulk_tokens_per_second": {
+      "sample_count_per_run": 1
+    },
+    "busy_retry_usefulness": {
+      "sample_count_per_run": 1
+    }
+  },
   "constant_selection": {
     "selection_order": [
       "connect_timeout_ms",
@@ -440,17 +514,17 @@
     ],
     "raw_source_cells": {
       "existing_owner_connect_duration": {
-        "artifact": "measurements.raw.json",
+        "artifact": "constant-calibration-run-*.raw.json",
         "metric": "existing_owner_connect",
         "operand": "awake_end_ns-awake_start_ns"
       },
       "spawn_convergence_duration": {
-        "artifact": "measurements.raw.json",
+        "artifact": "constant-calibration-run-*.raw.json",
         "metric": "spawn_convergence",
         "operand": "awake_end_ns-awake_start_ns"
       },
       "query_request_duration": {
-        "artifact": "measurements.raw.json",
+        "artifact": "constant-calibration-run-*.raw.json",
         "metrics": [
           "cold_first_vector",
           "first_product_ready",
@@ -459,7 +533,7 @@
         "operand": "awake_end_ns-awake_start_ns"
       },
       "bulk_request_duration": {
-        "artifact": "measurements.raw.json",
+        "artifact": "constant-calibration-run-*.raw.json",
         "metrics": [
           "warm_bulk_ipc",
           "bulk_documents_per_second",
@@ -468,12 +542,12 @@
         "operand": "awake_end_ns-awake_start_ns"
       },
       "capacity_condition_duration": {
-        "artifact": "measurements.raw.json",
+        "artifact": "constant-calibration-run-*.raw.json",
         "metric": "busy_retry_usefulness",
         "operand": "awake_end_ns-awake_start_ns"
       },
       "successful_operation_duration": {
-        "artifact": "measurements.raw.json",
+        "artifact": "constant-calibration-run-*.raw.json",
         "metrics": [
           "cold_first_vector",
           "first_product_ready",
@@ -487,9 +561,10 @@
     },
     "clean_run_requirements": {
       "minimum_runs_per_matrix_cell": 3,
-      "matrix_coverage": "every_calibration_matrix_cell",
+      "matrix_coverage": "every_required_calibration_matrix_cell",
       "source_identity": "one_exact_candidate_commit_and_tree",
       "artifact_selection": "all_preregistered_clean_runs",
+      "fresh_server_identity": "disjoint_across_clean_runs",
       "unplanned_suspend": false,
       "outlier_removal": "none"
     },
@@ -520,7 +595,8 @@
           "source_cells": [
             "bulk_request_duration"
           ],
-          "replay_success_budget_formula": "max(query_request_deadline_ms,ceiling(maximum_raw_value_ms_across_all_selected_samples*1.50))",
+          "replay_success_budget_formula": "max(144537,query_request_deadline_ms,ceiling(maximum_raw_value_ms_across_all_selected_samples*1.50))",
+          "replay_success_budget_slow_host_floor_ms": 144537,
           "formula": "hard_native_no_progress_ms+watchdog_cadence_ms+spawn_convergence_timeout_ms+bulk_replay_success_budget_ms"
         }
       },
@@ -528,7 +604,8 @@
         "source_cells": [
           "capacity_condition_duration"
         ],
-        "retry_after_ms_formula": "max(1,floor(minimum_raw_value_ms_across_all_selected_samples*0.50))",
+        "retry_after_ms_formula": "max(40,floor(minimum_raw_value_ms_across_all_selected_samples*0.50))",
+        "retry_after_slow_host_floor_ms": 40,
         "retry_class": "after_capacity_change",
         "retry_condition_source": "named_condition_from_typed_capacity_response"
       },
@@ -537,51 +614,55 @@
           "existing_owner_connect_duration",
           "spawn_convergence_duration"
         ],
-        "initial_backoff_ms_formula": "max(1,ceiling(maximum_existing_owner_connect_duration_ms_across_all_selected_samples*0.50))",
-        "maximum_backoff_ms_formula": "max(initial_backoff_ms,ceiling(maximum_spawn_convergence_duration_ms_across_all_selected_samples*0.25))",
+        "initial_backoff_ms_formula": "max(7,ceiling(maximum_existing_owner_connect_duration_ms_across_all_selected_samples*0.50))",
+        "initial_backoff_slow_host_floor_ms": 7,
+        "maximum_backoff_ms_formula": "max(102,initial_backoff_ms,ceiling(maximum_spawn_convergence_duration_ms_across_all_selected_samples*0.25))",
+        "maximum_backoff_slow_host_floor_ms": 102,
         "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]"
       },
       "hard_native_no_progress_ms": {
         "source_cells": [
           "successful_operation_duration"
         ],
-        "formula": "max(1,ceiling(maximum_complete_successful_operation_duration_ms_across_all_selected_samples*4.00))"
+        "formula": "max(385431,ceiling(maximum_complete_successful_operation_duration_ms_across_all_selected_samples*4.00))",
+        "slow_host_floor_ms": 385431
       },
       "watchdog_cadence_ms": {
         "source_cells": [
           "successful_operation_duration"
         ],
-        "formula": "max(1,floor(hard_native_no_progress_ms/20))"
+        "formula": "max(19271,floor(hard_native_no_progress_ms/20))",
+        "slow_host_floor_ms": 19271
       }
     },
     "post_result_formula_changes": false,
-    "slow_host_floor_rationale": "The calibration matrix is hosted Linux x64 and protected macOS arm64 only, so no Windows named-pipe host and no host without SHA hardware acceleration contributes to the maxima these budgets scale. A release executable also embeds the model, and the spawned server hashes its whole image before it binds, so the spawn budget must cover a multi-hundred-megabyte read on a cold cache. 1.50x over a CI maximum does not cover that population. The floors are the pre-freeze draft values, which were the vetted conservative behavior. Thresholds are deliberately not floored: qualification keeps measuring regressions against the calibrated maxima while users get budgets sized for the slowest supported host."
+    "slow_host_floor_rationale": "Protected macOS Metal is the sole required calibration cell, so its observations cannot safely shrink budgets used by supported Vulkan hosts. Every upper-bound runtime constant retains its previously accepted conservative value as a floor; optional Linux Vulkan evidence is advisory and cannot reduce those floors. The capacity retry floor preserves the accepted retry pacing instead of applying the upper-bound rule blindly. Qualification thresholds are a separate frozen-candidate contract and are never selected by calibration."
   },
-  "threshold_selection": {
-    "minimum_clean_calibration_runs_per_matrix_cell": 3,
-    "matrix_coverage": "every_calibration_matrix_cell",
-    "source_identity": "one_exact_candidate_commit_and_tree",
-    "producer_identity": "trusted_packaged_platform_pr_workflow_run_and_exact_artifact",
-    "artifact_selection": "all_preregistered_clean_runs",
-    "less_than_or_equal": "ceiling(maximum_cell_aggregate_across_all_runs*1.20)",
-    "greater_than_or_equal": "floor(minimum_cell_aggregate_across_all_runs*0.80)",
-    "equal": "exact_observed_contract_value",
-    "retrieval_quality": 1.0,
-    "outlier_removal": "none",
-    "post_result_threshold_changes": false
+  "qualification_threshold_contract": {
+    "source": "checked_in_frozen_candidate_contract",
+    "selected_by_calibration": false,
+    "omitted_measurements": "preserve_checked_in_thresholds",
+    "true_idle_exit": {
+      "idle_timeout_ms": 60000,
+      "observation_grace_ms": 2500,
+      "formula": "idle_timeout_ms+observation_grace_ms",
+      "required_threshold_ms": 62500,
+      "qualification_runs_per_available_gpu_platform": 1
+    }
   },
   "calibration_bundle_contract": {
     "schema_version": 1,
     "required_for_frozen_qualification": true,
     "matrix_cells": "exactly_every_calibration_matrix_cell",
     "independent_clean_runs_per_matrix_cell": 3,
+    "samples_per_metric_per_run": 1,
     "source_identity": "one_exact_candidate_commit_and_tree",
     "producer_identity": "trusted_packaged_platform_pr_workflow_run_and_exact_artifact",
     "contract_identity": [
       "protocol_sha256",
       "measurement_protocol_sha256"
     ],
-    "raw_artifact": "embedded_product_and_five_process_measurements_with_canonical_sha256",
+    "raw_artifact": "nine_constant_source_metrics_with_canonical_sha256",
     "clock_witnesses": "awake_monotonic_plus_suspend_inclusive_per_sample",
     "successful_operation_operand": "successful_operation_duration_ns",
     "freeze_digest_inputs": [
@@ -590,11 +671,10 @@
       "producer",
       "contracts",
       "run_artifact_sha256s",
-      "calibration_required_values",
-      "qualification_thresholds"
+      "calibration_required_values"
     ],
-    "constant_set_comparison": "exact_recomputed_values_thresholds_and_freeze_record",
-    "qualification_boundary": "installed_runtime_cells_are_post_freeze_qualification_only"
+    "constant_set_comparison": "exact_recomputed_runtime_constants_and_freeze_record",
+    "qualification_boundary": "lifecycle_fault_idle_memory_quality_accelerator_and_performance_are_frozen_candidate_qualification_only"
   },
   "measurement_rules": {
     "calibration_and_qualification_are_distinct": true,
@@ -602,6 +682,8 @@
     "quality_uses_publishable_three_repeat_packet_contract": true,
     "constants_frozen_before_qualification": true,
     "missing_required_cell_fails": true,
+    "calibration_runs_full_qualification": false,
+    "qualification_runs_once_per_available_gpu_platform": true,
     "outlier_removal": "none",
     "performance_block_rejects_unplanned_suspend_or_power_transition": true,
     "threshold_movement_after_results": false

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -155,7 +155,7 @@ impl SidecarProcessDefaults {
     pub fn embedding_allow_cpu(&self) -> bool {
         #[cfg(any(test, feature = "test-support"))]
         {
-            return default_flag(&self.runtime, "CODESTORY_TEST_EMBED_ALLOW_CPU", false);
+            default_flag(&self.runtime, "CODESTORY_TEST_EMBED_ALLOW_CPU", false)
         }
         #[cfg(not(any(test, feature = "test-support")))]
         {

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -19,7 +19,7 @@ const RUNTIME_ENV_KEYS: &[&str] = &[
     "CODESTORY_RETRIEVAL_RUN_ID",
     "CI",
     "GITHUB_ACTIONS",
-    "CODESTORY_EMBED_ALLOW_CPU",
+    "CODESTORY_TEST_EMBED_ALLOW_CPU",
     "CODESTORY_HYBRID_RETRIEVAL_ENABLED",
     "CODESTORY_SEMANTIC_DOC_SCOPE",
     "CODESTORY_SEMANTIC_DOC_ALIAS_MODE",
@@ -97,9 +97,9 @@ impl SidecarProfile {
 
 /// Fixed process embedding policy.
 ///
-/// All model, tokenizer, pooling, normalization, and backend selection inputs
-/// are compile-time product contracts. The sole runtime policy is whether an
-/// explicitly requested CPU engine is allowed.
+/// Product builds require an accelerated backend. The boolean remains in the
+/// internal contract only so test-support builds can exercise CPU-shaped
+/// failure and compatibility boundaries without making CPU a product mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EmbeddingRuntimeConfig {
     pub allow_cpu: bool,
@@ -153,7 +153,14 @@ impl SidecarProcessDefaults {
     }
 
     pub fn embedding_allow_cpu(&self) -> bool {
-        default_flag(&self.runtime, "CODESTORY_EMBED_ALLOW_CPU", false)
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            return default_flag(&self.runtime, "CODESTORY_TEST_EMBED_ALLOW_CPU", false);
+        }
+        #[cfg(not(any(test, feature = "test-support")))]
+        {
+            false
+        }
     }
 
     pub fn with_cache_root(&self, cache_root: PathBuf) -> Self {
@@ -691,9 +698,9 @@ mod tests {
     }
 
     #[test]
-    fn process_defaults_capture_the_only_embedding_policy() {
+    fn test_support_process_defaults_capture_the_cpu_fixture_policy() {
         let root = tempfile::tempdir().expect("cache root");
-        let defaults = defaults(root.path(), &[("CODESTORY_EMBED_ALLOW_CPU", "1")]);
+        let defaults = defaults(root.path(), &[("CODESTORY_TEST_EMBED_ALLOW_CPU", "1")]);
         let runtime = SidecarRuntimeConfig::for_project_profile_with_process_defaults(
             None,
             SidecarProfile::Local,

--- a/crates/codestory-retrieval/src/embedding_contract.rs
+++ b/crates/codestory-retrieval/src/embedding_contract.rs
@@ -25,7 +25,14 @@ const MAX_BATCH_SEQUENCES: u32 = 6;
 pub(crate) fn native_engine_config(allow_cpu: bool) -> Result<EmbeddingEngineConfig> {
     let capabilities = compiled_engine_capabilities();
     let (backend, device_class) = if allow_cpu {
-        ("cpu", NativeDeviceClass::Cpu)
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            ("cpu", NativeDeviceClass::Cpu)
+        }
+        #[cfg(not(any(test, feature = "test-support")))]
+        {
+            bail!("embedding_backend_policy_cpu_unsupported")
+        }
     } else {
         let backend = match capabilities.target_os {
             "macos" => "metal",
@@ -116,7 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn backend_policy_is_explicit_and_never_uses_implicit_cpu_fallback() {
+    fn product_backend_is_accelerated_while_test_support_can_model_cpu() {
         let cpu = native_engine_config(true).expect("explicit CPU config");
         assert_eq!(cpu.backend.backend, "cpu");
         assert_eq!(cpu.backend.device_class, NativeDeviceClass::Cpu);

--- a/crates/codestory-retrieval/src/per_user_embedding/server/lifecycle.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/server/lifecycle.rs
@@ -192,6 +192,10 @@ pub(in crate::per_user_embedding) fn reap_finished_connection_handlers(
 }
 
 fn validate_server_config(config: &PerUserEmbeddingServerConfig) -> Result<()> {
+    #[cfg(not(any(test, feature = "test-support")))]
+    if config.allow_cpu {
+        bail!("embedding_backend_policy_cpu_unsupported");
+    }
     if config.budgets.idle_timeout
         != Duration::from_millis(PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS)
     {

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -48,10 +48,10 @@ batching contract.
 | Windows x64 | v0.16 package with verified Vulkan acceleration |
 | Linux x64 | v0.16 package with verified Vulkan acceleration |
 | Other targets | no v0.16 package or runtime claim |
-| Hosted CI or maintainer diagnostic | CPU only with `CODESTORY_EMBED_ALLOW_CPU=1` |
 
-There is no silent GPU-to-CPU fallback. Software adapters such as llvmpipe,
-lavapipe, WARP, and SwiftShader do not satisfy accelerated policy.
+CPU embeddings are unsupported. There is no GPU-to-CPU fallback. Software
+adapters such as llvmpipe, lavapipe, WARP, and SwiftShader do not satisfy
+accelerated policy.
 
 ## Per-project artifact layout
 
@@ -173,7 +173,7 @@ publication. Broad agent surfaces additionally require:
 - a current core and source identity;
 - the exact server and producer identity;
 - a current or automatically restorable timed embedding smoke;
-- `accelerated` or explicitly permitted `cpu_explicit` policy;
+- `accelerated` policy with CPU embeddings disabled;
 - an allowed packet/search/context surface.
 
 This preserves the wire contract while preventing a full manifest from

--- a/docs/architecture/subsystems/llama-sys.md
+++ b/docs/architecture/subsystems/llama-sys.md
@@ -28,9 +28,9 @@ The build also embeds a parseable `codestory-native-engine-v1` marker with the
 target triple, native binary architecture, linkage and backend-loading mode,
 compiled backend set, llama crate/source identity, exact model digest, a stable
 digest of the model/vector/tokenizer contract, model presence, and producer
-version. macOS keeps Metal built in. Windows and Linux load packaged core, CPU,
-and Vulkan modules at runtime so the base executable does not acquire a
-mandatory Vulkan-loader dependency. Release packaging inspects PE imports, ELF
+version. macOS keeps Metal built in. Windows and Linux load packaged native
+modules at runtime so the base executable does not acquire a mandatory
+Vulkan-loader dependency. Release packaging inspects PE imports, ELF
 `DT_NEEDED`, or Mach-O load commands, verifies the complete target-specific
 runtime set, and records every artifact and digest in
 `codestory-native-manifest.json`.
@@ -59,7 +59,8 @@ batch limits, smoke input, backend, and device class. The crate checks only the
 compiled model compatibility facts it must execute, currently dimension and
 pooling, and returns raw vectors plus engine diagnostics. Model selection,
 prefixes, normalization, vector schema, batching policy, persisted evidence,
-and CPU/accelerator policy live in `codestory-retrieval`. The binding does not
+and accelerator admission policy live in `codestory-retrieval`. The binding
+does not
 select a project, publish a retrieval generation, or decide whether
 packet/search may serve.
 
@@ -68,7 +69,7 @@ packet/search may serve.
 A model, tokenizer, pooling, normalization, vector-dimension, backend, or ggml
 change creates a new producer identity and requires retrieval rebuild and
 same-run performance/quality evidence. Add capability reporting here; add
-product selection and fallback policy in retrieval. Production must never
+product selection and failure policy in retrieval. Production must never
 respond to accelerator failure by silently selecting CPU.
 
 ## Failure signatures

--- a/docs/architecture/subsystems/retrieval.md
+++ b/docs/architecture/subsystems/retrieval.md
@@ -28,7 +28,7 @@ dense-anchor inputs, and the immutable embedding policy. Outputs are:
   execution and result identity
 - `health.rs` and `mode.rs`: artifact classification and live readiness
 - `embedding_contract.rs`: model, prefix, pooling, normalization, dimension,
-  batching, backend, and explicit CPU/accelerator policy
+  batching, backend, and accelerated execution policy
 - `per_user_embedding.rs`: bounded protocol, compatibility, server scheduler,
   leases, client replay boundary, and diagnostics
 - `retention.rs`: generation leases and owned cleanup

--- a/docs/contributors/debugging.md
+++ b/docs/contributors/debugging.md
@@ -86,7 +86,9 @@ Check:
 - whether runtime rebuilt its search state after indexing
 - what retrieval mode `index`, `ground`, or `search` reported for the current run
 - whether retrieval is not full or symbol docs / dense anchors are missing
-- whether `CODESTORY_HYBRID_RETRIEVAL_ENABLED`, `CODESTORY_SEMANTIC_DOC_SCOPE`, or explicit CPU policy changed between runs
+- whether `CODESTORY_HYBRID_RETRIEVAL_ENABLED`,
+  `CODESTORY_SEMANTIC_DOC_SCOPE`, or a prohibited CPU selector appeared
+  between runs
 - whether graph-based boosts are overwhelming lexical matches
 
 Recovery order:

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -14,7 +14,8 @@ developer shell, use `CMAKE_GENERATOR=Ninja` when the nested Vulkan shader build
 selects MSBuild, and keep the worktree path short enough for CMake's object-path
 limit. On macOS, CodeStory development supports macOS 15 or later and requires
 the Xcode Command Line Tools. Apple Silicon is the protected Metal cell; Intel
-Mac development uses explicit CPU operation and never claims Metal.
+Mac development can run source-only checks but cannot exercise or prove broad
+retrieval. CPU-only hosts are unsupported.
 
 Debug Rust builds compile without embedding the release model. Prepare the
 checksum-pinned model explicitly before a release build, then pass the printed
@@ -184,13 +185,13 @@ Useful diagnostic policies:
 
 | Variable | Purpose |
 | --- | --- |
-| `CODESTORY_EMBED_ALLOW_CPU=1` | Explicit hosted-CI or maintainer CPU operation; never an acceleration claim |
 | `CODESTORY_SEMANTIC_DOC_SCOPE=all` | Broader all-symbol diagnostic document set |
 | `CODESTORY_SEMANTIC_DOC_ALIAS_MODE=no_alias|current_alias` | Reproduce nondefault alias experiments; default is compact `alias_variant` |
 | `CODESTORY_LLM_DOC_EMBED_BATCH_SIZE=<n>` | Embedding batch-size experiment |
 
 Hash embeddings and lexical-only modes are diagnostics, not agent-facing full
-retrieval.
+retrieval. CPU embeddings are unsupported; supported broad retrieval requires
+Metal or Vulkan acceleration.
 
 ## Cache reuse across worktrees
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -137,7 +137,7 @@ Focused proof covers:
   for release builds;
 - embedded-model digest and atomic materialization;
 - linked ggml build identity;
-- explicit `accelerated` or `cpu_explicit` policy;
+- explicit `accelerated` policy with CPU embeddings disabled;
 - prohibited silent CPU fallback and software-adapter rejection;
 - live embedding smoke plus post-encode backend observations for execution
   device/backend, layer placement, resident tensor count/bytes, execution nodes,
@@ -183,13 +183,25 @@ alone is not treated as OS-level denial. This proves the Cargo release boundary,
 not that the separately packaged Linux archive was produced by that discarded
 fresh-target build.
 
-Hosted source/package jobs may set:
+CPU embeddings are unsupported in package, calibration, qualification, and
+release-proof jobs. Source-only contract tests may exercise CPU rejection, but
+cannot emit product or release evidence.
 
-```sh
-CODESTORY_EMBED_ALLOW_CPU=1
-```
+Runtime-constant calibration runs three clean protected Apple Silicon Metal
+generations with one sample per metric per run. It builds and packages once,
+prepares the projects and model once, and performs no lifecycle, fault,
+true-idle, memory, retrieval-quality, or accelerator qualification. A manually
+dispatched Linux Vulkan calibration may emit optional diagnostic evidence, but
+it does not feed or block the frozen calibration bundle.
 
-They must report `cpu_explicit` and make no acceleration claim.
+Frozen-candidate qualification is a separate one-run-per-platform lane.
+Protected Metal produces the exact three-task, three-repeat holdout quality
+artifact from the packaged candidate, then Metal and Windows Vulkan each run
+the full lifecycle, fault, true-idle, memory, quality, and accelerator suite
+once. Protected Linux Vulkan may consume those exact package, calibration, and
+quality artifacts through a standalone dispatch when its GPU runner is online;
+it is not a coordinator closeout dependency and cannot block qualification
+when that runner is absent.
 
 ### Packaged proof
 
@@ -207,17 +219,19 @@ commit and tree, executable digest, server protocol, accepted constant set, and
 measurement protocol. `--version-only` proves package structure, version, and
 help; it does not prove a running server.
 
-Full calibration and qualification use the ordinary plugin launcher with two
-independently started host processes and different repositories.
+Protected and installed qualification use the ordinary plugin launcher with
+two independently started host processes and different repositories.
 `--server-behavior-only` is the smaller release path: one host grounds one
 project, waits for search readiness in that same project, and verifies the
 resident engine and server against the package manifest. It rejects
 calibration and quality inputs and makes no two-host or broader lifecycle
 claim.
 
-`--proof-tier calibration` may collect draft measurements, but cannot satisfy a
-package, hardware, installed, or release claim. A higher qualification tier
-requires a frozen constant set and a retained qualification record.
+`--proof-tier calibration` collects draft runtime-constant measurements from a
+private synthetic project, but cannot satisfy a package, hardware, installed,
+or release claim. It never accepts a repository project, plugin root, or plugin
+handoff. A higher qualification tier requires a frozen constant set and a
+retained qualification record.
 A packaged proof handed an authenticated calibration bundle -- the manually
 dispatched `qualification` frozen-candidate lane -- runs one extra
 `--version-only --proof-tier hosted_package` invocation with
@@ -229,10 +243,7 @@ version, calibrate on the bumped tree, then freeze and release. A
 calibrate-then-bump ordering fails the guard, which names the offending paths
 and the required ordering in its failure message. Dropping the flag does not
 weaken that invocation, it breaks it: a `--version-only` proof rejects
-calibration inputs unless the lineage is enforced. The heavier frozen
-`hosted_package` qualification carries the same flag but stays dark while it
-requires the optional release-evidence packet that package proof must not
-depend on.
+calibration inputs unless the lineage is enforced.
 `--produce-qualification-evidence` requires the separate
 `codestory-embedding-qualification` driver through `--qualification-driver`.
 The harness passes the exact packaged executable to that driver through
@@ -244,15 +255,16 @@ fails.
 
 macOS packages keep the selected backend built in. Windows and Linux packages
 ship the runtime executable and native modules in one immutable generation
-selected by the public launcher through a single atomic pointer. Optional
-hosted Linux calibration and quality proof does not install a Vulkan loader
-before help, stdio initialization, or explicit diagnostic CPU execution. It
-cannot replace the protected Vulkan release proof.
+selected by the public launcher through a single atomic pointer. Help, status,
+and local navigation do not require a Vulkan loader, but broad retrieval does.
+Optional Linux constant calibration runs only on the protected Vulkan host and
+cannot feed or block the frozen bundle.
 
-Use `--plugin-handoff`, `--engine-policy`, `--expected-backend`, and `--offline`
-to make the claim explicit. Protected and installed tiers additionally name
-their exact proof tier and retained qualification file. The harness self-test
-uses synthetic fixtures only:
+Non-calibration protected and installed tiers use `--plugin-handoff`,
+`--engine-policy accelerated`, `--expected-backend`, and `--offline` to make
+the claim explicit. Constant calibration uses only its synthetic-project
+collector flags and keeps proof output outside the initially empty retained
+calibration directory. The harness self-test uses synthetic fixtures only:
 
 ```sh
 python .github/scripts/check-packaged-agent-proof.py --self-test
@@ -433,7 +445,8 @@ primary, so evidence must use the reported matched key to distinguish them.
 
 The workflow-dispatch-only Windows manifest-missing lane installs the repository's
 checksum-pinned Vulkan SDK before it compiles and runs the real locked
-`ready_command` integration target with explicit CPU runtime permission. Its
+`ready_command` integration target. Any CPU-selector coverage in that lane is
+a test-only rejection or compatibility contract, not runtime evidence. Its
 exact-only cache binds the hosted OS, Rust release, host target, versioned proof
 shape, Ninja generator, CMake and Ninja versions, default feature topology,
 workspace and vendor manifests, installer script, and lockfile. It has no
@@ -447,7 +460,8 @@ hosted package cache also binds that generator and its CMake/Ninja tool versions
 the protected Vulkan lane pins the same generator before building its package
 and records both tool versions in the retained host evidence.
 
-That Windows lane is source and protocol evidence on a hosted CPU runner. The
+That Windows lane is source and protocol evidence on a hosted runner without
+protected GPU evidence. The
 SDK preserves the production-default native compile topology; it does not prove
 Vulkan execution, a packaged archive, an installed runtime, or protected
 hardware behavior. Those claims remain with the package and protected Windows
@@ -685,6 +699,7 @@ There is intentionally no `publish_release` field on this manual command.
 State the exact SHA, commands, machine/backend, cache state, and highest proof
 tier reached. Distinguish source, package, hardware, plugin, installed-runtime,
 and live behavior evidence. Include skipped work and platform evidence still
-owed; never upgrade a hosted CPU result into a Metal or Vulkan claim. A passing
+owed; never upgrade a hosted source or package result into a Metal or Vulkan
+claim. A passing
 lower-tier row cannot satisfy a higher-tier claim, and one current row cannot
 hide stale historical evidence for the same requirement.

--- a/docs/ops/retrieval-engine.md
+++ b/docs/ops/retrieval-engine.md
@@ -46,13 +46,14 @@ and vector-schema evidence. The binding retains only the compiled compatibility
 facts needed to execute the model.
 
 macOS keeps Metal built in. Windows and Linux put the native runtime executable
-and its core, CPU, and Vulkan modules in one immutable generation. The public
+and its target-specific modules in one immutable generation. The public
 `codestory-cli` launcher reads one atomically replaced generation pointer and
 starts the executable from that pinned directory.
 The base executable does not depend on the Vulkan loader, so help, status, local
-navigation, and explicit CPU execution remain available when that loader is
-absent. Packaging verifies the actual PE import table, ELF `DT_NEEDED` entries,
-or Mach-O load commands rather than trusting build markers alone.
+navigation, and diagnostics can start when that loader is absent. Broad
+retrieval remains unavailable until an eligible physical Vulkan adapter is
+verified. Packaging verifies the actual PE import table, ELF `DT_NEEDED`
+entries, or Mach-O load commands rather than trusting build markers alone.
 
 When llama.cpp needs a path for memory mapping, CodeStory verifies the embedded
 bytes and atomically materializes them under a content-addressed cache name. A
@@ -104,7 +105,7 @@ Engine readiness binds:
 - the exact model digest and size;
 - the linked llama.cpp/ggml build identity;
 - the selected backend and physical adapter;
-- `accelerated` or explicit `cpu_explicit` policy;
+- `accelerated` policy with CPU embeddings disabled;
 - a timed live embedding smoke;
 - a successful encode counter and backend-observed execution device/backend,
   nodes, resident accelerator tensor count/bytes, and layer placement; and
@@ -132,17 +133,12 @@ Windows source and package proof builds pin `CMAKE_GENERATOR=Ninja`; hosted
 native-build caches include the selected generator and CMake/Ninja versions.
 When protected Windows proof builds from source, it records those tool versions
 in its host artifact. This is build determinism evidence and does not upgrade a
-hosted CPU result into a Vulkan runtime claim.
+hosted source or package result into a Vulkan runtime claim.
 
 WARP, llvmpipe, lavapipe, and other software adapters cannot satisfy an
-accelerated policy. Production never silently falls back to CPU. Hosted CI may
-set:
-
-```sh
-CODESTORY_EMBED_ALLOW_CPU=1
-```
-
-That path must report `cpu_explicit` and carries no Metal or Vulkan claim.
+accelerated policy. CPU embeddings are unsupported in product, calibration,
+and release proof. Source-only contract tests may exercise rejection behavior,
+but they cannot produce runtime evidence.
 
 ## Diagnostics
 
@@ -212,9 +208,10 @@ ownership identity is current and unambiguous.
 
 ## Proof boundary
 
-Hosted CPU proof validates source, package, protocol, same-user IPC, and the
-explicit CPU runtime path. An acceleration claim requires the same manifest-
-bound package on physical hardware. Installed-runtime qualification additionally
+Hosted proof validates source, package structure, protocol framing, and
+rejection behavior; it does not qualify an embedding runtime. Broad retrieval
+requires the same manifest-bound package on physical Metal or Vulkan hardware.
+Installed-runtime qualification additionally
 requires two independent plugin hosts, all preregistered server fault scenarios,
 frozen thresholds, and exact source/tree/archive/executable/host/session/
 protocol/constant identities. See

--- a/docs/testing/embedding-backend-benchmarks.md
+++ b/docs/testing/embedding-backend-benchmarks.md
@@ -71,11 +71,11 @@ identity to the PR before accepting a future cutover.
 
 ## Product proof
 
-Hosted jobs may set `CODESTORY_EMBED_ALLOW_CPU=1` and must label the policy
-`cpu_explicit`. Apple Silicon evidence must use the packaged Metal executable.
-Windows and Linux hardware evidence must use their packaged Vulkan executables.
-The Linux claim requires `.github/workflows/linux-vulkan-proof.yml`; hosted CPU
-proof is insufficient.
+CPU embeddings are unsupported. Apple Silicon evidence must use the packaged
+Metal executable. Windows and Linux hardware evidence must use their packaged
+Vulkan executables. The Linux claim requires
+`.github/workflows/linux-vulkan-proof.yml`; source-only CPU rejection tests are
+not runtime evidence.
 
 The packaged proof also requires offline clean-cache execution, the exact
 embedded-model digest, ggml build identity, physical adapter identity, timed

--- a/docs/testing/per-user-embedding-server-qualification.md
+++ b/docs/testing/per-user-embedding-server-qualification.md
@@ -51,6 +51,9 @@ change. It cannot pass a package, hardware, installed-runtime, or release gate.
 Qualification starts only after the constant set says `frozen`, every selected
 value and threshold is non-null, and the freeze record names the source/tree,
 host profile, sample artifact hash, selection rule, and selected values.
+Calibration, qualification, and broad retrieval require physical Metal or
+Vulkan acceleration with CPU embeddings disabled. CPU-only hosts are
+unsupported.
 
 The qualification run cannot change its own thresholds. A failure returns to a
 new source revision, which requires a new binary and new evidence.
@@ -121,37 +124,43 @@ Synthetic self-tests validate the verifier only:
 python .github/scripts/check-packaged-agent-proof.py --self-test
 ```
 
-A draft exact-package run is explicitly calibration:
+A runtime-constant calibration run uses the protected Apple Silicon Metal cell:
 
 ```sh
 cargo build --release --locked -p codestory-bench \
-  --bin codestory_embedding_qualification
+  --bin codestory_embedding_constant_calibration
 python .github/scripts/check-packaged-agent-proof.py \
   --archive <archive> \
   --checksum-file <checksums> \
   --expected-version <version> \
-  --project <repo-a> \
-  --plugin-root plugins/codestory \
-  --plugin-handoff \
-  --engine-policy cpu_explicit \
-  --expected-backend CPU \
+  --engine-policy accelerated \
+  --expected-backend Metal \
   --proof-tier calibration \
-  --qualification-matrix-cell hosted_linux_x64_cpu \
-  --produce-qualification-evidence \
-  --qualification-driver target/release/codestory_embedding_qualification \
-  --qualification-evidence <calibration.json>
+  --qualification-matrix-cell protected_macos_arm64_metal \
+  --collect-constant-calibration \
+  --constant-calibration-output-dir <calibration-runs> \
+  --qualification-driver target/release/codestory_embedding_constant_calibration \
+  --out-dir <proof-output-outside-calibration-runs>
 ```
 
-The proof harness invokes this separate driver with `--cli` pointing at the
-exact unpacked packaged executable. Only the nonce-gated worker remains in the
-shipped CLI; scenario orchestration and evidence writing stay in the proof
-tool.
+The proof harness authenticates and unpacks once, prepares its projects and
+model once, then records three fresh server generations with one sample per
+constant-source metric. It does not run qualification scenarios or collect
+true-idle, memory, retrieval-quality, or accelerator evidence. Those belong to
+frozen-candidate qualification. Optional Linux Vulkan calibration is
+manual-only and cannot feed or block the frozen bundle.
+The collector owns its private synthetic project. The retained calibration
+directory must start empty, and ordinary proof output must remain outside it.
 
-Accuracy or performance qualification may replace `calibration` with its exact
-requested tier and pass `--retrieval-quality-evidence` the exact-head
-`packet-runtime-summary.json` emitted by the release-evidence workflow. v0.16
-release closeout does not consume that artifact. Hosted and protected package
-tiers may bind the unpacked archive through the source plugin launcher.
+Frozen-candidate qualification passes `--retrieval-quality-evidence` the
+exact-head `packet-runtime-summary.json` produced on protected Metal from the
+packaged candidate. That artifact covers all three checked-in
+`holdout-retrieval` tasks for three cold-CLI repeats. Metal and Windows Vulkan
+each consume it while running the full qualification suite once. Linux Vulkan
+may consume the same artifact through a standalone protected-runner dispatch;
+its absence does not block the coordinator. v0.16 release closeout does not
+consume this optional evaluation artifact. Hosted and protected package tiers
+may bind the unpacked archive through the source plugin launcher.
 `installed_runtime` instead requires the managed installed plugin and managed
 executable it claims; it rejects
 `CODESTORY_CLI`, a repository-source plugin root, and a direct unpacked binary
@@ -209,18 +218,11 @@ same ancestor and one-file-difference rule. It runs for both a proof-only
 head cannot authorize a later source tree. This check does not replace bundle
 authentication or turn package proof into a release-evidence consumer.
 
-The full frozen `hosted_package` qualification in the same workflow carries the
-same flag, but it cannot run today: `--produce-qualification-evidence` requires
-the exact-head release-evidence `packet-runtime-summary.json` at any
-non-calibration tier, and `packaged-platform-pr.yml` is required to pass no
-release evidence to package proof. The `protected_hardware` bundle consumers on
-the Metal, Windows Vulkan, and Linux Vulkan lanes are likewise exempt: on the
-release path they run `--server-behavior-only`, which takes their no-bundle
-branch, and on the coordinator path they carry the same release-evidence
-requirement. Those package and hardware invocations consume the already-frozen
-constant set without re-authenticating its bundle; the mandatory release
-preflight independently proves that the frozen source binding still covers the
-tree being released.
+Hosted package proof does not execute embeddings or produce qualification
+evidence. Protected Metal and Vulkan lanes and candidate-installed lanes own
+runtime proof. They consume the checked-in frozen constant set; mandatory
+release preflight independently proves that its source binding still covers
+the tree being released.
 
 That rule fixes the release ordering to **bump-then-calibrate**: bump the
 version first with `node scripts/bump-version.mjs --version <version>`,

--- a/docs/testing/retrieval-architecture.md
+++ b/docs/testing/retrieval-architecture.md
@@ -10,8 +10,8 @@ measurements live in
 | Tier | Required evidence | Supported claim |
 | --- | --- | --- |
 | Source | locked checks and focused crate tests | source compiles and contracts hold |
-| Hosted package | exact source/tree/archive/executable, inspected native imports, server/protocol/constant manifest, same-user IPC, explicit CPU policy, complete qualification record | package contract and CPU runtime are coherent; no acceleration claim |
-| Protected hardware | same manifest-bound package and qualification record, CPU disallowed, physical backend/adapter, backend-observed post-encode telemetry | Metal or Vulkan and the server contract work on that machine |
+| Hosted package | exact source/tree/archive/executable, inspected native imports, server/protocol/constant manifest, and rejection contracts | package structure is coherent; no embedding-runtime or acceleration claim |
+| Protected hardware | same manifest-bound package and qualification record, accelerated policy with CPU disabled, physical backend/adapter, backend-observed post-encode telemetry | Metal or Vulkan and the server contract work on that machine |
 | Product runtime | installed plugin launcher, full retrieval, packet/search, two independent hosts sharing one server/engine/load | installed agent path is coherent |
 | Restart | new process reuses verified materialized model content | content-addressed cache reuse works |
 | Performance/quality | same-run measurements and holdout gates | an engine change is promotion-eligible |
@@ -27,7 +27,7 @@ verifies:
 - endpoint authority, listener, server process, engine owner, native worker,
   load generation, and model-load identities;
 - exact model digest and ggml build identity;
-- backend, physical adapter, and `accelerated` or `cpu_explicit` policy;
+- backend, physical adapter, and `accelerated` policy with CPU disabled;
 - engine instance and model-load count;
 - initialization and live-smoke timing;
 - materialized path, digest, and reuse state;
@@ -38,8 +38,8 @@ verifies:
 Accelerated proof rejects software adapters and unknown or inferred execution
 evidence. Requested layer counts and process/GPU-memory deltas are observational
 unless the post-encode backend callback confirms execution and residency.
-Hosted proof requires explicit CPU permission; absent GPU hardware does not
-imply permission.
+CPU embeddings are unsupported. Absent eligible GPU hardware cannot produce
+runtime, calibration, qualification, or release evidence.
 
 ## Packaged product assertions
 
@@ -71,15 +71,15 @@ a separate protected-hardware result, and neither package nor execution proof
 is an answer-quality claim. The Windows and Linux release packages runtime-load
 their recorded backend modules; their base
 executables must not require a Vulkan loader, so help, status, local navigation,
-and explicit diagnostic CPU execution can start without one. Supported
-retrieval still requires Vulkan on both platforms.
+and diagnostics can start without one. Supported broad retrieval still requires
+physical Vulkan on both platforms.
 
 ## Workflow ownership
 
 | Workflow | Environment | Claim boundary |
 | --- | --- | --- |
-| `retrieval-engine-smoke.yml` | hosted Linux/Windows | explicit CPU source/protocol behavior |
-| `packaged-platform-proof.yml` | hosted package matrix | offline packaged behavior; CPU explicit where required |
+| `retrieval-engine-smoke.yml` | hosted Linux/Windows | source/protocol and prohibited-selector rejection behavior only |
+| `packaged-platform-proof.yml` | hosted package matrix | offline package identity and structure; no embedding-runtime claim |
 | `macos-metal-proof.yml` | protected Apple Silicon | packaged Metal, physical adapter, smoke, offload |
 | `windows-vulkan-proof.yml` | protected Windows GPU | packaged Vulkan, physical adapter, smoke, offload |
 | `linux-vulkan-proof.yml` | protected Linux GPU | packaged Vulkan, physical adapter, smoke, offload |
@@ -103,8 +103,8 @@ candidate-specific values.
 
 ## Focused failure boundaries
 
-Tests cover exact model/build identity, corrupt materialization, explicit CPU
-permission, prohibited fallback, software-adapter rejection, per-user reuse,
+Tests cover exact model/build identity, corrupt materialization, prohibited CPU
+selection and fallback, software-adapter rejection, per-user reuse,
 producer migration, generation-coherent reads, publication drift with one
 bounded retry, lease loss, malformed frames, queue pressure, cancellation,
 same-user endpoint authority, idle exit, frozen-owner non-takeover, and owned

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -151,8 +151,10 @@ Maintainer-only engine details: [retrieval operations](../ops/retrieval-engine.m
 | `CODESTORY_IDE_COMMAND` | Optional shell command template for definition-open actions. Supports `{file}`, `{line}`, and `{col}`; set only trusted local templates because the template runs through your shell. |
 | `CODESTORY_NO_TUI` | Disable TUI for `explore` in CI or scripts |
 | `CODESTORY_SUMMARY_ENDPOINT` | Trusted summary endpoint |
-| `CODESTORY_EMBED_ALLOW_CPU` | Explicitly allow CPU embeddings. Intended for hosted CI and maintainer diagnostics; production does not fall back silently. |
 | `CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG` | Process-wide opt-in allowing trusted project files to configure summary endpoints |
+
+CPU embeddings are unsupported. Broad retrieval requires an eligible Metal or
+Vulkan device and never falls back to CPU.
 
 ## Further reading
 

--- a/plugins/codestory/skills/codestory-grounding/references/doctor.md
+++ b/plugins/codestory/skills/codestory-grounding/references/doctor.md
@@ -28,7 +28,8 @@ Codex host/app session.
 
 - `doctor` does not accept `--refresh`; it is a read-only health surface.
 - The `attention:` block repeats warnings first so agents do not miss semantic partial/stale/failure messages buried in the full check list.
-- Environment rows report the explicit `CODESTORY_EMBED_ALLOW_CPU` policy when set.
+- Environment rows report `CODESTORY_EMBED_ALLOW_CPU` when set so a prohibited
+  CPU selector cannot be mistaken for supported runtime evidence.
 - Maintainer JSON identifies the exact model digest, linked ggml build, selected backend and physical adapter, live smoke timing, and process engine identity. Ordinary tool UX reports only whether retrieval is ready.
 - Treat `semantic ok` plus `retrieval_mode=full` as the health state suitable for broad repository explanation prompts. Under `graph_first_v2`, a zero dense-anchor count is valid only when graph and lexical artifacts are current. Treat `semantic partial`, `semantic stale`, `semantic failed`, vector-count mismatch, and non-`full` retrieval modes as unavailable broad evidence until automatic preparation or a maintainer-directed rebuild publishes a complete generation.
 - Prefer JSON for CI or doc-contract checks.

--- a/plugins/codestory/skills/codestory-grounding/references/index.md
+++ b/plugins/codestory/skills/codestory-grounding/references/index.md
@@ -39,12 +39,12 @@ High-signal environment toggles:
 | Variable | Use |
 |----------|-----|
 | `CODESTORY_SEMANTIC_DOC_SCOPE=all` | Include the broader all-symbol symbol-doc scope for diagnostics. Accepted aliases are `all`, `full`, `all-symbols`, and `all_symbols`; omitted or other values default to durable symbols. |
-| `CODESTORY_EMBED_ALLOW_CPU=1` | Explicitly allow CPU embeddings for hosted CI or a maintainer diagnostic. Production never falls back to CPU silently. |
 | `CODESTORY_SUMMARY_ENDPOINT=local` | Enable deterministic local summaries with `--summarize`. |
 
 The model, tokenizer, pooling, normalization, and batching contract is compiled
 into the executable. There is no embedding endpoint or backend download to
-configure.
+configure. CPU embeddings are unsupported; full retrieval requires Metal or
+Vulkan acceleration.
 Agent packet/search readiness requires `retrieval_mode=full`; see
 [status-contract.md](status-contract.md) and [retrieval-rollout.md](retrieval-rollout.md).
 

--- a/plugins/codestory/skills/codestory-grounding/references/retrieval-rollout.md
+++ b/plugins/codestory/skills/codestory-grounding/references/retrieval-rollout.md
@@ -10,7 +10,7 @@ benchmarks, packaging, or accelerator claims. Match the proof to the claim.
 | Runtime | Runtime library, generalization, and retrieval-eval lanes | Packet/search admission and result behavior |
 | CLI and plugin | Focused CLI protocol tests plus plugin static tests | Transport and user-facing capability state |
 | Performance | Same-build incumbent/candidate rows for cold initialization, warm search, bulk indexing, RSS, GPU memory, vector parity, quality, and multi-repository reuse | Promotion only when no repeatable regression exceeds the 5% noise allowance |
-| Hosted engine smoke | Managed CI with explicit CPU policy | Source and protocol behavior only; no Metal or Vulkan claim |
+| Hosted rejection contracts | Managed CI without protected GPU evidence | Source, protocol, and prohibited CPU-selector behavior only; no embedding-runtime claim |
 | Packaged hardware | Protected Metal or Vulkan workflow using the packaged executable offline | Only the exact backend and adapter exercised by that artifact |
 
 Normal plugin calls prepare retrieval automatically. They expose `ready`,
@@ -35,11 +35,11 @@ lifecycle. Maintainer JSON owns backend details.
    setup state. Private local IPC and the same executable's hidden server mode
    are the product path.
 
-Hosted CI sets `CODESTORY_EMBED_ALLOW_CPU=1` and must report `cpu_explicit`.
-Protected Apple Silicon proof must report Metal and verified accelerator
-execution. Windows and Linux hardware proof must report Vulkan. The Linux claim
-requires `.github/workflows/linux-vulkan-proof.yml`; hosted CPU proof is
-insufficient.
+CPU embeddings are unsupported. Protected Apple Silicon proof must report Metal
+and verified accelerator execution. Windows and Linux hardware proof must
+report Vulkan. The Linux claim requires
+`.github/workflows/linux-vulkan-proof.yml`; source-only CPU rejection tests are
+not runtime evidence.
 
 ## Quality and performance gate
 

--- a/release-claims.json
+++ b/release-claims.json
@@ -1,6 +1,6 @@
 {
   "schema": "codestory.release-claims/v1",
-  "graph_version": 8,
+  "graph_version": 9,
   "graph_id": "codestory-release-claims",
   "standard_release_claims": [
     "source_behavior",
@@ -1058,6 +1058,133 @@
         "extension": "tar.gz"
       }
     ],
+    "calibration": {
+      "coordinator_workflow": "packaged-platform-pr.yml",
+      "mode": "calibration",
+      "assembly_job": "calibration-assemble",
+      "required_cells": [
+        {
+          "id": "protected_macos_arm64_metal",
+          "workflow": "macos-metal-proof.yml",
+          "job": "packaged-metal",
+          "policy": "accelerated",
+          "backend": "metal",
+          "feeds_constant_selection": true
+        }
+      ],
+      "optional_cells": [
+        {
+          "id": "protected_linux_x64_vulkan",
+          "workflow": "linux-vulkan-proof.yml",
+          "job": "optional-constant-calibration",
+          "trigger": "workflow_dispatch",
+          "policy": "accelerated",
+          "backend": "vulkan",
+          "assembly_dependency": false,
+          "feeds_constant_selection": false
+        }
+      ],
+      "runs_per_required_cell": 3,
+      "samples_per_metric_per_run": 1,
+      "constant_metrics": [
+        "existing_owner_connect",
+        "spawn_convergence",
+        "cold_first_vector",
+        "first_product_ready",
+        "warm_query_ipc",
+        "warm_bulk_ipc",
+        "bulk_documents_per_second",
+        "bulk_tokens_per_second",
+        "busy_retry_usefulness"
+      ],
+      "forbidden_evidence": [
+        "qualification_scenarios",
+        "true_idle_exit",
+        "total_codestory_process_memory",
+        "retrieval_quality",
+        "backend_observed_accelerator_residency"
+      ],
+      "forbidden_policies": [
+        "cpu_explicit"
+      ],
+      "forbidden_backends": [
+        "cpu"
+      ],
+      "forbidden_environment": [
+        "CODESTORY_EMBED_ALLOW_CPU=1"
+      ]
+    },
+    "qualification": {
+      "coordinator_workflow": "packaged-platform-pr.yml",
+      "mode": "qualification",
+      "runs_per_available_cell": 1,
+      "required_cells": [
+        {
+          "id": "protected_macos_arm64_metal",
+          "workflow": "macos-metal-proof.yml",
+          "job": "packaged-metal",
+          "policy": "accelerated",
+          "backend": "metal",
+          "produces_quality": true
+        },
+        {
+          "id": "protected_windows_x64_vulkan",
+          "workflow": "windows-vulkan-proof.yml",
+          "job": "packaged-vulkan",
+          "policy": "accelerated",
+          "backend": "vulkan",
+          "produces_quality": false
+        }
+      ],
+      "optional_cells": [
+        {
+          "id": "protected_linux_x64_vulkan",
+          "workflow": "linux-vulkan-proof.yml",
+          "job": "packaged-vulkan",
+          "trigger": "workflow_dispatch",
+          "policy": "accelerated",
+          "backend": "vulkan",
+          "closeout_dependency": false,
+          "blocking": false
+        }
+      ],
+      "quality_contract": {
+        "producer_cell": "protected_macos_arm64_metal",
+        "corpus_id": "codestory-release-corpus-v1",
+        "evaluation_contract": "publishable-three-repeat-packet/v1",
+        "task_count": 3,
+        "repeats_per_task": 3,
+        "row_count": 9
+      },
+      "required_evidence": [
+        "qualification_scenarios",
+        "true_idle_exit",
+        "total_codestory_process_memory",
+        "retrieval_quality",
+        "backend_observed_accelerator_residency"
+      ],
+      "required_scenarios": [
+        "client_death",
+        "cold_race",
+        "frozen_owner",
+        "incompatible_owner",
+        "mixed_queue",
+        "server_crash",
+        "true_idle_respawn",
+        "worker_stall"
+      ],
+      "true_idle_timeout_ms": 60000,
+      "true_idle_observation_grace_ms": 2500,
+      "forbidden_policies": [
+        "cpu_explicit"
+      ],
+      "forbidden_backends": [
+        "cpu"
+      ],
+      "forbidden_environment": [
+        "CODESTORY_EMBED_ALLOW_CPU=1"
+      ]
+    },
     "protected_jobs": [
       {
         "workflow": "macos-metal-proof.yml",

--- a/scripts/codestory-benchmark-contract.mjs
+++ b/scripts/codestory-benchmark-contract.mjs
@@ -23,8 +23,8 @@ function unsupportedRetrievalContractRequests(env = process.env) {
     blockers.push("CODESTORY_RETRIEVAL=0 is unsupported; full retrieval is mandatory");
   }
   const cpuPolicy = String(env.CODESTORY_EMBED_ALLOW_CPU ?? "").trim();
-  if (cpuPolicy && cpuPolicy !== "0" && cpuPolicy !== "1") {
-    blockers.push("CODESTORY_EMBED_ALLOW_CPU must be 0 or 1");
+  if (cpuPolicy && cpuPolicy !== "0") {
+    blockers.push("CODESTORY_EMBED_ALLOW_CPU must be 0; CPU embeddings are unsupported");
   }
   return blockers;
 }
@@ -39,7 +39,7 @@ function retrievalContractSummary(env = process.env) {
     retrieval_contract: "in_process_v1",
     retrieval_enabled: !unsupportedRetrievalDisabledRequest(env),
     embedding_engine: "process_shared",
-    execution_policy: env.CODESTORY_EMBED_ALLOW_CPU === "1" ? "cpu_explicit" : "accelerated",
+    execution_policy: "accelerated",
   };
 }
 

--- a/scripts/codestory-evidence-provenance.mjs
+++ b/scripts/codestory-evidence-provenance.mjs
@@ -156,8 +156,8 @@ export function cacheProvenanceBlockers(result) {
   if (!provenance.embedding_engine_instance_id && !packetExecutionProven) {
     reasons.push("missing CodeStory embedding engine identity");
   }
-  if (!["accelerated", "cpu_explicit"].includes(provenance.embedding_policy)) {
-    reasons.push(`CodeStory embedding policy=${provenance.embedding_policy ?? "unknown"}; expected accelerated or cpu_explicit`);
+  if (provenance.embedding_policy !== "accelerated") {
+    reasons.push(`CodeStory embedding policy=${provenance.embedding_policy ?? "unknown"}; expected accelerated`);
   }
   if (provenance.semantic_backend == null) {
     reasons.push("missing CodeStory semantic backend");
@@ -201,8 +201,8 @@ export function packetEmbeddingExecutionProofBlockers(provenance) {
   if (proof.embedding_engine !== "process_shared") {
     reasons.push(`cold packet embedding engine=${proof.embedding_engine ?? "unknown"}; expected process_shared`);
   }
-  if (!["accelerated", "cpu_explicit"].includes(proof.embedding_policy)) {
-    reasons.push(`cold packet embedding policy=${proof.embedding_policy ?? "unknown"}; expected accelerated or cpu_explicit`);
+  if (proof.embedding_policy !== "accelerated") {
+    reasons.push(`cold packet embedding policy=${proof.embedding_policy ?? "unknown"}; expected accelerated`);
   }
   if (proof.retrieval_mode !== "full") {
     reasons.push(`cold packet retrieval mode=${proof.retrieval_mode ?? "unknown"}; expected full`);

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const GRAPH_SCHEMA = "codestory.release-claims/v1";
-const GRAPH_VERSION = 8;
+const GRAPH_VERSION = 9;
 const KNOWN_PACKAGE_TARGETS = new Set([
   "linux-arm64",
   "linux-x64",
@@ -530,6 +530,227 @@ function validateCatalogDelivery(policy, dependencies, cellGroups) {
   return delivery;
 }
 
+function validateCalibrationPolicy(value) {
+  const calibration = object(value, "workflow_policy.calibration");
+  if (
+    calibration.coordinator_workflow !== "packaged-platform-pr.yml"
+    || calibration.mode !== "calibration"
+    || calibration.assembly_job !== "calibration-assemble"
+  ) {
+    fail("workflow_policy.calibration must name the canonical calibration coordinator and assembly job");
+  }
+  if (calibration.runs_per_required_cell !== 3) {
+    fail("workflow_policy.calibration must require exactly three clean runs per required cell");
+  }
+  if (calibration.samples_per_metric_per_run !== 1) {
+    fail("workflow_policy.calibration must require exactly one sample per metric per run");
+  }
+  const requiredCells = calibration.required_cells;
+  if (!Array.isArray(requiredCells) || requiredCells.length !== 1) {
+    fail("workflow_policy.calibration must declare exactly one required cell");
+  }
+  const required = object(requiredCells[0], "workflow_policy.calibration.required_cells[0]");
+  if (
+    required.id !== "protected_macos_arm64_metal"
+    || required.workflow !== "macos-metal-proof.yml"
+    || required.job !== "packaged-metal"
+    || required.policy !== "accelerated"
+    || required.backend !== "metal"
+    || required.feeds_constant_selection !== true
+  ) {
+    fail("workflow_policy.calibration required cell must be protected macOS Metal");
+  }
+  const optionalCells = calibration.optional_cells;
+  if (!Array.isArray(optionalCells) || optionalCells.length !== 1) {
+    fail("workflow_policy.calibration must declare exactly one optional evidence cell");
+  }
+  const optional = object(optionalCells[0], "workflow_policy.calibration.optional_cells[0]");
+  if (
+    optional.id !== "protected_linux_x64_vulkan"
+    || optional.workflow !== "linux-vulkan-proof.yml"
+    || optional.job !== "optional-constant-calibration"
+    || optional.trigger !== "workflow_dispatch"
+    || optional.policy !== "accelerated"
+    || optional.backend !== "vulkan"
+    || optional.assembly_dependency !== false
+    || optional.feeds_constant_selection !== false
+  ) {
+    fail("workflow_policy.calibration optional cell must be standalone non-selecting Linux Vulkan evidence");
+  }
+  const expectedMetrics = [
+    "existing_owner_connect",
+    "spawn_convergence",
+    "cold_first_vector",
+    "first_product_ready",
+    "warm_query_ipc",
+    "warm_bulk_ipc",
+    "bulk_documents_per_second",
+    "bulk_tokens_per_second",
+    "busy_retry_usefulness",
+  ];
+  const metrics = stringArray(
+    calibration.constant_metrics,
+    "workflow_policy.calibration.constant_metrics",
+    { nonEmpty: true },
+  );
+  if (JSON.stringify(metrics) !== JSON.stringify(expectedMetrics)) {
+    fail("workflow_policy.calibration constant metrics must match the runtime-constant source set");
+  }
+  const expectedForbiddenEvidence = [
+    "qualification_scenarios",
+    "true_idle_exit",
+    "total_codestory_process_memory",
+    "retrieval_quality",
+    "backend_observed_accelerator_residency",
+  ];
+  const forbiddenEvidence = stringArray(
+    calibration.forbidden_evidence,
+    "workflow_policy.calibration.forbidden_evidence",
+    { nonEmpty: true },
+  );
+  if (JSON.stringify(forbiddenEvidence) !== JSON.stringify(expectedForbiddenEvidence)) {
+    fail("workflow_policy.calibration must exclude qualification-only evidence");
+  }
+  const forbiddenPolicies = stringArray(
+    calibration.forbidden_policies,
+    "workflow_policy.calibration.forbidden_policies",
+    { nonEmpty: true },
+  );
+  const forbiddenBackends = stringArray(
+    calibration.forbidden_backends,
+    "workflow_policy.calibration.forbidden_backends",
+    { nonEmpty: true },
+  );
+  const forbiddenEnvironment = stringArray(
+    calibration.forbidden_environment,
+    "workflow_policy.calibration.forbidden_environment",
+    { nonEmpty: true },
+  );
+  if (
+    JSON.stringify(forbiddenPolicies) !== JSON.stringify(["cpu_explicit"])
+    || JSON.stringify(forbiddenBackends) !== JSON.stringify(["cpu"])
+    || JSON.stringify(forbiddenEnvironment)
+      !== JSON.stringify(["CODESTORY_EMBED_ALLOW_CPU=1"])
+  ) {
+    fail("workflow_policy.calibration must forbid CPU environment, policy, and backend selection");
+  }
+}
+
+function validateQualificationPolicy(value) {
+  const qualification = object(value, "workflow_policy.qualification");
+  if (
+    qualification.coordinator_workflow !== "packaged-platform-pr.yml"
+    || qualification.mode !== "qualification"
+    || qualification.runs_per_available_cell !== 1
+  ) {
+    fail("workflow_policy.qualification must name the canonical one-run frozen-candidate coordinator");
+  }
+  const requiredCells = qualification.required_cells;
+  if (!Array.isArray(requiredCells) || requiredCells.length !== 2) {
+    fail("workflow_policy.qualification must require protected macOS Metal and Windows Vulkan");
+  }
+  const expectedRequiredCells = [
+    {
+      id: "protected_macos_arm64_metal",
+      workflow: "macos-metal-proof.yml",
+      job: "packaged-metal",
+      policy: "accelerated",
+      backend: "metal",
+      produces_quality: true,
+    },
+    {
+      id: "protected_windows_x64_vulkan",
+      workflow: "windows-vulkan-proof.yml",
+      job: "packaged-vulkan",
+      policy: "accelerated",
+      backend: "vulkan",
+      produces_quality: false,
+    },
+  ];
+  if (JSON.stringify(requiredCells) !== JSON.stringify(expectedRequiredCells)) {
+    fail("workflow_policy.qualification required cells must be the protected Metal and Vulkan producers");
+  }
+  const optionalCells = qualification.optional_cells;
+  const expectedOptionalCells = [
+    {
+      id: "protected_linux_x64_vulkan",
+      workflow: "linux-vulkan-proof.yml",
+      job: "packaged-vulkan",
+      trigger: "workflow_dispatch",
+      policy: "accelerated",
+      backend: "vulkan",
+      closeout_dependency: false,
+      blocking: false,
+    },
+  ];
+  if (JSON.stringify(optionalCells) !== JSON.stringify(expectedOptionalCells)) {
+    fail("workflow_policy.qualification Linux Vulkan cell must be standalone and nonblocking");
+  }
+  const quality = object(
+    qualification.quality_contract,
+    "workflow_policy.qualification.quality_contract",
+  );
+  if (
+    quality.producer_cell !== "protected_macos_arm64_metal"
+    || quality.corpus_id !== "codestory-release-corpus-v1"
+    || quality.evaluation_contract !== "publishable-three-repeat-packet/v1"
+    || quality.task_count !== 3
+    || quality.repeats_per_task !== 3
+    || quality.row_count !== 9
+  ) {
+    fail("workflow_policy.qualification quality contract must bind the protected Metal 3x3 holdout matrix");
+  }
+  const expectedEvidence = [
+    "qualification_scenarios",
+    "true_idle_exit",
+    "total_codestory_process_memory",
+    "retrieval_quality",
+    "backend_observed_accelerator_residency",
+  ];
+  if (
+    JSON.stringify(stringArray(
+      qualification.required_evidence,
+      "workflow_policy.qualification.required_evidence",
+      { nonEmpty: true },
+    )) !== JSON.stringify(expectedEvidence)
+  ) {
+    fail("workflow_policy.qualification must retain every frozen-candidate evidence class");
+  }
+  const expectedScenarios = [
+    "client_death",
+    "cold_race",
+    "frozen_owner",
+    "incompatible_owner",
+    "mixed_queue",
+    "server_crash",
+    "true_idle_respawn",
+    "worker_stall",
+  ];
+  if (
+    JSON.stringify(stringArray(
+      qualification.required_scenarios,
+      "workflow_policy.qualification.required_scenarios",
+      { nonEmpty: true },
+    )) !== JSON.stringify(expectedScenarios)
+  ) {
+    fail("workflow_policy.qualification must run each lifecycle and fault scenario once");
+  }
+  if (
+    qualification.true_idle_timeout_ms !== 60_000
+    || qualification.true_idle_observation_grace_ms !== 2_500
+  ) {
+    fail("workflow_policy.qualification true-idle bound must be the product timeout plus explicit grace");
+  }
+  if (
+    JSON.stringify(qualification.forbidden_policies) !== JSON.stringify(["cpu_explicit"])
+    || JSON.stringify(qualification.forbidden_backends) !== JSON.stringify(["cpu"])
+    || JSON.stringify(qualification.forbidden_environment)
+      !== JSON.stringify(["CODESTORY_EMBED_ALLOW_CPU=1"])
+  ) {
+    fail("workflow_policy.qualification must forbid CPU environment, policy, and backend selection");
+  }
+}
+
 function validatePublicSupport(graph, packageTargets, cellGroups) {
   const publicSupport = object(
     graph.public_support,
@@ -551,8 +772,8 @@ function validatePublicSupport(graph, packageTargets, cellGroups) {
     if (row.local_map !== "supported") {
       fail(`public_support package ${target} must support the local map`);
     }
-    if (!new Set(["accelerated", "cpu_explicit"]).has(row.broad_retrieval)) {
-      fail(`public_support package ${target} has an invalid broad retrieval path`);
+    if (row.broad_retrieval !== "accelerated") {
+      fail(`public_support package ${target} must require accelerated broad retrieval`);
     }
     if (!new Set(["none", "metal", "vulkan"]).has(row.accelerator_claim)) {
       fail(`public_support package ${target} has an invalid accelerator claim`);
@@ -580,11 +801,8 @@ function validatePublicSupport(graph, packageTargets, cellGroups) {
     ) {
       fail(`public accelerator claim ${target}/${row.accelerator_claim} has no required closeout cell`);
     }
-    if (
-      (row.accelerator_claim === "none")
-      !== (row.broad_retrieval === "cpu_explicit")
-    ) {
-      fail(`public_support package ${target} has inconsistent execution and accelerator claims`);
+    if (row.accelerator_claim === "none") {
+      fail(`public_support package ${target} must name its accelerator claim`);
     }
   }
 
@@ -1048,6 +1266,8 @@ export function validateReleaseClaimGraph(graph) {
     }
     targets.add(row.asset_target);
   }
+  validateCalibrationPolicy(policy.calibration);
+  validateQualificationPolicy(policy.qualification);
   validatePublicSupport(graph, targets, cellGroups);
   if (!Array.isArray(policy.protected_jobs) || policy.protected_jobs.length === 0) {
     fail("workflow_policy.protected_jobs must be a non-empty array");

--- a/scripts/lib/retrieval-generalization-lint.mjs
+++ b/scripts/lib/retrieval-generalization-lint.mjs
@@ -258,6 +258,21 @@ const allowedHarnessReferences = [
   ],
   [
     path.join(".github", "scripts", "check-workflow-policy.mjs"),
+    "retrieval-engine-smoke.yml",
+    '"retrieval-engine-smoke.yml",',
+  ],
+  [
+    path.join(".github", "scripts", "check-workflow-policy.mjs"),
+    "node scripts/codestory-agent-ab-benchmark.mjs",
+    '"node scripts/codestory-agent-ab-benchmark.mjs",',
+  ],
+  [
+    path.join(".github", "workflows", "macos-metal-proof.yml"),
+    "node scripts/codestory-agent-ab-benchmark.mjs",
+    "node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite holdout-retrieval --materialize-repos --repeats 3 --publishable --max-source-reads-after-packet 0 --codestory-cli $packaged_cli --timeout-ms 180000 --out-dir $quality_root/packet",
+  ],
+  [
+    path.join(".github", "scripts", "check-workflow-policy.mjs"),
     ".github/workflows/retrieval-engine-smoke.yml",
     '".github/workflows/retrieval-engine-smoke.yml",',
   ],
@@ -2608,6 +2623,14 @@ function harnessDependencyAllowed(prepared, line, pattern, occurrence) {
   );
 }
 
+function harnessPatternLineAllowed(prepared, line, pattern) {
+  return allowedHarnessReferences.some(({ relativePath, includes, use }) =>
+    allowedReferenceFileMatches(prepared.filePath, relativePath)
+    && allowedReferenceUseMatches(prepared, use, line.startLine, line.endLine)
+    && pattern.test(normalizeNativeSeparators(includes))
+  );
+}
+
 function compactHarnessDependencyAllowed(prepared, literals, marker) {
   const startLine = Math.min(...literals.map(({ line }) => line));
   const endLine = Math.max(...literals.map(({ line }) => line));
@@ -2642,7 +2665,13 @@ function allowedReferenceUseMatches(prepared, use, startLine, endLine) {
     && matches[0].endLine === endLine;
 }
 
-function scanProductionFile(prepared, patterns, combinedRe, segmentIdentifiers = false) {
+function scanProductionFile(
+  prepared,
+  patterns,
+  combinedRe,
+  segmentIdentifiers = false,
+  matchAllowed = () => false,
+) {
   const lines = prepared.logicalLines ?? prepared.lines.map((text, index) => ({
     text,
     startLine: index + 1,
@@ -2662,7 +2691,11 @@ function scanProductionFile(prepared, patterns, combinedRe, segmentIdentifiers =
     }
     for (const { pattern, re } of patterns) {
       const sourceLine = sourceLines[line.startLine - 1];
-      if (re.test(normalizedLine) && !lineAllowedForPattern(pattern, sourceLine)) {
+      if (
+        re.test(normalizedLine)
+        && !lineAllowedForPattern(pattern, sourceLine)
+        && !matchAllowed(line, re)
+      ) {
         if (!hitsByPattern.has(pattern)) {
           hitsByPattern.set(pattern, []);
         }
@@ -3347,6 +3380,8 @@ for (const filePath of [...protectedNonRustScanFiles].sort()) {
     prepared,
     corpusRegexPatterns,
     corpusCombinedRegex,
+    false,
+    (line, pattern) => harnessPatternLineAllowed(prepared, line, pattern),
   );
   for (const { pattern } of corpusRegexPatterns) {
     const hits = productionHits.get(pattern) ?? [];
@@ -3358,7 +3393,13 @@ for (const filePath of [...protectedNonRustScanFiles].sort()) {
     }
   }
   for (const pattern of evalCorpusCompactPatternList) {
-    const hits = scanProductionCompactPatterns(prepared, pattern, 1, true);
+    const hits = scanProductionCompactPatterns(
+      prepared,
+      pattern,
+      1,
+      true,
+      (literals, marker) => compactHarnessDependencyAllowed(prepared, literals, marker),
+    );
     if (hits.length > 0) {
       console.error(
         `Constructed eval/query dependency /${pattern}/ in protected non-Rust path ${path.relative(repoRoot, filePath)}:\n${hits.join("\n")}\n`,

--- a/scripts/release-evidence/guest-runner.sh
+++ b/scripts/release-evidence/guest-runner.sh
@@ -101,7 +101,7 @@ install_service() {
     "Environment=XDG_RUNTIME_DIR=$runtime_dir" \
     "Environment=XDG_CACHE_HOME=$runner_root/cache/xdg" \
     "Environment=CODESTORY_CACHE_DIR=$runner_root/cache/codestory" \
-    "Environment=CODESTORY_EMBED_ALLOW_CPU=1" \
+    "Environment=CODESTORY_EMBED_ALLOW_CPU=0" \
     "Environment=CODESTORY_REAL_REPO_DRILL_CASES=$runner_root/drills/real-repo-drill-cases.json" \
     "Environment=CODESTORY_RELEASE_EVIDENCE_PROFILE_ID=$profile_id" \
     "Environment=CODESTORY_RELEASE_EVIDENCE_PROVISIONING=$runner_root/artifacts/provisioning.json" \

--- a/scripts/release-evidence/guest-verify.sh
+++ b/scripts/release-evidence/guest-verify.sh
@@ -138,8 +138,13 @@ test "$(stat -c '%u:%g:%a' "$runtime_dir")" = \
 test -f "$runner_root/actions-runner/.service"
 service=$(sed -n '1p' "$runner_root/actions-runner/.service")
 test -n "$service"
-systemctl show "$service" --property=Environment --value \
-  | tr ' ' '\n' | grep -qxF "XDG_RUNTIME_DIR=$runtime_dir"
+service_environment=$(systemctl show "$service" --property=Environment --value | tr ' ' '\n')
+printf '%s\n' "$service_environment" | grep -qxF "XDG_RUNTIME_DIR=$runtime_dir"
+printf '%s\n' "$service_environment" | grep -qxF "CODESTORY_EMBED_ALLOW_CPU=0"
+if printf '%s\n' "$service_environment" | grep -qxF "CODESTORY_EMBED_ALLOW_CPU=1"; then
+  echo "release-evidence runner must reject CPU embeddings" >&2
+  exit 1
+fi
 source_sha=$(sed -n '1p' "$runner_root/validation/source-sha")
 printf '%s\n' "$source_sha" | grep -Eq '^[0-9a-f]{40}$'
 

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -128,7 +128,7 @@ test("cold packet embedding execution binds full retrieval to the prepared seman
     retrieval_contract: {
       retrieval_contract: "in_process_v1",
       embedding_engine: "process_shared",
-      execution_policy: "cpu_explicit",
+      execution_policy: "accelerated",
     },
     retrieval_status: { semantic_generation: "semantic-1" },
   };
@@ -164,7 +164,7 @@ test("cold packet embedding execution binds full retrieval to the prepared seman
       transport_mode: "cold_cli_packet",
       retrieval_contract: "in_process_v1",
       embedding_engine: "process_shared",
-      embedding_policy: "cpu_explicit",
+      embedding_policy: "accelerated",
       retrieval_mode: "full",
       diagnostic_count: 2,
       full_diagnostic_count: 2,
@@ -1960,14 +1960,14 @@ function localCacheProvenance(overrides = {}) {
 function localColdPacketCacheProvenance(overrides = {}) {
   return localCacheProvenance({
     embedding_engine_instance_id: null,
-    embedding_policy: "cpu_explicit",
+    embedding_policy: "accelerated",
     semantic_ready: false,
     packet_embedding_execution: {
       source: "packet.answer.retrieval_trace",
       transport_mode: "cold_cli_packet",
       retrieval_contract: "in_process_v1",
       embedding_engine: "process_shared",
-      embedding_policy: "cpu_explicit",
+      embedding_policy: "accelerated",
       retrieval_mode: "full",
       diagnostic_count: 2,
       full_diagnostic_count: 2,
@@ -1997,7 +1997,7 @@ test("cold packet execution proof replaces only unavailable process-local identi
     ["source", "status", /source=status/],
     ["transport_mode", "warm_stdio_packet", /transport=warm_stdio_packet/],
     ["embedding_engine", "other", /embedding engine=other/],
-    ["embedding_policy", "accelerated", /embedding policy does not match cache provenance/],
+    ["embedding_policy", "cpu_explicit", /expected accelerated/],
     ["retrieval_mode", null, /retrieval mode=unknown/],
     ["diagnostic_count", 0, /no sidecar diagnostics/],
     ["full_diagnostic_count", 1, /non-full sidecar diagnostic/],
@@ -2022,7 +2022,7 @@ test("skipped or degraded semantic stages cannot replace live engine identity", 
     retrieval_contract: {
       retrieval_contract: "in_process_v1",
       embedding_engine: "process_shared",
-      execution_policy: "cpu_explicit",
+      execution_policy: "accelerated",
     },
     retrieval_status: { semantic_generation: "proj-current" },
   };

--- a/scripts/tests/codestory-benchmark-contract.test.mjs
+++ b/scripts/tests/codestory-benchmark-contract.test.mjs
@@ -12,8 +12,8 @@ import {
   unsupportedRetrievalContractRequests,
 } from "../codestory-benchmark-contract.mjs";
 
-test("benchmark child env uses one fixed in-process retrieval contract", () => {
-  const env = benchmarkChildEnv({ CODESTORY_EMBED_ALLOW_CPU: "1" });
+test("benchmark child env uses one accelerated in-process retrieval contract", () => {
+  const env = benchmarkChildEnv({ CODESTORY_EMBED_ALLOW_CPU: "0" });
 
   assert.equal(env.CODESTORY_RETRIEVAL, "1");
   assert.equal(shouldPrepareRetrievalIndex(env), true);
@@ -21,16 +21,16 @@ test("benchmark child env uses one fixed in-process retrieval contract", () => {
     retrieval_contract: "in_process_v1",
     retrieval_enabled: true,
     embedding_engine: "process_shared",
-    execution_policy: "cpu_explicit",
+    execution_policy: "accelerated",
   });
   assert.deepEqual(retrievalEnv(env), {
     CODESTORY_RETRIEVAL: "1",
-    CODESTORY_EMBED_ALLOW_CPU: "1",
+    CODESTORY_EMBED_ALLOW_CPU: "0",
     CODESTORY_EVAL_PROBES: null,
   });
 });
 
-test("benchmark contract rejects disabled retrieval and invalid CPU policy", () => {
+test("benchmark contract rejects disabled retrieval and any CPU policy", () => {
   const env = {
     CODESTORY_RETRIEVAL: "0",
     CODESTORY_EMBED_ALLOW_CPU: "sometimes",
@@ -38,7 +38,11 @@ test("benchmark contract rejects disabled retrieval and invalid CPU policy", () 
 
   assert.equal(unsupportedRetrievalContractRequests(env).length, 2);
   assert.throws(() => assertRetrievalEngineEnv(env), /full retrieval is mandatory/u);
-  assert.throws(() => benchmarkChildEnv(env), /must be 0 or 1/u);
+  assert.throws(() => benchmarkChildEnv(env), /CPU embeddings are unsupported/u);
+  assert.throws(
+    () => benchmarkChildEnv({ CODESTORY_EMBED_ALLOW_CPU: "1" }),
+    /CPU embeddings are unsupported/u,
+  );
 });
 
 test("benchmark reuse contract accepts identical fingerprints and rejects drift", () => {
@@ -46,17 +50,17 @@ test("benchmark reuse contract accepts identical fingerprints and rejects drift"
   const current = benchmarkRunContract({
     opts: { runner: "codex", model: "new-model", sandbox: "workspace-write" },
     task,
-    env: { CODESTORY_EMBED_ALLOW_CPU: "1" },
+    env: { CODESTORY_EMBED_ALLOW_CPU: "0" },
   });
   const identical = benchmarkRunContract({
     opts: { runner: "codex", model: "new-model", sandbox: "workspace-write" },
     task,
-    env: { CODESTORY_EMBED_ALLOW_CPU: "1" },
+    env: { CODESTORY_EMBED_ALLOW_CPU: "0" },
   });
   const previous = benchmarkRunContract({
     opts: { runner: "codex", model: "old-model", sandbox: "workspace-write" },
     task,
-    env: { CODESTORY_EMBED_ALLOW_CPU: "1" },
+    env: { CODESTORY_EMBED_ALLOW_CPU: "0" },
   });
 
   assert.deepEqual(benchmarkContractCompatibility(current, identical), { compatible: true, mismatches: [] });

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -103,7 +103,7 @@ test("versioned claim graph has one deterministic digest and all declared contro
   assert.match(releaseClaimGraphDigest(graph), /^[0-9a-f]{64}$/u);
   assert.equal(positiveFixture().evidence[0].graph_sha256, releaseClaimGraphDigest(graph));
   assert.equal(graph.claims.length, 8);
-  assert.equal(graph.graph_version, 8);
+  assert.equal(graph.graph_version, 9);
   assert.deepEqual(
     [...graph.standard_release_claims].sort(),
     [
@@ -157,6 +157,120 @@ test("versioned claim graph has one deterministic digest and all declared contro
   assert.equal(graph.workflow_policy.promotion.manual_pr_ref_hint, "--ref <same-repository PR head branch>");
   assert.equal(graph.workflow_policy.promotion.source_cache_namespace, "source-proof-v2");
   assert.equal(graph.workflow_policy.promotion.packaged_cache_namespace, "codestory-cli-native-v4");
+});
+
+test("claim graph freezes Mac-only accelerated 3x1 constant calibration", () => {
+  const calibration = graph.workflow_policy.calibration;
+  assert.deepEqual(calibration.required_cells.map(({ id }) => id), [
+    "protected_macos_arm64_metal",
+  ]);
+  assert.deepEqual(calibration.optional_cells.map(({ id }) => id), [
+    "protected_linux_x64_vulkan",
+  ]);
+  assert.equal(calibration.optional_cells[0].assembly_dependency, false);
+  assert.equal(calibration.optional_cells[0].feeds_constant_selection, false);
+  assert.equal(calibration.runs_per_required_cell, 3);
+  assert.equal(calibration.samples_per_metric_per_run, 1);
+  assert.deepEqual(calibration.forbidden_environment, [
+    "CODESTORY_EMBED_ALLOW_CPU=1",
+  ]);
+
+  const mutations = [
+    [draft => {
+      draft.workflow_policy.calibration.required_cells[0].backend = "cpu";
+    }, /required cell must be protected macOS Metal/u],
+    [draft => {
+      draft.workflow_policy.calibration.required_cells[0].policy = "cpu_explicit";
+    }, /required cell must be protected macOS Metal/u],
+    [draft => {
+      draft.workflow_policy.calibration.optional_cells[0].assembly_dependency = true;
+    }, /optional cell must be standalone non-selecting Linux Vulkan evidence/u],
+    [draft => {
+      draft.workflow_policy.calibration.optional_cells[0].feeds_constant_selection = true;
+    }, /optional cell must be standalone non-selecting Linux Vulkan evidence/u],
+    [draft => {
+      draft.workflow_policy.calibration.runs_per_required_cell = 6;
+    }, /exactly three clean runs/u],
+    [draft => {
+      draft.workflow_policy.calibration.samples_per_metric_per_run = 3;
+    }, /exactly one sample per metric per run/u],
+    [draft => {
+      draft.workflow_policy.calibration.forbidden_environment = [
+        "CODESTORY_EMBED_ALLOW_CPU=0",
+      ];
+    }, /must forbid CPU environment, policy, and backend selection/u],
+    [draft => {
+      draft.public_support.packages[0].broad_retrieval = "cpu_explicit";
+    }, /must require accelerated broad retrieval/u],
+  ];
+  for (const [mutate, expected] of mutations) {
+    const draft = structuredClone(graph);
+    mutate(draft);
+    assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
+});
+
+test("claim graph freezes one GPU-only qualification run per available platform", () => {
+  const qualification = graph.workflow_policy.qualification;
+  assert.equal(qualification.runs_per_available_cell, 1);
+  assert.deepEqual(
+    qualification.required_cells.map(({ id }) => id),
+    [
+      "protected_macos_arm64_metal",
+      "protected_windows_x64_vulkan",
+    ],
+  );
+  assert.deepEqual(
+    qualification.optional_cells.map(({ id }) => id),
+    ["protected_linux_x64_vulkan"],
+  );
+  assert.equal(qualification.optional_cells[0].closeout_dependency, false);
+  assert.equal(qualification.optional_cells[0].blocking, false);
+  assert.deepEqual(qualification.quality_contract, {
+    producer_cell: "protected_macos_arm64_metal",
+    corpus_id: "codestory-release-corpus-v1",
+    evaluation_contract: "publishable-three-repeat-packet/v1",
+    task_count: 3,
+    repeats_per_task: 3,
+    row_count: 9,
+  });
+  assert.equal(
+    qualification.true_idle_timeout_ms
+      + qualification.true_idle_observation_grace_ms,
+    62_500,
+  );
+
+  const mutations = [
+    [draft => {
+      draft.workflow_policy.qualification.runs_per_available_cell = 3;
+    }, /canonical one-run frozen-candidate coordinator/u],
+    [draft => {
+      draft.workflow_policy.qualification.required_cells[0].backend = "cpu";
+    }, /protected Metal and Vulkan producers/u],
+    [draft => {
+      draft.workflow_policy.qualification.required_cells[1].policy = "cpu_explicit";
+    }, /protected Metal and Vulkan producers/u],
+    [draft => {
+      draft.workflow_policy.qualification.optional_cells[0].blocking = true;
+    }, /standalone and nonblocking/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract.row_count = 3;
+    }, /protected Metal 3x3 holdout matrix/u],
+    [draft => {
+      draft.workflow_policy.qualification.required_scenarios.pop();
+    }, /each lifecycle and fault scenario once/u],
+    [draft => {
+      draft.workflow_policy.qualification.true_idle_observation_grace_ms = 11_374;
+    }, /product timeout plus explicit grace/u],
+    [draft => {
+      draft.workflow_policy.qualification.forbidden_environment = [];
+    }, /must forbid CPU environment, policy, and backend selection/u],
+  ];
+  for (const [mutate, expected] of mutations) {
+    const draft = structuredClone(graph);
+    mutate(draft);
+    assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
 });
 
 test("benchmark leakage names only the one-process Node contract", () => {

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "6e3a706449d3fd82c7b63634c14f1cd56b86cf1daf50e6ee9c696a5b2f05e1f2",
+      "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {

--- a/scripts/tests/lint-retrieval-generalization.test.mjs
+++ b/scripts/tests/lint-retrieval-generalization.test.mjs
@@ -742,7 +742,8 @@ pub const PLANTED_TERMS: &[(&str, &str)] = &[
     ["plugins/codestory/skills/codestory-grounding/SKILL.md", "Run `node scripts/fetch-holdout-repos.mjs` before grounding.\n", ["fetch-holdout-repos.mjs"]],
     [".cursor/rules/codestory.mdc", "Read benchmarks/tasks/eval-probes.json before answering.\n", ["benchmarks/tasks"]],
     [".github/scripts/route-ci-proof.mjs", "        \".github/workflows/retrieval-engine-smoke.yml\",\n        \".github/workflows/retrieval-engine-smoke.yml\",\nawait import(\".github/workflows/retrieval-engine-smoke.yml\");\n", ["retrieval-engine-smoke.yml"]],
-    [".github/scripts/check-workflow-policy.mjs", "const retrievalFile = \"retrieval-engine-smoke.yml\";\nconst hostile = \".github/workflows/retrieval-\" + \"engine-smoke.yml\";\n", ["githubworkflowsretrievalenginesmokeyml"]],
+    [".github/scripts/check-workflow-policy.mjs", "const retrievalFile = \"retrieval-engine-smoke.yml\";\nconst hostile = \".github/workflows/retrieval-\" + \"engine-smoke.yml\";\nconst duplicated = [\n  \"node scripts/codestory-agent-ab-benchmark.mjs\",\n  \"node scripts/codestory-agent-ab-benchmark.mjs\",\n];\n", ["githubworkflowsretrievalenginesmokeyml", "codestory-agent-ab-benchmark.mjs"]],
+    [".github/workflows/macos-metal-proof.yml", "run: |\n  node scripts/codestory-agent-ab-benchmark.mjs \\\n    --packet-runtime \\\n    --packet-runtime-mode cold-cli \\\n    --task-suite holdout-retrieval \\\n    --materialize-repos \\\n    --repeats 4 \\\n    --publishable \\\n    --max-source-reads-after-packet 0 \\\n    --codestory-cli \"$packaged_cli\" \\\n    --timeout-ms 180000 \\\n    --out-dir \"$quality_root/packet\"\n", ["codestory-agent-ab-benchmark.mjs"]],
   ];
   for (const [relativePath, contents] of rejectedNonRust) {
     write(nonRustRoot, `rejected/${relativePath}`, contents);
@@ -761,7 +762,8 @@ pub const PLANTED_TERMS: &[(&str, &str)] = &[
     ["punctuated-apostrophe.yml", "message: rock-'n roll # scripts/fetch-holdout-repos.mjs\n"],
     ["doubled-single-quote.yml", "value: 'scripts/fetch-''holdout-repos.mjs'\n"],
     [".github/scripts/route-ci-proof.mjs", "        \".github/workflows/retrieval-engine-smoke.yml\",\n"],
-    [".github/scripts/check-workflow-policy.mjs", "const retrievalFile = \"retrieval-engine-smoke.yml\";\n"],
+    [".github/scripts/check-workflow-policy.mjs", "const retrievalFile = \"retrieval-engine-smoke.yml\";\nconst exactQualificationReferences = [\n  \"retrieval-engine-smoke.yml\",\n  \"node scripts/codestory-agent-ab-benchmark.mjs\",\n];\n"],
+    [".github/workflows/macos-metal-proof.yml", "run: |\n  node scripts/codestory-agent-ab-benchmark.mjs \\\n    --packet-runtime \\\n    --packet-runtime-mode cold-cli \\\n    --task-suite holdout-retrieval \\\n    --materialize-repos \\\n    --repeats 3 \\\n    --publishable \\\n    --max-source-reads-after-packet 0 \\\n    --codestory-cli \"$packaged_cli\" \\\n    --timeout-ms 180000 \\\n    --out-dir \"$quality_root/packet\"\n"],
   ];
   for (const [relativePath, contents] of allowedNonRust) {
     write(nonRustRoot, `allowed/${relativePath}`, contents);


### PR DESCRIPTION
## Context

CodeStory does not support CPU embeddings. The previous calibration path still carried a hosted Linux CPU cell and repeated the complete packaged qualification harness three times, mixing runtime-constant selection with lifecycle, fault, idle, memory, quality, and accelerator qualification.

Base: `2b97dd8b356a56e1def9018beae6fc99c3f23c83`  
Head: `0944b74be6feb349c8b9ae3b4d0761dd49851815`

## What changed

- Removes hosted Linux CPU calibration and makes protected Apple Silicon Metal the sole required calibration cell.
- Keeps protected Linux Vulkan as optional standalone evidence that cannot join constant selection or block assembly.
- Adds a constant-only producer: three fresh server generations, one sample per metric per run, one archive authentication/unpack, one project/model setup, and one shared Cargo build/package boundary.
- Separates the seven runtime constant groups from frozen-candidate thresholds. True-idle qualification uses the fixed 60-second product timeout plus a 2.5-second observation grace.
- Moves lifecycle, fault, memory, quality, accelerator, and true-idle proof to one frozen-candidate qualification run per available GPU platform. Metal produces the exact quality handoff consumed by required Windows Vulkan; Linux Vulkan is standalone and optional.
- Removes the public CPU selector, makes package manifests declare `cpu_fallback: unsupported`, and rejects CPU identities in calibration, qualification, benchmark, evidence, and release-proof contracts.
- Hardens workflow policy against CPU selectors, qualification work during calibration, 3x3 sampling, repeated setup/build/package/harness work, hidden Linux waiters, dead-code decoys, and skipped or rebound closeout checks.
- Updates the release claim graph, measurement protocol, package proof harness, docs, and test-only CPU fixture seam together.

## How to review

1. Start with `release-claims.json` and the calibration/qualification assertions in `.github/scripts/check-workflow-policy.mjs`.
2. Review the `calibration` and `qualification` routes in `packaged-platform-pr.yml`, then the Metal and Linux reusable workflows.
3. Review `constant_calibration.py` and the new Rust constant-calibration driver for the one-setup/three-fresh-generation boundary.
4. Review the measurement protocol and unfrozen constant-set split.
5. Run the hostile workflow-policy mutations; they execute the evasion shapes rather than checking only named examples.

## Verification

- Two independent cross-boundary reviews accepted the final exact tree after executing production CPU probes, requested mutations, adjacent evasion shapes, and the post-proof lint corrections.
- Exact-head source proof [30480794311](https://github.com/TheGreenCedar/CodeStory/actions/runs/30480794311) passed on `0944b74b`: 2,357/2,357 tests, 3m48s compile, 36.7s all-target/all-feature clippy, 131.6s test execution, 7m25s full-source job.
- Retrieval generalization completed in 42 seconds in that source proof.
- Workflow policy: 976/976 tests; policy validator passed.
- Requested mutation classes and adjacent dead-decoy, closeout metadata, route rebinding, and hidden Linux waiter attacks all fail.
- `cargo test --locked -p codestory-bench --lib`: 30/30.
- `cargo test --locked -p codestory-cli --test architecture_contracts`: 14/14.
- Focused CLI product rejection and test-support smoke tests passed.
- Packaged proof self-test and package self-test passed.
- Release claim graph: 38/38; digest `960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac`.
- Benchmark/evidence contract tests, release cell/closeout/evidence tests, actionlint, release version validation, docs links, Rust formatting, syntax checks, and `git diff --check` passed.

## Remaining proof

No calibration or hardware workflow has been dispatched from this branch. After merge, the release lane still must run and time the real Metal calibration, apply the generated constant set as the sole post-calibration source change, and qualify the frozen candidate. Calibration-input digest reuse is intentionally left for a follow-up.

Refs #1597

Closes #1603
