### PR TITLE
[codex] reuse packaged qualification drivers

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -431,6 +431,30 @@ function stepIndex(job, name) {
   return list(job?.steps).map(object).findIndex(step => step.name === name);
 }
 
+function qualificationDriverHandoffIsSealed(
+  job,
+  verifierName,
+  engineName,
+  expectedIntermediateNames,
+) {
+  const steps = list(job?.steps).map(object);
+  const verifierIndex = stepIndex(job, verifierName);
+  const engineIndex = stepIndex(job, engineName);
+  if (verifierIndex < 0 || engineIndex <= verifierIndex) return false;
+  const intermediate = steps.slice(verifierIndex + 1, engineIndex);
+  if (
+    JSON.stringify(intermediate.map(step => step.name))
+      !== JSON.stringify(expectedIntermediateNames)
+  ) {
+    return false;
+  }
+  return intermediate.every(step =>
+    !scalarStrings(step).some(value =>
+      value.includes("qualification-driver")
+      || value.includes("VERIFIED_QUALIFICATION_DRIVER")
+      || value.includes("codestory_embedding_qualification")));
+}
+
 function cacheSteps(job) {
   return list(job?.steps)
     .map(object)
@@ -517,6 +541,102 @@ function requireCalibrationProducerBoundary(
   );
 }
 
+const qualificationDriverIdentityFields = [
+  "schema_version",
+  "source.commit",
+  "source.tree",
+  "release_version",
+  "asset_target",
+  "archive.file",
+  "archive.bytes",
+  "archive.sha256",
+  "driver.file",
+  "driver.bytes",
+  "driver.sha256",
+];
+
+function expectedQualificationDriverContract() {
+  return {
+    producer_workflow: "packaged-platform-proof.yml",
+    producer_job: "build",
+    artifact_name_template: "codestory-cli-{asset_target}",
+    artifact_directory_template: "qualification-driver/{asset_target}",
+    identity_file: "qualification-driver-identity.json",
+    identity_schema_version: 1,
+    identity_fields: qualificationDriverIdentityFields,
+    build_invocations_per_platform: 1,
+    reuse_required: true,
+    public_release_asset: false,
+  };
+}
+
+export function qualificationDriverArtifactViolations(
+  source,
+  graph = loadReleaseClaimGraph(repositoryRoot),
+) {
+  const violations = [];
+  const contract = object(
+    object(graph.workflow_policy).qualification,
+  ).driver_contract;
+  add(
+    violations,
+    JSON.stringify(contract) === JSON.stringify(expectedQualificationDriverContract()),
+    "release-claims.json must bind the private archive-qualified driver contract exactly",
+  );
+  const normalized = String(source ?? "").replace(/\r\n/gu, "\n");
+  add(
+    violations,
+    createHash("sha256").update(normalized).digest("hex")
+      === qualificationDriverArtifactDigest,
+    "qualification-driver-artifact.mjs must match the reviewed archive-bound producer and verifier contract",
+  );
+  for (const fragment of [
+    '"linux-x64", {',
+    'archiveExtension: "tar.gz"',
+    'binary: "codestory_embedding_qualification"',
+    'rustTarget: "x86_64-unknown-linux-gnu"',
+    '"macos-arm64", {',
+    'rustTarget: "aarch64-apple-darwin"',
+    '"windows-x64", {',
+    'archiveExtension: "zip"',
+    'binary: "codestory_embedding_qualification.exe"',
+    'rustTarget: "x86_64-pc-windows-msvc"',
+    "metadata.isSymbolicLink()\n    || !metadata.isFile()\n    || metadata.nlink !== 1",
+    "metadata.isSymbolicLink() || !metadata.isDirectory()",
+    'fail("qualification driver helper arguments changed")',
+    "containedRelativePath(root, candidate, label)",
+    "rejectSymlinkedPath({",
+    "const rootMetadata = lstatSync(resolvedRoot)",
+    'fail(`${label} must not traverse symbolic links`)',
+    "`codestory-cli-v${version}-${assetTarget}.${contract.archiveExtension}`",
+    'targetDir,\n    contract.rustTarget,\n    "release",\n    contract.binary',
+    'fail("qualification driver artifact directory must start empty")',
+    "archiveBytes: archiveMetadata.size",
+    "archiveDigest: sha256(archivePath)",
+    "archiveFile: expectedArchiveFile",
+    "identity.archive.file !== expectedArchiveFile",
+    "archiveMetadata.size !== identity.archive.bytes",
+    "sha256(archivePath) !== identity.archive.sha256",
+    "metadata.size !== identity.driver.bytes",
+    "sha256(driver) !== identity.driver.sha256",
+    '"qualification-driver-identity.json"',
+    'fail("qualification driver artifact directory contains unexpected files")',
+    "chmodSync(driver, 0o755)",
+    'archive: required(values, "--archive")',
+    'trustedRoot: required(values, "--trusted-root")',
+    'targetDir: required(values, "--target-dir")',
+    'requireExactFlags(values, [...commonFlags, "--out-dir", "--target-dir"])',
+    'requireExactFlags(values, [...commonFlags, "--artifact-dir"])',
+  ]) {
+    add(
+      violations,
+      normalized.includes(fragment),
+      `qualification-driver-artifact.mjs must retain ${fragment}`,
+    );
+  }
+  return violations;
+}
+
 function requireJob(violations, file, workflow, name) {
   const found = object(workflow.jobs)[name];
   add(violations, found !== undefined, `${file} must contain job ${name}`);
@@ -544,18 +664,40 @@ const packagedPlatformCloseoutDigest =
 // parsed executable structure so an unreviewed earlier step cannot replace an
 // owner binary while leaving the locally digested finalizer unchanged.
 const packagedPlatformWorkflowDigest =
-  "b8d981623dfbec100ce23470559071d05c5dc384e81164a7f571f915d903b843";
+  "d96f36e08888ba2806103829ddf737829d66efee0374138ae9634ed6d71bd355";
+// The frozen-candidate coordinator and protected GPU workflows are small
+// release-control programs, not loose collections of independently safe
+// fragments. Pin their complete parsed structure so a required check cannot be
+// made advisory, parked in dead code, or followed by a payload substitution
+// while leaving the expected tokens in place.
+const packagedPlatformCoordinatorWorkflowDigest =
+  "8efd162e5e5c42e1cbeb0e40378f631ce358feb9404e90e27e02aa0b382d481e";
+const macosMetalWorkflowDigest =
+  "7ff48fa410330a96f3c6da5f3efbb6131d4304fee837bd69c97c8e88e553ea0c";
+const windowsVulkanWorkflowDigest =
+  "f4f6031cb9595a3d1623567ff5b7fcdca5ae34de0a392fbb801138ddb750aa14";
+const linuxVulkanWorkflowDigest =
+  "cd3b2b719dafea2645079503ff4b58da66c085f3522e3921f77a76360554de9b";
 // Linux owns its compiler server inside Docker, while macOS and Windows own one
 // in the host shell. Pin both executable programs so a swallowed stop or a
 // dead-code copy cannot satisfy the ownership fragments below.
 const packagedSccacheIdentityDigest =
   "f844b8a3b2e0f0013b43f4ec661c237fb090a01c49316d8c2b301ba01cac4342";
 const packagedLinuxBuildDigest =
-  "fc02f682c294983989d5f63151f8af9b31febda2da6fa0933aa9b1f7c221b4aa";
+  "968f2ab585eb1870eea20f521d576bfaad2900fc14e6438074f62246a0c8652b";
 const packagedCompileClockStopDigest =
   "ef9f7ee4636c3466830447e2ed8a10c2030ca3949bca082652d9262848d258a5";
 const packagedHostCompilerFinalizerDigest =
   "b77d8bb12c2748bfe016ab65ccb2f4581356f3ccf1d666e747306caffd6c0c46";
+// The companion qualification driver is intentionally retained only inside
+// the private Actions package artifact. This digest pins both sides of that
+// contract: the producer copies only the selected target binary and binds it
+// to the exact candidate archive, while the consumer rejects symlinks, extra
+// files, identity drift, and byte drift before restoring execute permission.
+// Any helper edit therefore requires a policy and mutation-test review in the
+// same PR as the workflow change.
+const qualificationDriverArtifactDigest =
+  "f7946e03fa6e272ca17f12616b82579da041de4d7c30b19d24ddbc5f1c7f0063";
 const draftProofCommands = [
   "cargo test --locked -p codestory-llama-sys --test native_staging",
   "cargo test --locked -p codestory-llama-sys --test model_staging",
@@ -2536,6 +2678,18 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     '"$live_head" != "$GITHUB_SHA"',
     "main moved from publishable head",
   ]);
+  const publishRun = shellLiteralNormalizedText(stepRun(
+    publish,
+    "Create GitHub release",
+  ));
+  add(
+    violations,
+    publishRun.includes("gh release create $TAG ${assets[@]}")
+      && publishRun.includes("find target/release-assets -maxdepth 1 -type f")
+      && !publishRun.includes("qualification-driver")
+      && !publishRun.includes("codestory_embedding_qualification"),
+    `${releaseFile} must publish only graph-declared root assets and exclude the private qualification driver`,
+  );
   add(violations, !scalarStrings(release).some(value => value.includes("--generate-notes")), `${releaseFile} must use curated release notes`);
 
   const marketplacePublish = requireJob(violations, releaseFile, release, "marketplace-publish");
@@ -2837,6 +2991,20 @@ function validatePackagedProof(workflows, violations, graph) {
       && hermeticInput.type === "boolean",
     `${file} frozen Linux qualification must be explicit and off by default`,
   );
