### PR TITLE
[v0.17 SRC-B2a] Prove the rehydrate gates for dirty, issue-bearing, and partial-inventory sources

### DIFF
--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -711,7 +711,7 @@ fn display_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::{git, git_available};
+    use crate::test_support::{git, git_available, git_output};
     use codestory_contracts::graph::{Node, NodeId, NodeKind};
     use sha2::{Digest, Sha256};
     use std::path::PathBuf;
@@ -1006,6 +1006,122 @@ mod tests {
 
         assert_eq!(output.status, "skipped");
         assert_eq!(output.reason.as_deref(), Some("git tree mismatch"));
+        assert!(!target_cache.path().join("codestory.db").exists());
+    }
+
+    #[test]
+    fn rehydrate_skips_when_target_worktree_is_dirty() {
+        let Some((source_project, target_project)) = matching_git_projects() else {
+            return;
+        };
+        fs::write(target_project.path().join("src.rs"), "pub fn dirty() {}\n")
+            .expect("dirty target");
+
+        let source_cache = tempdir().expect("source cache");
+        let target_cache = tempdir().expect("target cache");
+        seed_cache(
+            &source_cache.path().join("codestory.db"),
+            source_project.path(),
+        );
+
+        let output = rehydrate_cache(CacheRehydrateRequest {
+            source_project: source_project.path(),
+            source_cache_dir: source_cache.path(),
+            target_project: target_project.path(),
+            target_cache_dir: target_cache.path(),
+            dry_run: false,
+        })
+        .expect("rehydrate");
+
+        assert_eq!(output.status, "skipped");
+        let reason = output.reason.as_deref().expect("skip reason");
+        assert!(
+            reason.contains("git worktree is dirty"),
+            "dirty target must refuse reuse: {reason}"
+        );
+        assert!(!target_cache.path().join("codestory.db").exists());
+    }
+
+    #[test]
+    fn rehydrate_skips_when_target_metadata_reports_issues() {
+        let Some((source_project, target_project)) = matching_git_projects() else {
+            return;
+        };
+        // A gitlink index entry makes the target a submodule parent; the
+        // confined reader conservatively refuses worktree status for it.
+        let head = git_output(target_project.path(), &["rev-parse", "HEAD"]);
+        git(
+            target_project.path(),
+            &[
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                &format!("160000,{head},nested"),
+            ],
+        );
+
+        let source_cache = tempdir().expect("source cache");
+        let target_cache = tempdir().expect("target cache");
+        seed_cache(
+            &source_cache.path().join("codestory.db"),
+            source_project.path(),
+        );
+
+        let output = rehydrate_cache(CacheRehydrateRequest {
+            source_project: source_project.path(),
+            source_cache_dir: source_cache.path(),
+            target_project: target_project.path(),
+            target_cache_dir: target_cache.path(),
+            dry_run: false,
+        })
+        .expect("rehydrate");
+
+        assert_eq!(output.status, "skipped");
+        let reason = output.reason.as_deref().expect("skip reason");
+        assert!(
+            reason.contains("git metadata inspection failed")
+                || reason.contains("git worktree is dirty"),
+            "metadata issues must refuse reuse: {reason}"
+        );
+        assert!(!target_cache.path().join("codestory.db").exists());
+    }
+
+    #[test]
+    fn rehydrate_skips_when_a_tracked_source_is_repo_ignored() {
+        let Some((source_project, target_project)) = matching_git_projects() else {
+            return;
+        };
+        // A committed file later covered by the repository's own ignore rules
+        // makes the source inventory Partial, so freshness cannot be proven.
+        for project in [source_project.path(), target_project.path()] {
+            fs::write(project.join("ignored.rs"), "pub fn hidden() {}\n").expect("ignored source");
+            fs::write(project.join(".gitignore"), "ignored.rs\n").expect("gitignore");
+            git(project, &["add", "-f", "ignored.rs", ".gitignore"]);
+            git(project, &["commit", "-m", "track ignored"]);
+        }
+
+        let source_cache = tempdir().expect("source cache");
+        let target_cache = tempdir().expect("target cache");
+        seed_cache(
+            &source_cache.path().join("codestory.db"),
+            source_project.path(),
+        );
+
+        let output = rehydrate_cache(CacheRehydrateRequest {
+            source_project: source_project.path(),
+            source_cache_dir: source_cache.path(),
+            target_project: target_project.path(),
+            target_cache_dir: target_cache.path(),
+            dry_run: false,
+        })
+        .expect("rehydrate");
+
+        assert_eq!(output.status, "skipped");
+        let reason = output.reason.as_deref().expect("skip reason");
+        assert!(
+            reason.contains("source cache freshness check failed") && reason.contains("Partial"),
+            "a Partial source inventory must refuse reuse: {reason}"
+        );
         assert!(!target_cache.path().join("codestory.db").exists());
     }
 

--- a/crates/codestory-runtime/src/test_support.rs
+++ b/crates/codestory-runtime/src/test_support.rs
@@ -5,6 +5,22 @@ pub(crate) fn git_available() -> bool {
     Command::new("git").arg("--version").output().is_ok()
 }
 
+pub(crate) fn git_output(project: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project)
+        .args(args)
+        .output()
+        .expect("run git fixture query");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
 pub(crate) fn git(project: &Path, args: &[&str]) {
     let output = Command::new("git")
         .arg("-C")


### PR DESCRIPTION
Closes #1741.

## What

Three new direct tests at the rehydrate boundary, mirroring the existing skip-test fixtures:

- `rehydrate_skips_when_target_worktree_is_dirty` — an uncommitted edit in the target refuses reuse with the dirty-worktree reason.
- `rehydrate_skips_when_target_metadata_reports_issues` — a gitlink index entry (submodule parent) refuses reuse through the confined reader's conservative status.
- `rehydrate_skips_when_a_tracked_source_is_repo_ignored` — a committed-then-gitignored file makes the source inventory `Partial`, and rehydrate refuses with the freshness-unprovable reason.

All three assert nothing is copied. Adds a `git_output` fixture helper to runtime test support.

These gates' semantics decision (fail-closed vs downgrade for tracked-but-ignored) remains open on #1734 — the tests pin the current refusal behavior and only #1734's outcome may relax the partial-inventory case.

## Proof

`cargo test -p codestory-runtime --lib cache_rehydrate`: 12 passed (9 existing + 3 new). fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)