### PR TITLE
Release CodeStory 0.16.3

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -3076,23 +3076,43 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   requireStepRun(violations, releaseFile, preCloseout, "Authenticate pre-publish Actions provenance", [
     "producer-map",
     "--phase pre_publish",
-    "artifact_ids",
     "bash .github/scripts/collect-actions-job-evidence.sh",
     "--job-evidence target/release-closeout/job-evidence.json",
   ]);
-  const preDownload = namedStep(preCloseout, "Download selected pre-publish release cells");
+  const preDownload = namedStep(
+    preCloseout,
+    "Download and verify selected pre-publish release cells",
+  );
   add(
     violations,
-    preDownload?.uses === "actions/download-artifact@v8.0.1"
-      && object(preDownload.with)["artifact-ids"] === "${{ steps.pre-publish-provenance.outputs.artifact_ids }}"
-      && object(preDownload.with)["merge-multiple"] === false,
-    `${releaseFile} pre-publish closeout must download selected Actions artifact ids without flattening`,
+    preDownload?.uses === undefined && preDownload?.shell === "bash",
+    `${releaseFile} pre-publish closeout must materialize exact Actions artifact ids in blocking shell`,
   );
-  requireStepRun(violations, releaseFile, preCloseout, "Verify selected pre-publish artifact container digests", [
-    "/actions/artifacts/$artifact_id/zip",
-    "sha256sum",
-    "test \"$actual_digest\" = \"$expected_digest\"",
-  ]);
+  requireStepRun(
+    violations,
+    releaseFile,
+    preCloseout,
+    "Download and verify selected pre-publish release cells",
+    [
+      "test \"$(jq -r '.artifacts | length' \"$producer_map\")\" -gt 0",
+      ".artifacts[] | [.id, .name, .digest] | @tsv",
+      'destination="target/release-cell-manifests/$artifact_name"',
+      "test ! -e \"$destination\"",
+      "/actions/artifacts/$artifact_id/zip",
+      "sha256sum",
+      "test \"$actual_digest\" = \"$expected_digest\"",
+      "unzip -q \"$archive\" -d \"$destination\"",
+      "test -d \"target/release-cell-manifests/$artifact_name\"",
+    ],
+  );
+  add(
+    violations,
+    !list(preCloseout.steps).some(
+      (step) => object(step).uses === "actions/download-artifact@v8.0.1"
+        && object(step).with["artifact-ids"] !== undefined,
+    ),
+    `${releaseFile} pre-publish closeout must not filter mixed-run artifact ids through one Actions run`,
+  );
   requireStepRun(violations, releaseFile, preCloseout, "Evaluate authenticated pre-publish closeout", [
     "--trusted-producers",
     "codestory-release-closeout.mjs evaluate",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -5700,6 +5700,166 @@ test("controlled semantic workflow fixtures emit class-prefixed diagnostics", as
   }
 });
 
