### PR TITLE
[v0.17 W4-FIX2] Exclude CLI local-refresh artifacts from source discovery

### DIFF
--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -1418,4 +1418,72 @@ mod tests {
         fs::create_dir_all(&project).expect("project");
         assert!(clean_path_text(&project).ends_with("CaseSensitiveProject"));
     }
+
+    #[test]
+    fn local_refresh_state_is_never_discovered_as_project_source() {
+        use codestory_workspace::{WorkspaceInventoryOutcome, WorkspaceManifest};
+
+        let temp = tempfile::tempdir().expect("project");
+        let root = temp.path().join("project");
+        fs::create_dir_all(&root).expect("root");
+        let user_source = root.join("main.py");
+        fs::write(&user_source, "print(\"hello\")\n").expect("user source");
+        // The in-project cache root is a supported configuration
+        // (`--cache-dir` / config `cache_dir`), and the storage file lives
+        // directly inside it, so refresh state files are storage siblings.
+        let cache_root = root.join(".cache");
+        let storage_path = cache_root.join("codestory.db");
+
+        let discovered = |label: &str| -> Vec<PathBuf> {
+            let manifest =
+                WorkspaceManifest::open_with_storage_owned_exclusions(root.clone(), &storage_path)
+                    .expect(label);
+            let inventory = manifest.source_inventory().expect(label);
+            assert_eq!(
+                inventory.outcome,
+                WorkspaceInventoryOutcome::Complete,
+                "{label}: inventory must stay complete"
+            );
+            inventory.files
+        };
+
+        let lock = match try_acquire_local_refresh_lock(&cache_root, &root).expect("acquire") {
+            LocalRefreshLockAttempt::Acquired(lock) => lock,
+            LocalRefreshLockAttempt::Busy(busy) => {
+                panic!("lock should be acquired, got busy at {:?}", busy.lock_path)
+            }
+        };
+        write_local_refresh_status(
+            &cache_root,
+            &root,
+            "running",
+            "index",
+            lock.started_at_epoch_ms(),
+            lock.pid(),
+            None,
+        )
+        .expect("status write");
+        assert!(cache_root.join(LOCAL_REFRESH_STATUS_FILE).is_file());
+        assert!(cache_root.join(LOCAL_REFRESH_LOCK_FILE).is_file());
+        assert!(cache_root.join(LOCAL_REFRESH_STATE_GUARD_FILE).is_file());
+        assert_eq!(discovered("during refresh"), vec![user_source.clone()]);
+
+        // A heartbeat rewrite replaces the status file while discovery runs.
+        write_local_refresh_status(
+            &cache_root,
+            &root,
+            "running",
+            "index",
+            lock.started_at_epoch_ms(),
+            lock.pid(),
+            None,
+        )
+        .expect("heartbeat rewrite");
+        assert_eq!(discovered("after heartbeat"), vec![user_source.clone()]);
+
+        // Releasing the lock keeps the persistent state guard on disk.
+        drop(lock);
+        assert!(cache_root.join(LOCAL_REFRESH_STATE_GUARD_FILE).is_file());
+        assert_eq!(discovered("after release"), vec![user_source]);
+    }
 }

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -220,6 +220,7 @@ fn storage_owned_discovery_files(storage_path: &Path) -> Vec<PathBuf> {
     let rollback_backup = storage_path.with_extension("sqlite.backup");
     let legacy_search = legacy_search_directory_for_storage(storage_path);
     let search_generations = search_generation_directory_for_storage(storage_path);
+    let cache_root = storage_parent_for_observation(storage_path);
     vec![
         storage_path.to_path_buf(),
         path_with_native_suffix(storage_path, "-wal"),
@@ -236,6 +237,15 @@ fn storage_owned_discovery_files(storage_path: &Path) -> Vec<PathBuf> {
         path_with_native_suffix(&rollback_backup, "-journal"),
         path_with_native_suffix(&legacy_search, ".lock"),
         path_with_native_suffix(&search_generations, ".lock"),
+        // The CLI serializes local refresh in the cache root that holds the
+        // storage file; its status, lock, and persistent guard files are
+        // CodeStory-owned state, and the status file is rewritten on a
+        // heartbeat while a refresh runs. Names mirror
+        // crates/codestory-cli/src/local_refresh_status.rs until one shared
+        // owned-artifact registry replaces this enumeration.
+        cache_root.join("local-refresh-status.json"),
+        cache_root.join("local-refresh.lock"),
+        cache_root.join("local-refresh-state.guard"),
     ]
 }
 


### PR DESCRIPTION
Closes #1732.

## What

The CLI writes three CodeStory-owned files into the same cache root that holds `codestory.db`: `local-refresh-status.json` (rewritten on a 10s heartbeat during refresh), `local-refresh.lock`, and `local-refresh-state.guard` (persistent by design). None were in `storage_owned_discovery_files`, so a project with an in-tree cache directory (`--cache-dir` / config `cache_dir`) inventoried them as user sources — recreating the #1723 defect class through CLI flows the runtime-crate tests cannot see.

This adds the three artifacts to the workspace exclusion by identity, derived from the storage file's cache root. Names mirror `crates/codestory-cli/src/local_refresh_status.rs` until OWN-REG (#1733) replaces the enumeration with one shared registry.

## Proof

- New producer-driven regression test `local_refresh_state_is_never_discovered_as_project_source` in `codestory-cli`: acquires the real local-refresh lock, writes real status through the production writer, and asserts discovery over an in-project cache root inventories exactly the user source — during refresh, after a heartbeat rewrite, and after lock release (guard persists).
- Verified the test fails against the unfixed exclusion with exactly the audited defect: `local-refresh.lock` and `local-refresh-state.guard` inventoried as user sources.
- `cargo test -p codestory-workspace` (147) and `cargo test -p codestory-cli --lib` (290) green; the existing exclusion round-trip test extends automatically to the new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)