### PR TITLE
Avoid descendant waits in proof command capture

### DIFF
--- a/.github/scripts/packaged_agent_proof/self_test_process.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process.py
@@ -1,6 +1,7 @@
 """Process-level packaged proof self-test coordinator."""
 
 from .self_test_process_cleanup import run_process_cleanup_self_tests
+from .self_test_process_capture import run_process_capture_self_tests
 from .self_test_process_clock import run_process_clock_self_tests
 from .self_test_process_deadline import run_process_deadline_self_tests
 from .self_test_process_exit import run_process_exit_self_tests
@@ -13,3 +14,4 @@ def run_process_self_tests() -> None:
     run_process_deadline_self_tests()
     run_process_exit_self_tests()
     run_process_cleanup_self_tests()
+    run_process_capture_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_process_capture.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process_capture.py
@@ -215,8 +215,10 @@ time.sleep(10)
             require(
                 error.cmd == command
                 and error.timeout == 1
-                and error.stdout == b"timeout-stdout-sentinel\n"
-                and error.stderr == b"timeout-stderr-sentinel\n",
+                and error.stdout
+                == f"timeout-stdout-sentinel{os.linesep}".encode()
+                and error.stderr
+                == f"timeout-stderr-sentinel{os.linesep}".encode(),
                 "file-backed capture changed timeout identity or retained output",
             )
         else:

