### PR TITLE
[v0.17 QUAL-SRC] Bind qualification controls to the resident server directory

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2600,11 +2600,33 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
     const windowsNativeSteps = list(windowsNative.steps).map(object);
     add(
       violations,
-      windowsNativeSteps.length === 6
+      windowsNativeSteps.length === 7
         && windowsNativeSteps[0]?.uses === "actions/checkout@v5"
         && object(windowsNativeSteps[0]?.with).ref === "${{ needs.resolve.outputs.ref }}"
         && windowsNativeSteps.every(step => step?.["continue-on-error"] === undefined),
-      `${sourceFile} Windows native source contracts must keep the exact blocking six-step shape`,
+      `${sourceFile} Windows native source contracts must keep the exact blocking seven-step shape`,
+    );
+    // The qualification harness regression runs before the toolchain steps: it
+    // needs no build, and a Windows-native reproduction of the control
+    // directory mismatch is worth nothing if it only reports after a Vulkan
+    // SDK install and a release Cargo test have already spent the job.
+    add(
+      violations,
+      windowsNativeSteps[1]?.name
+        === "Prove the Windows-native qualification harness contracts",
+      `${sourceFile} Windows native source contracts must prove the qualification harness before any build step`,
+    );
+    requireStepRun(
+      violations,
+      sourceFile,
+      windowsNative,
+      "Prove the Windows-native qualification harness contracts",
+      [
+        "python .github/scripts/check-packaged-agent-proof.py --self-test",
+        "Windows-native qualification harness contracts failed",
+        "past their 90000 ms budget",
+        "Windows-native qualification harness contracts:",
+      ],
     );
     requireStepRun(violations, sourceFile, windowsNative, "Install Rust stable", [
       "rustup toolchain install stable --profile minimal",

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -4292,6 +4292,54 @@ test("exact-head source proof owns Windows path and native-staging harnesses", a
   }
 });
 
