### PR TITLE
[v0.17 EV-FIX] Restore evidence tier and latency contracts

### DIFF
--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -2046,7 +2046,7 @@ static PACKET_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
         .with_default(ValueLiteral::Boolean(true)),
         SchemaProperty::integer(
             "latency_budget_ms",
-            "Optional retrieval latency budget in milliseconds; defaults to 1500 when omitted.",
+            "Optional packet retrieval latency budget in milliseconds; defaults to 18000 when omitted.",
         )
         .with_bounds(1000, 120000)
         .nullable(),
@@ -2424,5 +2424,24 @@ mod tests {
             packet["inputSchema"]["allOf"].as_array().map(Vec::len),
             Some(PACKET_PROBE_MAX_COUNT)
         );
+    }
+
+    #[test]
+    fn packet_latency_budget_schema_matches_runtime_default_and_bounds() {
+        let catalog = tools_list_json();
+        let packet = catalog["result"]["tools"]
+            .as_array()
+            .expect("tools")
+            .iter()
+            .find(|tool| tool["name"] == "packet")
+            .expect("packet tool");
+        let budget = &packet["inputSchema"]["properties"]["latency_budget_ms"];
+
+        assert_eq!(
+            budget["description"],
+            "Optional packet retrieval latency budget in milliseconds; defaults to 18000 when omitted."
+        );
+        assert_eq!(budget["minimum"], 1_000);
+        assert_eq!(budget["maximum"], 120_000);
     }
 }

