### PR TITLE
Freeze the final repaired 0.16.3 calibration

### DIFF
--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,7 +1,7 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 40,
+      "retry_after_ms": 44,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
@@ -9,7 +9,7 @@
     "election_backoff_policy": {
       "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 102
+      "maximum_backoff_ms": 122
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "8e46bb349077ab8aa57c8641ead724b7550eae326dca5b2315a37b6131d65a92",
+    "calibration_freeze_digest": "9c84f7f2975edb0987c5e86b9e185f625293f9c0b97a2d60648150c5d11b6e32",
+    "input_constant_set_sha256": "ea58d298473ddf320469d15dc7c32176a1109d615a689c15ff76b67fb337e109",
+    "measurement_protocol_sha256": "d1bb9b2c7eb354fe98990aa32eedc0e165b0cf804212966e0a2ee362a2f5bf8e",
+    "protocol_sha256": "f4a3fa4afb4d5bcd8e707a5e21b687cdd023dc3398b28ff6891a2318e89c5ec7",
+    "run_artifact_sha256s": [
+      "1e163923abfa866471adf39cc8eaef76caf85f8e6b574e38c46f4d0521f784bc",
+      "5650984c5c20ae51dfd3d1d0a3991fcd8595cb56bb17c953363ed56a00455394",
+      "e7a17b60ac96684a952eeba8779bff6a2ac8614b8944d9e980120a6efc8dd0ee"
+    ],
+    "selected_at": "github-actions-run:30598888717:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "35efd4f08b6cc544dee11270fee3d61b28fd16a1",
+    "selection_source_tree": "9938542124d0b56578709efc13b30c077fa1eb1d"
+  },
   "qualification_thresholds": {
     "backend_observed_accelerator_residency": 1,
     "bulk_documents_per_second": 2,
@@ -60,5 +75,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,15 +1,15 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 66,
+      "retry_after_ms": 40,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 8,
+      "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 106
+      "maximum_backoff_ms": 102
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "9c9476f3098c7836394d84089a7856858c1c9eda7b6a8c0bc482796adc72f683",
-    "calibration_freeze_digest": "6ccda709725bfa3397e1595db0e866e94c1507e7ee370000b37e99ab803cdba2",
-    "input_constant_set_sha256": "ea58d298473ddf320469d15dc7c32176a1109d615a689c15ff76b67fb337e109",
-    "measurement_protocol_sha256": "d1bb9b2c7eb354fe98990aa32eedc0e165b0cf804212966e0a2ee362a2f5bf8e",
-    "protocol_sha256": "f4a3fa4afb4d5bcd8e707a5e21b687cdd023dc3398b28ff6891a2318e89c5ec7",
-    "run_artifact_sha256s": [
-      "1e3bd8da8bb21fd6196a71101d17a49e70c2a57bc8baf6f6d8a7e16463259a2b",
-      "b38c009d4190c360bcf7790239d2cf22beea6bfb64c2920a1cd48019b0851dbb",
-      "dd204de79a20f6347e2c83e00876ba62840d3d3b619befa5fb1712f85b6c1ba8"
-    ],
-    "selected_at": "github-actions-run:30590903374:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "ac2d788bd1de84ad7cc241f8d2a7efdabf8c9d35",
-    "selection_source_tree": "88583ad49a26f38cfb5f00aee6aee0236a70c833"
-  },
+  "freeze_record": null,
   "qualification_thresholds": {
     "backend_observed_accelerator_residency": 1,
     "bulk_documents_per_second": 2,
@@ -75,5 +60,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }


### PR DESCRIPTION
This freezes the final 0.16.3 runtime constants after all support PRs, including #1581, #1622, and the cross-run release-closeout repair #1630, were integrated into `dev/codestory-next`.

## What changed

The PR's net source diff is one file:

- `crates/codestory-llama-sys/per-user-embedding-server-constant-set.json`

Calibration source `35efd4f08b6cc544dee11270fee3d61b28fd16a1` restored that file to the canonical unfrozen input. Protected macOS Metal calibration run `30598888717` generated the frozen file now committed at `fba7dbdde7ec533188f84f3d3d63934f732d3782`. No workflow or product source changed after calibration.

## Evidence

- Focused draft source, Linux contracts, rustdoc, workflow-policy, and calibration self-tests passed.
- Calibration-source hostile mutations and the Windows native probe passed in run `30598710638`.
- The sole calibration run `30598888717` passed in 3m04s: macOS Metal only, three fresh server generations, one sample per metric, no CPU or qualification lane.
- The generated constant set is byte-identical to artifact `embedding-calibration-bundle-35efd4f08b6cc544dee11270fee3d61b28fd16a1` and is the only path changed from its calibration source.
- Deterministic selection and calibration-release lineage validation passed.
- Frozen-candidate hostile mutations and the Windows native probe passed in run `30599143120`.
- The one broad exact-head source proof is run `30599340822`; frozen-candidate qualification follows only if it passes.

## Risk and rollback

The runtime constants are bound to the authenticated calibration source and bundle. Any later source or workflow commit invalidates this candidate. Rollback is the prior constant set; it cannot be mixed with this candidate's proof receipt or calibration bundle.

Closes #1631
Refs #1179
