### PR TITLE
Resolve the native Windows sccache executable

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -544,12 +544,12 @@ const packagedPlatformCloseoutDigest =
 // parsed executable structure so an unreviewed earlier step cannot replace an
 // owner binary while leaving the locally digested finalizer unchanged.
 const packagedPlatformWorkflowDigest =
-  "6cb226d673bdbe5679b9f7010aad18c2c2a956129b51cff69ba457ed91962132";
+  "b8d981623dfbec100ce23470559071d05c5dc384e81164a7f571f915d903b843";
 // Linux owns its compiler server inside Docker, while macOS and Windows own one
 // in the host shell. Pin both executable programs so a swallowed stop or a
 // dead-code copy cannot satisfy the ownership fragments below.
 const packagedSccacheIdentityDigest =
-  "35f1976fd420c0ca6f2213c49ec3879dfa136d649529bbe3fe175f6b5ca633c6";
+  "f844b8a3b2e0f0013b43f4ec661c237fb090a01c49316d8c2b301ba01cac4342";
 const packagedLinuxBuildDigest =
   "fc02f682c294983989d5f63151f8af9b31febda2da6fa0933aa9b1f7c221b4aa";
 const packagedCompileClockStopDigest =
@@ -2882,6 +2882,17 @@ function validatePackagedProof(workflows, violations, graph) {
     packagedSccacheIdentityDigest,
     "pinned sccache identity capture",
   );
+  requireStepRun(violations, file, job, "Capture pinned sccache identity", [
+    'sccache_path="$(command -v sccache)"',
+    'if [[ "$RUNNER_OS" == "Windows" && "$sccache_path" != *.[eE][xX][eE] ]]',
+    'sccache_path="${sccache_path}.exe"',
+    'test -f "$sccache_path"',
+    'test -x "$sccache_path"',
+    'readFileSync(process.argv[1])',
+    "' \"$sccache_path\"",
+    'echo "path=$sccache_path"',
+    'echo "sha256=$sccache_sha256"',
+  ]);
   requireStepRun(violations, file, job, "Configure short Windows Cargo target", [
     '$workspaceTarget = Join-Path $env:GITHUB_WORKSPACE "target"',
     '$runnerRoot = [System.IO.Path]::GetPathRoot($workspaceTarget)',

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   mkdirSync,
@@ -1920,6 +1921,109 @@ test("source proof reuse accepts only whole successful workflow runs", async (t)
   }
 });
 
+test("Windows package proof retains the readable native sccache executable", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-windows-sccache-"));
+  try {
+    const extensionlessPath = path.join(directory, "sccache");
+    const nativePath = `${extensionlessPath}.exe`;
+    const captureOutput = path.join(directory, "capture-output");
+    const nativeCalls = path.join(directory, "native-calls");
+    const decoyCalls = path.join(directory, "decoy-calls");
+    const decoyDirectory = path.join(directory, "decoy");
+    const decoyPath = path.join(decoyDirectory, "sccache");
+    mkdirSync(decoyDirectory);
+    writeFileSync(
+      nativePath,
+      "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$SCCACHE_CALL_LOG\"\n",
+    );
+    chmodSync(nativePath, 0o755);
+    writeFileSync(
+      decoyPath,
+      "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DECOY_CALL_LOG\"\n",
+    );
+    chmodSync(decoyPath, 0o755);
+    writeFileSync(captureOutput, "");
+    writeFileSync(nativeCalls, "");
+    writeFileSync(decoyCalls, "");
+
+    const workflow = loadWorkflows().get("packaged-platform-proof.yml");
+    const captureRun = draftStep(
+      workflow.jobs.build,
+      "Capture pinned sccache identity",
+    ).run;
+    const captureResult = spawnSync(
+      "bash",
+      ["-c", `command() {
+  if [[ "$1" == "-v" && "$2" == "sccache" ]]; then
+    printf '%s\\n' "$SYNTHETIC_SCCACHE_COMMAND"
+  else
+    builtin command "$@"
+  fi
+}
+test() {
+  if [[ "$1" == "-x" && "$2" == "$SYNTHETIC_SCCACHE_COMMAND" ]]; then
+    return 0
+  fi
+  builtin test "$@"
+}
+${captureRun}`],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: captureOutput,
+          RUNNER_OS: "Windows",
+          SYNTHETIC_SCCACHE_COMMAND: extensionlessPath,
+        },
+      },
+    );
+    assert.equal(
+      captureResult.status,
+      0,
+      `capture failed:\n${captureResult.stdout}\n${captureResult.stderr}`,
+    );
+    const captured = Object.fromEntries(
+      readFileSync(captureOutput, "utf8")
+        .trim()
+        .split("\n")
+        .map(line => {
+          const separator = line.indexOf("=");
+          return [line.slice(0, separator), line.slice(separator + 1)];
+        }),
+    );
+    assert.equal(captured.path, nativePath);
+    assert.equal(
+      captured.sha256,
+      createHash("sha256").update(readFileSync(nativePath)).digest("hex"),
+    );
+
+    const finalizerRun = draftStep(
+      workflow.jobs.build,
+      "Finalize compiler objects",
+    ).run;
+    const finalizerResult = spawnSync("bash", ["-c", finalizerRun], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DECOY_CALL_LOG: decoyCalls,
+        PATH: `${decoyDirectory}:${process.env.PATH}`,
+        SCCACHE_BINARY: captured.path,
+        SCCACHE_CALL_LOG: nativeCalls,
+        SCCACHE_SHA256: captured.sha256,
+      },
+    });
+    assert.equal(
+      finalizerResult.status,
+      0,
+      `finalizer failed:\n${finalizerResult.stdout}\n${finalizerResult.stderr}`,
+    );
+    assert.equal(readFileSync(nativeCalls, "utf8"), "--show-stats\n--stop-server\n");
+    assert.equal(readFileSync(decoyCalls, "utf8"), "");
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("reusable compiler caches and proof modes reject hostile downgrades", async (t) => {
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
 
@@ -2066,6 +2170,27 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
       capture.run = capture.run.replace(
         'createHash("sha256").update(readFileSync(process.argv[1])).digest("hex")',
         '"unverified"',
+      );
+    }, /pinned sccache identity capture script exactly/u],
+    ["Windows sccache identity strips the native extension", packagedFile, workflow => {
+      const capture = draftStep(packagedJob(workflow), "Capture pinned sccache identity");
+      capture.run = capture.run.replace(
+        'sccache_path="${sccache_path}.exe"',
+        'sccache_path="${sccache_path%.exe}"',
+      );
+    }, /pinned sccache identity capture script exactly/u],
+    ["sccache identity returns to PATH after native resolution", packagedFile, workflow => {
+      const capture = draftStep(packagedJob(workflow), "Capture pinned sccache identity");
+      capture.run = capture.run.replace(
+        'test -f "$sccache_path"',
+        'sccache_path="$(command -v sccache)"\ntest -f "$sccache_path"',
+      );
+    }, /pinned sccache identity capture script exactly/u],
+    ["sccache identity hashes one path and retains another", packagedFile, workflow => {
+      const capture = draftStep(packagedJob(workflow), "Capture pinned sccache identity");
+      capture.run = capture.run.replace(
+        'echo "path=$sccache_path"',
+        'echo "path=$(command -v sccache)"',
       );
     }, /pinned sccache identity capture script exactly/u],
     ["source compiler cache waits for tests", sourceFile, workflow => {
@@ -2253,7 +2378,7 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
         "Build Linux x64 at the glibc 2.31 baseline",
       ).env.SCCACHE_BINARY = "sccache";
     }, /Linux container must strictly report and stop its owned compiler server/u],