--- a/crates/codestory-retrieval/src/ranker.rs
+++ b/crates/codestory-retrieval/src/ranker.rs
@@ -197,6 +197,21 @@ fn build_rank_features(candidate: &CandidateHit, query_tokens: &[String]) -> Ran
 }
 
 fn export_rank_features(candidate: &CandidateHit, mut features: RankFeatures) -> RankFeatures {
+    // Ranking may use cross-lane priors, but the public breakdown may only claim
+    // a lane that actually produced this candidate.
+    if !matches!(
+        candidate.source,
+        CandidateSource::Lexical | CandidateSource::Legacy
+    ) && !candidate_has_provenance(candidate, "lexical_source")
+    {
+        features.lexical = 0.0;
+    }
+    if !matches!(candidate.source, CandidateSource::Semantic)
+        && !candidate_has_provenance(candidate, "dense_anchor")
+        && !candidate_has_provenance(candidate, "component_report")
+    {
+        features.semantic = 0.0;
+    }
     if !candidate_has_graph_provenance(candidate) {
         features.scip_distance = 0.0;
     }
@@ -630,6 +645,25 @@ mod tests {
     }
 
     #[test]
+    fn ranker_exports_only_dense_feature_for_pure_dense_candidate() {
+        let features = classify_query("explain search service");
+        let mut dense = CandidateHit::with_source(
+            "src/search.rs",
+            Some("SearchService".into()),
+            0.9,
+            CandidateSource::Semantic,
+        );
+        dense.provenance = vec!["dense_anchor".into()];
+
+        let ranked = rank_candidates(&features, vec![dense]);
+        let rank_features = ranked[0].rank_features.as_ref().expect("rank features");
+
+        assert_eq!(rank_features.lexical, 0.0);
+        assert!(rank_features.semantic > 0.0);
+        assert_eq!(rank_features.scip_distance, 0.0);
+    }
+
+    #[test]
     fn ranker_prefers_entrypoint_role_over_test_role() {
         let features = classify_query("main startup entrypoint");
         let mut test_hit = CandidateHit::lexical_stub("src/main_test.rs", 0.94);
@@ -925,6 +959,8 @@ mod tests {
         let ranked = rank_candidates(&features, vec![graph]);
         let rank_features = ranked[0].rank_features.as_ref().expect("rank features");
 
+        assert_eq!(rank_features.lexical, 0.0);
+        assert_eq!(rank_features.semantic, 0.0);
         assert_eq!(rank_features.scip_distance, 0.5);
     }
 }

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::time::Instant;
 
-const DEFAULT_SLA_TARGET_MS: u32 = 1_500;
+const DEFAULT_SLA_TARGET_MS: u32 = 18_000;
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PacketLatencyBudget {
     pub(crate) started_at: Instant,
@@ -714,7 +714,7 @@ mod tests {
 
     #[test]
     fn packet_latency_budget_preserves_advertised_range_and_default() {
-        assert_eq!(PacketLatencyBudget::new(None).target_ms, 1_500);
+        assert_eq!(PacketLatencyBudget::new(None).target_ms, 18_000);
         assert_eq!(PacketLatencyBudget::new(Some(10)).target_ms, 1_000);
         assert_eq!(PacketLatencyBudget::new(Some(120_001)).target_ms, 120_000);
         assert!(PacketLatencyBudget::new(Some(1_000)).remaining_ms() >= 1_000);

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -1,8 +1,8 @@
 //! Typed evidence metadata for packet citations.
 
 use codestory_contracts::api::{
-    AgentCitationDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto, SearchHit,
-    SearchHitOrigin,
+    AgentCitationDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto,
+    RetrievalScoreBreakdownDto, SearchHit, SearchHitOrigin,
 };
 const OPENAPI_ENDPOINT_SCHEMA_PRODUCER: &str = "openapi_endpoint_schema";
 
@@ -40,6 +40,21 @@ pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
     hit.resolution_status = Some(resolution);
     hit.eligible_for_sufficiency =
         Some(!diagnostic_source_proof && evidence_is_sufficiency_eligible(tier, resolution));
+}
+
+pub(crate) fn decorate_lexical_search_hit_evidence(hit: &mut SearchHit) {
+    hit.score_breakdown = Some(RetrievalScoreBreakdownDto {
+        lexical: hit.score,
+        semantic: 0.0,
+        graph: 0.0,
+        total: hit.score,
+        tier_cap: None,
+        boosts: Vec::new(),
+        dampening: Vec::new(),
+        final_rank_reason: None,
+        provenance: vec!["lexical_source".to_string()],
+    });
+    decorate_search_hit_evidence(hit);
 }
 
 pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &SearchHit) {
@@ -140,10 +155,7 @@ pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
             return PacketEvidenceTier::LexicalSource;
         }
     }
-    match hit.origin {
-        SearchHitOrigin::IndexedSymbol => PacketEvidenceTier::ResolvedGraph,
-        SearchHitOrigin::TextMatch => PacketEvidenceTier::LexicalSource,
-    }
+    PacketEvidenceTier::GeneratedSummary
 }
 
 pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceResolution {
@@ -156,6 +168,9 @@ pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceReso
     }
     if let Some(resolution) = hit.resolution_status {
         return resolution;
+    }
+    if hit.evidence_tier.is_none() && hit.score_breakdown.is_none() {
+        return PacketEvidenceResolution::DiagnosticOnly;
     }
     if hit.resolvable {
         PacketEvidenceResolution::Resolved
@@ -216,10 +231,7 @@ pub(crate) fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketE
             return PacketEvidenceTier::LexicalSource;
         }
     }
