### PR TITLE
Make frozen-candidate quality optional

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -913,13 +913,15 @@ const packagedPlatformWorkflowDigest =
 // made advisory, parked in dead code, or followed by a payload substitution
 // while leaving the expected tokens in place.
 const packagedPlatformCoordinatorWorkflowDigest =
-  "8efd162e5e5c42e1cbeb0e40378f631ce358feb9404e90e27e02aa0b382d481e";
+  "464906e3cd7ec0e2f7e9195d60de035fdba76172c25d8b0861d0982f9d7dcc3e";
+const frozenCandidateQualityWorkflowDigest =
+  "92d0a7ab0e0df63dacd5cc3ef0b58500a6578036494c329aa35279048734f173";
 const macosMetalWorkflowDigest =
-  "4f9630adb30d24a358ba8b423c4faadfa347efe678b7ec8d48a72cb059ffe94a";
+  "e1c4a59b412ba3f2041e89177e2af5a6533cf5ef0371dc2fa18c0309fba5b1ca";
 const windowsVulkanWorkflowDigest =
-  "c94a218f5599a727c608259206a68acd54726f38e50471148cb4cf12e1f859c0";
+  "f1123f11d430591380ed433d751c6fc110adfb13225106f50deecf232ee89f9b";
 const linuxVulkanWorkflowDigest =
-  "65449c5b8040d9338cdb12bb5d4271020ee94f1be30dd821f0b56c7bf5c797ea";
+  "935c5df20a2d57ed18824cca11dc9b8590d72a207e3d1677bc2ceea3048b3dff";
 // Linux owns its compiler server inside Docker, while macOS and Windows own one
 // in the host shell. Pin both executable programs so a swallowed stop or a
 // dead-code copy cannot satisfy the ownership fragments below.
@@ -1638,6 +1640,7 @@ export function draftSourcePolicyViolations(jobValue, retrievalJobValue) {
 }
 
 export const releaseEvidenceWorkflowRef = "./.github/workflows/release-candidate-evidence.yml";
+export const frozenCandidateQualityWorkflowRef = "./.github/workflows/frozen-candidate-quality.yml";
 
 export function macosCliDistributionViolations(assessmentStep, executionStep, quarantinedPath) {
   const violations = [];
@@ -4796,6 +4799,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       "source-proof",
       "packaged-proof",
       "macos-metal-proof",
+      "frozen-candidate-quality",
       "windows-vulkan-proof",
       "linux-vulkan-proof",
       "closeout",
@@ -4832,7 +4836,6 @@ function validatePackagedCoordinator(workflows, violations, graph) {
             job: "packaged-metal",
             policy: "accelerated",
             backend: "metal",
-            produces_quality: true,
           },
           {
             id: "protected_windows_x64_vulkan",
@@ -4840,7 +4843,6 @@ function validatePackagedCoordinator(workflows, violations, graph) {
             job: "packaged-vulkan",
             policy: "accelerated",
             backend: "vulkan",
-            produces_quality: false,
           },
         ])
       && JSON.stringify(list(qualificationPolicy.optional_cells))
