### PR TITLE
[v0.17 EV-3] Collapse packet retrieval onto one honest fused lane

### DIFF
--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -2046,7 +2046,7 @@ static PACKET_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
         .with_default(ValueLiteral::Boolean(true)),
         SchemaProperty::integer(
             "latency_budget_ms",
-            "Optional retrieval latency budget in milliseconds.",
+            "Optional retrieval latency budget in milliseconds; defaults to 1500 when omitted.",
         )
         .with_bounds(1000, 120000)
         .nullable(),

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -228,7 +228,7 @@ impl<'a> QueryExecutor<'a> {
             cancel_reason = Some("deadline".into());
         }
 
-        if cancel_reason.is_none()
+        if query_completion_is_cacheable(cancel_reason.as_deref())
             && !self.cancelled.load(Ordering::Acquire)
             && Instant::now() < deadline
             && let Some(manifest) = self.manifest.as_ref()
@@ -557,6 +557,10 @@ impl<'a> QueryExecutor<'a> {
         }
         Ok(cancel_reason)
     }
+}
+
+fn query_completion_is_cacheable(cancel_reason: Option<&str>) -> bool {
+    matches!(cancel_reason, None | Some("marginal_gain"))
 }
 
 fn cancelled_query_result(
@@ -1148,6 +1152,41 @@ mod tests {
             "cancelled requests must not serve cache"
         );
         assert_eq!(cancelled_cache.len(), 1);
+    }
+
+    #[test]
+    fn executor_caches_successful_marginal_gain_stop() {
+        let query = "explain startup request flow";
+        let mock = Arc::new(MockSidecarSearch {
+            lexical: Mutex::new(HashMap::from([(
+                query.into(),
+                vec![CandidateHit::with_source(
+                    "src/startup.rs",
+                    Some("startup".into()),
+                    0.9,
+                    CandidateSource::Lexical,
+                )],
+            )])),
+            ..Default::default()
+        });
+        let mut cache = RetrievalCache::new();
+        let manifest = sample_manifest();
+
+        let mut executor = QueryExecutor {
+            sidecars: mock,
+            cache: &mut cache,
+            manifest: Some(manifest),
+            file_roles: Arc::new(HashMap::new()),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let first = executor.execute(query, Some(1_000)).expect("first query");
+        assert_eq!(first.trace.cancel_reason.as_deref(), Some("marginal_gain"));
+        assert!(!first.trace.cache_hit);
+
+        let cached = executor.execute(query, Some(1_000)).expect("cached query");
+        assert!(cached.trace.cache_hit);
+        assert_eq!(cached.hits, first.hits);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -386,13 +386,7 @@ pub(crate) fn agent_packet(
     let limits = packet_budget_limits(req.budget);
     let packet_latency = PacketLatencyBudget::new(req.latency_budget_ms);
     let retrieval_profile = packet_retrieval_profile(Some(plan.task_class), req.budget, &limits);
-    let initial_hybrid_weights = packet_initial_hybrid_weights(&plan, req.budget);
-    let retrieval_prompt = packet_retrieval_prompt(
-        &question,
-        &plan,
-        initial_hybrid_weights.as_ref(),
-        req.budget,
-    );
+    let retrieval_prompt = packet_retrieval_prompt(&question, &plan, req.budget);
     let mut answer = agent_ask(
         controller,
         AgentAskRequest {
@@ -403,7 +397,7 @@ pub(crate) fn agent_packet(
             response_mode: AgentResponseModeDto::Structured,
             latency_budget_ms: req.latency_budget_ms,
             include_evidence: req.include_evidence,
-            hybrid_weights: initial_hybrid_weights.clone(),
+            hybrid_weights: None,
         },
     )?;
     if !exact_probe_citations.is_empty() {
@@ -412,12 +406,6 @@ pub(crate) fn agent_packet(
             exact_probe_citations.len()
         ));
         answer.citations.extend(exact_probe_citations);
-    }
-    if packet_initial_retrieval_is_lexical_only(initial_hybrid_weights.as_ref()) {
-        answer.retrieval_trace.annotations.push(format!(
-            "packet_initial_retrieval semantic_skipped=true reason=compact_exact_anchor_probes probe_count={}",
-            packet_anchor_probe_queries(&plan).len()
-        ));
     }
     answer
         .retrieval_trace
@@ -648,14 +636,9 @@ fn append_packet_step_trace_annotation(answer: &mut AgentAnswerDto) {
 fn packet_retrieval_prompt(
     question: &str,
     plan: &PacketPlanDto,
-    initial_hybrid_weights: Option<&AgentHybridWeightsDto>,
     budget: PacketBudgetModeDto,
 ) -> String {
     let anchor_probes = packet_anchor_probe_queries(plan);
-    if packet_initial_retrieval_is_lexical_only(initial_hybrid_weights) && anchor_probes.is_empty()
-    {
-        return question.to_string();
-    }
     if plan.queries.len() <= 1 {
         return question.to_string();
     }
@@ -665,39 +648,31 @@ fn packet_retrieval_prompt(
         budget,
         PacketBudgetModeDto::Compact | PacketBudgetModeDto::Tiny
     );
-    let planned_lines =
-        if packet_initial_retrieval_is_lexical_only(initial_hybrid_weights) || compact {
-            let mut lines = packet_compact_retrieval_prompt_lines(anchor_probes)
-                .into_iter()
-                .map(|query| format!("- {query} (symbol probe)"))
-                .collect::<Vec<_>>();
-            if lines.is_empty() {
-                lines = plan
-                    .queries
-                    .iter()
-                    .take(8)
-                    .map(|query| format!("- {} ({})", query.query, query.purpose))
-                    .collect();
-            }
-            lines
-        } else {
-            plan.queries
+    let planned_lines = if compact {
+        let mut lines = packet_compact_retrieval_prompt_lines(anchor_probes)
+            .into_iter()
+            .map(|query| format!("- {query} (symbol probe)"))
+            .collect::<Vec<_>>();
+        if lines.is_empty() {
+            lines = plan
+                .queries
                 .iter()
+                .take(8)
                 .map(|query| format!("- {} ({})", query.query, query.purpose))
-                .collect()
-        };
+                .collect();
+        }
+        lines
+    } else {
+        plan.queries
+            .iter()
+            .map(|query| format!("- {} ({})", query.query, query.purpose))
+            .collect()
+    };
     for line in planned_lines {
         prompt.push('\n');
         prompt.push_str(&line);
     }
     prompt
-}
-
-fn packet_initial_hybrid_weights(
-    _plan: &PacketPlanDto,
-    _budget: PacketBudgetModeDto,
-) -> Option<AgentHybridWeightsDto> {
-    None
 }
 
 fn packet_compact_retrieval_prompt_lines(mut anchor_probes: Vec<String>) -> Vec<String> {
@@ -720,7 +695,7 @@ fn packet_compact_retrieval_prompt_lines(mut anchor_probes: Vec<String>) -> Vec<
     selected
 }
 
-fn packet_initial_retrieval_is_lexical_only(weights: Option<&AgentHybridWeightsDto>) -> bool {
+fn hybrid_weights_are_lexical_only(weights: Option<&AgentHybridWeightsDto>) -> bool {
     weights
         .and_then(|weights| weights.semantic)
         .is_some_and(|semantic| semantic <= f32::EPSILON)
@@ -3529,8 +3504,8 @@ fn execute_retrieval(
     trace: &mut TraceRecorder,
 ) -> Result<RetrievalBundle, ApiError> {
     let mut bundle = RetrievalBundle::default();
-    let semantic_required = hybrid_retrieval_enabled()
-        && !packet_initial_retrieval_is_lexical_only(req.hybrid_weights.as_ref());
+    let semantic_required =
+        hybrid_retrieval_enabled() && !hybrid_weights_are_lexical_only(req.hybrid_weights.as_ref());
 
     let max_results = req
         .max_results
@@ -7825,23 +7800,15 @@ mod tests {
     }
 
     #[test]
-    fn compact_packet_initial_retrieval_keeps_semantic_hybrid_and_anchor_prompt() {
+    fn compact_packet_retrieval_keeps_anchor_prompt() {
         let plan = build_packet_plan(
             "Explain how VS Code workbench startup reaches ExtensionService, ExtensionHostManager, AbstractExtHostExtensionService, and ExtHostCommands.executeCommand.",
             Some(PacketTaskClassDto::ArchitectureExplanation),
             PacketBudgetModeDto::Compact,
         );
 
-        assert!(
-            packet_initial_hybrid_weights(&plan, PacketBudgetModeDto::Compact).is_none(),
-            "compact packets should not collapse initial retrieval to lexical-only"
-        );
-        let prompt = packet_retrieval_prompt(
-            "Explain startup.",
-            &plan,
-            None,
-            PacketBudgetModeDto::Compact,
-        );
+        let prompt =
+            packet_retrieval_prompt("Explain startup.", &plan, PacketBudgetModeDto::Compact);
         assert!(prompt.starts_with("Explain startup."));
         assert!(prompt.contains("Planned CodeStory queries:"));
         assert!(prompt.contains("ExtensionService"));
@@ -14443,7 +14410,7 @@ mod tests {
         )];
         let prompt = "Explain how the client chooses adapters for request transport.";
         let mut answer = packet_answer_fixture(prompt, Vec::new());
-        crate::agent::packet_trace::merge_packet_lexical_subquery_batch(
+        crate::agent::packet_trace::merge_packet_fused_subquery_batch(
             &mut answer,
             &pending,
             &results,
@@ -14457,7 +14424,7 @@ mod tests {
         assert_eq!(answer.citations[0].display_name, "resolveHandle");
         assert_eq!(answer.citations[1].display_name, "adapters.js");
         assert!(answer.retrieval_trace.annotations.iter().any(|annotation| {
-            annotation.contains("packet_lexical_subquery")
+            annotation.contains("packet_fused_subquery")
                 && annotation.contains("hits=3")
                 && annotation.contains("citations_added=2")
         }));

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -4,36 +4,28 @@
 use super::citation::to_citation_from_hit;
 use super::packet_required_probes::packet_sufficiency_required_probe_queries_from_terms;
 use super::packet_scoring::{
-    normalize_identifier, packet_adjacent_query_stop_term, packet_citation_key,
-    packet_citation_rank, packet_query_stop_term, packet_stage_citation_carry_limit,
-    packet_subquery_hit_limit,
+    normalize_identifier, packet_citation_key, packet_citation_rank,
+    packet_stage_citation_carry_limit, packet_subquery_hit_limit,
 };
 use super::packet_terms::packet_probe_terms;
 use super::packet_trace::{
-    append_packet_query_timing_fields, merge_packet_lexical_subquery_batch,
-    merge_packet_semantic_subquery_batch, packet_query_diagnostic, packet_query_duration_ms,
+    append_packet_query_timing_fields, merge_packet_fused_subquery_batch, packet_query_diagnostic,
+    packet_query_duration_ms,
 };
-use super::planning::packet_subquery_hybrid_weights;
 use super::trace::field;
 use crate::{AppController, clamp_u128_to_u32, query_has_symbol_or_literal_signal};
 use codestory_contracts::api::{
-    AgentAnswerDto, AgentHybridWeightsDto, AgentRetrievalStepDto, AgentRetrievalStepKindDto,
-    AgentRetrievalStepStatusDto, ApiError, NodeKind, PacketBudgetLimitsDto, PacketBudgetModeDto,
-    PacketPlanDto, PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto, PacketTaskClassDto,
-    SearchHit, SearchHitOrigin, SearchMatchQualityDto, SemanticFallbackRecordDto,
+    AgentAnswerDto, AgentRetrievalStepDto, AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto,
+    ApiError, NodeKind, PacketBudgetLimitsDto, PacketBudgetModeDto, PacketPlanDto,
+    PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto, PacketTaskClassDto, SearchHit,
+    SearchHitOrigin, SearchMatchQualityDto,
 };
 use std::cmp::Ordering;
 use std::collections::HashSet;
+use std::sync::atomic::Ordering as AtomicOrdering;
 use std::time::Instant;
 
-const DEFAULT_SLA_TARGET_MS: u32 = 18_000;
-
-/// Hybrid weights for lexical-only subqueries that returned no indexed hits.
-const PACKET_LEXICAL_MISS_HYBRID_RETRY_WEIGHTS: AgentHybridWeightsDto = AgentHybridWeightsDto {
-    lexical: Some(0.35),
-    semantic: Some(0.55),
-    graph: Some(0.10),
-};
+const DEFAULT_SLA_TARGET_MS: u32 = 1_500;
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PacketLatencyBudget {
     pub(crate) started_at: Instant,
@@ -59,7 +51,7 @@ impl PacketLatencyBudget {
     }
 
     pub(crate) fn remaining_ms(&self) -> u32 {
-        clamp_u128_to_u32(self.target_ms.saturating_sub(self.elapsed_ms()).max(100))
+        clamp_u128_to_u32(self.target_ms.saturating_sub(self.elapsed_ms()).max(1_000))
     }
 
     pub(crate) fn budget_usage_percent(&self, consumed_trace_ms: u32) -> u128 {
@@ -104,239 +96,163 @@ pub(crate) fn run_packet_planned_subqueries(
 
     let per_query_limit = packet_subquery_hit_limit(limits);
     let stage_carry_limit = packet_stage_citation_carry_limit(limits);
-    let mut lexical_pending = Vec::new();
-    let mut semantic_pending = Vec::new();
-    for entry in &pending {
-        if packet_subquery_is_lexical_only(budget, entry.1) {
-            lexical_pending.push(*entry);
-        } else {
-            semantic_pending.push(*entry);
-        }
-    }
-
-    let warm_queries = pending
+    let batch = pending
         .iter()
-        .map(|(_, query)| query.query.clone())
+        .map(|(_, query)| (query.query.clone(), per_query_limit))
         .collect::<Vec<_>>();
-    if let Err(error) = controller.warm_packet_subquery_embeddings(&warm_queries) {
-        answer.retrieval_trace.annotations.push(format!(
-            "packet_subquery_embedding_warmup_failed error={:?}",
-            error
-        ));
-    }
-
     answer.retrieval_trace.annotations.push(format!(
-        "packet_subqueries lexical_batch={} semantic={} total={}",
-        lexical_pending.len(),
-        semantic_pending.len(),
+        "packet_subqueries fused_batch={} total={}",
+        batch.len(),
         pending.len()
     ));
 
-    if !lexical_pending.is_empty() {
-        let batch = lexical_pending
-            .iter()
-            .map(|(_, query)| (query.query.clone(), per_query_limit))
-            .collect::<Vec<_>>();
-        let started_at = Instant::now();
-        match controller.search_lexical_hybrid_batch(&batch, Some(packet_latency.remaining_ms())) {
-            Ok(outcome) => {
-                let duration_ms = clamp_u128_to_u32(started_at.elapsed().as_millis());
-                answer.retrieval_trace.total_latency_ms = answer
-                    .retrieval_trace
-                    .total_latency_ms
-                    .saturating_add(duration_ms);
-                answer
-                    .retrieval_trace
-                    .packet_sidecar_diagnostics
-                    .extend(outcome.sidecar_diagnostics.clone());
-                let results = outcome.results;
-                let diagnostics = outcome.sidecar_diagnostics;
-                annotate_packet_batch_timing(
-                    answer,
-                    "packet_lexical_subquery_batch",
-                    duration_ms,
-                    &diagnostics,
-                );
-                merge_packet_lexical_subquery_batch(
-                    answer,
-                    &lexical_pending,
-                    &results,
-                    duration_ms,
-                    &diagnostics,
-                    include_evidence,
-                    rank_terms,
-                    stage_carry_limit,
-                );
-
-                let hybrid_retry_pending: Vec<(usize, &PacketPlanQueryDto)> = lexical_pending
-                    .iter()
-                    .zip(results.iter())
-                    .filter(|((_, query), (_, hits))| {
-                        packet_lexical_subquery_needs_hybrid_retry(query, hits.len())
-                    })
-                    .map(|(entry, _)| *entry)
-                    .collect();
-                if !hybrid_retry_pending.is_empty() && !packet_latency.exhausted() {
-                    answer.retrieval_trace.annotations.push(format!(
-                        "packet_lexical_subquery_hybrid_retry count={}",
-                        hybrid_retry_pending.len()
-                    ));
-                    let retry_batch = hybrid_retry_pending
-                        .iter()
-                        .map(|(_, query)| {
-                            (
-                                query.query.clone(),
-                                per_query_limit,
-                                Some(PACKET_LEXICAL_MISS_HYBRID_RETRY_WEIGHTS),
-                            )
-                        })
-                        .collect::<Vec<_>>();
-                    let retry_started = Instant::now();
-                    match controller.search_semantic_hybrid_batch(
-                        &retry_batch,
-                        Some(packet_latency.remaining_ms()),
-                    ) {
-                        Ok(outcome) => {
-                            let retry_duration_ms =
-                                clamp_u128_to_u32(retry_started.elapsed().as_millis());
-                            answer.retrieval_trace.total_latency_ms = answer
-                                .retrieval_trace
-                                .total_latency_ms
-                                .saturating_add(retry_duration_ms);
-                            answer
-                                .retrieval_trace
-                                .packet_sidecar_diagnostics
-                                .extend(outcome.sidecar_diagnostics.clone());
-                            let diagnostics = outcome.sidecar_diagnostics;
-                            record_semantic_fallbacks(answer, &outcome.fallbacks);
-                            annotate_packet_batch_timing(
-                                answer,
-                                "packet_lexical_subquery_hybrid_retry_batch",
-                                retry_duration_ms,
-                                &diagnostics,
-                            );
-                            merge_packet_semantic_subquery_batch(
-                                answer,
-                                &hybrid_retry_pending,
-                                &outcome.results,
-                                retry_duration_ms,
-                                &diagnostics,
-                                include_evidence,
-                                rank_terms,
-                                budget,
-                                stage_carry_limit,
-                            );
-                        }
-                        Err(error) => {
-                            answer.retrieval_trace.annotations.push(format!(
-                                "packet_lexical_subquery_hybrid_retry_failed error={:?}",
-                                error
-                            ));
-                            return Err(error);
-                        }
-                    }
-                }
-            }
+    let started_at = Instant::now();
+    let outcome =
+        match controller.search_packet_fused_batch(&batch, Some(packet_latency.remaining_ms())) {
+            Ok(outcome) => outcome,
             Err(error) => {
                 answer.retrieval_trace.annotations.push(format!(
-                    "packet_lexical_subquery_batch_failed error={:?}",
-                    error
+                    "packet_fused_subquery_batch_failed error={error:?}"
                 ));
                 return Err(error);
             }
-        }
-    }
+        };
+    let duration_ms = clamp_u128_to_u32(started_at.elapsed().as_millis());
+    answer.retrieval_trace.total_latency_ms = answer
+        .retrieval_trace
+        .total_latency_ms
+        .saturating_add(duration_ms);
+    answer
+        .retrieval_trace
+        .packet_sidecar_diagnostics
+        .extend(outcome.sidecar_diagnostics.clone());
+    annotate_packet_batch_timing(
+        answer,
+        "packet_fused_subquery_batch",
+        duration_ms,
+        &outcome.sidecar_diagnostics,
+    );
 
-    if !semantic_pending.is_empty() {
+    let mut total_duration_ms = duration_ms;
+    let mut results = outcome.results;
+    let mut effective_diagnostics = outcome.sidecar_diagnostics;
+    let retry_pending = packet_fused_retry_pending(&pending, &outcome.retryable_queries);
+    if !retry_pending.is_empty() {
+        if !packet_fused_retry_is_live() {
+            return Err(ApiError::new(
+                "cancelled",
+                "packet fused retry was cancelled before dispatch",
+            ));
+        }
         if packet_latency.exhausted() {
-            answer.retrieval_trace.annotations.push(
-                "packet_semantic_subqueries skipped reason=latency_budget_exhausted".to_string(),
-            );
+            answer.retrieval_trace.annotations.push(format!(
+                "packet_fused_blocking_cancel_retry skipped reason=latency_budget_exhausted count={}",
+                retry_pending.len()
+            ));
         } else {
-            let batch = semantic_pending
+            answer.retrieval_trace.annotations.push(format!(
+                "packet_fused_blocking_cancel_retry count={}",
+                retry_pending.len()
+            ));
+            let retry_batch = retry_pending
                 .iter()
-                .map(|(_, query)| {
-                    (
-                        query.query.clone(),
-                        per_query_limit,
-                        packet_subquery_hybrid_weights(budget, query),
-                    )
-                })
+                .map(|(_, query)| (query.query.clone(), per_query_limit))
                 .collect::<Vec<_>>();
-            let started_at = Instant::now();
-            match controller
-                .search_semantic_hybrid_batch(&batch, Some(packet_latency.remaining_ms()))
-            {
-                Ok(outcome) => {
-                    let duration_ms = clamp_u128_to_u32(started_at.elapsed().as_millis());
-                    answer.retrieval_trace.total_latency_ms = answer
-                        .retrieval_trace
-                        .total_latency_ms
-                        .saturating_add(duration_ms);
-                    answer
-                        .retrieval_trace
-                        .packet_sidecar_diagnostics
-                        .extend(outcome.sidecar_diagnostics.clone());
-                    let diagnostics = outcome.sidecar_diagnostics;
-                    record_semantic_fallbacks(answer, &outcome.fallbacks);
-                    annotate_packet_batch_timing(
-                        answer,
-                        "packet_semantic_subquery_batch",
-                        duration_ms,
-                        &diagnostics,
-                    );
-                    merge_packet_semantic_subquery_batch(
-                        answer,
-                        &semantic_pending,
-                        &outcome.results,
-                        duration_ms,
-                        &diagnostics,
-                        include_evidence,
-                        rank_terms,
-                        budget,
-                        stage_carry_limit,
-                    );
-                }
-                Err(error) => {
-                    for (plan_index, query) in &semantic_pending {
-                        answer.retrieval_trace.annotations.push(format!(
-                            "packet_semantic_subquery_batch_failed index={} query=`{}` error={:?}",
-                            plan_index,
-                            query.query.replace('`', "'"),
-                            error
-                        ));
-                    }
-                    return Err(error);
-                }
+            let retry_started_at = Instant::now();
+            let retry_outcome = controller
+                .search_packet_fused_batch(&retry_batch, Some(packet_latency.remaining_ms()))
+                .map_err(|error| {
+                    answer.retrieval_trace.annotations.push(format!(
+                        "packet_fused_blocking_cancel_retry_failed error={error:?}"
+                    ));
+                    error
+                })?;
+            let retry_duration_ms = clamp_u128_to_u32(retry_started_at.elapsed().as_millis());
+            total_duration_ms = total_duration_ms.saturating_add(retry_duration_ms);
+            answer.retrieval_trace.total_latency_ms = answer
+                .retrieval_trace
+                .total_latency_ms
+                .saturating_add(retry_duration_ms);
+            answer
+                .retrieval_trace
+                .packet_sidecar_diagnostics
+                .extend(retry_outcome.sidecar_diagnostics.clone());
+            annotate_packet_batch_timing(
+                answer,
+                "packet_fused_blocking_cancel_retry_batch",
+                retry_duration_ms,
+                &retry_outcome.sidecar_diagnostics,
+            );
+            replace_packet_fused_results(&mut results, retry_outcome.results);
+            replace_packet_fused_diagnostics(
+                &mut effective_diagnostics,
+                retry_outcome.sidecar_diagnostics,
+            );
+            if !retry_outcome.retryable_queries.is_empty() {
+                answer.retrieval_trace.annotations.push(format!(
+                    "packet_fused_blocking_cancel_retry exhausted count={}",
+                    retry_outcome.retryable_queries.len()
+                ));
             }
         }
     }
+
+    merge_packet_fused_subquery_batch(
+        answer,
+        &pending,
+        &results,
+        total_duration_ms,
+        &effective_diagnostics,
+        include_evidence,
+        rank_terms,
+        stage_carry_limit,
+    );
     packet_latency.apply_to_trace(answer);
     Ok(())
 }
 
-pub(crate) fn record_semantic_fallbacks(
-    answer: &mut AgentAnswerDto,
-    fallbacks: &[SemanticFallbackRecordDto],
+fn packet_fused_retry_pending<'a>(
+    pending: &[(usize, &'a PacketPlanQueryDto)],
+    retryable_queries: &[String],
+) -> Vec<(usize, &'a PacketPlanQueryDto)> {
+    let retryable = retryable_queries
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    pending
+        .iter()
+        .copied()
+        .filter(|(_, query)| retryable.contains(query.query.as_str()))
+        .collect()
+}
+
+fn packet_fused_retry_is_live() -> bool {
+    !crate::services::active_public_operation_cancellation()
+        .is_some_and(|cancelled| cancelled.load(AtomicOrdering::Acquire))
+}
+
+fn replace_packet_fused_results(
+    results: &mut [(String, Vec<SearchHit>)],
+    retry_results: Vec<(String, Vec<SearchHit>)>,
 ) {
-    for fallback in fallbacks {
-        answer
-            .retrieval_trace
-            .semantic_fallbacks
-            .push(fallback.clone());
-        answer.retrieval_trace.annotations.push(format!(
-            "semantic_fallback query=`{}` reason={}",
-            fallback.query.replace('`', "'"),
-            fallback.reason
-        ));
+    for (retry_query, retry_hits) in retry_results {
+        if let Some((_, hits)) = results.iter_mut().find(|(query, _)| *query == retry_query) {
+            *hits = retry_hits;
+        }
     }
-    answer.retrieval_trace.semantic_fallback_count =
-        answer.retrieval_trace.semantic_fallbacks.len() as u32;
-    if !fallbacks.is_empty() {
-        answer.retrieval_trace.annotations.push(format!(
-            "semantic_fallback_summary count={} degraded_runtime=true",
-            fallbacks.len()
-        ));
+}
+
+fn replace_packet_fused_diagnostics(
+    diagnostics: &mut [PacketSidecarQueryDiagnosticDto],
+    retry_diagnostics: Vec<PacketSidecarQueryDiagnosticDto>,
+) {
+    for retry in retry_diagnostics {
+        if let Some(diagnostic) = diagnostics
+            .iter_mut()
+            .find(|diagnostic| diagnostic.query == retry.query)
+        {
+            *diagnostic = retry;
+        }
     }
 }
 
@@ -421,10 +337,10 @@ fn packet_planned_subquery_should_run(
     budget: PacketBudgetModeDto,
     query: &PacketPlanQueryDto,
 ) -> bool {
-    if !packet_subquery_is_lexical_only(budget, query) {
-        return true;
-    }
-    if !query
+    if !matches!(
+        budget,
+        PacketBudgetModeDto::Compact | PacketBudgetModeDto::Standard
+    ) || !query
         .purpose
         .contains("concrete symbol, file, route, or code term")
     {
@@ -492,11 +408,11 @@ pub(crate) fn run_packet_anchor_expansion(
     }
 
     let started_at = Instant::now();
-    let result = controller.search_symbolic_packet_anchor_batch(
-        &queries,
-        per_query_limit,
-        Some(packet_latency.remaining_ms()),
-    );
+    let batch = queries
+        .iter()
+        .map(|query| (query.clone(), per_query_limit))
+        .collect::<Vec<_>>();
+    let result = controller.search_packet_fused_batch(&batch, Some(packet_latency.remaining_ms()));
     let duration_ms = clamp_u128_to_u32(started_at.elapsed().as_millis());
     answer.retrieval_trace.total_latency_ms = answer
         .retrieval_trace
@@ -790,44 +706,6 @@ pub(crate) fn packet_file_stem_matches_query(query: &str, path: Option<&str>) ->
     normalize_identifier(stem) == normalized_query
 }
 
-fn packet_subquery_is_lexical_only(
-    budget: PacketBudgetModeDto,
-    query: &PacketPlanQueryDto,
-) -> bool {
-    packet_subquery_hybrid_weights(budget, query)
-        .and_then(|weights| weights.semantic)
-        .is_some_and(|semantic| semantic <= f32::EPSILON)
-}
-
-fn packet_lexical_subquery_needs_hybrid_retry(
-    query: &PacketPlanQueryDto,
-    hit_count: usize,
-) -> bool {
-    if hit_count > 0 {
-        return false;
-    }
-    let trimmed = query.query.trim();
-    let lowered = trimmed.to_ascii_lowercase();
-    if packet_query_stop_term(&lowered) || packet_adjacent_query_stop_term(&lowered) {
-        return false;
-    }
-    if trimmed.len() <= 3 {
-        return false;
-    }
-    if query_has_symbol_or_literal_signal(trimmed) {
-        return true;
-    }
-    if is_packet_code_like_term(trimmed) {
-        return true;
-    }
-    if query.purpose.contains("symbol") || query.purpose.contains("flow anchor") {
-        return trimmed.len() >= 5
-            && !packet_query_stop_term(&lowered)
-            && !packet_adjacent_query_stop_term(&lowered);
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -835,42 +713,30 @@ mod tests {
     use codestory_contracts::api::{PacketPlanDto, PacketPlanQueryDto, PacketTaskClassDto};
 
     #[test]
-    fn packet_lexical_subquery_hybrid_retry_for_empty_symbol_probe() {
-        let query = PacketPlanQueryDto {
-            query: "dispatchRequest".to_string(),
-            purpose: "concrete symbol, file, route, or code term".to_string(),
-        };
-        assert!(packet_lexical_subquery_needs_hybrid_retry(&query, 0));
-        assert!(!packet_lexical_subquery_needs_hybrid_retry(&query, 1));
+    fn packet_latency_budget_preserves_advertised_range_and_default() {
+        assert_eq!(PacketLatencyBudget::new(None).target_ms, 1_500);
+        assert_eq!(PacketLatencyBudget::new(Some(10)).target_ms, 1_000);
+        assert_eq!(PacketLatencyBudget::new(Some(120_001)).target_ms, 120_000);
+        assert!(PacketLatencyBudget::new(Some(1_000)).remaining_ms() >= 1_000);
     }
 
     #[test]
-    fn packet_lexical_subquery_hybrid_retry_for_short_concrete_term() {
-        let query = PacketPlanQueryDto {
-            query: "HTTP".to_string(),
-            purpose: "concrete symbol, file, route, or code term".to_string(),
+    fn packet_fused_retry_uses_only_reported_blocking_deadlines() {
+        let first = PacketPlanQueryDto {
+            query: "ordinary empty".to_string(),
+            purpose: "supplemental".to_string(),
         };
-        assert!(packet_lexical_subquery_needs_hybrid_retry(&query, 0));
-    }
+        let second = PacketPlanQueryDto {
+            query: "timed out".to_string(),
+            purpose: "required flow anchor".to_string(),
+        };
+        let pending = vec![(1, &first), (2, &second)];
 
-    #[test]
-    fn packet_lexical_subquery_skips_hybrid_retry_for_generic_concrete_terms() {
-        for query in [
-            PacketPlanQueryDto {
-                query: "Explain".to_string(),
-                purpose: "concrete symbol, file, route, or code term".to_string(),
-            },
-            PacketPlanQueryDto {
-                query: "CLI".to_string(),
-                purpose: "concrete symbol, file, route, or code term".to_string(),
-            },
-        ] {
-            assert!(
-                !packet_lexical_subquery_needs_hybrid_retry(&query, 0),
-                "generic term `{}` should not trigger hybrid retry",
-                query.query
-            );
-        }
+        assert!(packet_fused_retry_pending(&pending, &[]).is_empty());
+        let retry = packet_fused_retry_pending(&pending, &["timed out".to_string()]);
+        assert_eq!(retry.len(), 1);
+        assert_eq!(retry[0].0, 2);
+        assert_eq!(retry[0].1.query, "timed out");
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_search.rs
+++ b/crates/codestory-runtime/src/agent/packet_search.rs
@@ -1,28 +1,21 @@
 //! AppController batch search paths for packet retrieval.
 
+use crate::AppController;
 use crate::agent::retrieval_primary::{
     packet_batch_should_use_sidecar, search_sidecar_packet_batch,
     sidecar_retrieval_unavailable_error, sidecar_retrieval_unavailable_reason,
 };
-use crate::{AppController, HybridSearchScoredHit};
-use codestory_contracts::api::{
-    AgentHybridWeightsDto, ApiError, PacketSidecarQueryDiagnosticDto, SearchHit,
-    SemanticFallbackRecordDto,
-};
+use codestory_contracts::api::{ApiError, PacketSidecarQueryDiagnosticDto, SearchHit};
 
-pub(crate) struct SemanticHybridBatchOutcome {
-    pub results: Vec<(String, Vec<HybridSearchScoredHit>)>,
-    pub fallbacks: Vec<SemanticFallbackRecordDto>,
-    pub sidecar_diagnostics: Vec<PacketSidecarQueryDiagnosticDto>,
-}
-
-pub(crate) struct LexicalBatchOutcome {
+#[derive(Debug)]
+pub(crate) struct PacketFusedBatchOutcome {
     pub results: Vec<(String, Vec<SearchHit>)>,
+    pub retryable_queries: Vec<String>,
     pub sidecar_diagnostics: Vec<PacketSidecarQueryDiagnosticDto>,
 }
 
 fn packet_batch_error(controller: &AppController, error: ApiError, context: &str) -> ApiError {
-    if error.code == "publication_changed" {
+    if matches!(error.code.as_str(), "publication_changed" | "cancelled") {
         error
     } else {
         sidecar_retrieval_unavailable_error(
@@ -36,47 +29,36 @@ fn packet_batch_error(controller: &AppController, error: ApiError, context: &str
 }
 
 impl AppController {
-    pub(crate) fn search_symbolic_packet_anchor_batch(
-        &self,
-        queries: &[String],
-        max_results: usize,
-        latency_budget_ms: Option<u32>,
-    ) -> Result<LexicalBatchOutcome, ApiError> {
-        let batched = queries
-            .iter()
-            .map(|query| (query.clone(), max_results))
-            .collect::<Vec<_>>();
-        self.search_lexical_hybrid_batch(&batched, latency_budget_ms)
-    }
-
-    pub(crate) fn search_lexical_hybrid_batch(
+    pub(crate) fn search_packet_fused_batch(
         &self,
         queries: &[(String, usize)],
         latency_budget_ms: Option<u32>,
-    ) -> Result<LexicalBatchOutcome, ApiError> {
+    ) -> Result<PacketFusedBatchOutcome, ApiError> {
         if queries.is_empty() {
-            return Ok(LexicalBatchOutcome {
+            return Ok(PacketFusedBatchOutcome {
                 results: Vec::new(),
+                retryable_queries: Vec::new(),
                 sidecar_diagnostics: Vec::new(),
             });
         }
         if packet_batch_should_use_sidecar(self) {
             match search_sidecar_packet_batch(self, queries, latency_budget_ms) {
                 Ok(outcome) => {
-                    return Ok(LexicalBatchOutcome {
+                    return Ok(PacketFusedBatchOutcome {
                         results: outcome.results,
+                        retryable_queries: outcome.retryable_queries,
                         sidecar_diagnostics: outcome.diagnostics,
                     });
                 }
                 Err(error) => {
                     tracing::warn!(
-                        "sidecar retrieval packet lexical batch unavailable; fail-closed: {}",
+                        "sidecar retrieval packet fused batch unavailable; fail-closed: {}",
                         error.message
                     );
                     return Err(packet_batch_error(
                         self,
                         error,
-                        "sidecar retrieval packet lexical batch unavailable",
+                        "sidecar retrieval packet fused batch unavailable",
                     ));
                 }
             }
@@ -85,88 +67,7 @@ impl AppController {
         }
         Err(sidecar_retrieval_unavailable_error(
             self,
-            "full retrieval is mandatory for packet lexical batch",
-        ))
-    }
-
-    pub(crate) fn search_semantic_hybrid_batch(
-        &self,
-        queries: &[(String, usize, Option<AgentHybridWeightsDto>)],
-        latency_budget_ms: Option<u32>,
-    ) -> Result<SemanticHybridBatchOutcome, ApiError> {
-        if queries.is_empty() {
-            return Ok(SemanticHybridBatchOutcome {
-                results: Vec::new(),
-                fallbacks: Vec::new(),
-                sidecar_diagnostics: Vec::new(),
-            });
-        }
-        if packet_batch_should_use_sidecar(self) {
-            let batch = queries
-                .iter()
-                .map(|(query, max_results, _)| (query.clone(), *max_results))
-                .collect::<Vec<_>>();
-            match search_sidecar_packet_batch(self, &batch, latency_budget_ms) {
-                Ok(outcome) => {
-                    return Ok(SemanticHybridBatchOutcome {
-                        results: outcome
-                            .results
-                            .into_iter()
-                            .map(|(query, hits)| {
-                                (
-                                    query,
-                                    hits.into_iter()
-                                        .map(|hit| HybridSearchScoredHit {
-                                            lexical_score: hit.score,
-                                            semantic_score: 0.0,
-                                            graph_score: 0.0,
-                                            total_score: hit.score,
-                                            hit,
-                                        })
-                                        .collect(),
-                                )
-                            })
-                            .collect(),
-                        fallbacks: Vec::new(),
-                        sidecar_diagnostics: outcome.diagnostics,
-                    });
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        "sidecar retrieval packet semantic batch unavailable; fail-closed: {}",
-                        error.message
-                    );
-                    return Err(packet_batch_error(
-                        self,
-                        error,
-                        "sidecar retrieval packet semantic batch unavailable",
-                    ));
-                }
-            }
-        } else if let Some(reason) = sidecar_retrieval_unavailable_reason(self) {
-            return Err(sidecar_retrieval_unavailable_error(self, reason));
-        }
-        Err(sidecar_retrieval_unavailable_error(
-            self,
-            "full retrieval is mandatory for packet semantic batch",
-        ))
-    }
-
-    pub(crate) fn warm_packet_subquery_embeddings(
-        &self,
-        queries: &[String],
-    ) -> Result<(), ApiError> {
-        if queries.is_empty() {
-            return Ok(());
-        }
-        if packet_batch_should_use_sidecar(self) {
-            return Ok(());
-        } else if let Some(reason) = sidecar_retrieval_unavailable_reason(self) {
-            return Err(sidecar_retrieval_unavailable_error(self, reason));
-        }
-        Err(sidecar_retrieval_unavailable_error(
-            self,
-            "full retrieval is mandatory for packet subquery warmup",
+            "full retrieval is mandatory for packet fused batch",
         ))
     }
 }
@@ -185,6 +86,18 @@ mod tests {
 
         assert_eq!(error.code, "publication_changed");
         assert_eq!(error.message, "generation drift");
+    }
+
+    #[test]
+    fn packet_batch_preserves_public_cancellation() {
+        let error = packet_batch_error(
+            &AppController::new(),
+            ApiError::new("cancelled", "request cancelled"),
+            "packet batch",
+        );
+
+        assert_eq!(error.code, "cancelled");
+        assert_eq!(error.message, "request cancelled");
     }
 
     struct EnvVarGuard {
@@ -217,18 +130,18 @@ mod tests {
     }
 
     #[test]
-    fn packet_subquery_warmup_fails_closed_without_sidecar_primary() {
+    fn packet_fused_batch_fails_closed_without_sidecar_primary() {
         let _lock = crate::process_env_test_lock();
         let _retrieval_env = EnvVarGuard::cleared("CODESTORY_RETRIEVAL");
         let controller = AppController::new_with_config(crate::test_sidecar_runtime_from_env());
 
         let error = controller
-            .warm_packet_subquery_embeddings(&["run_exec_session".to_string()])
-            .expect_err("packet warmup must not fall back to the legacy in-process search engine");
+            .search_packet_fused_batch(&[("run_exec_session".to_string(), 5)], None)
+            .expect_err("packet fused batch must not fall back to legacy in-process search");
 
         assert!(
             error.message.contains("retrieval requires an open project"),
-            "warmup should report the mandatory retrieval gate, got: {}",
+            "fused batch should report the mandatory retrieval gate, got: {}",
             error.message
         );
         assert_eq!(error.code, "retrieval_unavailable");
@@ -236,7 +149,7 @@ mod tests {
         assert_eq!(details.failed_layer.as_deref(), Some("retrieval_engine"));
         assert!(
             !details.next_commands.is_empty(),
-            "warmup should include recovery commands"
+            "fused batch should include recovery commands"
         );
     }
 }

--- a/crates/codestory-runtime/src/agent/packet_trace.rs
+++ b/crates/codestory-runtime/src/agent/packet_trace.rs
@@ -4,13 +4,11 @@
 
 use super::citation::to_citation_from_hit;
 use super::packet_scoring::{packet_citation_key, packet_citation_rank};
-use super::planning::packet_subquery_hybrid_weights;
 use super::trace::field;
-use crate::HybridSearchScoredHit;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentResponseBlockDto, AgentResponseSectionDto, AgentRetrievalStepDto,
     AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto, AgentRetrievalSummaryFieldDto,
-    PacketBudgetModeDto, PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto, SearchHit,
+    PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto, SearchHit,
 };
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -32,7 +30,7 @@ fn sanitize_section_id(value: &str) -> String {
     id.trim_matches('-').chars().take(48).collect()
 }
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn merge_packet_lexical_subquery_batch(
+pub(crate) fn merge_packet_fused_subquery_batch(
     answer: &mut AgentAnswerDto,
     pending: &[(usize, &PacketPlanQueryDto)],
     results: &[(String, Vec<SearchHit>)],
@@ -74,7 +72,7 @@ pub(crate) fn merge_packet_lexical_subquery_batch(
         let mut output = vec![
             field("hits", hits.len().to_string()),
             field("citations_added", added.to_string()),
-            field("mode", "packet_lexical_batch".to_string()),
+            field("mode", "packet_fused_batch".to_string()),
         ];
         append_packet_query_timing_fields(&mut output, diagnostic);
         answer.retrieval_trace.steps.push(AgentRetrievalStepDto {
@@ -87,7 +85,7 @@ pub(crate) fn merge_packet_lexical_subquery_batch(
         });
         let timing_note = packet_query_timing_annotation(diagnostic);
         answer.retrieval_trace.annotations.push(format!(
-            "packet_lexical_subquery index={} query=`{}` purpose=`{}` hits={} citations_added={}{}",
+            "packet_fused_subquery index={} query=`{}` purpose=`{}` hits={} citations_added={}{}",
             plan_index,
             query.query.replace('`', "'"),
             query.purpose.replace('`', "'"),
@@ -100,92 +98,9 @@ pub(crate) fn merge_packet_lexical_subquery_batch(
             title: format!("Planned query: {}", query.query),
             blocks: vec![AgentResponseBlockDto::Markdown {
                 markdown: format!(
-                    "Purpose: {}\n\nLexical batch retrieval found {} candidate hits. Use packet citations for exact files and symbols.",
+                    "Purpose: {}\n\nFused packet retrieval found {} candidate hits. Use packet citations for exact files and symbols.",
                     query.purpose,
                     hits.len()
-                ),
-            }],
-        });
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn merge_packet_semantic_subquery_batch(
-    answer: &mut AgentAnswerDto,
-    pending: &[(usize, &PacketPlanQueryDto)],
-    results: &[(String, Vec<HybridSearchScoredHit>)],
-    duration_ms: u32,
-    diagnostics: &[PacketSidecarQueryDiagnosticDto],
-    include_evidence: bool,
-    rank_terms: &[String],
-    budget: PacketBudgetModeDto,
-    stage_carry_limit: usize,
-) {
-    let mut citation_keys = answer
-        .citations
-        .iter()
-        .map(packet_citation_key)
-        .collect::<HashSet<_>>();
-
-    for (diagnostic_index, ((plan_index, query), (result_query, scored_hits))) in
-        pending.iter().zip(results.iter()).enumerate()
-    {
-        debug_assert_eq!(query.query, *result_query);
-        let diagnostic = packet_query_diagnostic(diagnostics, diagnostic_index, result_query);
-        let step_duration = packet_query_duration_ms(diagnostic)
-            .unwrap_or(duration_ms / pending.len().max(1) as u32);
-        let mut added = 0usize;
-        let mut citations = scored_hits
-            .iter()
-            .map(|scored| to_citation_from_hit(&scored.hit, None, None, include_evidence))
-            .collect::<Vec<_>>();
-        citations.sort_by(|left, right| {
-            packet_citation_rank(right, rank_terms, true)
-                .partial_cmp(&packet_citation_rank(left, rank_terms, true))
-                .unwrap_or(Ordering::Equal)
-        });
-        for citation in citations.into_iter().take(stage_carry_limit) {
-            if citation_keys.insert(packet_citation_key(&citation)) {
-                answer.citations.push(citation);
-                added = added.saturating_add(1);
-            }
-        }
-        let mut output = vec![
-            field("hits", scored_hits.len().to_string()),
-            field("citations_added", added.to_string()),
-            field("mode", "packet_semantic_batch".to_string()),
-        ];
-        append_packet_query_timing_fields(&mut output, diagnostic);
-        answer.retrieval_trace.steps.push(AgentRetrievalStepDto {
-            kind: AgentRetrievalStepKindDto::Search,
-            status: AgentRetrievalStepStatusDto::Ok,
-            duration_ms: step_duration,
-            input: vec![field("query", query.query.clone())],
-            output,
-            message: Some(format!("packet semantic subquery `{}`", query.purpose)),
-        });
-        let timing_note = packet_query_timing_annotation(diagnostic);
-        answer.retrieval_trace.annotations.push(format!(
-            "packet_semantic_subquery index={} query=`{}` hits={} citations_added={}{}",
-            plan_index,
-            query.query.replace('`', "'"),
-            scored_hits.len(),
-            added,
-            timing_note
-        ));
-        let hybrid_weights = packet_subquery_hybrid_weights(budget, query);
-        let semantic_note = hybrid_weights
-            .and_then(|weights| weights.semantic)
-            .map(|semantic| format!(" semantic_weight={semantic:.2}"))
-            .unwrap_or_default();
-        answer.sections.push(AgentResponseSectionDto {
-            id: format!("packet-subquery-{}", sanitize_section_id(&query.query)),
-            title: format!("Planned query: {}", query.query),
-            blocks: vec![AgentResponseBlockDto::Markdown {
-                markdown: format!(
-                    "Purpose: {}\n\nHybrid batch retrieval found {} candidate hits with warmed embeddings.{semantic_note}",
-                    query.purpose,
-                    scored_hits.len()
                 ),
             }],
         });
@@ -277,7 +192,7 @@ mod golden_tests {
     };
 
     #[test]
-    fn merge_lexical_batch_golden_trace_shape() {
+    fn merge_fused_batch_golden_trace_shape() {
         let query = PacketPlanQueryDto {
             query: "exec_events".to_string(),
             purpose: "symbol probe".to_string(),
@@ -348,7 +263,7 @@ mod golden_tests {
             },
         };
 
-        merge_packet_lexical_subquery_batch(
+        merge_packet_fused_subquery_batch(
             &mut answer,
             &pending,
             &results,
@@ -367,7 +282,7 @@ mod golden_tests {
                 .iter()
                 .find(|field| field.key == "mode")
                 .map(|field| field.value.as_str()),
-            Some("packet_lexical_batch")
+            Some("packet_fused_batch")
         );
         assert_eq!(answer.retrieval_trace.steps[0].duration_ms, 12);
         assert_eq!(

--- a/crates/codestory-runtime/src/agent/planning.rs
+++ b/crates/codestory-runtime/src/agent/planning.rs
@@ -1,8 +1,6 @@
-//! Packet plan construction, query deduplication, and subquery hybrid policy.
+//! Packet plan query normalization and deduplication.
 
-use codestory_contracts::api::{
-    AgentHybridWeightsDto, PacketBudgetModeDto, PacketPlanDto, PacketPlanQueryDto,
-};
+use codestory_contracts::api::PacketPlanDto;
 use std::collections::HashSet;
 
 pub(crate) fn normalize_packet_subquery(query: &str) -> String {
@@ -35,38 +33,10 @@ pub(crate) fn dedupe_packet_plan_queries(plan: &mut PacketPlanDto) {
     plan.queries = deduped;
 }
 
-pub(crate) fn packet_subquery_hybrid_weights(
-    budget: PacketBudgetModeDto,
-    query: &PacketPlanQueryDto,
-) -> Option<AgentHybridWeightsDto> {
-    if !matches!(
-        budget,
-        PacketBudgetModeDto::Compact | PacketBudgetModeDto::Standard
-    ) {
-        return None;
-    }
-    let normalized = normalize_packet_subquery(&query.query);
-    let exact_signal = query.purpose.contains("symbol")
-        || query.purpose.contains("concrete")
-        || query.purpose.contains("flow anchor")
-        || normalized.contains("::")
-        || (normalized.contains('/') && normalized.contains('.'))
-        || (normalized.contains('/') && normalized.len() >= 12);
-    if exact_signal {
-        Some(AgentHybridWeightsDto {
-            lexical: Some(1.0),
-            semantic: Some(0.0),
-            graph: Some(0.0),
-        })
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use codestory_contracts::api::{PacketPlanDto, PacketTaskClassDto};
+    use codestory_contracts::api::{PacketPlanDto, PacketPlanQueryDto, PacketTaskClassDto};
 
     #[test]
     fn test_dedupe_packet_plan_queries_removes_stop_word_variants() {
@@ -88,16 +58,5 @@ mod tests {
         };
         dedupe_packet_plan_queries(&mut plan);
         assert_eq!(plan.queries.len(), 1);
-    }
-
-    #[test]
-    fn test_packet_subquery_hybrid_weights_lexical_for_symbol_probe() {
-        let query = PacketPlanQueryDto {
-            query: "ExtHostCommands".to_string(),
-            purpose: "concrete symbol probe".to_string(),
-        };
-        let weights = packet_subquery_hybrid_weights(PacketBudgetModeDto::Compact, &query)
-            .expect("expected lexical-only weights");
-        assert!(weights.semantic.is_some_and(|value| value <= f32::EPSILON));
     }
 }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -28,7 +28,8 @@ use std::rc::Rc;
 use std::time::Instant;
 
 const DEFAULT_SIDECAR_BUDGET_MS: u64 = 1_500;
-const DEFAULT_PACKET_BATCH_BUDGET_MS: u64 = 18_000;
+const DEFAULT_PACKET_BATCH_BUDGET_MS: u64 = 1_500;
+const MIN_PACKET_BATCH_BUDGET_MS: u64 = 1_000;
 const MAX_PACKET_BATCH_BUDGET_MS: u64 = 120_000;
 const MAX_SHADOW_CANDIDATES: usize = 20;
 const MAX_SHADOW_WOULD_RANK: usize = 10;
@@ -584,7 +585,7 @@ fn sidecar_packet_batch_budget_ms(latency_budget_ms: Option<u32>) -> u64 {
     latency_budget_ms
         .map(u64::from)
         .unwrap_or(DEFAULT_PACKET_BATCH_BUDGET_MS)
-        .clamp(100, MAX_PACKET_BATCH_BUDGET_MS)
+        .clamp(MIN_PACKET_BATCH_BUDGET_MS, MAX_PACKET_BATCH_BUDGET_MS)
 }
 
 fn with_detached_sidecar_query_cache<T>(
@@ -820,8 +821,10 @@ pub(crate) fn search_sidecar_packet_batch(
     })
 }
 
+#[derive(Debug)]
 pub(crate) struct SidecarPacketBatchOutcome {
     pub results: Vec<(String, Vec<SearchHit>)>,
+    pub retryable_queries: Vec<String>,
     pub diagnostics: Vec<PacketSidecarQueryDiagnosticDto>,
 }
 
@@ -973,6 +976,7 @@ fn build_sidecar_packet_batch_outcome(
         ));
     }
     let mut results = Vec::with_capacity(queries.len());
+    let mut retryable_queries = Vec::new();
     let mut diagnostics = Vec::with_capacity(queries.len());
     for ((query, max_results), query_result) in queries.iter().zip(query_results) {
         if query_result.query != *query {
@@ -982,6 +986,12 @@ fn build_sidecar_packet_batch_outcome(
                     "sidecar retrieval batch query mismatch expected `{}` got `{}`",
                     query, query_result.query
                 ),
+            ));
+        }
+        if sidecar_blocking_cancel_reason(&query_result) == Some("cancelled") {
+            return Err(ApiError::new(
+                "cancelled",
+                format!("packet fused batch query `{query}` was cancelled"),
             ));
         }
         let sidecar_query_ms = u32::try_from(query_result.trace.elapsed_ms).unwrap_or(u32::MAX);
@@ -1006,7 +1016,10 @@ fn build_sidecar_packet_batch_outcome(
         ));
         let resolved_hits = resolution.resolved_hits;
         if let Some(reason) = sidecar_packet_batch_rejection_reason(&query_result, &resolved_hits) {
-            if sidecar_blocking_cancel_reason(&query_result).is_some() {
+            if let Some("deadline" | "stage_deadline") =
+                sidecar_blocking_cancel_reason(&query_result)
+            {
+                retryable_queries.push(query.clone());
                 results.push((query.clone(), Vec::new()));
                 continue;
             }
@@ -1023,6 +1036,7 @@ fn build_sidecar_packet_batch_outcome(
     }
     Ok(SidecarPacketBatchOutcome {
         results,
+        retryable_queries,
         diagnostics,
     })
 }
@@ -3079,11 +3093,75 @@ mod tests {
         );
         assert_eq!(sidecar_packet_batch_budget_ms(Some(18_000)), 18_000);
         assert_eq!(sidecar_packet_batch_budget_ms(Some(5_000)), 5_000);
-        assert_eq!(sidecar_packet_batch_budget_ms(Some(5)), 100);
+        assert_eq!(sidecar_packet_batch_budget_ms(Some(5)), 1_000);
         assert_eq!(
             sidecar_packet_batch_budget_ms(Some(250_000)),
             MAX_PACKET_BATCH_BUDGET_MS
         );
+    }
+
+    #[test]
+    fn packet_batch_marks_only_deadlines_retryable_and_rejects_cancellation() {
+        use codestory_retrieval::classify_query;
+
+        let query_result = |cancel_reason: Option<&str>| QueryResult {
+            publication_identity: None,
+            query: "handler".into(),
+            features: classify_query("handler"),
+            hits: Vec::new(),
+            trace: QueryTrace {
+                retrieval_mode: "full".into(),
+                degraded_reason: None,
+                total_budget_ms: 1_000,
+                elapsed_ms: 1,
+                cancel_reason: cancel_reason.map(str::to_string),
+                cache_hit: false,
+                stages: Vec::new(),
+            },
+        };
+        let empty_resolution = |_: &QueryResult, _: usize| {
+            Ok(SidecarCandidateResolutionOutcome {
+                resolved_hits: Vec::new(),
+                unresolved_candidate_count: 0,
+                blocking_unresolved_candidate_count: 0,
+                attempted_candidate_indices: HashSet::new(),
+            })
+        };
+        let controller = AppController::new();
+        let queries = vec![("handler".to_string(), 5)];
+
+        let empty = build_sidecar_packet_batch_outcome(
+            &controller,
+            &queries,
+            vec![query_result(None)],
+            1,
+            empty_resolution,
+        )
+        .expect("ordinary empty result");
+        assert!(empty.retryable_queries.is_empty());
+
+        for reason in ["deadline", "stage_deadline"] {
+            let deadline = build_sidecar_packet_batch_outcome(
+                &controller,
+                &queries,
+                vec![query_result(Some(reason))],
+                1,
+                empty_resolution,
+            )
+            .expect("deadline result");
+            assert_eq!(deadline.retryable_queries, ["handler"]);
+            assert!(deadline.results[0].1.is_empty());
+        }
+
+        let cancelled = build_sidecar_packet_batch_outcome(
+            &controller,
+            &queries,
+            vec![query_result(Some("cancelled"))],
+            1,
+            empty_resolution,
+        )
+        .expect_err("public cancellation must not become an empty successful batch");
+        assert_eq!(cancelled.code, "cancelled");
     }
 
     #[test]
@@ -3845,7 +3923,7 @@ mod tests {
             &queries,
             Some(500),
             |_, batch| {
-                assert_eq!(batch, &[("helpers".to_string(), 500)]);
+                assert_eq!(batch, &[("helpers".to_string(), 1_000)]);
                 Ok(vec![QueryResult {
                     publication_identity: None,
                     query: "helpers".into(),
@@ -3859,7 +3937,7 @@ mod tests {
                     trace: QueryTrace {
                         retrieval_mode: "full".into(),
                         degraded_reason: None,
-                        total_budget_ms: 500,
+                        total_budget_ms: 1_000,
                         elapsed_ms: 1,
                         cancel_reason: None,
                         cache_hit: false,
@@ -3966,7 +4044,7 @@ mod tests {
             &queries,
             Some(500),
             |_, batch| {
-                assert_eq!(batch, &[("handler".to_string(), 500)]);
+                assert_eq!(batch, &[("handler".to_string(), 1_000)]);
                 Ok(vec![QueryResult {
                     publication_identity: None,
                     query: "handler".into(),
@@ -3980,7 +4058,7 @@ mod tests {
                     trace: QueryTrace {
                         retrieval_mode: "full".into(),
                         degraded_reason: None,
-                        total_budget_ms: 500,
+                        total_budget_ms: 1_000,
                         elapsed_ms: 1,
                         cancel_reason: None,
                         cache_hit: false,

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -390,7 +390,7 @@
             "type": "boolean"
           },
           "latency_budget_ms": {
-            "description": "Optional retrieval latency budget in milliseconds.",
+            "description": "Optional retrieval latency budget in milliseconds; defaults to 1500 when omitted.",
             "maximum": 120000,
             "minimum": 1000,
             "type": [


### PR DESCRIPTION
Closes #1648

Originally stacked on #1710 (EV-A) in native stack #1714. After EV-A merged, GitHub rebased this PR onto dev/codestory-next; the EV-3 patch is byte-for-byte equivalent.

## What changed

- Collapse packet batch retrieval onto the single search_packet_fused_batch production lane and remove the discarded lexical/semantic weights, wrappers, warmup, and pinning tests.
- Retry only sidecar-reported deadline and stage-deadline queries while the public operation remains live; preserve cancellation errors and the initial blocking diagnostics so a retry cannot turn cancelled evidence into sufficient evidence.
- Make packet trace labels match the fused path, enforce the 1000-120000 ms input contract with a 1500 ms default, and cache successful marginal-gain stops.

## Baseline cause table

| Category | Movement | Cause |
| --- | ---: | --- |
| anchor_placement | 0.000 | Lane consolidation and trace naming only; scoring and fixture expectations are unchanged. |
| readiness_boundary | 0.000 | Readiness and evidence-admission behavior are unchanged. |

## Proof

- cargo test --locked -p codestory-runtime --lib --quiet (916 passed)
- cargo test --locked -p codestory-retrieval --lib --quiet (227 passed, 3 ignored)
- cargo test --locked -p codestory-cli --test packet_search_eval --quiet (9 passed, 1 ignored)
- cargo clippy --locked -p codestory-retrieval -p codestory-runtime --lib -- -D warnings
- cargo clippy --locked -p codestory-cli --bins -- -D warnings
- cargo fmt --all -- --check
- node scripts/generate-codestory-skill-syntax.mjs --check
- git diff --check
- Automatic rebase verification: range-diff exact match and identical stable patch id / binary diff SHA-256.

## Environmental exceptions

- The live production packet/search eval remains intentionally ignored because it requires retrieval_mode=full sidecars for this checkout; the deterministic fixture baseline passed with zero expected movement.
- The first catalog check found no upper-worktree CLI binary. The exact upper CLI was then built and the catalog regenerated; the final generator check is clean.