-    match citation.origin {
-        SearchHitOrigin::IndexedSymbol => PacketEvidenceTier::ResolvedGraph,
-        SearchHitOrigin::TextMatch => PacketEvidenceTier::LexicalSource,
-    }
+    PacketEvidenceTier::GeneratedSummary
 }
 
 pub(crate) fn evidence_resolution_for_citation(
@@ -234,6 +246,9 @@ pub(crate) fn evidence_resolution_for_citation(
     }
     if let Some(resolution) = citation.resolution_status {
         return resolution;
+    }
+    if citation.evidence_tier.is_none() && citation.retrieval_score_breakdown.is_none() {
+        return PacketEvidenceResolution::DiagnosticOnly;
     }
     if citation.resolvable {
         PacketEvidenceResolution::Resolved
@@ -417,6 +432,53 @@ mod tests {
         );
         assert_eq!(hit.evidence_producer.as_deref(), Some("indexed_symbol"));
         assert_eq!(hit.eligible_for_sufficiency, Some(true));
+    }
+
+    #[test]
+    fn origin_without_typed_or_scored_evidence_is_diagnostic_only() {
+        for origin in [SearchHitOrigin::IndexedSymbol, SearchHitOrigin::TextMatch] {
+            let mut hit = workflow_hit();
+            hit.origin = origin;
+            hit.evidence_tier = None;
+            hit.evidence_producer = None;
+            hit.resolution_status = None;
+            hit.score_breakdown = None;
+
+            decorate_search_hit_evidence(&mut hit);
+
+            assert_eq!(
+                hit.evidence_tier,
+                Some(PacketEvidenceTier::GeneratedSummary)
+            );
+            assert_eq!(
+                hit.resolution_status,
+                Some(PacketEvidenceResolution::DiagnosticOnly)
+            );
+            assert_eq!(hit.eligible_for_sufficiency, Some(false));
+        }
+    }
+
+    #[test]
+    fn lexical_search_lane_is_explicit_before_classification() {
+        let mut hit = workflow_hit();
+        hit.evidence_tier = None;
+        hit.evidence_producer = None;
+        hit.resolution_status = None;
+        hit.score_breakdown = None;
+
+        decorate_lexical_search_hit_evidence(&mut hit);
+
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::LexicalSource));
+        assert_eq!(
+            hit.resolution_status,
+            Some(PacketEvidenceResolution::Resolved)
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(true));
+        let breakdown = hit.score_breakdown.as_ref().expect("score breakdown");
+        assert_eq!(breakdown.lexical, hit.score);
+        assert_eq!(breakdown.semantic, 0.0);
+        assert_eq!(breakdown.graph, 0.0);
+        assert_eq!(breakdown.provenance, vec!["lexical_source".to_string()]);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -1712,7 +1712,7 @@ fn packet_citation_provenance_labels(citation: &AgentCitationDto) -> BTreeSet<St
 }
 
 fn packet_pass_through_provenance_label(label: &str) -> bool {
-    matches!(label, "precise_semantic_import")
+    matches!(label, "precise_semantic_import" | "same_file_name_affinity")
 }
 
 fn packet_public_provenance_label(label: &str) -> bool {
@@ -1725,6 +1725,7 @@ fn packet_public_provenance_label(label: &str) -> bool {
                 | "graph_neighbor"
                 | "component_report"
                 | "dense_anchor"
+                | "same_file_name_affinity"
         )
 }
 
@@ -4943,6 +4944,25 @@ mod tests {
             future_precise_import,
             None,
         ));
+        let mut same_file_name_affinity = cited_anchor_with_tier(
+            "same_file_name_affinity",
+            "src/service.rs",
+            PacketEvidenceTierDto::DenseSemantic,
+            Some(false),
+        );
+        assert_eq!(
+            same_file_name_affinity.evidence_tier,
+            Some(PacketEvidenceTierDto::DenseSemantic),
+            "the affinity fixture must exercise the typed-tier pass-through path"
+        );
+        same_file_name_affinity.retrieval_score_breakdown =
+            Some(score_breakdown(vec!["same_file_name_affinity"]));
+        claims.push(cited_claim(
+            "Same-file name affinity remains visible without becoming graph proof.",
+            None,
+            same_file_name_affinity,
+            None,
+        ));
         let claim_count = claims.len();
         let diagnostic_tier_claim_count = claims
             .iter()