@@ -4858,18 +4860,31 @@ function validatePackagedCoordinator(workflows, violations, graph) {
         ])
       && JSON.stringify(object(qualificationPolicy.quality_contract))
         === JSON.stringify({
+          producer_workflow: "packaged-platform-pr.yml",
+          producer_job: "frozen-candidate-quality",
           producer_cell: "protected_macos_arm64_metal",
-          corpus_id: "codestory-release-corpus-v1",
+          scheduled_once_per_frozen_candidate: true,
+          blocking: false,
+          closeout_dependency: false,
+          claimed: false,
+          archive_cache_key_fields: [
+            "source.commit",
+            "target",
+            "archive.sha256",
+          ],
+          archive_cache_contract: "candidate_archive_cache",
+          archive_transfer: "authenticated_miss_only",
+          evaluation_owner: "isolated_reusable_workflow",
+          evaluation_owner_sha256: frozenCandidateQualityWorkflowDigest,
           evaluation_contract: "publishable-three-repeat-packet/v1",
-          task_count: 3,
+          task_count: 1,
           repeats_per_task: 3,
-          row_count: 9,
+          row_count: 3,
         })
       && sameMembers(list(qualificationPolicy.required_evidence), [
         "qualification_scenarios",
         "true_idle_exit",
         "total_codestory_process_memory",
-        "retrieval_quality",
         "backend_observed_accelerator_residency",
       ])
       && sameMembers(list(qualificationPolicy.required_scenarios), [
@@ -5195,22 +5210,298 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     violations,
     object(metal.with).server_behavior_only
         === "${{ needs.route.outputs.mode != 'qualification' }}"
-      && object(metal.with).quality_evidence_artifact === "",
-    `${file} qualification must run full Metal quality and lifecycle proof`,
+      && object(metal.with).quality_evidence_artifact === undefined,
+    `${file} qualification must run one full Metal lifecycle proof without optional quality inputs`,
+  );
+  const qualityCaller = requireJob(
+    violations,
+    file,
+    workflow,
+    "frozen-candidate-quality",
+  );
+  add(
+    violations,
+    sameMembers(needs(qualityCaller), [
+      "route",
+      "packaged-proof",
+      "macos-metal-proof",
+    ])
+      && qualityCaller.if
+        === "always() && needs.route.result == 'success' && needs.packaged-proof.result == 'success' && needs.macos-metal-proof.result == 'success' && needs.route.outputs.mode == 'qualification' && (needs.route.outputs.scope == 'macos' || needs.route.outputs.scope == 'full')"
+      && qualityCaller.uses === frozenCandidateQualityWorkflowRef
+      && hasExactKeys(qualityCaller, ["name", "if", "needs", "uses", "with"])
+      && qualityCaller.secrets === undefined
+      && hasExactKeys(object(qualityCaller.with), ["ref", "version"])
+      && object(qualityCaller.with).ref === "${{ needs.route.outputs.head_sha }}"
+      && object(qualityCaller.with).version === "${{ needs.route.outputs.version }}",
+    `${file} optional quality must call its isolated owner once after protected Metal`,
+  );
+  const qualityFile = path.basename(frozenCandidateQualityWorkflowRef);
+  const qualityWorkflow = workflows.get(qualityFile);
+  if (!qualityWorkflow) {
+    violations.push(`${qualityFile} must exist`);
+    return;
+  }
+  add(
+    violations,
+    createHash("sha256").update(JSON.stringify(qualityWorkflow)).digest("hex")
+      === frozenCandidateQualityWorkflowDigest,
+    `${qualityFile} must match the reviewed isolated evaluation-owner structure`,
+  );
+  const qualityCall = object(trigger(qualityWorkflow, "workflow_call"));
+  const qualityInputs = object(qualityCall.inputs);
+  add(
+    violations,
+    trigger(qualityWorkflow, "workflow_dispatch") === undefined
+      && hasExactKeys(qualityInputs, ["ref", "version"])
+      && object(qualityInputs.ref).required === true
+      && object(qualityInputs.ref).type === "string"
+      && object(qualityInputs.version).required === true
+      && object(qualityInputs.version).type === "string"
+      && JSON.stringify(qualityWorkflow.permissions)
+        === JSON.stringify({ actions: "read", contents: "read" })
+      && sameMembers(Object.keys(object(qualityWorkflow.jobs)), ["quality"]),
+    `${qualityFile} must remain a reusable-only, read-only evaluation owner`,
+  );
+  const quality = requireJob(violations, qualityFile, qualityWorkflow, "quality");
+  add(
+    violations,
+    JSON.stringify(quality["runs-on"])
+        === JSON.stringify(["self-hosted", "macOS", "ARM64", "codestory-metal"])
+      && quality.environment === "macos-metal-release"
+      && quality["continue-on-error"] === true
+      && quality["timeout-minutes"] === 60,
+    `${qualityFile} optional quality must stay nonblocking on protected Metal`,
+  );
+  const qualitySteps = list(quality.steps).map(object);
+  add(
+    violations,
+    qualitySteps.length === 9
+      && qualitySteps.filter(step => step.id === "quality").length === 1
+      && qualitySteps.filter(step => step.id === "quality-upload").length === 1,
+    `${qualityFile} must retain one authenticated measurement and upload boundary`,
+  );
+  const qualityCheckout = namedStep(quality, "Checkout exact frozen candidate");
+  add(
+    violations,
+    qualityCheckout?.uses === "actions/checkout@v5"
+      && hasExactKeys(object(qualityCheckout?.with), ["ref", "fetch-depth"])
+      && object(qualityCheckout?.with).ref === "${{ inputs.ref }}"
+      && object(qualityCheckout?.with)["fetch-depth"] === 0,
+    `${qualityFile} must check out the routed exact frozen candidate`,
+  );
+  const qualityAuthentication = namedStep(
+    quality,
+    "Authenticate exact candidate archive artifacts",
+  );
+  const qualityAuthenticationRun = shellLiteralNormalizedText(
+    stepRun(quality, "Authenticate exact candidate archive artifacts"),
+  );
+  add(
+    violations,
+    qualityAuthentication?.id === "candidate-artifacts"
+      && qualityAuthentication?.shell === "bash"
+      && qualityAuthentication?.["continue-on-error"] === undefined
+      && hasExactKeys(object(qualityAuthentication?.env), ["GH_TOKEN", "HEAD_SHA"])
+      && object(qualityAuthentication?.env).GH_TOKEN === "${{ github.token }}"
+      && object(qualityAuthentication?.env).HEAD_SHA === "${{ inputs.ref }}"
+      && qualityAuthenticationRun.includes("git rev-parse HEAD")
+      && qualityAuthenticationRun.includes(".head_repository.full_name")
+      && qualityAuthenticationRun.includes(
+        ".github/workflows/packaged-platform-pr.yml",
+      )
+      && qualityAuthenticationRun.includes(".head_sha")
+      && qualityAuthenticationRun.includes(".run_attempt")
+      && qualityAuthenticationRun.includes("select_artifact codestory-cli-macos-arm64")
+      && qualityAuthenticationRun.includes(
+        "select_artifact codestory-candidate-archive-record-macos-arm64",
+      )
+      && qualityAuthenticationRun.includes(".workflow_run.id == $run_id")
+      && qualityAuthenticationRun.includes(".workflow_run.head_sha == $sha")
+      && qualityAuthenticationRun.includes("package-id=$artifact_id")
+      && qualityAuthenticationRun.includes("package-bytes=$expected_size")
+      && qualityAuthenticationRun.includes(
+        "package-sha256=${expected_digest#sha256:}",
+      ),
+    `${qualityFile} must authenticate one current-run exact-head candidate archive and record`,
+  );
+  const qualityRecordDownload = namedStep(
+    quality,
+    "Download authenticated candidate record",
+  );
+  const qualityCacheRestore = namedStep(
+    quality,
+    "Restore exact candidate archive from protected host",
+  );
+  const qualityCacheMiss = namedStep(
+    quality,
+    "Download, authenticate, and admit candidate archive on miss",
+  );
+  add(
+    violations,
+    qualityRecordDownload?.uses === "actions/download-artifact@v8.0.1"
+      && hasExactKeys(object(qualityRecordDownload?.with), ["name", "path"])
+      && object(qualityRecordDownload?.with).name
+        === "codestory-candidate-archive-record-macos-arm64"
+      && object(qualityRecordDownload?.with).path
+        === "target/candidate-archive-record/macos-arm64"
+      && qualityCacheRestore?.id === "candidate-cache"
+      && qualityCacheRestore?.if === undefined
+      && qualityCacheRestore?.shell === "bash"
+      && qualityCacheRestore?.["continue-on-error"] === undefined,
+    `${qualityFile} cache lookup must consume only the exact small candidate record`,
+  );
+  requireStepRun(
+    violations,
+    qualityFile,
+    quality,
+    "Restore exact candidate archive from protected host",
+    [
+      "--arg repository \"$GITHUB_REPOSITORY\"",
+      "--arg source_sha \"$(git rev-parse HEAD)\"",
+      "--arg source_tree \"$(git rev-parse 'HEAD^{tree}')\"",
+      "--arg target macos-arm64",
+      ".source.commit == $source_sha",
+      ".source.tree == $source_tree",
+      ".target == $target",
+      "$RUNNER_TOOL_CACHE/codestory/candidate-archives",
+      "candidate-archive-store.mjs restore",
+      "--record \"$record\"",
+      "--output-dir target/release-dist",
+      "echo \"hit=$hit\" >> \"$GITHUB_OUTPUT\"",
+    ],
+  );
+  add(
+    violations,
+    qualityCacheMiss?.if === "steps.candidate-cache.outputs.hit != 'true'"
+      && qualityCacheMiss?.shell === "bash"
+      && qualityCacheMiss?.["continue-on-error"] === undefined
+      && hasExactKeys(object(qualityCacheMiss?.env), [
+        "ARTIFACT_ID",
+        "EXPECTED_SHA256",
+        "EXPECTED_SIZE",
+        "GH_TOKEN",
+      ])
+      && object(qualityCacheMiss?.env).ARTIFACT_ID
+        === "${{ steps.candidate-artifacts.outputs.package-id }}"
+      && object(qualityCacheMiss?.env).EXPECTED_SIZE
+        === "${{ steps.candidate-artifacts.outputs.package-bytes }}"
+      && object(qualityCacheMiss?.env).EXPECTED_SHA256
+        === "${{ steps.candidate-artifacts.outputs.package-sha256 }}"
+      && object(qualityCacheMiss?.env).GH_TOKEN === "${{ github.token }}",
+    `${qualityFile} archive transfer must be cache-miss-only and outer-digest authenticated`,
+  );
+  requireStepRun(
+    violations,
+    qualityFile,
+    quality,
+    "Download, authenticate, and admit candidate archive on miss",
+    [
+      "actions/artifacts/$ARTIFACT_ID/zip",
+      "--continue-at -",
+      "--max-time 120",
+      'test "$actual_size" = "$EXPECTED_SIZE"',
+      'test "$actual_digest" = "$EXPECTED_SHA256"',
+      "extract-candidate-actions-artifact.py",
+      "candidate-archive-store.mjs admit",
+      "--store-root \"$RUNNER_TOOL_CACHE/codestory/candidate-archives\"",
+      "--output-dir target/release-dist",
+    ],
+  );
+  const qualityProducer = qualitySteps.find(step => step.id === "quality");
+  const qualityProducerRun = shellLiteralNormalizedText(
+    String(qualityProducer?.run ?? ""),
+  );
+  add(
+    violations,
+    qualityProducer?.id === "quality"
+      && qualityProducer?.["continue-on-error"] === true
+      && qualityProducer?.shell === "bash"
+      && hasExactKeys(object(qualityProducer?.env), [
+        "VERSION",
+        "CODESTORY_EMBED_ALLOW_CPU",
+      ])
+      && object(qualityProducer?.env).VERSION === "${{ inputs.version }}"
+      && object(qualityProducer?.env).CODESTORY_EMBED_ALLOW_CPU === "0"
+      && qualityProducerRun.includes(
+        "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz",
+      )
+      && occurrenceCount(
+        qualityProducerRun,
+        "CODESTORY_RELEASE_EVIDENCE_CORPUS_ID=",
+      ) === 1
+      && occurrenceCount(
+        qualityProducerRun,
+        "CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT=",
+      ) === 1
+      && occurrenceCount(
+        qualityProducerRun,
+        "CODESTORY_RELEASE_EVIDENCE_CACHE_ID=",
+      ) === 1
+      && shellInvocationsContaining(qualityProducerRun, "--packet-runtime").length === 1
+      && qualityProducerRun.includes("--packet-runtime")
+      && qualityProducerRun.includes("--packet-runtime-mode cold-cli")
+      && occurrenceCount(qualityProducerRun, "--task-manifest") === 1
+      && !qualityProducerRun.includes("--task-suite")
+      && !qualityProducerRun.includes("--task-ids")
+      && qualityProducerRun.includes("--materialize-repos")
+      && qualityProducerRun.includes("--repeats 3")
+      && qualityProducerRun.includes("--publishable")
+      && qualityProducerRun.includes("--max-source-reads-after-packet 0")
+      && qualityProducerRun.includes("--codestory-cli $packaged_cli")
+      && qualityProducerRun.includes("--timeout-ms 180000")
+      && qualityProducerRun.includes("--out-dir $quality_root/packet"),
+    `${qualityFile} must run exactly one pinned three-repeat publishable evaluator`,
+  );
+  const qualityUpload = qualitySteps.find(step => step.id === "quality-upload");
+  const qualityOutcome = namedStep(quality, "Record optional quality outcome");
+  add(
+    violations,
+    qualityUpload?.id === "quality-upload"
+      && qualityUpload?.if === "steps.quality.outcome == 'success'"
+      && qualityUpload?.["continue-on-error"] === true
+      && qualityUpload?.uses === "actions/upload-artifact@v7.0.1"
+      && hasExactKeys(object(qualityUpload?.with), [
+        "name",
+        "path",
+        "if-no-files-found",
+        "retention-days",
+        "overwrite",
+      ])
+      && object(qualityUpload?.with).name
+        === "frozen-candidate-quality-${{ inputs.ref }}"
+      && object(qualityUpload?.with).path
+        === "target/frozen-candidate-quality/evidence"
+      && object(qualityUpload?.with)["if-no-files-found"] === "error"
+      && object(qualityUpload?.with)["retention-days"] === 30
+      && object(qualityUpload?.with).overwrite === true
+      && qualityOutcome?.if === "always()"
+      && qualityOutcome?.shell === "bash"
+      && qualityOutcome?.["continue-on-error"] === undefined
+      && hasExactKeys(object(qualityOutcome?.env), [
+        "QUALITY_OUTCOME",
+        "UPLOAD_OUTCOME",
+      ])
+      && object(qualityOutcome?.env).QUALITY_OUTCOME
+        === "${{ steps.quality.outcome }}"
+      && object(qualityOutcome?.env).UPLOAD_OUTCOME
+        === "${{ steps.quality-upload.outcome }}"
+      && stepRun(quality, "Record optional quality outcome").includes(
+        'echo "- Release or qualification gate: \\`false\\`"',
+      ),
+    `${qualityFile} must report both outcomes without becoming a qualification or release gate`,
   );
   const vulkan = requireJob(violations, file, workflow, "windows-vulkan-proof");
   add(
     violations,
-    sameMembers(needs(vulkan), ["route", "packaged-proof", "macos-metal-proof"]),
-    `${file} Windows qualification must wait for successful protected Metal quality`,
+    sameMembers(needs(vulkan), ["route", "packaged-proof"]),
+    `${file} Windows qualification must run independently of optional Metal quality`,
   );
   add(
     violations,
     String(vulkan.if ?? "").includes("needs.route.outputs.mode != 'package'")
-      && String(vulkan.if ?? "").includes(
-        "(needs.route.outputs.mode != 'qualification' || needs.macos-metal-proof.result == 'success')",
-      ),
-    `${file} package-only mode must skip Windows while qualification requires successful Metal`,
+      && !String(vulkan.if ?? "").includes("needs.macos-metal-proof"),
+    `${file} package-only mode must skip Windows without serializing it behind Metal`,
   );
   add(violations, object(vulkan.with).use_packaged_cli_artifact === true, `${file} Vulkan proof must use the packaged CLI`);
   add(
@@ -5221,9 +5512,8 @@ function validatePackagedCoordinator(workflows, violations, graph) {
   );
   add(
     violations,
-    object(vulkan.with).quality_evidence_artifact
-      === "${{ needs.route.outputs.mode == 'qualification' && format('frozen-candidate-quality-{0}', needs.route.outputs.head_sha) || '' }}",
-    `${file} Windows qualification must consume the exact protected Metal quality artifact`,
+    object(vulkan.with).quality_evidence_artifact === undefined,
+    `${file} Windows qualification must not consume optional quality evidence`,
   );
   add(
     violations,
@@ -5289,8 +5579,13 @@ function validatePackagedCoordinator(workflows, violations, graph) {
   add(
     violations,
     !needs(closeout).includes("release-evidence")
-      && !scalarStrings(closeout).some(value => value.includes("EVIDENCE_RESULT")),
-    `${file} normal closeout must not depend on optional release evidence`,
+      && !needs(closeout).includes("frozen-candidate-quality")
+      && !scalarStrings(closeout).some(value =>
+        value.includes("EVIDENCE_RESULT")
+          || value.includes("QUALITY_RESULT")
+          || value.includes("frozen-candidate-quality")
+      ),
+    `${file} normal closeout must not depend on optional release or quality evidence`,
   );
   const closeoutProofName = "Require one coherent accepted proof";
   const closeoutProof = namedStep(closeout, closeoutProofName);
@@ -5469,6 +5764,11 @@ function validateRemainingWorkflows(workflows, violations) {
       for (const key of ["calibration_bundle_artifact", "calibration_bundle_run_id"]) {
         requireOptionalStringInput(violations, metalFile, metal, event, key);
       }
+      add(
+        violations,
+        at(metal, "on", event, "inputs", "quality_evidence_artifact") === undefined,
+        `${metalFile} ${event} must not accept optional quality evidence`,
+      );
     }
     const candidateInput = object(at(
       metal,
@@ -5838,97 +6138,11 @@ function validateRemainingWorkflows(workflows, violations) {
         "Verify packaged qualification driver",
         "Prove protected Metal runtime",
         [
-          "Download exact-head publishable packet quality evidence",
-          "Produce exact-head holdout quality on protected Metal",
-          "Upload exact-head protected Metal quality evidence",
           "Authenticate calibration bundle producer",
           "Download frozen calibration bundle",
         ],
       ),
       `${metalFile} must not replace the verified qualification driver before execution`,
-    );
-    const qualityDownload = namedStep(
-      job,
-      "Download exact-head publishable packet quality evidence",
-    );
-    add(
-      violations,
-      qualityDownload?.if === "inputs.quality_evidence_artifact != ''"
-        && qualityDownload?.uses === "actions/download-artifact@v8.0.1"
-        && hasExactKeys(qualityDownload?.with, ["name", "path"])
-        && object(qualityDownload?.with).name
-          === "${{ inputs.quality_evidence_artifact }}"
-        && object(qualityDownload?.with).path === "target/release-quality-evidence",
-      `${metalFile} imported quality evidence must bind the caller-selected exact artifact`,
-    );
-    const qualityProducerName = "Produce exact-head holdout quality on protected Metal";
-    const qualityProducer = namedStep(job, qualityProducerName);
-    const qualityProducerRun = shellLiteralNormalizedText(
-      stepRun(job, qualityProducerName),
-    );
-    add(
-      violations,
-      qualityProducer?.if
-        === "${{ !inputs.calibration_mode && !inputs.server_behavior_only && inputs.quality_evidence_artifact == '' }}"
-        && qualityProducer?.shell === "bash"
-        && hasExactKeys(qualityProducer?.env, ["VERSION", "CODESTORY_EMBED_ALLOW_CPU"])
-        && object(qualityProducer?.env).VERSION === "${{ inputs.version }}"
-        && object(qualityProducer?.env).CODESTORY_EMBED_ALLOW_CPU === "0"
-        && qualityProducerRun.includes(
-          "target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz",
-        )
-        && qualityProducerRun.includes("mktemp -d $RUNNER_TEMP/codestory-quality-cli.")
-        && qualityProducerRun.includes("mktemp -d $RUNNER_TEMP/codestory-quality-cache.")
-        && qualityProducerRun.includes("mktemp -d $RUNNER_TEMP/codestory-quality-stdio.")
-        && qualityProducerRun.includes(
-          "CODESTORY_RELEASE_EVIDENCE_PROFILE=protected-macos-arm64-metal",
-        )
-        && qualityProducerRun.includes(
-          "CODESTORY_RELEASE_EVIDENCE_CORPUS_ID=codestory-release-corpus-v1",
-        )
-        && qualityProducerRun.includes(
-          "CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT=benchmarks/release-evidence/corpus-contracts/holdout-retrieval-v1.json",
-        )
-        && qualityProducerRun.includes(
-          "CODESTORY_RELEASE_EVIDENCE_CACHE_ID=frozen-candidate-holdout-v1",
-        )
-        && shellInvocationsContaining(
-          qualityProducerRun,
-          "node scripts/codestory-agent-ab-benchmark.mjs",
-        ).length === 1
-        && qualityProducerRun.includes("--packet-runtime")
-        && qualityProducerRun.includes("--packet-runtime-mode cold-cli")
-        && qualityProducerRun.includes("--task-suite holdout-retrieval")
-        && qualityProducerRun.includes("--materialize-repos")
-        && qualityProducerRun.includes("--repeats 3")
-        && qualityProducerRun.includes("--publishable")
-        && qualityProducerRun.includes("--max-source-reads-after-packet 0")
-        && qualityProducerRun.includes("--codestory-cli $packaged_cli")
-        && qualityProducerRun.includes("--timeout-ms 180000")
-        && qualityProducerRun.includes("--out-dir $quality_root/packet"),
-      `${metalFile} protected Metal must generate one exact-head three-repeat holdout quality artifact for qualification`,
-    );
-    const qualityUploadName = "Upload exact-head protected Metal quality evidence";
-    const qualityUpload = namedStep(job, qualityUploadName);
-    add(
-      violations,
-      qualityUpload?.if
-        === "${{ !inputs.calibration_mode && !inputs.server_behavior_only && inputs.quality_evidence_artifact == '' }}"
-        && qualityUpload?.uses === "actions/upload-artifact@v7.0.1"
-        && hasExactKeys(
-          qualityUpload?.with,
-          ["name", "path", "if-no-files-found", "retention-days", "overwrite"],
-        )
-        && object(qualityUpload?.with).name
-          === "frozen-candidate-quality-${{ inputs.ref || github.sha }}"
-        && object(qualityUpload?.with).path === "target/release-quality-evidence"
-        && object(qualityUpload?.with)["if-no-files-found"] === "error"
-        && object(qualityUpload?.with)["retention-days"] === 30
-        && object(qualityUpload?.with).overwrite === true
-        && stepIndex(job, qualityUploadName) > stepIndex(job, qualityProducerName)
-        && stepIndex(job, "Prove protected Metal runtime")
-          > stepIndex(job, qualityUploadName),
-      `${metalFile} protected Metal quality must upload one exact-head stable handoff before qualification`,
     );
     requireCalibrationProducerBoundary(
       violations,
@@ -6028,7 +6242,6 @@ function validateRemainingWorkflows(workflows, violations) {
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
       "--server-behavior-only",
-      'test -f "$quality_path"',
     ]);
     add(violations, object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${metalFile} engine proof must reject CPU fallback`);
     const engineRun = stepRun(
@@ -6194,19 +6407,10 @@ function validateRemainingWorkflows(workflows, violations) {
       for (const key of ["calibration_bundle_artifact", "calibration_bundle_run_id"]) {
         requireOptionalStringInput(violations, vulkanFile, vulkan, event, key);
       }
-      const qualityInput = object(at(
-        vulkan,
-        "on",
-        event,
-        "inputs",
-        "quality_evidence_artifact",
-      ));
       add(
         violations,
-        qualityInput.required === false
-          && qualityInput.type === "string"
-          && (qualityInput.default === "" || qualityInput.default === undefined),
-        `${vulkanFile} ${event} quality_evidence_artifact must be an optional empty string`,
+        at(vulkan, "on", event, "inputs", "quality_evidence_artifact") === undefined,
+        `${vulkanFile} ${event} must not accept optional quality evidence`,
       );
     }
     const candidateInput = object(at(
@@ -6613,26 +6817,11 @@ function validateRemainingWorkflows(workflows, violations) {
         "Verify packaged qualification driver",
         "Prove protected Windows Vulkan runtime",
         [
-          "Download exact-head publishable packet quality evidence",
           "Authenticate calibration bundle producer",
           "Download frozen calibration bundle",
         ],
       ),
       `${vulkanFile} must not replace the verified qualification driver before execution`,
-    );
-    const qualityDownload = namedStep(
-      job,
-      "Download exact-head publishable packet quality evidence",
-    );
-    add(
-      violations,
-      qualityDownload?.if === "inputs.quality_evidence_artifact != ''"
-        && qualityDownload?.uses === "actions/download-artifact@v8.0.1"
-        && hasExactKeys(qualityDownload?.with, ["name", "path"])
-        && object(qualityDownload?.with).name
-          === "${{ inputs.quality_evidence_artifact }}"
-        && object(qualityDownload?.with).path === "target/release-quality-evidence",
-      `${vulkanFile} qualification must download the exact protected Metal quality handoff`,
     );
     requireCalibrationProducerBoundary(
       violations,
@@ -6650,7 +6839,6 @@ function validateRemainingWorkflows(workflows, violations) {
       "--calibration-producer-run-id",
       "--calibration-producer-artifact",
       "--server-behavior-only",
-      "Test-Path $qualityPath",
     ]);
     add(violations, object(engine?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${vulkanFile} engine proof must reject CPU fallback`);
     const engineRun = stepRun(job, "Prove protected Windows Vulkan runtime");
@@ -6683,11 +6871,11 @@ function validateRemainingWorkflows(workflows, violations) {
         && engineRun.includes(
           '"--qualification-evidence", "target/windows-vulkan-proof/qualification.json"',
         )
-        && engineRun.includes('"--retrieval-quality-evidence", $qualityPath')
+        && !engineRun.includes("--retrieval-quality-evidence")
         && occurrenceCount(engineRun, "--produce-qualification-evidence") === 1
         && occurrenceCount(engineRun, "--calibration-bundle") === 1
         && occurrenceCount(engineRun, "check-packaged-agent-proof.py") === 1,
-      `${vulkanFile} server-behavior proof must omit calibration while qualification runs one full lifecycle and quality proof`,
+      `${vulkanFile} server-behavior proof must omit calibration while qualification runs one lifecycle proof without optional quality`,
     );
     add(
       violations,
@@ -6853,13 +7041,10 @@ function validateRemainingWorkflows(workflows, violations) {
         requireOptionalStringInput(violations, linuxVulkanFile, linuxVulkan, event, key);
       }
       for (const key of ["quality_evidence_artifact", "quality_evidence_run_id"]) {
-        const input = object(at(linuxVulkan, "on", event, "inputs", key));
         add(
           violations,
-          input.required === false
-            && input.type === "string"
-            && (input.default === "" || input.default === undefined),
-          `${linuxVulkanFile} ${event} ${key} must be an optional empty string`,
+          at(linuxVulkan, "on", event, "inputs", key) === undefined,
+          `${linuxVulkanFile} ${event} must not accept ${key}`,
         );
       }
       add(
@@ -7250,78 +7435,9 @@ function validateRemainingWorkflows(workflows, violations) {
         [
           "Authenticate calibration bundle producer",
           "Download frozen calibration bundle",
-          "Authenticate protected Metal quality producer",
-          "Download exact-head protected Metal quality evidence",
         ],
       ),
       `${linuxVulkanFile} must not replace the verified qualification driver before execution`,
-    );
-    const qualityAuthentication = namedStep(
-      job,
-      "Authenticate protected Metal quality producer",
-    );
-    const qualityAuthenticationRun = stepRun(
-      job,
-      "Authenticate protected Metal quality producer",
-    );
-    add(
-      violations,
-      qualityAuthentication?.if === "${{ !inputs.server_behavior_only }}"
-        && qualityAuthentication?.shell === "bash"
-        && hasExactKeys(qualityAuthentication?.env, [
-          "GH_TOKEN",
-          "QUALITY_ARTIFACT",
-          "QUALITY_RUN_ID",
-        ])
-        && object(qualityAuthentication?.env).GH_TOKEN === "${{ github.token }}"
-        && object(qualityAuthentication?.env).QUALITY_ARTIFACT
-          === "${{ inputs.quality_evidence_artifact }}"
-        && object(qualityAuthentication?.env).QUALITY_RUN_ID
-          === "${{ inputs.quality_evidence_run_id }}"
-        && qualityAuthenticationRun.includes('test -n "$QUALITY_ARTIFACT"')
-        && qualityAuthenticationRun.includes('test -n "$QUALITY_RUN_ID"')
-        && qualityAuthenticationRun.includes(
-          'test "$(jq -r \'.head_repository.full_name\' <<<"$run")" = "$GITHUB_REPOSITORY"',
-        )
-        && qualityAuthenticationRun.includes(
-          'test "$(jq -r \'.path\' <<<"$run")" = ".github/workflows/packaged-platform-pr.yml"',
-        )
-        && qualityAuthenticationRun.includes(
-          'test "$(jq -r \'.event\' <<<"$run")" = workflow_dispatch',
-        )
-        && qualityAuthenticationRun.includes(
-          'test "$(jq -r \'.conclusion\' <<<"$run")" = success',
-        )
-        && qualityAuthenticationRun.includes(
-          'test "$producer_sha" = "$(git rev-parse HEAD)"',
-        )
-        && qualityAuthenticationRun.includes(
-          'test "$QUALITY_ARTIFACT" = "frozen-candidate-quality-$producer_sha"',
-        )
-        && qualityAuthenticationRun.includes('test "$artifact_count" = 1'),
-      `${linuxVulkanFile} standalone qualification must authenticate exact-head protected Metal quality`,
-    );
-    const qualityDownload = namedStep(
-      job,
-      "Download exact-head protected Metal quality evidence",
-    );
-    add(
-      violations,
-      qualityDownload?.if === "${{ !inputs.server_behavior_only }}"
-        && qualityDownload?.uses === "actions/download-artifact@v8.0.1"
-        && hasExactKeys(
-          qualityDownload?.with,
-          ["name", "path", "run-id", "github-token"],
-        )
-        && object(qualityDownload?.with).name
-          === "${{ inputs.quality_evidence_artifact }}"
-        && object(qualityDownload?.with).path === "target/release-quality-evidence"
-        && object(qualityDownload?.with)["run-id"]
-          === "${{ inputs.quality_evidence_run_id }}"
-        && object(qualityDownload?.with)["github-token"] === "${{ github.token }}"
-        && stepIndex(job, "Download exact-head protected Metal quality evidence")
-          > stepIndex(job, "Authenticate protected Metal quality producer"),
-      `${linuxVulkanFile} standalone qualification must consume the authenticated protected Metal quality artifact`,
     );
     const engine = namedStep(job, "Prove offline Linux Vulkan retrieval");
     requireStepRun(violations, linuxVulkanFile, job, "Prove offline Linux Vulkan retrieval", [
@@ -7351,11 +7467,8 @@ function validateRemainingWorkflows(workflows, violations) {
       engineRun.includes("calibration_args=()")
         && engineRun.includes('"${calibration_args[@]}"')
         && engineRun.includes('claim_args=(--server-behavior-only)')
-        && engineRun.includes("quality_args=()")
         && engineRun.includes("qualification_args=()")
-        && normalizedEngineRun.includes(
-          "quality_args=(--retrieval-quality-evidence $quality_path)",
-        )
+        && !normalizedEngineRun.includes("--retrieval-quality-evidence")
         && normalizedEngineRun.includes("--produce-qualification-evidence")
         && object(engine?.env).VERIFIED_QUALIFICATION_DRIVER
           === "${{ steps.qualification-driver.outputs.path }}"
@@ -7374,7 +7487,7 @@ function validateRemainingWorkflows(workflows, violations) {
         && occurrenceCount(engineRun, "--produce-qualification-evidence") === 1
         && occurrenceCount(engineRun, "--calibration-bundle") === 1
         && occurrenceCount(engineRun, "check-packaged-agent-proof.py") === 1,
-      `${linuxVulkanFile} server-behavior proof must omit calibration while standalone qualification runs one full lifecycle and quality proof`,
+      `${linuxVulkanFile} server-behavior proof must omit calibration while standalone qualification runs one lifecycle proof without optional quality`,
     );
     requireStepRun(violations, linuxVulkanFile, job, "Stage isolated candidate-managed Linux install", [
       "--prepare-candidate-installed-proof",
@@ -8207,9 +8320,22 @@ export function absorbedFailureViolations(workflows) {
       // A job-level `continue-on-error` downgrades every step it contains at once, and the only
       // thing that can still require the failure is a downstream job reading `needs.<id>.result`.
       if (absorbs(job["continue-on-error"])) {
+        // The separately validated frozen-candidate adjunct is intentionally unclaimed and non-gating,
+        // including runner loss and timeout. It cannot appear in a downstream `needs` edge:
+        // doing so would turn optional evidence back into a closeout dependency. Its exact job
+        // structure, activation, protected host, cache boundary, evaluator, and outcome recorder
+        // are pinned by validatePackagedCoordinator and the whole-workflow digest.
+        const isOptionalFrozenCandidateQuality =
+          file === frozenCandidateQualityWorkflowRef.slice(
+            frozenCandidateQualityWorkflowRef.lastIndexOf("/") + 1,
+          )
+          && jobId === "quality";
         add(
           violations,
-          scalarStrings(workflow.jobs).some(text => text.includes(`needs.${jobId}.result`)),
+          isOptionalFrozenCandidateQuality
+            || scalarStrings(workflow.jobs).some(
+              text => text.includes(`needs.${jobId}.result`),
+            ),
           `${file} jobs.${jobId} absorbs its own failure and must have needs.${jobId}.result required`,
         );
       }
@@ -8500,10 +8626,6 @@ function validateReleaseArtifactRerunSafety(workflows, violations) {
     ["macos-metal-proof.yml/packaged-metal/Upload Metal calibration runs", {
       name: "embedding-calibration-macos-${{ inputs.version }}",
       path: "target/calibration-runs/macos",
-    }],
-    ["macos-metal-proof.yml/packaged-metal/Upload exact-head protected Metal quality evidence", {
-      name: "frozen-candidate-quality-${{ inputs.ref || github.sha }}",
-      path: "target/release-quality-evidence",
     }],
     ["release.yml/pre-publish-closeout/Upload accepted pre-publish closeout", {
       name: "release-closeout-pre-publish-${{ needs.preflight.outputs.version }}-${{ github.sha }}",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -961,9 +961,10 @@ test("constant calibration structure rejects qualification, 3x3 sampling, repeat
   }
 });
 
-test("frozen-candidate qualification keeps the Metal quality handoff and optional Linux topology", async (t) => {
+test("frozen-candidate quality stays optional, exact, and archive-authenticated", async (t) => {
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
   const coordinatorFile = "packaged-platform-pr.yml";
+  const qualityFile = "frozen-candidate-quality.yml";
   const metalFile = "macos-metal-proof.yml";
   const windowsFile = "windows-vulkan-proof.yml";
   const linuxFile = "linux-vulkan-proof.yml";
@@ -981,22 +982,14 @@ test("frozen-candidate qualification keeps the Metal quality handoff and optiona
     }, /qualification must run full Metal proof rather than candidate-installed proof/u],
     ["Metal qualification becomes server-behavior only", coordinatorFile, workflow => {
       workflow.jobs["macos-metal-proof"].with.server_behavior_only = true;
-    }, /qualification must run full Metal quality and lifecycle proof/u],
-    ["Windows no longer waits for Metal", coordinatorFile, workflow => {
-      workflow.jobs["windows-vulkan-proof"].needs
-        = workflow.jobs["windows-vulkan-proof"].needs
-          .filter(name => name !== "macos-metal-proof");
-    }, /Windows qualification must wait for successful protected Metal quality/u],
-    ["Windows ignores failed Metal qualification", coordinatorFile, workflow => {
-      workflow.jobs["windows-vulkan-proof"].if
-        = workflow.jobs["windows-vulkan-proof"].if.replace(
-          "(needs.route.outputs.mode != 'qualification' || needs.macos-metal-proof.result == 'success') &&",
-          "",
-        );
-    }, /qualification requires successful Metal/u],
-    ["Windows qualification loses exact quality artifact", coordinatorFile, workflow => {
-      workflow.jobs["windows-vulkan-proof"].with.quality_evidence_artifact = "";
-    }, /must consume the exact protected Metal quality artifact/u],
+    }, /qualification must run one full Metal lifecycle proof without optional quality inputs/u],
+    ["Windows qualification waits for optional quality", coordinatorFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].needs.push("frozen-candidate-quality");
+    }, /Windows qualification must run independently of optional Metal quality|reviewed frozen-candidate coordinator structure/u],
+    ["Windows qualification consumes optional quality", coordinatorFile, workflow => {
+      workflow.jobs["windows-vulkan-proof"].with.quality_evidence_artifact =
+        "${{ needs.frozen-candidate-quality.outputs.artifact }}";
+    }, /Windows qualification must not consume optional quality evidence/u],
     ["Windows qualification becomes candidate-installed only", coordinatorFile, workflow => {
       workflow.jobs["windows-vulkan-proof"].with.candidate_installed_proof = true;
     }, /qualification must run full Windows proof rather than candidate-installed proof/u],
@@ -1064,66 +1057,178 @@ test("frozen-candidate qualification keeps the Metal quality handoff and optiona
         "Require one coherent accepted proof",
       ).env.MODE = "qualification ";
     }, /closeout proof must bind every route and platform result from the reviewed jobs exactly/u],
-    ["Metal quality producer runs during calibration", metalFile, workflow => {
-      draftStep(
-        workflow.jobs["packaged-metal"],
-        "Produce exact-head holdout quality on protected Metal",
-      ).if = "${{ !inputs.server_behavior_only }}";
-    }, /must generate one exact-head three-repeat holdout quality artifact/u],
-    ["Metal quality producer weakens repeat contract", metalFile, workflow => {
-      const producer = draftStep(
-        workflow.jobs["packaged-metal"],
-        "Produce exact-head holdout quality on protected Metal",
+    ["optional quality caller attempts unsupported advisory syntax", coordinatorFile, workflow => {
+      workflow.jobs["frozen-candidate-quality"]["continue-on-error"] = true;
+    }, /optional quality must call its isolated owner once after protected Metal/u],
+    ["optional quality owner job becomes blocking", qualityFile, workflow => {
+      workflow.jobs.quality["continue-on-error"] = false;
+    }, /optional quality must stay nonblocking on protected Metal/u],
+    ["optional quality runs outside qualification", coordinatorFile, workflow => {
+      workflow.jobs["frozen-candidate-quality"].if
+        = workflow.jobs["frozen-candidate-quality"].if.replace(
+          "needs.route.outputs.mode == 'qualification'",
+          "needs.route.outputs.mode == 'platform'",
+        );
+    }, /optional quality must call its isolated owner once after protected Metal/u],
+    ["optional quality no longer waits for Metal", coordinatorFile, workflow => {
+      workflow.jobs["frozen-candidate-quality"].needs
+        = workflow.jobs["frozen-candidate-quality"].needs
+          .filter(name => name !== "macos-metal-proof");
+    }, /optional quality must call its isolated owner once after protected Metal/u],
+    ["optional quality moves off the protected Metal host", qualityFile, workflow => {
+      workflow.jobs.quality["runs-on"]
+        = ["self-hosted", "Linux", "X64", "codestory-vulkan"];
+    }, /optional quality must stay nonblocking on protected Metal/u],
+    ["optional quality stops authenticating the current run attempt", qualityFile, workflow => {
+      const authentication = draftStep(
+        workflow.jobs.quality,
+        "Authenticate exact candidate archive artifacts",
       );
-      producer.run = producer.run.replace("--repeats 3", "--repeats 1");
-    }, /must generate one exact-head three-repeat holdout quality artifact/u],
-    ["Metal quality upload loses exact-head name", metalFile, workflow => {
+      authentication.run = authentication.run.replace(
+        'test "$(jq -r \'.run_attempt\' <<<"$producer_run")" = "$GITHUB_RUN_ATTEMPT"',
+        "true",
+      );
+    }, /authenticate one current-run exact-head candidate archive and record/u],
+    ["optional quality cache accepts another source SHA", qualityFile, workflow => {
+      const restore = draftStep(
+        workflow.jobs.quality,
+        "Restore exact candidate archive from protected host",
+      );
+      restore.run = restore.run.replace(".source.commit == $source_sha", "true");
+    }, /step Restore exact candidate archive from protected host must run \.source\.commit == \$source_sha/u],
+    ["optional quality archive transfer becomes unconditional", qualityFile, workflow => {
+      delete draftStep(
+        workflow.jobs.quality,
+        "Download, authenticate, and admit candidate archive on miss",
+      ).if;
+    }, /archive transfer must be cache-miss-only and outer-digest authenticated/u],
+    ["optional quality archive skips the outer digest", qualityFile, workflow => {
+      const miss = draftStep(
+        workflow.jobs.quality,
+        "Download, authenticate, and admit candidate archive on miss",
+      );
+      miss.run = miss.run.replace(
+        'test "$actual_digest" = "$EXPECTED_SHA256"',
+        "true",
+      );
+    }, /step Download, authenticate, and admit candidate archive on miss must run test "\$actual_digest" = "\$EXPECTED_SHA256"/u],
+    ["optional quality restores the v1 corpus", qualityFile, workflow => {
+      const producer = draftStep(
+        workflow.jobs.quality,
+        "Produce optional Axios v2 quality evidence",
+      );
+      producer.run = producer.run.replaceAll(
+        "codestory-release-corpus-v0.16-axios-js-ts-v2",
+        "codestory-release-corpus-v1",
+      ).replace(
+        "v0.16-axios-js-ts-v2.json",
+        "holdout-retrieval-v1.json",
+      );
+    }, /reviewed isolated evaluation-owner structure/u],
+    ["optional quality selects the old Axios task", qualityFile, workflow => {
+      const producer = draftStep(
+        workflow.jobs.quality,
+        "Produce optional Axios v2 quality evidence",
+      );
+      producer.run = producer.run.replace(
+        "axios-request-dispatch-v2.task.json",
+        "axios-request-dispatch.task.json",
+      );
+    }, /reviewed isolated evaluation-owner structure/u],
+    ["optional quality appends a second task manifest", qualityFile, workflow => {
+      const producer = draftStep(
+        workflow.jobs.quality,
+        "Produce optional Axios v2 quality evidence",
+      );
+      producer.run = producer.run.replace(
+        "--materialize-repos",
+        "--task-manifest benchmarks/tasks/extra.task.json \\\n            --materialize-repos",
+      );
+    }, /run exactly one pinned three-repeat publishable evaluator/u],
+    ["optional quality widens selection to a suite", qualityFile, workflow => {
+      const producer = draftStep(
+        workflow.jobs.quality,
+        "Produce optional Axios v2 quality evidence",
+      );
+      producer.run = producer.run.replace(
+        "--materialize-repos",
+        "--task-suite holdout-retrieval \\\n            --materialize-repos",
+      );
+    }, /run exactly one pinned three-repeat publishable evaluator/u],
+    ["optional quality restores nested repeats", qualityFile, workflow => {
+      const producer = draftStep(
+        workflow.jobs.quality,
+        "Produce optional Axios v2 quality evidence",
+      );
+      producer.run = producer.run.replace("--repeats 3", "--repeats 9");
+    }, /run exactly one pinned three-repeat publishable evaluator/u],
+    ["optional quality permits CPU fallback", qualityFile, workflow => {
       draftStep(
-        workflow.jobs["packaged-metal"],
-        "Upload exact-head protected Metal quality evidence",
-      ).with.name = "frozen-candidate-quality";
-    }, /must upload one exact-head stable handoff/u],
-    ["Metal quality upload loses safe overwrite", metalFile, workflow => {
+        workflow.jobs.quality,
+        "Produce optional Axios v2 quality evidence",
+      ).env.CODESTORY_EMBED_ALLOW_CPU = "1";
+    }, /run exactly one pinned three-repeat publishable evaluator/u],
+    ["optional quality measurement becomes blocking", qualityFile, workflow => {
+      delete draftStep(
+        workflow.jobs.quality,
+        "Produce optional Axios v2 quality evidence",
+      )["continue-on-error"];
+    }, /run exactly one pinned three-repeat publishable evaluator/u],
+    ["optional quality upload becomes blocking", qualityFile, workflow => {
+      delete draftStep(
+        workflow.jobs.quality,
+        "Upload optional Axios v2 quality evidence",
+      )["continue-on-error"];
+    }, /report both outcomes without becoming a qualification or release gate/u],
+    ["optional quality outcome recorder is no longer unconditional", qualityFile, workflow => {
       draftStep(
-        workflow.jobs["packaged-metal"],
-        "Upload exact-head protected Metal quality evidence",
-      ).with.overwrite = false;
-    }, /must upload one exact-head stable handoff/u],
-    ["Windows downloads an unrelated quality artifact", windowsFile, workflow => {
+        workflow.jobs.quality,
+        "Record optional quality outcome",
+      ).if = "steps.quality.outcome == 'success'";
+    }, /report both outcomes without becoming a qualification or release gate/u],
+    ["optional quality outcome recorder uses a hardcoded sentinel", qualityFile, workflow => {
       draftStep(
-        workflow.jobs["packaged-vulkan"],
-        "Download exact-head publishable packet quality evidence",
-      ).with.name = "latest-quality";
-    }, /must download the exact protected Metal quality handoff/u],
+        workflow.jobs.quality,
+        "Record optional quality outcome",
+      ).env.QUALITY_OUTCOME = "success";
+    }, /report both outcomes without becoming a qualification or release gate/u],
+    ["closeout adds optional quality as a dependency", coordinatorFile, workflow => {
+      workflow.jobs.closeout.needs.push("frozen-candidate-quality");
+    }, /closeout must wait for every selected platform proof|normal closeout must not depend on optional release or quality evidence/u],
+    ["Metal lifecycle accepts quality evidence again", metalFile, workflow => {
+      workflow.on.workflow_call.inputs.quality_evidence_artifact = {
+        required: false,
+        type: "string",
+        default: "",
+      };
+    }, /workflow_call must not accept optional quality evidence/u],
+    ["Windows lifecycle accepts quality evidence again", windowsFile, workflow => {
+      workflow.on.workflow_call.inputs.quality_evidence_artifact = {
+        required: false,
+        type: "string",
+        default: "",
+      };
+    }, /workflow_call must not accept optional quality evidence/u],
+    ["Linux lifecycle accepts quality evidence again", linuxFile, workflow => {
+      workflow.on.workflow_call.inputs.quality_evidence_artifact = {
+        required: false,
+        type: "string",
+        default: "",
+      };
+    }, /workflow_call must not accept quality_evidence_artifact/u],
     ["Linux full qualification skips retained-driver verification", linuxFile, workflow => {
       draftStep(
         workflow.jobs["packaged-vulkan"],
         "Verify packaged qualification driver",
       ).if = "${{ inputs.server_behavior_only }}";
     }, /packaged qualification must verify the archive-bound private driver/u],
-    ["Linux trusts quality from another workflow", linuxFile, workflow => {
-      const authenticate = draftStep(
-        workflow.jobs["packaged-vulkan"],
-        "Authenticate protected Metal quality producer",
-      );
-      authenticate.run = authenticate.run.replace(
-        ".github/workflows/packaged-platform-pr.yml",
-        ".github/workflows/release.yml",
-      );
-    }, /must authenticate exact-head protected Metal quality/u],
-    ["Linux quality download loses producer run identity", linuxFile, workflow => {
-      draftStep(
-        workflow.jobs["packaged-vulkan"],
-        "Download exact-head protected Metal quality evidence",
-      ).with["run-id"] = "${{ github.run_id }}";
-    }, /must consume the authenticated protected Metal quality artifact/u],
     ["Linux standalone path removes lifecycle qualification", linuxFile, workflow => {
       const proof = draftStep(
         workflow.jobs["packaged-vulkan"],
         "Prove offline Linux Vulkan retrieval",
       );
       proof.run = proof.run.replace("--produce-qualification-evidence", "--server-behavior-only");
-    }, /standalone qualification runs one full lifecycle and quality proof/u],
+    }, /standalone qualification runs one lifecycle proof without optional quality/u],
   ];
 
   for (const [name, file, mutate, expected] of mutations) {
@@ -1142,6 +1247,30 @@ test("frozen-candidate qualification keeps the Metal quality handoff and optiona
     ["quality producer moves off protected Metal", graph => {
       graph.workflow_policy.qualification.quality_contract.producer_cell
         = "protected_windows_x64_vulkan";
+    }],
+    ["quality becomes a release gate", graph => {
+      graph.workflow_policy.qualification.quality_contract.blocking = true;
+    }],
+    ["quality becomes a claimed result", graph => {
+      graph.workflow_policy.qualification.quality_contract.claimed = true;
+    }],
+    ["quality stops using the global exact-package cache contract", graph => {
+      graph.workflow_policy.qualification.quality_contract.archive_cache_contract
+        = "mutable_candidate_cache";
+    }],
+    ["quality owner moves back into a protected product boundary", graph => {
+      graph.workflow_policy.qualification.quality_contract.evaluation_owner
+        = "protected_product_path";
+    }],
+    ["quality owner digest no longer binds the reviewed evaluator", graph => {
+      graph.workflow_policy.qualification.quality_contract.evaluation_owner_sha256
+        = "0".repeat(64);
+    }],
+    ["quality re-enters required qualification evidence", graph => {
+      graph.workflow_policy.qualification.required_evidence.push("retrieval_quality");
+    }],
+    ["Metal lifecycle claims it produces quality again", graph => {
+      graph.workflow_policy.qualification.required_cells[0].produces_quality = true;
     }],
     ["true-idle grace replaces the product timeout", graph => {
       graph.workflow_policy.qualification.true_idle_timeout_ms = 2_500;
@@ -1335,7 +1464,7 @@ test("qualification driver is built once, retained privately, authenticated, and
     ["Windows executes an unverified driver", windowsFile, workflow => {
       draftStep(windowsJob(workflow), "Prove protected Windows Vulkan runtime")
         .env.VERIFIED_QUALIFICATION_DRIVER = "target/release/other.exe";
-    }, /server-behavior proof must omit calibration while qualification runs one full lifecycle/u],
+    }, /server-behavior proof must omit calibration while qualification runs one lifecycle proof without optional quality/u],
     ["Windows substitutes driver after verification", windowsFile, workflow => {
       const steps = windowsJob(workflow).steps;
       const verifyIndex = steps.findIndex(
@@ -1415,7 +1544,7 @@ test("qualification driver is built once, retained privately, authenticated, and
             '--qualification-driver "$qualification_driver"',
             "--qualification-driver target/release/other-driver",
           );
-    }, /standalone qualification runs one full lifecycle and quality proof/u],
+    }, /standalone qualification runs one lifecycle proof without optional quality/u],
     ["Linux substitutes driver after verification", linuxFile, workflow => {
       const steps = linuxJob(workflow).steps;
       const verifyIndex = steps.findIndex(
@@ -2508,7 +2637,7 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
     }, /closeout must wait for every selected platform proof/u],
     ["closeout waits for release evidence", packagedCoordinatorFile, workflow => {
       workflow.jobs.closeout.needs.push("release-evidence");
-    }, /normal closeout must not depend on optional release evidence/u],
+    }, /normal closeout must not depend on optional release or quality evidence/u],
     ["Linux package matrix scope removed", packagedProofFile, workflow => {
       workflow.jobs.build.strategy.matrix
         = workflow.jobs.build.strategy.matrix.replace("inputs.scope == 'linux'", "inputs.scope == 'windows'");
@@ -3044,7 +3173,7 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
     ["package mode enables protected Windows proof", coordinatorFile, workflow => {
       workflow.jobs["windows-vulkan-proof"].if = workflow.jobs["windows-vulkan-proof"].if
         .replace("needs.route.outputs.mode != 'package' &&", "");
-    }, /package-only mode must skip Windows while qualification requires successful Metal/u],
+    }, /package-only mode must skip Windows without serializing it behind Metal/u],
     ["package mode enables protected Linux proof", coordinatorFile, workflow => {
       workflow.jobs["linux-vulkan-proof"].if = workflow.jobs["linux-vulkan-proof"].if
         .replace("needs.route.outputs.mode != 'package' &&", "");

--- a/.github/scripts/packaged_agent_proof/cli.py
+++ b/.github/scripts/packaged_agent_proof/cli.py
@@ -54,7 +54,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--server-behavior-only", action="store_true")
     parser.add_argument("--ground-only", action="store_true")
     parser.add_argument("--publication-fault-evidence", type=Path)
-    parser.add_argument("--retrieval-quality-evidence", type=Path)
     parser.add_argument("--calibration-bundle", type=Path)
     parser.add_argument("--enforce-calibration-freeze-lineage", action="store_true")
     parser.add_argument("--collect-constant-calibration", action="store_true")
@@ -98,7 +97,6 @@ def _resolve_optional_paths(args: argparse.Namespace) -> None:
         "qualification_evidence",
         "qualification_driver",
         "publication_fault_evidence",
-        "retrieval_quality_evidence",
         "calibration_bundle",
         "installed_plugin_attestation",
         "installed_plugin_data",
@@ -129,7 +127,6 @@ def _validate_calibration_mode(args: argparse.Namespace) -> None:
             and not args.produce_qualification_evidence
             and args.qualification_evidence is None
             and args.publication_fault_evidence is None
-            and args.retrieval_quality_evidence is None
             and args.calibration_bundle is None,
             "constant calibration requires its isolated GPU-only collector and rejects project, plugin, or qualification inputs",
         )

--- a/.github/scripts/packaged_agent_proof/contract_primitives.py
+++ b/.github/scripts/packaged_agent_proof/contract_primitives.py
@@ -229,9 +229,8 @@ def validate_runtime_claim_scope(args: argparse.Namespace) -> None:
         require(
             not args.produce_qualification_evidence
             and args.qualification_evidence is None
-            and args.retrieval_quality_evidence is None
             and args.publication_fault_evidence is None,
-            "server-behavior-only proof rejects qualification and retrieval-quality inputs",
+            "server-behavior-only proof rejects qualification inputs",
         )
     if args.ground_only:
         require(
@@ -242,7 +241,6 @@ def validate_runtime_claim_scope(args: argparse.Namespace) -> None:
             not args.server_behavior_only
             and not args.produce_qualification_evidence
             and args.qualification_evidence is None
-            and args.retrieval_quality_evidence is None
             and args.publication_fault_evidence is None,
-            "ground-only proof rejects server, qualification, and retrieval-quality inputs",
+            "ground-only proof rejects server and qualification inputs",
         )

--- a/.github/scripts/packaged_agent_proof/foundation.py
+++ b/.github/scripts/packaged_agent_proof/foundation.py
@@ -141,10 +141,23 @@ def resource_uri_matches(
         return False
 
 
-EXTERNAL_QUALIFICATION_METRICS = {
-    "retrieval_quality",
-    "total_codestory_process_memory",
-}
+REQUIRED_QUALIFICATION_METRICS = frozenset(
+    {
+        "backend_observed_accelerator_residency",
+        "bulk_documents_per_second",
+        "bulk_tokens_per_second",
+        "busy_retry_usefulness",
+        "cold_first_vector",
+        "existing_owner_connect",
+        "first_product_ready",
+        "spawn_convergence",
+        "total_codestory_process_memory",
+        "true_idle_exit",
+        "warm_bulk_ipc",
+        "warm_query_ipc",
+    }
+)
+EXTERNAL_QUALIFICATION_METRICS = {"total_codestory_process_memory"}
 MEASUREMENT_PROTOCOL = (
     REPOSITORY_ROOT
     / "crates"
@@ -220,6 +233,84 @@ REQUIRED_SERVER_SCENARIOS = {
     "true_idle_respawn",
     "incompatible_owner",
     "frozen_owner",
+}
+REQUIRED_SERVER_SCENARIO_ASSERTIONS = {
+    "client_death": frozenset(
+        {
+            "dead_client_queue_and_leases_reclaimed",
+            "other_client_continues",
+            "no_server_replacement",
+        }
+    ),
+    "cold_race": frozenset(
+        {
+            "two_independent_plugin_hosts",
+            "same_os_account",
+            "different_repositories",
+            "one_lifetime_authority",
+            "one_listener",
+            "one_server",
+            "one_engine_owner",
+            "one_native_worker",
+            "one_load_generation",
+            "one_model_load",
+        }
+    ),
+    "frozen_owner": frozenset(
+        {
+            "owner_unresponsive_is_bounded",
+            "authority_retained",
+            "no_unlink",
+            "no_pid_kill",
+            "no_takeover",
+            "no_second_engine",
+        }
+    ),
+    "incompatible_owner": frozenset(
+        {
+            "idle_owner_drains",
+            "active_owner_returns_typed_retry",
+            "one_authority",
+            "one_engine_maximum",
+        }
+    ),
+    "mixed_queue": frozenset(
+        {
+            "query_and_bulk_capacities_are_64",
+            "fifo_within_each_class",
+            "query_preferred_between_bulk_batches",
+            "bulk_resumes_when_query_queue_permits",
+            "no_project_or_scope_round_robin",
+            "typed_retry_names_useful_condition",
+            "no_project_or_request_text_leakage",
+        }
+    ),
+    "server_crash": frozenset(
+        {
+            "one_replacement_server",
+            "pure_embedding_rpc_replayed_at_most_once",
+            "lost_publication_lease_blocks_commit",
+            "previous_publication_remains_usable",
+        }
+    ),
+    "true_idle_respawn": frozenset(
+        {
+            "queued_active_and_leased_work_prevent_exit",
+            "idle_connections_and_diagnostics_do_not_extend_idle",
+            "exit_after_60000_awake_ms",
+            "next_product_operation_respawns_without_consent",
+            "verified_materialization_reused",
+        }
+    ),
+    "worker_stall": frozenset(
+        {
+            "independent_watchdog_fail_stops_server",
+            "unrelated_process_survives",
+            "pure_embedding_rpc_replayed_at_most_once",
+            "lost_publication_lease_blocks_commit",
+            "previous_publication_remains_usable",
+        }
+    ),
 }
 LOWER_TIER_NONCLAIMS = {
     "answer_quality",

--- a/.github/scripts/packaged_agent_proof/measurement_constant_selection.py
+++ b/.github/scripts/packaged_agent_proof/measurement_constant_selection.py
@@ -226,7 +226,7 @@ def _verify_thresholds_and_clock(protocol: dict) -> None:
             ],
             "constant_set_comparison": "exact_recomputed_runtime_constants_and_freeze_record",
             "qualification_boundary": (
-                "lifecycle_fault_idle_memory_quality_accelerator_and_performance_are_frozen_candidate_qualification_only"
+                "lifecycle_fault_idle_memory_accelerator_and_performance_are_frozen_candidate_qualification_only"
             ),
         },
         "measurement calibration-bundle contract is incomplete or mutable",
@@ -239,6 +239,8 @@ def _verify_thresholds_and_clock(protocol: dict) -> None:
         and rules.get("missing_required_cell_fails") is True
         and rules.get("calibration_runs_full_qualification") is False
         and rules.get("qualification_runs_once_per_available_gpu_platform") is True
+        and rules.get("optional_quality_adjunct_is_nonblocking") is True
+        and rules.get("quality_is_not_a_qualification_metric") is True
         and rules.get("threshold_movement_after_results") is False,
         "calibration and qualification boundary is incomplete or mutable",
     )

--- a/.github/scripts/packaged_agent_proof/measurement_protocol_validation.py
+++ b/.github/scripts/packaged_agent_proof/measurement_protocol_validation.py
@@ -6,19 +6,46 @@ import json
 from pathlib import Path
 
 from .contract_primitives import (
+    canonical_sha256,
     require_exact_keys,
     require_nonempty_string,
     require_positive_int,
 )
 from .foundation import (
     LOWER_TIER_NONCLAIMS,
-    MIN_RETRIEVAL_QUALITY_REPEATS,
     QUALIFICATION_SCHEMA_VERSION,
+    REQUIRED_QUALIFICATION_METRICS,
+    REQUIRED_SERVER_SCENARIO_ASSERTIONS,
     REQUIRED_SERVER_SCENARIOS,
-    RETRIEVAL_QUALITY_EVIDENCE_CONTRACT,
     ProofFailure,
     require,
 )
+
+QUALIFICATION_MEASUREMENT_SHAPE_FIELDS = (
+    "required_scenarios",
+    "scenario_contracts",
+    "required_metrics",
+    "phase_boundaries",
+    "workloads",
+    "metric_sampling",
+    "metric_contracts",
+    "calibration_required_metrics",
+    "calibration_phase_boundaries",
+    "calibration_metric_sampling",
+    "calibration_workload_state_overrides",
+)
+EXPECTED_QUALIFICATION_MEASUREMENT_SHAPE_SHA256 = (
+    "1c065562adc34d0d9978187857807e491c4e6d4aa233fdd94f5636931a7b730e"
+)
+
+
+def qualification_measurement_shape_sha256(protocol: dict) -> str:
+    return canonical_sha256(
+        {
+            field: protocol.get(field)
+            for field in QUALIFICATION_MEASUREMENT_SHAPE_FIELDS
+        }
+    )
 
 
 def _measurement_document(path: Path) -> dict:
@@ -36,6 +63,11 @@ def _measurement_document(path: Path) -> dict:
 
 
 def _verify_scenario_and_metric_contracts(protocol: dict) -> tuple[set[str], dict]:
+    require(
+        qualification_measurement_shape_sha256(protocol)
+        == EXPECTED_QUALIFICATION_MEASUREMENT_SHAPE_SHA256,
+        "frozen-candidate qualification measurement shape changed",
+    )
     require(
         set(protocol.get("required_scenarios", [])) == REQUIRED_SERVER_SCENARIOS,
         "measurement protocol does not name the complete server scenario set",
@@ -59,11 +91,19 @@ def _verify_scenario_and_metric_contracts(protocol: dict) -> tuple[set[str], dic
             ),
             f"measurement scenario {scenario} assertion contract is malformed",
         )
+        require(
+            set(contract["required"]) == REQUIRED_SERVER_SCENARIO_ASSERTIONS[scenario],
+            f"measurement scenario {scenario} assertion set changed",
+        )
     require(
         set(protocol.get("required_lower_tier_nonclaims", [])) == LOWER_TIER_NONCLAIMS,
         "measurement protocol does not name the complete lower-tier nonclaim set",
     )
     required_metrics = set(protocol.get("required_metrics", []))
+    require(
+        required_metrics == REQUIRED_QUALIFICATION_METRICS,
+        "frozen-candidate qualification metric set must remain lifecycle-only",
+    )
     phase_boundaries = protocol.get("phase_boundaries")
     require(
         isinstance(phase_boundaries, dict)
@@ -396,15 +436,7 @@ def _verify_measurement_sampling(
             policy.get("aggregation"),
             f"measurement sample policy {metric}.aggregation",
         )
-        if metric == "retrieval_quality":
-            require(
-                count == MIN_RETRIEVAL_QUALITY_REPEATS
-                and aggregation == "all_rows_pass_rate"
-                and policy.get("external_contract")
-                == RETRIEVAL_QUALITY_EVIDENCE_CONTRACT,
-                "retrieval quality sample policy changed",
-            )
-        elif metric in {
+        if metric in {
             "true_idle_exit",
             "backend_observed_accelerator_residency",
         }:
@@ -419,8 +451,7 @@ def _verify_measurement_sampling(
             "greater_than_or_equal": "minimum",
             "equal": "exact",
         }[metric_contracts[metric]["comparison"]]
-        if metric != "retrieval_quality":
-            require(
-                aggregation == expected_aggregation,
-                f"measurement metric {metric} aggregation is not conservative",
-            )
+        require(
+            aggregation == expected_aggregation,
+            f"measurement metric {metric} aggregation is not conservative",
+        )

--- a/.github/scripts/packaged_agent_proof/measurement_samples.py
+++ b/.github/scripts/packaged_agent_proof/measurement_samples.py
@@ -310,23 +310,6 @@ def _memory_metric_value(operands: dict) -> int:
     return total
 
 
-def _retrieval_quality_value(operands: dict) -> int:
-    require_exact_keys(
-        operands,
-        {"publishable_packet_pass", "raw_artifact_sha256"},
-        "qualification retrieval quality operands",
-    )
-    require_sha256(
-        operands["raw_artifact_sha256"],
-        "qualification retrieval quality raw artifact sha256",
-    )
-    require(
-        operands["publishable_packet_pass"] is True,
-        "qualification retrieval quality sample did not pass",
-    )
-    return 1
-
-
 def _accelerator_residency_value(
     operands: dict,
     *,
@@ -415,8 +398,6 @@ def qualification_measurement_sample_value(
         return _throughput_metric_value(metric, operands, awake_delta)
     if metric == "total_codestory_process_memory":
         return _memory_metric_value(operands)
-    if metric == "retrieval_quality":
-        return _retrieval_quality_value(operands)
     require(
         metric == "backend_observed_accelerator_residency",
         f"qualification measurement verifier omitted metric {metric}",

--- a/.github/scripts/packaged_agent_proof/qualification_metrics.py
+++ b/.github/scripts/packaged_agent_proof/qualification_metrics.py
@@ -14,7 +14,6 @@ from .contract_primitives import (
 from .foundation import require
 from .qualification_measurements import qualification_measurement_artifact
 from .qualification_production_types import (
-    QualificationExternalEvidence,
     QualificationProducerContext,
     QualificationRunnerEvidence,
 )
@@ -108,16 +107,9 @@ def _qualification_host(
 def _qualification_metric_value(
     metric: str,
     *,
-    external: QualificationExternalEvidence,
     measurement: dict,
     memory: dict,
 ) -> float | int | None:
-    if metric == "retrieval_quality":
-        return (
-            external.retrieval_quality["publishable_packet_pass_rate"]
-            if external.retrieval_quality is not None
-            else None
-        )
     if metric == "total_codestory_process_memory":
         return memory["value"]
     return measurement["values"][metric]
@@ -126,16 +118,9 @@ def _qualification_metric_value(
 def _qualification_raw_metric_evidence(
     metric: str,
     *,
-    external: QualificationExternalEvidence,
     measurement: dict,
     memory: dict,
 ) -> dict:
-    if metric == "retrieval_quality":
-        require(
-            external.retrieval_quality is not None,
-            "qualification retrieval quality omitted publishable packet evidence",
-        )
-        return external.retrieval_quality
     if metric == "total_codestory_process_memory":
         return memory["artifact"]
     return measurement["artifact"]
@@ -145,7 +130,6 @@ def _retained_qualification_metric(
     metric: str,
     *,
     context: QualificationProducerContext,
-    external: QualificationExternalEvidence,
     measurement: dict,
     memory: dict,
 ) -> dict:
@@ -153,31 +137,15 @@ def _retained_qualification_metric(
     contract = protocol["metric_contracts"][metric]
     value = _qualification_metric_value(
         metric,
-        external=external,
         measurement=measurement,
         memory=memory,
     )
-    if metric == "retrieval_quality" and value is None:
-        require(
-            context.args.proof_tier == "calibration",
-            "qualification retrieval quality omitted publishable packet evidence",
-        )
-        return {
-            "status": "not_measured",
-            "unit": contract["unit"],
-            "value": None,
-            "reason": (
-                "calibration omitted the separately produced exact-head "
-                "publishable packet artifact"
-            ),
-        }
     require(
         isinstance(value, (int, float)) and not isinstance(value, bool),
         f"qualification metric {metric} is not numeric",
     )
     raw_evidence = _qualification_raw_metric_evidence(
         metric,
-        external=external,
         measurement=measurement,
         memory=memory,
     )
@@ -213,7 +181,6 @@ def _retained_qualification_metric(
 def collect_qualification_measurements(
     context: QualificationProducerContext,
     runner: QualificationRunnerEvidence,
-    external: QualificationExternalEvidence,
 ) -> QualificationMeasurementEvidence:
     measurement, memory = _qualification_measurement_sources(context, runner)
     timing = {
@@ -229,7 +196,6 @@ def collect_qualification_measurements(
         metric: _retained_qualification_metric(
             metric,
             context=context,
-            external=external,
             measurement=measurement,
             memory=memory,
         )

--- a/.github/scripts/packaged_agent_proof/qualification_producer_setup.py
+++ b/.github/scripts/packaged_agent_proof/qualification_producer_setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from .contract_primitives import sha256
 from .failure_evidence import register_failure_evidence_secret
-from .foundation import RETRIEVAL_QUALITY_EVIDENCE_CONTRACT, ProofFailure, require
+from .foundation import require
 from .native_manifest import runtime_executable_sha256
 from .publication_consistency_verifier import (
     verify_fault_recovery_consistency_raw_evidence,
@@ -20,7 +20,6 @@ from .qualification_production_types import (
     QualificationExternalEvidence,
     QualificationProducerContext,
 )
-from .runtime_retrieval_quality import verify_retrieval_quality_raw_evidence
 
 
 def prepare_qualification_producer(
@@ -150,20 +149,7 @@ def collect_qualification_external_evidence(
         package=context.package,
         contracts=context.contracts,
     )
-    retrieval_quality = None
-    if args.retrieval_quality_evidence is not None:
-        retrieval_quality = verify_retrieval_quality_raw_evidence(
-            args.retrieval_quality_evidence,
-            source=context.manifest["source"],
-        )
-    elif args.proof_tier != "calibration":
-        raise ProofFailure(
-            f"{args.proof_tier} qualification requires "
-            "--retrieval-quality-evidence "
-            f"from {RETRIEVAL_QUALITY_EVIDENCE_CONTRACT}"
-        )
     return QualificationExternalEvidence(
         publication_fault,
         consistency,
-        retrieval_quality,
     )

--- a/.github/scripts/packaged_agent_proof/qualification_production_types.py
+++ b/.github/scripts/packaged_agent_proof/qualification_production_types.py
@@ -36,7 +36,6 @@ class QualificationProducerContext:
 class QualificationExternalEvidence:
     publication_fault: dict
     fault_recovery_consistency: dict | None
-    retrieval_quality: dict | None
 
 
 @dataclass(frozen=True)

--- a/.github/scripts/packaged_agent_proof/qualification_retained_metrics.py
+++ b/.github/scripts/packaged_agent_proof/qualification_retained_metrics.py
@@ -7,16 +7,18 @@ from pathlib import Path
 from .contract_primitives import (
     require_exact_keys,
     require_nonempty_string,
-    require_positive_int,
     require_sha256,
 )
 from .foundation import (
     LOWER_TIER_NONCLAIMS,
-    MIN_RETRIEVAL_QUALITY_REPEATS,
-    RELEASE_QUALITY_CORPUS_ID,
+    REQUIRED_QUALIFICATION_METRICS,
+    REQUIRED_SERVER_SCENARIO_ASSERTIONS,
     REQUIRED_SERVER_SCENARIOS,
-    RETRIEVAL_QUALITY_EVIDENCE_CONTRACT,
     require,
+)
+from .measurement_protocol_validation import (
+    EXPECTED_QUALIFICATION_MEASUREMENT_SHAPE_SHA256,
+    qualification_measurement_shape_sha256,
 )
 from .qualification_retained_types import (
     RetainedMeasurementBinding,
@@ -52,12 +54,25 @@ def _verified_scenario_artifact_names(scenario_id: str, artifacts: object) -> se
 
 def _verify_scenarios(contract: RetainedQualificationContract) -> None:
     scenarios = contract.evidence.scenarios
-    scenario_contracts = contract.measurement_contract["measurement_protocol"][
-        "scenario_contracts"
-    ]
+    protocol = contract.measurement_contract["measurement_protocol"]
+    scenario_contracts = protocol["scenario_contracts"]
+    require(
+        qualification_measurement_shape_sha256(protocol)
+        == EXPECTED_QUALIFICATION_MEASUREMENT_SHAPE_SHA256,
+        "retained qualification measurement shape changed",
+    )
     require(
         set(scenarios) == REQUIRED_SERVER_SCENARIOS,
         "retained qualification scenario set is incomplete",
+    )
+    require(
+        set(scenario_contracts) == REQUIRED_SERVER_SCENARIOS
+        and all(
+            set(scenario_contracts[scenario_id]["required"])
+            == REQUIRED_SERVER_SCENARIO_ASSERTIONS[scenario_id]
+            for scenario_id in REQUIRED_SERVER_SCENARIOS
+        ),
+        "retained qualification scenario assertion contracts changed",
     )
     for scenario_id in sorted(REQUIRED_SERVER_SCENARIOS):
         scenario = scenarios.get(scenario_id)
@@ -115,6 +130,10 @@ def _normalized_retained_metrics(
     protocol = contract.measurement_contract["measurement_protocol"]
     required_metrics = set(protocol["required_metrics"])
     require(
+        required_metrics == REQUIRED_QUALIFICATION_METRICS,
+        "retained qualification metric contract must remain lifecycle-only",
+    )
+    require(
         set(metrics) == required_metrics,
         "retained qualification metric set is incomplete",
     )
@@ -153,90 +172,12 @@ def _normalized_retained_metrics(
         raw_evidence = result.get("raw_evidence")
         require(
             isinstance(raw_evidence, dict),
-            (
-                "retrieval quality metric omitted raw evidence"
-                if metric == "retrieval_quality"
-                else f"metric {metric} omitted its raw measurement artifact"
-            ),
+            f"metric {metric} omitted its raw measurement artifact",
         )
         normalized.append(
             RetainedMetric(metric, value, threshold, comparison, raw_evidence)
         )
     return tuple(normalized)
-
-
-def _verify_retrieval_quality_metric(
-    contract: RetainedQualificationContract,
-    metric: RetainedMetric,
-) -> None:
-    raw_evidence = metric.raw_evidence
-    require_exact_keys(
-        raw_evidence,
-        {
-            "artifact",
-            "evaluation_contract",
-            "source_commit",
-            "source_tree",
-            "corpus_id",
-            "holdout_manifest_set_sha256",
-            "repeats",
-            "row_count",
-            "passing_row_count",
-            "publishable_packet_pass_rate",
-        },
-        "retrieval quality retained raw evidence",
-    )
-    artifact = raw_evidence["artifact"]
-    require(isinstance(artifact, dict), "retrieval quality raw artifact is malformed")
-    require_exact_keys(artifact, {"name", "sha256"}, "retrieval quality raw artifact")
-    require(
-        artifact["name"] == "packet-runtime-summary.json",
-        "retrieval quality raw artifact name is invalid",
-    )
-    require_sha256(artifact["sha256"], "retrieval quality raw artifact sha256")
-    require(
-        raw_evidence["evaluation_contract"] == RETRIEVAL_QUALITY_EVIDENCE_CONTRACT,
-        "retrieval quality retained evaluation contract changed",
-    )
-    require(
-        raw_evidence["source_commit"] == contract.evidence.source["commit"]
-        and raw_evidence["source_tree"] == contract.evidence.source["tree"],
-        "retrieval quality retained source identity is stale",
-    )
-    require(
-        require_positive_int(raw_evidence["repeats"], "retrieval quality repeats")
-        == MIN_RETRIEVAL_QUALITY_REPEATS,
-        "retrieval quality retained the wrong repeat count",
-    )
-    require(
-        raw_evidence["corpus_id"] == RELEASE_QUALITY_CORPUS_ID,
-        "retrieval quality retained the wrong holdout corpus",
-    )
-    require_sha256(
-        raw_evidence["holdout_manifest_set_sha256"],
-        "retrieval quality holdout manifest set sha256",
-    )
-    row_count = require_positive_int(
-        raw_evidence["row_count"],
-        "retrieval quality row count",
-    )
-    require(
-        require_positive_int(
-            raw_evidence["passing_row_count"],
-            "retrieval quality passing row count",
-        )
-        == row_count,
-        "retrieval quality retained a failing row",
-    )
-    pass_rate = raw_evidence["publishable_packet_pass_rate"]
-    require(
-        isinstance(pass_rate, (int, float)) and not isinstance(pass_rate, bool),
-        "retrieval quality pass rate is not numeric",
-    )
-    require(
-        pass_rate == metric.value,
-        "retrieval quality metric does not match its raw evidence",
-    )
 
 
 def _verify_measurement_metric(metric: RetainedMetric) -> None:
@@ -265,10 +206,7 @@ def _verify_metrics(
 ) -> tuple[RetainedMetric, ...]:
     metrics = _normalized_retained_metrics(contract)
     for metric in metrics:
-        if metric.name == "retrieval_quality":
-            _verify_retrieval_quality_metric(contract, metric)
-        else:
-            _verify_measurement_metric(metric)
+        _verify_measurement_metric(metric)
         passed = {
             "equal": metric.value == metric.threshold,
             "greater_than_or_equal": metric.value >= metric.threshold,

--- a/.github/scripts/packaged_agent_proof/qualification_workflow.py
+++ b/.github/scripts/packaged_agent_proof/qualification_workflow.py
@@ -40,11 +40,7 @@ def produce_qualification_evidence(
     external = collect_qualification_external_evidence(context)
     runner = run_qualification_producer(context)
     scenarios = collect_qualification_scenarios(context, runner, external)
-    measurements = collect_qualification_measurements(
-        context,
-        runner,
-        external,
-    )
+    measurements = collect_qualification_measurements(context, runner)
     return write_qualification_outputs(
         context,
         runner,

--- a/.github/scripts/packaged_agent_proof/self_test_calibration_lineage.py
+++ b/.github/scripts/packaged_agent_proof/self_test_calibration_lineage.py
@@ -288,7 +288,6 @@ def _lineage_probe_arguments(**overrides: object) -> argparse.Namespace:
         "ground_only": False,
         "produce_qualification_evidence": False,
         "qualification_evidence": None,
-        "retrieval_quality_evidence": None,
         "enforce_calibration_freeze_lineage": True,
         "calibration_bundle": Path("calibration-bundle.json"),
         "calibration_producer_run_id": "1234567890",

--- a/.github/scripts/packaged_agent_proof/self_test_cli.py
+++ b/.github/scripts/packaged_agent_proof/self_test_cli.py
@@ -24,7 +24,6 @@ def run_cli_self_tests() -> None:
             qualification_evidence=None,
             qualification_driver=None,
             publication_fault_evidence=None,
-            retrieval_quality_evidence=None,
             calibration_bundle=None,
             collect_constant_calibration=False,
             constant_calibration_output_dir=None,

--- a/.github/scripts/packaged_agent_proof/self_test_contract_scope.py
+++ b/.github/scripts/packaged_agent_proof/self_test_contract_scope.py
@@ -42,7 +42,6 @@ def _claim_scope_tests() -> None:
         additional_query=[],
         produce_qualification_evidence=False,
         qualification_evidence=None,
-        retrieval_quality_evidence=None,
         publication_fault_evidence=None,
         proof_tier="installed_runtime",
     )
@@ -53,7 +52,6 @@ def _claim_scope_tests() -> None:
         ("server_behavior_only", True),
         ("produce_qualification_evidence", True),
         ("qualification_evidence", Path("qualification.json")),
-        ("retrieval_quality_evidence", Path("quality.json")),
         ("publication_fault_evidence", Path("fault.json")),
     ):
         hostile_scope = argparse.Namespace(**vars(valid_ground_scope))

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_calibration.py
@@ -15,6 +15,7 @@ from .calibration_verification import verify_calibration_bundle
 from .constant_calibration import _validate_driver_output
 from .contract_primitives import canonical_sha256, sha256, write_json
 from .foundation import TARGET_CONTRACTS, ProofFailure, require
+from .measurement_protocol import load_measurement_protocol
 from .measurement_samples import selected_qualification_matrix_cell
 from .package_contracts import verify_package_server_contracts
 from .qualification_measurements import (
@@ -32,6 +33,102 @@ def _qualification_matrix_tests(fixture: FullStackFixture) -> dict:
         self_measurement_protocol,
         require_frozen=False,
     )
+    for quality_metric in (
+        "answer_quality",
+        "packet_quality",
+        "publishable_packet_pass_rate",
+    ):
+        quality_reintroduced = json.loads(
+            json.dumps(measurement_contract["measurement_protocol"])
+        )
+        quality_reintroduced["required_metrics"].append(quality_metric)
+        quality_reintroduced["phase_boundaries"][quality_metric] = [
+            "publishable_packet_candidate_fixed",
+            "publishable_packet_pass_rate_scored",
+        ]
+        quality_reintroduced["workloads"][quality_metric] = {
+            "workload_id": "publishable_three_repeat_packet_v1",
+            "owner_state": "external_exact_head_artifact",
+            "operation": "packet_runtime",
+            "input_generator": "axios_js_ts_v2",
+        }
+        quality_reintroduced["metric_sampling"][quality_metric] = {
+            "sample_count": 3,
+            "aggregation": "minimum",
+        }
+        quality_reintroduced["metric_contracts"][quality_metric] = {
+            "comparison": "greater_than_or_equal",
+            "unit": "publishable_packet_pass_rate",
+        }
+        quality_protocol_path = (
+            fixture.root / f"{quality_metric}-reintroduced-protocol.json"
+        )
+        write_json(quality_protocol_path, quality_reintroduced)
+        try:
+            load_measurement_protocol(quality_protocol_path)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                f"shape-complete {quality_metric} re-entered frozen-candidate qualification"
+            )
+    for quality_assertion in (
+        "answer_quality_sufficient",
+        "packet_quality_pass",
+        "publishable_packet_pass_rate_is_one",
+    ):
+        quality_reintroduced = json.loads(
+            json.dumps(measurement_contract["measurement_protocol"])
+        )
+        quality_reintroduced["scenario_contracts"]["frozen_owner"][
+            "required"
+        ].append(quality_assertion)
+        quality_protocol_path = (
+            fixture.root / f"{quality_assertion}-scenario-protocol.json"
+        )
+        write_json(quality_protocol_path, quality_reintroduced)
+        try:
+            load_measurement_protocol(quality_protocol_path)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(
+                f"{quality_assertion} re-entered lifecycle scenario qualification"
+            )
+    repurposed_metric = json.loads(
+        json.dumps(measurement_contract["measurement_protocol"])
+    )
+    repurposed_metric["phase_boundaries"]["warm_query_ipc"] = [
+        "publishable_packet_candidate_fixed",
+        "publishable_packet_pass_rate_scored",
+    ]
+    repurposed_metric["calibration_phase_boundaries"]["warm_query_ipc"] = list(
+        repurposed_metric["phase_boundaries"]["warm_query_ipc"]
+    )
+    repurposed_metric["workloads"]["warm_query_ipc"] = {
+        "workload_id": "publishable_three_repeat_packet_v1",
+        "owner_state": "external_exact_head_artifact",
+        "operation": "packet_runtime",
+        "input_generator": "axios_js_ts_v2",
+    }
+    repurposed_metric["metric_sampling"]["warm_query_ipc"] = {
+        "sample_count": 3,
+        "aggregation": "minimum",
+    }
+    repurposed_metric["metric_contracts"]["warm_query_ipc"] = {
+        "comparison": "greater_than_or_equal",
+        "unit": "publishable_packet_pass_rate",
+    }
+    repurposed_protocol_path = fixture.root / "repurposed-quality-metric.json"
+    write_json(repurposed_protocol_path, repurposed_metric)
+    try:
+        load_measurement_protocol(repurposed_protocol_path)
+    except ProofFailure:
+        pass
+    else:
+        raise ProofFailure(
+            "warm query metric was repurposed as packet quality"
+        )
     windows_cell_id = "protected_windows_x64_vulkan"
     windows_cell = selected_qualification_matrix_cell(
         measurement_contract["measurement_protocol"],

--- a/.github/scripts/packaged_agent_proof/self_test_full_stack_qualification.py
+++ b/.github/scripts/packaged_agent_proof/self_test_full_stack_qualification.py
@@ -145,17 +145,15 @@ def _build_retained_evidence(
     retained["scenarios"]["worker_stall"]["artifacts"].append(
         external.publication["artifact"]
     )
-    retained["metrics"]["retrieval_quality"]["raw_evidence"] = external.quality
     for metric, result in retained["metrics"].items():
-        if metric != "retrieval_quality":
-            result["raw_evidence"] = {
-                "name": (
-                    "total-codestory-process-memory.raw.json"
-                    if metric == "total_codestory_process_memory"
-                    else "measurements.raw.json"
-                ),
-                "sha256": "d" * 64,
-            }
+        result["raw_evidence"] = {
+            "name": (
+                "total-codestory-process-memory.raw.json"
+                if metric == "total_codestory_process_memory"
+                else "measurements.raw.json"
+            ),
+            "sha256": "d" * 64,
+        }
     return retained, qualification_contract
 
 
@@ -210,11 +208,27 @@ def _retained_hostile_tests(
     stale_shared["shared_identity"]["server_instance_id"] = "stale-server"
     wrong_cell = json.loads(json.dumps(retained))
     wrong_cell["package"]["matrix_cell_id"] = "hosted_linux_x64_cpu"
+    extra_quality_metric = json.loads(json.dumps(retained))
+    extra_quality_metric["metrics"]["packet_quality"] = {
+        "status": "pass",
+        "unit": "ratio",
+        "value": 1,
+        "threshold": 1,
+        "comparison": "greater_than_or_equal",
+        "raw_evidence": {
+            "name": "measurements.raw.json",
+            "sha256": "d" * 64,
+        },
+    }
     for candidate, message in (
         (missing_scenario, "incomplete scenario evidence was accepted"),
         (wrong_tier, "different-tier retained qualification was accepted"),
         (stale_shared, "stale retained shared server identity was accepted"),
         (wrong_cell, "wrong qualification matrix cell was accepted"),
+        (
+            extra_quality_metric,
+            "optional retrieval quality re-entered frozen-candidate qualification",
+        ),
     ):
         _expect_retained_rejected(
             candidate,
@@ -223,6 +237,82 @@ def _retained_hostile_tests(
             qualification_contract,
             message,
         )
+    quality_contract_reintroduced = json.loads(json.dumps(qualification_contract))
+    quality_contract_reintroduced["measurement_protocol"]["required_metrics"].append(
+        "publishable_packet_pass_rate"
+    )
+    quality_contract_reintroduced["measurement_protocol"]["metric_contracts"][
+        "publishable_packet_pass_rate"
+    ] = {
+        "comparison": "greater_than_or_equal",
+        "unit": "ratio",
+    }
+    quality_contract_reintroduced["constant_set"]["qualification_thresholds"][
+        "publishable_packet_pass_rate"
+    ] = 1
+    coherent_quality_metric = json.loads(json.dumps(retained))
+    coherent_quality_metric["metrics"]["publishable_packet_pass_rate"] = (
+        extra_quality_metric["metrics"]["packet_quality"]
+    )
+    _expect_retained_rejected(
+        coherent_quality_metric,
+        fixture,
+        server,
+        quality_contract_reintroduced,
+        "shape-complete retrieval quality re-entered retained qualification",
+    )
+    quality_assertion_contract = json.loads(json.dumps(qualification_contract))
+    quality_assertion_contract["measurement_protocol"]["scenario_contracts"][
+        "frozen_owner"
+    ]["required"].append("packet_quality_pass")
+    quality_assertion_evidence = json.loads(json.dumps(retained))
+    quality_assertion_evidence["scenarios"]["frozen_owner"]["assertions"][
+        "packet_quality_pass"
+    ] = True
+    _expect_retained_rejected(
+        quality_assertion_evidence,
+        fixture,
+        server,
+        quality_assertion_contract,
+        "packet quality re-entered retained lifecycle assertions",
+    )
+    repurposed_metric_contract = json.loads(json.dumps(qualification_contract))
+    repurposed_protocol = repurposed_metric_contract["measurement_protocol"]
+    repurposed_protocol["phase_boundaries"]["warm_query_ipc"] = [
+        "publishable_packet_candidate_fixed",
+        "publishable_packet_pass_rate_scored",
+    ]
+    repurposed_protocol["calibration_phase_boundaries"]["warm_query_ipc"] = list(
+        repurposed_protocol["phase_boundaries"]["warm_query_ipc"]
+    )
+    repurposed_protocol["workloads"]["warm_query_ipc"] = {
+        "workload_id": "publishable_three_repeat_packet_v1",
+        "owner_state": "external_exact_head_artifact",
+        "operation": "packet_runtime",
+        "input_generator": "axios_js_ts_v2",
+    }
+    repurposed_protocol["metric_sampling"]["warm_query_ipc"] = {
+        "sample_count": 3,
+        "aggregation": "minimum",
+    }
+    repurposed_protocol["metric_contracts"]["warm_query_ipc"] = {
+        "comparison": "greater_than_or_equal",
+        "unit": "publishable_packet_pass_rate",
+    }
+    repurposed_metric_evidence = json.loads(json.dumps(retained))
+    repurposed_metric_evidence["metrics"]["warm_query_ipc"].update(
+        {
+            "unit": "publishable_packet_pass_rate",
+            "comparison": "greater_than_or_equal",
+        }
+    )
+    _expect_retained_rejected(
+        repurposed_metric_evidence,
+        fixture,
+        server,
+        repurposed_metric_contract,
+        "warm query retained metric was repurposed as packet quality",
+    )
 
 
 def _engine_identity_hostiles(server: ServerIdentityFixture) -> None:
@@ -289,6 +379,27 @@ def run_retained_qualification_self_tests(
     external: ExternalEvidenceFixture,
     measurement_contract: dict,
 ) -> None:
+    protocol = measurement_contract["measurement_protocol"]
+    thresholds = measurement_contract["constant_set"]["qualification_thresholds"]
+    require(
+        set(protocol["required_metrics"])
+        == {
+            "backend_observed_accelerator_residency",
+            "bulk_documents_per_second",
+            "bulk_tokens_per_second",
+            "busy_retry_usefulness",
+            "cold_first_vector",
+            "existing_owner_connect",
+            "first_product_ready",
+            "spawn_convergence",
+            "total_codestory_process_memory",
+            "true_idle_exit",
+            "warm_bulk_ipc",
+            "warm_query_ipc",
+        }
+        and set(thresholds) == set(protocol["required_metrics"]),
+        "frozen-candidate qualification metric set changed",
+    )
     retained, qualification_contract = _build_retained_evidence(
         fixture,
         server,

--- a/.github/workflows/frozen-candidate-quality.yml
+++ b/.github/workflows/frozen-candidate-quality.yml
@@ -1,0 +1,314 @@
+name: Optional frozen-candidate quality evaluation
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Exact frozen-candidate release version.
+        required: true
+        type: string
+      ref:
+        description: Exact frozen-candidate source commit.
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  quality:
+    name: Optional frozen-candidate Axios v2 quality
+    continue-on-error: true
+    runs-on: [self-hosted, macOS, ARM64, codestory-metal]
+    environment: macos-metal-release
+    timeout-minutes: 60
+    steps:
+      - name: Checkout exact frozen candidate
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Capture optional quality host evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/frozen-candidate-quality
+          {
+            sw_vers
+            uname -a
+            uname -m
+            sysctl -n machdep.cpu.brand_string
+            node --version
+          } > target/frozen-candidate-quality/host.txt 2>&1
+          test "$(uname -m)" = arm64
+
+      - name: Authenticate exact candidate archive artifacts
+        id: candidate-artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          producer_run="$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          )"
+          test "$(jq -r '.head_repository.full_name' <<<"$producer_run")" = "$GITHUB_REPOSITORY"
+          test "$(jq -r '.path' <<<"$producer_run")" = ".github/workflows/packaged-platform-pr.yml"
+          test "$(jq -r '.head_sha' <<<"$producer_run")" = "$HEAD_SHA"
+          test "$(jq -r '.run_attempt' <<<"$producer_run")" = "$GITHUB_RUN_ATTEMPT"
+          artifacts="$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100"
+          )"
+          select_artifact() {
+            local name="$1"
+            jq \
+              --arg name "$name" \
+              --arg sha "$HEAD_SHA" \
+              --argjson run_id "$GITHUB_RUN_ID" \
+              '[
+                .artifacts[]
+                | select(
+                    .name == $name
+                    and .expired == false
+                    and .workflow_run.id == $run_id
+                    and .workflow_run.head_sha == $sha
+                  )
+              ] | if length == 1 then .[0] else error("expected one exact candidate artifact") end' \
+              <<<"$artifacts"
+          }
+          artifact="$(select_artifact codestory-cli-macos-arm64)"
+          record_artifact="$(select_artifact codestory-candidate-archive-record-macos-arm64)"
+          artifact_id="$(jq -r '.id' <<<"$artifact")"
+          expected_size="$(jq -r '.size_in_bytes' <<<"$artifact")"
+          expected_digest="$(jq -r '.digest' <<<"$artifact")"
+          [[ "$artifact_id" =~ ^[0-9]+$ ]]
+          [[ "$expected_size" =~ ^[0-9]+$ ]]
+          [[ "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$(jq -r '.id' <<<"$record_artifact")" =~ ^[0-9]+$ ]]
+          [[ "$(jq -r '.size_in_bytes' <<<"$record_artifact")" =~ ^[0-9]+$ ]]
+          [[ "$(jq -r '.digest' <<<"$record_artifact")" =~ ^sha256:[0-9a-f]{64}$ ]]
+          {
+            echo "package-id=$artifact_id"
+            echo "package-bytes=$expected_size"
+            echo "package-sha256=${expected_digest#sha256:}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download authenticated candidate record
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: codestory-candidate-archive-record-macos-arm64
+          path: target/candidate-archive-record/macos-arm64
+
+      - name: Restore exact candidate archive from protected host
+        id: candidate-cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          record=target/candidate-archive-record/macos-arm64/candidate-archive-record.json
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg source_sha "$(git rev-parse HEAD)" \
+            --arg source_tree "$(git rev-parse 'HEAD^{tree}')" \
+            --arg target macos-arm64 \
+            '.repository == $repository
+              and .source.commit == $source_sha
+              and .source.tree == $source_tree
+              and .target == $target' \
+            "$record" >/dev/null
+          store="$RUNNER_TOOL_CACHE/codestory/candidate-archives"
+          mkdir -p "$store" target
+          rm -rf target/release-dist
+          restored="$(
+            node .github/scripts/candidate-archive-store.mjs restore \
+              --record "$record" \
+              --store-root "$store" \
+              --output-root target \
+              --output-dir target/release-dist
+          )"
+          hit="$(jq -r .hit <<<"$restored")"
+          test "$hit" = true || test "$hit" = false
+          finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          elapsed_ms=$(((finished_ns - started_ns) / 1000000))
+          echo "hit=$hit" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Optional quality candidate archive"
+            echo
+            echo "- Protected-host cache lookup and verification: ${elapsed_ms} ms"
+            echo "- Cache hit: \`$hit\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download, authenticate, and admit candidate archive on miss
+        if: steps.candidate-cache.outputs.hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ steps.candidate-artifacts.outputs.package-id }}
+          EXPECTED_SIZE: ${{ steps.candidate-artifacts.outputs.package-bytes }}
+          EXPECTED_SHA256: ${{ steps.candidate-artifacts.outputs.package-sha256 }}
+        run: |
+          set -euo pipefail
+          transfer_started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          archive="$RUNNER_TEMP/codestory-cli-macos-arm64-$ARTIFACT_ID.zip"
+          download_url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip"
+          partial="$archive.partial"
+          rm -f "$archive" "$partial"
+          trap 'rm -f "$archive" "$partial"' EXIT
+
+          complete=false
+          for attempt in $(seq 1 30); do
+            if curl \
+              --fail \
+              --location \
+              --silent \
+              --show-error \
+              --connect-timeout 30 \
+              --max-time 120 \
+              --continue-at - \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$partial" \
+              "$download_url"; then
+              complete=true
+              break
+            fi
+
+            current_size=0
+            test ! -f "$partial" || current_size="$(stat -f %z "$partial")"
+            test "$current_size" -le "$EXPECTED_SIZE"
+            if [ "$current_size" = "$EXPECTED_SIZE" ]; then
+              complete=true
+              break
+            fi
+            echo "::warning title=Optional quality artifact transfer interrupted::Resuming the exact candidate at byte $current_size after attempt $attempt"
+            sleep 2
+          done
+          test "$complete" = true
+
+          actual_size="$(stat -f %z "$partial")"
+          actual_digest="$(shasum -a 256 "$partial" | awk '{print $1}')"
+          test "$actual_size" = "$EXPECTED_SIZE"
+          test "$actual_digest" = "$EXPECTED_SHA256"
+          mv "$partial" "$archive"
+          transfer_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+
+          record=target/candidate-archive-record/macos-arm64/candidate-archive-record.json
+          stage=target/candidate-archive-stage/macos-arm64
+          rm -rf "$stage"
+          python3 .github/scripts/extract-candidate-actions-artifact.py \
+            --artifact "$archive" \
+            --record "$record" \
+            --out "$stage"
+          admitted="$(
+            node .github/scripts/candidate-archive-store.mjs admit \
+              --record "$record" \
+              --input-root "$stage" \
+              --store-root "$RUNNER_TOOL_CACHE/codestory/candidate-archives" \
+              --output-root target \
+              --output-dir target/release-dist
+          )"
+          test "$(jq -r .hit <<<"$admitted")" = true || \
+            test "$(jq -r .admitted <<<"$admitted")" = true
+          admission_finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          transfer_ms=$(((transfer_finished_ns - transfer_started_ns) / 1000000))
+          verification_ms=$(((admission_finished_ns - transfer_finished_ns) / 1000000))
+          {
+            echo "- Authenticated Actions transfer: ${transfer_ms} ms"
+            echo "- Payload verification and atomic admission: ${verification_ms} ms"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Produce optional Axios v2 quality evidence
+        id: quality
+        continue-on-error: true
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          CODESTORY_EMBED_ALLOW_CPU: "0"
+        run: |
+          set -euo pipefail
+          started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          version="${VERSION#v}"
+          archive="target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz"
+          quality_root=target/frozen-candidate-quality/evidence
+          packaged_root="$(mktemp -d "$RUNNER_TEMP/codestory-quality-cli.XXXXXX")"
+          export CODESTORY_CACHE_ROOT
+          CODESTORY_CACHE_ROOT="$(mktemp -d "$RUNNER_TEMP/codestory-quality-cache.XXXXXX")"
+          export CODESTORY_STDIO_CACHE_ROOT
+          CODESTORY_STDIO_CACHE_ROOT="$(mktemp -d "$RUNNER_TEMP/codestory-quality-stdio.XXXXXX")"
+          rm -rf "$quality_root"
+          mkdir -p "$quality_root"
+          tar -xzf "$archive" -C "$packaged_root"
+          packaged_cli="$(
+            find "$packaged_root" -type f -name codestory-cli -print
+          )"
+          test "$(printf '%s\n' "$packaged_cli" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          test -x "$packaged_cli"
+          export CODESTORY_RELEASE_EVIDENCE_COMMIT
+          CODESTORY_RELEASE_EVIDENCE_COMMIT="$(git rev-parse HEAD)"
+          export CODESTORY_RELEASE_EVIDENCE_TREE
+          CODESTORY_RELEASE_EVIDENCE_TREE="$(git rev-parse 'HEAD^{tree}')"
+          export CODESTORY_RELEASE_EVIDENCE_PROFILE=protected-macos-arm64-metal
+          export CODESTORY_RELEASE_EVIDENCE_CORPUS_ID=codestory-release-corpus-v0.16-axios-js-ts-v2
+          export CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT=benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json
+          export CODESTORY_RELEASE_EVIDENCE_CACHE_ID=frozen-candidate-axios-js-ts-v2
+          export CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT
+          CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT="$(
+            shasum -a 256 target/frozen-candidate-quality/host.txt | awk '{print $1}'
+          )"
+          node scripts/codestory-agent-ab-benchmark.mjs \
+            --packet-runtime \
+            --packet-runtime-mode cold-cli \
+            --task-manifest benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json \
+            --materialize-repos \
+            --repeats 3 \
+            --publishable \
+            --max-source-reads-after-packet 0 \
+            --codestory-cli "$packaged_cli" \
+            --timeout-ms 180000 \
+            --out-dir "$quality_root/packet"
+          finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          echo "- Optional Axios v2 measurement: $(((finished_ns - started_ns) / 1000000)) ms" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload optional Axios v2 quality evidence
+        id: quality-upload
+        if: steps.quality.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: frozen-candidate-quality-${{ inputs.ref }}
+          path: target/frozen-candidate-quality/evidence
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
+
+      - name: Record optional quality outcome
+        if: always()
+        shell: bash
+        env:
+          QUALITY_OUTCOME: ${{ steps.quality.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.quality-upload.outcome }}
+        run: |
+          set -euo pipefail
+          quality_outcome="${QUALITY_OUTCOME:-skipped}"
+          upload_outcome="${UPLOAD_OUTCOME:-skipped}"
+          case "$quality_outcome" in
+            success | failure | cancelled | skipped) ;;
+            *) exit 1 ;;
+          esac
+          case "$upload_outcome" in
+            success | failure | cancelled | skipped) ;;
+            *) exit 1 ;;
+          esac
+          {
+            echo "### Optional Axios v2 quality outcome"
+            echo
+            echo "- Measurement: \`$quality_outcome\`"
+            echo "- Artifact upload: \`$upload_outcome\`"
+            echo "- Release or qualification gate: \`false\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/linux-vulkan-proof.yml
+++ b/.github/workflows/linux-vulkan-proof.yml
@@ -18,16 +18,6 @@ on:
         required: false
         default: ""
         type: string
-      quality_evidence_artifact:
-        description: Exact-head protected Metal quality artifact.
-        required: false
-        default: ""
-        type: string
-      quality_evidence_run_id:
-        description: Workflow run that produced the protected Metal quality artifact.
-        required: false
-        default: ""
-        type: string
       calibration_bundle_artifact:
         required: false
         default: ""
@@ -68,16 +58,6 @@ on:
         type: string
       package_run_id:
         description: Upstream packaged-platform run containing codestory-cli-linux-x64; omitted for standalone constant calibration.
-        required: false
-        default: ""
-        type: string
-      quality_evidence_artifact:
-        description: Exact-head protected Metal quality artifact.
-        required: false
-        default: ""
-        type: string
-      quality_evidence_run_id:
-        description: Workflow run that produced the protected Metal quality artifact.
         required: false
         default: ""
         type: string
@@ -437,41 +417,6 @@ jobs:
           run-id: ${{ inputs.calibration_bundle_run_id }}
           github-token: ${{ github.token }}
 
-      - name: Authenticate protected Metal quality producer
-        if: ${{ !inputs.server_behavior_only }}
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          QUALITY_ARTIFACT: ${{ inputs.quality_evidence_artifact }}
-          QUALITY_RUN_ID: ${{ inputs.quality_evidence_run_id }}
-        run: |
-          set -euo pipefail
-          test -n "$QUALITY_ARTIFACT"
-          test -n "$QUALITY_RUN_ID"
-          run="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$QUALITY_RUN_ID")"
-          producer_sha="$(jq -r '.head_sha' <<<"$run")"
-          test "$(jq -r '.head_repository.full_name' <<<"$run")" = "$GITHUB_REPOSITORY"
-          test "$(jq -r '.path' <<<"$run")" = ".github/workflows/packaged-platform-pr.yml"
-          test "$(jq -r '.event' <<<"$run")" = workflow_dispatch
-          test "$(jq -r '.conclusion' <<<"$run")" = success
-          test "$producer_sha" = "$(git rev-parse HEAD)"
-          test "$QUALITY_ARTIFACT" = "frozen-candidate-quality-$producer_sha"
-          artifact_count="$(
-            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$QUALITY_RUN_ID/artifacts?per_page=100" \
-              | jq --arg name "$QUALITY_ARTIFACT" \
-                '[.artifacts[] | select(.name == $name and .expired == false)] | length'
-          )"
-          test "$artifact_count" = 1
-
-      - name: Download exact-head protected Metal quality evidence
-        if: ${{ !inputs.server_behavior_only }}
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: ${{ inputs.quality_evidence_artifact }}
-          path: target/release-quality-evidence
-          run-id: ${{ inputs.quality_evidence_run_id }}
-          github-token: ${{ github.token }}
-
       - name: Prove offline Linux Vulkan retrieval
         if: ${{ !inputs.candidate_installed_proof }}
         shell: bash
@@ -490,7 +435,6 @@ jobs:
           source_sha="$(git rev-parse HEAD)"
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           claim_args=()
-          quality_args=()
           qualification_args=()
           calibration_args=()
           if [ "$SERVER_BEHAVIOR_ONLY" = true ]; then
@@ -501,9 +445,6 @@ jobs:
             qualification_driver="$VERIFIED_QUALIFICATION_DRIVER"
             test -n "$qualification_driver"
             test -x "$qualification_driver"
-            quality_path=target/release-quality-evidence/packet/packet-runtime-summary.json
-            test -f "$quality_path"
-            quality_args=(--retrieval-quality-evidence "$quality_path")
             qualification_args=(
               --produce-qualification-evidence
               --qualification-driver "$qualification_driver"
@@ -532,7 +473,6 @@ jobs:
             "${calibration_args[@]}" \
             --expected-source-sha "$source_sha" \
             --expected-source-tree "$source_tree" \
-            "${quality_args[@]}" \
             --timeout-secs 1800 \
             --out-dir target/linux-vulkan-proof/packaged-agent
 

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -21,11 +21,6 @@ on:
         required: false
         default: false
         type: boolean
-      quality_evidence_artifact:
-        description: Exact-head release-evidence artifact containing packet/packet-runtime-summary.json.
-        required: false
-        default: ""
-        type: string
       calibration_bundle_artifact:
         description: Frozen calibration bundle artifact name.
         required: false
@@ -73,10 +68,6 @@ on:
         type: string
       proof_key:
         description: Stable proof identity for cancellation.
-        required: false
-        type: string
-      quality_evidence_artifact:
-        description: Existing exact-head release-evidence artifact name.
         required: false
         type: string
       calibration_bundle_artifact:
@@ -455,71 +446,6 @@ jobs:
           )"
           echo "path=$(jq -r .driver <<<"$verified")" >> "$GITHUB_OUTPUT"
 
-      - name: Download exact-head publishable packet quality evidence
-        if: inputs.quality_evidence_artifact != ''
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: ${{ inputs.quality_evidence_artifact }}
-          path: target/release-quality-evidence
-
-      - name: Produce exact-head holdout quality on protected Metal
-        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only && inputs.quality_evidence_artifact == '' }}
-        shell: bash
-        env:
-          VERSION: ${{ inputs.version }}
-          CODESTORY_EMBED_ALLOW_CPU: "0"
-        run: |
-          set -euo pipefail
-          version="${VERSION#v}"
-          archive="target/release-dist/codestory-cli-v${version}-macos-arm64.tar.gz"
-          quality_root=target/release-quality-evidence
-          packaged_root="$(mktemp -d "$RUNNER_TEMP/codestory-quality-cli.XXXXXX")"
-          export CODESTORY_CACHE_ROOT
-          CODESTORY_CACHE_ROOT="$(mktemp -d "$RUNNER_TEMP/codestory-quality-cache.XXXXXX")"
-          export CODESTORY_STDIO_CACHE_ROOT
-          CODESTORY_STDIO_CACHE_ROOT="$(mktemp -d "$RUNNER_TEMP/codestory-quality-stdio.XXXXXX")"
-          rm -rf "$quality_root"
-          mkdir -p "$quality_root"
-          tar -xzf "$archive" -C "$packaged_root"
-          packaged_cli="$(
-            find "$packaged_root" -type f -name codestory-cli -print
-          )"
-          test "$(printf '%s\n' "$packaged_cli" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
-          test -x "$packaged_cli"
-          export CODESTORY_RELEASE_EVIDENCE_COMMIT
-          CODESTORY_RELEASE_EVIDENCE_COMMIT="$(git rev-parse HEAD)"
-          export CODESTORY_RELEASE_EVIDENCE_TREE
-          CODESTORY_RELEASE_EVIDENCE_TREE="$(git rev-parse 'HEAD^{tree}')"
-          export CODESTORY_RELEASE_EVIDENCE_PROFILE=protected-macos-arm64-metal
-          export CODESTORY_RELEASE_EVIDENCE_CORPUS_ID=codestory-release-corpus-v1
-          export CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT=benchmarks/release-evidence/corpus-contracts/holdout-retrieval-v1.json
-          export CODESTORY_RELEASE_EVIDENCE_CACHE_ID=frozen-candidate-holdout-v1
-          export CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT
-          CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT="$(
-            shasum -a 256 target/macos-metal-proof/host.txt | awk '{print $1}'
-          )"
-          node scripts/codestory-agent-ab-benchmark.mjs \
-            --packet-runtime \
-            --packet-runtime-mode cold-cli \
-            --task-suite holdout-retrieval \
-            --materialize-repos \
-            --repeats 3 \
-            --publishable \
-            --max-source-reads-after-packet 0 \
-            --codestory-cli "$packaged_cli" \
-            --timeout-ms 180000 \
-            --out-dir "$quality_root/packet"
-
-      - name: Upload exact-head protected Metal quality evidence
-        if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only && inputs.quality_evidence_artifact == '' }}
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: frozen-candidate-quality-${{ inputs.ref || github.sha }}
-          path: target/release-quality-evidence
-          if-no-files-found: error
-          retention-days: 30
-          overwrite: true
-
       - name: Authenticate calibration bundle producer
         if: ${{ !inputs.calibration_mode && !inputs.server_behavior_only }}
         shell: bash
@@ -570,24 +496,20 @@ jobs:
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           export TMPDIR="${RUNNER_TEMP}/codestory metal proof ü"
           mkdir -p "$TMPDIR"
-          quality_args=()
           qualification_args=()
           calibration_args=()
           claim_scope_args=()
-          quality_path="target/release-quality-evidence/packet/packet-runtime-summary.json"
           if [ "$SERVER_BEHAVIOR_ONLY" = true ]; then
             claim_scope_args=(--server-behavior-only)
           else
             calibration_bundle="$(find target/calibration-bundle -type f -name calibration-bundle.json -print)"
             test "$(printf '%s\n' "$calibration_bundle" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
-            test -f "$quality_path"
             qualification_driver=target/release/codestory_embedding_qualification
             if [ "$USE_PACKAGED_CLI_ARTIFACT" = true ]; then
               qualification_driver="$VERIFIED_QUALIFICATION_DRIVER"
               test -n "$qualification_driver"
             fi
             test -x "$qualification_driver"
-            quality_args=(--retrieval-quality-evidence "$quality_path")
             qualification_args=(
               --produce-qualification-evidence
               --qualification-driver "$qualification_driver"
@@ -616,7 +538,6 @@ jobs:
             "${calibration_args[@]}" \
             --expected-source-sha "$source_sha" \
             --expected-source-tree "$source_tree" \
-            "${quality_args[@]}" \
             --timeout-secs 1800 \
             --out-dir target/macos-metal-proof/packaged-agent
 

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -422,12 +422,29 @@ jobs:
       ref: ${{ needs.route.outputs.head_sha }}
       proof_key: ${{ needs.route.outputs.proof_key }}
       use_packaged_cli_artifact: true
-      quality_evidence_artifact: ""
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact || '' }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id || '' }}
       candidate_installed_proof: ${{ needs.route.outputs.mode != 'qualification' }}
       candidate_producer_workflow_path: .github/workflows/packaged-platform-pr.yml
       server_behavior_only: ${{ needs.route.outputs.mode != 'qualification' }}
+
+  frozen-candidate-quality:
+    name: Optional frozen-candidate quality
+    if: >-
+      always() &&
+      needs.route.result == 'success' &&
+      needs.packaged-proof.result == 'success' &&
+      needs.macos-metal-proof.result == 'success' &&
+      needs.route.outputs.mode == 'qualification' &&
+      (needs.route.outputs.scope == 'macos' || needs.route.outputs.scope == 'full')
+    needs:
+      - route
+      - packaged-proof
+      - macos-metal-proof
+    uses: ./.github/workflows/frozen-candidate-quality.yml
+    with:
+      version: ${{ needs.route.outputs.version }}
+      ref: ${{ needs.route.outputs.head_sha }}
 
   windows-vulkan-proof:
     if: >-
@@ -435,19 +452,16 @@ jobs:
       needs.route.result == 'success' &&
       needs.packaged-proof.result == 'success' &&
       needs.route.outputs.mode != 'package' &&
-      (needs.route.outputs.mode != 'qualification' || needs.macos-metal-proof.result == 'success') &&
       (needs.route.outputs.scope == 'windows' || needs.route.outputs.scope == 'full')
     needs:
       - route
       - packaged-proof
-      - macos-metal-proof
     uses: ./.github/workflows/windows-vulkan-proof.yml
     with:
       version: ${{ needs.route.outputs.version }}
       ref: ${{ needs.route.outputs.head_sha }}
       proof_key: ${{ needs.route.outputs.proof_key }}
       use_packaged_cli_artifact: true
-      quality_evidence_artifact: ${{ needs.route.outputs.mode == 'qualification' && format('frozen-candidate-quality-{0}', needs.route.outputs.head_sha) || '' }}
       calibration_bundle_artifact: ${{ inputs.calibration_bundle_artifact || '' }}
       calibration_bundle_run_id: ${{ inputs.calibration_bundle_run_id || '' }}
       candidate_installed_proof: ${{ needs.route.outputs.mode != 'qualification' }}

--- a/.github/workflows/windows-vulkan-proof.yml
+++ b/.github/workflows/windows-vulkan-proof.yml
@@ -17,10 +17,6 @@ on:
         required: false
         default: false
         type: boolean
-      quality_evidence_artifact:
-        required: false
-        default: ""
-        type: string
       calibration_bundle_artifact:
         required: false
         default: ""
@@ -57,9 +53,6 @@ on:
         required: false
         type: string
       proof_key:
-        required: false
-        type: string
-      quality_evidence_artifact:
         required: false
         type: string
       calibration_bundle_artifact:
@@ -434,13 +427,6 @@ jobs:
           "path=$($result.driver)" |
             Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      - name: Download exact-head publishable packet quality evidence
-        if: inputs.quality_evidence_artifact != ''
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: ${{ inputs.quality_evidence_artifact }}
-          path: target/release-quality-evidence
-
       - name: Authenticate calibration bundle producer
         if: ${{ !inputs.server_behavior_only }}
         shell: powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ". '{0}'"
@@ -499,7 +485,6 @@ jobs:
           $sourceTree = (git rev-parse 'HEAD^{tree}').Trim()
           $claimArgs = @()
           $calibrationArgs = @()
-          $qualityPath = "target/release-quality-evidence/packet/packet-runtime-summary.json"
           if ($env:SERVER_BEHAVIOR_ONLY -eq "true") {
             $claimArgs = @("--server-behavior-only")
           } else {
@@ -508,9 +493,6 @@ jobs:
             )
             if ($calibrationBundles.Count -ne 1) {
               throw "expected exactly one frozen calibration-bundle.json"
-            }
-            if (-not (Test-Path $qualityPath)) {
-              throw "protected Windows proof requires exact-head quality evidence"
             }
             $qualificationDriver = "target/release/codestory_embedding_qualification.exe"
             if ($env:USE_PACKAGED_CLI_ARTIFACT -eq "true") {
@@ -525,8 +507,7 @@ jobs:
             $claimArgs = @(
               "--produce-qualification-evidence",
               "--qualification-driver", $qualificationDriver,
-              "--qualification-evidence", "target/windows-vulkan-proof/qualification.json",
-              "--retrieval-quality-evidence", $qualityPath
+              "--qualification-evidence", "target/windows-vulkan-proof/qualification.json"
             )
             $calibrationArgs = @(
               "--calibration-bundle", $calibrationBundles[0].FullName,

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
+    "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
+        "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
+        "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "04574dbd3dc1f3d3bb0c86af052712afd712882e9df7d0372c4311430adf6d83",
+  "candidate_sha256": "dd96364938407289c45793d74de63084ad57619229c242096233129a7c6ff83c",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
+      "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
+      "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
+    "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/request.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/request.rs
@@ -36,7 +36,6 @@ pub(super) const REQUIRED_METRICS: &[&str] = &[
     "cold_first_vector",
     "existing_owner_connect",
     "first_product_ready",
-    "retrieval_quality",
     "spawn_convergence",
     "total_codestory_process_memory",
     "true_idle_exit",

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/measurements.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/measurements.rs
@@ -588,16 +588,13 @@ impl<'a> ScenarioRunner<'a> {
             BTreeMap::new(),
         )?;
 
-        if metrics.len() != REQUIRED_METRICS.len().saturating_sub(2) {
+        if metrics.len() != REQUIRED_METRICS.len().saturating_sub(1) {
             bail!("embedding_qualification_measurement_set_incomplete");
         }
         Ok(MeasurementArtifact {
             schema_version: 2,
             contracts: self.context.contracts.clone(),
-            external_metrics: vec![
-                "retrieval_quality".into(),
-                "total_codestory_process_memory".into(),
-            ],
+            external_metrics: vec!["total_codestory_process_memory".into()],
             metrics,
         })
     }

--- a/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
+++ b/crates/codestory-bench/src/bin/codestory_embedding_qualification/scenarios/artifact/runner/tests.rs
@@ -358,12 +358,7 @@ fn recorded_phases_and_workloads_are_exactly_the_protocol_declarations() {
     let driver_metrics = REQUIRED_METRICS
         .iter()
         .copied()
-        .filter(|metric| {
-            !matches!(
-                *metric,
-                "retrieval_quality" | "total_codestory_process_memory"
-            )
-        })
+        .filter(|metric| *metric != "total_codestory_process_memory")
         .collect::<Vec<_>>();
     assert_eq!(driver_metrics.len(), 11);
     for metric in driver_metrics {
@@ -392,12 +387,14 @@ fn recorded_phases_and_workloads_are_exactly_the_protocol_declarations() {
             "driver workload table diverged from the protocol for {metric}"
         );
     }
-    for unknown in ["retrieval_quality", "total_codestory_process_memory"] {
-        assert!(
-            declared_phase_boundaries(unknown).is_err(),
-            "externally owned metric {unknown} must not be recordable by the driver"
-        );
-    }
+    assert!(
+        declared_phase_boundaries("total_codestory_process_memory").is_err(),
+        "externally owned memory metric must not be recordable by the driver"
+    );
+    assert!(
+        !REQUIRED_METRICS.contains(&"retrieval_quality"),
+        "optional packet quality must not re-enter lifecycle qualification"
+    );
 }
 
 fn span_test_output() -> (WorkerOutput, EmbeddingQualificationWorkerMeasurementSpan) {

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -52,7 +52,6 @@
     "cold_first_vector": 1566,
     "existing_owner_connect": 16,
     "first_product_ready": 723,
-    "retrieval_quality": 1.0,
     "spawn_convergence": 486,
     "total_codestory_process_memory": 3366597428,
     "true_idle_exit": 62500,

--- a/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-measurement-protocol.json
@@ -167,10 +167,6 @@
     "backend_observed_accelerator_residency": [
       "accelerator_measurement_started",
       "backend_residency_evidence_validated"
-    ],
-    "retrieval_quality": [
-      "publishable_packet_candidate_fixed",
-      "publishable_packet_pass_rate_scored"
     ]
   },
   "calibration_phase_boundaries": {
@@ -307,12 +303,6 @@
       "owner_state": "resident",
       "operation": "engine_identity",
       "input_generator": "none"
-    },
-    "retrieval_quality": {
-      "workload_id": "publishable_three_repeat_packet_v1",
-      "owner_state": "external_exact_head_artifact",
-      "operation": "packet_runtime",
-      "input_generator": "holdout_retrieval_suite"
     }
   },
   "required_scenarios": [
@@ -455,11 +445,6 @@
       "sample_count": 1,
       "aggregation": "exact",
       "single_sample_reason": "categorical backend identity and residency counters are validated rather than estimated"
-    },
-    "retrieval_quality": {
-      "sample_count": 3,
-      "aggregation": "all_rows_pass_rate",
-      "external_contract": "publishable-three-repeat-packet/v1"
     }
   },
   "calibration_required_metrics": [
@@ -674,16 +659,16 @@
       "calibration_required_values"
     ],
     "constant_set_comparison": "exact_recomputed_runtime_constants_and_freeze_record",
-    "qualification_boundary": "lifecycle_fault_idle_memory_quality_accelerator_and_performance_are_frozen_candidate_qualification_only"
+    "qualification_boundary": "lifecycle_fault_idle_memory_accelerator_and_performance_are_frozen_candidate_qualification_only"
   },
   "measurement_rules": {
     "calibration_and_qualification_are_distinct": true,
-    "quality_artifact_uses_exact_candidate_source_and_tree": true,
-    "quality_uses_publishable_three_repeat_packet_contract": true,
     "constants_frozen_before_qualification": true,
     "missing_required_cell_fails": true,
     "calibration_runs_full_qualification": false,
     "qualification_runs_once_per_available_gpu_platform": true,
+    "optional_quality_adjunct_is_nonblocking": true,
+    "quality_is_not_a_qualification_metric": true,
     "outlier_removal": "none",
     "performance_block_rejects_unplanned_suspend_or_power_transition": true,
     "threshold_movement_after_results": false
@@ -700,8 +685,7 @@
     "busy_retry_usefulness",
     "true_idle_exit",
     "total_codestory_process_memory",
-    "backend_observed_accelerator_residency",
-    "retrieval_quality"
+    "backend_observed_accelerator_residency"
   ],
   "metric_contracts": {
     "backend_observed_accelerator_residency": {
@@ -731,10 +715,6 @@
     "first_product_ready": {
       "comparison": "less_than_or_equal",
       "unit": "milliseconds"
-    },
-    "retrieval_quality": {
-      "comparison": "greater_than_or_equal",
-      "unit": "publishable_packet_pass_rate"
     },
     "spawn_convergence": {
       "comparison": "less_than_or_equal",

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -14,7 +14,7 @@ Criterion targets.
 | --- | --- | --- |
 | Rust formatting or local logic | `cargo fmt --all -- --check`; owning crate tests | Workspace check/test/clippy |
 | Store/publication | Store tests plus named fault/concurrency cases | Workspace source gate |
-| Retrieval/embedding | Retrieval tests, runtime admission tests, engine proof self-test | Same-run quality/performance gate and required hardware proof |
+| Retrieval/embedding | Retrieval tests, runtime admission tests, engine proof self-test | Same-run performance gate, optional exact-candidate quality report, and required hardware proof |
 | CLI/stdio | Named CLI contract suites | Workspace source gate and packaged proof when package behavior changed |
 | Plugin launcher or CodeStoryDev staging | Installer tests plus `plugin-static` | Packaged plugin handoff |
 | Worktree setup | Node suite plus one platform adapter smoke | Mac/Windows platform cell when adapter changed |
@@ -195,13 +195,19 @@ dispatched Linux Vulkan calibration may emit optional diagnostic evidence, but
 it does not feed or block the frozen calibration bundle.
 
 Frozen-candidate qualification is a separate one-run-per-platform lane.
-Protected Metal produces the exact three-task, three-repeat holdout quality
-artifact from the packaged candidate, then Metal and Windows Vulkan each run
-the full lifecycle, fault, true-idle, memory, quality, and accelerator suite
-once. Protected Linux Vulkan may consume those exact package, calibration, and
-quality artifacts through a standalone dispatch when its GPU runner is online;
-it is not a coordinator closeout dependency and cannot block qualification
-when that runner is absent.
+Metal and Windows Vulkan each run the full lifecycle, fault, true-idle, memory,
+and accelerator suite once. Protected Linux Vulkan may run that same
+qualification through a standalone dispatch when its GPU runner is online; it
+is not a coordinator closeout dependency and cannot block qualification when
+that runner is absent.
+
+Answer quality is a separate, optional frozen-candidate adjunct. After the
+protected Metal package proof, it runs the checksum-bound Axios JavaScript and
+TypeScript v2 task for three cold-CLI repeats against the same authenticated
+macOS archive. Its failure or absence cannot block Metal, Windows, Linux, or
+closeout, and the standard release makes no answer-quality claim. Promotion and
+release decisions consume the coordinator's `closeout` job result directly;
+they do not wait for this optional job or for workflow-wide completion.
 
 ### Packaged proof
 
@@ -287,20 +293,24 @@ Before replacing a model or native embedding implementation, compare incumbent
 and candidate in the same release build on the same machine. Keep that
 measurement selector private and delete it before merge. A server-ownership
 cutover does not relabel pre-fault and post-fault searches as two
-implementations: it consumes the existing exact-head
-`publishable-three-repeat-packet/v1` artifact and derives the pass rate from
-every row and repeat. Freeze every production timing value and qualification
-threshold before running the unchanged qualification candidate; a result
-cannot define its own pass threshold.
+implementations. The separate frozen-candidate quality adjunct consumes the
+existing `publishable-three-repeat-packet/v1` evaluation contract and derives
+the pass rate from every scoped Axios v2 row and repeat. Freeze every
+production timing value and qualification threshold before running the
+unchanged qualification candidate; a result cannot define its own pass
+threshold.
 
 Measure existing-owner connect, listener spawn, first residency, first product
 ready, warm query/bulk IPC, bulk documents and tokens per second, useful retry
 latency, true-idle exit, total CodeStory process memory, accelerator residency,
-retrieval quality, multi-process reuse, and restart reuse separately. Use
+retrieval quality, multi-process reuse, and restart reuse separately. Retrieval
+quality remains evaluation evidence, not a required lifecycle-qualification
+metric. Use
 awake-time monotonic clocks within each process; never subtract timestamps from
-different process origins. Quality cannot regress. A repeatable throughput,
-warm-latency, or memory regression blocks the cutover; 5% is measurement noise,
-not an accepted sustained loss.
+different process origins. Report quality separately as unclaimed optional
+evidence; its absence or result does not gate qualification or release. A
+repeatable throughput, warm-latency, or memory regression blocks the cutover;
+5% is measurement noise, not an accepted sustained loss.
 
 Historical reference: 368-372 documents/sec, 84.7 ms cross-repository search
 p95, MRR@10 0.9824, Hit@10 1.0, Hit@1 0.973, and 829-1,020 MB peak working set.

--- a/docs/testing/per-user-embedding-server-qualification.md
+++ b/docs/testing/per-user-embedding-server-qualification.md
@@ -104,11 +104,8 @@ Each passing record contains:
 - shared endpoint, lifetime authority, listener, server, engine owner, native
   worker, load generation, and model-load identity;
 - every preregistered scenario assertion plus hashes of its raw artifacts;
-- every required metric, its unit, frozen threshold, comparison, and result.
-  Retrieval quality is the pass rate derived from the exact-head
-  `publishable-three-repeat-packet/v1` raw packet artifact; the verifier binds
-  its source commit and tree, requires every declared repeat and row, and
-  recomputes the 1.0 pass rate instead of trusting a declared quality result;
+- every required lifecycle, performance, memory, and accelerator metric, its
+  unit, frozen threshold, comparison, and result;
 - explicit lower-tier nonclaims; and
 - the highest tier actually exercised.
 
@@ -146,21 +143,23 @@ python .github/scripts/check-packaged-agent-proof.py \
 The proof harness authenticates and unpacks once, prepares its projects and
 model once, then records three fresh server generations with one sample per
 constant-source metric. It does not run qualification scenarios or collect
-true-idle, memory, retrieval-quality, or accelerator evidence. Those belong to
-frozen-candidate qualification. Optional Linux Vulkan calibration is
-manual-only and cannot feed or block the frozen bundle.
+true-idle, memory, retrieval-quality, or accelerator evidence. True-idle,
+memory, and accelerator evidence belong to frozen-candidate qualification;
+retrieval quality belongs to the separate optional adjunct. Optional Linux
+Vulkan calibration is manual-only and cannot feed or block the frozen bundle.
 The collector owns its private synthetic project. The retained calibration
 directory must start empty, and ordinary proof output must remain outside it.
 
-Frozen-candidate qualification passes `--retrieval-quality-evidence` the
-exact-head `packet-runtime-summary.json` produced on protected Metal from the
-packaged candidate. That artifact covers all three checked-in
-`holdout-retrieval` tasks for three cold-CLI repeats. Metal and Windows Vulkan
-each consume it while running the full qualification suite once. Linux Vulkan
-may consume the same artifact through a standalone protected-runner dispatch;
-its absence does not block the coordinator. v0.16 release closeout does not
-consume this optional evaluation artifact. Hosted and protected package tiers
-may bind the unpacked archive through the source plugin launcher.
+Frozen-candidate answer quality runs separately on protected Metal after its
+package proof. It uses the exact Axios JavaScript/TypeScript v2 task and
+checksum-bound project manifest for three cold-CLI repeats against the same
+authenticated candidate archive. The resulting `packet-runtime-summary.json`
+is optional evaluation evidence: lifecycle qualification does not accept it as
+an input, no platform or closeout job depends on it, and v0.16 makes no
+answer-quality claim. Release decisions consume the independent coordinator
+`closeout` result rather than waiting for optional quality or workflow-wide
+completion. Hosted and protected package tiers may bind the unpacked archive
+through the source plugin launcher.
 `installed_runtime` instead requires the managed installed plugin and managed
 executable it claims; it rejects
 `CODESTORY_CLI`, a repository-source plugin root, and a direct unpacked binary
@@ -176,8 +175,9 @@ The standard release path is narrower than qualification. On each protected
 host, `--server-behavior-only` initializes one plugin host, grounds one real
 project, waits for search readiness in that same project, and verifies the
 installed engine, server, package, and expected Metal or Vulkan backend
-identity. It rejects calibration and retrieval-quality inputs and makes no
-two-host sharing, answer-quality, performance, or broader lifecycle claim.
+identity. It rejects calibration inputs, has no retrieval-quality input, and
+makes no two-host sharing, answer-quality, performance, or broader lifecycle
+claim.
 
 The explicit `linux` coordinator scope runs that protected Linux x64 Vulkan
 package and candidate-installed proof without scheduling Mac or Windows

--- a/docs/testing/retrieval-architecture.md
+++ b/docs/testing/retrieval-architecture.md
@@ -14,7 +14,7 @@ measurements live in
 | Protected hardware | same manifest-bound package and qualification record, accelerated policy with CPU disabled, physical backend/adapter, backend-observed post-encode telemetry | Metal or Vulkan and the server contract work on that machine |
 | Product runtime | installed plugin launcher, full retrieval, packet/search, two independent hosts sharing one server/engine/load | installed agent path is coherent |
 | Restart | new process reuses verified materialized model content | content-addressed cache reuse works |
-| Performance/quality | same-run measurements and holdout gates | an engine change is promotion-eligible |
+| Performance/quality | same-run performance measurements plus optional exact-candidate quality evidence | performance is promotion-eligible; quality is reported separately and unclaimed |
 
 A lower tier cannot support a higher-tier claim.
 
@@ -84,19 +84,21 @@ physical Vulkan on both platforms.
 | `windows-vulkan-proof.yml` | protected Windows GPU | packaged Vulkan, physical adapter, smoke, offload |
 | `linux-vulkan-proof.yml` | protected Linux GPU | packaged Vulkan, physical adapter, smoke, offload |
 
-## Performance and quality acceptance
+## Performance acceptance and optional quality
 
 Measure existing-owner connect, spawn convergence, first residency and product
 ready, warm query/bulk IPC, bulk documents/tokens per second, useful busy retry,
 true-idle exit, total CodeStory process memory, GPU memory, vector parity,
 retrieval quality, multi-process reuse, and restart reuse separately. Native
 model/backend candidates use the same-build private comparison described by
-the embedding benchmark contract. The per-user server cutover instead imports
-the exact-head `publishable-three-repeat-packet/v1` artifact, verifies its
-source commit and tree plus complete row/repeat coverage, and derives a required
-1.0 packet pass rate. Pre-fault and post-replacement searches are retained only
-as crash-recovery consistency evidence. Freeze thresholds before the
-qualification run. No retrieval-quality loss is accepted; a repeatable
+the embedding benchmark contract. The per-user server cutover measures answer
+quality in a separate optional frozen-candidate adjunct. That adjunct uses the
+`publishable-three-repeat-packet/v1` evaluation contract, binds the exact Axios
+JavaScript/TypeScript v2 task and project manifest, verifies source identity and
+complete row/repeat coverage, and derives the pass rate. It is not a lifecycle
+qualification metric or a standard-release claim. Pre-fault and
+post-replacement searches are retained only as crash-recovery consistency
+evidence. Freeze thresholds before the qualification run. A repeatable
 throughput, latency, or memory regression blocks promotion. The checked-in
 constant set and qualification protocol, not prose on this page, own the
 candidate-specific values.

--- a/release-claims.json
+++ b/release-claims.json
@@ -1,6 +1,6 @@
 {
   "schema": "codestory.release-claims/v1",
-  "graph_version": 10,
+  "graph_version": 11,
   "graph_id": "codestory-release-claims",
   "standard_release_claims": [
     "source_behavior",
@@ -1216,16 +1216,14 @@
           "workflow": "macos-metal-proof.yml",
           "job": "packaged-metal",
           "policy": "accelerated",
-          "backend": "metal",
-          "produces_quality": true
+          "backend": "metal"
         },
         {
           "id": "protected_windows_x64_vulkan",
           "workflow": "windows-vulkan-proof.yml",
           "job": "packaged-vulkan",
           "policy": "accelerated",
-          "backend": "vulkan",
-          "produces_quality": false
+          "backend": "vulkan"
         }
       ],
       "optional_cells": [
@@ -1241,18 +1239,31 @@
         }
       ],
       "quality_contract": {
+        "producer_workflow": "packaged-platform-pr.yml",
+        "producer_job": "frozen-candidate-quality",
         "producer_cell": "protected_macos_arm64_metal",
-        "corpus_id": "codestory-release-corpus-v1",
+        "scheduled_once_per_frozen_candidate": true,
+        "blocking": false,
+        "closeout_dependency": false,
+        "claimed": false,
+        "archive_cache_key_fields": [
+          "source.commit",
+          "target",
+          "archive.sha256"
+        ],
+        "archive_cache_contract": "candidate_archive_cache",
+        "archive_transfer": "authenticated_miss_only",
+        "evaluation_owner": "isolated_reusable_workflow",
+        "evaluation_owner_sha256": "92d0a7ab0e0df63dacd5cc3ef0b58500a6578036494c329aa35279048734f173",
         "evaluation_contract": "publishable-three-repeat-packet/v1",
-        "task_count": 3,
+        "task_count": 1,
         "repeats_per_task": 3,
-        "row_count": 9
+        "row_count": 3
       },
       "required_evidence": [
         "qualification_scenarios",
         "true_idle_exit",
         "total_codestory_process_memory",
-        "retrieval_quality",
         "backend_observed_accelerator_residency"
       ],
       "required_scenarios": [

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const GRAPH_SCHEMA = "codestory.release-claims/v1";
-const GRAPH_VERSION = 10;
+const GRAPH_VERSION = 11;
 const KNOWN_PACKAGE_TARGETS = new Set([
   "linux-arm64",
   "linux-x64",
@@ -706,7 +706,6 @@ function validateQualificationPolicy(value) {
       job: "packaged-metal",
       policy: "accelerated",
       backend: "metal",
-      produces_quality: true,
     },
     {
       id: "protected_windows_x64_vulkan",
@@ -714,7 +713,6 @@ function validateQualificationPolicy(value) {
       job: "packaged-vulkan",
       policy: "accelerated",
       backend: "vulkan",
-      produces_quality: false,
     },
   ];
   if (JSON.stringify(requiredCells) !== JSON.stringify(expectedRequiredCells)) {
@@ -740,21 +738,38 @@ function validateQualificationPolicy(value) {
     qualification.quality_contract,
     "workflow_policy.qualification.quality_contract",
   );
+  const expectedQuality = {
+    producer_workflow: "packaged-platform-pr.yml",
+    producer_job: "frozen-candidate-quality",
+    producer_cell: "protected_macos_arm64_metal",
+    scheduled_once_per_frozen_candidate: true,
+    blocking: false,
+    closeout_dependency: false,
+    claimed: false,
+    archive_cache_key_fields: [
+      "source.commit",
+      "target",
+      "archive.sha256",
+    ],
+    archive_cache_contract: "candidate_archive_cache",
+    archive_transfer: "authenticated_miss_only",
+    evaluation_owner: "isolated_reusable_workflow",
+    evaluation_owner_sha256:
+      "92d0a7ab0e0df63dacd5cc3ef0b58500a6578036494c329aa35279048734f173",
+    evaluation_contract: "publishable-three-repeat-packet/v1",
+    task_count: 1,
+    repeats_per_task: 3,
+    row_count: 3,
+  };
   if (
-    quality.producer_cell !== "protected_macos_arm64_metal"
-    || quality.corpus_id !== "codestory-release-corpus-v1"
-    || quality.evaluation_contract !== "publishable-three-repeat-packet/v1"
-    || quality.task_count !== 3
-    || quality.repeats_per_task !== 3
-    || quality.row_count !== 9
+    JSON.stringify(quality) !== JSON.stringify(expectedQuality)
   ) {
-    fail("workflow_policy.qualification quality contract must bind the protected Metal 3x3 holdout matrix");
+    fail("workflow_policy.qualification quality contract must bind the optional isolated exact-package adjunct");
   }
   const expectedEvidence = [
     "qualification_scenarios",
     "true_idle_exit",
     "total_codestory_process_memory",
-    "retrieval_quality",
     "backend_observed_accelerator_residency",
   ];
   if (
@@ -764,7 +779,7 @@ function validateQualificationPolicy(value) {
       { nonEmpty: true },
     )) !== JSON.stringify(expectedEvidence)
   ) {
-    fail("workflow_policy.qualification must retain every frozen-candidate evidence class");
+    fail("workflow_policy.qualification must retain lifecycle evidence without optional retrieval quality");
   }
   const expectedScenarios = [
     "client_death",

--- a/scripts/lib/retrieval-generalization-lint.mjs
+++ b/scripts/lib/retrieval-generalization-lint.mjs
@@ -236,6 +236,7 @@ const corpusHarnessNonRustFiles = new Set([
   path.join(repoRoot, "scripts", "score-drill-ledger.mjs"),
   path.join(repoRoot, ".github", "scripts", "test-detect-codestory-release.py"),
   path.join(repoRoot, ".github", "scripts", "check-workflow-policy.test.mjs"),
+  path.join(repoRoot, ".github", "workflows", "frozen-candidate-quality.yml"),
   path.join(repoRoot, ".github", "workflows", "release-candidate-evidence.yml"),
   path.join(repoRoot, ".github", "workflows", "retrieval-engine-smoke.yml"),
 ].map((filePath) => path.resolve(filePath)));
@@ -285,6 +286,16 @@ const allowedHarnessReferences = [
     path.join(".github", "scripts", "check-workflow-policy.mjs"),
     ".github/workflows/release-candidate-evidence.yml",
     'export const releaseEvidenceWorkflowRef = "./.github/workflows/release-candidate-evidence.yml";',
+  ],
+  [
+    path.join(".github", "scripts", "check-workflow-policy.mjs"),
+    ".github/workflows/frozen-candidate-quality.yml",
+    'export const frozenCandidateQualityWorkflowRef = "./.github/workflows/frozen-candidate-quality.yml";',
+  ],
+  [
+    path.join(".github", "workflows", "packaged-platform-pr.yml"),
+    ".github/workflows/frozen-candidate-quality.yml",
+    "uses: ./.github/workflows/frozen-candidate-quality.yml",
   ],
   [
     path.join(".github", "workflows", "packaged-platform-pr.yml"),

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -103,7 +103,7 @@ test("versioned claim graph has one deterministic digest and all declared contro
   assert.match(releaseClaimGraphDigest(graph), /^[0-9a-f]{64}$/u);
   assert.equal(positiveFixture().evidence[0].graph_sha256, releaseClaimGraphDigest(graph));
   assert.equal(graph.claims.length, 8);
-  assert.equal(graph.graph_version, 10);
+  assert.equal(graph.graph_version, 11);
   assert.deepEqual(
     [...graph.standard_release_claims].sort(),
     [
@@ -360,13 +360,34 @@ test("claim graph freezes one GPU-only qualification run per available platform"
   assert.equal(qualification.optional_cells[0].closeout_dependency, false);
   assert.equal(qualification.optional_cells[0].blocking, false);
   assert.deepEqual(qualification.quality_contract, {
+    producer_workflow: "packaged-platform-pr.yml",
+    producer_job: "frozen-candidate-quality",
     producer_cell: "protected_macos_arm64_metal",
-    corpus_id: "codestory-release-corpus-v1",
+    scheduled_once_per_frozen_candidate: true,
+    blocking: false,
+    closeout_dependency: false,
+    claimed: false,
+    archive_cache_key_fields: [
+      "source.commit",
+      "target",
+      "archive.sha256",
+    ],
+    archive_cache_contract: "candidate_archive_cache",
+    archive_transfer: "authenticated_miss_only",
+    evaluation_owner: "isolated_reusable_workflow",
+    evaluation_owner_sha256:
+      "92d0a7ab0e0df63dacd5cc3ef0b58500a6578036494c329aa35279048734f173",
     evaluation_contract: "publishable-three-repeat-packet/v1",
-    task_count: 3,
+    task_count: 1,
     repeats_per_task: 3,
-    row_count: 9,
+    row_count: 3,
   });
+  assert.deepEqual(qualification.required_evidence, [
+    "qualification_scenarios",
+    "true_idle_exit",
+    "total_codestory_process_memory",
+    "backend_observed_accelerator_residency",
+  ]);
   assert.equal(
     qualification.true_idle_timeout_ms
       + qualification.true_idle_observation_grace_ms,
@@ -409,8 +430,37 @@ test("claim graph freezes one GPU-only qualification run per available platform"
       draft.workflow_policy.qualification.optional_cells[0].blocking = true;
     }, /standalone and nonblocking/u],
     [draft => {
-      draft.workflow_policy.qualification.quality_contract.row_count = 3;
-    }, /protected Metal 3x3 holdout matrix/u],
+      draft.workflow_policy.qualification.quality_contract.row_count = 9;
+    }, /optional isolated exact-package adjunct/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract.blocking = true;
+    }, /optional isolated exact-package adjunct/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract.claimed = true;
+    }, /optional isolated exact-package adjunct/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract
+        .archive_transfer = "unconditional_download";
+    }, /optional isolated exact-package adjunct/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract
+        .archive_cache_key_fields.shift();
+    }, /optional isolated exact-package adjunct/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract
+        .archive_cache_contract = "mutable_candidate_cache";
+    }, /optional isolated exact-package adjunct/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract.evaluation_owner =
+        "protected_product_path";
+    }, /optional isolated exact-package adjunct/u],
+    [draft => {
+      draft.workflow_policy.qualification.quality_contract.evaluation_owner_sha256 =
+        "0".repeat(64);
+    }, /optional isolated exact-package adjunct/u],
+    [draft => {
+      draft.workflow_policy.qualification.required_evidence.push("retrieval_quality");
+    }, /without optional retrieval quality/u],
     [draft => {
       draft.workflow_policy.qualification.required_scenarios.pop();
     }, /each lifecycle and fault scenario once/u],

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "051e6d21197b68a0c44f028cf616830e4bc7338987108fae723c76c61019ce2e",
+      "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {

--- a/scripts/tests/lint-retrieval-generalization.test.mjs
+++ b/scripts/tests/lint-retrieval-generalization.test.mjs
@@ -743,6 +743,8 @@ pub const PLANTED_TERMS: &[(&str, &str)] = &[
     [".cursor/rules/codestory.mdc", "Read benchmarks/tasks/eval-probes.json before answering.\n", ["benchmarks/tasks"]],
     [".github/scripts/route-ci-proof.mjs", "        \".github/workflows/retrieval-engine-smoke.yml\",\n        \".github/workflows/retrieval-engine-smoke.yml\",\nawait import(\".github/workflows/retrieval-engine-smoke.yml\");\n", ["retrieval-engine-smoke.yml"]],
     [".github/scripts/check-workflow-policy.mjs", "const retrievalFile = \"retrieval-engine-smoke.yml\";\nconst hostile = \".github/workflows/retrieval-\" + \"engine-smoke.yml\";\nconst duplicated = [\n  \"node scripts/codestory-agent-ab-benchmark.mjs\",\n  \"node scripts/codestory-agent-ab-benchmark.mjs\",\n];\n", ["githubworkflowsretrievalenginesmokeyml", "codestory-agent-ab-benchmark.mjs"]],
+    [".github/workflows/packaged-platform-pr.yml", "run: |\n  node scripts/codestory-agent-ab-benchmark.mjs \\\n    --task-manifest benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json\n", ["codestory-agent-ab-benchmark.mjs", "benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json"]],
+    ["scripts/codestory-release-claims.mjs", "const task = \"benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json\";\n", ["benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json"]],
     [".github/workflows/macos-metal-proof.yml", "run: |\n  node scripts/codestory-agent-ab-benchmark.mjs \\\n    --packet-runtime \\\n    --packet-runtime-mode cold-cli \\\n    --task-suite holdout-retrieval \\\n    --materialize-repos \\\n    --repeats 4 \\\n    --publishable \\\n    --max-source-reads-after-packet 0 \\\n    --codestory-cli \"$packaged_cli\" \\\n    --timeout-ms 180000 \\\n    --out-dir \"$quality_root/packet\"\n", ["codestory-agent-ab-benchmark.mjs"]],
   ];
   for (const [relativePath, contents] of rejectedNonRust) {
@@ -763,6 +765,8 @@ pub const PLANTED_TERMS: &[(&str, &str)] = &[
     ["doubled-single-quote.yml", "value: 'scripts/fetch-''holdout-repos.mjs'\n"],
     [".github/scripts/route-ci-proof.mjs", "        \".github/workflows/retrieval-engine-smoke.yml\",\n"],
     [".github/scripts/check-workflow-policy.mjs", "const retrievalFile = \"retrieval-engine-smoke.yml\";\nconst exactQualificationReferences = [\n  \"retrieval-engine-smoke.yml\",\n  \"node scripts/codestory-agent-ab-benchmark.mjs\",\n];\n"],
+    [".github/scripts/check-workflow-policy.mjs", "export const frozenCandidateQualityWorkflowRef = \"./.github/workflows/frozen-candidate-quality.yml\";\n"],
+    [".github/workflows/packaged-platform-pr.yml", "uses: ./.github/workflows/frozen-candidate-quality.yml\n"],
     [".github/workflows/macos-metal-proof.yml", "run: |\n  node scripts/codestory-agent-ab-benchmark.mjs \\\n    --packet-runtime \\\n    --packet-runtime-mode cold-cli \\\n    --task-suite holdout-retrieval \\\n    --materialize-repos \\\n    --repeats 3 \\\n    --publishable \\\n    --max-source-reads-after-packet 0 \\\n    --codestory-cli \"$packaged_cli\" \\\n    --timeout-ms 180000 \\\n    --out-dir \"$quality_root/packet\"\n"],
   ];
   for (const [relativePath, contents] of allowedNonRust) {
@@ -1071,6 +1075,12 @@ pub const PLANTED_TERMS: &[(&str, &str)] = &[
     const guarded = Object.values(result.guardedPaths)
       .flat()
       .filter((entry) => !entry.startsWith(".."));
+    assert.ok(
+      result.guardedPaths.protectedNonRustFiles.includes(
+        ".github/workflows/frozen-candidate-quality.yml",
+      ),
+      "the explicit evaluation-only workflow owner must remain inside the guarded trigger inventory",
+    );
     assert.ok(guarded.length >= 40, "guarded-path inventory became vacuous");
     for (const trigger of ["pull_request", "push"]) {
       const filters = workflowTriggerPaths(workflow, trigger);


### PR DESCRIPTION
## Context

Axios v2 answer quality should run on the frozen candidate, but it is evaluation evidence rather than a lifecycle-qualification metric or a v0.16 release claim. The old graph made protected quality an input to every GPU qualification lane, serializing Windows behind Metal and turning an optional result into a release dependency.

Base: `41e60bab6b2069622ac9af2f9954c20c0bbc2bbe`  
Reviewed head: `9d06644f553db7398a3fa9039caebed58459307b`

## What changed

- Removed retrieval-quality inputs and metrics from Metal, Windows, Linux, and the packaged qualification harness.
- Added one protected macOS adjunct after required Metal that runs exactly the Axios JavaScript/TypeScript v2 task for three cold-CLI repeats.
- Isolated all benchmark identities and evaluator invocation in `frozen-candidate-quality.yml`. The protected coordinator carries only a reusable-workflow edge; workflow policy and the claim graph bind the parsed owner structure by SHA-256.
- Kept the adjunct unclaimed, non-gating, and outside coordinator closeout. Windows qualification runs independently of Metal and quality.
- Reused the exact candidate archive through the protected-host content-addressed store. The cache record binds repository, source SHA/tree, target, size, and digest; hits reverify bytes; misses alone transfer the large Actions artifact and admit it atomically.
- Advanced the release claim graph to version 11 and updated workflow policy, hostile policy regressions, executable qualification contracts, the production generalization boundary, and operator documentation.
- Preserved the legacy v1 verifier only as unreachable test coverage.

## Review focus

The decision boundary is executable:

- no platform or closeout dependency on optional quality;
- no CPU fallback;
- no v1, suite-wide, or extra task selector;
- no benchmark identity in protected coordinator, policy, claim-validator, or product paths;
- no unconditional archive transfer;
- no stale, cross-SHA, wrong-target, digest-bypassed, or non-atomic cache admission;
- no way to reintroduce quality as a lifecycle metric or scenario assertion while retaining an accepted policy shape.

## Verification

- workflow policy: 1,173/1,173
- focused optional-quality policy: 50/50
- release claims, closeout, evidence, and runner contracts: 99/99
- production retrieval generalization lint: pass
- hostile generalization matrix: pass
- independent hostile workflow/cache mutations: 14/14 rejected
- final independent executable diff review: accepted; no deterministic defect
- packaged-proof self-test and focused Rust qualification tests
- actionlint, including rejection of unsupported caller `continue-on-error`
- codestory-bench formatting
- documentation links: 75 files, 266 links
- JSON parsing and `git diff --check`

The first pushed head also passed draft Rust/source checks in 2m51s. It exposed two real contract defects—a stale derived fixture hash and benchmark ownership in the protected coordinator—which this head repairs. No broad source proof, hardware proof, calibration, or release workflow was rerun.

## Risk and non-claims

The reusable quality owner shares the protected Metal runner only after required Metal completes. Its sole job is job-level `continue-on-error`; the caller uses only GitHub-supported reusable-workflow keywords. Closeout has no dependency on the call. A missing runner, failed measurement, or failed upload is reported but cannot withhold qualification or release.

This PR changes proof orchestration and qualification evidence boundaries; it does not claim Axios quality passed and does not change production retrieval behavior.

Closes #1395
Refs #1179
Refs #1200
Refs #1189
