### PR TITLE
[v0.17 OWN-REG] Declare owned artifact identities once in a shared registry

### DIFF
--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -12,9 +12,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use codestory_retrieval::{ProcessOwnerState, ProcessStartProbe};
 
-const LOCAL_REFRESH_STATUS_FILE: &str = "local-refresh-status.json";
-const LOCAL_REFRESH_LOCK_FILE: &str = "local-refresh.lock";
-const LOCAL_REFRESH_STATE_GUARD_FILE: &str = "local-refresh-state.guard";
+use codestory_contracts::owned_artifacts::{
+    LOCAL_REFRESH_LOCK_FILE, LOCAL_REFRESH_STATE_GUARD_FILE, LOCAL_REFRESH_STATUS_FILE,
+};
 const LOCAL_REFRESH_STATUS_SCHEMA_VERSION: u32 = 1;
 const LOCAL_REFRESH_STATUS_TTL: Duration = Duration::from_secs(30);
 const LOCAL_REFRESH_LOCK_STALE_TTL: Duration = Duration::from_secs(120);

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -641,3 +641,55 @@ fn legacy_crates_are_removed_from_the_workspace() {
         );
     }
 }
+
+#[test]
+fn owned_artifact_identities_are_declared_only_in_the_registry() {
+    // Every file identity CodeStory writes beside its storage file lives in
+    // codestory_contracts::owned_artifacts. A producer or the discovery
+    // exclusion spelling one of these names directly recreates the split
+    // naming that let owned artifacts leak into source discovery.
+    let literals = [
+        ".promotion.lock",
+        ".promotion.prepared.json",
+        ".promotion.committed.json",
+        ".promotion.cleanup-blocked",
+        "index-writer.lock",
+        "sqlite.backup",
+        "local-refresh-status.json",
+        "local-refresh.lock",
+        "local-refresh-state.guard",
+        "annotations.sqlite3",
+    ];
+    let producer_crates = [
+        "crates/codestory-workspace/src",
+        "crates/codestory-store/src",
+        "crates/codestory-runtime/src",
+        "crates/codestory-cli/src",
+        "crates/codestory-retrieval/src",
+        "crates/codestory-indexer/src",
+    ];
+    for dir in producer_crates {
+        let mut files = Vec::new();
+        collect_rs_files(&repo_root().join(dir), &mut files);
+        files.sort();
+        for path in files {
+            if path.components().any(|part| part.as_os_str() == "tests") {
+                continue;
+            }
+            let source = fs::read_to_string(&path).expect("read producer source");
+            // Inline test modules pin these names on purpose; production code
+            // above the crate's trailing test module must not spell them.
+            let production = source
+                .split("\n#[cfg(test)]\n")
+                .next()
+                .expect("split returns at least the full source");
+            for literal in literals {
+                assert!(
+                    !production.contains(literal),
+                    "{} spells owned artifact identity {literal:?}; derive it from codestory_contracts::owned_artifacts instead",
+                    path.display()
+                );
+            }
+        }
+    }
+}

--- a/crates/codestory-contracts/src/lib.rs
+++ b/crates/codestory-contracts/src/lib.rs
@@ -15,6 +15,7 @@ pub mod events;
 pub mod graph;
 pub mod grounding;
 pub mod language_support;
+pub mod owned_artifacts;
 pub mod query;
 pub mod trail;
 pub mod workspace;