+test("exact-head source proof owns the Windows-native qualification harness regression", async (t) => {
+  assert.deepEqual(validateWorkflows(loadWorkflows()), []);
+  const file = "source-proof.yml";
+  const stepName = "Prove the Windows-native qualification harness contracts";
+  const mutations = [
+    ["regression is removed", workflow => {
+      const job = workflow.jobs["windows-native-contracts"];
+      job.steps = job.steps.filter(step => step.name !== stepName);
+    }],
+    ["regression is deferred behind the build steps", workflow => {
+      const job = workflow.jobs["windows-native-contracts"];
+      const [step] = job.steps.splice(
+        job.steps.findIndex(candidate => candidate.name === stepName),
+        1,
+      );
+      job.steps.push(step);
+    }],
+    ["harness self-test stops running", workflow => {
+      const step = draftStep(workflow.jobs["windows-native-contracts"], stepName);
+      step.run = step.run.replace(
+        "python .github/scripts/check-packaged-agent-proof.py --self-test",
+        "python --version",
+      );
+    }],
+    ["regression budget is dropped", workflow => {
+      const step = draftStep(workflow.jobs["windows-native-contracts"], stepName);
+      step.run = step.run.replace("past their 90000 ms budget", "slow");
+    }],
+    ["regression becomes advisory", workflow => {
+      draftStep(
+        workflow.jobs["windows-native-contracts"],
+        stepName,
+      )["continue-on-error"] = true;
+    }],
+  ];
+
+  for (const [name, mutate] of mutations) {
+    await t.test(name, () => {
+      const workflows = loadWorkflows();
+      mutate(workflows.get(file));
+      assert.match(
+        validateWorkflows(workflows).join("\n"),
+        /Windows native source contracts|Windows-native qualification harness contracts|qualification harness before any build step/u,
+      );
+    });
+  }
+});
+
 test("reusable compiler caches and proof modes reject hostile downgrades", async (t) => {
   assert.deepEqual(validateWorkflows(loadWorkflows()), []);
 

--- a/.github/scripts/packaged_agent_proof/qualification_directory_binding.py
+++ b/.github/scripts/packaged_agent_proof/qualification_directory_binding.py
@@ -1,0 +1,263 @@
+"""One authenticated qualification directory per resident embedding server.
+
+``CODESTORY_EMBED_QUALIFICATION_DIR`` is read once per process. A server binds
+it at start and polls that one directory for the rest of its life, so rebinding
+the variable mid-run moves only the writers: a server an earlier phase left
+resident keeps polling the directory it was started with, every control written
+under the new directory is read by nobody, and the wait that follows can only
+end as an anonymous timeout.
+
+Proof run 30600248269 ended exactly there. Publication-fault production left a
+replacement server polling ``qualification-suite``; the measurement producer
+then rebound the variable to ``qualification-suite/artifacts`` without replacing
+that server; ``reset_owner`` observed the live server, wrote ``crash_server``
+under the child directory, and spent the rest of the Windows job on
+``embedding_qualification_control_event_timeout:crash_server`` waiting for an
+event from a process that was never going to read the command.
+
+Every binding goes through this module so the two rules that make that
+impossible are stated once: a directory is bound before anything is resident on
+it, and a rebind replaces the resident server *before* moving the writers and
+then proves, by exact process identity, that the server answering the new
+directory is not the one it was supposed to replace. The proof is what keeps
+the fix honest. A restored rebind fails here, by name, for the seconds one
+admitted query costs, instead of by timeout after the whole proof budget.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from .event_producer_liveness import EventProducer, NativeProcessProducer
+from .foundation import ProofFailure, require
+from .publication_protocol import (
+    control_timeout_secs,
+    ensure_resident_qualification_server,
+    read_jsonl,
+    send_control_to_resident_server,
+)
+
+QUALIFICATION_DIRECTORY_ENV = "CODESTORY_EMBED_QUALIFICATION_DIR"
+# The one code a stranded control producer may fail with. It names the seam --
+# which directory the server is bound to versus which directory the controls
+# are written under -- so the failure is diagnosable from the message alone,
+# which `embedding_qualification_control_event_timeout:crash_server` never was.
+QUALIFICATION_DIRECTORY_MISMATCH = "embedding_qualification_control_directory_mismatch"
+_REPLACEMENT_POLL_SECS = 0.05
+# A settling window, never a bound on how long a server may take to exit: a
+# crashed server releases its endpoint immediately but may spend up to the
+# frozen native teardown grace actually leaving, and failing on that would
+# reject correct product conduct. Its only job is to keep the successor probe
+# from racing a server that accepted the crash microseconds earlier. Expiry is
+# therefore not a failure -- the identity comparison that follows is the check.
+_REPLACEMENT_SETTLE_SECS = 5
+
+
+@dataclass(frozen=True)
+class ResidentQualificationServer:
+    """The exact server process answering controls under one directory."""
+
+    directory: str
+    producer: EventProducer
+    pid: int
+    process_start_id: str
+
+    @property
+    def identity(self) -> tuple[int, str]:
+        return (self.pid, self.process_start_id)
+
+    def describe(self) -> str:
+        return (
+            f"pid {self.pid} (start identity {self.process_start_id})"
+            f" bound to {self.directory}"
+        )
+
+
+def bound_qualification_directory(env: dict[str, str]) -> str | None:
+    return env.get(QUALIFICATION_DIRECTORY_ENV)
+
+
+def bind_qualification_directory(
+    env: dict[str, str],
+    directory: Path | str,
+    *,
+    server_cleanup_control: dict | None = None,
+) -> str:
+    """Bind every later control, event, and worker file to one directory.
+
+    Only safe while nothing is resident on the directory being replaced, which
+    is why the initial bind calls this and a mid-run move calls
+    ``rebind_qualification_directory`` instead.
+    """
+    resolved = Path(directory).resolve()
+    require(
+        resolved.is_dir() and not resolved.is_symlink(),
+        f"qualification directory is not a private directory: {resolved}",
+    )
+    value = str(resolved)
+    env[QUALIFICATION_DIRECTORY_ENV] = value
+    if server_cleanup_control is not None:
+        server_cleanup_control["qualification_directory"] = value
+    return value
+
+
+def _next_control_sequence(directory: Path, nonce: str) -> int:
+    """One past every sequence the server in this directory has answered.
+
+    The server refuses a sequence it has already recorded, and it reloads the
+    highest one from this log at start, so a replacement server rejects a reused
+    number exactly as its predecessor would. Deriving it from the log keeps this
+    caller independent of how many controls an earlier phase happened to issue.
+    """
+    highest = max(
+        (
+            event["sequence"]
+            for event in read_jsonl(directory / f"{nonce}.events.jsonl")
+            if isinstance(event.get("sequence"), int)
+            and not isinstance(event.get("sequence"), bool)
+        ),
+        default=0,
+    )
+    return highest + 1
+
+
+def _pinned_server(
+    producer: EventProducer,
+    directory: str,
+    phase: str,
+) -> ResidentQualificationServer:
+    if not isinstance(producer, NativeProcessProducer):
+        raise ProofFailure(
+            f"{QUALIFICATION_DIRECTORY_MISMATCH}: the server made resident on"
+            f" {directory} {phase} did not report an exact process identity"
+            f" ({producer.describe()}), so this rebind cannot prove which"
+            " directory the process answering qualification controls is bound to"
+        )
+    return ResidentQualificationServer(
+        directory,
+        producer,
+        producer.pid,
+        producer.process_start_id,
+    )
+
+
+def _settle_replaced_server(replaced: ResidentQualificationServer) -> bool:
+    """Let the accepted crash land, so the successor probe cannot see a ghost.
+
+    ``crash_server`` is answered before the server stops accepting work, so a
+    successor query issued in the same instant could still be served by the
+    process this step exists to remove, and an honest replacement would then
+    read as the surviving-server defect.
+    """
+    deadline = time.monotonic() + _REPLACEMENT_SETTLE_SECS
+    while time.monotonic() < deadline:
+        if replaced.producer.exited():
+            return True
+        time.sleep(_REPLACEMENT_POLL_SECS)
+    return False
+
+
+def rebind_qualification_directory(
+    directory: Path,
+    *,
+    cli: Path,
+    env: dict[str, str],
+    project: Path,
+    nonce: str,
+    executable_sha256: str,
+    timeout: int,
+    server_cleanup_control: dict,
+    label: str,
+) -> dict:
+    """Move every control producer to ``directory``, replacing the server first.
+
+    The replacement is unconditional. Absence of a resident server cannot be
+    observed -- a probe that finds none is indistinguishable from one that ran
+    before the server this phase is about to inherit finished starting -- so the
+    only fail-closed order is to make one resident, end it, and only then move
+    the writers.
+    """
+    previous = bound_qualification_directory(env)
+    require(
+        previous is not None,
+        "a qualification directory rebind needs a bound directory to move from",
+    )
+    target = str(Path(directory).resolve())
+    if previous == target:
+        return {"rebound": False, "directory": target, "replaced": None}
+    previous_directory = Path(previous)
+    established: list[EventProducer] = []
+
+    def establish(attempt: int) -> EventProducer:
+        # Each attempt names its own worker evidence: the worker refuses to
+        # overwrite an output, so a shared label would make the tolerated
+        # respawn unrunnable.
+        producer = ensure_resident_qualification_server(
+            cli,
+            env,
+            project,
+            previous_directory,
+            nonce,
+            executable_sha256=executable_sha256,
+            timeout=timeout,
+            activity=(
+                "answering the control that ends it before the qualification"
+                f" directory moves to {target}"
+            ),
+            label=f"{label}-{attempt}",
+        )
+        established.append(producer)
+        return producer
+
+    send_control_to_resident_server(
+        previous_directory,
+        nonce,
+        sequence=_next_control_sequence(previous_directory, nonce),
+        action="crash_server",
+        timeout=control_timeout_secs(timeout),
+        establish=establish,
+    )
+    replaced = _pinned_server(established[-1], previous, "to be replaced")
+    replaced_exited = _settle_replaced_server(replaced)
+    bind_qualification_directory(
+        env,
+        directory,
+        server_cleanup_control=server_cleanup_control,
+    )
+    successor = _pinned_server(
+        ensure_resident_qualification_server(
+            cli,
+            env,
+            project,
+            Path(target),
+            nonce,
+            executable_sha256=executable_sha256,
+            timeout=timeout,
+            activity=(
+                "answering every qualification control written under the"
+                " rebound directory"
+            ),
+            label=f"{label}-successor",
+        ),
+        target,
+        "after the rebind",
+    )
+    if successor.identity == replaced.identity:
+        raise ProofFailure(
+            f"{QUALIFICATION_DIRECTORY_MISMATCH}: {replaced.describe()} survived"
+            f" the crash control that was supposed to replace it and is still the"
+            f" server answering for {previous}, while every later control and"
+            f" event is written under {target}. Nothing polls the new directory,"
+            " so the next control has no reader and would fail as an"
+            " unattributed timeout instead of naming this"
+        )
+    return {
+        "rebound": True,
+        "directory": target,
+        "previous_directory": previous,
+        "replaced": replaced,
+        "replaced_exited": replaced_exited,
+        "successor": successor,
+    }

--- a/.github/scripts/packaged_agent_proof/qualification_producer_runner.py
+++ b/.github/scripts/packaged_agent_proof/qualification_producer_runner.py
@@ -13,6 +13,7 @@ from .contract_primitives import (
 )
 from .foundation import REQUIRED_SERVER_SCENARIOS, ProofFailure, require
 from .measurement_samples import selected_qualification_matrix_cell
+from .qualification_directory_binding import rebind_qualification_directory
 from .qualification_production_types import (
     QualificationProducerContext,
     QualificationRunnerEvidence,
@@ -149,9 +150,21 @@ def run_qualification_producer(
         matrix_cell_id=matrix_cell_id,
         matrix_cell=matrix_cell,
     )
-    artifact_root = str(context.artifact_root.resolve())
-    context.qualification_env["CODESTORY_EMBED_QUALIFICATION_DIR"] = artifact_root
-    context.server_cleanup_control["qualification_directory"] = artifact_root
+    # The publication-fault phase runs against the parent directory and leaves a
+    # server resident on it. That server polls the directory it was started
+    # with, so it can never answer a control the scenario runner writes under
+    # this child directory: it is replaced here, before anything moves.
+    rebind_qualification_directory(
+        context.artifact_root,
+        cli=context.qualification_cli,
+        env=context.qualification_env,
+        project=Path(context.projects[0]),
+        nonce=context.nonce,
+        executable_sha256=context.package["executable_sha256"],
+        timeout=context.args.timeout_secs,
+        server_cleanup_control=context.server_cleanup_control,
+        label="measurement-rebind",
+    )
     request_path = context.artifact_root / "request.json"
     output_path = context.artifact_root / "output.json"
     write_private_json(request_path, request)

--- a/.github/scripts/packaged_agent_proof/qualification_producer_setup.py
+++ b/.github/scripts/packaged_agent_proof/qualification_producer_setup.py
@@ -16,6 +16,7 @@ from .publication_consistency_verifier import (
 )
 from .publication_fault_producer import produce_product_publication_fault_evidence
 from .publication_fault_verifier import verify_publication_fault_raw_evidence
+from .qualification_directory_binding import bind_qualification_directory
 from .qualification_production_types import (
     QualificationExternalEvidence,
     QualificationProducerContext,
@@ -81,7 +82,9 @@ def prepare_qualification_producer(
     }
     qualification_env = dict(env)
     qualification_env.pop("CODESTORY_CLI", None)
-    qualification_env["CODESTORY_EMBED_QUALIFICATION_DIR"] = str(private_root.resolve())
+    # Nothing is resident on this directory yet, so the initial bind is the one
+    # binding that needs no server replacement. Every later move is a rebind.
+    bind_qualification_directory(qualification_env, private_root)
     qualification_env["CODESTORY_EMBED_QUALIFICATION_NONCE"] = nonce
     qualification_env["CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256"] = archive_sha256
     server_cleanup_control.update(

--- a/.github/scripts/packaged_agent_proof/self_test.py
+++ b/.github/scripts/packaged_agent_proof/self_test.py
@@ -10,6 +10,9 @@ from .self_test_marketplace_delivery import run_marketplace_delivery_self_tests
 from .self_test_process import run_process_self_tests
 from .self_test_producer_liveness import run_producer_liveness_self_tests
 from .self_test_qualification import run_qualification_self_tests
+from .self_test_qualification_directory import (
+    run_qualification_directory_self_tests,
+)
 from .self_test_server_idle import run_idle_boundary_self_tests
 
 
@@ -21,6 +24,7 @@ def self_test() -> None:
     run_producer_liveness_self_tests()
     run_idle_boundary_self_tests()
     run_qualification_self_tests()
+    run_qualification_directory_self_tests()
     run_installation_self_tests()
     run_marketplace_delivery_self_tests()
     run_managed_layout_self_tests()

--- a/.github/scripts/packaged_agent_proof/self_test_qualification_directory.py
+++ b/.github/scripts/packaged_agent_proof/self_test_qualification_directory.py
@@ -1,0 +1,704 @@
+"""Regression for the qualification directory a resident server is bound to.
+
+Proof run 30600248269 died as
+``embedding_qualification_control_event_timeout:crash_server`` on the Windows
+cell after real Vulkan execution had already passed. The cause was not the
+product: publication-fault production left a replacement server polling
+``qualification-suite``, the measurement producer rebound
+``CODESTORY_EMBED_QUALIFICATION_DIR`` to ``qualification-suite/artifacts``
+without replacing that server, and every later control was written into a
+directory nothing was polling.
+
+The tests here reproduce that parent/child mismatch deterministically, without
+building or running the packaged product: a stub CLI that hands back whichever
+server is already resident -- exactly the singleton behaviour that makes the
+defect possible -- and a stub server bound for life to the directory it was
+started with. In ``exits`` mode the crash control replaces it and the rebind
+succeeds. In ``survives`` mode the parent-directory server outlives the crash,
+which is the restored defect, and the rebind must fail by name in seconds
+rather than spend a proof budget on an unattributed timeout.
+
+Everything here is portable to a Windows-native runner: no POSIX-only
+primitive, no signals, no fork, and a total cost measured in seconds.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from . import qualification_producer_runner
+from .foundation import (
+    EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION,
+    REPOSITORY_ROOT,
+    ProofFailure,
+    require,
+)
+from .publication_protocol import read_jsonl
+from .qualification_directory_binding import (
+    QUALIFICATION_DIRECTORY_ENV,
+    QUALIFICATION_DIRECTORY_MISMATCH,
+    bind_qualification_directory,
+    bound_qualification_directory,
+    rebind_qualification_directory,
+)
+
+_NONCE = "self-test-rebind-nonce"
+_LABEL = "rebind-self-test"
+_EXECUTABLE_SHA256 = "a" * 64
+# Long enough that nothing here is bounded by it, short enough that a defect
+# that ignores the named check still cannot hang a `--self-test` run.
+_PROOF_BUDGET_SECS = 60
+# The rebind pays one settling window plus two stub worker invocations. A
+# failure that takes longer than this is the anonymous timeout this lane exists
+# to replace, whatever its message says.
+_NAMED_FAILURE_BUDGET_SECS = 20
+# The publication fault run owns sequences 1..3 on the parent directory, and a
+# server refuses a sequence it has already recorded, so the replacement control
+# has to continue that log rather than restart it.
+_PUBLICATION_FAULT_SEQUENCES = (1, 2, 3)
+
+# A server bound for life to the directory it was started with, like the
+# product: it polls that one directory for commands and appends its events
+# there. `survives` is the restored defect -- it answers the crash control and
+# keeps running, still polling the parent directory.
+_SERVER_STUB = '''\
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+directory = Path(sys.argv[1])
+nonce = sys.argv[2]
+state = Path(sys.argv[3])
+mode = sys.argv[4]
+command_path = directory / (nonce + ".command.json")
+events_path = directory / (nonce + ".events.jsonl")
+answered = set()
+deadline = time.monotonic() + 120
+while time.monotonic() < deadline:
+    try:
+        command = json.loads(command_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        time.sleep(0.01)
+        continue
+    sequence = command.get("sequence")
+    action = command.get("action")
+    if sequence in answered:
+        time.sleep(0.01)
+        continue
+    answered.add(sequence)
+    with open(events_path, "a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "sequence": sequence,
+                    "action": action,
+                    "status": "accepted" if action == "crash_server" else "completed",
+                    "snapshot": None,
+                },
+                sort_keys=True,
+            )
+            + "\\n"
+        )
+    if action == "crash_server" and mode == "exits":
+        break
+    time.sleep(0.01)
+try:
+    if json.loads(state.read_text(encoding="utf-8")).get("pid") == os.getpid():
+        state.unlink()
+except (OSError, ValueError):
+    pass
+'''
+
+# A stand-in for `codestory-cli internal-embedding-qualification-worker` with
+# the two clauses that decide this lane: the worker's request and output must
+# be direct children of the bound qualification directory (worker.rs
+# `validate_direct_child`), and one admitted query is served by whichever
+# server is already resident for this user -- whatever directory that server
+# was bound to. That second clause is the whole defect: the worker cannot move
+# a running server to a new directory, so a rebind that does not replace it
+# strands every control the harness writes afterwards.
+_WORKER_STUB = '''\
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.environ["SELF_TEST_SCRIPTS_ROOT"])
+from packaged_agent_proof.process_identity import (
+    process_start_identity,
+    terminated_process_state,
+)
+
+argv = sys.argv[1:]
+if not argv or argv[0] != "internal-embedding-qualification-worker":
+    sys.stderr.write("unexpected subcommand: " + " ".join(argv) + "\\n")
+    raise SystemExit(2)
+request_path = Path(argv[argv.index("--request") + 1])
+output_path = Path(argv[argv.index("--output") + 1])
+directory = Path(os.environ["CODESTORY_EMBED_QUALIFICATION_DIR"])
+if request_path.parent != directory or output_path.parent != directory:
+    sys.stderr.write("embedding_qualification_worker_directory_mismatch\\n")
+    raise SystemExit(4)
+if output_path.exists():
+    sys.stderr.write("embedding_qualification_output_exists\\n")
+    raise SystemExit(1)
+request = json.loads(request_path.read_text(encoding="utf-8"))
+state = Path(os.environ["SELF_TEST_SERVER_STATE"])
+
+
+def resident():
+    try:
+        recorded = json.loads(state.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    pid = recorded.get("pid")
+    if not isinstance(pid, int):
+        return None
+    if terminated_process_state(pid) is not None:
+        return None
+    try:
+        observed = process_start_identity(pid)
+    except BaseException:
+        return None
+    return recorded if observed == recorded.get("process_start_id") else None
+
+
+server = resident()
+if server is None:
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            os.environ["SELF_TEST_SERVER_SCRIPT"],
+            str(directory),
+            os.environ["CODESTORY_EMBED_QUALIFICATION_NONCE"],
+            str(state),
+            os.environ["SELF_TEST_SERVER_MODE"],
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    server = {
+        "pid": process.pid,
+        "process_start_id": process_start_identity(process.pid),
+        "server_instance_id": "self-test-server-" + str(process.pid),
+        "directory": str(directory),
+    }
+    state.write_text(json.dumps(server, sort_keys=True), encoding="utf-8")
+output_path.write_text(
+    json.dumps(
+        {
+            "schema_version": int(os.environ["SELF_TEST_WORKER_SCHEMA_VERSION"]),
+            "executable_sha256": request["executable_sha256"],
+            "error": None,
+            "result": {
+                "schema_version": 1,
+                "scenario": "query",
+                "operations": [{"status": "ok", "error_code": None}],
+                "final_snapshot": {
+                    "process": {
+                        "pid": server["pid"],
+                        "process_start_id": server["process_start_id"],
+                        "server_instance_id": server["server_instance_id"],
+                    }
+                },
+            },
+        }
+    ),
+    encoding="utf-8",
+)
+'''
+
+
+def _stub_cli(directory: Path, script: Path) -> Path:
+    """The stub as something the harness invokes exactly as it invokes a CLI."""
+    if os.name == "nt":
+        cli = directory / "qualification-stub.cmd"
+        cli.write_text(
+            f'@echo off\r\n"{sys.executable}" "{script}" %*\r\n',
+            encoding="utf-8",
+        )
+        return cli
+    cli = directory / "qualification-stub"
+    # `#!/bin/sh` stays inside every platform's shebang length limit; the
+    # interpreter path, which does not, lives in the body instead.
+    cli.write_text(
+        f'#!/bin/sh\nexec "{sys.executable}" "{script}" "$@"\n',
+        encoding="utf-8",
+    )
+    cli.chmod(0o700)
+    return cli
+
+
+class _Fixture:
+    """A parent qualification directory with a child artifact directory."""
+
+    def __init__(self, root: Path, mode: str) -> None:
+        self.root = root
+        self.private_root = root / "qualification-suite"
+        self.artifact_root = self.private_root / "artifacts"
+        self.private_root.mkdir(mode=0o700)
+        self.artifact_root.mkdir(mode=0o700)
+        self.project = root / "project"
+        self.project.mkdir()
+        binaries = root / "bin"
+        binaries.mkdir()
+        server_script = binaries / "server-stub.py"
+        server_script.write_text(_SERVER_STUB, encoding="utf-8")
+        worker_script = binaries / "worker-stub.py"
+        worker_script.write_text(_WORKER_STUB, encoding="utf-8")
+        self.cli = _stub_cli(binaries, worker_script)
+        self.state = root / "server-state.json"
+        self.control: dict = {}
+        self.env = dict(os.environ)
+        self.env.update(
+            {
+                "SELF_TEST_SCRIPTS_ROOT": str(REPOSITORY_ROOT / ".github" / "scripts"),
+                "SELF_TEST_SERVER_SCRIPT": str(server_script),
+                "SELF_TEST_SERVER_STATE": str(self.state),
+                "SELF_TEST_SERVER_MODE": mode,
+                "SELF_TEST_WORKER_SCHEMA_VERSION": str(
+                    EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION
+                ),
+                "CODESTORY_EMBED_QUALIFICATION_NONCE": _NONCE,
+            }
+        )
+        bind_qualification_directory(
+            self.env,
+            self.private_root,
+            server_cleanup_control=self.control,
+        )
+        self._seed_publication_fault_events()
+
+    def _seed_publication_fault_events(self) -> None:
+        """The three controls the publication fault run already answered here."""
+        with open(
+            self.private_root / f"{_NONCE}.events.jsonl",
+            "a",
+            encoding="utf-8",
+        ) as handle:
+            for sequence in _PUBLICATION_FAULT_SEQUENCES:
+                handle.write(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "sequence": sequence,
+                            "action": "snapshot",
+                            "status": "completed",
+                        },
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+
+    def rebind(self) -> dict:
+        return rebind_qualification_directory(
+            self.artifact_root,
+            cli=self.cli,
+            env=self.env,
+            project=self.project,
+            nonce=_NONCE,
+            executable_sha256=_EXECUTABLE_SHA256,
+            timeout=_PROOF_BUDGET_SECS,
+            server_cleanup_control=self.control,
+            label=_LABEL,
+        )
+
+    def parent_events(self) -> list[dict]:
+        return read_jsonl(self.private_root / f"{_NONCE}.events.jsonl")
+
+    def stop_stub_servers(self) -> None:
+        try:
+            recorded = json.loads(self.state.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return
+        pid = recorded.get("pid")
+        if not isinstance(pid, int):
+            return
+        try:
+            if os.name == "nt":
+                subprocess.run(
+                    ["taskkill", "/PID", str(pid), "/F"],
+                    check=False,
+                    capture_output=True,
+                    timeout=30,
+                )
+            else:
+                os.kill(pid, 9)
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+
+def _fixture(mode: str):
+    class _Scope:
+        def __enter__(self) -> _Fixture:
+            self._temporary = tempfile.TemporaryDirectory(
+                prefix="codestory-qualification-directory-self-test-"
+            )
+            self.fixture = _Fixture(Path(self._temporary.__enter__()), mode)
+            return self.fixture
+
+        def __exit__(self, *error: object) -> None:
+            self.fixture.stop_stub_servers()
+            self._temporary.__exit__(None, None, None)
+
+    return _Scope()
+
+
+def _a_replaced_server_lets_every_producer_move_together() -> None:
+    """The fix: replace the resident server, then move every writer."""
+    with _fixture("exits") as fixture:
+        result = fixture.rebind()
+        target = str(fixture.artifact_root.resolve())
+        previous = str(fixture.private_root.resolve())
+        require(
+            result["rebound"] is True
+            and result["directory"] == target
+            and result["previous_directory"] == previous,
+            "the qualification directory rebind did not report the move it made",
+        )
+        require(
+            bound_qualification_directory(fixture.env) == target
+            and fixture.control["qualification_directory"] == target,
+            "a rebind left a control or event producer on the previous"
+            " qualification directory",
+        )
+        require(
+            result["successor"].identity != result["replaced"].identity,
+            "the server answering the rebound directory is the one the rebind"
+            " was supposed to replace",
+        )
+        events = fixture.parent_events()
+        crash = [event for event in events if event.get("action") == "crash_server"]
+        require(
+            len(crash) == 1
+            and crash[0]["sequence"] == max(_PUBLICATION_FAULT_SEQUENCES) + 1
+            and crash[0]["status"] == "accepted",
+            "the replacement control did not continue the parent directory's"
+            f" own control sequence: {events}",
+        )
+        require(
+            not (fixture.private_root / f"{_NONCE}.command.json").exists(),
+            "the replacement control left its command file behind",
+        )
+        require(
+            (
+                fixture.private_root / f"publication-{_LABEL}-1-worker-output.json"
+            ).is_file(),
+            "the replaced server was established from outside the directory it"
+            " was bound to",
+        )
+        require(
+            (
+                fixture.artifact_root
+                / f"publication-{_LABEL}-successor-worker-output.json"
+            ).is_file(),
+            "the successor server was established from outside the rebound"
+            " directory",
+        )
+
+
+def _a_surviving_parent_directory_server_fails_by_name() -> None:
+    """The restored defect: it must be named, not waited out.
+
+    This is proof run 30600248269 in miniature. The parent-directory server
+    outlives the crash control, so it is still the server every later control
+    would be answered by -- while those controls are written into the child
+    directory it has never polled.
+    """
+    with _fixture("survives") as fixture:
+        started = time.monotonic()
+        try:
+            fixture.rebind()
+        except ProofFailure as error:
+            elapsed = time.monotonic() - started
+            message = str(error)
+            require(
+                elapsed < _NAMED_FAILURE_BUDGET_SECS,
+                "a surviving parent-directory server still cost the proof"
+                f" budget ({elapsed:.1f}s) instead of failing by name",
+            )
+            require(
+                QUALIFICATION_DIRECTORY_MISMATCH in message,
+                f"the directory mismatch was not named: {message}",
+            )
+            require(
+                str(fixture.private_root.resolve()) in message
+                and str(fixture.artifact_root.resolve()) in message,
+                "the directory mismatch did not name the directory the server"
+                f" is bound to and the one the controls move to: {message}",
+            )
+            require(
+                "timed out after" not in message,
+                f"the directory mismatch degraded into a generic timeout: {message}",
+            )
+        else:
+            raise ProofFailure(
+                "a rebind that left a server polling the parent directory was"
+                " accepted, so every later control would be written where"
+                " nothing reads it"
+            )
+
+
+def _rebinding_to_the_bound_directory_replaces_nothing() -> None:
+    """A no-op move must not crash the server the run is about to use."""
+    with _fixture("exits") as fixture:
+        bind_qualification_directory(
+            fixture.env,
+            fixture.artifact_root,
+            server_cleanup_control=fixture.control,
+        )
+        result = fixture.rebind()
+        require(
+            result["rebound"] is False
+            and result["directory"] == str(fixture.artifact_root.resolve()),
+            "a rebind to the already-bound directory reported a move",
+        )
+        require(
+            not fixture.state.exists(),
+            "a no-op rebind started and crashed a server for nothing",
+        )
+
+
+# The two measurements the scenario runner drives through `reset_owner`. If
+# they and the inflight `server_crash` scenario were ever split across two
+# producer invocations, a rebind could sit between them again and only the
+# second half would reach the server.
+_RESET_DRIVEN_METRICS = {"cold_first_vector", "spawn_convergence"}
+
+
+def _the_measurement_reset_and_server_crash_share_one_producer_sequence() -> None:
+    """One rebind, then one producer sequence carrying reset and crash alike."""
+    with tempfile.TemporaryDirectory(
+        prefix="codestory-qualification-sequence-self-test-"
+    ) as raw:
+        artifact_root = Path(raw)
+        context = SimpleNamespace(
+            args=SimpleNamespace(
+                expected_backend="metal",
+                qualification_matrix_cell="protected_macos_arm64_metal",
+                proof_tier="protected_hardware",
+                engine_policy="accelerated",
+                offline=True,
+                timeout_secs=_PROOF_BUDGET_SECS,
+            ),
+            runtime={"identity": {"embedding_backend": "metal"}},
+            manifest={
+                "source": {"commit": "0" * 40, "tree": "0" * 40, "tracked_dirty": False},
+                "asset_target": "macos-arm64",
+            },
+            package={"executable_sha256": _EXECUTABLE_SHA256},
+            contracts={"protocol_sha256": "b" * 64},
+            projects=("/self-test/project-a", "/self-test/project-b"),
+            measurement_contract={
+                "measurement_protocol": {
+                    "required_metrics": sorted(
+                        _RESET_DRIVEN_METRICS | {"true_idle_exit"}
+                    )
+                }
+            },
+            artifact_root=artifact_root,
+            nonce=_NONCE,
+            nonce_sha256="c" * 64,
+            qualification_env={},
+            server_cleanup_control={},
+            qualification_cli=Path("/self-test/cli"),
+            qualification_driver=Path("/self-test/driver"),
+            root=artifact_root,
+        )
+        ordered: list[str] = []
+        requests: list[dict] = []
+
+        def record_rebind(*_args: object, **_keywords: object) -> dict:
+            ordered.append("rebind")
+            return {"rebound": True}
+
+        def record_request(path: Path, payload: dict) -> None:
+            ordered.append("request")
+            requests.append(payload)
+
+        def record_run(*_args: object, **_keywords: object) -> dict:
+            ordered.append("run")
+            return {}
+
+        with (
+            patch.object(
+                qualification_producer_runner,
+                "selected_qualification_matrix_cell",
+                return_value={"cache_state": "reused", "residency_state": "resident"},
+            ),
+            patch.object(
+                qualification_producer_runner,
+                "rebind_qualification_directory",
+                side_effect=record_rebind,
+            ),
+            patch.object(
+                qualification_producer_runner,
+                "write_private_json",
+                side_effect=record_request,
+            ),
+            patch.object(
+                qualification_producer_runner,
+                "run",
+                side_effect=record_run,
+            ),
+            patch.object(
+                qualification_producer_runner,
+                "_validated_qualification_output",
+                return_value={},
+            ),
+        ):
+            qualification_producer_runner.run_qualification_producer(context)
+    require(
+        ordered == ["rebind", "request", "run"],
+        "the qualification producer no longer replaces its server, writes one"
+        f" request, and runs one producer sequence in that order: {ordered}",
+    )
+    require(len(requests) == 1, "the qualification producer wrote more than one request")
+    request = requests[0]
+    require(
+        "server_crash" in request["required_scenarios"]
+        and _RESET_DRIVEN_METRICS <= set(request["required_metrics"]),
+        "the inflight server_crash scenario and the reset-driven measurements no"
+        " longer travel in the same producer sequence, so a directory rebind"
+        " could once again sit between them",
+    )
+
+
+def _call_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    return node.func.attr if isinstance(node.func, ast.Attribute) else None
+
+
+def _is_directory_key(node: ast.expr) -> bool:
+    if isinstance(node, ast.Constant):
+        return node.value == QUALIFICATION_DIRECTORY_ENV
+    if isinstance(node, ast.Name):
+        return node.id == "QUALIFICATION_DIRECTORY_ENV"
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "QUALIFICATION_DIRECTORY_ENV"
+    )
+
+
+def _directory_environment_writes(tree: ast.AST) -> list[int]:
+    lines = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            lines.extend(
+                target.lineno
+                for target in node.targets
+                if isinstance(target, ast.Subscript) and _is_directory_key(target.slice)
+            )
+        elif isinstance(node, ast.Dict):
+            lines.extend(
+                key.lineno
+                for key in node.keys
+                if key is not None and _is_directory_key(key)
+            )
+    return sorted(lines)
+
+
+# Modules allowed to write the qualification directory environment variable,
+# each with the reason it is not the defect this lane closes: every one of them
+# binds an environment for a phase that has no resident server yet. A phase
+# that binds while a server is already resident has to call
+# `rebind_qualification_directory`, which replaces that server first.
+_DIRECTORY_BINDERS = {
+    "qualification_directory_binding.py": "owns binding and server replacement",
+    "installation_support.py": "binds the installed-runtime proof root first",
+    "server_cleanup.py": "rebinds the recorded directory for the cleanup client",
+    "self_test_contract_scope.py": "builds a self-test fixture environment",
+}
+
+
+def _only_the_binding_owner_moves_the_qualification_directory() -> None:
+    """Structural guard: the rebind that stranded the controls cannot come back."""
+    package = REPOSITORY_ROOT / ".github" / "scripts" / "packaged_agent_proof"
+    inspected = 0
+    for source in sorted(package.glob("*.py")):
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        writes = _directory_environment_writes(tree)
+        if not writes:
+            continue
+        inspected += len(writes)
+        require(
+            source.name in _DIRECTORY_BINDERS,
+            f"{source.name}:{writes[0]} binds"
+            f" {QUALIFICATION_DIRECTORY_ENV} directly. A server binds that"
+            " variable once, at start, and polls that one directory for life,"
+            " so a phase that moves it while a server is resident strands every"
+            " control it writes afterwards. Call"
+            " rebind_qualification_directory, which replaces the resident"
+            " server before the writers move",
+        )
+    require(
+        inspected >= len(_DIRECTORY_BINDERS),
+        f"the qualification directory binding audit inspected only {inspected}"
+        " bindings, so it can no longer see the phase that moves them",
+    )
+
+
+def _the_measurement_producer_replaces_its_server_before_rebinding() -> None:
+    """The exact site the Windows qualification cell stranded its controls."""
+    package = REPOSITORY_ROOT / ".github" / "scripts" / "packaged_agent_proof"
+    source = package / "qualification_producer_runner.py"
+    text = source.read_text(encoding="utf-8")
+    require(
+        QUALIFICATION_DIRECTORY_ENV not in text,
+        "qualification_producer_runner.py names the qualification directory"
+        " environment variable again: this producer runs after the"
+        " publication-fault phase has left a server resident on the parent"
+        " directory, so it may only move through rebind_qualification_directory",
+    )
+    tree = ast.parse(text, filename=str(source))
+    producer = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "run_qualification_producer"
+        ),
+        None,
+    )
+    require(
+        producer is not None,
+        "qualification_producer_runner lost its run_qualification_producer owner",
+    )
+    ordered = sorted(
+        (node.lineno, _call_name(node))
+        for node in ast.walk(producer)
+        if isinstance(node, ast.Call)
+        and _call_name(node)
+        in {"rebind_qualification_directory", "write_private_json", "run"}
+    )
+    require(
+        bool(ordered) and ordered[0][1] == "rebind_qualification_directory",
+        "qualification_producer_runner.py writes the scenario runner's request"
+        " or starts it before replacing the server bound to the parent"
+        " qualification directory, which is the ordering that produced"
+        " embedding_qualification_control_event_timeout:crash_server",
+    )
+
+
+def run_qualification_directory_self_tests() -> None:
+    _a_replaced_server_lets_every_producer_move_together()
+    _a_surviving_parent_directory_server_fails_by_name()
+    _rebinding_to_the_bound_directory_replaces_nothing()
+    _the_measurement_reset_and_server_crash_share_one_producer_sequence()
+    _only_the_binding_owner_moves_the_qualification_directory()
+    _the_measurement_producer_replaces_its_server_before_rebinding()

