### PR TITLE
Add architecture and crate-durability proof floor

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -12,6 +12,7 @@ import {
 
 const workflowRoot = path.join(".github", "workflows");
 const retrievalFile = "retrieval-engine-smoke.yml";
+const crateDurabilityFile = "crate-durability.yml";
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const retrievalGeneralizationSuiteFile = path.join(
   "scripts",
@@ -38,7 +39,7 @@ const nextestLinuxSha256 = "7d07712519615722b19ffe3b3d1097b7d4fa390995e3cac1f9d6
 const sccacheCacheSize = "1G";
 const windowsSccacheCacheSize = "2G";
 
-export { retrievalFile };
+export { crateDurabilityFile, retrievalFile };
 
 function tomlSection(source, section) {
   const header = `[${section}]`;
@@ -1330,6 +1331,216 @@ export function retrievalProducerTriggerPolicyViolations(workflowValue) {
     violations,
     includesAll(at(workflow, "on", "push", "paths"), retrievalProducerTriggerPaths),
     "retrieval cache producer dev push paths must cover every manifest and draft consumer change",
+  );
+  return violations;
+}
+
+export function proofFloorPolicyViolations(
+  workflows,
+  graph = loadReleaseClaimGraph(repositoryRoot),
+) {
+  const violations = [];
+  const policy = object(object(graph.workflow_policy).proof_floor);
+  const architecture = object(policy.architecture_contract);
+  add(
+    violations,
+    architecture.workflow === retrievalFile,
+    `architecture proof must remain owned by ${retrievalFile}`,
+  );
+  const architectureWorkflow = workflows.get(architecture.workflow);
+  add(
+    violations,
+    architectureWorkflow !== undefined,
+    `${architecture.workflow} must exist for the architecture proof floor`,
+  );
+  const architectureJob = object(at(
+    architectureWorkflow,
+    "jobs",
+    architecture.job,
+  ));
+  add(
+    violations,
+    hasExactKeys(architectureJob, ["runs-on", "timeout-minutes", "env", "steps"])
+      && architectureJob["runs-on"] === "ubuntu-latest",
+    `${architecture.workflow} ${architecture.job} must remain an unconditional universal job`,
+  );
+  const architectureStep = namedStep(
+    architectureJob,
+    "Architecture ownership contract tests",
+  );
+  add(
+    violations,
+    sameStrings(nonCommentLines(architectureStep?.run), [architecture.command])
+      && architectureStep?.if === undefined
+      && architectureStep?.["continue-on-error"] === undefined,
+    `${architecture.workflow} ${architecture.job} must run the exact blocking architecture contract`,
+  );
+  add(
+    violations,
+    stepIndex(architectureJob, "Architecture ownership contract tests")
+      < stepIndex(architectureJob, "Seed draft proof test-profile artifacts"),
+    `${architecture.workflow} architecture contract must complete before draft artifacts are seeded and saved`,
+  );
+
+  const durability = object(policy.crate_durability);
+  const file = String(durability.workflow ?? crateDurabilityFile);
+  const workflow = workflows.get(file);
+  add(violations, workflow !== undefined, `${file} must exist`);
+  const triggers = object(workflow?.on);
+  const pullRequest = object(triggers.pull_request);
+  const push = object(triggers.push);
+  const permissions = object(workflow?.permissions);
+  const concurrency = object(workflow?.concurrency);
+  const jobs = object(workflow?.jobs);
+  const job = object(jobs[durability.job]);
+  const steps = list(job.steps).map(object);
+
+  add(
+    violations,
+    hasExactKeys(workflow, ["name", "on", "permissions", "concurrency", "jobs"])
+      && workflow?.name === "crate-durability",
+    `${file} must keep the exact source-only top-level shape`,
+  );
+  add(
+    violations,
+    hasExactKeys(triggers, ["pull_request", "push", "workflow_dispatch"])
+      && triggers.workflow_dispatch === null,
+    `${file} must run only on path-scoped pull requests, base pushes, and input-free dispatch`,
+  );
+  for (const [event, eventValue] of [
+    ["pull_request", pullRequest],
+    ["push", push],
+  ]) {
+    add(
+      violations,
+      list(eventValue.paths).length === list(durability.paths).length
+        && sameMembers(eventValue.paths, durability.paths),
+      `${file} ${event} paths must match the exact owning-path set`,
+    );
+  }
+  add(
+    violations,
+    hasExactKeys(pullRequest, ["paths"])
+      && hasExactKeys(push, ["branches", "paths"])
+      && list(push.branches).length === list(durability.branches).length
+      && sameMembers(push.branches, durability.branches),
+    `${file} push must seed only the declared integration branches`,
+  );
+  add(
+    violations,
+    hasExactKeys(permissions, ["contents"]) && permissions.contents === "read",
+    `${file} permissions must remain contents: read only`,
+  );
+  add(
+    violations,
+    hasExactKeys(concurrency, ["group", "cancel-in-progress"])
+      && concurrency.group
+        === "crate-durability-${{ github.event.pull_request.number || github.ref }}"
+      && concurrency["cancel-in-progress"] === true,
+    `${file} must cancel stale work within one PR or branch`,
+  );
+  add(
+    violations,
+    hasExactKeys(jobs, [durability.job])
+      && hasExactKeys(job, ["runs-on", "timeout-minutes", "steps"])
+      && job["runs-on"] === "ubuntu-latest"
+      && job["timeout-minutes"] === durability.timeout_minutes,
+    `${file} must contain one bounded Ubuntu durability job`,
+  );
+
+  const expectedSteps = [
+    { uses: "actions/checkout@v5", keys: ["uses"] },
+    { name: "Install Rust stable", keys: ["name", "run"] },
+    { name: "Capture Rust cache identity", keys: ["name", "id", "shell", "run"] },
+    {
+      name: "Restore durability Cargo cache",
+      keys: ["name", "id", "uses", "continue-on-error", "with"],
+    },
+    { name: "Run durability and coverage contracts", keys: ["name", "run"] },
+    {
+      name: "Save durability Cargo cache",
+      keys: ["name", "if", "uses", "continue-on-error", "with"],
+    },
+  ];
+  add(
+    violations,
+    steps.length === expectedSteps.length
+      && steps.every((step, index) => {
+        const expected = expectedSteps[index];
+        return hasExactKeys(step, expected.keys)
+          && (expected.name === undefined || step.name === expected.name)
+          && (expected.uses === undefined || step.uses === expected.uses);
+      }),
+    `${file} must retain the exact serial checkout, cache, proof, and save sequence`,
+  );
+
+  const install = namedStep(job, "Install Rust stable");
+  add(
+    violations,
+    sameStrings(nonCommentLines(install?.run), [
+      "rustup toolchain install stable --profile minimal",
+      "rustup default stable",
+    ]),
+    `${file} must use the stable minimal Rust toolchain`,
+  );
+  const capture = namedStep(job, "Capture Rust cache identity");
+  add(
+    violations,
+    sameStrings(nonCommentLines(capture?.run), [
+      `echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"`,
+      `echo "target=$(rustc -Vv | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"`,
+    ]),
+    `${file} cache identity must bind the Rust release and host target`,
+  );
+
+  const restore = namedStep(job, "Restore durability Cargo cache");
+  const restoreWith = object(restore?.with);
+  const expectedCacheKey = [
+    "${{ runner.os }}",
+    durability.cache_namespace,
+    "${{ steps.rust-cache-key.outputs.version }}",
+    "${{ steps.rust-cache-key.outputs.target }}",
+    "${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}",
+    "${{ hashFiles('Cargo.lock') }}",
+  ].join("-");
+  add(
+    violations,
+    restore?.uses === "actions/cache/restore@v5"
+      && restore?.["continue-on-error"] === true
+      && hasExactKeys(restoreWith, ["path", "key"])
+      && sameStrings(nonCommentLines(restoreWith.path), draftCachePaths)
+      && restoreWith.key === expectedCacheKey,
+    `${file} must use its isolated exact Cargo cache without fallback prefixes`,
+  );
+
+  const proof = namedStep(job, "Run durability and coverage contracts");
+  add(
+    violations,
+    sameStrings(nonCommentLines(proof?.run), durability.commands)
+      && proof?.if === undefined
+      && proof?.["continue-on-error"] === undefined,
+    `${file} must run the three declared durability commands serially and blocking`,
+  );
+
+  const save = namedStep(job, "Save durability Cargo cache");
+  const saveWith = object(save?.with);
+  add(
+    violations,
+    save?.uses === "actions/cache/save@v5"
+      && save?.["continue-on-error"] === true
+      && save?.if === cacheSaveCondition
+      && hasExactKeys(saveWith, ["path", "key"])
+      && sameStrings(nonCommentLines(saveWith.path), draftCachePaths)
+      && saveWith.key === cacheSaveKey
+      && stepIndex(job, "Save durability Cargo cache")
+        > stepIndex(job, "Run durability and coverage contracts"),
+    `${file} must save the exact cache only after every durability command passes`,
+  );
+  add(
+    violations,
+    durability.artifact_free === true
+      && !scalarStrings(workflow).some(value => /actions\/upload-artifact@/u.test(value)),
+    `${file} must remain artifact-free`,
   );
   return violations;
 }
@@ -10364,6 +10575,7 @@ export function validateMarketplaceSync(workflows, violations) {
 
 export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
   const violations = [];
+  violations.push(...proofFloorPolicyViolations(workflows, graph));
   violations.push(...benchmarkDependencyIsolationViolations(
     fs.readFileSync(
       path.join(repositoryRoot, "crates", "codestory-bench", "Cargo.toml"),

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -25,6 +25,7 @@ import {
   annotationScopeViolations,
   basicWorkflowViolations,
   benchmarkDependencyIsolationViolations,
+  crateDurabilityFile,
   dispatchInputInterpolationViolations,
   draftSourcePolicyViolations,
   draftWorkflowPolicyViolations,
@@ -35,6 +36,7 @@ import {
   notaryStepViolations,
   packagedPrSigningViolations,
   parseWorkflow,
+  proofFloorPolicyViolations,
   qualificationDriverArtifactViolations,
   releaseEvidenceApprovalViolations,
   releaseProofCpuSelectorViolations,
@@ -5444,6 +5446,100 @@ test("package workflow keeps a packaging-only timeout", () => {
     validateWorkflows(workflows).join("\n"),
     /package build timeout must cover only signed macOS packaging/u,
   );
+});
+
+test("proof floor keeps architecture universal and durability path-scoped", async (t) => {
+  assert.deepEqual(proofFloorPolicyViolations(loadWorkflows()), []);
+
+  const redirectedGraph = structuredClone(loadReleaseClaimGraph(root));
+  redirectedGraph.workflow_policy.proof_floor.architecture_contract.workflow =
+    "alternate-proof.yml";
+  const aliasedWorkflows = loadWorkflows();
+  aliasedWorkflows.set(
+    "alternate-proof.yml",
+    structuredClone(aliasedWorkflows.get(retrievalFile)),
+  );
+  assert.notDeepEqual(
+    proofFloorPolicyViolations(aliasedWorkflows, redirectedGraph),
+    [],
+  );
+
+  const mutations = [
+    ["architecture command removed", workflows => {
+      const steps = workflows.get(retrievalFile).jobs["linux-contracts"].steps;
+      steps.splice(steps.findIndex(step =>
+        step.name === "Architecture ownership contract tests"), 1);
+    }],
+    ["architecture job made conditional", workflows => {
+      workflows.get(retrievalFile).jobs["linux-contracts"].if =
+        "github.event_name == 'workflow_dispatch'";
+    }],
+    ["architecture job made dependent", workflows => {
+      workflows.get(retrievalFile).jobs["linux-contracts"].needs =
+        "windows-manifest-missing";
+    }],
+    ["architecture job put behind an environment", workflows => {
+      workflows.get(retrievalFile).jobs["linux-contracts"].environment =
+        "source-proof";
+    }],
+    ["architecture job made nonblocking", workflows => {
+      workflows.get(retrievalFile).jobs["linux-contracts"]["continue-on-error"] = true;
+    }],
+    ["owning path removed", workflows => {
+      workflows.get(crateDurabilityFile).on.pull_request.paths.shift();
+    }],
+    ["unrelated crate path added", workflows => {
+      const workflow = workflows.get(crateDurabilityFile);
+      workflow.on.pull_request.paths.push("crates/codestory-runtime/**");
+      workflow.on.push.paths.push("crates/codestory-runtime/**");
+    }],
+    ["commands reordered", workflows => {
+      const job = workflows.get(crateDurabilityFile).jobs["linux-durability"];
+      const proof = draftStep(job, "Run durability and coverage contracts");
+      const commands = proof.run.trim().split("\n");
+      [commands[0], commands[1]] = [commands[1], commands[0]];
+      proof.run = commands.join("\n");
+    }],
+    ["cache namespace shared", workflows => {
+      const job = workflows.get(crateDurabilityFile).jobs["linux-durability"];
+      draftStep(job, "Restore durability Cargo cache").with.key =
+        "${{ runner.os }}-draft-v2";
+    }],
+    ["cache fallback added", workflows => {
+      const job = workflows.get(crateDurabilityFile).jobs["linux-durability"];
+      draftStep(job, "Restore durability Cargo cache").with["restore-keys"] =
+        "${{ runner.os }}-draft-";
+    }],
+    ["cache saved before proof", workflows => {
+      const steps = workflows.get(crateDurabilityFile).jobs["linux-durability"].steps;
+      const saveIndex = steps.findIndex(step => step.name === "Save durability Cargo cache");
+      const [save] = steps.splice(saveIndex, 1);
+      const proofIndex = steps.findIndex(step =>
+        step.name === "Run durability and coverage contracts");
+      steps.splice(proofIndex, 0, save);
+    }],
+    ["artifact upload added", workflows => {
+      workflows.get(crateDurabilityFile).jobs["linux-durability"].steps.push({
+        name: "Upload durability output",
+        uses: "actions/upload-artifact@v4",
+        with: { path: "target" },
+      });
+    }],
+    ["dev push removed", workflows => {
+      workflows.get(crateDurabilityFile).on.push.branches = ["main"];
+    }],
+    ["write permission granted", workflows => {
+      workflows.get(crateDurabilityFile).permissions.contents = "write";
+    }],
+  ];
+
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows);
+      assert.notDeepEqual(proofFloorPolicyViolations(workflows), []);
+    });
+  }
 });
 
 test("draft source workflow freezes its complete top-level contract", async (t) => {

--- a/.github/workflows/crate-durability.yml
+++ b/.github/workflows/crate-durability.yml
@@ -1,0 +1,87 @@
+name: crate-durability
+
+on:
+  pull_request:
+    paths:
+      - crates/codestory-store/**
+      - crates/codestory-indexer/**
+      - crates/codestory-workspace/**
+      - crates/codestory-contracts/**
+      - .github/workflows/crate-durability.yml
+      - .github/scripts/check-workflow-policy.mjs
+      - .github/scripts/check-workflow-policy.test.mjs
+      - release-claims.json
+      - scripts/codestory-release-claims.mjs
+      - scripts/tests/codestory-release-claims.test.mjs
+      - docs/contributors/testing-matrix.md
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - crates/codestory-store/**
+      - crates/codestory-indexer/**
+      - crates/codestory-workspace/**
+      - crates/codestory-contracts/**
+      - .github/workflows/crate-durability.yml
+      - .github/scripts/check-workflow-policy.mjs
+      - .github/scripts/check-workflow-policy.test.mjs
+      - release-claims.json
+      - scripts/codestory-release-claims.mjs
+      - scripts/tests/codestory-release-claims.test.mjs
+      - docs/contributors/testing-matrix.md
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crate-durability-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-durability:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Capture Rust cache identity
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "target=$(rustc -Vv | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore durability Cargo cache
+        id: cargo-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-crate-durability-v1-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-${{ hashFiles('Cargo.toml', 'crates/**/Cargo.toml', 'vendor/**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Run durability and coverage contracts
+        run: |
+          cargo test --locked -p codestory-store
+          cargo test --locked -p codestory-indexer --test fidelity_regression
+          cargo test --locked -p codestory-indexer --test tictactoe_language_coverage
+
+      - name: Save durability Cargo cache
+        if: success() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/retrieval-engine-smoke.yml
+++ b/.github/workflows/retrieval-engine-smoke.yml
@@ -171,6 +171,9 @@ jobs:
       - name: Retrieval crate unit tests
         run: cargo test --locked -p codestory-retrieval
 
+      - name: Architecture ownership contract tests
+        run: cargo test --locked -p codestory-cli --test architecture_contracts
+
       - name: Seed draft proof test-profile artifacts
         run: |
           cargo test --locked -p codestory-llama-sys --test native_staging --no-run

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "269b011b112506297d565d734baa2a08e0f31a2bce79037c6c61708abf9a52c9",
+    "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "269b011b112506297d565d734baa2a08e0f31a2bce79037c6c61708abf9a52c9",
+        "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "269b011b112506297d565d734baa2a08e0f31a2bce79037c6c61708abf9a52c9",
+        "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "35837d94ed1f96016acfc82ad4dfcf7003ba7b840736de06001fc16138b518ab",
+  "candidate_sha256": "a0ac24380fe4397d335922dd6fd2aebd71483c6a38e3848017cde2993e7e4f93",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "269b011b112506297d565d734baa2a08e0f31a2bce79037c6c61708abf9a52c9",
+      "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "269b011b112506297d565d734baa2a08e0f31a2bce79037c6c61708abf9a52c9",
+      "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "269b011b112506297d565d734baa2a08e0f31a2bce79037c6c61708abf9a52c9",
+    "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -21,6 +21,23 @@ Criterion targets.
 | Docs only | Read changed pages, doc links, `git diff --check` | No package matrix |
 | Release/version | Release and workflow policy scripts | Main-only signing, notarization, publish, install, and live runtime proof |
 
+`retrieval-engine-smoke.yml` runs the sub-second `architecture_contracts`
+binary in its universal `linux-contracts` job. Store, indexer, workspace, and
+contracts changes additionally run the path-scoped, artifact-free
+`crate-durability.yml` lane with these serial commands:
+
+```bash
+cargo test --locked -p codestory-store
+cargo test --locked -p codestory-indexer --test fidelity_regression
+cargo test --locked -p codestory-indexer --test tictactoe_language_coverage
+```
+
+That lane has its own exact-key Cargo cache, derives the key from the Rust host
+and manifests plus `Cargo.lock`, and saves only after all three commands pass.
+It does not emit artifacts or turn unrelated crate changes into durability
+work. Run broad source proof once on the frozen candidate rather than using
+this focused durability lane as a second source-proof coordinator.
+
 ## Draft source checks
 
 Run the relevant focused commands while implementing. A typical Rust lane is:

--- a/release-claims.json
+++ b/release-claims.json
@@ -1036,6 +1036,43 @@
   },
   "workflow_policy": {
     "artifact_retention_days": 30,
+    "proof_floor": {
+      "schema": 1,
+      "architecture_contract": {
+        "workflow": "retrieval-engine-smoke.yml",
+        "job": "linux-contracts",
+        "command": "cargo test --locked -p codestory-cli --test architecture_contracts"
+      },
+      "crate_durability": {
+        "workflow": "crate-durability.yml",
+        "job": "linux-durability",
+        "artifact_free": true,
+        "timeout_minutes": 60,
+        "branches": [
+          "main",
+          "dev/codestory-next"
+        ],
+        "paths": [
+          "crates/codestory-store/**",
+          "crates/codestory-indexer/**",
+          "crates/codestory-workspace/**",
+          "crates/codestory-contracts/**",
+          ".github/workflows/crate-durability.yml",
+          ".github/scripts/check-workflow-policy.mjs",
+          ".github/scripts/check-workflow-policy.test.mjs",
+          "release-claims.json",
+          "scripts/codestory-release-claims.mjs",
+          "scripts/tests/codestory-release-claims.test.mjs",
+          "docs/contributors/testing-matrix.md"
+        ],
+        "cache_namespace": "crate-durability-v1",
+        "commands": [
+          "cargo test --locked -p codestory-store",
+          "cargo test --locked -p codestory-indexer --test fidelity_regression",
+          "cargo test --locked -p codestory-indexer --test tictactoe_language_coverage"
+        ]
+      }
+    },
     "package_matrix": [
       {
         "os": "windows-latest",

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -826,6 +826,91 @@ function exactStringList(value, expected, label) {
   return actual;
 }
 
+function validateProofFloor(value) {
+  const floor = object(value, "workflow_policy.proof_floor");
+  if (
+    floor.schema !== 1
+    || JSON.stringify(Object.keys(floor).sort())
+      !== JSON.stringify(["architecture_contract", "crate_durability", "schema"])
+  ) {
+    fail("workflow_policy.proof_floor must use the exact schema 1 contract");
+  }
+
+  const architecture = object(
+    floor.architecture_contract,
+    "workflow_policy.proof_floor.architecture_contract",
+  );
+  nonEmptyText(
+    architecture.workflow,
+    "workflow_policy.proof_floor.architecture_contract.workflow",
+  );
+  if (
+    JSON.stringify(Object.keys(architecture).sort())
+      !== JSON.stringify(["command", "job", "workflow"])
+    || architecture.job !== "linux-contracts"
+    || architecture.command
+      !== "cargo test --locked -p codestory-cli --test architecture_contracts"
+  ) {
+    fail("workflow_policy.proof_floor architecture contract must stay in the universal linux-contracts lane");
+  }
+
+  const durability = object(
+    floor.crate_durability,
+    "workflow_policy.proof_floor.crate_durability",
+  );
+  if (
+    JSON.stringify(Object.keys(durability).sort())
+      !== JSON.stringify([
+        "artifact_free",
+        "branches",
+        "cache_namespace",
+        "commands",
+        "job",
+        "paths",
+        "timeout_minutes",
+        "workflow",
+      ])
+    || durability.workflow !== "crate-durability.yml"
+    || durability.job !== "linux-durability"
+    || durability.artifact_free !== true
+    || durability.timeout_minutes !== 60
+    || durability.cache_namespace !== "crate-durability-v1"
+  ) {
+    fail("workflow_policy.proof_floor crate durability lane must keep its source-only identity and bound");
+  }
+  exactStringList(
+    durability.branches,
+    ["main", "dev/codestory-next"],
+    "workflow_policy.proof_floor.crate_durability.branches",
+  );
+  exactStringList(
+    durability.paths,
+    [
+      "crates/codestory-store/**",
+      "crates/codestory-indexer/**",
+      "crates/codestory-workspace/**",
+      "crates/codestory-contracts/**",
+      ".github/workflows/crate-durability.yml",
+      ".github/scripts/check-workflow-policy.mjs",
+      ".github/scripts/check-workflow-policy.test.mjs",
+      "release-claims.json",
+      "scripts/codestory-release-claims.mjs",
+      "scripts/tests/codestory-release-claims.test.mjs",
+      "docs/contributors/testing-matrix.md",
+    ],
+    "workflow_policy.proof_floor.crate_durability.paths",
+  );
+  exactStringList(
+    durability.commands,
+    [
+      "cargo test --locked -p codestory-store",
+      "cargo test --locked -p codestory-indexer --test fidelity_regression",
+      "cargo test --locked -p codestory-indexer --test tictactoe_language_coverage",
+    ],
+    "workflow_policy.proof_floor.crate_durability.commands",
+  );
+}
+
 function validateWindowsPackageGraph(value) {
   const graph = object(value, "workflow_policy.windows_package_graph");
   if (
@@ -1440,6 +1525,7 @@ export function validateReleaseClaimGraph(graph) {
   if (!Number.isInteger(policy.artifact_retention_days) || policy.artifact_retention_days <= 0) {
     fail("workflow_policy.artifact_retention_days must be a positive integer");
   }
+  validateProofFloor(policy.proof_floor);
   if (!Array.isArray(policy.package_matrix) || policy.package_matrix.length !== 3) {
     fail("workflow_policy.package_matrix must define three release package rows");
   }

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -335,6 +335,55 @@ test("claim graph freezes one exact Windows release graph and protected content-
   }
 });
 
+test("claim graph owns the universal architecture and path-scoped durability floor", () => {
+  const floor = graph.workflow_policy.proof_floor;
+  assert.deepEqual(floor.architecture_contract, {
+    workflow: "retrieval-engine-smoke.yml",
+    job: "linux-contracts",
+    command: "cargo test --locked -p codestory-cli --test architecture_contracts",
+  });
+  assert.equal(floor.crate_durability.workflow, "crate-durability.yml");
+  assert.equal(floor.crate_durability.job, "linux-durability");
+  assert.equal(floor.crate_durability.artifact_free, true);
+  assert.deepEqual(floor.crate_durability.commands, [
+    "cargo test --locked -p codestory-store",
+    "cargo test --locked -p codestory-indexer --test fidelity_regression",
+    "cargo test --locked -p codestory-indexer --test tictactoe_language_coverage",
+  ]);
+  assert.ok(!floor.crate_durability.paths.includes("crates/**"));
+
+  const mutations = [
+    [draft => {
+      draft.workflow_policy.proof_floor.schema = 2;
+    }, /exact schema 1 contract/u],
+    [draft => {
+      draft.workflow_policy.proof_floor.architecture_contract.job = "optional-contracts";
+    }, /universal linux-contracts lane/u],
+    [draft => {
+      draft.workflow_policy.proof_floor.architecture_contract.workflow = "";
+    }, /architecture_contract\.workflow must be a non-empty string/u],
+    [draft => {
+      draft.workflow_policy.proof_floor.crate_durability.artifact_free = false;
+    }, /source-only identity and bound/u],
+    [draft => {
+      draft.workflow_policy.proof_floor.crate_durability.paths.push(
+        "crates/codestory-runtime/**",
+      );
+    }, /paths must be exactly/u],
+    [draft => {
+      draft.workflow_policy.proof_floor.crate_durability.commands.reverse();
+    }, /commands must be exactly/u],
+    [draft => {
+      draft.workflow_policy.proof_floor.crate_durability.cache_namespace = "draft-v2";
+    }, /source-only identity and bound/u],
+  ];
+  for (const [mutate, expected] of mutations) {
+    const draft = structuredClone(graph);
+    mutate(draft);
+    assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
+});
+
 test("claim graph freezes Mac-only accelerated 3x1 constant calibration", () => {
   const calibration = graph.workflow_policy.calibration;
   assert.deepEqual(calibration.required_cells.map(({ id }) => id), [

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "269b011b112506297d565d734baa2a08e0f31a2bce79037c6c61708abf9a52c9",
+      "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Result

Every routine retrieval smoke now exercises the CLI architecture ownership
contract, while changes to the four persistence-owning crates get a focused
artifact-free durability lane.

## Change

- run `architecture_contracts` late in `linux-contracts`, before draft proof
  artifacts are seeded and saved
- add one path-scoped `crate-durability` job for the full store suite plus the
  complete fidelity and tic-tac-toe language coverage binaries
- isolate that lane behind an exact-key Cargo cache that saves only after all
  three commands pass
- freeze the workflow shape, triggers, permissions, cache, command order, and
  no-artifact boundary in the release-claim graph and hostile policy tests
- document the focused lane and keep broad source proof on the single frozen
  candidate

The six pinned `rust-ci.yml` invocations are unchanged. No version or product
artifact surface is touched.

## Verification

- `node scripts/codestory-release-claims.mjs validate --repo .`
- `node --test scripts/tests/codestory-release-claims.test.mjs` (40 pass)
- `node scripts/lint-retrieval-generalization.mjs`
- `node --test scripts/tests/lint-retrieval-generalization.test.mjs` (4 pass)
- `node --test .github/scripts/check-workflow-policy.test.mjs` (1,322 pass)
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/run-actionlint.mjs`
- `node --test .github/scripts/run-actionlint.test.mjs` (3 pass)
- `node .github/scripts/route-ci-proof.mjs --self-test`
- `cargo test --locked -p codestory-cli --test architecture_contracts` (14 pass)
- `cargo test --locked -p codestory-store` (202 pass)
- `cargo test --locked -p codestory-indexer --test fidelity_regression` (8 pass)
- `cargo test --locked -p codestory-indexer --test tictactoe_language_coverage` (12 pass)
- `git diff --check`

Closes #1640
Refs #1179
