### PR TITLE
[v0.17 HOOK-FLAKE] Outlive fork-exec ghost holds on try-locked files

### DIFF
--- a/crates/codestory-runtime/src/index_commit.rs
+++ b/crates/codestory-runtime/src/index_commit.rs
@@ -87,12 +87,14 @@ impl IndexWriterGuard {
                     path.display()
                 ))
             })?;
-        if !FileExt::try_lock_exclusive(&file).map_err(|error| {
-            ApiError::internal(format!(
-                "Failed to acquire index writer lock {}: {error}",
-                path.display()
-            ))
-        })? {
+        if !codestory_workspace::locking::try_lock_exclusive_outliving_spawn_ghosts(&file).map_err(
+            |error| {
+                ApiError::internal(format!(
+                    "Failed to acquire index writer lock {}: {error}",
+                    path.display()
+                ))
+            },
+        )? {
             return Err(ApiError::new(
                 "cache_busy",
                 format!(

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -27,6 +27,7 @@ use std::path::{Component, Path, PathBuf};
 use uuid::Uuid;
 
 pub mod atomic_file;
+pub mod locking;
 pub mod owned_deletion;
 pub mod paths;
 mod repo_metadata;

--- a/crates/codestory-workspace/src/locking.rs
+++ b/crates/codestory-workspace/src/locking.rs
@@ -1,0 +1,76 @@
+//! Non-blocking file-lock acquisition that outlives fork/exec ghost holds.
+
+use fs4::fs_std::FileExt as _;
+use std::fs::File;
+use std::io;
+use std::time::Duration;
+
+/// One try-lock attempt can spuriously report contention: a concurrently
+/// spawned child process (fork then exec) inherits every open descriptor,
+/// including a sibling thread's `flock`ed lock, until exec applies
+/// `O_CLOEXEC`. Darwin's `posix_spawn` applies close-on-exec atomically in
+/// the kernel; Linux does not, so any process that spawns children while
+/// another thread acquires a lock sees ghost conflicts that clear within
+/// microseconds. A genuine holder keeps the lock far past this bounded
+/// budget, so retrying preserves fail-closed semantics: the final attempt's
+/// verdict is authoritative.
+pub fn try_lock_exclusive_outliving_spawn_ghosts(file: &File) -> io::Result<bool> {
+    try_lock_with_budget(file, 20, Duration::from_millis(2))
+}
+
+fn try_lock_with_budget(file: &File, retries: u32, step: Duration) -> io::Result<bool> {
+    for _ in 0..retries {
+        if file.try_lock_exclusive()? {
+            return Ok(true);
+        }
+        std::thread::sleep(step);
+    }
+    file.try_lock_exclusive()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+
+    fn lock_file() -> (tempfile::TempDir, File) {
+        let dir = tempfile::tempdir().expect("lock dir");
+        let path = dir.path().join("subject.lock");
+        let file = File::create(&path).expect("create lock");
+        (dir, file)
+    }
+
+    #[test]
+    fn briefly_held_lock_is_acquired_within_the_budget() {
+        let (dir, file) = lock_file();
+        let holder = File::open(dir.path().join("subject.lock")).expect("holder handle");
+        assert!(holder.try_lock_exclusive().expect("holder locks"));
+        let (release_started, release_gate) = mpsc::channel();
+        let releaser = thread::spawn(move || {
+            release_started.send(()).expect("signal release start");
+            thread::sleep(Duration::from_millis(6));
+            drop(holder);
+        });
+        release_gate.recv().expect("holder release scheduled");
+
+        assert!(
+            try_lock_exclusive_outliving_spawn_ghosts(&file).expect("retrying acquire"),
+            "a ghost-lived hold must clear within the retry budget"
+        );
+        releaser.join().expect("releaser thread");
+    }
+
+    #[test]
+    fn genuinely_held_lock_still_fails_closed() {
+        let (dir, file) = lock_file();
+        let holder = File::open(dir.path().join("subject.lock")).expect("holder handle");
+        assert!(holder.try_lock_exclusive().expect("holder locks"));
+
+        assert!(
+            !try_lock_with_budget(&file, 3, Duration::from_millis(1)).expect("bounded acquire"),
+            "a persistent holder must still report contention"
+        );
+        drop(holder);
+    }
+}

--- a/crates/codestory-workspace/src/repository_hooks.rs
+++ b/crates/codestory-workspace/src/repository_hooks.rs
@@ -12,7 +12,6 @@ use crate::{
     workspace_path_lexical_identity,
 };
 use fs_at::{OpenOptions as AtOpenOptions, OpenOptionsWriteMode};
-use fs4::fs_std::FileExt as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use std::{
@@ -2508,7 +2507,7 @@ fn acquire_transaction_lock(parent: &File) -> io::Result<File> {
     }
     let lock = options.open_at(parent, TRANSACTION_LOCK_NAME)?;
     validate_private_regular_file(&lock, "hook transaction lock")?;
-    if !lock.try_lock_exclusive()? {
+    if !crate::locking::try_lock_exclusive_outliving_spawn_ghosts(&lock)? {
         return Err(io::Error::new(
             io::ErrorKind::WouldBlock,
             "another hook transaction is active",


### PR DESCRIPTION
Closes #1738.

## Root cause

A one-shot `flock` try-lock races Linux `posix_spawn`: between clone and exec, a child spawned by any sibling thread holds every parent descriptor — including another thread's lock — until exec applies `O_CLOEXEC`. Proven with `/proc/locks` instrumentation: the failing acquire's inode was held by nobody microseconds after the spurious `EWOULDBLOCK` (evidence on the issue). Darwin applies close-on-exec atomically inside the `posix_spawn` syscall, which is why this never reproduced on macOS. Not test-only: `IndexWriterGuard::try_acquire` had the same exposure as a spurious `cache_busy`.

## Fix

New `codestory_workspace::locking::try_lock_exclusive_outliving_spawn_ghosts`: bounded retry (20 × 2 ms; the final attempt's verdict is authoritative), so ghost holds clear while genuine holders still fail closed. Adopted by the hook transaction lock and the index-writer guard. No interruption/recovery contract changes — the pre-READY recovery, concurrent-edit preservation, and lock-binding tests are untouched and green.

## Proof

- Before: full `codestory-workspace` suite failed ~1-in-4 runs on Linux (shifting victims); after: **25/25 consecutive full-suite Linux runs clean** (issue done-when asks for 20).
- Helper unit tests: a briefly-held lock is acquired within the budget; a persistent holder still reports contention.
- Workspace suite 149 green on macOS; clippy/fmt clean; runtime compiles with the guard switched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)