### PR TITLE
[v0.17 READY-A] Reuse a valid ready lease across unchanged broad calls

### DIFF
--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -22,6 +22,18 @@ use std::sync::atomic::AtomicBool;
 use crate::args::{ProjectArgs, QuerySelectorOutput, RefreshMode, TargetSelection};
 use crate::display::{clean_path_string, quote_command_path};
 
+#[cfg(test)]
+thread_local! {
+    static RUNTIME_CONTEXT_CONSTRUCTION_COUNT: std::cell::Cell<u64> = const {
+        std::cell::Cell::new(0)
+    };
+}
+
+#[cfg(test)]
+pub(crate) fn runtime_context_construction_count_for_test() -> u64 {
+    RUNTIME_CONTEXT_CONSTRUCTION_COUNT.with(std::cell::Cell::get)
+}
+
 #[derive(Debug)]
 /// Project state after a command has opened or refreshed the repository.
 ///
@@ -55,6 +67,7 @@ pub(crate) struct RuntimeContext {
     pub(crate) browser: ReadOnlyBrowserService,
     pub(crate) events: crossbeam_channel::Receiver<AppEventPayload>,
     pub(crate) project_root: PathBuf,
+    project_identity: codestory_workspace::ProjectIdentityV3,
     /// Stable logical/workspace identity plus the immutable runtime
     /// configuration used to build this context. Multi-project transports use
     /// this key instead of a path spelling, mutable artifact eligibility, or a
@@ -63,6 +76,7 @@ pub(crate) struct RuntimeContext {
     pub(crate) cache_root: PathBuf,
     pub(crate) storage_path: PathBuf,
     pub(crate) sidecar: codestory_retrieval::SidecarRuntimeConfig,
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) source_index_policy: codestory_contracts::workspace::SourceIndexPolicy,
 }
 