--- a/.github/workflows/source-proof.yml
+++ b/.github/workflows/source-proof.yml
@@ -767,6 +767,24 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.ref }}
 
+      - name: Prove the Windows-native qualification harness contracts
+        shell: pwsh
+        run: |
+          $started = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          python .github/scripts/check-packaged-agent-proof.py --self-test
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows-native qualification harness contracts failed with exit code $LASTEXITCODE"
+          }
+          $elapsed = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() - $started
+          if ($elapsed -lt 0) {
+            throw "Windows-native qualification harness timing was negative"
+          }
+          if ($elapsed -ge 90000) {
+            throw "Windows-native qualification harness contracts took ${elapsed} ms, past their 90000 ms budget: the qualification directory regression has to stay reproducible without rebuilding the package"
+          }
+          "- Windows-native qualification harness contracts: ${elapsed} ms" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
       - name: Install Rust stable
         shell: pwsh
         run: |

--- a/docs/testing/per-user-embedding-server-qualification.md
+++ b/docs/testing/per-user-embedding-server-qualification.md
@@ -95,6 +95,17 @@ endpoint namespace and enables deterministic fault controls; it is absent from
 public help and ordinary product APIs. Raw nonce values and project paths are
 not retained.
 
+A server reads that directory once, at start, and polls only that directory for
+the rest of its life. Moving the variable while a server is resident therefore
+moves the writers alone and strands every control the harness writes afterwards,
+so the harness binds it through
+`packaged_agent_proof.qualification_directory_binding`: the publication-fault
+phase's server is replaced before the measurement producer moves to the artifact
+directory, and the move then proves by exact process identity that a different
+server answers there. A surviving parent-directory server fails as
+`embedding_qualification_control_directory_mismatch` rather than as a control
+event timeout.
+
 Each passing record contains:
 
 - exact source/tree, archive, executable, package target, protocol, constants,


### PR DESCRIPTION
Closes #1707.

Repairs the qualification-harness race retained on #1634 (run 30600248269): a single owner (`qualification_directory_binding.py`) binds every control/event producer to one authenticated qualification directory, and the parent-directory server is *replaced* before writers move rather than rebound underneath a resident process. The control sequence is derived from the log rather than hardcoded.

## Review

Independently reviewed against the contract before opening: verdict **merge with follow-up**. Both Done-when lines delivered. The one flagged risk that survived adversarial verification was downgraded to minor (the 90-second budget is enforced as a failure message, not a ratchet — it can be raised without tripping policy); a second flag (unpinned `python` on the new Windows step) was refuted on re-examination. Remaining items are minor/note-level and tracked as follow-ups, not merge blockers.

Workflow touch is mirrored: `.github/workflows/source-proof.yml` gains one step in `windows-native-contracts` and `check-workflow-policy.mjs` updates that job's pinned shape in the same commit. Version surfaces untouched.

Note: #1634 stays open — its remaining Done-when line needs a dispatched Windows qualification run on the frozen candidate, which no source package may dispatch.

## Proof

7 tests. Workflow policy checker and its test file pass on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)