### PR TITLE
[v0.17 RUN-C] Bound locks, cancellation, and embedding exchanges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,10 +580,12 @@ version = "0.16.3"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
+ "fs4",
  "serde",
  "serde_json",
  "serde_with",
  "specta",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -635,6 +637,7 @@ dependencies = [
 name = "codestory-llama-sys"
 version = "0.16.3"
 dependencies = [
+ "codestory-contracts",
  "crossbeam-channel",
  "fs4",
  "llama-cpp-2",
@@ -657,7 +660,6 @@ dependencies = [
  "codestory-store",
  "codestory-workspace",
  "directories",
- "fs4",
  "libc",
  "rusqlite",
  "serde",
@@ -702,7 +704,6 @@ version = "0.16.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
- "fs4",
  "parking_lot",
  "rusqlite",
  "serde",
@@ -719,7 +720,6 @@ version = "0.16.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
- "fs4",
  "fs_at",
  "gix",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,6 @@ version = "0.16.3"
 dependencies = [
  "codestory-contracts",
  "crossbeam-channel",
- "fs4",
  "llama-cpp-2",
  "llama-cpp-sys-2",
  "serde_json",
@@ -683,7 +682,6 @@ dependencies = [
  "codestory-store",
  "codestory-workspace",
  "crossbeam-channel",
- "fs4",
  "nucleo-matcher",
  "parking_lot",
  "rayon",

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -25,7 +25,6 @@ codestory-runtime = { workspace = true }
 codestory-workspace = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-fs4 = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -60,6 +59,9 @@ windows-sys = { workspace = true, features = [
 
 [dev-dependencies]
 codestory-workspace = { workspace = true, features = ["test-support"] }
+# Integration tests hold raw advisory locks to build hostile fixtures;
+# production CLI source takes them through codestory_contracts::bounded_locks.
+fs4 = { workspace = true }
 codestory-retrieval = { workspace = true, features = ["test-support"] }
 codestory-runtime = { workspace = true, features = ["test-support"] }
 rusqlite = { workspace = true }

--- a/crates/codestory-cli/src/diagnostics.rs
+++ b/crates/codestory-cli/src/diagnostics.rs
@@ -7,7 +7,7 @@
 //! launcher.
 
 use anyhow::{Context, Result, bail};
-use fs4::fs_std::FileExt;
+use codestory_contracts::bounded_locks::{self, FileLockKind};
 use serde_json::{Map, Value, json};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
@@ -55,6 +55,18 @@ pub(crate) fn install_process_diagnostics() {
         let _ = Registry::default().with(layer).try_init();
     }
     install_panic_hook();
+    install_activation_fail_stop_hook();
+}
+
+/// A cancelled activation worker that never reaches a quiescent boundary may
+/// still hold a publication or store lock. Detaching it and serving on would
+/// let owned mutation continue behind an evicted context, so the hosting
+/// process records evidence and stops.
+fn install_activation_fail_stop_hook() {
+    codestory_runtime::set_activation_fail_stop_hook(Some(Arc::new(|reason_code: &str| {
+        record_fail_stop(reason_code);
+        std::process::abort();
+    })));
 }
 
 pub(crate) fn record_command_failure(error: &anyhow::Error) {
@@ -236,11 +248,13 @@ impl DiagnosticSink {
         ensure_private_directory(&directory)?;
         let lock_path = directory.join(LOCK_FILE);
         let lock = open_private_file(&lock_path, false, false)?;
-        if !FileExt::try_lock_exclusive(&lock).context("lock diagnostic log")? {
+        if !bounded_locks::try_acquire(&lock, FileLockKind::Exclusive)
+            .context("lock diagnostic log")?
+        {
             return self.append_emergency_line(encoded);
         }
         let result = self.append_locked_line(encoded);
-        let _ = FileExt::unlock(&lock);
+        let _ = bounded_locks::release(&lock);
         result
     }
 
@@ -298,7 +312,7 @@ fn write_bounded_slot(
     let slot_lock_path = directory.join(format!(".{stem}-{slot:02}.lock"));
     refuse_symlink(&slot_lock_path)?;
     let slot_lock = open_private_file(&slot_lock_path, false, false)?;
-    if !FileExt::try_lock_exclusive(&slot_lock)
+    if !bounded_locks::try_acquire(&slot_lock, FileLockKind::Exclusive)
         .with_context(|| format!("lock bounded {stem} evidence slot"))?
     {
         bail!("bounded {stem} evidence slot is busy");
@@ -318,7 +332,7 @@ fn write_bounded_slot(
         sync_directory(directory)?;
         Ok(destination)
     })();
-    let _ = FileExt::unlock(&slot_lock);
+    let _ = bounded_locks::release(&slot_lock);
     result
 }
 
@@ -467,7 +481,9 @@ fn bounded_text(value: &str) -> String {
 
 fn safe_reason_code(value: &str) -> String {
     match value {
-        "embedding_engine_stalled" | "embedding_qualification_crash" => value.to_string(),
+        "embedding_engine_stalled"
+        | "embedding_qualification_crash"
+        | codestory_runtime::ACTIVATION_QUIESCENCE_FAIL_STOP => value.to_string(),
         _ => "unknown_fail_stop".into(),
     }
 }
@@ -802,7 +818,12 @@ mod tests {
         ensure_private_directory(&sink.diagnostics_dir())?;
         let lock_path = sink.diagnostics_dir().join(LOCK_FILE);
         let lock = open_private_file(&lock_path, false, false)?;
-        FileExt::lock_exclusive(&lock)?;
+        bounded_locks::acquire_with_deadline(
+            &lock,
+            FileLockKind::Exclusive,
+            bounded_locks::LockDeadline::immediate(),
+            None,
+        )?;
         for index in 0..(EMERGENCY_LOG_SLOTS * 3) {
             sink.write_record(json!({
                 "event": "lock_contention",
@@ -810,7 +831,7 @@ mod tests {
                 "index": index,
             }))?;
         }
-        FileExt::unlock(&lock)?;
+        bounded_locks::release(&lock)?;
 
         let files = evidence_files(&sink.diagnostics_dir(), "emergency-", ".jsonl")?;
         assert!(files.len() <= EMERGENCY_LOG_SLOTS);
@@ -849,6 +870,10 @@ mod tests {
             "embedding_qualification_crash"
         );
         assert_eq!(
+            safe_reason_code(codestory_runtime::ACTIVATION_QUIESCENCE_FAIL_STOP),
+            "activation_quiescence_timeout"
+        );
+        assert_eq!(
             safe_reason_code("unlabeled_private_query"),
             "unknown_fail_stop"
         );
@@ -859,7 +884,12 @@ mod tests {
         let directory = tempfile::tempdir()?;
         let lock_path = directory.path().join(".emergency-00.lock");
         let lock = open_private_file(&lock_path, false, false)?;
-        FileExt::lock_exclusive(&lock)?;
+        bounded_locks::acquire_with_deadline(
+            &lock,
+            FileLockKind::Exclusive,
+            bounded_locks::LockDeadline::immediate(),
+            None,
+        )?;
 
         let error = write_bounded_slot(
             directory.path(),
@@ -872,7 +902,7 @@ mod tests {
         assert!(error.to_string().contains("slot is busy"));
         assert!(!directory.path().join("emergency-00.jsonl").exists());
         assert!(!directory.path().join(".emergency-00.tmp").exists());
-        FileExt::unlock(&lock)?;
+        bounded_locks::release(&lock)?;
         Ok(())
     }
 

--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -549,6 +549,8 @@ fn acquire_local_refresh_state_guard(cache_root: &Path) -> Result<LocalRefreshSt
     fs::create_dir_all(cache_root)?;
     let path = cache_root.join(LOCAL_REFRESH_STATE_GUARD_FILE);
     let file = open_local_refresh_state_guard_file(&path)?;
+    // The critical section is one read-modify-write of the state file, never a
+    // publication, so the foreground budget is the matching one.
     acquire_with_deadline(
         &file,
         FileLockKind::Exclusive,

--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use fs4::fs_std::FileExt;
+use codestory_contracts::bounded_locks::{
+    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, acquire_with_deadline,
+};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
 use std::io::ErrorKind;
@@ -91,7 +93,7 @@ struct LocalRefreshStateGuard {
 
 impl Drop for LocalRefreshStateGuard {
     fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.file);
+        let _ = bounded_locks::release(&self.file);
     }
 }
 
@@ -547,7 +549,12 @@ fn acquire_local_refresh_state_guard(cache_root: &Path) -> Result<LocalRefreshSt
     fs::create_dir_all(cache_root)?;
     let path = cache_root.join(LOCAL_REFRESH_STATE_GUARD_FILE);
     let file = open_local_refresh_state_guard_file(&path)?;
-    FileExt::lock_exclusive(&file)?;
+    acquire_with_deadline(
+        &file,
+        FileLockKind::Exclusive,
+        LockDeadline::after(DEFAULT_LOCK_WAIT),
+        None,
+    )?;
     anyhow::ensure!(
         locked_guard_path_matches(&file, &path),
         "local refresh state guard was replaced at {}",
@@ -1044,10 +1051,19 @@ mod tests {
                 .send(())
                 .expect("announce replacement lock attempt");
             contention_tx
-                .send(FileExt::try_lock_exclusive(&guard_file).expect("try replacement guard"))
+                .send(
+                    bounded_locks::try_acquire(&guard_file, FileLockKind::Exclusive)
+                        .expect("try replacement guard"),
+                )
                 .expect("report replacement contention");
             retry_rx.recv().expect("retry replacement guard");
-            FileExt::lock_exclusive(&guard_file).expect("acquire replacement guard");
+            acquire_with_deadline(
+                &guard_file,
+                FileLockKind::Exclusive,
+                LockDeadline::after(DEFAULT_LOCK_WAIT),
+                None,
+            )
+            .expect("acquire replacement guard");
             let replacement_token = "replacement-owner".to_string();
             crate::file_state::write_json_atomic(
                 &local_refresh_lock_path(&replacement_cache),
@@ -1079,7 +1095,7 @@ mod tests {
                 },
             )
             .expect("replacement terminal status");
-            FileExt::unlock(&guard_file).expect("unlock replacement guard");
+            bounded_locks::release(&guard_file).expect("unlock replacement guard");
         });
         replacement_attempt_rx
             .recv()

--- a/crates/codestory-cli/src/native_launcher.rs
+++ b/crates/codestory-cli/src/native_launcher.rs
@@ -1,4 +1,4 @@
-use fs4::fs_std::FileExt;
+use codestory_contracts::bounded_locks::{FileLockKind, LockDeadline, acquire_with_deadline};
 use sha2::{Digest, Sha256};
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
@@ -6,6 +6,7 @@ use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use crate::native_runtime_layout::{
     NATIVE_RUNTIME_CURRENT_FILE, NATIVE_RUNTIME_EXECUTABLE, NATIVE_RUNTIME_FILE_LIST,
@@ -14,6 +15,10 @@ use crate::native_runtime_layout::{
 };
 
 const STAGING_LOCK: &str = ".codestory-native-staging.lock";
+/// A sibling launcher that is staging a generation copies and verifies the
+/// whole runtime tree, so this budget is generous; it exists so a wedged
+/// staging process can never hold a new launcher for the session's lifetime.
+const STAGING_LOCK_WAIT: Duration = Duration::from_secs(120);
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) fn run() -> ExitCode {
@@ -81,7 +86,13 @@ fn prepare_runtime_at(root: &Path) -> io::Result<PathBuf> {
         .truncate(false)
         .open(root.join(STAGING_LOCK))
         .map_err(|error| staging_lock_error(root, error))?;
-    FileExt::lock_exclusive(&lock)?;
+    acquire_with_deadline(
+        &lock,
+        FileLockKind::Exclusive,
+        LockDeadline::after(STAGING_LOCK_WAIT),
+        None,
+    )
+    .map_err(|error| io::Error::other(error.to_string()))?;
 
     let seed_id = runtime_seed_id(&candidate)?;
     let seed_dir = root.join(NATIVE_RUNTIME_SEEDS_DIR).join(&seed_id);

--- a/crates/codestory-cli/src/native_launcher.rs
+++ b/crates/codestory-cli/src/native_launcher.rs
@@ -1,4 +1,6 @@
-use codestory_contracts::bounded_locks::{FileLockKind, LockDeadline, acquire_with_deadline};
+use codestory_contracts::bounded_locks::{
+    FileLockKind, LockDeadline, PUBLICATION_LOCK_WAIT, acquire_with_deadline,
+};
 use sha2::{Digest, Sha256};
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
@@ -16,9 +18,15 @@ use crate::native_runtime_layout::{
 
 const STAGING_LOCK: &str = ".codestory-native-staging.lock";
 /// A sibling launcher that is staging a generation copies and verifies the
-/// whole runtime tree, so this budget is generous; it exists so a wedged
-/// staging process can never hold a new launcher for the session's lifetime.
-const STAGING_LOCK_WAIT: Duration = Duration::from_secs(120);
+/// whole runtime tree, which is the same publication-class hold every other
+/// long budget names. It exists so a wedged staging process can never hold a
+/// new launcher for the session's lifetime.
+///
+/// This wait runs before the runtime exists, so it has no cancellation flag to
+/// inherit and is uninterruptible for its whole budget. That is sound only
+/// because no thread here is joined against a quiescence budget: the launcher
+/// process has no activation worker and installs no fail-stop hook.
+const STAGING_LOCK_WAIT: Duration = PUBLICATION_LOCK_WAIT;
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) fn run() -> ExitCode {

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -479,6 +479,73 @@ fn production_source_never_spawns_git() {
 }
 
 #[test]
+fn advisory_file_locks_have_exactly_one_bounded_entry_point() {
+    // A blocking `flock` observes neither a deadline nor a cancellation flag,
+    // so a stalled sibling could hold an unrelated request, an eviction, or
+    // shutdown for as long as it liked. Acquisition lives behind one bounded
+    // module; nothing else in production source may reach `fs4` directly.
+    let owner = repo_root().join("crates/codestory-contracts/src/bounded_locks.rs");
+    let mut files = Vec::new();
+    collect_rs_files(&repo_root().join("crates"), &mut files);
+    files.sort();
+    let mut violations = Vec::new();
+    for path in files {
+        if !path
+            .components()
+            .any(|component| component.as_os_str() == "src")
+            || path == owner
+        {
+            continue;
+        }
+        let source = fs::read_to_string(&path).expect("read Rust source");
+        // Inline test modules may still drive raw locks to build fixtures;
+        // production code above the trailing test module may not.
+        let production = source
+            .split("\n#[cfg(test)]\n")
+            .next()
+            .expect("split returns at least the full source");
+        if production.contains("fs4::") {
+            violations.push(path.display().to_string());
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "advisory locks must be taken through codestory_contracts::bounded_locks:\n{}",
+        violations.join("\n")
+    );
+
+    let bounded = read("crates/codestory-contracts/src/bounded_locks.rs");
+    assert!(
+        bounded.contains("pub fn acquire_with_deadline(")
+            && bounded.contains("deadline: LockDeadline")
+            && bounded.contains("cancel: Option<&AtomicBool>"),
+        "the bounded entry point must take an absolute deadline and a cancellation flag"
+    );
+    for blocking in ["FileExt::lock_exclusive", "FileExt::lock_shared"] {
+        assert!(
+            !bounded.contains(blocking),
+            "the bounded entry point must never call the uninterruptible {blocking}"
+        );
+    }
+}
+
+#[test]
+fn evicting_a_context_never_detaches_an_unquiesced_activation_worker() {
+    let services = read("crates/codestory-runtime/src/services.rs");
+    assert!(
+        services.contains("pub fn cancel_and_wait_within(&self, budget: Duration)")
+            && services.contains("ActivationQuiescence::FailStopRequired")
+            && services.contains("run_activation_fail_stop(ACTIVATION_QUIESCENCE_FAIL_STOP)"),
+        "eviction must join with a deadline and fail-stop instead of detaching a worker that may hold a publication or store lock"
+    );
+    let diagnostics = read("crates/codestory-cli/src/diagnostics.rs");
+    assert!(
+        diagnostics.contains("set_activation_fail_stop_hook"),
+        "the hosting binary must install the activation fail-stop evidence path"
+    );
+}
+
+#[test]
 fn web_cockpit_stays_deferred_until_browser_surface_gate_opens() {
     let cli_args = read("crates/codestory-cli/src/args.rs");
     let http_transport = read("crates/codestory-cli/src/http_transport.rs");

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -84,6 +84,55 @@ fn production_source_prefix(source: &str) -> &str {
         .map_or(source, |(production, _)| production)
 }
 
+/// Everything in `source` that a release build actually compiles: every
+/// top-level `#[cfg(test)]` item is removed, wherever in the file it sits.
+///
+/// The shape this replaces was `source.split("\n#[cfg(test)]\n").next()`, which
+/// keeps only the text before the *first* gate. A single `#[cfg(test)] use ..;`
+/// in a file's import block therefore exempted the entire rest of that file
+/// from every contract built on the helper — including
+/// `crates/codestory-runtime/src/search/engine.rs` (gate on line 2),
+/// `crates/codestory-runtime/src/index_commit.rs` (line 3),
+/// `crates/codestory-store/src/storage_impl/mod.rs` (line 12), and
+/// `crates/codestory-runtime/src/lib.rs` (line 41), which between them hold the
+/// biggest lock and owned-artifact call sites in the tree.
+///
+/// `#[cfg(any(test, feature = "test-support"))]` is deliberately *not* stripped:
+/// that gate compiles into a release build whenever the feature is on, so its
+/// body is production code.
+fn production_source(source: &str) -> String {
+    let mut kept = String::with_capacity(source.len());
+    let mut lines = source.lines();
+    while let Some(line) = lines.next() {
+        if line.trim_end() == "#[cfg(test)]" {
+            skip_gated_item(&mut lines);
+            continue;
+        }
+        kept.push_str(line);
+        kept.push('\n');
+    }
+    kept
+}
+
+/// Consume the item a top-level `#[cfg(test)]` gates. Rustfmt guarantees the
+/// two shapes that matter: a block item closes with a column-zero `}` or `};`,
+/// and a statement item ends at the first line closing with `;`.
+fn skip_gated_item<'a>(lines: &mut impl Iterator<Item = &'a str>) {
+    let mut opened_block = false;
+    for line in lines {
+        if line.starts_with('}') {
+            return;
+        }
+        if line.contains('{') {
+            opened_block = true;
+            continue;
+        }
+        if !opened_block && line.trim_end().ends_with(';') {
+            return;
+        }
+    }
+}
+
 fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
     let start_index = source.find(start).expect("start marker exists");
     let tail = &source[start_index..];
@@ -489,22 +538,23 @@ fn advisory_file_locks_have_exactly_one_bounded_entry_point() {
     collect_rs_files(&repo_root().join("crates"), &mut files);
     files.sort();
     let mut violations = Vec::new();
+    let mut scanned = 0_usize;
     for path in files {
-        if !path
+        // Everything a crate ships or builds with is in scope: `src`, build
+        // scripts at the crate root, and modules they include. Only integration
+        // test targets, which exist to build hostile fixtures, are exempt.
+        if path
             .components()
-            .any(|component| component.as_os_str() == "src")
+            .any(|component| component.as_os_str() == "tests")
             || path == owner
         {
             continue;
         }
+        scanned += 1;
         let source = fs::read_to_string(&path).expect("read Rust source");
-        // Inline test modules may still drive raw locks to build fixtures;
-        // production code above the trailing test module may not.
-        let production = source
-            .split("\n#[cfg(test)]\n")
-            .next()
-            .expect("split returns at least the full source");
-        if production.contains("fs4::") {
+        // Inline `#[cfg(test)]` items may still drive raw locks to build
+        // fixtures; nothing a release build compiles may.
+        if production_source(&source).contains("fs4::") {
             violations.push(path.display().to_string());
         }
     }
@@ -512,6 +562,10 @@ fn advisory_file_locks_have_exactly_one_bounded_entry_point() {
         violations.is_empty(),
         "advisory locks must be taken through codestory_contracts::bounded_locks:\n{}",
         violations.join("\n")
+    );
+    assert!(
+        scanned > 100,
+        "the fs4 gate scanned only {scanned} files; its file filter has stopped matching"
     );
 
     let bounded = read("crates/codestory-contracts/src/bounded_locks.rs");
@@ -521,12 +575,158 @@ fn advisory_file_locks_have_exactly_one_bounded_entry_point() {
             && bounded.contains("cancel: Option<&AtomicBool>"),
         "the bounded entry point must take an absolute deadline and a cancellation flag"
     );
+    assert!(
+        bounded.contains("let cancel = cancel.or(inherited.as_deref());"),
+        "a call site with no flag of its own must inherit the thread's cancellation"
+    );
     for blocking in ["FileExt::lock_exclusive", "FileExt::lock_shared"] {
         assert!(
             !bounded.contains(blocking),
             "the bounded entry point must never call the uninterruptible {blocking}"
         );
     }
+}
+
+/// The helper above is the whole reason the fs4 and owned-artifact gates see
+/// anything at all, so it is proven directly rather than trusted.
+#[test]
+fn the_production_source_helper_strips_every_test_gate_not_just_the_first() {
+    let gate_in_the_import_block = "\
+use std::fs::File;
+#[cfg(test)]
+use std::sync::Arc;
+
+fn production() {
+    real_call();
+}
+
+#[cfg(test)]
+mod tests {
+    fn fixture() {
+        gated_call();
+    }
+}
+";
+    let production = production_source(gate_in_the_import_block);
+    assert!(
+        production.contains("real_call()"),
+        "production code must survive the strip: {production}"
+    );
+    assert!(
+        !production.contains("use std::sync::Arc;"),
+        "a gated use statement must be stripped: {production}"
+    );
+    assert!(
+        !production.contains("gated_call()"),
+        "a gated module after an earlier gate must still be stripped: {production}"
+    );
+
+    let feature_gated = "\
+#[cfg(any(test, feature = \"test-support\"))]
+pub fn shipped_with_the_feature() {
+    real_call();
+}
+";
+    assert!(
+        production_source(feature_gated).contains("real_call()"),
+        "a feature-reachable gate compiles into a release build and is production code"
+    );
+
+    let multiline_gated_use = "\
+#[cfg(test)]
+use crate::{
+    first, second,
+};
+
+fn production() {
+    real_call();
+}
+";
+    let production = production_source(multiline_gated_use);
+    assert!(!production.contains("first, second"));
+    assert!(production.contains("real_call()"));
+}
+
+/// Every lock a peer holds for a whole publication must be waited on with the
+/// publication budget. `DEFAULT_LOCK_WAIT` is ten seconds — shorter than a
+/// legitimate commit — so pointing one of these at it converts ordinary
+/// contention into a hard failure for a reader that previously waited.
+#[test]
+fn publication_class_lock_waits_carry_the_publication_budget() {
+    let publication_class = [
+        // The atomic old-or-new promotion.
+        (
+            "crates/codestory-store/src/storage_impl/mod.rs",
+            "fn acquire(path: &Path) -> Result<Self, StorageError> {",
+        ),
+        // The persisted search index publication.
+        (
+            "crates/codestory-runtime/src/search/engine.rs",
+            "fn acquire_with_mode(search_dir: &Path, mode: PersistedSearchIndexLockMode)",
+        ),
+        // The search generation catalog write.
+        (
+            "crates/codestory-runtime/src/search_publication.rs",
+            "acquire_with_deadline(",
+        ),
+        // Sidecar generation publication and retention, both directions.
+        (
+            "crates/codestory-retrieval/src/retention.rs",
+            "pub fn acquire_with_cancel(",
+        ),
+        (
+            "crates/codestory-retrieval/src/retention.rs",
+            "pub fn acquire_shared_with_cancel(",
+        ),
+    ];
+    for (path, marker) in publication_class {
+        let source = read(path);
+        let body = source_between(&source, marker, "\n    }\n");
+        assert!(
+            body.contains("PUBLICATION_LOCK_WAIT"),
+            "{path} waits on a publication-class lock with a budget other than PUBLICATION_LOCK_WAIT:\n{body}"
+        );
+    }
+
+    // A long budget is only safe while it stays interruptible, and the two
+    // constants must not collapse into each other.
+    let bounded = read("crates/codestory-contracts/src/bounded_locks.rs");
+    assert!(
+        bounded.contains("pub const DEFAULT_LOCK_WAIT: Duration = Duration::from_secs(10);")
+            && bounded
+                .contains("pub const PUBLICATION_LOCK_WAIT: Duration = Duration::from_secs(120);"),
+        "the two wait classes must stay distinct and named"
+    );
+}
+
+/// Bounded acquisition replaced a blocking `flock`; it must not also have
+/// changed what callers report. A refusal keeps the surface each site already
+/// had and carries the typed lock code in its message.
+#[test]
+fn bounded_acquisition_did_not_change_public_error_codes() {
+    let publication = read("crates/codestory-runtime/src/search_publication.rs");
+    assert!(
+        !publication.contains("ApiError::new(\n                error.code(),")
+            && !publication.contains("ApiError::new(\n            error.code(),")
+            && !publication.contains("ApiError::new(\n        error.code(),"),
+        "search publication lock refusals must keep reporting `internal`, not promote the lock code to a public API error code"
+    );
+    for context in [
+        "Failed to acquire search generation catalog lock",
+        "Failed to inspect persisted search generation lock",
+        "Failed to lock persisted search generation",
+    ] {
+        assert!(
+            publication.contains(context),
+            "the refusal for {context:?} must survive"
+        );
+    }
+
+    let storage = read("crates/codestory-store/src/storage_impl/mod.rs");
+    assert!(
+        storage.contains("StorageError::Other(format!(\n                \"Failed to acquire promotion lock for {} ({}): {error}\","),
+        "the promotion refusal must stay a StorageError::Other carrying the typed lock code, matching the other sites"
+    );
 }
 
 #[test]
@@ -538,6 +738,29 @@ fn evicting_a_context_never_detaches_an_unquiesced_activation_worker() {
             && services.contains("run_activation_fail_stop(ACTIVATION_QUIESCENCE_FAIL_STOP)"),
         "eviction must join with a deadline and fail-stop instead of detaching a worker that may hold a publication or store lock"
     );
+    // The budget only bounds the worker if the worker's own lock waits can end
+    // on cancellation. Past that budget the CLI hook aborts the process, so a
+    // worker merely waiting behind a peer's publication would kill a healthy
+    // session and blame quiescence for it. Scoped to the worker's body: another
+    // caller installing a scope proves nothing about this thread.
+    let worker_body = source_between(
+        &services,
+        "fn run_activation_worker(",
+        "\nimpl ActivationOperation {",
+    );
+    assert!(
+        worker_body.contains("bounded_locks::with_thread_cancellation(")
+            && worker_body.contains("Arc::clone(&operation.cancelled)"),
+        "run_activation_worker must install the operation's cancellation as the ambient one for every bounded lock wait the worker performs:\n{worker_body}"
+    );
+    assert!(
+        services.contains("ACTIVATION_QUIESCENCE_BUDGET.as_millis()")
+            && services.contains(
+                "codestory_contracts::bounded_locks::MAX_CANCELLATION_LATENCY.as_millis()"
+            ),
+        "the quiescence budget must be asserted against the bounded-lock cancellation latency"
+    );
+
     let diagnostics = read("crates/codestory-cli/src/diagnostics.rs");
     assert!(
         diagnostics.contains("set_activation_fail_stop_hook"),
@@ -872,12 +1095,9 @@ fn owned_artifact_identities_are_declared_only_in_the_registry() {
                 continue;
             }
             let source = fs::read_to_string(&path).expect("read producer source");
-            // Inline test modules pin these names on purpose; production code
-            // above the crate's trailing test module must not spell them.
-            let production = source
-                .split("\n#[cfg(test)]\n")
-                .next()
-                .expect("split returns at least the full source");
+            // Inline test modules pin these names on purpose; nothing a release
+            // build compiles may spell them.
+            let production = production_source(&source);
             for literal in literals {
                 assert!(
                     !production.contains(literal),

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = { workspace = true }
 crossbeam-channel = { workspace = true }
+fs4 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -13,3 +14,6 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 serde_with = { workspace = true }
 specta = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/codestory-contracts/src/bounded_locks.rs
+++ b/crates/codestory-contracts/src/bounded_locks.rs
@@ -11,22 +11,30 @@
 //! This module owns the only `fs4` import in production source; an
 //! architecture contract enforces that.
 
+use std::cell::RefCell;
 use std::fmt;
 use std::fs::File;
 use std::io;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use fs4::fs_std::FileExt;
 
-/// Default wait budget for a lock that guards a routine sibling operation.
-/// Long enough to absorb a peer's publication commit, short enough that a
-/// wedged holder cannot outlive one foreground request.
+/// Default wait budget for a lock whose critical section is a single small
+/// read-modify-write — a state file, a status guard, a diagnostics slot. A
+/// holder that needs longer than this is wedged, not busy.
 pub const DEFAULT_LOCK_WAIT: Duration = Duration::from_secs(10);
 
-/// Wait budget for a lock a peer holds for the length of a whole publication
-/// or cleanup pass. Only background workers wait this long; a foreground
-/// request reaches its own preparing verdict long before.
+/// Wait budget for a lock a peer holds for the length of a whole publication,
+/// promotion, or retention pass. Every waiter that can be behind such a pass
+/// uses this: a legitimate commit routinely outlasts [`DEFAULT_LOCK_WAIT`], so
+/// a shorter budget would turn ordinary contention into a hard failure.
+///
+/// A wait this long is only safe because it is interruptible: the waiter either
+/// passes its own flag or inherits one from [`with_thread_cancellation`], so a
+/// cancelled request, eviction, or shutdown ends it within
+/// [`MAX_CANCELLATION_LATENCY`] instead of the peer's hold.
 pub const PUBLICATION_LOCK_WAIT: Duration = Duration::from_secs(120);
 
 /// First re-poll gap. A concurrently spawned child inherits open descriptors
@@ -37,6 +45,16 @@ const FIRST_POLL_STEP: Duration = Duration::from_millis(2);
 /// Longest gap between re-polls. Bounds wake-ups on a long wait without
 /// letting the observed acquisition lag the real release by much.
 const MAX_POLL_STEP: Duration = Duration::from_millis(25);
+
+/// Longest a bounded acquisition keeps waiting after its cancellation source is
+/// raised. The wait sleeps only in re-poll gaps and re-reads the flag at the
+/// top of every one, so a raised flag is observed within one gap.
+///
+/// This is the whole reason a [`PUBLICATION_LOCK_WAIT`] is not a liveness
+/// hazard: a joiner that cancels a worker and then waits for it to quiesce must
+/// only budget past this, not past the lock's wait budget. Any such joiner is
+/// expected to assert its budget exceeds this constant.
+pub const MAX_CANCELLATION_LATENCY: Duration = MAX_POLL_STEP;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileLockKind {
@@ -157,8 +175,55 @@ impl LockDeadline {
     }
 }
 
+thread_local! {
+    static THREAD_CANCELLATION: RefCell<Option<Arc<AtomicBool>>> = const { RefCell::new(None) };
+}
+
+struct ThreadCancellationGuard {
+    previous: Option<Arc<AtomicBool>>,
+}
+
+impl Drop for ThreadCancellationGuard {
+    fn drop(&mut self) {
+        THREAD_CANCELLATION.with(|active| {
+            active.replace(self.previous.take());
+        });
+    }
+}
+
+/// Run `body` with `cancel` as the ambient cancellation for every bounded lock
+/// acquisition this thread performs, however deep.
+///
+/// A lock wait several crates below the caller has no cancellation flag in its
+/// signature and cannot grow one without a cross-crate cascade, yet it is
+/// exactly where a cancelled worker gets stuck: `PromotionLock`, the search
+/// index and generation-catalog guards, retention, and model materialization
+/// are all reached through APIs that never took a flag. Installing the flag on
+/// the thread reaches all of them, and reaches call sites added later that
+/// nobody remembered to plumb.
+///
+/// An explicit `cancel` argument still wins where a call site has one; this is
+/// the floor, not a replacement.
+pub fn with_thread_cancellation<T>(cancel: Arc<AtomicBool>, body: impl FnOnce() -> T) -> T {
+    let previous = THREAD_CANCELLATION.with(|active| active.replace(Some(cancel)));
+    let _guard = ThreadCancellationGuard { previous };
+    body()
+}
+
+/// The ambient cancellation installed by the innermost
+/// [`with_thread_cancellation`] on this thread, if any.
+pub fn thread_cancellation() -> Option<Arc<AtomicBool>> {
+    THREAD_CANCELLATION.with(|active| active.borrow().clone())
+}
+
 /// Acquire `kind` on `file`, waiting no longer than `deadline` and abandoning
-/// the wait as soon as `cancel` is raised.
+/// the wait as soon as a cancellation source is raised.
+///
+/// The cancellation source is `cancel` when the call site has one, and this
+/// thread's [`with_thread_cancellation`] flag otherwise. A wait with neither is
+/// uninterruptible for its whole budget, so no thread whose quiescence is
+/// joined against a deadline may reach one — see the assertion beside
+/// `ACTIVATION_QUIESCENCE_BUDGET`.
 ///
 /// This is the only blocking-capable lock acquisition in production source.
 /// It never calls `fs4`'s blocking `lock_shared`/`lock_exclusive`: those cannot
@@ -169,6 +234,8 @@ pub fn acquire_with_deadline(
     deadline: LockDeadline,
     cancel: Option<&AtomicBool>,
 ) -> Result<(), FileLockError> {
+    let inherited = cancel.is_none().then(thread_cancellation).flatten();
+    let cancel = cancel.or(inherited.as_deref());
     let started = Instant::now();
     let mut step = FIRST_POLL_STEP;
     loop {
@@ -353,6 +420,99 @@ mod tests {
         .expect("a released lock must be acquired");
         releaser.join().expect("releaser thread");
         release(&waiter).expect("release waiter");
+    }
+
+    /// The realistic shape of the bug this exists to prevent: a call site
+    /// several crates below the cancelling worker passes `None` because its
+    /// signature has no flag. Without ambient inheritance it waits out the
+    /// whole publication budget and the worker is declared unquiesced.
+    #[test]
+    fn a_call_site_with_no_flag_inherits_the_threads_cancellation() {
+        let dir = tempfile::tempdir().expect("lock dir");
+        let holder = lock_file(dir.path());
+        assert!(try_acquire(&holder, FileLockKind::Exclusive).expect("holder locks"));
+        let waiter = lock_file(dir.path());
+        let cancel = Arc::new(AtomicBool::new(false));
+        let raiser = Arc::clone(&cancel);
+        let canceller = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            raiser.store(true, Ordering::Release);
+        });
+
+        let started = Instant::now();
+        let error = with_thread_cancellation(Arc::clone(&cancel), || {
+            // Exactly what a deep call site does today: no flag of its own and
+            // the full publication budget.
+            acquire_with_deadline(
+                &waiter,
+                FileLockKind::Exclusive,
+                LockDeadline::after(PUBLICATION_LOCK_WAIT),
+                None,
+            )
+            .expect_err("an inherited cancellation must end the wait")
+        });
+        let waited = started.elapsed();
+
+        canceller.join().expect("cancellation thread");
+        assert_eq!(error.code(), "lock_wait_cancelled");
+        assert!(
+            waited < Duration::from_secs(5),
+            "the wait ran {waited:?} instead of ending on the inherited flag"
+        );
+        release(&holder).expect("release holder");
+    }
+
+    #[test]
+    fn the_thread_cancellation_scope_is_restored_when_the_body_returns() {
+        let outer = Arc::new(AtomicBool::new(false));
+        let inner = Arc::new(AtomicBool::new(false));
+        assert!(thread_cancellation().is_none());
+        with_thread_cancellation(Arc::clone(&outer), || {
+            assert!(Arc::ptr_eq(
+                &thread_cancellation().expect("outer scope"),
+                &outer
+            ));
+            with_thread_cancellation(Arc::clone(&inner), || {
+                assert!(Arc::ptr_eq(
+                    &thread_cancellation().expect("inner scope"),
+                    &inner
+                ));
+            });
+            assert!(Arc::ptr_eq(
+                &thread_cancellation().expect("outer scope restored"),
+                &outer
+            ));
+        });
+        assert!(thread_cancellation().is_none());
+    }
+
+    /// A joiner that cancels a worker and then waits for it to quiesce budgets
+    /// against this, not against the lock's wait budget. If the re-poll gap
+    /// ever grew past it the published guarantee would be false.
+    #[test]
+    fn a_raised_flag_is_observed_within_the_published_cancellation_latency() {
+        assert_eq!(MAX_CANCELLATION_LATENCY, MAX_POLL_STEP);
+        let dir = tempfile::tempdir().expect("lock dir");
+        let holder = lock_file(dir.path());
+        assert!(try_acquire(&holder, FileLockKind::Exclusive).expect("holder locks"));
+        let waiter = lock_file(dir.path());
+        // Raised before the wait even starts: the very first poll must see it.
+        let cancel = AtomicBool::new(true);
+
+        let started = Instant::now();
+        let error = acquire_with_deadline(
+            &waiter,
+            FileLockKind::Exclusive,
+            LockDeadline::after(PUBLICATION_LOCK_WAIT),
+            Some(&cancel),
+        )
+        .expect_err("an already-raised flag must refuse immediately");
+        assert_eq!(error.code(), "lock_wait_cancelled");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "an already-raised flag must not enter a re-poll gap at all"
+        );
+        release(&holder).expect("release holder");
     }
 
     #[test]

--- a/crates/codestory-contracts/src/bounded_locks.rs
+++ b/crates/codestory-contracts/src/bounded_locks.rs
@@ -1,0 +1,380 @@
+//! The single bounded entry point for advisory file locks.
+//!
+//! Every advisory lock CodeStory takes — publication, promotion, retention,
+//! search generations, diagnostics, model materialization — is acquired here.
+//! A blocking `flock` has no timeout and no cancellation poll, so one stalled
+//! sibling process could hold an unrelated request, an eviction, or shutdown
+//! for as long as it liked. Acquisition therefore always carries an absolute
+//! deadline and an optional cancellation flag, and reports refusal with a
+//! typed code instead of an opaque `io::Error`.
+//!
+//! This module owns the only `fs4` import in production source; an
+//! architecture contract enforces that.
+
+use std::fmt;
+use std::fs::File;
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use fs4::fs_std::FileExt;
+
+/// Default wait budget for a lock that guards a routine sibling operation.
+/// Long enough to absorb a peer's publication commit, short enough that a
+/// wedged holder cannot outlive one foreground request.
+pub const DEFAULT_LOCK_WAIT: Duration = Duration::from_secs(10);
+
+/// Wait budget for a lock a peer holds for the length of a whole publication
+/// or cleanup pass. Only background workers wait this long; a foreground
+/// request reaches its own preparing verdict long before.
+pub const PUBLICATION_LOCK_WAIT: Duration = Duration::from_secs(120);
+
+/// First re-poll gap. A concurrently spawned child inherits open descriptors
+/// until `exec` applies `O_CLOEXEC`, so a ghost conflict clears within
+/// microseconds; starting small keeps that case free.
+const FIRST_POLL_STEP: Duration = Duration::from_millis(2);
+
+/// Longest gap between re-polls. Bounds wake-ups on a long wait without
+/// letting the observed acquisition lag the real release by much.
+const MAX_POLL_STEP: Duration = Duration::from_millis(25);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileLockKind {
+    Shared,
+    Exclusive,
+}
+
+impl FileLockKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Shared => "shared",
+            Self::Exclusive => "exclusive",
+        }
+    }
+}
+
+impl fmt::Display for FileLockKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Why a bounded acquisition did not produce a held lock.
+#[derive(Debug)]
+pub enum FileLockError {
+    /// The wait budget expired while another holder kept the lock.
+    Timeout {
+        kind: FileLockKind,
+        waited: Duration,
+    },
+    /// The caller's cancellation flag was raised while waiting.
+    Cancelled {
+        kind: FileLockKind,
+        waited: Duration,
+    },
+    /// The platform refused the lock operation outright.
+    Unavailable {
+        kind: FileLockKind,
+        source: io::Error,
+    },
+}
+
+impl FileLockError {
+    /// Stable, machine-matchable failure code.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Timeout { .. } => "lock_wait_timeout",
+            Self::Cancelled { .. } => "lock_wait_cancelled",
+            Self::Unavailable { .. } => "lock_unavailable",
+        }
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, Self::Timeout { .. })
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled { .. })
+    }
+}
+
+impl fmt::Display for FileLockError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout { kind, waited } => write!(
+                formatter,
+                "lock_wait_timeout: another holder kept the {kind} lock for the whole {} ms budget",
+                waited.as_millis()
+            ),
+            Self::Cancelled { kind, waited } => write!(
+                formatter,
+                "lock_wait_cancelled: the {kind} lock wait was cancelled after {} ms",
+                waited.as_millis()
+            ),
+            Self::Unavailable { kind, source } => {
+                write!(
+                    formatter,
+                    "lock_unavailable: the {kind} lock could not be taken: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for FileLockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Unavailable { source, .. } => Some(source),
+            Self::Timeout { .. } | Self::Cancelled { .. } => None,
+        }
+    }
+}
+
+/// Absolute point in time by which acquisition must succeed or report refusal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LockDeadline {
+    at: Instant,
+}
+
+impl LockDeadline {
+    pub fn after(budget: Duration) -> Self {
+        Self {
+            // A saturating add keeps an absurd budget from wrapping into an
+            // already-expired deadline.
+            at: Instant::now()
+                .checked_add(budget)
+                .unwrap_or_else(Instant::now),
+        }
+    }
+
+    /// Expires immediately: one non-blocking attempt, no waiting.
+    pub fn immediate() -> Self {
+        Self { at: Instant::now() }
+    }
+
+    fn remaining(&self) -> Duration {
+        self.at.saturating_duration_since(Instant::now())
+    }
+}
+
+/// Acquire `kind` on `file`, waiting no longer than `deadline` and abandoning
+/// the wait as soon as `cancel` is raised.
+///
+/// This is the only blocking-capable lock acquisition in production source.
+/// It never calls `fs4`'s blocking `lock_shared`/`lock_exclusive`: those cannot
+/// observe a deadline or a cancellation flag once they enter the kernel.
+pub fn acquire_with_deadline(
+    file: &File,
+    kind: FileLockKind,
+    deadline: LockDeadline,
+    cancel: Option<&AtomicBool>,
+) -> Result<(), FileLockError> {
+    let started = Instant::now();
+    let mut step = FIRST_POLL_STEP;
+    loop {
+        if cancelled(cancel) {
+            return Err(FileLockError::Cancelled {
+                kind,
+                waited: started.elapsed(),
+            });
+        }
+        if try_acquire(file, kind)? {
+            return Ok(());
+        }
+        let remaining = deadline.remaining();
+        if remaining.is_zero() {
+            return Err(FileLockError::Timeout {
+                kind,
+                waited: started.elapsed(),
+            });
+        }
+        std::thread::sleep(step.min(remaining));
+        step = (step * 2).min(MAX_POLL_STEP);
+    }
+}
+
+/// One non-blocking attempt. Reports contention as `Ok(false)` so callers can
+/// keep their fail-closed "busy" verdicts.
+pub fn try_acquire(file: &File, kind: FileLockKind) -> Result<bool, FileLockError> {
+    let attempt = match kind {
+        FileLockKind::Shared => FileExt::try_lock_shared(file),
+        FileLockKind::Exclusive => FileExt::try_lock_exclusive(file),
+    };
+    match attempt {
+        Ok(acquired) => Ok(acquired),
+        // Some platforms report contention as an error rather than `false`.
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(false),
+        Err(source) => Err(FileLockError::Unavailable { kind, source }),
+    }
+}
+
+/// Release a lock held on `file`.
+pub fn release(file: &File) -> Result<(), FileLockError> {
+    FileExt::unlock(file).map_err(|source| FileLockError::Unavailable {
+        kind: FileLockKind::Exclusive,
+        source,
+    })
+}
+
+/// Convert an exclusive hold into a shared one without a release window on
+/// platforms whose `flock` atomically downgrades.
+pub fn downgrade_to_shared(file: &File, deadline: LockDeadline) -> Result<(), FileLockError> {
+    #[cfg(unix)]
+    {
+        acquire_with_deadline(file, FileLockKind::Shared, deadline, None)
+    }
+    #[cfg(not(unix))]
+    {
+        release(file)?;
+        acquire_with_deadline(file, FileLockKind::Shared, deadline, None)
+    }
+}
+
+fn cancelled(cancel: Option<&AtomicBool>) -> bool {
+    cancel.is_some_and(|flag| flag.load(Ordering::Acquire))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::OpenOptions;
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::thread;
+
+    fn lock_file(dir: &std::path::Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(dir.join("subject.lock"))
+            .expect("open lock file")
+    }
+
+    #[test]
+    fn a_free_lock_is_acquired_immediately() {
+        let dir = tempfile::tempdir().expect("lock dir");
+        let file = lock_file(dir.path());
+        acquire_with_deadline(
+            &file,
+            FileLockKind::Exclusive,
+            LockDeadline::immediate(),
+            None,
+        )
+        .expect("free lock");
+        release(&file).expect("release");
+    }
+
+    #[test]
+    fn a_held_lock_times_out_with_a_typed_code_instead_of_blocking() {
+        let dir = tempfile::tempdir().expect("lock dir");
+        let holder = lock_file(dir.path());
+        assert!(
+            try_acquire(&holder, FileLockKind::Exclusive).expect("holder locks"),
+            "the holder must take the lock first"
+        );
+        let waiter = lock_file(dir.path());
+
+        let started = Instant::now();
+        let error = acquire_with_deadline(
+            &waiter,
+            FileLockKind::Exclusive,
+            LockDeadline::after(Duration::from_millis(120)),
+            None,
+        )
+        .expect_err("a persistently held lock must refuse");
+
+        assert_eq!(error.code(), "lock_wait_timeout");
+        assert!(error.is_timeout());
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "acquisition must return on its own deadline, not the holder's lifetime"
+        );
+        release(&holder).expect("release holder");
+    }
+
+    #[test]
+    fn a_raised_cancel_flag_abandons_the_wait_before_the_deadline() {
+        let dir = tempfile::tempdir().expect("lock dir");
+        let holder = lock_file(dir.path());
+        assert!(try_acquire(&holder, FileLockKind::Exclusive).expect("holder locks"));
+        let waiter = lock_file(dir.path());
+        let cancel = Arc::new(AtomicBool::new(false));
+        let raiser = Arc::clone(&cancel);
+        let (raised, raised_rx) = mpsc::channel();
+        let canceller = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            raiser.store(true, Ordering::Release);
+            raised.send(()).expect("signal cancellation");
+        });
+
+        let started = Instant::now();
+        let error = acquire_with_deadline(
+            &waiter,
+            FileLockKind::Exclusive,
+            // A budget far past the cancellation so only the flag can end the wait.
+            LockDeadline::after(Duration::from_secs(30)),
+            Some(cancel.as_ref()),
+        )
+        .expect_err("a cancelled wait must refuse");
+
+        raised_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("cancellation raised");
+        canceller.join().expect("cancellation thread");
+        assert_eq!(error.code(), "lock_wait_cancelled");
+        assert!(error.is_cancelled());
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "cancellation must end the wait long before the deadline"
+        );
+        release(&holder).expect("release holder");
+    }
+
+    #[test]
+    fn a_briefly_held_lock_is_acquired_within_the_budget() {
+        let dir = tempfile::tempdir().expect("lock dir");
+        let holder = lock_file(dir.path());
+        assert!(try_acquire(&holder, FileLockKind::Exclusive).expect("holder locks"));
+        let waiter = lock_file(dir.path());
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(20));
+            release(&holder).expect("release holder");
+            drop(holder);
+        });
+
+        acquire_with_deadline(
+            &waiter,
+            FileLockKind::Exclusive,
+            LockDeadline::after(Duration::from_secs(30)),
+            None,
+        )
+        .expect("a released lock must be acquired");
+        releaser.join().expect("releaser thread");
+        release(&waiter).expect("release waiter");
+    }
+
+    #[test]
+    fn shared_holders_do_not_exclude_each_other() {
+        let dir = tempfile::tempdir().expect("lock dir");
+        let first = lock_file(dir.path());
+        let second = lock_file(dir.path());
+        acquire_with_deadline(
+            &first,
+            FileLockKind::Shared,
+            LockDeadline::immediate(),
+            None,
+        )
+        .expect("first shared");
+        acquire_with_deadline(
+            &second,
+            FileLockKind::Shared,
+            LockDeadline::immediate(),
+            None,
+        )
+        .expect("second shared");
+        release(&first).expect("release first");
+        release(&second).expect("release second");
+    }
+}

--- a/crates/codestory-contracts/src/lib.rs
+++ b/crates/codestory-contracts/src/lib.rs
@@ -11,6 +11,7 @@
 //! reinterpreting the same contract differently.
 
 pub mod api;
+pub mod bounded_locks;
 pub mod config_registry;
 pub mod events;
 pub mod graph;

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -12,14 +12,13 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]
-fs4 = { workspace = true }
+# The build script stages the native runtime under an advisory lock, and takes
+# it through the same bounded entry point production source uses.
+codestory-contracts = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-# The native staging test target compiles the build-script source directly, so
-# it needs the same raw lock dependency the build script has.
-fs4 = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/codestory-llama-sys/Cargo.toml
+++ b/crates/codestory-llama-sys/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 build = "build.rs"
 
 [dependencies]
+codestory-contracts = { workspace = true }
 crossbeam-channel = { workspace = true }
-fs4 = { workspace = true }
 llama-cpp-sys-2 = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
@@ -17,6 +17,9 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+# The native staging test target compiles the build-script source directly, so
+# it needs the same raw lock dependency the build script has.
+fs4 = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/codestory-llama-sys/native_staging.rs
+++ b/crates/codestory-llama-sys/native_staging.rs
@@ -1,4 +1,6 @@
-use fs4::fs_std::FileExt;
+use codestory_contracts::bounded_locks::{
+    FileLockKind, LockDeadline, PUBLICATION_LOCK_WAIT, acquire_with_deadline,
+};
 use sha2::{Digest, Sha256};
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
@@ -900,7 +902,16 @@ fn acquire_profile_staging_lock(profile_dir: &Path) -> io::Result<File> {
         .create(true)
         .truncate(false)
         .open(profile_dir.join(".codestory-native-staging.lock"))?;
-    FileExt::lock_exclusive(&lock)?;
+    // A sibling build staging the same profile holds this for a full runtime
+    // tree copy and verify. Bounded rather than blocking so a wedged sibling
+    // cannot hang the build forever.
+    acquire_with_deadline(
+        &lock,
+        FileLockKind::Exclusive,
+        LockDeadline::after(PUBLICATION_LOCK_WAIT),
+        None,
+    )
+    .map_err(|error| io::Error::other(error.to_string()))?;
     Ok(lock)
 }
 

--- a/crates/codestory-llama-sys/src/lib.rs
+++ b/crates/codestory-llama-sys/src/lib.rs
@@ -42,10 +42,16 @@ include!(concat!(env!("OUT_DIR"), "/model_contract.rs"));
 include!(concat!(env!("OUT_DIR"), "/embedding_server_contract.rs"));
 
 const ENGINE_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
-/// A peer materializing the embedded model writes and verifies the whole
-/// model file, so this budget is generous; it exists so a wedged peer can
-/// never hold activation open indefinitely.
-const MODEL_MATERIALIZE_LOCK_WAIT: Duration = Duration::from_secs(120);
+/// A peer materializing the embedded model writes and verifies the whole model
+/// file — the same publication-class hold every other long budget names. It
+/// exists so a wedged peer can never hold activation open indefinitely.
+///
+/// The activation worker reaches this through
+/// `ensure_product_embedding_backend_for_runtime`, whose signature carries no
+/// cancellation flag. The wait inherits the worker's flag from
+/// `bounded_locks::with_thread_cancellation` instead, so a cancelled activation
+/// leaves it without waiting out the peer.
+const MODEL_MATERIALIZE_LOCK_WAIT: Duration = bounded_locks::PUBLICATION_LOCK_WAIT;
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static QUALIFICATION_NATIVE_STALL: AtomicBool = AtomicBool::new(false);

--- a/crates/codestory-llama-sys/src/lib.rs
+++ b/crates/codestory-llama-sys/src/lib.rs
@@ -9,8 +9,8 @@ pub use admission::{
 };
 
 use admission::EmbeddingAdmissionTracker;
+use codestory_contracts::bounded_locks::{self, FileLockKind, LockDeadline, acquire_with_deadline};
 use crossbeam_channel::{Receiver, Sender, TryRecvError, after, bounded, select_biased, unbounded};
-use fs4::fs_std::FileExt;
 use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::context::params::{LlamaAttentionType, LlamaContextParams, LlamaPoolingType};
 use llama_cpp_2::llama_backend::LlamaBackend;
@@ -42,6 +42,10 @@ include!(concat!(env!("OUT_DIR"), "/model_contract.rs"));
 include!(concat!(env!("OUT_DIR"), "/embedding_server_contract.rs"));
 
 const ENGINE_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+/// A peer materializing the embedded model writes and verifies the whole
+/// model file, so this budget is generous; it exists so a wedged peer can
+/// never hold activation open indefinitely.
+const MODEL_MATERIALIZE_LOCK_WAIT: Duration = Duration::from_secs(120);
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static QUALIFICATION_NATIVE_STALL: AtomicBool = AtomicBool::new(false);
@@ -1936,9 +1940,16 @@ pub fn materialize_embedded_model(cache_root: &Path) -> Result<MaterializedModel
         .write(true)
         .open(directory.join(".materialize.lock"))
         .map_err(cache_error)?;
-    FileExt::lock_exclusive(&lock).map_err(cache_error)?;
+    acquire_with_deadline(
+        &lock,
+        FileLockKind::Exclusive,
+        LockDeadline::after(MODEL_MATERIALIZE_LOCK_WAIT),
+        None,
+    )
+    .map_err(|error| EngineError::ModelCache(error.to_string()))?;
     let result = materialize_embedded_model_locked(&directory);
-    let unlock = FileExt::unlock(&lock).map_err(cache_error);
+    let unlock =
+        bounded_locks::release(&lock).map_err(|error| EngineError::ModelCache(error.to_string()));
     match (result, unlock) {
         (Ok(reused), Ok(())) => Ok(MaterializedModel {
             path: directory.join(MODEL_FILE_NAME),

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -14,7 +14,6 @@ codestory-llama-sys = { workspace = true }
 codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }
 directories = { workspace = true }
-fs4 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -538,13 +538,22 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
     let project_id = project_identity.artifact_scope_id;
     let workspace_id = project_identity.workspace_id;
     let global_gc_state_file = global_generation_gc_state_file(runtime);
-    let _global_gc_lock = GenerationRetentionLock::acquire_shared(
+    // Both waits can sit behind a sibling's whole publication pass. The
+    // finalize caller's cancellation flag is in scope here, so pass it: a
+    // cancelled activation must leave these waits at once instead of holding
+    // an eviction or shutdown open for the peer's commit.
+    let _global_gc_lock = GenerationRetentionLock::acquire_shared_with_cancel(
         &global_gc_state_file,
         GLOBAL_GENERATION_GC_LOCK_SCOPE,
+        Some(cancelled),
     )
     .context("coordinate sidecar publication with global generation cleanup")?;
-    let _generation_lock = GenerationRetentionLock::acquire(&layout.state_file, &project_id)
-        .context("lock sidecar generation publication and retention")?;
+    let _generation_lock = GenerationRetentionLock::acquire_with_cancel(
+        &layout.state_file,
+        &project_id,
+        Some(cancelled),
+    )
+    .context("lock sidecar generation publication and retention")?;
     layout.ensure_data_dirs()?;
     let embedding_residency =
         crate::embeddings::acquire_product_embedding_residency_for_runtime(runtime)

--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -41,7 +41,7 @@ pub use transport::{
 };
 
 use exchange::{
-    configure_exchange_timeout, decode_vectors, duration_ms, elapsed_since, embedding_scope_id,
+    arm_exchange_deadline, decode_vectors, duration_ms, elapsed_since, embedding_scope_id,
     encode_vectors, exchange, hello, is_server_loss, is_sha256, positive_duration_ms, read_frame,
     request, response_result, validate_engine_identity, validate_engine_server_identity,
     validate_lease_server_identity, validate_same_server, validate_server_snapshot, vectors_result,

--- a/crates/codestory-retrieval/src/per_user_embedding/client.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/client.rs
@@ -5,14 +5,14 @@ use super::qualification_control::{
     EmbeddingQualificationAttemptExchange, EmbeddingQualificationAttemptResult,
 };
 use super::{
-    CONNECTION_POLL, EmbeddingClientBudgets, EmbeddingClientTransport, EmbeddingCompatibility,
-    EmbeddingConnectIntent, EmbeddingConnectOutcome, EmbeddingEngineIdentity,
-    EmbeddingEngineLeaseIdentity, EmbeddingExecutableIdentity, EmbeddingOperation, EmbeddingResult,
-    EmbeddingServerSnapshot, EmbeddingServerStream, PerUserEmbeddingError,
-    configure_exchange_timeout, decode_vectors, duration_ms, elapsed_since, embedding_scope_id,
-    exchange, hello, is_server_loss, positive_duration_ms, request, response_result,
-    validate_engine_identity, validate_engine_server_identity, validate_lease_server_identity,
-    validate_same_server, validate_server_snapshot, vectors_result,
+    AwakeMonotonicClock, CONNECTION_POLL, EmbeddingClientBudgets, EmbeddingClientTransport,
+    EmbeddingCompatibility, EmbeddingConnectIntent, EmbeddingConnectOutcome,
+    EmbeddingEngineIdentity, EmbeddingEngineLeaseIdentity, EmbeddingExecutableIdentity,
+    EmbeddingOperation, EmbeddingResult, EmbeddingServerSnapshot, EmbeddingServerStream,
+    PerUserEmbeddingError, arm_exchange_deadline, decode_vectors, duration_ms, elapsed_since,
+    embedding_scope_id, exchange, hello, is_server_loss, positive_duration_ms, request,
+    response_result, validate_engine_identity, validate_engine_server_identity,
+    validate_lease_server_identity, validate_same_server, validate_server_snapshot, vectors_result,
 };
 use crate::config::SidecarRuntimeConfig;
 use crate::embedding_contract::normalize_and_validate_vectors;
@@ -361,7 +361,7 @@ impl PerUserEmbeddingClient {
     pub fn ensure_resident(&self) -> Result<EmbeddingEngineIdentity> {
         let budgets = self.transport.budgets();
         let mut connection = self.connect(EmbeddingConnectIntent::Activate, true)?;
-        configure_exchange_timeout(&*connection.stream, budgets.bulk_request)?;
+        let _deadline = arm_exchange_deadline(self.transport.clock(), budgets.bulk_request)?;
         let request_id = Uuid::new_v4().to_string();
         let operation = EmbeddingOperation::EnsureResident {
             scope_id: self.scope_id.clone(),
@@ -383,7 +383,7 @@ impl PerUserEmbeddingClient {
     pub fn acquire_residency_lease(&self) -> Result<PerUserEmbeddingResidencyLease> {
         let budgets = self.transport.budgets();
         let mut connection = self.connect(EmbeddingConnectIntent::Activate, true)?;
-        configure_exchange_timeout(&*connection.stream, budgets.bulk_request)?;
+        let _deadline = arm_exchange_deadline(self.transport.clock(), budgets.bulk_request)?;
         let request_id = Uuid::new_v4().to_string();
         let operation = EmbeddingOperation::AcquireLease {
             scope_id: self.scope_id.clone(),
@@ -407,6 +407,7 @@ impl PerUserEmbeddingClient {
             identity: *identity,
             server: connection.snapshot,
             budgets,
+            clock: self.transport.clock(),
         })
     }
 
@@ -424,7 +425,8 @@ impl PerUserEmbeddingClient {
             Err(error) if error.to_string().contains("embedding_server_absent") => return Ok(None),
             Err(error) => return Err(error),
         };
-        configure_exchange_timeout(&*connection.stream, self.transport.budgets().connect)?;
+        let _deadline =
+            arm_exchange_deadline(self.transport.clock(), self.transport.budgets().connect)?;
         let request_id = Uuid::new_v4().to_string();
         let (response, _) = exchange(
             &mut *connection.stream,
@@ -490,7 +492,7 @@ impl PerUserEmbeddingClient {
             let remaining = control.remaining(operation_timeout)?;
             let request_operation =
                 operation(positive_duration_ms(remaining), cancel_token.clone());
-            configure_exchange_timeout(&*connection.stream, remaining)?;
+            let _deadline = arm_exchange_deadline(Arc::clone(&clock), remaining)?;
             let server_instance_id = connection.snapshot.process.server_instance_id.clone();
             let submitted_ns = clock.now_ns();
             let completed = AtomicBool::new(false);
@@ -572,7 +574,8 @@ impl PerUserEmbeddingClient {
 
     fn send_cancel(&self, target_request_id: &str, cancel_token: &str) -> Result<bool> {
         let mut connection = self.connect(EmbeddingConnectIntent::Activate, false)?;
-        configure_exchange_timeout(&*connection.stream, self.transport.budgets().connect)?;
+        let _deadline =
+            arm_exchange_deadline(self.transport.clock(), self.transport.budgets().connect)?;
         let request_id = Uuid::new_v4().to_string();
         let (response, _) = exchange(
             &mut *connection.stream,
@@ -655,7 +658,7 @@ impl PerUserEmbeddingClient {
                 .map_err(anyhow::Error::new)?
             {
                 EmbeddingConnectOutcome::Connected(mut stream) => {
-                    configure_exchange_timeout(&*stream, connect_budget)?;
+                    let _deadline = arm_exchange_deadline(self.transport.clock(), connect_budget)?;
                     let transport_identity = stream.transport_identity().clone();
                     let executable = self.transport.executable_identity();
                     let snapshot = match hello(
@@ -740,6 +743,7 @@ pub struct PerUserEmbeddingResidencyLease {
     identity: EmbeddingEngineIdentity,
     server: EmbeddingServerSnapshot,
     budgets: EmbeddingClientBudgets,
+    clock: Arc<dyn AwakeMonotonicClock>,
 }
 
 impl fmt::Debug for PerUserEmbeddingResidencyLease {
@@ -766,7 +770,7 @@ impl PerUserEmbeddingResidencyLease {
             .stream
             .as_mut()
             .ok_or_else(|| anyhow!("embedding_publication_lease_released"))?;
-        configure_exchange_timeout(&**stream, self.budgets.bulk_request)?;
+        let _deadline = arm_exchange_deadline(Arc::clone(&self.clock), self.budgets.bulk_request)?;
         let request_id = Uuid::new_v4().to_string();
         let (response, _) = exchange(
             &mut **stream,
@@ -812,7 +816,7 @@ impl PerUserEmbeddingResidencyLease {
         let Some(mut stream) = self.stream.take() else {
             return Ok(());
         };
-        configure_exchange_timeout(&*stream, self.budgets.connect)?;
+        let _deadline = arm_exchange_deadline(Arc::clone(&self.clock), self.budgets.connect)?;
         let request_id = Uuid::new_v4().to_string();
         let (response, _) = exchange(
             &mut *stream,

--- a/crates/codestory-retrieval/src/per_user_embedding/exchange.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/exchange.rs
@@ -15,9 +15,143 @@ use crate::config::SidecarRuntimeConfig;
 use crate::embedding_contract::RETRIEVAL_EMBEDDING_DIM;
 use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
 use std::io;
+use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
+
+/// Smallest timeout armed on a socket. A zero `Duration` means "block
+/// forever" to both the Unix and the Windows transport, so an almost-expired
+/// budget must never be handed over verbatim.
+const MIN_ARMED_TIMEOUT: Duration = Duration::from_millis(1);
+
+thread_local! {
+    static EXCHANGE_DEADLINE: RefCell<Option<ExchangeDeadline>> = const { RefCell::new(None) };
+}
+
+/// One absolute deadline for a whole exchange.
+///
+/// Socket timeouts restart on every `read`/`write` syscall, and one exchange
+/// issues several: two length reads, two body reads, four writes and a flush.
+/// Installing the full remaining budget as the socket timeout therefore
+/// bounded each syscall, not the exchange — a peer that trickled bytes held
+/// the caller without limit. Every syscall is re-armed from this absolute
+/// point instead, so the exchange as a whole cannot outlive it.
+#[derive(Clone)]
+pub(super) struct ExchangeDeadline {
+    clock: Arc<dyn AwakeMonotonicClock>,
+    deadline_ns: u64,
+}
+
+impl ExchangeDeadline {
+    pub(super) fn new(clock: Arc<dyn AwakeMonotonicClock>, budget: Duration) -> Result<Self> {
+        if budget.is_zero() {
+            bail!("embedding_server_timeout_invalid");
+        }
+        let budget_ns = budget.as_nanos().min(u128::from(u64::MAX)) as u64;
+        let deadline_ns = clock.now_ns().saturating_add(budget_ns);
+        Ok(Self { clock, deadline_ns })
+    }
+
+    /// Budget left for the next syscall, or a timed-out error once the
+    /// absolute deadline has passed.
+    fn remaining(&self) -> io::Result<Duration> {
+        let now = self.clock.now_ns();
+        if now >= self.deadline_ns {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "the embedding exchange deadline elapsed",
+            ));
+        }
+        Ok(Duration::from_nanos(self.deadline_ns - now).max(MIN_ARMED_TIMEOUT))
+    }
+}
+
+/// Restores the enclosing exchange deadline, so a nested exchange (the
+/// best-effort cancel connection, for instance) cannot widen its parent's.
+pub(super) struct ArmedExchangeDeadline {
+    previous: Option<ExchangeDeadline>,
+}
+
+impl Drop for ArmedExchangeDeadline {
+    fn drop(&mut self) {
+        EXCHANGE_DEADLINE.with(|armed| {
+            armed.replace(self.previous.take());
+        });
+    }
+}
+
+/// Arm the absolute deadline covering every syscall of the next exchange on
+/// this thread. Replaces `configure_exchange_timeout`'s whole-budget-per-call
+/// arming at every exchange call site.
+pub(super) fn arm_exchange_deadline(
+    clock: Arc<dyn AwakeMonotonicClock>,
+    budget: Duration,
+) -> Result<ArmedExchangeDeadline> {
+    let deadline = ExchangeDeadline::new(clock, budget)?;
+    let previous = EXCHANGE_DEADLINE.with(|armed| armed.replace(Some(deadline)));
+    Ok(ArmedExchangeDeadline { previous })
+}
+
+fn armed_deadline() -> Option<ExchangeDeadline> {
+    EXCHANGE_DEADLINE.with(|armed| armed.borrow().clone())
+}
+
+/// Read exactly `buffer.len()` bytes, re-arming the read timeout with the
+/// budget remaining on the exchange deadline before every syscall.
+fn read_exact_bounded(stream: &mut dyn EmbeddingServerStream, buffer: &mut [u8]) -> io::Result<()> {
+    let Some(deadline) = armed_deadline() else {
+        return stream.read_exact(buffer);
+    };
+    let mut filled = 0;
+    while filled < buffer.len() {
+        stream.set_read_timeout(Some(deadline.remaining()?))?;
+        match stream.read(&mut buffer[filled..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "the embedding peer closed the connection mid-frame",
+                ));
+            }
+            Ok(read) => filled += read,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+/// Write every byte, re-arming the write timeout with the budget remaining on
+/// the exchange deadline before every syscall.
+fn write_all_bounded(stream: &mut dyn EmbeddingServerStream, bytes: &[u8]) -> io::Result<()> {
+    let Some(deadline) = armed_deadline() else {
+        return stream.write_all(bytes);
+    };
+    let mut written = 0;
+    while written < bytes.len() {
+        stream.set_write_timeout(Some(deadline.remaining()?))?;
+        match stream.write(&bytes[written..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "the embedding peer accepted no bytes",
+                ));
+            }
+            Ok(wrote) => written += wrote,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn flush_bounded(stream: &mut dyn EmbeddingServerStream) -> io::Result<()> {
+    if let Some(deadline) = armed_deadline() {
+        stream.set_write_timeout(Some(deadline.remaining()?))?;
+    }
+    stream.flush()
+}
 
 pub(super) fn request(
     request_id: &str,
@@ -239,19 +373,13 @@ pub(super) fn write_frame<T: Serialize>(
     {
         bail!("embedding_server_frame_too_large");
     }
-    stream
-        .write_all(&(control.len() as u32).to_be_bytes())
+    write_all_bounded(stream, &(control.len() as u32).to_be_bytes())
         .context("write embedding control length")?;
-    stream
-        .write_all(&(payload.len() as u32).to_be_bytes())
+    write_all_bounded(stream, &(payload.len() as u32).to_be_bytes())
         .context("write embedding payload length")?;
-    stream
-        .write_all(&control)
-        .context("write embedding control frame")?;
-    stream
-        .write_all(payload)
-        .context("write embedding payload frame")?;
-    stream.flush().context("flush embedding protocol frame")
+    write_all_bounded(stream, &control).context("write embedding control frame")?;
+    write_all_bounded(stream, payload).context("write embedding payload frame")?;
+    flush_bounded(stream).context("flush embedding protocol frame")
 }
 
 pub(super) fn read_frame<T: for<'de> Deserialize<'de>>(
@@ -259,12 +387,8 @@ pub(super) fn read_frame<T: for<'de> Deserialize<'de>>(
 ) -> Result<(T, Vec<u8>)> {
     let mut control_len = [0_u8; 4];
     let mut payload_len = [0_u8; 4];
-    stream
-        .read_exact(&mut control_len)
-        .context("read embedding control length")?;
-    stream
-        .read_exact(&mut payload_len)
-        .context("read embedding payload length")?;
+    read_exact_bounded(stream, &mut control_len).context("read embedding control length")?;
+    read_exact_bounded(stream, &mut payload_len).context("read embedding payload length")?;
     let control_len = u32::from_be_bytes(control_len) as usize;
     let payload_len = u32::from_be_bytes(payload_len) as usize;
     if control_len == 0
@@ -275,12 +399,8 @@ pub(super) fn read_frame<T: for<'de> Deserialize<'de>>(
     }
     let mut control = vec![0_u8; control_len];
     let mut payload = vec![0_u8; payload_len];
-    stream
-        .read_exact(&mut control)
-        .context("read embedding control frame")?;
-    stream
-        .read_exact(&mut payload)
-        .context("read embedding payload frame")?;
+    read_exact_bounded(stream, &mut control).context("read embedding control frame")?;
+    read_exact_bounded(stream, &mut payload).context("read embedding payload frame")?;
     let control =
         serde_json::from_slice(&control).context("decode embedding protocol control frame")?;
     Ok((control, payload))
@@ -427,34 +547,6 @@ pub(super) fn validate_server_snapshot(
         bail!("embedding_server_executable_identity_mismatch");
     }
     Ok(())
-}
-
-pub(super) fn configure_exchange_timeout(
-    stream: &dyn EmbeddingServerStream,
-    timeout: Duration,
-) -> Result<()> {
-    if timeout.is_zero() {
-        bail!("embedding_server_timeout_invalid");
-    }
-    stream
-        .set_read_timeout(Some(timeout))
-        .map_err(exchange_timeout_configuration_error)?;
-    stream
-        .set_write_timeout(Some(timeout))
-        .map_err(exchange_timeout_configuration_error)?;
-    Ok(())
-}
-
-pub(super) fn exchange_timeout_configuration_error(error: io::Error) -> anyhow::Error {
-    PerUserEmbeddingError {
-        code: "embedding_server_owner_unresponsive".into(),
-        message: format!("could not bound the embedding server exchange: {error}"),
-        retry_class: "after_server_change".into(),
-        retry_after_ms: duration_ms(EmbeddingClientBudgets::current().retry_after),
-        retry_condition: "the lifetime authority or server instance changes".into(),
-        capacity: None,
-    }
-    .into()
 }
 
 pub(super) fn is_sha256(value: &str) -> bool {

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/mod.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/mod.rs
@@ -19,7 +19,7 @@ use identities::{
     test_transport_identity,
 };
 use server_fixtures::{PollingStream, WatchdogTransport};
-use transport_fixtures::{MemoryStream, TestClock};
+use transport_fixtures::{MemoryStream, TestClock, TricklePeerStream};
 
 mod lazy_transport {
     use super::super::client::LazyClientTransport;

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/protocol_transport.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/protocol_transport.rs
@@ -1,17 +1,18 @@
 use super::super::{
-    EmbeddingClientBudgets, EmbeddingCompatibility, EmbeddingEngineLeaseIdentity,
-    EmbeddingOperation, EmbeddingProtocolRequest, EmbeddingResult, IncrementalProtocolFrameReader,
-    PER_USER_EMBEDDING_MAX_METADATA_BYTES, PER_USER_EMBEDDING_PROTOCOL_SHA256,
-    PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS, PER_USER_EMBEDDING_SERVER_PROOF_MARKER,
-    PerUserEmbeddingServerState, ProtocolFramePoll, ServerLeaseActivity,
-    configure_server_operation_timeout, elapsed_since, embedding_retry_state, exchange,
-    exchange_raw_os_error, hex_sha256, map_bounded_exchange_error, read_frame, request,
-    serve_embedding_connection, success_response, validate_lease_server_identity,
-    validate_same_server, validate_server_snapshot,
+    AwakeMonotonicClock, EmbeddingClientBudgets, EmbeddingCompatibility,
+    EmbeddingEngineLeaseIdentity, EmbeddingOperation, EmbeddingProtocolRequest, EmbeddingResult,
+    IncrementalProtocolFrameReader, PER_USER_EMBEDDING_MAX_METADATA_BYTES,
+    PER_USER_EMBEDDING_PROTOCOL_SHA256, PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS,
+    PER_USER_EMBEDDING_SERVER_PROOF_MARKER, PerUserEmbeddingServerState, ProtocolFramePoll,
+    ServerLeaseActivity, arm_exchange_deadline, configure_server_operation_timeout, elapsed_since,
+    embedding_retry_state, exchange, exchange_raw_os_error, hex_sha256, map_bounded_exchange_error,
+    read_frame, request, serve_embedding_connection, success_response,
+    validate_lease_server_identity, validate_same_server, validate_server_snapshot,
 };
 use super::{
-    MemoryStream, PollingStream, encode_test_frame, test_engine_identity, test_executable,
-    test_hello_operation, test_server_state, test_snapshot, test_transport_identity,
+    MemoryStream, PollingStream, TestClock, TricklePeerStream, encode_test_frame,
+    test_engine_identity, test_executable, test_hello_operation, test_server_state, test_snapshot,
+    test_transport_identity,
 };
 use std::io;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -349,5 +350,67 @@ fn lease_end_restarts_the_full_true_idle_window_before_native_release() {
     assert_eq!(
         elapsed_since(state.clock.as_ref(), idle_start),
         Duration::from_millis(PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS)
+    );
+}
+
+#[test]
+fn a_trickling_peer_cannot_hold_the_exchange_past_one_absolute_deadline() {
+    // The response frame is long enough that a one-byte-per-syscall peer needs
+    // far more stalls than the budget allows.
+    let response = success_response("trickle", EmbeddingResult::Released);
+    let clock = TestClock::new();
+    let budget = Duration::from_millis(1_000);
+    let stall = Duration::from_millis(100);
+    let stream =
+        TricklePeerStream::new(encode_test_frame(&response, &[]), Arc::clone(&clock), stall);
+    let read_timeouts = stream.read_timeouts();
+    let mut stream = stream;
+
+    let started_ns = clock.now_ns();
+    let armed = arm_exchange_deadline(clock.clone(), budget).expect("arm exchange deadline");
+    let error = exchange(
+        &mut stream,
+        request(
+            "trickle",
+            EmbeddingCompatibility::current(true),
+            EmbeddingOperation::Snapshot,
+        ),
+    )
+    .expect_err("a trickling peer must not outlive the exchange deadline");
+    drop(armed);
+
+    assert!(
+        error
+            .to_string()
+            .contains("embedding_server_owner_unresponsive"),
+        "a bounded exchange timeout must stay typed: {error:#}"
+    );
+    let elapsed_ns = clock.now_ns() - started_ns;
+    assert!(
+        elapsed_ns <= budget.as_nanos() as u64 + stall.as_nanos() as u64,
+        "the exchange ran {elapsed_ns} ns past its {budget:?} deadline"
+    );
+
+    let armed_timeouts = read_timeouts
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    assert!(
+        armed_timeouts.len() > 1,
+        "every read syscall must re-arm its own timeout"
+    );
+    assert!(
+        armed_timeouts
+            .windows(2)
+            .all(|pair| pair[0] > pair[1] && pair[1] > Some(Duration::ZERO)),
+        "each syscall must be re-armed with the shrinking remaining budget: {armed_timeouts:?}"
+    );
+    assert!(
+        armed_timeouts
+            .first()
+            .copied()
+            .flatten()
+            .is_some_and(|first| first <= budget),
+        "no syscall may be armed with more than the whole remaining budget"
     );
 }

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/transport_fixtures.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/transport_fixtures.rs
@@ -165,6 +165,90 @@ impl EmbeddingServerStream for MemoryStream {
     }
 }
 
+/// A peer that answers every read with one byte after stalling just short of
+/// the armed socket timeout.
+///
+/// Socket timeouts restart per syscall, so this peer used to hold the caller
+/// for as long as it liked: no single `read` ever timed out. It exists to
+/// prove the exchange as a whole is bounded by one absolute deadline.
+pub(super) struct TricklePeerStream {
+    pub(super) identity: EmbeddingTransportIdentity,
+    pub(super) input: Cursor<Vec<u8>>,
+    pub(super) clock: Arc<TestClock>,
+    pub(super) stall: Duration,
+    pub(super) output: Arc<Mutex<Vec<u8>>>,
+    pub(super) read_timeouts: Arc<Mutex<Vec<Option<Duration>>>>,
+}
+
+impl TricklePeerStream {
+    pub(super) fn new(input: Vec<u8>, clock: Arc<TestClock>, stall: Duration) -> Self {
+        Self {
+            identity: test_transport_identity(),
+            input: Cursor::new(input),
+            clock,
+            stall,
+            output: Arc::new(Mutex::new(Vec::new())),
+            read_timeouts: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub(super) fn read_timeouts(&self) -> Arc<Mutex<Vec<Option<Duration>>>> {
+        Arc::clone(&self.read_timeouts)
+    }
+}
+
+impl Read for TricklePeerStream {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        // The peer waits, then delivers exactly one byte, so the armed socket
+        // timeout is never reached by any single syscall.
+        self.clock.sleep(self.stall);
+        self.input.read(&mut buffer[..1])
+    }
+}
+
+impl Write for TricklePeerStream {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.output
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl EmbeddingServerStream for TricklePeerStream {
+    fn transport_identity(&self) -> &EmbeddingTransportIdentity {
+        &self.identity
+    }
+
+    fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        self.read_timeouts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(timeout);
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn peer_is_alive(&self) -> io::Result<bool> {
+        Ok(true)
+    }
+
+    fn shutdown(&self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 /// The raw Win32 code a named-pipe writer observes when the peer end closed:
 /// ERROR_NO_DATA, "the pipe is being closed".
 pub(super) const WINDOWS_PIPE_CLOSING_RAW_CODE: i32 = 232;

--- a/crates/codestory-retrieval/src/retention.rs
+++ b/crates/codestory-retrieval/src/retention.rs
@@ -3,8 +3,7 @@
 use crate::config::{SidecarLayout, SidecarProfile, SidecarRuntimeConfig};
 use anyhow::{Context, Result, bail};
 use codestory_contracts::bounded_locks::{
-    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, PUBLICATION_LOCK_WAIT,
-    acquire_with_deadline,
+    self, FileLockKind, LockDeadline, PUBLICATION_LOCK_WAIT, acquire_with_deadline,
 };
 use codestory_store::{RetrievalIndexManifest, RetrievalIndexRollbackRecord, Store};
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
@@ -77,26 +76,48 @@ pub struct GenerationRetentionLock {
 }
 
 impl GenerationRetentionLock {
-    /// Exclusive retention lock for a publication or cleanup pass. Only
-    /// background workers take it, so it carries the longer publication
-    /// budget rather than the foreground one.
+    /// Exclusive retention lock for a publication or cleanup pass. The holder
+    /// keeps it for the whole pass, so waiters carry the publication budget:
+    /// a shorter one would refuse ordinary contention.
     pub fn acquire(state_file: &Path, scope_id: &str) -> Result<Self> {
+        Self::acquire_with_cancel(state_file, scope_id, None)
+    }
+
+    /// [`Self::acquire`] for a caller that holds the cancellation flag of the
+    /// work being done, so the wait ends on cancellation rather than on the
+    /// peer's whole publication.
+    pub fn acquire_with_cancel(
+        state_file: &Path,
+        scope_id: &str,
+        cancel: Option<&AtomicBool>,
+    ) -> Result<Self> {
         Self::acquire_bounded(
             state_file,
             scope_id,
             FileLockKind::Exclusive,
             LockDeadline::after(PUBLICATION_LOCK_WAIT),
-            None,
+            cancel,
         )
     }
 
+    /// The shared side waits behind the same exclusive publication holder, so
+    /// it carries the same budget. Ten seconds refused a legitimate commit.
     pub fn acquire_shared(state_file: &Path, scope_id: &str) -> Result<Self> {
+        Self::acquire_shared_with_cancel(state_file, scope_id, None)
+    }
+
+    /// [`Self::acquire_shared`] for a caller that holds a cancellation flag.
+    pub fn acquire_shared_with_cancel(
+        state_file: &Path,
+        scope_id: &str,
+        cancel: Option<&AtomicBool>,
+    ) -> Result<Self> {
         Self::acquire_bounded(
             state_file,
             scope_id,
             FileLockKind::Shared,
-            LockDeadline::after(DEFAULT_LOCK_WAIT),
-            None,
+            LockDeadline::after(PUBLICATION_LOCK_WAIT),
+            cancel,
         )
     }
 
@@ -1849,5 +1870,61 @@ mod tests {
         );
 
         holder.wait().expect("holder process exits");
+    }
+
+    /// A publication pass routinely holds this lock longer than
+    /// [`codestory_contracts::bounded_locks::DEFAULT_LOCK_WAIT`]. A waiter that
+    /// refuses at ten seconds turns ordinary contention behind a legitimate
+    /// commit into a hard failure, so the shared side carries the publication
+    /// budget — and stays interruptible, which is the only reason a budget that
+    /// long is safe.
+    ///
+    /// Both halves are proven at once: past the ten-second mark the wait is
+    /// still running (so the budget is not the default one) and it then ends on
+    /// the cancellation flag rather than on a timeout.
+    #[test]
+    fn a_publication_length_hold_is_waited_out_rather_than_refused_at_the_default_budget() {
+        use codestory_contracts::bounded_locks::DEFAULT_LOCK_WAIT;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let root = tempdir().expect("root");
+        let state_file = root.path().join("retrieval-sidecars.json");
+        let _holder = GenerationRetentionLock::acquire(&state_file, "long_publication")
+            .expect("a peer takes the lock for its publication pass");
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        let raiser = Arc::clone(&cancel);
+        let past_the_default_budget = DEFAULT_LOCK_WAIT + Duration::from_millis(750);
+        let canceller = std::thread::spawn(move || {
+            std::thread::sleep(past_the_default_budget);
+            raiser.store(true, Ordering::Release);
+        });
+
+        let started = Instant::now();
+        let waiter_state_file = state_file.clone();
+        let waiter_cancel = Arc::clone(&cancel);
+        let waiter = std::thread::spawn(move || {
+            // The ambient scope stands in for the activation worker's: the
+            // production call site below passes no flag of its own.
+            codestory_contracts::bounded_locks::with_thread_cancellation(waiter_cancel, || {
+                GenerationRetentionLock::acquire_shared(&waiter_state_file, "long_publication")
+            })
+        });
+        let outcome = waiter.join().expect("waiter thread");
+        let waited = started.elapsed();
+        canceller.join().expect("cancellation thread");
+
+        let error = outcome.expect_err("the peer never released, so the wait cannot succeed");
+        assert!(
+            error
+                .chain()
+                .any(|cause| cause.to_string().contains("lock_wait_cancelled")),
+            "the wait must end on cancellation, not on a budget shorter than the peer's pass: {error:#}"
+        );
+        assert!(
+            waited >= DEFAULT_LOCK_WAIT,
+            "the wait gave up after {waited:?}, inside the {DEFAULT_LOCK_WAIT:?} foreground budget, so a legitimate publication would be refused"
+        );
     }
 }

--- a/crates/codestory-retrieval/src/retention.rs
+++ b/crates/codestory-retrieval/src/retention.rs
@@ -2,13 +2,17 @@
 
 use crate::config::{SidecarLayout, SidecarProfile, SidecarRuntimeConfig};
 use anyhow::{Context, Result, bail};
+use codestory_contracts::bounded_locks::{
+    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, PUBLICATION_LOCK_WAIT,
+    acquire_with_deadline,
+};
 use codestory_store::{RetrievalIndexManifest, RetrievalIndexRollbackRecord, Store};
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
-use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
 const RETENTION_SCHEMA_VERSION: u32 = 1;
 const RETENTION_DIR: &str = "retention";
@@ -67,39 +71,68 @@ impl GenerationRetentionMarker {
     }
 }
 
+#[derive(Debug)]
 pub struct GenerationRetentionLock {
     file: File,
 }
 
 impl GenerationRetentionLock {
+    /// Exclusive retention lock for a publication or cleanup pass. Only
+    /// background workers take it, so it carries the longer publication
+    /// budget rather than the foreground one.
     pub fn acquire(state_file: &Path, scope_id: &str) -> Result<Self> {
-        Self::acquire_with_mode(state_file, scope_id, false)
+        Self::acquire_bounded(
+            state_file,
+            scope_id,
+            FileLockKind::Exclusive,
+            LockDeadline::after(PUBLICATION_LOCK_WAIT),
+            None,
+        )
     }
 
     pub fn acquire_shared(state_file: &Path, scope_id: &str) -> Result<Self> {
-        Self::acquire_with_mode(state_file, scope_id, true)
+        Self::acquire_bounded(
+            state_file,
+            scope_id,
+            FileLockKind::Shared,
+            LockDeadline::after(DEFAULT_LOCK_WAIT),
+            None,
+        )
     }
 
     pub fn try_acquire_shared(state_file: &Path, scope_id: &str) -> Result<Option<Self>> {
-        let path = retention_lock_path(state_file, scope_id)?;
-        ensure_retention_dir(state_file)?;
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&path)
-            .with_context(|| format!("open generation retention lock {}", path.display()))?;
-        match FileExt::try_lock_shared(&file) {
+        let (path, file) = Self::open_lock_file(state_file, scope_id)?;
+        match bounded_locks::try_acquire(&file, FileLockKind::Shared) {
             Ok(true) => Ok(Some(Self { file })),
             Ok(false) => Ok(None),
-            Err(error) => Err(error).with_context(|| {
+            Err(error) => Err(anyhow::Error::new(error)).with_context(|| {
                 format!("try lock shared generation retention {}", path.display())
             }),
         }
     }
 
-    fn acquire_with_mode(state_file: &Path, scope_id: &str, shared: bool) -> Result<Self> {
+    /// Every blocking retention acquisition goes through one absolute deadline:
+    /// a sibling publication holding this lock must never be able to stall an
+    /// unrelated query, eviction, or shutdown for longer than the caller's
+    /// budget.
+    pub fn acquire_bounded(
+        state_file: &Path,
+        scope_id: &str,
+        kind: FileLockKind,
+        deadline: LockDeadline,
+        cancel: Option<&AtomicBool>,
+    ) -> Result<Self> {
+        let (path, file) = Self::open_lock_file(state_file, scope_id)?;
+        acquire_with_deadline(&file, kind, deadline, cancel).map_err(|error| {
+            anyhow::Error::new(error).context(format!(
+                "acquire {kind} generation retention {}",
+                path.display()
+            ))
+        })?;
+        Ok(Self { file })
+    }
+
+    fn open_lock_file(state_file: &Path, scope_id: &str) -> Result<(PathBuf, File)> {
         let path = retention_lock_path(state_file, scope_id)?;
         ensure_retention_dir(state_file)?;
         let file = OpenOptions::new()
@@ -109,20 +142,13 @@ impl GenerationRetentionLock {
             .truncate(false)
             .open(&path)
             .with_context(|| format!("open generation retention lock {}", path.display()))?;
-        if shared {
-            FileExt::lock_shared(&file)
-                .with_context(|| format!("lock shared generation retention {}", path.display()))?;
-        } else {
-            FileExt::lock_exclusive(&file)
-                .with_context(|| format!("lock generation retention {}", path.display()))?;
-        }
-        Ok(Self { file })
+        Ok((path, file))
     }
 }
 
 impl Drop for GenerationRetentionLock {
     fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.file);
+        let _ = bounded_locks::release(&self.file);
     }
 }
 
@@ -1219,6 +1245,7 @@ fn directory_size(path: &Path) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
     use tempfile::tempdir;
 
     fn manifest(project_id: &str, suffix: &str, built_at_epoch_ms: i64) -> RetrievalIndexManifest {
@@ -1742,5 +1769,85 @@ mod tests {
         assert_eq!(scan.active.len(), 1);
         assert_eq!(scan.errors.len(), 1);
         assert!(scan.errors[0].contains("bad.json"));
+    }
+
+    /// A second OS process holds the retention lock for longer than the
+    /// caller's budget. Before bounded acquisition the caller blocked in
+    /// `flock` for the holder's whole lifetime, so an eviction or shutdown
+    /// waiting behind a routine sibling publication never returned.
+    #[test]
+    fn a_second_process_holding_the_retention_lock_cannot_outlive_the_caller_budget() {
+        const HOLD_ENV: &str = "CODESTORY_TEST_HOLD_RETENTION_LOCK";
+        const HOLD_MS_ENV: &str = "CODESTORY_TEST_HOLD_RETENTION_LOCK_MS";
+        const READY_ENV: &str = "CODESTORY_TEST_HOLD_RETENTION_LOCK_READY";
+
+        if let Some(state_file) = std::env::var_os(HOLD_ENV) {
+            let state_file = PathBuf::from(state_file);
+            let lock = GenerationRetentionLock::acquire(&state_file, "held_scope")
+                .expect("child acquires the retention lock");
+            std::fs::write(
+                PathBuf::from(std::env::var_os(READY_ENV).expect("ready marker path")),
+                b"held",
+            )
+            .expect("publish holder readiness");
+            let hold_ms: u64 = std::env::var(HOLD_MS_ENV)
+                .expect("hold budget")
+                .parse()
+                .expect("numeric hold budget");
+            std::thread::sleep(Duration::from_millis(hold_ms));
+            drop(lock);
+            return;
+        }
+
+        let root = tempdir().expect("root");
+        let state_file = root.path().join("retrieval-sidecars.json");
+        let ready = root.path().join("holder.ready");
+        let mut holder = std::process::Command::new(
+            std::env::current_exe().expect("current test executable"),
+        )
+        .arg("--exact")
+        .arg("retention::tests::a_second_process_holding_the_retention_lock_cannot_outlive_the_caller_budget")
+        .arg("--nocapture")
+        .env(HOLD_ENV, &state_file)
+        .env(READY_ENV, &ready)
+        .env(HOLD_MS_ENV, "5000")
+        .spawn()
+        .expect("spawn holder process");
+
+        let holder_deadline = Instant::now() + Duration::from_secs(20);
+        while !ready.exists() && Instant::now() < holder_deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(ready.exists(), "the holder process never took the lock");
+
+        let started = Instant::now();
+        let error = GenerationRetentionLock::acquire_bounded(
+            &state_file,
+            "held_scope",
+            FileLockKind::Exclusive,
+            LockDeadline::after(Duration::from_millis(250)),
+            None,
+        )
+        .expect_err("a cross-process holder must not block the caller");
+        let waited = started.elapsed();
+
+        assert!(
+            error
+                .to_string()
+                .contains("acquire exclusive generation retention"),
+            "the refusal must name the contended lock: {error:#}"
+        );
+        assert!(
+            error
+                .chain()
+                .any(|cause| cause.to_string().contains("lock_wait_timeout")),
+            "the refusal must carry the typed timeout code: {error:#}"
+        );
+        assert!(
+            waited < Duration::from_secs(3),
+            "acquisition waited {waited:?}, far past its 250 ms budget"
+        );
+
+        holder.wait().expect("holder process exits");
     }
 }

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -15,7 +15,6 @@ codestory-retrieval = { workspace = true }
 codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }
 crossbeam-channel = { workspace = true }
-fs4 = { workspace = true }
 nucleo-matcher = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }

--- a/crates/codestory-runtime/src/browser.rs
+++ b/crates/codestory-runtime/src/browser.rs
@@ -14,10 +14,21 @@ use codestory_contracts::query::{
 
 use crate::{
     AppController, PublicOperationService, SymbolWorkflowOutcome, SymbolWorkflowRequest,
-    TargetResolution, TargetSelection, compare_ranked_hits, symbol_name_match_rank,
+    TargetResolution, TargetSelection, active_public_operation_cancellation, compare_ranked_hits,
+    symbol_name_match_rank,
 };
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+
+/// The facade runs inside whatever public operation the transport already
+/// opened. Minting a fresh flag here replaced the caller's live cancellation
+/// with a permanently-false one, so a host that cancelled mid-tool-body was
+/// never observed by anything the body called. Inheriting keeps the host's
+/// signal reachable; an unwrapped entry (tests, embedders) still gets an
+/// isolated flag rather than a shared global.
+fn inherited_cancellation() -> Arc<AtomicBool> {
+    active_public_operation_cancellation().unwrap_or_else(|| Arc::new(AtomicBool::new(false)))
+}
 
 #[derive(Debug, Clone)]
 pub struct BrowserQueryItem {
@@ -108,7 +119,7 @@ impl ReadOnlyBrowserService {
         build: impl FnMut() -> Result<T, ApiError>,
     ) -> Result<T, ApiError> {
         self.public_operation
-            .run_with_cancel(operation, Arc::new(AtomicBool::new(false)), build)
+            .run_with_cancel(operation, inherited_cancellation(), build)
             .map(|operation| operation.value)
     }
 
@@ -118,7 +129,7 @@ impl ReadOnlyBrowserService {
         build: impl FnMut() -> Result<T, ApiError>,
     ) -> Result<T, ApiError> {
         self.public_operation
-            .run_observational_with_cancel(operation, Arc::new(AtomicBool::new(false)), build)
+            .run_observational_with_cancel(operation, inherited_cancellation(), build)
             .map(|operation| operation.value)
     }
 

--- a/crates/codestory-runtime/src/index_commit.rs
+++ b/crates/codestory-runtime/src/index_commit.rs
@@ -11,6 +11,7 @@ use crate::{
     current_epoch_ms, publish_source_policy_exclusions, revalidate_source_policy_exclusions,
 };
 use codestory_contracts::api::{ApiError, IndexPublicationDto, IndexPublicationModeDto};
+use codestory_contracts::bounded_locks;
 use codestory_indexer::CancellationToken;
 use codestory_store::{
     IndexPublicationMode, IndexPublicationRecord, StagedSnapshot, StagedSnapshotPublishStats,
@@ -18,7 +19,6 @@ use codestory_store::{
 use codestory_workspace::{
     OversizedSourceExclusionCandidate, SourceIndexPolicy, WorkspaceManifest,
 };
-use fs4::fs_std::FileExt;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
@@ -110,7 +110,7 @@ impl IndexWriterGuard {
 
 impl Drop for IndexWriterGuard {
     fn drop(&mut self) {
-        if let Err(error) = FileExt::unlock(&self.file) {
+        if let Err(error) = bounded_locks::release(&self.file) {
             tracing::warn!(
                 path = %self.path.display(),
                 "Failed to unlock index writer lock: {error}"

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -29,6 +29,9 @@ use codestory_contracts::api::{
     StoredSemanticDocsContractDto, SymbolContextDto, TrailConfigDto, TrailContextDto,
     WorkspaceMemberIndexDto,
 };
+use codestory_contracts::bounded_locks::{
+    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, acquire_with_deadline,
+};
 use codestory_contracts::graph::{AccessKind, Edge as GraphEdge, Node as GraphNode};
 use codestory_contracts::language_support::{
     LanguageSupportProfile, language_support_profile_for_ext,
@@ -52,7 +55,6 @@ use codestory_workspace::{
     WorkspaceManifest, WorkspacePathIdentity,
 };
 use crossbeam_channel::{Receiver, Sender};
-use fs4::fs_std::FileExt;
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -354,11 +356,12 @@ use semantic_doc_text::{
 #[doc(hidden)]
 pub use services::set_before_retrieval_pin_test_hook;
 pub use services::{
-    ActivationCapabilities, ActivationCapabilityState, ActivationOperation, ActivationRun,
+    ACTIVATION_QUIESCENCE_FAIL_STOP, ActivationCapabilities, ActivationCapabilityState,
+    ActivationFailStopHook, ActivationOperation, ActivationQuiescence, ActivationRun,
     ActivationService, ActivationSnapshot, ActivationStage, ActivationState,
     ActivePublicOperationPublication, AgentService, BookmarkService, GroundingService,
     IndexService, ProjectService, PublicOperation, PublicOperationService, SearchService,
-    TrailService, embedding_api_error,
+    TrailService, embedding_api_error, set_activation_fail_stop_hook,
 };
 pub use symbol_workflow::{
     SymbolWorkflowCaps, SymbolWorkflowMode, SymbolWorkflowNode, SymbolWorkflowOutcome,
@@ -370,6 +373,7 @@ pub use target_resolution::{
     prefer_function_body_target,
 };
 
+pub(crate) use services::active_public_operation_cancellation;
 pub(crate) use support::{
     FocusedSourceContext, HYBRID_RETRIEVAL_ENABLED_ENV, SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES,
     SEMANTIC_FILE_TEXT_MAX_BYTES, aggregate_symbol_matches, clamp_i64_to_u32, clamp_u64_to_u32,

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -30,7 +30,7 @@ use codestory_contracts::api::{
     WorkspaceMemberIndexDto,
 };
 use codestory_contracts::bounded_locks::{
-    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, acquire_with_deadline,
+    self, FileLockKind, LockDeadline, PUBLICATION_LOCK_WAIT, acquire_with_deadline,
 };
 use codestory_contracts::graph::{AccessKind, Edge as GraphEdge, Node as GraphNode};
 use codestory_contracts::language_support::{

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -2,9 +2,11 @@ use crate::symbol_query::RetrievalFileRole;
 #[cfg(test)]
 use crate::symbol_query::query_mentions_non_primary_source;
 use anyhow::{Context, Result, anyhow, bail};
+use codestory_contracts::bounded_locks::{
+    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, acquire_with_deadline,
+};
 use codestory_contracts::graph::NodeId;
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
-use fs4::fs_std::FileExt;
 use nucleo_matcher::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config as NucleoConfig, Matcher, Utf32String};
 use rayon::prelude::*;
@@ -499,23 +501,17 @@ impl PersistedSearchIndexGuard {
             .truncate(false)
             .open(&lock_path)
             .with_context(|| format!("Failed to open search index lock {}", lock_path.display()))?;
-        match mode {
-            PersistedSearchIndexLockMode::Shared => {
-                FileExt::lock_shared(&file).with_context(|| {
-                    format!(
-                        "Failed to take shared search index lock {}",
-                        search_dir.display()
-                    )
-                })?
-            }
-            PersistedSearchIndexLockMode::Exclusive => FileExt::lock_exclusive(&file)
-                .with_context(|| {
-                    format!(
-                        "Failed to take exclusive search index lock {}",
-                        search_dir.display()
-                    )
-                })?,
-        }
+        let kind = match mode {
+            PersistedSearchIndexLockMode::Shared => FileLockKind::Shared,
+            PersistedSearchIndexLockMode::Exclusive => FileLockKind::Exclusive,
+        };
+        acquire_with_deadline(&file, kind, LockDeadline::after(DEFAULT_LOCK_WAIT), None)
+            .with_context(|| {
+                format!(
+                    "Failed to take {kind} search index lock {}",
+                    search_dir.display()
+                )
+            })?;
         Ok(Self {
             file,
             path: lock_path,
@@ -555,21 +551,13 @@ impl PersistedSearchIndexGuard {
             .truncate(false)
             .open(&lock_path)
             .with_context(|| format!("Failed to open search index lock {}", lock_path.display()))?;
-        let acquired = match mode {
-            PersistedSearchIndexLockMode::Shared => FileExt::try_lock_shared(&file),
-            PersistedSearchIndexLockMode::Exclusive => FileExt::try_lock_exclusive(&file),
-        }
-        .or_else(|error| {
-            if error.kind() == std::io::ErrorKind::WouldBlock {
-                Ok(false)
-            } else {
-                Err(error)
-            }
-        })
-        .with_context(|| {
+        let kind = match mode {
+            PersistedSearchIndexLockMode::Shared => FileLockKind::Shared,
+            PersistedSearchIndexLockMode::Exclusive => FileLockKind::Exclusive,
+        };
+        let acquired = bounded_locks::try_acquire(&file, kind).with_context(|| {
             format!(
-                "Failed to take {:?} search index lock {}",
-                mode,
+                "Failed to take {kind} search index lock {}",
                 search_dir.display()
             )
         })?;
@@ -595,28 +583,13 @@ impl PersistedSearchIndexGuard {
         if !self.is_exclusive() {
             return Ok(());
         }
-        #[cfg(unix)]
-        FileExt::lock_shared(&self.file).with_context(|| {
-            format!(
-                "Failed to downgrade persisted search index lock {} to shared",
-                self.path.display()
-            )
-        })?;
-        #[cfg(not(unix))]
-        {
-            FileExt::unlock(&self.file).with_context(|| {
+        bounded_locks::downgrade_to_shared(&self.file, LockDeadline::after(DEFAULT_LOCK_WAIT))
+            .with_context(|| {
                 format!(
-                    "Failed to unlock persisted search index {} before shared reopen",
+                    "Failed to downgrade persisted search index lock {} to shared",
                     self.path.display()
                 )
             })?;
-            FileExt::lock_shared(&self.file).with_context(|| {
-                format!(
-                    "Failed to reacquire persisted search index lock {} as shared",
-                    self.path.display()
-                )
-            })?;
-        }
         self.mode = PersistedSearchIndexLockMode::Shared;
         Ok(())
     }
@@ -624,7 +597,7 @@ impl PersistedSearchIndexGuard {
 
 impl Drop for PersistedSearchIndexGuard {
     fn drop(&mut self) {
-        if let Err(error) = FileExt::unlock(&self.file) {
+        if let Err(error) = bounded_locks::release(&self.file) {
             tracing::warn!(
                 path = %self.path.display(),
                 "Failed to unlock persisted search index lock: {error}"

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -3,7 +3,7 @@ use crate::symbol_query::RetrievalFileRole;
 use crate::symbol_query::query_mentions_non_primary_source;
 use anyhow::{Context, Result, anyhow, bail};
 use codestory_contracts::bounded_locks::{
-    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, acquire_with_deadline,
+    self, FileLockKind, LockDeadline, PUBLICATION_LOCK_WAIT, acquire_with_deadline,
 };
 use codestory_contracts::graph::NodeId;
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
@@ -505,13 +505,21 @@ impl PersistedSearchIndexGuard {
             PersistedSearchIndexLockMode::Shared => FileLockKind::Shared,
             PersistedSearchIndexLockMode::Exclusive => FileLockKind::Exclusive,
         };
-        acquire_with_deadline(&file, kind, LockDeadline::after(DEFAULT_LOCK_WAIT), None)
-            .with_context(|| {
-                format!(
-                    "Failed to take {kind} search index lock {}",
-                    search_dir.display()
-                )
-            })?;
+        // The exclusive side is held for a whole search index publication, so
+        // both sides wait on the publication budget. The wait is interruptible
+        // through the caller's ambient cancellation.
+        acquire_with_deadline(
+            &file,
+            kind,
+            LockDeadline::after(PUBLICATION_LOCK_WAIT),
+            None,
+        )
+        .with_context(|| {
+            format!(
+                "Failed to take {kind} search index lock {}",
+                search_dir.display()
+            )
+        })?;
         Ok(Self {
             file,
             path: lock_path,
@@ -583,7 +591,7 @@ impl PersistedSearchIndexGuard {
         if !self.is_exclusive() {
             return Ok(());
         }
-        bounded_locks::downgrade_to_shared(&self.file, LockDeadline::after(DEFAULT_LOCK_WAIT))
+        bounded_locks::downgrade_to_shared(&self.file, LockDeadline::after(PUBLICATION_LOCK_WAIT))
             .with_context(|| {
                 format!(
                     "Failed to downgrade persisted search index lock {} to shared",

--- a/crates/codestory-runtime/src/search_publication.rs
+++ b/crates/codestory-runtime/src/search_publication.rs
@@ -1,11 +1,11 @@
 use super::{
-    ApiError, CancellationToken, EmbeddingProfileContractDto, FileExt,
-    HYBRID_RETRIEVAL_ENABLED_ENV, HashMap, IndexPublicationRecord, Instant, OwnedDeletionRoot,
-    Path, PathBuf, RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalStateDto, SearchEngine,
-    SearchSymbolProjection, SemanticModeDto, Storage, Store, StoredSemanticDocsContractDto,
-    UNIX_EPOCH, Uuid, clamp_u128_to_u32, clamp_usize_to_u32,
-    embedding_runtime_availability_from_config, indexing_cancelled_error, is_indexing_cancelled,
-    open_storage_for_read,
+    ApiError, CancellationToken, DEFAULT_LOCK_WAIT, EmbeddingProfileContractDto, FileLockKind,
+    HYBRID_RETRIEVAL_ENABLED_ENV, HashMap, IndexPublicationRecord, Instant, LockDeadline,
+    OwnedDeletionRoot, Path, PathBuf, RetrievalFallbackReasonDto, RetrievalModeDto,
+    RetrievalStateDto, SearchEngine, SearchSymbolProjection, SemanticModeDto, Storage, Store,
+    StoredSemanticDocsContractDto, UNIX_EPOCH, Uuid, acquire_with_deadline, bounded_locks,
+    clamp_u128_to_u32, clamp_usize_to_u32, embedding_runtime_availability_from_config,
+    indexing_cancelled_error, is_indexing_cancelled, open_storage_for_read,
 };
 #[cfg(test)]
 use super::{
@@ -178,11 +178,20 @@ impl SearchGenerationCatalogGuard {
                     path.display()
                 ))
             })?;
-        FileExt::lock_exclusive(&file).map_err(|error| {
-            ApiError::internal(format!(
-                "Failed to acquire search generation catalog lock {}: {error}",
-                path.display()
-            ))
+        acquire_with_deadline(
+            &file,
+            FileLockKind::Exclusive,
+            LockDeadline::after(DEFAULT_LOCK_WAIT),
+            None,
+        )
+        .map_err(|error| {
+            ApiError::new(
+                error.code(),
+                format!(
+                    "Failed to acquire search generation catalog lock {}: {error}",
+                    path.display()
+                ),
+            )
         })?;
         Ok(Self { file, path })
     }
@@ -190,7 +199,7 @@ impl SearchGenerationCatalogGuard {
 
 impl Drop for SearchGenerationCatalogGuard {
     fn drop(&mut self) {
-        if let Err(error) = FileExt::unlock(&self.file) {
+        if let Err(error) = bounded_locks::release(&self.file) {
             tracing::warn!(
                 path = %self.path.display(),
                 "Failed to unlock search generation catalog: {error}"
@@ -213,11 +222,14 @@ pub(super) fn inspect_search_generation(path: &Path) -> Result<Option<bool>, Api
                 lock_path.display()
             ))
         })?;
-    if !FileExt::try_lock_shared(&lock).map_err(|error| {
-        ApiError::internal(format!(
-            "Failed to inspect persisted search generation lock {}: {error}",
-            lock_path.display()
-        ))
+    if !bounded_locks::try_acquire(&lock, FileLockKind::Shared).map_err(|error| {
+        ApiError::new(
+            error.code(),
+            format!(
+                "Failed to inspect persisted search generation lock {}: {error}",
+                lock_path.display()
+            ),
+        )
     })? {
         return Ok(None);
     }
@@ -230,7 +242,7 @@ pub(super) fn inspect_search_generation(path: &Path) -> Result<Option<bool>, Api
         SearchEngine::open_existing(path)
             .is_ok_and(|engine| engine.tantivy_doc_count() as u64 == marker.tantivy_doc_count)
     });
-    let _ = FileExt::unlock(&lock);
+    let _ = bounded_locks::release(&lock);
     Ok(Some(valid))
 }
 
@@ -252,16 +264,19 @@ pub(super) fn try_remove_search_generation(
                 lock_path.display()
             ))
         })?;
-    if !FileExt::try_lock_exclusive(&lock).map_err(|error| {
-        ApiError::internal(format!(
-            "Failed to lock persisted search generation {} for removal: {error}",
-            path.display()
-        ))
+    if !bounded_locks::try_acquire(&lock, FileLockKind::Exclusive).map_err(|error| {
+        ApiError::new(
+            error.code(),
+            format!(
+                "Failed to lock persisted search generation {} for removal: {error}",
+                path.display()
+            ),
+        )
     })? {
         return Ok(false);
     }
     let removal = deletion.remove(relative);
-    let _ = FileExt::unlock(&lock);
+    let _ = bounded_locks::release(&lock);
     let removed = removal.map_err(|error| {
         ApiError::internal(format!(
             "Failed to remove persisted search generation {}: {error}",

--- a/crates/codestory-runtime/src/search_publication.rs
+++ b/crates/codestory-runtime/src/search_publication.rs
@@ -1,11 +1,12 @@
 use super::{
-    ApiError, CancellationToken, DEFAULT_LOCK_WAIT, EmbeddingProfileContractDto, FileLockKind,
+    ApiError, CancellationToken, EmbeddingProfileContractDto, FileLockKind,
     HYBRID_RETRIEVAL_ENABLED_ENV, HashMap, IndexPublicationRecord, Instant, LockDeadline,
-    OwnedDeletionRoot, Path, PathBuf, RetrievalFallbackReasonDto, RetrievalModeDto,
-    RetrievalStateDto, SearchEngine, SearchSymbolProjection, SemanticModeDto, Storage, Store,
-    StoredSemanticDocsContractDto, UNIX_EPOCH, Uuid, acquire_with_deadline, bounded_locks,
-    clamp_u128_to_u32, clamp_usize_to_u32, embedding_runtime_availability_from_config,
-    indexing_cancelled_error, is_indexing_cancelled, open_storage_for_read,
+    OwnedDeletionRoot, PUBLICATION_LOCK_WAIT, Path, PathBuf, RetrievalFallbackReasonDto,
+    RetrievalModeDto, RetrievalStateDto, SearchEngine, SearchSymbolProjection, SemanticModeDto,
+    Storage, Store, StoredSemanticDocsContractDto, UNIX_EPOCH, Uuid, acquire_with_deadline,
+    bounded_locks, clamp_u128_to_u32, clamp_usize_to_u32,
+    embedding_runtime_availability_from_config, indexing_cancelled_error, is_indexing_cancelled,
+    open_storage_for_read,
 };
 #[cfg(test)]
 use super::{
@@ -181,17 +182,17 @@ impl SearchGenerationCatalogGuard {
         acquire_with_deadline(
             &file,
             FileLockKind::Exclusive,
-            LockDeadline::after(DEFAULT_LOCK_WAIT),
+            LockDeadline::after(PUBLICATION_LOCK_WAIT),
             None,
         )
         .map_err(|error| {
-            ApiError::new(
-                error.code(),
-                format!(
-                    "Failed to acquire search generation catalog lock {}: {error}",
-                    path.display()
-                ),
-            )
+            // The typed code rides in the message; the public error code stays
+            // `internal`, as it was before acquisition became bounded.
+            ApiError::internal(format!(
+                "Failed to acquire search generation catalog lock {} ({}): {error}",
+                path.display(),
+                error.code()
+            ))
         })?;
         Ok(Self { file, path })
     }
@@ -223,13 +224,11 @@ pub(super) fn inspect_search_generation(path: &Path) -> Result<Option<bool>, Api
             ))
         })?;
     if !bounded_locks::try_acquire(&lock, FileLockKind::Shared).map_err(|error| {
-        ApiError::new(
-            error.code(),
-            format!(
-                "Failed to inspect persisted search generation lock {}: {error}",
-                lock_path.display()
-            ),
-        )
+        ApiError::internal(format!(
+            "Failed to inspect persisted search generation lock {} ({}): {error}",
+            lock_path.display(),
+            error.code()
+        ))
     })? {
         return Ok(None);
     }
@@ -265,13 +264,11 @@ pub(super) fn try_remove_search_generation(
             ))
         })?;
     if !bounded_locks::try_acquire(&lock, FileLockKind::Exclusive).map_err(|error| {
-        ApiError::new(
-            error.code(),
-            format!(
-                "Failed to lock persisted search generation {} for removal: {error}",
-                path.display()
-            ),
-        )
+        ApiError::internal(format!(
+            "Failed to lock persisted search generation {} for removal ({}): {error}",
+            path.display(),
+            error.code()
+        ))
     })? {
         return Ok(false);
     }

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -26,10 +26,28 @@ use std::time::{Duration, Instant};
 const DEFAULT_ACTIVATION_FOREGROUND_BUDGET: Duration = Duration::from_secs(5);
 const ACTIVATION_WAIT_SLICE: Duration = Duration::from_millis(25);
 /// Longest an eviction or shutdown waits for a cancelled activation worker to
-/// reach a quiescent boundary. The worker checks cancellation between every
-/// preparation stage and inside indexing, so exceeding this budget means the
-/// worker is wedged inside owned mutation or a held publication/store lock.
+/// reach a quiescent boundary before fail-stopping the process.
+///
+/// The worker checks cancellation between every preparation stage and inside
+/// indexing, and [`run_activation_worker`] installs its cancellation flag as
+/// the ambient one for every bounded lock acquisition on the worker thread. A
+/// lock wait therefore never blocks the worker for its own budget — a peer's
+/// whole publication, up to [`bounded_locks::PUBLICATION_LOCK_WAIT`] — but only
+/// until the flag is observed, within
+/// [`bounded_locks::MAX_CANCELLATION_LATENCY`]. Exceeding this budget means the
+/// worker is wedged inside owned mutation, not merely waiting for a peer.
 const ACTIVATION_QUIESCENCE_BUDGET: Duration = Duration::from_secs(20);
+
+/// The invariant this whole path rests on: the budget an eviction uses before
+/// aborting the process must exceed the longest a worker can stay inside a
+/// bounded lock wait after its cancellation is raised. Without the ambient
+/// scope that longest wait would instead be `PUBLICATION_LOCK_WAIT`, and an
+/// ordinary slow activation would abort a healthy session.
+const _: () = assert!(
+    ACTIVATION_QUIESCENCE_BUDGET.as_millis()
+        > codestory_contracts::bounded_locks::MAX_CANCELLATION_LATENCY.as_millis(),
+    "the quiescence budget must exceed the bounded-lock cancellation latency"
+);
 /// Fail-stop reason recorded when a cancelled activation worker never reaches
 /// a quiescent boundary.
 pub const ACTIVATION_QUIESCENCE_FAIL_STOP: &str = "activation_quiescence_timeout";
@@ -118,10 +136,14 @@ fn with_public_operation_cancellation<T>(
     cancelled: Arc<AtomicBool>,
     build: impl FnOnce() -> T,
 ) -> T {
-    let previous =
-        ACTIVE_PUBLIC_OPERATION_CANCELLATION.with(|active| active.replace(Some(cancelled)));
+    let previous = ACTIVE_PUBLIC_OPERATION_CANCELLATION
+        .with(|active| active.replace(Some(Arc::clone(&cancelled))));
     let _guard = ActivePublicOperationCancellationGuard { previous };
-    build()
+    // A request body reaches the same publication-class locks the activation
+    // worker does, and waits behind a peer's whole publication pass. That is
+    // only tolerable while the request's own cancellation can end the wait, so
+    // the flag becomes the ambient one for every bounded acquisition below.
+    codestory_contracts::bounded_locks::with_thread_cancellation(cancelled, build)
 }
 
 pub(crate) fn active_public_operation_cancellation() -> Option<Arc<AtomicBool>> {
@@ -369,41 +391,7 @@ enum CompleteCoreAdmission {
 
 struct ReadyLeaseProbe {
     admissible: bool,
-    retained_core_publication: RetainedCoreObservation,
-}
-
-/// What one observational read of the on-disk core publication proved.
-///
-/// A transient read failure — SQLite lock contention past the busy timeout is
-/// the realistic trigger — is not evidence that no retained publication exists.
-/// Collapsing both into `None` demoted retained local navigation that the
-/// on-disk core would still have admitted, so the two stay distinct.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum RetainedCoreObservation {
-    Observed(Option<IndexPublicationDto>),
-    Unobservable,
-}
-
-impl RetainedCoreObservation {
-    fn from_read(result: Result<Option<IndexPublicationDto>, ApiError>) -> Self {
-        match result {
-            Ok(retained) => Self::Observed(retained),
-            Err(error) => {
-                tracing::warn!(
-                    code = %error.code,
-                    "retained core publication could not be observed; keeping the last proven retained capability"
-                );
-                Self::Unobservable
-            }
-        }
-    }
-
-    fn observed(&self) -> Option<&IndexPublicationDto> {
-        match self {
-            Self::Observed(retained) => retained.as_ref(),
-            Self::Unobservable => None,
-        }
-    }
+    retained_core_publication: Option<IndexPublicationDto>,
 }
 
 fn ready_retrieval_identity_matches(
@@ -856,7 +844,7 @@ impl ActivationService {
             }
 
             let retained_core_publication =
-                RetainedCoreObservation::from_read(self.retained_core_publication(storage_path));
+                self.retained_core_publication(storage_path).unwrap_or(None);
             let mut state = self
                 .coordinator
                 .state
@@ -976,11 +964,8 @@ impl ActivationService {
         let retrieval_matches =
             ready_retrieval_identity_matches(retrieval_identity.as_ref(), &lease.retrieval);
         let retained_core_publication =
-            RetainedCoreObservation::from_read(self.retained_core_publication(storage_path));
-        // An unobservable core cannot prove the lease still matches, so
-        // admission stays fail-closed even though the retained capability is
-        // preserved below.
-        let core_matches = retained_core_publication.observed() == Some(&lease.core_publication);
+            self.retained_core_publication(storage_path).unwrap_or(None);
+        let core_matches = retained_core_publication.as_ref() == Some(&lease.core_publication);
         ReadyLeaseProbe {
             admissible: configuration_matches
                 && lease.source.is_admissible_snapshot()
@@ -994,7 +979,7 @@ impl ActivationService {
         &self,
         state: &mut ActivationCoordinatorState,
         target: &ActivationTarget,
-        retained_core_publication: RetainedCoreObservation,
+        retained_core_publication: Option<IndexPublicationDto>,
     ) -> (String, Arc<AtomicBool>) {
         if !state
             .target
@@ -1020,30 +1005,17 @@ impl ActivationService {
                 snapshot.stage = ActivationStage::Discovery;
                 snapshot.progress = activation_stage_progress(ActivationStage::Discovery);
             }
-            match retained_core_publication {
-                RetainedCoreObservation::Observed(retained) => {
-                    let retained_was_ready = snapshot.capabilities.local_navigation
-                        == ActivationCapabilityState::Ready
-                        && snapshot.retained_core_publication == retained;
-                    snapshot.retained_core_publication = retained;
-                    snapshot.capabilities.local_navigation = if retained_was_ready {
-                        ActivationCapabilityState::Ready
-                    } else if snapshot.retained_core_publication.is_some() {
-                        ActivationCapabilityState::Retained
-                    } else {
-                        ActivationCapabilityState::Unavailable
-                    };
-                }
-                // A failed read proves nothing about the on-disk core, so the
-                // previously proven retained publication and its capability
-                // survive the replacement instead of being stripped.
-                RetainedCoreObservation::Unobservable => {
-                    if snapshot.capabilities.local_navigation == ActivationCapabilityState::Ready {
-                        snapshot.capabilities.local_navigation =
-                            ActivationCapabilityState::Retained;
-                    }
-                }
-            }
+            let retained_was_ready = snapshot.capabilities.local_navigation
+                == ActivationCapabilityState::Ready
+                && snapshot.retained_core_publication == retained_core_publication;
+            snapshot.retained_core_publication = retained_core_publication;
+            snapshot.capabilities.local_navigation = if retained_was_ready {
+                ActivationCapabilityState::Ready
+            } else if snapshot.retained_core_publication.is_some() {
+                ActivationCapabilityState::Retained
+            } else {
+                ActivationCapabilityState::Unavailable
+            };
             snapshot.capabilities.broad_search = ActivationCapabilityState::Unavailable;
             snapshot.operation_id.clone()
         } else {
@@ -1070,11 +1042,9 @@ impl ActivationService {
                 failure_code: None,
                 failure: None,
                 failure_details: None,
-                retained_core_publication: retained_core_publication.observed().cloned(),
+                retained_core_publication: retained_core_publication.clone(),
                 capabilities: ActivationCapabilities {
-                    // A first activation has no earlier proof to preserve, so
-                    // an unobservable core is indistinguishable from none.
-                    local_navigation: if retained_core_publication.observed().is_some() {
+                    local_navigation: if retained_core_publication.is_some() {
                         ActivationCapabilityState::Retained
                     } else {
                         ActivationCapabilityState::Unavailable
@@ -1894,16 +1864,29 @@ fn run_activation_worker(
     operation: &ActivationOperation,
     activate: impl FnOnce() -> Result<(), ApiError>,
 ) {
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        let attempt = operation.attempt();
-        activate().map_err(|error| classify_activation_api_error_for_attempt(error, attempt))
-    }))
-    .unwrap_or_else(|_| {
-        Err(ApiError::new(
-            "project_unavailable",
-            "project activation worker stopped unexpectedly",
-        ))
-    });
+    // This thread is the one whose quiescence an eviction or shutdown joins
+    // against ACTIVATION_QUIESCENCE_BUDGET, and past that budget the process
+    // aborts. Its lock waits must therefore all be interruptible. The deep ones
+    // — model materialization, promotion, the search index and generation
+    // catalog guards, retention — are reached through APIs that carry no
+    // cancellation flag, so the flag is installed on the thread instead and
+    // every bounded acquisition below inherits it.
+    let result = codestory_contracts::bounded_locks::with_thread_cancellation(
+        Arc::clone(&operation.cancelled),
+        || {
+            catch_unwind(AssertUnwindSafe(|| {
+                let attempt = operation.attempt();
+                activate()
+                    .map_err(|error| classify_activation_api_error_for_attempt(error, attempt))
+            }))
+            .unwrap_or_else(|_| {
+                Err(ApiError::new(
+                    "project_unavailable",
+                    "project activation worker stopped unexpectedly",
+                ))
+            })
+        },
+    );
     let _ = operation.finish(result.as_ref().err());
 }
 
@@ -4328,29 +4311,127 @@ mod bounded_runtime_tests {
         }
     }
 
-    fn ready_snapshot(
-        retained: Option<IndexPublicationDto>,
-        local_navigation: ActivationCapabilityState,
-    ) -> ActivationSnapshot {
+    fn preparing_snapshot(operation_id: &str) -> ActivationSnapshot {
         ActivationSnapshot {
-            operation_id: "activation-bounded-fixture".into(),
-            revision: 4,
-            state: ActivationState::Ready,
-            stage: ActivationStage::Ready,
-            progress: activation_stage_progress(ActivationStage::Ready),
-            attempt: 2,
-            retry_after_ms: None,
+            operation_id: operation_id.to_string(),
+            revision: 1,
+            state: ActivationState::Preparing,
+            stage: ActivationStage::Publication,
+            progress: activation_stage_progress(ActivationStage::Publication),
+            attempt: 1,
+            retry_after_ms: Some(250),
             embedding_capacity: None,
             embedding_retry: None,
             failure_code: None,
             failure: None,
             failure_details: None,
-            retained_core_publication: retained,
+            retained_core_publication: None,
             capabilities: ActivationCapabilities {
-                local_navigation,
-                broad_search: ActivationCapabilityState::Ready,
+                local_navigation: ActivationCapabilityState::Unavailable,
+                broad_search: ActivationCapabilityState::Unavailable,
             },
         }
+    }
+
+    /// The invariant the fail-stop budget rests on: the longest a worker can be
+    /// stuck without observing cancellation must stay under
+    /// `ACTIVATION_QUIESCENCE_BUDGET`.
+    ///
+    /// A peer holding a retention lock for a whole publication is ordinary, not
+    /// a fault, and the waiter's own budget for it is
+    /// `PUBLICATION_LOCK_WAIT` — six times the quiescence budget. Unless the
+    /// wait ends on cancellation, an eviction or a shutdown during a slow first
+    /// activation joins a worker that is merely waiting, calls it unquiesced,
+    /// and aborts the process out from under a healthy session.
+    ///
+    /// `GenerationRetentionLock::acquire` is a real production call site that
+    /// passes no cancellation flag of its own, exactly like the promotion,
+    /// search index, generation catalog, and model materialization waits the
+    /// worker also reaches. It must inherit the worker's.
+    #[test]
+    fn a_worker_waiting_on_a_held_publication_lock_quiesces_on_cancellation() {
+        let fixture = bounded_runtime_fixture();
+        let service = fixture.runtime.activation_service();
+        let state_file = fixture.project.path().join("retrieval-sidecars.json");
+        let holder = codestory_retrieval::GenerationRetentionLock::acquire(
+            &state_file,
+            "quiescence_contention",
+        )
+        .expect("a peer takes the retention lock for its publication pass");
+
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let operation_id = "activation-quiescence-contention".to_string();
+        {
+            let mut state = service
+                .coordinator
+                .state
+                .lock()
+                .expect("activation coordinator");
+            state.current = Some(preparing_snapshot(&operation_id));
+            state.running = true;
+            state.current_cancel = Some(Arc::clone(&cancelled));
+        }
+        let operation = ActivationOperation {
+            service: service.clone(),
+            operation_id,
+            cancelled: Arc::clone(&cancelled),
+        };
+        let (entered, entered_rx) = std::sync::mpsc::channel();
+        let waited_state_file = state_file.clone();
+        let worker = std::thread::spawn(move || {
+            run_activation_worker(&operation, || {
+                entered
+                    .send(())
+                    .expect("announce that the worker is running");
+                // Either outcome ends the body; the worker always reports a
+                // failure so completion takes the error path rather than the
+                // ready-lease one this fixture never publishes.
+                match codestory_retrieval::GenerationRetentionLock::acquire(
+                    &waited_state_file,
+                    "quiescence_contention",
+                ) {
+                    Ok(_) => Err(ApiError::new(
+                        "activation_retryable",
+                        "the wait outlived cancellation and ended by acquiring the lock",
+                    )),
+                    Err(error) => Err(ApiError::new("cancelled", error.to_string())),
+                }
+            });
+        });
+        entered_rx
+            .recv_timeout(Duration::from_secs(30))
+            .expect("worker entered its body");
+
+        let started = Instant::now();
+        let quiescence = service.cancel_and_wait_within(ACTIVATION_QUIESCENCE_BUDGET);
+        let waited = started.elapsed();
+
+        // Released before the join so a regression fails in the worker's own
+        // budget rather than parking this test behind PUBLICATION_LOCK_WAIT.
+        drop(holder);
+        worker.join().expect("activation worker thread");
+        let failure_code = service
+            .snapshot()
+            .expect("the fixture seeded a snapshot")
+            .failure_code;
+
+        assert_eq!(
+            quiescence,
+            ActivationQuiescence::Quiesced,
+            "a worker merely waiting behind a peer's publication was reported unquiesced after {waited:?}, which aborts the process"
+        );
+        assert!(
+            waited < Duration::from_secs(5),
+            "the cancelled worker took {waited:?} to leave a lock wait it should have left within {:?}",
+            codestory_contracts::bounded_locks::MAX_CANCELLATION_LATENCY
+        );
+        // Not merely fast: the wait ended because the flag was raised, and not
+        // because the peer happened to release first.
+        assert_eq!(
+            failure_code.as_deref(),
+            Some("cancelled"),
+            "the worker must leave the lock wait on its cancellation flag"
+        );
     }
 
     #[test]
@@ -4437,65 +4518,5 @@ mod bounded_runtime_tests {
         });
 
         assert_eq!(error.code, "cancelled");
-    }
-
-    #[test]
-    fn an_unobservable_retained_core_keeps_the_proven_local_navigation_capability() {
-        // SQLite lock contention past the busy timeout is a read failure, not
-        // proof that the on-disk core is gone. Collapsing the two stripped
-        // retained local navigation the core would still have admitted.
-        let fixture = bounded_runtime_fixture();
-        let service = fixture.runtime.activation_service();
-        let storage_path = fixture.project.path().join("codestory.db");
-        let target = ActivationTarget::new(fixture.project.path(), &storage_path);
-        let publication = IndexPublicationDto {
-            generation: 9,
-            generation_id: "generation-bounded".into(),
-            run_id: "run-bounded".into(),
-            mode: codestory_contracts::api::IndexPublicationModeDto::Full,
-            published_at_epoch_ms: 17,
-        };
-
-        let mut state = service
-            .coordinator
-            .state
-            .lock()
-            .expect("activation coordinator");
-        state.target = Some(target.clone());
-        state.current = Some(ready_snapshot(
-            Some(publication.clone()),
-            ActivationCapabilityState::Ready,
-        ));
-        service.begin_activation_locked(&mut state, &target, RetainedCoreObservation::Unobservable);
-        let after_unobservable = state.current.clone().expect("replacement snapshot");
-        assert_eq!(
-            after_unobservable.retained_core_publication,
-            Some(publication.clone()),
-            "an unreadable core must not erase the proven retained publication"
-        );
-        assert_eq!(
-            after_unobservable.capabilities.local_navigation,
-            ActivationCapabilityState::Retained
-        );
-
-        state.running = false;
-        state.current = Some(ready_snapshot(
-            Some(publication),
-            ActivationCapabilityState::Ready,
-        ));
-        service.begin_activation_locked(
-            &mut state,
-            &target,
-            RetainedCoreObservation::Observed(None),
-        );
-        let after_absent = state.current.clone().expect("replacement snapshot");
-        assert_eq!(
-            after_absent.retained_core_publication, None,
-            "a successful read proving no retained core must still demote"
-        );
-        assert_eq!(
-            after_absent.capabilities.local_navigation,
-            ActivationCapabilityState::Unavailable
-        );
     }
 }

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -1154,7 +1154,7 @@ impl ActivationService {
     }
 
     /// Cancel the in-flight activation and wait for it to reach a quiescent
-    /// boundary. Past [`ACTIVATION_QUIESCENCE_BUDGET`] the worker is never
+    /// boundary. Past the activation quiescence budget the worker is never
     /// detached: it may still hold a publication or store lock, so the process
     /// fail-stops with the recorded reason instead of continuing.
     pub fn cancel_and_wait(&self) -> ActivationQuiescence {

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -20,11 +20,58 @@ use std::cell::RefCell;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 const DEFAULT_ACTIVATION_FOREGROUND_BUDGET: Duration = Duration::from_secs(5);
 const ACTIVATION_WAIT_SLICE: Duration = Duration::from_millis(25);
+/// Longest an eviction or shutdown waits for a cancelled activation worker to
+/// reach a quiescent boundary. The worker checks cancellation between every
+/// preparation stage and inside indexing, so exceeding this budget means the
+/// worker is wedged inside owned mutation or a held publication/store lock.
+const ACTIVATION_QUIESCENCE_BUDGET: Duration = Duration::from_secs(20);
+/// Fail-stop reason recorded when a cancelled activation worker never reaches
+/// a quiescent boundary.
+pub const ACTIVATION_QUIESCENCE_FAIL_STOP: &str = "activation_quiescence_timeout";
+
+/// Process-level fail-stop installed by the host binary. The runtime never
+/// aborts on its own: an embedder or a test observes the verdict instead.
+pub type ActivationFailStopHook = Arc<dyn Fn(&str) + Send + Sync>;
+
+static ACTIVATION_FAIL_STOP: RwLock<Option<ActivationFailStopHook>> = RwLock::new(None);
+
+/// Install (or clear) the process fail-stop used when a cancelled activation
+/// worker cannot be proven quiescent. Returns the previous hook.
+pub fn set_activation_fail_stop_hook(
+    hook: Option<ActivationFailStopHook>,
+) -> Option<ActivationFailStopHook> {
+    let mut installed = ACTIVATION_FAIL_STOP
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    std::mem::replace(&mut *installed, hook)
+}
+
+fn run_activation_fail_stop(reason_code: &str) {
+    let hook = ACTIVATION_FAIL_STOP
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    match hook {
+        Some(hook) => hook(reason_code),
+        None => tracing::error!(
+            reason_code,
+            "a cancelled activation worker never reached a quiescent boundary and no process fail-stop is installed"
+        ),
+    }
+}
+
+/// Whether a cancelled activation worker reached a boundary at which it
+/// provably holds no publication or store lock and mutates no owned state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationQuiescence {
+    Quiesced,
+    FailStopRequired,
+}
 
 #[cfg(any(test, feature = "test-support"))]
 thread_local! {
@@ -322,7 +369,41 @@ enum CompleteCoreAdmission {
 
 struct ReadyLeaseProbe {
     admissible: bool,
-    retained_core_publication: Option<IndexPublicationDto>,
+    retained_core_publication: RetainedCoreObservation,
+}
+
+/// What one observational read of the on-disk core publication proved.
+///
+/// A transient read failure — SQLite lock contention past the busy timeout is
+/// the realistic trigger — is not evidence that no retained publication exists.
+/// Collapsing both into `None` demoted retained local navigation that the
+/// on-disk core would still have admitted, so the two stay distinct.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RetainedCoreObservation {
+    Observed(Option<IndexPublicationDto>),
+    Unobservable,
+}
+
+impl RetainedCoreObservation {
+    fn from_read(result: Result<Option<IndexPublicationDto>, ApiError>) -> Self {
+        match result {
+            Ok(retained) => Self::Observed(retained),
+            Err(error) => {
+                tracing::warn!(
+                    code = %error.code,
+                    "retained core publication could not be observed; keeping the last proven retained capability"
+                );
+                Self::Unobservable
+            }
+        }
+    }
+
+    fn observed(&self) -> Option<&IndexPublicationDto> {
+        match self {
+            Self::Observed(retained) => retained.as_ref(),
+            Self::Unobservable => None,
+        }
+    }
 }
 
 fn ready_retrieval_identity_matches(
@@ -775,7 +856,7 @@ impl ActivationService {
             }
 
             let retained_core_publication =
-                self.retained_core_publication(storage_path).unwrap_or(None);
+                RetainedCoreObservation::from_read(self.retained_core_publication(storage_path));
             let mut state = self
                 .coordinator
                 .state
@@ -895,8 +976,11 @@ impl ActivationService {
         let retrieval_matches =
             ready_retrieval_identity_matches(retrieval_identity.as_ref(), &lease.retrieval);
         let retained_core_publication =
-            self.retained_core_publication(storage_path).unwrap_or(None);
-        let core_matches = retained_core_publication.as_ref() == Some(&lease.core_publication);
+            RetainedCoreObservation::from_read(self.retained_core_publication(storage_path));
+        // An unobservable core cannot prove the lease still matches, so
+        // admission stays fail-closed even though the retained capability is
+        // preserved below.
+        let core_matches = retained_core_publication.observed() == Some(&lease.core_publication);
         ReadyLeaseProbe {
             admissible: configuration_matches
                 && lease.source.is_admissible_snapshot()
@@ -910,7 +994,7 @@ impl ActivationService {
         &self,
         state: &mut ActivationCoordinatorState,
         target: &ActivationTarget,
-        retained_core_publication: Option<IndexPublicationDto>,
+        retained_core_publication: RetainedCoreObservation,
     ) -> (String, Arc<AtomicBool>) {
         if !state
             .target
@@ -936,17 +1020,30 @@ impl ActivationService {
                 snapshot.stage = ActivationStage::Discovery;
                 snapshot.progress = activation_stage_progress(ActivationStage::Discovery);
             }
-            let retained_was_ready = snapshot.capabilities.local_navigation
-                == ActivationCapabilityState::Ready
-                && snapshot.retained_core_publication == retained_core_publication;
-            snapshot.retained_core_publication = retained_core_publication;
-            snapshot.capabilities.local_navigation = if retained_was_ready {
-                ActivationCapabilityState::Ready
-            } else if snapshot.retained_core_publication.is_some() {
-                ActivationCapabilityState::Retained
-            } else {
-                ActivationCapabilityState::Unavailable
-            };
+            match retained_core_publication {
+                RetainedCoreObservation::Observed(retained) => {
+                    let retained_was_ready = snapshot.capabilities.local_navigation
+                        == ActivationCapabilityState::Ready
+                        && snapshot.retained_core_publication == retained;
+                    snapshot.retained_core_publication = retained;
+                    snapshot.capabilities.local_navigation = if retained_was_ready {
+                        ActivationCapabilityState::Ready
+                    } else if snapshot.retained_core_publication.is_some() {
+                        ActivationCapabilityState::Retained
+                    } else {
+                        ActivationCapabilityState::Unavailable
+                    };
+                }
+                // A failed read proves nothing about the on-disk core, so the
+                // previously proven retained publication and its capability
+                // survive the replacement instead of being stripped.
+                RetainedCoreObservation::Unobservable => {
+                    if snapshot.capabilities.local_navigation == ActivationCapabilityState::Ready {
+                        snapshot.capabilities.local_navigation =
+                            ActivationCapabilityState::Retained;
+                    }
+                }
+            }
             snapshot.capabilities.broad_search = ActivationCapabilityState::Unavailable;
             snapshot.operation_id.clone()
         } else {
@@ -973,9 +1070,11 @@ impl ActivationService {
                 failure_code: None,
                 failure: None,
                 failure_details: None,
-                retained_core_publication: retained_core_publication.clone(),
+                retained_core_publication: retained_core_publication.observed().cloned(),
                 capabilities: ActivationCapabilities {
-                    local_navigation: if retained_core_publication.is_some() {
+                    // A first activation has no earlier proof to preserve, so
+                    // an unobservable core is indistinguishable from none.
+                    local_navigation: if retained_core_publication.observed().is_some() {
                         ActivationCapabilityState::Retained
                     } else {
                         ActivationCapabilityState::Unavailable
@@ -1084,7 +1183,28 @@ impl ActivationService {
         }
     }
 
-    pub fn cancel_and_wait(&self) {
+    /// Cancel the in-flight activation and wait for it to reach a quiescent
+    /// boundary. Past [`ACTIVATION_QUIESCENCE_BUDGET`] the worker is never
+    /// detached: it may still hold a publication or store lock, so the process
+    /// fail-stops with the recorded reason instead of continuing.
+    pub fn cancel_and_wait(&self) -> ActivationQuiescence {
+        self.cancel_and_wait_or_fail_stop(ACTIVATION_QUIESCENCE_BUDGET)
+    }
+
+    fn cancel_and_wait_or_fail_stop(&self, budget: Duration) -> ActivationQuiescence {
+        let quiescence = self.cancel_and_wait_within(budget);
+        if quiescence == ActivationQuiescence::FailStopRequired {
+            run_activation_fail_stop(ACTIVATION_QUIESCENCE_FAIL_STOP);
+        }
+        quiescence
+    }
+
+    /// Bounded quiescence join without the fail-stop side effect, so callers
+    /// (and deterministic tests) can observe the verdict directly.
+    pub fn cancel_and_wait_within(&self, budget: Duration) -> ActivationQuiescence {
+        let deadline = Instant::now()
+            .checked_add(budget)
+            .unwrap_or_else(Instant::now);
         let mut state = self
             .coordinator
             .state
@@ -1094,12 +1214,19 @@ impl ActivationService {
             cancelled.store(true, Ordering::Release);
         }
         while state.running {
+            let now = Instant::now();
+            if now >= deadline {
+                return ActivationQuiescence::FailStopRequired;
+            }
+            let remaining = deadline.saturating_duration_since(now);
             state = self
                 .coordinator
                 .changed
-                .wait(state)
-                .expect("activation coordinator poisoned");
+                .wait_timeout(state, remaining.min(ACTIVATION_WAIT_SLICE))
+                .expect("activation coordinator poisoned")
+                .0;
         }
+        ActivationQuiescence::Quiesced
     }
 
     fn activate_once(
@@ -4162,5 +4289,213 @@ mod activation_tests {
         assert!(snapshot.allows_operation("ground"));
         assert!(!snapshot.allows_operation("packet"));
         assert_ne!(snapshot.state, ActivationState::Ready);
+    }
+}
+
+#[cfg(test)]
+mod bounded_runtime_tests {
+    use super::*;
+    use crate::Runtime;
+    use std::fs;
+
+    struct BoundedRuntimeFixture {
+        project: tempfile::TempDir,
+        _cache: tempfile::TempDir,
+        runtime: Runtime,
+    }
+
+    /// A runtime with no published core: every test here decides before any
+    /// snapshot work, so publishing one would only slow the proof down.
+    fn bounded_runtime_fixture() -> BoundedRuntimeFixture {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        fs::write(project.path().join("anchor.rs"), "// BOUNDED_ANCHOR\n")
+            .expect("write source anchor");
+        let sidecar_cache = cache.path().join("sidecar");
+        fs::create_dir_all(&sidecar_cache).expect("create sidecar cache");
+        let mut sidecar = codestory_retrieval::with_test_cache_root(&sidecar_cache, || {
+            codestory_retrieval::SidecarRuntimeConfig::for_project_profile(
+                Some(project.path()),
+                codestory_retrieval::SidecarProfile::Agent,
+            )
+        });
+        sidecar.embedding.allow_cpu = true;
+        let runtime = Runtime::new_with_config(sidecar);
+        BoundedRuntimeFixture {
+            project,
+            _cache: cache,
+            runtime,
+        }
+    }
+
+    fn ready_snapshot(
+        retained: Option<IndexPublicationDto>,
+        local_navigation: ActivationCapabilityState,
+    ) -> ActivationSnapshot {
+        ActivationSnapshot {
+            operation_id: "activation-bounded-fixture".into(),
+            revision: 4,
+            state: ActivationState::Ready,
+            stage: ActivationStage::Ready,
+            progress: activation_stage_progress(ActivationStage::Ready),
+            attempt: 2,
+            retry_after_ms: None,
+            embedding_capacity: None,
+            embedding_retry: None,
+            failure_code: None,
+            failure: None,
+            failure_details: None,
+            retained_core_publication: retained,
+            capabilities: ActivationCapabilities {
+                local_navigation,
+                broad_search: ActivationCapabilityState::Ready,
+            },
+        }
+    }
+
+    #[test]
+    fn an_unquiesced_activation_worker_fail_stops_instead_of_being_detached() {
+        // A worker that has not reached a cancellation checkpoint may still
+        // hold a publication or store lock. Returning to the caller would
+        // detach it behind an evicted context, so the join reports a fail-stop
+        // and the hosting process records evidence and aborts.
+        let fixture = bounded_runtime_fixture();
+        let service = fixture.runtime.activation_service();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        {
+            let mut state = service
+                .coordinator
+                .state
+                .lock()
+                .expect("activation coordinator");
+            state.running = true;
+            state.current_cancel = Some(Arc::clone(&cancelled));
+        }
+        let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
+        let sink = Arc::clone(&recorded);
+        let previous = set_activation_fail_stop_hook(Some(Arc::new(move |reason: &str| {
+            sink.lock()
+                .expect("fail-stop sink")
+                .push(reason.to_string());
+        })));
+
+        let started = Instant::now();
+        let quiescence = service.cancel_and_wait_or_fail_stop(Duration::from_millis(80));
+        let waited = started.elapsed();
+        set_activation_fail_stop_hook(previous);
+
+        assert_eq!(quiescence, ActivationQuiescence::FailStopRequired);
+        assert!(
+            cancelled.load(Ordering::Acquire),
+            "the join must raise the worker's cancellation flag first"
+        );
+        assert_eq!(
+            recorded.lock().expect("fail-stop sink").as_slice(),
+            [ACTIVATION_QUIESCENCE_FAIL_STOP.to_string()]
+        );
+        assert!(
+            waited < Duration::from_secs(5),
+            "the join waited {waited:?} instead of its 80 ms budget"
+        );
+
+        {
+            let mut state = service
+                .coordinator
+                .state
+                .lock()
+                .expect("activation coordinator");
+            state.running = false;
+            state.current_cancel = None;
+        }
+        service.coordinator.changed.notify_all();
+        assert_eq!(
+            service.cancel_and_wait_within(Duration::from_millis(80)),
+            ActivationQuiescence::Quiesced,
+            "a worker at a quiescent boundary must join without a fail-stop"
+        );
+    }
+
+    #[test]
+    fn the_read_only_facade_inherits_the_active_public_operation_cancellation() {
+        // The facade used to mint a fresh, permanently-false flag on entry,
+        // which replaced the host's live cancellation for the whole tool body.
+        let fixture = bounded_runtime_fixture();
+        let browser = fixture.runtime.browser_service();
+        let cancelled = Arc::new(AtomicBool::new(true));
+
+        let error = with_public_operation_cancellation(Arc::clone(&cancelled), || {
+            browser
+                .search(SearchRequest {
+                    query: "anchor".into(),
+                    repo_text: codestory_contracts::api::SearchRepoTextMode::Off,
+                    limit_per_source: 1,
+                    expand_search_plan: false,
+                    hybrid_weights: None,
+                    hybrid_limits: None,
+                })
+                .expect_err("an already-cancelled host request must not run a tool body")
+        });
+
+        assert_eq!(error.code, "cancelled");
+    }
+
+    #[test]
+    fn an_unobservable_retained_core_keeps_the_proven_local_navigation_capability() {
+        // SQLite lock contention past the busy timeout is a read failure, not
+        // proof that the on-disk core is gone. Collapsing the two stripped
+        // retained local navigation the core would still have admitted.
+        let fixture = bounded_runtime_fixture();
+        let service = fixture.runtime.activation_service();
+        let storage_path = fixture.project.path().join("codestory.db");
+        let target = ActivationTarget::new(fixture.project.path(), &storage_path);
+        let publication = IndexPublicationDto {
+            generation: 9,
+            generation_id: "generation-bounded".into(),
+            run_id: "run-bounded".into(),
+            mode: codestory_contracts::api::IndexPublicationModeDto::Full,
+            published_at_epoch_ms: 17,
+        };
+
+        let mut state = service
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator");
+        state.target = Some(target.clone());
+        state.current = Some(ready_snapshot(
+            Some(publication.clone()),
+            ActivationCapabilityState::Ready,
+        ));
+        service.begin_activation_locked(&mut state, &target, RetainedCoreObservation::Unobservable);
+        let after_unobservable = state.current.clone().expect("replacement snapshot");
+        assert_eq!(
+            after_unobservable.retained_core_publication,
+            Some(publication.clone()),
+            "an unreadable core must not erase the proven retained publication"
+        );
+        assert_eq!(
+            after_unobservable.capabilities.local_navigation,
+            ActivationCapabilityState::Retained
+        );
+
+        state.running = false;
+        state.current = Some(ready_snapshot(
+            Some(publication),
+            ActivationCapabilityState::Ready,
+        ));
+        service.begin_activation_locked(
+            &mut state,
+            &target,
+            RetainedCoreObservation::Observed(None),
+        );
+        let after_absent = state.current.clone().expect("replacement snapshot");
+        assert_eq!(
+            after_absent.retained_core_publication, None,
+            "a successful read proving no retained core must still demote"
+        );
+        assert_eq!(
+            after_absent.capabilities.local_navigation,
+            ActivationCapabilityState::Unavailable
+        );
     }
 }

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -3,7 +3,7 @@ use super::{
     BUILD_EDGE_SEED_BATCH_SIZE, CURRENT_SCHEMA_VERSION, CancellationToken,
     DEFAULT_SOURCE_FILE_BYTE_CAP, DENSE_CENTRAL_RELATIONSHIP_THRESHOLD,
     DENSE_CENTRAL_SCORE_THRESHOLD, DIRECT_SNIPPET_MAX_BYTES, DIRECT_SNIPPET_TRUNCATION_SUFFIX,
-    DenseAnchorCentrality, DenseAnchorInput, DenseAnchorReason, FileExt, FileInfo, GraphRequest,
+    DenseAnchorCentrality, DenseAnchorInput, DenseAnchorReason, FileInfo, GraphRequest,
     GroundingBudgetDto, HYBRID_RETRIEVAL_ENABLED_ENV, HybridSearchConfig, IndexFreshnessStatusDto,
     IndexPublicationRecord, IndexWriterGuard, IndexedFileRoleDto, IndexingPhaseTimings,
     LEGACY_OVERSIZED_SOURCE_POLICY_VERSION, LLM_DOC_EMBED_BATCH_SIZE_ENV,

--- a/crates/codestory-runtime/src/tests/search_scoring.rs
+++ b/crates/codestory-runtime/src/tests/search_scoring.rs
@@ -1,5 +1,5 @@
 use super::{
-    AgentHybridWeightsDto, AppController, CancellationToken, CoreNodeId, EnvGuard, FileExt,
+    AgentHybridWeightsDto, AppController, CancellationToken, CoreNodeId, EnvGuard,
     GroundingBudgetDto, HYBRID_RETRIEVAL_ENABLED_ENV, HashMap, HybridSearchConfig,
     IndexFreshnessStatusDto, IndexMode, Node, NodeId, NodeKind, Occurrence, OccurrenceKind,
     OpenProjectRequest, Path, PathBuf, PublicationTestAction, PublicationTestBoundary,
@@ -22,6 +22,7 @@ use super::{
     test_retrieval_manifest, test_sidecar_runtime_from_env, unbounded,
     write_search_generation_completion, write_semantic_fixture,
 };
+use codestory_contracts::bounded_locks::{self, FileLockKind};
 
 #[test]
 fn semantic_doc_text_alias_modes_are_switchable_for_research() {
@@ -1752,14 +1753,21 @@ fn search_generation_retention_keeps_active_and_one_verified_rollback() {
         .write(true)
         .open(&partial_lock_path)
         .expect("open second durable lock handle");
-    assert!(FileExt::try_lock_exclusive(&first_lock).expect("lock first handle"));
     assert!(
-        !FileExt::try_lock_exclusive(&second_lock).expect("contend second handle"),
+        bounded_locks::try_acquire(&first_lock, FileLockKind::Exclusive)
+            .expect("lock first handle")
+    );
+    assert!(
+        !bounded_locks::try_acquire(&second_lock, FileLockKind::Exclusive)
+            .expect("contend second handle"),
         "both handles must coordinate through the same durable lock file"
     );
-    FileExt::unlock(&first_lock).expect("unlock first handle");
-    assert!(FileExt::try_lock_exclusive(&second_lock).expect("lock second handle after release"));
-    FileExt::unlock(&second_lock).expect("unlock second handle");
+    bounded_locks::release(&first_lock).expect("unlock first handle");
+    assert!(
+        bounded_locks::try_acquire(&second_lock, FileLockKind::Exclusive)
+            .expect("lock second handle after release")
+    );
+    bounded_locks::release(&second_lock).expect("unlock second handle");
     assert!(
         search_index_generation_root(&storage_path)
             .join(ids[0])

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 codestory-contracts = { workspace = true }
 anyhow = { workspace = true }
-fs4 = { workspace = true }
 parking_lot = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -1,3 +1,6 @@
+use codestory_contracts::bounded_locks::{
+    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, acquire_with_deadline,
+};
 use codestory_contracts::owned_artifacts;
 
 use codestory_contracts::graph::{
@@ -10,7 +13,6 @@ use codestory_contracts::workspace::OversizedSourceExclusionCandidate;
 use codestory_contracts::workspace::{
     DEFAULT_SOURCE_FILE_BYTE_CAP, OVERSIZED_SOURCE_POLICY_VERSION,
 };
-use fs4::fs_std::FileExt;
 use parking_lot::RwLock;
 use rusqlite::{
     Connection, MAIN_DB, OpenFlags, OptionalExtension, Result, Row, limits::Limit, params,
@@ -1196,7 +1198,13 @@ impl PromotionLock {
 
     fn acquire(path: &Path) -> Result<Self, StorageError> {
         let file = Self::open(path)?;
-        FileExt::lock_exclusive(&file).map_err(|error| {
+        acquire_with_deadline(
+            &file,
+            FileLockKind::Exclusive,
+            LockDeadline::after(DEFAULT_LOCK_WAIT),
+            None,
+        )
+        .map_err(|error| {
             StorageError::Other(format!(
                 "Failed to acquire promotion lock for {}: {error}",
                 path.display()
@@ -1207,7 +1215,7 @@ impl PromotionLock {
 
     fn try_acquire(path: &Path) -> Result<Option<Self>, StorageError> {
         let file = Self::open(path)?;
-        FileExt::try_lock_exclusive(&file)
+        bounded_locks::try_acquire(&file, FileLockKind::Exclusive)
             .map(|locked| locked.then_some(Self { file }))
             .map_err(|error| {
                 StorageError::Other(format!(
@@ -1220,7 +1228,7 @@ impl PromotionLock {
 
 impl Drop for PromotionLock {
     fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.file);
+        let _ = bounded_locks::release(&self.file);
     }
 }
 

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -1,5 +1,5 @@
 use codestory_contracts::bounded_locks::{
-    self, DEFAULT_LOCK_WAIT, FileLockKind, LockDeadline, acquire_with_deadline,
+    self, FileLockKind, LockDeadline, PUBLICATION_LOCK_WAIT, acquire_with_deadline,
 };
 use codestory_contracts::owned_artifacts;
 
@@ -1196,18 +1196,24 @@ impl PromotionLock {
             })
     }
 
+    /// A peer holds this for the whole atomic old-or-new promotion, so the
+    /// budget is the publication one: a foreground budget would refuse
+    /// ordinary contention behind a legitimate commit. The wait stays
+    /// interruptible through the caller's ambient cancellation, so a cancelled
+    /// request or activation still leaves it at once.
     fn acquire(path: &Path) -> Result<Self, StorageError> {
         let file = Self::open(path)?;
         acquire_with_deadline(
             &file,
             FileLockKind::Exclusive,
-            LockDeadline::after(DEFAULT_LOCK_WAIT),
+            LockDeadline::after(PUBLICATION_LOCK_WAIT),
             None,
         )
         .map_err(|error| {
             StorageError::Other(format!(
-                "Failed to acquire promotion lock for {}: {error}",
-                path.display()
+                "Failed to acquire promotion lock for {} ({}): {error}",
+                path.display(),
+                error.code()
             ))
         })?;
         Ok(Self { file })

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -10,7 +10,6 @@ test-support = []
 anyhow = { workspace = true }
 codestory-contracts = { workspace = true }
 fs_at = { workspace = true }
-fs4 = { workspace = true }
 glob = { workspace = true }
 gix = { workspace = true }
 ignore = { workspace = true }

--- a/crates/codestory-workspace/src/locking.rs
+++ b/crates/codestory-workspace/src/locking.rs
@@ -1,6 +1,8 @@
 //! Non-blocking file-lock acquisition that outlives fork/exec ghost holds.
 
-use fs4::fs_std::FileExt as _;
+use codestory_contracts::bounded_locks::{
+    FileLockError, FileLockKind, LockDeadline, acquire_with_deadline,
+};
 use std::fs::File;
 use std::io;
 use std::time::Duration;
@@ -14,23 +16,27 @@ use std::time::Duration;
 /// microseconds. A genuine holder keeps the lock far past this bounded
 /// budget, so retrying preserves fail-closed semantics: the final attempt's
 /// verdict is authoritative.
-pub fn try_lock_exclusive_outliving_spawn_ghosts(file: &File) -> io::Result<bool> {
-    try_lock_with_budget(file, 20, Duration::from_millis(2))
-}
+const SPAWN_GHOST_BUDGET: Duration = Duration::from_millis(40);
 
-fn try_lock_with_budget(file: &File, retries: u32, step: Duration) -> io::Result<bool> {
-    for _ in 0..retries {
-        if file.try_lock_exclusive()? {
-            return Ok(true);
-        }
-        std::thread::sleep(step);
+pub fn try_lock_exclusive_outliving_spawn_ghosts(file: &File) -> io::Result<bool> {
+    match acquire_with_deadline(
+        file,
+        FileLockKind::Exclusive,
+        LockDeadline::after(SPAWN_GHOST_BUDGET),
+        None,
+    ) {
+        Ok(()) => Ok(true),
+        Err(FileLockError::Timeout { .. }) => Ok(false),
+        // No cancellation flag is supplied here, so only a platform refusal
+        // can reach this arm; it stays an error rather than a busy verdict.
+        Err(error) => Err(io::Error::other(error.to_string())),
     }
-    file.try_lock_exclusive()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codestory_contracts::bounded_locks::{release, try_acquire};
     use std::sync::mpsc;
     use std::thread;
 
@@ -45,7 +51,7 @@ mod tests {
     fn briefly_held_lock_is_acquired_within_the_budget() {
         let (dir, file) = lock_file();
         let holder = File::open(dir.path().join("subject.lock")).expect("holder handle");
-        assert!(holder.try_lock_exclusive().expect("holder locks"));
+        assert!(try_acquire(&holder, FileLockKind::Exclusive).expect("holder locks"));
         let (release_started, release_gate) = mpsc::channel();
         let releaser = thread::spawn(move || {
             release_started.send(()).expect("signal release start");
@@ -59,16 +65,17 @@ mod tests {
             "a ghost-lived hold must clear within the retry budget"
         );
         releaser.join().expect("releaser thread");
+        release(&file).expect("release waiter");
     }
 
     #[test]
     fn genuinely_held_lock_still_fails_closed() {
         let (dir, file) = lock_file();
         let holder = File::open(dir.path().join("subject.lock")).expect("holder handle");
-        assert!(holder.try_lock_exclusive().expect("holder locks"));
+        assert!(try_acquire(&holder, FileLockKind::Exclusive).expect("holder locks"));
 
         assert!(
-            !try_lock_with_budget(&file, 3, Duration::from_millis(1)).expect("bounded acquire"),
+            !try_lock_exclusive_outliving_spawn_ghosts(&file).expect("bounded acquire"),
             "a persistent holder must still report contention"
         );
         drop(holder);


### PR DESCRIPTION
Closes #1706. Delivers W5.4, W5.5, W5.6.

Implementation commit `8a7ab15d` + repair commit `8e24e09b`.

## What

`codestory_contracts::bounded_locks` becomes the single advisory-lock entry point: every production fs4 call site acquires under an absolute deadline and a cancellation flag, with typed `lock_wait_timeout` / `lock_wait_cancelled` / `lock_unavailable` outcomes and no reachable blocking `lock_shared`/`lock_exclusive`. Activation eviction joins under a budget and fail-stops rather than detaching an unquiesced worker. The read-only facade inherits the active public-operation cancellation. Embedding exchanges arm one absolute deadline and re-arm each syscall from the remaining budget, so a trickling peer cannot outlive it.

## Review and repair

An adversarial review of the implementation commit **blocked** it on six findings, each independently re-verified. All six are repaired in `8e24e09b`:

1. **Blocker — the fail-stop could abort healthy processes.** The 20 s quiescence budget was shorter than the 120 s lock budgets the same commit gave the worker's own path, and every production call site passed `cancel = None`, so a slow first-run activation (or ordinary stdio shutdown during one) would `abort()` the live session and misattribute the cause. Fixed at the root — cancellation is now actually delivered, via an ambient thread scope installed by `run_activation_worker` and `with_public_operation_cancellation`, so waits that cannot grow a parameter still inherit a flag. A `const _: () = assert!(...)` ties the quiescence budget to the published cancellation latency. This also closes the contract's "cancel-aware" half, which was previously unimplemented.
2. **Major — the new fs4 contract gate was blind to its four biggest call-site files** (including the hotspot it was written to protect), because "production source" was everything before the *first* column-0 `#[cfg(test)]` — and those files put one in their import block. Replaced with a shared helper that strips every gated item wherever it sits; **the owned-artifact gate from #1739 shared the same flaw and is fixed with it**. Build scripts are no longer excluded, and a `scanned > 100` guard stops a future filter change from silently emptying the gate.
3. **Major — undeclared fail-open**: an unreadable retained core publication preserved the Retained local-navigation capability. Reverted to demoting.
4. **Major — undeclared public error-code change** on the search-publication surface, applied inconsistently against the store. Reverted; both surfaces keep their prior shapes.
5. **Major — publication-length holds hard-failing at 10 s.** Per-site budgets now match the operation: publication-class waits carry `PUBLICATION_LOCK_WAIT`, declared in the commit body and pinned by a static gate over all five sites.
6. Unused `fs4` manifest entries removed; the crate is now reachable only from `codestory-contracts` and CLI test fixtures.

## Proof

Every repair carries fail-without-fix evidence: reverting the ambient scope reproduces the 20 s abort; removing the inheritance line yields a 120 s `lock_wait_timeout` instead of `lock_wait_cancelled`; planted `fs4::` and owned-identity literals in the previously-blind regions now fail both gates (and were confirmed invisible to the old split). Owning-crate suites, per-PR lane filters, fmt and clippy all clean.

**Known residual, declared:** the ambient cancellation scope covers waits on the worker's thread; it is verified empirically that today's publish path stays on that thread, but moving a stage onto a pool would silently lose the flag, and no committed test catches that specific regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)