### PR TITLE
Accept Cargo test-capable Windows release binaries

### DIFF
--- a/.github/scripts/cargo-build-artifacts.mjs
+++ b/.github/scripts/cargo-build-artifacts.mjs
@@ -354,8 +354,9 @@ export function buildCargoArtifactManifest({
     );
     if (
       !Array.isArray(message.target.crate_types)
-      || !message.target.crate_types.includes("bin")
-      || message.target.test !== (expectation.kind === "test")
+      || JSON.stringify(message.target.kind) !== JSON.stringify([expectation.kind])
+      || JSON.stringify(message.target.crate_types) !== JSON.stringify(["bin"])
+      || typeof message.target.test !== "boolean"
     ) {
       fail(`Cargo artifact target contract changed for ${expectation.alias}`);
     }

--- a/.github/scripts/cargo-build-artifacts.test.mjs
+++ b/.github/scripts/cargo-build-artifacts.test.mjs
@@ -18,7 +18,10 @@ function sha256(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
-function fixture() {
+function fixture({
+  includeQualificationDriver = true,
+  binaryTargetTest = true,
+} = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-cargo-artifacts-"));
   const targetDir = path.join(root, "target");
   const releaseDir = path.join(targetDir, RUST_TARGET, "release");
@@ -59,6 +62,16 @@ function fixture() {
       contents: "path identity",
     },
   ];
+  if (includeQualificationDriver) {
+    artifacts.push({
+      alias: "qualification_driver",
+      packageName: "codestory-bench",
+      kind: "bin",
+      targetName: "codestory_embedding_qualification",
+      executable: path.join(releaseDir, "codestory_embedding_qualification.exe"),
+      contents: "qualification driver",
+    });
+  }
   for (const artifact of artifacts) {
     fs.writeFileSync(artifact.executable, artifact.contents);
     const manifest = path.join(root, "crates", artifact.packageName, "Cargo.toml");
@@ -84,7 +97,9 @@ function fixture() {
       edition: "2024",
       doc: false,
       doctest: false,
-      test: artifact.kind === "test",
+      // Cargo reports whether a target is test-capable here. Release binaries
+      // commonly report true; profile.test below identifies the active build.
+      test: artifact.kind === "test" ? true : binaryTargetTest,
     },
     profile: {
       opt_level: "3",
@@ -184,6 +199,24 @@ test("binds each requested executable to the exact Windows release graph", () =>
   );
 });
 
+test("accepts the release graph without the optional qualification driver", () => {
+  const input = fixture({ includeQualificationDriver: false });
+  const { manifest } = build(input);
+
+  assert.deepEqual(
+    Object.keys(manifest.artifacts).sort(),
+    ["cli", "native_staging", "runtime", "windows_path_identity"],
+  );
+});
+
+test("does not confuse a binary target's test capability with its active profile", () => {
+  const input = fixture({ binaryTargetTest: false });
+  const { manifest } = build(input);
+
+  assert.equal(input.messages[1].target.test, false);
+  assert.equal(manifest.artifacts.cli.profile.test, false);
+});
+
 test("rejects duplicate compiler artifacts instead of choosing one by path order", () => {
   const input = fixture();
   input.jsonLines = [...input.messages, input.messages[1]]
@@ -203,6 +236,36 @@ test("rejects debug-profile output even when the target name matches", () => {
   input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
 
   assert.throws(() => build(input), /not built with the release profile/u);
+});
+
+test("rejects a production binary actually built with the test profile", () => {
+  const input = fixture();
+  input.messages[1].profile.test = true;
+  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+
+  assert.throws(() => build(input), /profile\.test did not match bin/u);
+});
+
+test("rejects an expanded Cargo target kind instead of accepting a partial match", () => {
+  const input = fixture();
+  input.messages[1].target.kind = ["bin", "test"];
+  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+
+  assert.throws(
+    () => build(input),
+    /Cargo artifact target contract changed for cli/u,
+  );
+});
+
+test("rejects a renamed Cargo target instead of substituting another binary", () => {
+  const input = fixture();
+  input.messages[1].target.name = "codestory-cli-shadow";
+  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+
+  assert.throws(
+    () => build(input),
+    /expected exactly one Cargo artifact for cli, found 0/u,
+  );
 });
 
 test("rejects an executable emitted outside the exact target release directory", () => {


### PR DESCRIPTION
Closes #1616

## Context

Qualification run 30532833480 built the exact-head Windows release graph once, then rejected the valid CLI artifact. Cargo reports target.test as target capability metadata; the release CLI had target.test=true while profile.test=false. The selector incorrectly treated those fields as the same build-mode signal.

## What changed

- accept either boolean target.test value without using it to classify the active build
- keep profile.test as the exact binary-versus-test-harness discriminator
- require exact singleton target.kind and crate_types arrays
- cover both supported graphs, with and without the optional qualification driver
- preserve exact package, target, release path, native identity, source SHA/tree, size, and digest checks

## How to review

Start at the target contract in .github/scripts/cargo-build-artifacts.mjs. The fixture mirrors the five Cargo JSON records captured by the failed Windows build. Negative tests exercise duplicate artifacts, mixed test/release profiles, expanded or renamed targets, stale paths, cross-graph hardlinks, changed bytes, and cross-SHA manifests.

## Verification

Exact head: 9de940957dc4514ee1397c4250744571962194a1

- node --test .github/scripts/cargo-build-artifacts.test.mjs — 16/16 passed
- node .github/scripts/check-workflow-policy.mjs — passed
- git diff --check — passed
- independent executable mutation pass: restoring the old capability check, accepting duplicates, dropping profile.test enforcement, or dropping exact source identity each made its owning regression fail
- independent final diff review — accepted

## Risk

The change is limited to post-build artifact selection. It does not edit workflow YAML, the job graph, or release claim semantics. A fresh qualification is intentionally deferred until this source change is integrated, recalibrated, and frozen at a new exact head; the rejected frozen head will not be rerun.