--- a/crates/codestory-contracts/src/owned_artifacts.rs
+++ b/crates/codestory-contracts/src/owned_artifacts.rs
@@ -1,0 +1,246 @@
+//! One registry of every file identity CodeStory writes beside its core
+//! storage file.
+//!
+//! Producers derive their artifact paths from these constants and functions,
+//! and the workspace discovery exclusion consumes the same registry, so an
+//! artifact name exists in exactly one place. The architecture contract test
+//! rejects production sources that spell these identities directly, which is
+//! what keeps a future owned artifact from silently entering source discovery
+//! the way an unregistered one would.
+
+use std::path::{Path, PathBuf};
+
+/// SQLite sidecar suffixes appended to a live database file name.
+pub const SQLITE_SIDECAR_SUFFIXES: [&str; 3] = ["-wal", "-shm", "-journal"];
+
+/// Extension replacing the storage extension for the rollback backup.
+pub const ROLLBACK_BACKUP_EXTENSION: &str = "sqlite.backup";
+
+/// Extension replacing the storage extension for the index-writer lock.
+pub const INDEX_WRITER_LOCK_EXTENSION: &str = "index-writer.lock";
+
+/// Suffixes appended to the full storage file name by staged promotion.
+pub const PROMOTION_LOCK_SUFFIX: &str = ".promotion.lock";
+pub const PROMOTION_PREPARED_JOURNAL_SUFFIX: &str = ".promotion.prepared.json";
+pub const PROMOTION_COMMITTED_JOURNAL_SUFFIX: &str = ".promotion.committed.json";
+pub const PROMOTION_CLEANUP_BLOCKED_SUFFIX: &str = ".promotion.cleanup-blocked";
+
+/// Every promotion sibling suffix, in stable order.
+pub const PROMOTION_SIBLING_SUFFIXES: [&str; 4] = [
+    PROMOTION_LOCK_SUFFIX,
+    PROMOTION_PREPARED_JOURNAL_SUFFIX,
+    PROMOTION_COMMITTED_JOURNAL_SUFFIX,
+    PROMOTION_CLEANUP_BLOCKED_SUFFIX,
+];
+
+/// Infix between the storage stem and the `{pid}-{epoch}` unique part of a
+/// staged snapshot name.
+pub const STAGED_SNAPSHOT_INFIX: &str = ".staged.";
+
+/// Directory-name suffixes for the search trees owned by one storage file,
+/// applied to the storage stem. Each directory also owns a sibling
+/// `<directory>.lock` file.
+pub const SEARCH_DIRECTORY_SUFFIXES: [&str; 2] = ["search", "search-generations"];
+
+/// Local-refresh serialization files written by the CLI into the cache root
+/// that holds the storage file. The state guard is persistent by design.
+pub const LOCAL_REFRESH_STATUS_FILE: &str = "local-refresh-status.json";
+pub const LOCAL_REFRESH_LOCK_FILE: &str = "local-refresh.lock";
+pub const LOCAL_REFRESH_STATE_GUARD_FILE: &str = "local-refresh-state.guard";
+
+/// Annotations sidecar beside the storage file. Registered ahead of the
+/// sidecar cutover so discovery excludes it from the first write.
+pub const ANNOTATIONS_SIDECAR_FILE: &str = "annotations.sqlite3";
+
+/// Fixed file names CodeStory owns inside the cache root that holds the
+/// storage file, independent of the storage file's own name.
+pub const CACHE_ROOT_OWNED_FILE_NAMES: [&str; 3] = [
+    LOCAL_REFRESH_STATUS_FILE,
+    LOCAL_REFRESH_LOCK_FILE,
+    LOCAL_REFRESH_STATE_GUARD_FILE,
+];
+
+fn cache_root_for(storage_path: &Path) -> &Path {
+    storage_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn storage_stem(storage_path: &Path) -> &str {
+    storage_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("codestory")
+}
+
+fn storage_extension(storage_path: &Path) -> &str {
+    storage_path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("sqlite")
+}
+
+fn path_with_display_suffix(path: &Path, suffix: &str) -> PathBuf {
+    PathBuf::from(format!("{}{}", path.display(), suffix))
+}
+
+fn path_with_native_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut suffixed = path.as_os_str().to_os_string();
+    suffixed.push(suffix);
+    PathBuf::from(suffixed)
+}
+
+/// The live file plus its SQLite sidecars.
+pub fn sqlite_file_with_sidecars(live_path: &Path) -> Vec<PathBuf> {
+    let mut files = vec![live_path.to_path_buf()];
+    files.extend(
+        SQLITE_SIDECAR_SUFFIXES
+            .iter()
+            .map(|suffix| path_with_native_suffix(live_path, suffix)),
+    );
+    files
+}
+
+/// Search directory owned by one storage file for the given registry suffix.
+pub fn search_directory_for_storage(storage_path: &Path, suffix: &str) -> PathBuf {
+    cache_root_for(storage_path).join(format!("{}.{suffix}", storage_stem(storage_path)))
+}
+
+/// Exact owned file identities beside one storage file: the database and its
+/// sidecars, the index-writer lock, promotion siblings, the rollback backup
+/// and its sidecars, the search directory locks, the local-refresh files, and
+/// the annotations sidecar with its sidecars.
+pub fn storage_owned_file_identities(storage_path: &Path) -> Vec<PathBuf> {
+    let cache_root = cache_root_for(storage_path);
+    let rollback_backup = storage_path.with_extension(ROLLBACK_BACKUP_EXTENSION);
+    let mut files = sqlite_file_with_sidecars(storage_path);
+    files.push(storage_path.with_extension(INDEX_WRITER_LOCK_EXTENSION));
+    files.extend(
+        PROMOTION_SIBLING_SUFFIXES
+            .iter()
+            .map(|suffix| path_with_display_suffix(storage_path, suffix)),
+    );
+    files.extend(sqlite_file_with_sidecars(&rollback_backup));
+    files.extend(SEARCH_DIRECTORY_SUFFIXES.iter().map(|suffix| {
+        path_with_native_suffix(&search_directory_for_storage(storage_path, suffix), ".lock")
+    }));
+    files.extend(
+        CACHE_ROOT_OWNED_FILE_NAMES
+            .iter()
+            .map(|name| cache_root.join(name)),
+    );
+    files.extend(sqlite_file_with_sidecars(
+        &cache_root.join(ANNOTATIONS_SIDECAR_FILE),
+    ));
+    files
+}
+
+/// Build the staged snapshot path for one live database and unique parts.
+pub fn staged_snapshot_path(live_path: &Path, pid: u32, epoch_ns: u128) -> PathBuf {
+    cache_root_for(live_path).join(format!(
+        "{}{}{pid}-{epoch_ns}.{}",
+        storage_stem(live_path),
+        STAGED_SNAPSHOT_INFIX,
+        storage_extension(live_path)
+    ))
+}
+
+/// Whether one file name belongs to the staged snapshot namespace of the
+/// given storage file: `{stem}.staged.{pid}-{epoch}.{ext}[-wal|-shm|-journal]`.
+pub fn is_staged_snapshot_name(storage_path: &Path, file_name: &str) -> bool {
+    let prefix = format!("{}{}", storage_stem(storage_path), STAGED_SNAPSHOT_INFIX);
+    let extension = storage_extension(storage_path);
+    let Some(candidate) = file_name.strip_prefix(&prefix) else {
+        return false;
+    };
+    let mut suffixes = vec![format!(".{extension}")];
+    suffixes.extend(
+        SQLITE_SIDECAR_SUFFIXES
+            .iter()
+            .map(|sidecar| format!(".{extension}{sidecar}")),
+    );
+    let Some(unique) = suffixes
+        .iter()
+        .find_map(|suffix| candidate.strip_suffix(suffix.as_str()))
+    else {
+        return false;
+    };
+    let mut unique_parts = unique.split('-');
+    unique_parts
+        .next()
+        .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && unique_parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && unique_parts.next().is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owned_identities_cover_every_registered_family() {
+        let storage = Path::new("/cache/custom-core.db");
+        let files = storage_owned_file_identities(storage);
+        let expect = |name: &str| {
+            assert!(
+                files.iter().any(|file| file == Path::new(name)),
+                "{name} must be registry-owned"
+            );
+        };
+        expect("/cache/custom-core.db");
+        expect("/cache/custom-core.db-wal");
+        expect("/cache/custom-core.index-writer.lock");
+        expect("/cache/custom-core.db.promotion.lock");
+        expect("/cache/custom-core.db.promotion.cleanup-blocked");
+        expect("/cache/custom-core.sqlite.backup");
+        expect("/cache/custom-core.sqlite.backup-journal");
+        expect("/cache/custom-core.search.lock");
+        expect("/cache/custom-core.search-generations.lock");
+        expect("/cache/local-refresh-status.json");
+        expect("/cache/local-refresh.lock");
+        expect("/cache/local-refresh-state.guard");
+        expect("/cache/annotations.sqlite3");
+        expect("/cache/annotations.sqlite3-shm");
+    }
+
+    #[test]
+    fn staged_namespace_matches_only_pid_epoch_names() {
+        let storage = Path::new("/cache/custom-core.db");
+        let staged = staged_snapshot_path(storage, 123, 456);
+        assert_eq!(staged, Path::new("/cache/custom-core.staged.123-456.db"));
+        assert!(is_staged_snapshot_name(
+            storage,
+            "custom-core.staged.123-456.db"
+        ));
+        assert!(is_staged_snapshot_name(
+            storage,
+            "custom-core.staged.123-456.db-wal"
+        ));
+        assert!(!is_staged_snapshot_name(
+            storage,
+            "custom-core.staged.notes.db"
+        ));
+        assert!(!is_staged_snapshot_name(
+            storage,
+            "custom-core.staged.123-456-789.db"
+        ));
+        assert!(!is_staged_snapshot_name(storage, "other.staged.123-456.db"));
+    }
+
+    #[test]
+    fn bare_storage_names_observe_the_current_directory() {
+        let files = storage_owned_file_identities(Path::new("codestory.db"));
+        assert!(
+            files
+                .iter()
+                .any(|file| file == Path::new("./local-refresh.lock"))
+        );
+        assert_eq!(
+            staged_snapshot_path(Path::new("codestory.db"), 1, 2),
+            Path::new("./codestory.staged.1-2.db")
+        );
+    }
+}

