### PR TITLE
[v0.17 P1] Trigger crate durability on dependency graph changes

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1086,6 +1086,11 @@ const draftCompilerSaveCondition =
   "success() && steps.compiler-cache-restore.outputs.cache-hit != 'true' && steps.compiler-cache-restore.outputs.cache-primary-key != ''";
 const draftCompilerSaveKey = "${{ steps.compiler-cache-restore.outputs.cache-primary-key }}";
 const cacheSaveKey = "${{ steps.cargo-cache-restore.outputs.cache-primary-key }}";
+const crateDurabilityDependencyTriggerPaths = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "vendor/**",
+];
 const draftWorkflowPaths = [
   "Cargo.lock",
   "Cargo.toml",
@@ -1416,6 +1421,11 @@ export function proofFloorPolicyViolations(
       list(eventValue.paths).length === list(durability.paths).length
         && sameMembers(eventValue.paths, durability.paths),
       `${file} ${event} paths must match the exact owning-path set`,
+    );
+    add(
+      violations,
+      includesAll(eventValue.paths, crateDurabilityDependencyTriggerPaths),
+      `${file} ${event} paths must cover root Cargo manifests, the lockfile, and vendored dependencies`,
     );
   }
   add(

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -5831,6 +5831,31 @@ test("proof floor keeps architecture universal and durability path-scoped", asyn
     [],
   );
 
+  for (const requiredPath of ["Cargo.toml", "Cargo.lock", "vendor/**"]) {
+    await t.test(`${requiredPath} remains a dependency-graph trigger`, () => {
+      const workflows = loadWorkflows();
+      const graph = structuredClone(loadReleaseClaimGraph(root));
+      graph.workflow_policy.proof_floor.crate_durability.paths =
+        graph.workflow_policy.proof_floor.crate_durability.paths
+          .filter(triggerPath => triggerPath !== requiredPath);
+      const workflow = workflows.get(crateDurabilityFile);
+      for (const event of ["pull_request", "push"]) {
+        workflow.on[event].paths = workflow.on[event].paths
+          .filter(triggerPath => triggerPath !== requiredPath);
+      }
+
+      const violations = proofFloorPolicyViolations(workflows, graph).join("\n");
+      assert.match(
+        violations,
+        /crate-durability\.yml pull_request paths must cover root Cargo manifests, the lockfile, and vendored dependencies/u,
+      );
+      assert.match(
+        violations,
+        /crate-durability\.yml push paths must cover root Cargo manifests, the lockfile, and vendored dependencies/u,
+      );
+    });
+  }
+
   const mutations = [
     ["architecture command removed", workflows => {
       const steps = workflows.get(retrievalFile).jobs["linux-contracts"].steps;

--- a/.github/workflows/crate-durability.yml
+++ b/.github/workflows/crate-durability.yml
@@ -3,6 +3,9 @@ name: crate-durability
 on:
   pull_request:
     paths:
+      - Cargo.toml
+      - Cargo.lock
+      - vendor/**
       - crates/codestory-store/**
       - crates/codestory-indexer/**
       - crates/codestory-workspace/**
@@ -19,6 +22,9 @@ on:
       - main
       - dev/codestory-next
     paths:
+      - Cargo.toml
+      - Cargo.lock
+      - vendor/**
       - crates/codestory-store/**
       - crates/codestory-indexer/**
       - crates/codestory-workspace/**

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
+    "graph_sha256": "34dc4e918411612b24a4986483066e58561df9b7fbc748d2bd7221e5465bf467",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
+        "graph_sha256": "34dc4e918411612b24a4986483066e58561df9b7fbc748d2bd7221e5465bf467",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
+        "graph_sha256": "34dc4e918411612b24a4986483066e58561df9b7fbc748d2bd7221e5465bf467",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "a0ac24380fe4397d335922dd6fd2aebd71483c6a38e3848017cde2993e7e4f93",
+  "candidate_sha256": "d60e6a1b169906c5854535e784610a1864e7b4f062c8448de35e9dd3124ad708",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
+      "graph_sha256": "34dc4e918411612b24a4986483066e58561df9b7fbc748d2bd7221e5465bf467",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
+      "graph_sha256": "34dc4e918411612b24a4986483066e58561df9b7fbc748d2bd7221e5465bf467",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
+    "graph_sha256": "34dc4e918411612b24a4986483066e58561df9b7fbc748d2bd7221e5465bf467",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -1053,6 +1053,9 @@
           "dev/codestory-next"
         ],
         "paths": [
+          "Cargo.toml",
+          "Cargo.lock",
+          "vendor/**",
           "crates/codestory-store/**",
           "crates/codestory-indexer/**",
           "crates/codestory-workspace/**",

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -886,6 +886,9 @@ function validateProofFloor(value) {
   exactStringList(
     durability.paths,
     [
+      "Cargo.toml",
+      "Cargo.lock",
+      "vendor/**",
       "crates/codestory-store/**",
       "crates/codestory-indexer/**",
       "crates/codestory-workspace/**",

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -350,6 +350,11 @@ test("claim graph owns the universal architecture and path-scoped durability flo
     "cargo test --locked -p codestory-indexer --test fidelity_regression",
     "cargo test --locked -p codestory-indexer --test tictactoe_language_coverage",
   ]);
+  assert.deepEqual(floor.crate_durability.paths.slice(0, 3), [
+    "Cargo.toml",
+    "Cargo.lock",
+    "vendor/**",
+  ]);
   assert.ok(!floor.crate_durability.paths.includes("crates/**"));
 
   const mutations = [
@@ -381,6 +386,16 @@ test("claim graph owns the universal architecture and path-scoped durability flo
     const draft = structuredClone(graph);
     mutate(draft);
     assert.throws(() => validateReleaseClaimGraph(draft), expected);
+  }
+  for (const requiredPath of ["Cargo.toml", "Cargo.lock", "vendor/**"]) {
+    const draft = structuredClone(graph);
+    draft.workflow_policy.proof_floor.crate_durability.paths =
+      draft.workflow_policy.proof_floor.crate_durability.paths
+        .filter(triggerPath => triggerPath !== requiredPath);
+    assert.throws(
+      () => validateReleaseClaimGraph(draft),
+      /crate_durability\.paths must be exactly/u,
+    );
   }
 });
 

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "26d8f5e1a285d588c50e244e447c25df15bdd2fa2060686c6be6ffdfefaade1c",
+      "graph_sha256": "34dc4e918411612b24a4986483066e58561df9b7fbc748d2bd7221e5465bf467",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

The crate-durability cache identity already includes the root manifest, lockfile, and vendored manifests, but its event filters did not. A dependency-only change could therefore alter store, indexer, workspace, or contracts behavior while skipping the durability consumers.

## What changed

- trigger crate durability for root `Cargo.toml`, `Cargo.lock`, and `vendor/**` changes on pull requests and pushes to `main` or `dev/codestory-next`
- add those inputs to the release-claim graph and its exact-list validator
- add a hard-coded workflow-policy fence plus adversarial mutations that reject coordinated removal from both workflow and claim graph
- refresh graph-bound deterministic fixtures for the new canonical claim digest

## Review

The durability job body, its three Cargo commands, cache identity, permissions, concurrency, and existing owning paths are unchanged. `rust-ci.yml` and product version surfaces are untouched.

Base: `35466b9c9d87a6312877e2cd18d6abac7512abb1`

Head: `fbcfa97d4692c3b4407b609e7f3fb8fc2b070ccc`

## Verification

- `node --test .github/scripts/check-workflow-policy.test.mjs` — 1,336 passed
- focused durability mutation test — 18 passed, including all three dependency inputs
- `node --test scripts/tests/codestory-release-claims.test.mjs` — 40 passed
- deterministic candidate/report attestation test — passed
- `node .github/scripts/check-workflow-policy.mjs` — passed
- `node scripts/codestory-release-claims.mjs validate` — passed with graph `34dc4e918411612b24a4986483066e58561df9b7fbc748d2bd7221e5465bf467`
- `git diff --check` — passed

No Cargo command was run for this workflow-policy-only repair; the process table was checked and had no active Cargo or rustc work.

Closes #1719
