### PR TITLE
Materialize reused source proof before release closeout

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -3076,23 +3076,43 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   requireStepRun(violations, releaseFile, preCloseout, "Authenticate pre-publish Actions provenance", [
     "producer-map",
     "--phase pre_publish",
-    "artifact_ids",
     "bash .github/scripts/collect-actions-job-evidence.sh",
     "--job-evidence target/release-closeout/job-evidence.json",
   ]);
-  const preDownload = namedStep(preCloseout, "Download selected pre-publish release cells");
+  const preDownload = namedStep(
+    preCloseout,
+    "Download and verify selected pre-publish release cells",
+  );
   add(
     violations,
-    preDownload?.uses === "actions/download-artifact@v8.0.1"
-      && object(preDownload.with)["artifact-ids"] === "${{ steps.pre-publish-provenance.outputs.artifact_ids }}"
-      && object(preDownload.with)["merge-multiple"] === false,
-    `${releaseFile} pre-publish closeout must download selected Actions artifact ids without flattening`,
+    preDownload?.uses === undefined && preDownload?.shell === "bash",
+    `${releaseFile} pre-publish closeout must materialize exact Actions artifact ids in blocking shell`,
   );
-  requireStepRun(violations, releaseFile, preCloseout, "Verify selected pre-publish artifact container digests", [
-    "/actions/artifacts/$artifact_id/zip",
-    "sha256sum",
-    "test \"$actual_digest\" = \"$expected_digest\"",
-  ]);
+  requireStepRun(
+    violations,
+    releaseFile,
+    preCloseout,
+    "Download and verify selected pre-publish release cells",
+    [
+      "test \"$(jq -r '.artifacts | length' \"$producer_map\")\" -gt 0",
+      ".artifacts[] | [.id, .name, .digest] | @tsv",
+      'destination="target/release-cell-manifests/$artifact_name"',
+      "test ! -e \"$destination\"",
+      "/actions/artifacts/$artifact_id/zip",
+      "sha256sum",
+      "test \"$actual_digest\" = \"$expected_digest\"",
+      "unzip -q \"$archive\" -d \"$destination\"",
+      "test -d \"target/release-cell-manifests/$artifact_name\"",
+    ],
+  );
+  add(
+    violations,
+    !list(preCloseout.steps).some(
+      (step) => object(step).uses === "actions/download-artifact@v8.0.1"
+        && object(step).with["artifact-ids"] !== undefined,
+    ),
+    `${releaseFile} pre-publish closeout must not filter mixed-run artifact ids through one Actions run`,
+  );
   requireStepRun(violations, releaseFile, preCloseout, "Evaluate authenticated pre-publish closeout", [
     "--trusted-producers",
     "codestory-release-closeout.mjs evaluate",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -5700,6 +5700,166 @@ test("controlled semantic workflow fixtures emit class-prefixed diagnostics", as
   }
 });
 