-    ["host compiler finalizer is restored on Linux", packagedFile, workflow => {
+    ["Linux gains a host compiler finalizer fallback", packagedFile, workflow => {
       draftStep(packagedJob(workflow), "Finalize compiler objects").if =
         "always() && ((matrix.asset_target == 'linux-x64' && steps.linux-build.outcome == 'success') || (matrix.asset_target != 'linux-x64' && steps.package-build.outcome == 'success'))";
     }, /host finalizer must strictly stop only the host package-build compiler server/u],

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -165,6 +165,10 @@ jobs:
         shell: bash
         run: |
           sccache_path="$(command -v sccache)"
+          if [[ "$RUNNER_OS" == "Windows" && "$sccache_path" != *.[eE][xX][eE] ]]; then
+            sccache_path="${sccache_path}.exe"
+          fi
+          test -f "$sccache_path"
           test -x "$sccache_path"
           sccache_sha256="$(
             node --input-type=module -e '


### PR DESCRIPTION
Closes #1607
Refs #1597

## Context

Frozen-candidate qualification run 30495141257 failed before Windows compilation. Git Bash returned the installed sccache command as an extensionless path, but the native file is `sccache.exe`; the identity step passed that nonexistent spelling to Node and failed with `ENOENT`.

This was a workflow defect on exact source `f511689e0a7164ee11f3a453c736276cdf89ee5c`, not runner unavailability. The same run proved the existing macOS host finalizer and strict Linux Docker-owned finalizer. It emitted no false platform or qualification receipt.

## What changed

- Resolve Git Bash's extensionless Windows spelling to the existing native `.exe` before hashing it.
- Require the retained path to be a real executable file, then bind that exact path and SHA-256 through host finalization.
- Add an executable MSYS-shaped regression that uses a real temporary `.exe`, an extensionless command result, and a PATH decoy.
- Pin the revised workflow and capture script in workflow policy.
- Add hostile policy mutations for extension stripping, PATH rebinding, retained/hash path drift, and Linux host-finalizer fallback.

The job DAG and claim graph are unchanged, so `release-claims.json` is intentionally unchanged.

## Review and verification

Base: `fc065a104978f9daca1de5824f44b88b18902932`
Head: `733eeb857ad937c31092a1b199ab26d6291c115e`
Tree: `a38d16018e10159b0643df09c878c2a48b8beff0`

- Executed the production capture/finalizer under GitHub's `bash -e -o pipefail` semantics across 11 path/identity cases: extensionless to `.exe`, `.EXE` casing, spaces, drive-like spellings, PATH decoy, replacement/hash drift, stripped extension, deletion, and missing native file.
- Independently attacked 10 policy shapes; all were rejected.
- Focused hostile workflow-policy suite: 87/87 passed.
- Full workflow-policy suite: 1005/1005 passed.
- Workflow policy, actionlint, and `git diff --check`: passed.
- Exact-head source proof 30496543544 passed: retrieval 49s; 2,357/2,357 workspace tests passed with 29 skipped in 129.526s. The source job took 17m06s because the branch-scoped compiler cache missed; compile/clippy took 851s and the newly populated cache saved successfully.
- Workflow DAG digest and `release-claims.json` digest are unchanged.
- PR #1581 is not included and has no path overlap.

Native Windows package proof remains intentionally pending the next frozen-candidate qualification; this PR does not claim it from local simulation.
