### PR TITLE
Default drill and drill-suite to auto refresh

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -24,8 +24,10 @@ const INDEX_REFRESH_HELP: &str = "Index defaults to `auto`: it chooses `full` fo
 const READ_REFRESH_HELP: &str = "Read commands default to `none` so they only query the existing cache. Use `incremental` to \
 refresh an existing cache in place, or `full` after a cache reset, schema change, or indexing \
 failure. Explicit `incremental` fails with `full_refresh_required` instead of escalating.";
-const DRILL_REFRESH_HELP: &str = "Drill defaults to `full` so each report is mechanically fresh. Use `none` only after a \
-fresh index, or `incremental` to refresh a compatible existing cache without allowing full-refresh escalation.";
+const DRILL_REFRESH_HELP: &str = "Drill defaults to `auto`: it chooses `full` for an empty, pre-current, or structurally \
+incompatible cache and `incremental` for a compatible existing publication, so each report is mechanically fresh without \
+forcing a full rebuild of a compatible cache. Use `none` to query the existing cache only, or `full` to force a rebuild \
+after a cache reset, schema change, or indexing failure. Explicit `incremental` never escalates to `full`.";
 const CLI_LONG_ABOUT: &str = "\
 CodeStory turns a local repository into auditable grounding evidence.
 
@@ -954,7 +956,7 @@ pub(crate) struct DrillCommand {
     #[arg(
         long,
         value_enum,
-        default_value_t = RefreshMode::Full,
+        default_value_t = RefreshMode::Auto,
         long_help = DRILL_REFRESH_HELP
     )]
     pub(crate) refresh: RefreshMode,
@@ -997,7 +999,7 @@ pub(crate) struct DrillSuiteCommand {
     #[arg(
         long,
         value_enum,
-        default_value_t = RefreshMode::Full,
+        default_value_t = RefreshMode::Auto,
         long_help = DRILL_REFRESH_HELP
     )]
     pub(crate) refresh: RefreshMode,
@@ -2652,7 +2654,50 @@ mod tests {
         assert!(help.contains("--profile <PROFILE>"));
         assert!(help.contains("--run-id <ID>"));
         assert!(help.contains("Stored in the report only; it is not interpreted"));
-        assert!(help.contains("Drill defaults to `full`"));
+        assert!(help.contains("Drill defaults to `auto`"));
+        assert!(help.contains("without forcing a full rebuild of a compatible cache"));
+    }
+
+    #[test]
+    fn drill_commands_default_to_auto_refresh() {
+        // `full` replaces the database without copying its bookmark tables, so
+        // making it the default drops annotations even when the existing cache
+        // is compatible. `auto` still guarantees a mechanically fresh report
+        // because it escalates to `full` whenever the cache is empty,
+        // pre-current, or structurally incompatible. Ordinary incremental
+        // `FullReplace` updates have their own annotation-loss path through
+        // `delete_file_projection`; this default change is only containment.
+        let drill = Cli::try_parse_from([
+            "codestory-cli",
+            "drill",
+            "--project",
+            ".",
+            "--anchors",
+            "Alpha",
+            "--output-dir",
+            "target/drill",
+        ])
+        .expect("parse drill");
+        let Command::Drill(drill) = drill.command else {
+            panic!("expected drill command");
+        };
+        assert_eq!(drill.refresh, RefreshMode::Auto);
+
+        let suite = Cli::try_parse_from([
+            "codestory-cli",
+            "drill-suite",
+            "--project",
+            ".",
+            "--case-file",
+            "cases.json",
+            "--output-dir",
+            "target/drill-suite",
+        ])
+        .expect("parse drill-suite");
+        let Command::DrillSuite(suite) = suite.command else {
+            panic!("expected drill-suite command");
+        };
+        assert_eq!(suite.refresh, RefreshMode::Auto);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1638
Refs #1179

## Stack

Top layer of native GitHub stack #1694. Its layer base is PR #1637 at
`5b8c8126abd31a512d45b15a86240f6d2b8d5c3a`; the stack trunk is
`dev/codestory-next` at `49063f9801c62eeebebc2daad62f9ed10cdd55ad`.
Merging this PR through the stack lands both reviewed support layers atomically.

## Context

`drill` and `drill-suite` defaulted to `--refresh full`, so every report forced
the most expensive refresh even when the existing cache was compatible. Full
refresh builds a replacement database, and
`copy_forward_full_refresh_artifacts` does not copy `bookmark_category` or
`bookmark_node`; promoting that replacement therefore drops user annotations.

Ordinary incremental `FullReplace` updates have a separate annotation-loss
path through `delete_file_projection`. This PR is interim containment for the
full-refresh default, not the durable annotation-ownership fix.

## What changed

- Both commands now default to `auto`.
- Help explains that `auto` chooses `full` for an empty, pre-current, or
  structurally incompatible cache and `incremental` for a compatible
  publication, without forcing a full rebuild of a compatible cache.
- The CLI contract tests pin both defaults and the compatible-cache wording.

Reports stay honest:
`crates/codestory-cli/src/app/drill/execution.rs` renders
`refresh_label(cmd.refresh, opened.refresh_mode)`, so an `auto` request that
escalates still reports the effective `full` mode.

## Review

The layer diff is confined to `crates/codestory-cli/src/args.rs`. Review the two
Clap defaults, the shared long-help contract, and the default-parsing test. The
durable sidecar-backed annotation work remains separate.

## Verification

- exact layer base: `5b8c8126abd31a512d45b15a86240f6d2b8d5c3a`
- exact head: `d5ae56d50afb0c9de71503a0a46e4b5d5c60df39`
- the pre-stack and stacked commits have the same stable patch ID:
  `cb576e3001b4487d6c717c8c3ae293e9db0b1f1c`
- `cargo fmt --all -- --check`
- `cargo test --locked -p codestory-cli --lib drill_` — 11 passed on the
  stacked exact head
- `cargo test --locked -p codestory-cli --lib` — 270 passed before the
  topology-only rebase
- `cargo clippy --locked -p codestory-cli --lib -- -D warnings`
- `cargo build --locked -p codestory-cli --bin codestory-cli`
- `node scripts/generate-codestory-skill-syntax.mjs --check`
- `git diff --check HEAD^...HEAD`

## Risk and follow-up

`auto` still selects `full` when compatibility requires it, and incremental
`FullReplace` can still remove annotations. Moving annotations outside
projection/publication lifecycle remains the durable fix.
