### PR TITLE
fix(release): pin plugin CLI archive digests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,13 @@ adapter to compensate for incorrect upstream state.
   - `plugins/codestory/.codex-plugin/plugin.json`
   - `plugins/codestory/.claude-plugin/plugin.json`
   - `plugins/codestory/.github/plugin/plugin.json`
+- For a plugin-only release, use
+  `node scripts/bump-version.mjs --version <plugin-version> --lane plugin`.
+  That lane leaves native and model versions unchanged, fetches the pinned
+  CLI release's published checksum file, and writes all three archive digests
+  into `plugins/codestory/cli-version.json`.
+  `--archive-checksums <path-or-https-url>` is the explicit offline/test source;
+  never type those digests by hand.
 - Release ordering is **bump-then-calibrate**. Bump the version first,
   calibrate the per-user embedding server on the bumped tree, land the
   constant-set freeze commit, then package and release. The frozen-candidate

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -7,11 +7,15 @@
 //
 //   node scripts/bump-version.mjs --version 0.17.0
 //   node scripts/bump-version.mjs --version 0.17.0 --check
+//   node scripts/bump-version.mjs --version 0.17.1 --lane plugin
+//   node scripts/bump-version.mjs --version 0.17.1 --lane plugin --check
 
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { parsePublishedArchiveDigests } from "./lib/pinned-archive-digests.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
@@ -39,6 +43,8 @@ const MODEL_CONTRACT = "crates/codestory-llama-sys/model-contract.json";
 const CHANGELOG = "CHANGELOG.md";
 const CLI_VERSION_PIN = "plugins/codestory/cli-version.json";
 const CARGO_LOCK = "Cargo.lock";