+test("pre-publish closeout materializes exact artifact ids across workflow runs", (t) => {
+  const workflow = loadWorkflows().get("release.yml");
+  const materialize = draftStep(
+    workflow.jobs["pre-publish-closeout"],
+    "Download and verify selected pre-publish release cells",
+  ).run;
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), "codestory-cross-run-closeout-"));
+  t.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const makeArchive = (id, fileName, contents) => {
+    const source = path.join(fixtureRoot, `source-${id}`);
+    const archive = path.join(fixtureRoot, `${id}.zip`);
+    mkdirSync(source);
+    writeFileSync(path.join(source, fileName), contents);
+    const zipped = spawnSync("zip", ["-q", archive, fileName], {
+      cwd: source,
+      encoding: "utf8",
+    });
+    assert.equal(zipped.status, 0, zipped.stderr || zipped.stdout);
+    return {
+      archive,
+      digest: `sha256:${createHash("sha256").update(readFileSync(archive)).digest("hex")}`,
+      fileName,
+      contents,
+    };
+  };
+  const current = {
+    id: "1001",
+    name: "release-cell-prepublish-package-linux-x64-attempt-2",
+    runId: "12345",
+    ...makeArchive("1001", "package_identity_linux-x64.json", "{\"run\":\"current\"}\n"),
+  };
+  const reused = {
+    id: "2002",
+    name: "release-cell-prepublish-source-attempt-1",
+    runId: "777",
+    ...makeArchive("2002", "source_behavior.json", "{\"run\":\"reused\"}\n"),
+  };
+
+  const fakeBin = path.join(fixtureRoot, "bin");
+  mkdirSync(fakeBin);
+  const fakeCurl = path.join(fakeBin, "curl");
+  writeFileSync(fakeCurl, `#!/usr/bin/env bash
+set -euo pipefail
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output=$2
+      shift 2
+      ;;
+    --header)
+      shift 2
+      ;;
+    --fail|--location|--silent|--show-error)
+      shift
+      ;;
+    http*)
+      url=$1
+      shift
+      ;;
+    *)
+      echo "unexpected curl argument: $1" >&2
+      exit 64
+      ;;
+  esac
+done
+case "$url" in
+  */actions/artifacts/1001/zip) source_archive=$FIXTURE_CURRENT_ARCHIVE ;;
+  */actions/artifacts/2002/zip) source_archive=$FIXTURE_REUSED_ARCHIVE ;;
+  *)
+    echo "artifact was not requested by exact repository artifact id: $url" >&2
+    exit 65
+    ;;
+esac
+cp "$source_archive" "$output"
+printf '%s\\n' "$url" >> "$FIXTURE_URL_LOG"
+`);
+  chmodSync(fakeCurl, 0o755);
+
+  const producerMap = {
+    artifacts: [current, reused].map(({ id, name, digest, runId }) => ({
+      id,
+      name,
+      digest,
+      workflow_run_id: runId,
+    })),
+  };
+  const execute = (script, label) => {
+    const directory = path.join(fixtureRoot, label);
+    const closeout = path.join(directory, "target", "release-closeout");
+    const urlLog = path.join(directory, "urls.log");
+    mkdirSync(closeout, { recursive: true });
+    writeFileSync(
+      path.join(closeout, "trusted-pre-publish-producers.json"),
+      `${JSON.stringify(producerMap)}\n`,
+    );
+    writeFileSync(urlLog, "");
+    return {
+      directory,
+      urlLog,
+      result: spawnSync("bash", ["-c", script], {
+        cwd: directory,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+          FIXTURE_CURRENT_ARCHIVE: current.archive,
+          FIXTURE_REUSED_ARCHIVE: reused.archive,
+          FIXTURE_URL_LOG: urlLog,
+          GH_TOKEN: "test-token",
+          GITHUB_API_URL: "https://api.github.test",
+          GITHUB_REPOSITORY: "TheGreenCedar/CodeStory",
+          GITHUB_RUN_ID: current.runId,
+        },
+      }),
+    };
+  };
+
+  const accepted = execute(materialize, "accepted");
+  assert.equal(
+    accepted.result.status,
+    0,
+    accepted.result.stderr || accepted.result.stdout,
+  );
+  for (const artifact of [current, reused]) {
+    assert.equal(
+      readFileSync(
+        path.join(
+          accepted.directory,
+          "target",
+          "release-cell-manifests",
+          artifact.name,
+          artifact.fileName,
+        ),
+        "utf8",
+      ),
+      artifact.contents,
+    );
+  }
+  const requested = readFileSync(accepted.urlLog, "utf8").trim().split("\n");
+  assert.deepEqual(requested, [
+    "https://api.github.test/repos/TheGreenCedar/CodeStory/actions/artifacts/1001/zip",
+    "https://api.github.test/repos/TheGreenCedar/CodeStory/actions/artifacts/2002/zip",
+  ]);
+
+  const currentRunOnly = materialize.replace(
+    ".artifacts[] | [.id, .name, .digest] | @tsv",
+    ".artifacts[] | select(.workflow_run_id == env.GITHUB_RUN_ID) | [.id, .name, .digest] | @tsv",
+  );
+  assert.notEqual(currentRunOnly, materialize, "current-run-only mutation did not apply");
+  const rejected = execute(currentRunOnly, "current-run-only");
+  assert.equal(
+    rejected.result.status,
+    1,
+    "a current-run-only transfer silently dropped the reused source container",
+  );
+});
+
 test("release policy rejects manifest producer, trusted-map, and publication bypasses", () => {
   const mutations = [
     ["call expected head", workflows => { delete workflows.get("release.yml").on.workflow_call.inputs.expected_head_sha; }],
@@ -5793,16 +5953,40 @@ test("release policy rejects manifest producer, trusted-map, and publication byp
         .find(({ name }) => name === "Evaluate authenticated pre-publish closeout");
       step.run = step.run.replace("--trusted-producers", "--self-attested-producers");
     }],
-    ["flattened current-run JSON", workflows => {
+    ["run-scoped pre-publish artifact action", workflows => {
+      const steps = workflows.get("release.yml").jobs["pre-publish-closeout"].steps;
+      const index = steps.findIndex(
+        ({ name }) => name === "Download and verify selected pre-publish release cells",
+      );
+      steps[index] = {
+        name: "Download and verify selected pre-publish release cells",
+        uses: "actions/download-artifact@v8.0.1",
+        with: {
+          "artifact-ids": "${{ steps.pre-publish-provenance.outputs.artifact_ids }}",
+          path: "target/release-cell-manifests",
+          "merge-multiple": false,
+        },
+      };
+    }],
+    ["current-run-only pre-publish artifact selection", workflows => {
       const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
-        .find(({ name }) => name === "Download selected pre-publish release cells");
-      delete step.with["artifact-ids"];
-      step.with.pattern = "release-cell-prepublish-*";
-      step.with["merge-multiple"] = true;
+        .find(({ name }) => name === "Download and verify selected pre-publish release cells");
+      step.run = step.run.replace(
+        ".artifacts[] | [.id, .name, .digest] | @tsv",
+        ".artifacts[] | select(.workflow_run_id == env.GITHUB_RUN_ID) | [.id, .name, .digest] | @tsv",
+      );
+    }],
+    ["flattened pre-publish artifact extraction", workflows => {
+      const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
+        .find(({ name }) => name === "Download and verify selected pre-publish release cells");
+      step.run = step.run.replace(
+        'destination="target/release-cell-manifests/$artifact_name"',
+        'destination="target/release-cell-manifests"',
+      );
     }],
     ["container digest warning accepted", workflows => {
       const step = workflows.get("release.yml").jobs["pre-publish-closeout"].steps
-        .find(({ name }) => name === "Verify selected pre-publish artifact container digests");
+        .find(({ name }) => name === "Download and verify selected pre-publish release cells");
       step.run = step.run.replace(
         'test "$actual_digest" = "$expected_digest"',
         'echo "$actual_digest $expected_digest"',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -561,7 +561,6 @@ jobs:
           fetch-depth: 0
 
       - name: Authenticate pre-publish Actions provenance
-        id: pre-publish-provenance
         env:
           GH_TOKEN: ${{ github.token }}
           REUSE_SELECTION: ${{ needs.preflight.outputs.reuse }}
@@ -581,36 +580,34 @@ jobs:
             --reuse "$REUSE_SELECTION" \
             --job-evidence target/release-closeout/job-evidence.json \
             --out target/release-closeout/trusted-pre-publish-producers.json
-          artifact_ids="$(jq -r '[.artifacts[].id] | join(",")' target/release-closeout/trusted-pre-publish-producers.json)"
-          test -n "$artifact_ids"
-          echo "artifact_ids=$artifact_ids" >> "$GITHUB_OUTPUT"
 
-      - name: Download selected pre-publish release cells
-        uses: actions/download-artifact@v8.0.1
-        with:
-          artifact-ids: ${{ steps.pre-publish-provenance.outputs.artifact_ids }}
-          path: target/release-cell-manifests
-          merge-multiple: false
-
-      - name: Verify selected pre-publish artifact container digests
+      - name: Download and verify selected pre-publish release cells
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p target/release-cell-containers
-          jq -r '.artifacts[] | [.id, .digest] | @tsv' target/release-closeout/trusted-pre-publish-producers.json |
-            while IFS=$'\t' read -r artifact_id expected_digest; do
-              archive="target/release-cell-containers/$artifact_id.zip"
-              curl --fail --location --silent --show-error \
-                --header "Accept: application/vnd.github+json" \
-                --header "Authorization: Bearer $GH_TOKEN" \
-                --header "X-GitHub-Api-Version: 2022-11-28" \
-                "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
-                --output "$archive"
-              actual_digest="sha256:$(sha256sum "$archive" | awk '{print $1}')"
-              test "$actual_digest" = "$expected_digest"
-            done
+          producer_map=target/release-closeout/trusted-pre-publish-producers.json
+          test "$(jq -r '.artifacts | length' "$producer_map")" -gt 0
+          mkdir -p target/release-cell-containers target/release-cell-manifests
+          while IFS=$'\t' read -r artifact_id artifact_name expected_digest; do
+            archive="target/release-cell-containers/$artifact_id.zip"
+            destination="target/release-cell-manifests/$artifact_name"
+            test ! -e "$destination"
+            curl --fail --location --silent --show-error \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
+              --output "$archive"
+            actual_digest="sha256:$(sha256sum "$archive" | awk '{print $1}')"
+            test "$actual_digest" = "$expected_digest"
+            mkdir "$destination"
+            unzip -q "$archive" -d "$destination"
+          done < <(jq -r '.artifacts[] | [.id, .name, .digest] | @tsv' "$producer_map")
+          while IFS= read -r artifact_name; do
+            test -d "target/release-cell-manifests/$artifact_name"
+          done < <(jq -r '.artifacts[].name' "$producer_map")
 
       - name: Evaluate authenticated pre-publish closeout
         shell: bash

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,7 +1,7 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 40,
+      "retry_after_ms": 44,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
@@ -9,7 +9,7 @@
     "election_backoff_policy": {
       "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 102
+      "maximum_backoff_ms": 122
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,7 +43,22 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": null,
+  "freeze_record": {
+    "calibration_bundle_sha256": "8e46bb349077ab8aa57c8641ead724b7550eae326dca5b2315a37b6131d65a92",
+    "calibration_freeze_digest": "9c84f7f2975edb0987c5e86b9e185f625293f9c0b97a2d60648150c5d11b6e32",
+    "input_constant_set_sha256": "ea58d298473ddf320469d15dc7c32176a1109d615a689c15ff76b67fb337e109",
+    "measurement_protocol_sha256": "d1bb9b2c7eb354fe98990aa32eedc0e165b0cf804212966e0a2ee362a2f5bf8e",
+    "protocol_sha256": "f4a3fa4afb4d5bcd8e707a5e21b687cdd023dc3398b28ff6891a2318e89c5ec7",
+    "run_artifact_sha256s": [
+      "1e163923abfa866471adf39cc8eaef76caf85f8e6b574e38c46f4d0521f784bc",
+      "5650984c5c20ae51dfd3d1d0a3991fcd8595cb56bb17c953363ed56a00455394",
+      "e7a17b60ac96684a952eeba8779bff6a2ac8614b8944d9e980120a6efc8dd0ee"
+    ],
+    "selected_at": "github-actions-run:30598888717:1",
+    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
+    "selection_source_commit": "35efd4f08b6cc544dee11270fee3d61b28fd16a1",
+    "selection_source_tree": "9938542124d0b56578709efc13b30c077fa1eb1d"
+  },
   "qualification_thresholds": {
     "backend_observed_accelerator_residency": 1,
     "bulk_documents_per_second": 2,
@@ -60,5 +75,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "unfrozen"
+  "status": "frozen"
 }

--- a/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
+++ b/crates/codestory-llama-sys/per-user-embedding-server-constant-set.json
@@ -1,15 +1,15 @@
 {
   "calibration_required_values": {
     "capacity_retry_policy": {
-      "retry_after_ms": 66,
+      "retry_after_ms": 40,
       "retry_class": "after_capacity_change",
       "retry_condition_source": "named_condition_from_typed_capacity_response"
     },
     "connect_timeout_ms": 2000,
     "election_backoff_policy": {
-      "initial_backoff_ms": 8,
+      "initial_backoff_ms": 7,
       "jitter": "sha256(process_start_id||attempt) modulo inclusive [initial_backoff_ms,maximum_backoff_ms]",
-      "maximum_backoff_ms": 106
+      "maximum_backoff_ms": 102
     },
     "hard_native_no_progress_ms": 385431,
     "request_deadlines_ms": {
@@ -43,22 +43,7 @@
     "query_queue_capacity": 64,
     "true_idle_observation_grace_ms": 2500
   },
-  "freeze_record": {
-    "calibration_bundle_sha256": "9c9476f3098c7836394d84089a7856858c1c9eda7b6a8c0bc482796adc72f683",
-    "calibration_freeze_digest": "6ccda709725bfa3397e1595db0e866e94c1507e7ee370000b37e99ab803cdba2",
-    "input_constant_set_sha256": "ea58d298473ddf320469d15dc7c32176a1109d615a689c15ff76b67fb337e109",
-    "measurement_protocol_sha256": "d1bb9b2c7eb354fe98990aa32eedc0e165b0cf804212966e0a2ee362a2f5bf8e",
-    "protocol_sha256": "f4a3fa4afb4d5bcd8e707a5e21b687cdd023dc3398b28ff6891a2318e89c5ec7",
-    "run_artifact_sha256s": [
-      "1e3bd8da8bb21fd6196a71101d17a49e70c2a57bc8baf6f6d8a7e16463259a2b",
-      "b38c009d4190c360bcf7790239d2cf22beea6bfb64c2920a1cd48019b0851dbb",
-      "dd204de79a20f6347e2c83e00876ba62840d3d3b619befa5fb1712f85b6c1ba8"
-    ],
-    "selected_at": "github-actions-run:30590903374:1",
-    "selection_rule": "constant_only_three_fresh_generations_one_sample_each+slow_host_floors_v2",
-    "selection_source_commit": "ac2d788bd1de84ad7cc241f8d2a7efdabf8c9d35",
-    "selection_source_tree": "88583ad49a26f38cfb5f00aee6aee0236a70c833"
-  },
+  "freeze_record": null,
   "qualification_thresholds": {
     "backend_observed_accelerator_residency": 1,
     "bulk_documents_per_second": 2,
@@ -75,5 +60,5 @@
   },
   "schema_version": 1,
   "selection_protocol": "codestory-per-user-embedding-server-v1",
-  "status": "frozen"
+  "status": "unfrozen"
 }


### PR DESCRIPTION
Promotes the accepted 0.16.3 candidate from `dev/codestory-next` to `main`.

Accepted evidence is bound to frozen source head `fba7dbdde7ec533188f84f3d3d63934f732d3782` and preserved by the dev merge commit: the exact-head source proof passed; the candidate archives were authenticated by source SHA and digest; package integrity passed; and real macOS Metal and Windows Vulkan execution was observed. Linux Actions proof is honestly omitted because protected Linux Vulkan hardware was unavailable. Marketplace delivery remains non-gating.

The optional Windows qualification harness timed out waiting for a `crash_server` control event after real Vulkan execution. That harness defect and the linker-timing telemetry defect are accepted follow-ups and do not block this release.