### PR TITLE
Build Windows release graph once and reuse exact candidate archives

### DIFF
--- a/.github/scripts/candidate-archive-store.mjs
+++ b/.github/scripts/candidate-archive-store.mjs
@@ -1,0 +1,1203 @@
+#!/usr/bin/env node
+
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RECORD_SCHEMA = "codestory-candidate-archive-store/v1";
+const SHA = /^[0-9a-f]{40}$/u;
+const SHA256 = /^[0-9a-f]{64}$/u;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
+const TARGET = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
+const COMPANION_ROLES = new Set([
+  "archive_checksum",
+  "checksum_manifest",
+]);
+const RECORD_FILE = "candidate-archive-record.json";
+const PAYLOAD_DIRECTORY = "payload";
+const BUFFER_BYTES = 1024 * 1024;
+const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
+const PORTABLE_COMPONENT = /^[A-Za-z0-9](?:[A-Za-z0-9._+-]*[A-Za-z0-9])?$/u;
+const WINDOWS_RESERVED_COMPONENT =
+  /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/iu;
+
+// GitHub producer/run authentication stays in the workflow. This helper owns
+// the inner byte boundary after that authentication: an exact record selects
+// <source SHA>/<target>/<archive SHA-256>, and every use revalidates the full
+// allowlisted payload before copying it out of the protected-host store.
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function exactKeys(value, keys, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} keys changed`);
+  }
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireDigest(value, pattern, label) {
+  requireString(value, label);
+  if (!pattern.test(value)) {
+    fail(`${label} has an invalid digest`);
+  }
+  return value;
+}
+
+function requireBytes(value, label) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    fail(`${label} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function simpleName(value, label) {
+  requireString(value, label);
+  if (
+    value === "."
+    || value === ".."
+    || value.includes("/")
+    || value.includes("\\")
+    || value.includes("\0")
+    || path.basename(value) !== value
+    || !PORTABLE_COMPONENT.test(value)
+    || WINDOWS_RESERVED_COMPONENT.test(value)
+  ) {
+    fail(`${label} must be a portable simple filename`);
+  }
+  return value;
+}
+
+function relativePayloadPath(value, label) {
+  requireString(value, label);
+  if (
+    value.includes("\\")
+    || value.includes("\0")
+    || path.posix.isAbsolute(value)
+    || path.win32.isAbsolute(value)
+    || path.posix.normalize(value) !== value
+    || value === "."
+    || value === ".."
+    || value.startsWith("../")
+    || value.split("/").some((component) => component === "" || component === "." || component === "..")
+  ) {
+    fail(`${label} must be a normalized relative POSIX path`);
+  }
+  for (const component of value.split("/")) {
+    if (
+      !PORTABLE_COMPONENT.test(component)
+      || WINDOWS_RESERVED_COMPONENT.test(component)
+    ) {
+      fail(`${label} must contain only portable path components`);
+    }
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function pathIdentity(value) {
+  const resolved = path.resolve(value);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function requireRealRoot(root, label) {
+  const resolved = path.resolve(root);
+  const metadata = lstatSync(resolved);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    fail(`${label} must be a real directory`);
+  }
+  const canonical = realpathSync.native(resolved);
+  if (pathIdentity(canonical) !== pathIdentity(resolved)) {
+    fail(`${label} must not have symbolic-link or reparse ancestry`);
+  }
+  return resolved;
+}
+
+function containedRelativePath(root, candidate, label, { allowEqual = false } = {}) {
+  const relative = path.relative(root, candidate);
+  if (
+    (!allowEqual && relative === "")
+    || relative === ".."
+    || relative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relative)
+  ) {
+    fail(`${label} must be a descendant of its trusted root`);
+  }
+  return relative;
+}
+
+function inspectPathAncestry({
+  allowMissing,
+  candidate,
+  label,
+  root,
+}) {
+  const resolvedRoot = requireRealRoot(root, `${label} trusted root`);
+  const resolvedCandidate = path.resolve(candidate);
+  const relative = containedRelativePath(resolvedRoot, resolvedCandidate, label);
+  let cursor = resolvedRoot;
+  const components = relative.split(path.sep);
+  for (let index = 0; index < components.length; index += 1) {
+    cursor = path.join(cursor, components[index]);
+    if (!existsSync(cursor)) {
+      if (allowMissing) return { resolvedCandidate, resolvedRoot };
+      fail(`${label} path component is missing`);
+    }
+    const metadata = lstatSync(cursor);
+    if (metadata.isSymbolicLink()) {
+      fail(`${label} must not traverse symbolic links or reparse points`);
+    }
+    if (index < components.length - 1 && !metadata.isDirectory()) {
+      fail(`${label} ancestor must be a directory`);
+    }
+  }
+  return { resolvedCandidate, resolvedRoot };
+}
+
+function safeRegularFile(file, label, { requireSingleLink }) {
+  const metadata = lstatSync(file, { bigint: true });
+  if (
+    metadata.isSymbolicLink()
+    || !metadata.isFile()
+    || (requireSingleLink && metadata.nlink !== 1n)
+  ) {
+    fail(
+      requireSingleLink
+        ? `${label} must be a regular, non-symlink, singly linked file`
+        : `${label} must be a regular non-symlink file`,
+    );
+  }
+  const handle = openSync(file, constants.O_RDONLY | O_NOFOLLOW);
+  const opened = fstatSync(handle, { bigint: true });
+  if (
+    !opened.isFile()
+    || opened.dev !== metadata.dev
+    || opened.ino !== metadata.ino
+    || opened.size !== metadata.size
+    || (requireSingleLink && opened.nlink !== 1n)
+  ) {
+    closeSync(handle);
+    fail(`${label} changed while it was opened`);
+  }
+  if (opened.size > BigInt(Number.MAX_SAFE_INTEGER)) {
+    closeSync(handle);
+    fail(`${label} is too large`);
+  }
+  return {
+    handle,
+    size: Number(opened.size),
+  };
+}
+
+function digestHandle(handle) {
+  const digest = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(BUFFER_BYTES);
+  let position = 0;
+  for (;;) {
+    const bytesRead = readSync(handle, buffer, 0, buffer.length, position);
+    if (bytesRead === 0) break;
+    digest.update(buffer.subarray(0, bytesRead));
+    position += bytesRead;
+  }
+  return digest.digest("hex");
+}
+
+function readHandle(handle, bytes, label) {
+  const output = Buffer.allocUnsafe(bytes);
+  let position = 0;
+  while (position < bytes) {
+    const count = readSync(
+      handle,
+      output,
+      position,
+      bytes - position,
+      position,
+    );
+    if (count === 0) {
+      fail(`${label} changed while it was read`);
+    }
+    position += count;
+  }
+  const sentinel = Buffer.allocUnsafe(1);
+  if (readSync(handle, sentinel, 0, 1, position) !== 0) {
+    fail(`${label} changed while it was read`);
+  }
+  return output;
+}
+
+function sha256File(file, label, { requireSingleLink = true } = {}) {
+  const opened = safeRegularFile(file, label, { requireSingleLink });
+  try {
+    return {
+      bytes: opened.size,
+      sha256: digestHandle(opened.handle),
+    };
+  } finally {
+    closeSync(opened.handle);
+  }
+}
+
+function writeAll(handle, buffer, position) {
+  let written = 0;
+  while (written < buffer.length) {
+    const count = writeSync(
+      handle,
+      buffer,
+      written,
+      buffer.length - written,
+      position + written,
+    );
+    if (count <= 0) fail("short write while materializing candidate archive payload");
+    written += count;
+  }
+}
+
+function copyVerifiedFile({
+  destination,
+  expected,
+  label,
+  source,
+  sourceRequiresSingleLink,
+}) {
+  const opened = safeRegularFile(source, `${label} source`, {
+    requireSingleLink: sourceRequiresSingleLink,
+  });
+  let output;
+  try {
+    output = openSync(
+      destination,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+      0o600,
+    );
+    const digest = createHash("sha256");
+    const buffer = Buffer.allocUnsafe(BUFFER_BYTES);
+    let position = 0;
+    for (;;) {
+      const bytesRead = readSync(opened.handle, buffer, 0, buffer.length, position);
+      if (bytesRead === 0) break;
+      const chunk = buffer.subarray(0, bytesRead);
+      digest.update(chunk);
+      writeAll(output, chunk, position);
+      position += bytesRead;
+    }
+    fsyncSync(output);
+    const actualDigest = digest.digest("hex");
+    if (position !== expected.bytes || actualDigest !== expected.sha256) {
+      fail(`${label} source does not match its expected size and SHA-256`);
+    }
+  } finally {
+    closeSync(opened.handle);
+    if (output !== undefined) closeSync(output);
+  }
+  const retained = sha256File(destination, `${label} destination`);
+  if (retained.bytes !== expected.bytes || retained.sha256 !== expected.sha256) {
+    fail(`${label} destination changed after materialization`);
+  }
+}
+
+function companionPathContract(role, relativePath, archiveName) {
+  if (role === "archive_checksum") {
+    if (relativePath !== `${archiveName}.sha256`) {
+      fail("archive checksum companion path does not match the archive name");
+    }
+    return;
+  }
+  if (role === "checksum_manifest") {
+    if (relativePath !== "SHA256SUMS.txt") {
+      fail("checksum manifest companion must be SHA256SUMS.txt");
+    }
+    return;
+  }
+  fail(`${role} is not a public candidate archive companion`);
+}
+
+function normalizeCompanions(companions, archiveName) {
+  if (!Array.isArray(companions)) {
+    fail("candidate archive companions must be an array");
+  }
+  const roles = new Set();
+  const paths = new Set();
+  const normalized = companions.map((companion, index) => {
+    exactKeys(
+      companion,
+      ["role", "relative_path", "bytes", "sha256"],
+      `candidate archive companion ${index}`,
+    );
+    const role = requireString(
+      companion.role,
+      `candidate archive companion ${index} role`,
+    );
+    if (!COMPANION_ROLES.has(role) || roles.has(role)) {
+      fail("candidate archive companion roles must be unique and supported");
+    }
+    roles.add(role);
+    const relativePath = relativePayloadPath(
+      companion.relative_path,
+      `candidate archive companion ${role} path`,
+    );
+    companionPathContract(role, relativePath, archiveName);
+    const pathKey = relativePath.toLowerCase();
+    if (paths.has(pathKey)) {
+      fail("candidate archive payload paths must remain distinct on Windows");
+    }
+    paths.add(pathKey);
+    return {
+      role,
+      relative_path: relativePath,
+      bytes: requireBytes(
+        companion.bytes,
+        `candidate archive companion ${role} bytes`,
+      ),
+      sha256: requireDigest(
+        companion.sha256,
+        SHA256,
+        `candidate archive companion ${role} SHA-256`,
+      ),
+    };
+  });
+  if (
+    roles.size !== COMPANION_ROLES.size
+    || [...COMPANION_ROLES].some((role) => !roles.has(role))
+  ) {
+    fail("candidate archive must retain exactly its two public checksum companions");
+  }
+  const archiveChecksum = normalized.find(
+    (companion) => companion.role === "archive_checksum",
+  );
+  const checksumManifest = normalized.find(
+    (companion) => companion.role === "checksum_manifest",
+  );
+  if (
+    archiveChecksum.bytes !== checksumManifest.bytes
+    || archiveChecksum.sha256 !== checksumManifest.sha256
+  ) {
+    fail("per-candidate checksum files must retain the same checksum line");
+  }
+  return normalized.sort((left, right) => left.role.localeCompare(right.role));
+}
+
+export function buildCandidateArchiveRecord({
+  archive,
+  companions = [],
+  repository,
+  sourceSha,
+  sourceTree,
+  target,
+}) {
+  if (!REPOSITORY.test(requireString(repository, "repository"))) {
+    fail("repository must use the exact owner/name form");
+  }
+  requireDigest(sourceSha, SHA, "source SHA");
+  requireDigest(sourceTree, SHA, "source tree");
+  if (!TARGET.test(requireString(target, "target"))) {
+    fail("target must use a stable lowercase target name");
+  }
+  exactKeys(
+    archive,
+    ["name", "relative_path", "bytes", "sha256"],
+    "candidate archive",
+  );
+  const name = simpleName(archive.name, "candidate archive name");
+  const relativePath = relativePayloadPath(
+    archive.relative_path,
+    "candidate archive relative path",
+  );
+  if (relativePath !== name) {
+    fail("candidate archive must be at the payload root under its exact name");
+  }
+  const archivePathKey = relativePath.toLowerCase();
+  const normalizedCompanions = normalizeCompanions(companions, name);
+  if (
+    normalizedCompanions.some(
+      (companion) => companion.relative_path.toLowerCase() === archivePathKey,
+    )
+  ) {
+    fail("candidate archive and companion paths must be distinct");
+  }
+  return {
+    schema: RECORD_SCHEMA,
+    repository,
+    source: {
+      commit: sourceSha,
+      tree: sourceTree,
+    },
+    target,
+    archive: {
+      name,
+      relative_path: relativePath,
+      bytes: requireBytes(archive.bytes, "candidate archive bytes"),
+      sha256: requireDigest(
+        archive.sha256,
+        SHA256,
+        "candidate archive SHA-256",
+      ),
+    },
+    companions: normalizedCompanions,
+  };
+}
+
+export function validateCandidateArchiveRecord(record) {
+  exactKeys(
+    record,
+    ["schema", "repository", "source", "target", "archive", "companions"],
+    "candidate archive record",
+  );
+  if (record.schema !== RECORD_SCHEMA) {
+    fail("candidate archive record schema changed");
+  }
+  exactKeys(record.source, ["commit", "tree"], "candidate archive source");
+  const normalized = buildCandidateArchiveRecord({
+    archive: record.archive,
+    companions: record.companions,
+    repository: record.repository,
+    sourceSha: record.source.commit,
+    sourceTree: record.source.tree,
+    target: record.target,
+  });
+  if (canonicalJson(normalized) !== canonicalJson(record)) {
+    fail("candidate archive record is not canonical");
+  }
+  return normalized;
+}
+
+export function candidateArchiveStoreKey(record) {
+  const expected = validateCandidateArchiveRecord(record);
+  return [
+    expected.source.commit,
+    expected.target,
+    expected.archive.sha256,
+  ].join("/");
+}
+
+function entryPaths(storeRoot, record) {
+  const root = requireRealRoot(storeRoot, "candidate archive store root");
+  const key = candidateArchiveStoreKey(record);
+  const entry = path.join(root, "objects", "v1", ...key.split("/"));
+  return {
+    entry,
+    key,
+    parent: path.dirname(entry),
+    payload: path.join(entry, PAYLOAD_DIRECTORY),
+    recordFile: path.join(entry, RECORD_FILE),
+    root,
+  };
+}
+
+function requiredPayloads(record) {
+  return [
+    {
+      role: "archive",
+      relative_path: record.archive.relative_path,
+      bytes: record.archive.bytes,
+      sha256: record.archive.sha256,
+    },
+    ...record.companions,
+  ];
+}
+
+function expectedDirectories(payloads) {
+  const directories = new Set();
+  for (const payload of payloads) {
+    const components = payload.relative_path.split("/");
+    components.pop();
+    let cursor = "";
+    for (const component of components) {
+      cursor = cursor === "" ? component : `${cursor}/${component}`;
+      directories.add(cursor);
+    }
+  }
+  return directories;
+}
+
+function walkPayloadTree(root, label, { requireSingleLink }) {
+  requireRealRoot(root, label);
+  const files = new Map();
+  const directories = new Set();
+  const pending = [{ absolute: root, relative: "" }];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const name of readdirSync(current.absolute)) {
+      const absolute = path.join(current.absolute, name);
+      const relative = current.relative === ""
+        ? name
+        : `${current.relative}/${name}`;
+      relativePayloadPath(relative, `${label} entry`);
+      const metadata = lstatSync(absolute);
+      if (metadata.isSymbolicLink()) {
+        fail(`${label} must not contain symbolic links or reparse points`);
+      }
+      if (metadata.isDirectory()) {
+        directories.add(relative);
+        pending.push({ absolute, relative });
+      } else if (metadata.isFile()) {
+        if (requireSingleLink && metadata.nlink !== 1) {
+          fail(`${label} files must be singly linked`);
+        }
+        files.set(relative, absolute);
+      } else {
+        fail(`${label} must contain only regular files and directories`);
+      }
+    }
+  }
+  return { directories, files };
+}
+
+function verifyPayloadTree(root, record, label, { requireSingleLink = true } = {}) {
+  const payloads = requiredPayloads(record);
+  const expectedFiles = new Set(payloads.map((payload) => payload.relative_path));
+  const expectedDirs = expectedDirectories(payloads);
+  const actual = walkPayloadTree(root, label, { requireSingleLink });
+  if (
+    canonicalJson([...actual.files.keys()].sort())
+      !== canonicalJson([...expectedFiles].sort())
+    || canonicalJson([...actual.directories].sort())
+      !== canonicalJson([...expectedDirs].sort())
+  ) {
+    fail(`${label} does not contain the exact candidate payload allowlist`);
+  }
+  for (const payload of payloads) {
+    const file = actual.files.get(payload.relative_path);
+    const measured = sha256File(file, `${label} ${payload.role}`, {
+      requireSingleLink,
+    });
+    if (measured.bytes !== payload.bytes || measured.sha256 !== payload.sha256) {
+      fail(`${label} ${payload.role} does not match its retained size and SHA-256`);
+    }
+  }
+  return actual;
+}
+
+function readRecordFile(recordFile, label) {
+  const resolved = path.resolve(recordFile);
+  const canonical = realpathSync.native(resolved);
+  if (pathIdentity(canonical) !== pathIdentity(resolved)) {
+    fail(`${label} must not have symbolic-link or reparse ancestry`);
+  }
+  const opened = safeRegularFile(
+    resolved,
+    label,
+    { requireSingleLink: true },
+  );
+  if (opened.size > 64 * 1024) {
+    closeSync(opened.handle);
+    fail(`${label} is too large`);
+  }
+  let encoded;
+  try {
+    encoded = readHandle(
+      opened.handle,
+      opened.size,
+      label,
+    ).toString("utf8");
+  } finally {
+    closeSync(opened.handle);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(encoded);
+  } catch {
+    fail(`${label} is not valid JSON`);
+  }
+  return validateCandidateArchiveRecord(parsed);
+}
+
+export function readCandidateArchiveRecord(recordFile) {
+  return readRecordFile(recordFile, "candidate archive authenticated record");
+}
+
+export function writeCandidateArchiveRecord(recordFile, record) {
+  const expected = validateCandidateArchiveRecord(record);
+  const resolved = path.resolve(recordFile);
+  const parent = requireRealRoot(
+    path.dirname(resolved),
+    "candidate archive record output directory",
+  );
+  containedRelativePath(
+    parent,
+    resolved,
+    "candidate archive record output",
+  );
+  writeStoredRecord(resolved, expected);
+  return resolved;
+}
+
+function sameRecord(left, right) {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+function verifyStoreEntry(storeRoot, expectedRecord) {
+  const expected = validateCandidateArchiveRecord(expectedRecord);
+  const paths = entryPaths(storeRoot, expected);
+  inspectPathAncestry({
+    allowMissing: false,
+    candidate: paths.entry,
+    label: "candidate archive store entry",
+    root: paths.root,
+  });
+  const entryMetadata = lstatSync(paths.entry);
+  if (entryMetadata.isSymbolicLink() || !entryMetadata.isDirectory()) {
+    fail("candidate archive store entry must be a real directory");
+  }
+  const entries = readdirSync(paths.entry).sort();
+  if (canonicalJson(entries) !== canonicalJson([PAYLOAD_DIRECTORY, RECORD_FILE].sort())) {
+    fail("candidate archive store entry contains unexpected files");
+  }
+  const stored = readRecordFile(
+    paths.recordFile,
+    "candidate archive stored record",
+  );
+  if (!sameRecord(stored, expected)) {
+    fail("candidate archive store entry belongs to a different candidate");
+  }
+  verifyPayloadTree(paths.payload, expected, "candidate archive store payload");
+  return { paths, record: stored };
+}
+
+function ensureRealDescendantDirectories(root, candidate, label) {
+  const resolvedRoot = requireRealRoot(root, `${label} root`);
+  const resolvedCandidate = path.resolve(candidate);
+  const relative = containedRelativePath(
+    resolvedRoot,
+    resolvedCandidate,
+    label,
+    { allowEqual: true },
+  );
+  if (relative === "") return resolvedCandidate;
+  let cursor = resolvedRoot;
+  for (const component of relative.split(path.sep)) {
+    cursor = path.join(cursor, component);
+    if (!existsSync(cursor)) {
+      mkdirSync(cursor, { mode: 0o700 });
+    }
+    const metadata = lstatSync(cursor);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+      fail(`${label} must not traverse symbolic links, reparse points, or files`);
+    }
+  }
+  return resolvedCandidate;
+}
+
+function writeStoredRecord(file, record) {
+  const output = openSync(
+    file,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+    0o600,
+  );
+  try {
+    const bytes = Buffer.from(`${JSON.stringify(record, null, 2)}\n`, "utf8");
+    writeAll(output, bytes, 0);
+    fsyncSync(output);
+  } finally {
+    closeSync(output);
+  }
+}
+
+function uniqueTemporarySibling(parent, basename) {
+  return path.join(
+    parent,
+    `.${basename}.partial-${process.pid}-${randomBytes(12).toString("hex")}`,
+  );
+}
+
+function requireOwnedCorruptEntry(paths) {
+  inspectPathAncestry({
+    allowMissing: false,
+    candidate: paths.entry,
+    label: "candidate archive corrupt store entry",
+    root: paths.root,
+  });
+  const entryMetadata = lstatSync(paths.entry, { bigint: true });
+  if (entryMetadata.isSymbolicLink() || !entryMetadata.isDirectory()) {
+    fail("candidate archive corrupt store entry must be a real directory");
+  }
+  const canonical = realpathSync.native(paths.entry);
+  if (pathIdentity(canonical) !== pathIdentity(paths.entry)) {
+    fail("candidate archive corrupt store entry must have real ancestry");
+  }
+  const pending = [paths.entry];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    for (const name of readdirSync(directory)) {
+      const entry = path.join(directory, name);
+      const metadata = lstatSync(entry, { bigint: true });
+      if (metadata.isSymbolicLink()) {
+        fail("candidate archive corrupt store entry contains a symbolic link or reparse point");
+      }
+      if (metadata.isDirectory()) {
+        pending.push(entry);
+      } else if (!metadata.isFile() || metadata.nlink !== 1n) {
+        fail("candidate archive corrupt store entry contains an unowned file");
+      }
+    }
+  }
+  return entryMetadata;
+}
+
+function quarantineCorruptStoreEntry(paths) {
+  const before = requireOwnedCorruptEntry(paths);
+  const rejectedEntry = path.join(
+    paths.parent,
+    `.${path.basename(paths.entry)}.rejected-${process.pid}-${randomBytes(12).toString("hex")}`,
+  );
+  renameSync(paths.entry, rejectedEntry);
+  const after = lstatSync(rejectedEntry, { bigint: true });
+  if (
+    !after.isDirectory()
+    || after.isSymbolicLink()
+    || after.dev !== before.dev
+    || after.ino !== before.ino
+  ) {
+    fail("candidate archive rejected store entry changed during quarantine");
+  }
+  return rejectedEntry;
+}
+
+function removeOwnedTemporary(directory, parent, basename) {
+  const resolvedParent = path.resolve(parent);
+  const resolved = path.resolve(directory);
+  containedRelativePath(resolvedParent, resolved, "owned temporary directory");
+  if (!path.basename(resolved).startsWith(`.${basename}.partial-${process.pid}-`)) {
+    fail("refusing to remove an unowned temporary directory");
+  }
+  rmSync(resolved, { force: true, recursive: true });
+}
+
+function copyPayloadTree({
+  destination,
+  record,
+  source,
+  sourceRequiresSingleLink,
+}) {
+  const payloads = requiredPayloads(record);
+  mkdirSync(destination, { mode: 0o700 });
+  for (const directory of [...expectedDirectories(payloads)].sort()) {
+    ensureRealDescendantDirectories(destination, path.join(destination, ...directory.split("/")), "candidate payload directory");
+  }
+  for (const payload of payloads) {
+    const components = payload.relative_path.split("/");
+    copyVerifiedFile({
+      destination: path.join(destination, ...components),
+      expected: payload,
+      label: `candidate payload ${payload.role}`,
+      source: path.join(source, ...components),
+      sourceRequiresSingleLink,
+    });
+  }
+  verifyPayloadTree(destination, record, "materialized candidate payload");
+}
+
+function publishStoreEntry(storeRoot, inputRoot, record) {
+  const expected = validateCandidateArchiveRecord(record);
+  const paths = entryPaths(storeRoot, expected);
+  verifyPayloadTree(
+    requireRealRoot(inputRoot, "candidate archive input root"),
+    expected,
+    "candidate archive input payload",
+  );
+  if (existsSync(paths.entry)) {
+    return { admitted: false, ...verifyStoreEntry(storeRoot, expected) };
+  }
+  ensureRealDescendantDirectories(paths.root, paths.parent, "candidate archive store parent");
+  const temporary = uniqueTemporarySibling(paths.parent, path.basename(paths.entry));
+  try {
+    mkdirSync(temporary, { mode: 0o700 });
+    const temporaryPayload = path.join(temporary, PAYLOAD_DIRECTORY);
+    copyPayloadTree({
+      destination: temporaryPayload,
+      record: expected,
+      source: inputRoot,
+      sourceRequiresSingleLink: true,
+    });
+    writeStoredRecord(path.join(temporary, RECORD_FILE), expected);
+    const temporaryEntries = readdirSync(temporary).sort();
+    if (
+      canonicalJson(temporaryEntries)
+        !== canonicalJson([PAYLOAD_DIRECTORY, RECORD_FILE].sort())
+    ) {
+      fail("candidate archive temporary entry changed before publication");
+    }
+    const temporaryRecord = readRecordFile(
+      path.join(temporary, RECORD_FILE),
+      "candidate archive temporary record",
+    );
+    if (!sameRecord(temporaryRecord, expected)) {
+      fail("candidate archive temporary record changed before publication");
+    }
+    verifyPayloadTree(
+      temporaryPayload,
+      expected,
+      "candidate archive temporary payload",
+    );
+
+    if (existsSync(paths.entry)) {
+      const concurrent = verifyStoreEntry(storeRoot, expected);
+      removeOwnedTemporary(temporary, paths.parent, path.basename(paths.entry));
+      return { admitted: false, ...concurrent };
+    }
+    try {
+      renameSync(temporary, paths.entry);
+    } catch (error) {
+      if (!["EEXIST", "ENOTEMPTY"].includes(error?.code) || !existsSync(paths.entry)) {
+        throw error;
+      }
+      const concurrent = verifyStoreEntry(storeRoot, expected);
+      removeOwnedTemporary(temporary, paths.parent, path.basename(paths.entry));
+      return { admitted: false, ...concurrent };
+    }
+    return { admitted: true, ...verifyStoreEntry(storeRoot, expected) };
+  } catch (error) {
+    if (existsSync(temporary)) {
+      removeOwnedTemporary(temporary, paths.parent, path.basename(paths.entry));
+    }
+    throw error;
+  }
+}
+
+function materializeStoreEntry({
+  outputDir,
+  outputRoot,
+  record,
+  storeRoot,
+}) {
+  const verified = verifyStoreEntry(storeRoot, record);
+  const trustedOutputRoot = requireRealRoot(
+    outputRoot,
+    "candidate archive output root",
+  );
+  const resolvedOutput = path.resolve(outputDir);
+  containedRelativePath(
+    trustedOutputRoot,
+    resolvedOutput,
+    "candidate archive output directory",
+  );
+  const outputParent = ensureRealDescendantDirectories(
+    trustedOutputRoot,
+    path.dirname(resolvedOutput),
+    "candidate archive output parent",
+  );
+  if (existsSync(resolvedOutput)) {
+    fail("candidate archive output directory must not already exist");
+  }
+  const temporary = uniqueTemporarySibling(outputParent, path.basename(resolvedOutput));
+  try {
+    copyPayloadTree({
+      destination: temporary,
+      record: verified.record,
+      source: verified.paths.payload,
+      sourceRequiresSingleLink: true,
+    });
+    if (existsSync(resolvedOutput)) {
+      fail("candidate archive output directory appeared during materialization");
+    }
+    renameSync(temporary, resolvedOutput);
+    const materialized = verifyPayloadTree(
+      resolvedOutput,
+      verified.record,
+      "candidate archive restored payload",
+    );
+    const companions = Object.fromEntries(
+      verified.record.companions.map((companion) => [
+        companion.role,
+        materialized.files.get(companion.relative_path),
+      ]),
+    );
+    return {
+      archive: materialized.files.get(verified.record.archive.relative_path),
+      companions,
+      key: verified.paths.key,
+      outputDir: resolvedOutput,
+      record: verified.record,
+    };
+  } catch (error) {
+    if (existsSync(temporary)) {
+      removeOwnedTemporary(
+        temporary,
+        outputParent,
+        path.basename(resolvedOutput),
+      );
+    }
+    throw error;
+  }
+}
+
+export function restoreCandidateArchive({
+  outputDir,
+  outputRoot,
+  record,
+  storeRoot,
+}) {
+  const expected = validateCandidateArchiveRecord(record);
+  const paths = entryPaths(storeRoot, expected);
+  if (!existsSync(paths.entry)) {
+    return {
+      hit: false,
+      key: paths.key,
+      record: expected,
+    };
+  }
+  try {
+    verifyStoreEntry(storeRoot, expected);
+  } catch (error) {
+    const rejectedEntry = quarantineCorruptStoreEntry(paths);
+    return {
+      hit: false,
+      key: paths.key,
+      record: expected,
+      rejectedCorrupt: true,
+      rejectedEntry,
+      rejection: error.message,
+    };
+  }
+  return {
+    hit: true,
+    ...materializeStoreEntry({
+      outputDir,
+      outputRoot,
+      record: expected,
+      storeRoot,
+    }),
+  };
+}
+
+export function admitCandidateArchive({
+  inputRoot,
+  outputDir,
+  outputRoot,
+  record,
+  storeRoot,
+}) {
+  const expected = validateCandidateArchiveRecord(record);
+  const stored = publishStoreEntry(storeRoot, inputRoot, expected);
+  return {
+    admitted: stored.admitted,
+    hit: !stored.admitted,
+    ...materializeStoreEntry({
+      outputDir,
+      outputRoot,
+      record: expected,
+      storeRoot,
+    }),
+  };
+}
+
+function parseArguments(argv) {
+  const [command, ...rest] = argv;
+  const values = new Map();
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      fail(`invalid argument near ${flag ?? "<end>"}`);
+    }
+    if (!values.has(flag)) values.set(flag, []);
+    values.get(flag).push(value);
+  }
+  return { command, values };
+}
+
+function one(values, flag) {
+  const found = values.get(flag) ?? [];
+  if (found.length !== 1) {
+    fail(`${flag} must be supplied exactly once`);
+  }
+  return found[0];
+}
+
+function parsePositiveInteger(value, label) {
+  if (!/^[1-9][0-9]*$/u.test(value)) {
+    fail(`${label} must be a positive integer`);
+  }
+  return requireBytes(Number.parseInt(value, 10), label);
+}
+
+function parseCompanion(value) {
+  const parts = value.split("|");
+  if (parts.length !== 4) {
+    fail("--companion must use role|relative_path|bytes|sha256");
+  }
+  return {
+    role: parts[0],
+    relative_path: parts[1],
+    bytes: parsePositiveInteger(parts[2], "companion bytes"),
+    sha256: parts[3],
+  };
+}
+
+function exactFlags(values, allowed) {
+  const actual = [...values.keys()].sort();
+  const expected = [...allowed].sort();
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    fail("candidate archive store arguments changed");
+  }
+}
+
+function recordFromArguments(values) {
+  if (values.has("--record")) {
+    return readCandidateArchiveRecord(one(values, "--record"));
+  }
+  const archiveName = one(values, "--archive-name");
+  return buildCandidateArchiveRecord({
+    repository: one(values, "--repository"),
+    sourceSha: one(values, "--source-sha"),
+    sourceTree: one(values, "--source-tree"),
+    target: one(values, "--target"),
+    archive: {
+      name: archiveName,
+      relative_path: archiveName,
+      bytes: parsePositiveInteger(
+        one(values, "--archive-bytes"),
+        "archive bytes",
+      ),
+      sha256: one(values, "--archive-sha256"),
+    },
+    companions: (values.get("--companion") ?? []).map(parseCompanion),
+  });
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  candidate-archive-store.mjs record --output JSON --repository OWNER/REPO --source-sha SHA --source-tree TREE --target TARGET --archive-name NAME --archive-bytes BYTES --archive-sha256 SHA256 --companion 'role|relative_path|bytes|sha256'...",
+    "  candidate-archive-store.mjs restore --record AUTHENTICATED_JSON --store-root DIR --output-root DIR --output-dir DIR",
+    "  candidate-archive-store.mjs admit --record AUTHENTICATED_JSON --input-root DIR --store-root DIR --output-root DIR --output-dir DIR",
+    "",
+    "Explicit record fields are retained for bounded tooling and tests:",
+    "  candidate-archive-store.mjs restore --store-root DIR --output-root DIR --output-dir DIR --repository OWNER/REPO --source-sha SHA --source-tree TREE --target TARGET --archive-name NAME --archive-bytes BYTES --archive-sha256 SHA256 [--companion 'role|relative_path|bytes|sha256']...",
+    "  candidate-archive-store.mjs admit --input-root DIR --store-root DIR --output-root DIR --output-dir DIR --repository OWNER/REPO --source-sha SHA --source-tree TREE --target TARGET --archive-name NAME --archive-bytes BYTES --archive-sha256 SHA256 [--companion 'role|relative_path|bytes|sha256']...",
+  ].join("\n");
+}
+
+function main(argv) {
+  const { command, values } = parseArguments(argv);
+  const operational = [
+    "--output-dir",
+    "--output-root",
+    "--store-root",
+  ];
+  const recordFields = [
+    "--archive-bytes",
+    "--archive-name",
+    "--archive-sha256",
+    "--repository",
+    "--source-sha",
+    "--source-tree",
+    "--target",
+  ];
+  const usesRecord = values.has("--record");
+  if (
+    usesRecord
+    && [...recordFields, "--companion"].some((flag) => values.has(flag))
+  ) {
+    fail("--record cannot be combined with explicit record fields");
+  }
+  const allowed = usesRecord
+    ? [...operational, "--record"]
+    : [
+      ...operational,
+      ...recordFields,
+      ...(values.has("--companion") ? ["--companion"] : []),
+    ];
+  if (command === "record") {
+    if (usesRecord) {
+      fail("record production requires explicit authenticated fields");
+    }
+    exactFlags(values, [
+      ...recordFields,
+      "--output",
+      ...(values.has("--companion") ? ["--companion"] : []),
+    ]);
+    const written = writeCandidateArchiveRecord(
+      one(values, "--output"),
+      recordFromArguments(values),
+    );
+    process.stdout.write(`${JSON.stringify({ record: written })}\n`);
+    return;
+  }
+  if (command === "restore") {
+    exactFlags(values, allowed);
+  } else if (command === "admit") {
+    exactFlags(values, [...allowed, "--input-root"]);
+  } else {
+    fail(usage());
+  }
+  const commonArguments = {
+    outputDir: one(values, "--output-dir"),
+    outputRoot: one(values, "--output-root"),
+    record: recordFromArguments(values),
+    storeRoot: one(values, "--store-root"),
+  };
+  const result = command === "restore"
+    ? restoreCandidateArchive(commonArguments)
+    : admitCandidateArchive({
+      ...commonArguments,
+      inputRoot: one(values, "--input-root"),
+    });
+  if (result.rejectedCorrupt) {
+    process.stderr.write(
+      `candidate archive cache rejected corrupt entry ${result.key}: `
+      + `${result.rejection}; quarantined at ${result.rejectedEntry}\n`,
+    );
+  }
+  process.stdout.write(`${JSON.stringify({
+    admitted: result.admitted ?? false,
+    archive: result.archive ?? null,
+    companions: result.companions ?? {},
+    hit: result.hit,
+    key: result.key,
+    output_dir: result.outputDir ?? null,
+    rejected_corrupt: result.rejectedCorrupt ?? false,
+    rejected_entry: result.rejectedEntry ?? null,
+  })}\n`);
+}
+
+const isMain = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/candidate-archive-store.test.mjs
+++ b/.github/scripts/candidate-archive-store.test.mjs
@@ -1,0 +1,900 @@
+import assert from "node:assert/strict";
+import {
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  admitCandidateArchive,
+  buildCandidateArchiveRecord,
+  candidateArchiveStoreKey,
+  readCandidateArchiveRecord,
+  restoreCandidateArchive,
+  validateCandidateArchiveRecord,
+  writeCandidateArchiveRecord,
+} from "./candidate-archive-store.mjs";
+
+const SCRIPT = fileURLToPath(
+  new URL("./candidate-archive-store.mjs", import.meta.url),
+);
+const REPOSITORY = "TheGreenCedar/CodeStory";
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+const TREE_A = "1".repeat(40);
+const TREE_B = "2".repeat(40);
+const TARGET = "windows-x64";
+const ARCHIVE_NAME = "codestory-cli-v0.16.3-windows-x64.zip";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function descriptor(role, relativePath, bytes) {
+  return {
+    role,
+    relative_path: relativePath,
+    bytes: bytes.length,
+    sha256: sha256(bytes),
+  };
+}
+
+function fixtureRecord({
+  sourceSha = SHA_A,
+  sourceTree = TREE_A,
+  archiveBytes = Buffer.from("exact Windows archive bytes"),
+} = {}) {
+  const archiveDigest = sha256(archiveBytes);
+  const companions = [
+    descriptor(
+      "archive_checksum",
+      `${ARCHIVE_NAME}.sha256`,
+      Buffer.from(`${archiveDigest}  ${ARCHIVE_NAME}\n`),
+    ),
+    descriptor(
+      "checksum_manifest",
+      "SHA256SUMS.txt",
+      Buffer.from(`${archiveDigest}  ${ARCHIVE_NAME}\n`),
+    ),
+  ];
+  return buildCandidateArchiveRecord({
+    repository: REPOSITORY,
+    sourceSha,
+    sourceTree,
+    target: TARGET,
+    archive: {
+      name: ARCHIVE_NAME,
+      relative_path: ARCHIVE_NAME,
+      bytes: archiveBytes.length,
+      sha256: archiveDigest,
+    },
+    companions,
+  });
+}
+
+function payloads(record, archiveBytes = Buffer.from("exact Windows archive bytes")) {
+  const values = new Map([[record.archive.relative_path, archiveBytes]]);
+  for (const companion of record.companions) {
+    if (companion.role === "archive_checksum" || companion.role === "checksum_manifest") {
+      values.set(
+        companion.relative_path,
+        Buffer.from(`${record.archive.sha256}  ${record.archive.name}\n`),
+      );
+    }
+  }
+  return values;
+}
+
+function writePayloadTree(root, record, values = payloads(record)) {
+  for (const [relative, bytes] of values) {
+    const file = path.join(root, ...relative.split("/"));
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, bytes, { flag: "wx" });
+  }
+}
+
+function createFixture(options = {}) {
+  const temporaryRoot = realpathSync.native(os.tmpdir());
+  const root = mkdtempSync(path.join(temporaryRoot, "codestory-candidate-store-"));
+  const inputRoot = path.join(root, "input");
+  const outputRoot = path.join(root, "outputs");
+  const storeRoot = path.join(root, "store");
+  mkdirSync(inputRoot);
+  mkdirSync(outputRoot);
+  mkdirSync(storeRoot);
+  const record = fixtureRecord(options);
+  writePayloadTree(inputRoot, record, payloads(record, options.archiveBytes));
+  return {
+    inputRoot,
+    outputRoot,
+    record,
+    root,
+    storeRoot,
+  };
+}
+
+function cleanup(fixture) {
+  rmSync(fixture.root, { force: true, recursive: true });
+}
+
+function outputDir(fixture, name = "release-dist") {
+  return path.join(fixture.outputRoot, name);
+}
+
+function entryDir(fixture, record = fixture.record) {
+  return path.join(
+    fixture.storeRoot,
+    "objects",
+    "v1",
+    ...candidateArchiveStoreKey(record).split("/"),
+  );
+}
+
+function storedRecordPath(fixture, record = fixture.record) {
+  return path.join(entryDir(fixture, record), "candidate-archive-record.json");
+}
+
+function storedPayloadPath(fixture, relativePath, record = fixture.record) {
+  return path.join(entryDir(fixture, record), "payload", ...relativePath.split("/"));
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function admit(fixture, name = "release-dist") {
+  return admitCandidateArchive({
+    inputRoot: fixture.inputRoot,
+    outputDir: outputDir(fixture, name),
+    outputRoot: fixture.outputRoot,
+    record: fixture.record,
+    storeRoot: fixture.storeRoot,
+  });
+}
+
+function cliArguments(fixture, command, name, { recordFile } = {}) {
+  const arguments_ = [
+    SCRIPT,
+    command,
+    "--store-root",
+    fixture.storeRoot,
+    "--output-root",
+    fixture.outputRoot,
+    "--output-dir",
+    outputDir(fixture, name),
+  ];
+  if (command === "admit") {
+    arguments_.push("--input-root", fixture.inputRoot);
+  }
+  if (recordFile) {
+    arguments_.push("--record", recordFile);
+  } else {
+    arguments_.push(
+      "--repository",
+      fixture.record.repository,
+      "--source-sha",
+      fixture.record.source.commit,
+      "--source-tree",
+      fixture.record.source.tree,
+      "--target",
+      fixture.record.target,
+      "--archive-name",
+      fixture.record.archive.name,
+      "--archive-bytes",
+      String(fixture.record.archive.bytes),
+      "--archive-sha256",
+      fixture.record.archive.sha256,
+    );
+    for (const companion of fixture.record.companions) {
+      arguments_.push(
+        "--companion",
+        [
+          companion.role,
+          companion.relative_path,
+          companion.bytes,
+          companion.sha256,
+        ].join("|"),
+      );
+    }
+  }
+  return arguments_;
+}
+
+function writeAuthenticatedRecord(fixture, record = fixture.record, name = "record.json") {
+  const file = path.join(fixture.root, name);
+  writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, { flag: "wx" });
+  return file;
+}
+
+test("the canonical store key contains only source SHA, target, and archive digest", () => {
+  const record = fixtureRecord();
+  assert.equal(
+    candidateArchiveStoreKey(record),
+    `${SHA_A}/${TARGET}/${record.archive.sha256}`,
+  );
+  const nextSource = fixtureRecord({ sourceSha: SHA_B, sourceTree: TREE_B });
+  assert.notEqual(candidateArchiveStoreKey(nextSource), candidateArchiveStoreKey(record));
+});
+
+test("restore reports an explicit miss without publishing output", () => {
+  const fixture = createFixture();
+  try {
+    const output = outputDir(fixture);
+    const result = restoreCandidateArchive({
+      outputDir: output,
+      outputRoot: fixture.outputRoot,
+      record: fixture.record,
+      storeRoot: fixture.storeRoot,
+    });
+    assert.equal(result.hit, false);
+    assert.equal(result.key, candidateArchiveStoreKey(fixture.record));
+    assert.equal(lstatSync(fixture.storeRoot).isDirectory(), true);
+    assert.equal(statExists(output), false);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("admission and a later hit materialize the complete exact payload as fresh copies", () => {
+  const fixture = createFixture();
+  try {
+    const admitted = admit(fixture, "first");
+    assert.equal(admitted.admitted, true);
+    assert.equal(admitted.hit, false);
+    assert.equal(
+      readFileSync(admitted.archive, "utf8"),
+      "exact Windows archive bytes",
+    );
+    assert.deepEqual(
+      Object.keys(admitted.companions).sort(),
+      fixture.record.companions.map((entry) => entry.role).sort(),
+    );
+
+    const restored = restoreCandidateArchive({
+      outputDir: outputDir(fixture, "second"),
+      outputRoot: fixture.outputRoot,
+      record: fixture.record,
+      storeRoot: fixture.storeRoot,
+    });
+    assert.equal(restored.hit, true);
+    assert.equal(statSync(restored.archive).nlink, 1);
+    assert.equal(
+      statSync(storedPayloadPath(fixture, fixture.record.archive.relative_path)).nlink,
+      1,
+    );
+    assert.notEqual(restored.archive, admitted.archive);
+    assert.notEqual(
+      restored.archive,
+      storedPayloadPath(fixture, fixture.record.archive.relative_path),
+    );
+    for (const companion of fixture.record.companions) {
+      const restoredFile = restored.companions[companion.role];
+      assert.equal(statSync(restoredFile).nlink, 1);
+      assert.notEqual(restoredFile, storedPayloadPath(fixture, companion.relative_path));
+    }
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("the public checksum companion pair is mandatory", () => {
+  const fixture = createFixture();
+  try {
+    const result = admit(fixture);
+    assert.equal(result.admitted, true);
+    assert.deepEqual(
+      Object.keys(result.companions).sort(),
+      ["archive_checksum", "checksum_manifest"],
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("an exact archive digest is never reused across source SHAs", () => {
+  const fixture = createFixture();
+  try {
+    admit(fixture, "source-a");
+    const sourceB = fixtureRecord({ sourceSha: SHA_B, sourceTree: TREE_B });
+    const miss = restoreCandidateArchive({
+      outputDir: outputDir(fixture, "source-b-miss"),
+      outputRoot: fixture.outputRoot,
+      record: sourceB,
+      storeRoot: fixture.storeRoot,
+    });
+    assert.equal(miss.hit, false);
+    assert.notEqual(candidateArchiveStoreKey(sourceB), candidateArchiveStoreKey(fixture.record));
+
+    const admittedB = admitCandidateArchive({
+      inputRoot: fixture.inputRoot,
+      outputDir: outputDir(fixture, "source-b"),
+      outputRoot: fixture.outputRoot,
+      record: sourceB,
+      storeRoot: fixture.storeRoot,
+    });
+    assert.equal(admittedB.admitted, true);
+    assert.equal(statExists(entryDir(fixture, fixture.record)), true);
+    assert.equal(statExists(entryDir(fixture, sourceB)), true);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("stored record omissions, substitutions, and extra keys never become hits", async (t) => {
+  const mutations = [
+    ["missing repository", (record) => { delete record.repository; }],
+    ["missing source tree", (record) => { delete record.source.tree; }],
+    ["missing archive digest", (record) => { delete record.archive.sha256; }],
+    ["source substitution", (record) => { record.source.commit = SHA_B; }],
+    ["tree substitution", (record) => { record.source.tree = TREE_B; }],
+    ["target substitution", (record) => { record.target = "linux-x64"; }],
+    ["archive name drift", (record) => { record.archive.name = "wrong.zip"; }],
+    ["schema substitution", (record) => { record.schema = "codestory-candidate-archive-store/v2"; }],
+    ["extra key", (record) => { record.untrusted = true; }],
+  ];
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const fixture = createFixture();
+      try {
+        admit(fixture, "initial");
+        const stored = JSON.parse(readFileSync(storedRecordPath(fixture), "utf8"));
+        mutate(stored);
+        writeFileSync(storedRecordPath(fixture), `${JSON.stringify(stored)}\n`);
+        const originalEntry = entryDir(fixture);
+        const result = restoreCandidateArchive({
+          outputDir: outputDir(fixture, "mutated"),
+          outputRoot: fixture.outputRoot,
+          record: fixture.record,
+          storeRoot: fixture.storeRoot,
+        });
+        assert.equal(result.hit, false);
+        assert.equal(result.rejectedCorrupt, true);
+        assert.match(result.rejection, /candidate archive/u);
+        assert.equal(statExists(originalEntry), false);
+        assert.equal(statExists(result.rejectedEntry), true);
+        assert.equal(statExists(outputDir(fixture, "mutated")), false);
+      } finally {
+        cleanup(fixture);
+      }
+    });
+  }
+});
+
+test("owned malformed and partial store entries are quarantined as authenticated misses", async (t) => {
+  await t.test("malformed record", () => {
+    const fixture = createFixture();
+    try {
+      admit(fixture, "initial");
+      writeFileSync(storedRecordPath(fixture), "{broken");
+      const originalEntry = entryDir(fixture);
+      const result = restoreCandidateArchive({
+        outputDir: outputDir(fixture, "malformed"),
+        outputRoot: fixture.outputRoot,
+        record: fixture.record,
+        storeRoot: fixture.storeRoot,
+      });
+      assert.equal(result.hit, false);
+      assert.equal(result.rejectedCorrupt, true);
+      assert.match(result.rejection, /not valid JSON/u);
+      assert.equal(statExists(originalEntry), false);
+      assert.equal(statExists(result.rejectedEntry), true);
+    } finally {
+      cleanup(fixture);
+    }
+  });
+
+  await t.test("published directory missing its record", () => {
+    const fixture = createFixture();
+    try {
+      const entry = entryDir(fixture);
+      mkdirSync(path.join(entry, "payload"), { recursive: true });
+      writeFileSync(
+        path.join(entry, "payload", ARCHIVE_NAME),
+        "partial archive",
+      );
+      const result = restoreCandidateArchive({
+        outputDir: outputDir(fixture, "partial"),
+        outputRoot: fixture.outputRoot,
+        record: fixture.record,
+        storeRoot: fixture.storeRoot,
+      });
+      assert.equal(result.hit, false);
+      assert.equal(result.rejectedCorrupt, true);
+      assert.match(result.rejection, /unexpected files/u);
+      assert.equal(statExists(entry), false);
+      assert.equal(statExists(result.rejectedEntry), true);
+      assert.equal(statExists(outputDir(fixture, "partial")), false);
+    } finally {
+      cleanup(fixture);
+    }
+  });
+
+  await t.test("orphaned temporary sibling is not a cache hit", () => {
+    const fixture = createFixture();
+    try {
+      const entry = entryDir(fixture);
+      mkdirSync(path.dirname(entry), { recursive: true });
+      mkdirSync(path.join(path.dirname(entry), `.${path.basename(entry)}.partial-orphan`));
+      const result = restoreCandidateArchive({
+        outputDir: outputDir(fixture, "orphan"),
+        outputRoot: fixture.outputRoot,
+        record: fixture.record,
+        storeRoot: fixture.storeRoot,
+      });
+      assert.equal(result.hit, false);
+      assert.equal(statExists(outputDir(fixture, "orphan")), false);
+    } finally {
+      cleanup(fixture);
+    }
+  });
+});
+
+test("every retained payload is rehashed and owned corruption becomes a miss", async (t) => {
+  const mutations = [
+    ["truncated archive", (fixture) => {
+      truncateSync(
+        storedPayloadPath(fixture, fixture.record.archive.relative_path),
+        5,
+      );
+    }],
+    ["mutated checksum", (fixture) => {
+      const companion = fixture.record.companions.find(
+        (entry) => entry.role === "checksum_manifest",
+      );
+      writeFileSync(storedPayloadPath(fixture, companion.relative_path), "wrong\n");
+    }],
+    ["missing archive checksum", (fixture) => {
+      const companion = fixture.record.companions.find(
+        (entry) => entry.role === "archive_checksum",
+      );
+      rmSync(storedPayloadPath(fixture, companion.relative_path));
+    }],
+    ["extra companion", (fixture) => {
+      writeFileSync(
+        path.join(entryDir(fixture), "payload", "unlisted.bin"),
+        "unlisted",
+      );
+    }],
+  ];
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const fixture = createFixture();
+      try {
+        admit(fixture, "initial");
+        mutate(fixture);
+        const originalEntry = entryDir(fixture);
+        const result = restoreCandidateArchive({
+          outputDir: outputDir(fixture, "mutated"),
+          outputRoot: fixture.outputRoot,
+          record: fixture.record,
+          storeRoot: fixture.storeRoot,
+        });
+        assert.equal(result.hit, false);
+        assert.equal(result.rejectedCorrupt, true);
+        assert.match(result.rejection, /candidate archive/u);
+        assert.equal(statExists(originalEntry), false);
+        assert.equal(statExists(result.rejectedEntry), true);
+        assert.equal(statExists(outputDir(fixture, "mutated")), false);
+      } finally {
+        cleanup(fixture);
+      }
+    });
+  }
+});
+
+test("unowned links in a corrupt store entry fail closed without quarantine", async (t) => {
+  const mutations = [
+    ["hardlinked retained archive", (fixture) => {
+      linkSync(
+        storedPayloadPath(fixture, fixture.record.archive.relative_path),
+        path.join(fixture.root, "retained-archive-link"),
+      );
+    }],
+    ["hardlinked retained record", (fixture) => {
+      linkSync(
+        storedRecordPath(fixture),
+        path.join(fixture.root, "retained-record-link"),
+      );
+    }],
+    ["symlinked retained payload", (fixture) => {
+      const archive = storedPayloadPath(
+        fixture,
+        fixture.record.archive.relative_path,
+      );
+      rmSync(archive);
+      symlinkSync(
+        path.join(fixture.root, "outside-archive"),
+        archive,
+      );
+    }],
+  ];
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const fixture = createFixture();
+      try {
+        admit(fixture, "initial");
+        writeFileSync(path.join(fixture.root, "outside-archive"), "outside");
+        mutate(fixture);
+        const originalEntry = entryDir(fixture);
+        assert.throws(
+          () => restoreCandidateArchive({
+            outputDir: outputDir(fixture, "unowned"),
+            outputRoot: fixture.outputRoot,
+            record: fixture.record,
+            storeRoot: fixture.storeRoot,
+          }),
+          /unowned file|symbolic link or reparse point/u,
+        );
+        assert.equal(statExists(originalEntry), true);
+        assert.equal(statExists(outputDir(fixture, "unowned")), false);
+      } finally {
+        cleanup(fixture);
+      }
+    });
+  }
+});
+
+test("admission rejects missing, mutated, extra, and hardlinked input payloads", async (t) => {
+  const mutations = [
+    ["missing companion", (fixture) => {
+      const companion = fixture.record.companions.find(
+        (entry) => entry.role === "checksum_manifest",
+      );
+      rmSync(path.join(fixture.inputRoot, ...companion.relative_path.split("/")));
+    }],
+    ["mutated companion", (fixture) => {
+      const companion = fixture.record.companions.find(
+        (entry) => entry.role === "archive_checksum",
+      );
+      writeFileSync(
+        path.join(fixture.inputRoot, ...companion.relative_path.split("/")),
+        "wrong driver",
+      );
+    }],
+    ["extra file", (fixture) => {
+      writeFileSync(path.join(fixture.inputRoot, "untrusted.txt"), "extra");
+    }],
+    ["extra directory", (fixture) => {
+      mkdirSync(path.join(fixture.inputRoot, "untrusted"));
+    }],
+    ["hardlinked companion", (fixture) => {
+      const companion = fixture.record.companions.find(
+        (entry) => entry.role === "archive_checksum",
+      );
+      const checksum = path.join(
+        fixture.inputRoot,
+        ...companion.relative_path.split("/"),
+      );
+      linkSync(checksum, path.join(fixture.root, "second-checksum-link"));
+    }],
+  ];
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const fixture = createFixture();
+      try {
+        mutate(fixture);
+        assert.throws(() => admit(fixture), /candidate archive|candidate payload/u);
+        assert.equal(statExists(entryDir(fixture)), false);
+        assert.equal(statExists(outputDir(fixture)), false);
+      } finally {
+        cleanup(fixture);
+      }
+    });
+  }
+});
+
+test("symlinked input and traversal-shaped record paths are rejected", async (t) => {
+  await t.test("symlinked input root", (context) => {
+    const fixture = createFixture();
+    try {
+      const linked = path.join(fixture.root, "linked-input");
+      try {
+        symlinkSync(fixture.inputRoot, linked, "dir");
+      } catch (error) {
+        if (["EPERM", "EACCES"].includes(error?.code)) {
+          context.skip("host cannot create a directory symlink");
+          return;
+        }
+        throw error;
+      }
+      assert.throws(
+        () => admitCandidateArchive({
+          inputRoot: linked,
+          outputDir: outputDir(fixture),
+          outputRoot: fixture.outputRoot,
+          record: fixture.record,
+          storeRoot: fixture.storeRoot,
+        }),
+        /real directory|reparse ancestry/u,
+      );
+    } finally {
+      cleanup(fixture);
+    }
+  });
+
+  await t.test("symlinked payload", (context) => {
+      const fixture = createFixture();
+      try {
+        const companion = fixture.record.companions.find(
+        (entry) => entry.role === "archive_checksum",
+        );
+      const checksum = path.join(
+        fixture.inputRoot,
+        ...companion.relative_path.split("/"),
+      );
+      rmSync(checksum);
+      try {
+        symlinkSync(path.join(fixture.root, "outside-checksum"), checksum, "file");
+      } catch (error) {
+        if (["EPERM", "EACCES"].includes(error?.code)) {
+          context.skip("host cannot create a file symlink");
+          return;
+        }
+        throw error;
+      }
+      assert.throws(() => admit(fixture), /symbolic links|reparse points/u);
+    } finally {
+      cleanup(fixture);
+    }
+  });
+
+  await t.test("traversal companion", () => {
+    const record = clone(fixtureRecord());
+    const companion = record.companions.find(
+      (entry) => entry.role === "checksum_manifest",
+    );
+    companion.relative_path = "../SHA256SUMS.txt";
+    assert.throws(
+      () => validateCandidateArchiveRecord(record),
+      /normalized relative POSIX path/u,
+    );
+  });
+
+  await t.test("unsupported arbitrary companion", () => {
+    const record = fixtureRecord();
+    assert.throws(
+      () => buildCandidateArchiveRecord({
+        archive: record.archive,
+        companions: [
+          ...record.companions,
+          descriptor("arbitrary", "arbitrary.bin", Buffer.from("wrong")),
+        ],
+        repository: record.repository,
+        sourceSha: record.source.commit,
+        sourceTree: record.source.tree,
+        target: record.target,
+      }),
+      /roles must be unique and supported/u,
+    );
+  });
+});
+
+test("qualification driver payloads cannot enter the public candidate record", () => {
+  const record = fixtureRecord();
+  assert.throws(
+    () => buildCandidateArchiveRecord({
+      archive: record.archive,
+      companions: [
+        ...record.companions,
+        descriptor(
+          "qualification_driver",
+          "qualification-driver/windows-x64/driver.exe",
+          Buffer.from("private qualification driver"),
+        ),
+      ],
+      repository: record.repository,
+      sourceSha: record.source.commit,
+      sourceTree: record.source.tree,
+      target: record.target,
+    }),
+    /roles must be unique and supported/u,
+  );
+});
+
+test("the per-candidate checksum manifest cannot drift from the archive checksum", () => {
+  const record = clone(fixtureRecord());
+  const manifest = record.companions.find(
+    (entry) => entry.role === "checksum_manifest",
+  );
+  manifest.sha256 = "f".repeat(64);
+  assert.throws(
+    () => validateCandidateArchiveRecord(record),
+    /same checksum line/u,
+  );
+});
+
+test("authenticated record files require the exact schema and a real singly linked path", async (t) => {
+  await t.test("canonical record", () => {
+    const fixture = createFixture();
+    try {
+      const file = writeAuthenticatedRecord(fixture);
+      assert.deepEqual(readCandidateArchiveRecord(file), fixture.record);
+    } finally {
+      cleanup(fixture);
+    }
+  });
+
+  await t.test("extra record field", () => {
+    const fixture = createFixture();
+    try {
+      const mutated = clone(fixture.record);
+      mutated.untrusted = true;
+      const file = writeAuthenticatedRecord(fixture, mutated);
+      assert.throws(
+        () => readCandidateArchiveRecord(file),
+        /record keys changed/u,
+      );
+    } finally {
+      cleanup(fixture);
+    }
+  });
+
+  await t.test("hardlinked record", () => {
+    const fixture = createFixture();
+    try {
+      const file = writeAuthenticatedRecord(fixture);
+      linkSync(file, path.join(fixture.root, "record-link.json"));
+      assert.throws(
+        () => readCandidateArchiveRecord(file),
+        /singly linked/u,
+      );
+    } finally {
+      cleanup(fixture);
+    }
+  });
+
+  await t.test("symlinked record", (context) => {
+    const fixture = createFixture();
+    try {
+      const file = writeAuthenticatedRecord(fixture);
+      const linked = path.join(fixture.root, "linked-record.json");
+      try {
+        symlinkSync(file, linked, "file");
+      } catch (error) {
+        if (["EPERM", "EACCES"].includes(error?.code)) {
+          context.skip("host cannot create a file symlink");
+          return;
+        }
+        throw error;
+      }
+      assert.throws(
+        () => readCandidateArchiveRecord(linked),
+        /symbolic-link or reparse ancestry/u,
+      );
+    } finally {
+      cleanup(fixture);
+    }
+  });
+});
+
+test("record producer writes one canonical public record without overwriting", () => {
+  const fixture = createFixture();
+  try {
+    const directory = path.join(fixture.root, "record-output");
+    mkdirSync(directory);
+    const file = path.join(directory, "candidate-archive-record.json");
+    assert.equal(writeCandidateArchiveRecord(file, fixture.record), file);
+    assert.deepEqual(readCandidateArchiveRecord(file), fixture.record);
+    assert.throws(
+      () => writeCandidateArchiveRecord(file, fixture.record),
+      /EEXIST|exist/u,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("materialization refuses to overwrite an existing output directory", () => {
+  const fixture = createFixture();
+  try {
+    admit(fixture, "initial");
+    const destination = outputDir(fixture, "occupied");
+    mkdirSync(destination);
+    writeFileSync(path.join(destination, "sentinel"), "keep");
+    assert.throws(
+      () => restoreCandidateArchive({
+        outputDir: destination,
+        outputRoot: fixture.outputRoot,
+        record: fixture.record,
+        storeRoot: fixture.storeRoot,
+      }),
+      /must not already exist/u,
+    );
+    assert.equal(readFileSync(path.join(destination, "sentinel"), "utf8"), "keep");
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("the executable CLI reports a miss without network or input flags", () => {
+  const fixture = createFixture();
+  try {
+    const result = spawnSync(process.execPath, cliArguments(fixture, "restore", "miss"), {
+      encoding: "utf8",
+      env: {},
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.hit, false);
+    assert.equal(output.archive, null);
+    assert.equal(output.key, candidateArchiveStoreKey(fixture.record));
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("the executable CLI admits and materializes the exact companion set", () => {
+  const fixture = createFixture();
+  try {
+    const recordFile = writeAuthenticatedRecord(fixture);
+    const result = spawnSync(
+      process.execPath,
+      cliArguments(fixture, "admit", "cli-admit", { recordFile }),
+      {
+        encoding: "utf8",
+        env: {},
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.admitted, true);
+    assert.equal(output.hit, false);
+    assert.equal(readFileSync(output.archive, "utf8"), "exact Windows archive bytes");
+    assert.deepEqual(
+      Object.keys(output.companions).sort(),
+      fixture.record.companions.map((entry) => entry.role).sort(),
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("the executable CLI rejects record files combined with substitute fields", () => {
+  const fixture = createFixture();
+  try {
+    const recordFile = writeAuthenticatedRecord(fixture);
+    const arguments_ = cliArguments(
+      fixture,
+      "restore",
+      "record-conflict",
+      { recordFile },
+    );
+    arguments_.push("--source-sha", SHA_B);
+    const result = spawnSync(process.execPath, arguments_, {
+      encoding: "utf8",
+      env: {},
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /cannot be combined with explicit record fields/u,
+    );
+    assert.equal(statExists(outputDir(fixture, "record-conflict")), false);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+function statExists(file) {
+  try {
+    lstatSync(file);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}

--- a/.github/scripts/cargo-build-artifacts.mjs
+++ b/.github/scripts/cargo-build-artifacts.mjs
@@ -1,0 +1,623 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SCHEMA = "codestory.cargo-build-artifacts/v1";
+const SHA40 = /^[0-9a-f]{40}$/u;
+const SHA256 = /^[0-9a-f]{64}$/u;
+const ALIAS = /^[a-z][a-z0-9_]*$/u;
+const WINDOWS_TARGET = "x86_64-pc-windows-msvc";
+const RELEASE_OPT_LEVELS = new Set(["1", "2", "3", "s", "z"]);
+const ARTIFACT_CONTRACT = {
+  cli: {
+    packageName: "codestory-cli",
+    kind: "bin",
+    targetName: "codestory-cli",
+  },
+  runtime: {
+    packageName: "codestory-cli",
+    kind: "bin",
+    targetName: "codestory-cli-runtime",
+  },
+  native_staging: {
+    packageName: "codestory-llama-sys",
+    kind: "test",
+    targetName: "native_staging",
+  },
+  windows_path_identity: {
+    packageName: "codestory-workspace",
+    kind: "test",
+    targetName: "windows_path_identity",
+  },
+  qualification_driver: {
+    packageName: "codestory-bench",
+    kind: "bin",
+    targetName: "codestory_embedding_qualification",
+  },
+};
+const REQUIRED_ALIASES = [
+  "cli",
+  "runtime",
+  "native_staging",
+  "windows_path_identity",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function exactKeys(value, keys, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} keys changed`);
+  }
+}
+
+function requireSha(value, label) {
+  if (!SHA40.test(value)) {
+    fail(`${label} must be a full lowercase Git digest`);
+  }
+}
+
+function requireWindowsTarget(value) {
+  if (value !== WINDOWS_TARGET) {
+    fail(`unsupported Cargo artifact target ${value}`);
+  }
+}
+
+function packageNameFromId(packageId) {
+  if (typeof packageId !== "string") {
+    fail("Cargo compiler artifact package_id must be a string");
+  }
+  const fragment = packageId.lastIndexOf("#");
+  if (fragment >= 0) {
+    const packageAndVersion = packageId.slice(fragment + 1);
+    const separator = packageAndVersion.lastIndexOf("@");
+    if (separator > 0) return packageAndVersion.slice(0, separator);
+  }
+  const legacy = /^([^\s]+)\s+\d+\.\d+\.\d+(?:[-+][^\s]+)?(?:\s|$)/u.exec(packageId);
+  if (legacy) return legacy[1];
+  return null;
+}
+
+function packageNameFromArtifact(message) {
+  const fromId = packageNameFromId(message.package_id);
+  if (fromId) return fromId;
+  if (typeof message.manifest_path !== "string" || message.manifest_path === "") {
+    fail(`Cargo artifact package name is unavailable for ${message.package_id}`);
+  }
+  const manifest = fs.readFileSync(message.manifest_path, "utf8");
+  let inPackage = false;
+  for (const line of manifest.split(/\r?\n/u)) {
+    const section = /^\s*\[([^\]]+)\]\s*$/u.exec(line);
+    if (section) {
+      inPackage = section[1] === "package";
+      continue;
+    }
+    if (!inPackage) continue;
+    const name = /^\s*name\s*=\s*["']([^"']+)["']\s*(?:#.*)?$/u.exec(line);
+    if (name) return name[1];
+  }
+  fail(`Cargo package manifest has no package name: ${message.manifest_path}`);
+}
+
+function parseExpectation(value) {
+  if (typeof value !== "string") fail("artifact expectation must be a string");
+  const separator = value.indexOf("=");
+  if (separator <= 0 || separator === value.length - 1) {
+    fail("artifact expectation must use alias=package:kind:target");
+  }
+  const alias = value.slice(0, separator);
+  const fields = value.slice(separator + 1).split(":");
+  if (!ALIAS.test(alias)) fail(`invalid artifact alias ${alias}`);
+  if (fields.length !== 3 || fields.some((field) => field === "")) {
+    fail(`invalid artifact expectation ${value}`);
+  }
+  const [packageName, kind, targetName] = fields;
+  if (!["bin", "test"].includes(kind)) {
+    fail(`unsupported artifact kind ${kind}`);
+  }
+  return { alias, packageName, kind, targetName };
+}
+
+function requireArtifactContract(expectations) {
+  const aliases = expectations.map(({ alias }) => alias).sort();
+  const required = [...REQUIRED_ALIASES].sort();
+  const withDriver = [...REQUIRED_ALIASES, "qualification_driver"].sort();
+  if (
+    JSON.stringify(aliases) !== JSON.stringify(required)
+    && JSON.stringify(aliases) !== JSON.stringify(withDriver)
+  ) {
+    fail("Windows release graph artifact set changed");
+  }
+  for (const expectation of expectations) {
+    const contract = ARTIFACT_CONTRACT[expectation.alias];
+    if (
+      !contract
+      || expectation.packageName !== contract.packageName
+      || expectation.kind !== contract.kind
+      || expectation.targetName !== contract.targetName
+    ) {
+      fail(`Windows release graph artifact contract changed for ${expectation.alias}`);
+    }
+  }
+}
+
+function parseCargoMessages(jsonLines) {
+  const messages = [];
+  for (const [index, line] of jsonLines.split(/\r?\n/u).entries()) {
+    if (line.trim() === "") continue;
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      fail(`Cargo JSON output line ${index + 1} is not valid JSON`);
+    }
+    if (message?.reason === "compiler-artifact") messages.push(message);
+  }
+  return messages;
+}
+
+function releaseProfile(message, kind) {
+  const profile = message.profile;
+  exactKeys(
+    profile,
+    [
+      "opt_level",
+      "debuginfo",
+      "debug_assertions",
+      "overflow_checks",
+      "test",
+    ],
+    "Cargo artifact profile",
+  );
+  const optLevel = String(profile.opt_level);
+  if (
+    !RELEASE_OPT_LEVELS.has(optLevel)
+    || profile.debug_assertions !== false
+    || profile.overflow_checks !== false
+  ) {
+    fail("Cargo artifact was not built with the release profile");
+  }
+  const expectedTest = kind === "test";
+  if (profile.test !== expectedTest) {
+    fail(`Cargo artifact profile.test did not match ${kind}`);
+  }
+  return {
+    opt_level: optLevel,
+    debuginfo: profile.debuginfo,
+    debug_assertions: false,
+    overflow_checks: false,
+    test: expectedTest,
+  };
+}
+
+function isWithin(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== ""
+    && relative !== ".."
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative)
+  );
+}
+
+function hashFile(file) {
+  const hash = crypto.createHash("sha256");
+  const handle = fs.openSync(file, "r");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    for (;;) {
+      const bytesRead = fs.readSync(handle, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    fs.closeSync(handle);
+  }
+  return hash.digest("hex");
+}
+
+function validatedExecutable(message, {
+  kind,
+  profileRoot,
+  targetName,
+}) {
+  if (typeof message.executable !== "string" || message.executable === "") {
+    fail(`Cargo artifact ${targetName} did not emit an executable`);
+  }
+  if (
+    !Array.isArray(message.filenames)
+    || !message.filenames.some(
+      (filename) => path.resolve(filename) === path.resolve(message.executable),
+    )
+  ) {
+    fail(`Cargo artifact ${targetName} executable is not one of its emitted filenames`);
+  }
+  const executable = path.resolve(message.executable);
+  const metadata = fs.lstatSync(executable);
+  if (
+    !metadata.isFile()
+    || metadata.isSymbolicLink()
+    || metadata.nlink !== 1
+  ) {
+    fail(
+      `Cargo artifact ${targetName} must be a regular, non-symlink, singly linked file`,
+    );
+  }
+  if (path.extname(executable).toLowerCase() !== ".exe") {
+    fail(`Cargo artifact ${targetName} is not a Windows executable`);
+  }
+
+  const realProfileRoot = fs.realpathSync(profileRoot);
+  const realExecutable = fs.realpathSync(executable);
+  if (!isWithin(realProfileRoot, realExecutable)) {
+    fail(`Cargo artifact ${targetName} escaped the exact target release directory`);
+  }
+  const relative = path.relative(realProfileRoot, realExecutable);
+  if (kind === "test" && path.dirname(relative) !== "deps") {
+    fail(`Cargo test artifact ${targetName} was not emitted under release/deps`);
+  }
+  if (kind === "bin" && path.dirname(relative) !== ".") {
+    fail(`Cargo binary artifact ${targetName} was not emitted at the release root`);
+  }
+
+  return {
+    path: executable,
+    relative_path: relative.split(path.sep).join("/"),
+    bytes: metadata.size,
+    sha256: hashFile(executable),
+  };
+}
+
+function matchingArtifacts(messages, expectation, workspaceRoot) {
+  const expectedManifest = fs.realpathSync(
+    path.join(workspaceRoot, "crates", expectation.packageName, "Cargo.toml"),
+  );
+  return messages.filter((message) => {
+    if (message?.target?.name !== expectation.targetName) return false;
+    if (!Array.isArray(message.target.kind)) return false;
+    if (!message.target.kind.includes(expectation.kind)) return false;
+    if (packageNameFromArtifact(message) !== expectation.packageName) return false;
+    return fs.realpathSync(message.manifest_path) === expectedManifest;
+  });
+}
+
+export function buildCargoArtifactManifest({
+  exactSha,
+  exactTree,
+  expectations,
+  jsonLines,
+  rustTarget,
+  targetDir,
+  workspaceRoot,
+}) {
+  requireSha(exactSha, "source SHA");
+  requireSha(exactTree, "source tree");
+  requireWindowsTarget(rustTarget);
+  if (!Array.isArray(expectations) || expectations.length === 0) {
+    fail("at least one Cargo artifact expectation is required");
+  }
+  const parsedExpectations = expectations.map((value) =>
+    typeof value === "string" ? parseExpectation(value) : value
+  );
+  requireArtifactContract(parsedExpectations);
+  const aliases = new Set();
+  const identities = new Set();
+  for (const expectation of parsedExpectations) {
+    if (!ALIAS.test(expectation.alias)) fail(`invalid artifact alias ${expectation.alias}`);
+    if (aliases.has(expectation.alias)) fail(`duplicate artifact alias ${expectation.alias}`);
+    aliases.add(expectation.alias);
+    const identity =
+      `${expectation.packageName}:${expectation.kind}:${expectation.targetName}`;
+    if (identities.has(identity)) fail(`duplicate artifact expectation ${identity}`);
+    identities.add(identity);
+  }
+
+  const resolvedTargetDir = path.resolve(targetDir);
+  const resolvedWorkspaceRoot = fs.realpathSync(workspaceRoot);
+  const profileRoot = path.join(resolvedTargetDir, rustTarget, "release");
+  if (!fs.statSync(profileRoot).isDirectory()) {
+    fail("exact target release directory is missing");
+  }
+  const messages = parseCargoMessages(jsonLines);
+  const artifacts = {};
+  for (const expectation of parsedExpectations) {
+    const matches = matchingArtifacts(messages, expectation, resolvedWorkspaceRoot);
+    if (matches.length !== 1) {
+      fail(
+        `expected exactly one Cargo artifact for ${expectation.alias}, found ${matches.length}`,
+      );
+    }
+    const [message] = matches;
+    exactKeys(
+      message.target,
+      [
+        "kind",
+        "crate_types",
+        "name",
+        "src_path",
+        "edition",
+        "doc",
+        "doctest",
+        "test",
+      ],
+      `Cargo artifact target ${expectation.targetName}`,
+    );
+    if (
+      !Array.isArray(message.target.crate_types)
+      || !message.target.crate_types.includes("bin")
+      || message.target.test !== (expectation.kind === "test")
+    ) {
+      fail(`Cargo artifact target contract changed for ${expectation.alias}`);
+    }
+    const profile = releaseProfile(message, expectation.kind);
+    artifacts[expectation.alias] = {
+      package: expectation.packageName,
+      target: expectation.targetName,
+      kind: expectation.kind,
+      profile,
+      ...validatedExecutable(message, {
+        kind: expectation.kind,
+        profileRoot,
+        targetName: expectation.targetName,
+      }),
+    };
+  }
+
+  return {
+    schema: SCHEMA,
+    source: {
+      commit: exactSha,
+      tree: exactTree,
+    },
+    build: {
+      rust_target: rustTarget,
+      profile: "release",
+      target_dir: resolvedTargetDir,
+      workspace_root: resolvedWorkspaceRoot,
+    },
+    artifacts,
+  };
+}
+
+function validateManifestShape(manifest) {
+  exactKeys(manifest, ["schema", "source", "build", "artifacts"], "artifact manifest");
+  if (manifest.schema !== SCHEMA) fail("artifact manifest schema changed");
+  exactKeys(manifest.source, ["commit", "tree"], "artifact manifest source");
+  exactKeys(
+    manifest.build,
+    ["rust_target", "profile", "target_dir", "workspace_root"],
+    "artifact manifest build",
+  );
+  if (manifest.build.profile !== "release") fail("artifact manifest profile is not release");
+  requireWindowsTarget(manifest.build.rust_target);
+  requireSha(manifest.source.commit, "manifest source SHA");
+  requireSha(manifest.source.tree, "manifest source tree");
+  if (
+    manifest.artifacts === null
+    || typeof manifest.artifacts !== "object"
+    || Array.isArray(manifest.artifacts)
+    || Object.keys(manifest.artifacts).length === 0
+  ) {
+    fail("artifact manifest must contain artifacts");
+  }
+  const aliases = Object.keys(manifest.artifacts).sort();
+  const required = [...REQUIRED_ALIASES].sort();
+  const withDriver = [...REQUIRED_ALIASES, "qualification_driver"].sort();
+  if (
+    JSON.stringify(aliases) !== JSON.stringify(required)
+    && JSON.stringify(aliases) !== JSON.stringify(withDriver)
+  ) {
+    fail("artifact manifest release graph changed");
+  }
+}
+
+export function verifyCargoArtifactManifest({
+  exactSha,
+  exactTree,
+  manifest,
+  rustTarget,
+  workspaceRoot,
+}) {
+  validateManifestShape(manifest);
+  if (
+    manifest.source.commit !== exactSha
+    || manifest.source.tree !== exactTree
+  ) {
+    fail("artifact manifest source identity does not match the exact checkout");
+  }
+  if (manifest.build.rust_target !== rustTarget) {
+    fail("artifact manifest Rust target does not match");
+  }
+  if (
+    fs.realpathSync(manifest.build.workspace_root) !== fs.realpathSync(workspaceRoot)
+  ) {
+    fail("artifact manifest workspace root does not match");
+  }
+
+  const profileRoot = path.join(
+    path.resolve(manifest.build.target_dir),
+    rustTarget,
+    "release",
+  );
+  const realProfileRoot = fs.realpathSync(profileRoot);
+  const verified = {};
+  for (const [alias, artifact] of Object.entries(manifest.artifacts)) {
+    if (!ALIAS.test(alias)) fail(`invalid artifact manifest alias ${alias}`);
+    exactKeys(
+      artifact,
+      [
+        "package",
+        "target",
+        "kind",
+        "profile",
+        "path",
+        "relative_path",
+        "bytes",
+        "sha256",
+      ],
+      `artifact manifest entry ${alias}`,
+    );
+    if (
+      typeof artifact.package !== "string"
+      || artifact.package === ""
+      || typeof artifact.target !== "string"
+      || artifact.target === ""
+      || !["bin", "test"].includes(artifact.kind)
+      || !Number.isSafeInteger(artifact.bytes)
+      || artifact.bytes < 0
+      || !SHA256.test(artifact.sha256)
+      || typeof artifact.relative_path !== "string"
+      || artifact.relative_path === ""
+    ) {
+      fail(`artifact manifest entry ${alias} values changed`);
+    }
+    const contract = ARTIFACT_CONTRACT[alias];
+    if (
+      !contract
+      || artifact.package !== contract.packageName
+      || artifact.kind !== contract.kind
+      || artifact.target !== contract.targetName
+    ) {
+      fail(`artifact manifest contract changed for ${alias}`);
+    }
+    releaseProfile({ profile: artifact.profile }, artifact.kind);
+    const executable = path.resolve(artifact.path);
+    const metadata = fs.lstatSync(executable);
+    if (
+      !metadata.isFile()
+      || metadata.isSymbolicLink()
+      || metadata.nlink !== 1
+    ) {
+      fail(
+        `artifact ${alias} is no longer a regular, non-symlink, singly linked file`,
+      );
+    }
+    const realExecutable = fs.realpathSync(executable);
+    if (!isWithin(realProfileRoot, realExecutable)) {
+      fail(`artifact ${alias} escaped the exact target release directory`);
+    }
+    const relative = path.relative(realProfileRoot, realExecutable)
+      .split(path.sep)
+      .join("/");
+    if (
+      (artifact.kind === "test" && path.posix.dirname(relative) !== "deps")
+      || (artifact.kind === "bin" && path.posix.dirname(relative) !== ".")
+      || path.extname(executable).toLowerCase() !== ".exe"
+    ) {
+      fail(`artifact ${alias} no longer has its expected release-graph path`);
+    }
+    if (
+      relative !== artifact.relative_path
+      || metadata.size !== artifact.bytes
+      || hashFile(executable) !== artifact.sha256
+    ) {
+      fail(`artifact ${alias} no longer matches its authenticated build output`);
+    }
+    verified[alias] = executable;
+  }
+  return verified;
+}
+
+function parseArguments(argv) {
+  const [command, ...rest] = argv;
+  const values = new Map();
+  for (let index = 0; index < rest.length; index += 1) {
+    const flag = rest[index];
+    if (!flag?.startsWith("--")) fail(`unexpected argument ${flag ?? "<end>"}`);
+    const value = rest[index + 1];
+    if (value === undefined || value.startsWith("--")) fail(`missing value for ${flag}`);
+    if (!values.has(flag)) values.set(flag, []);
+    values.get(flag).push(value);
+    index += 1;
+  }
+  return { command, values };
+}
+
+function one(values, flag, { required = true } = {}) {
+  const entries = values.get(flag) ?? [];
+  if (entries.length > 1) fail(`${flag} may be supplied only once`);
+  if (entries.length === 0) {
+    if (required) fail(`missing ${flag}`);
+    return "";
+  }
+  return entries[0];
+}
+
+function writeManifest(file, manifest) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(manifest, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+}
+
+function appendOutputs(file, manifestFile, artifacts) {
+  const rows = [`manifest=${path.resolve(manifestFile)}`];
+  for (const [alias, artifact] of Object.entries(artifacts)) {
+    rows.push(`${alias}=${artifact.path ?? artifact}`);
+  }
+  fs.appendFileSync(file, `${rows.join("\n")}\n`, "utf8");
+}
+
+function runSelect(values) {
+  const expectations = values.get("--expect") ?? [];
+  const input = one(values, "--input");
+  const output = one(values, "--out");
+  const manifest = buildCargoArtifactManifest({
+    exactSha: one(values, "--source-sha"),
+    exactTree: one(values, "--source-tree"),
+    expectations,
+    jsonLines: fs.readFileSync(input, "utf8"),
+    rustTarget: one(values, "--rust-target"),
+    targetDir: one(values, "--target-dir"),
+    workspaceRoot: one(values, "--workspace-root"),
+  });
+  writeManifest(output, manifest);
+  const githubOutput = one(values, "--github-output", { required: false });
+  if (githubOutput) appendOutputs(githubOutput, output, manifest.artifacts);
+}
+
+function runVerify(values) {
+  const manifestFile = one(values, "--manifest");
+  const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+  const artifacts = verifyCargoArtifactManifest({
+    exactSha: one(values, "--source-sha"),
+    exactTree: one(values, "--source-tree"),
+    manifest,
+    rustTarget: one(values, "--rust-target"),
+    workspaceRoot: one(values, "--workspace-root"),
+  });
+  const githubOutput = one(values, "--github-output", { required: false });
+  if (githubOutput) appendOutputs(githubOutput, manifestFile, artifacts);
+}
+
+function main(argv) {
+  const { command, values } = parseArguments(argv);
+  if (command === "select") {
+    runSelect(values);
+  } else if (command === "verify") {
+    runVerify(values);
+  } else {
+    fail(`unsupported command ${command ?? "<missing>"}`);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/.github/scripts/cargo-build-artifacts.test.mjs
+++ b/.github/scripts/cargo-build-artifacts.test.mjs
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildCargoArtifactManifest,
+  verifyCargoArtifactManifest,
+} from "./cargo-build-artifacts.mjs";
+
+const SOURCE_SHA = "a".repeat(40);
+const SOURCE_TREE = "b".repeat(40);
+const RUST_TARGET = "x86_64-pc-windows-msvc";
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-cargo-artifacts-"));
+  const targetDir = path.join(root, "target");
+  const releaseDir = path.join(targetDir, RUST_TARGET, "release");
+  const depsDir = path.join(releaseDir, "deps");
+  fs.mkdirSync(depsDir, { recursive: true });
+
+  const artifacts = [
+    {
+      alias: "cli",
+      packageName: "codestory-cli",
+      kind: "bin",
+      targetName: "codestory-cli",
+      executable: path.join(releaseDir, "codestory-cli.exe"),
+      contents: "cli",
+    },
+    {
+      alias: "runtime",
+      packageName: "codestory-cli",
+      kind: "bin",
+      targetName: "codestory-cli-runtime",
+      executable: path.join(releaseDir, "codestory-cli-runtime.exe"),
+      contents: "runtime",
+    },
+    {
+      alias: "native_staging",
+      packageName: "codestory-llama-sys",
+      kind: "test",
+      targetName: "native_staging",
+      executable: path.join(depsDir, "native_staging-123456.exe"),
+      contents: "native staging",
+    },
+    {
+      alias: "windows_path_identity",
+      packageName: "codestory-workspace",
+      kind: "test",
+      targetName: "windows_path_identity",
+      executable: path.join(depsDir, "windows_path_identity-123456.exe"),
+      contents: "path identity",
+    },
+  ];
+  for (const artifact of artifacts) {
+    fs.writeFileSync(artifact.executable, artifact.contents);
+    const manifest = path.join(root, "crates", artifact.packageName, "Cargo.toml");
+    if (!fs.existsSync(manifest)) {
+      fs.mkdirSync(path.dirname(manifest), { recursive: true });
+      fs.writeFileSync(
+        manifest,
+        `[package]\nname = "${artifact.packageName}"\nversion = "0.16.3"\n`,
+      );
+    }
+    artifact.manifest = manifest;
+  }
+
+  const messages = artifacts.map((artifact) => ({
+    reason: "compiler-artifact",
+    package_id: `path+file://${path.dirname(artifact.manifest)}#0.16.3`,
+    manifest_path: artifact.manifest,
+    target: {
+      kind: [artifact.kind],
+      crate_types: ["bin"],
+      name: artifact.targetName,
+      src_path: `/checkout/crates/${artifact.packageName}/target.rs`,
+      edition: "2024",
+      doc: false,
+      doctest: false,
+      test: artifact.kind === "test",
+    },
+    profile: {
+      opt_level: "3",
+      debuginfo: 0,
+      debug_assertions: false,
+      overflow_checks: false,
+      test: artifact.kind === "test",
+    },
+    features: [],
+    filenames: [artifact.executable],
+    executable: artifact.executable,
+    fresh: false,
+  }));
+  messages.unshift({
+    reason: "compiler-artifact",
+    package_id: "registry+https://example.invalid/index#serde@1.0.0",
+    target: {
+      kind: ["lib"],
+      crate_types: ["lib"],
+      name: "serde",
+      src_path: "/registry/serde/src/lib.rs",
+      edition: "2021",
+      doc: true,
+      doctest: true,
+      test: true,
+    },
+    profile: {
+      opt_level: "3",
+      debuginfo: 0,
+      debug_assertions: false,
+      overflow_checks: false,
+      test: false,
+    },
+    filenames: [path.join(releaseDir, "deps", "libserde.rlib")],
+    executable: null,
+  });
+
+  return {
+    artifacts,
+    expectations: artifacts.map(
+      ({ alias, packageName, kind, targetName }) =>
+        `${alias}=${packageName}:${kind}:${targetName}`,
+    ),
+    jsonLines: messages.map((message) => JSON.stringify(message)).join("\n"),
+    messages,
+    releaseDir,
+    root,
+    targetDir,
+  };
+}
+
+function build(input = fixture()) {
+  const manifest = buildCargoArtifactManifest({
+    exactSha: SOURCE_SHA,
+    exactTree: SOURCE_TREE,
+    expectations: input.expectations,
+    jsonLines: input.jsonLines,
+    rustTarget: RUST_TARGET,
+    targetDir: input.targetDir,
+    workspaceRoot: input.root,
+  });
+  return { input, manifest };
+}
+
+test("binds each requested executable to the exact Windows release graph", () => {
+  const { input, manifest } = build();
+
+  assert.equal(manifest.schema, "codestory.cargo-build-artifacts/v1");
+  assert.deepEqual(manifest.source, {
+    commit: SOURCE_SHA,
+    tree: SOURCE_TREE,
+  });
+  assert.equal(manifest.build.profile, "release");
+  assert.equal(manifest.build.rust_target, RUST_TARGET);
+  for (const artifact of input.artifacts) {
+    const selected = manifest.artifacts[artifact.alias];
+    assert.equal(selected.path, path.resolve(artifact.executable));
+    assert.equal(selected.bytes, Buffer.byteLength(artifact.contents));
+    assert.equal(selected.sha256, sha256(artifact.contents));
+    assert.equal(selected.profile.test, artifact.kind === "test");
+  }
+
+  assert.deepEqual(
+    verifyCargoArtifactManifest({
+      exactSha: SOURCE_SHA,
+      exactTree: SOURCE_TREE,
+      manifest,
+      rustTarget: RUST_TARGET,
+      workspaceRoot: input.root,
+    }),
+    Object.fromEntries(
+      input.artifacts.map((artifact) => [
+        artifact.alias,
+        path.resolve(artifact.executable),
+      ]),
+    ),
+  );
+});
+
+test("rejects duplicate compiler artifacts instead of choosing one by path order", () => {
+  const input = fixture();
+  input.jsonLines = [...input.messages, input.messages[1]]
+    .map((message) => JSON.stringify(message))
+    .join("\n");
+
+  assert.throws(
+    () => build(input),
+    /expected exactly one Cargo artifact for cli, found 2/u,
+  );
+});
+
+test("rejects debug-profile output even when the target name matches", () => {
+  const input = fixture();
+  input.messages[1].profile.debug_assertions = true;
+  input.messages[1].profile.opt_level = "0";
+  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+
+  assert.throws(() => build(input), /not built with the release profile/u);
+});
+
+test("rejects an executable emitted outside the exact target release directory", () => {
+  const input = fixture();
+  const stale = path.join(input.root, "debug", "codestory-cli.exe");
+  fs.mkdirSync(path.dirname(stale), { recursive: true });
+  fs.writeFileSync(stale, "stale debug cli");
+  input.messages[1].executable = stale;
+  input.messages[1].filenames = [stale];
+  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+
+  assert.throws(
+    () => build(input),
+    /escaped the exact target release directory/u,
+  );
+});
+
+test("rejects a release-path executable hardlinked to another build graph", () => {
+  const input = fixture();
+  const releaseCli = input.artifacts[0].executable;
+  const debugCli = path.join(input.targetDir, RUST_TARGET, "debug", "codestory-cli.exe");
+  fs.mkdirSync(path.dirname(debugCli), { recursive: true });
+  fs.writeFileSync(debugCli, input.artifacts[0].contents);
+  fs.unlinkSync(releaseCli);
+  fs.linkSync(debugCli, releaseCli);
+
+  assert.throws(
+    () => build(input),
+    /regular, non-symlink, singly linked file/u,
+  );
+});
+
+test("rejects a mixed test and production profile", () => {
+  const input = fixture();
+  const native = input.messages.find(
+    (message) => message.target?.name === "native_staging",
+  );
+  native.profile.test = false;
+  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+
+  assert.throws(
+    () => build(input),
+    /profile\.test did not match test/u,
+  );
+});
+
+test("rejects bytes changed after Cargo emitted the authenticated executable", () => {
+  const { input, manifest } = build();
+  fs.appendFileSync(input.artifacts[0].executable, "mutated");
+
+  assert.throws(
+    () =>
+      verifyCargoArtifactManifest({
+        exactSha: SOURCE_SHA,
+        exactTree: SOURCE_TREE,
+        manifest,
+        rustTarget: RUST_TARGET,
+        workspaceRoot: input.root,
+      }),
+    /no longer matches its authenticated build output/u,
+  );
+});
+
+test("rejects a hardlink added after Cargo artifact selection", () => {
+  const { input, manifest } = build();
+  const alias = path.join(input.root, "cross-graph-cli.exe");
+  fs.linkSync(input.artifacts[0].executable, alias);
+
+  assert.throws(
+    () =>
+      verifyCargoArtifactManifest({
+        exactSha: SOURCE_SHA,
+        exactTree: SOURCE_TREE,
+        manifest,
+        rustTarget: RUST_TARGET,
+        workspaceRoot: input.root,
+      }),
+    /regular, non-symlink, singly linked file/u,
+  );
+});
+
+test("rejects a manifest from another exact source SHA", () => {
+  const { input, manifest } = build();
+
+  assert.throws(
+    () =>
+      verifyCargoArtifactManifest({
+        exactSha: "c".repeat(40),
+        exactTree: SOURCE_TREE,
+        manifest,
+        rustTarget: RUST_TARGET,
+        workspaceRoot: input.root,
+      }),
+    /source identity does not match the exact checkout/u,
+  );
+});
+
+test("rejects a manifest that drops one required release-graph artifact", () => {
+  const { input, manifest } = build();
+  delete manifest.artifacts.cli;
+
+  assert.throws(
+    () =>
+      verifyCargoArtifactManifest({
+        exactSha: SOURCE_SHA,
+        exactTree: SOURCE_TREE,
+        manifest,
+        rustTarget: RUST_TARGET,
+        workspaceRoot: input.root,
+      }),
+    /artifact manifest release graph changed/u,
+  );
+});
+
+test("rejects malformed Cargo JSON rather than silently dropping an artifact line", () => {
+  const input = fixture();
+  input.jsonLines = `${input.jsonLines}\nnot-json`;
+
+  assert.throws(
+    () => build(input),
+    /Cargo JSON output line .* is not valid JSON/u,
+  );
+});

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -559,8 +559,8 @@ function expectedQualificationDriverContract() {
   return {
     producer_workflow: "packaged-platform-proof.yml",
     producer_job: "build",
-    artifact_name_template: "codestory-cli-{asset_target}",
-    artifact_directory_template: "qualification-driver/{asset_target}",
+    artifact_name_template: "codestory-qualification-driver-{asset_target}",
+    artifact_directory_template: ".",
     identity_file: "qualification-driver-identity.json",
     identity_schema_version: 1,
     identity_fields: qualificationDriverIdentityFields,
@@ -664,7 +664,7 @@ const packagedPlatformCloseoutDigest =
 // parsed executable structure so an unreviewed earlier step cannot replace an
 // owner binary while leaving the locally digested finalizer unchanged.
 const packagedPlatformWorkflowDigest =
-  "d96f36e08888ba2806103829ddf737829d66efee0374138ae9634ed6d71bd355";
+  "ae53e5a2ab7cc72bfba4eec4264a682dabb75b45913e3e0b5341d2ca5c08c776";
 // The frozen-candidate coordinator and protected GPU workflows are small
 // release-control programs, not loose collections of independently safe
 // fragments. Pin their complete parsed structure so a required check cannot be
@@ -673,11 +673,11 @@ const packagedPlatformWorkflowDigest =
 const packagedPlatformCoordinatorWorkflowDigest =
   "8efd162e5e5c42e1cbeb0e40378f631ce358feb9404e90e27e02aa0b382d481e";
 const macosMetalWorkflowDigest =
-  "7ff48fa410330a96f3c6da5f3efbb6131d4304fee837bd69c97c8e88e553ea0c";
+  "4f9630adb30d24a358ba8b423c4faadfa347efe678b7ec8d48a72cb059ffe94a";
 const windowsVulkanWorkflowDigest =
-  "f4f6031cb9595a3d1623567ff5b7fcdca5ae34de0a392fbb801138ddb750aa14";
+  "c94a218f5599a727c608259206a68acd54726f38e50471148cb4cf12e1f859c0";
 const linuxVulkanWorkflowDigest =
-  "cd3b2b719dafea2645079503ff4b58da66c085f3522e3921f77a76360554de9b";
+  "65449c5b8040d9338cdb12bb5d4271020ee94f1be30dd821f0b56c7bf5c797ea";
 // Linux owns its compiler server inside Docker, while macOS and Windows own one
 // in the host shell. Pin both executable programs so a swallowed stop or a
 // dead-code copy cannot satisfy the ownership fragments below.
@@ -3215,14 +3215,12 @@ function validatePackagedProof(workflows, violations, graph) {
     "--save-result",
     "--path \"$SCCACHE_DIR\"",
   ]);
-  requireStepRun(violations, file, job, "Compile immutable native staging regression on Windows", [
-    "cargo test --release --locked",
-    "--test native_staging",
-    "--no-run",
-  ]);
-  requireStepRun(violations, file, job, "Compile native workspace path regression on Windows", [
-    "cargo test --locked -p codestory-workspace repository_identity --no-run",
-  ]);
+  add(
+    violations,
+    namedStep(job, "Compile immutable native staging regression on Windows") === undefined
+      && namedStep(job, "Compile native workspace path regression on Windows") === undefined,
+    `${file} Windows package proof must not compile either regression in a second Cargo invocation`,
+  );
   const packageBuild = namedStep(job, "Build package and qualification driver");
   const linuxBuild = namedStep(job, "Build Linux x64 at the glibc 2.31 baseline");
   const expectedSccacheIdentityEnv = {
@@ -3355,23 +3353,69 @@ function validatePackagedProof(workflows, violations, graph) {
       && hasExactKeys(object(packageBuild?.env), [
         "INCLUDE_QUALIFICATION_DRIVER",
         "RELEASE_RUST_TARGET",
+        "SOURCE_SHA",
+        "SOURCE_TREE",
       ])
       && object(packageBuild?.env).INCLUDE_QUALIFICATION_DRIVER
         === "${{ inputs.include_qualification_driver }}"
       && object(packageBuild?.env).RELEASE_RUST_TARGET
-        === "${{ matrix.rust_target }}",
+        === "${{ matrix.rust_target }}"
+      && object(packageBuild?.env).SOURCE_SHA
+        === "${{ steps.source-identity.outputs.sha }}"
+      && object(packageBuild?.env).SOURCE_TREE
+        === "${{ steps.source-identity.outputs.tree }}",
     `${file} native package build must not override the selected generator and must bind the reviewed target and qualification workload`,
   );
   requireStepRun(violations, file, job, "Smoke codestory-cli on Windows", [
-    "$env:CARGO_TARGET_DIR",
-    "${{ matrix.rust_target }}/release/codestory-cli",
+    '$bin = "$env:WINDOWS_CLI"',
+    "throw \"Windows CLI version smoke failed",
+    "throw \"Windows CLI help smoke failed",
   ]);
+  const windowsCliSmoke = namedStep(job, "Smoke codestory-cli on Windows");
+  add(
+    violations,
+    windowsCliSmoke?.if === "runner.os == 'Windows'"
+      && windowsCliSmoke?.shell === "pwsh"
+      && hasExactKeys(object(windowsCliSmoke?.env), ["WINDOWS_CLI"])
+      && object(windowsCliSmoke?.env).WINDOWS_CLI
+        === "${{ steps.package-build.outputs.cli }}"
+      && windowsCliSmoke?.["continue-on-error"] === undefined,
+    `${file} Windows CLI smoke must execute only the exact release binary selected from Cargo output`,
+  );
   requireStepRun(violations, file, job, "Package release asset on Windows", [
-    "$env:CARGO_TARGET_DIR",
-    "${{ matrix.rust_target }}/release/codestory-cli",
+    "cargo-build-artifacts.mjs verify",
+    '--manifest "$env:ARTIFACT_MANIFEST"',
+    '--source-sha "$env:SOURCE_SHA"',
+    '--source-tree "$env:SOURCE_TREE"',
+    '--rust-target "$env:RELEASE_RUST_TARGET"',
+    '$bin = "$env:WINDOWS_CLI"',
     "package-codestory-release.py",
     "--binary $bin",
   ]);
+  const windowsPackage = namedStep(job, "Package release asset on Windows");
+  add(
+    violations,
+    windowsPackage?.if === "runner.os == 'Windows'"
+      && windowsPackage?.shell === "pwsh"
+      && hasExactKeys(object(windowsPackage?.env), [
+        "ARTIFACT_MANIFEST",
+        "INPUT_VERSION",
+        "RELEASE_RUST_TARGET",
+        "SOURCE_SHA",
+        "SOURCE_TREE",
+        "WINDOWS_CLI",
+      ])
+      && object(windowsPackage?.env).ARTIFACT_MANIFEST
+        === "${{ steps.package-build.outputs.manifest }}"
+      && object(windowsPackage?.env).WINDOWS_CLI
+        === "${{ steps.package-build.outputs.cli }}"
+      && object(windowsPackage?.env).SOURCE_SHA
+        === "${{ steps.source-identity.outputs.sha }}"
+      && object(windowsPackage?.env).SOURCE_TREE
+        === "${{ steps.source-identity.outputs.tree }}"
+      && windowsPackage?.["continue-on-error"] === undefined,
+    `${file} Windows packaging must verify and package only the exact Cargo-selected release binary`,
+  );
   requireStepRun(violations, file, job, "Prepare checksum-pinned embedded model", [
     "node scripts/prepare-embedded-model.mjs",
   ]);
@@ -3379,17 +3423,28 @@ function validatePackagedProof(workflows, violations, graph) {
     "bash .github/scripts/install-linux-vulkan-build-deps.sh",
   ]);
   const windowsNativeStagingTest = namedStep(job, "Test immutable native staging on Windows");
+  const windowsPathIdentityTest = namedStep(job, "Prove native workspace path identity");
   add(
     violations,
-    windowsNativeStagingTest?.if === "runner.os == 'Windows'",
-    `${file} immutable native staging regression must run on Windows`,
+    windowsNativeStagingTest?.if === "runner.os == 'Windows'"
+      && windowsNativeStagingTest?.shell === "pwsh"
+      && object(windowsNativeStagingTest?.env).TEST_BINARY
+        === "${{ steps.package-build.outputs.native_staging }}"
+      && windowsNativeStagingTest?.["continue-on-error"] === undefined
+      && windowsPathIdentityTest?.if === "runner.os == 'Windows'"
+      && windowsPathIdentityTest?.shell === "pwsh"
+      && object(windowsPathIdentityTest?.env).TEST_BINARY
+        === "${{ steps.package-build.outputs.windows_path_identity }}"
+      && windowsPathIdentityTest?.["continue-on-error"] === undefined,
+    `${file} Windows regressions must execute the exact release test binaries emitted by the one Cargo graph`,
   );
   requireStepRun(violations, file, job, "Test immutable native staging on Windows", [
-    "cargo test --release --locked",
-    "-p codestory-llama-sys",
-    "--test native_staging",
-    '--target "${{ matrix.rust_target }}"',
-    "stages_complete_immutable_native_seeds",
+    '& "$env:TEST_BINARY" --nocapture',
+    "immutable native-staging release harness failed",
+  ]);
+  requireStepRun(violations, file, job, "Prove native workspace path identity", [
+    '& "$env:TEST_BINARY" --nocapture',
+    "Windows path-identity release harness failed",
   ]);
   requireStepRun(violations, file, job, "Build pinned Linux toolchain image", [
     ".github/docker/linux-glibc-build.Dockerfile",
@@ -3404,9 +3459,19 @@ function validatePackagedProof(workflows, violations, graph) {
     job,
     "Build Linux x64 at the glibc 2.31 baseline",
   ));
+  const cargoBuildStepNames = list(job?.steps)
+    .map(object)
+    .filter(step =>
+      shellInvocationsContaining(
+        shellLiteralNormalizedText(step.run),
+        "cargo build",
+      ).length > 0)
+    .map(step => step.name)
+    .sort();
   add(
     violations,
     shellInvocationsContaining(packageBuildRun, "cargo build").length === 1
+      && packageBuildRun.includes("cargo build --release --locked")
       && packageBuildRun.includes("-p codestory-cli")
       && packageBuildRun.includes("--bin codestory-cli")
       && packageBuildRun.includes("--bin codestory-cli-runtime")
@@ -3414,9 +3479,33 @@ function validatePackagedProof(workflows, violations, graph) {
       && packageBuildRun.includes("-p codestory-bench")
       && packageBuildRun.includes("--bin codestory_embedding_qualification")
       && packageBuildRun.includes("--target $RELEASE_RUST_TARGET")
+      && packageBuildRun.includes("if [ $RUNNER_OS = Windows ]")
+      && packageBuildRun.includes("-p codestory-llama-sys")
+      && packageBuildRun.includes("--test native_staging")
+      && packageBuildRun.includes("-p codestory-workspace")
+      && packageBuildRun.includes("--test windows_path_identity")
+      && packageBuildRun.includes("--message-format=json-render-diagnostics")
+      && packageBuildRun.includes("--timings")
+      && packageBuildRun.includes("cargo-build-artifacts.mjs select")
+      && packageBuildRun.includes("--source-sha $SOURCE_SHA")
+      && packageBuildRun.includes("--source-tree $SOURCE_TREE")
+      && occurrenceCount(packageBuildRun, "build_package_graph") === 3
       && !packageBuildRun.includes("codestory_embedding_constant_calibration")
+      && !packageBuildRun.includes("target/debug")
       && !/(?:^|\s)--bins(?:\s|$)/u.test(packageBuildRun),
-    `${file} host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation`,
+    `${file} host package must build the complete Windows release graph in one exact Cargo invocation`,
+  );
+  add(
+    violations,
+    JSON.stringify(cargoBuildStepNames) === JSON.stringify([
+      "Build Linux x64 at the glibc 2.31 baseline",
+      "Build package and qualification driver",
+    ])
+      && jobShellInvocationsContaining(job, "cargo test").length === 0
+      && jobShellInvocationsContaining(job, "cargo check").length === 0
+      && jobShellInvocationsContaining(job, "rustc ").length === 1
+      && jobShellInvocationsContaining(job, "rustc ")[0].includes("rustc -Vv"),
+    `${file} package proof must not compile outside the two mutually exclusive reviewed Cargo build steps`,
   );
   add(
     violations,
@@ -3709,22 +3798,78 @@ function validatePackagedProof(workflows, violations, graph) {
   );
   requireStepUses(violations, file, job, "Upload release asset", "actions/upload-artifact@v7.0.1");
   const releaseAssetUpload = namedStep(job, "Upload release asset");
+  const candidateRecordStep = namedStep(job, "Produce exact candidate archive record");
+  const candidateRecordUpload = namedStep(job, "Upload exact candidate archive record");
+  const qualificationDriverUpload = namedStep(job, "Upload separate qualification driver");
+  requireStepRun(violations, file, job, "Produce exact candidate archive record", [
+    "candidate-archive-store.mjs record",
+    "--output \"$record_dir/candidate-archive-record.json\"",
+    "--repository \"$GITHUB_REPOSITORY\"",
+    "--source-sha \"$SOURCE_SHA\"",
+    "--source-tree \"$SOURCE_TREE\"",
+    "--target \"${{ matrix.asset_target }}\"",
+    "--archive-name \"$archive_name\"",
+    "--archive-bytes",
+    "--archive-sha256",
+    "--companion \"archive_checksum|",
+    "--companion \"checksum_manifest|SHA256SUMS.txt|",
+  ]);
+  add(
+    violations,
+    candidateRecordStep?.shell === "bash"
+      && candidateRecordStep?.["continue-on-error"] === undefined
+      && hasExactKeys(object(candidateRecordStep?.env), [
+        "INPUT_VERSION",
+        "SOURCE_SHA",
+        "SOURCE_TREE",
+      ])
+      && object(candidateRecordStep?.env).INPUT_VERSION === "${{ inputs.version }}"
+      && object(candidateRecordStep?.env).SOURCE_SHA
+        === "${{ steps.source-identity.outputs.sha }}"
+      && object(candidateRecordStep?.env).SOURCE_TREE
+        === "${{ steps.source-identity.outputs.tree }}"
+      && stepIndex(job, "Produce exact candidate archive record")
+        > stepIndex(job, "Report fresh package identity")
+      && stepIndex(job, "Produce exact candidate archive record")
+        < stepIndex(job, "Upload release asset"),
+    `${file} package producer must derive one exact public candidate record from the authenticated package bytes`,
+  );
+  const expectedPublicPackagePath = [
+    "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}",
+    "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}.sha256",
+    "target/release-dist/SHA256SUMS.txt",
+    "",
+  ].join("\n");
   add(
     violations,
     object(releaseAssetUpload?.with).name
         === "codestory-cli-${{ matrix.asset_target }}"
-      && String(object(releaseAssetUpload?.with).path ?? "")
-        === [
-          "target/release-dist/*.tar.gz",
-          "target/release-dist/*.zip",
-          "target/release-dist/*.sha256",
-          "target/release-dist/SHA256SUMS.txt",
-          "target/release-dist/qualification-driver/${{ matrix.asset_target }}",
-          "",
-        ].join("\n")
+      && String(object(releaseAssetUpload?.with).path ?? "") === expectedPublicPackagePath
       && object(releaseAssetUpload?.with)["if-no-files-found"] === "error"
+      && object(releaseAssetUpload?.with)["retention-days"] === 30
       && object(releaseAssetUpload?.with).overwrite === true,
-    `${file} existing package artifact must retain the private driver directory without changing its public archive`,
+    `${file} public package artifact must contain exactly the archive and its two candidate-local checksum files`,
+  );
+  add(
+    violations,
+    candidateRecordUpload?.uses === "actions/upload-artifact@v7.0.1"
+      && object(candidateRecordUpload?.with).name
+        === "codestory-candidate-archive-record-${{ matrix.asset_target }}"
+      && object(candidateRecordUpload?.with).path
+        === "target/candidate-archive-record/${{ matrix.asset_target }}/candidate-archive-record.json"
+      && object(candidateRecordUpload?.with)["if-no-files-found"] === "error"
+      && object(candidateRecordUpload?.with)["retention-days"] === 30
+      && object(candidateRecordUpload?.with).overwrite === true
+      && qualificationDriverUpload?.uses === "actions/upload-artifact@v7.0.1"
+      && qualificationDriverUpload?.if === "inputs.include_qualification_driver"
+      && object(qualificationDriverUpload?.with).name
+        === "codestory-qualification-driver-${{ matrix.asset_target }}"
+      && object(qualificationDriverUpload?.with).path
+        === "target/release-dist/qualification-driver/${{ matrix.asset_target }}"
+      && object(qualificationDriverUpload?.with)["if-no-files-found"] === "error"
+      && object(qualificationDriverUpload?.with)["retention-days"] === 30
+      && object(qualificationDriverUpload?.with).overwrite === true,
+    `${file} candidate record and private qualification driver must be separate exact stable artifacts`,
   );
   requireStepUses(violations, file, job, "Upload macOS notarization proof", "actions/upload-artifact@v7.0.1");
   requireStepRun(violations, file, job, "Emit authenticated package release cell", [
@@ -3934,6 +4079,247 @@ function validatePostPublish(workflows, violations, graph) {
     violations,
     object(workflow.env).CODEX_CLI_VERSION === "0.144.5",
     `${file} must pin the Codex CLI used for marketplace installation`,
+  );
+  const publishedAuthentication = namedStep(
+    job,
+    "Authenticate published candidate assets",
+  );
+  add(
+    violations,
+    publishedAuthentication?.id === "published-assets"
+      && publishedAuthentication?.shell === "bash"
+      && publishedAuthentication?.if === undefined
+      && publishedAuthentication?.["continue-on-error"] === undefined
+      && hasExactKeys(object(publishedAuthentication?.env), [
+        "ASSET_TARGET",
+        "EXTENSION",
+        "GH_TOKEN",
+        "PUBLISHED_COMMIT",
+        "TAG",
+        "VERSION",
+      ])
+      && object(publishedAuthentication?.env).GH_TOKEN === "${{ github.token }}"
+      && object(publishedAuthentication?.env).TAG === "${{ steps.release.outputs.tag }}"
+      && object(publishedAuthentication?.env).VERSION
+        === "${{ steps.release.outputs.version }}"
+      && object(publishedAuthentication?.env).ASSET_TARGET
+        === "${{ matrix.asset_target }}"
+      && object(publishedAuthentication?.env).EXTENSION
+        === "${{ matrix.extension }}"
+      && object(publishedAuthentication?.env).PUBLISHED_COMMIT
+        === "${{ steps.published.outputs.commit }}",
+    `${file} published candidate authentication must bind the release tag, commit, target, and exact asset metadata`,
+  );
+  requireStepRun(violations, file, job, "Authenticate published candidate assets", [
+    'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG"',
+    'test "$(jq -r .tag_name <<<"$release")" = "$TAG"',
+    'test "$(jq -r .draft <<<"$release")" = false',
+    "expected one published release asset",
+    'archive_asset="$(select_asset "$asset")"',
+    'checksum_asset="$(select_asset "$checksum")"',
+    "manifest_asset=\"$(select_asset SHA256SUMS.txt)\"",
+    '[[ "$(jq -r .id <<<"$value")" =~ ^[0-9]+$ ]]',
+    '[[ "$(jq -r .size <<<"$value")" =~ ^[0-9]+$ ]]',
+    '[[ "$(jq -r .digest <<<"$value")" =~ ^sha256:[0-9a-f]{64}$ ]]',
+    'validate_asset "$archive_asset"',
+    'validate_asset "$checksum_asset"',
+    'validate_asset "$manifest_asset"',
+    "candidate-archive-store.mjs record",
+    '--source-sha "$PUBLISHED_COMMIT"',
+    "--source-tree \"$(git rev-parse 'HEAD^{tree}')\"",
+    '--target "$ASSET_TARGET"',
+    "--archive-bytes",
+    "--archive-sha256",
+    '--companion "archive_checksum|',
+    '--companion "checksum_manifest|SHA256SUMS.txt|',
+    "archive-id=",
+    "archive-bytes=",
+    "archive-sha256=",
+    "checksum-id=",
+    "checksum-bytes=",
+    "checksum-sha256=",
+    "manifest-id=",
+    "manifest-bytes=",
+    "manifest-sha256=",
+  ]);
+  const publishedRestore = namedStep(
+    job,
+    "Restore published candidate archive from protected host",
+  );
+  add(
+    violations,
+    publishedRestore?.id === "candidate-cache"
+      && publishedRestore?.shell === "bash"
+      && publishedRestore?.if === undefined
+      && publishedRestore?.["continue-on-error"] === undefined
+      && hasExactKeys(object(publishedRestore?.env), [
+        "ASSET_TARGET",
+        "PUBLISHED_COMMIT",
+      ])
+      && object(publishedRestore?.env).ASSET_TARGET
+        === "${{ matrix.asset_target }}"
+      && object(publishedRestore?.env).PUBLISHED_COMMIT
+        === "${{ steps.published.outputs.commit }}",
+    `${file} published candidate cache lookup must be unconditional and exact-source bound`,
+  );
+  requireStepRun(
+    violations,
+    file,
+    job,
+    "Restore published candidate archive from protected host",
+    [
+      "--arg repository \"$GITHUB_REPOSITORY\"",
+      '--arg source_sha "$PUBLISHED_COMMIT"',
+      "--arg source_tree \"$(git rev-parse 'HEAD^{tree}')\"",
+      '--arg target "$ASSET_TARGET"',
+      ".repository == $repository",
+      ".source.commit == $source_sha",
+      ".source.tree == $source_tree",
+      ".target == $target",
+      "$RUNNER_TOOL_CACHE/codestory/candidate-archives",
+      "candidate-archive-store.mjs restore",
+      "--record \"$record\"",
+      "--output-dir target/post-publish-release-assets",
+      'echo "hit=$hit" >> "$GITHUB_OUTPUT"',
+    ],
+  );
+  const publishedMiss = namedStep(
+    job,
+    "Download, verify, and admit published candidate on miss",
+  );
+  add(
+    violations,
+    publishedMiss?.if === "steps.candidate-cache.outputs.hit != 'true'"
+      && publishedMiss?.shell === "bash"
+      && publishedMiss?.["continue-on-error"] === undefined
+      && hasExactKeys(object(publishedMiss?.env), [
+        "ARCHIVE_BYTES",
+        "ARCHIVE_ID",
+        "ARCHIVE_NAME",
+        "ARCHIVE_SHA256",
+        "ASSET_TARGET",
+        "CHECKSUM_BYTES",
+        "CHECKSUM_ID",
+        "CHECKSUM_SHA256",
+        "GH_TOKEN",
+      ])
+      && object(publishedMiss?.env).GH_TOKEN === "${{ github.token }}"
+      && object(publishedMiss?.env).ASSET_TARGET === "${{ matrix.asset_target }}"
+      && object(publishedMiss?.env).ARCHIVE_NAME
+        === "${{ steps.published-assets.outputs.archive-name }}"
+      && object(publishedMiss?.env).ARCHIVE_ID
+        === "${{ steps.published-assets.outputs.archive-id }}"
+      && object(publishedMiss?.env).ARCHIVE_BYTES
+        === "${{ steps.published-assets.outputs.archive-bytes }}"
+      && object(publishedMiss?.env).ARCHIVE_SHA256
+        === "${{ steps.published-assets.outputs.archive-sha256 }}"
+      && object(publishedMiss?.env).CHECKSUM_ID
+        === "${{ steps.published-assets.outputs.checksum-id }}"
+      && object(publishedMiss?.env).CHECKSUM_BYTES
+        === "${{ steps.published-assets.outputs.checksum-bytes }}"
+      && object(publishedMiss?.env).CHECKSUM_SHA256
+        === "${{ steps.published-assets.outputs.checksum-sha256 }}",
+    `${file} published archive transfer must run only on an exact cache miss`,
+  );
+  requireStepRun(
+    violations,
+    file,
+    job,
+    "Download, verify, and admit published candidate on miss",
+    [
+      "releases/assets/$id",
+      "--continue-at -",
+      "--max-time 120",
+      'test "${actual%% *}" = "$expected_bytes"',
+      'test "${actual#* }" = "$expected_sha256"',
+      'download_asset "$ARCHIVE_ID" "$ARCHIVE_NAME"',
+      'download_asset "$CHECKSUM_ID" "$ARCHIVE_NAME.sha256"',
+      'cp "$stage/$ARCHIVE_NAME.sha256" "$stage/SHA256SUMS.txt"',
+      "candidate-archive-store.mjs admit",
+      "--store-root \"$RUNNER_TOOL_CACHE/codestory/candidate-archives\"",
+      "--output-dir target/post-publish-release-assets",
+    ],
+  );
+  const publishedManifest = namedStep(
+    job,
+    "Download authenticated published checksum manifest",
+  );
+  const publishedBinding = namedStep(
+    job,
+    "Bind materialized published asset paths",
+  );
+  add(
+    violations,
+    publishedManifest?.id === "published-checksum"
+      && publishedManifest?.if === undefined
+      && publishedManifest?.shell === "bash"
+      && publishedManifest?.["continue-on-error"] === undefined
+      && hasExactKeys(object(publishedManifest?.env), [
+        "GH_TOKEN",
+        "MANIFEST_BYTES",
+        "MANIFEST_ID",
+        "MANIFEST_SHA256",
+      ])
+      && object(publishedManifest?.env).GH_TOKEN === "${{ github.token }}"
+      && object(publishedManifest?.env).MANIFEST_ID
+        === "${{ steps.published-assets.outputs.manifest-id }}"
+      && object(publishedManifest?.env).MANIFEST_BYTES
+        === "${{ steps.published-assets.outputs.manifest-bytes }}"
+      && object(publishedManifest?.env).MANIFEST_SHA256
+        === "${{ steps.published-assets.outputs.manifest-sha256 }}"
+      && publishedBinding?.id === "asset"
+      && publishedBinding?.if === undefined
+      && publishedBinding?.shell === "bash"
+      && hasExactKeys(object(publishedBinding?.env), [
+        "ASSET_NAME",
+        "PUBLISHED_CHECKSUM",
+      ])
+      && object(publishedBinding?.env).ASSET_NAME
+        === "${{ steps.published-assets.outputs.archive-name }}"
+      && object(publishedBinding?.env).PUBLISHED_CHECKSUM
+        === "${{ steps.published-checksum.outputs.checksum }}",
+    `${file} global published checksum must stay independently authenticated and bind the materialized candidate`,
+  );
+  requireStepRun(
+    violations,
+    file,
+    job,
+    "Download authenticated published checksum manifest",
+    [
+      "releases/assets/$MANIFEST_ID",
+      'test "${actual%% *}" = "$MANIFEST_BYTES"',
+      'test "${actual#* }" = "$MANIFEST_SHA256"',
+      'echo "checksum=$checksum" >> "$GITHUB_OUTPUT"',
+    ],
+  );
+  requireStepRun(
+    violations,
+    file,
+    job,
+    "Bind materialized published asset paths",
+    [
+      'test -f "$dir/$ASSET_NAME"',
+      'echo "archive=$dir/$ASSET_NAME" >> "$GITHUB_OUTPUT"',
+      'echo "checksum=$PUBLISHED_CHECKSUM" >> "$GITHUB_OUTPUT"',
+    ],
+  );
+  add(
+    violations,
+    stepIndex(job, "Authenticate published candidate assets")
+      < stepIndex(job, "Restore published candidate archive from protected host")
+      && stepIndex(job, "Restore published candidate archive from protected host")
+        < stepIndex(job, "Download, verify, and admit published candidate on miss")
+      && stepIndex(job, "Download, verify, and admit published candidate on miss")
+        < stepIndex(job, "Download authenticated published checksum manifest")
+      && stepIndex(job, "Download authenticated published checksum manifest")
+        < stepIndex(job, "Bind materialized published asset paths")
+      && jobShellInvocationsContaining(job, "releases/assets/$id").length === 1
+      && jobShellInvocationsContaining(
+        job,
+        "releases/assets/$MANIFEST_ID",
+      ).length === 1
+      && !scalarStrings(workflow).some(value => value.includes("gh release download")),
+    `${file} must resolve the protected cache before any large release-asset transfer and never use an unconditional bulk download`,
   );
   const catalogDelivery = graph.workflow_policy.catalog_delivery;
   const resolveStepName = "Resolve the published plugin through the marketplace catalog";
@@ -4909,7 +5295,10 @@ function validateRemainingWorkflows(workflows, violations) {
       SERVER_BEHAVIOR_ONLY: "${{ inputs.server_behavior_only }}",
       CALIBRATION_MODE: "${{ inputs.calibration_mode }}",
     });
-    requireStepRun(violations, metalFile, job, "Prepare checksum-pinned embedded model", ["node scripts/prepare-embedded-model.mjs"]);
+    requireStepRun(violations, metalFile, job, "Prepare checksum-pinned embedded model", [
+      "node scripts/prepare-embedded-model.mjs",
+      '--cache-root "$RUNNER_TOOL_CACHE/codestory/model-material"',
+    ]);
     requireStepRun(violations, metalFile, job, "Capture host evidence", ["python3 --version", 'test "$macos_major" -ge 15']);
     const calibrationClock = namedStep(
       job,
@@ -5007,20 +5396,54 @@ function validateRemainingWorkflows(workflows, violations) {
         && normalizedNativeBuildRun.includes(">> $GITHUB_OUTPUT"),
       `${metalFile} calibration must build CLI and constant collector once through one shared Cargo invocation and package once`,
     );
-    const packagedArtifactDownload = namedStep(job, "Download packaged CLI artifact");
+    const candidateAuthentication = namedStep(
+      job,
+      "Authenticate exact candidate artifacts",
+    );
+    const recordDownload = namedStep(
+      job,
+      "Download authenticated candidate record",
+    );
+    const cacheRestore = namedStep(
+      job,
+      "Restore exact candidate archive from protected host",
+    );
+    const cacheMiss = namedStep(
+      job,
+      "Download, authenticate, and admit candidate archive on miss",
+    );
+    const driverDownload = namedStep(
+      job,
+      "Download separate authenticated qualification driver",
+    );
     add(
       violations,
-      packagedArtifactDownload?.if === "inputs.use_packaged_cli_artifact"
-        && packagedArtifactDownload?.shell === "bash"
-        && object(packagedArtifactDownload?.env).GH_TOKEN === "${{ github.token }}"
-        && object(packagedArtifactDownload?.env).ARTIFACT_NAME === "codestory-cli-macos-arm64"
-        && object(packagedArtifactDownload?.env).CANDIDATE_PRODUCER_WORKFLOW_PATH
+      candidateAuthentication?.id === "candidate-artifacts"
+        && candidateAuthentication?.if === "inputs.use_packaged_cli_artifact"
+        && candidateAuthentication?.shell === "bash"
+        && candidateAuthentication?.["continue-on-error"] === undefined
+        && hasExactKeys(object(candidateAuthentication?.env), [
+          "ARTIFACT_NAME",
+          "CANDIDATE_PRODUCER_WORKFLOW_PATH",
+          "CANDIDATE_RECORD_ARTIFACT",
+          "GH_TOKEN",
+          "QUALIFICATION_ARTIFACT",
+          "SERVER_BEHAVIOR_ONLY",
+        ])
+        && object(candidateAuthentication?.env).GH_TOKEN === "${{ github.token }}"
+        && object(candidateAuthentication?.env).ARTIFACT_NAME
+          === "codestory-cli-macos-arm64"
+        && object(candidateAuthentication?.env).CANDIDATE_RECORD_ARTIFACT
+          === "codestory-candidate-archive-record-macos-arm64"
+        && object(candidateAuthentication?.env).QUALIFICATION_ARTIFACT
+          === "codestory-qualification-driver-macos-arm64"
+        && object(candidateAuthentication?.env).CANDIDATE_PRODUCER_WORKFLOW_PATH
           === "${{ inputs.candidate_producer_workflow_path }}"
-        && object(packagedArtifactDownload?.env).SERVER_BEHAVIOR_ONLY
+        && object(candidateAuthentication?.env).SERVER_BEHAVIOR_ONLY
           === "${{ inputs.server_behavior_only }}",
-      `${metalFile} packaged CLI download must be an authenticated exact-artifact Bash boundary`,
+      `${metalFile} packaged candidate authentication must bind all exact artifacts before cache lookup`,
     );
-    requireStepRun(violations, metalFile, job, "Download packaged CLI artifact", [
+    requireStepRun(violations, metalFile, job, "Authenticate exact candidate artifacts", [
       "actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100",
       ".github/workflows/auto-release.yml",
       ".github/workflows/release.yml",
@@ -5033,14 +5456,104 @@ function validateRemainingWorkflows(workflows, violations) {
       '.run_attempt\' <<<"$producer_run")" = "$GITHUB_RUN_ATTEMPT"',
       ".workflow_run.id == $run_id",
       ".workflow_run.head_sha == $sha",
-      ".digest",
-      ".size_in_bytes",
+      "expected one exact candidate artifact",
+      'artifact="$(select_artifact "$ARTIFACT_NAME")"',
+      'record_artifact="$(select_artifact "$CANDIDATE_RECORD_ARTIFACT")"',
+      'select_artifact "$QUALIFICATION_ARTIFACT"',
+      "package-id=$artifact_id",
+      "package-bytes=$expected_size",
+      "package-sha256=${expected_digest#sha256:}",
+    ]);
+    add(
+      violations,
+      recordDownload?.if === "inputs.use_packaged_cli_artifact"
+        && recordDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(object(recordDownload?.with), ["name", "path"])
+        && object(recordDownload?.with).name
+          === "codestory-candidate-archive-record-macos-arm64"
+        && object(recordDownload?.with).path
+          === "target/candidate-archive-record/macos-arm64"
+        && cacheRestore?.id === "candidate-cache"
+        && cacheRestore?.if === "inputs.use_packaged_cli_artifact"
+        && cacheRestore?.shell === "bash"
+        && cacheRestore?.["continue-on-error"] === undefined,
+      `${metalFile} protected cache lookup must consume only the exact small candidate record`,
+    );
+    requireStepRun(
+      violations,
+      metalFile,
+      job,
+      "Restore exact candidate archive from protected host",
+      [
+        "--arg repository \"$GITHUB_REPOSITORY\"",
+        "--arg source_sha \"$(git rev-parse HEAD)\"",
+        "--arg source_tree \"$(git rev-parse 'HEAD^{tree}')\"",
+        "--arg target macos-arm64",
+        "$RUNNER_TOOL_CACHE/codestory/candidate-archives",
+        "candidate-archive-store.mjs restore",
+        "--record \"$record\"",
+        "--output-dir target/release-dist",
+        "echo \"hit=$hit\" >> \"$GITHUB_OUTPUT\"",
+      ],
+    );
+    add(
+      violations,
+      cacheMiss?.if
+        === "inputs.use_packaged_cli_artifact && steps.candidate-cache.outputs.hit != 'true'"
+        && cacheMiss?.shell === "bash"
+        && cacheMiss?.["continue-on-error"] === undefined
+        && hasExactKeys(object(cacheMiss?.env), [
+          "ARTIFACT_ID",
+          "EXPECTED_SHA256",
+          "EXPECTED_SIZE",
+          "GH_TOKEN",
+        ])
+        && object(cacheMiss?.env).ARTIFACT_ID
+          === "${{ steps.candidate-artifacts.outputs.package-id }}"
+        && object(cacheMiss?.env).EXPECTED_SIZE
+          === "${{ steps.candidate-artifacts.outputs.package-bytes }}"
+        && object(cacheMiss?.env).EXPECTED_SHA256
+          === "${{ steps.candidate-artifacts.outputs.package-sha256 }}"
+        && object(cacheMiss?.env).GH_TOKEN === "${{ github.token }}",
+      `${metalFile} large Actions artifact transfer must be a cache-miss-only authenticated boundary`,
+    );
+    requireStepRun(
+      violations,
+      metalFile,
+      job,
+      "Download, authenticate, and admit candidate archive on miss",
+      [
+        "actions/artifacts/$ARTIFACT_ID/zip",
       "--continue-at -",
       "--max-time 120",
-      "test \"$actual_size\" = \"$expected_size\"",
-      "test \"$actual_digest\" = \"${expected_digest#sha256:}\"",
-      "ditto -x -k",
-    ]);
+        'test "$actual_size" = "$EXPECTED_SIZE"',
+        'test "$actual_digest" = "$EXPECTED_SHA256"',
+        "extract-candidate-actions-artifact.py",
+        "candidate-archive-store.mjs admit",
+        "--store-root \"$RUNNER_TOOL_CACHE/codestory/candidate-archives\"",
+        "--output-dir target/release-dist",
+      ],
+    );
+    add(
+      violations,
+      driverDownload?.if
+        === "${{ inputs.use_packaged_cli_artifact && !inputs.calibration_mode && !inputs.server_behavior_only }}"
+        && driverDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(object(driverDownload?.with), ["name", "path"])
+        && object(driverDownload?.with).name
+          === "codestory-qualification-driver-macos-arm64"
+        && object(driverDownload?.with).path
+          === "target/qualification-driver-artifact/macos-arm64"
+        && stepIndex(job, "Authenticate exact candidate artifacts")
+          < stepIndex(job, "Download authenticated candidate record")
+        && stepIndex(job, "Download authenticated candidate record")
+          < stepIndex(job, "Restore exact candidate archive from protected host")
+        && stepIndex(job, "Restore exact candidate archive from protected host")
+          < stepIndex(job, "Download, authenticate, and admit candidate archive on miss")
+        && stepIndex(job, "Download, authenticate, and admit candidate archive on miss")
+          < stepIndex(job, "Download separate authenticated qualification driver"),
+      `${metalFile} private driver must remain a separate authenticated artifact after candidate cache resolution`,
+    );
     const metalDriverVerify = namedStep(job, "Verify packaged qualification driver");
     const metalDriverVerifyRun = shellLiteralNormalizedText(
       stepRun(job, "Verify packaged qualification driver"),
@@ -5067,13 +5580,13 @@ function validateRemainingWorkflows(workflows, violations) {
         )
         && metalDriverVerifyRun.includes("--trusted-root $GITHUB_WORKSPACE")
         && metalDriverVerifyRun.includes(
-          "--artifact-dir target/release-dist/qualification-driver/macos-arm64",
+          "--artifact-dir target/qualification-driver-artifact/macos-arm64",
         )
         && metalDriverVerifyRun.includes(
           "echo path=$(jq -r .driver <<<$verified) >> $GITHUB_OUTPUT",
         )
         && stepIndex(job, "Verify packaged qualification driver")
-          > stepIndex(job, "Download packaged CLI artifact"),
+          === stepIndex(job, "Download separate authenticated qualification driver") + 1,
       `${metalFile} packaged qualification must verify the archive-bound private driver`,
     );
     add(
@@ -5535,7 +6048,9 @@ function validateRemainingWorkflows(workflows, violations) {
       "Capture source build tool evidence",
       "Install pinned Rust",
       "Build and package native CLI",
-      "Authenticate exact Windows package producer",
+      "Authenticate exact Windows candidate artifacts",
+      "Restore exact candidate archive from protected host",
+      "Download, authenticate, and admit candidate archive on miss",
       "Verify packaged qualification driver",
       "Authenticate calibration bundle producer",
       "Prove protected Windows Vulkan runtime",
@@ -5574,7 +6089,10 @@ function validateRemainingWorkflows(workflows, violations) {
       "cmake --version",
       "ninja --version",
     ]);
-    requireStepRun(violations, vulkanFile, job, "Prepare checksum-pinned embedded model", ["node scripts/prepare-embedded-model.mjs"]);
+    requireStepRun(violations, vulkanFile, job, "Prepare checksum-pinned embedded model", [
+      "node scripts/prepare-embedded-model.mjs",
+      '--cache-root "$env:RUNNER_TOOL_CACHE/codestory/model-material"',
+    ]);
     const nativeBuild = namedStep(job, "Build and package native CLI");
     const nativeBuildRun = shellLiteralNormalizedText(String(nativeBuild?.run ?? ""));
     add(
@@ -5624,14 +6142,15 @@ function validateRemainingWorkflows(workflows, violations) {
     );
     const windowsPackageAuthentication = namedStep(
       job,
-      "Authenticate exact Windows package producer",
+      "Authenticate exact Windows candidate artifacts",
     );
     const windowsPackageAuthenticationRun = shellLiteralNormalizedText(
-      stepRun(job, "Authenticate exact Windows package producer"),
+      stepRun(job, "Authenticate exact Windows candidate artifacts"),
     );
     add(
       violations,
-      windowsPackageAuthentication?.if === "inputs.use_packaged_cli_artifact"
+      windowsPackageAuthentication?.id === "candidate-artifacts"
+        && windowsPackageAuthentication?.if === "inputs.use_packaged_cli_artifact"
         && windowsPackageAuthentication?.shell === windowsPowerShellShell
         && windowsPackageAuthentication?.["continue-on-error"] === undefined
         && hasExactKeys(object(windowsPackageAuthentication?.env), [
@@ -5673,7 +6192,7 @@ function validateRemainingWorkflows(workflows, violations) {
           "[string]$run.run_attempt -ne $env:GITHUB_RUN_ATTEMPT",
         )
         && windowsPackageAuthenticationRun.includes(
-          "$_.name -eq codestory-cli-windows-x64",
+          "$_.name -eq $name",
         )
         && windowsPackageAuthenticationRun.includes(
           "[string]$_.workflow_run.id -eq $env:GITHUB_RUN_ID",
@@ -5682,22 +6201,133 @@ function validateRemainingWorkflows(workflows, violations) {
           "$_.workflow_run.head_sha -eq $sourceSha",
         )
         && windowsPackageAuthenticationRun.includes(
-          "if ($artifactCount -ne 1)",
+          "expected exactly one authenticated $name artifact",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "codestory-cli-windows-x64",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "codestory-candidate-archive-record-windows-x64",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "codestory-qualification-driver-windows-x64",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "package-id=$($package.id)",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "package-bytes=$($package.size_in_bytes)",
+        )
+        && windowsPackageAuthenticationRun.includes(
+          "package-sha256=$($package.digest.Substring(7))",
         ),
-      `${vulkanFile} packaged proof must authenticate one exact-head package from an allowlisted producer`,
+      `${vulkanFile} packaged proof must authenticate the exact candidate record, package, and private driver from an allowlisted producer`,
     );
-    const windowsPackageDownload = namedStep(job, "Download packaged CLI artifact");
+    const windowsRecordDownload = namedStep(
+      job,
+      "Download authenticated candidate record",
+    );
+    const windowsCacheRestore = namedStep(
+      job,
+      "Restore exact candidate archive from protected host",
+    );
+    const windowsCacheMiss = namedStep(
+      job,
+      "Download, authenticate, and admit candidate archive on miss",
+    );
+    const windowsDriverDownload = namedStep(
+      job,
+      "Download separate authenticated qualification driver",
+    );
     add(
       violations,
-      windowsPackageDownload?.if === "inputs.use_packaged_cli_artifact"
-        && windowsPackageDownload?.uses === "actions/download-artifact@v8.0.1"
-        && hasExactKeys(windowsPackageDownload?.with, ["name", "path"])
-        && object(windowsPackageDownload?.with).name
-          === "codestory-cli-windows-x64"
-        && object(windowsPackageDownload?.with).path === "target/release-dist"
-        && stepIndex(job, "Download packaged CLI artifact")
-          === stepIndex(job, "Authenticate exact Windows package producer") + 1,
-      `${vulkanFile} must download only the authenticated Windows package`,
+      windowsRecordDownload?.if === "inputs.use_packaged_cli_artifact"
+        && windowsRecordDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(object(windowsRecordDownload?.with), ["name", "path"])
+        && object(windowsRecordDownload?.with).name
+          === "codestory-candidate-archive-record-windows-x64"
+        && object(windowsRecordDownload?.with).path
+          === "target/candidate-archive-record/windows-x64"
+        && windowsCacheRestore?.id === "candidate-cache"
+        && windowsCacheRestore?.if === "inputs.use_packaged_cli_artifact"
+        && windowsCacheRestore?.shell === windowsPowerShellShell
+        && windowsCacheRestore?.["continue-on-error"] === undefined,
+      `${vulkanFile} protected cache lookup must consume only the exact small Windows candidate record`,
+    );
+    requireStepRun(
+      violations,
+      vulkanFile,
+      job,
+      "Restore exact candidate archive from protected host",
+      [
+        "$record.source.commit -ne $sourceSha",
+        "$record.source.tree -ne $sourceTree",
+        "$record.target -ne \"windows-x64\"",
+        "codestory/candidate-archives",
+        "candidate-archive-store.mjs restore",
+        "--record $recordPath",
+        "--output-dir target/release-dist",
+        "\"hit=$hit\"",
+        "$env:GITHUB_OUTPUT",
+      ],
+    );
+    add(
+      violations,
+      windowsCacheMiss?.if
+        === "inputs.use_packaged_cli_artifact && steps.candidate-cache.outputs.hit != 'true'"
+        && windowsCacheMiss?.shell === windowsPowerShellShell
+        && windowsCacheMiss?.["continue-on-error"] === undefined
+        && hasExactKeys(object(windowsCacheMiss?.env), [
+          "ARTIFACT_ID",
+          "EXPECTED_SHA256",
+          "EXPECTED_SIZE",
+          "GH_TOKEN",
+        ])
+        && object(windowsCacheMiss?.env).ARTIFACT_ID
+          === "${{ steps.candidate-artifacts.outputs.package-id }}"
+        && object(windowsCacheMiss?.env).EXPECTED_SIZE
+          === "${{ steps.candidate-artifacts.outputs.package-bytes }}"
+        && object(windowsCacheMiss?.env).EXPECTED_SHA256
+          === "${{ steps.candidate-artifacts.outputs.package-sha256 }}"
+        && object(windowsCacheMiss?.env).GH_TOKEN === "${{ github.token }}",
+      `${vulkanFile} large Windows Actions artifact transfer must be cache-miss-only and outer-digest authenticated`,
+    );
+    requireStepRun(
+      violations,
+      vulkanFile,
+      job,
+      "Download, authenticate, and admit candidate archive on miss",
+      [
+        "actions/artifacts/$env:ARTIFACT_ID/zip",
+        "--continue-at -",
+        "--max-time 120",
+        "$actualSize -ne [long]$env:EXPECTED_SIZE",
+        "$actualDigest -ne $env:EXPECTED_SHA256",
+        "extract-candidate-actions-artifact.py",
+        "candidate-archive-store.mjs admit",
+        "--store-root $store",
+        "--output-dir target/release-dist",
+      ],
+    );
+    add(
+      violations,
+      windowsDriverDownload?.if
+        === "${{ inputs.use_packaged_cli_artifact && !inputs.server_behavior_only }}"
+        && windowsDriverDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(object(windowsDriverDownload?.with), ["name", "path"])
+        && object(windowsDriverDownload?.with).name
+          === "codestory-qualification-driver-windows-x64"
+        && object(windowsDriverDownload?.with).path
+          === "target/qualification-driver-artifact/windows-x64"
+        && stepIndex(job, "Authenticate exact Windows candidate artifacts")
+          < stepIndex(job, "Download authenticated candidate record")
+        && stepIndex(job, "Download authenticated candidate record")
+          < stepIndex(job, "Restore exact candidate archive from protected host")
+        && stepIndex(job, "Restore exact candidate archive from protected host")
+          < stepIndex(job, "Download, authenticate, and admit candidate archive on miss")
+        && stepIndex(job, "Download, authenticate, and admit candidate archive on miss")
+          < stepIndex(job, "Download separate authenticated qualification driver"),
+      `${vulkanFile} private Windows qualification driver must stay separate from the cached public candidate`,
     );
     const windowsDriverVerify = namedStep(job, "Verify packaged qualification driver");
     const windowsDriverVerifyRun = shellLiteralNormalizedText(
@@ -5726,12 +6356,12 @@ function validateRemainingWorkflows(workflows, violations) {
         )
         && windowsDriverVerifyRun.includes("--trusted-root $env:GITHUB_WORKSPACE")
         && windowsDriverVerifyRun.includes(
-          "--artifact-dir target/release-dist/qualification-driver/windows-x64",
+          "--artifact-dir target/qualification-driver-artifact/windows-x64",
         )
         && windowsDriverVerifyRun.includes("$result.driver")
         && windowsDriverVerifyRun.includes("$env:GITHUB_OUTPUT")
         && stepIndex(job, "Verify packaged qualification driver")
-          === stepIndex(job, "Download packaged CLI artifact") + 1,
+          === stepIndex(job, "Download separate authenticated qualification driver") + 1,
       `${vulkanFile} packaged qualification must verify the archive-bound private driver`,
     );
     add(
@@ -6114,14 +6744,15 @@ function validateRemainingWorkflows(workflows, violations) {
     });
     const packageAuthentication = namedStep(
       job,
-      "Authenticate exact Linux package producer",
+      "Authenticate exact Linux candidate artifacts",
     );
     const packageAuthenticationRun = shellLiteralNormalizedText(
-      stepRun(job, "Authenticate exact Linux package producer"),
+      stepRun(job, "Authenticate exact Linux candidate artifacts"),
     );
     add(
       violations,
-      packageAuthentication?.shell === "bash"
+      packageAuthentication?.id === "candidate-artifacts"
+        && packageAuthentication?.shell === "bash"
         && packageAuthentication?.if === undefined
         && packageAuthentication?.["continue-on-error"] === undefined
         && hasExactKeys(object(packageAuthentication?.env), [
@@ -6177,18 +6808,42 @@ function validateRemainingWorkflows(workflows, violations) {
           "test $(jq -r .conclusion <<<$run) = success",
         )
         && packageAuthenticationRun.includes(
-          ".name == codestory-cli-linux-x64",
+          "expected one exact candidate artifact",
         )
         && packageAuthenticationRun.includes(
-          ".workflow_run.id == $run_id",
+          "select_artifact codestory-cli-linux-x64",
         )
         && packageAuthenticationRun.includes(
-          ".workflow_run.head_sha == $sha",
+          "select_artifact codestory-candidate-archive-record-linux-x64",
         )
-        && packageAuthenticationRun.includes("test $artifact_count = 1"),
-      `${linuxVulkanFile} must authenticate one exact-head package from an allowlisted producer`,
+        && packageAuthenticationRun.includes(
+          "select_artifact codestory-qualification-driver-linux-x64",
+        )
+        && packageAuthenticationRun.includes(".workflow_run.id == $run_id")
+        && packageAuthenticationRun.includes(".workflow_run.head_sha == $sha")
+        && packageAuthenticationRun.includes("package-id=$artifact_id")
+        && packageAuthenticationRun.includes("package-bytes=$expected_size")
+        && packageAuthenticationRun.includes(
+          "package-sha256=${expected_digest#sha256:}",
+        ),
+      `${linuxVulkanFile} must authenticate one exact-head candidate record, package, and private driver from an allowlisted producer`,
     );
-    const packageDownload = namedStep(job, "Download exact Linux package");
+    const packageDownload = namedStep(
+      job,
+      "Download authenticated candidate record",
+    );
+    const linuxCacheRestore = namedStep(
+      job,
+      "Restore exact candidate archive from protected host",
+    );
+    const linuxCacheMiss = namedStep(
+      job,
+      "Download, authenticate, and admit candidate archive on miss",
+    );
+    const linuxDriverDownload = namedStep(
+      job,
+      "Download separate authenticated qualification driver",
+    );
     add(
       violations,
       packageDownload?.uses === "actions/download-artifact@v8.0.1"
@@ -6196,14 +6851,98 @@ function validateRemainingWorkflows(workflows, violations) {
           packageDownload?.with,
           ["name", "path", "run-id", "github-token"],
         )
-        && object(packageDownload.with).name === "codestory-cli-linux-x64"
-        && object(packageDownload.with).path === "target/release-dist"
+        && object(packageDownload.with).name
+          === "codestory-candidate-archive-record-linux-x64"
+        && object(packageDownload.with).path
+          === "target/candidate-archive-record/linux-x64"
         && object(packageDownload.with)["run-id"]
           === "${{ inputs.package_run_id || github.run_id }}"
         && object(packageDownload.with)["github-token"] === "${{ github.token }}"
-        && stepIndex(job, "Download exact Linux package")
-          === stepIndex(job, "Authenticate exact Linux package producer") + 1,
-      `${linuxVulkanFile} must consume only the authenticated Linux x64 package`,
+        && linuxCacheRestore?.id === "candidate-cache"
+        && linuxCacheRestore?.if === undefined
+        && linuxCacheRestore?.shell === "bash"
+        && linuxCacheRestore?.["continue-on-error"] === undefined,
+      `${linuxVulkanFile} protected cache lookup must consume only the exact small Linux candidate record`,
+    );
+    requireStepRun(
+      violations,
+      linuxVulkanFile,
+      job,
+      "Restore exact candidate archive from protected host",
+      [
+        "--arg repository \"$GITHUB_REPOSITORY\"",
+        "--arg source_sha \"$(git rev-parse HEAD)\"",
+        "--arg source_tree \"$(git rev-parse 'HEAD^{tree}')\"",
+        "--arg target linux-x64",
+        "$RUNNER_TOOL_CACHE/codestory/candidate-archives",
+        "candidate-archive-store.mjs restore",
+        "--record \"$record\"",
+        "--output-dir target/release-dist",
+        "echo \"hit=$hit\" >> \"$GITHUB_OUTPUT\"",
+      ],
+    );
+    add(
+      violations,
+      linuxCacheMiss?.if === "steps.candidate-cache.outputs.hit != 'true'"
+        && linuxCacheMiss?.shell === "bash"
+        && linuxCacheMiss?.["continue-on-error"] === undefined
+        && hasExactKeys(object(linuxCacheMiss?.env), [
+          "ARTIFACT_ID",
+          "EXPECTED_SHA256",
+          "EXPECTED_SIZE",
+          "GH_TOKEN",
+        ])
+        && object(linuxCacheMiss?.env).ARTIFACT_ID
+          === "${{ steps.candidate-artifacts.outputs.package-id }}"
+        && object(linuxCacheMiss?.env).EXPECTED_SIZE
+          === "${{ steps.candidate-artifacts.outputs.package-bytes }}"
+        && object(linuxCacheMiss?.env).EXPECTED_SHA256
+          === "${{ steps.candidate-artifacts.outputs.package-sha256 }}"
+        && object(linuxCacheMiss?.env).GH_TOKEN === "${{ github.token }}",
+      `${linuxVulkanFile} large Linux Actions artifact transfer must be cache-miss-only and outer-digest authenticated`,
+    );
+    requireStepRun(
+      violations,
+      linuxVulkanFile,
+      job,
+      "Download, authenticate, and admit candidate archive on miss",
+      [
+        "actions/artifacts/$ARTIFACT_ID/zip",
+        "--continue-at -",
+        "--max-time 120",
+        'test "$actual_size" = "$EXPECTED_SIZE"',
+        'test "$actual_digest" = "$EXPECTED_SHA256"',
+        "extract-candidate-actions-artifact.py",
+        "candidate-archive-store.mjs admit",
+        "--store-root \"$RUNNER_TOOL_CACHE/codestory/candidate-archives\"",
+        "--output-dir target/release-dist",
+      ],
+    );
+    add(
+      violations,
+      linuxDriverDownload?.if === "${{ !inputs.server_behavior_only }}"
+        && linuxDriverDownload?.uses === "actions/download-artifact@v8.0.1"
+        && hasExactKeys(
+          object(linuxDriverDownload?.with),
+          ["name", "path", "run-id", "github-token"],
+        )
+        && object(linuxDriverDownload?.with).name
+          === "codestory-qualification-driver-linux-x64"
+        && object(linuxDriverDownload?.with).path
+          === "target/qualification-driver-artifact/linux-x64"
+        && object(linuxDriverDownload?.with)["run-id"]
+          === "${{ inputs.package_run_id || github.run_id }}"
+        && object(linuxDriverDownload?.with)["github-token"]
+          === "${{ github.token }}"
+        && stepIndex(job, "Authenticate exact Linux candidate artifacts")
+          < stepIndex(job, "Download authenticated candidate record")
+        && stepIndex(job, "Download authenticated candidate record")
+          < stepIndex(job, "Restore exact candidate archive from protected host")
+        && stepIndex(job, "Restore exact candidate archive from protected host")
+          < stepIndex(job, "Download, authenticate, and admit candidate archive on miss")
+        && stepIndex(job, "Download, authenticate, and admit candidate archive on miss")
+          < stepIndex(job, "Download separate authenticated qualification driver"),
+      `${linuxVulkanFile} private Linux qualification driver must stay separate from the cached public candidate`,
     );
     requireCalibrationProducerBoundary(
       violations,
@@ -6251,13 +6990,13 @@ function validateRemainingWorkflows(workflows, violations) {
         )
         && linuxDriverVerifyRun.includes("--trusted-root $GITHUB_WORKSPACE")
         && linuxDriverVerifyRun.includes(
-          "--artifact-dir target/release-dist/qualification-driver/linux-x64",
+          "--artifact-dir target/qualification-driver-artifact/linux-x64",
         )
         && linuxDriverVerifyRun.includes(
           "echo path=$(jq -r .driver <<<$verified) >> $GITHUB_OUTPUT",
         )
         && stepIndex(job, "Verify packaged qualification driver")
-          === stepIndex(job, "Download exact Linux package") + 1,
+          === stepIndex(job, "Download separate authenticated qualification driver") + 1,
       `${linuxVulkanFile} packaged qualification must verify the archive-bound private driver`,
     );
     add(
@@ -6468,6 +7207,16 @@ function validateRemainingWorkflows(workflows, violations) {
           === JSON.stringify(["self-hosted", "Linux", "X64", "codestory-linux-vulkan"])
         && optionalCalibration.environment === "linux-vulkan-proof",
       `${linuxVulkanFile} optional calibration must be a standalone protected manual Vulkan job`,
+    );
+    requireStepRun(
+      violations,
+      linuxVulkanFile,
+      optionalCalibration,
+      "Prepare checksum-pinned embedded model",
+      [
+        "node scripts/prepare-embedded-model.mjs",
+        '--cache-root "$RUNNER_TOOL_CACHE/codestory/model-material"',
+      ],
     );
     const optionalCollectorName = "Collect optional Linux Vulkan constant calibration";
     requireStepRun(violations, linuxVulkanFile, optionalCalibration, optionalCollectorName, [
@@ -7408,6 +8157,26 @@ export function lostRunnerRecoveryViolations(workflows, graph) {
   requireStepRun(violations, releaseFile, job, "Decide withheld accelerator hosts", [
     "node .github/scripts/lost-runner-recovery.mjs plan-non-claim",
   ]);
+  const recordDownload = namedStep(
+    job,
+    "Download authenticated candidate records for withheld identity",
+  );
+  add(
+    violations,
+    recordDownload?.if === "steps.non-claim.outputs.withheld_hosts != ''"
+      && recordDownload?.uses === "actions/download-artifact@v8.0.1"
+      && hasExactKeys(object(recordDownload?.with), [
+        "merge-multiple",
+        "path",
+        "pattern",
+      ])
+      && object(recordDownload?.with).pattern
+        === "codestory-candidate-archive-record-*"
+      && object(recordDownload?.with).path
+        === "target/release-non-claim/candidate-records"
+      && object(recordDownload?.with)["merge-multiple"] === false,
+    `${releaseFile} non-claim producer must download only tiny authenticated candidate records`,
+  );
   const record = namedStep(job, "Record populated accelerator non-claims");
   add(
     violations,
@@ -7417,7 +8186,18 @@ export function lostRunnerRecoveryViolations(workflows, graph) {
   requireStepRun(violations, releaseFile, job, "Record populated accelerator non-claims", [
     "scripts/codestory-release-cell-manifest.mjs withhold",
     '--producer-run-attempt "$GITHUB_RUN_ATTEMPT"',
+    '--candidate-record "target/release-non-claim/candidate-records/codestory-candidate-archive-record-$target/candidate-archive-record.json"',
   ]);
+  add(
+    violations,
+    !shellLiteralNormalizedText(stepRun(
+      job,
+      "Record populated accelerator non-claims",
+    )).includes("--archive ")
+      && !scalarStrings(recordDownload).some(value =>
+        value.includes("codestory-cli-")),
+    `${releaseFile} non-claim producer must never transfer or read a large package archive`,
+  );
   // A non-claim producer that emitted evidence for a host that reported would overwrite a real
   // proof, so every upload is bound to the classifier's own withheld list. Each closeout phase gets
   // its own container: a phase authorizes every manifest inside the container it downloads, so a
@@ -7465,7 +8245,15 @@ function validateReleaseArtifactRerunSafety(workflows, violations) {
     }],
     ["packaged-platform-proof.yml/build/Upload release asset", {
       name: "codestory-cli-${{ matrix.asset_target }}",
-      path: "target/release-dist/*.tar.gz\ntarget/release-dist/*.zip\ntarget/release-dist/*.sha256\ntarget/release-dist/SHA256SUMS.txt\ntarget/release-dist/qualification-driver/${{ matrix.asset_target }}\n",
+      path: "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}\ntarget/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}.sha256\ntarget/release-dist/SHA256SUMS.txt\n",
+    }],
+    ["packaged-platform-proof.yml/build/Upload exact candidate archive record", {
+      name: "codestory-candidate-archive-record-${{ matrix.asset_target }}",
+      path: "target/candidate-archive-record/${{ matrix.asset_target }}/candidate-archive-record.json",
+    }],
+    ["packaged-platform-proof.yml/build/Upload separate qualification driver", {
+      name: "codestory-qualification-driver-${{ matrix.asset_target }}",
+      path: "target/release-dist/qualification-driver/${{ matrix.asset_target }}",
     }],
     ["macos-metal-proof.yml/packaged-metal/Upload Metal calibration runs", {
       name: "embedding-calibration-macos-${{ inputs.version }}",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1186,25 +1186,25 @@ test("qualification driver is built once, retained privately, authenticated, and
     }, /private qualification-driver retention must be explicit and off by default/u],
     ["host package repeats Cargo build", packagedFile, workflow => {
       hostBuild(workflow).run += '\ncargo build --release --locked "${cargo_args[@]}"';
-    }, /host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
     ["host package drops runtime", packagedFile, workflow => {
       hostBuild(workflow).run = hostBuild(workflow).run.replace(
         "--bin codestory-cli-runtime",
         "--bin ignored-runtime",
       );
-    }, /host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
     ["host package broadens to all bins", packagedFile, workflow => {
       hostBuild(workflow).run = hostBuild(workflow).run.replace(
         "--bin codestory-cli-runtime",
         "--bins",
       );
-    }, /host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
     ["host package substitutes calibration driver", packagedFile, workflow => {
       hostBuild(workflow).run = hostBuild(workflow).run.replace(
         "codestory_embedding_qualification",
         "codestory_embedding_constant_calibration",
       );
-    }, /host package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation/u],
+    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
     ["Linux package repeats Cargo build", packagedFile, workflow => {
       linuxBuild(workflow).run = linuxBuild(workflow).run.replace(
         "/sccache/sccache --show-stats",
@@ -1238,13 +1238,11 @@ test("qualification driver is built once, retained privately, authenticated, and
         '--target-dir "${CARGO_TARGET_DIR:-target}"',
       );
     }, /retain one archive-bound private qualification driver beside each selected package/u],
-    ["package artifact drops private driver directory", packagedFile, workflow => {
+    ["public package artifact admits the private driver", packagedFile, workflow => {
       const upload = draftStep(packagedJob(workflow), "Upload release asset");
-      upload.with.path = upload.with.path.replace(
-        "target/release-dist/qualification-driver/${{ matrix.asset_target }}\n",
-        "",
-      );
-    }, /existing package artifact must retain the private driver directory/u],
+      upload.with.path +=
+        "target/release-dist/qualification-driver/${{ matrix.asset_target }}\n";
+    }, /public package artifact must contain exactly the archive and its two candidate-local checksum files/u],
     ["public archive includes qualification driver", packagedFile, workflow => {
       draftStep(packagedJob(workflow), "Package release asset").run +=
         "\ntar -rf \"$archive\" target/release-dist/qualification-driver";
@@ -1325,13 +1323,13 @@ test("qualification driver is built once, retained privately, authenticated, and
     ["Windows trusts an arbitrary producer workflow", windowsFile, workflow => {
       const authenticate = draftStep(
         windowsJob(workflow),
-        "Authenticate exact Windows package producer",
+        "Authenticate exact Windows candidate artifacts",
       );
       authenticate.run = authenticate.run.replace(
         '$env:CANDIDATE_PRODUCER_WORKFLOW_PATH -notin $allowedWorkflows',
         "$false",
       );
-    }, /authenticate one exact-head package from an allowlisted producer/u],
+    }, /authenticate the exact candidate record, package, and private driver from an allowlisted producer/u],
     ["Windows executes an unverified driver", windowsFile, workflow => {
       draftStep(windowsJob(workflow), "Prove protected Windows Vulkan runtime")
         .env.VERIFIED_QUALIFICATION_DRIVER = "target/release/other.exe";
@@ -1357,17 +1355,17 @@ test("qualification driver is built once, retained privately, authenticated, and
     ["Linux trusts an arbitrary producer workflow", linuxFile, workflow => {
       const authenticate = draftStep(
         linuxJob(workflow),
-        "Authenticate exact Linux package producer",
+        "Authenticate exact Linux candidate artifacts",
       );
       authenticate.run = authenticate.run.replace(
         'case "$CANDIDATE_PRODUCER_WORKFLOW_PATH" in',
         'case ".github/workflows/packaged-platform-pr.yml" in',
       );
-    }, /authenticate one exact-head package from an allowlisted producer/u],
+    }, /authenticate one exact-head candidate record, package, and private driver from an allowlisted producer/u],
     ["Linux allowlist admits an untrusted producer through dead checks", linuxFile, workflow => {
       const authenticate = draftStep(
         linuxJob(workflow),
-        "Authenticate exact Linux package producer",
+        "Authenticate exact Linux candidate artifacts",
       );
       authenticate.run = authenticate.run.replace(
         ".github/workflows/packaged-platform-pr.yml)",
@@ -1381,7 +1379,7 @@ test("qualification driver is built once, retained privately, authenticated, and
     ["Linux producer path equality becomes advisory", linuxFile, workflow => {
       const authenticate = draftStep(
         linuxJob(workflow),
-        "Authenticate exact Linux package producer",
+        "Authenticate exact Linux candidate artifacts",
       );
       authenticate.run = authenticate.run.replace(
         'test "$(jq -r \'.path\' <<<"$run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"',
@@ -1391,23 +1389,23 @@ test("qualification driver is built once, retained privately, authenticated, and
     ["Linux accepts an incomplete external package run", linuxFile, workflow => {
       const authenticate = draftStep(
         linuxJob(workflow),
-        "Authenticate exact Linux package producer",
+        "Authenticate exact Linux candidate artifacts",
       );
       authenticate.run = authenticate.run.replace(
         'test "$(jq -r \'.conclusion\' <<<"$run")" = success',
         "true",
       );
-    }, /authenticate one exact-head package from an allowlisted producer/u],
+    }, /authenticate one exact-head candidate record, package, and private driver from an allowlisted producer/u],
     ["Linux accepts a package artifact from another head", linuxFile, workflow => {
       const authenticate = draftStep(
         linuxJob(workflow),
-        "Authenticate exact Linux package producer",
+        "Authenticate exact Linux candidate artifacts",
       );
       authenticate.run = authenticate.run.replace(
         "and .workflow_run.head_sha == $sha",
         "",
       );
-    }, /authenticate one exact-head package from an allowlisted producer/u],
+    }, /authenticate one exact-head candidate record, package, and private driver from an allowlisted producer/u],
     ["Linux executes a hardcoded driver", linuxFile, workflow => {
       draftStep(linuxJob(workflow), "Prove offline Linux Vulkan retrieval").run =
         draftStep(linuxJob(workflow), "Prove offline Linux Vulkan retrieval").run
@@ -1494,6 +1492,411 @@ test("qualification driver is built once, retained privately, authenticated, and
         validateWorkflows(loadWorkflows(), graph).join("\n"),
         /private archive-qualified driver contract exactly|release claim graph qualification contract/u,
       );
+    });
+  }
+});
+
+test("Windows packages one release graph into exact public and private artifacts", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const file = "packaged-platform-proof.yml";
+  const job = workflow => workflow.jobs.build;
+  const step = (workflow, name) => draftStep(job(workflow), name);
+  const replaceRun = (workflow, name, from, to) => {
+    const selected = step(workflow, name);
+    const before = selected.run;
+    selected.run = before.replace(from, to);
+    assert.notEqual(selected.run, before, `mutation did not change ${name}`);
+  };
+  const mutations = [
+    ["a second Windows Cargo build appears in another step", workflow => {
+      job(workflow).steps.push({
+        name: "Rebuild a Windows regression",
+        if: "runner.os == 'Windows'",
+        shell: "bash",
+        run: "cargo build --release --locked -p codestory-workspace --test windows_path_identity",
+      });
+    }, /package proof must not compile outside the two mutually exclusive reviewed Cargo build steps/u],
+    ["the one package build invokes Cargo twice", workflow => {
+      step(workflow, "Build package and qualification driver").run +=
+        "\ncargo build --release --locked -p codestory-cli";
+    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
+    ["the package graph loses release mode", workflow => {
+      replaceRun(
+        workflow,
+        "Build package and qualification driver",
+        "cargo build --release --locked",
+        "cargo build --locked",
+      );
+    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
+    ["the path regression is replaced by a debug output", workflow => {
+      step(workflow, "Prove native workspace path identity").env.TEST_BINARY =
+        "target/debug/deps/windows_path_identity.exe";
+    }, /Windows regressions must execute the exact release test binaries emitted by the one Cargo graph/u],
+    ["the staging regression is replaced by a debug output", workflow => {
+      step(workflow, "Test immutable native staging on Windows").env.TEST_BINARY =
+        "target/debug/deps/native_staging.exe";
+    }, /Windows regressions must execute the exact release test binaries emitted by the one Cargo graph/u],
+    ["Windows packaging is fed a debug CLI", workflow => {
+      step(workflow, "Package release asset on Windows").env.WINDOWS_CLI =
+        "target/debug/codestory-cli.exe";
+    }, /Windows packaging must verify and package only the exact Cargo-selected release binary/u],
+    ["the public artifact uses a broad release glob", workflow => {
+      step(workflow, "Upload release asset").with.path = "target/release-dist/**";
+    }, /public package artifact must contain exactly the archive and its two candidate-local checksum files/u],
+    ["the public artifact includes the private qualification driver", workflow => {
+      step(workflow, "Upload release asset").with.path +=
+        "target/release-dist/qualification-driver/${{ matrix.asset_target }}\n";
+    }, /public package artifact must contain exactly the archive and its two candidate-local checksum files/u],
+    ["the public artifact drops its candidate-local checksum manifest", workflow => {
+      const upload = step(workflow, "Upload release asset");
+      upload.with.path = upload.with.path.replace(
+        "target/release-dist/SHA256SUMS.txt\n",
+        "",
+      );
+    }, /public package artifact must contain exactly the archive and its two candidate-local checksum files/u],
+    ["the candidate record is not source-SHA bound", workflow => {
+      replaceRun(
+        workflow,
+        "Produce exact candidate archive record",
+        '--source-sha "$SOURCE_SHA"',
+        '--source-sha "$GITHUB_SHA"',
+      );
+    }, /Produce exact candidate archive record must run --source-sha/u],
+    ["the candidate-record artifact is missing", workflow => {
+      job(workflow).steps = job(workflow).steps.filter(
+        ({ name }) => name !== "Upload exact candidate archive record",
+      );
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the candidate-record artifact name drifts", workflow => {
+      step(workflow, "Upload exact candidate archive record").with.name =
+        "codestory-candidate-record-${{ matrix.asset_target }}";
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the candidate-record artifact path drifts", workflow => {
+      step(workflow, "Upload exact candidate archive record").with.path =
+        "target/release-dist/candidate-archive-record.json";
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the candidate-record artifact stops replacing its same-run stable name", workflow => {
+      step(workflow, "Upload exact candidate archive record").with.overwrite = false;
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the separate qualification-driver artifact is missing", workflow => {
+      job(workflow).steps = job(workflow).steps.filter(
+        ({ name }) => name !== "Upload separate qualification driver",
+      );
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the separate qualification-driver artifact name drifts", workflow => {
+      step(workflow, "Upload separate qualification driver").with.name =
+        "qualification-driver-${{ matrix.asset_target }}";
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the separate qualification-driver artifact path drifts", workflow => {
+      step(workflow, "Upload separate qualification driver").with.path =
+        "target/release-dist/qualification-driver";
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the separate qualification-driver artifact is uploaded unconditionally", workflow => {
+      delete step(workflow, "Upload separate qualification driver").if;
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the separate qualification-driver artifact stops replacing its same-run stable name", workflow => {
+      step(workflow, "Upload separate qualification driver").with.overwrite = false;
+    }, /candidate record and private qualification driver must be separate exact stable artifacts/u],
+    ["the public package stable artifact stops replacing its same-run name", workflow => {
+      step(workflow, "Upload release asset").with.overwrite = false;
+    }, /public package artifact must contain exactly the archive and its two candidate-local checksum files|stable release artifact/u],
+  ];
+
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expected);
+    });
+  }
+});
+
+test("protected candidate consumers key cache reuse by exact source and transfer only on miss", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const replaceRun = (workflow, jobName, stepName, from, to) => {
+    const selected = draftStep(workflow.jobs[jobName], stepName);
+    const before = selected.run;
+    selected.run = before.replace(from, to);
+    assert.notEqual(selected.run, before, `mutation did not change ${stepName}`);
+  };
+  const cases = [
+    {
+      file: "macos-metal-proof.yml",
+      job: "packaged-metal",
+      authentication: "Authenticate exact candidate artifacts",
+      authenticationSha: ".workflow_run.head_sha == $sha",
+      authenticationExpected: /Authenticate exact candidate artifacts must run .workflow_run.head_sha == \$sha/u,
+      recordName: "codestory-candidate-archive-record-macos-arm64",
+      recordExpected: /protected cache lookup must consume only the exact small candidate record/u,
+      restoreSha: ".source.commit == $source_sha",
+      missIf: "inputs.use_packaged_cli_artifact",
+      missExpected: /large Actions artifact transfer must be a cache-miss-only authenticated boundary/u,
+      driverName: "codestory-qualification-driver-macos-arm64",
+      driverExpected: /private driver must remain a separate authenticated artifact after candidate cache resolution/u,
+      modelCache: '--cache-root "$RUNNER_TOOL_CACHE/codestory/model-material"',
+    },
+    {
+      file: "windows-vulkan-proof.yml",
+      job: "packaged-vulkan",
+      authentication: "Authenticate exact Windows candidate artifacts",
+      authenticationSha: "$_.workflow_run.head_sha -eq $sourceSha",
+      authenticationExpected: /packaged proof must authenticate the exact candidate record, package, and private driver from an allowlisted producer/u,
+      recordName: "codestory-candidate-archive-record-windows-x64",
+      recordExpected: /protected cache lookup must consume only the exact small Windows candidate record/u,
+      restoreSha: "$record.source.commit -ne $sourceSha",
+      missIf: "inputs.use_packaged_cli_artifact",
+      missExpected: /large Windows Actions artifact transfer must be cache-miss-only and outer-digest authenticated/u,
+      driverName: "codestory-qualification-driver-windows-x64",
+      driverExpected: /private Windows qualification driver must stay separate from the cached public candidate/u,
+      modelCache: '--cache-root "$env:RUNNER_TOOL_CACHE/codestory/model-material"',
+    },
+    {
+      file: "linux-vulkan-proof.yml",
+      job: "packaged-vulkan",
+      authentication: "Authenticate exact Linux candidate artifacts",
+      authenticationSha: ".workflow_run.head_sha == $sha",
+      authenticationExpected: /must authenticate one exact-head candidate record, package, and private driver from an allowlisted producer/u,
+      recordName: "codestory-candidate-archive-record-linux-x64",
+      recordExpected: /protected cache lookup must consume only the exact small Linux candidate record/u,
+      restoreSha: ".source.commit == $source_sha",
+      missIf: "true",
+      missExpected: /large Linux Actions artifact transfer must be cache-miss-only and outer-digest authenticated/u,
+      driverName: "codestory-qualification-driver-linux-x64",
+      driverExpected: /private Linux qualification driver must stay separate from the cached public candidate/u,
+    },
+  ];
+
+  for (const platform of cases) {
+    await t.test(`${platform.file}: producer artifact SHA check removed`, () => {
+      const workflows = loadWorkflows();
+      const workflow = workflows.get(platform.file);
+      replaceRun(
+        workflow,
+        platform.job,
+        platform.authentication,
+        platform.authenticationSha,
+        "true",
+      );
+      assert.match(validateWorkflows(workflows).join("\n"), platform.authenticationExpected);
+    });
+
+    await t.test(`${platform.file}: record source SHA check removed from cache key`, () => {
+      const workflows = loadWorkflows();
+      const workflow = workflows.get(platform.file);
+      replaceRun(
+        workflow,
+        platform.job,
+        "Restore exact candidate archive from protected host",
+        platform.restoreSha,
+        "true",
+      );
+      assert.match(
+        validateWorkflows(workflows).join("\n"),
+        /Restore exact candidate archive from protected host|reviewed protected .* workflow structure/u,
+      );
+    });
+
+    await t.test(`${platform.file}: large transfer made unconditional`, () => {
+      const workflows = loadWorkflows();
+      const workflow = workflows.get(platform.file);
+      draftStep(
+        workflow.jobs[platform.job],
+        "Download, authenticate, and admit candidate archive on miss",
+      ).if = platform.missIf;
+      assert.match(validateWorkflows(workflows).join("\n"), platform.missExpected);
+    });
+
+    await t.test(`${platform.file}: small candidate record name drifts`, () => {
+      const workflows = loadWorkflows();
+      const workflow = workflows.get(platform.file);
+      draftStep(
+        workflow.jobs[platform.job],
+        "Download authenticated candidate record",
+      ).with.name = platform.recordName.replace("candidate-archive-record", "package-record");
+      assert.match(validateWorkflows(workflows).join("\n"), platform.recordExpected);
+    });
+
+    await t.test(`${platform.file}: private driver is read from the public package`, () => {
+      const workflows = loadWorkflows();
+      const workflow = workflows.get(platform.file);
+      const download = draftStep(
+        workflow.jobs[platform.job],
+        "Download separate authenticated qualification driver",
+      );
+      download.with.name = platform.driverName.replace(
+        "codestory-qualification-driver",
+        "codestory-cli",
+      );
+      assert.match(validateWorkflows(workflows).join("\n"), platform.driverExpected);
+    });
+
+    if (platform.modelCache) {
+      await t.test(`${platform.file}: protected model material cache is omitted`, () => {
+        const workflows = loadWorkflows();
+        const workflow = workflows.get(platform.file);
+        replaceRun(
+          workflow,
+          platform.job,
+          "Prepare checksum-pinned embedded model",
+          platform.modelCache,
+          "--cache-root target/model-material",
+        );
+        assert.match(
+          validateWorkflows(workflows).join("\n"),
+          /Prepare checksum-pinned embedded model/u,
+        );
+      });
+    }
+  }
+
+  await t.test("optional Linux Vulkan calibration omits the protected model cache", () => {
+    const workflows = loadWorkflows();
+    const workflow = workflows.get("linux-vulkan-proof.yml");
+    replaceRun(
+      workflow,
+      "optional-constant-calibration",
+      "Prepare checksum-pinned embedded model",
+      '--cache-root "$RUNNER_TOOL_CACHE/codestory/model-material"',
+      "--cache-root target/model-material",
+    );
+    assert.match(
+      validateWorkflows(workflows).join("\n"),
+      /Prepare checksum-pinned embedded model/u,
+    );
+  });
+});
+
+test("post-publish candidate reuse authenticates release metadata and transfers large bytes once", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const file = "post-publish-release-smoke.yml";
+  const job = workflow => workflow.jobs.smoke;
+  const step = (workflow, name) => draftStep(job(workflow), name);
+  const replaceRun = (workflow, name, from, to) => {
+    const selected = step(workflow, name);
+    const before = selected.run;
+    selected.run = before.replace(from, to);
+    assert.notEqual(selected.run, before, `mutation did not change ${name}`);
+  };
+  const mutations = [
+    ["the release tag lookup is replaced by latest", workflow => {
+      replaceRun(
+        workflow,
+        "Authenticate published candidate assets",
+        'releases/tags/$TAG',
+        "releases/latest",
+      );
+    }, /published candidate authentication must bind the release tag, commit, target, and exact asset metadata|Authenticate published candidate assets/u],
+    ["the returned release tag is not checked", workflow => {
+      replaceRun(
+        workflow,
+        "Authenticate published candidate assets",
+        'test "$(jq -r .tag_name <<<"$release")" = "$TAG"',
+        "true",
+      );
+    }, /Authenticate published candidate assets/u],
+    ["published asset size provenance is not validated", workflow => {
+      replaceRun(
+        workflow,
+        "Authenticate published candidate assets",
+        '[[ "$(jq -r .size <<<"$value")" =~ ^[0-9]+$ ]]',
+        "true",
+      );
+    }, /Authenticate published candidate assets/u],
+    ["published asset digest provenance is not validated", workflow => {
+      replaceRun(
+        workflow,
+        "Authenticate published candidate assets",
+        '[[ "$(jq -r .digest <<<"$value")" =~ ^sha256:[0-9a-f]{64}$ ]]',
+        "true",
+      );
+    }, /Authenticate published candidate assets/u],
+    ["published record source SHA is rebound to the workflow checkout", workflow => {
+      step(workflow, "Authenticate published candidate assets").env.PUBLISHED_COMMIT =
+        "${{ github.sha }}";
+    }, /published candidate authentication must bind the release tag, commit, target, and exact asset metadata/u],
+    ["published cache key no longer checks the source SHA", workflow => {
+      replaceRun(
+        workflow,
+        "Restore published candidate archive from protected host",
+        ".source.commit == $source_sha",
+        "true",
+      );
+    }, /Restore published candidate archive from protected host/u],
+    ["published cache lookup loses its exact source binding", workflow => {
+      delete step(workflow, "Restore published candidate archive from protected host")
+        .env.PUBLISHED_COMMIT;
+    }, /published candidate cache lookup must be unconditional and exact-source bound/u],
+    ["published large archive transfer is unconditional", workflow => {
+      delete step(workflow, "Download, verify, and admit published candidate on miss").if;
+    }, /published archive transfer must run only on an exact cache miss/u],
+    ["published large archive is downloaded a second time", workflow => {
+      step(workflow, "Download authenticated published checksum manifest").run +=
+        '\ncurl "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/assets/$id"';
+    }, /must resolve the protected cache before any large release-asset transfer and never use an unconditional bulk download/u],
+    ["bulk gh release download returns", workflow => {
+      step(workflow, "Download authenticated published checksum manifest").run +=
+        '\ngh release download "$TAG"';
+    }, /must resolve the protected cache before any large release-asset transfer and never use an unconditional bulk download/u],
+    ["published archive size output is dropped", workflow => {
+      replaceRun(
+        workflow,
+        "Authenticate published candidate assets",
+        'echo "archive-bytes=$(jq -r .size <<<"$archive_asset")"',
+        "true",
+      );
+    }, /Authenticate published candidate assets/u],
+    ["published archive digest output is dropped", workflow => {
+      replaceRun(
+        workflow,
+        "Authenticate published candidate assets",
+        'echo "archive-sha256=$(jq -r .digest <<<"$archive_asset" | sed \'s/^sha256://\')"',
+        "true",
+      );
+    }, /Authenticate published candidate assets/u],
+  ];
+
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expected);
+    });
+  }
+});
+
+test("withheld accelerator cells consume only tiny exact candidate records", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const file = "release.yml";
+  const mutations = [
+    ["the non-claim lane downloads public package archives", workflow => {
+      draftStep(
+        workflow.jobs["accelerator-non-claim"],
+        "Download authenticated candidate records for withheld identity",
+      ).with.pattern = "codestory-cli-*";
+    }, /non-claim producer must download only tiny authenticated candidate records|must never transfer or read a large package archive/u],
+    ["the non-claim lane reads a large archive", workflow => {
+      const record = draftStep(
+        workflow.jobs["accelerator-non-claim"],
+        "Record populated accelerator non-claims",
+      );
+      record.run = record.run.replace(
+        '--candidate-record "target/release-non-claim/candidate-records/codestory-candidate-archive-record-$target/candidate-archive-record.json"',
+        '--archive "target/release-non-claim/candidate-records/codestory-cli-$target/archive"',
+      );
+    }, /non-claim producer must never transfer or read a large package archive|Record populated accelerator non-claims/u],
+  ];
+
+  for (const [name, mutate, expected] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      const violations = validateWorkflows(workflows);
+      assert.notDeepEqual(violations, []);
+      assert.match(violations.join("\n"), expected);
     });
   }
 });
@@ -3469,7 +3872,7 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     }, /Configure short Windows Cargo target/u],
     ["packaged native staging regression made cross-platform", packagedFile, workflow => {
       packagedNativeStaging(workflow).if = "runner.os != 'Windows'";
-    }, /immutable native staging regression must run on Windows/u],
+    }, /Windows regressions must execute the exact release test binaries emitted by the one Cargo graph/u],
     ["packaged native staging regression removed", packagedFile, workflow => {
       packagedNativeStaging(workflow).run = "cargo test --release --locked";
     }, /Test immutable native staging on Windows/u],
@@ -3620,23 +4023,23 @@ test("protected candidate installs prove accelerated server behavior without CPU
   }
 });
 
-test("protected macOS package download is resumable and container-verified", async (t) => {
+test("protected macOS candidate transfer is resumable, exact-head bound, and cache-miss only", async (t) => {
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
 
   const file = "macos-metal-proof.yml";
   const mutations = [
     ["resume removed", step => {
       step.run = step.run.replace("--continue-at -", "--remote-name");
-    }, /Download packaged CLI artifact/u],
+    }, /Download, authenticate, and admit candidate archive on miss/u],
     ["container digest bypassed", step => {
       step.run = step.run.replace(
-        'test "$actual_digest" = "${expected_digest#sha256:}"',
+        'test "$actual_digest" = "$EXPECTED_SHA256"',
         "true",
       );
-    }, /Download packaged CLI artifact/u],
-    ["producer SHA binding removed", step => {
-      step.run = step.run.replace(".workflow_run.head_sha == $sha", "true");
-    }, /Download packaged CLI artifact/u],
+    }, /Download, authenticate, and admit candidate archive on miss/u],
+    ["large transfer made unconditional", step => {
+      step.if = "inputs.use_packaged_cli_artifact";
+    }, /large Actions artifact transfer must be a cache-miss-only authenticated boundary/u],
   ];
 
   for (const [name, mutate, expectedReason] of mutations) {
@@ -3644,7 +4047,7 @@ test("protected macOS package download is resumable and container-verified", asy
       const workflows = loadWorkflows();
       const step = draftStep(
         workflows.get(file).jobs["packaged-metal"],
-        "Download packaged CLI artifact",
+        "Download, authenticate, and admit candidate archive on miss",
       );
       mutate(step);
       const violations = validateWorkflows(workflows);

--- a/.github/scripts/extract-candidate-actions-artifact.py
+++ b/.github/scripts/extract-candidate-actions-artifact.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Extract one authenticated Actions artifact into a public candidate payload."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+import zipfile
+from pathlib import Path
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+TARGET = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+PORTABLE_NAME = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._+-]*[A-Za-z0-9])?$")
+RESERVED_NAME = re.compile(
+    r"^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$",
+    re.IGNORECASE,
+)
+RECORD_SCHEMA = "codestory-candidate-archive-store/v1"
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def exact_keys(value: object, keys: set[str], label: str) -> dict:
+    if not isinstance(value, dict) or set(value) != keys:
+        fail(f"{label} keys changed")
+    return value
+
+
+def positive_bytes(value: object, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        fail(f"{label} must be a positive integer")
+    return value
+
+
+def digest(value: object, pattern: re.Pattern[str], label: str) -> str:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        fail(f"{label} is invalid")
+    return value
+
+
+def portable_name(value: object, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not PORTABLE_NAME.fullmatch(value)
+        or RESERVED_NAME.fullmatch(value)
+        or "/" in value
+        or "\\" in value
+    ):
+        fail(f"{label} must be a portable simple filename")
+    return value
+
+
+def descriptor(value: object, role: str, expected_path: str) -> tuple[str, int, str]:
+    item = exact_keys(
+        value,
+        {"role", "relative_path", "bytes", "sha256"},
+        f"{role} descriptor",
+    )
+    if item["role"] != role or item["relative_path"] != expected_path:
+        fail(f"{role} descriptor path changed")
+    return (
+        expected_path,
+        positive_bytes(item["bytes"], f"{role} bytes"),
+        digest(item["sha256"], SHA256, f"{role} SHA-256"),
+    )
+
+
+def load_record(record_path: Path) -> dict[str, tuple[int, str]]:
+    record = exact_keys(
+        json.loads(record_path.read_text(encoding="utf-8")),
+        {"schema", "repository", "source", "target", "archive", "companions"},
+        "candidate archive record",
+    )
+    if record["schema"] != RECORD_SCHEMA:
+        fail("candidate archive record schema changed")
+    if (
+        not isinstance(record["repository"], str)
+        or record["repository"].count("/") != 1
+    ):
+        fail("candidate repository changed")
+    source = exact_keys(record["source"], {"commit", "tree"}, "candidate source")
+    digest(source["commit"], SHA, "candidate source SHA")
+    digest(source["tree"], SHA, "candidate source tree")
+    digest(record["target"], TARGET, "candidate target")
+    archive = exact_keys(
+        record["archive"],
+        {"name", "relative_path", "bytes", "sha256"},
+        "candidate archive",
+    )
+    archive_name = portable_name(archive["name"], "candidate archive name")
+    if archive["relative_path"] != archive_name:
+        fail("candidate archive path changed")
+    expected = {
+        archive_name: (
+            positive_bytes(archive["bytes"], "candidate archive bytes"),
+            digest(archive["sha256"], SHA256, "candidate archive SHA-256"),
+        )
+    }
+    companions = record["companions"]
+    if not isinstance(companions, list) or len(companions) != 2:
+        fail("candidate record must retain exactly the two public checksum files")
+    by_role = {
+        item.get("role"): item
+        for item in companions
+        if isinstance(item, dict)
+    }
+    if set(by_role) != {"archive_checksum", "checksum_manifest"}:
+        fail("candidate record companions must remain public-only")
+    archive_checksum = descriptor(
+        by_role["archive_checksum"],
+        "archive_checksum",
+        f"{archive_name}.sha256",
+    )
+    checksum_manifest = descriptor(
+        by_role["checksum_manifest"],
+        "checksum_manifest",
+        "SHA256SUMS.txt",
+    )
+    if archive_checksum[1:] != checksum_manifest[1:]:
+        fail("per-candidate checksum files must retain the same checksum line")
+    for path, size, sha256 in (archive_checksum, checksum_manifest):
+        expected[path] = (size, sha256)
+    return expected
+
+
+def zip_entry_is_regular(info: zipfile.ZipInfo) -> bool:
+    unix_mode = info.external_attr >> 16
+    file_type = stat.S_IFMT(unix_mode)
+    return file_type in (0, stat.S_IFREG)
+
+
+def extract(artifact: Path, record: Path, output: Path) -> None:
+    expected = load_record(record)
+    output = output.resolve()
+    if output.exists():
+        fail(f"candidate staging output already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(
+        tempfile.mkdtemp(
+            prefix=f".{output.name}.partial-",
+            dir=output.parent,
+        )
+    )
+    try:
+        with zipfile.ZipFile(artifact) as bundle:
+            members = bundle.infolist()
+            names = [member.filename for member in members]
+            if len(names) != len(set(names)) or set(names) != set(expected):
+                fail("Actions artifact does not contain the exact public candidate allowlist")
+            for member in members:
+                if (
+                    member.is_dir()
+                    or member.flag_bits & 0x1
+                    or not zip_entry_is_regular(member)
+                    or portable_name(member.filename, "Actions artifact member")
+                    != member.filename
+                ):
+                    fail("Actions artifact members must be unencrypted regular root files")
+                expected_size, expected_sha256 = expected[member.filename]
+                if member.file_size != expected_size:
+                    fail(f"Actions artifact member size changed: {member.filename}")
+                destination = temporary / member.filename
+                measured = hashlib.sha256()
+                written = 0
+                with bundle.open(member) as source, destination.open("xb") as target:
+                    while chunk := source.read(1024 * 1024):
+                        written += len(chunk)
+                        if written > expected_size:
+                            fail(f"Actions artifact member exceeded its size: {member.filename}")
+                        measured.update(chunk)
+                        target.write(chunk)
+                    target.flush()
+                    os.fsync(target.fileno())
+                if written != expected_size or measured.hexdigest() != expected_sha256:
+                    fail(f"Actions artifact member identity changed: {member.filename}")
+        temporary.rename(output)
+    except BaseException:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact", required=True, type=Path)
+    parser.add_argument("--record", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+    extract(args.artifact, args.record, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/extract-candidate-actions-artifact.test.py
+++ b/.github/scripts/extract-candidate-actions-artifact.test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("extract-candidate-actions-artifact.py")
+SPEC = importlib.util.spec_from_file_location("candidate_extract", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+class CandidateArtifactExtractionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.archive_name = "codestory-cli-v0.16.3-windows-x64.zip"
+        self.payloads = {
+            self.archive_name: b"candidate bytes",
+            f"{self.archive_name}.sha256": b"archive checksum\n",
+            "SHA256SUMS.txt": b"archive checksum\n",
+        }
+        self.record = {
+            "schema": "codestory-candidate-archive-store/v1",
+            "repository": "TheGreenCedar/CodeStory",
+            "source": {"commit": "a" * 40, "tree": "b" * 40},
+            "target": "windows-x64",
+            "archive": {
+                "name": self.archive_name,
+                "relative_path": self.archive_name,
+                "bytes": len(self.payloads[self.archive_name]),
+                "sha256": sha256(self.payloads[self.archive_name]),
+            },
+            "companions": [
+                {
+                    "role": "archive_checksum",
+                    "relative_path": f"{self.archive_name}.sha256",
+                    "bytes": len(self.payloads[f"{self.archive_name}.sha256"]),
+                    "sha256": sha256(
+                        self.payloads[f"{self.archive_name}.sha256"]
+                    ),
+                },
+                {
+                    "role": "checksum_manifest",
+                    "relative_path": "SHA256SUMS.txt",
+                    "bytes": len(self.payloads["SHA256SUMS.txt"]),
+                    "sha256": sha256(self.payloads["SHA256SUMS.txt"]),
+                },
+            ],
+        }
+        self.record_path = self.root / "candidate-archive-record.json"
+        self.write_record()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_record(self) -> None:
+        self.record_path.write_text(json.dumps(self.record), encoding="utf-8")
+
+    def write_artifact(
+        self,
+        payloads: dict[str, bytes] | None = None,
+        *,
+        duplicate: str | None = None,
+    ) -> Path:
+        path = self.root / "artifact.zip"
+        with zipfile.ZipFile(path, "w") as bundle:
+            for name, value in (payloads or self.payloads).items():
+                bundle.writestr(name, value)
+            if duplicate is not None:
+                bundle.writestr(duplicate, b"duplicate")
+        return path
+
+    def test_extracts_only_the_exact_public_candidate_payload(self) -> None:
+        artifact = self.write_artifact()
+        output = self.root / "staged"
+        MODULE.extract(artifact, self.record_path, output)
+        self.assertEqual(
+            {path.name: path.read_bytes() for path in output.iterdir()},
+            self.payloads,
+        )
+
+    def test_rejects_qualification_material_in_the_public_record(self) -> None:
+        self.record["companions"].append(
+            {
+                "role": "qualification_driver",
+                "relative_path": "qualification.exe",
+                "bytes": 1,
+                "sha256": "c" * 64,
+            }
+        )
+        self.write_record()
+        with self.assertRaisesRegex(ValueError, "two public checksum"):
+            MODULE.extract(
+                self.write_artifact(),
+                self.record_path,
+                self.root / "staged",
+            )
+
+    def test_rejects_missing_extra_duplicate_and_mutated_members(self) -> None:
+        mutations = {
+            "missing": {
+                name: value
+                for name, value in self.payloads.items()
+                if name != "SHA256SUMS.txt"
+            },
+            "extra": {**self.payloads, "untrusted.bin": b"extra"},
+            "mutated": {**self.payloads, self.archive_name: b"wrong bytes"},
+        }
+        for name, payloads in mutations.items():
+            with self.subTest(name=name):
+                artifact = self.write_artifact(payloads)
+                with self.assertRaises(ValueError):
+                    MODULE.extract(
+                        artifact,
+                        self.record_path,
+                        self.root / f"staged-{name}",
+                    )
+                artifact.unlink()
+        artifact = self.write_artifact(duplicate=self.archive_name)
+        with self.assertRaisesRegex(ValueError, "exact public candidate allowlist"):
+            MODULE.extract(artifact, self.record_path, self.root / "staged-duplicate")
+
+    def test_rejects_traversal_and_nested_members(self) -> None:
+        for bad_name in ("../SHA256SUMS.txt", "nested/SHA256SUMS.txt"):
+            payloads = dict(self.payloads)
+            payloads.pop("SHA256SUMS.txt")
+            payloads[bad_name] = b"archive checksum\n"
+            artifact = self.write_artifact(payloads)
+            with self.assertRaises(ValueError):
+                MODULE.extract(
+                    artifact,
+                    self.record_path,
+                    self.root / f"staged-{bad_name.replace('/', '-')}",
+                )
+            artifact.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/linux-vulkan-proof.yml
+++ b/.github/workflows/linux-vulkan-proof.yml
@@ -176,7 +176,8 @@ jobs:
           SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
         run: test "$SERVER_BEHAVIOR_ONLY" = true
 
-      - name: Authenticate exact Linux package producer
+      - name: Authenticate exact Linux candidate artifacts
+        id: candidate-artifacts
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -209,28 +210,177 @@ jobs:
             test "$(jq -r '.status' <<<"$run")" = completed
             test "$(jq -r '.conclusion' <<<"$run")" = success
           fi
-          artifact_count="$(
-            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PACKAGE_RUN_ID/artifacts?per_page=100" \
-              | jq \
-                --arg sha "$(git rev-parse HEAD)" \
-                --argjson run_id "$PACKAGE_RUN_ID" \
-                '[
-                  .artifacts[]
-                  | select(
-                      .name == "codestory-cli-linux-x64"
-                      and .expired == false
-                      and .workflow_run.id == $run_id
-                      and .workflow_run.head_sha == $sha
-                    )
-                ] | length'
+          artifacts="$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PACKAGE_RUN_ID/artifacts?per_page=100"
           )"
-          test "$artifact_count" = 1
+          select_artifact() {
+            local name="$1"
+            jq \
+              --arg name "$name" \
+              --arg sha "$(git rev-parse HEAD)" \
+              --argjson run_id "$PACKAGE_RUN_ID" \
+              '[
+                .artifacts[]
+                | select(
+                    .name == $name
+                    and .expired == false
+                    and .workflow_run.id == $run_id
+                    and .workflow_run.head_sha == $sha
+                  )
+              ] | if length == 1 then .[0] else error("expected one exact candidate artifact") end' \
+              <<<"$artifacts"
+          }
+          artifact="$(select_artifact codestory-cli-linux-x64)"
+          record_artifact="$(
+            select_artifact codestory-candidate-archive-record-linux-x64
+          )"
+          if [ "$SERVER_BEHAVIOR_ONLY" != true ]; then
+            select_artifact codestory-qualification-driver-linux-x64 >/dev/null
+          fi
+          artifact_id="$(jq -r .id <<<"$artifact")"
+          expected_size="$(jq -r .size_in_bytes <<<"$artifact")"
+          expected_digest="$(jq -r .digest <<<"$artifact")"
+          [[ "$artifact_id" =~ ^[0-9]+$ ]]
+          [[ "$expected_size" =~ ^[0-9]+$ ]]
+          [[ "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$(jq -r .id <<<"$record_artifact")" =~ ^[0-9]+$ ]]
+          [[ "$(jq -r .size_in_bytes <<<"$record_artifact")" =~ ^[0-9]+$ ]]
+          [[ "$(jq -r .digest <<<"$record_artifact")" =~ ^sha256:[0-9a-f]{64}$ ]]
+          {
+            echo "package-id=$artifact_id"
+            echo "package-bytes=$expected_size"
+            echo "package-sha256=${expected_digest#sha256:}"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Download exact Linux package
+      - name: Download authenticated candidate record
         uses: actions/download-artifact@v8.0.1
         with:
-          name: codestory-cli-linux-x64
-          path: target/release-dist
+          name: codestory-candidate-archive-record-linux-x64
+          path: target/candidate-archive-record/linux-x64
+          run-id: ${{ inputs.package_run_id || github.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Restore exact candidate archive from protected host
+        id: candidate-cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          record=target/candidate-archive-record/linux-x64/candidate-archive-record.json
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg source_sha "$(git rev-parse HEAD)" \
+            --arg source_tree "$(git rev-parse 'HEAD^{tree}')" \
+            --arg target linux-x64 \
+            '.repository == $repository
+              and .source.commit == $source_sha
+              and .source.tree == $source_tree
+              and .target == $target' \
+            "$record" >/dev/null
+          store="$RUNNER_TOOL_CACHE/codestory/candidate-archives"
+          mkdir -p "$store" target
+          rm -rf target/release-dist
+          restored="$(
+            node .github/scripts/candidate-archive-store.mjs restore \
+              --record "$record" \
+              --store-root "$store" \
+              --output-root target \
+              --output-dir target/release-dist
+          )"
+          hit="$(jq -r .hit <<<"$restored")"
+          test "$hit" = true || test "$hit" = false
+          finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          elapsed_ms=$(((finished_ns - started_ns) / 1000000))
+          echo "hit=$hit" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Candidate archive transfer"
+            echo
+            echo "- Protected-host cache lookup and verification: ${elapsed_ms} ms"
+            echo "- Cache hit: \`$hit\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download, authenticate, and admit candidate archive on miss
+        if: steps.candidate-cache.outputs.hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ steps.candidate-artifacts.outputs.package-id }}
+          EXPECTED_SIZE: ${{ steps.candidate-artifacts.outputs.package-bytes }}
+          EXPECTED_SHA256: ${{ steps.candidate-artifacts.outputs.package-sha256 }}
+        run: |
+          set -euo pipefail
+          transfer_started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          archive="$RUNNER_TEMP/codestory-cli-linux-x64-$ARTIFACT_ID.zip"
+          partial="$archive.partial"
+          download_url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip"
+          rm -f "$archive" "$partial"
+          trap 'rm -f "$archive" "$partial"' EXIT
+          complete=false
+          for attempt in $(seq 1 30); do
+            if curl \
+              --fail \
+              --location \
+              --silent \
+              --show-error \
+              --connect-timeout 30 \
+              --max-time 120 \
+              --continue-at - \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$partial" \
+              "$download_url"; then
+              complete=true
+              break
+            fi
+            current_size=0
+            test ! -f "$partial" || current_size="$(stat -c %s "$partial")"
+            test "$current_size" -le "$EXPECTED_SIZE"
+            if [ "$current_size" = "$EXPECTED_SIZE" ]; then
+              complete=true
+              break
+            fi
+            echo "::warning title=Linux artifact transfer interrupted::Resuming the exact candidate at byte $current_size after attempt $attempt"
+            sleep 2
+          done
+          test "$complete" = true
+          actual_size="$(stat -c %s "$partial")"
+          actual_digest="$(sha256sum "$partial" | awk '{print $1}')"
+          test "$actual_size" = "$EXPECTED_SIZE"
+          test "$actual_digest" = "$EXPECTED_SHA256"
+          mv "$partial" "$archive"
+          transfer_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          record=target/candidate-archive-record/linux-x64/candidate-archive-record.json
+          stage=target/candidate-archive-stage/linux-x64
+          rm -rf "$stage"
+          python3 .github/scripts/extract-candidate-actions-artifact.py \
+            --artifact "$archive" \
+            --record "$record" \
+            --out "$stage"
+          admitted="$(
+            node .github/scripts/candidate-archive-store.mjs admit \
+              --record "$record" \
+              --input-root "$stage" \
+              --store-root "$RUNNER_TOOL_CACHE/codestory/candidate-archives" \
+              --output-root target \
+              --output-dir target/release-dist
+          )"
+          test "$(jq -r .hit <<<"$admitted")" = true || \
+            test "$(jq -r .admitted <<<"$admitted")" = true
+          admission_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          transfer_ms=$(((transfer_finished_ns - transfer_started_ns) / 1000000))
+          verification_ms=$(((admission_finished_ns - transfer_finished_ns) / 1000000))
+          {
+            echo "- Authenticated Actions transfer: ${transfer_ms} ms"
+            echo "- Payload verification and atomic admission: ${verification_ms} ms"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download separate authenticated qualification driver
+        if: ${{ !inputs.server_behavior_only }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: codestory-qualification-driver-linux-x64
+          path: target/qualification-driver-artifact/linux-x64
           run-id: ${{ inputs.package_run_id || github.run_id }}
           github-token: ${{ github.token }}
 
@@ -251,7 +401,7 @@ jobs:
               --version "$version" \
               --archive "target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz" \
               --trusted-root "$GITHUB_WORKSPACE" \
-              --artifact-dir target/release-dist/qualification-driver/linux-x64
+              --artifact-dir target/qualification-driver-artifact/linux-x64
           )"
           echo "path=$(jq -r .driver <<<"$verified")" >> "$GITHUB_OUTPUT"
 
@@ -611,7 +761,9 @@ jobs:
           test "$(uname -m)" = x86_64
 
       - name: Prepare checksum-pinned embedded model
-        run: node scripts/prepare-embedded-model.mjs
+        run: >-
+          node scripts/prepare-embedded-model.mjs
+          --cache-root "$RUNNER_TOOL_CACHE/codestory/model-material"
 
       - name: Build and package native CLI and constant driver
         shell: bash

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -181,7 +181,8 @@ jobs:
         run: |
           set -euo pipefail
           model_prepare_started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
-          node scripts/prepare-embedded-model.mjs
+          node scripts/prepare-embedded-model.mjs \
+            --cache-root "$RUNNER_TOOL_CACHE/codestory/model-material"
           model_prepare_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
           echo "duration-ms=$(((model_prepare_finished_ns - model_prepare_started_ns) / 1000000))" \
             >> "$GITHUB_OUTPUT"
@@ -224,12 +225,15 @@ jobs:
           echo "duration-ms=$(((build_package_finished_ns - build_package_started_ns) / 1000000))" \
             >> "$GITHUB_OUTPUT"
 
-      - name: Download packaged CLI artifact
+      - name: Authenticate exact candidate artifacts
+        id: candidate-artifacts
         if: inputs.use_packaged_cli_artifact
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           ARTIFACT_NAME: codestory-cli-macos-arm64
+          CANDIDATE_RECORD_ARTIFACT: codestory-candidate-archive-record-macos-arm64
+          QUALIFICATION_ARTIFACT: codestory-qualification-driver-macos-arm64
           CANDIDATE_PRODUCER_WORKFLOW_PATH: ${{ inputs.candidate_producer_workflow_path }}
           SERVER_BEHAVIOR_ONLY: ${{ inputs.server_behavior_only }}
         run: |
@@ -254,35 +258,109 @@ jobs:
           test "$(jq -r '.path' <<<"$producer_run")" = "$CANDIDATE_PRODUCER_WORKFLOW_PATH"
           test "$(jq -r '.head_sha' <<<"$producer_run")" = "$(git rev-parse HEAD)"
           test "$(jq -r '.run_attempt' <<<"$producer_run")" = "$GITHUB_RUN_ATTEMPT"
-          artifact="$(
+          artifacts="$(
             gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
-              | jq \
-                --arg name "$ARTIFACT_NAME" \
-                --arg sha "$GITHUB_SHA" \
-                --argjson run_id "$GITHUB_RUN_ID" \
-                '[
-                  .artifacts[]
-                  | select(
-                      .name == $name
-                      and .expired == false
-                      and .workflow_run.id == $run_id
-                      and .workflow_run.head_sha == $sha
-                    )
-                ] | sort_by(.created_at) | last'
           )"
-          test "$artifact" != null
-
+          select_artifact() {
+            local name="$1"
+            jq \
+              --arg name "$name" \
+              --arg sha "$(git rev-parse HEAD)" \
+              --argjson run_id "$GITHUB_RUN_ID" \
+              '[
+                .artifacts[]
+                | select(
+                    .name == $name
+                    and .expired == false
+                    and .workflow_run.id == $run_id
+                    and .workflow_run.head_sha == $sha
+                  )
+              ] | if length == 1 then .[0] else error("expected one exact candidate artifact") end' \
+              <<<"$artifacts"
+          }
+          artifact="$(select_artifact "$ARTIFACT_NAME")"
+          record_artifact="$(select_artifact "$CANDIDATE_RECORD_ARTIFACT")"
+          if [ "$SERVER_BEHAVIOR_ONLY" != true ]; then
+            select_artifact "$QUALIFICATION_ARTIFACT" >/dev/null
+          fi
           artifact_id="$(jq -r '.id' <<<"$artifact")"
           expected_size="$(jq -r '.size_in_bytes' <<<"$artifact")"
           expected_digest="$(jq -r '.digest' <<<"$artifact")"
           [[ "$artifact_id" =~ ^[0-9]+$ ]]
           [[ "$expected_size" =~ ^[0-9]+$ ]]
           [[ "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$(jq -r '.id' <<<"$record_artifact")" =~ ^[0-9]+$ ]]
+          [[ "$(jq -r '.size_in_bytes' <<<"$record_artifact")" =~ ^[0-9]+$ ]]
+          [[ "$(jq -r '.digest' <<<"$record_artifact")" =~ ^sha256:[0-9a-f]{64}$ ]]
+          {
+            echo "package-id=$artifact_id"
+            echo "package-bytes=$expected_size"
+            echo "package-sha256=${expected_digest#sha256:}"
+          } >> "$GITHUB_OUTPUT"
 
-          archive="$RUNNER_TEMP/$ARTIFACT_NAME-$artifact_id.zip"
-          download_url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip"
-          rm -f "$archive"
-          trap 'rm -f "$archive"' EXIT
+      - name: Download authenticated candidate record
+        if: inputs.use_packaged_cli_artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: codestory-candidate-archive-record-macos-arm64
+          path: target/candidate-archive-record/macos-arm64
+
+      - name: Restore exact candidate archive from protected host
+        id: candidate-cache
+        if: inputs.use_packaged_cli_artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          record=target/candidate-archive-record/macos-arm64/candidate-archive-record.json
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg source_sha "$(git rev-parse HEAD)" \
+            --arg source_tree "$(git rev-parse 'HEAD^{tree}')" \
+            --arg target macos-arm64 \
+            '.repository == $repository
+              and .source.commit == $source_sha
+              and .source.tree == $source_tree
+              and .target == $target' \
+            "$record" >/dev/null
+          store="$RUNNER_TOOL_CACHE/codestory/candidate-archives"
+          mkdir -p "$store" target
+          rm -rf target/release-dist
+          restored="$(
+            node .github/scripts/candidate-archive-store.mjs restore \
+              --record "$record" \
+              --store-root "$store" \
+              --output-root target \
+              --output-dir target/release-dist
+          )"
+          hit="$(jq -r .hit <<<"$restored")"
+          test "$hit" = true || test "$hit" = false
+          finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          elapsed_ms=$(((finished_ns - started_ns) / 1000000))
+          echo "hit=$hit" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Candidate archive transfer"
+            echo
+            echo "- Protected-host cache lookup and verification: ${elapsed_ms} ms"
+            echo "- Cache hit: \`$hit\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download, authenticate, and admit candidate archive on miss
+        if: inputs.use_packaged_cli_artifact && steps.candidate-cache.outputs.hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ steps.candidate-artifacts.outputs.package-id }}
+          EXPECTED_SIZE: ${{ steps.candidate-artifacts.outputs.package-bytes }}
+          EXPECTED_SHA256: ${{ steps.candidate-artifacts.outputs.package-sha256 }}
+        run: |
+          set -euo pipefail
+          transfer_started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          archive="$RUNNER_TEMP/codestory-cli-macos-arm64-$ARTIFACT_ID.zip"
+          download_url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip"
+          partial="$archive.partial"
+          rm -f "$archive" "$partial"
+          trap 'rm -f "$archive" "$partial"' EXIT
 
           complete=false
           for attempt in $(seq 1 30); do
@@ -297,33 +375,64 @@ jobs:
               --header "Accept: application/vnd.github+json" \
               --header "Authorization: Bearer $GH_TOKEN" \
               --header "X-GitHub-Api-Version: 2022-11-28" \
-              --output "$archive" \
+              --output "$partial" \
               "$download_url"; then
               complete=true
               break
             fi
 
             current_size=0
-            test ! -f "$archive" || current_size="$(stat -f %z "$archive")"
-            test "$current_size" -le "$expected_size"
-            if [ "$current_size" = "$expected_size" ]; then
+            test ! -f "$partial" || current_size="$(stat -f %z "$partial")"
+            test "$current_size" -le "$EXPECTED_SIZE"
+            if [ "$current_size" = "$EXPECTED_SIZE" ]; then
               complete=true
               break
             fi
-            echo "::warning title=macOS artifact transfer interrupted::Resuming $ARTIFACT_NAME at byte $current_size after attempt $attempt"
+            echo "::warning title=macOS artifact transfer interrupted::Resuming the exact candidate at byte $current_size after attempt $attempt"
             sleep 2
           done
           test "$complete" = true
 
-          actual_size="$(stat -f %z "$archive")"
-          actual_digest="$(shasum -a 256 "$archive" | awk '{print $1}')"
-          test "$actual_size" = "$expected_size"
-          test "$actual_digest" = "${expected_digest#sha256:}"
+          actual_size="$(stat -f %z "$partial")"
+          actual_digest="$(shasum -a 256 "$partial" | awk '{print $1}')"
+          test "$actual_size" = "$EXPECTED_SIZE"
+          test "$actual_digest" = "$EXPECTED_SHA256"
+          mv "$partial" "$archive"
+          transfer_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
           printf 'artifact_id=%s artifact_bytes=%s artifact_digest=%s\n' \
-            "$artifact_id" "$actual_size" "$expected_digest"
+            "$ARTIFACT_ID" "$actual_size" "$actual_digest"
 
-          mkdir -p target/release-dist
-          ditto -x -k "$archive" target/release-dist
+          record=target/candidate-archive-record/macos-arm64/candidate-archive-record.json
+          stage=target/candidate-archive-stage/macos-arm64
+          rm -rf "$stage"
+          python3 .github/scripts/extract-candidate-actions-artifact.py \
+            --artifact "$archive" \
+            --record "$record" \
+            --out "$stage"
+          admitted="$(
+            node .github/scripts/candidate-archive-store.mjs admit \
+              --record "$record" \
+              --input-root "$stage" \
+              --store-root "$RUNNER_TOOL_CACHE/codestory/candidate-archives" \
+              --output-root target \
+              --output-dir target/release-dist
+          )"
+          test "$(jq -r .hit <<<"$admitted")" = true || \
+            test "$(jq -r .admitted <<<"$admitted")" = true
+          admission_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          transfer_ms=$(((transfer_finished_ns - transfer_started_ns) / 1000000))
+          verification_ms=$(((admission_finished_ns - transfer_finished_ns) / 1000000))
+          {
+            echo "- Authenticated Actions transfer: ${transfer_ms} ms"
+            echo "- Payload verification and atomic admission: ${verification_ms} ms"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download separate authenticated qualification driver
+        if: ${{ inputs.use_packaged_cli_artifact && !inputs.calibration_mode && !inputs.server_behavior_only }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: codestory-qualification-driver-macos-arm64
+          path: target/qualification-driver-artifact/macos-arm64
 
       - name: Verify packaged qualification driver
         id: qualification-driver
@@ -342,7 +451,7 @@ jobs:
               --version "$version" \
               --archive "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz" \
               --trusted-root "$GITHUB_WORKSPACE" \
-              --artifact-dir target/release-dist/qualification-driver/macos-arm64
+              --artifact-dir target/qualification-driver-artifact/macos-arm64
           )"
           echo "path=$(jq -r .driver <<<"$verified")" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -147,6 +147,11 @@ jobs:
           New-Item -ItemType Junction -Path $shortTarget -Target $workspaceTarget | Out-Null
           "CARGO_TARGET_DIR=$shortTarget" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Start Windows native setup clock
+        id: windows-native-setup-clock
+        if: runner.os == 'Windows'
+        run: node .github/scripts/cargo-cache-contract.mjs start
+
       - name: Prepare checksum-pinned embedded model
         run: node scripts/prepare-embedded-model.mjs
 
@@ -154,6 +159,27 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: .github/scripts/install-windows-vulkan-sdk.ps1
+
+      - name: Stop Windows native setup clock
+        id: windows-native-setup-clock-stop
+        if: runner.os == 'Windows'
+        run: node .github/scripts/cargo-cache-contract.mjs stop
+
+      - name: Report Windows native setup timing
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          STARTED_MS: ${{ steps.windows-native-setup-clock.outputs.started-ms }}
+          ENDED_MS: ${{ steps.windows-native-setup-clock-stop.outputs.ended-ms }}
+        run: |
+          set -euo pipefail
+          elapsed_ms=$((ENDED_MS - STARTED_MS))
+          test "$elapsed_ms" -ge 0
+          {
+            echo "### Windows package timing"
+            echo
+            echo "- Model and native SDK setup: ${elapsed_ms} ms"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install Linux Vulkan build dependencies
         if: runner.os == 'Linux'
@@ -237,6 +263,7 @@ jobs:
           if [ "$RUNNER_OS" = Windows ]; then
             generator=ninja
             ninja_version="$(ninja --version)"
+            extra_identity+=(--identity windows_rustflags=-Clink-arg=/TIME)
             # shellcheck disable=SC2016
             native_toolchain="$(
               pwsh -NoProfile -Command '
@@ -279,6 +306,11 @@ jobs:
             --cargo-config .cargo/config.toml \
             "${relevant_inputs[@]}" \
             "${extra_identity[@]}"
+
+      - name: Start Windows cache restoration clock
+        id: windows-cache-restore-clock
+        if: runner.os == 'Windows'
+        run: node .github/scripts/cargo-cache-contract.mjs start
 
       - name: Restore Cargo dependency inputs
         id: cargo-dependency-cache
@@ -333,6 +365,24 @@ jobs:
             --cache-hit "${CACHE_HIT:-false}" \
             --path "$SCCACHE_DIR"
 
+      - name: Stop Windows cache restoration clock
+        id: windows-cache-restore-clock-stop
+        if: runner.os == 'Windows'
+        run: node .github/scripts/cargo-cache-contract.mjs stop
+
+      - name: Report Windows cache restoration timing
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          STARTED_MS: ${{ steps.windows-cache-restore-clock.outputs.started-ms }}
+          ENDED_MS: ${{ steps.windows-cache-restore-clock-stop.outputs.ended-ms }}
+        run: |
+          set -euo pipefail
+          elapsed_ms=$((ENDED_MS - STARTED_MS))
+          test "$elapsed_ms" -ge 0
+          echo "- Cargo input and compiler-object cache restoration: ${elapsed_ms} ms" \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Build pinned Linux toolchain image
         if: matrix.asset_target == 'linux-x64'
         shell: bash
@@ -348,21 +398,6 @@ jobs:
         id: compile-clock
         run: node .github/scripts/cargo-cache-contract.mjs start
 
-      - name: Compile native workspace path regression on Windows
-        id: windows-workspace-compile
-        if: runner.os == 'Windows'
-        run: cargo test --locked -p codestory-workspace repository_identity --no-run
-
-      - name: Compile immutable native staging regression on Windows
-        id: windows-native-compile
-        if: runner.os == 'Windows'
-        run: >-
-          cargo test --release --locked
-          -p codestory-llama-sys
-          --test native_staging
-          --target "${{ matrix.rust_target }}"
-          --no-run
-
       - name: Build package and qualification driver
         id: package-build
         if: matrix.asset_target != 'linux-x64'
@@ -370,6 +405,8 @@ jobs:
         env:
           INCLUDE_QUALIFICATION_DRIVER: ${{ inputs.include_qualification_driver }}
           RELEASE_RUST_TARGET: ${{ matrix.rust_target }}
+          SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
+          SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
         run: |
           set -euo pipefail
           cargo_args=(
@@ -383,9 +420,76 @@ jobs:
               --bin codestory_embedding_qualification
             )
           fi
-          cargo build --release --locked \
-            "${cargo_args[@]}" \
-            --target "$RELEASE_RUST_TARGET"
+          build_package_graph() {
+            cargo build --release --locked \
+              "${cargo_args[@]}" \
+              --target "$RELEASE_RUST_TARGET" \
+              "$@"
+          }
+          if [ "$RUNNER_OS" = Windows ]; then
+            cargo_args+=(
+              -p codestory-llama-sys
+              --test native_staging
+              -p codestory-workspace
+              --test windows_path_identity
+            )
+            timing_dir="target/windows-package-build-timing"
+            mkdir -p "$timing_dir"
+            cargo_json="$timing_dir/cargo-messages.jsonl"
+            linker_log="$timing_dir/msvc-link-time.log"
+            build_started_ms="$(node -p 'Date.now()')"
+            export RUSTFLAGS="-C link-arg=/TIME"
+            build_package_graph \
+              --message-format=json-render-diagnostics \
+              --timings \
+              2> >(tee "$linker_log" >&2) \
+              | tee "$cargo_json"
+            build_ended_ms="$(node -p 'Date.now()')"
+            build_elapsed_ms=$((build_ended_ms - build_started_ms))
+            test "$build_elapsed_ms" -ge 0
+
+            expectations=(
+              --expect "cli=codestory-cli:bin:codestory-cli"
+              --expect "runtime=codestory-cli:bin:codestory-cli-runtime"
+              --expect "native_staging=codestory-llama-sys:test:native_staging"
+              --expect "windows_path_identity=codestory-workspace:test:windows_path_identity"
+            )
+            if [ "$INCLUDE_QUALIFICATION_DRIVER" = true ]; then
+              expectations+=(
+                --expect "qualification_driver=codestory-bench:bin:codestory_embedding_qualification"
+              )
+            fi
+            node .github/scripts/cargo-build-artifacts.mjs select \
+              --input "$cargo_json" \
+              --out "$timing_dir/cargo-build-artifacts.json" \
+              --target-dir "$CARGO_TARGET_DIR" \
+              --workspace-root "$GITHUB_WORKSPACE" \
+              --rust-target "$RELEASE_RUST_TARGET" \
+              --source-sha "$SOURCE_SHA" \
+              --source-tree "$SOURCE_TREE" \
+              --github-output "$GITHUB_OUTPUT" \
+              "${expectations[@]}"
+            node --input-type=module -e '
+              import fs from "node:fs";
+              import path from "node:path";
+              const source = path.join(process.env.CARGO_TARGET_DIR, "cargo-timings");
+              const destination = path.join(
+                "target",
+                "windows-package-build-timing",
+                "cargo-timings",
+              );
+              if (fs.existsSync(source)) {
+                fs.cpSync(source, destination, { recursive: true });
+              }
+            '
+            linker_rows="$(grep -Eic '(^|[[:space:]])time([[:space:](:]|$)' "$linker_log" || true)"
+            {
+              echo "- Exact release graph build: ${build_elapsed_ms} ms"
+              echo "- MSVC /TIME linker rows retained: ${linker_rows}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            build_package_graph
+          fi
 
       - name: Build Linux x64 at the glibc 2.31 baseline
         id: linux-build
@@ -591,16 +695,25 @@ jobs:
 
       - name: Prove native workspace path identity
         if: runner.os == 'Windows'
-        run: cargo test --locked -p codestory-workspace repository_identity
+        shell: pwsh
+        env:
+          TEST_BINARY: ${{ steps.package-build.outputs.windows_path_identity }}
+        run: |
+          & "$env:TEST_BINARY" --nocapture
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows path-identity release harness failed with exit code $LASTEXITCODE"
+          }
 
       - name: Test immutable native staging on Windows
         if: runner.os == 'Windows'
-        run: >-
-          cargo test --release --locked
-          -p codestory-llama-sys
-          --test native_staging
-          --target "${{ matrix.rust_target }}"
-          stages_complete_immutable_native_seeds
+        shell: pwsh
+        env:
+          TEST_BINARY: ${{ steps.package-build.outputs.native_staging }}
+        run: |
+          & "$env:TEST_BINARY" --nocapture
+          if ($LASTEXITCODE -ne 0) {
+            throw "immutable native-staging release harness failed with exit code $LASTEXITCODE"
+          }
 
       - name: Sign and notarize macOS CLI
         if: runner.os == 'macOS' && inputs.sign_macos
@@ -796,10 +909,18 @@ jobs:
       - name: Smoke codestory-cli on Windows
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          WINDOWS_CLI: ${{ steps.package-build.outputs.cli }}
         run: |
-          $bin = Join-Path $env:CARGO_TARGET_DIR "${{ matrix.rust_target }}/release/codestory-cli${{ matrix.exe_suffix }}"
+          $bin = "$env:WINDOWS_CLI"
           & $bin --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows CLI version smoke failed with exit code $LASTEXITCODE"
+          }
           & $bin --help
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows CLI help smoke failed with exit code $LASTEXITCODE"
+          }
 
       - name: Clear release asset output
         run: python -c "import shutil; shutil.rmtree('target/release-dist', ignore_errors=True)"
@@ -952,13 +1073,34 @@ jobs:
         shell: pwsh
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          ARTIFACT_MANIFEST: ${{ steps.package-build.outputs.manifest }}
+          WINDOWS_CLI: ${{ steps.package-build.outputs.cli }}
+          SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
+          SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
+          RELEASE_RUST_TARGET: ${{ matrix.rust_target }}
         run: |
-          $bin = Join-Path $env:CARGO_TARGET_DIR "${{ matrix.rust_target }}/release/codestory-cli${{ matrix.exe_suffix }}"
+          node .github/scripts/cargo-build-artifacts.mjs verify `
+            --manifest "$env:ARTIFACT_MANIFEST" `
+            --source-sha "$env:SOURCE_SHA" `
+            --source-tree "$env:SOURCE_TREE" `
+            --workspace-root "$env:GITHUB_WORKSPACE" `
+            --rust-target "$env:RELEASE_RUST_TARGET"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows build-artifact verification failed with exit code $LASTEXITCODE"
+          }
+          $started = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          $bin = "$env:WINDOWS_CLI"
           python .github/scripts/package-codestory-release.py `
             --version "$env:INPUT_VERSION" `
             --target "${{ matrix.asset_target }}" `
             --binary $bin `
             --out-dir target/release-dist
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows release packaging failed with exit code $LASTEXITCODE"
+          }
+          $elapsed = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() - $started
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY `
+            -Value "- Exact emitted CLI packaging: $elapsed ms"
 
       - name: Smoke packaged release asset on Windows
         if: runner.os == 'Windows'
@@ -984,16 +1126,17 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
           SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
-        run: >-
-          node .github/scripts/qualification-driver-artifact.mjs produce
-          --asset-target "${{ matrix.asset_target }}"
-          --source-sha "$SOURCE_SHA"
-          --source-tree "$SOURCE_TREE"
-          --version "$INPUT_VERSION"
-          --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}"
-          --trusted-root "$GITHUB_WORKSPACE"
-          --target-dir target
-          --out-dir "target/release-dist/qualification-driver/${{ matrix.asset_target }}"
+        run: |
+          set -euo pipefail
+          node .github/scripts/qualification-driver-artifact.mjs produce \
+            --asset-target "${{ matrix.asset_target }}" \
+            --source-sha "$SOURCE_SHA" \
+            --source-tree "$SOURCE_TREE" \
+            --version "$INPUT_VERSION" \
+            --archive "target/release-dist/codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}" \
+            --trusted-root "$GITHUB_WORKSPACE" \
+            --target-dir target \
+            --out-dir "target/release-dist/qualification-driver/${{ matrix.asset_target }}"
 
       - name: Report fresh package identity
         id: fresh-package
@@ -1018,6 +1161,38 @@ jobs:
             echo "- Archive SHA-256: \`$archive_sha256\`"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "archive-sha256=$archive_sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Produce exact candidate archive record
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          SOURCE_SHA: ${{ steps.source-identity.outputs.sha }}
+          SOURCE_TREE: ${{ steps.source-identity.outputs.tree }}
+        run: |
+          set -euo pipefail
+          archive_name="codestory-cli-v${INPUT_VERSION}-${{ matrix.asset_target }}.${{ matrix.extension }}"
+          archive="target/release-dist/$archive_name"
+          archive_checksum="${archive}.sha256"
+          checksum_manifest=target/release-dist/SHA256SUMS.txt
+          record_dir="target/candidate-archive-record/${{ matrix.asset_target }}"
+          mkdir -p "$record_dir"
+          file_bytes() {
+            python -c 'import os, sys; print(os.path.getsize(sys.argv[1]))' "$1"
+          }
+          file_sha256() {
+            python -c 'import hashlib, sys; print(hashlib.file_digest(open(sys.argv[1], "rb"), "sha256").hexdigest())' "$1"
+          }
+          node .github/scripts/candidate-archive-store.mjs record \
+            --output "$record_dir/candidate-archive-record.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --source-sha "$SOURCE_SHA" \
+            --source-tree "$SOURCE_TREE" \
+            --target "${{ matrix.asset_target }}" \
+            --archive-name "$archive_name" \
+            --archive-bytes "$(file_bytes "$archive")" \
+            --archive-sha256 "$(file_sha256 "$archive")" \
+            --companion "archive_checksum|${archive_name}.sha256|$(file_bytes "$archive_checksum")|$(file_sha256 "$archive_checksum")" \
+            --companion "checksum_manifest|SHA256SUMS.txt|$(file_bytes "$checksum_manifest")|$(file_sha256 "$checksum_manifest")"
 
       - name: Upload packaged version proof
         if: always()
@@ -1063,19 +1238,71 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+      - name: Start package artifact transfer clock
+        id: package-transfer-clock
+        if: runner.os == 'Windows'
+        run: node .github/scripts/cargo-cache-contract.mjs start
+
       - name: Upload release asset
         uses: actions/upload-artifact@v7.0.1
         with:
           name: codestory-cli-${{ matrix.asset_target }}
           path: |
-            target/release-dist/*.tar.gz
-            target/release-dist/*.zip
-            target/release-dist/*.sha256
+            target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}
+            target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}.sha256
             target/release-dist/SHA256SUMS.txt
-            target/release-dist/qualification-driver/${{ matrix.asset_target }}
           if-no-files-found: error
           retention-days: 30
           overwrite: true
+
+      - name: Upload exact candidate archive record
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: codestory-candidate-archive-record-${{ matrix.asset_target }}
+          path: target/candidate-archive-record/${{ matrix.asset_target }}/candidate-archive-record.json
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
+
+      - name: Upload separate qualification driver
+        if: inputs.include_qualification_driver
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: codestory-qualification-driver-${{ matrix.asset_target }}
+          path: target/release-dist/qualification-driver/${{ matrix.asset_target }}
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
+
+      - name: Stop package artifact transfer clock
+        id: package-transfer-clock-stop
+        if: runner.os == 'Windows'
+        run: node .github/scripts/cargo-cache-contract.mjs stop
+
+      - name: Report package artifact transfer timing
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          STARTED_MS: ${{ steps.package-transfer-clock.outputs.started-ms }}
+          ENDED_MS: ${{ steps.package-transfer-clock-stop.outputs.ended-ms }}
+        run: |
+          set -euo pipefail
+          elapsed_ms=$((ENDED_MS - STARTED_MS))
+          test "$elapsed_ms" -ge 0
+          mkdir -p target/windows-package-build-timing
+          printf 'artifact_transfer_ms=%s\n' "$elapsed_ms" \
+            > target/windows-package-build-timing/artifact-transfer.txt
+          echo "- Candidate artifact upload: ${elapsed_ms} ms" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Windows package build timing
+        if: always() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: windows-package-build-timing-attempt-${{ github.run_attempt }}
+          path: target/windows-package-build-timing
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: Upload macOS notarization proof
         if: always() && runner.os == 'macOS' && inputs.sign_macos

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -163,8 +163,8 @@ jobs:
           name: ${{ inputs.pre_publish_closeout_artifact }}
           path: target/pre-publish-closeout
 
-      - name: Download published asset and checksum
-        id: asset
+      - name: Authenticate published candidate assets
+        id: published-assets
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -172,19 +172,259 @@ jobs:
           VERSION: ${{ steps.release.outputs.version }}
           ASSET_TARGET: ${{ matrix.asset_target }}
           EXTENSION: ${{ matrix.extension }}
+          PUBLISHED_COMMIT: ${{ steps.published.outputs.commit }}
         run: |
           set -euo pipefail
-          dir="target/post-publish-release-assets"
           asset="codestory-cli-v${VERSION}-${ASSET_TARGET}.${EXTENSION}"
+          checksum="$asset.sha256"
+          release="$(
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG"
+          )"
+          test "$(jq -r .tag_name <<<"$release")" = "$TAG"
+          test "$(jq -r .draft <<<"$release")" = false
+          select_asset() {
+            local name="$1"
+            jq \
+              --arg name "$name" \
+              '[.assets[] | select(.name == $name)]
+                | if length == 1 then .[0] else error("expected one published release asset") end' \
+              <<<"$release"
+          }
+          archive_asset="$(select_asset "$asset")"
+          checksum_asset="$(select_asset "$checksum")"
+          manifest_asset="$(select_asset SHA256SUMS.txt)"
+          validate_asset() {
+            local value="$1"
+            [[ "$(jq -r .id <<<"$value")" =~ ^[0-9]+$ ]]
+            [[ "$(jq -r .size <<<"$value")" =~ ^[0-9]+$ ]]
+            [[ "$(jq -r .digest <<<"$value")" =~ ^sha256:[0-9a-f]{64}$ ]]
+          }
+          validate_asset "$archive_asset"
+          validate_asset "$checksum_asset"
+          validate_asset "$manifest_asset"
+          record_dir=target/candidate-archive-record/${ASSET_TARGET}
+          mkdir -p "$record_dir"
+          record="$record_dir/candidate-archive-record.json"
+          rm -f "$record"
+          node .github/scripts/candidate-archive-store.mjs record \
+            --repository "$GITHUB_REPOSITORY" \
+            --source-sha "$PUBLISHED_COMMIT" \
+            --source-tree "$(git rev-parse 'HEAD^{tree}')" \
+            --target "$ASSET_TARGET" \
+            --archive-name "$asset" \
+            --archive-bytes "$(jq -r .size <<<"$archive_asset")" \
+            --archive-sha256 "$(jq -r .digest <<<"$archive_asset" | sed 's/^sha256://')" \
+            --companion "archive_checksum|$checksum|$(jq -r .size <<<"$checksum_asset")|$(jq -r .digest <<<"$checksum_asset" | sed 's/^sha256://')" \
+            --companion "checksum_manifest|SHA256SUMS.txt|$(jq -r .size <<<"$checksum_asset")|$(jq -r .digest <<<"$checksum_asset" | sed 's/^sha256://')" \
+            --output "$record"
+          {
+            echo "archive-id=$(jq -r .id <<<"$archive_asset")"
+            echo "archive-bytes=$(jq -r .size <<<"$archive_asset")"
+            echo "archive-sha256=$(jq -r .digest <<<"$archive_asset" | sed 's/^sha256://')"
+            echo "checksum-id=$(jq -r .id <<<"$checksum_asset")"
+            echo "checksum-bytes=$(jq -r .size <<<"$checksum_asset")"
+            echo "checksum-sha256=$(jq -r .digest <<<"$checksum_asset" | sed 's/^sha256://')"
+            echo "manifest-id=$(jq -r .id <<<"$manifest_asset")"
+            echo "manifest-bytes=$(jq -r .size <<<"$manifest_asset")"
+            echo "manifest-sha256=$(jq -r .digest <<<"$manifest_asset" | sed 's/^sha256://')"
+            echo "archive-name=$asset"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore published candidate archive from protected host
+        id: candidate-cache
+        shell: bash
+        env:
+          ASSET_TARGET: ${{ matrix.asset_target }}
+          PUBLISHED_COMMIT: ${{ steps.published.outputs.commit }}
+        run: |
+          set -euo pipefail
+          started_ns="$(python -c 'import time; print(time.monotonic_ns())')"
+          record=target/candidate-archive-record/${ASSET_TARGET}/candidate-archive-record.json
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg source_sha "$PUBLISHED_COMMIT" \
+            --arg source_tree "$(git rev-parse 'HEAD^{tree}')" \
+            --arg target "$ASSET_TARGET" \
+            '.repository == $repository
+              and .source.commit == $source_sha
+              and .source.tree == $source_tree
+              and .target == $target' \
+            "$record" >/dev/null
+          store="$RUNNER_TOOL_CACHE/codestory/candidate-archives"
+          mkdir -p "$store" target
+          rm -rf target/post-publish-release-assets
+          restored="$(
+            node .github/scripts/candidate-archive-store.mjs restore \
+              --record "$record" \
+              --store-root "$store" \
+              --output-root target \
+              --output-dir target/post-publish-release-assets
+          )"
+          hit="$(jq -r .hit <<<"$restored")"
+          test "$hit" = true || test "$hit" = false
+          finished_ns="$(python -c 'import time; print(time.monotonic_ns())')"
+          elapsed_ms=$(((finished_ns - started_ns) / 1000000))
+          echo "hit=$hit" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Published candidate archive transfer"
+            echo
+            echo "- Protected-host cache lookup and verification: ${elapsed_ms} ms"
+            echo "- Cache hit: \`$hit\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download, verify, and admit published candidate on miss
+        if: steps.candidate-cache.outputs.hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSET_TARGET: ${{ matrix.asset_target }}
+          ARCHIVE_NAME: ${{ steps.published-assets.outputs.archive-name }}
+          ARCHIVE_ID: ${{ steps.published-assets.outputs.archive-id }}
+          ARCHIVE_BYTES: ${{ steps.published-assets.outputs.archive-bytes }}
+          ARCHIVE_SHA256: ${{ steps.published-assets.outputs.archive-sha256 }}
+          CHECKSUM_ID: ${{ steps.published-assets.outputs.checksum-id }}
+          CHECKSUM_BYTES: ${{ steps.published-assets.outputs.checksum-bytes }}
+          CHECKSUM_SHA256: ${{ steps.published-assets.outputs.checksum-sha256 }}
+        run: |
+          set -euo pipefail
+          started_ns="$(python -c 'import time; print(time.monotonic_ns())')"
+          stage=target/candidate-archive-stage/${ASSET_TARGET}
+          rm -rf "$stage"
+          mkdir -p "$stage"
+          download_asset() {
+            local id="$1"
+            local name="$2"
+            local expected_bytes="$3"
+            local expected_sha256="$4"
+            local destination="$stage/$name"
+            local partial="$destination.partial"
+            local url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/assets/$id"
+            rm -f "$destination" "$partial"
+            local complete=false
+            for attempt in $(seq 1 30); do
+              if curl \
+                --fail \
+                --location \
+                --silent \
+                --show-error \
+                --connect-timeout 30 \
+                --max-time 120 \
+                --continue-at - \
+                --header "Accept: application/octet-stream" \
+                --header "Authorization: Bearer $GH_TOKEN" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                --output "$partial" \
+                "$url"; then
+                complete=true
+                break
+              fi
+              current_size="$(python - "$partial" <<'PY'
+          import os
+          import sys
+          print(os.path.getsize(sys.argv[1]) if os.path.isfile(sys.argv[1]) else 0)
+          PY
+          )"
+              test "$current_size" -le "$expected_bytes"
+              if [ "$current_size" = "$expected_bytes" ]; then
+                complete=true
+                break
+              fi
+              echo "::warning title=Release asset transfer interrupted::Resuming $name at byte $current_size after attempt $attempt"
+              sleep 2
+            done
+            test "$complete" = true
+            actual="$(
+              python - "$partial" <<'PY'
+          import hashlib
+          import os
+          import sys
+          path = sys.argv[1]
+          with open(path, "rb") as source:
+              print(f"{os.path.getsize(path)} {hashlib.file_digest(source, 'sha256').hexdigest()}")
+          PY
+            )"
+            test "${actual%% *}" = "$expected_bytes"
+            test "${actual#* }" = "$expected_sha256"
+            mv "$partial" "$destination"
+          }
+          download_asset "$ARCHIVE_ID" "$ARCHIVE_NAME" \
+            "$ARCHIVE_BYTES" "$ARCHIVE_SHA256"
+          download_asset "$CHECKSUM_ID" "$ARCHIVE_NAME.sha256" \
+            "$CHECKSUM_BYTES" "$CHECKSUM_SHA256"
+          transfer_finished_ns="$(python -c 'import time; print(time.monotonic_ns())')"
+          # package-codestory-release.py defines the candidate-local manifest as
+          # the same single checksum line. The published global manifest is
+          # authenticated separately below and never mutates this cache record.
+          cp "$stage/$ARCHIVE_NAME.sha256" "$stage/SHA256SUMS.txt"
+          record=target/candidate-archive-record/${ASSET_TARGET}/candidate-archive-record.json
+          admitted="$(
+            node .github/scripts/candidate-archive-store.mjs admit \
+              --record "$record" \
+              --input-root "$stage" \
+              --store-root "$RUNNER_TOOL_CACHE/codestory/candidate-archives" \
+              --output-root target \
+              --output-dir target/post-publish-release-assets
+          )"
+          test "$(jq -r .hit <<<"$admitted")" = true || \
+            test "$(jq -r .admitted <<<"$admitted")" = true
+          admission_finished_ns="$(python -c 'import time; print(time.monotonic_ns())')"
+          transfer_ms=$(((transfer_finished_ns - started_ns) / 1000000))
+          verification_ms=$(((admission_finished_ns - transfer_finished_ns) / 1000000))
+          {
+            echo "- Published archive and checksum transfer: ${transfer_ms} ms"
+            echo "- Payload verification and atomic admission: ${verification_ms} ms"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download authenticated published checksum manifest
+        id: published-checksum
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_ID: ${{ steps.published-assets.outputs.manifest-id }}
+          MANIFEST_BYTES: ${{ steps.published-assets.outputs.manifest-bytes }}
+          MANIFEST_SHA256: ${{ steps.published-assets.outputs.manifest-sha256 }}
+        run: |
+          set -euo pipefail
+          dir=target/post-publish-release-checksums
           mkdir -p "$dir"
-          gh release download "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern "$asset" \
-            --pattern "SHA256SUMS.txt" \
-            --dir "$dir" \
-            --clobber
-          echo "archive=$dir/$asset" >> "$GITHUB_OUTPUT"
-          echo "checksum=$dir/SHA256SUMS.txt" >> "$GITHUB_OUTPUT"
+          checksum="$dir/SHA256SUMS.txt"
+          rm -f "$checksum"
+          curl \
+            --fail \
+            --location \
+            --silent \
+            --show-error \
+            --header "Accept: application/octet-stream" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --output "$checksum" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/assets/$MANIFEST_ID"
+          actual="$(
+            python - "$checksum" <<'PY'
+          import hashlib
+          import os
+          import sys
+          path = sys.argv[1]
+          with open(path, "rb") as source:
+              print(f"{os.path.getsize(path)} {hashlib.file_digest(source, 'sha256').hexdigest()}")
+          PY
+          )"
+          test "${actual%% *}" = "$MANIFEST_BYTES"
+          test "${actual#* }" = "$MANIFEST_SHA256"
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Bind materialized published asset paths
+        id: asset
+        shell: bash
+        env:
+          ASSET_NAME: ${{ steps.published-assets.outputs.archive-name }}
+          PUBLISHED_CHECKSUM: ${{ steps.published-checksum.outputs.checksum }}
+        run: |
+          set -euo pipefail
+          dir=target/post-publish-release-assets
+          test -f "$dir/$ASSET_NAME"
+          echo "archive=$dir/$ASSET_NAME" >> "$GITHUB_OUTPUT"
+          echo "checksum=$PUBLISHED_CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Prove packaged version, help, and stdio shape
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,12 +394,12 @@ jobs:
             --input target/release-non-claim/plan-input.json \
             --out target/release-non-claim/plan.json
 
-      - name: Download release packages for withheld identity
+      - name: Download authenticated candidate records for withheld identity
         if: steps.non-claim.outputs.withheld_hosts != ''
         uses: actions/download-artifact@v8.0.1
         with:
-          pattern: codestory-cli-*
-          path: target/release-dist
+          pattern: codestory-candidate-archive-record-*
+          path: target/release-non-claim/candidate-records
           merge-multiple: false
 
       - name: Record populated accelerator non-claims
@@ -418,9 +418,9 @@ jobs:
             > target/release-non-claim/identity.json
           for host in $WITHHELD_HOSTS; do
             case "$host" in
-              macos-arm64-metal) target=macos-arm64; extension=tar.gz ;;
-              windows-x64-vulkan) target=windows-x64; extension=zip ;;
-              linux-x64-vulkan) target=linux-x64; extension=tar.gz ;;
+              macos-arm64-metal) target=macos-arm64 ;;
+              windows-x64-vulkan) target=windows-x64 ;;
+              linux-x64-vulkan) target=linux-x64 ;;
               *) echo "::error::unknown non-claim host $host"; exit 1 ;;
             esac
             node scripts/codestory-release-cell-manifest.mjs withhold \
@@ -431,7 +431,7 @@ jobs:
               --producer-run-id "$GITHUB_RUN_ID" \
               --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
               --identity target/release-non-claim/identity.json \
-              --archive "target/release-dist/codestory-cli-$target/codestory-cli-v$version-$target.$extension" \
+              --candidate-record "target/release-non-claim/candidate-records/codestory-candidate-archive-record-$target/candidate-archive-record.json" \
               --out-dir "target/release-non-claim/cells/$host"
           done
 

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -152,7 +152,9 @@ jobs:
         # The self-hosted runner service account has the default Restricted execution
         # policy, so every run step must carry the bypass shell or die before running.
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
-        run: node scripts/prepare-embedded-model.mjs
+        run: >-
+          node scripts/prepare-embedded-model.mjs
+          --cache-root "$env:RUNNER_TOOL_CACHE/codestory/model-material"
 
       - name: Build and package native CLI
         if: ${{ !inputs.use_packaged_cli_artifact }}
@@ -184,7 +186,8 @@ jobs:
             --binary target/release/codestory-cli.exe `
             --out-dir target/release-dist
 
-      - name: Authenticate exact Windows package producer
+      - name: Authenticate exact Windows candidate artifacts
+        id: candidate-artifacts
         if: inputs.use_packaged_cli_artifact
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
@@ -222,24 +225,192 @@ jobs:
           $artifacts = gh api `
             "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID/artifacts?per_page=100" |
             ConvertFrom-Json
-          $artifactCount = @(
-            $artifacts.artifacts | Where-Object {
-              $_.name -eq "codestory-cli-windows-x64" -and
-              $_.expired -eq $false -and
-              [string]$_.workflow_run.id -eq $env:GITHUB_RUN_ID -and
-              $_.workflow_run.head_sha -eq $sourceSha
+          function Select-ExactArtifact([string] $name) {
+            $selected = @(
+              $artifacts.artifacts | Where-Object {
+                $_.name -eq $name -and
+                $_.expired -eq $false -and
+                [string]$_.workflow_run.id -eq $env:GITHUB_RUN_ID -and
+                $_.workflow_run.head_sha -eq $sourceSha
+              }
+            )
+            if ($selected.Count -ne 1) {
+              throw "expected exactly one authenticated $name artifact"
             }
-          ).Count
-          if ($artifactCount -ne 1) {
-            throw "expected exactly one authenticated Windows package artifact"
+            return $selected[0]
           }
+          $package = Select-ExactArtifact "codestory-cli-windows-x64"
+          $record = Select-ExactArtifact `
+            "codestory-candidate-archive-record-windows-x64"
+          if ($env:SERVER_BEHAVIOR_ONLY -ne "true") {
+            $null = Select-ExactArtifact `
+              "codestory-qualification-driver-windows-x64"
+          }
+          if (
+            [string]$package.id -notmatch '^[0-9]+$' -or
+            [string]$package.size_in_bytes -notmatch '^[0-9]+$' -or
+            [string]$package.digest -notmatch '^sha256:[0-9a-f]{64}$' -or
+            [string]$record.id -notmatch '^[0-9]+$' -or
+            [string]$record.size_in_bytes -notmatch '^[0-9]+$' -or
+            [string]$record.digest -notmatch '^sha256:[0-9a-f]{64}$'
+          ) {
+            throw "candidate artifact metadata is incomplete"
+          }
+          @(
+            "package-id=$($package.id)",
+            "package-bytes=$($package.size_in_bytes)",
+            "package-sha256=$($package.digest.Substring(7))"
+          ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      - name: Download packaged CLI artifact
+      - name: Download authenticated candidate record
         if: inputs.use_packaged_cli_artifact
         uses: actions/download-artifact@v8.0.1
         with:
-          name: codestory-cli-windows-x64
-          path: target/release-dist
+          name: codestory-candidate-archive-record-windows-x64
+          path: target/candidate-archive-record/windows-x64
+
+      - name: Restore exact candidate archive from protected host
+        id: candidate-cache
+        if: inputs.use_packaged_cli_artifact
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $started = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          $recordPath = "target/candidate-archive-record/windows-x64/candidate-archive-record.json"
+          $record = Get-Content -Raw -LiteralPath $recordPath | ConvertFrom-Json
+          $sourceSha = (git rev-parse HEAD).Trim()
+          $sourceTree = (git rev-parse 'HEAD^{tree}').Trim()
+          if (
+            $record.repository -ne $env:GITHUB_REPOSITORY -or
+            $record.source.commit -ne $sourceSha -or
+            $record.source.tree -ne $sourceTree -or
+            $record.target -ne "windows-x64"
+          ) {
+            throw "candidate record provenance does not match the protected proof"
+          }
+          $store = Join-Path $env:RUNNER_TOOL_CACHE `
+            "codestory/candidate-archives"
+          New-Item -ItemType Directory -Force $store | Out-Null
+          New-Item -ItemType Directory -Force target | Out-Null
+          Remove-Item -Recurse -Force target/release-dist -ErrorAction SilentlyContinue
+          $restored = node .github/scripts/candidate-archive-store.mjs restore `
+            --record $recordPath `
+            --store-root $store `
+            --output-root target `
+            --output-dir target/release-dist | ConvertFrom-Json
+          $hit = "$($restored.hit)".ToLowerInvariant()
+          if ($hit -notin @("true", "false")) {
+            throw "candidate cache returned an invalid hit state"
+          }
+          "hit=$hit" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $elapsed = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() - $started
+          @(
+            "### Candidate archive transfer",
+            "",
+            "- Protected-host cache lookup and verification: $elapsed ms",
+            "- Cache hit: ``$hit``"
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Download, authenticate, and admit candidate archive on miss
+        if: inputs.use_packaged_cli_artifact && steps.candidate-cache.outputs.hit != 'true'
+        shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ steps.candidate-artifacts.outputs.package-id }}
+          EXPECTED_SIZE: ${{ steps.candidate-artifacts.outputs.package-bytes }}
+          EXPECTED_SHA256: ${{ steps.candidate-artifacts.outputs.package-sha256 }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $started = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          $archive = Join-Path $env:RUNNER_TEMP `
+            "codestory-cli-windows-x64-$env:ARTIFACT_ID.zip"
+          $partial = "$archive.partial"
+          Remove-Item -Force $archive, $partial -ErrorAction SilentlyContinue
+          $url = "$env:GITHUB_API_URL/repos/$env:GITHUB_REPOSITORY/actions/artifacts/$env:ARTIFACT_ID/zip"
+          $complete = $false
+          foreach ($attempt in 1..30) {
+            & curl.exe `
+              --fail `
+              --location `
+              --silent `
+              --show-error `
+              --connect-timeout 30 `
+              --max-time 120 `
+              --continue-at - `
+              --header "Accept: application/vnd.github+json" `
+              --header "Authorization: Bearer $env:GH_TOKEN" `
+              --header "X-GitHub-Api-Version: 2022-11-28" `
+              --output $partial `
+              $url
+            if ($LASTEXITCODE -eq 0) {
+              $complete = $true
+              break
+            }
+            $currentSize = if (Test-Path -LiteralPath $partial -PathType Leaf) {
+              (Get-Item -LiteralPath $partial).Length
+            } else {
+              0
+            }
+            if ($currentSize -gt [long]$env:EXPECTED_SIZE) {
+              throw "candidate artifact exceeded its authenticated size"
+            }
+            if ($currentSize -eq [long]$env:EXPECTED_SIZE) {
+              $complete = $true
+              break
+            }
+            Write-Warning `
+              "resuming exact candidate at byte $currentSize after attempt $attempt"
+            Start-Sleep -Seconds 2
+          }
+          if (-not $complete) {
+            throw "exact candidate artifact transfer did not complete"
+          }
+          $actualSize = (Get-Item -LiteralPath $partial).Length
+          $actualDigest = (
+            Get-FileHash -Algorithm SHA256 -LiteralPath $partial
+          ).Hash.ToLowerInvariant()
+          if (
+            $actualSize -ne [long]$env:EXPECTED_SIZE -or
+            $actualDigest -ne $env:EXPECTED_SHA256
+          ) {
+            throw "candidate artifact container identity changed"
+          }
+          Move-Item -LiteralPath $partial -Destination $archive
+          $transferEnded = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          $recordPath = "target/candidate-archive-record/windows-x64/candidate-archive-record.json"
+          $stage = "target/candidate-archive-stage/windows-x64"
+          Remove-Item -Recurse -Force $stage -ErrorAction SilentlyContinue
+          python .github/scripts/extract-candidate-actions-artifact.py `
+            --artifact $archive `
+            --record $recordPath `
+            --out $stage
+          if ($LASTEXITCODE -ne 0) {
+            throw "candidate artifact extraction failed"
+          }
+          $store = Join-Path $env:RUNNER_TOOL_CACHE `
+            "codestory/candidate-archives"
+          $admitted = node .github/scripts/candidate-archive-store.mjs admit `
+            --record $recordPath `
+            --input-root $stage `
+            --store-root $store `
+            --output-root target `
+            --output-dir target/release-dist | ConvertFrom-Json
+          if (-not $admitted.hit -and -not $admitted.admitted) {
+            throw "candidate archive was not admitted or restored"
+          }
+          $admissionEnded = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          @(
+            "- Authenticated Actions transfer: $($transferEnded - $started) ms",
+            "- Payload verification and atomic admission: $($admissionEnded - $transferEnded) ms"
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Download separate authenticated qualification driver
+        if: ${{ inputs.use_packaged_cli_artifact && !inputs.server_behavior_only }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: codestory-qualification-driver-windows-x64
+          path: target/qualification-driver-artifact/windows-x64
 
       - name: Verify packaged qualification driver
         id: qualification-driver
@@ -258,7 +429,7 @@ jobs:
             --version $version `
             --archive "target/release-dist/codestory-cli-v$version-windows-x64.zip" `
             --trusted-root $env:GITHUB_WORKSPACE `
-            --artifact-dir target/release-dist/qualification-driver/windows-x64
+            --artifact-dir target/qualification-driver-artifact/windows-x64
           $result = $verified | ConvertFrom-Json
           "path=$($result.driver)" |
             Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
+    "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
+        "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
+        "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "17acbb5053b01853fbd4f2423c905ff0ee56b3aae5e794cbd61e47b37c277a74",
+  "candidate_sha256": "04574dbd3dc1f3d3bb0c86af052712afd712882e9df7d0372c4311430adf6d83",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
+      "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
+      "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
+    "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/crates/codestory-workspace/tests/windows_path_identity.rs
+++ b/crates/codestory-workspace/tests/windows_path_identity.rs
@@ -1,0 +1,81 @@
+#![cfg(windows)]
+
+use codestory_workspace::{
+    same_workspace_path, workspace_file_identity, workspace_path_identity,
+    workspace_path_lexical_identity, workspace_relative_path,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn native_windows_path_identity_preserves_existing_and_missing_alias_rules() {
+    let project = tempfile::tempdir().expect("project");
+    let existing = project.path().join("CodeStory");
+    fs::create_dir(&existing).expect("mixed-case directory");
+    let existing_alias = project.path().join("codestory");
+
+    assert_eq!(
+        workspace_path_identity(&existing).expect("existing identity"),
+        workspace_path_identity(&existing_alias).expect("existing alias identity")
+    );
+    assert!(same_workspace_path(&existing, &existing_alias));
+    assert_eq!(
+        workspace_relative_path(&existing, &existing_alias.join("src/lib.rs")),
+        Some(PathBuf::from("src/lib.rs"))
+    );
+
+    let identity_file = existing.join("identity.txt");
+    fs::write(&identity_file, "identity").expect("identity file");
+    let open_file = fs::File::open(&identity_file).expect("open identity file");
+    assert_eq!(
+        workspace_file_identity(&open_file).expect("open-file identity"),
+        workspace_path_identity(&identity_file).expect("path identity")
+    );
+
+    let missing = project.path().join("Missing").join(".").join("child");
+    let missing_alias = project.path().join("missing").join("CHILD");
+    assert_eq!(
+        workspace_path_identity(&missing).expect("missing identity"),
+        workspace_path_identity(&missing_alias).expect("missing alias identity")
+    );
+    assert!(same_workspace_path(&missing, &missing_alias));
+
+    let dotted = project
+        .path()
+        .join("Missing")
+        .join(".")
+        .join("child")
+        .join("..")
+        .join("Älias");
+    let normalized = project.path().join("missing").join("äLIAS");
+    assert!(same_workspace_path(&dotted, &normalized));
+
+    let extended = PathBuf::from(format!(r"\\?\{}", project.path().display()));
+    assert_eq!(
+        workspace_path_identity(&extended.join("missing")).expect("extended missing identity"),
+        workspace_path_identity(&project.path().join("MISSING"))
+            .expect("ordinary missing identity")
+    );
+    assert!(same_workspace_path(
+        &extended.join("missing"),
+        &project.path().join("MISSING")
+    ));
+    assert_ne!(
+        workspace_path_identity(Path::new(r"C:missing")).expect("drive-relative identity"),
+        workspace_path_identity(Path::new(r"C:\missing")).expect("drive-rooted identity")
+    );
+}
+
+#[test]
+fn native_windows_lexical_containment_is_case_insensitive_and_segment_bounded() {
+    let root =
+        workspace_path_lexical_identity(Path::new(r"C:\Source\CodeStory")).expect("root identity");
+    let descendant = workspace_path_lexical_identity(Path::new(r"c:\source\codestory\src\lib.rs"))
+        .expect("descendant identity");
+    let sibling =
+        workspace_path_lexical_identity(Path::new(r"C:\Source\CodeStory-other\src\lib.rs"))
+            .expect("sibling identity");
+
+    assert!(descendant.is_within(&root));
+    assert!(!sibling.is_within(&root));
+}

--- a/release-claims.json
+++ b/release-claims.json
@@ -1,6 +1,6 @@
 {
   "schema": "codestory.release-claims/v1",
-  "graph_version": 9,
+  "graph_version": 10,
   "graph_id": "codestory-release-claims",
   "standard_release_claims": [
     "source_behavior",
@@ -981,6 +981,7 @@
     "producer_job_name": "Withhold unproven accelerator claims",
     "withhold_policy": {
       "maximum_withheld_hosts": 1,
+      "archive_identity_source": "candidate_archive_record",
       "claims_requiring_proof": [
         "accelerator_execution",
         "installed_runtime_behavior",
@@ -1058,6 +1059,73 @@
         "extension": "tar.gz"
       }
     ],
+    "windows_package_graph": {
+      "asset_target": "windows-x64",
+      "cargo_profile": "release",
+      "cargo_build_invocations": 1,
+      "cargo_test_invocations_after_build": 0,
+      "artifacts": [
+        "codestory-cli",
+        "codestory-cli-runtime",
+        "codestory_embedding_qualification",
+        "native_staging",
+        "windows_path_identity"
+      ],
+      "direct_test_harnesses": [
+        "native_staging",
+        "windows_path_identity"
+      ],
+      "package_artifact": "codestory-cli",
+      "timing_phases": [
+        "cache_restore",
+        "native_setup",
+        "cargo_graph",
+        "msvc_link",
+        "regression_execution",
+        "packaging",
+        "artifact_transfer"
+      ]
+    },
+    "candidate_archive_cache": {
+      "record_schema": "codestory-candidate-archive-store/v1",
+      "key_fields": [
+        "source.commit",
+        "target",
+        "archive.sha256"
+      ],
+      "protected_host_root": "runner_tool_cache",
+      "package_producer_workflow": "packaged-platform-proof.yml",
+      "package_artifact_name": "codestory-cli-{asset_target}",
+      "record_artifact_name": "codestory-candidate-archive-record-{asset_target}",
+      "qualification_driver_artifact_name": "codestory-qualification-driver-{asset_target}",
+      "hit_verification": [
+        "repository",
+        "source.commit",
+        "source.tree",
+        "target",
+        "archive.file",
+        "archive.bytes",
+        "archive.sha256"
+      ],
+      "miss_admission": "same_filesystem_atomic_rename",
+      "owned_corruption": "quarantine_then_authenticated_miss",
+      "unowned_corruption": "fail_closed",
+      "cross_source_reuse": false,
+      "restore_prefixes": false,
+      "public_asset_reauthentication": true
+    },
+    "model_material_cache": {
+      "key_field": "model.sha256",
+      "source_sha_in_key": false,
+      "toolchain_in_key": false,
+      "hit_verification": [
+        "model.real_ancestry",
+        "model.single_link",
+        "model.size_bytes",
+        "model.sha256"
+      ],
+      "miss_admission": "same_filesystem_atomic_no_replace"
+    },
     "calibration": {
       "coordinator_workflow": "packaged-platform-pr.yml",
       "mode": "calibration",
@@ -1120,8 +1188,8 @@
       "driver_contract": {
         "producer_workflow": "packaged-platform-proof.yml",
         "producer_job": "build",
-        "artifact_name_template": "codestory-cli-{asset_target}",
-        "artifact_directory_template": "qualification-driver/{asset_target}",
+        "artifact_name_template": "codestory-qualification-driver-{asset_target}",
+        "artifact_directory_template": ".",
         "identity_file": "qualification-driver-identity.json",
         "identity_schema_version": 1,
         "identity_fields": [

--- a/scripts/codestory-release-cell-manifest.mjs
+++ b/scripts/codestory-release-cell-manifest.mjs
@@ -23,9 +23,13 @@ import {
   classifyJobFailure,
   countLostExecutions,
 } from "../.github/scripts/lost-runner-recovery.mjs";
+import {
+  readCandidateArchiveRecord,
+} from "../.github/scripts/candidate-archive-store.mjs";
 
 const PRODUCER_MAP_SCHEMA = "codestory.release-actions-provenance/v1";
 const ACTIONS_DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const SHA256 = /^[0-9a-f]{64}$/u;
 
 function fail(message) {
   throw new Error(message);
@@ -52,6 +56,39 @@ function fileAttestation(filePath) {
     name: path.basename(absolute),
     sha256: createHash("sha256").update(bytes).digest("hex"),
     bytes: bytes.length,
+  };
+}
+
+function archiveAttestation(value) {
+  if (
+    value === null
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || JSON.stringify(Object.keys(value).sort())
+      !== JSON.stringify(["bytes", "name", "sha256"])
+  ) {
+    fail("archive attestation keys changed");
+  }
+  const name = text(value.name, "archive attestation name");
+  if (
+    path.basename(name) !== name
+    || name === "."
+    || name === ".."
+    || name.includes("/")
+    || name.includes("\\")
+  ) {
+    fail("archive attestation name must be a simple filename");
+  }
+  if (!Number.isSafeInteger(value.bytes) || value.bytes <= 0) {
+    fail("archive attestation bytes must be a positive safe integer");
+  }
+  if (typeof value.sha256 !== "string" || !SHA256.test(value.sha256)) {
+    fail("archive attestation sha256 must be a lowercase SHA-256 digest");
+  }
+  return {
+    name,
+    sha256: value.sha256,
+    bytes: value.bytes,
   };
 }
 
@@ -141,6 +178,7 @@ export function produceReleaseCellManifest({
   observedAt,
   artifactPath = null,
   archivePath = null,
+  retainedArchive = null,
   prePublishLedger = null,
   evidence = null,
   nonClaim = null,
@@ -162,7 +200,16 @@ export function produceReleaseCellManifest({
   if (cell.required_identity.includes("producer_version")) identity.producer_version = version;
   if (cell.required_identity.includes("runtime_version")) identity.runtime_version = version;
 
-  const artifact = archivePath ? fileAttestation(archivePath) : artifactPath ? fileAttestation(artifactPath) : null;
+  if (archivePath && retainedArchive) {
+    fail("archivePath and retainedArchive are mutually exclusive");
+  }
+  const artifact = archivePath
+    ? fileAttestation(archivePath)
+    : retainedArchive
+      ? archiveAttestation(retainedArchive)
+      : artifactPath
+        ? fileAttestation(artifactPath)
+        : null;
   if (artifact && cell.required_identity.includes("artifact_sha256")) {
     identity.artifact_sha256 = artifact.sha256;
   }
@@ -186,10 +233,14 @@ export function produceReleaseCellManifest({
   };
   if (nonClaim) manifest.non_claim = nonClaim;
   if (cell.archive_role === "pre_publish") {
-    if (!artifact || !archivePath) fail(`${cell.id} requires --archive`);
+    if (!artifact || (!archivePath && !retainedArchive)) {
+      fail(`${cell.id} requires authenticated archive identity`);
+    }
     manifest.archive = { name: artifact.name, sha256: artifact.sha256, bytes: artifact.bytes };
   } else if (cell.archive_role === "post_publish_compare") {
-    if (!artifact || !archivePath) fail(`${cell.id} requires --archive`);
+    if (!artifact || (!archivePath && !retainedArchive)) {
+      fail(`${cell.id} requires authenticated archive identity`);
+    }
     const packageRow = retainedPackageRow(prePublishLedger, identity.target);
     identity.pre_publish_artifact_sha256 = packageRow.archive.sha256;
     manifest.comparison = {
@@ -260,9 +311,30 @@ function withholdHost(values) {
     fail(`a non-claim may be recorded only after ${policy.maximum_run_attempts} run attempts`);
   }
   const identity = values.identity ? JSON.parse(readFileSync(values.identity, "utf8")) : {};
+  const candidateRecord = readCandidateArchiveRecord(
+    text(values["candidate-record"], "--candidate-record"),
+  );
+  if (
+    candidateRecord.repository !== gitIdentity.repository
+    || candidateRecord.source.commit !== gitIdentity.commit
+    || candidateRecord.source.tree !== gitIdentity.source_tree
+  ) {
+    fail("candidate archive record does not match the exact withheld source");
+  }
+  const retainedArchive = {
+    name: candidateRecord.archive.name,
+    bytes: candidateRecord.archive.bytes,
+    sha256: candidateRecord.archive.sha256,
+  };
   const outDir = text(values["out-dir"], "--out-dir");
   for (const cellId of host.withheld_cells) {
     const cell = selectedCell(graph, cellId);
+    const cellTarget = resolveReleaseCellConstraints(cell, attempt).target;
+    if (cellTarget !== candidateRecord.target) {
+      fail(
+        `candidate archive record target ${candidateRecord.target} does not match ${cell.id}`,
+      );
+    }
     // Each closeout phase downloads and authorizes its own container, so the manifests are written
     // into one directory per phase and uploaded as one artifact per phase.
     const producer = authenticatedProducer({
@@ -280,7 +352,7 @@ function withholdHost(values) {
       identity,
       producer,
       observedAt: values["observed-at"],
-      archivePath: values.archive,
+      retainedArchive,
       nonClaim: {
         host: host.id,
         runtime_execution: policy.runtime_execution,

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const GRAPH_SCHEMA = "codestory.release-claims/v1";
-const GRAPH_VERSION = 9;
+const GRAPH_VERSION = 10;
 const KNOWN_PACKAGE_TARGETS = new Set([
   "linux-arm64",
   "linux-x64",
@@ -359,6 +359,11 @@ function validateWithholdPolicy(policy, hosts, cellGroups) {
       + `host proven (${hosts.size} hosts are declared)`,
     );
   }
+  if (withhold.archive_identity_source !== "candidate_archive_record") {
+    fail(
+      "non_claim_policy.withhold_policy.archive_identity_source must be candidate_archive_record",
+    );
+  }
   const required = stringArray(
     withhold.claims_requiring_proof,
     "non_claim_policy.withhold_policy.claims_requiring_proof",
@@ -678,8 +683,9 @@ function validateQualificationPolicy(value) {
     JSON.stringify(Object.keys(driver).sort()) !== JSON.stringify(expectedDriverKeys)
     || driver.producer_workflow !== "packaged-platform-proof.yml"
     || driver.producer_job !== "build"
-    || driver.artifact_name_template !== "codestory-cli-{asset_target}"
-    || driver.artifact_directory_template !== "qualification-driver/{asset_target}"
+    || driver.artifact_name_template
+      !== "codestory-qualification-driver-{asset_target}"
+    || driver.artifact_directory_template !== "."
     || driver.identity_file !== "qualification-driver-identity.json"
     || driver.identity_schema_version !== 1
     || JSON.stringify(driver.identity_fields) !== JSON.stringify(expectedIdentityFields)
@@ -793,6 +799,118 @@ function validateQualificationPolicy(value) {
   ) {
     fail("workflow_policy.qualification must forbid CPU environment, policy, and backend selection");
   }
+}
+
+function exactStringList(value, expected, label) {
+  const actual = stringArray(value, label, { nonEmpty: true });
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} must be exactly ${expected.join(", ")}`);
+  }
+  return actual;
+}
+
+function validateWindowsPackageGraph(value) {
+  const graph = object(value, "workflow_policy.windows_package_graph");
+  if (
+    graph.asset_target !== "windows-x64"
+    || graph.cargo_profile !== "release"
+    || graph.cargo_build_invocations !== 1
+    || graph.cargo_test_invocations_after_build !== 0
+    || graph.package_artifact !== "codestory-cli"
+  ) {
+    fail("workflow_policy.windows_package_graph must build and package one exact Windows release graph");
+  }
+  exactStringList(
+    graph.artifacts,
+    [
+      "codestory-cli",
+      "codestory-cli-runtime",
+      "codestory_embedding_qualification",
+      "native_staging",
+      "windows_path_identity",
+    ],
+    "workflow_policy.windows_package_graph.artifacts",
+  );
+  exactStringList(
+    graph.direct_test_harnesses,
+    ["native_staging", "windows_path_identity"],
+    "workflow_policy.windows_package_graph.direct_test_harnesses",
+  );
+  exactStringList(
+    graph.timing_phases,
+    [
+      "cache_restore",
+      "native_setup",
+      "cargo_graph",
+      "msvc_link",
+      "regression_execution",
+      "packaging",
+      "artifact_transfer",
+    ],
+    "workflow_policy.windows_package_graph.timing_phases",
+  );
+}
+
+function validateCandidateArchiveCache(value) {
+  const cache = object(value, "workflow_policy.candidate_archive_cache");
+  if (
+    cache.record_schema !== "codestory-candidate-archive-store/v1"
+    || cache.protected_host_root !== "runner_tool_cache"
+    || cache.package_producer_workflow !== "packaged-platform-proof.yml"
+    || cache.package_artifact_name !== "codestory-cli-{asset_target}"
+    || cache.record_artifact_name
+      !== "codestory-candidate-archive-record-{asset_target}"
+    || cache.qualification_driver_artifact_name
+      !== "codestory-qualification-driver-{asset_target}"
+    || cache.miss_admission !== "same_filesystem_atomic_rename"
+    || cache.owned_corruption !== "quarantine_then_authenticated_miss"
+    || cache.unowned_corruption !== "fail_closed"
+    || cache.cross_source_reuse !== false
+    || cache.restore_prefixes !== false
+    || cache.public_asset_reauthentication !== true
+  ) {
+    fail("workflow_policy.candidate_archive_cache must retain exact-source atomic protected-host reuse");
+  }
+  exactStringList(
+    cache.key_fields,
+    ["source.commit", "target", "archive.sha256"],
+    "workflow_policy.candidate_archive_cache.key_fields",
+  );
+  exactStringList(
+    cache.hit_verification,
+    [
+      "repository",
+      "source.commit",
+      "source.tree",
+      "target",
+      "archive.file",
+      "archive.bytes",
+      "archive.sha256",
+    ],
+    "workflow_policy.candidate_archive_cache.hit_verification",
+  );
+}
+
+function validateModelMaterialCache(value) {
+  const cache = object(value, "workflow_policy.model_material_cache");
+  if (
+    cache.key_field !== "model.sha256"
+    || cache.source_sha_in_key !== false
+    || cache.toolchain_in_key !== false
+    || cache.miss_admission !== "same_filesystem_atomic_no_replace"
+  ) {
+    fail("workflow_policy.model_material_cache must key immutable model material only by model SHA");
+  }
+  exactStringList(
+    cache.hit_verification,
+    [
+      "model.real_ancestry",
+      "model.single_link",
+      "model.size_bytes",
+      "model.sha256",
+    ],
+    "workflow_policy.model_material_cache.hit_verification",
+  );
 }
 
 function validatePublicSupport(graph, packageTargets, cellGroups) {
@@ -1310,6 +1428,9 @@ export function validateReleaseClaimGraph(graph) {
     }
     targets.add(row.asset_target);
   }
+  validateWindowsPackageGraph(policy.windows_package_graph);
+  validateCandidateArchiveCache(policy.candidate_archive_cache);
+  validateModelMaterialCache(policy.model_material_cache);
   validateCalibrationPolicy(policy.calibration);
   validateQualificationPolicy(policy.qualification);
   validatePublicSupport(graph, targets, cellGroups);

--- a/scripts/prepare-embedded-model.mjs
+++ b/scripts/prepare-embedded-model.mjs
@@ -9,10 +9,11 @@ import {
   mkdir,
   open,
   readFile,
+  realpath,
   rm,
 } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, parse, relative, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
@@ -171,6 +172,7 @@ async function valid(path, contract) {
     const metadata = await lstat(path);
     return (
       metadata.isFile() &&
+      metadata.nlink === 1 &&
       metadata.size === contract.size &&
       (await digest(path)) === contract.sha256
     );
@@ -275,6 +277,35 @@ async function destinationMetadata(path) {
   }
 }
 
+function pathIdentity(path) {
+  const resolved = resolve(path);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+async function ensureRealDirectoryTree(directory, label) {
+  const resolved = resolve(directory);
+  const root = parse(resolved).root;
+  const components = relative(root, resolved).split(sep).filter(Boolean);
+  let cursor = root;
+  for (const component of components) {
+    cursor = resolve(cursor, component);
+    try {
+      await mkdir(cursor);
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+    const metadata = await lstat(cursor);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+      throw new Error(`${label} must not traverse symbolic links, reparse points, or files: ${cursor}`);
+    }
+    const canonical = await realpath(cursor);
+    if (pathIdentity(canonical) !== pathIdentity(cursor)) {
+      throw new Error(`${label} must have real directory ancestry: ${cursor}`);
+    }
+  }
+  return resolved;
+}
+
 async function requireAbsentDestination(path) {
   if (await destinationMetadata(path)) {
     throw new Error(`refusing to overwrite model destination: ${path}`);
@@ -291,19 +322,38 @@ async function publishNoReplace(temporary, destination, contract) {
     }
     throw error;
   }
+  try {
+    await rm(temporary);
+  } catch (error) {
+    await rm(destination, { force: true });
+    throw error;
+  }
   if (!(await valid(destination, contract))) {
     await rm(destination, { force: true });
     throw new Error(`published model failed verification: ${destination}`);
   }
-  await rm(temporary);
 }
 
 const contract = await loadContract(resolve(argument("--contract") ?? defaultContract));
+const outputArgument = argument("--output");
+const cacheRootArgument = argument("--cache-root");
+if (outputArgument && cacheRootArgument) {
+  throw new Error("--output and --cache-root are mutually exclusive");
+}
+const cacheRoot = cacheRootArgument
+  ? await ensureRealDirectoryTree(cacheRootArgument, "model cache root")
+  : undefined;
 const destination = resolve(
-  argument("--output") ??
-    `target/build-assets/sha256/${contract.sha256}/${contract.fileName}`,
+  outputArgument ??
+    (cacheRoot
+      ? resolve(cacheRoot, "sha256", contract.sha256, contract.fileName)
+      : `target/build-assets/sha256/${contract.sha256}/${contract.fileName}`),
 );
-await mkdir(dirname(destination), { recursive: true });
+if (cacheRoot) {
+  await ensureRealDirectoryTree(dirname(destination), "model cache path");
+} else {
+  await mkdir(dirname(destination), { recursive: true });
+}
 const existingDestination = await destinationMetadata(destination);
 if (existingDestination && !existingDestination.isFile()) {
   throw new Error(`model destination is not a regular file: ${destination}`);
@@ -326,6 +376,9 @@ if (!(await valid(destination, contract))) {
     }
     if (!published) throw aggregatedDownloadError(failures);
   }
+}
+if (cacheRoot) {
+  await ensureRealDirectoryTree(dirname(destination), "model cache path");
 }
 
 if (process.env.GITHUB_ENV) {

--- a/scripts/tests/codestory-release-cell-manifest.test.mjs
+++ b/scripts/tests/codestory-release-cell-manifest.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -14,6 +21,7 @@ import {
   resolveReleaseCellConstraints,
 } from "../codestory-release-closeout.mjs";
 import { loadReleaseClaimGraph } from "../codestory-release-claims.mjs";
+import { buildCandidateArchiveRecord } from "../../.github/scripts/candidate-archive-store.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const graph = loadReleaseClaimGraph(root);
@@ -627,17 +635,61 @@ test("withheld manifests carry the populated non-claim and refuse an unspent ret
 test("withhold writes one container per closeout phase, never a phase-mixed one", () => {
   // Each phase's trusted producer map authorizes only the manifests it selected, so a container
   // holding another phase's cell is rejected at download time and the release is lost anyway.
-  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-release-withhold-"));
-  const archive = path.join(directory, "codestory-cli-v0.16.0-linux-x64.tar.gz");
-  writeFileSync(archive, "release archive bytes");
+  const directory = mkdtempSync(
+    path.join(realpathSync.native(os.tmpdir()), "codestory-release-withhold-"),
+  );
+  const archiveName = "codestory-cli-v0.16.0-linux-x64.tar.gz";
+  const archiveBytes = Buffer.from("release archive bytes");
+  const archiveSha256 = createHash("sha256").update(archiveBytes).digest("hex");
+  const checksumBytes = Buffer.from(`${archiveSha256}  ${archiveName}\n`);
+  const checksumSha256 = createHash("sha256").update(checksumBytes).digest("hex");
+  const candidateRecord = path.join(directory, "candidate-archive-record.json");
+  const head = execFileSync(
+    "git",
+    ["rev-parse", "HEAD"],
+    { cwd: root, encoding: "utf8" },
+  ).trim();
+  const sourceTree = execFileSync(
+    "git",
+    ["rev-parse", "HEAD^{tree}"],
+    { cwd: root, encoding: "utf8" },
+  ).trim();
+  writeFileSync(
+    candidateRecord,
+    `${JSON.stringify(buildCandidateArchiveRecord({
+      repository: gitIdentity.repository,
+      sourceSha: head,
+      sourceTree,
+      target: "linux-x64",
+      archive: {
+        name: archiveName,
+        relative_path: archiveName,
+        bytes: archiveBytes.length,
+        sha256: archiveSha256,
+      },
+      companions: [
+        {
+          role: "archive_checksum",
+          relative_path: `${archiveName}.sha256`,
+          bytes: checksumBytes.length,
+          sha256: checksumSha256,
+        },
+        {
+          role: "checksum_manifest",
+          relative_path: "SHA256SUMS.txt",
+          bytes: checksumBytes.length,
+          sha256: checksumSha256,
+        },
+      ],
+    }), null, 2)}\n`,
+  );
   const identityPath = path.join(directory, "identity.json");
   writeFileSync(identityPath, JSON.stringify({
     installer: "candidate_managed_plugin",
     native_engine: "coderank_q8_embedded",
   }));
   const outDir = path.join(directory, "cells");
-  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
-  const result = spawnSync(process.execPath, [
+  const withholdArgs = [
     path.join(root, "scripts/codestory-release-cell-manifest.mjs"), "withhold",
     "--repo", root,
     "--expected-sha", head,
@@ -646,10 +698,32 @@ test("withhold writes one container per closeout phase, never a phase-mixed one"
     "--producer-run-id", "12345",
     "--producer-run-attempt", String(nonClaimPolicy.maximum_run_attempts),
     "--identity", identityPath,
-    "--archive", archive,
+    "--candidate-record", candidateRecord,
     "--out-dir", outDir,
-  ], { encoding: "utf8", env: producerEnv({ GITHUB_RUN_ID: "12345" }) });
+  ];
+  const result = spawnSync(process.execPath, withholdArgs, {
+    encoding: "utf8",
+    env: producerEnv({ GITHUB_RUN_ID: "12345" }),
+  });
   assert.equal(result.status, 0, result.stderr);
+
+  const staleRecord = path.join(directory, "stale-candidate-archive-record.json");
+  const stale = JSON.parse(readFileSync(candidateRecord, "utf8"));
+  stale.source.commit = "f".repeat(40);
+  writeFileSync(staleRecord, `${JSON.stringify(stale, null, 2)}\n`);
+  const staleResult = spawnSync(
+    process.execPath,
+    withholdArgs.map((value) => value === candidateRecord ? staleRecord : value),
+    {
+      encoding: "utf8",
+      env: producerEnv({ GITHUB_RUN_ID: "12345" }),
+    },
+  );
+  assert.notEqual(staleResult.status, 0);
+  assert.match(
+    staleResult.stderr,
+    /candidate archive record does not match the exact withheld source/u,
+  );
 
   const expected = {
     pre_publish: {
@@ -669,6 +743,7 @@ test("withhold writes one container per closeout phase, never a phase-mixed one"
     for (const manifest of written) {
       assert.equal(manifest.phase, phase);
       assert.equal(manifest.evidence.status, "withheld");
+      assert.equal(manifest.evidence.identity.artifact_sha256, archiveSha256);
       assert.equal(
         manifest.evidence.identity.producer_artifact,
         artifact.replaceAll("{attempt}", String(nonClaimPolicy.maximum_run_attempts)),

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -103,7 +103,7 @@ test("versioned claim graph has one deterministic digest and all declared contro
   assert.match(releaseClaimGraphDigest(graph), /^[0-9a-f]{64}$/u);
   assert.equal(positiveFixture().evidence[0].graph_sha256, releaseClaimGraphDigest(graph));
   assert.equal(graph.claims.length, 8);
-  assert.equal(graph.graph_version, 9);
+  assert.equal(graph.graph_version, 10);
   assert.deepEqual(
     [...graph.standard_release_claims].sort(),
     [
@@ -157,6 +157,115 @@ test("versioned claim graph has one deterministic digest and all declared contro
   assert.equal(graph.workflow_policy.promotion.manual_pr_ref_hint, "--ref <same-repository PR head branch>");
   assert.equal(graph.workflow_policy.promotion.source_cache_namespace, "source-proof-v2");
   assert.equal(graph.workflow_policy.promotion.packaged_cache_namespace, "codestory-cli-native-v4");
+});
+
+test("claim graph freezes one exact Windows release graph and protected content-addressed reuse", () => {
+  assert.deepEqual(graph.workflow_policy.windows_package_graph, {
+    asset_target: "windows-x64",
+    cargo_profile: "release",
+    cargo_build_invocations: 1,
+    cargo_test_invocations_after_build: 0,
+    artifacts: [
+      "codestory-cli",
+      "codestory-cli-runtime",
+      "codestory_embedding_qualification",
+      "native_staging",
+      "windows_path_identity",
+    ],
+    direct_test_harnesses: ["native_staging", "windows_path_identity"],
+    package_artifact: "codestory-cli",
+    timing_phases: [
+      "cache_restore",
+      "native_setup",
+      "cargo_graph",
+      "msvc_link",
+      "regression_execution",
+      "packaging",
+      "artifact_transfer",
+    ],
+  });
+  assert.deepEqual(graph.workflow_policy.candidate_archive_cache.key_fields, [
+    "source.commit",
+    "target",
+    "archive.sha256",
+  ]);
+  assert.equal(
+    graph.workflow_policy.candidate_archive_cache.qualification_driver_artifact_name,
+    "codestory-qualification-driver-{asset_target}",
+  );
+  assert.equal(graph.workflow_policy.candidate_archive_cache.cross_source_reuse, false);
+  assert.equal(graph.workflow_policy.candidate_archive_cache.restore_prefixes, false);
+  assert.equal(
+    graph.workflow_policy.candidate_archive_cache.owned_corruption,
+    "quarantine_then_authenticated_miss",
+  );
+  assert.equal(
+    graph.workflow_policy.candidate_archive_cache.unowned_corruption,
+    "fail_closed",
+  );
+  assert.deepEqual(graph.workflow_policy.model_material_cache, {
+    key_field: "model.sha256",
+    source_sha_in_key: false,
+    toolchain_in_key: false,
+    hit_verification: [
+      "model.real_ancestry",
+      "model.single_link",
+      "model.size_bytes",
+      "model.sha256",
+    ],
+    miss_admission: "same_filesystem_atomic_no_replace",
+  });
+
+  const mutations = [
+    [draft => {
+      draft.workflow_policy.windows_package_graph.cargo_build_invocations = 2;
+    }, /one exact Windows release graph/u],
+    [draft => {
+      draft.workflow_policy.windows_package_graph.cargo_profile = "debug";
+    }, /one exact Windows release graph/u],
+    [draft => {
+      draft.workflow_policy.windows_package_graph.cargo_test_invocations_after_build = 1;
+    }, /one exact Windows release graph/u],
+    [draft => {
+      draft.workflow_policy.windows_package_graph.direct_test_harnesses.pop();
+    }, /direct_test_harnesses must be exactly/u],
+    [draft => {
+      draft.workflow_policy.candidate_archive_cache.key_fields.shift();
+    }, /key_fields must be exactly/u],
+    [draft => {
+      draft.workflow_policy.candidate_archive_cache.cross_source_reuse = true;
+    }, /exact-source atomic protected-host reuse/u],
+    [draft => {
+      draft.workflow_policy.candidate_archive_cache.restore_prefixes = true;
+    }, /exact-source atomic protected-host reuse/u],
+    [draft => {
+      draft.workflow_policy.candidate_archive_cache.public_asset_reauthentication = false;
+    }, /exact-source atomic protected-host reuse/u],
+    [draft => {
+      draft.workflow_policy.candidate_archive_cache.owned_corruption = "fail_closed";
+    }, /exact-source atomic protected-host reuse/u],
+    [draft => {
+      draft.workflow_policy.candidate_archive_cache.unowned_corruption =
+        "quarantine_then_authenticated_miss";
+    }, /exact-source atomic protected-host reuse/u],
+    [draft => {
+      draft.workflow_policy.model_material_cache.key_field = "source.commit";
+    }, /only by model SHA/u],
+    [draft => {
+      draft.workflow_policy.model_material_cache.source_sha_in_key = true;
+    }, /only by model SHA/u],
+    [draft => {
+      draft.workflow_policy.model_material_cache.hit_verification = [
+        "model.size_bytes",
+        "model.sha256",
+      ];
+    }, /hit_verification must be exactly/u],
+  ];
+  for (const [mutate, expected] of mutations) {
+    const draft = structuredClone(graph);
+    mutate(draft);
+    assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
 });
 
 test("claim graph freezes Mac-only accelerated 3x1 constant calibration", () => {
@@ -215,8 +324,8 @@ test("claim graph freezes one GPU-only qualification run per available platform"
   assert.deepEqual(qualification.driver_contract, {
     producer_workflow: "packaged-platform-proof.yml",
     producer_job: "build",
-    artifact_name_template: "codestory-cli-{asset_target}",
-    artifact_directory_template: "qualification-driver/{asset_target}",
+    artifact_name_template: "codestory-qualification-driver-{asset_target}",
+    artifact_directory_template: ".",
     identity_file: "qualification-driver-identity.json",
     identity_schema_version: 1,
     identity_fields: [
@@ -495,6 +604,14 @@ test("graph rejects ambiguous dependencies and unstructured proof lanes", () => 
   assert.throws(
     () => validateReleaseClaimGraph(zeroCap),
     /maximum_withheld_hosts must be a positive integer/u,
+  );
+
+  const packageDownloadWithholding = structuredClone(graph);
+  packageDownloadWithholding.non_claim_policy.withhold_policy.archive_identity_source =
+    "downloaded_archive";
+  assert.throws(
+    () => validateReleaseClaimGraph(packageDownloadWithholding),
+    /archive_identity_source must be candidate_archive_record/u,
   );
 
   // Dropping a claim a lost host can erase would make the cap silent about exactly that claim.

--- a/scripts/tests/codestory-release-closeout.test.mjs
+++ b/scripts/tests/codestory-release-closeout.test.mjs
@@ -1399,6 +1399,7 @@ test("a release that withholds every accelerator host is refused, not published"
     JSON.stringify(result.summary.input_errors),
   );
   assert.deepEqual(result.ledger.withhold_policy, {
+    archive_identity_source: withholdPolicy.archive_identity_source,
     claims_requiring_proof: [...withholdPolicy.claims_requiring_proof],
     maximum_withheld_hosts: withholdPolicy.maximum_withheld_hosts,
   });

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "a3a52e219497cd20f1708244443ff10c72f13f72dd617dcd6076dfcb50b6e815",
+      "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {

--- a/scripts/tests/prepare-embedded-model.test.mjs
+++ b/scripts/tests/prepare-embedded-model.test.mjs
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  link,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -41,7 +51,9 @@ function contractDigest(domain, value) {
 }
 
 async function fixture(t, expected = Buffer.from("good"), sourceCount = 1) {
-  const directory = await mkdtemp(resolve(tmpdir(), "codestory-model-contract-"));
+  const directory = await realpath(
+    await mkdtemp(resolve(tmpdir(), "codestory-model-contract-")),
+  );
   t.after(() => rm(directory, { force: true, recursive: true }));
   const contract = resolve(directory, "contract.json");
   const modelSha256 = sha256(expected);
@@ -177,6 +189,144 @@ test("copies and verifies an explicit source while offline", async (t) => {
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), output);
   assert.deepEqual(await readFile(output), expected);
+});
+
+test("persistent content root is keyed solely by the checked-in model SHA", async (t) => {
+  const { contract, directory, expected } = await fixture(t);
+  const source = resolve(directory, "source.gguf");
+  const cacheRoot = resolve(directory, "persistent-model-cache");
+  await writeFile(source, expected);
+
+  const first = run(
+    ["--contract", contract, "--source", source, "--cache-root", cacheRoot, "--offline"],
+    directory,
+  );
+
+  assert.equal(first.status, 0, first.stderr);
+  const expectedPath = resolve(cacheRoot, "sha256", sha256(expected), "model.gguf");
+  assert.equal(first.stdout.trim(), expectedPath);
+  assert.deepEqual(await readFile(expectedPath), expected);
+
+  await writeFile(source, "baad");
+  const hit = run(
+    ["--contract", contract, "--cache-root", cacheRoot, "--offline"],
+    directory,
+  );
+  assert.equal(hit.status, 0, hit.stderr);
+  assert.equal(hit.stdout.trim(), expectedPath);
+  assert.deepEqual(await readFile(expectedPath), expected);
+});
+
+test("persistent content root revalidates bytes before reporting a hit", async (t) => {
+  const { contract, directory, expected } = await fixture(t);
+  const source = resolve(directory, "source.gguf");
+  const cacheRoot = resolve(directory, "persistent-model-cache");
+  await writeFile(source, expected);
+
+  const first = run(
+    ["--contract", contract, "--source", source, "--cache-root", cacheRoot, "--offline"],
+    directory,
+  );
+  assert.equal(first.status, 0, first.stderr);
+  await writeFile(first.stdout.trim(), "baad");
+
+  const rejected = run(
+    ["--contract", contract, "--cache-root", cacheRoot, "--offline"],
+    directory,
+  );
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /offline model preparation requires/u);
+});
+
+test("persistent content root rejects a hardlinked cache destination", async (t) => {
+  const { contract, directory, expected } = await fixture(t);
+  const source = resolve(directory, "source.gguf");
+  const cacheRoot = resolve(directory, "persistent-model-cache");
+  await writeFile(source, expected);
+
+  const first = run(
+    ["--contract", contract, "--source", source, "--cache-root", cacheRoot, "--offline"],
+    directory,
+  );
+  assert.equal(first.status, 0, first.stderr);
+  await link(first.stdout.trim(), resolve(directory, "external-hardlink.gguf"));
+
+  const rejected = run(
+    ["--contract", contract, "--cache-root", cacheRoot, "--offline"],
+    directory,
+  );
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /offline model preparation requires/u);
+});
+
+test("persistent content root rejects a symlinked or reparse cache root", async (t) => {
+  const { contract, directory, expected } = await fixture(t);
+  const source = resolve(directory, "source.gguf");
+  const external = resolve(directory, "external-cache");
+  const cacheRoot = resolve(directory, "linked-cache");
+  await writeFile(source, expected);
+  await mkdir(external);
+  await symlink(
+    external,
+    cacheRoot,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+
+  const rejected = run(
+    ["--contract", contract, "--source", source, "--cache-root", cacheRoot, "--offline"],
+    directory,
+  );
+
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /must not traverse symbolic links, reparse points, or files/u);
+  assert.deepEqual(await readdir(external), []);
+});
+
+test("persistent content root rejects a symlinked or reparse digest ancestor", async (t) => {
+  const { contract, directory, expected } = await fixture(t);
+  const source = resolve(directory, "source.gguf");
+  const external = resolve(directory, "external-sha256");
+  const cacheRoot = resolve(directory, "persistent-model-cache");
+  await writeFile(source, expected);
+  await mkdir(cacheRoot);
+  await mkdir(external);
+  await symlink(
+    external,
+    resolve(cacheRoot, "sha256"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
+
+  const rejected = run(
+    ["--contract", contract, "--source", source, "--cache-root", cacheRoot, "--offline"],
+    directory,
+  );
+
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /must not traverse symbolic links, reparse points, or files/u);
+  assert.deepEqual(await readdir(external), []);
+});
+
+test("explicit output cannot weaken the persistent content-addressed path", async (t) => {
+  const { contract, directory, expected } = await fixture(t);
+  const source = resolve(directory, "source.gguf");
+  await writeFile(source, expected);
+
+  const result = run(
+    [
+      "--contract",
+      contract,
+      "--source",
+      source,
+      "--cache-root",
+      resolve(directory, "persistent-model-cache"),
+      "--output",
+      resolve(directory, "arbitrary.gguf"),
+    ],
+    directory,
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /mutually exclusive/u);
 });
 
 test("rejects a missing explicit source", async (t) => {


### PR DESCRIPTION
## Context

Windows packaged proof rebuilt three overlapping Cargo graphs, then protected proof phases repeatedly transferred the same 160–180 MB candidate. This keeps the exact-package invariant while removing work that adds no evidence.

## What changed

- Builds the Windows release CLI, runtime, optional qualification driver, native-staging harness, and path-identity harness through one release Cargo invocation.
- Selects and revalidates the exact Cargo-emitted binaries before running the harnesses and packaging the CLI. No later Cargo invocation is permitted.
- Publishes the public candidate, its small authenticated archive record, and the private qualification driver as separate exact artifacts.
- Caches candidate archives on protected hosts by source commit, target, and archive SHA-256. Every hit rechecks repository/source/tree/target, file set, size, digest, ancestry, and link identity.
- Downloads and atomically admits the large Actions or Release artifact only on a miss. Owned corruption is quarantined and redownloaded; unowned links and reparse paths fail closed.
- Caches model material by model SHA-256 with size, digest, single-link, and real-ancestry checks.
- Reuses authenticated records for withheld host identity instead of downloading every package, and independently authenticates the published global checksum manifest.
- Publishes separate Windows timings for cache restoration, native setup, the Cargo graph and MSVC linker log, regressions, packaging, and artifact transfer.

## Review

Start with `packaged-platform-proof.yml`, then the candidate archive store and Cargo artifact helpers. The workflow-policy tests execute mutations for duplicate builds, debug/release mixing, public/private artifact drift, cross-SHA reuse, unconditional transfer, stale Release API provenance, model-cache aliases, and large non-claim downloads.

## Verification

Exact head: `121699713b4301ccb05c052d631741b5e82f3b67`

- Workflow policy mutation suite: 1129/1129
- Release claim/evidence suites: 59/59
- Candidate archive store: 51/51
- Model material preparation: 17/17
- Release-cell manifest: 15/15
- Cargo artifact selection: 11/11
- Exact Actions artifact extraction: 4/4
- Workflow policy command, release validator, actionlint, per-crate formatting, and diff checks: passed

No broad source proof or hardware proof was dispatched. Those belong once on the final integrated release head; no unchanged candidate was rerun.

## Risk and follow-up

The first real Windows run still needs to supply the measured timing breakdown. Quarantined corrupt archives are retained for diagnosis; bounded cleanup is a follow-up, not an identity or release-safety gap.

Closes #1611
Refs #1179