+const RELEASE_REPOSITORY = "TheGreenCedar/CodeStory";
+const PYTHON = process.env.CODESTORY_PYTHON || "python3";
 
 function fail(message) {
   console.error(`bump-version: ${message}`);
@@ -46,7 +52,7 @@ function fail(message) {
 }
 
 function parseArguments(argv) {
-  const values = { check: false };
+  const values = { check: false, lane: "native" };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--check") {
@@ -56,13 +62,25 @@ function parseArguments(argv) {
     const separator = argument.indexOf("=");
     const name = separator < 0 ? argument : argument.slice(0, separator);
     const inline = separator < 0 ? undefined : argument.slice(separator + 1);
-    if (name !== "--version") fail(`unknown argument ${argument}`);
-    values.version = inline ?? argv[++index];
+    const next = argv[index + 1];
+    const value =
+      inline ?? (next && !next.startsWith("--") ? argv[++index] : undefined);
+    if (!value) fail(`${name} requires a value`);
+    if (name === "--version") values.version = value;
+    else if (name === "--lane") values.lane = value;
+    else if (name === "--archive-checksums") values.archiveChecksums = value;
+    else fail(`unknown argument ${argument}`);
   }
   if (!values.version) fail("--version is required");
   values.version = values.version.replace(/^v/u, "");
   if (!SEMVER.test(values.version)) {
     fail(`--version must be strict semver like 0.17.0, got ${values.version}`);
+  }
+  if (!new Set(["native", "plugin"]).has(values.lane)) {
+    fail(`--lane must be native or plugin, got ${values.lane}`);
+  }
+  if (values.lane === "native" && values.archiveChecksums) {
+    fail("--archive-checksums belongs only to the plugin lane");
   }
   return values;
 }
@@ -82,6 +100,13 @@ function setPackageVersion(source, version) {
   const packageSection = /(^\[package\][\s\S]*?^version\s*=\s*")([^"]+)(")/mu;
   if (!packageSection.test(source)) fail("crate manifest has no [package] version");
   return source.replace(packageSection, `$1${version}$3`);
+}
+
+function packageVersion(source) {
+  const packageSection = /(^\[package\][\s\S]*?^version\s*=\s*")([^"]+)(")/mu;
+  const version = packageSection.exec(source)?.[2];
+  if (!version) fail("crate manifest has no [package] version");
+  return version;
 }
 
 /// Replace one JSON string value in place.
@@ -135,10 +160,120 @@ function cargoLockCarriesVersion(source, version) {
   return [...cargoLockVersions(source).values()].every((current) => current === version);
 }
 
-function main() {
-  const { version, check } = parseArguments(process.argv.slice(2));
+function compareSemverCore(left, right) {
+  const parse = (value) => value.split("-")[0].split(".").map(Number);
+  const [leftMajor, leftMinor, leftPatch] = parse(left);
+  const [rightMajor, rightMinor, rightPatch] = parse(right);
+  if (leftMajor !== rightMajor) return leftMajor - rightMajor;
+  if (leftMinor !== rightMinor) return leftMinor - rightMinor;
+  return leftPatch - rightPatch;
+}
+
+async function publishedArchiveDigests(pin, checksumSource) {
+  if (
+    !pin ||
+    typeof pin.cli_version !== "string" ||
+    !SEMVER.test(pin.cli_version) ||
+    pin.release_tag !== `v${pin.cli_version}`
+  ) {
+    fail(`${CLI_VERSION_PIN} does not name a valid published CLI release`);
+  }
+  const source =
+    checksumSource ??
+    `https://github.com/${RELEASE_REPOSITORY}/releases/download/` +
+      `${encodeURIComponent(pin.release_tag)}/SHA256SUMS.txt`;
+  let contents;
+  if (/^https:\/\//u.test(source)) {
+    const response = await fetch(source, { signal: AbortSignal.timeout(30_000) });
+    if (!response.ok) {
+      fail(`could not fetch ${source}: HTTP ${response.status}`);
+    }
+    contents = await response.text();
+  } else {
+    contents = readFileSync(path.resolve(repositoryRoot, source), "utf8");
+  }
+  try {
+    return parsePublishedArchiveDigests(contents, pin.cli_version);
+  } catch (error) {
+    fail(error.message);
+  }
+}
+
+async function main() {
+  const { version, check, lane, archiveChecksums } = parseArguments(
+    process.argv.slice(2),
+  );
   const changes = [];
   const cargoLockBefore = readFileSync(path.join(repositoryRoot, CARGO_LOCK), "utf8");
+
+  if (lane === "plugin") {
+    const cliVersion = packageVersion(
+      readFileSync(
+        path.join(repositoryRoot, "crates/codestory-cli/Cargo.toml"),
+        "utf8",
+      ),
+    );
+    const pinSource = readFileSync(path.join(repositoryRoot, CLI_VERSION_PIN), "utf8");
+    const pin = JSON.parse(pinSource);
+    if (pin.cli_version !== cliVersion) {
+      fail(
+        `${CLI_VERSION_PIN} pins ${pin.cli_version}, but the workspace CLI is ${cliVersion}`,
+      );
+    }
+    if (compareSemverCore(version, cliVersion) <= 0) {
+      fail(`plugin version ${version} must be ahead of pinned CLI ${cliVersion}`);
+    }
+    const archives = await publishedArchiveDigests(pin, archiveChecksums);
+
+    for (const manifest of PLUGIN_MANIFESTS) {
+      rewrite(
+        manifest,
+        (source) => setJsonVersion(source, version, ["version"]),
+        changes,
+        { check },
+      );
+    }
+    rewrite(
+      CLI_VERSION_PIN,
+      (source) => {
+        const current = JSON.parse(source);
+        const next = { ...current, archives };
+        const after = `${JSON.stringify(next, null, 2)}\n`;
+        return after === source ? source : after;
+      },
+      changes,
+      { check },
+    );
+    rewrite(CHANGELOG, (source) => promoteChangelog(source, version), changes, { check });
+
+    if (check) {
+      if (changes.length > 0) {
+        fail(`these plugin surfaces do not carry ${version}:\n  ${changes.join("\n  ")}`);
+      }
+      console.log(
+        `Every plugin release surface already carries ${version} with pinned CLI digests.`,
+      );
+      return;
+    }
+
+    execFileSync(
+      PYTHON,
+      [
+        ".github/scripts/check-codestory-release.py",
+        "--version",
+        version,
+        "--lane",
+        "plugin",
+      ],
+      { cwd: repositoryRoot, stdio: "inherit" },
+    );
+    console.log(
+      changes.length > 0
+        ? `Set plugin ${version} across ${changes.length} files:\n  ${changes.join("\n  ")}`
+        : `Every plugin release surface already carried ${version}.`,
+    );
+    return;
+  }
 
   for (const member of WORKSPACE_MEMBERS) {
     rewrite(
@@ -200,7 +335,7 @@ function main() {
 
   // Fail here rather than in CI if a surface was missed.
   execFileSync(
-    "python3",
+    PYTHON,
     [".github/scripts/check-codestory-release.py", "--version", version],
     { cwd: repositoryRoot, stdio: "inherit" },
   );
@@ -212,4 +347,4 @@ function main() {
   );
 }
 
-main();
+main().catch((error) => fail(error.message));

--- a/scripts/lib/pinned-archive-digests.mjs
+++ b/scripts/lib/pinned-archive-digests.mjs
@@ -1,0 +1,49 @@
+const SHA256 = /^[0-9a-f]{64}$/u;
+
+export const PINNED_ARCHIVE_TARGETS = Object.freeze({
+  "macos-arm64": (version) => `codestory-cli-v${version}-macos-arm64.tar.gz`,
+  "windows-x64": (version) => `codestory-cli-v${version}-windows-x64.zip`,
+  "linux-x64": (version) => `codestory-cli-v${version}-linux-x64.tar.gz`,
+});
+
+export function parsePublishedArchiveDigests(source, version) {
+  const published = new Map();
+  for (const [lineIndex, rawLine] of source.split(/\r?\n/u).entries()) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const match = /^([0-9a-f]{64})\s+\*?(\S+)$/u.exec(line);
+    if (!match) {
+      throw new Error(`SHA256SUMS.txt line ${lineIndex + 1} is malformed`);
+    }
+    const [, digest, filename] = match;
+    if (published.has(filename)) {
+      throw new Error(`SHA256SUMS.txt repeats ${filename}`);
+    }
+    published.set(filename, digest);
+  }
+
+  return Object.fromEntries(
+    Object.entries(PINNED_ARCHIVE_TARGETS).map(([target, assetName]) => {
+      const filename = assetName(version);
+      const digest = published.get(filename);
+      if (!digest) {
+        throw new Error(`SHA256SUMS.txt does not contain ${filename}`);
+      }
+      return [target, digest];
+    }),
+  );
+}
+
+export function requirePinnedArchiveDigest(pin, target, observedDigest) {
+  const pinnedDigest = pin?.archives?.[target];
+  if (typeof pinnedDigest !== "string" || !SHA256.test(pinnedDigest)) {
+    throw new Error(`CLI pin has no valid ${target} archive digest`);
+  }
+  if (observedDigest !== pinnedDigest) {
+    throw new Error(
+      `provisioned archive digest ${observedDigest} does not match the pin's ` +
+        `${target} digest ${pinnedDigest}`,
+    );
+  }
+  return pinnedDigest;
+}

--- a/scripts/prove-plugin-pinned-provision.mjs
+++ b/scripts/prove-plugin-pinned-provision.mjs
@@ -19,6 +19,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { waitForManagedRuntime } from "./lib/wait-for-managed-runtime.mjs";
+import { requirePinnedArchiveDigest } from "./lib/pinned-archive-digests.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const launcher = path.join(repositoryRoot, "plugins/codestory/scripts/codestory-mcp.cjs");
@@ -85,11 +86,10 @@ if (manifest.version !== pin.cli_version) {
 if (manifest.build_source !== "github_release") {
   fail(`expected a github_release provision, observed ${manifest.build_source}.`);
 }
-if (pin.archives?.[target] && manifest.archive_sha256 !== pin.archives[target]) {
-  fail(
-    `provisioned archive digest ${manifest.archive_sha256} does not match the pin's ` +
-      `${target} digest ${pin.archives[target]}.`,
-  );
+try {
+  requirePinnedArchiveDigest(pin, target, manifest.archive_sha256);
+} catch (error) {
+  fail(`${error.message}.`);
 }
 const binary = path.join(versionDir, manifest.path);
 const reported = execFileSync(binary, ["--version"], { encoding: "utf8" }).trim();

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -13,10 +13,21 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { parsePublishedArchiveDigests } from "../lib/pinned-archive-digests.mjs";
+
 const repositoryRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
+const testPython = ["python", "python3"].find((candidate) => {
+  try {
+    execFileSync(candidate, ["-c", "import tomllib"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+});
+assert.ok(testPython, "bump-version tests require Python with tomllib");
 
 /// A minimal tree carrying every surface the script owns.
 function fixtureRoot(version) {
@@ -62,7 +73,14 @@ function fixtureRoot(version) {
   writeFileSync(
     path.join(root, "crates/codestory-llama-sys/model-contract.json"),
     `${JSON.stringify(
-      { model: { file_name: "m.gguf" }, producer: { name: "codestory-llama-sys", version } },
+      {
+        model: { file_name: "m.gguf" },
+        producer: {
+          name: "codestory-llama-sys",
+          version,
+          embedding_revision: version,
+        },
+      },
       null,
       2,
     )}\n`,
@@ -89,6 +107,16 @@ function fixtureRoot(version) {
     path.join(repositoryRoot, "scripts/bump-version.mjs"),
     path.join(root, "scripts/bump-version.mjs"),
   );
+  mkdirSync(path.join(root, "scripts/lib"), { recursive: true });
+  cpSync(
+    path.join(repositoryRoot, "scripts/lib/pinned-archive-digests.mjs"),
+    path.join(root, "scripts/lib/pinned-archive-digests.mjs"),
+  );
+  mkdirSync(path.join(root, ".github/scripts"), { recursive: true });
+  cpSync(
+    path.join(repositoryRoot, ".github/scripts/check-codestory-release.py"),
+    path.join(root, ".github/scripts/check-codestory-release.py"),
+  );
   return root;
 }
 
@@ -112,16 +140,45 @@ function readVersions(root) {
       "producer",
       "version",
     ]),
+    pin: JSON.parse(
+      readFileSync(path.join(root, "plugins/codestory/cli-version.json"), "utf8"),
+    ),
+    cargoLock: readFileSync(path.join(root, "Cargo.lock"), "utf8"),
     changelog: readFileSync(path.join(root, "CHANGELOG.md"), "utf8"),
   };
 }
 
-/// Run the script without cargo/python, which the fixture tree cannot satisfy.
+function publishedChecksums(root, version, digests = {}) {
+  const values = {
+    "macos-arm64": "1".repeat(64),
+    "windows-x64": "2".repeat(64),
+    "linux-x64": "3".repeat(64),
+    ...digests,
+  };
+  const checksumPath = path.join(root, "SHA256SUMS.txt");
+  writeFileSync(
+    checksumPath,
+    [
+      `${values["macos-arm64"]}  codestory-cli-v${version}-macos-arm64.tar.gz`,
+      `${values["windows-x64"]}  codestory-cli-v${version}-windows-x64.zip`,
+      `${values["linux-x64"]}  codestory-cli-v${version}-linux-x64.tar.gz`,
+      `${"4".repeat(64)}  unrelated-release-asset.txt`,
+    ].join("\n") + "\n",
+  );
+  return { checksumPath, values };
+}
+
+/// Run the version owner against the isolated fixture and the real release validator.
 function bump(root, args) {
   return execFileSync(
     process.execPath,
     [path.join(root, "scripts/bump-version.mjs"), ...args],
-    { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, CODESTORY_PYTHON: testPython },
+    },
   );
 }
 
@@ -189,8 +246,113 @@ test("a bad version is rejected before anything is written", () => {
   try {
     assert.throws(() => bump(root, ["--version", "0.17"]), /strict semver/u);
     assert.throws(() => bump(root, ["--version", "not-a-version"]), /strict semver/u);
+    assert.throws(
+      () => bump(root, ["--version", "0.16.2", "--lane", "plugin", "--archive-checksums"]),
+      /--archive-checksums requires a value/u,
+    );
     assert.equal(readVersions(root).cli, "0.16.1");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("the plugin lane pins published CLI digests without moving native versions", () => {
+  const root = fixtureRoot("0.16.1");
+  try {
+    const before = readVersions(root);
+    const { checksumPath, values } = publishedChecksums(root, "0.16.1");
+    const output = bump(root, [
+      "--version",
+      "0.16.2",
+      "--lane",
+      "plugin",
+      "--archive-checksums",
+      checksumPath,
+    ]);
+    const after = readVersions(root);
+    assert.match(output, /Set plugin 0\.16\.2/u);
+    assert.equal(after.cli, "0.16.1");
+    assert.equal(after.bench, "0.16.1");
+    assert.equal(after.producer, "0.16.1");
+    assert.equal(after.cargoLock, before.cargoLock);
+    assert.equal(after.codexPlugin, "0.16.2");
+    assert.equal(after.claudePlugin, "0.16.2");
+    assert.equal(after.githubPlugin, "0.16.2");
+    assert.equal(after.pin.cli_version, "0.16.1");
+    assert.equal(after.pin.release_tag, "v0.16.1");
+    assert.deepEqual(after.pin.archives, values);
+    assert.match(after.changelog, /\n## 0\.16\.2\n/u);
+
+    assert.match(
+      bump(root, [
+        "--version=0.16.2",
+        "--lane=plugin",
+        "--check",
+        `--archive-checksums=${checksumPath}`,
+      ]),
+      /already carries 0\.16\.2 with pinned CLI digests/u,
+    );
+
+    after.pin.archives["linux-x64"] = "f".repeat(64);
+    writeFileSync(
+      path.join(root, "plugins/codestory/cli-version.json"),
+      `${JSON.stringify(after.pin, null, 2)}\n`,
+    );
+    assert.throws(
+      () =>
+        bump(root, [
+          "--version=0.16.2",
+          "--lane=plugin",
+          "--check",
+          `--archive-checksums=${checksumPath}`,
+        ]),
+      /plugins\/codestory\/cli-version\.json/u,
+    );
+    assert.equal(
+      readVersions(root).pin.archives["linux-x64"],
+      "f".repeat(64),
+      "check mode must not repair drift",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a missing published archive fails before the plugin bump writes", () => {
+  const root = fixtureRoot("0.16.1");
+  try {
+    const before = readVersions(root);
+    const checksumPath = path.join(root, "SHA256SUMS.txt");
+    writeFileSync(
+      checksumPath,
+      `${"1".repeat(64)}  codestory-cli-v0.16.1-macos-arm64.tar.gz\n`,
+    );
+    assert.throws(
+      () =>
+        bump(root, [
+          "--version=0.16.2",
+          "--lane=plugin",
+          `--archive-checksums=${checksumPath}`,
+        ]),
+      /does not contain codestory-cli-v0\.16\.1-windows-x64\.zip/u,
+    );
+    assert.deepEqual(readVersions(root), before);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("published checksum parsing rejects malformed and duplicate rows", () => {
+  assert.throws(
+    () => parsePublishedArchiveDigests("not a checksum\n", "0.16.1"),
+    /line 1 is malformed/u,
+  );
+  const digest = "a".repeat(64);
+  const duplicate =
+    `${digest}  codestory-cli-v0.16.1-macos-arm64.tar.gz\n` +
+    `${digest}  codestory-cli-v0.16.1-macos-arm64.tar.gz\n`;
+  assert.throws(
+    () => parsePublishedArchiveDigests(duplicate, "0.16.1"),
+    /repeats codestory-cli-v0\.16\.1-macos-arm64\.tar\.gz/u,
+  );
 });

--- a/scripts/tests/prove-plugin-pinned-provision.test.mjs
+++ b/scripts/tests/prove-plugin-pinned-provision.test.mjs
@@ -6,6 +6,8 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { requirePinnedArchiveDigest } from "../lib/pinned-archive-digests.mjs";
+
 const scriptsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const proofScript = path.join(scriptsDir, "prove-plugin-pinned-provision.mjs");
 const waitModuleUrl = pathToFileURL(path.join(scriptsDir, "lib/wait-for-managed-runtime.mjs")).href;
@@ -14,6 +16,46 @@ const waitModuleUrl = pathToFileURL(path.join(scriptsDir, "lib/wait-for-managed-
 // on disk, so drive it in its own process and kill it if it outlives the bound. A hang here is a
 // reported failure, not a wedged test run.
 const KILL_AFTER_MS = 5_000;
+const VALID_DIGEST = "a".repeat(64);
+
+test("the provision gate requires a source-pinned digest", () => {
+  assert.throws(
+    () => requirePinnedArchiveDigest({ schema_version: 1 }, "macos-arm64", VALID_DIGEST),
+    /no valid macos-arm64 archive digest/u,
+  );
+  assert.throws(
+    () =>
+      requirePinnedArchiveDigest(
+        { archives: { "macos-arm64": "not-a-digest" } },
+        "macos-arm64",
+        VALID_DIGEST,
+      ),
+    /no valid macos-arm64 archive digest/u,
+  );
+});
+
+test("the provision gate rejects a hostile archive digest", () => {
+  assert.throws(
+    () =>
+      requirePinnedArchiveDigest(
+        { archives: { "linux-x64": VALID_DIGEST } },
+        "linux-x64",
+        "b".repeat(64),
+      ),
+    /does not match the pin's linux-x64 digest/u,
+  );
+});
+
+test("the provision gate accepts the exact source-pinned digest", () => {
+  assert.equal(
+    requirePinnedArchiveDigest(
+      { archives: { "windows-x64": VALID_DIGEST } },
+      "windows-x64",
+      VALID_DIGEST,
+    ),
+    VALID_DIGEST,
+  );
+});
 
 function runNode(args, options = {}) {
   return new Promise((resolve) => {


### PR DESCRIPTION
Closes #1646

## What changed

- add an explicit plugin-only mode to the version owner;
- fetch the pinned CLI release's published checksum file and write the exact three-target archive map without moving native/model versions;
- keep native version bumps unchanged and archive-digest-free until native assets exist;
- make the end-to-end pinned provision proof fail when a target digest is absent, malformed, or different from the provisioned archive;
- document the single supported plugin-only bump path.

## Proof

- `node --test scripts/tests/bump-version.test.mjs scripts/tests/prove-plugin-pinned-provision.test.mjs` (18 passed)
- `node --test plugins/codestory/tests/plugin-static.test.mjs` (102 passed, 1 Windows-only skip)
- `node scripts/bump-version.mjs --version 0.16.3 --check`
- `python .github/scripts/check-codestory-release.py --version 0.16.3`
- `python .github/scripts/test-detect-codestory-release.py` (10 passed)
- `node .github/scripts/check-workflow-policy.mjs`
- live read-only plugin check fetched v0.16.3's published checksum file and correctly reported the five source surfaces a hypothetical 0.16.4 plugin bump would change
- `git diff --check`

No product, package, plugin, model, changelog, or pin version value changes.