@@ -70,7 +84,114 @@ pub(crate) struct RuntimeContext {
 pub(crate) struct ProjectContextKey {
     pub(crate) project_id: String,
     pub(crate) workspace_id: String,
+    pub(crate) repository_instance: codestory_workspace::RepositoryInstanceIdentity,
     pub(crate) configuration_id: String,
+}
+
+struct RuntimeContextConfiguration {
+    project_root: PathBuf,
+    project_identity: codestory_workspace::ProjectIdentityV3,
+    context_key: ProjectContextKey,
+    cache_root: PathBuf,
+    storage_path: PathBuf,
+    sidecar: codestory_retrieval::SidecarRuntimeConfig,
+    source_index_policy: codestory_contracts::workspace::SourceIndexPolicy,
+}
+
+impl RuntimeContextConfiguration {
+    fn resolve(
+        args: &ProjectArgs,
+        startup: &crate::config::CliStartupConfig,
+        retained_project_identity: Option<&codestory_workspace::ProjectIdentityV3>,
+        retained_logical_identity: Option<&codestory_workspace::LogicalProjectIdentityV3>,
+    ) -> Result<Self> {
+        let project_root = canonicalize_project_root(&args.project)?;
+        let project_identity = retained_project_identity.cloned().unwrap_or_else(|| {
+            let repository_identity =
+                codestory_workspace::inspect_repository_identity_v2(&project_root);
+            codestory_workspace::project_identity_v3_from_repository(
+                &project_root,
+                &repository_identity,
+            )
+        });
+        let logical_identity = retained_logical_identity.cloned().unwrap_or_else(|| {
+            codestory_workspace::observe_logical_project_identity_v3(&project_root)
+        });
+        let config = crate::config::load_config_with_startup(&project_root, startup)?;
+        let cache_override = args.cache_dir.clone().or_else(|| config.cache_dir.clone());
+        let process_cache_root = canonicalize_configuration_path(
+            startup
+                .stdio_cache_root
+                .as_deref()
+                .unwrap_or_else(|| startup.sidecar_defaults.cache_root()),
+        )?;
+        let cache_root = cache_root_for_project_in(
+            &project_root,
+            cache_override.as_deref(),
+            &process_cache_root,
+        )?;
+        let storage_path = canonicalize_configuration_path(&cache_root.join("codestory.db"))?;
+        let sidecar_defaults = startup.sidecar_defaults.with_cache_root(process_cache_root);
+        let sidecar = crate::sidecar_runtime::for_project_auto_with_process_defaults_and_identity(
+            &project_identity,
+            &sidecar_defaults,
+            &config.runtime_overrides(),
+        );
+        let source_index_policy = startup.source_index_policy.clone();
+        let context_key = ProjectContextKey {
+            project_id: project_identity.project_id.clone(),
+            workspace_id: project_identity.workspace_id.clone(),
+            repository_instance: logical_identity.repository_instance,
+            configuration_id: runtime_configuration_id(&cache_root, &sidecar, &source_index_policy),
+        };
+        Ok(Self {
+            project_root,
+            project_identity,
+            context_key,
+            cache_root,
+            storage_path,
+            sidecar,
+            source_index_policy,
+        })
+    }
+
+    fn with_profile_and_run_id(
+        mut self,
+        profile: codestory_retrieval::SidecarProfile,
+        run_id: Option<&str>,
+    ) -> Self {
+        self.sidecar =
+            self.sidecar
+                .with_profile_and_run_id(Some(&self.project_root), profile, run_id);
+        self.context_key.configuration_id =
+            runtime_configuration_id(&self.cache_root, &self.sidecar, &self.source_index_policy);
+        self
+    }
+
+    fn build(self) -> RuntimeContext {
+        let runtime = Runtime::new_with_process_config(RuntimeProcessConfig::new(
+            self.sidecar.clone(),
+            self.source_index_policy.clone(),
+        ));
+        let events = runtime.events();
+        RuntimeContext {
+            activation: runtime.activation_service(),
+            public_operation: runtime.public_operation_service(),
+            project: runtime.project_service(),
+            index: runtime.index_service(),
+            grounding: runtime.grounding_service(),
+            bookmarks: runtime.bookmark_service(),
+            browser: runtime.browser_service(),
+            events,
+            project_root: self.project_root,
+            project_identity: self.project_identity,
+            context_key: self.context_key,
+            cache_root: self.cache_root,
+            storage_path: self.storage_path,
+            sidecar: self.sidecar,
+            source_index_policy: self.source_index_policy,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -150,6 +271,8 @@ impl RuntimeContext {
         args: &ProjectArgs,
         startup: &crate::config::CliStartupConfig,
     ) -> Result<Self> {
+        #[cfg(test)]
+        RUNTIME_CONTEXT_CONSTRUCTION_COUNT.with(|count| count.set(count.get() + 1));
         Self::new_agent_sidecar_with_startup_and_selection(args, startup, None, None)
     }
 
@@ -172,32 +295,39 @@ impl RuntimeContext {
         profile: Option<crate::args::CliSidecarProfile>,
         run_id: Option<&str>,
     ) -> Result<Self> {
-        let mut context = Self::new_with_startup(args, startup)?;
         let selected = profile
             .map(Into::into)
             .unwrap_or(codestory_retrieval::SidecarProfile::Agent);
-        context.sidecar =
-            context
-                .sidecar
-                .with_profile_and_run_id(Some(&context.project_root), selected, run_id);
-        context.context_key.configuration_id = runtime_configuration_id(
-            &context.cache_root,
-            &context.sidecar,
-            &context.source_index_policy,
-        );
-        let runtime = Runtime::new_with_process_config(RuntimeProcessConfig::new(
-            context.sidecar.clone(),
-            context.source_index_policy.clone(),
-        ));
-        context.project = runtime.project_service();
-        context.index = runtime.index_service();
-        context.grounding = runtime.grounding_service();
-        context.bookmarks = runtime.bookmark_service();
-        context.browser = runtime.browser_service();
-        context.activation = runtime.activation_service();
-        context.public_operation = runtime.public_operation_service();
-        context.events = runtime.events();
-        Ok(context)
+        Ok(
+            RuntimeContextConfiguration::resolve(args, startup, None, None)?
+                .with_profile_and_run_id(selected, run_id)
+                .build(),
+        )
+    }
+
+    pub(crate) fn agent_sidecar_context_key_with_startup(
+        args: &ProjectArgs,
+        startup: &crate::config::CliStartupConfig,
+        retained: &Self,
+    ) -> Result<Option<ProjectContextKey>> {
+        let logical =
+            codestory_workspace::observe_logical_project_identity_v3(&retained.project_root);
+        if logical.project_id != retained.context_key.project_id
+            || logical.workspace_id != retained.context_key.workspace_id
+            || logical.repository_instance != retained.context_key.repository_instance
+        {
+            return Ok(None);
+        }
+        Ok(Some(
+            RuntimeContextConfiguration::resolve(
+                args,
+                startup,
+                Some(&retained.project_identity),
+                Some(&logical),
+            )?
+            .with_profile_and_run_id(codestory_retrieval::SidecarProfile::Agent, None)
+            .context_key,
+        ))
     }
 
     /// Open runtime services without initializing the embedded engine.
@@ -217,60 +347,7 @@ impl RuntimeContext {
         args: &ProjectArgs,
         startup: &crate::config::CliStartupConfig,
     ) -> Result<Self> {
-        let project_root = canonicalize_project_root(&args.project)?;
-        let repository_identity =
-            codestory_workspace::inspect_repository_identity_v2(&project_root);
-        let project_identity = codestory_workspace::project_identity_v3_from_repository(
-            &project_root,
-            &repository_identity,
-        );
-        let config = crate::config::load_config_with_startup(&project_root, startup)?;
-        let cache_override = args.cache_dir.clone().or_else(|| config.cache_dir.clone());
-        let process_cache_root = canonicalize_configuration_path(
-            startup
-                .stdio_cache_root
-                .as_deref()
-                .unwrap_or_else(|| startup.sidecar_defaults.cache_root()),
-        )?;
-        let cache_root = cache_root_for_project_in(
-            &project_root,
-            cache_override.as_deref(),
-            &process_cache_root,
-        )?;
-        let storage_path = canonicalize_configuration_path(&cache_root.join("codestory.db"))?;
-        let sidecar_defaults = startup.sidecar_defaults.with_cache_root(process_cache_root);
-        let sidecar = crate::sidecar_runtime::for_project_auto_with_process_defaults_and_identity(
-            &project_identity,
-            &sidecar_defaults,
-            &config.runtime_overrides(),
-        );
-        let source_index_policy = startup.source_index_policy.clone();
-        let context_key = ProjectContextKey {
-            project_id: project_identity.project_id.clone(),
-            workspace_id: project_identity.workspace_id.clone(),
-            configuration_id: runtime_configuration_id(&cache_root, &sidecar, &source_index_policy),
-        };
-        let runtime = Runtime::new_with_process_config(RuntimeProcessConfig::new(
-            sidecar.clone(),
-            source_index_policy.clone(),
-        ));
-        let events = runtime.events();
-        Ok(Self {
-            activation: runtime.activation_service(),
-            public_operation: runtime.public_operation_service(),
-            project: runtime.project_service(),
-            index: runtime.index_service(),
-            grounding: runtime.grounding_service(),
-            bookmarks: runtime.bookmark_service(),
-            browser: runtime.browser_service(),
-            events,
-            project_root,
-            context_key,
-            cache_root,
-            storage_path,
-            sidecar,
-            source_index_policy,
-        })
+        Ok(RuntimeContextConfiguration::resolve(args, startup, None, None)?.build())
     }
 
     /// Open project state and run the resolved refresh request when needed.
@@ -510,117 +587,8 @@ fn runtime_configuration_id(
     sidecar: &codestory_retrieval::SidecarRuntimeConfig,
     source_index_policy: &codestory_contracts::workspace::SourceIndexPolicy,
 ) -> String {
-    // Do not hash credentials. Their presence participates in the immutable
-    // configuration boundary, while secret material remains outside logs and
-    // diagnostic identifiers.
-    let mut identity = format!(
-        "{}\0{:?}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}",
-        configuration_path_identity(cache_root),
-        sidecar.profile,
-        sidecar.namespace,
-        sidecar.embedding.allow_cpu,
-        sidecar.retrieval.hybrid_enabled,
-        sidecar.retrieval.semantic_doc_scope,
-        sidecar.retrieval.semantic_doc_alias_mode,
-        sidecar.retrieval.semantic_doc_max_tokens,
-        sidecar.retrieval.llm_doc_embed_batch_size,
-        sidecar.retrieval.stream_pending_docs,
-        sidecar.retrieval.stream_sort_window_batches,
-        sidecar.summary.endpoint.as_deref().unwrap_or(""),
-        sidecar.summary.api_key.is_some(),
-    );
-    identity.push_str(&format!(
-        "\0{}\0{:?}\0{:?}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}",
-        sidecar.summary.model,
-        sidecar.summary.max_tokens,
-        sidecar.summary.timeout,
-        sidecar.run_id.as_deref().unwrap_or(""),
-        configuration_path_identity(&sidecar.layout.lexical_data_dir),
-        configuration_path_identity(&sidecar.layout.semantic_data_dir),
-        configuration_path_identity(&sidecar.layout.scip_artifacts_root),
-        configuration_path_identity(&sidecar.layout.state_file),
-        source_index_policy.policy_version,
-        source_index_policy.byte_cap,
-        source_index_policy.structural_unit_cap,
-    ));
-    fnv1a_hex(identity.as_bytes())
-}
-
-fn configuration_path_identity(path: &Path) -> String {
-    #[cfg(windows)]
-    {
-        windows_ordinal_configuration_path_identity(path)
-    }
-    #[cfg(not(windows))]
-    {
-        clean_path_string(&path.to_string_lossy())
-    }
-}
-
-#[cfg(windows)]
-fn windows_ordinal_configuration_path_identity(path: &Path) -> String {
-    use std::ptr;
-
-    #[link(name = "kernel32")]
-    unsafe extern "system" {
-        fn LCMapStringEx(
-            locale_name: *const u16,
-            map_flags: u32,
-            source: *const u16,
-            source_len: i32,
-            destination: *mut u16,
-            destination_len: i32,
-            version_information: *mut std::ffi::c_void,
-            reserved: *mut std::ffi::c_void,
-            sort_handle: isize,
-        ) -> i32;
-    }
-
-    const LCMAP_UPPERCASE: u32 = 0x0000_0200;
-    let normalized = clean_path_string(&path.to_string_lossy()).replace('/', "\\");
-    let source = normalized.encode_utf16().collect::<Vec<_>>();
-    let Ok(source_len) = i32::try_from(source.len()) else {
-        return normalized.to_uppercase();
-    };
-    let invariant_locale = [0_u16];
-    // SAFETY: all pointers remain valid for the supplied lengths. The invariant
-    // locale uses the same language-independent uppercase table as Windows
-    // ordinal ignore-case comparison.
-    let required = unsafe {
-        LCMapStringEx(
-            invariant_locale.as_ptr(),
-            LCMAP_UPPERCASE,
-            source.as_ptr(),
-            source_len,
-            ptr::null_mut(),
-            0,
-            ptr::null_mut(),
-            ptr::null_mut(),
-            0,
-        )
-    };
-    if required <= 0 {
-        return normalized.to_uppercase();
-    }
-    let mut mapped = vec![0_u16; required as usize];
-    // SAFETY: `mapped` has the size returned by the preceding mapping query.
-    let written = unsafe {
-        LCMapStringEx(
-            invariant_locale.as_ptr(),
-            LCMAP_UPPERCASE,
-            source.as_ptr(),
-            source_len,
-            mapped.as_mut_ptr(),
-            required,
-            ptr::null_mut(),
-            ptr::null_mut(),
-            0,
-        )
-    };
-    if written <= 0 {
-        return normalized.to_uppercase();
-    }
-    String::from_utf16_lossy(&mapped[..written as usize])
+    RuntimeProcessConfig::new(sidecar.clone(), source_index_policy.clone())
+        .configuration_id(cache_root)
 }
 
 /// Resolve a CLI target selector into one graph-backed search hit.
@@ -810,6 +778,7 @@ fn normalize_canonical_configuration_path(path: PathBuf) -> PathBuf {
 }
 
 /// Small stable hash used for path-derived cache directory names.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn fnv1a_hex(bytes: &[u8]) -> String {
     let mut hash = 0xcbf29ce484222325_u64;
     for byte in bytes {
@@ -1542,18 +1511,19 @@ mod tests {
         let before_folded = canonicalize_configuration_path(&folded).expect("folded missing path");
         let before_extended =
             canonicalize_configuration_path(&extended).expect("extended missing path");
-        let expected = configuration_path_identity(&before_mixed);
-        assert_eq!(configuration_path_identity(&before_folded), expected);
-        assert_eq!(configuration_path_identity(&before_extended), expected);
+        let configuration = RuntimeProcessConfig::local();
+        let expected = configuration.configuration_id(&before_mixed);
+        assert_eq!(configuration.configuration_id(&before_folded), expected);
+        assert_eq!(configuration.configuration_id(&before_extended), expected);
 
         fs::create_dir_all(&mixed).expect("create mixed-case configuration path");
         let after_mixed = canonicalize_configuration_path(&mixed).expect("mixed existing path");
         let after_folded = canonicalize_configuration_path(&folded).expect("folded existing path");
         let after_extended =
             canonicalize_configuration_path(&extended).expect("extended existing path");
-        assert_eq!(configuration_path_identity(&after_mixed), expected);
-        assert_eq!(configuration_path_identity(&after_folded), expected);
-        assert_eq!(configuration_path_identity(&after_extended), expected);
+        assert_eq!(configuration.configuration_id(&after_mixed), expected);
+        assert_eq!(configuration.configuration_id(&after_folded), expected);
+        assert_eq!(configuration.configuration_id(&after_extended), expected);
     }
 
     #[test]

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -642,30 +642,37 @@ impl StdioServerSession {
         }
         let project_root = crate::runtime::canonicalize_project_root(Path::new(project))
             .map_err(|error| anyhow::anyhow!("project_unavailable: {error}"))?;
-        if !self.project_required
-            && self.active_project.as_ref().is_some_and(|active| {
-                codestory_workspace::same_workspace_path(
-                    &active.runtime.project_root,
-                    &project_root,
-                )
-            })
-        {
-            return Ok(());
-        }
+        let active_same_root = self.active_project.as_ref().filter(|active| {
+            codestory_workspace::same_workspace_path(&active.runtime.project_root, &project_root)
+        });
         let workspace_id = codestory_workspace::workspace_id_v3_for_root(&project_root);
-        let cache_dir = self
-            .startup
-            .stdio_cache_root
-            .as_ref()
-            .cloned()
-            .map(|root| root.join(&workspace_id));
-        let candidate = RuntimeContext::new_agent_sidecar_with_startup(
-            &args::ProjectArgs {
-                project: project_root.clone(),
-                cache_dir,
-            },
-            &self.startup,
-        )?;
+        let cache_dir = active_same_root
+            .filter(|_| !self.project_required)
+            .map(|active| active.runtime.cache_root.clone())
+            .or_else(|| {
+                self.startup
+                    .stdio_cache_root
+                    .as_ref()
+                    .map(|root| root.join(&workspace_id))
+            });
+        let args = args::ProjectArgs {
+            project: project_root.clone(),
+            cache_dir,
+        };
+        if let Some(active) = active_same_root {
+            let candidate_key = RuntimeContext::agent_sidecar_context_key_with_startup(
+                &args,
+                &self.startup,
+                &active.runtime,
+            )?;
+            if candidate_key
+                .as_ref()
+                .is_some_and(|candidate| active.runtime.context_key == *candidate)
+            {
+                return Ok(());
+            }
+        }
+        let candidate = RuntimeContext::new_agent_sidecar_with_startup(&args, &self.startup)?;
         if self
             .active_project
             .as_ref()
@@ -7673,7 +7680,7 @@ version = "0.11.20"
     }
 
     #[test]
-    fn multi_project_session_keys_same_path_by_runtime_configuration() {
+    fn multi_project_session_skips_context_construction_until_configuration_changes() {
         let cache = tempfile::tempdir().expect("cache");
         let project = tempfile::tempdir().expect("project");
         let config_path = project.path().join(".codestory.toml");
@@ -7699,6 +7706,16 @@ version = "0.11.20"
             .runtime
             .context_key
             .clone();
+        let constructions = crate::runtime::runtime_context_construction_count_for_test();
+
+        session
+            .select_project(project.path().join(".").to_str())
+            .expect("reselect unchanged active project through alias");
+        assert_eq!(
+            crate::runtime::runtime_context_construction_count_for_test(),
+            constructions,
+            "same unchanged active project must return before constructing another runtime context"
+        );
 
         std::fs::write(&config_path, "semantic_doc_scope = \"all\"\n")
             .expect("write changed config");
@@ -7713,6 +7730,11 @@ version = "0.11.20"
             .context_key
             .clone();
         assert_ne!(default_key, changed_key);
+        assert_eq!(
+            crate::runtime::runtime_context_construction_count_for_test(),
+            constructions + 1,
+            "configuration drift must construct exactly one replacement runtime context"
+        );
         assert!(
             session
                 .retained_projects
@@ -7732,6 +7754,480 @@ version = "0.11.20"
                 .runtime
                 .context_key,
             default_key
+        );
+    }
+
+    #[test]
+    fn multi_project_session_replaces_same_root_once_when_remote_changes() {
+        let cache = tempfile::tempdir().expect("cache");
+        let project = tempfile::tempdir().expect("project");
+        let git = |args: &[&str]| {
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(project.path())
+                .args(args)
+                .status()
+                .expect("run git fixture command");
+            assert!(status.success(), "git fixture command failed: {args:?}");
+        };
+        git(&["init", "-q"]);
+        git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://example.com/team/repository-a.git",
+        ]);
+        let mut session = StdioServerSession::new(None);
+        session.startup = crate::config::CliStartupConfig {
+            user_home: None,
+            project_network_config_allowed: false,
+            stdio_cache_root: Some(cache.path().to_path_buf()),
+            sidecar_defaults: codestory_retrieval::SidecarProcessDefaults::new(
+                cache.path().to_path_buf(),
+                codestory_retrieval::SidecarRuntimeDefaults::default(),
+            ),
+            source_index_policy: codestory_contracts::workspace::SourceIndexPolicy::default(),
+        };
+
+        codestory_workspace::with_repository_metadata_observation_limit_for_test(2, || {
+            session
+                .select_project(project.path().to_str())
+                .expect("select remote A");
+            let remote_a = session
+                .active_project
+                .as_ref()
+                .expect("remote A active")
+                .runtime
+                .context_key
+                .clone();
+            let constructions = crate::runtime::runtime_context_construction_count_for_test();
+
+            git(&[
+                "remote",
+                "set-url",
+                "origin",
+                "https://example.com/team/repository-b.git",
+            ]);
+            session
+                .select_project(project.path().to_str())
+                .expect("select remote B");
+            let remote_b = session
+                .active_project
+                .as_ref()
+                .expect("remote B active")
+                .runtime
+                .context_key
+                .clone();
+            assert_eq!(remote_a.workspace_id, remote_b.workspace_id);
+            assert_ne!(remote_a.project_id, remote_b.project_id);
+            assert_eq!(remote_a.repository_instance, remote_b.repository_instance);
+            assert_eq!(
+                crate::runtime::runtime_context_construction_count_for_test(),
+                constructions + 1,
+                "logical identity drift must construct exactly one replacement context"
+            );
+            assert!(session.retained_projects.iter().any(|retained| {
+                retained.runtime.context_key.project_id == remote_a.project_id
+            }));
+
+            session
+                .select_project(project.path().join(".").to_str())
+                .expect("reselect unchanged remote B");
+            assert_eq!(
+                crate::runtime::runtime_context_construction_count_for_test(),
+                constructions + 1,
+                "the replacement context must be reused after logical identity converges"
+            );
+        });
+
+        let active = session.active_project.as_ref().expect("replacement active");
+        let activation = active.runtime.activation.clone();
+        let _ = activation.activate_project_with_foreground_budget(
+            &active.runtime.project_root,
+            &active.runtime.storage_path,
+            Arc::new(AtomicBool::new(false)),
+            Duration::ZERO,
+        );
+        assert_eq!(
+            activation
+                .snapshot()
+                .expect("replacement activation")
+                .attempt,
+            1
+        );
+        activation.cancel_and_wait();
+    }
+
+    #[test]
+    fn multi_project_session_replaces_same_root_once_after_reinit_without_remote() {
+        let cache = tempfile::tempdir().expect("cache");
+        let project = tempfile::tempdir().expect("project");
+        let git = |args: &[&str]| {
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(project.path())
+                .args(args)
+                .status()
+                .expect("run git fixture command");
+            assert!(status.success(), "git fixture command failed: {args:?}");
+        };
+        git(&["init", "-q"]);
+        git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://example.com/team/repository-a.git",
+        ]);
+        let mut session = StdioServerSession::new(None);
+        session.startup = crate::config::CliStartupConfig {
+            user_home: None,
+            project_network_config_allowed: false,
+            stdio_cache_root: Some(cache.path().to_path_buf()),
+            sidecar_defaults: codestory_retrieval::SidecarProcessDefaults::new(
+                cache.path().to_path_buf(),
+                codestory_retrieval::SidecarRuntimeDefaults::default(),
+            ),
+            source_index_policy: codestory_contracts::workspace::SourceIndexPolicy::default(),
+        };
+
+        codestory_workspace::with_repository_metadata_observation_limit_for_test(2, || {
+            session
+                .select_project(project.path().to_str())
+                .expect("select original repository");
+            let original = session
+                .active_project
+                .as_ref()
+                .expect("original active")
+                .runtime
+                .context_key
+                .clone();
+            let constructions = crate::runtime::runtime_context_construction_count_for_test();
+
+            std::fs::rename(
+                project.path().join(".git"),
+                project.path().join(".git-retired"),
+            )
+            .expect("retire original repository metadata");
+            git(&["init", "-q"]);
+            session
+                .select_project(project.path().to_str())
+                .expect("select reinitialized repository");
+            let reinitialized = session
+                .active_project
+                .as_ref()
+                .expect("reinitialized active")
+                .runtime
+                .context_key
+                .clone();
+            assert_eq!(original.workspace_id, reinitialized.workspace_id);
+            assert_ne!(original.project_id, reinitialized.project_id);
+            assert_eq!(reinitialized.project_id, reinitialized.workspace_id);
+            assert_ne!(
+                original.repository_instance,
+                reinitialized.repository_instance
+            );
+            assert_eq!(
+                crate::runtime::runtime_context_construction_count_for_test(),
+                constructions + 1,
+                "reinit must construct exactly one no-remote replacement context"
+            );
+
+            session
+                .select_project(project.path().to_str())
+                .expect("reselect unchanged reinitialized repository");
+            assert_eq!(
+                crate::runtime::runtime_context_construction_count_for_test(),
+                constructions + 1
+            );
+        });
+    }
+
+    #[test]
+    fn multi_project_session_replaces_same_root_once_after_same_remote_reinit() {
+        let cache = tempfile::tempdir().expect("cache");
+        let project = tempfile::tempdir().expect("project");
+        let git = |args: &[&str]| {
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(project.path())
+                .args(args)
+                .status()
+                .expect("run git fixture command");
+            assert!(status.success(), "git fixture command failed: {args:?}");
+        };
+        git(&["init", "-q"]);
+        git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://example.com/team/repository-a.git",
+        ]);
+        let mut session = StdioServerSession::new(None);
+        session.startup = crate::config::CliStartupConfig {
+            user_home: None,
+            project_network_config_allowed: false,
+            stdio_cache_root: Some(cache.path().to_path_buf()),
+            sidecar_defaults: codestory_retrieval::SidecarProcessDefaults::new(
+                cache.path().to_path_buf(),
+                codestory_retrieval::SidecarRuntimeDefaults::default(),
+            ),
+            source_index_policy: codestory_contracts::workspace::SourceIndexPolicy::default(),
+        };
+
+        codestory_workspace::with_repository_metadata_observation_limit_for_test(2, || {
+            session
+                .select_project(project.path().to_str())
+                .expect("select original repository instance");
+            let original = session
+                .active_project
+                .as_ref()
+                .expect("original active")
+                .runtime
+                .context_key
+                .clone();
+            let constructions = crate::runtime::runtime_context_construction_count_for_test();
+
+            std::fs::rename(
+                project.path().join(".git"),
+                project.path().join(".git-retired"),
+            )
+            .expect("retire original repository metadata");
+            git(&["init", "-q"]);
+            git(&[
+                "remote",
+                "add",
+                "origin",
+                "https://example.com/team/repository-a.git",
+            ]);
+            session
+                .select_project(project.path().to_str())
+                .expect("select recreated repository instance");
+            let recreated = session
+                .active_project
+                .as_ref()
+                .expect("recreated active")
+                .runtime
+                .context_key
+                .clone();
+            assert_eq!(original.project_id, recreated.project_id);
+            assert_eq!(original.workspace_id, recreated.workspace_id);
+            assert_ne!(original.repository_instance, recreated.repository_instance);
+            assert_eq!(
+                crate::runtime::runtime_context_construction_count_for_test(),
+                constructions + 1,
+                "same-remote metadata recreation must construct exactly one replacement context"
+            );
+
+            session
+                .select_project(project.path().to_str())
+                .expect("reselect stable recreated repository");
+            assert_eq!(
+                crate::runtime::runtime_context_construction_count_for_test(),
+                constructions + 1
+            );
+        });
+    }
+
+    #[test]
+    fn ready_lease_reuses_one_runtime_across_packet_then_search_without_preparation() {
+        fn call_until_ready(
+            session: &mut StdioServerSession,
+            name: &str,
+            arguments: serde_json::Value,
+            id_prefix: &str,
+        ) -> serde_json::Value {
+            let deadline = Instant::now() + Duration::from_secs(20);
+            for attempt in 0..20 {
+                let id = format!("{id_prefix}-{attempt}");
+                let response = handle_stdio_message(
+                    session,
+                    &json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "method": "tools/call",
+                        "params": {"name": name, "arguments": arguments.clone()}
+                    })
+                    .to_string(),
+                    &Arc::new(AtomicBool::new(false)),
+                )
+                .expect("tool response");
+                if response.pointer("/result/isError") != Some(&json!(true)) {
+                    assert!(response.pointer("/result/structuredContent").is_some());
+                    return response;
+                }
+                let error = &response["result"]["structuredContent"];
+                assert_eq!(
+                    error["code"],
+                    json!("codestory_preparing"),
+                    "ready-lease fixture must converge instead of becoming unavailable: {response}"
+                );
+                assert!(
+                    Instant::now() < deadline,
+                    "broad call did not become ready: {error}"
+                );
+                std::thread::sleep(Duration::from_millis(
+                    error["retry_after_ms"].as_u64().unwrap_or(50).min(500),
+                ));
+            }
+            panic!("broad call did not converge within the bounded retry count")
+        }
+
+        let cache = tempfile::tempdir().expect("cache");
+        let project = tempfile::tempdir().expect("project");
+        std::fs::write(
+            project.path().join("metadata.rs"),
+            "// READY_LEASE_STDIO_ANCHOR\n",
+        )
+        .expect("write zero-dense stdio fixture");
+        let git = |args: &[&str]| {
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(project.path())
+                .args(args)
+                .status()
+                .expect("run ready-lease git fixture command");
+            assert!(status.success(), "git fixture command failed: {args:?}");
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "codestory-tests@example.com"]);
+        git(&["config", "user.name", "CodeStory Tests"]);
+        git(&["add", "metadata.rs"]);
+        git(&["commit", "-qm", "ready lease fixture"]);
+        let mut session = StdioServerSession::new(None);
+        session.startup = crate::config::CliStartupConfig {
+            user_home: None,
+            project_network_config_allowed: false,
+            stdio_cache_root: Some(cache.path().join("stdio-cache")),
+            sidecar_defaults: codestory_retrieval::SidecarProcessDefaults::new(
+                cache.path().join("sidecar-cache"),
+                codestory_retrieval::SidecarRuntimeDefaults::default(),
+            ),
+            source_index_policy: codestory_contracts::workspace::SourceIndexPolicy::default(),
+        };
+        session
+            .select_project(project.path().to_str())
+            .expect("select ready-lease project");
+        let active = session.active_project.as_ref().expect("active project");
+        active
+            .runtime
+            .ensure_open(args::RefreshMode::Full)
+            .expect("publish ready-lease core");
+        codestory_retrieval::test_support::publish_zero_dense_pinned_query_fixture(
+            &active.runtime.project_root,
+            &active.runtime.storage_path,
+            &active.runtime.sidecar,
+        )
+        .expect("publish strict zero-dense retrieval fixture");
+        active
+            .runtime
+            .activation
+            .use_published_retrieval_fixture_for_test();
+        let context_constructions = crate::runtime::runtime_context_construction_count_for_test();
+
+        let initialized = handle_stdio_message(
+            &mut session,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": "init-ready-lease-reuse",
+                "method": "initialize",
+                "params": {}
+            })
+            .to_string(),
+            &Arc::new(AtomicBool::new(false)),
+        )
+        .expect("initialize response");
+        assert!(initialized.get("result").is_some());
+
+        let project_argument = project.path().to_string_lossy().to_string();
+        let packet = call_until_ready(
+            &mut session,
+            "packet",
+            json!({
+                "project": project_argument,
+                "question": "Where is READY_LEASE_STDIO_ANCHOR?"
+            }),
+            "ready-lease-packet",
+        );
+        let packet_publication = packet["result"]["_meta"]["codestory_publication"].clone();
+        assert!(packet_publication["core_publication"].is_object());
+        assert!(packet_publication["retrieval_publication"].is_object());
+        let activation = session
+            .active_project
+            .as_ref()
+            .expect("active ready project")
+            .runtime
+            .activation
+            .clone();
+        assert_eq!(
+            activation.preparation_counts_for_test(),
+            (1, 1),
+            "the first broad call must prepare native embedding and finalize retrieval exactly once"
+        );
+        assert_eq!(
+            crate::runtime::runtime_context_construction_count_for_test(),
+            context_constructions,
+            "packet activation must retain the selected runtime context"
+        );
+        let before_warm_admission = activation.snapshot().expect("ready activation snapshot");
+        let storage_path = session
+            .active_project
+            .as_ref()
+            .expect("active ready project")
+            .runtime
+            .storage_path
+            .clone();
+        let (warm_admission, metadata_tree_traversals) =
+            codestory_workspace::with_repository_metadata_tree_traversal_count_for_test(|| {
+                activation
+                    .activate_project(
+                        project.path(),
+                        &storage_path,
+                        Arc::new(AtomicBool::new(false)),
+                    )
+                    .expect("warm ready lease admission")
+            });
+        assert_eq!(metadata_tree_traversals, 0);
+        assert_eq!(warm_admission.snapshot, before_warm_admission);
+        let (_, full_observation_traversals) =
+            codestory_workspace::with_repository_metadata_tree_traversal_count_for_test(|| {
+                codestory_workspace::project_identity_v3(project.path())
+            });
+        assert!(
+            full_observation_traversals > 0,
+            "the warm-admission zero-traversal counter needs an armed full-observation control"
+        );
+        activation.arm_preparation_seams_for_test();
+
+        // Public search performs its own source/freshness proof and deliberately
+        // stays outside the warm-admission traversal counter.
+        let search = call_until_ready(
+            &mut session,
+            "search",
+            json!({
+                "project": project.path(),
+                "query": "READY_LEASE_STDIO_ANCHOR"
+            }),
+            "ready-lease-search",
+        );
+        let search_publication = search["result"]["_meta"]["codestory_publication"].clone();
+        assert_eq!(
+            search_publication["core_publication"], packet_publication["core_publication"],
+            "ready reuse must retain one complete core identity"
+        );
+        assert_eq!(
+            search_publication["retrieval_publication"],
+            packet_publication["retrieval_publication"],
+            "ready reuse must retain one retrieval generation and producer identity"
+        );
+        assert_eq!(
+            activation.preparation_counts_for_test(),
+            (1, 1),
+            "the second broad tool must not reach either armed preparation seam"
+        );
+        assert_eq!(
+            crate::runtime::runtime_context_construction_count_for_test(),
+            context_constructions,
+            "the second broad tool must not construct another runtime context"
         );
     }
 

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -152,6 +152,8 @@ pub use retention::{
 };
 pub use scip_client::ScipClient;
 pub use sidecar::{
+    ReadyEmbeddingEngineIdentity, ReadyRetrievalIdentity,
+    observe_ready_retrieval_identity_for_project_id, ready_retrieval_identity_for_runtime,
     sidecar_status, strict_sidecar_status, strict_sidecar_status_for_profile,
     strict_sidecar_status_for_runtime,
 };

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -17,6 +17,33 @@ use codestory_store::Store;
 use codestory_workspace::{RefreshInputs, WorkspaceManifest};
 use std::path::Path;
 
