### PR TITLE
Retain model-cache state from qualification evidence

### DIFF
--- a/.github/scripts/packaged_agent_proof/qualification_metrics.py
+++ b/.github/scripts/packaged_agent_proof/qualification_metrics.py
@@ -16,6 +16,7 @@ from .qualification_measurements import qualification_measurement_artifact
 from .qualification_production_types import (
     QualificationProducerContext,
     QualificationRunnerEvidence,
+    QualificationScenarioEvidence,
 )
 from .runtime_evidence_support import metric_passes
 from .runtime_memory import retain_five_process_memory_evidence
@@ -66,14 +67,24 @@ def _qualification_measurement_sources(
 def _qualification_host(
     context: QualificationProducerContext,
     runner: QualificationRunnerEvidence,
+    scenarios: QualificationScenarioEvidence,
     measurement: dict,
 ) -> dict:
     identity = context.runtime["identity"]
-    cache_state = (
-        "reused"
-        if context.runtime["materialization"]["reused_on_rejoin"] is True
-        else "materialized"
+    cache_state = require_nonempty_string(
+        runner.matrix_cell.get("cache_state"),
+        "qualification matrix cache state",
     )
+    if cache_state == "reused":
+        true_idle = scenarios.scenarios.get("true_idle_respawn")
+        assertions = (
+            true_idle.get("assertions") if isinstance(true_idle, dict) else None
+        )
+        require(
+            isinstance(assertions, dict)
+            and assertions.get("verified_materialization_reused") is True,
+            "qualification reused cache state lacks validated replacement reuse evidence",
+        )
     residency_state = require_nonempty_string(
         identity["embedding_engine_residency"],
         "runtime engine residency",
@@ -181,6 +192,7 @@ def _retained_qualification_metric(
 def collect_qualification_measurements(
     context: QualificationProducerContext,
     runner: QualificationRunnerEvidence,
+    scenarios: QualificationScenarioEvidence,
 ) -> QualificationMeasurementEvidence:
     measurement, memory = _qualification_measurement_sources(context, runner)
     timing = {
@@ -207,6 +219,6 @@ def collect_qualification_measurements(
         measurement,
         memory,
         timing,
-        _qualification_host(context, runner, measurement),
+        _qualification_host(context, runner, scenarios, measurement),
         metrics,
     )

--- a/.github/scripts/packaged_agent_proof/qualification_metrics.py
+++ b/.github/scripts/packaged_agent_proof/qualification_metrics.py
@@ -64,15 +64,12 @@ def _qualification_measurement_sources(
     return measurement, memory
 
 
-def _qualification_host(
-    context: QualificationProducerContext,
-    runner: QualificationRunnerEvidence,
+def _qualification_cache_state_from_scenarios(
+    selected_cache_state: object,
     scenarios: QualificationScenarioEvidence,
-    measurement: dict,
-) -> dict:
-    identity = context.runtime["identity"]
+) -> str:
     cache_state = require_nonempty_string(
-        runner.matrix_cell.get("cache_state"),
+        selected_cache_state,
         "qualification matrix cache state",
     )
     if cache_state == "reused":
@@ -85,6 +82,17 @@ def _qualification_host(
             and assertions.get("verified_materialization_reused") is True,
             "qualification reused cache state lacks validated replacement reuse evidence",
         )
+    return cache_state
+
+
+def _qualification_host(
+    context: QualificationProducerContext,
+    runner: QualificationRunnerEvidence,
+    measurement: dict,
+    *,
+    cache_state: str,
+) -> dict:
+    identity = context.runtime["identity"]
     residency_state = require_nonempty_string(
         identity["embedding_engine_residency"],
         "runtime engine residency",
@@ -195,6 +203,10 @@ def collect_qualification_measurements(
     scenarios: QualificationScenarioEvidence,
 ) -> QualificationMeasurementEvidence:
     measurement, memory = _qualification_measurement_sources(context, runner)
+    cache_state = _qualification_cache_state_from_scenarios(
+        runner.matrix_cell.get("cache_state"),
+        scenarios,
+    )
     timing = {
         "clock_domain": "awake_monotonic",
         "cross_process_timestamp_subtraction": False,
@@ -219,6 +231,11 @@ def collect_qualification_measurements(
         measurement,
         memory,
         timing,
-        _qualification_host(context, runner, scenarios, measurement),
+        _qualification_host(
+            context,
+            runner,
+            measurement,
+            cache_state=cache_state,
+        ),
         metrics,
     )

--- a/.github/scripts/packaged_agent_proof/qualification_metrics.py
+++ b/.github/scripts/packaged_agent_proof/qualification_metrics.py
@@ -65,11 +65,11 @@ def _qualification_measurement_sources(
 
 
 def _qualification_cache_state_from_scenarios(
-    selected_cache_state: object,
+    runner: QualificationRunnerEvidence,
     scenarios: QualificationScenarioEvidence,
 ) -> str:
     cache_state = require_nonempty_string(
-        selected_cache_state,
+        runner.matrix_cell.get("cache_state"),
         "qualification matrix cache state",
     )
     if cache_state == "reused":
@@ -204,7 +204,7 @@ def collect_qualification_measurements(
 ) -> QualificationMeasurementEvidence:
     measurement, memory = _qualification_measurement_sources(context, runner)
     cache_state = _qualification_cache_state_from_scenarios(
-        runner.matrix_cell.get("cache_state"),
+        runner,
         scenarios,
     )
     timing = {

--- a/.github/scripts/packaged_agent_proof/qualification_workflow.py
+++ b/.github/scripts/packaged_agent_proof/qualification_workflow.py
@@ -40,7 +40,7 @@ def produce_qualification_evidence(
     external = collect_qualification_external_evidence(context)
     runner = run_qualification_producer(context)
     scenarios = collect_qualification_scenarios(context, runner, external)
-    measurements = collect_qualification_measurements(context, runner)
+    measurements = collect_qualification_measurements(context, runner, scenarios)
     return write_qualification_outputs(
         context,
         runner,

--- a/.github/scripts/packaged_agent_proof/self_test_qualification.py
+++ b/.github/scripts/packaged_agent_proof/self_test_qualification.py
@@ -6,7 +6,7 @@ import copy
 from types import SimpleNamespace
 from unittest.mock import patch, sentinel
 
-from . import qualification_workflow
+from . import qualification_metrics, qualification_workflow
 from .foundation import ProofFailure, require
 from .qualification_metrics import (
     _qualification_cache_state_from_scenarios,
@@ -76,7 +76,7 @@ def _qualification_cache_state_self_tests() -> None:
     )
     measurement = {"unplanned_suspend": False}
     cache_state = _qualification_cache_state_from_scenarios(
-        runner.matrix_cell["cache_state"],
+        runner,
         reused_scenario,
     )
     host = _qualification_host(
@@ -113,13 +113,96 @@ def _qualification_cache_state_self_tests() -> None:
     ):
         try:
             _qualification_cache_state_from_scenarios(
-                runner.matrix_cell["cache_state"],
+                runner,
                 hostile,
             )
         except ProofFailure:
             pass
         else:
             raise ProofFailure(message)
+
+
+def _qualification_measurement_dataflow_self_test() -> None:
+    measurement_context = SimpleNamespace(
+        measurement_contract={
+            "constant_set": {"status": "frozen"},
+            "measurement_protocol": {"required_metrics": ["sentinel_metric"]},
+        },
+        contracts={"constant_set_sha256": "a" * 64},
+    )
+    runner = SimpleNamespace(matrix_cell={"cache_state": "reused"})
+    scenarios = QualificationScenarioEvidence(
+        shared_identity={},
+        scenarios={
+            "true_idle_respawn": {
+                "assertions": {"verified_materialization_reused": True}
+            }
+        },
+    )
+    retained_measurement = {"unplanned_suspend": False}
+    real_cache_state = qualification_metrics._qualification_cache_state_from_scenarios
+
+    def derive_cache_state(actual_runner, actual_scenarios):
+        require(
+            actual_runner is runner and actual_scenarios is scenarios,
+            "qualification measurement collection replaced validated runner or scenarios",
+        )
+        return real_cache_state(actual_runner, actual_scenarios)
+
+    def retain_metric(metric, *, context, measurement, memory):
+        require(
+            metric == "sentinel_metric"
+            and context is measurement_context
+            and measurement is retained_measurement
+            and memory is sentinel.memory,
+            "qualification measurement collection replaced metric phase evidence",
+        )
+        return sentinel.metric
+
+    def retain_host(actual_context, actual_runner, actual_measurement, *, cache_state):
+        require(
+            actual_context is measurement_context
+            and actual_runner is runner
+            and actual_measurement is retained_measurement
+            and cache_state == "reused",
+            "qualification host did not receive the proved cache state",
+        )
+        return sentinel.host
+
+    with (
+        patch.object(
+            qualification_metrics,
+            "_qualification_measurement_sources",
+            return_value=(retained_measurement, sentinel.memory),
+        ),
+        patch.object(
+            qualification_metrics,
+            "_qualification_cache_state_from_scenarios",
+            side_effect=derive_cache_state,
+        ),
+        patch.object(
+            qualification_metrics,
+            "_retained_qualification_metric",
+            side_effect=retain_metric,
+        ),
+        patch.object(
+            qualification_metrics,
+            "_qualification_host",
+            side_effect=retain_host,
+        ),
+    ):
+        retained = qualification_metrics.collect_qualification_measurements(
+            measurement_context,
+            runner,
+            scenarios,
+        )
+    require(
+        retained.measurement is retained_measurement
+        and retained.memory is sentinel.memory
+        and retained.host is sentinel.host
+        and retained.metrics == {"sentinel_metric": sentinel.metric},
+        "qualification measurement collection returned stale phase evidence",
+    )
 
 
 def _qualification_workflow_dataflow_self_test() -> None:
@@ -195,6 +278,7 @@ def _qualification_workflow_dataflow_self_test() -> None:
 
 def run_qualification_self_tests() -> None:
     _qualification_cache_state_self_tests()
+    _qualification_measurement_dataflow_self_test()
     _qualification_workflow_dataflow_self_test()
     retry = validate_retry_state(
         {

--- a/.github/scripts/packaged_agent_proof/self_test_qualification.py
+++ b/.github/scripts/packaged_agent_proof/self_test_qualification.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 import copy
+from types import SimpleNamespace
 
 from .foundation import ProofFailure, require
+from .qualification_metrics import _qualification_host
+from .qualification_production_types import (
+    QualificationRunnerEvidence,
+    QualificationScenarioEvidence,
+)
 from .qualification_scenario_evidence import validate_replay_attempts, validate_retry_state
 
 
@@ -28,7 +34,80 @@ def _replay_attempt(
     return attempt
 
 
+def _qualification_cache_state_self_tests() -> None:
+    context = SimpleNamespace(
+        args=SimpleNamespace(engine_policy="accelerated"),
+        runtime={
+            "identity": {
+                "embedding_backend": "metal",
+                "embedding_engine_residency": "resident",
+            },
+            "same_account": {"account_id": "uid:501"},
+            "materialization": {
+                "sha256": "a" * 64,
+                "reused_on_rejoin": False,
+            },
+        },
+        manifest={"asset_target": "macos-arm64"},
+        archive_sha256="b" * 64,
+    )
+    runner = QualificationRunnerEvidence(
+        output={},
+        expected_status="pass",
+        expected_backend="metal",
+        matrix_cell_id="protected_macos_arm64_metal",
+        matrix_cell={
+            "host_class": "protected_self_hosted_macos_arm64",
+            "accelerator_claim": "metal",
+            "cache_state": "reused",
+        },
+    )
+    reused_scenario = QualificationScenarioEvidence(
+        shared_identity={},
+        scenarios={
+            "true_idle_respawn": {
+                "assertions": {"verified_materialization_reused": True}
+            }
+        },
+    )
+    measurement = {"unplanned_suspend": False}
+    host = _qualification_host(context, runner, reused_scenario, measurement)
+    require(
+        context.runtime["materialization"]["reused_on_rejoin"] is False
+        and host["cache_state"] == "reused",
+        "cold bootstrap state overrode proved qualification replacement reuse",
+    )
+
+    for hostile, message in (
+        (
+            QualificationScenarioEvidence(
+                shared_identity={},
+                scenarios={
+                    "true_idle_respawn": {
+                        "assertions": {"verified_materialization_reused": False}
+                    }
+                },
+            ),
+            "false qualification replacement reuse was accepted",
+        ),
+        (
+            QualificationScenarioEvidence(
+                shared_identity={},
+                scenarios={"true_idle_respawn": {"assertions": {}}},
+            ),
+            "missing qualification replacement reuse proof was accepted",
+        ),
+    ):
+        try:
+            _qualification_host(context, runner, hostile, measurement)
+        except ProofFailure:
+            pass
+        else:
+            raise ProofFailure(message)
+
+
 def run_qualification_self_tests() -> None:
+    _qualification_cache_state_self_tests()
     retry = validate_retry_state(
         {
             "code": "embedding_server_owner_unresponsive",

--- a/.github/scripts/packaged_agent_proof/self_test_qualification.py
+++ b/.github/scripts/packaged_agent_proof/self_test_qualification.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import copy
 from types import SimpleNamespace
+from unittest.mock import patch, sentinel
 
+from . import qualification_workflow
 from .foundation import ProofFailure, require
-from .qualification_metrics import _qualification_host
+from .qualification_metrics import (
+    _qualification_cache_state_from_scenarios,
+    _qualification_host,
+)
 from .qualification_production_types import (
     QualificationRunnerEvidence,
     QualificationScenarioEvidence,
@@ -49,7 +54,6 @@ def _qualification_cache_state_self_tests() -> None:
             },
         },
         manifest={"asset_target": "macos-arm64"},
-        archive_sha256="b" * 64,
     )
     runner = QualificationRunnerEvidence(
         output={},
@@ -71,7 +75,16 @@ def _qualification_cache_state_self_tests() -> None:
         },
     )
     measurement = {"unplanned_suspend": False}
-    host = _qualification_host(context, runner, reused_scenario, measurement)
+    cache_state = _qualification_cache_state_from_scenarios(
+        runner.matrix_cell["cache_state"],
+        reused_scenario,
+    )
+    host = _qualification_host(
+        context,
+        runner,
+        measurement,
+        cache_state=cache_state,
+    )
     require(
         context.runtime["materialization"]["reused_on_rejoin"] is False
         and host["cache_state"] == "reused",
@@ -99,15 +112,90 @@ def _qualification_cache_state_self_tests() -> None:
         ),
     ):
         try:
-            _qualification_host(context, runner, hostile, measurement)
+            _qualification_cache_state_from_scenarios(
+                runner.matrix_cell["cache_state"],
+                hostile,
+            )
         except ProofFailure:
             pass
         else:
             raise ProofFailure(message)
 
 
+def _qualification_workflow_dataflow_self_test() -> None:
+    validated_scenarios = QualificationScenarioEvidence(
+        shared_identity={"server_instance_id": "validated"},
+        scenarios={"true_idle_respawn": {"assertions": {}}},
+    )
+
+    def retain_measurements(context, runner, scenarios):
+        require(
+            context is sentinel.context
+            and runner is sentinel.runner
+            and scenarios is validated_scenarios,
+            "qualification workflow replaced validated scenarios before measurement retention",
+        )
+        return sentinel.measurements
+
+    def retain_outputs(context, runner, scenarios, measurements):
+        require(
+            context is sentinel.context
+            and runner is sentinel.runner
+            and scenarios is validated_scenarios
+            and measurements is sentinel.measurements,
+            "qualification workflow replaced validated producer phase evidence",
+        )
+        return sentinel.output
+
+    with (
+        patch.object(
+            qualification_workflow,
+            "prepare_qualification_producer",
+            return_value=sentinel.context,
+        ),
+        patch.object(
+            qualification_workflow,
+            "collect_qualification_external_evidence",
+            return_value=sentinel.external,
+        ),
+        patch.object(
+            qualification_workflow,
+            "run_qualification_producer",
+            return_value=sentinel.runner,
+        ),
+        patch.object(
+            qualification_workflow,
+            "collect_qualification_scenarios",
+            return_value=validated_scenarios,
+        ),
+        patch.object(
+            qualification_workflow,
+            "collect_qualification_measurements",
+            side_effect=retain_measurements,
+        ),
+        patch.object(
+            qualification_workflow,
+            "write_qualification_outputs",
+            side_effect=retain_outputs,
+        ),
+    ):
+        result = qualification_workflow.produce_qualification_evidence(
+            sentinel.args,
+            sentinel.qualification_cli,
+            sentinel.env,
+            sentinel.root,
+            sentinel.runtime,
+            sentinel.manifest,
+            sentinel.archive_sha256,
+            sentinel.measurement_contract,
+            sentinel.server_cleanup_control,
+        )
+    require(result is sentinel.output, "qualification workflow returned stale evidence")
+
+
 def run_qualification_self_tests() -> None:
     _qualification_cache_state_self_tests()
+    _qualification_workflow_dataflow_self_test()
     retry = validate_retry_state(
         {
             "code": "embedding_server_owner_unresponsive",


### PR DESCRIPTION
## Context

The exact macOS package passed Metal execution, all 11 qualification metrics, all eight lifecycle/fault scenarios, and true-idle at 60,005.15ms under the 62,500ms bound. Retention then mislabeled the warmed qualification model cache from the earlier intentionally cold two-host bootstrap state.

Archive candidate caching is separate and remains keyed by exact source SHA, target, and archive digest.

## Change

- thread the exact validated runner and scenario objects through qualification production
- derive cache state in a narrow helper that accepts only that runner plus validated scenarios and reads the runner matrix internally
- retain `cache_state: reused` only when `true_idle_respawn` proved replacement materialization reuse
- reject false or missing reuse evidence instead of copying the selected claim
- pin object identity across workflow → measurement collection → cache derivation → output

## Review

Exact head: `32f92ab0d4c4eaee7d473d1fa6c3650718516204`

The change is confined to qualification evidence production and its focused Python self-test. No workflow, claim graph, package, Rust, archive-cache, accelerator, or threshold change.

## Verification

- focused qualification self-test: 0.06s
- independent verifier rejected archive/context substitution, fabricated runner, fabricated scenarios, cold-bootstrap derivation, false reuse, missing reuse, unproved selected state, both workflow-to-collection identity breaks, and both output identity breaks
- exact-head plugin-static packaged-proof contracts passed in 3m01s
- unrelated retrieval Rust job was cancelled under the focused-support-PR rule
- two earlier revisions were rejected and superseded before merge; their evidence is invalid

## Risk

Retention now depends on the exact runner and scenario objects already accepted by the preregistered assertion contract. Neither archive transfer state nor earlier bootstrap materialization is an input to cache-state derivation. No Metal or broad proof belongs on this support PR.

Closes #1626
Refs #1558.