@@ -4988,6 +5008,7 @@ mod tests {
             "graph_neighbor",
             "lexical_source",
             "precise_semantic_import",
+            "same_file_name_affinity",
             "symbol_doc",
         ];
         assert_eq!(

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 use std::time::Instant;
 
 const DEFAULT_SIDECAR_BUDGET_MS: u64 = 1_500;
-const DEFAULT_PACKET_BATCH_BUDGET_MS: u64 = 1_500;
+const DEFAULT_PACKET_BATCH_BUDGET_MS: u64 = 18_000;
 const MIN_PACKET_BATCH_BUDGET_MS: u64 = 1_000;
 const MAX_PACKET_BATCH_BUDGET_MS: u64 = 120_000;
 const MAX_SHADOW_CANDIDATES: usize = 20;
@@ -576,9 +576,9 @@ fn sidecar_blocking_cancel_reason(query_result: &QueryResult) -> Option<&str> {
 
 pub(crate) fn sidecar_budget_ms(latency_budget_ms: Option<u32>) -> u64 {
     latency_budget_ms
-        .map(|ms| u64::from(ms).min(DEFAULT_SIDECAR_BUDGET_MS))
+        .map(u64::from)
         .unwrap_or(DEFAULT_SIDECAR_BUDGET_MS)
-        .max(100)
+        .clamp(MIN_PACKET_BATCH_BUDGET_MS, MAX_PACKET_BATCH_BUDGET_MS)
 }
 
 fn sidecar_packet_batch_budget_ms(latency_budget_ms: Option<u32>) -> u64 {
@@ -1884,10 +1884,6 @@ fn classify_resolved_candidate_hit(mut hit: SearchHit, candidate: &CandidateHit)
         hit.file_path = Some(candidate.file_path.clone());
         hit.line = candidate.start_line;
         hit.resolvable = false;
-        hit.evidence_tier = None;
-        hit.evidence_producer = None;
-        hit.resolution_status = None;
-        hit.eligible_for_sufficiency = None;
         hit.source_excerpt = candidate.source_excerpt.clone();
     }
     decorate_search_hit_evidence(&mut hit);
@@ -2673,6 +2669,8 @@ mod tests {
         let breakdown = score_breakdown_for_candidate(candidate);
         let hit = search_hit_for_candidate(candidate);
 
+        assert!(breakdown.lexical > 0.0);
+        assert_eq!(breakdown.semantic, 0.0);
         assert_eq!(breakdown.graph, 0.0);
         assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::LexicalSource));
     }
@@ -2692,8 +2690,11 @@ mod tests {
         let breakdown = score_breakdown_for_candidate(candidate);
         let hit = search_hit_for_candidate(candidate);
 
+        assert_eq!(breakdown.lexical, 0.0);
+        assert!(breakdown.semantic > 0.0);
         assert_eq!(breakdown.graph, 0.0);
-        assert_ne!(hit.evidence_tier, Some(PacketEvidenceTier::ResolvedGraph));
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::DenseSemantic));
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }
 
     #[test]
@@ -2707,6 +2708,12 @@ mod tests {
             CandidateSource::Lexical,
         );
         lexical.provenance = vec!["lexical_source".into()];