+/// Stable live engine fields that make a ready retrieval publication
+/// admissible for reuse without starting or reloading the native worker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadyEmbeddingEngineIdentity {
+    pub instance_id: String,
+    pub load_generation: u64,
+    pub model_load_count: u64,
+    pub model_digest: String,
+    pub ggml_build_identity: String,
+    pub backend: String,
+    pub adapter_name: String,
+    pub policy: String,
+    pub execution_device_names: Vec<String>,
+    pub execution_backend_names: Vec<String>,
+    pub accelerator_execution_verified: bool,
+}
+
+/// Bounded retrieval pointer and producer observation retained by runtime
+/// activation. Artifact contents remain protected by pinned reader admission;
+/// this identity only decides whether activation itself can be skipped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadyRetrievalIdentity {
+    pub manifest: codestory_store::RetrievalIndexManifest,
+    pub producer_compatibility_identity: String,
+    pub engine: Option<ReadyEmbeddingEngineIdentity>,
+}
+
 /// Observe retrieval-generation health for the selected project.
 pub fn sidecar_status(
     project_root: &Path,
@@ -61,6 +88,87 @@ pub fn strict_sidecar_status_for_runtime(
     runtime: SidecarRuntimeConfig,
 ) -> Result<RetrievalStatusReport> {
     status_with_runtime(project_root, storage_path, true, runtime)
+}
+
+/// Observe the current retrieval publication, producer, and live engine
+/// identities without finalizing a generation, loading a model, or validating
+/// every immutable artifact row.
+///
+/// The initial lease is captured only after strict readiness succeeds. Repeat
+/// activation uses [`observe_ready_retrieval_identity_for_project_id`] with
+/// the retained manifest owner; the pinned query boundary still performs deep
+/// artifact validation before serving.
+pub fn ready_retrieval_identity_for_runtime(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<Option<ReadyRetrievalIdentity>> {
+    if !storage_path.is_file() {
+        return Ok(None);
+    }
+    let project_id = sidecar_project_id_for_runtime(project_root, runtime)?;
+    observe_ready_retrieval_identity_for_project_id(storage_path, runtime, &project_id)
+}
+
+/// Observe a retained ready lease by its already-validated manifest project id.
+///
+/// This is the warm-admission boundary: it reads only the exact observational
+/// manifest row plus in-memory producer/live-engine identity. It accepts no
+/// project root and therefore cannot re-enter repository identity, source
+/// freshness, or mutable Git state. Initial activation and lease capture must
+/// continue to use [`ready_retrieval_identity_for_runtime`].
+pub fn observe_ready_retrieval_identity_for_project_id(
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+    project_id: &str,
+) -> Result<Option<ReadyRetrievalIdentity>> {
+    if !storage_path.is_file() {
+        return Ok(None);
+    }
+    let embedding_snapshot = crate::embeddings::embedding_engine_snapshot_for_runtime(runtime);
+    if !embedding_snapshot.probe.reachable || !embedding_snapshot.device.full_retrieval_allowed {
+        return Ok(None);
+    }
+    #[cfg(not(feature = "test-support"))]
+    if embedding_snapshot.identity.is_none() {
+        return Ok(None);
+    }
+
+    let producer_compatibility_identity =
+        crate::embedded_vector::vector_producer_compatibility_identity(
+            &embedding_snapshot.device,
+            embedding_snapshot.identity.as_ref(),
+            u32::try_from(crate::embeddings::semantic_vector_dim())
+                .context("embedding dimension exceeds ready-lease contract")?,
+        )?;
+    let storage = Store::open_observational(storage_path)
+        .context("open storage observationally for ready retrieval identity")?;
+    let Some(manifest) = storage
+        .get_retrieval_index_manifest(project_id)
+        .context("load retrieval manifest for ready retrieval identity")?
+    else {
+        return Ok(None);
+    };
+    let engine = embedding_snapshot
+        .identity
+        .map(|identity| ReadyEmbeddingEngineIdentity {
+            instance_id: identity.instance_id,
+            load_generation: identity.load_generation,
+            model_load_count: identity.model_load_count,
+            model_digest: identity.model_digest.to_string(),
+            ggml_build_identity: identity.ggml_build_identity.to_string(),
+            backend: identity.backend,
+            adapter_name: identity.adapter_name,
+            policy: identity.policy.to_string(),
+            execution_device_names: identity.execution_device_names,
+            execution_backend_names: identity.execution_backend_names,
+            accelerator_execution_verified: identity.accelerator_execution_verified,
+        });
+    Ok(Some(ReadyRetrievalIdentity {
+        manifest,
+        producer_compatibility_identity,
+        engine,
+    }))
 }
 
 fn status_with_runtime(

--- a/crates/codestory-runtime/src/controller_core.rs
+++ b/crates/codestory-runtime/src/controller_core.rs
@@ -59,6 +59,7 @@ impl AppController {
                 node_names: HashMap::new(),
                 search_engine: None,
                 search_publication: None,
+                observed_core_publication: None,
                 is_indexing: false,
                 index_freshness_cache: None,
                 #[cfg(test)]
@@ -128,6 +129,16 @@ impl AppController {
 
     pub(crate) fn identity(&self) -> usize {
         Arc::as_ptr(&self.state) as usize
+    }
+
+    pub(crate) fn runtime_configuration_id(&self) -> Result<String, ApiError> {
+        let storage_path = self.require_storage_path()?;
+        let project_cache_root = storage_path.parent().unwrap_or(storage_path.as_path());
+        Ok(RuntimeProcessConfig::new(
+            self.runtime_config.as_ref().clone(),
+            self.source_index_policy.as_ref().clone(),
+        )
+        .configuration_id(project_cache_root))
     }
 
     pub(crate) fn open_storage(&self) -> Result<Storage, ApiError> {

--- a/crates/codestory-runtime/src/controller_indexing.rs
+++ b/crates/codestory-runtime/src/controller_indexing.rs
@@ -132,14 +132,34 @@ impl AppController {
             ))
         })?;
 
-        {
+        let changed = {
             let mut s = self.state.lock();
+            let target_changed =
+                s.project_root.as_ref().is_none_or(|current| {
+                    !codestory_workspace::same_workspace_path(current, &root)
+                }) || s.storage_path.as_ref().is_none_or(|current| {
+                    !codestory_workspace::same_workspace_path(current, &storage_path)
+                });
+            let core_changed = s.observed_core_publication.as_ref() != summary.publication.as_ref();
+            let resident_search_changed = s
+                .search_publication
+                .as_ref()
+                .cloned()
+                .map(index_publication_dto)
+                .is_some_and(|publication| Some(&publication) != summary.publication.as_ref());
+            let changed = target_changed || core_changed || resident_search_changed;
             s.project_root = Some(root);
             s.storage_path = Some(storage_path);
-            s.node_names.clear();
-            clear_search_engine(&mut s);
+            s.observed_core_publication = summary.publication.clone();
+            if changed {
+                s.node_names.clear();
+                clear_search_engine(&mut s);
+            }
+            changed
+        };
+        if changed {
+            self.sidecar_query_cache.lock().clear();
         }
-        self.sidecar_query_cache.lock().clear();
 
         Ok(summary)
     }
@@ -166,6 +186,7 @@ impl AppController {
             let mut s = self.state.lock();
             s.project_root = Some(root);
             s.storage_path = Some(storage_path);
+            s.observed_core_publication = summary.publication.clone();
             s.node_names = loaded.node_names;
             publish_search_engine(&mut s, loaded.engine, loaded.publication);
         }
@@ -600,6 +621,16 @@ impl AppController {
                     "The complete core publication disappeared before search preparation.",
                 )
             })?;
+        let resident_search_is_current = {
+            let state = self.state.lock();
+            state.storage_path.as_ref().is_some_and(|current| {
+                codestory_workspace::same_workspace_path(current, &storage_path)
+            }) && state.search_engine.is_some()
+                && state.search_publication.as_ref() == Some(&expected_publication)
+        };
+        if resident_search_is_current {
+            return Ok(());
+        }
         let mut validate_before_completion =
             |prepared_publication: &IndexPublicationRecord| -> Result<(), ApiError> {
                 if cancel_token.is_cancelled() {

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -16,17 +16,18 @@ use codestory_contracts::api::{
     GroundingOrientationDto, GroundingOrientationUncertaintyDto, GroundingSnapshotDto,
     GroundingSymbolDigestDto, IndexFreshnessChangeKindDto, IndexFreshnessDto,
     IndexFreshnessNotCheckedCauseDto, IndexFreshnessSampleDto, IndexFreshnessStatusDto,
-    IndexedFileRoleDto, IndexingPhaseTimings, NodeDetailsRequest, NodeId, NodeKind,
-    RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalScoreBreakdownDto,
-    RetrievalStateDto, RouteEndpointKindDto, RouteEndpointMetadataDto, SearchHit, SearchHitOrigin,
-    SearchHybridLimitsDto, SearchMatchQualityDto, SearchPlanAnchorGroupDto,
-    SearchPlanBridgeConfidenceDto, SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto,
-    SearchPlanBridgeStatusDto, SearchPlanCandidateWindowDto, SearchPlanChannelDto,
-    SearchPlanDroppedTermDto, SearchPlanDto, SearchPlanNextActionDto, SearchPlanPromotionStatusDto,
-    SearchPlanRejectedHitDto, SearchPlanSubqueryDto, SearchPlanTermsDto, SearchQueryAssessmentDto,
-    SearchRepoTextMode, SearchRequest, SearchResultsDto, SemanticModeDto, SnippetContextDto,
-    StorageStatsDto, StoredSemanticDocsContractDto, SymbolContextDto, TrailConfigDto,
-    TrailContextDto, WorkspaceMemberIndexDto,
+    IndexPublicationDto, IndexedFileRoleDto, IndexingPhaseTimings, NodeDetailsRequest, NodeId,
+    NodeKind, RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalModeDto,
+    RetrievalScoreBreakdownDto, RetrievalStateDto, RouteEndpointKindDto, RouteEndpointMetadataDto,
+    SearchHit, SearchHitOrigin, SearchHybridLimitsDto, SearchMatchQualityDto,
+    SearchPlanAnchorGroupDto, SearchPlanBridgeConfidenceDto, SearchPlanBridgeDto,
+    SearchPlanBridgeEvidenceKindDto, SearchPlanBridgeStatusDto, SearchPlanCandidateWindowDto,
+    SearchPlanChannelDto, SearchPlanDroppedTermDto, SearchPlanDto, SearchPlanNextActionDto,
+    SearchPlanPromotionStatusDto, SearchPlanRejectedHitDto, SearchPlanSubqueryDto,
+    SearchPlanTermsDto, SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest,
+    SearchResultsDto, SemanticModeDto, SnippetContextDto, StorageStatsDto,
+    StoredSemanticDocsContractDto, SymbolContextDto, TrailConfigDto, TrailContextDto,
+    WorkspaceMemberIndexDto,
 };
 use codestory_contracts::graph::{AccessKind, Edge as GraphEdge, Node as GraphNode};
 use codestory_contracts::language_support::{
@@ -530,6 +531,7 @@ struct AppState {
     node_names: HashMap<codestory_contracts::graph::NodeId, String>,
     search_engine: Option<SearchEngine>,
     search_publication: Option<IndexPublicationRecord>,
+    observed_core_publication: Option<IndexPublicationDto>,
     is_indexing: bool,
     index_freshness_cache: Option<CachedIndexFreshness>,
     #[cfg(test)]
@@ -543,6 +545,7 @@ fn publish_search_engine(
     publication: Option<IndexPublicationRecord>,
 ) {
     state.index_freshness_cache = None;
+    state.observed_core_publication = publication.clone().map(index_publication_dto);
     state.search_engine = Some(engine);
     state.search_publication = publication;
 }

--- a/crates/codestory-runtime/src/process_config.rs
+++ b/crates/codestory-runtime/src/process_config.rs
@@ -1,5 +1,6 @@
 use codestory_contracts::workspace::SourceIndexPolicy;
 use codestory_retrieval::SidecarRuntimeConfig;
+use std::path::Path;
 
 /// Immutable process-owned defaults injected into one runtime.
 ///
@@ -23,4 +24,146 @@ impl RuntimeProcessConfig {
     pub fn local() -> Self {
         Self::new(SidecarRuntimeConfig::local(), SourceIndexPolicy::default())
     }
+
+    /// Return the non-secret identity of the immutable project runtime
+    /// configuration captured by the owning adapter.
+    ///
+    /// The project cache root is supplied separately because the embedding
+    /// server cache is process-scoped while core storage remains project-owned.
+    /// Keeping this digest below adapters gives activation leases and retained
+    /// transport contexts one definition of configuration equality.
+    pub fn configuration_id(&self, project_cache_root: &Path) -> String {
+        // Credentials never enter the digest. Their presence participates in
+        // the immutable boundary, while secret material remains outside logs
+        // and diagnostic identifiers.
+        let sidecar = &self.sidecar;
+        let source_index_policy = &self.source_index_policy;
+        let mut identity = format!(
+            "{}\0{:?}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}",
+            configuration_path_identity(project_cache_root),
+            sidecar.profile,
+            sidecar.namespace,
+            sidecar.embedding.allow_cpu,
+            sidecar.retrieval.hybrid_enabled,
+            sidecar.retrieval.semantic_doc_scope,
+            sidecar.retrieval.semantic_doc_alias_mode,
+            sidecar.retrieval.semantic_doc_max_tokens,
+            sidecar.retrieval.llm_doc_embed_batch_size,
+            sidecar.retrieval.stream_pending_docs,
+            sidecar.retrieval.stream_sort_window_batches,
+            sidecar.summary.endpoint.as_deref().unwrap_or(""),
+            sidecar.summary.api_key.is_some(),
+        );
+        identity.push_str(&format!(
+            "\0{}\0{:?}\0{:?}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}",
+            sidecar.summary.model,
+            sidecar.summary.max_tokens,
+            sidecar.summary.timeout,
+            sidecar.run_id.as_deref().unwrap_or(""),
+            configuration_path_identity(&sidecar.layout.lexical_data_dir),
+            configuration_path_identity(&sidecar.layout.semantic_data_dir),
+            configuration_path_identity(&sidecar.layout.scip_artifacts_root),
+            configuration_path_identity(&sidecar.layout.state_file),
+            source_index_policy.policy_version,
+            source_index_policy.byte_cap,
+            source_index_policy.structural_unit_cap,
+        ));
+        fnv1a_hex(identity.as_bytes())
+    }
+}
+
+fn configuration_path_identity(path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        windows_ordinal_configuration_path_identity(path)
+    }
+    #[cfg(not(windows))]
+    {
+        clean_path_string(&path.to_string_lossy())
+    }
+}
+
+fn clean_path_string(path: &str) -> String {
+    let mut stringified = path.replace('\\', "/");
+    if let Some(stripped) = stringified.strip_prefix("//?/UNC/") {
+        stringified = format!("//{stripped}");
+    } else if stringified.starts_with("//?/") {
+        stringified = stringified[4..].to_string();
+    }
+    stringified
+}
+
+#[cfg(windows)]
+fn windows_ordinal_configuration_path_identity(path: &Path) -> String {
+    use std::ptr;
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn LCMapStringEx(
+            locale_name: *const u16,
+            map_flags: u32,
+            source: *const u16,
+            source_len: i32,
+            destination: *mut u16,
+            destination_len: i32,
+            version_information: *mut std::ffi::c_void,
+            reserved: *mut std::ffi::c_void,
+            sort_handle: isize,
+        ) -> i32;
+    }
+
+    const LCMAP_UPPERCASE: u32 = 0x0000_0200;
+    let normalized = clean_path_string(&path.to_string_lossy()).replace('/', "\\");
+    let source = normalized.encode_utf16().collect::<Vec<_>>();
+    let Ok(source_len) = i32::try_from(source.len()) else {
+        return normalized.to_uppercase();
+    };
+    let invariant_locale = [0_u16];
+    // SAFETY: all pointers remain valid for the supplied lengths. The
+    // invariant locale uses the same language-independent uppercase table as
+    // Windows ordinal ignore-case comparison.
+    let required = unsafe {
+        LCMapStringEx(
+            invariant_locale.as_ptr(),
+            LCMAP_UPPERCASE,
+            source.as_ptr(),
+            source_len,
+            ptr::null_mut(),
+            0,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if required <= 0 {
+        return normalized.to_uppercase();
+    }
+    let mut mapped = vec![0_u16; required as usize];
+    // SAFETY: `mapped` has the size returned by the preceding mapping query.
+    let written = unsafe {
+        LCMapStringEx(
+            invariant_locale.as_ptr(),
+            LCMAP_UPPERCASE,
+            source.as_ptr(),
+            source_len,
+            mapped.as_mut_ptr(),
+            required,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if written <= 0 {
+        return normalized.to_uppercase();
+    }
+    String::from_utf16_lossy(&mapped[..written as usize])
+}
+
+fn fnv1a_hex(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
 }

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -178,23 +178,85 @@ pub struct ActivationRun {
 struct ActivationCoordinatorState {
     target: Option<ActivationTarget>,
     current: Option<ActivationSnapshot>,
+    ready_lease: Option<ReadyLease>,
     running: bool,
     current_cancel: Option<Arc<AtomicBool>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReadySourceIdentity {
+    status: IndexFreshnessStatusDto,
+    not_checked_cause: Option<IndexFreshnessNotCheckedCauseDto>,
+    changed_file_count: u32,
+    new_file_count: u32,
+    removed_file_count: u32,
+    checked_file_count: u32,
+    indexed_file_count: u32,
+    gap: Option<String>,
+}
+
+impl From<&IndexFreshnessDto> for ReadySourceIdentity {
+    fn from(freshness: &IndexFreshnessDto) -> Self {
+        Self {
+            status: freshness.status,
+            not_checked_cause: freshness.not_checked_cause,
+            changed_file_count: freshness.changed_file_count,
+            new_file_count: freshness.new_file_count,
+            removed_file_count: freshness.removed_file_count,
+            checked_file_count: freshness.checked_file_count,
+            indexed_file_count: freshness.indexed_file_count,
+            gap: freshness.reason.clone(),
+        }
+    }
+}
+
+impl ReadySourceIdentity {
+    fn is_admissible_snapshot(&self) -> bool {
+        let no_observed_drift = self.changed_file_count == 0
+            && self.new_file_count == 0
+            && self.removed_file_count == 0;
+        match self.status {
+            IndexFreshnessStatusDto::Fresh => {
+                no_observed_drift
+                    && self.checked_file_count == self.indexed_file_count
+                    && self.not_checked_cause.is_none()
+                    && self.gap.is_none()
+            }
+            IndexFreshnessStatusDto::NotChecked => {
+                no_observed_drift
+                    && self.checked_file_count <= self.indexed_file_count
+                    && self.not_checked_cause
+                        == Some(IndexFreshnessNotCheckedCauseDto::BoundedInventory)
+                    && self.gap.is_some()
+            }
+            IndexFreshnessStatusDto::Stale => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReadyLease {
+    configuration_id: String,
+    core_publication: IndexPublicationDto,
+    retrieval: codestory_retrieval::ReadyRetrievalIdentity,
+    source: ReadySourceIdentity,
 }
 
 #[derive(Debug, Clone)]
 struct ActivationTarget {
     project_id: String,
     workspace_id: String,
+    repository_instance: codestory_workspace::RepositoryInstanceIdentity,
     storage_path: PathBuf,
 }
 
 impl ActivationTarget {
     fn new(project_root: &Path, storage_path: &Path) -> Self {
-        let project = codestory_workspace::project_identity_v3(project_root);
+        let project = codestory_workspace::observe_logical_project_identity_v3(project_root);
         Self {
             project_id: project.project_id,
             workspace_id: project.workspace_id,
+            repository_instance: project.repository_instance,
             storage_path: storage_path
                 .canonicalize()
                 .unwrap_or_else(|_| storage_path.to_path_buf()),
@@ -204,6 +266,7 @@ impl ActivationTarget {
     fn matches(&self, other: &Self) -> bool {
         self.project_id == other.project_id
             && self.workspace_id == other.workspace_id
+            && self.repository_instance == other.repository_instance
             && (self.storage_path == other.storage_path
                 || codestory_workspace::same_workspace_path(
                     &self.storage_path,
@@ -217,6 +280,28 @@ struct ActivationCoordinator {
     state: Mutex<ActivationCoordinatorState>,
     changed: Condvar,
     next_id: AtomicU64,
+    #[cfg(any(test, feature = "test-support"))]
+    worker_start_count: AtomicU64,
+    #[cfg(any(test, feature = "test-support"))]
+    worker_start_gate: Mutex<Option<Arc<(Mutex<bool>, Condvar)>>>,
+    #[cfg(any(test, feature = "test-support"))]
+    native_preparation_count: AtomicU64,
+    #[cfg(any(test, feature = "test-support"))]
+    retrieval_finalization_count: AtomicU64,
+    #[cfg(any(test, feature = "test-support"))]
+    preparation_seams_armed: AtomicBool,
+    #[cfg(any(test, feature = "test-support"))]
+    native_preparation_limit: AtomicU64,
+    #[cfg(any(test, feature = "test-support"))]
+    retrieval_finalization_limit: AtomicU64,
+    #[cfg(any(test, feature = "test-support"))]
+    use_published_retrieval_fixture: AtomicBool,
+}
+
+#[derive(Clone, Copy)]
+enum ActivationPreparationPhase {
+    NativeEmbedding,
+    RetrievalFinalization,
 }
 
 /// Runtime-owned single-flight activation for one logical project, core store,
@@ -233,6 +318,18 @@ enum CompleteCoreAdmission {
     Cold,
     Fenced,
     Corrupt(ApiError),
+}
+
+struct ReadyLeaseProbe {
+    admissible: bool,
+    retained_core_publication: Option<IndexPublicationDto>,
+}
+
+fn ready_retrieval_identity_matches(
+    observed: Option<&codestory_retrieval::ReadyRetrievalIdentity>,
+    retained: &codestory_retrieval::ReadyRetrievalIdentity,
+) -> bool {
+    observed == Some(retained)
 }
 
 impl ActivationService {
@@ -252,12 +349,121 @@ impl ActivationService {
             .clone()
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[allow(dead_code)]
+    fn set_worker_start_gate_for_test(&self, gate: Option<Arc<(Mutex<bool>, Condvar)>>) {
+        *self
+            .coordinator
+            .worker_start_gate
+            .lock()
+            .expect("activation worker gate poisoned") = gate;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[allow(dead_code)]
+    fn worker_start_count_for_test(&self) -> u64 {
+        self.coordinator.worker_start_count.load(Ordering::Acquire)
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn preparation_counts_for_test(&self) -> (u64, u64) {
+        (
+            self.coordinator
+                .native_preparation_count
+                .load(Ordering::Acquire),
+            self.coordinator
+                .retrieval_finalization_count
+                .load(Ordering::Acquire),
+        )
+    }
+
+    /// Make any later native preparation or retrieval finalization fail the
+    /// owning activation. Tests arm this only after the first activation has
+    /// established the expected phase counts.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn arm_preparation_seams_for_test(&self) {
+        let (native, finalization) = self.preparation_counts_for_test();
+        self.coordinator
+            .native_preparation_limit
+            .store(native, Ordering::Release);
+        self.coordinator
+            .retrieval_finalization_limit
+            .store(finalization, Ordering::Release);
+        self.coordinator
+            .preparation_seams_armed
+            .store(true, Ordering::Release);
+    }
+
+    /// Use an already strict published retrieval fixture at the finalization
+    /// seam. The activation worker still advances through and records the
+    /// native-preparation/finalization boundaries, then performs the normal
+    /// strict readiness and identity validation before publishing its lease.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn use_published_retrieval_fixture_for_test(&self) {
+        self.coordinator
+            .use_published_retrieval_fixture
+            .store(true, Ordering::Release);
+    }
+
+    fn should_finalize_retrieval_for_activation(&self) -> bool {
+        #[cfg(any(test, feature = "test-support"))]
+        if self
+            .coordinator
+            .use_published_retrieval_fixture
+            .load(Ordering::Acquire)
+        {
+            return false;
+        }
+        true
+    }
+
+    fn record_preparation_phase(&self, phase: ActivationPreparationPhase) -> Result<(), ApiError> {
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            let (count, limit, label) = match phase {
+                ActivationPreparationPhase::NativeEmbedding => (
+                    self.coordinator
+                        .native_preparation_count
+                        .fetch_add(1, Ordering::AcqRel)
+                        + 1,
+                    self.coordinator
+                        .native_preparation_limit
+                        .load(Ordering::Acquire),
+                    "native embedding preparation",
+                ),
+                ActivationPreparationPhase::RetrievalFinalization => (
+                    self.coordinator
+                        .retrieval_finalization_count
+                        .fetch_add(1, Ordering::AcqRel)
+                        + 1,
+                    self.coordinator
+                        .retrieval_finalization_limit
+                        .load(Ordering::Acquire),
+                    "retrieval finalization",
+                ),
+            };
+            if self
+                .coordinator
+                .preparation_seams_armed
+                .load(Ordering::Acquire)
+                && count > limit
+            {
+                return Err(ApiError::internal(format!(
+                    "test preparation seam was invoked again: {label}"
+                )));
+            }
+        }
+        #[cfg(not(any(test, feature = "test-support")))]
+        let _ = phase;
+        Ok(())
+    }
+
     fn snapshot_for_target(
         &self,
         project_root: &Path,
         storage_path: &Path,
     ) -> Option<ActivationSnapshot> {
-        let target = ActivationTarget::new(project_root, storage_path);
+        let requested = ActivationTarget::new(project_root, storage_path);
         let state = self
             .coordinator
             .state
@@ -266,9 +472,26 @@ impl ActivationService {
         state
             .target
             .as_ref()
-            .is_some_and(|current| current.matches(&target))
+            .is_some_and(|current| current.matches(&requested))
             .then(|| state.current.clone())
             .flatten()
+    }
+
+    fn target_for_request(&self, project_root: &Path, storage_path: &Path) -> ActivationTarget {
+        let requested = ActivationTarget::new(project_root, storage_path);
+        if let Some(target) = self
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator poisoned")
+            .target
+            .as_ref()
+            .filter(|target| target.matches(&requested))
+            .cloned()
+        {
+            return target;
+        }
+        requested
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -280,6 +503,7 @@ impl ActivationService {
             .lock()
             .expect("activation coordinator poisoned");
         state.current = snapshot;
+        state.ready_lease = None;
     }
 
     pub fn activate_project(
@@ -428,150 +652,371 @@ impl ActivationService {
                 "request cancelled before project activation",
             ));
         }
-        let target = ActivationTarget::new(project_root, storage_path);
-        let retained_core_publication =
-            self.retained_core_publication(storage_path).unwrap_or(None);
-        let mut state = self
-            .coordinator
-            .state
-            .lock()
-            .expect("activation coordinator poisoned");
-        let joined = state.running;
-        let operation_id = if joined {
-            if !state
-                .target
-                .as_ref()
-                .is_some_and(|current| current.matches(&target))
-            {
-                return Err(ApiError::new(
-                    "project_unavailable",
-                    "a different logical project is already activating in this runtime context",
-                ));
-            }
-            let operation_id = state
-                .current
-                .as_ref()
-                .expect("running activation has a snapshot")
-                .operation_id
-                .clone();
-            drop(state);
-            operation_id
-        } else {
-            if !state
-                .target
-                .as_ref()
-                .is_some_and(|current| current.matches(&target))
-            {
-                state.target = Some(target.clone());
-                state.current = None;
-            }
-
-            let operation_id = if let Some(snapshot) = state
-                .current
-                .as_mut()
-                .filter(|snapshot| snapshot.state != ActivationState::Ready)
-            {
-                snapshot.attempt += 1;
-                snapshot.revision += 1;
-                snapshot.failure = None;
-                snapshot.failure_code = None;
-                snapshot.failure_details = None;
-                snapshot.embedding_capacity = None;
-                snapshot.embedding_retry = None;
-                snapshot.retry_after_ms = Some(250);
-                snapshot.state = ActivationState::Preparing;
-                let retained_was_ready = snapshot.capabilities.local_navigation
-                    == ActivationCapabilityState::Ready
-                    && snapshot.retained_core_publication == retained_core_publication;
-                snapshot.retained_core_publication = retained_core_publication.clone();
-                snapshot.capabilities.local_navigation = if retained_was_ready {
-                    ActivationCapabilityState::Ready
-                } else if snapshot.retained_core_publication.is_some() {
-                    ActivationCapabilityState::Retained
-                } else {
-                    ActivationCapabilityState::Unavailable
-                };
-                snapshot.capabilities.broad_search = ActivationCapabilityState::Unavailable;
-                snapshot.operation_id.clone()
-            } else {
-                let project_scope = target
-                    .project_id
-                    .chars()
-                    .filter(|character| character.is_ascii_alphanumeric())
-                    .take(12)
-                    .collect::<String>();
-                let operation_id = format!(
-                    "activation-{project_scope}-{}",
-                    self.coordinator.next_id.fetch_add(1, Ordering::Relaxed) + 1
-                );
-                state.current = Some(ActivationSnapshot {
-                    operation_id: operation_id.clone(),
-                    revision: 1,
-                    state: ActivationState::Preparing,
-                    stage: ActivationStage::Discovery,
-                    progress: activation_stage_progress(ActivationStage::Discovery),
-                    attempt: 1,
-                    retry_after_ms: Some(250),
-                    embedding_capacity: None,
-                    embedding_retry: None,
-                    failure_code: None,
-                    failure: None,
-                    failure_details: None,
-                    retained_core_publication: retained_core_publication.clone(),
-                    capabilities: ActivationCapabilities {
-                        local_navigation: if retained_core_publication.is_some() {
-                            ActivationCapabilityState::Retained
-                        } else {
-                            ActivationCapabilityState::Unavailable
-                        },
-                        broad_search: ActivationCapabilityState::Unavailable,
-                    },
-                });
-                operation_id
+        let target = self.target_for_request(project_root, storage_path);
+        let (operation_id, activation_cancelled) = loop {
+            let ready_candidate = {
+                let mut state = self
+                    .coordinator
+                    .state
+                    .lock()
+                    .expect("activation coordinator poisoned");
+                if state.running {
+                    if !state
+                        .target
+                        .as_ref()
+                        .is_some_and(|current| current.matches(&target))
+                    {
+                        return Err(ApiError::new(
+                            "project_unavailable",
+                            "a different logical project is already activating in this runtime context",
+                        ));
+                    }
+                    let operation_id = state
+                        .current
+                        .as_ref()
+                        .expect("running activation has a snapshot")
+                        .operation_id
+                        .clone();
+                    drop(state);
+                    return self.wait_for_activation(
+                        &target,
+                        &operation_id,
+                        true,
+                        request_cancelled.as_ref(),
+                        foreground_budget,
+                    );
+                }
+                if !state
+                    .target
+                    .as_ref()
+                    .is_some_and(|current| current.matches(&target))
+                {
+                    state.target = Some(target.clone());
+                    state.current = None;
+                    state.ready_lease = None;
+                }
+                match (state.current.as_ref(), state.ready_lease.as_ref()) {
+                    (Some(snapshot), Some(lease)) if snapshot.state == ActivationState::Ready => {
+                        Some((snapshot.clone(), lease.clone()))
+                    }
+                    _ => None,
+                }
             };
-            let activation_cancelled = Arc::new(AtomicBool::new(false));
-            state.running = true;
-            state.current_cancel = Some(Arc::clone(&activation_cancelled));
-            drop(state);
 
-            let operation = ActivationOperation {
-                service: self.clone(),
-                operation_id: operation_id.clone(),
-                cancelled: activation_cancelled,
-            };
-            let worker_operation = operation.clone();
-            let worker_service = self.clone();
-            let worker_project_root = project_root.to_path_buf();
-            let worker_storage_path = storage_path.to_path_buf();
-            if let Err(error) = std::thread::Builder::new()
-                .name(format!("codestory-{operation_id}"))
-                .spawn(move || {
-                    run_activation_worker(&worker_operation, || {
-                        worker_service.activate_once(
-                            &worker_operation,
-                            worker_project_root,
-                            worker_storage_path,
-                        )
+            if let Some((candidate_snapshot, candidate_lease)) = ready_candidate {
+                let probe = self.probe_ready_lease(storage_path, &candidate_lease);
+                if request_cancelled.load(Ordering::Acquire) {
+                    return Err(ApiError::new(
+                        "cancelled",
+                        "request cancelled while observing the ready project lease",
+                    ));
+                }
+                let mut state = self
+                    .coordinator
+                    .state
+                    .lock()
+                    .expect("activation coordinator poisoned");
+                if state.running {
+                    if !state
+                        .target
+                        .as_ref()
+                        .is_some_and(|current| current.matches(&target))
+                    {
+                        return Err(ApiError::new(
+                            "project_unavailable",
+                            "a different logical project started activation while the ready lease was being observed",
+                        ));
+                    }
+                    let operation_id = state
+                        .current
+                        .as_ref()
+                        .expect("running activation has a snapshot")
+                        .operation_id
+                        .clone();
+                    drop(state);
+                    return self.wait_for_activation(
+                        &target,
+                        &operation_id,
+                        true,
+                        request_cancelled.as_ref(),
+                        foreground_budget,
+                    );
+                }
+                let candidate_is_current = state
+                    .target
+                    .as_ref()
+                    .is_some_and(|current| current.matches(&target))
+                    && state.current.as_ref().is_some_and(|snapshot| {
+                        snapshot.state == ActivationState::Ready
+                            && snapshot.operation_id == candidate_snapshot.operation_id
+                            && snapshot.revision == candidate_snapshot.revision
+                    })
+                    && state.ready_lease.as_ref() == Some(&candidate_lease);
+                if !candidate_is_current {
+                    drop(state);
+                    continue;
+                }
+                if probe.admissible {
+                    let snapshot = state
+                        .current
+                        .clone()
+                        .expect("validated ready lease has a snapshot");
+                    drop(state);
+                    return Ok(ActivationRun {
+                        snapshot,
+                        joined: false,
                     });
-                })
-            {
-                let error = ApiError::new(
-                    "project_unavailable",
-                    format!("failed to start project activation worker: {error}"),
+                }
+                break self.begin_activation_locked(
+                    &mut state,
+                    &target,
+                    probe.retained_core_publication,
                 );
-                let _ = operation.finish(Some(&error));
-                return Err(error);
             }
-            operation_id
+
+            let retained_core_publication =
+                self.retained_core_publication(storage_path).unwrap_or(None);
+            let mut state = self
+                .coordinator
+                .state
+                .lock()
+                .expect("activation coordinator poisoned");
+            if state.running {
+                if !state
+                    .target
+                    .as_ref()
+                    .is_some_and(|current| current.matches(&target))
+                {
+                    return Err(ApiError::new(
+                        "project_unavailable",
+                        "a different logical project is already activating in this runtime context",
+                    ));
+                }
+                let operation_id = state
+                    .current
+                    .as_ref()
+                    .expect("running activation has a snapshot")
+                    .operation_id
+                    .clone();
+                drop(state);
+                return self.wait_for_activation(
+                    &target,
+                    &operation_id,
+                    true,
+                    request_cancelled.as_ref(),
+                    foreground_budget,
+                );
+            }
+            if state
+                .current
+                .as_ref()
+                .is_some_and(|snapshot| snapshot.state == ActivationState::Ready)
+                && state.ready_lease.is_some()
+            {
+                drop(state);
+                continue;
+            }
+            break self.begin_activation_locked(&mut state, &target, retained_core_publication);
         };
+
+        let operation = ActivationOperation {
+            service: self.clone(),
+            operation_id: operation_id.clone(),
+            cancelled: activation_cancelled,
+        };
+        let worker_operation = operation.clone();
+        let worker_service = self.clone();
+        let worker_project_root = project_root.to_path_buf();
+        let worker_storage_path = storage_path.to_path_buf();
+        #[cfg(any(test, feature = "test-support"))]
+        let worker_start_gate = self
+            .coordinator
+            .worker_start_gate
+            .lock()
+            .expect("activation worker gate poisoned")
+            .clone();
+        if let Err(error) = std::thread::Builder::new()
+            .name(format!("codestory-{operation_id}"))
+            .spawn(move || {
+                #[cfg(any(test, feature = "test-support"))]
+                worker_service
+                    .coordinator
+                    .worker_start_count
+                    .fetch_add(1, Ordering::AcqRel);
+                #[cfg(any(test, feature = "test-support"))]
+                if let Some(gate) = worker_start_gate {
+                    let (released, changed) = gate.as_ref();
+                    let mut released = released
+                        .lock()
+                        .expect("activation worker test gate poisoned");
+                    while !*released {
+                        released = changed
+                            .wait(released)
+                            .expect("activation worker test gate poisoned");
+                    }
+                }
+                run_activation_worker(&worker_operation, || {
+                    worker_service.activate_once(
+                        &worker_operation,
+                        worker_project_root,
+                        worker_storage_path,
+                    )
+                });
+            })
+        {
+            let error = ApiError::new(
+                "project_unavailable",
+                format!("failed to start project activation worker: {error}"),
+            );
+            let _ = operation.finish(Some(&error));
+            return Err(error);
+        }
 
         self.wait_for_activation(
             &target,
             &operation_id,
-            joined,
+            false,
             request_cancelled.as_ref(),
             foreground_budget,
         )
+    }
+
+    fn probe_ready_lease(&self, storage_path: &Path, lease: &ReadyLease) -> ReadyLeaseProbe {
+        let configuration_matches = self.controller.runtime_configuration_id().ok().as_ref()
+            == Some(&lease.configuration_id);
+        let retrieval_identity =
+            codestory_retrieval::observe_ready_retrieval_identity_for_project_id(
+                storage_path,
+                &self.controller.runtime_config,
+                &lease.retrieval.manifest.project_id,
+            )
+            .ok()
+            .flatten();
+        let retrieval_matches =
+            ready_retrieval_identity_matches(retrieval_identity.as_ref(), &lease.retrieval);
+        let retained_core_publication =
+            self.retained_core_publication(storage_path).unwrap_or(None);
+        let core_matches = retained_core_publication.as_ref() == Some(&lease.core_publication);
+        ReadyLeaseProbe {
+            admissible: configuration_matches
+                && lease.source.is_admissible_snapshot()
+                && retrieval_matches
+                && core_matches,
+            retained_core_publication,
+        }
+    }
+
+    fn begin_activation_locked(
+        &self,
+        state: &mut ActivationCoordinatorState,
+        target: &ActivationTarget,
+        retained_core_publication: Option<IndexPublicationDto>,
+    ) -> (String, Arc<AtomicBool>) {
+        if !state
+            .target
+            .as_ref()
+            .is_some_and(|current| current.matches(target))
+        {
+            state.target = Some(target.clone());
+            state.current = None;
+        }
+        state.ready_lease = None;
+        let operation_id = if let Some(snapshot) = state.current.as_mut() {
+            let replacing_ready = snapshot.state == ActivationState::Ready;
+            snapshot.attempt += 1;
+            snapshot.revision += 1;
+            snapshot.failure = None;
+            snapshot.failure_code = None;
+            snapshot.failure_details = None;
+            snapshot.embedding_capacity = None;
+            snapshot.embedding_retry = None;
+            snapshot.retry_after_ms = Some(250);
+            snapshot.state = ActivationState::Preparing;
+            if replacing_ready {
+                snapshot.stage = ActivationStage::Discovery;
+                snapshot.progress = activation_stage_progress(ActivationStage::Discovery);
+            }
+            let retained_was_ready = snapshot.capabilities.local_navigation
+                == ActivationCapabilityState::Ready
+                && snapshot.retained_core_publication == retained_core_publication;
+            snapshot.retained_core_publication = retained_core_publication;
+            snapshot.capabilities.local_navigation = if retained_was_ready {
+                ActivationCapabilityState::Ready
+            } else if snapshot.retained_core_publication.is_some() {
+                ActivationCapabilityState::Retained
+            } else {
+                ActivationCapabilityState::Unavailable
+            };
+            snapshot.capabilities.broad_search = ActivationCapabilityState::Unavailable;
+            snapshot.operation_id.clone()
+        } else {
+            let project_scope = target
+                .project_id
+                .chars()
+                .filter(|character| character.is_ascii_alphanumeric())
+                .take(12)
+                .collect::<String>();
+            let operation_id = format!(
+                "activation-{project_scope}-{}",
+                self.coordinator.next_id.fetch_add(1, Ordering::Relaxed) + 1
+            );
+            state.current = Some(ActivationSnapshot {
+                operation_id: operation_id.clone(),
+                revision: 1,
+                state: ActivationState::Preparing,
+                stage: ActivationStage::Discovery,
+                progress: activation_stage_progress(ActivationStage::Discovery),
+                attempt: 1,
+                retry_after_ms: Some(250),
+                embedding_capacity: None,
+                embedding_retry: None,
+                failure_code: None,
+                failure: None,
+                failure_details: None,
+                retained_core_publication: retained_core_publication.clone(),
+                capabilities: ActivationCapabilities {
+                    local_navigation: if retained_core_publication.is_some() {
+                        ActivationCapabilityState::Retained
+                    } else {
+                        ActivationCapabilityState::Unavailable
+                    },
+                    broad_search: ActivationCapabilityState::Unavailable,
+                },
+            });
+            operation_id
+        };
+        let activation_cancelled = Arc::new(AtomicBool::new(false));
+        state.running = true;
+        state.current_cancel = Some(Arc::clone(&activation_cancelled));
+        (operation_id, activation_cancelled)
+    }
+
+    fn require_ready_retrieval_identity_unchanged(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+        expected: &codestory_retrieval::ReadyRetrievalIdentity,
+    ) -> Result<(), ApiError> {
+        let current = codestory_retrieval::ready_retrieval_identity_for_runtime(
+            project_root,
+            storage_path,
+            &self.controller.runtime_config,
+        )
+        .map_err(|error| {
+            ApiError::new(
+                "publication_changed",
+                format!(
+                    "failed to revalidate retrieval identity before ready-lease publication: {error}"
+                ),
+            )
+        })?;
+        if current.as_ref() != Some(expected) {
+            return Err(ApiError::new(
+                "publication_changed",
+                "the retrieval publication or producer changed during ready-lease validation",
+            ));
+        }
+        Ok(())
     }
 
     fn wait_for_activation(
@@ -667,6 +1112,7 @@ impl ActivationService {
         let mut summary = self
             .controller
             .open_project_summary_with_storage_path(project_root.clone(), storage_path.clone())?;
+        summary.freshness = Some(self.controller.index_freshness_uncached()?);
 
         operation.set_stage(ActivationStage::CoreFreshness);
         let core_stale = summary.publication.is_none()
@@ -695,6 +1141,7 @@ impl ActivationService {
                 project_root.clone(),
                 storage_path.clone(),
             )?;
+            summary.freshness = Some(self.controller.index_freshness_uncached()?);
         }
         let local_ready = summary.publication.is_some()
             && summary.stats.node_count > 0
@@ -721,12 +1168,11 @@ impl ActivationService {
                 "activation did not produce a fresh complete core publication",
             ));
         }
-        operation.set_local_publication(
-            summary
-                .publication
-                .clone()
-                .expect("fresh complete core has a publication identity"),
-        );
+        let local_publication = summary
+            .publication
+            .clone()
+            .expect("fresh complete core has a publication identity");
+        operation.set_local_publication(local_publication.clone());
 
         operation.ensure_not_cancelled("search preparation")?;
         operation.set_stage(ActivationStage::SearchPreparation);
@@ -736,21 +1182,37 @@ impl ActivationService {
 
         operation.ensure_not_cancelled("dense preparation")?;
         operation.set_stage(ActivationStage::DensePreparation);
+        self.record_preparation_phase(ActivationPreparationPhase::NativeEmbedding)?;
         codestory_retrieval::ensure_product_embedding_backend_for_runtime(
             &self.controller.runtime_config,
         )
         .map_err(map_activation_error)?;
         operation.ensure_not_cancelled("retrieval publication")?;
         operation.set_stage(ActivationStage::Publication);
-        codestory_retrieval::finalize_index_for_runtime_with_cancel(
+        self.record_preparation_phase(ActivationPreparationPhase::RetrievalFinalization)?;
+        if self.should_finalize_retrieval_for_activation() {
+            codestory_retrieval::finalize_index_for_runtime_with_cancel(
+                &project_root,
+                &storage_path,
+                &self.controller.runtime_config,
+                operation.cancelled.as_ref(),
+            )
+            .map_err(map_activation_error)?;
+        }
+        operation.ensure_not_cancelled("retrieval validation")?;
+        operation.set_stage(ActivationStage::Validation);
+        let retrieval = codestory_retrieval::ready_retrieval_identity_for_runtime(
             &project_root,
             &storage_path,
             &self.controller.runtime_config,
-            operation.cancelled.as_ref(),
         )
-        .map_err(map_activation_error)?;
-        operation.ensure_not_cancelled("retrieval validation")?;
-        operation.set_stage(ActivationStage::Validation);
+        .map_err(map_activation_error)?
+        .ok_or_else(|| {
+            ApiError::new(
+                "project_unavailable",
+                "retrieval identity became unavailable before strict ready-lease validation",
+            )
+        })?;
         let status = codestory_retrieval::strict_sidecar_status_for_runtime(
             &project_root,
             Some(&storage_path),
@@ -763,6 +1225,54 @@ impl ActivationService {
                 "retrieval publication is not live-ready after activation",
             ));
         }
+        let source_freshness = self.controller.index_freshness_uncached()?;
+        if !index_freshness_admits_operation(&source_freshness) {
+            return Err(ApiError::new(
+                "publication_changed",
+                index_freshness_block_message("activation", &source_freshness),
+            ));
+        }
+        let core_publication = self
+            .retained_core_publication(&storage_path)?
+            .ok_or_else(|| {
+                ApiError::new(
+                    "publication_changed",
+                    "the complete core publication disappeared before ready-lease publication",
+                )
+            })?;
+        if core_publication != local_publication {
+            return Err(ApiError::new(
+                "publication_changed",
+                "the complete core publication changed before ready-lease publication",
+            ));
+        }
+        self.require_ready_retrieval_identity_unchanged(&project_root, &storage_path, &retrieval)?;
+        let revalidated_core = self
+            .retained_core_publication(&storage_path)?
+            .ok_or_else(|| {
+                ApiError::new(
+                    "publication_changed",
+                    "the complete core publication disappeared during ready-lease validation",
+                )
+            })?;
+        if revalidated_core != core_publication {
+            return Err(ApiError::new(
+                "publication_changed",
+                "the complete core publication changed during ready-lease validation",
+            ));
+        }
+        if revalidated_core != local_publication {
+            return Err(ApiError::new(
+                "publication_changed",
+                "the revalidated core publication differs from the activated core",
+            ));
+        }
+        operation.set_ready_lease(ReadyLease {
+            configuration_id: self.controller.runtime_configuration_id()?,
+            core_publication: revalidated_core,
+            retrieval,
+            source: ReadySourceIdentity::from(&source_freshness),
+        });
         operation.set_capability(true, ActivationCapabilityState::Ready);
         Ok(())
     }
@@ -1351,6 +1861,23 @@ impl ActivationOperation {
         self.service.coordinator.changed.notify_all();
     }
 
+    fn set_ready_lease(&self, lease: ReadyLease) {
+        let mut state = self
+            .service
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator poisoned");
+        if state
+            .current
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.operation_id == self.operation_id)
+        {
+            state.ready_lease = Some(lease);
+        }
+        self.service.coordinator.changed.notify_all();
+    }
+
     fn set_capability(&self, broad: bool, capability: ActivationCapabilityState) {
         let mut state = self
             .service
@@ -1380,6 +1907,10 @@ impl ActivationOperation {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if error.is_some() {
+            state.ready_lease = None;
+        }
+        let ready_lease_present = state.ready_lease.is_some();
         let Some(snapshot) = state
             .current
             .as_mut()
@@ -1437,6 +1968,10 @@ impl ActivationOperation {
                 });
             snapshot.failure = Some(error.message.clone());
         } else {
+            debug_assert!(
+                ready_lease_present,
+                "successful activation must publish its ready lease before completion"
+            );
             snapshot.state = ActivationState::Ready;
             snapshot.stage = ActivationStage::Ready;
             snapshot.progress = activation_stage_progress(ActivationStage::Ready);
@@ -1981,6 +2516,118 @@ mod activation_tests {
     use crate::test_support::git;
     use std::fs;
 
+    struct ReadyActivationFixture {
+        project: tempfile::TempDir,
+        _cache: tempfile::TempDir,
+        runtime: Runtime,
+        storage_path: PathBuf,
+        lease: ReadyLease,
+    }
+
+    fn ready_activation_fixture() -> ReadyActivationFixture {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        let storage_path = cache.path().join("codestory.db");
+        fs::write(
+            project.path().join("metadata.rs"),
+            "// READY_LEASE_SOURCE_ANCHOR\n",
+        )
+        .expect("write zero-dense source fixture");
+        let sidecar_cache = cache.path().join("sidecar");
+        fs::create_dir_all(&sidecar_cache).expect("create sidecar cache");
+        let mut sidecar = codestory_retrieval::with_test_cache_root(&sidecar_cache, || {
+            codestory_retrieval::SidecarRuntimeConfig::for_project_profile(
+                Some(project.path()),
+                codestory_retrieval::SidecarProfile::Agent,
+            )
+        });
+        sidecar.embedding.allow_cpu = true;
+        let runtime = Runtime::new_with_config(sidecar.clone());
+        runtime
+            .project_service()
+            .open_project_summary_with_storage_path(
+                project.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("bind ready-lease fixture");
+        runtime
+            .index_service()
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("publish ready-lease core");
+        codestory_retrieval::test_support::publish_zero_dense_pinned_query_fixture(
+            project.path(),
+            &storage_path,
+            &sidecar,
+        )
+        .expect("publish ready-lease retrieval fixture");
+
+        let service = runtime.activation_service();
+        let core_publication = service
+            .retained_core_publication(&storage_path)
+            .expect("read ready core")
+            .expect("complete ready core");
+        let source_freshness = service
+            .controller
+            .index_freshness_uncached()
+            .expect("verify ready source snapshot");
+        assert!(index_freshness_admits_operation(&source_freshness));
+        let retrieval = codestory_retrieval::ready_retrieval_identity_for_runtime(
+            project.path(),
+            &storage_path,
+            &sidecar,
+        )
+        .expect("observe ready retrieval identity")
+        .expect("ready retrieval identity");
+        let lease = ReadyLease {
+            configuration_id: service
+                .controller
+                .runtime_configuration_id()
+                .expect("ready runtime configuration identity"),
+            core_publication: core_publication.clone(),
+            retrieval,
+            source: ReadySourceIdentity::from(&source_freshness),
+        };
+        assert!(lease.source.is_admissible_snapshot());
+        {
+            let mut state = service
+                .coordinator
+                .state
+                .lock()
+                .expect("activation coordinator");
+            state.target = Some(ActivationTarget::new(project.path(), &storage_path));
+            state.current = Some(ActivationSnapshot {
+                operation_id: "activation-ready-lease-fixture".into(),
+                revision: 17,
+                state: ActivationState::Ready,
+                stage: ActivationStage::Ready,
+                progress: activation_stage_progress(ActivationStage::Ready),
+                attempt: 3,
+                retry_after_ms: None,
+                embedding_capacity: None,
+                embedding_retry: None,
+                failure_code: None,
+                failure: None,
+                failure_details: None,
+                retained_core_publication: Some(core_publication),
+                capabilities: ActivationCapabilities {
+                    local_navigation: ActivationCapabilityState::Ready,
+                    broad_search: ActivationCapabilityState::Ready,
+                },
+            });
+            state.ready_lease = Some(lease.clone());
+            state.running = false;
+            state.current_cancel = None;
+        }
+
+        ReadyActivationFixture {
+            project,
+            _cache: cache,
+            runtime,
+            storage_path,
+            lease,
+        }
+    }
+
     fn initialize_identifiable_git_project(project: &Path) {
         git(project, &["init", "-q"]);
         git(
@@ -2001,6 +2648,242 @@ mod activation_tests {
                 "https://example.com/codestory/fixture.git",
             ],
         );
+    }
+
+    #[test]
+    fn unchanged_ready_lease_returns_without_starting_or_advancing_activation() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.activation_service();
+        let before = service.snapshot().expect("ready snapshot");
+
+        let reused = service
+            .activate_project(
+                fixture.project.path(),
+                &fixture.storage_path,
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect("unchanged ready lease must be reused");
+
+        assert!(!reused.joined);
+        assert_eq!(reused.snapshot, before);
+        assert_eq!(service.worker_start_count_for_test(), 0);
+        let state = service
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator");
+        assert!(!state.running);
+        assert_eq!(state.ready_lease.as_ref(), Some(&fixture.lease));
+    }
+
+    #[test]
+    fn ready_lease_probe_rejects_each_bounded_identity_drift() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.activation_service();
+        assert!(
+            service
+                .probe_ready_lease(&fixture.storage_path, &fixture.lease)
+                .admissible
+        );
+
+        let mut configuration_drift = fixture.lease.clone();
+        configuration_drift.configuration_id.push_str("-changed");
+        assert!(
+            !service
+                .probe_ready_lease(&fixture.storage_path, &configuration_drift)
+                .admissible
+        );
+
+        let mut core_drift = fixture.lease.clone();
+        core_drift.core_publication.generation_id = "changed-core-generation".into();
+        assert!(
+            !service
+                .probe_ready_lease(&fixture.storage_path, &core_drift)
+                .admissible
+        );
+
+        let mut manifest_drift = fixture.lease.clone();
+        manifest_drift.retrieval.manifest.built_at_epoch_ms += 1;
+        assert!(
+            !service
+                .probe_ready_lease(&fixture.storage_path, &manifest_drift)
+                .admissible
+        );
+
+        let mut producer_drift = fixture.lease.clone();
+        producer_drift
+            .retrieval
+            .producer_compatibility_identity
+            .push_str("-changed");
+        assert!(
+            !service
+                .probe_ready_lease(&fixture.storage_path, &producer_drift)
+                .admissible
+        );
+
+        let synthetic_engine = codestory_retrieval::ReadyEmbeddingEngineIdentity {
+            instance_id: "embedding-server-1".into(),
+            load_generation: 7,
+            model_load_count: 2,
+            model_digest: "sha256:model-a".into(),
+            ggml_build_identity: "llama.cpp-build-a".into(),
+            backend: "metal".into(),
+            adapter_name: "Apple M3 Max".into(),
+            policy: "accelerator_required".into(),
+            execution_device_names: vec!["Apple M3 Max".into()],
+            execution_backend_names: vec!["Metal".into()],
+            accelerator_execution_verified: true,
+        };
+        let mut engine_presence_drift = fixture.lease.clone();
+        engine_presence_drift.retrieval.engine = Some(synthetic_engine.clone());
+        assert!(
+            !service
+                .probe_ready_lease(&fixture.storage_path, &engine_presence_drift)
+                .admissible,
+            "a changed live engine identity must invalidate ready reuse"
+        );
+
+        let mut exact_engine_identity = fixture.lease.retrieval.clone();
+        exact_engine_identity.engine = Some(synthetic_engine);
+        assert!(ready_retrieval_identity_matches(
+            Some(&exact_engine_identity),
+            &exact_engine_identity,
+        ));
+        macro_rules! reject_engine_field_drift {
+            ($field:ident, $changed:expr) => {{
+                let mut observed = exact_engine_identity.clone();
+                observed
+                    .engine
+                    .as_mut()
+                    .expect("synthetic engine identity")
+                    .$field = $changed;
+                assert!(
+                    !ready_retrieval_identity_matches(Some(&observed), &exact_engine_identity),
+                    concat!(
+                        "ready retrieval equality omitted engine field `",
+                        stringify!($field),
+                        "`"
+                    )
+                );
+            }};
+        }
+        reject_engine_field_drift!(instance_id, "embedding-server-2".into());
+        reject_engine_field_drift!(load_generation, 8);
+        reject_engine_field_drift!(model_load_count, 3);
+        reject_engine_field_drift!(model_digest, "sha256:model-b".into());
+        reject_engine_field_drift!(ggml_build_identity, "llama.cpp-build-b".into());
+        reject_engine_field_drift!(backend, "cuda".into());
+        reject_engine_field_drift!(adapter_name, "NVIDIA RTX".into());
+        reject_engine_field_drift!(policy, "cpu_explicit".into());
+        reject_engine_field_drift!(execution_device_names, vec!["NVIDIA RTX".into()]);
+        reject_engine_field_drift!(execution_backend_names, vec!["CUDA".into()]);
+        reject_engine_field_drift!(accelerator_execution_verified, false);
+
+        let mut invalid_source_snapshot = fixture.lease.clone();
+        invalid_source_snapshot.source.status = IndexFreshnessStatusDto::Stale;
+        assert!(
+            !service
+                .probe_ready_lease(&fixture.storage_path, &invalid_source_snapshot)
+                .admissible
+        );
+    }
+
+    #[test]
+    fn ready_lease_revalidation_rejects_manifest_change_after_initial_capture() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.activation_service();
+        Store::open(&fixture.storage_path)
+            .expect("open fixture storage")
+            .get_connection()
+            .execute(
+                "UPDATE retrieval_index_manifest \
+                 SET built_at_epoch_ms = built_at_epoch_ms + 1",
+                [],
+            )
+            .expect("mutate retrieval pointer after initial capture");
+
+        let error = service
+            .require_ready_retrieval_identity_unchanged(
+                fixture.project.path(),
+                &fixture.storage_path,
+                &fixture.lease.retrieval,
+            )
+            .expect_err("changed retrieval pointer must reject ready-lease publication");
+
+        assert_eq!(error.code, "publication_changed");
+    }
+
+    #[test]
+    fn concurrent_missing_pointer_callers_start_one_fail_closed_replacement() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.activation_service();
+        let ready = service.snapshot().expect("ready snapshot");
+        Store::open(&fixture.storage_path)
+            .expect("open fixture storage")
+            .get_connection()
+            .execute("DELETE FROM retrieval_index_manifest", [])
+            .expect("remove retrieval identity pointer");
+
+        let worker_gate = Arc::new((Mutex::new(false), Condvar::new()));
+        service.set_worker_start_gate_for_test(Some(Arc::clone(&worker_gate)));
+        let caller_gate = Arc::new(std::sync::Barrier::new(7));
+        let callers = (0..6)
+            .map(|_| {
+                let service = service.clone();
+                let project_root = fixture.project.path().to_path_buf();
+                let storage_path = fixture.storage_path.clone();
+                let caller_gate = Arc::clone(&caller_gate);
+                std::thread::spawn(move || {
+                    caller_gate.wait();
+                    let error = service
+                        .activate_project_with_foreground_budget(
+                            &project_root,
+                            &storage_path,
+                            Arc::new(AtomicBool::new(false)),
+                            Duration::ZERO,
+                        )
+                        .expect_err("missing pointer must start replacement");
+                    (error, service.snapshot().expect("replacement snapshot"))
+                })
+            })
+            .collect::<Vec<_>>();
+        caller_gate.wait();
+        let observations = callers
+            .into_iter()
+            .map(|caller| caller.join().expect("join replacement caller"))
+            .collect::<Vec<_>>();
+
+        assert!(observations.iter().all(|(error, snapshot)| {
+            error.code == "activation_preparing"
+                && snapshot.operation_id == ready.operation_id
+                && snapshot.attempt == ready.attempt + 1
+                && snapshot.capabilities.broad_search == ActivationCapabilityState::Unavailable
+        }));
+        assert!(
+            observations
+                .iter()
+                .all(|(_, snapshot)| snapshot.revision > ready.revision),
+            "replacement must expose phase/progress revision evidence"
+        );
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while service.worker_start_count_for_test() == 0 && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert_eq!(service.worker_start_count_for_test(), 1);
+        let replacement = service.snapshot().expect("replacement snapshot");
+        assert_eq!(replacement.stage, ActivationStage::Discovery);
+        assert_eq!(
+            replacement.progress,
+            activation_stage_progress(ActivationStage::Discovery)
+        );
+
+        service.set_worker_start_gate_for_test(None);
+        let (released, changed) = worker_gate.as_ref();
+        *released
+            .lock()
+            .expect("activation worker test gate poisoned") = true;
+        changed.notify_all();
+        service.cancel_and_wait();
     }
 
     #[test]
@@ -2067,6 +2950,135 @@ mod activation_tests {
         assert_eq!(clean_identity.project_id, dirty_identity.project_id);
         assert_eq!(clean_identity.workspace_id, dirty_identity.workspace_id);
         assert!(clean.matches(&dirty));
+    }
+
+    #[test]
+    fn activation_target_reobserves_same_root_remote_change_and_no_remote_reinit() {
+        let project = tempfile::tempdir().expect("project");
+        initialize_identifiable_git_project(project.path());
+        let storage = project.path().join("cache").join("codestory.db");
+        let service = Runtime::new().activation_service();
+        let remote_a = ActivationTarget::new(project.path(), &storage);
+        let snapshot = ActivationSnapshot {
+            operation_id: "activation-logical-target-fixture".into(),
+            revision: 1,
+            state: ActivationState::Ready,
+            stage: ActivationStage::Ready,
+            progress: activation_stage_progress(ActivationStage::Ready),
+            attempt: 1,
+            retry_after_ms: None,
+            embedding_capacity: None,
+            embedding_retry: None,
+            failure_code: None,
+            failure: None,
+            failure_details: None,
+            retained_core_publication: None,
+            capabilities: ActivationCapabilities {
+                local_navigation: ActivationCapabilityState::Ready,
+                broad_search: ActivationCapabilityState::Ready,
+            },
+        };
+        {
+            let mut state = service
+                .coordinator
+                .state
+                .lock()
+                .expect("activation coordinator");
+            state.target = Some(remote_a.clone());
+            state.current = Some(snapshot.clone());
+        }
+        assert_eq!(
+            service.snapshot_for_target(project.path(), &storage),
+            Some(snapshot.clone())
+        );
+
+        git(
+            project.path(),
+            &[
+                "remote",
+                "set-url",
+                "origin",
+                "https://example.com/codestory/other-fixture.git",
+            ],
+        );
+        let remote_b = ActivationTarget::new(project.path(), &storage);
+        assert_eq!(remote_a.workspace_id, remote_b.workspace_id);
+        assert_ne!(remote_a.project_id, remote_b.project_id);
+        assert_eq!(remote_a.repository_instance, remote_b.repository_instance);
+        assert!(!remote_a.matches(&remote_b));
+        assert!(
+            service
+                .snapshot_for_target(project.path(), &storage)
+                .is_none()
+        );
+        assert_eq!(
+            service
+                .target_for_request(project.path(), &storage)
+                .project_id,
+            remote_b.project_id
+        );
+        {
+            let mut state = service
+                .coordinator
+                .state
+                .lock()
+                .expect("activation coordinator");
+            state.target = Some(remote_b.clone());
+            state.current = Some(snapshot);
+        }
+
+        fs::rename(
+            project.path().join(".git"),
+            project.path().join(".git-retired"),
+        )
+        .expect("retire original repository metadata");
+        git(project.path(), &["init", "-q"]);
+        let no_remote = ActivationTarget::new(project.path(), &storage);
+        assert_eq!(remote_b.workspace_id, no_remote.workspace_id);
+        assert_eq!(no_remote.project_id, no_remote.workspace_id);
+        assert_ne!(remote_b.repository_instance, no_remote.repository_instance);
+        assert!(!remote_b.matches(&no_remote));
+        assert!(
+            service
+                .snapshot_for_target(project.path(), &storage)
+                .is_none()
+        );
+        assert_eq!(
+            service
+                .target_for_request(project.path(), &storage)
+                .project_id,
+            no_remote.project_id
+        );
+    }
+
+    #[test]
+    fn activation_target_rejects_same_remote_metadata_recreation() {
+        let project = tempfile::tempdir().expect("project");
+        initialize_identifiable_git_project(project.path());
+        let storage = project.path().join("cache").join("codestory.db");
+        let original = ActivationTarget::new(project.path(), &storage);
+
+        fs::rename(
+            project.path().join(".git"),
+            project.path().join(".git-retired"),
+        )
+        .expect("retire original repository metadata");
+        git(project.path(), &["init", "-q"]);
+        git(
+            project.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://example.com/codestory/fixture.git",
+            ],
+        );
+        let recreated = ActivationTarget::new(project.path(), &storage);
+
+        assert_eq!(original.project_id, recreated.project_id);
+        assert_eq!(original.workspace_id, recreated.workspace_id);
+        assert_ne!(original.repository_instance, recreated.repository_instance);
+        assert!(!original.matches(&recreated));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/tests/search_scoring.rs
+++ b/crates/codestory-runtime/src/tests/search_scoring.rs
@@ -873,25 +873,220 @@ fn build_search_state_prefers_qualified_name() {
 }
 
 #[test]
-fn open_project_summary_clears_search_state() {
-    let temp = tempdir().expect("create temp dir");
+fn open_project_summary_preserves_search_state_for_the_same_complete_publication() {
+    let temp = copy_tictactoe_workspace();
     let storage_path = temp.path().join("cache").join("codestory.db");
     let controller = AppController::new();
 
     controller
-        .open_project_with_storage_path(temp.path().to_path_buf(), storage_path.clone())
-        .expect("open project with search state");
-    assert!(
-        controller.state.lock().search_engine.is_some(),
-        "expected full open to initialize search state"
+        .open_project_summary_with_storage_path(temp.path().to_path_buf(), storage_path.clone())
+        .expect("open project summary");
+    controller
+        .run_indexing_blocking(IndexMode::Full)
+        .expect("publish complete project and search state");
+    let before_cache_generation = controller.sidecar_query_cache.lock().snapshot().0;
+    let before = controller.state.lock();
+    assert!(before.search_engine.is_some());
+    assert!(!before.node_names.is_empty());
+    let publication = before
+        .search_publication
+        .clone()
+        .expect("search publication");
+    let node_count = before.node_names.len();
+    drop(before);
+
+    controller
+        .open_project_summary_with_storage_path(temp.path().to_path_buf(), storage_path)
+        .expect("open project summary");
+    let state = controller.state.lock();
+    assert!(state.search_engine.is_some());
+    assert_eq!(state.search_publication.as_ref(), Some(&publication));
+    assert_eq!(state.node_names.len(), node_count);
+    assert_eq!(
+        controller.sidecar_query_cache.lock().snapshot().0,
+        before_cache_generation,
+        "unchanged summary open must preserve the sidecar query cache epoch"
     );
+}
+
+#[test]
+fn activation_search_preparation_preserves_resident_state_for_retrieval_only_replacement() {
+    let project = tempdir().expect("project");
+    let cache = tempdir().expect("cache");
+    fs::write(
+        project.path().join("metadata.rs"),
+        "// RETRIEVAL_ONLY_REPLACEMENT_ANCHOR\n",
+    )
+    .expect("write zero-dense project");
+    let sidecar_cache = cache.path().join("sidecar");
+    fs::create_dir_all(&sidecar_cache).expect("create sidecar cache");
+    let runtime = codestory_retrieval::with_test_cache_root(&sidecar_cache, || {
+        codestory_retrieval::SidecarRuntimeConfig::for_project_profile(
+            Some(project.path()),
+            codestory_retrieval::SidecarProfile::Agent,
+        )
+    });
+    let storage_path = cache.path().join("codestory.db");
+    let controller = AppController::new_with_config(runtime.clone());
+    controller
+        .open_project_summary_with_storage_path(project.path().to_path_buf(), storage_path.clone())
+        .expect("open project summary");
+    controller
+        .run_indexing_blocking(IndexMode::Full)
+        .expect("publish complete core and resident search state");
+    let manifest_a = codestory_retrieval::test_support::publish_zero_dense_pinned_query_fixture(
+        project.path(),
+        &storage_path,
+        &runtime,
+    )
+    .expect("publish retrieval identity A");
+    let mut manifest_b = manifest_a.clone();
+    manifest_b.built_at_epoch_ms += 1;
+    Storage::open(&storage_path)
+        .expect("open retrieval pointer store")
+        .upsert_retrieval_index_manifest(&manifest_b)
+        .expect("publish retrieval-only identity B");
+
+    let sentinel_id = CoreNodeId(9_999_991);
+    let sentinel_name = "retrieval_only_resident_search_sentinel";
+    let core_publication = {
+        let mut state = controller.state.lock();
+        state
+            .node_names
+            .insert(sentinel_id, sentinel_name.to_string());
+        let engine = state
+            .search_engine
+            .as_mut()
+            .expect("resident search engine");
+        engine.extend_symbol_projection([(sentinel_id, sentinel_name.to_string())]);
+        state
+            .search_publication
+            .clone()
+            .expect("resident search publication")
+    };
+    let cache_key = codestory_retrieval::RetrievalCacheKey::from_manifest(
+        &manifest_b,
+        "retrieval-only-cache-sentinel",
+    );
+    controller.sidecar_query_cache.lock().insert(
+        cache_key.clone(),
+        vec![codestory_retrieval::CandidateHit::lexical_stub(
+            "metadata.rs",
+            1.0,
+        )],
+    );
+    let cache_generation = controller.sidecar_query_cache.lock().snapshot().0;
+
+    controller
+        .prepare_search_state_for_activation(&CancellationToken::new())
+        .expect("same-core retrieval replacement must reuse resident search state");
+
+    {
+        let state = controller.state.lock();
+        assert_eq!(
+            state.node_names.get(&sentinel_id).map(String::as_str),
+            Some(sentinel_name)
+        );
+        assert_eq!(state.search_publication.as_ref(), Some(&core_publication));
+        assert!(
+            state
+                .search_engine
+                .as_ref()
+                .expect("resident search engine survives")
+                .search_symbol(sentinel_name)
+                .contains(&sentinel_id),
+            "retrieval-only activation rebuilt the resident search engine"
+        );
+    }
+    let cache = controller.sidecar_query_cache.lock();
+    assert_eq!(cache.snapshot().0, cache_generation);
+    assert_eq!(
+        cache.get(&cache_key).expect("sidecar cache entry survives")[0].file_path,
+        "metadata.rs"
+    );
+    drop(cache);
+
+    codestory_retrieval::test_support::publish_replacement_core_and_zero_dense_fixture(
+        project.path(),
+        &storage_path,
+        &runtime,
+        core_publication.generation + 1,
+        "33333333-3333-4333-8333-333333333333",
+        "retrieval-only-core-replacement",
+    )
+    .expect("publish true core replacement");
+    controller
+        .open_project_summary_with_storage_path(project.path().to_path_buf(), storage_path.clone())
+        .expect("observe true core replacement");
+    {
+        let state = controller.state.lock();
+        assert!(state.search_engine.is_none());
+        assert!(state.search_publication.is_none());
+        assert!(state.node_names.is_empty());
+    }
+    assert_eq!(
+        controller.sidecar_query_cache.lock().snapshot().0,
+        cache_generation.wrapping_add(1),
+        "true core replacement must clear the sidecar cache once"
+    );
+    controller
+        .open_project_summary_with_storage_path(project.path().to_path_buf(), storage_path)
+        .expect("reobserve unchanged replacement core");
+    assert_eq!(
+        controller.sidecar_query_cache.lock().snapshot().0,
+        cache_generation.wrapping_add(1),
+        "one core transition must not repeatedly clear resident state"
+    );
+}
+
+#[test]
+fn open_project_summary_clears_state_bound_to_another_core_publication() {
+    let temp = copy_tictactoe_workspace();
+    let storage_path = temp.path().join("cache").join("codestory.db");
+    let controller = AppController::new();
+
+    controller
+        .open_project_summary_with_storage_path(temp.path().to_path_buf(), storage_path.clone())
+        .expect("open project summary");
+    controller
+        .run_indexing_blocking(IndexMode::Full)
+        .expect("publish complete project and search state");
+    let before_cache_generation = controller.sidecar_query_cache.lock().snapshot().0;
+    {
+        let mut state = controller.state.lock();
+        let mut stale = state
+            .search_publication
+            .clone()
+            .expect("search publication");
+        stale.generation_id = "stale-search-publication".into();
+        state.search_publication = Some(stale);
+    }
 
     controller
         .open_project_summary_with_storage_path(temp.path().to_path_buf(), storage_path)
         .expect("open project summary");
     let state = controller.state.lock();
     assert!(state.search_engine.is_none());
+    assert!(state.search_publication.is_none());
     assert!(state.node_names.is_empty());
+    assert_eq!(
+        controller.sidecar_query_cache.lock().snapshot().0,
+        before_cache_generation.wrapping_add(1),
+        "changed core identity must invalidate the sidecar query cache once"
+    );
+    drop(state);
+
+    controller
+        .open_project_summary_with_storage_path(
+            temp.path().to_path_buf(),
+            temp.path().join("cache").join("codestory.db"),
+        )
+        .expect("reopen the already-observed core publication");
+    assert_eq!(
+        controller.sidecar_query_cache.lock().snapshot().0,
+        before_cache_generation.wrapping_add(1),
+        "one publication transition must not repeatedly invalidate resident caches"
+    );
 }
 
 #[test]

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -31,17 +31,21 @@ pub mod owned_deletion;
 pub mod paths;
 mod repo_metadata;
 mod repository_identity;
-#[cfg(any(test, feature = "test-support"))]
-#[doc(hidden)]
-pub use repo_metadata::with_repository_metadata_observation_limit_for_test;
 pub use repo_metadata::{
     RepositoryChange, RepositoryChangeKind, RepositoryChangeScope, RepositoryMetadata,
     RepositoryMetadataIssue, read_repository_changes, read_repository_metadata,
 };
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub use repo_metadata::{
+    with_repository_metadata_observation_limit_for_test,
+    with_repository_metadata_tree_traversal_count_for_test,
+};
 pub use repository_identity::{
-    PROJECT_IDENTITY_V3_SCHEMA_VERSION, ProjectIdentityV3, REPOSITORY_IDENTITY_V2_SCHEMA_VERSION,
-    RepositoryIdentityV2, WorkspacePathIdentity, WorkspacePathLexicalIdentity,
-    inspect_repository_identity_v2, project_identity_v3, project_identity_v3_from_repository,
+    LogicalProjectIdentityV3, PROJECT_IDENTITY_V3_SCHEMA_VERSION, ProjectIdentityV3,
+    REPOSITORY_IDENTITY_V2_SCHEMA_VERSION, RepositoryIdentityV2, RepositoryInstanceIdentity,
+    WorkspacePathIdentity, WorkspacePathLexicalIdentity, inspect_repository_identity_v2,
+    observe_logical_project_identity_v3, project_identity_v3, project_identity_v3_from_repository,
     same_workspace_path, workspace_file_identity, workspace_id_v3_for_root,
     workspace_path_identity, workspace_path_lexical_identity,
 };

--- a/crates/codestory-workspace/src/repo_metadata.rs
+++ b/crates/codestory-workspace/src/repo_metadata.rs
@@ -14,6 +14,7 @@ use std::path::{Component, Path, PathBuf};
 thread_local! {
     static OBSERVATION_LIMIT: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
     static OBSERVATION_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static METADATA_TREE_TRAVERSAL_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -23,6 +24,8 @@ thread_local! {
     static BEFORE_GIX_OPEN_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
         const { std::cell::RefCell::new(None) };
     static BEFORE_LOCAL_CONFIG_OPEN_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+    static AFTER_BOUNDED_IDENTITY_CAPTURE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
         const { std::cell::RefCell::new(None) };
 }
 
@@ -50,6 +53,22 @@ fn run_before_local_config_open_hook() {
         if let Some(hook) = hook.borrow_mut().take() {
             hook();
         }
+    });
+}
+
+#[cfg(test)]
+fn run_after_bounded_identity_capture_hook() {
+    AFTER_BOUNDED_IDENTITY_CAPTURE_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn set_after_bounded_identity_capture_hook_for_test(hook: impl FnOnce() + 'static) {
+    AFTER_BOUNDED_IDENTITY_CAPTURE_HOOK.with(|slot| {
+        *slot.borrow_mut() = Some(Box::new(hook));
     });
 }
 
@@ -147,6 +166,83 @@ pub fn read_repository_metadata(project_root: &Path) -> RepositoryMetadata {
     reader.metadata()
 }
 
+/// One bounded repeated-admission observation. The repository instance uses
+/// only native identities for the resolved gitdir and common-dir directories.
+pub(crate) enum BoundedRepositoryIdentityObservation {
+    Absent,
+    Present {
+        remote_url: Option<String>,
+        git_dir_identity: crate::repository_identity::WorkspacePathIdentity,
+        common_dir_identity: crate::repository_identity::WorkspacePathIdentity,
+    },
+}
+
+/// Read only `.git`/`commondir`, local config bytes, and the native identities
+/// of the two resolved metadata roots. Includes are never followed. This path
+/// deliberately does not open a gix repository or inspect HEAD, the index,
+/// status, refs, objects, alternates, tracked paths, or nested metadata trees.
+pub(crate) fn observe_bounded_repository_identity(
+    project_root: &Path,
+) -> Result<BoundedRepositoryIdentityObservation> {
+    let root = canonical_existing(project_root)
+        .with_context(|| format!("canonicalize project root {}", project_root.display()))?;
+    let dot_git = root.join(".git");
+    match fs::symlink_metadata(&dot_git) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            #[cfg(test)]
+            run_after_bounded_identity_capture_hook();
+            return match fs::symlink_metadata(&dot_git) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    Ok(BoundedRepositoryIdentityObservation::Absent)
+                }
+                _ => bail!("repository .git entry changed during bounded identity observation"),
+            };
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect {}", dot_git.display()));
+        }
+    }
+
+    let captured = MetadataRoots::resolve(&root)?;
+    captured.validate_configured_worktree()?;
+    let remote_url = captured.remote_url()?;
+    let git_dir_identity = crate::repository_identity::workspace_path_identity(&captured.git_dir)
+        .context("observe repository gitdir native identity")?;
+    let common_dir_identity =
+        crate::repository_identity::workspace_path_identity(&captured.common_dir)
+            .context("observe repository common-dir native identity")?;
+
+    #[cfg(test)]
+    run_after_bounded_identity_capture_hook();
+
+    let current = MetadataRoots::resolve(&root)
+        .map_err(|_| anyhow!("repository metadata changed during bounded identity observation"))?;
+    current
+        .validate_configured_worktree()
+        .map_err(|_| anyhow!("repository metadata changed during bounded identity observation"))?;
+    if current != captured {
+        bail!("repository pointer or local config changed during bounded identity observation");
+    }
+    let current_git_dir_identity =
+        crate::repository_identity::workspace_path_identity(&current.git_dir)
+            .context("revalidate repository gitdir native identity")?;
+    let current_common_dir_identity =
+        crate::repository_identity::workspace_path_identity(&current.common_dir)
+            .context("revalidate repository common-dir native identity")?;
+    if current_git_dir_identity != git_dir_identity
+        || current_common_dir_identity != common_dir_identity
+    {
+        bail!("repository metadata root identity changed during bounded identity observation");
+    }
+
+    Ok(BoundedRepositoryIdentityObservation::Present {
+        remote_url,
+        git_dir_identity,
+        common_dir_identity,
+    })
+}
+
 #[cfg(any(test, feature = "test-support"))]
 fn record_repository_metadata_observation() {
     OBSERVATION_LIMIT.with(|limit| {
@@ -190,6 +286,32 @@ pub fn with_repository_metadata_observation_limit_for_test<T>(
         previous_count,
     };
     task()
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn record_repository_metadata_tree_traversal() {
+    METADATA_TREE_TRAVERSAL_COUNT.with(|count| count.set(count.get().saturating_add(1)));
+}
+
+/// Run test support with an isolated counter for metadata-directory walks.
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub fn with_repository_metadata_tree_traversal_count_for_test<T>(
+    task: impl FnOnce() -> T,
+) -> (T, usize) {
+    struct Reset(usize);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            METADATA_TREE_TRAVERSAL_COUNT.with(|count| count.set(self.0));
+        }
+    }
+
+    let previous = METADATA_TREE_TRAVERSAL_COUNT.with(|count| count.replace(0));
+    let reset = Reset(previous);
+    let result = task();
+    let observed = METADATA_TREE_TRAVERSAL_COUNT.with(std::cell::Cell::get);
+    drop(reset);
+    (result, observed)
 }
 
 /// Read changed paths without invoking the Git executable.
@@ -561,7 +683,7 @@ fn change_from_index_worktree(
     })
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 struct MetadataRoots {
     root: PathBuf,
     git_dir: PathBuf,
@@ -571,7 +693,7 @@ struct MetadataRoots {
     local_configs: Vec<MetadataConfigFile>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 struct MetadataPointer {
     path: PathBuf,
     expected_contents: Vec<u8>,
@@ -589,7 +711,7 @@ impl MetadataPointer {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 struct MetadataConfigFile {
     path: PathBuf,
     expected_contents: Option<Vec<u8>>,
@@ -623,10 +745,20 @@ impl MetadataConfigFile {
     }
 
     fn configured_worktree(&self) -> Result<Option<PathBuf>> {
+        let Some(config) = self.parsed()? else {
+            return Ok(None);
+        };
+        config
+            .string("core.worktree")
+            .map(|value| bytes_to_path(value.as_ref()))
+            .transpose()
+    }
+
+    fn parsed(&self) -> Result<Option<gix::config::File>> {
         let Some(contents) = self.expected_contents.as_deref() else {
             return Ok(None);
         };
-        let config = gix::config::File::from_bytes_no_includes(
+        gix::config::File::from_bytes_no_includes(
             contents,
             gix::config::file::Metadata::default(),
             gix::config::file::init::Options {
@@ -634,11 +766,8 @@ impl MetadataConfigFile {
                 ..Default::default()
             },
         )
-        .with_context(|| format!("parse repository local config {}", self.path.display()))?;
-        config
-            .string("core.worktree")
-            .map(|value| bytes_to_path(value.as_ref()))
-            .transpose()
+        .with_context(|| format!("parse repository local config {}", self.path.display()))
+        .map(Some)
     }
 }
 
@@ -667,6 +796,13 @@ struct MetadataDirectoryFingerprint {
     creation_time: u64,
     #[cfg(windows)]
     last_write_time: u64,
+}
+
+fn configured_origin_url(config: &gix::config::File) -> Option<String> {
+    config
+        .string("remote.origin.url")
+        .map(|value| String::from_utf8_lossy(value.as_ref()).trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 impl MetadataRoots {
@@ -722,7 +858,13 @@ impl MetadataRoots {
         }
 
         let commondir_path = git_dir.join("commondir");
-        let commondir_metadata = fs::symlink_metadata(&commondir_path).ok();
+        let commondir_metadata = match fs::symlink_metadata(&commondir_path) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(error).with_context(|| format!("inspect {}", commondir_path.display()));
+            }
+        };
         let (common_dir, common_dir_pointer) = if let Some(metadata) = commondir_metadata {
             if metadata.file_type().is_symlink() {
                 bail!("repository commondir pointer must not be a symlink");
@@ -779,6 +921,35 @@ impl MetadataRoots {
             common_dir_pointer,
             local_configs,
         })
+    }
+
+    fn remote_url(&self) -> Result<Option<String>> {
+        let common_config = self
+            .local_config(&self.common_dir.join("config"))
+            .context("captured repository common config is missing")?
+            .parsed()?;
+        let mut remote_url = common_config.as_ref().and_then(configured_origin_url);
+        let worktree_config_enabled = match common_config.as_ref() {
+            Some(config) => config
+                .boolean("extensions.worktreeConfig")
+                .context("parse extensions.worktreeConfig from repository local config")?
+                .unwrap_or(false),
+            None => false,
+        };
+        if worktree_config_enabled
+            && let Some(worktree_config) = self
+                .local_config(&self.git_dir.join("config.worktree"))
+                .context("captured repository worktree config is missing")?
+                .parsed()?
+            && let Some(worktree_remote_url) = configured_origin_url(&worktree_config)
+        {
+            remote_url = Some(worktree_remote_url);
+        }
+        Ok(remote_url)
+    }
+
+    fn local_config(&self, path: &Path) -> Option<&MetadataConfigFile> {
+        self.local_configs.iter().find(|config| config.path == path)
     }
 
     fn validate_configured_worktree(&self) -> Result<()> {
@@ -1089,6 +1260,8 @@ fn reject_nested_metadata_symlinks(
 
     let mut pending = vec![root.to_path_buf()];
     while let Some(directory) = pending.pop() {
+        #[cfg(any(test, feature = "test-support"))]
+        record_repository_metadata_tree_traversal();
         for entry in fs::read_dir(&directory).with_context(|| {
             format!("read repository metadata directory {}", directory.display())
         })? {
@@ -1116,6 +1289,8 @@ fn reject_nested_metadata_symlinks(
 }
 
 fn reject_shared_index_symlinks(git_dir: &Path) -> Result<()> {
+    #[cfg(any(test, feature = "test-support"))]
+    record_repository_metadata_tree_traversal();
     for entry in fs::read_dir(git_dir)
         .with_context(|| format!("read repository gitdir {}", git_dir.display()))?
     {

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -2,6 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static INDETERMINATE_REPOSITORY_OBSERVATION_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Lossless repository identity hashing contract available for migration.
 pub const REPOSITORY_IDENTITY_V2_SCHEMA_VERSION: u32 = 2;
@@ -30,6 +33,44 @@ enum WorkspacePathIdentityKind {
     MissingUnix(PathBuf),
     #[cfg(windows)]
     MissingWindows(Vec<u16>),
+}
+
+/// Opaque native identity for one repository metadata instance.
+///
+/// A present identity is the pair of native gitdir and common-dir identities;
+/// repository contents and mutable Git state never participate. An
+/// indeterminate observation is deliberately unique so a failed bounded probe
+/// cannot admit reuse.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RepositoryInstanceIdentity(RepositoryInstanceIdentityKind);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum RepositoryInstanceIdentityKind {
+    Absent,
+    Present {
+        git_dir: WorkspacePathIdentity,
+        common_dir: WorkspacePathIdentity,
+    },
+    Indeterminate(u64),
+}
+
+impl RepositoryInstanceIdentity {
+    fn absent() -> Self {
+        Self(RepositoryInstanceIdentityKind::Absent)
+    }
+
+    fn present(git_dir: WorkspacePathIdentity, common_dir: WorkspacePathIdentity) -> Self {
+        Self(RepositoryInstanceIdentityKind::Present {
+            git_dir,
+            common_dir,
+        })
+    }
+
+    fn indeterminate() -> Self {
+        Self(RepositoryInstanceIdentityKind::Indeterminate(
+            INDETERMINATE_REPOSITORY_OBSERVATION_ID.fetch_add(1, Ordering::Relaxed),
+        ))
+    }
 }
 
 /// Operation-scoped platform-lexical path spelling for containment checks.
@@ -104,6 +145,18 @@ pub struct ProjectIdentityV3 {
     pub portable_reuse_reason: String,
 }
 
+/// Bounded logical identity used on repeated same-root admissions.
+///
+/// This intentionally carries only the remote-derived project id and the
+/// native-root workspace id. It never observes HEAD, dirtiness, tracked paths,
+/// or artifact portability.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LogicalProjectIdentityV3 {
+    pub project_id: String,
+    pub workspace_id: String,
+    pub repository_instance: RepositoryInstanceIdentity,
+}
+
 /// Inspect the lossless repository identity without migrating current consumers.
 pub fn inspect_repository_identity_v2(project_root: &Path) -> RepositoryIdentityV2 {
     let metadata = crate::read_repository_metadata(project_root);
@@ -141,6 +194,41 @@ pub fn inspect_repository_identity_v2(project_root: &Path) -> RepositoryIdentity
 pub fn project_identity_v3(project_root: &Path) -> ProjectIdentityV3 {
     let repository_identity = inspect_repository_identity_v2(project_root);
     project_identity_v3_from_repository(project_root, &repository_identity)
+}
+
+/// Observe logical repository ownership without executing Git or scanning the
+/// repository contents. An absent, invalid, or unreadable remote fails closed
+/// to the native workspace identity. The irreducible blind spot is an in-place
+/// metadata replacement that preserves both native gitdir/common-dir identities
+/// and the exact local remote bytes; no bounded filesystem observation can
+/// distinguish that event without reading mutable repository state.
+pub fn observe_logical_project_identity_v3(project_root: &Path) -> LogicalProjectIdentityV3 {
+    let workspace_id = workspace_id_v3_for_root(project_root);
+    let (remote_url, repository_instance) =
+        match crate::repo_metadata::observe_bounded_repository_identity(project_root) {
+            Ok(crate::repo_metadata::BoundedRepositoryIdentityObservation::Absent) => {
+                (None, RepositoryInstanceIdentity::absent())
+            }
+            Ok(crate::repo_metadata::BoundedRepositoryIdentityObservation::Present {
+                remote_url,
+                git_dir_identity,
+                common_dir_identity,
+            }) => (
+                remote_url,
+                RepositoryInstanceIdentity::present(git_dir_identity, common_dir_identity),
+            ),
+            Err(_) => (None, RepositoryInstanceIdentity::indeterminate()),
+        };
+    let project_id = remote_url
+        .as_deref()
+        .and_then(parse_repository_identity_v2)
+        .map(|identity| canonical_repository_id_v2(&identity.canonical))
+        .unwrap_or_else(|| workspace_id.clone());
+    LogicalProjectIdentityV3 {
+        project_id,
+        workspace_id,
+        repository_instance,
+    }
 }
 
 /// Resolve the lossless V3 identity from an existing Git observation.
@@ -1080,6 +1168,199 @@ mod tests {
         assert_eq!(clean.workspace_id, dirty.workspace_id);
         assert!(clean.portable_reuse_eligible);
         assert!(!dirty.portable_reuse_eligible);
+    }
+
+    #[test]
+    fn bounded_logical_identity_never_walks_metadata_and_ignores_dirty_or_commit_state() {
+        let Some(project) = git_project() else {
+            return;
+        };
+
+        let ((clean, dirty, committed, remote_b), traversals) =
+            crate::with_repository_metadata_tree_traversal_count_for_test(|| {
+                let clean = observe_logical_project_identity_v3(project.path());
+                fs::write(project.path().join("lib.rs"), "pub fn dirty() {}\n")
+                    .expect("dirty source");
+                let dirty = observe_logical_project_identity_v3(project.path());
+                git(project.path(), &["add", "lib.rs"]);
+                git(project.path(), &["commit", "-m", "bounded identity commit"]);
+                let committed = observe_logical_project_identity_v3(project.path());
+                git(
+                    project.path(),
+                    &[
+                        "remote",
+                        "set-url",
+                        "origin",
+                        "https://example.com/team/repository-b.git",
+                    ],
+                );
+                let remote_b = observe_logical_project_identity_v3(project.path());
+                (clean, dirty, committed, remote_b)
+            });
+
+        assert_eq!(traversals, 0, "bounded admission walked Git metadata");
+        assert_eq!(clean.project_id, dirty.project_id);
+        assert_eq!(dirty.project_id, committed.project_id);
+        assert_ne!(committed.project_id, remote_b.project_id);
+        assert_eq!(clean.repository_instance, dirty.repository_instance);
+        assert_eq!(dirty.repository_instance, committed.repository_instance);
+        assert_eq!(committed.repository_instance, remote_b.repository_instance);
+        let (_, full_observation_traversals) =
+            crate::with_repository_metadata_tree_traversal_count_for_test(|| {
+                crate::read_repository_metadata(project.path())
+            });
+        assert!(
+            full_observation_traversals > 0,
+            "the zero-traversal assertion needs an armed positive control"
+        );
+    }
+
+    #[test]
+    fn bounded_logical_identity_tracks_no_remote_metadata_recreation() {
+        let Some(project) = git_project() else {
+            return;
+        };
+
+        let remote = observe_logical_project_identity_v3(project.path());
+        fs::rename(
+            project.path().join(".git"),
+            project.path().join(".git-retired"),
+        )
+        .expect("retire original repository metadata");
+        git(project.path(), &["init"]);
+        let no_remote = observe_logical_project_identity_v3(project.path());
+
+        assert_eq!(remote.workspace_id, no_remote.workspace_id);
+        assert_ne!(remote.project_id, no_remote.project_id);
+        assert_eq!(no_remote.project_id, no_remote.workspace_id);
+        assert_ne!(remote.repository_instance, no_remote.repository_instance);
+    }
+
+    #[test]
+    fn bounded_logical_identity_tracks_same_remote_metadata_recreation() {
+        let Some(project) = git_project() else {
+            return;
+        };
+
+        let original = observe_logical_project_identity_v3(project.path());
+        fs::rename(
+            project.path().join(".git"),
+            project.path().join(".git-retired"),
+        )
+        .expect("retire original repository metadata");
+        git(project.path(), &["init"]);
+        git(
+            project.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/TheGreenCedar/CodeStory.git",
+            ],
+        );
+        let recreated = observe_logical_project_identity_v3(project.path());
+
+        assert_eq!(original.project_id, recreated.project_id);
+        assert_eq!(original.workspace_id, recreated.workspace_id);
+        assert_ne!(original.repository_instance, recreated.repository_instance);
+    }
+
+    #[test]
+    fn bounded_logical_identity_fails_closed_on_local_config_toctou() {
+        let Some(project) = git_project() else {
+            return;
+        };
+
+        let original = observe_logical_project_identity_v3(project.path());
+        let config = project.path().join(".git/config");
+        crate::repo_metadata::set_after_bounded_identity_capture_hook_for_test(move || {
+            let contents = fs::read_to_string(&config).expect("read captured local config");
+            fs::write(
+                &config,
+                contents.replace(
+                    "https://github.com/TheGreenCedar/CodeStory.git",
+                    "https://example.com/team/repository-b.git",
+                ),
+            )
+            .expect("replace local config after bounded capture");
+        });
+        let raced = observe_logical_project_identity_v3(project.path());
+        let stable_replacement = observe_logical_project_identity_v3(project.path());
+
+        assert_eq!(raced.project_id, raced.workspace_id);
+        assert_ne!(raced.repository_instance, original.repository_instance);
+        assert_ne!(
+            raced.repository_instance,
+            stable_replacement.repository_instance
+        );
+        assert_ne!(original.project_id, stable_replacement.project_id);
+    }
+
+    #[test]
+    fn bounded_logical_identity_fails_closed_on_native_metadata_directory_replacement() {
+        let Some(project) = git_project() else {
+            return;
+        };
+
+        let original = observe_logical_project_identity_v3(project.path());
+        let git_dir = project.path().join(".git");
+        let retired_git_dir = project.path().join(".git-captured");
+        crate::repo_metadata::set_after_bounded_identity_capture_hook_for_test(move || {
+            fs::rename(&git_dir, &retired_git_dir)
+                .expect("retire captured repository metadata directory");
+            fs::create_dir(&git_dir).expect("create replacement repository metadata directory");
+            fs::copy(retired_git_dir.join("config"), git_dir.join("config"))
+                .expect("copy identical local config into replacement metadata directory");
+        });
+        let raced = observe_logical_project_identity_v3(project.path());
+        let stable_replacement = observe_logical_project_identity_v3(project.path());
+
+        assert_eq!(raced.project_id, raced.workspace_id);
+        assert_eq!(original.project_id, stable_replacement.project_id);
+        assert_ne!(
+            original.repository_instance,
+            stable_replacement.repository_instance
+        );
+        assert_ne!(
+            raced.repository_instance,
+            stable_replacement.repository_instance
+        );
+    }
+
+    #[test]
+    fn bounded_logical_identity_fails_closed_on_gitdir_pointer_toctou() {
+        let Some(project) = git_project() else {
+            return;
+        };
+        let Some(alternate) = git_project() else {
+            return;
+        };
+        let worktree_parent = tempdir().expect("worktree parent");
+        let worktree = worktree_parent.path().join("linked-worktree");
+        git(
+            project.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                worktree.to_str().expect("worktree path"),
+                "HEAD",
+            ],
+        );
+        let original = observe_logical_project_identity_v3(&worktree);
+        let pointer = worktree.join(".git");
+        let alternate_git_dir = alternate.path().join(".git");
+        crate::repo_metadata::set_after_bounded_identity_capture_hook_for_test(move || {
+            fs::write(
+                &pointer,
+                format!("gitdir: {}\n", alternate_git_dir.display()),
+            )
+            .expect("replace gitdir pointer after bounded capture");
+        });
+        let raced = observe_logical_project_identity_v3(&worktree);
+
+        assert_eq!(raced.project_id, raced.workspace_id);
+        assert_ne!(raced.repository_instance, original.repository_instance);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reuse a runtime-owned `ReadyLease` while the core, retrieval, engine, configuration, and repository identities remain unchanged, preserving resident state across broad calls.
- Detect same-root remote changes and Git metadata recreation with a bounded logical-identity read that does not scan mutable repository state.
- Validate warm retrieval against the exact retained manifest and join one replacement when identity drift is observed.

## Verification

- 23 focused pre-rebase tests passed across bounded workspace identity, runtime lease reuse/replacement, retrieval-only cache reuse, summary identity, and CLI warm-path behavior.
- After rebasing cleanly onto current `dev/codestory-next`: 6/6 bounded workspace identity tests, 3/3 runtime `ready_lease` tests, and the packet-to-search stdio reuse test passed.
- After correcting single-project cache-root retention exposed by hosted CI: the full stdio protocol suite passed 51/51, the cross-process complete-generation regression passed 1/1, and all 6 exact READY selector/lease controls passed.
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1727

Refs #1599 and #1179.