--- a/.github/scripts/packaged_agent_proof/self_test_process_capture.py
+++ b/.github/scripts/packaged_agent_proof/self_test_process_capture.py
@@ -1,0 +1,230 @@
+"""Synchronous subprocess capture self-tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from .foundation import ProofFailure, require
+from .subprocess_control import run
+
+_DIRECT_STDOUT = "direct-child-stdout\n"
+_DIRECT_STDERR = "direct-child-stderr\n"
+_LARGE_OUTPUT_BYTES = 2 * 1024 * 1024
+
+
+def _write_script(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+
+
+def _wait_for_path(path: Path, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while not path.exists():
+        require(
+            time.monotonic() < deadline,
+            f"timed out waiting for subprocess self-test path {path}",
+        )
+        time.sleep(0.01)
+
+
+def _run_inherited_descendant_leg() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-process-capture-descendant-"
+    ) as raw:
+        root = Path(raw)
+        descendant_path = root / "descendant.py"
+        parent_path = root / "parent.py"
+        ready_path = root / "ready"
+        release_path = root / "release"
+        stopped_path = root / "stopped"
+        _write_script(
+            descendant_path,
+            """
+import sys
+import time
+from pathlib import Path
+
+ready = Path(sys.argv[1])
+release = Path(sys.argv[2])
+stopped = Path(sys.argv[3])
+ready.write_text("ready\\n", encoding="utf-8")
+deadline = time.monotonic() + 2.5
+while not release.exists() and time.monotonic() < deadline:
+    time.sleep(0.01)
+stopped.write_text("stopped\\n", encoding="utf-8")
+""".lstrip(),
+        )
+        _write_script(
+            parent_path,
+            f"""
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ready = Path(sys.argv[2])
+subprocess.Popen([sys.executable, sys.argv[1], *sys.argv[2:]])
+deadline = time.monotonic() + 2
+while not ready.exists():
+    if time.monotonic() >= deadline:
+        raise SystemExit("descendant did not start")
+    time.sleep(0.01)
+sys.stdout.write({_DIRECT_STDOUT!r})
+sys.stdout.flush()
+sys.stderr.write({_DIRECT_STDERR!r})
+sys.stderr.flush()
+""".lstrip(),
+        )
+        command = [
+            sys.executable,
+            str(parent_path),
+            str(descendant_path),
+            str(ready_path),
+            str(release_path),
+            str(stopped_path),
+        ]
+        started = time.perf_counter()
+        result = run(
+            command,
+            env=os.environ.copy(),
+            cwd=root,
+            timeout=10,
+        )
+        elapsed = time.perf_counter() - started
+        release_path.write_text("release\n", encoding="utf-8")
+        _wait_for_path(stopped_path, 2)
+        require(
+            elapsed < 1.5,
+            "synchronous capture waited for an inheriting descendant instead "
+            f"of only the direct child ({elapsed:.3f}s)",
+        )
+        require(
+            result["stdout"] == _DIRECT_STDOUT
+            and result["stderr"] == _DIRECT_STDERR,
+            "inheriting-descendant capture changed direct-child output",
+        )
+
+
+def _run_large_output_leg() -> None:
+    with tempfile.TemporaryDirectory(prefix="codestory-process-capture-large-") as raw:
+        root = Path(raw)
+        script_path = root / "large_output.py"
+        stdout = "O" * _LARGE_OUTPUT_BYTES + ":stdout-end\n"
+        stderr = "E" * _LARGE_OUTPUT_BYTES + ":stderr-end\n"
+        _write_script(
+            script_path,
+            f"""
+import sys
+
+sys.stdout.write("O" * {_LARGE_OUTPUT_BYTES} + ":stdout-end\\n")
+sys.stdout.flush()
+sys.stderr.write("E" * {_LARGE_OUTPUT_BYTES} + ":stderr-end\\n")
+sys.stderr.flush()
+""".lstrip(),
+        )
+        command = [sys.executable, str(script_path)]
+        result = run(
+            command,
+            env=os.environ.copy(),
+            cwd=root,
+            timeout=10,
+        )
+        require(
+            set(result) == {"command", "exit_code", "wall_ms", "stdout", "stderr"}
+            and result["command"] == command
+            and result["exit_code"] == 0
+            and isinstance(result["wall_ms"], float),
+            "file-backed capture changed the synchronous command result shape",
+        )
+        require(
+            result["stdout"] == stdout and result["stderr"] == stderr,
+            "file-backed capture truncated output larger than pipe capacity",
+        )
+
+
+def _run_nonzero_tail_leg() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-process-capture-nonzero-"
+    ) as raw:
+        root = Path(raw)
+        script_path = root / "nonzero.py"
+        _write_script(
+            script_path,
+            """
+import sys
+
+sys.stdout.write("discarded-stdout-" + "o" * 2500 + "-stdout-tail-sentinel\\n")
+sys.stdout.flush()
+sys.stderr.write("discarded-stderr-" + "e" * 2500 + "-stderr-tail-sentinel\\n")
+sys.stderr.flush()
+raise SystemExit(23)
+""".lstrip(),
+        )
+        command = [sys.executable, str(script_path)]
+        try:
+            run(
+                command,
+                env=os.environ.copy(),
+                cwd=root,
+                timeout=10,
+            )
+        except ProofFailure as error:
+            message = str(error)
+            require(
+                "command failed (23)" in message
+                and "stdout-tail-sentinel" in message
+                and "stderr-tail-sentinel" in message,
+                "nonzero command failure lost its exit code or an output tail",
+            )
+        else:
+            raise ProofFailure("nonzero command passed synchronous capture self-test")
+
+
+def _run_timeout_leg() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-process-capture-timeout-"
+    ) as raw:
+        root = Path(raw)
+        script_path = root / "timeout.py"
+        _write_script(
+            script_path,
+            """
+import sys
+import time
+
+sys.stdout.write("timeout-stdout-sentinel\\n")
+sys.stdout.flush()
+sys.stderr.write("timeout-stderr-sentinel\\n")
+sys.stderr.flush()
+time.sleep(10)
+""".lstrip(),
+        )
+        command = [sys.executable, str(script_path)]
+        try:
+            run(
+                command,
+                env=os.environ.copy(),
+                cwd=root,
+                timeout=1,
+            )
+        except subprocess.TimeoutExpired as error:
+            require(
+                error.cmd == command
+                and error.timeout == 1
+                and error.stdout == b"timeout-stdout-sentinel\n"
+                and error.stderr == b"timeout-stderr-sentinel\n",
+                "file-backed capture changed timeout identity or retained output",
+            )
+        else:
+            raise ProofFailure("timed-out command passed synchronous capture self-test")
+
+
+def run_process_capture_self_tests() -> None:
+    _run_inherited_descendant_leg()
+    _run_large_output_leg()
+    _run_nonzero_tail_leg()
+    _run_timeout_leg()

--- a/.github/scripts/packaged_agent_proof/subprocess_control.py
+++ b/.github/scripts/packaged_agent_proof/subprocess_control.py
@@ -22,24 +22,51 @@ from .foundation import (
 
 def run(command: list[str], *, env: dict[str, str], cwd: Path, timeout: int) -> dict:
     started = time.perf_counter()
-    completed = subprocess.run(
-        command,
-        cwd=cwd,
-        env=env,
-        text=True,
-        capture_output=True,
-        timeout=timeout,
-    )
+    # A packaged worker can start the resident embedding server and then exit.
+    # Pipe capture makes communicate() wait for EOF from that descendant too,
+    # even though the direct worker has finished. Regular files retain the same
+    # output while letting subprocess.run() wait only for the process it owns.
+    with (
+        tempfile.TemporaryFile(mode="w+", encoding=None) as stdout_capture,
+        tempfile.TemporaryFile(mode="w+", encoding=None) as stderr_capture,
+    ):
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=cwd,
+                env=env,
+                text=True,
+                stdout=stdout_capture,
+                stderr=stderr_capture,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as error:
+            stdout_capture.flush()
+            stderr_capture.flush()
+            stdout_capture.buffer.seek(0)
+            stderr_capture.buffer.seek(0)
+            stdout = stdout_capture.buffer.read()
+            stderr = stderr_capture.buffer.read()
+            # TimeoutExpired retains raw bytes even when subprocess text mode
+            # is enabled. Preserve that public shape as well as the output.
+            error.timeout = timeout
+            error.stdout = stdout or None
+            error.stderr = stderr or None
+            raise
+        stdout_capture.seek(0)
+        stderr_capture.seek(0)
+        stdout = stdout_capture.read()
+        stderr = stderr_capture.read()
     result = {
         "command": command,
         "exit_code": completed.returncode,
         "wall_ms": round((time.perf_counter() - started) * 1000, 3),
-        "stdout": completed.stdout,
-        "stderr": completed.stderr,
+        "stdout": stdout,
+        "stderr": stderr,
     }
     if completed.returncode != 0:
-        stdout_tail = completed.stdout[-2000:].strip()
-        stderr_tail = completed.stderr[-2000:].strip()
+        stdout_tail = stdout[-2000:].strip()
+        stderr_tail = stderr[-2000:].strip()
         details = "\n".join(
             part
             for part in (


### PR DESCRIPTION
## Context

Windows frozen-candidate qualification completed a real Vulkan query, but its synchronous Python worker call stayed blocked until the detached server reached the correct 60-second idle exit. A 5.5-second native probe against the authenticated exact archive proved the direct worker had exited and its output was ready while the resident server still held captured pipe handles. Writing the pending snapshot then completed in 27ms.

## Change

- capture synchronous command stdout/stderr in temporary regular files instead of pipes
- keep waiting, timeout, result, exact output, and failure-tail contracts attached to the direct child
- preserve raw timeout bytes, platform newlines, and caller-supplied timeout identity
- add hostile coverage for inherited descendant handles, output larger than pipe capacity, nonzero tails, and timeout output

## Review

Exact head: `04dd5808a306c1c776f45707149177a1e63b4436`

The owning seam is `.github/scripts/packaged_agent_proof/subprocess_control.py::run`; no Rust, workflow, package, accelerator, idle-timeout, or claim-graph contract changes.

## Verification

- exact-head focused suite passed on Python 3.9.6, 3.12.13, 3.13.14, and 3.14.6 in 1.10–1.13s
- native Windows exact-head suite passed in 1.416s
- 2 MiB per stream retained exactly
- exit-23 stdout/stderr tails retained
- timeout command, raw-byte output, platform newline, and requested timeout retained
- independent verifier rejected nine mutations: pipe restoration, platform-conditional pipe capture, either-stream truncation, either dropped failure tail, and three timeout-shape corruptions
- relevant plugin-static contract job passed in 2m26s
- unrelated retrieval Rust job was cancelled under the focused-support-PR rule

## Risk

The helper is shared by package proof and calibration commands. File-backed capture deliberately preserves its public result/error shape; the focused tests pin the output and timeout edges that could otherwise drift. No broad or hardware proof belongs on this support PR.

Closes #1625
Refs #1558 and #1521.