### PR TITLE
Contain hostile-repo fsmonitor execution in read-only git calls

### DIFF
--- a/crates/codestory-cli/src/app/source_commands/affected.rs
+++ b/crates/codestory-cli/src/app/source_commands/affected.rs
@@ -87,7 +87,15 @@ pub(super) fn affected_change_records(
 
 pub(super) fn affected_git_change_output(cmd: &AffectedCommand) -> Result<std::process::Output> {
     let mut command = std::process::Command::new("git");
-    command.arg("-C").arg(&cmd.project.project);
+    // The selected project is untrusted input: repository-local config can
+    // name a `core.fsmonitor` executable that status/diff walks would run.
+    // Disable it (and index writes) for these read-only queries.
+    command
+        .arg("-c")
+        .arg("core.fsmonitor=false")
+        .arg("--no-optional-locks")
+        .arg("-C")
+        .arg(&cmd.project.project);
     match cmd.changes {
         AffectedChangeSource::Head => {
             command

--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -331,7 +331,13 @@ fn git_identity(project: &Path) -> Result<GitIdentity> {
 }
 
 fn git_output(project: &Path, args: &[&str]) -> Result<String> {
+    // The inspected checkout is untrusted: repository-local config can name a
+    // `core.fsmonitor` executable that `git status` would run. Disable it (and
+    // index writes) on every invocation of this read-only inspection.
     let output = Command::new("git")
+        .arg("-c")
+        .arg("core.fsmonitor=false")
+        .arg("--no-optional-locks")
         .arg("-C")
         .arg(project)
         .args(args)

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -862,7 +862,14 @@ fn windows_ordinal_case_fold(source: &[u16]) -> io::Result<Vec<u16>> {
 }
 
 fn git_output(project: &Path, args: &[&str]) -> Result<String, ()> {
+    // The repository under inspection is untrusted input: a checkout can carry
+    // `.git/config` naming a `core.fsmonitor` executable that `git status`
+    // would run. Disable it (and index writes, which a read-only inspection
+    // must never perform) on every invocation.
     let output = Command::new("git")
+        .arg("-c")
+        .arg("core.fsmonitor=false")
+        .arg("--no-optional-locks")
         .arg("-C")
         .arg(project)
         .args(args)
@@ -1372,6 +1379,55 @@ mod tests {
         assert_eq!(dirty.artifact_scope_id, dirty.workspace_id);
         assert_ne!(clean.artifact_scope_id, dirty.artifact_scope_id);
         assert_eq!(dirty.portable_reuse_reason, "git_worktree_dirty");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn hostile_fsmonitor_hook_never_executes_during_identity_inspection() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let Some(project) = git_project() else {
+            return;
+        };
+
+        let marker = project.path().join("fsmonitor-executed");
+        let hook = project.path().join("fsmonitor-hook.sh");
+        fs::write(
+            &hook,
+            format!("#!/bin/sh\ntouch \"{}\"\n", marker.display()),
+        )
+        .expect("write hook");
+        let mut permissions = fs::metadata(&hook).expect("hook metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&hook, permissions).expect("make hook executable");
+        git(
+            project.path(),
+            &["config", "core.fsmonitor", &hook.display().to_string()],
+        );
+
+        // Prove the sentinel is live first: an unconstrained `git status` in
+        // this repository executes the configured hook. Without that, a git
+        // version that ignores `core.fsmonitor` would make the containment
+        // assertion below pass vacuously.
+        let unconstrained = Command::new("git")
+            .arg("-C")
+            .arg(project.path())
+            .args(["status", "--porcelain"])
+            .output()
+            .expect("run unconstrained git status");
+        assert!(unconstrained.status.success());
+        assert!(
+            marker.exists(),
+            "unconstrained git status did not execute the configured core.fsmonitor hook"
+        );
+        fs::remove_file(&marker).expect("reset sentinel");
+
+        let identity = project_identity_v3(project.path());
+        assert!(!identity.project_id.is_empty());
+        assert!(
+            !marker.exists(),
+            "core.fsmonitor hook executed during repository identity inspection"
+        );
     }
 
     fn git_project() -> Option<tempfile::TempDir> {


### PR DESCRIPTION
Closes #1636
Refs #1179

## Stack

Bottom layer of native GitHub stack #1694, targeting
`dev/codestory-next`. PR #1639 is the only layer above it. GitHub applies the
dev branch protections and CI contract to both layers and can merge the pair
atomically from the top PR.

## What

ARCH-000 containment. All three production Git subprocess sites now pass
`-c core.fsmonitor=false --no-optional-locks`:

- `crates/codestory-workspace/src/repository_identity.rs` — `git_output`,
  reached from runtime-context construction and project-scoped requests
- `crates/codestory-runtime/src/cache_rehydrate.rs` — cache rehydration
  identity inspection
- `crates/codestory-cli/src/app/source_commands/affected.rs` — Git-backed
  affected-change discovery

`core.fsmonitor` can execute a repository-configured command during
`git status`. The override prevents an inspected checkout from running that
command as the CodeStory user. `--no-optional-locks` also keeps these
observational reads from opportunistically writing the inspected repository's
index.

The Unix regression test creates an executable fsmonitor sentinel, requires an
unconstrained `git status` to execute it, clears the marker, then proves
CodeStory identity inspection does not execute it. Failure to observe the
unconstrained hook is an assertion failure, so the containment assertion cannot
pass vacuously.

## Scope

Containment only. The broad architecture and code-review snapshots are owned by
the merged v0.17 control-plane package and are not part of this PR. Replacing
Git subprocess inspection with a non-executing in-process reader remains
separate work.

## Exact head

- stack trunk: `49063f9801c62eeebebc2daad62f9ed10cdd55ad`
- head: `5b8c8126abd31a512d45b15a86240f6d2b8d5c3a`

## Local verification

- `cargo test --locked -p codestory-workspace hostile_fsmonitor_hook_never_executes_during_identity_inspection -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo check --locked -p codestory-workspace -p codestory-runtime -p codestory-cli` — passed
- `cargo test --locked -p codestory-cli --test architecture_contracts` — 14 passed
- `node .github/scripts/check-workflow-policy.mjs` — passed
- `node --test .github/scripts/check-workflow-policy.test.mjs` — 1,322 passed
- `cargo test --locked -p codestory-store` — 202 passed
- `cargo test --locked -p codestory-indexer --test fidelity_regression` — 8 passed
- `cargo test --locked -p codestory-indexer --test tictactoe_language_coverage` — 12 passed
- `cargo clippy --locked -p codestory-workspace -p codestory-runtime -p codestory-cli --lib -- -D warnings` — passed
- `git diff --check origin/dev/codestory-next...HEAD` — passed

Exact-head independent review and CI are clean. This PR remains draft until the
top layer is accepted for one atomic stack merge.