--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -343,7 +343,9 @@ fn target_cache_has_contents(path: &Path) -> Result<bool> {
     for entry in
         fs::read_dir(path).with_context(|| format!("read target cache dir {}", path.display()))?
     {
-        if entry?.file_name() != "codestory.index-writer.lock" {
+        let writer_lock = Path::new("codestory.db")
+            .with_extension(codestory_contracts::owned_artifacts::INDEX_WRITER_LOCK_EXTENSION);
+        if entry?.file_name() != writer_lock.as_os_str() {
             return Ok(true);
         }
     }

--- a/crates/codestory-runtime/src/index_commit.rs
+++ b/crates/codestory-runtime/src/index_commit.rs
@@ -63,7 +63,8 @@ pub(super) struct IndexWriterGuard {
 
 impl IndexWriterGuard {
     pub(super) fn try_acquire(storage_path: &Path) -> Result<Self, ApiError> {
-        let path = storage_path.with_extension("index-writer.lock");
+        let path = storage_path
+            .with_extension(codestory_contracts::owned_artifacts::INDEX_WRITER_LOCK_EXTENSION);
         if let Some(parent) = path
             .parent()
             .filter(|parent| !parent.as_os_str().is_empty())

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -53,17 +53,15 @@ impl<'a> SnapshotStore<'a> {
 
     /// Build a unique SQLite path beside the intended live database.
     pub fn staged_path(live_path: &Path) -> PathBuf {
-        let parent = live_path.parent().unwrap_or_else(|| Path::new("."));
-        let stem = live_path
-            .file_stem()
-            .and_then(|value| value.to_str())
-            .unwrap_or("codestory");
-        let extension = live_path
-            .extension()
-            .and_then(|value| value.to_str())
-            .unwrap_or("sqlite");
-        let unique = unique_staged_suffix();
-        parent.join(format!("{stem}.staged.{unique}.{extension}"))
+        let epoch_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        codestory_contracts::owned_artifacts::staged_snapshot_path(
+            live_path,
+            std::process::id(),
+            epoch_ns,
+        )
     }
 
     /// Open a fresh staged database in build mode.

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -297,14 +297,6 @@ fn staged_snapshot_finalize_stats(
     }
 }
 
-fn unique_staged_suffix() -> String {
-    let epoch_ns = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    format!("{}-{}", std::process::id(), epoch_ns)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -1,3 +1,5 @@
+use codestory_contracts::owned_artifacts;
+
 use codestory_contracts::graph::{
     AccessKind, Bookmark, BookmarkCategory, CallableProjectionState, Edge, EdgeId, EdgeKind,
     EnumConversionError, FileCoverageReason, Node, NodeId, NodeKind, Occurrence, OccurrenceKind,
@@ -925,24 +927,29 @@ fn require_candidate_structural_text_identity(
 }
 
 fn promotion_lock_path(path: &Path) -> PathBuf {
-    PathBuf::from(format!("{}.promotion.lock", path.display()))
+    promotion_sibling_path(path, owned_artifacts::PROMOTION_LOCK_SUFFIX)
 }
 
 fn promotion_prepared_journal_path(path: &Path) -> PathBuf {
-    PathBuf::from(format!("{}.promotion.prepared.json", path.display()))
+    promotion_sibling_path(path, owned_artifacts::PROMOTION_PREPARED_JOURNAL_SUFFIX)
 }
 
 fn promotion_committed_journal_path(path: &Path) -> PathBuf {
-    PathBuf::from(format!("{}.promotion.committed.json", path.display()))
+    promotion_sibling_path(path, owned_artifacts::PROMOTION_COMMITTED_JOURNAL_SUFFIX)
 }
 
 #[cfg(test)]
 fn promotion_cleanup_failure_path(path: &Path) -> PathBuf {
-    PathBuf::from(format!("{}.promotion.cleanup-blocked", path.display()))
+    promotion_sibling_path(path, owned_artifacts::PROMOTION_CLEANUP_BLOCKED_SUFFIX)
+}
+
+fn promotion_sibling_path(path: &Path, suffix: &str) -> PathBuf {
+    PathBuf::from(format!("{}{suffix}", path.display()))
 }
 
 fn promotion_artifacts_exist(path: &Path) -> bool {
-    path.with_extension("sqlite.backup").exists()
+    path.with_extension(owned_artifacts::ROLLBACK_BACKUP_EXTENSION)
+        .exists()
         || promotion_prepared_journal_path(path).exists()
         || promotion_committed_journal_path(path).exists()
 }
@@ -1230,7 +1237,7 @@ fn recover_interrupted_promotion(path: &Path) -> Result<(), StorageError> {
 }
 
 fn recover_interrupted_promotion_locked(path: &Path) -> Result<(), StorageError> {
-    let backup_path = path.with_extension("sqlite.backup");
+    let backup_path = path.with_extension(owned_artifacts::ROLLBACK_BACKUP_EXTENSION);
     let prepared_path = promotion_prepared_journal_path(path);
     let committed_path = promotion_committed_journal_path(path);
 
@@ -1336,7 +1343,7 @@ fn rollback_prepared_promotion(
             live_path.display()
         )));
     }
-    let backup_path = live_path.with_extension("sqlite.backup");
+    let backup_path = live_path.with_extension(owned_artifacts::ROLLBACK_BACKUP_EXTENSION);
     let prepared_path = promotion_prepared_journal_path(live_path);
     let recovery_contract = RecoveryDatabaseContract::Journal(prepared.version);
     let live_identity = read_recovery_database_identity(live_path, recovery_contract)?;
@@ -1609,7 +1616,7 @@ fn cleanup_committed_promotion_artifacts(live_path: &Path) -> Result<(), Storage
         ));
     }
 
-    let backup_path = live_path.with_extension("sqlite.backup");
+    let backup_path = live_path.with_extension(owned_artifacts::ROLLBACK_BACKUP_EXTENSION);
     cleanup_sqlite_sidecars(&backup_path)?;
     let committed_path = promotion_committed_journal_path(live_path);
     remove_promotion_file(&committed_path)
@@ -5411,7 +5418,7 @@ impl Storage {
                 live_path.display()
             )));
         }