+test("pre-publish closeout materializes exact artifact ids across workflow runs", (t) => {
+  const workflow = loadWorkflows().get("release.yml");
+  const materialize = draftStep(
+    workflow.jobs["pre-publish-closeout"],
+    "Download and verify selected pre-publish release cells",
+  ).run;
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), "codestory-cross-run-closeout-"));
+  t.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const makeArchive = (id, fileName, contents) => {
+    const source = path.join(fixtureRoot, `source-${id}`);
+    const archive = path.join(fixtureRoot, `${id}.zip`);
+    mkdirSync(source);
+    writeFileSync(path.join(source, fileName), contents);
+    const zipped = spawnSync("zip", ["-q", archive, fileName], {
+      cwd: source,
+      encoding: "utf8",
+    });
+    assert.equal(zipped.status, 0, zipped.stderr || zipped.stdout);
+    return {
+      archive,
+      digest: `sha256:${createHash("sha256").update(readFileSync(archive)).digest("hex")}`,
+      fileName,
+      contents,
+    };
+  };
+  const current = {
+    id: "1001",
+    name: "release-cell-prepublish-package-linux-x64-attempt-2",
+    runId: "12345",
+    ...makeArchive("1001", "package_identity_linux-x64.json", "{\"run\":\"current\"}\n"),
+  };
+  const reused = {
+    id: "2002",
+    name: "release-cell-prepublish-source-attempt-1",
+    runId: "777",
+    ...makeArchive("2002", "source_behavior.json", "{\"run\":\"reused\"}\n"),
+  };
+
+  const fakeBin = path.join(fixtureRoot, "bin");
+  mkdirSync(fakeBin);
+  const fakeCurl = path.join(fakeBin, "curl");
+  writeFileSync(fakeCurl, `#!/usr/bin/env bash
+set -euo pipefail
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output=$2
+      shift 2
+      ;;
+    --header)
+      shift 2
+      ;;
+    --fail|--location|--silent|--show-error)
+      shift
+      ;;
+    http*)
+      url=$1
+      shift
+      ;;
+    *)
+      echo "unexpected curl argument: $1" >&2
+      exit 64
+      ;;
+  esac
+done
+case "$url" in
+  */actions/artifacts/1001/zip) source_archive=$FIXTURE_CURRENT_ARCHIVE ;;
+  */actions/artifacts/2002/zip) source_archive=$FIXTURE_REUSED_ARCHIVE ;;
+  *)
+    echo "artifact was not requested by exact repository artifact id: $url" >&2
+    exit 65
+    ;;
+esac
+cp "$source_archive" "$output"
+printf '%s\\n' "$url" >> "$FIXTURE_URL_LOG"
+`);
+  chmodSync(fakeCurl, 0o755);
+
+  const producerMap = {
+    artifacts: [current, reused].map(({ id, name, digest, runId }) => ({
+      id,
+      name,
+      digest,
+      workflow_run_id: runId,
+    })),
+  };
+  const execute = (script, label) => {
+    const directory = path.join(fixtureRoot, label);
+    const closeout = path.join(directory, "target", "release-closeout");
+    const urlLog = path.join(directory, "urls.log");
+    mkdirSync(closeout, { recursive: true });
+    writeFileSync(
+      path.join(closeout, "trusted-pre-publish-producers.json"),
+      `${JSON.stringify(producerMap)}\n`,
+    );
+    writeFileSync(urlLog, "");
+    return {
+      directory,
+      urlLog,
+      result: spawnSync("bash", ["-c", script], {
+        cwd: directory,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+          FIXTURE_CURRENT_ARCHIVE: current.archive,
+          FIXTURE_REUSED_ARCHIVE: reused.archive,
+          FIXTURE_URL_LOG: urlLog,
+          GH_TOKEN: "test-token",
+          GITHUB_API_URL: "https://api.github.test",
+          GITHUB_REPOSITORY: "TheGreenCedar/CodeStory",
+          GITHUB_RUN_ID: current.runId,
+        },
+      }),
+    };
+  };
+
+  const accepted = execute(materialize, "accepted");
+  assert.equal(
+    accepted.result.status,
+    0,
+    accepted.result.stderr || accepted.result.stdout,
+  );
+  for (const artifact of [current, reused]) {
+    assert.equal(
+      readFileSync(
+        path.join(
+          accepted.directory,
+          "target",
+          "release-cell-manifests",
+          artifact.name,
+          artifact.fileName,
+        ),
+        "utf8",
+      ),
+      artifact.contents,
+    );
+  }
+  const requested = readFileSync(accepted.urlLog, "utf8").trim().split("\n");
+  assert.deepEqual(requested, [
+    "https://api.github.test/repos/TheGreenCedar/CodeStory/actions/artifacts/1001/zip",
+    "https://api.github.test/repos/TheGreenCedar/CodeStory/actions/artifacts/2002/zip",
+  ]);
+
+  const currentRunOnly = materialize.replace(
+    ".artifacts[] | [.id, .name, .digest] | @tsv",
+    ".artifacts[] | select(.workflow_run_id == env.GITHUB_RUN_ID) | [.id, .name, .digest] | @tsv",
+  );
+  assert.notEqual(currentRunOnly, materialize, "current-run-only mutation did not apply");
+  const rejected = execute(currentRunOnly, "current-run-only");
+  assert.equal(
+    rejected.result.status,
+    1,
+    "a current-run-only transfer silently dropped the reused source container",
+  );
+});
+
 test("release policy rejects manifest producer, trusted-map, and publication bypasses", () => {
   const mutations = [
     ["call expected head", workflows => { delete workflows.get("release.yml").on.workflow_call.inputs.expected_head_sha; }],
@@ -5793,16 +5953,40 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
         .find(({ name }) => name === "Evaluate authenticated pre-publish closeout");
       step.run = step.run.replace("--trusted-producers", "--self-attested-producers");
     }],
-    ["flattened current-run JSON", workflows => {
+    ["run-scoped pre-publish artifact action", workflows => {
+      const steps = workflows.get("release.yml").jobs["pre-publish-closeout"].steps;
+      const index = steps.findIndex(
+        ({ name }) => name === "Download and verify selected pre-publish release cells",
+      );
+      steps[index] = {
+        name: "Download and verify selected pre-publish release cells",
+        uses: "actions/download-artifact@v8.0.1",
+        with: {
+          "artifact-ids": "${{ steps.pre-publish-provenance.outputs.artifact_ids }}",
+          path: "target/release-cell-manifests",
+          "merge-multiple": false,
+        },
+      };
+    }],
+    ["current-run-only pre-publish artifact selection", workflows => {
       const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
-        .find(({ name }) => name === "Download selected pre-publish release cells");
-      delete step.with["artifact-ids"];
-      step.with.pattern = "release-cell-prepublish-*";
-      step.with["merge-multiple"] = true;
+        .find(({ name }) => name === "Download and verify selected pre-publish release cells");
+      step.run = step.run.replace(
+        ".artifacts[] | [.id, .name, .digest] | @tsv",
+        ".artifacts[] | select(.workflow_run_id == env.GITHUB_RUN_ID) | [.id, .name, .digest] | @tsv",
+      );
+    }],
+    ["flattened pre-publish artifact extraction", workflows => {
+      const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
+        .find(({ name }) => name === "Download and verify selected pre-publish release cells");
+      step.run = step.run.replace(
+        'destination="target/release-cell-manifests/$artifact_name"',
+        'destination="target/release-cell-manifests"',
+      );
     }],
     ["container digest warning accepted", workflows => {
       const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
-        .find(({ name }) => name === "Verify selected pre-publish artifact container digests");
+        .find(({ name }) => name === "Download and verify selected pre-publish release cells");
       step.run = step.run.replace(
         'test "$actual_digest" = "$expected_digest"',
         'echo "$actual_digest $expected_digest"',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -561,7 +561,6 @@ jobs:
           fetch-depth: 0
 
       - name: Authenticate pre-publish Actions provenance
-        id: pre-publish-provenance
         env:
           GH_TOKEN: ${{ github.token }}
           REUSE_SELECTION: ${{ needs.preflight.outputs.reuse }}
@@ -581,36 +580,34 @@ jobs:
             --reuse "$REUSE_SELECTION" \
             --job-evidence target/release-closeout/job-evidence.json \
             --out target/release-closeout/trusted-pre-publish-producers.json
-          artifact_ids="$(jq -r '[.artifacts[].id] | join(",")' target/release-closeout/trusted-pre-publish-producers.json)"
-          test -n "$artifact_ids"
-          echo "artifact_ids=$artifact_ids" >> "$GITHUB_OUTPUT"
 
-      - name: Download selected pre-publish release cells
-        uses: actions/download-artifact@v8.0.1
-        with:
-          artifact-ids: ${{ steps.pre-publish-provenance.outputs.artifact_ids }}
-          path: target/release-cell-manifests
-          merge-multiple: false
-
-      - name: Verify selected pre-publish artifact container digests
+      - name: Download and verify selected pre-publish release cells
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p target/release-cell-containers
-          jq -r '.artifacts[] | [.id, .digest] | @tsv' target/release-closeout/trusted-pre-publish-producers.json |
-            while IFS=$'\t' read -r artifact_id expected_digest; do
-              archive="target/release-cell-containers/$artifact_id.zip"
-              curl --fail --location --silent --show-error \
-                --header "Accept: application/vnd.github+json" \
-                --header "Authorization: Bearer $GH_TOKEN" \
-                --header "X-GitHub-Api-Version: 2022-11-28" \
-                "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
-                --output "$archive"
-              actual_digest="sha256:$(sha256sum "$archive" | awk '{print $1}')"
-              test "$actual_digest" = "$expected_digest"
-            done
+          producer_map=target/release-closeout/trusted-pre-publish-producers.json
+          test "$(jq -r '.artifacts | length' "$producer_map")" -gt 0
+          mkdir -p target/release-cell-containers target/release-cell-manifests
+          while IFS=$'\t' read -r artifact_id artifact_name expected_digest; do
+            archive="target/release-cell-containers/$artifact_id.zip"
+            destination="target/release-cell-manifests/$artifact_name"
+            test ! -e "$destination"
+            curl --fail --location --silent --show-error \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
+              --output "$archive"
+            actual_digest="sha256:$(sha256sum "$archive" | awk '{print $1}')"
+            test "$actual_digest" = "$expected_digest"
+            mkdir "$destination"
+            unzip -q "$archive" -d "$destination"
+          done < <(jq -r '.artifacts[] | [.id, .name, .digest] | @tsv' "$producer_map")
+          while IFS= read -r artifact_name; do
+            test -d "target/release-cell-manifests/$artifact_name"
+          done < <(jq -r '.artifacts[].name' "$producer_map")
 
       - name: Evaluate authenticated pre-publish closeout
         shell: bash


### PR DESCRIPTION
Auto Release run 30594340584 proved every package and protected GPU lane, then stopped before publication. The pre-publish producer map selected ten authenticated release-cell artifacts, including the reused source proof from run 30591388832, but one run-scoped `actions/download-artifact` invocation unpacked only the nine artifacts produced by the publishing run. Its later exact-ID REST loop authenticated all ten ZIPs but did not extract them.

## What changed

- Pre-publish closeout now downloads every selected container once through its exact repository artifact ID.
- It verifies the producer-map SHA-256 before extracting each container under its authenticated artifact name.
- Duplicate destinations, digest mismatches, missing extraction, flattening, and current-run-only selection remain blocking failures.
- Workflow policy owns the transport shape, and its test executes a mixed-run fixture through the real inline shell step.

The job DAG and claim graph do not change, so `release-claims.json` is intentionally unchanged.

## Review

The critical path is `.github/workflows/release.yml` → `Download and verify selected pre-publish release cells`. The policy must continue requiring exact ID, digest equality, one named destination per artifact, and extraction before closeout evaluation.

## Verification

Independent verifier, exact branch head `5cfdfdc9`:

- Real producer map from Auto Release 30594340584 attempt 2 selected 10/10 artifacts: nine current-run cells plus reused source artifact `8778645373` from run 30591388832.
- The patched inline step downloaded and verified all ten; existing closeout evaluation accepted with `required=10`, `passed=10`, `failed=0`, `missing=0`.
- Current-run-only selection, flattened output, duplicate names, omitted extraction, and digest-check-as-advice mutations all failed.
- Focused workflow-policy regressions: 2/2 passed.
- Workflow policy, actionlint, and `git diff --check` passed.

No calibration, broad source proof, package build, or release run was dispatched on this support PR head.

## Risk

This replaces two pre-publish downloads with one exact-ID download per selected small release-cell container. Post-publish transport is unchanged because it has no cross-run reuse. Publication remains behind the same producer map and closeout evaluator.

Closes #1629