+        lexical.start_line = Some(1);
+        lexical.target = Some(SearchTargetDto::FileRange {
+            file_path: "src/service.rs".into(),
+            start_byte: 0,
+            end_byte: 10,
+        });
         let neutral = classify_resolved_candidate_hit(
             undecorated_search_hit_for_candidate(&lexical),
             &lexical,
@@ -2731,6 +2738,10 @@ mod tests {
             structural.evidence_producer.as_deref(),
             Some("structural_markdown_collector")
         );
+        assert_eq!(
+            structural.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
         assert_eq!(structural.eligible_for_sufficiency, Some(false));
 
         let mut exact = undecorated_search_hit_for_candidate(&lexical);
@@ -2740,6 +2751,10 @@ mod tests {
         exact.eligible_for_sufficiency = Some(false);
         let exact = classify_resolved_candidate_hit(exact, &lexical);
         assert_eq!(exact.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(
+            exact.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
         assert_eq!(exact.eligible_for_sufficiency, Some(false));
 
         let mut affinity = CandidateHit::with_source(
@@ -3081,9 +3096,10 @@ mod tests {
 
     #[test]
     fn sidecar_budget_respects_latency_cap() {
-        assert_eq!(sidecar_budget_ms(Some(400)), 400);
-        assert_eq!(sidecar_budget_ms(Some(5_000)), 1_500);
+        assert_eq!(sidecar_budget_ms(Some(400)), 1_000);
+        assert_eq!(sidecar_budget_ms(Some(5_000)), 5_000);
         assert_eq!(sidecar_budget_ms(None), 1_500);
+        assert_eq!(sidecar_budget_ms(Some(250_000)), 120_000);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/controller_symbols.rs
+++ b/crates/codestory-runtime/src/controller_symbols.rs
@@ -1,3 +1,4 @@
+use crate::agent::packet_evidence::decorate_lexical_search_hit_evidence;
 use crate::route_coverage::{
     RouteHandlerCandidate, compare_route_handler_candidates,
     route_endpoint_metadata_from_canonical, route_endpoint_metadata_from_openapi_label,
@@ -156,6 +157,10 @@ impl AppController {
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .flatten()
+            .map(|mut hit| {
+                decorate_lexical_search_hit_evidence(&mut hit);
+                hit
+            })
             .collect::<Vec<_>>();
         let project_root = self.require_project_root().ok();
         hits.sort_by(|left, right| {

--- a/crates/codestory-runtime/src/search_scoring.rs
+++ b/crates/codestory-runtime/src/search_scoring.rs
@@ -12,6 +12,9 @@ use super::{
     looks_like_standalone_symbol_query, mixed_natural_language_query, normalized_hybrid_weights,
     query_mentions_non_primary_source,
 };
+use crate::agent::packet_evidence::decorate_lexical_search_hit_evidence;
+#[cfg(test)]
+use crate::agent::packet_evidence::decorate_search_hit_evidence;
 #[cfg(test)]
 use crate::search_publication::{
     retrieval_state_from_engine, retrieval_state_from_engine_with_storage_contract,
@@ -417,6 +420,10 @@ impl AppController {
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .flatten()
+            .map(|mut hit| {
+                decorate_lexical_search_hit_evidence(&mut hit);
+                hit
+            })
             .collect())
     }
 
@@ -662,6 +669,7 @@ impl AppController {
                     final_rank_reason: None,
                     provenance: Vec::new(),
                 });
+                decorate_search_hit_evidence(&mut hit);
                 out.push(HybridSearchScoredHit {
                     hit,
                     lexical_score: scored.lexical_score,

--- a/crates/codestory-runtime/src/tests/search_scoring.rs
+++ b/crates/codestory-runtime/src/tests/search_scoring.rs
@@ -623,8 +623,35 @@ fn search_requires_full_sidecars_for_exact_type_queries() {
 
     let controller = AppController::new();
     controller
-        .open_project_with_storage_path(temp.path().to_path_buf(), db_path)
+        .open_project_with_storage_path(temp.path().to_path_buf(), db_path.clone())
         .expect("open project");
+
+    let indexed = controller
+        .resolve_indexed_symbol_candidates("AppController", 10)
+        .expect("resolve indexed candidates");
+    let storage = Storage::open(&db_path).expect("reopen storage");
+    let expanded = controller
+        .expanded_symbol_hits(&storage, "AppController")
+        .expect("resolve expanded candidates");
+    for (lane, hits) in [("indexed", indexed), ("expanded", expanded)] {
+        assert!(!hits.is_empty(), "{lane} lexical lane should return hits");
+        assert!(
+            hits.iter().all(|hit| {
+                hit.evidence_tier
+                    == Some(codestory_contracts::api::PacketEvidenceTierDto::LexicalSource)
+                    && hit.resolution_status
+                        == Some(codestory_contracts::api::PacketEvidenceResolutionDto::Resolved)
+                    && hit.eligible_for_sufficiency == Some(true)
+                    && hit.score_breakdown.as_ref().is_some_and(|breakdown| {
+                        breakdown.lexical > 0.0
+                            && breakdown.semantic == 0.0
+                            && breakdown.graph == 0.0
+                            && breakdown.provenance == ["lexical_source"]
+                    })
+            }),
+            "{lane} lexical lane must bind provenance before classification: {hits:#?}"
+        );
+    }
 
     let error = controller
         .search(SearchRequest {

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -390,7 +390,7 @@
             "type": "boolean"
           },
           "latency_budget_ms": {
-            "description": "Optional retrieval latency budget in milliseconds; defaults to 1500 when omitted.",
+            "description": "Optional packet retrieval latency budget in milliseconds; defaults to 18000 when omitted.",
             "maximum": 120000,
             "minimum": 1000,
             "type": [


### PR DESCRIPTION
Closes #1718

## What changed

- keeps rank scoring behavior intact while exporting only the lexical, semantic, and graph lanes that actually produced each candidate
- classifies pure dense evidence as `DenseSemantic` and non-sufficient, with origin-only fallback now diagnostic instead of implicit graph proof
- preserves node-intrinsic `StructuralText` and `ExactSource` stamps when a sidecar candidate becomes a typed FILE/range hit
- stamps indexed and expanded lexical search hits before evidence classification, and keeps `same_file_name_affinity` public without treating it as graph provenance
- restores the packet default to 18,000 ms; an unspecified single-sidecar request stays at 1,500 ms, while explicit requests clamp only to the advertised 1,000–120,000 ms range

## Cause table

| Category | Before | After | Result movement |
|---|---|---|---|
| Dense-only | synthetic lexical export made `DenseSemantic` unreachable and sufficiency-eligible | lexical `0`, semantic `>0`, graph `0`; `DenseSemantic`, ineligible | removes a false sufficient path; no partial-to-sufficient movement |
| Structural / exact source | typed FILE conversion cleared intrinsic tier, producer, resolution, and eligibility | intrinsic diagnostic classification survives conversion | prevents diagnostic evidence from being promoted |
| Indexed / expanded lexical | raw hit relied on origin fallback | explicit `lexical_source` breakdown precedes one classification | same intended lexical eligibility, now attributable |
| Same-file affinity | internal provenance disappeared from the public packet report | public `same_file_name_affinity`, graph score remains `0` | reporting-only; no graph or sufficiency promotion |
| Packet latency | packet default and explicit sidecar requests were capped at 1,500 ms | packet default 18,000 ms; explicit range 1,000–120,000 ms; unspecified sidecar 1,500 ms | timeout-contract restoration; no evidence-tier promotion |
| `packet_search_eval` | anchor-placement and readiness-boundary baselines all `1.0` | both categories remain `1.0` | zero baseline movement |

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked -p codestory-retrieval` (228 passed, 3 explicitly ignored; integration and holdout suites green)
- `cargo test --locked -p codestory-runtime --lib agent::retrieval_primary::tests` (47 passed)
- `cargo test --locked -p codestory-runtime --lib agent::packet_sufficiency::tests` (102 passed)
- `cargo test --locked -p codestory-runtime --lib tests::search_scoring_tests` (39 passed)
- `cargo test --locked -p codestory-runtime --lib agent::packet_evidence::tests` (9 passed)
- `cargo test --locked -p codestory-cli --test packet_search_eval` (9 passed, live full-sidecar case explicitly ignored by the owning gate)
- `cargo test --locked -p codestory-cli packet_latency_budget_schema_matches_runtime_default_and_bounds` (1 passed; generated catalog default and bounds match runtime)
- `node scripts/generate-codestory-skill-syntax.mjs --check --cli target/debug/codestory-cli`
- `cargo clippy --locked -p codestory-retrieval -p codestory-runtime --all-targets -- -D warnings`

The final commit `e6bec07d98178c97f5930a736543475a28204d25` was rebased directly onto current dev `0f3c4b0143a07ae9120a98e755072c5d11a3aac7`. Its stable patch ID remains `a0bf43f1b32b7639832292eab79b5784e37b49fe`; no version surface changed.
