### PR TITLE
Isolate the Windows release package graph

### DIFF
--- a/.github/scripts/cargo-build-artifacts.mjs
+++ b/.github/scripts/cargo-build-artifacts.mjs
@@ -13,6 +13,20 @@ const DECIMAL_BIGINT = /^(?:0|[1-9][0-9]*)$/u;
 const ALIAS = /^[a-z][a-z0-9_]*$/u;
 const WINDOWS_TARGET = "x86_64-pc-windows-msvc";
 const RELEASE_OPT_LEVELS = new Set(["1", "2", "3", "s", "z"]);
+const SHIPPING_BINARIES = [
+  {
+    packageName: "codestory-cli",
+    targetName: "codestory-cli",
+  },
+  {
+    packageName: "codestory-cli",
+    targetName: "codestory-cli-runtime",
+  },
+];
+const FORBIDDEN_SHIPPING_FEATURES = new Map([
+  ["codestory-retrieval", new Set(["test-support"])],
+  ["codestory-runtime", new Set(["benchmark-support", "test-support"])],
+]);
 const ARTIFACT_CONTRACT = {
   cli: {
     packageName: "codestory-cli",
@@ -24,28 +38,13 @@ const ARTIFACT_CONTRACT = {
     kind: "bin",
     targetName: "codestory-cli-runtime",
   },
-  native_staging: {
-    packageName: "codestory-llama-sys",
-    kind: "test",
-    targetName: "native_staging",
-  },
-  windows_path_identity: {
-    packageName: "codestory-workspace",
-    kind: "test",
-    targetName: "windows_path_identity",
-  },
   qualification_driver: {
     packageName: "codestory-bench",
     kind: "bin",
     targetName: "codestory_embedding_qualification",
   },
 };
-const REQUIRED_ALIASES = [
-  "cli",
-  "runtime",
-  "native_staging",
-  "windows_path_identity",
-];
+const REQUIRED_ALIASES = ["cli", "runtime"];
 
 function fail(message) {
   throw new Error(message);
@@ -86,6 +85,15 @@ function packageNameFromId(packageId) {
   }
   const legacy = /^([^\s]+)\s+\d+\.\d+\.\d+(?:[-+][^\s]+)?(?:\s|$)/u.exec(packageId);
   if (legacy) return legacy[1];
+  if (packageId.startsWith("path+file:")) {
+    const source = packageId.slice("path+".length).split("#", 1)[0];
+    try {
+      const directory = path.posix.basename(new URL(source).pathname);
+      if (directory !== "") return decodeURIComponent(directory);
+    } catch {
+      // Fall through to the manifest-backed parser below.
+    }
+  }
   return null;
 }
 
@@ -153,7 +161,12 @@ function requireArtifactContract(expectations) {
 }
 
 function parseCargoMessages(jsonLines) {
-  const messages = [];
+  return parseCargoMessageStream(jsonLines).compilerArtifacts;
+}
+
+function parseCargoMessageStream(jsonLines) {
+  const compilerArtifacts = [];
+  const buildFinished = [];
   for (const [index, line] of jsonLines.split(/\r?\n/u).entries()) {
     if (line.trim() === "") continue;
     let message;
@@ -162,9 +175,99 @@ function parseCargoMessages(jsonLines) {
     } catch {
       fail(`Cargo JSON output line ${index + 1} is not valid JSON`);
     }
-    if (message?.reason === "compiler-artifact") messages.push(message);
+    if (message?.reason === "compiler-artifact") compilerArtifacts.push(message);
+    if (message?.reason === "build-finished") buildFinished.push(message);
   }
-  return messages;
+  return { compilerArtifacts, buildFinished };
+}
+
+export function assertShippingFeatureContract({
+  jsonLines,
+  workspaceRoot,
+}) {
+  const resolvedWorkspaceRoot = fs.realpathSync(workspaceRoot);
+  if (!fs.statSync(resolvedWorkspaceRoot).isDirectory()) {
+    fail("shipping Cargo workspace root is not a directory");
+  }
+  const { compilerArtifacts, buildFinished } = parseCargoMessageStream(jsonLines);
+  if (
+    buildFinished.length !== 1
+    || buildFinished[0]?.success !== true
+  ) {
+    fail("shipping Cargo message stream did not finish successfully");
+  }
+
+  const artifacts = compilerArtifacts.map((message) => {
+    const packageName = packageNameFromArtifact(message);
+    const targetName = message?.target?.name;
+    const targetKinds = message?.target?.kind;
+    if (
+      typeof targetName !== "string"
+      || targetName === ""
+      || !Array.isArray(targetKinds)
+      || targetKinds.some((kind) => typeof kind !== "string")
+      || message?.profile === null
+      || typeof message?.profile !== "object"
+    ) {
+      fail(`Cargo compiler artifact shape changed for ${packageName}`);
+    }
+    if (
+      message.profile.test === true
+      || targetKinds.includes("test")
+      || targetKinds.includes("bench")
+    ) {
+      fail(
+        `shipping Cargo graph emitted a test or benchmark target: `
+          + `${packageName}:${targetName}`,
+      );
+    }
+    return {
+      message,
+      packageName,
+      targetKinds,
+      targetName,
+    };
+  });
+
+  for (const expected of SHIPPING_BINARIES) {
+    const matches = artifacts.filter(({ message, packageName, targetKinds, targetName }) =>
+      packageName === expected.packageName
+      && targetName === expected.targetName
+      && JSON.stringify(targetKinds) === JSON.stringify(["bin"])
+      && message.profile.test === false
+    );
+    if (matches.length !== 1) {
+      fail(
+        `shipping Cargo graph must emit exactly one production binary `
+          + `${expected.packageName}:${expected.targetName}; found ${matches.length}`,
+      );
+    }
+  }
+
+  for (const [packageName, forbidden] of FORBIDDEN_SHIPPING_FEATURES) {
+    const matches = artifacts.filter((artifact) =>
+      artifact.packageName === packageName
+    );
+    if (matches.length === 0) {
+      fail(`shipping Cargo graph omitted feature evidence for ${packageName}`);
+    }
+    for (const { message } of matches) {
+      if (
+        !Array.isArray(message.features)
+        || message.features.some((feature) => typeof feature !== "string")
+      ) {
+        fail(`shipping Cargo feature evidence changed for ${packageName}`);
+      }
+      for (const feature of message.features) {
+        if (forbidden.has(feature)) {
+          fail(
+            `shipping Cargo graph enabled forbidden feature `
+              + `${packageName}/${feature}`,
+          );
+        }
+      }
+    }
+  }
 }
 
 function releaseProfile(message, kind) {
@@ -453,6 +556,7 @@ export function buildCargoArtifactManifest({
   targetDir,
   workspaceRoot,
 }) {
+  assertShippingFeatureContract({ jsonLines, workspaceRoot });
   requireSha(exactSha, "source SHA");
   requireSha(exactTree, "source tree");
   requireWindowsTarget(rustTarget);
@@ -813,6 +917,13 @@ function runSelect(values) {
   if (githubOutput) appendOutputs(githubOutput, output, manifest.artifacts);
 }
 
+function runFeatures(values) {
+  assertShippingFeatureContract({
+    jsonLines: fs.readFileSync(one(values, "--input"), "utf8"),
+    workspaceRoot: one(values, "--workspace-root"),
+  });
+}
+
 function runVerify(values) {
   const manifestFile = one(values, "--manifest");
   const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
@@ -829,7 +940,9 @@ function runVerify(values) {
 
 function main(argv) {
   const { command, values } = parseArguments(argv);
-  if (command === "select") {
+  if (command === "features") {
+    runFeatures(values);
+  } else if (command === "select") {
     runSelect(values);
   } else if (command === "verify") {
     runVerify(values);

--- a/.github/scripts/cargo-build-artifacts.test.mjs
+++ b/.github/scripts/cargo-build-artifacts.test.mjs
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
+  assertShippingFeatureContract,
   buildCargoArtifactManifest,
   verifyCargoArtifactManifest,
 } from "./cargo-build-artifacts.mjs";
@@ -13,6 +16,7 @@ import {
 const SOURCE_SHA = "a".repeat(40);
 const SOURCE_TREE = "b".repeat(40);
 const RUST_TARGET = "x86_64-pc-windows-msvc";
+const SCRIPT = fileURLToPath(new URL("./cargo-build-artifacts.mjs", import.meta.url));
 
 function sha256(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
@@ -27,6 +31,18 @@ function fixture({
   const releaseDir = path.join(targetDir, RUST_TARGET, "release");
   const depsDir = path.join(releaseDir, "deps");
   fs.mkdirSync(depsDir, { recursive: true });
+
+  function writePackageManifest(packageName) {
+    const manifest = path.join(root, "crates", packageName, "Cargo.toml");
+    if (!fs.existsSync(manifest)) {
+      fs.mkdirSync(path.dirname(manifest), { recursive: true });
+      fs.writeFileSync(
+        manifest,
+        `[package]\nname = "${packageName}"\nversion = "0.16.3"\n`,
+      );
+    }
+    return manifest;
+  }
 
   const artifacts = [
     {
@@ -45,22 +61,6 @@ function fixture({
       executable: path.join(releaseDir, "codestory-cli-runtime.exe"),
       contents: "runtime",
     },
-    {
-      alias: "native_staging",
-      packageName: "codestory-llama-sys",
-      kind: "test",
-      targetName: "native_staging",
-      executable: path.join(depsDir, "native_staging-123456.exe"),
-      contents: "native staging",
-    },
-    {
-      alias: "windows_path_identity",
-      packageName: "codestory-workspace",
-      kind: "test",
-      targetName: "windows_path_identity",
-      executable: path.join(depsDir, "windows_path_identity-123456.exe"),
-      contents: "path identity",
-    },
   ];
   if (includeQualificationDriver) {
     artifacts.push({
@@ -74,15 +74,7 @@ function fixture({
   }
   for (const artifact of artifacts) {
     fs.writeFileSync(artifact.executable, artifact.contents);
-    const manifest = path.join(root, "crates", artifact.packageName, "Cargo.toml");
-    if (!fs.existsSync(manifest)) {
-      fs.mkdirSync(path.dirname(manifest), { recursive: true });
-      fs.writeFileSync(
-        manifest,
-        `[package]\nname = "${artifact.packageName}"\nversion = "0.16.3"\n`,
-      );
-    }
-    artifact.manifest = manifest;
+    artifact.manifest = writePackageManifest(artifact.packageName);
   }
 
   const messages = artifacts.map((artifact) => ({
@@ -99,20 +91,52 @@ function fixture({
       doctest: false,
       // Cargo reports whether a target is test-capable here. Release binaries
       // commonly report true; profile.test below identifies the active build.
-      test: artifact.kind === "test" ? true : binaryTargetTest,
+      test: binaryTargetTest,
     },
     profile: {
       opt_level: "3",
       debuginfo: 0,
       debug_assertions: false,
       overflow_checks: false,
-      test: artifact.kind === "test",
+      test: false,
     },
     features: [],
     filenames: [artifact.executable],
     executable: artifact.executable,
     fresh: false,
   }));
+  for (const packageName of ["codestory-retrieval", "codestory-runtime"]) {
+    const manifest = writePackageManifest(packageName);
+    messages.push({
+      reason: "compiler-artifact",
+      package_id:
+        `path+file://${path.dirname(manifest)}#${packageName}@0.16.3`,
+      manifest_path: manifest,
+      target: {
+        kind: ["lib"],
+        crate_types: ["lib"],
+        name: packageName.replaceAll("-", "_"),
+        src_path: `/checkout/crates/${packageName}/src/lib.rs`,
+        edition: "2024",
+        doc: true,
+        doctest: true,
+        test: true,
+      },
+      profile: {
+        opt_level: "3",
+        debuginfo: 0,
+        debug_assertions: false,
+        overflow_checks: false,
+        test: false,
+      },
+      features: [],
+      filenames: [
+        path.join(releaseDir, "deps", `lib${packageName.replaceAll("-", "_")}.rlib`),
+      ],
+      executable: null,
+      fresh: false,
+    });
+  }
   messages.unshift({
     reason: "compiler-artifact",
     package_id: "registry+https://example.invalid/index#serde@1.0.0",
@@ -136,6 +160,10 @@ function fixture({
     filenames: [path.join(releaseDir, "deps", "libserde.rlib")],
     executable: null,
   });
+  messages.push({
+    reason: "build-finished",
+    success: true,
+  });
 
   return {
     artifacts,
@@ -149,6 +177,20 @@ function fixture({
     root,
     targetDir,
   };
+}
+
+function refreshCargoJson(input) {
+  input.jsonLines = input.messages
+    .map((message) => JSON.stringify(message))
+    .join("\n");
+}
+
+function featureMessage(input, packageName) {
+  const message = input.messages.find(
+    (entry) => entry.target?.name === packageName.replaceAll("-", "_"),
+  );
+  assert.ok(message, `missing fixture message for ${packageName}`);
+  return message;
 }
 
 function build(input = fixture()) {
@@ -202,7 +244,7 @@ test("binds each requested executable to the exact Windows release graph", () =>
     assert.equal(selected.path, path.resolve(artifact.executable));
     assert.equal(selected.bytes, Buffer.byteLength(artifact.contents));
     assert.equal(selected.sha256, sha256(artifact.contents));
-    assert.equal(selected.profile.test, artifact.kind === "test");
+    assert.equal(selected.profile.test, false);
     assert.equal(selected.native_links.count, 1);
     assert.deepEqual(selected.native_links.paths, [selected.relative_path]);
     assert.match(selected.native_links.device, /^(?:0|[1-9][0-9]*)$/u);
@@ -258,7 +300,7 @@ test("accepts the release graph without the optional qualification driver", () =
 
   assert.deepEqual(
     Object.keys(manifest.artifacts).sort(),
-    ["cli", "native_staging", "runtime", "windows_path_identity"],
+    ["cli", "runtime"],
   );
 });
 
@@ -270,6 +312,133 @@ test("does not confuse a binary target's test capability with its active profile
   assert.equal(manifest.artifacts.cli.profile.test, false);
 });
 
+test("accepts an isolated shipping feature graph", () => {
+  const input = fixture();
+
+  assert.doesNotThrow(() =>
+    assertShippingFeatureContract({
+      jsonLines: input.jsonLines,
+      workspaceRoot: input.root,
+    })
+  );
+});
+
+test("rejects retrieval test support in the shipping graph", () => {
+  const input = fixture();
+  featureMessage(input, "codestory-retrieval").features = ["test-support"];
+  refreshCargoJson(input);
+
+  assert.throws(
+    () =>
+      assertShippingFeatureContract({
+        jsonLines: input.jsonLines,
+        workspaceRoot: input.root,
+      }),
+    /forbidden feature codestory-retrieval\/test-support/u,
+  );
+});
+
+test("rejects runtime benchmark or test support in the shipping graph", async (t) => {
+  for (const feature of ["benchmark-support", "test-support"]) {
+    await t.test(feature, () => {
+      const input = fixture();
+      featureMessage(input, "codestory-runtime").features = [feature];
+      refreshCargoJson(input);
+
+      assert.throws(
+        () =>
+          assertShippingFeatureContract({
+            jsonLines: input.jsonLines,
+            workspaceRoot: input.root,
+          }),
+        new RegExp(`forbidden feature codestory-runtime/${feature}`, "u"),
+      );
+    });
+  }
+});
+
+test("rejects any test or benchmark target mixed into the shipping build", () => {
+  const input = fixture();
+  input.messages.splice(-1, 0, {
+    reason: "compiler-artifact",
+    package_id: "registry+https://example.invalid/index#probe@1.0.0",
+    target: {
+      kind: ["test"],
+      name: "probe",
+    },
+    profile: {
+      test: true,
+    },
+    features: [],
+  });
+  refreshCargoJson(input);
+
+  assert.throws(
+    () =>
+      assertShippingFeatureContract({
+        jsonLines: input.jsonLines,
+        workspaceRoot: input.root,
+      }),
+    /shipping Cargo graph emitted a test or benchmark target: probe:probe/u,
+  );
+});
+
+test("requires one successful Cargo build completion", () => {
+  const input = fixture();
+  input.messages.at(-1).success = false;
+  refreshCargoJson(input);
+
+  assert.throws(
+    () =>
+      assertShippingFeatureContract({
+        jsonLines: input.jsonLines,
+        workspaceRoot: input.root,
+      }),
+    /shipping Cargo message stream did not finish successfully/u,
+  );
+});
+
+test("exposes the feature contract through the command-line helper", () => {
+  const input = fixture();
+  const jsonFile = path.join(input.root, "cargo.jsonl");
+  fs.writeFileSync(jsonFile, input.jsonLines);
+
+  const accepted = spawnSync(
+    process.execPath,
+    [
+      SCRIPT,
+      "features",
+      "--input",
+      jsonFile,
+      "--workspace-root",
+      input.root,
+    ],
+    { encoding: "utf8" },
+  );
+  assert.equal(accepted.status, 0, accepted.stderr);
+
+  featureMessage(input, "codestory-runtime").features = ["benchmark-support"];
+  refreshCargoJson(input);
+  fs.writeFileSync(jsonFile, input.jsonLines);
+  const rejected = spawnSync(
+    process.execPath,
+    [
+      SCRIPT,
+      "features",
+      "--input",
+      jsonFile,
+      "--workspace-root",
+      input.root,
+    ],
+    { encoding: "utf8" },
+  );
+  assert.equal(rejected.status, 1);
+  assert.match(
+    rejected.stderr,
+    /forbidden feature codestory-runtime\/benchmark-support/u,
+  );
+});
+
 test("rejects duplicate compiler artifacts instead of choosing one by path order", () => {
   const input = fixture();
   input.jsonLines = [...input.messages, input.messages[1]]
@@ -278,7 +447,7 @@ test("rejects duplicate compiler artifacts instead of choosing one by path order
 
   assert.throws(
     () => build(input),
-    /expected exactly one Cargo artifact for cli, found 2/u,
+    /must emit exactly one production binary codestory-cli:codestory-cli; found 2/u,
   );
 });
 
@@ -305,30 +474,33 @@ test("rejects debug-profile output even when the target name matches", () => {
 test("rejects a production binary actually built with the test profile", () => {
   const input = fixture();
   input.messages[1].profile.test = true;
-  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+  refreshCargoJson(input);
 
-  assert.throws(() => build(input), /profile\.test did not match bin/u);
+  assert.throws(
+    () => build(input),
+    /shipping Cargo graph emitted a test or benchmark target/u,
+  );
 });
 
 test("rejects an expanded Cargo target kind instead of accepting a partial match", () => {
   const input = fixture();
   input.messages[1].target.kind = ["bin", "test"];
-  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+  refreshCargoJson(input);
 
   assert.throws(
     () => build(input),
-    /Cargo artifact target contract changed for cli/u,
+    /shipping Cargo graph emitted a test or benchmark target/u,
   );
 });
 
 test("rejects a renamed Cargo target instead of substituting another binary", () => {
   const input = fixture();
   input.messages[1].target.name = "codestory-cli-shadow";
-  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
+  refreshCargoJson(input);
 
   assert.throws(
     () => build(input),
-    /expected exactly one Cargo artifact for cli, found 0/u,
+    /must emit exactly one production binary codestory-cli:codestory-cli; found 0/u,
   );
 });
 
@@ -419,32 +591,6 @@ test("rejects the release-root spelling where Cargo uses a normalized deps peer"
   assert.throws(
     () => build(input),
     /not exactly the release-root executable and one release\/deps peer/u,
-  );
-});
-
-test("rejects a hardlinked Cargo test executable", () => {
-  const input = fixture();
-  const native = input.artifacts.find((artifact) => artifact.alias === "native_staging");
-  const alias = path.join(input.releaseDir, "deps", "native_staging-copy.exe");
-  fs.linkSync(native.executable, alias);
-
-  assert.throws(
-    () => build(input),
-    /test executable has native aliases outside its Cargo output path/u,
-  );
-});
-
-test("rejects a mixed test and production profile", () => {
-  const input = fixture();
-  const native = input.messages.find(
-    (message) => message.target?.name === "native_staging",
-  );
-  native.profile.test = false;
-  input.jsonLines = input.messages.map((message) => JSON.stringify(message)).join("\n");
-
-  assert.throws(
-    () => build(input),
-    /profile\.test did not match test/u,
   );
 });
 

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -40,6 +40,58 @@ const windowsSccacheCacheSize = "2G";
 
 export { retrievalFile };
 
+function tomlSection(source, section) {
+  const header = `[${section}]`;
+  const start = source.indexOf(`${header}\n`);
+  if (start < 0) return null;
+  const bodyStart = start + header.length + 1;
+  const next = source.slice(bodyStart).search(/^\[[^\]]+\]\s*$/mu);
+  return next < 0
+    ? source.slice(bodyStart)
+    : source.slice(bodyStart, bodyStart + next);
+}
+
+export function benchmarkDependencyIsolationViolations(source) {
+  const violations = [];
+  const dependencies = tomlSection(source, "dependencies");
+  const devDependencies = tomlSection(source, "dev-dependencies");
+  if (dependencies === null || devDependencies === null) {
+    return ["codestory-bench must separate product-driver and benchmark dependencies"];
+  }
+  const benchmarkOnly = [
+    "codestory-cli",
+    "codestory-contracts",
+    "codestory-indexer",
+    "codestory-runtime",
+    "codestory-store",
+    "criterion",
+    "uuid",
+  ];
+  const dependencyNames = new Set(
+    [...dependencies.matchAll(/^([A-Za-z0-9_-]+)\s*=/gmu)]
+      .map((match) => match[1]),
+  );
+  const devDependencyNames = new Set(
+    [...devDependencies.matchAll(/^([A-Za-z0-9_-]+)\s*=/gmu)]
+      .map((match) => match[1]),
+  );
+  add(
+    violations,
+    benchmarkOnly.every(
+      (name) => !dependencyNames.has(name) && devDependencyNames.has(name),
+    ),
+    "codestory-bench benchmark-only dependencies must not enter packaged qualification binaries",
+  );
+  add(
+    violations,
+    /^codestory-runtime\s*=\s*\{\s*workspace\s*=\s*true,\s*features\s*=\s*\["benchmark-support"\]\s*\}\s*$/mu
+      .test(devDependencies)
+      && !/\b(?:benchmark-support|test-support)\b/u.test(dependencies),
+    "codestory-bench product dependencies must not enable benchmark-support or test-support",
+  );
+  return violations;
+}
+
 export function rustRetrievalWrapperSourcePresent(source) {
   return (
     /lint-retrieval-generalization|retrieval[_-]generalization[_-](?:guard|lint)/u
@@ -906,7 +958,7 @@ const packagedPlatformCloseoutDigest =
 // parsed executable structure so an unreviewed earlier step cannot replace an
 // owner binary while leaving the locally digested finalizer unchanged.
 const packagedPlatformWorkflowDigest =
-  "ae53e5a2ab7cc72bfba4eec4264a682dabb75b45913e3e0b5341d2ca5c08c776";
+  "3767898b5225ab53ffc7a0ebbfa7096c3fd833e33edacfe1d425fc00c2e53995";
 // The frozen-candidate coordinator and protected GPU workflows are small
 // release-control programs, not loose collections of independently safe
 // fragments. Pin their complete parsed structure so a required check cannot be
@@ -928,7 +980,7 @@ const linuxVulkanWorkflowDigest =
 const packagedSccacheIdentityDigest =
   "f844b8a3b2e0f0013b43f4ec661c237fb090a01c49316d8c2b301ba01cac4342";
 const packagedLinuxBuildDigest =
-  "968f2ab585eb1870eea20f521d576bfaad2900fc14e6438074f62246a0c8652b";
+  "f101cc525f52f75686acbb1cf240412409f3f388793890993cefae9175685a6f";
 const packagedCompileClockStopDigest =
   "ef9f7ee4636c3466830447e2ed8a10c2030ca3949bca082652d9262848d258a5";
 const packagedHostCompilerFinalizerDigest =
@@ -2212,6 +2264,95 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
         `${sourceFile} retrieval generalization ${name} must run its exact blocking Node command`,
       );
     }
+    const windowsNative = requireJob(
+      violations,
+      sourceFile,
+      source,
+      "windows-native-contracts",
+    );
+    add(
+      violations,
+      hasExactKeys(windowsNative, [
+        "name",
+        "needs",
+        "if",
+        "runs-on",
+        "timeout-minutes",
+        "env",
+        "steps",
+      ])
+        && windowsNative.name === "windows-native-contracts"
+        && sameMembers(needs(windowsNative), ["resolve"])
+        && windowsNative.if === "needs.resolve.outputs.reuse != 'true'"
+        && windowsNative["runs-on"] === "windows-latest"
+        && windowsNative["timeout-minutes"] === 15
+        && object(windowsNative.env).CMAKE_GENERATOR === "Ninja"
+        && windowsNative["continue-on-error"] === undefined,
+      `${sourceFile} Windows native source contracts must run in parallel on the resolved exact head`,
+    );
+    const windowsNativeSteps = list(windowsNative.steps).map(object);
+    add(
+      violations,
+      windowsNativeSteps.length === 6
+        && windowsNativeSteps[0]?.uses === "actions/checkout@v5"
+        && object(windowsNativeSteps[0]?.with).ref === "${{ needs.resolve.outputs.ref }}"
+        && windowsNativeSteps.every(step => step?.["continue-on-error"] === undefined),
+      `${sourceFile} Windows native source contracts must keep the exact blocking six-step shape`,
+    );
+    requireStepRun(violations, sourceFile, windowsNative, "Install Rust stable", [
+      "rustup toolchain install stable --profile minimal",
+      "rustup default stable",
+    ]);
+    requireStepRun(
+      violations,
+      sourceFile,
+      windowsNative,
+      "Configure short Windows Cargo target",
+      [
+        '$workspaceTarget = Join-Path $env:GITHUB_WORKSPACE "target"',
+        '$shortTarget = Join-Path $runnerRoot "t"',
+        "New-Item -ItemType Junction -Path $shortTarget -Target $workspaceTarget",
+        '"CARGO_TARGET_DIR=$shortTarget"',
+      ],
+    );
+    requireStepRun(
+      violations,
+      sourceFile,
+      windowsNative,
+      "Prepare checksum-pinned embedded model",
+      ["node scripts/prepare-embedded-model.mjs"],
+    );
+    requireStepRun(
+      violations,
+      sourceFile,
+      windowsNative,
+      "Install checksum-pinned Windows Vulkan SDK",
+      [".github/scripts/install-windows-vulkan-sdk.ps1"],
+    );
+    requireStepRun(
+      violations,
+      sourceFile,
+      windowsNative,
+      "Prove Windows path and native-staging source contracts",
+      [
+        "cargo test --release --locked",
+        "-p codestory-workspace --test windows_path_identity",
+        "-p codestory-llama-sys --test native_staging",
+        "Windows native source contracts failed",
+        "Windows path and native-staging source contracts:",
+      ],
+    );
+    const windowsNativeRun = shellLiteralNormalizedText(stepRun(
+      windowsNative,
+      "Prove Windows path and native-staging source contracts",
+    ));
+    add(
+      violations,
+      shellInvocationsContaining(windowsNativeRun, "cargo test").length === 1
+        && jobShellInvocationsContaining(windowsNative, "cargo build").length === 0
+        && jobShellInvocationsContaining(windowsNative, "cargo check").length === 0,
+      `${sourceFile} Windows path and native-staging contracts must share one source-only Cargo invocation`,
+    );
     add(
       violations,
       object(source.env).SCCACHE_VERSION === sccacheVersion
@@ -3430,8 +3571,8 @@ function validatePackagedProof(workflows, violations, graph) {
   );
   const compilerSaveIndex = stepIndex(job, "Save compiler objects after compilation");
   for (const lateStep of [
-    "Prove native workspace path identity",
-    "Test immutable native staging on Windows",
+    "Prove production feature identity",
+    "Prove production feature identity on Windows",
     "Sign and notarize macOS CLI",
     "Package release asset",
     "Package release asset on Windows",
@@ -3667,30 +3808,48 @@ function validatePackagedProof(workflows, violations, graph) {
   requireStepRun(violations, file, job, "Install Linux Vulkan build dependencies", [
     "bash .github/scripts/install-linux-vulkan-build-deps.sh",
   ]);
-  const windowsNativeStagingTest = namedStep(job, "Test immutable native staging on Windows");
-  const windowsPathIdentityTest = namedStep(job, "Prove native workspace path identity");
+  const productFeatureProbe = namedStep(job, "Prove production feature identity");
   add(
     violations,
-    windowsNativeStagingTest?.if === "runner.os == 'Windows'"
-      && windowsNativeStagingTest?.shell === "pwsh"
-      && object(windowsNativeStagingTest?.env).TEST_BINARY
-        === "${{ steps.package-build.outputs.native_staging }}"
-      && windowsNativeStagingTest?.["continue-on-error"] === undefined
-      && windowsPathIdentityTest?.if === "runner.os == 'Windows'"
-      && windowsPathIdentityTest?.shell === "pwsh"
-      && object(windowsPathIdentityTest?.env).TEST_BINARY
-        === "${{ steps.package-build.outputs.windows_path_identity }}"
-      && windowsPathIdentityTest?.["continue-on-error"] === undefined,
-    `${file} Windows regressions must execute the exact release test binaries emitted by the one Cargo graph`,
+    productFeatureProbe?.if === "runner.os != 'Windows'"
+      && productFeatureProbe?.shell === "bash"
+      && object(productFeatureProbe?.env).CODESTORY_EMBED_ALLOW_CPU === "0"
+      && productFeatureProbe?.["continue-on-error"] === undefined,
+    `${file} Unix packages must fail closed on a non-product embedding feature identity`,
   );
-  requireStepRun(violations, file, job, "Test immutable native staging on Windows", [
-    '& "$env:TEST_BINARY" --nocapture',
-    "immutable native-staging release harness failed",
+  requireStepRun(violations, file, job, "Prove production feature identity", [
+    "retrieval status",
+    '--cache-dir "$cache"',
+    '.embedding_device_observation_source == "per_user_server"',
+    "Production feature identity probe:",
   ]);
-  requireStepRun(violations, file, job, "Prove native workspace path identity", [
-    '& "$env:TEST_BINARY" --nocapture',
-    "Windows path-identity release harness failed",
-  ]);
+  const windowsProductFeatureProbe = namedStep(
+    job,
+    "Prove production feature identity on Windows",
+  );
+  add(
+    violations,
+    windowsProductFeatureProbe?.if === "runner.os == 'Windows'"
+      && windowsProductFeatureProbe?.shell === "pwsh"
+      && object(windowsProductFeatureProbe?.env).CODESTORY_EMBED_ALLOW_CPU === "0"
+      && object(windowsProductFeatureProbe?.env).WINDOWS_CLI
+        === "${{ steps.package-build.outputs.cli }}"
+      && windowsProductFeatureProbe?.["continue-on-error"] === undefined,
+    `${file} Windows package must execute the exact selected CLI for its product feature probe`,
+  );
+  requireStepRun(
+    violations,
+    file,
+    job,
+    "Prove production feature identity on Windows",
+    [
+      'retrieval status',
+      '--cache-dir "$cache"',
+      '$status.embedding_device_observation_source -ne "per_user_server"',
+      "non-product embedding observation source",
+      "Production feature identity probe:",
+    ],
+  );
   requireStepRun(violations, file, job, "Build pinned Linux toolchain image", [
     ".github/docker/linux-glibc-build.Dockerfile",
     "LINUX_GLIBC_BUILD_IMAGE",
@@ -3725,20 +3884,19 @@ function validatePackagedProof(workflows, violations, graph) {
       && packageBuildRun.includes("--bin codestory_embedding_qualification")
       && packageBuildRun.includes("--target $RELEASE_RUST_TARGET")
       && packageBuildRun.includes("if [ $RUNNER_OS = Windows ]")
-      && packageBuildRun.includes("-p codestory-llama-sys")
-      && packageBuildRun.includes("--test native_staging")
-      && packageBuildRun.includes("-p codestory-workspace")
-      && packageBuildRun.includes("--test windows_path_identity")
       && packageBuildRun.includes("--message-format=json-render-diagnostics")
       && packageBuildRun.includes("--timings")
       && packageBuildRun.includes("cargo-build-artifacts.mjs select")
+      && packageBuildRun.includes("cargo-build-artifacts.mjs features")
+      && occurrenceCount(packageBuildRun, "--workspace-root $GITHUB_WORKSPACE") === 2
       && packageBuildRun.includes("--source-sha $SOURCE_SHA")
       && packageBuildRun.includes("--source-tree $SOURCE_TREE")
       && occurrenceCount(packageBuildRun, "build_package_graph") === 3
       && !packageBuildRun.includes("codestory_embedding_constant_calibration")
       && !packageBuildRun.includes("target/debug")
+      && !/(?:^|\s)--test(?:s)?(?:\s|$)/u.test(packageBuildRun)
       && !/(?:^|\s)--bins(?:\s|$)/u.test(packageBuildRun),
-    `${file} host package must build the complete Windows release graph in one exact Cargo invocation`,
+    `${file} host package must build only the production bins and optional qualification driver in one exact Cargo invocation`,
   );
   add(
     violations,
@@ -3766,6 +3924,9 @@ function validatePackagedProof(workflows, violations, graph) {
       && linuxBuildRun.includes("-p codestory-bench")
       && linuxBuildRun.includes("--bin codestory_embedding_qualification")
       && linuxBuildRun.includes("--target $RELEASE_RUST_TARGET")
+      && linuxBuildRun.includes("--message-format=json-render-diagnostics")
+      && linuxBuildRun.includes("cargo-build-artifacts.mjs features")
+      && linuxBuildRun.includes("--workspace-root $GITHUB_WORKSPACE")
       && !linuxBuildRun.includes("codestory_embedding_constant_calibration")
       && !/(?:^|\s)--bins(?:\s|$)/u.test(linuxBuildRun),
     `${file} Linux package must build CLI, runtime, and conditional qualification driver in one exact Cargo invocation`,
@@ -9167,6 +9328,12 @@ export function validateMarketplaceSync(workflows, violations) {
 
 export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
   const violations = [];
+  violations.push(...benchmarkDependencyIsolationViolations(
+    fs.readFileSync(
+      path.join(repositoryRoot, "crates", "codestory-bench", "Cargo.toml"),
+      "utf8",
+    ),
+  ));
   violations.push(...retrievalGeneralizationSuitePolicyViolations(
     fs.readFileSync(
       path.join(repositoryRoot, retrievalGeneralizationSuiteFile),

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -22,6 +22,7 @@ import {
   absorbedFailureViolations,
   annotationScopeViolations,
   basicWorkflowViolations,
+  benchmarkDependencyIsolationViolations,
   dispatchInputInterpolationViolations,
   draftSourcePolicyViolations,
   draftWorkflowPolicyViolations,
@@ -71,6 +72,33 @@ function retrievalSourceWorkflow() {
 function windowsManifestWorkflow() {
   return retrievalSourceWorkflow();
 }
+
+test("packaged qualification dependencies stay outside the benchmark graph", () => {
+  const source = readFileSync(
+    path.join(root, "crates", "codestory-bench", "Cargo.toml"),
+    "utf8",
+  );
+  assert.deepEqual(benchmarkDependencyIsolationViolations(source), []);
+
+  const runtimeDependency =
+    'codestory-runtime = { workspace = true, features = ["benchmark-support"] }\n';
+  const runtimeInProduct = source
+    .replace(runtimeDependency, "")
+    .replace("[dependencies]\n", `[dependencies]\n${runtimeDependency}`);
+  assert.match(
+    benchmarkDependencyIsolationViolations(runtimeInProduct).join("\n"),
+    /benchmark-only dependencies|must not enable benchmark-support/u,
+  );
+
+  const testSupportInProduct = source.replace(
+    "codestory-retrieval = { workspace = true }",
+    'codestory-retrieval = { workspace = true, features = ["test-support"] }',
+  );
+  assert.match(
+    benchmarkDependencyIsolationViolations(testSupportInProduct).join("\n"),
+    /must not enable benchmark-support or test-support/u,
+  );
+});
 
 function draftStep(job, name) {
   const matches = job.steps.filter(step => step.name === name);
@@ -1317,25 +1345,25 @@ test("qualification driver is built once, retained privately, authenticated, and
     }, /private qualification-driver retention must be explicit and off by default/u],
     ["host package repeats Cargo build", packagedFile, workflow => {
       hostBuild(workflow).run += '\ncargo build --release --locked "${cargo_args[@]}"';
-    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
+    }, /host package must build only the production bins and optional qualification driver in one exact Cargo invocation/u],
     ["host package drops runtime", packagedFile, workflow => {
       hostBuild(workflow).run = hostBuild(workflow).run.replace(
         "--bin codestory-cli-runtime",
         "--bin ignored-runtime",
       );
-    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
+    }, /host package must build only the production bins and optional qualification driver in one exact Cargo invocation/u],
     ["host package broadens to all bins", packagedFile, workflow => {
       hostBuild(workflow).run = hostBuild(workflow).run.replace(
         "--bin codestory-cli-runtime",
         "--bins",
       );
-    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
+    }, /host package must build only the production bins and optional qualification driver in one exact Cargo invocation/u],
     ["host package substitutes calibration driver", packagedFile, workflow => {
       hostBuild(workflow).run = hostBuild(workflow).run.replace(
         "codestory_embedding_qualification",
         "codestory_embedding_constant_calibration",
       );
-    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
+    }, /host package must build only the production bins and optional qualification driver in one exact Cargo invocation/u],
     ["Linux package repeats Cargo build", packagedFile, workflow => {
       linuxBuild(workflow).run = linuxBuild(workflow).run.replace(
         "/sccache/sccache --show-stats",
@@ -1650,7 +1678,7 @@ test("Windows packages one release graph into exact public and private artifacts
     ["the one package build invokes Cargo twice", workflow => {
       step(workflow, "Build package and qualification driver").run +=
         "\ncargo build --release --locked -p codestory-cli";
-    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
+    }, /host package must build only the production bins and optional qualification driver in one exact Cargo invocation/u],
     ["the package graph loses release mode", workflow => {
       replaceRun(
         workflow,
@@ -1658,15 +1686,28 @@ test("Windows packages one release graph into exact public and private artifacts
         "cargo build --release --locked",
         "cargo build --locked",
       );
-    }, /host package must build the complete Windows release graph in one exact Cargo invocation/u],
-    ["the path regression is replaced by a debug output", workflow => {
-      step(workflow, "Prove native workspace path identity").env.TEST_BINARY =
-        "target/debug/deps/windows_path_identity.exe";
-    }, /Windows regressions must execute the exact release test binaries emitted by the one Cargo graph/u],
-    ["the staging regression is replaced by a debug output", workflow => {
-      step(workflow, "Test immutable native staging on Windows").env.TEST_BINARY =
-        "target/debug/deps/native_staging.exe";
-    }, /Windows regressions must execute the exact release test binaries emitted by the one Cargo graph/u],
+    }, /host package must build only the production bins and optional qualification driver in one exact Cargo invocation/u],
+    ["a source-test target contaminates the package graph", workflow => {
+      step(workflow, "Build package and qualification driver").run =
+        step(workflow, "Build package and qualification driver").run.replace(
+          "timing_dir=\"target/windows-package-build-timing\"",
+          'cargo_args+=( -p codestory-workspace --test windows_path_identity )\n            timing_dir="target/windows-package-build-timing"',
+        );
+    }, /host package must build only the production bins/u],
+    ["the host feature contract is removed", workflow => {
+      step(workflow, "Build package and qualification driver").run =
+        step(workflow, "Build package and qualification driver").run.replace(
+          "node .github/scripts/cargo-build-artifacts.mjs features",
+          "true",
+        );
+    }, /host package must build only the production bins/u],
+    ["the Windows runtime probe accepts test support", workflow => {
+      step(workflow, "Prove production feature identity on Windows").run =
+        step(workflow, "Prove production feature identity on Windows").run.replace(
+          '"per_user_server"',
+          '"test_support"',
+        );
+    }, /Prove production feature identity on Windows|non-product embedding feature identity/u],
     ["Windows packaging is fed a debug CLI", workflow => {
       step(workflow, "Package release asset on Windows").env.WINDOWS_CLI =
         "target/debug/codestory-cli.exe";
@@ -2921,6 +2962,60 @@ ${captureRun}`],
   }
 });
 
+test("exact-head source proof owns Windows path and native-staging harnesses", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const file = "source-proof.yml";
+  const mutations = [
+    ["job is removed", workflow => {
+      delete workflow.jobs["windows-native-contracts"];
+    }],
+    ["job becomes advisory", workflow => {
+      workflow.jobs["windows-native-contracts"]["continue-on-error"] = true;
+    }],
+    ["checkout stops using the resolved head", workflow => {
+      workflow.jobs["windows-native-contracts"].steps[0].with.ref = "dev/codestory-next";
+    }],
+    ["path identity is omitted", workflow => {
+      const step = draftStep(
+        workflow.jobs["windows-native-contracts"],
+        "Prove Windows path and native-staging source contracts",
+      );
+      step.run = step.run.replace(
+        "-p codestory-workspace --test windows_path_identity `\n",
+        "",
+      );
+    }],
+    ["native staging is omitted", workflow => {
+      const step = draftStep(
+        workflow.jobs["windows-native-contracts"],
+        "Prove Windows path and native-staging source contracts",
+      );
+      step.run = step.run.replace(
+        "-p codestory-llama-sys --test native_staging",
+        "-p codestory-llama-sys",
+      );
+    }],
+    ["source contracts compile twice", workflow => {
+      const step = draftStep(
+        workflow.jobs["windows-native-contracts"],
+        "Prove Windows path and native-staging source contracts",
+      );
+      step.run += "\ncargo test --release --locked -p codestory-workspace";
+    }],
+  ];
+
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(
+        validateWorkflows(workflows).join("\n"),
+        /Windows native source contracts|Prove Windows path and native-staging source contracts|Windows path and native-staging contracts/u,
+      );
+    });
+  }
+});
+
 test("reusable compiler caches and proof modes reject hostile downgrades", async (t) => {
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
 
@@ -3100,13 +3195,13 @@ test("reusable compiler caches and proof modes reject hostile downgrades", async
         "Test the complete workspace once",
       );
     }, /source-proof\.yml compiler cache must save before test execution or release-cell failure/u],
-    ["packaged compiler cache waits for protected regression", packagedFile, workflow => {
+    ["packaged compiler cache waits for product feature proof", packagedFile, workflow => {
       moveNamedStepAfter(
         packagedJob(workflow),
         "Save compiler objects after compilation",
-        "Test immutable native staging on Windows",
+        "Prove production feature identity on Windows",
       );
-    }, /compiler cache must save before late Test immutable native staging on Windows failure/u],
+    }, /compiler cache must save before late Prove production feature identity on Windows failure/u],
     ["packaged compiler cache waits for signing", packagedFile, workflow => {
       moveNamedStepAfter(
         packagedJob(workflow),
@@ -4072,10 +4167,6 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
     workflow.jobs.build,
     "Configure short Windows Cargo target",
   );
-  const packagedNativeStaging = workflow => draftStep(
-    workflow.jobs.build,
-    "Test immutable native staging on Windows",
-  );
   const protectedSourceTools = workflow => draftStep(
     workflow.jobs["packaged-vulkan"],
     "Capture source build tool evidence",
@@ -4125,12 +4216,6 @@ test("Windows source package builds pin Ninja and bind native tool identity", as
       packagedShortTarget(workflow).run = packagedShortTarget(workflow).run
         .replace("| Out-File -FilePath $env:GITHUB_ENV", "| Write-Output");
     }, /Configure short Windows Cargo target/u],
-    ["packaged native staging regression made cross-platform", packagedFile, workflow => {
-      packagedNativeStaging(workflow).if = "runner.os != 'Windows'";
-    }, /Windows regressions must execute the exact release test binaries emitted by the one Cargo graph/u],
-    ["packaged native staging regression removed", packagedFile, workflow => {
-      packagedNativeStaging(workflow).run = "cargo test --release --locked";
-    }, /Test immutable native staging on Windows/u],
     ["packaged build overrides generator", packagedFile, workflow => {
       packagedBuild(workflow).env = { CMAKE_GENERATOR: "Visual Studio 18 2026" };
     }, /native package build must not override the selected generator/u],

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -427,12 +427,6 @@ jobs:
               "$@"
           }
           if [ "$RUNNER_OS" = Windows ]; then
-            cargo_args+=(
-              -p codestory-llama-sys
-              --test native_staging
-              -p codestory-workspace
-              --test windows_path_identity
-            )
             timing_dir="target/windows-package-build-timing"
             mkdir -p "$timing_dir"
             cargo_json="$timing_dir/cargo-messages.jsonl"
@@ -451,8 +445,6 @@ jobs:
             expectations=(
               --expect "cli=codestory-cli:bin:codestory-cli"
               --expect "runtime=codestory-cli:bin:codestory-cli-runtime"
-              --expect "native_staging=codestory-llama-sys:test:native_staging"
-              --expect "windows_path_identity=codestory-workspace:test:windows_path_identity"
             )
             if [ "$INCLUDE_QUALIFICATION_DRIVER" = true ]; then
               expectations+=(
@@ -488,7 +480,16 @@ jobs:
               echo "- MSVC /TIME linker rows retained: ${linker_rows}"
             } >> "$GITHUB_STEP_SUMMARY"
           else
-            build_package_graph
+            timing_dir="target/package-build-contract/${{ matrix.asset_target }}"
+            mkdir -p "$timing_dir"
+            cargo_json="$timing_dir/cargo-messages.jsonl"
+            build_package_graph \
+              --message-format=json-render-diagnostics \
+              > "$cargo_json"
+            cat "$cargo_json"
+            node .github/scripts/cargo-build-artifacts.mjs features \
+              --input "$cargo_json" \
+              --workspace-root "$GITHUB_WORKSPACE"
           fi
 
       - name: Build Linux x64 at the glibc 2.31 baseline
@@ -513,6 +514,7 @@ jobs:
           )"
           test "$actual_sccache_sha256" = "$SCCACHE_SHA256"
           mkdir -p "$CARGO_HOME" "$SCCACHE_DIR"
+          mkdir -p "target/package-build-contract/${{ matrix.asset_target }}"
           model_relative="${CODESTORY_EMBED_MODEL_SOURCE#"$PWD/"}"
           docker run --rm --platform linux/amd64 \
             --user "$(id -u):$(id -g)" \
@@ -543,10 +545,17 @@ jobs:
                   -p codestory-bench \
                   --bin codestory_embedding_qualification
               fi
-              cargo build --release --locked "$@" --target "$RELEASE_RUST_TARGET"
+              cargo build --release --locked "$@" \
+                --target "$RELEASE_RUST_TARGET" \
+                --message-format=json-render-diagnostics \
+                > /workspace/target/package-build-contract/linux-x64/cargo-messages.jsonl
+              cat /workspace/target/package-build-contract/linux-x64/cargo-messages.jsonl
               /sccache/sccache --show-stats
               /sccache/sccache --stop-server
             '
+          node .github/scripts/cargo-build-artifacts.mjs features \
+            --input "target/package-build-contract/${{ matrix.asset_target }}/cargo-messages.jsonl" \
+            --workspace-root "$GITHUB_WORKSPACE"
           mkdir -p "target/${{ matrix.rust_target }}/release"
           cp "target/glibc-2.31/${{ matrix.rust_target }}/release/codestory-cli" \
             "target/${{ matrix.rust_target }}/release/codestory-cli"
@@ -692,28 +701,6 @@ jobs:
             --save-started-ms "$SAVE_STARTED_MS" \
             --save-result "$SAVE_RESULT" \
             --path "$SCCACHE_DIR"
-
-      - name: Prove native workspace path identity
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          TEST_BINARY: ${{ steps.package-build.outputs.windows_path_identity }}
-        run: |
-          & "$env:TEST_BINARY" --nocapture
-          if ($LASTEXITCODE -ne 0) {
-            throw "Windows path-identity release harness failed with exit code $LASTEXITCODE"
-          }
-
-      - name: Test immutable native staging on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          TEST_BINARY: ${{ steps.package-build.outputs.native_staging }}
-        run: |
-          & "$env:TEST_BINARY" --nocapture
-          if ($LASTEXITCODE -ne 0) {
-            throw "immutable native-staging release harness failed with exit code $LASTEXITCODE"
-          }
 
       - name: Sign and notarize macOS CLI
         if: runner.os == 'macOS' && inputs.sign_macos
@@ -906,6 +893,32 @@ jobs:
           "$bin" --version
           "$bin" --help
 
+      - name: Prove production feature identity
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          CODESTORY_EMBED_ALLOW_CPU: "0"
+        run: |
+          set -euo pipefail
+          started_ms="$(node -p 'Date.now()')"
+          bin="target/${{ matrix.rust_target }}/release/codestory-cli"
+          cache="$RUNNER_TEMP/codestory-package-feature-probe-${{ matrix.asset_target }}"
+          mkdir "$cache"
+          status="$(
+            "$bin" retrieval status \
+              --project "$GITHUB_WORKSPACE" \
+              --cache-dir "$cache" \
+              --format json
+          )"
+          jq -e \
+            '.embedding_device_observation_source == "per_user_server"' \
+            <<<"$status"
+          ended_ms="$(node -p 'Date.now()')"
+          elapsed_ms=$((ended_ms - started_ms))
+          test "$elapsed_ms" -ge 0
+          echo "- Production feature identity probe: ${elapsed_ms} ms" \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Smoke codestory-cli on Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -921,6 +934,35 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Windows CLI help smoke failed with exit code $LASTEXITCODE"
           }
+
+      - name: Prove production feature identity on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          CODESTORY_EMBED_ALLOW_CPU: "0"
+          WINDOWS_CLI: ${{ steps.package-build.outputs.cli }}
+        run: |
+          $started = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          $cache = Join-Path $env:RUNNER_TEMP "codestory-package-feature-probe-windows-x64"
+          New-Item -ItemType Directory -Path $cache | Out-Null
+          $statusJson = & "$env:WINDOWS_CLI" retrieval status `
+            --project "$env:GITHUB_WORKSPACE" `
+            --cache-dir "$cache" `
+            --format json
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows production feature probe failed with exit code $LASTEXITCODE"
+          }
+          $status = $statusJson | ConvertFrom-Json
+          if ($status.embedding_device_observation_source -ne "per_user_server") {
+            throw "production package contains a non-product embedding observation source: $($status.embedding_device_observation_source)"
+          }
+          $ended = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          $elapsed = $ended - $started
+          if ($elapsed -lt 0) {
+            throw "Windows production feature-probe timing was negative"
+          }
+          "- Production feature identity probe: ${elapsed} ms" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
       - name: Clear release asset output
         run: python -c "import shutil; shutil.rmtree('target/release-dist', ignore_errors=True)"

--- a/.github/workflows/source-proof.yml
+++ b/.github/workflows/source-proof.yml
@@ -448,3 +448,64 @@ jobs:
 
       - name: Generalization lint hostile matrix
         run: node --test scripts/tests/lint-retrieval-generalization.test.mjs
+
+  windows-native-contracts:
+    name: windows-native-contracts
+    needs: resolve
+    if: needs.resolve.outputs.reuse != 'true'
+    runs-on: windows-latest
+    timeout-minutes: 15
+    env:
+      CMAKE_GENERATOR: Ninja
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+
+      - name: Install Rust stable
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Configure short Windows Cargo target
+        shell: pwsh
+        run: |
+          $workspaceTarget = Join-Path $env:GITHUB_WORKSPACE "target"
+          $runnerRoot = [System.IO.Path]::GetPathRoot($workspaceTarget)
+          if ([string]::IsNullOrWhiteSpace($runnerRoot)) {
+            throw "workspace target has no volume root: $workspaceTarget"
+          }
+          $shortTarget = Join-Path $runnerRoot "t"
+          New-Item -ItemType Directory -Force -Path $workspaceTarget | Out-Null
+          if (Test-Path -LiteralPath $shortTarget) {
+            throw "short Cargo target already exists: $shortTarget"
+          }
+          New-Item -ItemType Junction -Path $shortTarget -Target $workspaceTarget | Out-Null
+          "CARGO_TARGET_DIR=$shortTarget" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Prepare checksum-pinned embedded model
+        run: node scripts/prepare-embedded-model.mjs
+
+      - name: Install checksum-pinned Windows Vulkan SDK
+        shell: pwsh
+        run: .github/scripts/install-windows-vulkan-sdk.ps1
+
+      - name: Prove Windows path and native-staging source contracts
+        shell: pwsh
+        run: |
+          $started = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          cargo test --release --locked `
+            -p codestory-workspace --test windows_path_identity `
+            -p codestory-llama-sys --test native_staging
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows native source contracts failed with exit code $LASTEXITCODE"
+          }
+          $ended = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          $elapsed = $ended - $started
+          if ($elapsed -lt 0) {
+            throw "Windows native source-contract timing was negative"
+          }
+          "- Windows path and native-staging source contracts: ${elapsed} ms" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
+    "graph_sha256": "7385b32924d42e94c14b8d1f41fcec50bded200fc0e65fec05f43036e2896087",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
+        "graph_sha256": "7385b32924d42e94c14b8d1f41fcec50bded200fc0e65fec05f43036e2896087",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
+        "graph_sha256": "7385b32924d42e94c14b8d1f41fcec50bded200fc0e65fec05f43036e2896087",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "dd96364938407289c45793d74de63084ad57619229c242096233129a7c6ff83c",
+  "candidate_sha256": "e30832aa8c4d39b07835a3484bcb8d0573904b68fe62b16752c86ff2d740ae70",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
+      "graph_sha256": "7385b32924d42e94c14b8d1f41fcec50bded200fc0e65fec05f43036e2896087",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
+      "graph_sha256": "7385b32924d42e94c14b8d1f41fcec50bded200fc0e65fec05f43036e2896087",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
+    "graph_sha256": "7385b32924d42e94c14b8d1f41fcec50bded200fc0e65fec05f43036e2896087",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -5,22 +5,24 @@ edition = "2024"
 publish = false
 
 [dependencies]
-codestory-contracts = { workspace = true }
-codestory-indexer = { workspace = true }
-codestory-cli = { workspace = true }
-codestory-runtime = { workspace = true, features = ["benchmark-support"] }
 codestory-retrieval = { workspace = true }
-codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }
-criterion = { workspace = true }
 tempfile = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-uuid = { workspace = true }
 clap = { workspace = true }
 libc = { workspace = true }
 sha2 = { workspace = true }
+
+[dev-dependencies]
+codestory-cli = { workspace = true }
+codestory-contracts = { workspace = true }
+codestory-indexer = { workspace = true }
+codestory-runtime = { workspace = true, features = ["benchmark-support"] }
+codestory-store = { workspace = true }
+criterion = { workspace = true }
+uuid = { workspace = true }
 
 [[bench]]
 name = "indexing"

--- a/release-claims.json
+++ b/release-claims.json
@@ -1067,13 +1067,16 @@
       "artifacts": [
         "codestory-cli",
         "codestory-cli-runtime",
-        "codestory_embedding_qualification",
+        "codestory_embedding_qualification"
+      ],
+      "direct_test_harnesses": [],
+      "source_test_harnesses": [
         "native_staging",
         "windows_path_identity"
       ],
-      "direct_test_harnesses": [
-        "native_staging",
-        "windows_path_identity"
+      "production_feature_probes": [
+        "cargo_message_feature_contract",
+        "runtime_observation_source"
       ],
       "package_artifact": "codestory-cli",
       "timing_phases": [
@@ -1081,7 +1084,7 @@
         "native_setup",
         "cargo_graph",
         "msvc_link",
-        "regression_execution",
+        "feature_probe",
         "packaging",
         "artifact_transfer"
       ]

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -841,15 +841,26 @@ function validateWindowsPackageGraph(value) {
       "codestory-cli",
       "codestory-cli-runtime",
       "codestory_embedding_qualification",
-      "native_staging",
-      "windows_path_identity",
     ],
     "workflow_policy.windows_package_graph.artifacts",
   );
+  if (
+    JSON.stringify(stringArray(
+      graph.direct_test_harnesses,
+      "workflow_policy.windows_package_graph.direct_test_harnesses",
+    )) !== JSON.stringify([])
+  ) {
+    fail("workflow_policy.windows_package_graph.direct_test_harnesses must be empty");
+  }
   exactStringList(
-    graph.direct_test_harnesses,
+    graph.source_test_harnesses,
     ["native_staging", "windows_path_identity"],
-    "workflow_policy.windows_package_graph.direct_test_harnesses",
+    "workflow_policy.windows_package_graph.source_test_harnesses",
+  );
+  exactStringList(
+    graph.production_feature_probes,
+    ["cargo_message_feature_contract", "runtime_observation_source"],
+    "workflow_policy.windows_package_graph.production_feature_probes",
   );
   exactStringList(
     graph.timing_phases,
@@ -858,7 +869,7 @@ function validateWindowsPackageGraph(value) {
       "native_setup",
       "cargo_graph",
       "msvc_link",
-      "regression_execution",
+      "feature_probe",
       "packaging",
       "artifact_transfer",
     ],

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -169,17 +169,20 @@ test("claim graph freezes one exact Windows release graph and protected content-
       "codestory-cli",
       "codestory-cli-runtime",
       "codestory_embedding_qualification",
-      "native_staging",
-      "windows_path_identity",
     ],
-    direct_test_harnesses: ["native_staging", "windows_path_identity"],
+    direct_test_harnesses: [],
+    source_test_harnesses: ["native_staging", "windows_path_identity"],
+    production_feature_probes: [
+      "cargo_message_feature_contract",
+      "runtime_observation_source",
+    ],
     package_artifact: "codestory-cli",
     timing_phases: [
       "cache_restore",
       "native_setup",
       "cargo_graph",
       "msvc_link",
-      "regression_execution",
+      "feature_probe",
       "packaging",
       "artifact_transfer",
     ],
@@ -227,8 +230,14 @@ test("claim graph freezes one exact Windows release graph and protected content-
       draft.workflow_policy.windows_package_graph.cargo_test_invocations_after_build = 1;
     }, /one exact Windows release graph/u],
     [draft => {
-      draft.workflow_policy.windows_package_graph.direct_test_harnesses.pop();
-    }, /direct_test_harnesses must be exactly/u],
+      draft.workflow_policy.windows_package_graph.direct_test_harnesses.push("native_staging");
+    }, /direct_test_harnesses must be empty/u],
+    [draft => {
+      draft.workflow_policy.windows_package_graph.source_test_harnesses.pop();
+    }, /source_test_harnesses must be exactly/u],
+    [draft => {
+      draft.workflow_policy.windows_package_graph.production_feature_probes.pop();
+    }, /production_feature_probes must be exactly/u],
     [draft => {
       draft.workflow_policy.candidate_archive_cache.key_fields.shift();
     }, /key_fields must be exactly/u],

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "54a9a45c1df1c2a738da405f9bca7120cb75d422bb94e9b05cd8cf4f0c3c247b",
+      "graph_sha256": "7385b32924d42e94c14b8d1f41fcec50bded200fc0e65fec05f43036e2896087",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

Windows qualification on candidate `e980b8205499545a61d3caa0c9937b2cf54cab48` exposed that the package Cargo invocation mixed source-test targets with the shipping CLI/runtime and qualification driver. Cargo feature unification compiled the production runtime with `test-support` and `benchmark-support`, so the authenticated archive reported `test_support` instead of the required `per_user_server` observation source.

## What changed

- build the Windows package graph from production CLI/runtime bins plus the optional qualification driver only;
- move the Windows path-identity and immutable-native-staging source harnesses into the exact-head source-proof lane, in one release Cargo invocation;
- split benchmark-only `codestory-bench` dependencies away from packaged driver dependencies;
- reject test/benchmark targets and forbidden product features directly from Cargo JSON messages;
- execute a read-only packaged-runtime identity probe before packaging;
- retain exact SHA/tree, native identity, artifact digest, and content-addressed archive guarantees;
- update workflow policy, hostile mutation tests, and the release claim graph together.

## Verification

Accepted commit: `40fb32107ed23ac51fa11de925421bd50407435e`

- workflow policy: 1,181 tests passed;
- package artifact/feature helper: 36 tests passed;
- release claim graph: 39 tests passed;
- release cell, closeout, evidence, and runner contracts: 75 tests passed;
- actionlint passed for both changed workflows;
- locked Cargo metadata passed;
- both packaged calibration and qualification drivers passed focused release checks with the checksum-pinned model;
- independent hostile pass rejected duplicate builds, source-test contamination, forbidden features, debug output, neutralized runtime probing, lost SHA binding, and cross-SHA archive reuse.

No broad source, package, calibration, or hardware proof was dispatched for this support PR.

## Risk

The source-only Windows regressions now run in the final exact-head source proof rather than contaminating package compilation. Package and downstream proof remain bound to the same exact source SHA, tree, selected release binaries, archive digest, and native identity.

Closes #1611