+  const qualificationDriverInput = object(at(
+    workflow,
+    "on",
+    "workflow_call",
+    "inputs",
+    "include_qualification_driver",
+  ));
+  add(
+    violations,
+    qualificationDriverInput.required === false
+      && qualificationDriverInput.default === false
+      && qualificationDriverInput.type === "boolean",
+    `${file} private qualification-driver retention must be explicit and off by default`,
+  );
   const shortWindowsTarget = namedStep(job, "Configure short Windows Cargo target");
   const checkout = namedStep(job, "Checkout");
   add(
@@ -2936,8 +3104,11 @@ function validatePackagedProof(workflows, violations, graph) {
       && nativeIdentityRun.includes("--lock-file Cargo.lock")
       && nativeIdentityRun.includes("--cargo-config .cargo/config.toml")
       && nativeIdentityRun.includes("--identity cargo_incremental=0")
-      && nativeIdentityRun.includes("qualification_driver=disabled")
-      && !nativeIdentityRun.includes("qualification_driver=enabled")
+      && object(nativeIdentity?.env).INCLUDE_QUALIFICATION_DRIVER
+        === "${{ inputs.include_qualification_driver }}"
+      && nativeIdentityRun.includes(
+        '--identity "qualification_driver=$INCLUDE_QUALIFICATION_DRIVER"',
+      )
       && nativeIdentityRun.includes(".cargo/llama-dynamic-backends.cmake")
       && nativeIdentityRun.includes("git ls-files '*Cargo.toml'")
       && nativeIdentityRun.includes("model-contract.json")
@@ -3052,7 +3223,7 @@ function validatePackagedProof(workflows, violations, graph) {
   requireStepRun(violations, file, job, "Compile native workspace path regression on Windows", [
     "cargo test --locked -p codestory-workspace repository_identity --no-run",
   ]);
-  const packageBuild = namedStep(job, "Build codestory-cli");
+  const packageBuild = namedStep(job, "Build package and qualification driver");
   const linuxBuild = namedStep(job, "Build Linux x64 at the glibc 2.31 baseline");
   const expectedSccacheIdentityEnv = {
     SCCACHE_BINARY: "${{ steps.sccache-identity.outputs.path }}",
@@ -3068,12 +3239,17 @@ function validatePackagedProof(workflows, violations, graph) {
     "$SCCACHE_BINARY:/sccache/sccache:ro",
     "$SCCACHE_DIR:/sccache/cache",
   ]);
+  const expectedLinuxBuildEnv = {
+    ...expectedSccacheIdentityEnv,
+    INCLUDE_QUALIFICATION_DRIVER: "${{ inputs.include_qualification_driver }}",
+    RELEASE_RUST_TARGET: "${{ matrix.rust_target }}",
+  };
   add(
     violations,
     linuxBuild?.if === "matrix.asset_target == 'linux-x64'"
       && linuxBuild?.shell === "bash"
-      && hasExactKeys(object(linuxBuild?.env), Object.keys(expectedSccacheIdentityEnv))
-      && Object.entries(expectedSccacheIdentityEnv).every(
+      && hasExactKeys(object(linuxBuild?.env), Object.keys(expectedLinuxBuildEnv))
+      && Object.entries(expectedLinuxBuildEnv).every(
         ([key, value]) => object(linuxBuild?.env)[key] === value,
       )
       && linuxBuild?.["continue-on-error"] === undefined,
@@ -3139,7 +3315,7 @@ function validatePackagedProof(workflows, violations, graph) {
   );
   add(
     violations,
-    compilerSaveIndex > stepIndex(job, "Build codestory-cli")
+    compilerSaveIndex > stepIndex(job, "Build package and qualification driver")
       && compilerSaveIndex > stepIndex(job, "Build Linux x64 at the glibc 2.31 baseline"),
     `${file} compiler cache must save after every selected compilation step`,
   );
@@ -3148,7 +3324,7 @@ function validatePackagedProof(workflows, violations, graph) {
     stepIndex(job, "Build pinned Linux toolchain image")
       < stepIndex(job, "Start compilation clock")
       && stepIndex(job, "Stop compilation clock")
-        > stepIndex(job, "Build qualification driver")
+        > stepIndex(job, "Build package and qualification driver")
       && stepIndex(job, "Stop compilation clock") < compilerSaveIndex
       && stepIndex(job, "Start compiler cache save clock")
         > stepIndex(job, "Save Cargo dependency inputs")
@@ -3175,8 +3351,16 @@ function validatePackagedProof(workflows, violations, graph) {
   }
   add(
     violations,
-    packageBuild?.env === undefined,
-    `${file} native package build must not override the selected generator`,
+    packageBuild?.shell === "bash"
+      && hasExactKeys(object(packageBuild?.env), [
+        "INCLUDE_QUALIFICATION_DRIVER",
+        "RELEASE_RUST_TARGET",
+      ])
+      && object(packageBuild?.env).INCLUDE_QUALIFICATION_DRIVER
+        === "${{ inputs.include_qualification_driver }}"
+      && object(packageBuild?.env).RELEASE_RUST_TARGET
+        === "${{ matrix.rust_target }}",
+    `${file} native package build must not override the selected generator and must bind the reviewed target and qualification workload`,
   );
   requireStepRun(violations, file, job, "Smoke codestory-cli on Windows", [
     "$env:CARGO_TARGET_DIR",
@@ -3212,11 +3396,46 @@ function validatePackagedProof(workflows, violations, graph) {
     "LINUX_GLIBC_BUILD_IMAGE",
     "LINUX_GLSLC_IMAGE",
   ]);
-  requireStepRun(violations, file, job, "Build Linux x64 at the glibc 2.31 baseline", [
-    "cargo build --release --locked -p codestory-cli",
-    "CARGO_TARGET_DIR=/workspace/target/glibc-2.31",
-    "CXXFLAGS=-std=c++17",
-  ]);
+  const packageBuildRun = shellLiteralNormalizedText(stepRun(
+    job,
+    "Build package and qualification driver",
+  ));
+  const linuxBuildRun = shellLiteralNormalizedText(stepRun(
+    job,
+    "Build Linux x64 at the glibc 2.31 baseline",
+  ));
+  add(
+    violations,
+    shellInvocationsContaining(packageBuildRun, "cargo build").length === 1
+      && packageBuildRun.includes("-p codestory-cli")
+      && packageBuildRun.includes("--bin codestory-cli")
+      && packageBuildRun.includes("--bin codestory-cli-runtime")
+      && packageBuildRun.includes("if [ $INCLUDE_QUALIFICATION_DRIVER = true ]")
+      && packageBuildRun.includes("-p codestory-bench")
+      && packageBuildRun.includes("--bin codestory_embedding_qualification")
+      && packageBuildRun.includes("--target $RELEASE_RUST_TARGET")
+      && !packageBuildRun.includes("codestory_embedding_constant_calibration")
+      && !/(?:^|\s)--bins(?:\s|$)/u.test(packageBuildRun),
+    `${file} host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation`,
+  );
+  add(
+    violations,
+    shellInvocationsContaining(linuxBuildRun, "cargo build").length === 1
+      && linuxBuildRun.includes("CARGO_TARGET_DIR=/workspace/target/glibc-2.31")
+      && linuxBuildRun.includes("CXXFLAGS=-std=c++17")
+      && linuxBuildRun.includes("INCLUDE_QUALIFICATION_DRIVER=$INCLUDE_QUALIFICATION_DRIVER")
+      && linuxBuildRun.includes("RELEASE_RUST_TARGET=$RELEASE_RUST_TARGET")
+      && linuxBuildRun.includes("-p codestory-cli")
+      && linuxBuildRun.includes("--bin codestory-cli")
+      && linuxBuildRun.includes("--bin codestory-cli-runtime")
+      && linuxBuildRun.includes("if [ $INCLUDE_QUALIFICATION_DRIVER = true ]")
+      && linuxBuildRun.includes("-p codestory-bench")
+      && linuxBuildRun.includes("--bin codestory_embedding_qualification")
+      && linuxBuildRun.includes("--target $RELEASE_RUST_TARGET")
+      && !linuxBuildRun.includes("codestory_embedding_constant_calibration")
+      && !/(?:^|\s)--bins(?:\s|$)/u.test(linuxBuildRun),
+    `${file} Linux package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation`,
+  );
   // The identity the smoke reads is the one `source-identity` proved against the dispatched ref,
   // and it now arrives through `env:` rather than spliced into the command. Both halves are pinned:
   // the script names the variable, and the variable names that step's output.
@@ -3234,6 +3453,63 @@ function validatePackagedProof(workflows, violations, graph) {
     ]);
     requireStepEnv(violations, file, job, smokeStep, sourceIdentityBindings);
   }
+  const driverStageName = "Stage qualification driver in package proof artifact";
+  const driverStage = namedStep(job, driverStageName);
+  const driverStageRun = shellLiteralNormalizedText(stepRun(job, driverStageName));
+  add(
+    violations,
+    driverStage?.if === "inputs.include_qualification_driver"
+      && driverStage?.shell === "bash"
+      && driverStage?.["continue-on-error"] === undefined
+      && hasExactKeys(object(driverStage?.env), [
+        "INPUT_VERSION",
+        "SOURCE_SHA",
+        "SOURCE_TREE",
+      ])
+      && object(driverStage?.env).INPUT_VERSION === "${{ inputs.version }}"
+      && object(driverStage?.env).SOURCE_SHA
+        === "${{ steps.source-identity.outputs.sha }}"
+      && object(driverStage?.env).SOURCE_TREE
+        === "${{ steps.source-identity.outputs.tree }}"
+      && shellInvocationsContaining(
+        driverStageRun,
+        "node .github/scripts/qualification-driver-artifact.mjs produce",
+      ).length === 1
+      && driverStageRun.includes("--asset-target ${{ matrix.asset_target }}")
+      && driverStageRun.includes("--source-sha $SOURCE_SHA")
+      && driverStageRun.includes("--source-tree $SOURCE_TREE")
+      && driverStageRun.includes("--version $INPUT_VERSION")
+      && driverStageRun.includes(
+        "--archive target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}",
+      )
+      && driverStageRun.includes("--trusted-root $GITHUB_WORKSPACE")
+      && driverStageRun.includes("--target-dir target")
+      && driverStageRun.includes(
+        "--out-dir target/release-dist/qualification-driver/${{ matrix.asset_target }}",
+      ),
+    `${file} must retain one archive-bound private qualification driver beside each selected package`,
+  );
+  add(
+    violations,
+    stepIndex(job, driverStageName) > stepIndex(job, "Package release asset")
+      && stepIndex(job, driverStageName)
+        > stepIndex(job, "Package release asset on Windows")
+      && stepIndex(job, driverStageName) < stepIndex(job, "Upload release asset"),
+    `${file} must bind the private qualification driver after archive creation and before artifact upload`,
+  );
+  add(
+    violations,
+    [
+      "Package release asset",
+      "Package release asset on Windows",
+      "Sign and notarize macOS CLI",
+    ].every(stepName => {
+      const run = shellLiteralNormalizedText(stepRun(job, stepName));
+      return !run.includes("qualification-driver")
+        && !run.includes("codestory_embedding_qualification");
+    }),
+    `${file} public archives and signing inputs must exclude the private qualification driver`,
+  );
   requireStepRun(violations, file, job, "Report fresh package identity", [
     "archive_sha256=",
     "Source SHA: \\`$SOURCE_SHA\\`",
@@ -3333,7 +3609,7 @@ function validatePackagedProof(workflows, violations, graph) {
       && namedStep(job, "Upload hosted Linux calibration runs") === undefined
       && namedStep(job, "Upload hosted Linux calibration failure evidence") === undefined
       && namedStep(job, "Upload packaged agent proof artifacts") === undefined,
-    `${file} package-only workflow must not collect calibration or run hosted qualification`,
+    `${file} package workflow must not add a second driver build, calibration, or hosted qualification`,
   );
   requireCalibrationProducerBoundary(
     violations,
@@ -3432,6 +3708,24 @@ function validatePackagedProof(workflows, violations, graph) {
     `${file} package-only workflow must not contain installed-runtime or server-scope routing`,
   );
   requireStepUses(violations, file, job, "Upload release asset", "actions/upload-artifact@v7.0.1");
+  const releaseAssetUpload = namedStep(job, "Upload release asset");
+  add(
+    violations,
+    object(releaseAssetUpload?.with).name
+        === "codestory-cli-${{ matrix.asset_target }}"
+      && String(object(releaseAssetUpload?.with).path ?? "")
+        === [
+          "target/release-dist/*.tar.gz",
+          "target/release-dist/*.zip",
+          "target/release-dist/*.sha256",
+          "target/release-dist/SHA256SUMS.txt",
+          "target/release-dist/qualification-driver/${{ matrix.asset_target }}",
+          "",
+        ].join("\n")
+      && object(releaseAssetUpload?.with)["if-no-files-found"] === "error"
+      && object(releaseAssetUpload?.with).overwrite === true,
+    `${file} existing package artifact must retain the private driver directory without changing its public archive`,
+  );
   requireStepUses(violations, file, job, "Upload macOS notarization proof", "actions/upload-artifact@v7.0.1");
   requireStepRun(violations, file, job, "Emit authenticated package release cell", [
     "codestory-release-cell-manifest.mjs produce",
@@ -3855,6 +4149,12 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     violations.push(`${file} must exist`);
     return;
   }
+  add(
+    violations,
+    createHash("sha256").update(JSON.stringify(workflow)).digest("hex")
+      === packagedPlatformCoordinatorWorkflowDigest,
+    `${file} must match the reviewed frozen-candidate coordinator structure`,
+  );
   const promotion = graph.workflow_policy.promotion;
   const calibrationPolicy = object(graph.workflow_policy.calibration);
   const qualificationPolicy = object(graph.workflow_policy.qualification);
@@ -3961,7 +4261,9 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && sameMembers(
         list(qualificationPolicy.forbidden_environment),
         ["CODESTORY_EMBED_ALLOW_CPU=1"],
-      ),
+      )
+      && JSON.stringify(object(qualificationPolicy.driver_contract))
+        === JSON.stringify(expectedQualificationDriverContract()),
     `${file} must implement the release claim graph qualification contract`,
   );
   const expectedConcurrency = [
@@ -4212,8 +4514,16 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && String(packaged.if ?? "").includes("needs.route.outputs.mode == 'platform'")
       && String(packaged.if ?? "").includes("needs.route.outputs.mode == 'qualification'")
       && object(packaged.with).hermetic_linux
+        === "${{ needs.route.outputs.mode == 'qualification' }}"
+      && object(packaged.with).include_qualification_driver
         === "${{ needs.route.outputs.mode == 'qualification' }}",
     `${file} package and platform modes must build fresh archives while only qualification runs the cold Linux boundary`,
+  );
+  add(
+    violations,
+    object(packaged.with).include_qualification_driver
+      === "${{ needs.route.outputs.mode == 'qualification' }}",
+    `${file} must retain the private qualification driver only for frozen-candidate qualification`,
   );
   for (const key of [
     "candidate_installed_proof",
@@ -4520,6 +4830,12 @@ function validateRemainingWorkflows(workflows, violations) {
   if (!metal) {
     violations.push(`${metalFile} must exist`);
   } else {
+    add(
+      violations,
+      createHash("sha256").update(JSON.stringify(metal)).digest("hex")
+        === macosMetalWorkflowDigest,
+      `${metalFile} must match the reviewed protected Metal workflow structure`,
+    );
     add(violations, trigger(metal, "workflow_call") !== undefined && trigger(metal, "workflow_dispatch") !== undefined, `${metalFile} must support reusable and manual proof`);
     for (const event of ["workflow_call", "workflow_dispatch"]) {
       for (const key of ["calibration_bundle_artifact", "calibration_bundle_run_id"]) {
@@ -4626,21 +4942,27 @@ function validateRemainingWorkflows(workflows, violations) {
     add(
       violations,
       namedStep(job, "Install pinned Rust")?.if
-        === "${{ !inputs.use_packaged_cli_artifact || inputs.calibration_mode || !inputs.server_behavior_only }}",
-      `${metalFile} packaged server-behavior proof must skip unused Rust installation`,
+        === "${{ !inputs.use_packaged_cli_artifact }}",
+      `${metalFile} every packaged proof must skip Rust installation`,
     );
     add(
       violations,
-      namedStep(job, "Build qualification driver")?.if
-        === "${{ !inputs.calibration_mode && !inputs.server_behavior_only }}",
-      `${metalFile} calibration and packaged server-behavior proof must skip the qualification driver`,
+      namedStep(job, "Build qualification driver") === undefined,
+      `${metalFile} must not rebuild the qualification driver after package download`,
     );
     const nativeBuild = namedStep(job, "Build and package native CLI");
     const nativeBuildRun = executableRunText(String(nativeBuild?.run ?? ""));
     const normalizedNativeBuildRun = shellLiteralNormalizedText(nativeBuildRun);
     add(
       violations,
-      object(nativeBuild?.env).CALIBRATION_MODE === "${{ inputs.calibration_mode }}"
+      hasExactKeys(object(nativeBuild?.env), [
+        "VERSION",
+        "CALIBRATION_MODE",
+        "SERVER_BEHAVIOR_ONLY",
+      ])
+        && object(nativeBuild?.env).CALIBRATION_MODE === "${{ inputs.calibration_mode }}"
+        && object(nativeBuild?.env).SERVER_BEHAVIOR_ONLY
+          === "${{ inputs.server_behavior_only }}"
         && nativeBuild?.id === "native-build-package"
         && shellInvocationsContaining(normalizedNativeBuildRun, "cargo build").length === 1
         && normalizedNativeBuildRun.includes("-p codestory-cli")
@@ -4648,11 +4970,26 @@ function validateRemainingWorkflows(workflows, violations) {
         && normalizedNativeBuildRun.includes("--bin codestory-cli")
         && normalizedNativeBuildRun.includes("--bin codestory-cli-runtime")
         && normalizedNativeBuildRun.includes("--bin codestory_embedding_constant_calibration")
+        && normalizedNativeBuildRun.includes(
+          "--bin codestory_embedding_qualification",
+        )
+        && normalizedNativeBuildRun.includes("if [ $CALIBRATION_MODE = true ]")
+        && normalizedNativeBuildRun.includes(
+          "elif [ $SERVER_BEHAVIOR_ONLY != true ]",
+        )
+        && occurrenceCount(
+          normalizedNativeBuildRun,
+          "--bin codestory_embedding_qualification",
+        ) === 1
+        && occurrenceCount(
+          normalizedNativeBuildRun,
+          "--bin codestory_embedding_constant_calibration",
+        ) === 1
         && shellInvocationsContaining(
           normalizedNativeBuildRun,
           "python3 .github/scripts/package-codestory-release.py",
         ).length === 1
-        && jobShellInvocationsContaining(job, "cargo build").length === 2
+        && jobShellInvocationsContaining(job, "cargo build").length === 1
         && jobShellInvocationsContaining(
           job,
           ".github/scripts/package-codestory-release.py",
@@ -4676,11 +5013,24 @@ function validateRemainingWorkflows(workflows, violations) {
       packagedArtifactDownload?.if === "inputs.use_packaged_cli_artifact"
         && packagedArtifactDownload?.shell === "bash"
         && object(packagedArtifactDownload?.env).GH_TOKEN === "${{ github.token }}"
-        && object(packagedArtifactDownload?.env).ARTIFACT_NAME === "codestory-cli-macos-arm64",
+        && object(packagedArtifactDownload?.env).ARTIFACT_NAME === "codestory-cli-macos-arm64"
+        && object(packagedArtifactDownload?.env).CANDIDATE_PRODUCER_WORKFLOW_PATH
+          === "${{ inputs.candidate_producer_workflow_path }}"
+        && object(packagedArtifactDownload?.env).SERVER_BEHAVIOR_ONLY
+          === "${{ inputs.server_behavior_only }}",
       `${metalFile} packaged CLI download must be an authenticated exact-artifact Bash boundary`,
     );
     requireStepRun(violations, metalFile, job, "Download packaged CLI artifact", [
       "actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100",
+      ".github/workflows/auto-release.yml",
+      ".github/workflows/release.yml",
+      ".github/workflows/packaged-platform-pr.yml",
+      'if [ "$SERVER_BEHAVIOR_ONLY" != true ]; then',
+      'test "$CANDIDATE_PRODUCER_WORKFLOW_PATH" =',
+      ".head_repository.full_name",
+      '.path\' <<<"$producer_run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"',
+      '.head_sha\' <<<"$producer_run")" = "$(git rev-parse HEAD)"',
+      '.run_attempt\' <<<"$producer_run")" = "$GITHUB_RUN_ATTEMPT"',
       ".workflow_run.id == $run_id",
       ".workflow_run.head_sha == $sha",
       ".digest",
@@ -4691,6 +5041,57 @@ function validateRemainingWorkflows(workflows, violations) {
       "test \"$actual_digest\" = \"${expected_digest#sha256:}\"",
       "ditto -x -k",
     ]);
+    const metalDriverVerify = namedStep(job, "Verify packaged qualification driver");
+    const metalDriverVerifyRun = shellLiteralNormalizedText(
+      stepRun(job, "Verify packaged qualification driver"),
+    );
+    add(
+      violations,
+      metalDriverVerify?.id === "qualification-driver"
+        && metalDriverVerify?.if
+          === "${{ inputs.use_packaged_cli_artifact && !inputs.calibration_mode && !inputs.server_behavior_only }}"
+        && metalDriverVerify?.shell === "bash"
+        && metalDriverVerify?.["continue-on-error"] === undefined
+        && hasExactKeys(object(metalDriverVerify?.env), ["INPUT_VERSION"])
+        && object(metalDriverVerify?.env).INPUT_VERSION === "${{ inputs.version }}"
+        && shellInvocationsContaining(
+          metalDriverVerifyRun,
+          "node .github/scripts/qualification-driver-artifact.mjs verify",
+        ).length === 1
+        && metalDriverVerifyRun.includes("--asset-target macos-arm64")
+        && metalDriverVerifyRun.includes("--source-sha $(git rev-parse HEAD)")
+        && metalDriverVerifyRun.includes("--source-tree $(git rev-parse HEAD^{tree})")
+        && metalDriverVerifyRun.includes("--version $version")
+        && metalDriverVerifyRun.includes(
+          "--archive target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz",
+        )
+        && metalDriverVerifyRun.includes("--trusted-root $GITHUB_WORKSPACE")
+        && metalDriverVerifyRun.includes(
+          "--artifact-dir target/release-dist/qualification-driver/macos-arm64",
+        )
+        && metalDriverVerifyRun.includes(
+          "echo path=$(jq -r .driver <<<$verified) >> $GITHUB_OUTPUT",
+        )
+        && stepIndex(job, "Verify packaged qualification driver")
+          > stepIndex(job, "Download packaged CLI artifact"),
+      `${metalFile} packaged qualification must verify the archive-bound private driver`,
+    );
+    add(
+      violations,
+      qualificationDriverHandoffIsSealed(
+        job,
+        "Verify packaged qualification driver",
+        "Prove protected Metal runtime",
+        [
+          "Download exact-head publishable packet quality evidence",
+          "Produce exact-head holdout quality on protected Metal",
+          "Upload exact-head protected Metal quality evidence",
+          "Authenticate calibration bundle producer",
+          "Download frozen calibration bundle",
+        ],
+      ),
+      `${metalFile} must not replace the verified qualification driver before execution`,
+    );
     const qualityDownload = namedStep(
       job,
       "Download exact-head publishable packet quality evidence",
@@ -4884,7 +5285,26 @@ function validateRemainingWorkflows(workflows, violations) {
       engineRun.includes("calibration_args=()")
         && engineRun.includes('"${calibration_args[@]}"')
         && engineRun.includes('claim_scope_args=(--server-behavior-only)')
-        && occurrenceCount(engineRun, "--calibration-bundle") === 1,
+        && occurrenceCount(engineRun, "--calibration-bundle") === 1
+        && object(engine?.env).USE_PACKAGED_CLI_ARTIFACT
+          === "${{ inputs.use_packaged_cli_artifact }}"
+        && object(engine?.env).VERIFIED_QUALIFICATION_DRIVER
+          === "${{ steps.qualification-driver.outputs.path }}"
+        && engineRun.includes(
+          "qualification_driver=target/release/codestory_embedding_qualification",
+        )
+        && engineRun.includes(
+          'if [ "$USE_PACKAGED_CLI_ARTIFACT" = true ]; then',
+        )
+        && engineRun.includes(
+          'qualification_driver="$VERIFIED_QUALIFICATION_DRIVER"',
+        )
+        && occurrenceCount(engineRun, "qualification_driver=") === 2
+        && engineRun.includes('test -x "$qualification_driver"')
+        && engineRun.includes('--qualification-driver "$qualification_driver"')
+        && !engineRun.includes(
+          "--qualification-driver target/release/codestory_embedding_qualification",
+        ),
       `${metalFile} server-behavior proof must omit calibration while qualification retains it`,
     );
     add(
@@ -5008,6 +5428,12 @@ function validateRemainingWorkflows(workflows, violations) {
   if (!vulkan) {
     violations.push(`${vulkanFile} must exist`);
   } else {
+    add(
+      violations,
+      createHash("sha256").update(JSON.stringify(vulkan)).digest("hex")
+        === windowsVulkanWorkflowDigest,
+      `${vulkanFile} must match the reviewed protected Windows Vulkan workflow structure`,
+    );
     add(violations, trigger(vulkan, "workflow_call") !== undefined && trigger(vulkan, "workflow_dispatch") !== undefined, `${vulkanFile} must support reusable and manual proof`);
     for (const event of ["workflow_call", "workflow_dispatch"]) {
       for (const key of ["calibration_bundle_artifact", "calibration_bundle_run_id"]) {
@@ -5109,6 +5535,8 @@ function validateRemainingWorkflows(workflows, violations) {
       "Capture source build tool evidence",
       "Install pinned Rust",
       "Build and package native CLI",
+      "Authenticate exact Windows package producer",
+      "Verify packaged qualification driver",
       "Authenticate calibration bundle producer",
       "Prove protected Windows Vulkan runtime",
       "Stage isolated candidate-managed Windows install",
@@ -5148,27 +5576,177 @@ function validateRemainingWorkflows(workflows, violations) {
     ]);
     requireStepRun(violations, vulkanFile, job, "Prepare checksum-pinned embedded model", ["node scripts/prepare-embedded-model.mjs"]);
     const nativeBuild = namedStep(job, "Build and package native CLI");
+    const nativeBuildRun = shellLiteralNormalizedText(String(nativeBuild?.run ?? ""));
     add(
       violations,
-      hasExactKeys(object(nativeBuild?.env), ["VERSION", "CMAKE_GENERATOR"])
+      hasExactKeys(object(nativeBuild?.env), [
+        "VERSION",
+        "CMAKE_GENERATOR",
+        "SERVER_BEHAVIOR_ONLY",
+      ])
         && object(nativeBuild?.env).CMAKE_GENERATOR === windowsNativeGenerator,
       `${vulkanFile} source package build must use the Ninja native generator`,
     );
-    requireStepRun(violations, vulkanFile, job, "Build and package native CLI", [
-      "cargo build --release --locked -p codestory-cli",
-      "package-codestory-release.py",
-    ]);
     add(
       violations,
-      namedStep(job, "Install pinned Rust")?.if
-        === "${{ !inputs.use_packaged_cli_artifact || !inputs.server_behavior_only }}",
-      `${vulkanFile} packaged server-behavior proof must skip unused Rust installation`,
+      shellInvocationsContaining(nativeBuildRun, "cargo @cargoArgs").length === 1
+        && nativeBuildRun.includes("-p, codestory-cli")
+        && nativeBuildRun.includes("--bin, codestory-cli")
+        && nativeBuildRun.includes("--bin, codestory-cli-runtime")
+        && nativeBuildRun.includes("$env:SERVER_BEHAVIOR_ONLY -ne true")
+        && nativeBuildRun.includes("-p, codestory-bench")
+        && nativeBuildRun.includes(
+          "--bin, codestory_embedding_qualification",
+        )
+        && occurrenceCount(
+          nativeBuildRun,
+          "codestory_embedding_qualification",
+        ) === 1
+        && !nativeBuildRun.includes("codestory_embedding_constant_calibration")
+        && shellInvocationsContaining(
+          nativeBuildRun,
+          "python .github/scripts/package-codestory-release.py",
+        ).length === 1
+        && jobShellInvocationsContaining(job, "cargo @cargoArgs").length === 1
+        && jobShellInvocationsContaining(job, "cargo build").length === 0,
+      `${vulkanFile} source fallback must build CLI, runtime, and qualification driver in one Cargo invocation`,
     );
     add(
       violations,
-      namedStep(job, "Build qualification driver")?.if
-        === "${{ !inputs.server_behavior_only }}",
-      `${vulkanFile} packaged server-behavior proof must skip the qualification driver`,
+      namedStep(job, "Install pinned Rust")?.if
+        === "${{ !inputs.use_packaged_cli_artifact }}",
+      `${vulkanFile} every packaged proof must skip Rust installation`,
+    );
+    add(
+      violations,
+      namedStep(job, "Build qualification driver") === undefined,
+      `${vulkanFile} must not rebuild the qualification driver after package download`,
+    );
+    const windowsPackageAuthentication = namedStep(
+      job,
+      "Authenticate exact Windows package producer",
+    );
+    const windowsPackageAuthenticationRun = shellLiteralNormalizedText(
+      stepRun(job, "Authenticate exact Windows package producer"),
+    );
+    add(
+      violations,
+      windowsPackageAuthentication?.if === "inputs.use_packaged_cli_artifact"
+        && windowsPackageAuthentication?.shell === windowsPowerShellShell
+        && windowsPackageAuthentication?.["continue-on-error"] === undefined
+        && hasExactKeys(object(windowsPackageAuthentication?.env), [
+          "GH_TOKEN",
+          "CANDIDATE_PRODUCER_WORKFLOW_PATH",
+          "SERVER_BEHAVIOR_ONLY",
+        ])
+        && object(windowsPackageAuthentication?.env).GH_TOKEN
+          === "${{ github.token }}"
+        && object(windowsPackageAuthentication?.env).CANDIDATE_PRODUCER_WORKFLOW_PATH
+          === "${{ inputs.candidate_producer_workflow_path }}"
+        && object(windowsPackageAuthentication?.env).SERVER_BEHAVIOR_ONLY
+          === "${{ inputs.server_behavior_only }}"
+        && windowsPackageAuthenticationRun.includes(
+          ".github/workflows/auto-release.yml",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          ".github/workflows/release.yml",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          ".github/workflows/packaged-platform-pr.yml",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "$env:SERVER_BEHAVIOR_ONLY -ne true",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "$env:CANDIDATE_PRODUCER_WORKFLOW_PATH -notin $allowedWorkflows",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "$run.head_repository.full_name -ne $env:GITHUB_REPOSITORY",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "$run.path -ne $env:CANDIDATE_PRODUCER_WORKFLOW_PATH",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "$run.head_sha -ne $sourceSha",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "[string]$run.run_attempt -ne $env:GITHUB_RUN_ATTEMPT",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "$_.name -eq codestory-cli-windows-x64",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "[string]$_.workflow_run.id -eq $env:GITHUB_RUN_ID",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "$_.workflow_run.head_sha -eq $sourceSha",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "if ($artifactCount -ne 1)",
+        ),
+      `${vulkanFile} packaged proof must authenticate one exact-head package from an allowlisted producer`,
+    );
+    const windowsPackageDownload = namedStep(job, "Download packaged CLI artifact");
+    add(
+      violations,
+      windowsPackageDownload?.if === "inputs.use_packaged_cli_artifact"
+        && windowsPackageDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(windowsPackageDownload?.with, ["name", "path"])
+        && object(windowsPackageDownload?.with).name
+          === "codestory-cli-windows-x64"
+        && object(windowsPackageDownload?.with).path === "target/release-dist"
+        && stepIndex(job, "Download packaged CLI artifact")
+          === stepIndex(job, "Authenticate exact Windows package producer") + 1,
+      `${vulkanFile} must download only the authenticated Windows package`,
+    );
+    const windowsDriverVerify = namedStep(job, "Verify packaged qualification driver");
+    const windowsDriverVerifyRun = shellLiteralNormalizedText(
+      stepRun(job, "Verify packaged qualification driver"),
+    );
+    add(
+      violations,
+      windowsDriverVerify?.id === "qualification-driver"
+        && windowsDriverVerify?.if
+          === "${{ inputs.use_packaged_cli_artifact && !inputs.server_behavior_only }}"
+        && windowsDriverVerify?.shell === windowsPowerShellShell
+        && windowsDriverVerify?.["continue-on-error"] === undefined
+        && hasExactKeys(object(windowsDriverVerify?.env), ["INPUT_VERSION"])
+        && object(windowsDriverVerify?.env).INPUT_VERSION
+          === "${{ inputs.version }}"
+        && shellInvocationsContaining(
+          windowsDriverVerifyRun,
+          "node .github/scripts/qualification-driver-artifact.mjs verify",
+        ).length === 1
+        && windowsDriverVerifyRun.includes("--asset-target windows-x64")
+        && windowsDriverVerifyRun.includes("--source-sha $sourceSha")
+        && windowsDriverVerifyRun.includes("--source-tree $sourceTree")
+        && windowsDriverVerifyRun.includes("--version $version")
+        && windowsDriverVerifyRun.includes(
+          "--archive target/release-dist/codestory-cli-v$version-windows-x64.zip",
+        )
+        && windowsDriverVerifyRun.includes("--trusted-root $env:GITHUB_WORKSPACE")
+        && windowsDriverVerifyRun.includes(
+          "--artifact-dir target/release-dist/qualification-driver/windows-x64",
+        )
+        && windowsDriverVerifyRun.includes("$result.driver")
+        && windowsDriverVerifyRun.includes("$env:GITHUB_OUTPUT")
+        && stepIndex(job, "Verify packaged qualification driver")
+          === stepIndex(job, "Download packaged CLI artifact") + 1,
+      `${vulkanFile} packaged qualification must verify the archive-bound private driver`,
+    );
+    add(
+      violations,
+      qualificationDriverHandoffIsSealed(
+        job,
+        "Verify packaged qualification driver",
+        "Prove protected Windows Vulkan runtime",
+        [
+          "Download exact-head publishable packet quality evidence",
+          "Authenticate calibration bundle producer",
+          "Download frozen calibration bundle",
+        ],
+      ),
+      `${vulkanFile} must not replace the verified qualification driver before execution`,
     );
     const qualityDownload = namedStep(
       job,
@@ -5210,8 +5788,25 @@ function validateRemainingWorkflows(workflows, violations) {
         && engineRun.includes("@calibrationArgs")
         && engineRun.includes('$claimArgs = @("--server-behavior-only")')
         && engineRun.includes('"--produce-qualification-evidence"')
+        && object(engine?.env).USE_PACKAGED_CLI_ARTIFACT
+          === "${{ inputs.use_packaged_cli_artifact }}"
+        && object(engine?.env).VERIFIED_QUALIFICATION_DRIVER
+          === "${{ steps.qualification-driver.outputs.path }}"
         && engineRun.includes(
-          '"--qualification-driver", "target/release/codestory_embedding_qualification.exe"',
+          '$qualificationDriver = "target/release/codestory_embedding_qualification.exe"',
+        )
+        && engineRun.includes(
+          'if ($env:USE_PACKAGED_CLI_ARTIFACT -eq "true")',
+        )
+        && engineRun.includes(
+          "$qualificationDriver = $env:VERIFIED_QUALIFICATION_DRIVER",
+        )
+        && occurrenceCount(engineRun, "$qualificationDriver =") === 2
+        && engineRun.includes(
+          'Test-Path -LiteralPath $qualificationDriver -PathType Leaf',
+        )
+        && engineRun.includes(
+          '"--qualification-driver", $qualificationDriver',
         )
         && engineRun.includes(
           '"--qualification-evidence", "target/windows-vulkan-proof/qualification.json"',
@@ -5371,6 +5966,12 @@ function validateRemainingWorkflows(workflows, violations) {
   } else {
     add(
       violations,
+      createHash("sha256").update(JSON.stringify(linuxVulkan)).digest("hex")
+        === linuxVulkanWorkflowDigest,
+      `${linuxVulkanFile} must match the reviewed protected Linux Vulkan workflow structure`,
+    );
+    add(
+      violations,
       trigger(linuxVulkan, "workflow_call") !== undefined
         && trigger(linuxVulkan, "workflow_dispatch") !== undefined,
       `${linuxVulkanFile} must support reusable and manual proof`,
@@ -5511,12 +6112,98 @@ function validateRemainingWorkflows(workflows, violations) {
     requireStepEnv(violations, linuxVulkanFile, job, "Validate candidate-installed mode", {
       SERVER_BEHAVIOR_ONLY: "${{ inputs.server_behavior_only }}",
     });
+    const packageAuthentication = namedStep(
+      job,
+      "Authenticate exact Linux package producer",
+    );
+    const packageAuthenticationRun = shellLiteralNormalizedText(
+      stepRun(job, "Authenticate exact Linux package producer"),
+    );
+    add(
+      violations,
+      packageAuthentication?.shell === "bash"
+        && packageAuthentication?.if === undefined
+        && packageAuthentication?.["continue-on-error"] === undefined
+        && hasExactKeys(object(packageAuthentication?.env), [
+          "GH_TOKEN",
+          "CANDIDATE_PRODUCER_WORKFLOW_PATH",
+          "PACKAGE_RUN_ID",
+          "SERVER_BEHAVIOR_ONLY",
+        ])
+        && object(packageAuthentication?.env).GH_TOKEN === "${{ github.token }}"
+        && object(packageAuthentication?.env).CANDIDATE_PRODUCER_WORKFLOW_PATH
+          === "${{ inputs.candidate_producer_workflow_path }}"
+        && object(packageAuthentication?.env).PACKAGE_RUN_ID
+          === "${{ inputs.package_run_id || github.run_id }}"
+        && object(packageAuthentication?.env).SERVER_BEHAVIOR_ONLY
+          === "${{ inputs.server_behavior_only }}"
+        && packageAuthenticationRun.includes(
+          ".github/workflows/auto-release.yml",
+        )
+        && packageAuthenticationRun.includes(
+          ".github/workflows/release.yml",
+        )
+        && packageAuthenticationRun.includes(
+          ".github/workflows/packaged-platform-pr.yml",
+        )
+        && packageAuthenticationRun.includes(
+          "case $CANDIDATE_PRODUCER_WORKFLOW_PATH in",
+        )
+        && packageAuthenticationRun.includes(
+          "if [ $SERVER_BEHAVIOR_ONLY != true ]",
+        )
+        && packageAuthenticationRun.includes(
+          "test $CANDIDATE_PRODUCER_WORKFLOW_PATH =",
+        )
+        && packageAuthenticationRun.includes(
+          ".head_repository.full_name",
+        )
+        && packageAuthenticationRun.includes(
+          "test $(jq -r .path <<<$run) = $CANDIDATE_PRODUCER_WORKFLOW_PATH",
+        )
+        && packageAuthenticationRun.includes(
+          "test $(jq -r .head_sha <<<$run) = $(git rev-parse HEAD)",
+        )
+        && packageAuthenticationRun.includes(
+          "if [ $PACKAGE_RUN_ID = $GITHUB_RUN_ID ]",
+        )
+        && packageAuthenticationRun.includes(
+          "test $(jq -r .run_attempt <<<$run) = $GITHUB_RUN_ATTEMPT",
+        )
+        && packageAuthenticationRun.includes(
+          "test $(jq -r .status <<<$run) = completed",
+        )
+        && packageAuthenticationRun.includes(
+          "test $(jq -r .conclusion <<<$run) = success",
+        )
+        && packageAuthenticationRun.includes(
+          ".name == codestory-cli-linux-x64",
+        )
+        && packageAuthenticationRun.includes(
+          ".workflow_run.id == $run_id",
+        )
+        && packageAuthenticationRun.includes(
+          ".workflow_run.head_sha == $sha",
+        )
+        && packageAuthenticationRun.includes("test $artifact_count = 1"),
+      `${linuxVulkanFile} must authenticate one exact-head package from an allowlisted producer`,
+    );
     const packageDownload = namedStep(job, "Download exact Linux package");
     add(
       violations,
       packageDownload?.uses === "actions/download-artifact@v8.0.1"
-        && object(packageDownload.with).name === "codestory-cli-linux-x64",
-      `${linuxVulkanFile} must consume the graph-declared Linux x64 package`,
+        && hasExactKeys(
+          packageDownload?.with,
+          ["name", "path", "run-id", "github-token"],
+        )
+        && object(packageDownload.with).name === "codestory-cli-linux-x64"
+        && object(packageDownload.with).path === "target/release-dist"
+        && object(packageDownload.with)["run-id"]
+          === "${{ inputs.package_run_id || github.run_id }}"
+        && object(packageDownload.with)["github-token"] === "${{ github.token }}"
+        && stepIndex(job, "Download exact Linux package")
+          === stepIndex(job, "Authenticate exact Linux package producer") + 1,
+      `${linuxVulkanFile} must consume only the authenticated Linux x64 package`,
     );
     requireCalibrationProducerBoundary(
       violations,
@@ -5524,23 +6211,69 @@ function validateRemainingWorkflows(workflows, violations) {
       job,
       "${{ !inputs.server_behavior_only }}",
     );
-    const qualificationRust = namedStep(
-      job,
-      "Install pinned Rust for frozen-candidate qualification",
-    );
-    const qualificationDriver = namedStep(job, "Build qualification driver");
     add(
       violations,
-      qualificationRust?.if === "${{ !inputs.server_behavior_only }}"
-        && qualificationRust?.shell === "bash"
-        && String(qualificationRust?.run ?? "").includes(
-          "rustup toolchain install 1.95.0 --profile minimal",
+      namedStep(job, "Install pinned Rust for frozen-candidate qualification")
+          === undefined
+        && namedStep(job, "Build qualification driver") === undefined
+        && jobShellInvocationsContaining(job, "cargo build").length === 0
+        && jobShellInvocationsContaining(
+          job,
+          "node scripts/prepare-embedded-model.mjs",
+        ).length === 0
+        && jobShellInvocationsContaining(job, "rustup toolchain install").length
+          === 0,
+      `${linuxVulkanFile} packaged qualification must not reinstall Rust, prepare a model, or rebuild the retained driver`,
+    );
+    const linuxDriverVerify = namedStep(job, "Verify packaged qualification driver");
+    const linuxDriverVerifyRun = shellLiteralNormalizedText(
+      stepRun(job, "Verify packaged qualification driver"),
+    );
+    add(
+      violations,
+      linuxDriverVerify?.id === "qualification-driver"
+        && linuxDriverVerify?.if === "${{ !inputs.server_behavior_only }}"
+        && linuxDriverVerify?.shell === "bash"
+        && linuxDriverVerify?.["continue-on-error"] === undefined
+        && hasExactKeys(object(linuxDriverVerify?.env), ["INPUT_VERSION"])
+        && object(linuxDriverVerify?.env).INPUT_VERSION
+          === "${{ inputs.version }}"
+        && shellInvocationsContaining(
+          linuxDriverVerifyRun,
+          "node .github/scripts/qualification-driver-artifact.mjs verify",
+        ).length === 1
+        && linuxDriverVerifyRun.includes("--asset-target linux-x64")
+        && linuxDriverVerifyRun.includes("--source-sha $(git rev-parse HEAD)")
+        && linuxDriverVerifyRun.includes("--source-tree $(git rev-parse HEAD^{tree})")
+        && linuxDriverVerifyRun.includes("--version $version")
+        && linuxDriverVerifyRun.includes(
+          "--archive target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz",
         )
-        && qualificationDriver?.if === "${{ !inputs.server_behavior_only }}"
-        && qualificationDriver?.shell === "bash"
-        && String(qualificationDriver?.run ?? "")
-          === "cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification",
-      `${linuxVulkanFile} standalone qualification must build its pinned full qualification driver exactly once`,
+        && linuxDriverVerifyRun.includes("--trusted-root $GITHUB_WORKSPACE")
+        && linuxDriverVerifyRun.includes(
+          "--artifact-dir target/release-dist/qualification-driver/linux-x64",
+        )
+        && linuxDriverVerifyRun.includes(
+          "echo path=$(jq -r .driver <<<$verified) >> $GITHUB_OUTPUT",
+        )
+        && stepIndex(job, "Verify packaged qualification driver")
+          === stepIndex(job, "Download exact Linux package") + 1,
+      `${linuxVulkanFile} packaged qualification must verify the archive-bound private driver`,
+    );
+    add(
+      violations,
+      qualificationDriverHandoffIsSealed(
+        job,
+        "Verify packaged qualification driver",
+        "Prove offline Linux Vulkan retrieval",
+        [
+          "Authenticate calibration bundle producer",
+          "Download frozen calibration bundle",
+          "Authenticate protected Metal quality producer",
+          "Download exact-head protected Metal quality evidence",
+        ],
+      ),
+      `${linuxVulkanFile} must not replace the verified qualification driver before execution`,
     );
     const qualityAuthentication = namedStep(
       job,
@@ -5643,8 +6376,16 @@ function validateRemainingWorkflows(workflows, violations) {
           "quality_args=(--retrieval-quality-evidence $quality_path)",
         )
         && normalizedEngineRun.includes("--produce-qualification-evidence")
+        && object(engine?.env).VERIFIED_QUALIFICATION_DRIVER
+          === "${{ steps.qualification-driver.outputs.path }}"
         && normalizedEngineRun.includes(
-          "--qualification-driver target/release/codestory_embedding_qualification",
+          "qualification_driver=$VERIFIED_QUALIFICATION_DRIVER",
+        )
+        && occurrenceCount(normalizedEngineRun, "qualification_driver=") === 1
+        && normalizedEngineRun.includes("test -n $qualification_driver")
+        && normalizedEngineRun.includes("test -x $qualification_driver")
+        && normalizedEngineRun.includes(
+          "--qualification-driver $qualification_driver",
         )
         && normalizedEngineRun.includes(
           "--qualification-evidence target/linux-vulkan-proof/qualification.json",
@@ -5951,9 +6692,15 @@ function workflowCpuSelectorViolations(file, value) {
       violations.push(`[cpu_selector] ${file} ${location} selects CPU backend`);
     }
     const executable = shellLiteralNormalizedText(text);
+    const executableWithoutHostInventory = executable.replaceAll(
+      "machdep.cpu.brand_string",
+      "",
+    );
     if (
       hasNonLiteralCpuAssignment(executable)
+      || /\bCODESTORY_EMBED_ALLOW_CPU\b/iu.test(executable)
       || /\bcpu_explicit\b/iu.test(executable)
+      || /\bcpu\b/iu.test(executableWithoutHostInventory)
       || /--expected-backend(?:\s+|=)cpu\b/iu.test(executable)
       || /(?:expected_backend|backend)\s*=\s*cpu\b/iu.test(executable)
     ) {
@@ -6718,7 +7465,7 @@ function validateReleaseArtifactRerunSafety(workflows, violations) {
     }],
     ["packaged-platform-proof.yml/build/Upload release asset", {
       name: "codestory-cli-${{ matrix.asset_target }}",
-      path: "target/release-dist/*.tar.gz\ntarget/release-dist/*.zip\ntarget/release-dist/*.sha256\ntarget/release-dist/SHA256SUMS.txt\n",
+      path: "target/release-dist/*.tar.gz\ntarget/release-dist/*.zip\ntarget/release-dist/*.sha256\ntarget/release-dist/SHA256SUMS.txt\ntarget/release-dist/qualification-driver/${{ matrix.asset_target }}\n",
     }],
     ["macos-metal-proof.yml/packaged-metal/Upload Metal calibration runs", {
       name: "embedding-calibration-macos-${{ inputs.version }}",
@@ -7268,6 +8015,18 @@ export function validateMarketplaceSync(workflows, violations) {
 
 export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
   const violations = [];
+  violations.push(...qualificationDriverArtifactViolations(
+    fs.readFileSync(
+      path.join(
+        repositoryRoot,
+        ".github",
+        "scripts",
+        "qualification-driver-artifact.mjs",
+      ),
+      "utf8",
+    ),
+    graph,
+  ));
   for (const [file, workflow] of workflows) {
     violations.push(...basicWorkflowViolations(file, workflow));
   }

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -32,6 +32,7 @@ import {
   notaryStepViolations,
   packagedPrSigningViolations,
   parseWorkflow,
+  qualificationDriverArtifactViolations,
   releaseEvidenceApprovalViolations,
   releaseProofCpuSelectorViolations,
   releaseEvidenceWorkflowRef,
@@ -432,6 +433,14 @@ test("every release-proof workflow rejects CPU selectors at every structural lev
         run: "CODESTORY_EMBED_ALLOW_CPU=$(printf 1) true",
       });
     }],
+    ["indirect environment assignment", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected selector indirection",
+        run: 'selector=CODESTORY_EMBED_ALLOW_CPU; export "$selector=1"',
+      });
+    }],
     ["equal-form engine policy", workflow => {
       const job = Object.values(workflow.jobs)[0];
       job.steps ??= [];
@@ -462,6 +471,14 @@ test("every release-proof workflow rejects CPU selectors at every structural lev
       job.steps.push({
         name: "Injected CPU selector",
         run: 'codestory-proof --expected-backend "c"pu',
+      });
+    }],
+    ["indirect backend arguments", workflow => {
+      const job = Object.values(workflow.jobs)[0];
+      job.steps ??= [];
+      job.steps.push({
+        name: "Injected backend indirection",
+        run: "backend_flag=--expected-backend; backend_value=cpu; codestory-proof \"$backend_flag\" \"$backend_value\"",
       });
     }],
     ["matrix semantic key", workflow => {
@@ -646,6 +663,10 @@ test("constant calibration structure rejects qualification, 3x3 sampling, repeat
     ["full qualification producer enters calibration", metalFile, workflow => {
       collector(workflow).run += "\n--produce-qualification-evidence";
     }, /without full qualification or nested sampling/u],
+    ["full qualification driver executes during calibration", metalFile, workflow => {
+      collector(workflow).run +=
+        "\ntarget/release/codestory_embedding_qualification --project target/calibration-project";
+    }, /reviewed protected Metal workflow structure/u],
     ["shell-concatenated qualification producer enters calibration", metalFile, workflow => {
       collector(workflow).run = collector(workflow).run.replace(
         "--out-dir target/calibration-proof/macos",
@@ -1072,12 +1093,12 @@ test("frozen-candidate qualification keeps the Metal quality handoff and optiona
         "Download exact-head publishable packet quality evidence",
       ).with.name = "latest-quality";
     }, /must download the exact protected Metal quality handoff/u],
-    ["Linux full qualification skips driver build", linuxFile, workflow => {
+    ["Linux full qualification skips retained-driver verification", linuxFile, workflow => {
       draftStep(
         workflow.jobs["packaged-vulkan"],
-        "Build qualification driver",
+        "Verify packaged qualification driver",
       ).if = "${{ inputs.server_behavior_only }}";
-    }, /must build its pinned full qualification driver exactly once/u],
+    }, /packaged qualification must verify the archive-bound private driver/u],
     ["Linux trusts quality from another workflow", linuxFile, workflow => {
       const authenticate = draftStep(
         workflow.jobs["packaged-vulkan"],
@@ -1130,6 +1151,348 @@ test("frozen-candidate qualification keeps the Metal quality handoff and optiona
       assert.match(
         validateWorkflows(loadWorkflows(), graph).join("\n"),
         /must implement the release claim graph qualification contract/u,
+      );
+    });
+  }
+});
+
+test("qualification driver is built once, retained privately, authenticated, and reused", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const packagedFile = "packaged-platform-proof.yml";
+  const coordinatorFile = "packaged-platform-pr.yml";
+  const metalFile = "macos-metal-proof.yml";
+  const windowsFile = "windows-vulkan-proof.yml";
+  const linuxFile = "linux-vulkan-proof.yml";
+  const packagedJob = workflow => workflow.jobs.build;
+  const hostBuild = workflow => draftStep(
+    packagedJob(workflow),
+    "Build package and qualification driver",
+  );
+  const linuxBuild = workflow => draftStep(
+    packagedJob(workflow),
+    "Build Linux x64 at the glibc 2.31 baseline",
+  );
+  const stage = workflow => draftStep(
+    packagedJob(workflow),
+    "Stage qualification driver in package proof artifact",
+  );
+  const metalJob = workflow => workflow.jobs["packaged-metal"];
+  const windowsJob = workflow => workflow.jobs["packaged-vulkan"];
+  const linuxJob = workflow => workflow.jobs["packaged-vulkan"];
+
+  const mutations = [
+    ["driver retention defaults on", packagedFile, workflow => {
+      workflow.on.workflow_call.inputs.include_qualification_driver.default = true;
+    }, /private qualification-driver retention must be explicit and off by default/u],
+    ["host package repeats Cargo build", packagedFile, workflow => {
+      hostBuild(workflow).run += '\ncargo build --release --locked "${cargo_args[@]}"';
+    }, /host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    ["host package drops runtime", packagedFile, workflow => {
+      hostBuild(workflow).run = hostBuild(workflow).run.replace(
+        "--bin codestory-cli-runtime",
+        "--bin ignored-runtime",
+      );
+    }, /host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    ["host package broadens to all bins", packagedFile, workflow => {
+      hostBuild(workflow).run = hostBuild(workflow).run.replace(
+        "--bin codestory-cli-runtime",
+        "--bins",
+      );
+    }, /host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    ["host package substitutes calibration driver", packagedFile, workflow => {
+      hostBuild(workflow).run = hostBuild(workflow).run.replace(
+        "codestory_embedding_qualification",
+        "codestory_embedding_constant_calibration",
+      );
+    }, /host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    ["Linux package repeats Cargo build", packagedFile, workflow => {
+      linuxBuild(workflow).run = linuxBuild(workflow).run.replace(
+        "/sccache/sccache --show-stats",
+        'cargo build --release --locked "$@" --target "$RELEASE_RUST_TARGET"\n              /sccache/sccache --show-stats',
+      );
+    }, /Linux package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    ["qualification driver cache identity becomes fixed", packagedFile, workflow => {
+      draftStep(
+        packagedJob(workflow),
+        "Capture reusable build cache contract",
+      ).env.INCLUDE_QUALIFICATION_DRIVER = "false";
+    }, /must compute one complete reusable compiler compatibility contract/u],
+    ["coordinator retains driver for every package", coordinatorFile, workflow => {
+      workflow.jobs["packaged-proof"].with.include_qualification_driver = true;
+    }, /retain the private qualification driver only for frozen-candidate qualification/u],
+    ["coordinator stops retaining qualification driver", coordinatorFile, workflow => {
+      workflow.jobs["packaged-proof"].with.include_qualification_driver = false;
+    }, /retain the private qualification driver only for frozen-candidate qualification/u],
+    ["driver staging becomes unconditional", packagedFile, workflow => {
+      stage(workflow).if = "always()";
+    }, /retain one archive-bound private qualification driver beside each selected package/u],
+    ["driver staging binds a decoy archive", packagedFile, workflow => {
+      stage(workflow).run = stage(workflow).run.replace(
+        "--archive \"target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}\"",
+        "--archive target/release-dist/decoy.tar.gz",
+      );
+    }, /retain one archive-bound private qualification driver beside each selected package/u],
+    ["driver staging trusts the Windows target junction", packagedFile, workflow => {
+      stage(workflow).run = stage(workflow).run.replace(
+        "--target-dir target",
+        '--target-dir "${CARGO_TARGET_DIR:-target}"',
+      );
+    }, /retain one archive-bound private qualification driver beside each selected package/u],
+    ["package artifact drops private driver directory", packagedFile, workflow => {
+      const upload = draftStep(packagedJob(workflow), "Upload release asset");
+      upload.with.path = upload.with.path.replace(
+        "target/release-dist/qualification-driver/${{ matrix.asset_target }}\n",
+        "",
+      );
+    }, /existing package artifact must retain the private driver directory/u],
+    ["public archive includes qualification driver", packagedFile, workflow => {
+      draftStep(packagedJob(workflow), "Package release asset").run +=
+        "\ntar -rf \"$archive\" target/release-dist/qualification-driver";
+    }, /public archives and signing inputs must exclude the private qualification driver/u],
+    ["GitHub release publishes private qualification driver", "release.yml", workflow => {
+      draftStep(workflow.jobs.publish, "Create GitHub release").run =
+        draftStep(workflow.jobs.publish, "Create GitHub release").run.replace(
+          'gh release create "$TAG" "${assets[@]}"',
+          'gh release create "$TAG" "${assets[@]}" target/release-assets/qualification-driver',
+        );
+    }, /publish only graph-declared root assets and exclude the private qualification driver/u],
+    ["Metal verifier reads a decoy archive", metalFile, workflow => {
+      const verify = draftStep(
+        metalJob(workflow),
+        "Verify packaged qualification driver",
+      );
+      verify.run = verify.run.replace(
+        "codestory-cli-v${version}-macos-arm64.tar.gz",
+        "decoy-macos.tar.gz",
+      );
+    }, /packaged qualification must verify the archive-bound private driver/u],
+    ["Metal verifier output is not retained", metalFile, workflow => {
+      draftStep(
+        metalJob(workflow),
+        "Verify packaged qualification driver",
+      ).run = "node .github/scripts/qualification-driver-artifact.mjs verify";
+    }, /packaged qualification must verify the archive-bound private driver/u],
+    ["Metal verifier becomes advisory with a forged fallback", metalFile, workflow => {
+      const verify = draftStep(
+        metalJob(workflow),
+        "Verify packaged qualification driver",
+      );
+      verify.run = verify.run.replace(
+        "set -euo pipefail",
+        "set +e",
+      );
+      verify.run +=
+        "\nset -e\nprintf 'path=target/evil\\n' >> \"$GITHUB_OUTPUT\"";
+    }, /reviewed protected Metal workflow structure/u],
+    ["Metal substitutes driver after verification", metalFile, workflow => {
+      const steps = metalJob(workflow).steps;
+      const verifyIndex = steps.findIndex(
+        step => step.name === "Verify packaged qualification driver",
+      );
+      steps.splice(verifyIndex + 1, 0, {
+        name: "Replace retained driver",
+        shell: "bash",
+        run: "cp target/evil target/release-dist/qualification-driver/macos-arm64/codestory_embedding_qualification",
+      });
+    }, /must not replace the verified qualification driver before execution/u],
+    ["Metal executes a different driver", metalFile, workflow => {
+      draftStep(metalJob(workflow), "Prove protected Metal runtime").run =
+        draftStep(metalJob(workflow), "Prove protected Metal runtime").run
+          .replace(
+            '--qualification-driver "$qualification_driver"',
+            "--qualification-driver target/release/other-driver",
+          );
+    }, /server-behavior proof must omit calibration while qualification retains it/u],
+    ["Metal packaged qualification reinstalls Rust", metalFile, workflow => {
+      draftStep(metalJob(workflow), "Install pinned Rust").if =
+        "${{ !inputs.use_packaged_cli_artifact || !inputs.server_behavior_only }}";
+    }, /every packaged proof must skip Rust installation/u],
+    ["Metal rebuilds driver after download", metalFile, workflow => {
+      metalJob(workflow).steps.push({
+        name: "Build qualification driver",
+        if: "${{ !inputs.server_behavior_only }}",
+        shell: "bash",
+        run: "cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification",
+      });
+    }, /must not rebuild the qualification driver after package download/u],
+    ["Metal calibration also builds qualification driver", metalFile, workflow => {
+      const build = draftStep(metalJob(workflow), "Build and package native CLI");
+      build.run = build.run.replace(
+        'elif [ "$SERVER_BEHAVIOR_ONLY" != true ]; then',
+        'if [ "$SERVER_BEHAVIOR_ONLY" != true ]; then',
+      );
+    }, /calibration must build CLI and constant collector once through one shared Cargo invocation/u],
+    ["Windows trusts an arbitrary producer workflow", windowsFile, workflow => {
+      const authenticate = draftStep(
+        windowsJob(workflow),
+        "Authenticate exact Windows package producer",
+      );
+      authenticate.run = authenticate.run.replace(
+        '$env:CANDIDATE_PRODUCER_WORKFLOW_PATH -notin $allowedWorkflows',
+        "$false",
+      );
+    }, /authenticate one exact-head package from an allowlisted producer/u],
+    ["Windows executes an unverified driver", windowsFile, workflow => {
+      draftStep(windowsJob(workflow), "Prove protected Windows Vulkan runtime")
+        .env.VERIFIED_QUALIFICATION_DRIVER = "target/release/other.exe";
+    }, /server-behavior proof must omit calibration while qualification runs one full lifecycle/u],
+    ["Windows substitutes driver after verification", windowsFile, workflow => {
+      const steps = windowsJob(workflow).steps;
+      const verifyIndex = steps.findIndex(
+        step => step.name === "Verify packaged qualification driver",
+      );
+      steps.splice(verifyIndex + 1, 0, {
+        name: "Replace retained driver",
+        shell: "powershell",
+        run: "Copy-Item target/evil.exe target/release-dist/qualification-driver/windows-x64/codestory_embedding_qualification.exe",
+      });
+    }, /must not replace the verified qualification driver before execution/u],
+    ["Windows rebuilds driver after download", windowsFile, workflow => {
+      windowsJob(workflow).steps.push({
+        name: "Build qualification driver",
+        shell: "powershell",
+        run: "cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification",
+      });
+    }, /must not rebuild the qualification driver after package download/u],
+    ["Linux trusts an arbitrary producer workflow", linuxFile, workflow => {
+      const authenticate = draftStep(
+        linuxJob(workflow),
+        "Authenticate exact Linux package producer",
+      );
+      authenticate.run = authenticate.run.replace(
+        'case "$CANDIDATE_PRODUCER_WORKFLOW_PATH" in',
+        'case ".github/workflows/packaged-platform-pr.yml" in',
+      );
+    }, /authenticate one exact-head package from an allowlisted producer/u],
+    ["Linux allowlist admits an untrusted producer through dead checks", linuxFile, workflow => {
+      const authenticate = draftStep(
+        linuxJob(workflow),
+        "Authenticate exact Linux package producer",
+      );
+      authenticate.run = authenticate.run.replace(
+        ".github/workflows/packaged-platform-pr.yml)",
+        ".github/workflows/packaged-platform-pr.yml | .github/workflows/evil.yml)",
+      );
+      authenticate.run = authenticate.run.replace(
+        'test "$CANDIDATE_PRODUCER_WORKFLOW_PATH" = \\\n              .github/workflows/packaged-platform-pr.yml',
+        'true || test "$CANDIDATE_PRODUCER_WORKFLOW_PATH" = \\\n              .github/workflows/packaged-platform-pr.yml',
+      );
+    }, /reviewed protected Linux Vulkan workflow structure/u],
+    ["Linux producer path equality becomes advisory", linuxFile, workflow => {
+      const authenticate = draftStep(
+        linuxJob(workflow),
+        "Authenticate exact Linux package producer",
+      );
+      authenticate.run = authenticate.run.replace(
+        'test "$(jq -r \'.path\' <<<"$run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"',
+        'true || test "$(jq -r \'.path\' <<<"$run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"',
+      );
+    }, /reviewed protected Linux Vulkan workflow structure/u],
+    ["Linux accepts an incomplete external package run", linuxFile, workflow => {
+      const authenticate = draftStep(
+        linuxJob(workflow),
+        "Authenticate exact Linux package producer",
+      );
+      authenticate.run = authenticate.run.replace(
+        'test "$(jq -r \'.conclusion\' <<<"$run")" = success',
+        "true",
+      );
+    }, /authenticate one exact-head package from an allowlisted producer/u],
+    ["Linux accepts a package artifact from another head", linuxFile, workflow => {
+      const authenticate = draftStep(
+        linuxJob(workflow),
+        "Authenticate exact Linux package producer",
+      );
+      authenticate.run = authenticate.run.replace(
+        "and .workflow_run.head_sha == $sha",
+        "",
+      );
+    }, /authenticate one exact-head package from an allowlisted producer/u],
+    ["Linux executes a hardcoded driver", linuxFile, workflow => {
+      draftStep(linuxJob(workflow), "Prove offline Linux Vulkan retrieval").run =
+        draftStep(linuxJob(workflow), "Prove offline Linux Vulkan retrieval").run
+          .replace(
+            '--qualification-driver "$qualification_driver"',
+            "--qualification-driver target/release/other-driver",
+          );
+    }, /standalone qualification runs one full lifecycle and quality proof/u],
+    ["Linux substitutes driver after verification", linuxFile, workflow => {
+      const steps = linuxJob(workflow).steps;
+      const verifyIndex = steps.findIndex(
+        step => step.name === "Verify packaged qualification driver",
+      );
+      steps.splice(verifyIndex + 1, 0, {
+        name: "Replace retained driver",
+        shell: "bash",
+        run: "cp target/evil target/release-dist/qualification-driver/linux-x64/codestory_embedding_qualification",
+      });
+    }, /must not replace the verified qualification driver before execution/u],
+    ["Linux rebuilds driver after download", linuxFile, workflow => {
+      linuxJob(workflow).steps.push({
+        name: "Build qualification driver",
+        shell: "bash",
+        run: "cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification",
+      });
+    }, /must not reinstall Rust, prepare a model, or rebuild the retained driver/u],
+  ];
+
+  for (const [name, file, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(validateWorkflows(workflows).join("\n"), expected);
+    });
+  }
+
+  const helperSource = readFileSync(
+    path.join(root, ".github/scripts/qualification-driver-artifact.mjs"),
+    "utf8",
+  );
+  for (const [name, mutate] of [
+    ["helper stops hashing the candidate archive", source =>
+      source.replace("sha256(archivePath) !== identity.archive.sha256", "false")],
+    ["helper follows linked path ancestors", source =>
+      source.replace("lstatSync(cursor).isSymbolicLink()", "false")],
+    ["helper accepts hardlinked drivers", source =>
+      source.replace("metadata.nlink !== 1", "false")],
+    ["helper accepts extra identity fields", source =>
+      source.replace('fail(`${label} keys changed`)', "return")],
+    ["helper accepts unknown flags", source =>
+      source.replace("requireExactFlags(values, [...commonFlags, \"--artifact-dir\"])", "true")],
+    ["helper verifies one driver and returns another", source =>
+      source.replace("return { driver, identity, identityPath };", "return { driver: archivePath, identity, identityPath };")],
+  ]) {
+    await t.test(name, () => {
+      assert.match(
+        qualificationDriverArtifactViolations(
+          mutate(helperSource),
+          loadReleaseClaimGraph(root),
+        ).join("\n"),
+        /must match the reviewed archive-bound producer and verifier contract/u,
+      );
+    });
+  }
+
+  for (const [name, mutate] of [
+    ["claim graph publishes driver", graph => {
+      graph.workflow_policy.qualification.driver_contract.public_release_asset = true;
+    }],
+    ["claim graph drops archive digest", graph => {
+      graph.workflow_policy.qualification.driver_contract.identity_fields =
+        graph.workflow_policy.qualification.driver_contract.identity_fields
+          .filter(field => field !== "archive.sha256");
+    }],
+    ["claim graph allows repeated builds", graph => {
+      graph.workflow_policy.qualification.driver_contract
+        .build_invocations_per_platform = 2;
+    }],
+  ]) {
+    await t.test(`claim graph: ${name}`, () => {
+      const graph = structuredClone(loadReleaseClaimGraph(root));
+      mutate(graph);
+      assert.match(
+        validateWorkflows(loadWorkflows(), graph).join("\n"),
+        /private archive-qualified driver contract exactly|release claim graph qualification contract/u,
       );
     });
   }
@@ -2156,7 +2519,10 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     }, /packaged-platform-proof\.yml must compute one complete reusable compiler compatibility contract/u],
     ["packaged workload variants collide", packagedFile, workflow => {
       packagedIdentity(workflow).run = packagedIdentity(workflow).run
-        .replace("--identity qualification_driver=disabled", "--workload ignored");
+        .replace(
+          '--identity "qualification_driver=$INCLUDE_QUALIFICATION_DRIVER"',
+          "--workload ignored",
+        );
     }, /packaged-platform-proof\.yml must compute one complete reusable compiler compatibility contract/u],
     ["pinned sccache identity capture moves away from installation", packagedFile, workflow => {
       moveNamedStepAfter(
@@ -2383,7 +2749,10 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
         "always() && ((matrix.asset_target == 'linux-x64' && steps.linux-build.outcome == 'success') || (matrix.asset_target != 'linux-x64' && steps.package-build.outcome == 'success'))";
     }, /host finalizer must strictly stop only the host package-build compiler server/u],
     ["host package build becomes Linux-reachable", packagedFile, workflow => {
-      draftStep(packagedJob(workflow), "Build codestory-cli").if = "always()";
+      draftStep(
+        packagedJob(workflow),
+        "Build package and qualification driver",
+      ).if = "always()";
     }, /host finalizer must strictly stop only the host package-build compiler server/u],
     ["clock stop prepends a fake compiler cache binary", packagedFile, workflow => {
       const stop = draftStep(packagedJob(workflow), "Stop compilation clock");
@@ -3037,7 +3406,10 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     workflow.jobs.build,
     "Configure bounded compiler cache",
   );
-  const packagedBuild = workflow => draftStep(workflow.jobs.build, "Build codestory-cli");
+  const packagedBuild = workflow => draftStep(
+    workflow.jobs.build,
+    "Build package and qualification driver",
+  );
   const packagedShortTarget = workflow => draftStep(
     workflow.jobs.build,
     "Configure short Windows Cargo target",

--- a/.github/scripts/qualification-driver-artifact.mjs
+++ b/.github/scripts/qualification-driver-artifact.mjs
@@ -1,0 +1,508 @@
+#!/usr/bin/env node
+
+import {
+  chmodSync,
+  closeSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HEX_SHA = /^[0-9a-f]{40}$/u;
+const HEX_SHA256 = /^[0-9a-f]{64}$/u;
+const VERSION = /^[0-9]+\.[0-9]+\.[0-9]+$/u;
+const TARGETS = new Map([
+  ["linux-x64", {
+    archiveExtension: "tar.gz",
+    binary: "codestory_embedding_qualification",
+    rustTarget: "x86_64-unknown-linux-gnu",
+  }],
+  ["macos-arm64", {
+    archiveExtension: "tar.gz",
+    binary: "codestory_embedding_qualification",
+    rustTarget: "aarch64-apple-darwin",
+  }],
+  ["windows-x64", {
+    archiveExtension: "zip",
+    binary: "codestory_embedding_qualification.exe",
+    rustTarget: "x86_64-pc-windows-msvc",
+  }],
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const values = new Map();
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      fail(`invalid argument near ${flag ?? "<end>"}`);
+    }
+    if (values.has(flag)) {
+      fail(`duplicate argument ${flag}`);
+    }
+    values.set(flag, value);
+  }
+  return { command, values };
+}
+
+function required(values, flag) {
+  const value = values.get(flag);
+  if (!value) {
+    fail(`missing ${flag}`);
+  }
+  return value;
+}
+
+function requireExactFlags(values, expected) {
+  const actual = [...values.keys()].sort();
+  const allowed = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(allowed)) {
+    fail("qualification driver helper arguments changed");
+  }
+}
+
+function exactKeys(value, keys, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} keys changed`);
+  }
+}
+
+function targetContract(assetTarget) {
+  const contract = TARGETS.get(assetTarget);
+  if (!contract) {
+    fail(`unsupported asset target ${assetTarget}`);
+  }
+  return contract;
+}
+
+function requireSha(value, label) {
+  if (!HEX_SHA.test(value)) {
+    fail(`${label} must be a full lowercase commit digest`);
+  }
+}
+
+function requireVersion(value) {
+  if (!VERSION.test(value)) {
+    fail("release version must be plain semver");
+  }
+}
+
+function regularFile(file, label) {
+  const metadata = lstatSync(file);
+  if (
+    metadata.isSymbolicLink()
+    || !metadata.isFile()
+    || metadata.nlink !== 1
+  ) {
+    fail(`${label} must be a regular, non-symlink, singly linked file`);
+  }
+  return metadata;
+}
+
+function regularDirectory(directory, label) {
+  const metadata = lstatSync(directory);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    fail(`${label} must be a real non-symlink directory`);
+  }
+  return metadata;
+}
+
+function containedRelativePath(root, candidate, label) {
+  const relative = path.relative(root, candidate);
+  if (
+    relative === ""
+    || relative === ".."
+    || relative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relative)
+  ) {
+    fail(`${label} must be a descendant of its trusted root`);
+  }
+  return relative;
+}
+
+function rejectSymlinkedPath({
+  allowMissing,
+  candidate,
+  label,
+  root,
+}) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedCandidate = path.resolve(candidate);
+  const relative = containedRelativePath(resolvedRoot, resolvedCandidate, label);
+  const rootMetadata = lstatSync(resolvedRoot);
+  if (
+    !rootMetadata.isDirectory()
+    || rootMetadata.isSymbolicLink()
+  ) {
+    fail(`${label} trusted root must be a real directory`);
+  }
+
+  let cursor = resolvedRoot;
+  for (const component of relative.split(path.sep)) {
+    cursor = path.join(cursor, component);
+    if (!existsSync(cursor)) {
+      if (allowMissing) return;
+      fail(`${label} path component is missing`);
+    }
+    if (lstatSync(cursor).isSymbolicLink()) {
+      fail(`${label} must not traverse symbolic links`);
+    }
+  }
+}
+
+function sha256(file) {
+  const hash = createHash("sha256");
+  const handle = openSync(file, "r");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    for (;;) {
+      const bytesRead = readSync(handle, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    closeSync(handle);
+  }
+  return hash.digest("hex");
+}
+
+function canonicalIdentity({
+  archiveBytes,
+  archiveDigest,
+  archiveFile,
+  assetTarget,
+  binary,
+  bytes,
+  digest,
+  sourceSha,
+  sourceTree,
+  version,
+}) {
+  return {
+    schema_version: 1,
+    source: {
+      commit: sourceSha,
+      tree: sourceTree,
+    },
+    release_version: version,
+    asset_target: assetTarget,
+    archive: {
+      file: archiveFile,
+      bytes: archiveBytes,
+      sha256: archiveDigest,
+    },
+    driver: {
+      file: binary,
+      bytes,
+      sha256: digest,
+    },
+  };
+}
+
+function writeJsonAtomically(output, value) {
+  const temporary = `${output}.tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  renameSync(temporary, output);
+}
+
+export function produceQualificationDriverArtifact({
+  archive,
+  assetTarget,
+  outDir,
+  sourceSha,
+  sourceTree,
+  targetDir = process.env.CARGO_TARGET_DIR || "target",
+  trustedRoot = process.cwd(),
+  version,
+}) {
+  const contract = targetContract(assetTarget);
+  requireSha(sourceSha, "source SHA");
+  requireSha(sourceTree, "source tree");
+  requireVersion(version);
+
+  const expectedArchiveFile =
+    `codestory-cli-v${version}-${assetTarget}.${contract.archiveExtension}`;
+  const archivePath = path.resolve(archive);
+  rejectSymlinkedPath({
+    allowMissing: false,
+    candidate: archivePath,
+    label: "candidate archive",
+    root: trustedRoot,
+  });
+  const archiveMetadata = regularFile(archivePath, "candidate archive");
+  if (path.basename(archivePath) !== expectedArchiveFile) {
+    fail("candidate archive name does not match the release target");
+  }
+
+  const source = path.resolve(
+    targetDir,
+    contract.rustTarget,
+    "release",
+    contract.binary,
+  );
+  rejectSymlinkedPath({
+    allowMissing: false,
+    candidate: source,
+    label: "qualification driver source",
+    root: targetDir,
+  });
+  const sourceMetadata = regularFile(source, "qualification driver");
+  if (process.platform !== "win32" && (sourceMetadata.mode & 0o111) === 0) {
+    fail("qualification driver must be executable");
+  }
+
+  const outputDirectory = path.resolve(outDir);
+  rejectSymlinkedPath({
+    allowMissing: true,
+    candidate: outputDirectory,
+    label: "qualification driver artifact directory",
+    root: trustedRoot,
+  });
+  mkdirSync(outputDirectory, { recursive: true, mode: 0o700 });
+  rejectSymlinkedPath({
+    allowMissing: false,
+    candidate: outputDirectory,
+    label: "qualification driver artifact directory",
+    root: trustedRoot,
+  });
+  regularDirectory(outputDirectory, "qualification driver artifact directory");
+  if (readdirSync(outputDirectory).length !== 0) {
+    fail("qualification driver artifact directory must start empty");
+  }
+  const staged = path.join(outputDirectory, contract.binary);
+  const identityPath = path.join(
+    outputDirectory,
+    "qualification-driver-identity.json",
+  );
+  if (path.resolve(source) === path.resolve(staged)) {
+    fail("qualification driver source and artifact paths must differ");
+  }
+  copyFileSync(source, staged);
+  if (process.platform !== "win32") {
+    chmodSync(staged, 0o755);
+  }
+  const stagedMetadata = regularFile(staged, "staged qualification driver");
+  const digest = sha256(staged);
+  const identity = canonicalIdentity({
+    archiveBytes: archiveMetadata.size,
+    archiveDigest: sha256(archivePath),
+    archiveFile: expectedArchiveFile,
+    assetTarget,
+    binary: contract.binary,
+    bytes: stagedMetadata.size,
+    digest,
+    sourceSha,
+    sourceTree,
+    version,
+  });
+  writeJsonAtomically(identityPath, identity);
+  return { driver: staged, identity, identityPath };
+}
+
+export function verifyQualificationDriverArtifact({
+  archive,
+  artifactDir,
+  assetTarget,
+  sourceSha,
+  sourceTree,
+  trustedRoot = process.cwd(),
+  version,
+}) {
+  const contract = targetContract(assetTarget);
+  requireSha(sourceSha, "expected source SHA");
+  requireSha(sourceTree, "expected source tree");
+  requireVersion(version);
+
+  const expectedArchiveFile =
+    `codestory-cli-v${version}-${assetTarget}.${contract.archiveExtension}`;
+  const archivePath = path.resolve(archive);
+  rejectSymlinkedPath({
+    allowMissing: false,
+    candidate: archivePath,
+    label: "candidate archive",
+    root: trustedRoot,
+  });
+  const archiveMetadata = regularFile(archivePath, "candidate archive");
+  if (path.basename(archivePath) !== expectedArchiveFile) {
+    fail("candidate archive name does not match the release target");
+  }
+
+  const directory = path.resolve(artifactDir);
+  rejectSymlinkedPath({
+    allowMissing: false,
+    candidate: directory,
+    label: "qualification driver artifact directory",
+    root: trustedRoot,
+  });
+  regularDirectory(directory, "qualification driver artifact directory");
+  const identityPath = path.join(
+    directory,
+    "qualification-driver-identity.json",
+  );
+  regularFile(identityPath, "qualification driver identity");
+  const identity = JSON.parse(readFileSync(identityPath, "utf8"));
+  exactKeys(
+    identity,
+    [
+      "schema_version",
+      "source",
+      "release_version",
+      "asset_target",
+      "archive",
+      "driver",
+    ],
+    "qualification driver identity",
+  );
+  exactKeys(
+    identity.source,
+    ["commit", "tree"],
+    "qualification driver source",
+  );
+  exactKeys(
+    identity.archive,
+    ["file", "bytes", "sha256"],
+    "qualification driver archive identity",
+  );
+  exactKeys(
+    identity.driver,
+    ["file", "bytes", "sha256"],
+    "qualification driver file identity",
+  );
+  if (
+    identity.schema_version !== 1
+    || identity.source.commit !== sourceSha
+    || identity.source.tree !== sourceTree
+    || identity.release_version !== version
+    || identity.asset_target !== assetTarget
+    || identity.archive.file !== expectedArchiveFile
+    || !Number.isSafeInteger(identity.archive.bytes)
+    || identity.archive.bytes <= 0
+    || !HEX_SHA256.test(identity.archive.sha256)
+    || identity.driver.file !== contract.binary
+    || !Number.isSafeInteger(identity.driver.bytes)
+    || identity.driver.bytes <= 0
+    || !HEX_SHA256.test(identity.driver.sha256)
+  ) {
+    fail("qualification driver identity does not match the expected candidate");
+  }
+  if (
+    archiveMetadata.size !== identity.archive.bytes
+    || sha256(archivePath) !== identity.archive.sha256
+  ) {
+    fail("candidate archive digest changed");
+  }
+
+  const driver = path.join(directory, identity.driver.file);
+  const metadata = regularFile(driver, "qualification driver artifact");
+  if (
+    metadata.size !== identity.driver.bytes
+    || sha256(driver) !== identity.driver.sha256
+  ) {
+    fail("qualification driver artifact digest changed");
+  }
+  const expectedDirectoryEntries = [
+    "qualification-driver-identity.json",
+    contract.binary,
+  ].sort();
+  if (
+    JSON.stringify(readdirSync(directory).sort())
+      !== JSON.stringify(expectedDirectoryEntries)
+  ) {
+    fail("qualification driver artifact directory contains unexpected files");
+  }
+  // GitHub artifact extraction does not preserve Unix execute bits. Restore
+  // execution only after the downloaded regular file has matched the retained
+  // source/tree/target identity and byte digest.
+  if (process.platform !== "win32") {
+    chmodSync(driver, 0o755);
+  }
+  return { driver, identity, identityPath };
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  qualification-driver-artifact.mjs produce --asset-target TARGET --source-sha SHA --source-tree TREE --version VERSION --archive FILE --trusted-root DIR --target-dir DIR --out-dir DIR",
+    "  qualification-driver-artifact.mjs verify --asset-target TARGET --source-sha SHA --source-tree TREE --version VERSION --archive FILE --trusted-root DIR --artifact-dir DIR",
+  ].join("\n");
+}
+
+function main(argv) {
+  const { command, values } = parseArgs(argv);
+  const commonFlags = [
+    "--archive",
+    "--asset-target",
+    "--source-sha",
+    "--source-tree",
+    "--trusted-root",
+    "--version",
+  ];
+  if (command === "produce") {
+    requireExactFlags(values, [...commonFlags, "--out-dir", "--target-dir"]);
+  } else if (command === "verify") {
+    requireExactFlags(values, [...commonFlags, "--artifact-dir"]);
+  } else {
+    fail(usage());
+  }
+  const common = {
+    assetTarget: required(values, "--asset-target"),
+    archive: required(values, "--archive"),
+    sourceSha: required(values, "--source-sha"),
+    sourceTree: required(values, "--source-tree"),
+    trustedRoot: required(values, "--trusted-root"),
+    version: required(values, "--version").replace(/^v/u, ""),
+  };
+  let result;
+  if (command === "produce") {
+    result = produceQualificationDriverArtifact({
+      ...common,
+      outDir: required(values, "--out-dir"),
+      targetDir: required(values, "--target-dir"),
+    });
+  } else if (command === "verify") {
+    result = verifyQualificationDriverArtifact({
+      ...common,
+      artifactDir: required(values, "--artifact-dir"),
+    });
+  }
+  process.stdout.write(`${JSON.stringify({
+    driver: result.driver,
+    sha256: result.identity.driver.sha256,
+  })}\n`);
+}
+
+const isMain = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/workflows/linux-vulkan-proof.yml
+++ b/.github/workflows/linux-vulkan-proof.yml
@@ -155,13 +155,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install pinned Rust for frozen-candidate qualification
-        if: ${{ !inputs.server_behavior_only }}
-        shell: bash
-        run: |
-          rustup toolchain install 1.95.0 --profile minimal
-          rustup default 1.95.0
-
       - name: Capture Linux Vulkan host evidence
         shell: bash
         run: |
@@ -183,6 +176,56 @@ jobs:
           SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
         run: test "$SERVER_BEHAVIOR_ONLY" = true
 
+      - name: Authenticate exact Linux package producer
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_PRODUCER_WORKFLOW_PATH: ${{ inputs.candidate_producer_workflow_path }}
+          PACKAGE_RUN_ID: ${{ inputs.package_run_id || github.run_id }}
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+        run: |
+          set -euo pipefail
+          test -n "$CANDIDATE_PRODUCER_WORKFLOW_PATH"
+          case "$CANDIDATE_PRODUCER_WORKFLOW_PATH" in
+            .github/workflows/auto-release.yml | \
+            .github/workflows/release.yml | \
+            .github/workflows/packaged-platform-pr.yml)
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
+          if [ "$SERVER_BEHAVIOR_ONLY" != true ]; then
+            test "$CANDIDATE_PRODUCER_WORKFLOW_PATH" = \
+              .github/workflows/packaged-platform-pr.yml
+          fi
+          run="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PACKAGE_RUN_ID")"
+          test "$(jq -r '.head_repository.full_name' <<<"$run")" = "$GITHUB_REPOSITORY"
+          test "$(jq -r '.path' <<<"$run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"
+          test "$(jq -r '.head_sha' <<<"$run")" = "$(git rev-parse HEAD)"
+          if [ "$PACKAGE_RUN_ID" = "$GITHUB_RUN_ID" ]; then
+            test "$(jq -r '.run_attempt' <<<"$run")" = "$GITHUB_RUN_ATTEMPT"
+          else
+            test "$(jq -r '.status' <<<"$run")" = completed
+            test "$(jq -r '.conclusion' <<<"$run")" = success
+          fi
+          artifact_count="$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PACKAGE_RUN_ID/artifacts?per_page=100" \
+              | jq \
+                --arg sha "$(git rev-parse HEAD)" \
+                --argjson run_id "$PACKAGE_RUN_ID" \
+                '[
+                  .artifacts[]
+                  | select(
+                      .name == "codestory-cli-linux-x64"
+                      and .expired == false
+                      and .workflow_run.id == $run_id
+                      and .workflow_run.head_sha == $sha
+                    )
+                ] | length'
+          )"
+          test "$artifact_count" = 1
+
       - name: Download exact Linux package
         uses: actions/download-artifact@v8.0.1
         with:
@@ -190,6 +233,27 @@ jobs:
           path: target/release-dist
           run-id: ${{ inputs.package_run_id || github.run_id }}
           github-token: ${{ github.token }}
+
+      - name: Verify packaged qualification driver
+        id: qualification-driver
+        if: ${{ !inputs.server_behavior_only }}
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="${INPUT_VERSION#v}"
+          verified="$(
+            node .github/scripts/qualification-driver-artifact.mjs verify \
+              --asset-target linux-x64 \
+              --source-sha "$(git rev-parse HEAD)" \
+              --source-tree "$(git rev-parse 'HEAD^{tree}')" \
+              --version "$version" \
+              --archive "target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz" \
+              --trusted-root "$GITHUB_WORKSPACE" \
+              --artifact-dir target/release-dist/qualification-driver/linux-x64
+          )"
+          echo "path=$(jq -r .driver <<<"$verified")" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate calibration bundle producer
         if: ${{ !inputs.server_behavior_only }}
@@ -222,11 +286,6 @@ jobs:
           path: target/calibration-bundle
           run-id: ${{ inputs.calibration_bundle_run_id }}
           github-token: ${{ github.token }}
-
-      - name: Build qualification driver
-        if: ${{ !inputs.server_behavior_only }}
-        shell: bash
-        run: cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification
 
       - name: Authenticate protected Metal quality producer
         if: ${{ !inputs.server_behavior_only }}
@@ -270,6 +329,7 @@ jobs:
           CODESTORY_EMBED_ALLOW_CPU: "0"
           INPUT_VERSION: ${{ inputs.version }}
           SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+          VERIFIED_QUALIFICATION_DRIVER: ${{ steps.qualification-driver.outputs.path }}
           CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
           CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
         run: |
@@ -288,12 +348,15 @@ jobs:
           else
             calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
             test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+            qualification_driver="$VERIFIED_QUALIFICATION_DRIVER"
+            test -n "$qualification_driver"
+            test -x "$qualification_driver"
             quality_path=target/release-quality-evidence/packet/packet-runtime-summary.json
             test -f "$quality_path"
             quality_args=(--retrieval-quality-evidence "$quality_path")
             qualification_args=(
               --produce-qualification-evidence
-              --qualification-driver target/release/codestory_embedding_qualification
+              --qualification-driver "$qualification_driver"
               --qualification-evidence target/linux-vulkan-proof/qualification.json
             )
             calibration_args=(

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -162,7 +162,7 @@ jobs:
           test "$CALIBRATION_MODE" = false
 
       - name: Install pinned Rust
-        if: ${{ !inputs.use_packaged_cli_artifact || inputs.calibration_mode || !inputs.server_behavior_only }}
+        if: ${{ !inputs.use_packaged_cli_artifact }}
         shell: bash
         run: |
           rustup toolchain install 1.95.0 --profile minimal
@@ -193,6 +193,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           CALIBRATION_MODE: ${{ inputs.calibration_mode }}
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
         run: |
           set -euo pipefail
           build_package_started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
@@ -206,6 +207,11 @@ jobs:
             cargo_args+=(
               -p codestory-bench
               --bin codestory_embedding_constant_calibration
+            )
+          elif [ "$SERVER_BEHAVIOR_ONLY" != true ]; then
+            cargo_args+=(
+              -p codestory-bench
+              --bin codestory_embedding_qualification
             )
           fi
           cargo build --release --locked "${cargo_args[@]}"
@@ -224,8 +230,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ARTIFACT_NAME: codestory-cli-macos-arm64
+          CANDIDATE_PRODUCER_WORKFLOW_PATH: ${{ inputs.candidate_producer_workflow_path }}
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
         run: |
           set -euo pipefail
+          case "$CANDIDATE_PRODUCER_WORKFLOW_PATH" in
+            .github/workflows/auto-release.yml | \
+            .github/workflows/release.yml | \
+            .github/workflows/packaged-platform-pr.yml)
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
+          if [ "$SERVER_BEHAVIOR_ONLY" != true ]; then
+            test "$CANDIDATE_PRODUCER_WORKFLOW_PATH" = \
+              .github/workflows/packaged-platform-pr.yml
+          fi
+          producer_run="$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          )"
+          test "$(jq -r '.head_repository.full_name' <<<"$producer_run")" = "$GITHUB_REPOSITORY"
+          test "$(jq -r '.path' <<<"$producer_run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"
+          test "$(jq -r '.head_sha' <<<"$producer_run")" = "$(git rev-parse HEAD)"
+          test "$(jq -r '.run_attempt' <<<"$producer_run")" = "$GITHUB_RUN_ATTEMPT"
           artifact="$(
             gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
               | jq \
@@ -297,10 +325,26 @@ jobs:
           mkdir -p target/release-dist
           ditto -x -k "$archive" target/release-dist
 
-      - name: Build qualification driver
-        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only }}
+      - name: Verify packaged qualification driver
+        id: qualification-driver
+        if: ${{ inputs.use_packaged_cli_artifact && !inputs.calibration_mode && !inputs.server_behavior_only }}
         shell: bash
-        run: cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="${INPUT_VERSION#v}"
+          verified="$(
+            node .github/scripts/qualification-driver-artifact.mjs verify \
+              --asset-target macos-arm64 \
+              --source-sha "$(git rev-parse HEAD)" \
+              --source-tree "$(git rev-parse 'HEAD^{tree}')" \
+              --version "$version" \
+              --archive "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz" \
+              --trusted-root "$GITHUB_WORKSPACE" \
+              --artifact-dir target/release-dist/qualification-driver/macos-arm64
+          )"
+          echo "path=$(jq -r .driver <<<"$verified")" >> "$GITHUB_OUTPUT"
 
       - name: Download exact-head publishable packet quality evidence
         if: inputs.quality_evidence_artifact != ''
@@ -406,6 +450,8 @@ jobs:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "0"
           SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+          USE_PACKAGED_CLI_ARTIFACT: ${{ inputs.use_packaged_cli_artifact }}
+          VERIFIED_QUALIFICATION_DRIVER: ${{ steps.qualification-driver.outputs.path }}
           CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
           CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
         run: |
@@ -426,10 +472,16 @@ jobs:
             calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
             test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
             test -f "$quality_path"
+            qualification_driver=target/release/codestory_embedding_qualification
+            if [ "$USE_PACKAGED_CLI_ARTIFACT" = true ]; then
+              qualification_driver="$VERIFIED_QUALIFICATION_DRIVER"
+              test -n "$qualification_driver"
+            fi
+            test -x "$qualification_driver"
             quality_args=(--retrieval-quality-evidence "$quality_path")
             qualification_args=(
               --produce-qualification-evidence
-              --qualification-driver target/release/codestory_embedding_qualification
+              --qualification-driver "$qualification_driver"
               --qualification-evidence target/macos-metal-proof/qualification.json
             )
             calibration_args=(

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -402,6 +402,7 @@ jobs:
       proof_key: ${{ needs.route.outputs.proof_key }}
       sign_macos: false
       hermetic_linux: ${{ needs.route.outputs.mode == 'qualification' }}
+      include_qualification_driver: ${{ needs.route.outputs.mode == 'qualification' }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact || '' }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id || '' }}
 

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -46,6 +46,11 @@ on:
         required: false
         default: false
         type: boolean
+      include_qualification_driver:
+        description: Build and retain the exact full-qualification driver beside the candidate packages.
+        required: false
+        default: false
+        type: boolean
     secrets:
       APPLE_DEVELOPER_ID_P12_BASE64:
         required: false
@@ -209,6 +214,7 @@ jobs:
         shell: bash
         env:
           EXACT_SHA: ${{ inputs.ref }}
+          INCLUDE_QUALIFICATION_DRIVER: ${{ inputs.include_qualification_driver }}
         run: |
           set -euo pipefail
           rust_version="$(rustc -Vv | sed -n 's/^release: //p')"
@@ -223,7 +229,7 @@ jobs:
           )
           extra_identity=(
             --identity cargo_incremental=0
-            --identity qualification_driver=disabled
+            --identity "qualification_driver=$INCLUDE_QUALIFICATION_DRIVER"
           )
           while IFS= read -r manifest; do
             relevant_inputs+=(--relevant-input "$manifest")
@@ -357,16 +363,37 @@ jobs:
           --target "${{ matrix.rust_target }}"
           --no-run
 
-      - name: Build codestory-cli
+      - name: Build package and qualification driver
         id: package-build
         if: matrix.asset_target != 'linux-x64'
-        run: cargo build --release --locked -p codestory-cli --target "${{ matrix.rust_target }}"
+        shell: bash
+        env:
+          INCLUDE_QUALIFICATION_DRIVER: ${{ inputs.include_qualification_driver }}
+          RELEASE_RUST_TARGET: ${{ matrix.rust_target }}
+        run: |
+          set -euo pipefail
+          cargo_args=(
+            -p codestory-cli
+            --bin codestory-cli
+            --bin codestory-cli-runtime
+          )
+          if [ "$INCLUDE_QUALIFICATION_DRIVER" = true ]; then
+            cargo_args+=(
+              -p codestory-bench
+              --bin codestory_embedding_qualification
+            )
+          fi
+          cargo build --release --locked \
+            "${cargo_args[@]}" \
+            --target "$RELEASE_RUST_TARGET"
 
       - name: Build Linux x64 at the glibc 2.31 baseline
         id: linux-build
         if: matrix.asset_target == 'linux-x64'
         shell: bash
         env:
+          INCLUDE_QUALIFICATION_DRIVER: ${{ inputs.include_qualification_driver }}
+          RELEASE_RUST_TARGET: ${{ matrix.rust_target }}
           SCCACHE_BINARY: ${{ steps.sccache-identity.outputs.path }}
           SCCACHE_SHA256: ${{ steps.sccache-identity.outputs.sha256 }}
         run: |
@@ -394,6 +421,8 @@ jobs:
             --env SCCACHE_CACHE_SIZE="$SCCACHE_CACHE_SIZE" \
             --env CMAKE_C_COMPILER_LAUNCHER=/sccache/sccache \
             --env CMAKE_CXX_COMPILER_LAUNCHER=/sccache/sccache \
+            --env INCLUDE_QUALIFICATION_DRIVER="$INCLUDE_QUALIFICATION_DRIVER" \
+            --env RELEASE_RUST_TARGET="$RELEASE_RUST_TARGET" \
             --volume "$CARGO_HOME:/cargo" \
             --volume "$PWD:/workspace" \
             --volume "$SCCACHE_BINARY:/sccache/sccache:ro" \
@@ -401,8 +430,16 @@ jobs:
             --workdir /workspace \
             codestory-linux-glibc-build \
             sh -ceu '
-              cargo build --release --locked -p codestory-cli \
-                --target "${{ matrix.rust_target }}"
+              set -- \
+                -p codestory-cli \
+                --bin codestory-cli \
+                --bin codestory-cli-runtime
+              if [ "$INCLUDE_QUALIFICATION_DRIVER" = true ]; then
+                set -- "$@" \
+                  -p codestory-bench \
+                  --bin codestory_embedding_qualification
+              fi
+              cargo build --release --locked "$@" --target "$RELEASE_RUST_TARGET"
               /sccache/sccache --show-stats
               /sccache/sccache --stop-server
             '
@@ -411,6 +448,10 @@ jobs:
             "target/${{ matrix.rust_target }}/release/codestory-cli"
           cp "target/glibc-2.31/${{ matrix.rust_target }}/release/codestory-cli-runtime" \
             "target/${{ matrix.rust_target }}/release/codestory-cli-runtime"
+          if [ "$INCLUDE_QUALIFICATION_DRIVER" = true ]; then
+            cp "target/glibc-2.31/${{ matrix.rust_target }}/release/codestory_embedding_qualification" \
+              "target/${{ matrix.rust_target }}/release/codestory_embedding_qualification"
+          fi
           rm -rf "target/${{ matrix.rust_target }}/release/.codestory-native-seeds"
           cp -R "target/glibc-2.31/${{ matrix.rust_target }}/release/.codestory-native-seeds" \
             "target/${{ matrix.rust_target }}/release/.codestory-native-seeds"
@@ -936,6 +977,24 @@ jobs:
             --version-only `
             --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
 
+      - name: Stage qualification driver in package proof artifact
+        if: inputs.include_qualification_driver
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
+          SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
+        run: >-
+          node .github/scripts/qualification-driver-artifact.mjs produce
+          --asset-target "${{ matrix.asset_target }}"
+          --source-sha "$SOURCE_SHA"
+          --source-tree "$SOURCE_TREE"
+          --version "$INPUT_VERSION"
+          --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}"
+          --trusted-root "$GITHUB_WORKSPACE"
+          --target-dir target
+          --out-dir "target/release-dist/qualification-driver/${{ matrix.asset_target }}"
+
       - name: Report fresh package identity
         id: fresh-package
         shell: bash
@@ -1013,6 +1072,7 @@ jobs:
             target/release-dist/*.zip
             target/release-dist/*.sha256
             target/release-dist/SHA256SUMS.txt
+            target/release-dist/qualification-driver/${{ matrix.asset_target }}
           if-no-files-found: error
           retention-days: 30
           overwrite: true

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -141,7 +141,7 @@ jobs:
           ninja --version | Out-File -Append target/windows-vulkan-proof/host.txt
 
       - name: Install pinned Rust
-        if: ${{ !inputs.use_packaged_cli_artifact || !inputs.server_behavior_only }}
+        if: ${{ !inputs.use_packaged_cli_artifact }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           rustup toolchain install 1.95.0 --profile minimal
@@ -160,14 +160,79 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           CMAKE_GENERATOR: Ninja
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
         run: |
           $version = $env:VERSION.TrimStart('v')
-          cargo build --release --locked -p codestory-cli
+          $cargoArgs = @(
+            "build",
+            "--release",
+            "--locked",
+            "-p", "codestory-cli",
+            "--bin", "codestory-cli",
+            "--bin", "codestory-cli-runtime"
+          )
+          if ($env:SERVER_BEHAVIOR_ONLY -ne "true") {
+            $cargoArgs += @(
+              "-p", "codestory-bench",
+              "--bin", "codestory_embedding_qualification"
+            )
+          }
+          cargo @cargoArgs
           python .github/scripts/package-codestory-release.py `
             --version $version `
             --target windows-x64 `
             --binary target/release/codestory-cli.exe `
             --out-dir target/release-dist
+
+      - name: Authenticate exact Windows package producer
+        if: inputs.use_packaged_cli_artifact
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_PRODUCER_WORKFLOW_PATH: ${{ inputs.candidate_producer_workflow_path }}
+          SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $allowedWorkflows = @(
+            ".github/workflows/auto-release.yml",
+            ".github/workflows/release.yml",
+            ".github/workflows/packaged-platform-pr.yml"
+          )
+          if ($env:CANDIDATE_PRODUCER_WORKFLOW_PATH -notin $allowedWorkflows) {
+            throw "candidate producer workflow is not trusted"
+          }
+          if (
+            $env:SERVER_BEHAVIOR_ONLY -ne "true" -and
+            $env:CANDIDATE_PRODUCER_WORKFLOW_PATH -ne
+              ".github/workflows/packaged-platform-pr.yml"
+          ) {
+            throw "full qualification requires the exact qualification coordinator"
+          }
+          $sourceSha = (git rev-parse HEAD).Trim()
+          $run = gh api "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID" |
+            ConvertFrom-Json
+          if (
+            $run.head_repository.full_name -ne $env:GITHUB_REPOSITORY -or
+            $run.path -ne $env:CANDIDATE_PRODUCER_WORKFLOW_PATH -or
+            $run.head_sha -ne $sourceSha -or
+            [string]$run.run_attempt -ne $env:GITHUB_RUN_ATTEMPT
+          ) {
+            throw "Windows package producer is not the trusted exact-head run"
+          }
+          $artifacts = gh api `
+            "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID/artifacts?per_page=100" |
+            ConvertFrom-Json
+          $artifactCount = @(
+            $artifacts.artifacts | Where-Object {
+              $_.name -eq "codestory-cli-windows-x64" -and
+              $_.expired -eq $false -and
+              [string]$_.workflow_run.id -eq $env:GITHUB_RUN_ID -and
+              $_.workflow_run.head_sha -eq $sourceSha
+            }
+          ).Count
+          if ($artifactCount -ne 1) {
+            throw "expected exactly one authenticated Windows package artifact"
+          }
 
       - name: Download packaged CLI artifact
         if: inputs.use_packaged_cli_artifact
@@ -176,10 +241,27 @@ jobs:
           name: codestory-cli-windows-x64
           path: target/release-dist
 
-      - name: Build qualification driver
-        if: ${{ !inputs.server_behavior_only }}
+      - name: Verify packaged qualification driver
+        id: qualification-driver
+        if: ${{ inputs.use_packaged_cli_artifact && !inputs.server_behavior_only }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
-        run: cargo build --release --locked -p codestory-bench --bin codestory_embedding_qualification
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          $sourceSha = (git rev-parse HEAD).Trim()
+          $sourceTree = (git rev-parse 'HEAD^{tree}').Trim()
+          $version = $env:INPUT_VERSION.TrimStart('v')
+          $verified = node .github/scripts/qualification-driver-artifact.mjs verify `
+            --asset-target windows-x64 `
+            --source-sha $sourceSha `
+            --source-tree $sourceTree `
+            --version $version `
+            --archive "target/release-dist/codestory-cli-v$version-windows-x64.zip" `
+            --trusted-root $env:GITHUB_WORKSPACE `
+            --artifact-dir target/release-dist/qualification-driver/windows-x64
+          $result = $verified | ConvertFrom-Json
+          "path=$($result.driver)" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Download exact-head publishable packet quality evidence
         if: inputs.quality_evidence_artifact != ''
@@ -235,6 +317,8 @@ jobs:
           VERSION: ${{ inputs.version }}
           CODESTORY_EMBED_ALLOW_CPU: "0"
           SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
+          USE_PACKAGED_CLI_ARTIFACT: ${{ inputs.use_packaged_cli_artifact }}
+          VERIFIED_QUALIFICATION_DRIVER: ${{ steps.qualification-driver.outputs.path }}
           CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
           CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
         run: |
@@ -257,9 +341,19 @@ jobs:
             if (-not (Test-Path $qualityPath)) {
               throw "protected Windows proof requires exact-head quality evidence"
             }
+            $qualificationDriver = "target/release/codestory_embedding_qualification.exe"
+            if ($env:USE_PACKAGED_CLI_ARTIFACT -eq "true") {
+              $qualificationDriver = $env:VERIFIED_QUALIFICATION_DRIVER
+              if ([String]::IsNullOrWhiteSpace($qualificationDriver)) {
+                throw "packaged qualification driver was not verified"
+              }
+            }
+            if (-not (Test-Path -LiteralPath $qualificationDriver -PathType Leaf)) {
+              throw "protected Windows proof requires the authenticated qualification driver"
+            }
             $claimArgs = @(
               "--produce-qualification-evidence",
-              "--qualification-driver", "target/release/codestory_embedding_qualification.exe",
+              "--qualification-driver", $qualificationDriver,
               "--qualification-evidence", "target/windows-vulkan-proof/qualification.json",
               "--retrieval-quality-evidence", $qualityPath
             )

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
+    "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
+        "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
+        "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "6925404522d26cdd90b63ccf6322394a8a1b6ba5cb9e64207a0fb65c03a642f0",
+  "candidate_sha256": "17acbb5053b01853fbd4f2423c905ff0ee56b3aae5e794cbd61e47b37c277a74",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
+      "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
+      "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
+    "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1117,6 +1117,30 @@
     "qualification": {
       "coordinator_workflow": "packaged-platform-pr.yml",
       "mode": "qualification",
+      "driver_contract": {
+        "producer_workflow": "packaged-platform-proof.yml",
+        "producer_job": "build",
+        "artifact_name_template": "codestory-cli-{asset_target}",
+        "artifact_directory_template": "qualification-driver/{asset_target}",
+        "identity_file": "qualification-driver-identity.json",
+        "identity_schema_version": 1,
+        "identity_fields": [
+          "schema_version",
+          "source.commit",
+          "source.tree",
+          "release_version",
+          "asset_target",
+          "archive.file",
+          "archive.bytes",
+          "archive.sha256",
+          "driver.file",
+          "driver.bytes",
+          "driver.sha256"
+        ],
+        "build_invocations_per_platform": 1,
+        "reuse_required": true,
+        "public_release_asset": false
+      },
       "runs_per_available_cell": 1,
       "required_cells": [
         {

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -645,6 +645,50 @@ function validateQualificationPolicy(value) {
   ) {
     fail("workflow_policy.qualification must name the canonical one-run frozen-candidate coordinator");
   }
+  const driver = object(
+    qualification.driver_contract,
+    "workflow_policy.qualification.driver_contract",
+  );
+  const expectedDriverKeys = [
+    "artifact_directory_template",
+    "artifact_name_template",
+    "build_invocations_per_platform",
+    "identity_fields",
+    "identity_file",
+    "identity_schema_version",
+    "producer_job",
+    "producer_workflow",
+    "public_release_asset",
+    "reuse_required",
+  ].sort();
+  const expectedIdentityFields = [
+    "schema_version",
+    "source.commit",
+    "source.tree",
+    "release_version",
+    "asset_target",
+    "archive.file",
+    "archive.bytes",
+    "archive.sha256",
+    "driver.file",
+    "driver.bytes",
+    "driver.sha256",
+  ];
+  if (
+    JSON.stringify(Object.keys(driver).sort()) !== JSON.stringify(expectedDriverKeys)
+    || driver.producer_workflow !== "packaged-platform-proof.yml"
+    || driver.producer_job !== "build"
+    || driver.artifact_name_template !== "codestory-cli-{asset_target}"
+    || driver.artifact_directory_template !== "qualification-driver/{asset_target}"
+    || driver.identity_file !== "qualification-driver-identity.json"
+    || driver.identity_schema_version !== 1
+    || JSON.stringify(driver.identity_fields) !== JSON.stringify(expectedIdentityFields)
+    || driver.build_invocations_per_platform !== 1
+    || driver.reuse_required !== true
+    || driver.public_release_asset !== false
+  ) {
+    fail("workflow_policy.qualification must bind one archive-matched package-built qualification driver");
+  }
   const requiredCells = qualification.required_cells;
   if (!Array.isArray(requiredCells) || requiredCells.length !== 2) {
     fail("workflow_policy.qualification must require protected macOS Metal and Windows Vulkan");

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -212,6 +212,30 @@ test("claim graph freezes Mac-only accelerated 3x1 constant calibration", () => 
 
 test("claim graph freezes one GPU-only qualification run per available platform", () => {
   const qualification = graph.workflow_policy.qualification;
+  assert.deepEqual(qualification.driver_contract, {
+    producer_workflow: "packaged-platform-proof.yml",
+    producer_job: "build",
+    artifact_name_template: "codestory-cli-{asset_target}",
+    artifact_directory_template: "qualification-driver/{asset_target}",
+    identity_file: "qualification-driver-identity.json",
+    identity_schema_version: 1,
+    identity_fields: [
+      "schema_version",
+      "source.commit",
+      "source.tree",
+      "release_version",
+      "asset_target",
+      "archive.file",
+      "archive.bytes",
+      "archive.sha256",
+      "driver.file",
+      "driver.bytes",
+      "driver.sha256",
+    ],
+    build_invocations_per_platform: 1,
+    reuse_required: true,
+    public_release_asset: false,
+  });
   assert.equal(qualification.runs_per_available_cell, 1);
   assert.deepEqual(
     qualification.required_cells.map(({ id }) => id),
@@ -244,6 +268,28 @@ test("claim graph freezes one GPU-only qualification run per available platform"
     [draft => {
       draft.workflow_policy.qualification.runs_per_available_cell = 3;
     }, /canonical one-run frozen-candidate coordinator/u],
+    [draft => {
+      draft.workflow_policy.qualification.driver_contract.producer_workflow =
+        "macos-metal-proof.yml";
+    }, /archive-matched package-built qualification driver/u],
+    [draft => {
+      draft.workflow_policy.qualification.driver_contract
+        .build_invocations_per_platform = 2;
+    }, /archive-matched package-built qualification driver/u],
+    [draft => {
+      draft.workflow_policy.qualification.driver_contract.reuse_required = false;
+    }, /archive-matched package-built qualification driver/u],
+    [draft => {
+      draft.workflow_policy.qualification.driver_contract
+        .artifact_directory_template = "qualification-driver";
+    }, /archive-matched package-built qualification driver/u],
+    [draft => {
+      draft.workflow_policy.qualification.driver_contract.identity_fields
+        .splice(5, 3);
+    }, /archive-matched package-built qualification driver/u],
+    [draft => {
+      draft.workflow_policy.qualification.driver_contract.public_release_asset = true;
+    }, /archive-matched package-built qualification driver/u],
     [draft => {
       draft.workflow_policy.qualification.required_cells[0].backend = "cpu";
     }, /protected Metal and Vulkan producers/u],

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "960e7071ba1e97425a9c0be13dc107dd35374bd8e9a6ed49fc522d1aa85062ac",
+      "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

Frozen-candidate qualification run 30499687396 authenticated and downloaded the exact macOS package, then rebuilt codestory_embedding_qualification in a second Cargo invocation. Packaged mode correctly had no model-preparation environment, so the release build failed before Metal or quality proof. Windows and standalone Linux carried the same repeated-build shape.

Base: 4f8befe97529614b1c39f6537895d15802188fd8
Head: c8714b677f98b0eaaa7a9b723935c43ebbe82274
Tree: a8a0bbdd8f9a5b5b4995bec2a2fb9bd92ff9dd27

## What changed

- Package qualification builds the CLI, runtime, and qualification driver in one shared Cargo invocation for each selected platform.
- The driver is retained only inside the existing private Actions package artifact. Its strict identity binds source commit/tree, version, platform, driver bytes, and the exact candidate archive bytes.
- Metal, Windows Vulkan, and Linux Vulkan proofs authenticate the package producer, verify the retained driver, and execute the verifier's exact returned path without Rust installation, model preparation, or another Cargo build.
- The public release archive and release asset list still exclude the qualification driver.
- release-claims.json records the private archive-bound driver contract and the deterministic graph fixtures carry the new graph digest.
- Workflow policy pins the complete coordinator/protected GPU programs and rejects CPU indirection, advisory verification, dead-code producer checks, repeated build/setup, calibration contamination, and driver substitution.

## Review

Start with qualification-driver-artifact.mjs, then the package build/stage/upload steps, then each protected verifier/proof handoff. The policy mutations in check-workflow-policy.test.mjs encode the attacks used during independent review.

## Verification

- Exact Cargo selection executed on aarch64-apple-darwin: CLI, runtime, and qualification driver only; no constant-calibration or Criterion binary.
- Independent helper attacks: 17/17 rejected, including archive/driver mutation, ancestor links, hardlinks, extra fields/files, wrong target/version/source, and path escape.
- Independent workflow attacks: 26/26 rejected; claim-graph attacks: 14/14 rejected.
- Workflow policy: passed; mutation suite: 1,073/1,073 passed.
- Release claims: 38/38 passed; claim/cell/closeout/evidence focused group: 112/112 passed.
- Full actionlint, release version validation, release-claim validation, and diff checks passed.
- Exact-head source proof 30505378661 passed: cold-cache compile plus Clippy 980s; 2,357/2,357 workspace tests passed in 124.324s; retrieval generalization passed in 44s.

Real packaged/protected GPU execution belongs to the recalibrated frozen-candidate qualification after this source repair lands. The frozen constant set must be restored to its unfrozen baseline and recalibrated before qualification resumes.

Closes #1609
Refs #1597