-        let backup_path = live_path.with_extension("sqlite.backup");
+        let backup_path = live_path.with_extension(owned_artifacts::ROLLBACK_BACKUP_EXTENSION);
         let prepared_path = promotion_prepared_journal_path(live_path);
         let committed_path = promotion_committed_journal_path(live_path);
         durations.lock_recovery = lock_recovery_started.elapsed();

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -198,11 +198,7 @@ fn default_source_exclude_patterns() -> Vec<String> {
     .collect()
 }
 
-fn path_with_display_suffix(path: &Path, suffix: &str) -> PathBuf {
-    // Match the sibling naming used by the storage promotion owner.
-    PathBuf::from(format!("{}{}", path.display(), suffix))
-}
-
+#[cfg(test)]
 fn path_with_native_suffix(path: &Path, suffix: &str) -> PathBuf {
     let mut suffixed = path.as_os_str().to_os_string();
     suffixed.push(suffix);
@@ -217,55 +213,11 @@ fn storage_parent_for_observation(storage_path: &Path) -> &Path {
 }
 
 fn storage_owned_discovery_files(storage_path: &Path) -> Vec<PathBuf> {
-    let rollback_backup = storage_path.with_extension("sqlite.backup");
-    let legacy_search = legacy_search_directory_for_storage(storage_path);
-    let search_generations = search_generation_directory_for_storage(storage_path);
-    let cache_root = storage_parent_for_observation(storage_path);
-    vec![
-        storage_path.to_path_buf(),
-        path_with_native_suffix(storage_path, "-wal"),
-        path_with_native_suffix(storage_path, "-shm"),
-        path_with_native_suffix(storage_path, "-journal"),
-        storage_path.with_extension("index-writer.lock"),
-        path_with_display_suffix(storage_path, ".promotion.lock"),
-        path_with_display_suffix(storage_path, ".promotion.prepared.json"),
-        path_with_display_suffix(storage_path, ".promotion.committed.json"),
-        path_with_display_suffix(storage_path, ".promotion.cleanup-blocked"),
-        rollback_backup.clone(),
-        path_with_native_suffix(&rollback_backup, "-wal"),
-        path_with_native_suffix(&rollback_backup, "-shm"),
-        path_with_native_suffix(&rollback_backup, "-journal"),
-        path_with_native_suffix(&legacy_search, ".lock"),
-        path_with_native_suffix(&search_generations, ".lock"),
-        // The CLI serializes local refresh in the cache root that holds the
-        // storage file; its status, lock, and persistent guard files are
-        // CodeStory-owned state, and the status file is rewritten on a
-        // heartbeat while a refresh runs. Names mirror
-        // crates/codestory-cli/src/local_refresh_status.rs until one shared
-        // owned-artifact registry replaces this enumeration.
-        cache_root.join("local-refresh-status.json"),
-        cache_root.join("local-refresh.lock"),
-        cache_root.join("local-refresh-state.guard"),
-    ]
+    codestory_contracts::owned_artifacts::storage_owned_file_identities(storage_path)
 }
 
 fn storage_owned_staged_discovery_files(storage_path: &Path) -> io::Result<Vec<PathBuf>> {
     let parent = storage_parent_for_observation(storage_path);
-    let stem = storage_path
-        .file_stem()
-        .and_then(|value| value.to_str())
-        .unwrap_or("codestory");
-    let extension = storage_path
-        .extension()
-        .and_then(|value| value.to_str())
-        .unwrap_or("sqlite");
-    let prefix = format!("{stem}.staged.");
-    let suffixes = [
-        format!(".{extension}"),
-        format!(".{extension}-wal"),
-        format!(".{extension}-shm"),
-        format!(".{extension}-journal"),
-    ];
     let entries = match fs::read_dir(parent) {
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -277,24 +229,7 @@ fn storage_owned_staged_discovery_files(storage_path: &Path) -> io::Result<Vec<P
         let Some(name) = entry.file_name().to_str().map(str::to_string) else {
             continue;
         };
-        let Some(candidate) = name.strip_prefix(&prefix) else {
-            continue;
-        };
-        let Some(unique) = suffixes
-            .iter()
-            .find_map(|suffix| candidate.strip_suffix(suffix))
-        else {
-            continue;
-        };
-        let mut unique_parts = unique.split('-');
-        if unique_parts
-            .next()
-            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
-            && unique_parts.next().is_some_and(|part| {
-                !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit())
-            })
-            && unique_parts.next().is_none()
-        {
+        if codestory_contracts::owned_artifacts::is_staged_snapshot_name(storage_path, &name) {
             owned.push(entry.path());
         }
     }
@@ -763,21 +698,18 @@ impl WorkspaceManifest {
 
 /// Legacy mutable search directory associated with one core database.
 pub fn legacy_search_directory_for_storage(storage_path: &Path) -> PathBuf {
-    storage_owned_sibling_path(storage_path, "search")
+    codestory_contracts::owned_artifacts::search_directory_for_storage(
+        storage_path,
+        codestory_contracts::owned_artifacts::SEARCH_DIRECTORY_SUFFIXES[0],
+    )
 }
 
 /// Immutable search-generation directory associated with one core database.
 pub fn search_generation_directory_for_storage(storage_path: &Path) -> PathBuf {
-    storage_owned_sibling_path(storage_path, "search-generations")
-}
-
-fn storage_owned_sibling_path(storage_path: &Path, suffix: &str) -> PathBuf {
-    let parent = storage_path.parent().unwrap_or_else(|| Path::new("."));
-    let stem = storage_path
-        .file_stem()
-        .and_then(|value| value.to_str())
-        .unwrap_or("codestory");
-    parent.join(format!("{stem}.{suffix}"))
+    codestory_contracts::owned_artifacts::search_directory_for_storage(
+        storage_path,
+        codestory_contracts::owned_artifacts::SEARCH_DIRECTORY_SUFFIXES[1],
+    )
 }
 
 impl WorkspaceDiscovery {


### PR DESCRIPTION
Closes #1733.

## What

Every file identity CodeStory writes beside its core storage file now lives in one registry: `codestory_contracts::owned_artifacts` — SQLite sidecar suffixes, the index-writer lock, the four promotion siblings, the rollback backup, the staged-snapshot namespace (builder + matcher), the search directory names and locks, the CLI local-refresh trio, and — registered ahead of the ANNO-B cutover per #1733's done-when — `annotations.sqlite3` with its sidecars, which the workspace exclusion now already covers.

Consumers switched to derive from the registry instead of spelling names:

- `codestory-workspace`: `storage_owned_discovery_files`, the staged-namespace scan, and both search-directory derivations
- `codestory-store`: promotion sibling paths, rollback-backup extension (5 sites), staged snapshot naming
- `codestory-runtime`: index-writer lock derivation and the rehydrate writer-lock comparison
- `codestory-cli`: the local-refresh file names

## Enforcement

New `architecture_contracts` test (runs per PR in `linux-contracts`): production sources in the six producer crates must not spell any owned identity literal — inline test modules may pin them, production code must derive. Negative-controlled: a canary literal inserted into production code fails the gate with the expected message; removed, it passes.

## Proof

All affected suites green at this head: contracts 52, workspace 147, store 202+5+2, runtime cache-rehydrate/index-commit filters, cli lib 290, architecture_contracts 16. fmt and clippy clean; behavior-preserving by construction (identical derived names, verified by the unchanged exclusion round-trip and staged-namespace tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)