### PR TITLE
[v0.17 W4-A] Repair first-wave source intake and template identity

### DIFF
--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16701,11 +16701,23 @@ fn prepare_template_index_work(
     index_template_file(path, template_kind, &source)
 }
 
+fn parser_source_is_complete(source: &str, language_config: &LanguageConfig) -> Result<bool> {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&language_config.language)
+        .map_err(|error| anyhow!("Language error: {error:?}"))?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| anyhow!("Failed to parse template script regions"))?;
+    Ok(!tree.root_node().has_error())
+}
+
 fn index_template_file(
     path: &Path,
     template_kind: template_pipeline::TemplateKind,
     source: &str,
 ) -> Result<IntermediateStorage> {
+    let content_hash = source_content_hash(source.as_bytes());
     let prepared = template_pipeline::prepare_template_source(template_kind, source);
     let script_ext = match prepared.script_language {
         "typescript" => "ts",
@@ -16715,9 +16727,12 @@ fn index_template_file(
         .ok_or_else(|| anyhow!("missing tree-sitter config for template script language"))?;
 
     let mut index_result = index_file(path, &prepared.blanked, &language_config, None, None)?;
+    let parser_region_complete =
+        parser_source_is_complete(&prepared.completeness_blanked, &language_config)?;
     let surface_language = template_pipeline::template_surface_language(path).unwrap_or("template");
     if let Some(file_info) = index_result.files.first_mut() {
         file_info.language = surface_language.to_string();
+        file_info.complete = parser_region_complete;
     }
 
     let file_id = index_result
@@ -16730,6 +16745,12 @@ fn index_template_file(
     local_storage.files.extend(index_result.files);
     local_storage.nodes.extend(index_result.nodes);
     local_storage.occurrences.extend(index_result.occurrences);
+    local_storage
+        .component_access
+        .extend(index_result.component_access);
+    local_storage
+        .impl_anchor_node_ids
+        .extend(index_result.impl_anchor_node_ids);
     append_text_only_framework_routes(path, surface_language, source, file_id, &mut local_storage);
     // Insert Tauri invoke edges before tree-sitter CALL edges so SQLite ON CONFLICT keeps
     // the heuristic uncertain boundary evidence when identities collide.
@@ -16741,27 +16762,62 @@ fn index_template_file(
         file_id,
         &mut local_storage,
     );
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("template");
     let file_identity = WorkspaceIndexer::file_identity_path(path);
     let flags = index_feature_flags();
     let (final_nodes, id_remap) = canonicalize_nodes_with_file_identity(
-        file_name,
+        &file_identity,
         &file_identity,
         local_storage.nodes,
         &HashMap::new(),
     );
     let new_file_id = id_remap.get(&file_id).copied().unwrap_or(file_id);
     local_storage.nodes = final_nodes;
+    let final_node_ids = local_storage
+        .nodes
+        .iter()
+        .map(|node| node.id)
+        .collect::<HashSet<_>>();
     remap_file_affinity(&mut local_storage.nodes, new_file_id);
     remap_edges(&mut local_storage.edges, new_file_id, &id_remap, flags);
     remap_occurrences(&mut local_storage.occurrences, &id_remap);
+    local_storage.component_access = local_storage
+        .component_access
+        .into_iter()
+        .filter_map(|(node_id, access)| {
+            let remapped = id_remap.get(&node_id).copied().unwrap_or(node_id);
+            final_node_ids
+                .contains(&remapped)
+                .then_some((remapped, access))
+        })
+        .collect();
+    local_storage.structural_unit_node_ids = local_storage
+        .structural_unit_node_ids
+        .into_iter()
+        .map(|node_id| id_remap.get(&node_id).copied().unwrap_or(node_id))
+        .filter(|node_id| final_node_ids.contains(node_id))
+        .collect();
+    local_storage.structural_unit_node_ids.sort_unstable();
+    local_storage.structural_unit_node_ids.dedup();
+    local_storage.impl_anchor_node_ids = local_storage
+        .impl_anchor_node_ids
+        .into_iter()
+        .map(|node_id| id_remap.get(&node_id).copied().unwrap_or(node_id))
+        .filter(|node_id| final_node_ids.contains(node_id))
+        .collect();
+    local_storage.impl_anchor_node_ids.sort_unstable();
+    local_storage.impl_anchor_node_ids.dedup();
     if let Some(file_info) = local_storage.files.first_mut()
         && let Some(remapped) = id_remap.get(&NodeId(file_info.id))
     {
         file_info.id = remapped.0;
+    }
+    if let Some(file_info) = local_storage.files.first() {
+        local_storage
+            .file_content_hashes
+            .push(codestory_store::FileContentHash {
+                file_id: file_info.id,
+                content_hash,
+            });
     }
     local_storage.callable_projection_states = build_callable_projection_states(
         &local_storage.nodes,
@@ -16773,6 +16829,7 @@ fn index_template_file(
 
 fn index_text_only_file(path: &Path) -> Result<IntermediateStorage> {
     let source = std::fs::read_to_string(path)?;
+    let content_hash = source_content_hash(source.as_bytes());
     let mut local_storage = IntermediateStorage::default();
     let (file_node, _file_name, file_id) = file_node_from_source(path, &source);
     local_storage.files.push(codestory_store::FileInfo {
@@ -16807,6 +16864,12 @@ fn index_text_only_file(path: &Path) -> Result<IntermediateStorage> {
         &local_storage.edges,
         &local_storage.occurrences,
     );
+    local_storage
+        .file_content_hashes
+        .push(codestory_store::FileContentHash {
+            file_id: local_storage.files[0].id,
+            content_hash,
+        });
     Ok(local_storage)
 }
 
@@ -26640,6 +26703,60 @@ jobs:
         assert_eq!(storage.files[0].path, path);
         assert!(storage.nodes.iter().any(|node| node.kind == NodeKind::FILE));
         assert!(storage.edges.is_empty());
+        assert_eq!(storage.file_content_hashes.len(), 1);
+        assert_eq!(
+            storage.file_content_hashes[0].content_hash,
+            source_content_hash(
+                b"<script>\n  import { invoke } from '@tauri-apps/api/core';\n</script>\n"
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn template_collector_records_verified_source_hash() -> Result<()> {
+        let source = "<script>export const answer = 42</script>\n";
+        let storage = index_template_file(
+            Path::new("src/Answer.svelte"),
+            template_pipeline::TemplateKind::Svelte,
+            source,
+        )?;
+
+        assert_eq!(storage.file_content_hashes.len(), 1);
+        assert_eq!(storage.file_content_hashes[0].file_id, storage.files[0].id);
+        assert_eq!(
+            storage.file_content_hashes[0].content_hash,
+            source_content_hash(source.as_bytes())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn same_basename_templates_keep_distinct_symbol_identities() -> Result<()> {
+        let source = r#"<script lang="ts">
+export interface Props { title: string }
+</script>
+"#;
+        let left = index_template_file(
+            Path::new("src/left/index.vue"),
+            template_pipeline::TemplateKind::Vue,
+            source,
+        )?;
+        let right = index_template_file(
+            Path::new("src/right/index.vue"),
+            template_pipeline::TemplateKind::Vue,
+            source,
+        )?;
+        let props_id = |storage: &IntermediateStorage| {
+            storage
+                .nodes
+                .iter()
+                .find(|node| node.serialized_name == "Props")
+                .map(|node| node.id)
+                .expect("Props symbol")
+        };
+
+        assert_ne!(props_id(&left), props_id(&right));
         Ok(())
     }
 
@@ -26730,6 +26847,7 @@ jobs:
             .iter()
             .find(|node| node.canonical_id.as_deref() == Some("tauri:command:get_snapshot"))
             .expect("tauri command node");
+        let file_id = local.files[0].id;
         assert!(local.edges.iter().any(|edge| {
             edge.kind == EdgeKind::CALL
                 && edge.target == command.id
@@ -26754,6 +26872,10 @@ jobs:
             })?;
 
         let edges = storage.get_edges()?;
+        assert_eq!(
+            storage.get_file_content_hash(file_id)?.as_deref(),
+            Some(source_content_hash(source.as_bytes()).as_str())
+        );
         assert!(
             edges.iter().any(|edge| {
                 edge.kind == EdgeKind::CALL

--- a/crates/codestory-indexer/src/template_pipeline.rs
+++ b/crates/codestory-indexer/src/template_pipeline.rs
@@ -34,6 +34,9 @@ pub struct StyleBlockRange {
 #[derive(Debug, Clone)]
 pub struct TemplatePrepareResult {
     pub blanked: String,
+    /// Retained executable regions, used to decide whether the parser-backed
+    /// portion of the template is complete.
+    pub completeness_blanked: String,
     /// `javascript` or `typescript` — selects tree-sitter ruleset.
     pub script_language: &'static str,
     pub style_blocks: Vec<StyleBlockRange>,
@@ -63,6 +66,7 @@ pub fn template_surface_language(path: &Path) -> Option<&'static str> {
 
 pub fn prepare_template_source(kind: TemplateKind, source: &str) -> TemplatePrepareResult {
     let mut keep_ranges = Vec::new();
+    let mut svelte_inline_ranges = Vec::new();
     let mut style_blocks = Vec::new();
     let mut script_language = "javascript";
 
@@ -73,17 +77,44 @@ pub fn prepare_template_source(kind: TemplateKind, source: &str) -> TemplatePrep
         collect_astro_frontmatter(source, &mut keep_ranges, &mut script_language);
     }
     if matches!(kind, TemplateKind::Svelte) {
-        let script_ranges = keep_ranges.clone();
-        collect_svelte_inline_expressions(source, &script_ranges, &mut keep_ranges);
+        let mut excluded_ranges = keep_ranges.clone();
+        excluded_ranges.extend(style_blocks.iter().map(|block| block.range));
+        collect_svelte_inline_expressions(source, &excluded_ranges, &mut svelte_inline_ranges);
+        keep_ranges.extend(svelte_inline_ranges.iter().copied());
     }
 
     keep_ranges.sort_by_key(|range| range.start);
     keep_ranges = merge_ranges(keep_ranges);
 
     let blanked = blank_source(source, &keep_ranges);
+    let mut completeness_blanked = blank_source(source, &keep_ranges).into_bytes();
+    // A Svelte object-literal expression is spelled `{{ ... }}`. As a raw JS
+    // program that becomes a labelled block and can report a false syntax
+    // error. Group only that form; ordinary braces must remain because Svelte
+    // also admits declaration forms such as `{let value = ...}`.
+    for range in svelte_inline_ranges {
+        if source[range.start + 1..range.end - 1]
+            .trim_start()
+            .starts_with('{')
+        {
+            completeness_blanked[range.start] = b'(';
+            completeness_blanked[range.end - 1] = b')';
+            if let Some((separator, b' ')) = completeness_blanked[range.end..]
+                .iter()
+                .copied()
+                .enumerate()
+                .find(|(_, byte)| *byte != b'\n' && *byte != b'\r')
+            {
+                completeness_blanked[range.end + separator] = b';';
+            }
+        }
+    }
+    let completeness_blanked =
+        String::from_utf8(completeness_blanked).expect("blanking preserves UTF-8");
 
     TemplatePrepareResult {
         blanked,
+        completeness_blanked,
         script_language,
         style_blocks,
     }
@@ -119,10 +150,14 @@ fn collect_script_blocks(
 
     while let Some(rel) = lower[search_from..].find("<script") {
         let start = search_from + rel;
-        let Some(open_end) = lower[start..].find('>') else {
+        let after_name = start + "<script".len();
+        if !is_tag_name_boundary(bytes.get(after_name).copied()) {
+            search_from = after_name;
+            continue;
+        }
+        let Some(open_end) = find_opening_tag_end(source, after_name) else {
             break;
         };
-        let open_end = start + open_end + 1;
         let Some(close_rel) = lower[open_end..].find("</script>") else {
             break;
         };
@@ -140,15 +175,20 @@ fn collect_script_blocks(
 }
 
 fn collect_style_blocks(source: &str, style_blocks: &mut Vec<StyleBlockRange>) {
+    let bytes = source.as_bytes();
     let lower = source.to_ascii_lowercase();
     let mut search_from = 0usize;
 
     while let Some(rel) = lower[search_from..].find("<style") {
         let start = search_from + rel;
-        let Some(open_end) = lower[start..].find('>') else {
+        let after_name = start + "<style".len();
+        if !is_tag_name_boundary(bytes.get(after_name).copied()) {
+            search_from = after_name;
+            continue;
+        }
+        let Some(open_end) = find_opening_tag_end(source, after_name) else {
             break;
         };
-        let open_end = start + open_end + 1;
         let Some(close_rel) = lower[open_end..].find("</style>") else {
             break;
         };
@@ -189,11 +229,9 @@ fn collect_astro_frontmatter(
         start: content_start,
         end: close_line_start,
     });
-    if source[content_start..close_line_start].contains("lang=\"ts\"")
-        || source[content_start..close_line_start].contains("lang='ts'")
-    {
-        *script_language = "typescript";
-    }
+    // Astro frontmatter is TypeScript by convention; there is no script tag
+    // whose `lang` attribute could select the grammar.
+    *script_language = "typescript";
 }
 
 fn collect_svelte_inline_expressions(
@@ -213,12 +251,43 @@ fn collect_svelte_inline_expressions(
             continue;
         }
         if let Some(end) = find_brace_expression_end(source, index) {
-            keep_ranges.push(ByteRange { start: index, end });
+            if !matches!(bytes.get(index + 1), Some(b'#' | b':' | b'/' | b'@'))
+                && bytes.get(index + 1..index + 4) != Some(b"...")
+            {
+                keep_ranges.push(ByteRange { start: index, end });
+            }
             index = end;
         } else {
             index += 1;
         }
     }
+}
+
+fn is_tag_name_boundary(byte: Option<u8>) -> bool {
+    byte.is_some_and(|byte| byte.is_ascii_whitespace() || matches!(byte, b'>' | b'/'))
+}
+
+/// Return the byte immediately after the opening tag's `>`, ignoring `>`
+/// characters inside quoted attributes.
+fn find_opening_tag_end(source: &str, mut index: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut quote = None;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if let Some(active_quote) = quote {
+            if byte == active_quote {
+                quote = None;
+            }
+        } else {
+            match byte {
+                b'\'' | b'"' => quote = Some(byte),
+                b'>' => return Some(index + 1),
+                _ => {}
+            }
+        }
+        index += 1;
+    }
+    None
 }
 
 fn find_brace_expression_end(source: &str, open_index: usize) -> Option<usize> {
@@ -445,7 +514,12 @@ const site = 'codestory'
 </html>
 "#;
         let prepared = prepare_template_source(TemplateKind::Astro, source);
-        let language_config = get_language_for_ext("ts").expect("typescript config");
+        assert_eq!(prepared.script_language, "typescript");
+        let language_config = get_language_for_ext(match prepared.script_language {
+            "typescript" => "ts",
+            _ => "js",
+        })
+        .expect("template script config");
         let result = index_file(
             Path::new("src/pages/index.astro"),
             &prepared.blanked,
@@ -455,6 +529,7 @@ const site = 'codestory'
         )?;
 
         assert_symbol_on_original_source_line(source, &result, "buildTitle");
+        assert!(result.files[0].complete);
         Ok(())
     }
 
@@ -463,5 +538,74 @@ const site = 'codestory'
         let source = r#"<script lang="ts">export const x = 1</script>"#;
         let prepared = prepare_template_source(TemplateKind::Vue, source);
         assert_eq!(prepared.script_language, "typescript");
+    }
+
+    #[test]
+    fn opening_tag_scan_ignores_greater_than_inside_quoted_attributes() -> anyhow::Result<()> {
+        let source = r#"<script lang="ts" generic="T extends Item<K>">
+interface Props<T> { item: T }
+export const props: Props<string> = { item: "ok" }
+</script>
+"#;
+        let prepared = prepare_template_source(TemplateKind::Vue, source);
+
+        assert_eq!(prepared.script_language, "typescript");
+        assert!(prepared.blanked.contains("interface Props<T>"));
+        let storage =
+            crate::index_template_file(Path::new("Component.vue"), TemplateKind::Vue, source)?;
+        assert!(storage.files[0].complete);
+        Ok(())
+    }
+
+    #[test]
+    fn svelte_completeness_uses_script_regions_not_template_directives_or_styles()
+    -> anyhow::Result<()> {
+        let source = r#"<script>
+export let visible = true
+</script>
+{#if visible}
+  <div {...restProps} use:action={{ visible, nested: { enabled: true } }}>{visible}</div>
+{:else}
+  <span>hidden</span>
+{/if}
+<style>
+  div { font-weight: var(--weight); }
+</style>
+"#;
+
+        let storage = crate::index_template_file(
+            Path::new("Component.svelte"),
+            TemplateKind::Svelte,
+            source,
+        )?;
+
+        assert!(
+            storage.files[0].complete,
+            "{}",
+            prepare_template_source(TemplateKind::Svelte, source).completeness_blanked
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_svelte_script_remains_incomplete() -> anyhow::Result<()> {
+        let source = "<script>export function broken( {</script>\n<h1>Broken</h1>\n";
+
+        let storage =
+            crate::index_template_file(Path::new("Broken.svelte"), TemplateKind::Svelte, source)?;
+
+        assert!(!storage.files[0].complete);
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_kept_svelte_inline_expression_remains_incomplete() -> anyhow::Result<()> {
+        let source = "<script>export let value = 1</script>\n<p>{broken(}</p>\n";
+
+        let storage =
+            crate::index_template_file(Path::new("Broken.svelte"), TemplateKind::Svelte, source)?;
+
+        assert!(!storage.files[0].complete);
+        Ok(())
     }
 }

--- a/crates/codestory-indexer/tests/oss_language_corpus.rs
+++ b/crates/codestory-indexer/tests/oss_language_corpus.rs
@@ -47,6 +47,8 @@ struct CorpusReport {
     codestory_input_files: usize,
     codestory_stored_files: usize,
     codestory_indexed_files: usize,
+    incomplete_files: usize,
+    incomplete_file_samples: Vec<String>,
     nodes: usize,
     edges: usize,
     errors: usize,
@@ -58,7 +60,7 @@ struct CorpusReport {
     stats: IncrementalIndexingStats,
 }
 
-const SUPPORTED_LANGUAGE_NAMES: &[&str] = &[
+const CORPUS_LANGUAGE_NAMES: &[&str] = &[
     "python",
     "java",
     "rust",
@@ -77,6 +79,9 @@ const SUPPORTED_LANGUAGE_NAMES: &[&str] = &[
     "html",
     "css",
     "sql",
+    "svelte",
+    "vue",
+    "astro",
 ];
 
 const SKIPPED_DIRS: &[&str] = &[
@@ -334,6 +339,48 @@ const OSS_CORPUS: &[OssCorpusCase] = &[
         min_nodes: 10,
         max_errors: 0,
     },
+    OssCorpusCase {
+        language: "svelte",
+        repo_name: "sveltejs/svelte",
+        repo_url: "https://github.com/sveltejs/svelte.git",
+        // svelte@5.56.8
+        commit: "44a7813730579b94004e182e5a67aab27aa9d2a6",
+        project_subdir: Some("packages/svelte/tests/runtime-runes/samples"),
+        extensions: &["svelte"],
+        min_baseline_files: 1_000,
+        min_baseline_loc: 1_000,
+        min_indexed_files: 1_000,
+        min_nodes: 25,
+        max_errors: 0,
+    },
+    OssCorpusCase {
+        language: "vue",
+        repo_name: "vuejs/core",
+        repo_url: "https://github.com/vuejs/core.git",
+        // v3.5.40
+        commit: "fa2885d8c48768d26f1666a01bd540ffe3b20f9b",
+        project_subdir: None,
+        extensions: &["vue"],
+        min_baseline_files: 10,
+        min_baseline_loc: 300,
+        min_indexed_files: 10,
+        min_nodes: 10,
+        max_errors: 0,
+    },
+    OssCorpusCase {
+        language: "astro",
+        repo_name: "withastro/astro",
+        repo_url: "https://github.com/withastro/astro.git",
+        // astro@7.1.6
+        commit: "9865d1c03af6d1a1f15c9811858778cc952ca4e4",
+        project_subdir: Some("examples"),
+        extensions: &["astro"],
+        min_baseline_files: 80,
+        min_baseline_loc: 500,
+        min_indexed_files: 80,
+        min_nodes: 25,
+        max_errors: 0,
+    },
 ];
 
 #[test]
@@ -384,11 +431,12 @@ fn oss_language_corpus_compares_raw_baseline_to_codestory() -> Result<()> {
                 let row = report_json(&report);
                 writeln!(writer, "{row}")?;
                 println!(
-                    "{}: raw_files={} raw_loc={} codestory_indexed_files={} nodes={} edges={} errors={} index_ms={}",
+                    "{}: raw_files={} raw_loc={} codestory_indexed_files={} incomplete_files={} nodes={} edges={} errors={} index_ms={}",
                     report.language,
                     report.raw_files,
                     report.raw_loc,
                     report.codestory_indexed_files,
+                    report.incomplete_files,
                     report.nodes,
                     report.edges,
                     report.errors,
@@ -454,6 +502,13 @@ fn run_case(case: &OssCorpusCase, cache_root: &Path) -> Result<CorpusReport> {
 
     let stored_files = storage.get_files()?;
     let codestory_indexed_files = stored_files.iter().filter(|file| file.indexed).count();
+    let incomplete_files = stored_files.iter().filter(|file| !file.complete).count();
+    let incomplete_file_samples = stored_files
+        .iter()
+        .filter(|file| !file.complete)
+        .take(10)
+        .map(|file| file.path.display().to_string())
+        .collect();
     let nodes = storage.get_nodes()?;
     let edges = storage.get_edges()?;
     let errors = storage.get_errors(None)?;
@@ -478,6 +533,8 @@ fn run_case(case: &OssCorpusCase, cache_root: &Path) -> Result<CorpusReport> {
         codestory_input_files: baseline.files.len(),
         codestory_stored_files: stored_files.len(),
         codestory_indexed_files,
+        incomplete_files,
+        incomplete_file_samples,
         nodes: nodes.len(),
         edges: edges.len(),
         errors: errors.len(),
@@ -494,7 +551,7 @@ fn run_case(case: &OssCorpusCase, cache_root: &Path) -> Result<CorpusReport> {
 }
 
 fn validate_manifest() -> Result<()> {
-    let expected: BTreeSet<&str> = SUPPORTED_LANGUAGE_NAMES.iter().copied().collect();
+    let expected: BTreeSet<&str> = CORPUS_LANGUAGE_NAMES.iter().copied().collect();
     let actual: BTreeSet<&str> = OSS_CORPUS.iter().map(|case| case.language).collect();
     if expected != actual {
         let missing: Vec<&str> = expected.difference(&actual).copied().collect();
@@ -508,6 +565,15 @@ fn validate_manifest() -> Result<()> {
     for case in OSS_CORPUS {
         if !repos.insert(case.repo_name) {
             bail!("duplicate OSS corpus repo {}", case.repo_name);
+        }
+        if is_template_language(case.language) {
+            if case.extensions != [case.language] {
+                bail!(
+                    "{} template corpus must use its matching extension",
+                    case.language
+                );
+            }
+            continue;
         }
         let profile = language_support_profile_for_language_name(case.language)
             .with_context(|| format!("{} is not a supported language", case.language))?;
@@ -563,7 +629,7 @@ fn selected_languages() -> Result<Option<HashSet<String>>> {
         _ => return Ok(None),
     };
 
-    let supported: HashSet<&str> = SUPPORTED_LANGUAGE_NAMES.iter().copied().collect();
+    let supported: HashSet<&str> = CORPUS_LANGUAGE_NAMES.iter().copied().collect();
     let mut selected = HashSet::new();
     for part in value.split(',') {
         let language = part.trim().to_ascii_lowercase();
@@ -645,6 +711,14 @@ fn assert_codestory_thresholds(case: &OssCorpusCase, report: &CorpusReport) -> R
             "{} CodeStory emitted {} fatal errors",
             case.language,
             report.fatal_errors
+        );
+    }
+    if is_template_language(case.language) && report.incomplete_files > 0 {
+        bail!(
+            "{} CodeStory marked {} pinned template corpus files incomplete: {:?}",
+            case.language,
+            report.incomplete_files,
+            report.incomplete_file_samples
         );
     }
     Ok(())
@@ -849,6 +923,8 @@ fn report_json(report: &CorpusReport) -> serde_json::Value {
             "input_files": report.codestory_input_files,
             "stored_files": report.codestory_stored_files,
             "indexed_files": report.codestory_indexed_files,
+            "incomplete_files": report.incomplete_files,
+            "incomplete_file_samples": report.incomplete_file_samples,
             "nodes": report.nodes,
             "edges": report.edges,
             "errors": report.errors,
@@ -878,6 +954,10 @@ fn normalize_extension(extension: &str) -> String {
         .trim()
         .trim_start_matches('.')
         .to_ascii_lowercase()
+}
+
+fn is_template_language(language: &str) -> bool {
+    matches!(language, "svelte" | "vue" | "astro")
 }
 
 fn sanitize_repo_name(repo_name: &str) -> String {

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -167,6 +167,19 @@ pub struct WorkspaceManifest {
     discovery_exclusion_observation_count: Cell<usize>,
 }
 
+fn default_source_exclude_patterns() -> Vec<String> {
+    [
+        "**/node_modules/**",
+        "**/target/**",
+        "**/.git/**",
+        "**/dist/**",
+        "**/build/**",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
 /// Multi-member workspace manifest.
 ///
 /// Each member becomes a synthetic source group rooted at that member path.
@@ -366,13 +379,7 @@ impl WorkspaceManifest {
                 language: Language::Rust,
                 standard: LanguageStandard::Default,
                 source_paths: vec![root_path],
-                exclude_patterns: vec![
-                    "**/node_modules/**".to_string(),
-                    "**/target/**".to_string(),
-                    "**/.git/**".to_string(),
-                    "**/dist/**".to_string(),
-                    "**/build/**".to_string(),
-                ],
+                exclude_patterns: default_source_exclude_patterns(),
                 include_paths: Vec::new(),
                 defines: HashMap::new(),
                 language_specific: LanguageSpecificSettings::Other,
@@ -423,13 +430,7 @@ impl WorkspaceManifest {
                 language: Language::Rust,
                 standard: LanguageStandard::Default,
                 source_paths: vec![member.clone()],
-                exclude_patterns: vec![
-                    "**/node_modules/**".to_string(),
-                    "**/target/**".to_string(),
-                    "**/.git/**".to_string(),
-                    "**/dist/**".to_string(),
-                    "**/build/**".to_string(),
-                ],
+                exclude_patterns: default_source_exclude_patterns(),
                 include_paths: Vec::new(),
                 defines: HashMap::new(),
                 language_specific: LanguageSpecificSettings::Other,
@@ -951,6 +952,9 @@ impl WorkspaceDiscovery {
                     let mut builder = ignore::WalkBuilder::new(&full_path);
                     builder.follow_links(true);
                     builder.require_git(false);
+                    // Hidden source trees such as .github are product input. The
+                    // manifest's explicit excludes still prune repository metadata.
+                    builder.hidden(false);
                     let workspace_root_for_filter = workspace_root.clone();
                     let source_root_for_filter = source_root.clone();
                     let exclude_patterns = exclude_patterns.clone();
@@ -2992,6 +2996,26 @@ mod tests {
         assert!(files.contains(&root.join("app.ts")));
         assert!(files.contains(&root.join("App.svelte")));
         assert!(files.contains(&root.join("src").join("main.py")));
+        Ok(())
+    }
+
+    #[test]
+    fn synthetic_manifest_discovers_hidden_sources_but_excludes_git_metadata() -> Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        let workflow = root.join(".github/workflows/ci.yml");
+        let git_source = root.join(".git/objects/should-not-index.rs");
+        fs::create_dir_all(workflow.parent().expect("workflow parent"))?;
+        fs::create_dir_all(git_source.parent().expect("git source parent"))?;
+        fs::write(&workflow, "name: CI\non: push\njobs: {}\n")?;
+        fs::write(&git_source, "pub fn repository_metadata() {}\n")?;
+
+        let manifest = WorkspaceManifest::open(root.clone())?;
+        let inventory = manifest.source_inventory()?;
+
+        assert_eq!(inventory.outcome, WorkspaceInventoryOutcome::Complete);
+        assert!(inventory.files.contains(&workflow));
+        assert!(!inventory.files.contains(&git_source));
         Ok(())
     }
 


### PR DESCRIPTION
Closes #1645

## What changed

- discovers hidden source files while retaining explicit build and Git metadata exclusions
- makes Vue, Svelte, and Astro template extraction quote-aware and completeness-safe
- keeps same-basename template identities distinct and persists template/text content hashes
- pins the Svelte 5, Vue 3, and Astro corpus fixtures to exact upstream commits

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked -p codestory-workspace` (76 passed)
- `cargo test --locked -p codestory-indexer --lib` (251 passed, 1 explicitly ignored)
- `cargo test --locked -p codestory-indexer --test fidelity_regression` (8 passed)
- `cargo test --locked -p codestory-indexer --test tictactoe_language_coverage` (12 passed)
- `cargo clippy --locked -p codestory-workspace -p codestory-indexer --all-targets -- -D warnings`
- pinned Svelte/Vue/Astro corpus: 1,454 files, zero incomplete files, zero errors

## Boundary

The external corpus gate covers only the pinned Svelte, Vue, and Astro fixtures required by this layer. No merge or release action is included.