### PR TITLE
Guard the fast retrieval fixture architecture

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -13,6 +13,22 @@ import {
 const workflowRoot = path.join(".github", "workflows");
 const retrievalFile = "retrieval-engine-smoke.yml";
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const retrievalGeneralizationSuiteFile = path.join(
+  "scripts",
+  "tests",
+  "lint-retrieval-generalization.test.mjs",
+);
+const legacyRetrievalGeneralizationWrapper = path.join(
+  "crates",
+  "codestory-runtime",
+  "tests",
+  "retrieval_generalization_guard.rs",
+);
+const runtimeIntegrationTestRoot = path.join(
+  "crates",
+  "codestory-runtime",
+  "tests",
+);
 const trustedActionOwners = new Set(["actions", "github"]);
 const fullSha = /^[0-9a-f]{40}$/iu;
 const sccacheAction = "mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696";
@@ -23,6 +39,134 @@ const sccacheCacheSize = "1G";
 const windowsSccacheCacheSize = "2G";
 
 export { retrievalFile };
+
+function serializedRustRetrievalWrapperPresent() {
+  const root = path.join(repositoryRoot, runtimeIntegrationTestRoot);
+  if (!fs.existsSync(root)) return false;
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else if (
+        entry.name.endsWith(".rs")
+        && /lint-retrieval-generalization|retrieval[_-]generalization[_-](?:guard|lint)/u
+          .test(fs.readFileSync(entryPath, "utf8"))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function retrievalGeneralizationSuitePolicyViolations(
+  source,
+  {
+    legacyWrapperPresent = false,
+  } = {},
+) {
+  const violations = [];
+  const invocationCount = source.match(/\brunRetrievalGeneralizationLint\s*\(/gu)?.length ?? 0;
+  const checkoutDigestCount = source.match(/\btreeDigest\(repositoryRoot\)/gu)?.length ?? 0;
+  const temporaryRootCount = source.match(/\bos\.tmpdir\(\)/gu)?.length ?? 0;
+  const importSpecifiers = [...source.matchAll(
+    /^\s*import\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["'];\s*$/gmu,
+  )].map((match) => match[1]);
+  const allowedImports = [
+    "node:assert/strict",
+    "node:crypto",
+    "node:fs",
+    "node:os",
+    "node:path",
+    "node:test",
+    "node:url",
+    "../lib/retrieval-generalization-lint.mjs",
+  ];
+  const forbiddenConcurrencySurface = [
+    /(?:node:)?child_process/u,
+    /(?:node:)?worker_threads/u,
+    /(?:node:)?cluster/u,
+    /\b(?:createRequire|getBuiltinModule)\b/u,
+    /\bprocess\.binding\s*\(/u,
+    /\brequire\s*\(/u,
+    /\bBun\.(?:spawn|spawnSync)\b/u,
+    /\bDeno\.Command\b/u,
+  ].some((pattern) => pattern.test(source));
+  const forbiddenLockSurface = [
+    /\b(?:flock|lock_exclusive|try_lock_exclusive|proper-lockfile)\b/iu,
+    /\bopenSync\s*\(/u,
+    /\bAtomics\.wait\s*\(/u,
+    /retrieval-generalization(?:-guard)?\.lock/iu,
+    /process\.env\.(?:RUNNER_TEMP|TEMP|TMP|TMPDIR)\b/u,
+    /["']\/tmp(?:\/|["'])/u,
+  ].some((pattern) => pattern.test(source));
+
+  add(
+    violations,
+    !legacyWrapperPresent,
+    `${legacyRetrievalGeneralizationWrapper} must stay deleted so workspace nextest cannot rediscover the serialized Rust wrapper`,
+  );
+  add(
+    violations,
+    invocationCount === 1,
+    `${retrievalGeneralizationSuiteFile} must execute the hostile fixture matrix through one in-process lint invocation`,
+  );
+  add(
+    violations,
+    !forbiddenConcurrencySurface
+      && importSpecifiers.length === allowedImports.length
+      && sameMembers(importSpecifiers, allowedImports),
+    `${retrievalGeneralizationSuiteFile} must not create subprocesses, workers, or clusters for hostile fixtures`,
+  );
+  add(
+    violations,
+    !forbiddenLockSurface,
+    `${retrievalGeneralizationSuiteFile} must not restore a global or cross-process fixture lock`,
+  );
+  add(
+    violations,
+    source.includes(
+      'fs.mkdtempSync(path.join(os.tmpdir(), "codestory-generalization-"))',
+    )
+      && temporaryRootCount === 1
+      && source.includes(
+        'assert.ok(\n    path.relative(repositoryRoot, fixtureRoot).startsWith(".."),',
+      )
+      && source.includes("const productionRepositoryRoot = path.join(\n    fixtureRoot,")
+      && source.includes("const extraRustRoot = path.join(fixtureRoot,")
+      && source.includes("const nonRustRoot = path.join(fixtureRoot,")
+      && source.includes("const taskRoot = path.join(fixtureRoot,"),
+    `${retrievalGeneralizationSuiteFile} must keep every mutable hostile fixture under one temporary tree outside the checkout`,
+  );
+  add(
+    violations,
+    checkoutDigestCount === 2
+      && source.includes("const checkoutBefore = treeDigest(repositoryRoot);")
+      && source.includes(
+        "assert.equal(\n      treeDigest(repositoryRoot),\n      checkoutBefore,",
+      )
+      && source.includes(
+        '"lint changed the whole checkout tree, including tracked bytes or untracked paths"',
+      ),
+    `${retrievalGeneralizationSuiteFile} must prove the real checkout is byte-for-byte read-only`,
+  );
+  add(
+    violations,
+    source.includes("structuralScanRoots: [rustRoot, extraRustRoot],")
+      && source.includes("CODESTORY_RETRIEVAL_GENERALIZATION_EXTRA_SCAN_ROOTS: extraRustRoot,")
+      && source.includes("CODESTORY_RETRIEVAL_GENERALIZATION_EXTRA_TASK_ROOTS: taskRoot,"),
+    `${retrievalGeneralizationSuiteFile} must register every additive hostile fixture root in the single lint invocation`,
+  );
+  add(
+    violations,
+    source.includes("fs.rmSync(fixtureRoot, { recursive: true, force: true });"),
+    `${retrievalGeneralizationSuiteFile} must remove its isolated fixture tree after the matrix`,
+  );
+  return violations;
+}
 
 function object(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value) ? value : {};
@@ -8015,6 +8159,17 @@ export function validateMarketplaceSync(workflows, violations) {
 
 export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
   const violations = [];
+  violations.push(...retrievalGeneralizationSuitePolicyViolations(
+    fs.readFileSync(
+      path.join(repositoryRoot, retrievalGeneralizationSuiteFile),
+      "utf8",
+    ),
+    {
+      legacyWrapperPresent:
+        fs.existsSync(path.join(repositoryRoot, legacyRetrievalGeneralizationWrapper))
+        || serializedRustRetrievalWrapperPresent(),
+    },
+  ));
   violations.push(...qualificationDriverArtifactViolations(
     fs.readFileSync(
       path.join(

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -40,6 +40,15 @@ const windowsSccacheCacheSize = "2G";
 
 export { retrievalFile };
 
+export function rustRetrievalWrapperSourcePresent(source) {
+  return (
+    /lint-retrieval-generalization|retrieval[_-]generalization[_-](?:guard|lint)/u
+      .test(source)
+    || /\b(?:std|tokio|async_std)::process\b|\bprocess::Command\b|\bCommand\s*::\s*(?:new|from)\s*\(|\b(?:assert_cmd|duct|xshell)\b/u
+      .test(source)
+  );
+}
+
 function serializedRustRetrievalWrapperPresent() {
   const root = path.join(repositoryRoot, runtimeIntegrationTestRoot);
   if (!fs.existsSync(root)) return false;
@@ -50,12 +59,11 @@ function serializedRustRetrievalWrapperPresent() {
       const entryPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
         pending.push(entryPath);
-      } else if (
-        entry.name.endsWith(".rs")
-        && /lint-retrieval-generalization|retrieval[_-]generalization[_-](?:guard|lint)/u
-          .test(fs.readFileSync(entryPath, "utf8"))
-      ) {
-        return true;
+      } else if (entry.name.endsWith(".rs")) {
+        const source = fs.readFileSync(entryPath, "utf8");
+        if (rustRetrievalWrapperSourcePresent(source)) {
+          return true;
+        }
       }
     }
   }
@@ -70,8 +78,80 @@ export function retrievalGeneralizationSuitePolicyViolations(
 ) {
   const violations = [];
   const invocationCount = source.match(/\brunRetrievalGeneralizationLint\s*\(/gu)?.length ?? 0;
+  const lintReferenceCount =
+    source.match(/\brunRetrievalGeneralizationLint\b/gu)?.length ?? 0;
   const checkoutDigestCount = source.match(/\btreeDigest\(repositoryRoot\)/gu)?.length ?? 0;
+  const repositoryRootReferenceCount = source.match(/\brepositoryRoot\b/gu)?.length ?? 0;
+  const fixtureRootReferenceCount = source.match(/\bfixtureRoot\b/gu)?.length ?? 0;
+  const productionRepositoryRootReferenceCount =
+    source.match(/\bproductionRepositoryRoot\b/gu)?.length ?? 0;
   const temporaryRootCount = source.match(/\bos\.tmpdir\(\)/gu)?.length ?? 0;
+  const temporaryTreeCount = source.match(/\bfs\.mkdtempSync\s*\(/gu)?.length ?? 0;
+  const dynamicImportCount = source.match(/\bimport\s*\(/gu)?.length ?? 0;
+  const fsReferenceCount = source.match(/\bfs\b/gu)?.length ?? 0;
+  const filesystemMemberReferences = [...source.matchAll(
+    /\bfs\.([A-Za-z_$][\w$]*)\b/gu,
+  )].map((match) => match[1]);
+  const expectedFilesystemMemberCounts = {
+    existsSync: 1,
+    mkdirSync: 6,
+    mkdtempSync: 1,
+    readFileSync: 4,
+    readdirSync: 4,
+    readlinkSync: 1,
+    rmSync: 1,
+    writeFileSync: 1,
+  };
+  const filesystemMemberCounts = new Map();
+  for (const name of filesystemMemberReferences) {
+    filesystemMemberCounts.set(
+      name,
+      (filesystemMemberCounts.get(name) ?? 0) + 1,
+    );
+  }
+  const fixtureFilesystemShapeIsExact =
+    fsReferenceCount === 21
+    && filesystemMemberReferences.length === 19
+    && Object.entries(expectedFilesystemMemberCounts).every(
+      ([name, count]) => (filesystemMemberCounts.get(name) ?? 0) === count,
+    )
+    && [
+      "const destination = path.join(root, relativePath);",
+      "fs.mkdirSync(path.dirname(destination), { recursive: true });",
+      "fs.writeFileSync(destination, contents);",
+      "fs.mkdirSync(rustRoot, { recursive: true });",
+      "fs.mkdirSync(retrievalRoot, { recursive: true });",
+      "fs.mkdirSync(extraRustRoot);",
+      "fs.mkdirSync(nonRustRoot);",
+      "fs.mkdirSync(taskRoot);",
+      "fs.rmSync(fixtureRoot, { recursive: true, force: true });",
+    ].every((fragment) => source.includes(fragment));
+  const writeReferenceCount = source.match(/\bwrite\b/gu)?.length ?? 0;
+  const writeFirstArguments = [...source.matchAll(
+    /\bwrite\s*\(\s*([A-Za-z_$][\w$]*)/gu,
+  )].map((match) => match[1]);
+  const registeredWriteRoots = new Set([
+    "root",
+    "rustRoot",
+    "retrievalRoot",
+    "extraRustRoot",
+    "nonRustRoot",
+    "taskRoot",
+  ]);
+  const syntheticWritesStayInRegisteredRoots =
+    writeReferenceCount === 14
+    && writeFirstArguments.length === writeReferenceCount
+    && writeFirstArguments.every((root) => registeredWriteRoots.has(root));
+  const fixturePathReferenceShapeIsExact =
+    repositoryRootReferenceCount === 12
+    && fixtureRootReferenceCount === 10
+    && productionRepositoryRootReferenceCount === 4;
+  const protectedRetrievalWorkflow = `.github/workflows/${retrievalFile}`;
+  const retainedDynamicImportFixtures = [
+    "await import(harness);",
+    String.raw`await import(\"${protectedRetrievalWorkflow}\");`,
+    `await import("${protectedRetrievalWorkflow}");`,
+  ];
   const importSpecifiers = [...source.matchAll(
     /^\s*import\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["'];\s*$/gmu,
   )].map((match) => match[1]);
@@ -90,7 +170,13 @@ export function retrievalGeneralizationSuitePolicyViolations(
     /(?:node:)?worker_threads/u,
     /(?:node:)?cluster/u,
     /\b(?:createRequire|getBuiltinModule)\b/u,
-    /\bprocess\.binding\s*\(/u,
+    /\bprocess\s*\[/u,
+    /\bprocess\.(?:binding|_linkedBinding)\s*\(/u,
+    /\b(?:Function|eval)\s*\(/u,
+    /\bglobalThis\b/u,
+    /\bReflect\.(?:apply|construct|get)\b/u,
+    /\bmodule\s*\.\s*(?:constructor|createRequire)\b/u,
+    /\bWebAssembly\b/u,
     /\brequire\s*\(/u,
     /\bBun\.(?:spawn|spawnSync)\b/u,
     /\bDeno\.Command\b/u,
@@ -98,7 +184,8 @@ export function retrievalGeneralizationSuitePolicyViolations(
   const forbiddenLockSurface = [
     /\b(?:flock|lock_exclusive|try_lock_exclusive|proper-lockfile)\b/iu,
     /\bopenSync\s*\(/u,
-    /\bAtomics\.wait\s*\(/u,
+    /\bAtomics\.wait(?:Async)?\s*\(/u,
+    /\b(?:fs|os)\s*\[/u,
     /retrieval-generalization(?:-guard)?\.lock/iu,
     /process\.env\.(?:RUNNER_TEMP|TEMP|TMP|TMPDIR)\b/u,
     /["']\/tmp(?:\/|["'])/u,
@@ -111,12 +198,14 @@ export function retrievalGeneralizationSuitePolicyViolations(
   );
   add(
     violations,
-    invocationCount === 1,
+    invocationCount === 1 && lintReferenceCount === 2,
     `${retrievalGeneralizationSuiteFile} must execute the hostile fixture matrix through one in-process lint invocation`,
   );
   add(
     violations,
     !forbiddenConcurrencySurface
+      && dynamicImportCount === retainedDynamicImportFixtures.length
+      && retainedDynamicImportFixtures.every((fixture) => source.includes(fixture))
       && importSpecifiers.length === allowedImports.length
       && sameMembers(importSpecifiers, allowedImports),
     `${retrievalGeneralizationSuiteFile} must not create subprocesses, workers, or clusters for hostile fixtures`,
@@ -128,10 +217,19 @@ export function retrievalGeneralizationSuitePolicyViolations(
   );
   add(
     violations,
+    fixtureFilesystemShapeIsExact
+      && syntheticWritesStayInRegisteredRoots
+      && fixturePathReferenceShapeIsExact
+      && !/\bfs\.promises\b/u.test(source),
+    `${retrievalGeneralizationSuiteFile} must confine every filesystem mutation to registered roots in its one synthetic fixture tree`,
+  );
+  add(
+    violations,
     source.includes(
       'fs.mkdtempSync(path.join(os.tmpdir(), "codestory-generalization-"))',
     )
       && temporaryRootCount === 1
+      && temporaryTreeCount === 1
       && source.includes(
         'assert.ok(\n    path.relative(repositoryRoot, fixtureRoot).startsWith(".."),',
       )

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -37,6 +37,7 @@ import {
   releaseProofCpuSelectorViolations,
   releaseEvidenceWorkflowRef,
   releaseWorkflowContractViolations,
+  retrievalGeneralizationSuitePolicyViolations,
   retrievalFile,
   retrievalProducerTriggerPolicyViolations,
   shellDependentBindingViolations,
@@ -3177,6 +3178,75 @@ test("retrieval smoke keeps the one-process generalization lane blocking", async
       const workflows = loadWorkflows();
       workflows.set(retrievalFile, candidate);
       assert.match(validateWorkflows(workflows).join("\n"), expectedReason);
+    });
+  }
+});
+
+test("retrieval generalization fixture architecture rejects serialized regressions", async (t) => {
+  const suitePath = path.join(
+    root,
+    "scripts",
+    "tests",
+    "lint-retrieval-generalization.test.mjs",
+  );
+  const source = readFileSync(suitePath, "utf8");
+  assert.deepEqual(retrievalGeneralizationSuitePolicyViolations(source), []);
+
+  const mutations = [
+    ["legacy Rust integration test returns", source, {
+      legacyWrapperPresent: true,
+    }, /must stay deleted so workspace nextest cannot rediscover/u],
+    ["per-fixture Node subprocess returns", `${source}
+import { spawnSync as runFixture } from "node:child_process";
+runFixture(process.execPath, ["scripts/lint-retrieval-generalization.mjs"]);
+`, {}, /must not create subprocesses, workers, or clusters/u],
+    ["indirect builtin subprocess loading returns", `${source}
+process.getBuiltinModule("child" + "_process").spawnSync(
+  process.execPath,
+  ["scripts/lint-retrieval-generalization.mjs"],
+);
+`, {}, /must not create subprocesses, workers, or clusters/u],
+    ["worker-per-fixture execution returns", `${source}
+await import("node:worker_threads");
+`, {}, /must not create subprocesses, workers, or clusters/u],
+    ["matrix calls the lint twice", `${source}
+runRetrievalGeneralizationLint({});
+`, {}, /through one in-process lint invocation/u],
+    ["global file lock returns", `${source}
+fs.openSync(path.join(os.tmpdir(), "retrieval-generalization.lock"), "wx");
+`, {}, /must not restore a global or cross-process fixture lock/u],
+    ["second global temporary root returns", `${source}
+const sharedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shared-suite-"));
+fs.mkdirSync(path.join(sharedRoot, "sentinel"));
+`, {}, /under one temporary tree outside the checkout/u],
+    ["fixtures move into the checkout", source.replace(
+      'fs.mkdtempSync(path.join(os.tmpdir(), "codestory-generalization-"))',
+      'fs.mkdtempSync(path.join(repositoryRoot, "codestory-generalization-"))',
+    ), {}, /under one temporary tree outside the checkout/u],
+    ["checkout read-only comparison is removed", source.replace(
+      "const checkoutBefore = treeDigest(repositoryRoot);",
+      "const checkoutBefore = null;",
+    ), {}, /prove the real checkout is byte-for-byte read-only/u],
+    ["checkout read-only comparison is inverted", source.replace(
+      "assert.equal(\n      treeDigest(repositoryRoot),\n      checkoutBefore,",
+      "assert.notEqual(\n      treeDigest(repositoryRoot),\n      checkoutBefore,",
+    ), {}, /prove the real checkout is byte-for-byte read-only/u],
+    ["additive Rust root is unregistered", source.replace(
+      "structuralScanRoots: [rustRoot, extraRustRoot],",
+      "structuralScanRoots: [rustRoot],",
+    ), {}, /register every additive hostile fixture root/u],
+    ["fixture cleanup is removed", source.replace(
+      "fs.rmSync(fixtureRoot, { recursive: true, force: true });",
+      "",
+    ), {}, /remove its isolated fixture tree/u],
+  ];
+
+  for (const [name, candidate, options, expectedReason] of mutations) {
+    await t.test(name, () => {
+      assert.match(
+        retrievalGeneralizationSuitePolicyViolations(candidate, options).join("\n"),
+        expectedReason,
+      );
     });
   }
 });

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -40,6 +40,7 @@ import {
   retrievalGeneralizationSuitePolicyViolations,
   retrievalFile,
   retrievalProducerTriggerPolicyViolations,
+  rustRetrievalWrapperSourcePresent,
   shellDependentBindingViolations,
   validateCargoTestFilters,
   validateWorkflows,
@@ -3594,6 +3595,17 @@ test("retrieval generalization fixture architecture rejects serialized regressio
   );
   const source = readFileSync(suitePath, "utf8");
   assert.deepEqual(retrievalGeneralizationSuitePolicyViolations(source), []);
+  assert.equal(
+    rustRetrievalWrapperSourcePresent(`
+use std::process::Command;
+#[test]
+fn renamed_guard() {
+    Command::new("node").arg("-e").arg("import('./scripts/lib/retrieval-generalization-lint.mjs')").status().unwrap();
+}
+`),
+    true,
+    "a renamed Rust subprocess wrapper must remain detectable without the old filename or command",
+  );
 
   const mutations = [
     ["legacy Rust integration test returns", source, {
@@ -3609,17 +3621,44 @@ process.getBuiltinModule("child" + "_process").spawnSync(
   ["scripts/lint-retrieval-generalization.mjs"],
 );
 `, {}, /must not create subprocesses, workers, or clusters/u],
+    ["bracketed process binding returns", `${source}
+process["binding"]("spawn_sync");
+`, {}, /must not create subprocesses, workers, or clusters/u],
+    ["computed dynamic subprocess import returns", `${source}
+await import("node:" + "child" + "_process");
+`, {}, /must not create subprocesses, workers, or clusters/u],
     ["worker-per-fixture execution returns", `${source}
 await import("node:worker_threads");
 `, {}, /must not create subprocesses, workers, or clusters/u],
     ["matrix calls the lint twice", `${source}
 runRetrievalGeneralizationLint({});
 `, {}, /through one in-process lint invocation/u],
+    ["matrix aliases the lint for a second invocation", source.replace(
+      "    const result = runRetrievalGeneralizationLint({",
+      [
+        "    const invokeAgain = runRetrievalGeneralizationLint;",
+        "    invokeAgain({});",
+        "    const result = runRetrievalGeneralizationLint({",
+      ].join("\n"),
+    ), {}, /through one in-process lint invocation/u],
     ["global file lock returns", `${source}
 fs.openSync(path.join(os.tmpdir(), "retrieval-generalization.lock"), "wx");
 `, {}, /must not restore a global or cross-process fixture lock/u],
+    ["exclusive sibling lock through the fixture filesystem returns", source.replace(
+      "  const productionRepositoryRoot = path.join(",
+      [
+        '  const globalSentinel = path.join(path.dirname(fixtureRoot), "serial-token");',
+        '  fs.writeFileSync(globalSentinel, "", { flag: ["w", "x"].join("") });',
+        "  fs.rmSync(globalSentinel, { force: true });",
+        "  const productionRepositoryRoot = path.join(",
+      ].join("\n"),
+    ), {}, /confine every filesystem mutation/u],
     ["second global temporary root returns", `${source}
 const sharedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shared-suite-"));
+fs.mkdirSync(path.join(sharedRoot, "sentinel"));
+`, {}, /under one temporary tree outside the checkout/u],
+    ["second sibling temporary root returns", `${source}
+const sharedRoot = fs.mkdtempSync(path.join(path.dirname(fixtureRoot), "shared-suite-"));
 fs.mkdirSync(path.join(sharedRoot, "sentinel"));
 `, {}, /under one temporary tree outside the checkout/u],
     ["fixtures move into the checkout", source.replace(
@@ -3634,10 +3673,27 @@ fs.mkdirSync(path.join(sharedRoot, "sentinel"));
       "assert.equal(\n      treeDigest(repositoryRoot),\n      checkoutBefore,",
       "assert.notEqual(\n      treeDigest(repositoryRoot),\n      checkoutBefore,",
     ), {}, /prove the real checkout is byte-for-byte read-only/u],
+    ["checkout is changed and restored before the final digest", source.replace(
+      "  const checkoutBefore = treeDigest(repositoryRoot);",
+      [
+        "  const checkoutBefore = treeDigest(repositoryRoot);",
+        '  const transientCheckoutPath = path.join(repositoryRoot, ".policy-transient-fixture");',
+        '  fs.writeFileSync(transientCheckoutPath, "hostile");',
+        "  fs.rmSync(transientCheckoutPath, { force: true });",
+      ].join("\n"),
+    ), {}, /confine every filesystem mutation/u],
     ["additive Rust root is unregistered", source.replace(
       "structuralScanRoots: [rustRoot, extraRustRoot],",
       "structuralScanRoots: [rustRoot],",
     ), {}, /register every additive hostile fixture root/u],
+    ["a fifth fixture root is planted without registration", source.replace(
+      "  const productionRepositoryRoot = path.join(",
+      [
+        '  const unregisteredRoot = path.join(fixtureRoot, "unregistered");',
+        '  write(unregisteredRoot, "ignored.rs", `pub const LEAK: &str = "createApplication";\\n`);',
+        "  const productionRepositoryRoot = path.join(",
+      ].join("\n"),
+    ), {}, /confine every filesystem mutation/u],
     ["fixture cleanup is removed", source.replace(
       "fs.rmSync(fixtureRoot, { recursive: true, force: true });",
       "",


### PR DESCRIPTION
## Context

PR #1602 replaced the serialized Rust process-per-fixture wrapper with one in-process Node matrix, reducing the hostile contract to about 1.2 seconds and the real-repository smoke to about 11 seconds. The architecture was still convention-only: a renamed Rust wrapper, a second Node invocation, checkout mutation, a sibling lock, or another unregistered fixture tree could return without failing workflow policy.

Base: `d0f5834df228b558f151abc8c79fa9a987e6f7b3`  
Reviewed head: `6e36c7f4bd5c0ad32697725a9792f67506c774b2`

## What changed

- Keep every runtime integration test free of Rust process-spawn surfaces, independent of its filename or named lint command.
- Freeze the hostile suite to one importable lint invocation and its exact allowed module surface.
- Freeze one temporary tree, the registered fixture roots, and the exact filesystem mutation surface.
- Keep the real checkout byte-for-byte read-only.
- Reject global or sibling locks, workers, clusters, subprocesses, dynamic runtime loading, and extra mutable roots.

No workflow job or claim edge changed, so `release-claims.json` is intentionally unchanged.

## Independent attack

The first policy version accepted all seven executed regressions:

- bracketed `process["binding"]` subprocess access;
- a computed dynamic `child_process` import;
- a second lint call through an alias;
- a second sibling temporary tree;
- an exclusive sibling lock;
- a checkout write removed before the final digest;
- a fifth fixture root omitted from the lint registration.

The reviewed head rejects all seven. The tests encode the evasion shapes rather than only their original names.

## Verification

- `node --test .github/scripts/check-workflow-policy.test.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test scripts/tests/lint-retrieval-generalization.test.mjs` — 4/4 in about 1.2 seconds
- `node scripts/lint-retrieval-generalization.mjs` — clean in about 11 seconds
- `git diff --check`

No Rust workspace or release proof was rerun for this policy-only repair.

Closes #1612
