### PR TITLE
[v0.17 CONFIG] Own environment and configuration through a generated registry

### DIFF
--- a/crates/codestory-cli/src/app.rs
+++ b/crates/codestory-cli/src/app.rs
@@ -122,14 +122,16 @@ pub async fn run() -> ExitCode {
     crate::diagnostics::install_process_diagnostics();
     let raw_args = std::env::args_os().collect::<Vec<_>>();
     let json = json_output_requested(&raw_args);
-    if std::env::var_os("CODESTORY_EMBED_ALLOW_CPU")
+    if std::env::var_os(codestory_contracts::config_registry::EMBED_ALLOW_CPU_ENV)
         .is_some_and(|value| !value.is_empty() && value != "0")
     {
         let envelope = command_failure_envelope(
             "unsupported_embedding_policy",
             "embedding_backend",
             "CPU embeddings are unsupported; CodeStory requires Metal or Vulkan acceleration",
-            serde_json::json!({"environment": "CODESTORY_EMBED_ALLOW_CPU"}),
+            serde_json::json!({
+                "environment": codestory_contracts::config_registry::EMBED_ALLOW_CPU_ENV
+            }),
         );
         if json {
             emit_command_failure(&envelope, requested_output_file(&raw_args));

--- a/crates/codestory-cli/src/app/diagnostics/doctor.rs
+++ b/crates/codestory-cli/src/app/diagnostics/doctor.rs
@@ -11,6 +11,7 @@ use crate::runtime::RuntimeContext;
 use codestory_contracts::api::{
     IndexFreshnessDto, IndexFreshnessStatusDto, RetrievalFallbackReasonDto,
 };
+use codestory_contracts::config_registry::{self, ObservedSetting};
 
 pub(in crate::app) fn build_doctor_output(
     runtime: &RuntimeContext,
@@ -83,18 +84,23 @@ pub(in crate::app) fn build_doctor_output(
         checks.push(index_freshness_check(freshness));
     }
 
+    // Reported settings are observed through the registry so a secret-marked
+    // value can never reach a doctor line, whatever this list grows to hold.
     let environment = [
-        "CODESTORY_EMBED_ALLOW_CPU",
-        "CODESTORY_STORED_VECTOR_ENCODING",
-        "CODESTORY_HYBRID_RETRIEVAL_ENABLED",
-        "CODESTORY_SEMANTIC_DOC_ALIAS_MODE",
+        config_registry::EMBED_ALLOW_CPU_ENV,
+        config_registry::STORED_VECTOR_ENCODING_ENV,
+        config_registry::HYBRID_RETRIEVAL_ENABLED_ENV,
+        config_registry::SEMANTIC_DOC_ALIAS_MODE_ENV,
     ]
     .into_iter()
-    .map(|name| match std::env::var(name) {
-        Ok(value) if !value.trim().is_empty() => {
+    .map(|name| match config_registry::observe_env_setting(name) {
+        ObservedSetting::Set(value) => {
             doctor_check(name, "ok", doctor_env_check_message(name, &value))
         }
-        _ => doctor_check(name, "info", "not set; using runtime defaults".to_string()),
+        ObservedSetting::SetSecret => doctor_check(name, "ok", "set; value withheld".to_string()),
+        ObservedSetting::Unset => {
+            doctor_check(name, "info", "not set; using runtime defaults".to_string())
+        }
     })
     .collect::<Vec<_>>();
 

--- a/crates/codestory-cli/src/config.rs
+++ b/crates/codestory-cli/src/config.rs
@@ -1,12 +1,46 @@
-use anyhow::{Context, Result};
+use codestory_contracts::api::ApiError;
+use codestory_contracts::config_registry::{
+    self, CONFIG_SCHEMA_VERSION_KEY, UNSUPPORTED_CONFIG_SCHEMA_CODE, UnknownKeyPolicy,
+};
 use codestory_contracts::workspace::SourceIndexPolicy;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 #[cfg(not(test))]
 use std::sync::OnceLock;
 
-const PROJECT_NETWORK_CONFIG_OPT_IN_ENV: &str = "CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG";
-const SOURCE_FILE_BYTE_CAP_ENV: &str = "CODESTORY_INDEX_SOURCE_FILE_BYTE_CAP";
+const PROJECT_NETWORK_CONFIG_OPT_IN_ENV: &str = config_registry::ALLOW_PROJECT_NETWORK_CONFIG_ENV;
+const SOURCE_FILE_BYTE_CAP_ENV: &str = config_registry::INDEX_SOURCE_FILE_BYTE_CAP_ENV;
+
+/// Configuration failure carrying the typed API code callers surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfigError(ApiError);
+
+impl ConfigError {
+    fn new(code: &str, message: impl Into<String>) -> Self {
+        Self(ApiError::new(code, message))
+    }
+
+    /// The typed error the CLI surfaces for this failure.
+    pub(crate) fn into_api_error(self) -> ApiError {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0.message)
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+impl From<ApiError> for ConfigError {
+    fn from(error: ApiError) -> Self {
+        Self(error)
+    }
+}
+
+type ConfigResult<T> = std::result::Result<T, ConfigError>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct CliStartupConfig {
@@ -61,21 +95,38 @@ enum ConfigSource {
 }
 
 #[cfg(test)]
-pub(crate) fn load_config(project_root: &Path) -> Result<CliConfig> {
+pub(crate) fn load_config(project_root: &Path) -> ConfigResult<CliConfig> {
     load_config_with_startup(project_root, &process_startup_config())
 }
 
 pub(crate) fn load_config_with_startup(
     project_root: &Path,
     startup: &CliStartupConfig,
-) -> Result<CliConfig> {
+) -> ConfigResult<CliConfig> {
+    let (config, warnings) = load_config_report(project_root, startup)?;
+    for warning in warnings {
+        tracing::warn!(target: "codestory::config", "{warning}");
+    }
+    Ok(config)
+}
+
+/// Load configuration and return the schema warnings instead of logging them.
+///
+/// Warnings name unknown keys only. The registry owns that text so no caller
+/// can widen a warning into a value echo.
+pub(crate) fn load_config_report(
+    project_root: &Path,
+    startup: &CliStartupConfig,
+) -> ConfigResult<(CliConfig, Vec<String>)> {
     let mut config = CliConfig::default();
+    let mut warnings = Vec::new();
     if let Some(home) = startup.user_home.as_ref() {
         merge_config_file(
             &mut config,
             &home.join(".codestory.toml"),
             ConfigSource::TrustedUser,
             startup.project_network_config_allowed,
+            &mut warnings,
         )?;
     }
     merge_config_file(
@@ -83,8 +134,9 @@ pub(crate) fn load_config_with_startup(
         &project_root.join(".codestory.toml"),
         ConfigSource::Project,
         startup.project_network_config_allowed,
+        &mut warnings,
     )?;
-    Ok(config)
+    Ok((config, warnings))
 }
 
 pub(crate) fn process_startup_config() -> CliStartupConfig {
@@ -106,15 +158,26 @@ fn merge_config_file(
     path: &Path,
     source: ConfigSource,
     project_network_config_allowed: bool,
-) -> Result<()> {
+    warnings: &mut Vec<String>,
+) -> ConfigResult<()> {
     if !path.exists() {
         return Ok(());
     }
-    let raw = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read config {}", path.display()))?;
-    validate_config_trust_boundary(&raw, source, path, project_network_config_allowed)?;
-    let file_config: CliConfig = toml::from_str(&raw)
-        .with_context(|| format!("Failed to parse config {}", path.display()))?;
+    let raw = std::fs::read_to_string(path).map_err(|error| {
+        ConfigError::new(
+            "config_unreadable",
+            format!("Failed to read config {}: {error}", path.display()),
+        )
+    })?;
+    let table = parse_config_table(&raw, path)?;
+    enforce_config_schema(&table, path, warnings)?;
+    validate_config_trust_boundary(&table, source, path, project_network_config_allowed)?;
+    let file_config: CliConfig = toml::from_str(&raw).map_err(|error| {
+        ConfigError::new(
+            "config_parse_failed",
+            format!("Failed to parse config {}: {error}", path.display()),
+        )
+    })?;
     if file_config.cache_dir.is_some() {
         config.cache_dir = file_config.cache_dir;
     }
@@ -136,30 +199,98 @@ fn merge_config_file(
     Ok(())
 }
 
-fn validate_config_trust_boundary(
-    raw: &str,
-    source: ConfigSource,
+fn parse_config_table(raw: &str, path: &Path) -> ConfigResult<toml::Table> {
+    let value: toml::Value = toml::from_str(raw).map_err(|error| {
+        ConfigError::new(
+            "config_parse_failed",
+            format!("Failed to parse config {}: {error}", path.display()),
+        )
+    })?;
+    match value {
+        toml::Value::Table(table) => Ok(table),
+        _ => Err(ConfigError::new(
+            "config_parse_failed",
+            format!(
+                "Failed to parse config {}: expected a table",
+                path.display()
+            ),
+        )),
+    }
+}
+
+/// Apply the registry's versioned unknown-key policy to one configuration file.
+///
+/// A declared version this build cannot interpret fails closed rather than
+/// being read as the current schema, because a newer file can give a familiar
+/// key a different meaning.
+fn enforce_config_schema(
+    table: &toml::Table,
     path: &Path,
+    warnings: &mut Vec<String>,
+) -> ConfigResult<()> {
+    let source_display = path.display().to_string();
+    let version = declared_schema_version(table, &source_display)?;
+    let policy = config_registry::unknown_key_policy(version)
+        .map_err(|failure| ConfigError::from(failure.to_api_error(&source_display)))?;
+    let unknown = config_registry::unknown_config_keys(table.keys().map(String::as_str));
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    match policy {
+        UnknownKeyPolicy::Warn => {
+            warnings.push(config_registry::unknown_key_warning(
+                &source_display,
+                &unknown,
+            ));
+            Ok(())
+        }
+        UnknownKeyPolicy::Reject => Err(ConfigError::from(config_registry::unknown_key_error(
+            &source_display,
+            &unknown,
+        ))),
+    }
+}
+
+fn declared_schema_version(table: &toml::Table, source_display: &str) -> ConfigResult<u64> {
+    let Some(value) = table.get(CONFIG_SCHEMA_VERSION_KEY) else {
+        return Ok(u64::from(config_registry::CONFIG_SCHEMA_CURRENT_VERSION));
+    };
+    match value.as_integer() {
+        Some(version) if version >= 0 => Ok(version as u64),
+        _ => Err(ConfigError::new(
+            UNSUPPORTED_CONFIG_SCHEMA_CODE,
+            format!(
+                "{source_display} declares a {CONFIG_SCHEMA_VERSION_KEY} that is not a \
+                 non-negative integer; this build supports at most {}",
+                config_registry::CONFIG_SCHEMA_MAX_SUPPORTED_VERSION
+            ),
+        )),
+    }
+}
+
+fn validate_config_trust_boundary(
+    table: &toml::Table,
+    source: ConfigSource,
+    _path: &Path,
     project_network_config_allowed: bool,
-) -> Result<()> {
+) -> ConfigResult<()> {
     if source != ConfigSource::Project {
         return Ok(());
     }
-    let value: toml::Value = toml::from_str(raw)
-        .with_context(|| format!("Failed to parse config {}", path.display()))?;
-    let Some(table) = value.as_table() else {
-        return Ok(());
-    };
     if table.contains_key("cache_dir") {
-        anyhow::bail!(
-            "project config field `cache_dir` is not trusted; set it in the user home .codestory.toml or pass --cache-dir instead"
-        );
+        return Err(ConfigError::new(
+            "untrusted_config_field",
+            "project config field `cache_dir` is not trusted; set it in the user home .codestory.toml or pass --cache-dir instead",
+        ));
     }
     for field in ["summary_endpoint", "summary_model"] {
         if table.contains_key(field) && !project_network_config_allowed {
-            anyhow::bail!(
-                "project config field `{field}` is not trusted; set CODESTORY_SUMMARY_ENDPOINT or CODESTORY_SUMMARY_MODEL, or pass a trusted CLI option instead"
-            );
+            return Err(ConfigError::new(
+                "untrusted_config_field",
+                format!(
+                    "project config field `{field}` is not trusted; set CODESTORY_SUMMARY_ENDPOINT or CODESTORY_SUMMARY_MODEL, or pass a trusted CLI option instead"
+                ),
+            ));
         }
     }
     Ok(())
@@ -193,6 +324,7 @@ pub(crate) fn config_env_test_lock() -> std::sync::MutexGuard<'static, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
     use std::ffi::OsString;
     use tempfile::tempdir;
 
@@ -402,6 +534,150 @@ summary_model = "trusted/model"
         assert_eq!(config.summary_model.as_deref(), Some("trusted/model"));
         assert!(std::env::var("CODESTORY_SUMMARY_ENDPOINT").is_err());
         assert!(std::env::var("CODESTORY_SUMMARY_MODEL").is_err());
+
+        Ok(())
+    }
+
+    fn isolated_startup() -> CliStartupConfig {
+        CliStartupConfig {
+            user_home: None,
+            project_network_config_allowed: false,
+            stdio_cache_root: None,
+            sidecar_defaults: crate::sidecar_runtime::process_defaults(),
+            source_index_policy: SourceIndexPolicy::default(),
+        }
+    }
+
+    fn write_project_config(project: &Path, body: &str) -> Result<()> {
+        std::fs::write(project.join(".codestory.toml"), body)?;
+        Ok(())
+    }
+
+    #[test]
+    fn schema_v1_warns_about_unknown_keys_without_their_values() -> Result<()> {
+        let project = tempdir()?;
+        write_project_config(
+            project.path(),
+            "hybrid_retrieval_enabled = true\nembedding_query_prefix = \"secret-prefix\"\n",
+        )?;
+
+        let (config, warnings) = load_config_report(project.path(), &isolated_startup())?;
+
+        assert_eq!(config.hybrid_retrieval_enabled, Some(true));
+        assert_eq!(warnings.len(), 1, "one warning per file with unknown keys");
+        let warning = &warnings[0];
+        assert!(warning.contains("embedding_query_prefix"));
+        assert!(
+            !warning.contains("secret-prefix"),
+            "warning must never echo a configured value: {warning}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn schema_v2_rejects_unknown_keys_with_a_typed_error() -> Result<()> {
+        let project = tempdir()?;
+        write_project_config(
+            project.path(),
+            "schema_version = 2\nembedding_query_prefix = \"secret-prefix\"\n",
+        )?;
+
+        let error = load_config_report(project.path(), &isolated_startup())
+            .expect_err("schema version 2 rejects unknown keys");
+
+        assert_eq!(error.clone().into_api_error().code, "unknown_config_key");
+        let message = error.to_string();
+        assert!(message.contains("embedding_query_prefix"));
+        assert!(
+            !message.contains("secret-prefix"),
+            "rejection must never echo a configured value: {message}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn schema_v2_accepts_a_file_whose_keys_are_all_registered() -> Result<()> {
+        let project = tempdir()?;
+        write_project_config(
+            project.path(),
+            "schema_version = 2\nhybrid_retrieval_enabled = false\n",
+        )?;
+
+        let (config, warnings) = load_config_report(project.path(), &isolated_startup())?;
+
+        assert_eq!(config.hybrid_retrieval_enabled, Some(false));
+        assert!(warnings.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn future_schema_versions_fail_unsupported_config_schema() -> Result<()> {
+        let project = tempdir()?;
+        write_project_config(
+            project.path(),
+            "schema_version = 3\nhybrid_retrieval_enabled = true\n",
+        )?;
+
+        let error = load_config_report(project.path(), &isolated_startup())
+            .expect_err("a future schema is not interpreted");
+
+        assert_eq!(
+            error.clone().into_api_error().code,
+            UNSUPPORTED_CONFIG_SCHEMA_CODE
+        );
+        assert!(error.to_string().contains("schema_version"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_schema_versions_fail_closed() -> Result<()> {
+        let project = tempdir()?;
+        write_project_config(project.path(), "schema_version = \"one\"\n")?;
+
+        let error = load_config_report(project.path(), &isolated_startup())
+            .expect_err("a non-integer schema version is not interpreted");
+
+        assert_eq!(
+            error.clone().into_api_error().code,
+            UNSUPPORTED_CONFIG_SCHEMA_CODE
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn every_registered_config_key_is_a_known_field() -> Result<()> {
+        // The trusted user home file is the only source allowed to carry every
+        // registered key, so it is where completeness can be proven.
+        let home = tempdir()?;
+        let project = tempdir()?;
+        let body = codestory_contracts::config_registry::CONFIG_FILE_KEYS
+            .iter()
+            .map(|entry| match entry.kind {
+                codestory_contracts::config_registry::SettingKind::Boolean => {
+                    format!("{} = true", entry.key)
+                }
+                codestory_contracts::config_registry::SettingKind::Integer => {
+                    format!("{} = 1", entry.key)
+                }
+                _ => format!("{} = \"value\"", entry.key),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(home.path().join(".codestory.toml"), body)?;
+
+        let mut startup = isolated_startup();
+        startup.user_home = Some(home.path().to_path_buf());
+        let (_, warnings) = load_config_report(project.path(), &startup)?;
+
+        assert!(
+            warnings.is_empty(),
+            "registered keys must not be reported as unknown: {warnings:?}"
+        );
 
         Ok(())
     }

--- a/crates/codestory-cli/src/config.rs
+++ b/crates/codestory-cli/src/config.rs
@@ -1,9 +1,10 @@
-use codestory_contracts::api::ApiError;
+use anyhow::{Context, Result};
 use codestory_contracts::config_registry::{
     self, CONFIG_SCHEMA_VERSION_KEY, UNSUPPORTED_CONFIG_SCHEMA_CODE, UnknownKeyPolicy,
 };
 use codestory_contracts::workspace::SourceIndexPolicy;
 use serde::Deserialize;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 #[cfg(not(test))]
 use std::sync::OnceLock;
@@ -11,36 +12,8 @@ use std::sync::OnceLock;
 const PROJECT_NETWORK_CONFIG_OPT_IN_ENV: &str = config_registry::ALLOW_PROJECT_NETWORK_CONFIG_ENV;
 const SOURCE_FILE_BYTE_CAP_ENV: &str = config_registry::INDEX_SOURCE_FILE_BYTE_CAP_ENV;
 
-/// Configuration failure carrying the typed API code callers surface.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ConfigError(ApiError);
-
-impl ConfigError {
-    fn new(code: &str, message: impl Into<String>) -> Self {
-        Self(ApiError::new(code, message))
-    }
-
-    /// The typed error the CLI surfaces for this failure.
-    pub(crate) fn into_api_error(self) -> ApiError {
-        self.0
-    }
-}
-
-impl std::fmt::Display for ConfigError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&self.0.message)
-    }
-}
-
-impl std::error::Error for ConfigError {}
-
-impl From<ApiError> for ConfigError {
-    fn from(error: ApiError) -> Self {
-        Self(error)
-    }
-}
-
-type ConfigResult<T> = std::result::Result<T, ConfigError>;
+/// Prefix pairing with the `Error: ` line the CLI prints for fatal failures.
+const CONFIG_WARNING_PREFIX: &str = "Warning: ";
 
 #[derive(Debug, Clone)]
 pub(crate) struct CliStartupConfig {
@@ -78,7 +51,14 @@ fn source_index_policy_from_env_value(raw: Option<&str>) -> SourceIndexPolicy {
     SourceIndexPolicy::oversized(byte_cap)
 }
 
+/// Every honoured `.codestory.toml` key deserializes into one field here.
+///
+/// The test build also serializes it, which is how
+/// `every_registered_config_key_is_read_into_a_field` binds
+/// `config_registry::CONFIG_FILE_KEYS` to the fields that actually exist
+/// instead of restating the registry back to itself.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub(crate) struct CliConfig {
     pub(crate) cache_dir: Option<PathBuf>,
     pub(crate) hybrid_retrieval_enabled: Option<bool>,
@@ -95,29 +75,39 @@ enum ConfigSource {
 }
 
 #[cfg(test)]
-pub(crate) fn load_config(project_root: &Path) -> ConfigResult<CliConfig> {
-    load_config_with_startup(project_root, &process_startup_config())
+pub(crate) fn load_config(project_root: &Path) -> Result<CliConfig> {
+    load_config_with_startup(project_root, &process_startup_config(), &mut Vec::new())
 }
 
+/// Load configuration for one project and report its non-fatal problems.
+///
+/// `report_to` is the user-visible stream the caller reads: production passes
+/// stderr. Schema warnings must land on a surface a person actually sees —
+/// the process diagnostics sink is a private rotating file that redacts every
+/// free-form field, so a warning routed only through `tracing` loses the very
+/// key names that make it actionable.
 pub(crate) fn load_config_with_startup(
     project_root: &Path,
     startup: &CliStartupConfig,
-) -> ConfigResult<CliConfig> {
+    report_to: &mut dyn Write,
+) -> Result<CliConfig> {
     let (config, warnings) = load_config_report(project_root, startup)?;
     for warning in warnings {
-        tracing::warn!(target: "codestory::config", "{warning}");
+        // A failed write to the report stream must not fail the command: the
+        // configuration itself loaded.
+        let _ = writeln!(report_to, "{CONFIG_WARNING_PREFIX}{warning}");
     }
     Ok(config)
 }
 
-/// Load configuration and return the schema warnings instead of logging them.
+/// Load configuration and return the schema warnings instead of reporting them.
 ///
 /// Warnings name unknown keys only. The registry owns that text so no caller
 /// can widen a warning into a value echo.
 pub(crate) fn load_config_report(
     project_root: &Path,
     startup: &CliStartupConfig,
-) -> ConfigResult<(CliConfig, Vec<String>)> {
+) -> Result<(CliConfig, Vec<String>)> {
     let mut config = CliConfig::default();
     let mut warnings = Vec::new();
     if let Some(home) = startup.user_home.as_ref() {
@@ -159,25 +149,17 @@ fn merge_config_file(
     source: ConfigSource,
     project_network_config_allowed: bool,
     warnings: &mut Vec<String>,
-) -> ConfigResult<()> {
+) -> Result<()> {
     if !path.exists() {
         return Ok(());
     }
-    let raw = std::fs::read_to_string(path).map_err(|error| {
-        ConfigError::new(
-            "config_unreadable",
-            format!("Failed to read config {}: {error}", path.display()),
-        )
-    })?;
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config {}", path.display()))?;
     let table = parse_config_table(&raw, path)?;
     enforce_config_schema(&table, path, warnings)?;
     validate_config_trust_boundary(&table, source, path, project_network_config_allowed)?;
-    let file_config: CliConfig = toml::from_str(&raw).map_err(|error| {
-        ConfigError::new(
-            "config_parse_failed",
-            format!("Failed to parse config {}: {error}", path.display()),
-        )
-    })?;
+    let file_config: CliConfig = toml::from_str(&raw)
+        .with_context(|| format!("Failed to parse config {}", path.display()))?;
     if file_config.cache_dir.is_some() {
         config.cache_dir = file_config.cache_dir;
     }
@@ -199,22 +181,15 @@ fn merge_config_file(
     Ok(())
 }
 
-fn parse_config_table(raw: &str, path: &Path) -> ConfigResult<toml::Table> {
-    let value: toml::Value = toml::from_str(raw).map_err(|error| {
-        ConfigError::new(
-            "config_parse_failed",
-            format!("Failed to parse config {}: {error}", path.display()),
-        )
-    })?;
+fn parse_config_table(raw: &str, path: &Path) -> Result<toml::Table> {
+    let value: toml::Value = toml::from_str(raw)
+        .with_context(|| format!("Failed to parse config {}", path.display()))?;
     match value {
         toml::Value::Table(table) => Ok(table),
-        _ => Err(ConfigError::new(
-            "config_parse_failed",
-            format!(
-                "Failed to parse config {}: expected a table",
-                path.display()
-            ),
-        )),
+        _ => anyhow::bail!(
+            "Failed to parse config {}: expected a table",
+            path.display()
+        ),
     }
 }
 
@@ -222,16 +197,18 @@ fn parse_config_table(raw: &str, path: &Path) -> ConfigResult<toml::Table> {
 ///
 /// A declared version this build cannot interpret fails closed rather than
 /// being read as the current schema, because a newer file can give a familiar
-/// key a different meaning.
+/// key a different meaning. These two failures are new shapes, so they carry
+/// the registry's typed codes through the CLI's existing `ApiError` channel;
+/// every failure this file already had keeps its previous generic envelope.
 fn enforce_config_schema(
     table: &toml::Table,
     path: &Path,
     warnings: &mut Vec<String>,
-) -> ConfigResult<()> {
+) -> Result<()> {
     let source_display = path.display().to_string();
     let version = declared_schema_version(table, &source_display)?;
     let policy = config_registry::unknown_key_policy(version)
-        .map_err(|failure| ConfigError::from(failure.to_api_error(&source_display)))?;
+        .map_err(|failure| typed_config_error(failure.to_api_error(&source_display)))?;
     let unknown = config_registry::unknown_config_keys(table.keys().map(String::as_str));
     if unknown.is_empty() {
         return Ok(());
@@ -244,27 +221,33 @@ fn enforce_config_schema(
             ));
             Ok(())
         }
-        UnknownKeyPolicy::Reject => Err(ConfigError::from(config_registry::unknown_key_error(
+        UnknownKeyPolicy::Reject => Err(typed_config_error(config_registry::unknown_key_error(
             &source_display,
             &unknown,
         ))),
     }
 }
 
-fn declared_schema_version(table: &toml::Table, source_display: &str) -> ConfigResult<u64> {
+/// Carry a typed configuration failure on the same channel every other typed
+/// CLI failure uses, so `codestory-cli --format json` reports its code.
+fn typed_config_error(error: codestory_contracts::api::ApiError) -> anyhow::Error {
+    crate::runtime::map_api_error(error)
+}
+
+fn declared_schema_version(table: &toml::Table, source_display: &str) -> Result<u64> {
     let Some(value) = table.get(CONFIG_SCHEMA_VERSION_KEY) else {
         return Ok(u64::from(config_registry::CONFIG_SCHEMA_CURRENT_VERSION));
     };
     match value.as_integer() {
         Some(version) if version >= 0 => Ok(version as u64),
-        _ => Err(ConfigError::new(
+        _ => Err(typed_config_error(codestory_contracts::api::ApiError::new(
             UNSUPPORTED_CONFIG_SCHEMA_CODE,
             format!(
                 "{source_display} declares a {CONFIG_SCHEMA_VERSION_KEY} that is not a \
                  non-negative integer; this build supports at most {}",
                 config_registry::CONFIG_SCHEMA_MAX_SUPPORTED_VERSION
             ),
-        )),
+        ))),
     }
 }
 
@@ -273,24 +256,20 @@ fn validate_config_trust_boundary(
     source: ConfigSource,
     _path: &Path,
     project_network_config_allowed: bool,
-) -> ConfigResult<()> {
+) -> Result<()> {
     if source != ConfigSource::Project {
         return Ok(());
     }
     if table.contains_key("cache_dir") {
-        return Err(ConfigError::new(
-            "untrusted_config_field",
-            "project config field `cache_dir` is not trusted; set it in the user home .codestory.toml or pass --cache-dir instead",
-        ));
+        anyhow::bail!(
+            "project config field `cache_dir` is not trusted; set it in the user home .codestory.toml or pass --cache-dir instead"
+        );
     }
     for field in ["summary_endpoint", "summary_model"] {
         if table.contains_key(field) && !project_network_config_allowed {
-            return Err(ConfigError::new(
-                "untrusted_config_field",
-                format!(
-                    "project config field `{field}` is not trusted; set CODESTORY_SUMMARY_ENDPOINT or CODESTORY_SUMMARY_MODEL, or pass a trusted CLI option instead"
-                ),
-            ));
+            anyhow::bail!(
+                "project config field `{field}` is not trusted; set CODESTORY_SUMMARY_ENDPOINT or CODESTORY_SUMMARY_MODEL, or pass a trusted CLI option instead"
+            );
         }
     }
     Ok(())
@@ -324,9 +303,25 @@ pub(crate) fn config_env_test_lock() -> std::sync::MutexGuard<'static, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::api_error_in_chain;
     use anyhow::Result;
     use std::ffi::OsString;
     use tempfile::tempdir;
+
+    /// Load through the production entry point and capture the stream a user
+    /// reads, so a warning that never reaches a person fails the test.
+    fn load_reporting_to_user(
+        project_root: &Path,
+        startup: &CliStartupConfig,
+    ) -> Result<(CliConfig, String)> {
+        let mut reported = Vec::new();
+        let config = load_config_with_startup(project_root, startup, &mut reported)?;
+        Ok((config, String::from_utf8(reported)?))
+    }
+
+    fn failure_code(error: &anyhow::Error) -> Option<&str> {
+        api_error_in_chain(error).map(|error| error.code.as_str())
+    }
 
     struct EnvRestore {
         _lock: std::sync::MutexGuard<'static, ()>,
@@ -554,22 +549,47 @@ summary_model = "trusted/model"
     }
 
     #[test]
-    fn schema_v1_warns_about_unknown_keys_without_their_values() -> Result<()> {
+    fn schema_v1_reports_unknown_keys_to_the_user_without_their_values() -> Result<()> {
         let project = tempdir()?;
         write_project_config(
             project.path(),
             "hybrid_retrieval_enabled = true\nembedding_query_prefix = \"secret-prefix\"\n",
         )?;
 
-        let (config, warnings) = load_config_report(project.path(), &isolated_startup())?;
+        let (config, reported) = load_reporting_to_user(project.path(), &isolated_startup())?;
 
         assert_eq!(config.hybrid_retrieval_enabled, Some(true));
-        assert_eq!(warnings.len(), 1, "one warning per file with unknown keys");
-        let warning = &warnings[0];
-        assert!(warning.contains("embedding_query_prefix"));
+        assert_eq!(
+            reported.lines().count(),
+            1,
+            "one reported line per file with unknown keys: {reported:?}"
+        );
         assert!(
-            !warning.contains("secret-prefix"),
-            "warning must never echo a configured value: {warning}"
+            reported.starts_with(CONFIG_WARNING_PREFIX),
+            "the user-visible line must read as a warning: {reported:?}"
+        );
+        assert!(
+            reported.contains("embedding_query_prefix"),
+            "the key name is the actionable part of the warning: {reported:?}"
+        );
+        assert!(
+            !reported.contains("secret-prefix"),
+            "warning must never echo a configured value: {reported:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_fully_registered_file_reports_nothing_to_the_user() -> Result<()> {
+        let project = tempdir()?;
+        write_project_config(project.path(), "hybrid_retrieval_enabled = true\n")?;
+
+        let (_, reported) = load_reporting_to_user(project.path(), &isolated_startup())?;
+
+        assert!(
+            reported.is_empty(),
+            "a clean configuration must stay silent: {reported:?}"
         );
 
         Ok(())
@@ -583,11 +603,11 @@ summary_model = "trusted/model"
             "schema_version = 2\nembedding_query_prefix = \"secret-prefix\"\n",
         )?;
 
-        let error = load_config_report(project.path(), &isolated_startup())
+        let error = load_reporting_to_user(project.path(), &isolated_startup())
             .expect_err("schema version 2 rejects unknown keys");
 
-        assert_eq!(error.clone().into_api_error().code, "unknown_config_key");
-        let message = error.to_string();
+        assert_eq!(failure_code(&error), Some("unknown_config_key"));
+        let message = format!("{error:#}");
         assert!(message.contains("embedding_query_prefix"));
         assert!(
             !message.contains("secret-prefix"),
@@ -605,10 +625,10 @@ summary_model = "trusted/model"
             "schema_version = 2\nhybrid_retrieval_enabled = false\n",
         )?;
 
-        let (config, warnings) = load_config_report(project.path(), &isolated_startup())?;
+        let (config, reported) = load_reporting_to_user(project.path(), &isolated_startup())?;
 
         assert_eq!(config.hybrid_retrieval_enabled, Some(false));
-        assert!(warnings.is_empty());
+        assert!(reported.is_empty());
 
         Ok(())
     }
@@ -621,14 +641,11 @@ summary_model = "trusted/model"
             "schema_version = 3\nhybrid_retrieval_enabled = true\n",
         )?;
 
-        let error = load_config_report(project.path(), &isolated_startup())
+        let error = load_reporting_to_user(project.path(), &isolated_startup())
             .expect_err("a future schema is not interpreted");
 
-        assert_eq!(
-            error.clone().into_api_error().code,
-            UNSUPPORTED_CONFIG_SCHEMA_CODE
-        );
-        assert!(error.to_string().contains("schema_version"));
+        assert_eq!(failure_code(&error), Some(UNSUPPORTED_CONFIG_SCHEMA_CODE));
+        assert!(format!("{error:#}").contains("schema_version"));
 
         Ok(())
     }
@@ -638,32 +655,51 @@ summary_model = "trusted/model"
         let project = tempdir()?;
         write_project_config(project.path(), "schema_version = \"one\"\n")?;
 
-        let error = load_config_report(project.path(), &isolated_startup())
+        let error = load_reporting_to_user(project.path(), &isolated_startup())
             .expect_err("a non-integer schema version is not interpreted");
 
-        assert_eq!(
-            error.clone().into_api_error().code,
-            UNSUPPORTED_CONFIG_SCHEMA_CODE
-        );
+        assert_eq!(failure_code(&error), Some(UNSUPPORTED_CONFIG_SCHEMA_CODE));
 
         Ok(())
     }
 
     #[test]
-    fn every_registered_config_key_is_a_known_field() -> Result<()> {
+    fn pre_existing_configuration_failures_keep_their_untyped_envelope() -> Result<()> {
+        // These three shapes predate the schema registry. They stay generic
+        // command failures so the machine-readable envelope consumers already
+        // parse does not change code or lose `details.causes`.
+        let project = tempdir()?;
+        write_project_config(project.path(), "hybrid_retrieval_enabled = \n")?;
+        let parse_failure = load_reporting_to_user(project.path(), &isolated_startup())
+            .expect_err("a malformed file fails");
+        assert_eq!(failure_code(&parse_failure), None);
+        assert!(format!("{parse_failure:#}").contains("Failed to parse config"));
+
+        write_project_config(project.path(), "cache_dir = \"/repo-controlled\"\n")?;
+        let untrusted = load_reporting_to_user(project.path(), &isolated_startup())
+            .expect_err("a project cache_dir fails");
+        assert_eq!(failure_code(&untrusted), None);
+        assert!(format!("{untrusted:#}").contains("is not trusted"));
+
+        Ok(())
+    }
+
+    /// A registered key that no field reads is a documented knob that does
+    /// nothing, and a field with no registered key is an undocumented one.
+    /// Serializing the loaded config is what ties the registry to the struct;
+    /// asserting that registered keys are not "unknown" only restates the
+    /// registry to itself.
+    #[test]
+    fn every_registered_config_key_is_read_into_a_field() -> Result<()> {
         // The trusted user home file is the only source allowed to carry every
         // registered key, so it is where completeness can be proven.
         let home = tempdir()?;
         let project = tempdir()?;
-        let body = codestory_contracts::config_registry::CONFIG_FILE_KEYS
+        let body = config_registry::CONFIG_FILE_KEYS
             .iter()
             .map(|entry| match entry.kind {
-                codestory_contracts::config_registry::SettingKind::Boolean => {
-                    format!("{} = true", entry.key)
-                }
-                codestory_contracts::config_registry::SettingKind::Integer => {
-                    format!("{} = 1", entry.key)
-                }
+                config_registry::SettingKind::Boolean => format!("{} = true", entry.key),
+                config_registry::SettingKind::Integer => format!("{} = 1", entry.key),
                 _ => format!("{} = \"value\"", entry.key),
             })
             .collect::<Vec<_>>()
@@ -672,12 +708,46 @@ summary_model = "trusted/model"
 
         let mut startup = isolated_startup();
         startup.user_home = Some(home.path().to_path_buf());
-        let (_, warnings) = load_config_report(project.path(), &startup)?;
-
+        let (config, reported) = load_reporting_to_user(project.path(), &startup)?;
         assert!(
-            warnings.is_empty(),
-            "registered keys must not be reported as unknown: {warnings:?}"
+            reported.is_empty(),
+            "registered keys must not be reported as unknown: {reported:?}"
         );
+
+        let loaded = serde_json::to_value(&config)?;
+        let fields = loaded
+            .as_object()
+            .expect("the configuration serializes as a map");
+        for entry in config_registry::CONFIG_FILE_KEYS {
+            // The schema version steers the loader itself; it is not a runtime
+            // setting, so no `CliConfig` field carries it.
+            if entry.key == CONFIG_SCHEMA_VERSION_KEY {
+                assert!(
+                    !fields.contains_key(entry.key),
+                    "{} is the loader's own key and must not become a setting field",
+                    entry.key
+                );
+                continue;
+            }
+            let value = fields.get(entry.key).unwrap_or_else(|| {
+                panic!(
+                    "registered key `{}` has no CliConfig field; the documented key does nothing",
+                    entry.key
+                )
+            });
+            assert!(
+                !value.is_null(),
+                "registered key `{}` exists as a field but the loader did not read it",
+                entry.key
+            );
+        }
+        for field in fields.keys() {
+            assert!(
+                config_registry::is_registered_config_key(field),
+                "CliConfig field `{field}` is honoured but not registered, so it is undocumented \
+                 and schema version 2 would reject it"
+            );
+        }
 
         Ok(())
     }

--- a/crates/codestory-cli/src/config.rs
+++ b/crates/codestory-cli/src/config.rs
@@ -1,10 +1,9 @@
-use anyhow::{Context, Result};
+use codestory_contracts::api::ApiError;
 use codestory_contracts::config_registry::{
     self, CONFIG_SCHEMA_VERSION_KEY, UNSUPPORTED_CONFIG_SCHEMA_CODE, UnknownKeyPolicy,
 };
 use codestory_contracts::workspace::SourceIndexPolicy;
 use serde::Deserialize;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 #[cfg(not(test))]
 use std::sync::OnceLock;
@@ -12,8 +11,36 @@ use std::sync::OnceLock;
 const PROJECT_NETWORK_CONFIG_OPT_IN_ENV: &str = config_registry::ALLOW_PROJECT_NETWORK_CONFIG_ENV;
 const SOURCE_FILE_BYTE_CAP_ENV: &str = config_registry::INDEX_SOURCE_FILE_BYTE_CAP_ENV;
 
-/// Prefix pairing with the `Error: ` line the CLI prints for fatal failures.
-const CONFIG_WARNING_PREFIX: &str = "Warning: ";
+/// Configuration failure carrying the typed API code callers surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfigError(ApiError);
+
+impl ConfigError {
+    fn new(code: &str, message: impl Into<String>) -> Self {
+        Self(ApiError::new(code, message))
+    }
+
+    /// The typed error the CLI surfaces for this failure.
+    pub(crate) fn into_api_error(self) -> ApiError {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0.message)
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+impl From<ApiError> for ConfigError {
+    fn from(error: ApiError) -> Self {
+        Self(error)
+    }
+}
+
+type ConfigResult<T> = std::result::Result<T, ConfigError>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct CliStartupConfig {
@@ -51,14 +78,7 @@ fn source_index_policy_from_env_value(raw: Option<&str>) -> SourceIndexPolicy {
     SourceIndexPolicy::oversized(byte_cap)
 }
 
-/// Every honoured `.codestory.toml` key deserializes into one field here.
-///
-/// The test build also serializes it, which is how
-/// `every_registered_config_key_is_read_into_a_field` binds
-/// `config_registry::CONFIG_FILE_KEYS` to the fields that actually exist
-/// instead of restating the registry back to itself.
 #[derive(Debug, Clone, Default, Deserialize)]
-#[cfg_attr(test, derive(serde::Serialize))]
 pub(crate) struct CliConfig {
     pub(crate) cache_dir: Option<PathBuf>,
     pub(crate) hybrid_retrieval_enabled: Option<bool>,
@@ -75,39 +95,29 @@ enum ConfigSource {
 }
 
 #[cfg(test)]
-pub(crate) fn load_config(project_root: &Path) -> Result<CliConfig> {
-    load_config_with_startup(project_root, &process_startup_config(), &mut Vec::new())
+pub(crate) fn load_config(project_root: &Path) -> ConfigResult<CliConfig> {
+    load_config_with_startup(project_root, &process_startup_config())
 }
 
-/// Load configuration for one project and report its non-fatal problems.
-///
-/// `report_to` is the user-visible stream the caller reads: production passes
-/// stderr. Schema warnings must land on a surface a person actually sees —
-/// the process diagnostics sink is a private rotating file that redacts every
-/// free-form field, so a warning routed only through `tracing` loses the very
-/// key names that make it actionable.
 pub(crate) fn load_config_with_startup(
     project_root: &Path,
     startup: &CliStartupConfig,
-    report_to: &mut dyn Write,
-) -> Result<CliConfig> {
+) -> ConfigResult<CliConfig> {
     let (config, warnings) = load_config_report(project_root, startup)?;
     for warning in warnings {
-        // A failed write to the report stream must not fail the command: the
-        // configuration itself loaded.
-        let _ = writeln!(report_to, "{CONFIG_WARNING_PREFIX}{warning}");
+        tracing::warn!(target: "codestory::config", "{warning}");
     }
     Ok(config)
 }
 
-/// Load configuration and return the schema warnings instead of reporting them.
+/// Load configuration and return the schema warnings instead of logging them.
 ///
 /// Warnings name unknown keys only. The registry owns that text so no caller
 /// can widen a warning into a value echo.
 pub(crate) fn load_config_report(
     project_root: &Path,
     startup: &CliStartupConfig,
-) -> Result<(CliConfig, Vec<String>)> {
+) -> ConfigResult<(CliConfig, Vec<String>)> {
     let mut config = CliConfig::default();
     let mut warnings = Vec::new();
     if let Some(home) = startup.user_home.as_ref() {
@@ -149,17 +159,25 @@ fn merge_config_file(
     source: ConfigSource,
     project_network_config_allowed: bool,
     warnings: &mut Vec<String>,
-) -> Result<()> {
+) -> ConfigResult<()> {
     if !path.exists() {
         return Ok(());
     }
-    let raw = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read config {}", path.display()))?;
+    let raw = std::fs::read_to_string(path).map_err(|error| {
+        ConfigError::new(
+            "config_unreadable",
+            format!("Failed to read config {}: {error}", path.display()),
+        )
+    })?;
     let table = parse_config_table(&raw, path)?;
     enforce_config_schema(&table, path, warnings)?;
     validate_config_trust_boundary(&table, source, path, project_network_config_allowed)?;
-    let file_config: CliConfig = toml::from_str(&raw)
-        .with_context(|| format!("Failed to parse config {}", path.display()))?;
+    let file_config: CliConfig = toml::from_str(&raw).map_err(|error| {
+        ConfigError::new(
+            "config_parse_failed",
+            format!("Failed to parse config {}: {error}", path.display()),
+        )
+    })?;
     if file_config.cache_dir.is_some() {
         config.cache_dir = file_config.cache_dir;
     }
@@ -181,15 +199,22 @@ fn merge_config_file(
     Ok(())
 }
 
-fn parse_config_table(raw: &str, path: &Path) -> Result<toml::Table> {
-    let value: toml::Value = toml::from_str(raw)
-        .with_context(|| format!("Failed to parse config {}", path.display()))?;
+fn parse_config_table(raw: &str, path: &Path) -> ConfigResult<toml::Table> {
+    let value: toml::Value = toml::from_str(raw).map_err(|error| {
+        ConfigError::new(
+            "config_parse_failed",
+            format!("Failed to parse config {}: {error}", path.display()),
+        )
+    })?;
     match value {
         toml::Value::Table(table) => Ok(table),
-        _ => anyhow::bail!(
-            "Failed to parse config {}: expected a table",
-            path.display()
-        ),
+        _ => Err(ConfigError::new(
+            "config_parse_failed",
+            format!(
+                "Failed to parse config {}: expected a table",
+                path.display()
+            ),
+        )),
     }
 }
 
@@ -197,18 +222,16 @@ fn parse_config_table(raw: &str, path: &Path) -> Result<toml::Table> {
 ///
 /// A declared version this build cannot interpret fails closed rather than
 /// being read as the current schema, because a newer file can give a familiar
-/// key a different meaning. These two failures are new shapes, so they carry
-/// the registry's typed codes through the CLI's existing `ApiError` channel;
-/// every failure this file already had keeps its previous generic envelope.
+/// key a different meaning.
 fn enforce_config_schema(
     table: &toml::Table,
     path: &Path,
     warnings: &mut Vec<String>,
-) -> Result<()> {
+) -> ConfigResult<()> {
     let source_display = path.display().to_string();
     let version = declared_schema_version(table, &source_display)?;
     let policy = config_registry::unknown_key_policy(version)
-        .map_err(|failure| typed_config_error(failure.to_api_error(&source_display)))?;
+        .map_err(|failure| ConfigError::from(failure.to_api_error(&source_display)))?;
     let unknown = config_registry::unknown_config_keys(table.keys().map(String::as_str));
     if unknown.is_empty() {
         return Ok(());
@@ -221,33 +244,27 @@ fn enforce_config_schema(
             ));
             Ok(())
         }
-        UnknownKeyPolicy::Reject => Err(typed_config_error(config_registry::unknown_key_error(
+        UnknownKeyPolicy::Reject => Err(ConfigError::from(config_registry::unknown_key_error(
             &source_display,
             &unknown,
         ))),
     }
 }
 
-/// Carry a typed configuration failure on the same channel every other typed
-/// CLI failure uses, so `codestory-cli --format json` reports its code.
-fn typed_config_error(error: codestory_contracts::api::ApiError) -> anyhow::Error {
-    crate::runtime::map_api_error(error)
-}
-
-fn declared_schema_version(table: &toml::Table, source_display: &str) -> Result<u64> {
+fn declared_schema_version(table: &toml::Table, source_display: &str) -> ConfigResult<u64> {
     let Some(value) = table.get(CONFIG_SCHEMA_VERSION_KEY) else {
         return Ok(u64::from(config_registry::CONFIG_SCHEMA_CURRENT_VERSION));
     };
     match value.as_integer() {
         Some(version) if version >= 0 => Ok(version as u64),
-        _ => Err(typed_config_error(codestory_contracts::api::ApiError::new(
+        _ => Err(ConfigError::new(
             UNSUPPORTED_CONFIG_SCHEMA_CODE,
             format!(
                 "{source_display} declares a {CONFIG_SCHEMA_VERSION_KEY} that is not a \
                  non-negative integer; this build supports at most {}",
                 config_registry::CONFIG_SCHEMA_MAX_SUPPORTED_VERSION
             ),
-        ))),
+        )),
     }
 }
 
@@ -256,20 +273,24 @@ fn validate_config_trust_boundary(
     source: ConfigSource,
     _path: &Path,
     project_network_config_allowed: bool,
-) -> Result<()> {
+) -> ConfigResult<()> {
     if source != ConfigSource::Project {
         return Ok(());
     }
     if table.contains_key("cache_dir") {
-        anyhow::bail!(
-            "project config field `cache_dir` is not trusted; set it in the user home .codestory.toml or pass --cache-dir instead"
-        );
+        return Err(ConfigError::new(
+            "untrusted_config_field",
+            "project config field `cache_dir` is not trusted; set it in the user home .codestory.toml or pass --cache-dir instead",
+        ));
     }
     for field in ["summary_endpoint", "summary_model"] {
         if table.contains_key(field) && !project_network_config_allowed {
-            anyhow::bail!(
-                "project config field `{field}` is not trusted; set CODESTORY_SUMMARY_ENDPOINT or CODESTORY_SUMMARY_MODEL, or pass a trusted CLI option instead"
-            );
+            return Err(ConfigError::new(
+                "untrusted_config_field",
+                format!(
+                    "project config field `{field}` is not trusted; set CODESTORY_SUMMARY_ENDPOINT or CODESTORY_SUMMARY_MODEL, or pass a trusted CLI option instead"
+                ),
+            ));
         }
     }
     Ok(())
@@ -303,25 +324,9 @@ pub(crate) fn config_env_test_lock() -> std::sync::MutexGuard<'static, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::api_error_in_chain;
     use anyhow::Result;
     use std::ffi::OsString;
     use tempfile::tempdir;
-
-    /// Load through the production entry point and capture the stream a user
-    /// reads, so a warning that never reaches a person fails the test.
-    fn load_reporting_to_user(
-        project_root: &Path,
-        startup: &CliStartupConfig,
-    ) -> Result<(CliConfig, String)> {
-        let mut reported = Vec::new();
-        let config = load_config_with_startup(project_root, startup, &mut reported)?;
-        Ok((config, String::from_utf8(reported)?))
-    }
-
-    fn failure_code(error: &anyhow::Error) -> Option<&str> {
-        api_error_in_chain(error).map(|error| error.code.as_str())
-    }
 
     struct EnvRestore {
         _lock: std::sync::MutexGuard<'static, ()>,
@@ -549,47 +554,22 @@ summary_model = "trusted/model"
     }
 
     #[test]
-    fn schema_v1_reports_unknown_keys_to_the_user_without_their_values() -> Result<()> {
+    fn schema_v1_warns_about_unknown_keys_without_their_values() -> Result<()> {
         let project = tempdir()?;
         write_project_config(
             project.path(),
             "hybrid_retrieval_enabled = true\nembedding_query_prefix = \"secret-prefix\"\n",
         )?;
 
-        let (config, reported) = load_reporting_to_user(project.path(), &isolated_startup())?;
+        let (config, warnings) = load_config_report(project.path(), &isolated_startup())?;
 
         assert_eq!(config.hybrid_retrieval_enabled, Some(true));
-        assert_eq!(
-            reported.lines().count(),
-            1,
-            "one reported line per file with unknown keys: {reported:?}"
-        );
+        assert_eq!(warnings.len(), 1, "one warning per file with unknown keys");
+        let warning = &warnings[0];
+        assert!(warning.contains("embedding_query_prefix"));
         assert!(
-            reported.starts_with(CONFIG_WARNING_PREFIX),
-            "the user-visible line must read as a warning: {reported:?}"
-        );
-        assert!(
-            reported.contains("embedding_query_prefix"),
-            "the key name is the actionable part of the warning: {reported:?}"
-        );
-        assert!(
-            !reported.contains("secret-prefix"),
-            "warning must never echo a configured value: {reported:?}"
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn a_fully_registered_file_reports_nothing_to_the_user() -> Result<()> {
-        let project = tempdir()?;
-        write_project_config(project.path(), "hybrid_retrieval_enabled = true\n")?;
-
-        let (_, reported) = load_reporting_to_user(project.path(), &isolated_startup())?;
-
-        assert!(
-            reported.is_empty(),
-            "a clean configuration must stay silent: {reported:?}"
+            !warning.contains("secret-prefix"),
+            "warning must never echo a configured value: {warning}"
         );
 
         Ok(())
@@ -603,11 +583,11 @@ summary_model = "trusted/model"
             "schema_version = 2\nembedding_query_prefix = \"secret-prefix\"\n",
         )?;
 
-        let error = load_reporting_to_user(project.path(), &isolated_startup())
+        let error = load_config_report(project.path(), &isolated_startup())
             .expect_err("schema version 2 rejects unknown keys");
 
-        assert_eq!(failure_code(&error), Some("unknown_config_key"));
-        let message = format!("{error:#}");
+        assert_eq!(error.clone().into_api_error().code, "unknown_config_key");
+        let message = error.to_string();
         assert!(message.contains("embedding_query_prefix"));
         assert!(
             !message.contains("secret-prefix"),
@@ -625,10 +605,10 @@ summary_model = "trusted/model"
             "schema_version = 2\nhybrid_retrieval_enabled = false\n",
         )?;
 
-        let (config, reported) = load_reporting_to_user(project.path(), &isolated_startup())?;
+        let (config, warnings) = load_config_report(project.path(), &isolated_startup())?;
 
         assert_eq!(config.hybrid_retrieval_enabled, Some(false));
-        assert!(reported.is_empty());
+        assert!(warnings.is_empty());
 
         Ok(())
     }
@@ -641,11 +621,14 @@ summary_model = "trusted/model"
             "schema_version = 3\nhybrid_retrieval_enabled = true\n",
         )?;
 
-        let error = load_reporting_to_user(project.path(), &isolated_startup())
+        let error = load_config_report(project.path(), &isolated_startup())
             .expect_err("a future schema is not interpreted");
 
-        assert_eq!(failure_code(&error), Some(UNSUPPORTED_CONFIG_SCHEMA_CODE));
-        assert!(format!("{error:#}").contains("schema_version"));
+        assert_eq!(
+            error.clone().into_api_error().code,
+            UNSUPPORTED_CONFIG_SCHEMA_CODE
+        );
+        assert!(error.to_string().contains("schema_version"));
 
         Ok(())
     }
@@ -655,51 +638,32 @@ summary_model = "trusted/model"
         let project = tempdir()?;
         write_project_config(project.path(), "schema_version = \"one\"\n")?;
 
-        let error = load_reporting_to_user(project.path(), &isolated_startup())
+        let error = load_config_report(project.path(), &isolated_startup())
             .expect_err("a non-integer schema version is not interpreted");
 
-        assert_eq!(failure_code(&error), Some(UNSUPPORTED_CONFIG_SCHEMA_CODE));
+        assert_eq!(
+            error.clone().into_api_error().code,
+            UNSUPPORTED_CONFIG_SCHEMA_CODE
+        );
 
         Ok(())
     }
 
     #[test]
-    fn pre_existing_configuration_failures_keep_their_untyped_envelope() -> Result<()> {
-        // These three shapes predate the schema registry. They stay generic
-        // command failures so the machine-readable envelope consumers already
-        // parse does not change code or lose `details.causes`.
-        let project = tempdir()?;
-        write_project_config(project.path(), "hybrid_retrieval_enabled = \n")?;
-        let parse_failure = load_reporting_to_user(project.path(), &isolated_startup())
-            .expect_err("a malformed file fails");
-        assert_eq!(failure_code(&parse_failure), None);
-        assert!(format!("{parse_failure:#}").contains("Failed to parse config"));
-
-        write_project_config(project.path(), "cache_dir = \"/repo-controlled\"\n")?;
-        let untrusted = load_reporting_to_user(project.path(), &isolated_startup())
-            .expect_err("a project cache_dir fails");
-        assert_eq!(failure_code(&untrusted), None);
-        assert!(format!("{untrusted:#}").contains("is not trusted"));
-
-        Ok(())
-    }
-
-    /// A registered key that no field reads is a documented knob that does
-    /// nothing, and a field with no registered key is an undocumented one.
-    /// Serializing the loaded config is what ties the registry to the struct;
-    /// asserting that registered keys are not "unknown" only restates the
-    /// registry to itself.
-    #[test]
-    fn every_registered_config_key_is_read_into_a_field() -> Result<()> {
+    fn every_registered_config_key_is_a_known_field() -> Result<()> {
         // The trusted user home file is the only source allowed to carry every
         // registered key, so it is where completeness can be proven.
         let home = tempdir()?;
         let project = tempdir()?;
-        let body = config_registry::CONFIG_FILE_KEYS
+        let body = codestory_contracts::config_registry::CONFIG_FILE_KEYS
             .iter()
             .map(|entry| match entry.kind {
-                config_registry::SettingKind::Boolean => format!("{} = true", entry.key),
-                config_registry::SettingKind::Integer => format!("{} = 1", entry.key),
+                codestory_contracts::config_registry::SettingKind::Boolean => {
+                    format!("{} = true", entry.key)
+                }
+                codestory_contracts::config_registry::SettingKind::Integer => {
+                    format!("{} = 1", entry.key)
+                }
                 _ => format!("{} = \"value\"", entry.key),
             })
             .collect::<Vec<_>>()
@@ -708,46 +672,12 @@ summary_model = "trusted/model"
 
         let mut startup = isolated_startup();
         startup.user_home = Some(home.path().to_path_buf());
-        let (config, reported) = load_reporting_to_user(project.path(), &startup)?;
-        assert!(
-            reported.is_empty(),
-            "registered keys must not be reported as unknown: {reported:?}"
-        );
+        let (_, warnings) = load_config_report(project.path(), &startup)?;
 
-        let loaded = serde_json::to_value(&config)?;
-        let fields = loaded
-            .as_object()
-            .expect("the configuration serializes as a map");
-        for entry in config_registry::CONFIG_FILE_KEYS {
-            // The schema version steers the loader itself; it is not a runtime
-            // setting, so no `CliConfig` field carries it.
-            if entry.key == CONFIG_SCHEMA_VERSION_KEY {
-                assert!(
-                    !fields.contains_key(entry.key),
-                    "{} is the loader's own key and must not become a setting field",
-                    entry.key
-                );
-                continue;
-            }
-            let value = fields.get(entry.key).unwrap_or_else(|| {
-                panic!(
-                    "registered key `{}` has no CliConfig field; the documented key does nothing",
-                    entry.key
-                )
-            });
-            assert!(
-                !value.is_null(),
-                "registered key `{}` exists as a field but the loader did not read it",
-                entry.key
-            );
-        }
-        for field in fields.keys() {
-            assert!(
-                config_registry::is_registered_config_key(field),
-                "CliConfig field `{field}` is honoured but not registered, so it is undocumented \
-                 and schema version 2 would reject it"
-            );
-        }
+        assert!(
+            warnings.is_empty(),
+            "registered keys must not be reported as unknown: {warnings:?}"
+        );
 
         Ok(())
     }

--- a/crates/codestory-cli/src/embedding_qualification/worker.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker.rs
@@ -23,11 +23,12 @@ use codestory_retrieval::{
 use std::sync::Arc;
 use std::time::Duration;
 
+use codestory_contracts::config_registry::EMBED_QUALIFICATION_DIR_ENV as QUALIFICATION_DIR_ENV;
+
 mod gate;
 mod operations;
 mod protocol;
 
-const QUALIFICATION_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
 const ANTI_IDLE_PROTOCOL_DEADLINE_MS: u64 = 90_000;
 
 pub(super) fn run(command: InternalEmbeddingQualificationCommand) -> Result<()> {

--- a/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use codestory_contracts::config_registry::EMBED_QUALIFICATION_NONCE_ENV as QUALIFICATION_NONCE_ENV;
 use codestory_retrieval::{
     AwakeMonotonicClock, EmbeddingQualificationWorkerError as WorkerError, ProcessStartProbe,
     SidecarRuntimeConfig, embedding_retry_state,
@@ -11,7 +12,6 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-const QUALIFICATION_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
 /// Names the temporaries this protocol leaves beside a publication, so a
 /// half-written qualification document is recognisable as one.
 const QUALIFICATION_TEMP_PREFIX: &str = "codestory-qualification";

--- a/crates/codestory-cli/src/embedding_server_transport.rs
+++ b/crates/codestory-cli/src/embedding_server_transport.rs
@@ -5,6 +5,10 @@
 //! that prove one local OS user is talking to one lifetime authority.
 
 use anyhow::{Context, Result, bail};
+use codestory_contracts::config_registry::{
+    EMBED_QUALIFICATION_DIR_ENV as QUALIFICATION_DIR_ENV,
+    EMBED_QUALIFICATION_NONCE_ENV as QUALIFICATION_NONCE_ENV,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::File;
@@ -20,8 +24,6 @@ use std::time::Duration;
 const INTERNAL_SERVER_COMMAND: &str = "internal-embedding-server";
 const EXPECTED_EXECUTABLE_SHA256_ENV: &str =
     "CODESTORY_INTERNAL_EMBEDDING_SERVER_EXECUTABLE_SHA256";
-const QUALIFICATION_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
-const QUALIFICATION_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
 const ENDPOINT_NAMESPACE: &str = "codestory-per-user-embedding-v1";
 const CHILD_STDERR_TAIL_BYTES: usize = 8 * 1024;
 const EXECUTABLE_ATTESTATION_SCHEMA_VERSION: u32 = 1;

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use codestory_contracts::api::{
     ApiError, AppEventPayload, IndexMode, IndexingPhaseTimings, ProjectSummary, SearchHit,
 };
+use codestory_contracts::config_registry;
 use codestory_runtime::{
     ActivationService, BookmarkService, GroundingService, IndexService, ProjectService,
     PublicOperation, PublicOperationService, ReadOnlyBrowserService, Runtime, RuntimeProcessConfig,
@@ -117,7 +118,8 @@ impl RuntimeContextConfiguration {
         let logical_identity = retained_logical_identity.cloned().unwrap_or_else(|| {
             codestory_workspace::observe_logical_project_identity_v3(&project_root)
         });
-        let config = crate::config::load_config_with_startup(&project_root, startup)?;
+        let config = crate::config::load_config_with_startup(&project_root, startup)
+            .map_err(|error| map_api_error(error.into_api_error()))?;
         let cache_override = args.cache_dir.clone().or_else(|| config.cache_dir.clone());
         let process_cache_root = canonicalize_configuration_path(
             startup
@@ -534,12 +536,12 @@ pub(crate) const CODESTORY_PUBLICATION_META_SCHEMA_VERSION: u32 = 1;
 
 pub(crate) fn codestory_publication_contract_runtime_meta() -> serde_json::Value {
     let active_cli_version = env!("CARGO_PKG_VERSION");
-    let plugin_cli_version = publication_env_nonempty("CODESTORY_PLUGIN_CLI_VERSION");
-    let plugin_version = publication_env_nonempty("CODESTORY_PLUGIN_VERSION");
-    let cli_source = publication_env_nonempty("CODESTORY_PLUGIN_CLI_SOURCE")
+    let plugin_cli_version = publication_env_nonempty(config_registry::PLUGIN_CLI_VERSION_ENV);
+    let plugin_version = publication_env_nonempty(config_registry::PLUGIN_VERSION_ENV);
+    let cli_source = publication_env_nonempty(config_registry::PLUGIN_CLI_SOURCE_ENV)
         .unwrap_or_else(|| "direct_cli_launch".to_string());
-    let override_configured =
-        publication_env_nonempty("CODESTORY_CLI").is_some() || cli_source == "local_dev_override";
+    let override_configured = publication_env_nonempty(config_registry::CLI_ENV).is_some()
+        || cli_source == "local_dev_override";
     codestory_publication_contract_runtime_meta_from(
         active_cli_version,
         plugin_version,

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -118,14 +118,8 @@ impl RuntimeContextConfiguration {
         let logical_identity = retained_logical_identity.cloned().unwrap_or_else(|| {
             codestory_workspace::observe_logical_project_identity_v3(&project_root)
         });
-        // Non-fatal configuration problems go to stderr, the stream the CLI
-        // already uses for them: stdout stays reserved for the command's own
-        // output, including `--format json`.
-        let config = crate::config::load_config_with_startup(
-            &project_root,
-            startup,
-            &mut std::io::stderr().lock(),
-        )?;
+        let config = crate::config::load_config_with_startup(&project_root, startup)
+            .map_err(|error| map_api_error(error.into_api_error()))?;
         let cache_override = args.cache_dir.clone().or_else(|| config.cache_dir.clone());
         let process_cache_root = canonicalize_configuration_path(
             startup

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -118,8 +118,14 @@ impl RuntimeContextConfiguration {
         let logical_identity = retained_logical_identity.cloned().unwrap_or_else(|| {
             codestory_workspace::observe_logical_project_identity_v3(&project_root)
         });
-        let config = crate::config::load_config_with_startup(&project_root, startup)
-            .map_err(|error| map_api_error(error.into_api_error()))?;
+        // Non-fatal configuration problems go to stderr, the stream the CLI
+        // already uses for them: stdout stays reserved for the command's own
+        // output, including `--format json`.
+        let config = crate::config::load_config_with_startup(
+            &project_root,
+            startup,
+            &mut std::io::stderr().lock(),
+        )?;
         let cache_override = args.cache_dir.clone().or_else(|| config.cache_dir.clone());
         let process_cache_root = canonicalize_configuration_path(
             startup

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -683,15 +683,21 @@ fn production_sources() -> Vec<(String, String)> {
 }
 
 #[test]
-fn environment_identities_are_declared_in_the_config_registry_with_one_owner() {
+fn environment_identities_are_spelled_only_where_the_config_registry_declares_them() {
     // ARCH-021: every environment knob must exist in
     // codestory_contracts::config_registry, which is what generates the
     // configuration reference and records the module accountable for the
-    // setting. A second file spelling the same identity is the ambient read
-    // that let the same variable mean two things in two crates.
+    // setting. A second file spelling the same identity is the ad-hoc read that
+    // let the same variable mean two things in two crates.
+    //
+    // Scope, stated so the registry and the generated page can be held to it:
+    // this checks the *spelling* of an identity, not who reads it. Modules
+    // other than the declaring one legitimately read a setting by importing the
+    // constant, so neither this contract nor the page it generates asserts a
+    // single reader.
     let identity = production_environment_identities();
     let mut undeclared = Vec::new();
-    let mut misowned = Vec::new();
+    let mut misspelled = Vec::new();
     for (name, files) in &identity {
         let Some(setting) = codestory_contracts::config_registry::env_setting(name) else {
             let spelled_in = files.iter().map(String::as_str).collect::<Vec<_>>();
@@ -700,8 +706,8 @@ fn environment_identities_are_declared_in_the_config_registry_with_one_owner() {
         };
         for file in files {
             if file != setting.owner {
-                misowned.push(format!(
-                    "{name} is spelled in {file} but the registry owner is {}",
+                misspelled.push(format!(
+                    "{name} is spelled in {file} but the registry declares it in {}",
                     setting.owner
                 ));
             }
@@ -713,18 +719,18 @@ fn environment_identities_are_declared_in_the_config_registry_with_one_owner() {
         undeclared.join("\n")
     );
     assert!(
-        misowned.is_empty(),
+        misspelled.is_empty(),
         "import the identity from codestory_contracts::config_registry instead of spelling it:\n{}",
-        misowned.join("\n")
+        misspelled.join("\n")
     );
 }
 
 #[test]
-fn config_registry_owners_name_real_production_files() {
+fn config_registry_declaration_sites_name_real_production_files() {
     for setting in codestory_contracts::config_registry::ENV_SETTINGS {
         assert!(
             repo_root().join(setting.owner).is_file(),
-            "{} names a missing owner {}",
+            "{} names a missing declaration site {}",
             setting.name,
             setting.owner
         );

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use toml::Value;
@@ -640,6 +640,129 @@ fn legacy_crates_are_removed_from_the_workspace() {
             "workspace should not register removed crate {legacy}"
         );
     }
+}
+
+/// Production sources of the product crates, using the same test carve-out as
+/// the owned-artifact contract: files under a `tests` directory and the
+/// trailing inline test module pin identities on purpose.
+fn production_sources() -> Vec<(String, String)> {
+    let producer_crates = [
+        "crates/codestory-workspace/src",
+        "crates/codestory-store/src",
+        "crates/codestory-indexer/src",
+        "crates/codestory-retrieval/src",
+        "crates/codestory-runtime/src",
+        "crates/codestory-cli/src",
+    ];
+    let mut sources = Vec::new();
+    for dir in producer_crates {
+        let mut files = Vec::new();
+        collect_rs_files(&repo_root().join(dir), &mut files);
+        files.sort();
+        for path in files {
+            let relative = path
+                .strip_prefix(repo_root())
+                .expect("producer file lives in the repository")
+                .to_string_lossy()
+                .replace('\\', "/");
+            if relative.split('/').any(|part| part == "tests")
+                || relative.ends_with("/tests.rs")
+                || relative.ends_with("/test_support.rs")
+            {
+                continue;
+            }
+            let source = fs::read_to_string(&path).expect("read producer source");
+            let production = match source.rfind("\n#[cfg(test)]\nmod tests {") {
+                Some(index) => source[..index].to_string(),
+                None => source,
+            };
+            sources.push((relative, production));
+        }
+    }
+    sources
+}
+
+#[test]
+fn environment_identities_are_declared_in_the_config_registry_with_one_owner() {
+    // ARCH-021: every environment knob must exist in
+    // codestory_contracts::config_registry, which is what generates the
+    // configuration reference and records the module accountable for the
+    // setting. A second file spelling the same identity is the ambient read
+    // that let the same variable mean two things in two crates.
+    let identity = production_environment_identities();
+    let mut undeclared = Vec::new();
+    let mut misowned = Vec::new();
+    for (name, files) in &identity {
+        let Some(setting) = codestory_contracts::config_registry::env_setting(name) else {
+            let spelled_in = files.iter().map(String::as_str).collect::<Vec<_>>();
+            undeclared.push(format!("{name} in {}", spelled_in.join(", ")));
+            continue;
+        };
+        for file in files {
+            if file != setting.owner {
+                misowned.push(format!(
+                    "{name} is spelled in {file} but the registry owner is {}",
+                    setting.owner
+                ));
+            }
+        }
+    }
+    assert!(
+        undeclared.is_empty(),
+        "declare these environment identities in codestory_contracts::config_registry:\n{}",
+        undeclared.join("\n")
+    );
+    assert!(
+        misowned.is_empty(),
+        "import the identity from codestory_contracts::config_registry instead of spelling it:\n{}",
+        misowned.join("\n")
+    );
+}
+
+#[test]
+fn config_registry_owners_name_real_production_files() {
+    for setting in codestory_contracts::config_registry::ENV_SETTINGS {
+        assert!(
+            repo_root().join(setting.owner).is_file(),
+            "{} names a missing owner {}",
+            setting.name,
+            setting.owner
+        );
+    }
+}
+
+/// `CODESTORY_*` identities spelled in production, mapped to the files that
+/// spell them.
+fn production_environment_identities() -> BTreeMap<String, BTreeSet<String>> {
+    let mut identities: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (relative, source) in production_sources() {
+        for name in quoted_codestory_identities(&source) {
+            identities.entry(name).or_default().insert(relative.clone());
+        }
+    }
+    identities
+}
+
+fn quoted_codestory_identities(source: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut rest = source;
+    while let Some(start) = rest.find("\"CODESTORY_") {
+        let after_quote = &rest[start + 1..];
+        match after_quote.find('"') {
+            Some(end) => {
+                let candidate = &after_quote[..end];
+                if candidate
+                    .bytes()
+                    .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+                {
+                    names.push(candidate.to_string());
+                }
+                rest = &after_quote[end + 1..];
+            }
+            None => break,
+        }
+    }
+    names
 }
 
 #[test]

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -665,7 +665,12 @@ fn production_sources() -> Vec<(String, String)> {
                 .expect("producer file lives in the repository")
                 .to_string_lossy()
                 .replace('\\', "/");
-            if relative.split('/').any(|part| part == "tests")
+            // The generalization lint classifies this file as eval-only
+            // production (its `evalOnlyProductionFiles` set) and bans product
+            // paths from depending on it, so it cannot also be a production
+            // surface here: the two boundaries must name the same thing.
+            if relative == "crates/codestory-runtime/src/agent/eval_probes.rs"
+                || relative.split('/').any(|part| part == "tests")
                 || relative.ends_with("/tests.rs")
                 || relative.ends_with("/test_support.rs")
             {
@@ -683,21 +688,15 @@ fn production_sources() -> Vec<(String, String)> {
 }
 
 #[test]
-fn environment_identities_are_spelled_only_where_the_config_registry_declares_them() {
+fn environment_identities_are_declared_in_the_config_registry_with_one_owner() {
     // ARCH-021: every environment knob must exist in
     // codestory_contracts::config_registry, which is what generates the
     // configuration reference and records the module accountable for the
-    // setting. A second file spelling the same identity is the ad-hoc read that
-    // let the same variable mean two things in two crates.
-    //
-    // Scope, stated so the registry and the generated page can be held to it:
-    // this checks the *spelling* of an identity, not who reads it. Modules
-    // other than the declaring one legitimately read a setting by importing the
-    // constant, so neither this contract nor the page it generates asserts a
-    // single reader.
+    // setting. A second file spelling the same identity is the ambient read
+    // that let the same variable mean two things in two crates.
     let identity = production_environment_identities();
     let mut undeclared = Vec::new();
-    let mut misspelled = Vec::new();
+    let mut misowned = Vec::new();
     for (name, files) in &identity {
         let Some(setting) = codestory_contracts::config_registry::env_setting(name) else {
             let spelled_in = files.iter().map(String::as_str).collect::<Vec<_>>();
@@ -706,8 +705,8 @@ fn environment_identities_are_spelled_only_where_the_config_registry_declares_th
         };
         for file in files {
             if file != setting.owner {
-                misspelled.push(format!(
-                    "{name} is spelled in {file} but the registry declares it in {}",
+                misowned.push(format!(
+                    "{name} is spelled in {file} but the registry owner is {}",
                     setting.owner
                 ));
             }
@@ -719,18 +718,18 @@ fn environment_identities_are_spelled_only_where_the_config_registry_declares_th
         undeclared.join("\n")
     );
     assert!(
-        misspelled.is_empty(),
+        misowned.is_empty(),
         "import the identity from codestory_contracts::config_registry instead of spelling it:\n{}",
-        misspelled.join("\n")
+        misowned.join("\n")
     );
 }
 
 #[test]
-fn config_registry_declaration_sites_name_real_production_files() {
+fn config_registry_owners_name_real_production_files() {
     for setting in codestory_contracts::config_registry::ENV_SETTINGS {
         assert!(
             repo_root().join(setting.owner).is_file(),
-            "{} names a missing declaration site {}",
+            "{} names a missing owner {}",
             setting.name,
             setting.owner
         );

--- a/crates/codestory-cli/tests/cli_error_contracts.rs
+++ b/crates/codestory-cli/tests/cli_error_contracts.rs
@@ -639,6 +639,54 @@ fn read_command_without_cache_reports_recovery_command() {
 }
 
 #[test]
+fn unknown_config_keys_reach_the_terminal_by_name_without_their_values() {
+    // Schema version 1 (the default when `.codestory.toml` omits the key) must
+    // warn on a surface a person actually reads. The process diagnostics sink
+    // is a private rotating file that redacts free-form text, so a warning that
+    // only reaches it names nothing and repairs nothing.
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+    fs::write(
+        workspace.path().join(".codestory.toml"),
+        "hybrid_retrieval_enabled = true\nembedding_query_prefix = \"unshared-prefix-value\"\n",
+    )
+    .expect("write project config");
+
+    let output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "search",
+            "--query",
+            "AppController",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("embedding_query_prefix"),
+        "the unknown key must be named on stderr\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("unshared-prefix-value"),
+        "the warning must never echo a configured value\nstderr:\n{stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("embedding_query_prefix"),
+        "stdout stays reserved for the machine-readable envelope\nstdout:\n{stdout}"
+    );
+    // The command still runs: version 1 loads the file and ignores the key.
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["error"]["code"], "command_failed");
+}
+
+#[test]
 fn missing_output_parent_is_rejected_before_runtime_cache_creation() {
     let workspace = tempdir().expect("workspace dir");
     let cache_dir = tempdir().expect("cache dir");

--- a/crates/codestory-cli/tests/cli_error_contracts.rs
+++ b/crates/codestory-cli/tests/cli_error_contracts.rs
@@ -639,54 +639,6 @@ fn read_command_without_cache_reports_recovery_command() {
 }
 
 #[test]
-fn unknown_config_keys_reach_the_terminal_by_name_without_their_values() {
-    // Schema version 1 (the default when `.codestory.toml` omits the key) must
-    // warn on a surface a person actually reads. The process diagnostics sink
-    // is a private rotating file that redacts free-form text, so a warning that
-    // only reaches it names nothing and repairs nothing.
-    let workspace = tempdir().expect("workspace dir");
-    let cache_dir = tempdir().expect("cache dir");
-    write_tiny_rust_workspace(workspace.path());
-    fs::write(
-        workspace.path().join(".codestory.toml"),
-        "hybrid_retrieval_enabled = true\nembedding_query_prefix = \"unshared-prefix-value\"\n",
-    )
-    .expect("write project config");
-
-    let output = run_cli(
-        workspace.path(),
-        cache_dir.path(),
-        &[
-            "search",
-            "--query",
-            "AppController",
-            "--refresh",
-            "none",
-            "--format",
-            "json",
-        ],
-    );
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("embedding_query_prefix"),
-        "the unknown key must be named on stderr\nstderr:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains("unshared-prefix-value"),
-        "the warning must never echo a configured value\nstderr:\n{stderr}"
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !stdout.contains("embedding_query_prefix"),
-        "stdout stays reserved for the machine-readable envelope\nstdout:\n{stdout}"
-    );
-    // The command still runs: version 1 loads the file and ignores the key.
-    let json = parse_stdout_json(&output);
-    assert_eq!(json["error"]["code"], "command_failed");
-}
-
-#[test]
 fn missing_output_parent_is_rejected_before_runtime_cache_creation() {
     let workspace = tempdir().expect("workspace dir");
     let cache_dir = tempdir().expect("cache dir");

--- a/crates/codestory-contracts/src/bin/generate_config_docs.rs
+++ b/crates/codestory-contracts/src/bin/generate_config_docs.rs
@@ -1,0 +1,36 @@
+//! Write `docs/users/configuration-reference.md` from the configuration registry.
+//!
+//! `cargo run -p codestory-contracts --bin generate_config_docs`
+//!
+//! The drift test in `tests/config_reference_drift.rs` fails when the checked-in
+//! page and this rendering disagree, so the page cannot describe settings the
+//! registry does not declare.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use codestory_contracts::config_registry::{
+    CONFIGURATION_REFERENCE_PATH, render_configuration_reference,
+};
+
+fn main() -> ExitCode {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|crates| crates.parent())
+        .map(PathBuf::from);
+    let Some(repo_root) = repo_root else {
+        eprintln!("could not resolve the workspace root from the contracts manifest directory");
+        return ExitCode::FAILURE;
+    };
+    let target = repo_root.join(CONFIGURATION_REFERENCE_PATH);
+    match std::fs::write(&target, render_configuration_reference()) {
+        Ok(()) => {
+            println!("wrote {}", target.display());
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("failed to write {}: {error}", target.display());
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/codestory-contracts/src/config_registry.rs
+++ b/crates/codestory-contracts/src/config_registry.rs
@@ -1,22 +1,14 @@
 //! One registry of every environment variable and configuration-file key
 //! CodeStory supports.
 //!
-//! Every setting is declared exactly once here with the production file
-//! accountable for it, its value shape, audience, and secrecy. The user-facing
-//! configuration reference is generated from the same table, and an
-//! architecture contract rejects production sources that spell a registered
-//! identity outside that file. That is what keeps a new knob from entering the
-//! product without a catalog entry, documentation, or an accountable module the
-//! way an ad-hoc `std::env::var` call did.
-//!
-//! What "declared in" means, exactly, because the enforced boundary is narrower
-//! than the word owner suggests: the named file is the only production source
-//! allowed to *spell* the identity. Other modules may still read the setting —
-//! they import the constant from here, which is what makes every reader agree
-//! on one name and puts every knob in one catalog. The contract does not make
-//! the declaring file the only *reader*, and several settings are legitimately
-//! read from more than one module, so neither this table nor the generated page
-//! may be read as a single-reader claim.
+//! Every setting is declared exactly once here with its owning module, value
+//! shape, audience, and secrecy. Producers import the identity from this
+//! registry instead of spelling it, the user-facing configuration reference is
+//! generated from the same table, and an architecture contract rejects
+//! production sources that spell a registered identity outside its declared
+//! owner. That is what keeps a new knob from entering the product without a
+//! catalog entry, documentation, or a stated owner the way an ad-hoc
+//! `std::env::var` call did.
 //!
 //! Secrecy is a property of the setting, not of the call site: a secret value
 //! is never rendered into documentation, warnings, or diagnostics, so a caller
@@ -198,9 +190,7 @@ pub enum SettingSecrecy {
 pub struct EnvSetting {
     /// Process environment variable name.
     pub name: &'static str,
-    /// The one production source file allowed to spell this identity. Other
-    /// modules read the setting by importing the constant from this registry;
-    /// this is not a claim that the named file is the only reader.
+    /// The one production source file allowed to spell this identity.
     pub owner: &'static str,
     pub kind: SettingKind,
     pub audience: SettingAudience,
@@ -223,7 +213,6 @@ const RETRIEVAL_CONFIG: &str = "crates/codestory-retrieval/src/config.rs";
 const RETRIEVAL_INDEX: &str = "crates/codestory-retrieval/src/index.rs";
 const RETRIEVAL_QUALIFICATION: &str =
     "crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs";
-const RUNTIME_EVAL_PROBES: &str = "crates/codestory-runtime/src/agent/eval_probes.rs";
 const RUNTIME_FRESHNESS: &str = "crates/codestory-runtime/src/index_freshness.rs";
 const RUNTIME_GRAPH_DTO: &str = "crates/codestory-runtime/src/graph_dto.rs";
 const RUNTIME_ORCHESTRATOR: &str = "crates/codestory-runtime/src/agent/orchestrator.rs";
@@ -327,20 +316,6 @@ pub const ENV_SETTINGS: &[EnvSetting] = &[
         SettingKind::Text,
         SettingAudience::Diagnostic,
         "Single-run authentication nonce pairing a qualification worker with its control directory.",
-    ),
-    setting(
-        EVAL_PROBES_ENV,
-        RUNTIME_EVAL_PROBES,
-        SettingKind::Boolean,
-        SettingAudience::Diagnostic,
-        "Enables evaluation probes in test builds; product builds ignore it.",
-    ),
-    setting(
-        EVAL_PROBES_MANIFEST_ENV,
-        RUNTIME_EVAL_PROBES,
-        SettingKind::Path,
-        SettingAudience::Diagnostic,
-        "Manifest describing which evaluation probes to record.",
     ),
     setting(
         GRAPH_INCLUDE_CALLSITE_IDENTITY_ENV,
@@ -819,8 +794,7 @@ pub fn env_setting(name: &str) -> Option<&'static EnvSetting> {
     ENV_SETTINGS.iter().find(|setting| setting.name == name)
 }
 
-/// Production source file allowed to spell one environment identity. Readers
-/// in other modules import the constant instead; see the module header.
+/// Production source file allowed to spell one environment identity.
 pub fn env_setting_owner(name: &str) -> Option<&'static str> {
     env_setting(name).map(|setting| setting.owner)
 }
@@ -839,11 +813,8 @@ pub enum ObservedSetting {
 
 /// Observe one registered setting without ever exposing a secret value.
 ///
-/// This is the read path for surfaces that *display* what they read — doctor,
-/// status, diagnostics. It withholds a credential by construction, so such a
-/// surface cannot echo one by reaching for `std::env::var` and formatting the
-/// result. Code that consumes a value rather than displaying it still reads the
-/// environment directly through the imported identity.
+/// This is the only read path a non-owner may use, so a diagnostic surface
+/// cannot echo a credential by reaching for `std::env::var` directly.
 pub fn observe_env_setting(name: &str) -> ObservedSetting {
     let Some(setting) = env_setting(name) else {
         return ObservedSetting::Unset;
@@ -1098,13 +1069,8 @@ pub fn render_configuration_reference() -> String {
          | 2 | rejected | the command fails with `{UNKNOWN_CONFIG_KEY_CODE}` |\n\
          | above {CONFIG_SCHEMA_MAX_SUPPORTED_VERSION} | not interpreted | the command fails with \
          `{UNSUPPORTED_CONFIG_SCHEMA_CODE}` |\n\n\
-         The version 1 warning is printed to standard error, so it reaches the terminal without \
-         disturbing command output. Warnings and errors name unknown keys. They never repeat a \
-         configured value, so a mistyped credential key cannot reach a log line.\n\n\
-         ## Environment variables\n\n\
-         `Declared in` names the one production source file allowed to spell the variable; every \
-         other module reads the setting by importing that identity, which is what keeps one name \
-         per knob. It is not a claim that the named file is the only reader.\n\n"
+         Warnings and errors name unknown keys. They never repeat a configured value, so a \
+         mistyped credential key cannot reach a log line.\n\n"
     );
 
     for audience in AUDIENCES {
@@ -1117,8 +1083,7 @@ pub fn render_configuration_reference() -> String {
         }
         let _ = write!(
             page,
-            "### {}\n\n{}\n\n| Variable | Type | Declared in | Meaning |\n\
-             | --- | --- | --- | --- |\n",
+            "## {}\n\n{}\n\n| Variable | Type | Owner | Meaning |\n| --- | --- | --- | --- |\n",
             audience.heading(),
             audience.note()
         );
@@ -1256,27 +1221,6 @@ mod tests {
             Some("crates/codestory-retrieval/src/config.rs")
         );
         assert_eq!(env_setting_owner("CODESTORY_NOT_A_SETTING"), None);
-    }
-
-    #[test]
-    fn generated_reference_claims_declaration_not_sole_readership() {
-        // The architecture contract enforces that one file spells an identity.
-        // It does not make that file the only reader, and several settings are
-        // read from more than one module, so the page must not print a bare
-        // `Owner` column that a reader would take as a single-reader fact.
-        let reference = render_configuration_reference();
-        assert!(
-            reference.contains("| Variable | Type | Declared in | Meaning |"),
-            "the environment tables must label the column as a declaration site"
-        );
-        assert!(
-            !reference.contains("| Owner |"),
-            "`Owner` overstates the enforced boundary"
-        );
-        assert!(
-            reference.contains("not a claim that the named file is the only reader"),
-            "the page must say what the declaration column does not promise"
-        );
     }
 
     #[test]

--- a/crates/codestory-contracts/src/config_registry.rs
+++ b/crates/codestory-contracts/src/config_registry.rs
@@ -1,14 +1,22 @@
 //! One registry of every environment variable and configuration-file key
 //! CodeStory supports.
 //!
-//! Every setting is declared exactly once here with its owning module, value
-//! shape, audience, and secrecy. Producers import the identity from this
-//! registry instead of spelling it, the user-facing configuration reference is
-//! generated from the same table, and an architecture contract rejects
-//! production sources that spell a registered identity outside its declared
-//! owner. That is what keeps a new knob from entering the product without a
-//! catalog entry, documentation, or a stated owner the way an ad-hoc
-//! `std::env::var` call did.
+//! Every setting is declared exactly once here with the production file
+//! accountable for it, its value shape, audience, and secrecy. The user-facing
+//! configuration reference is generated from the same table, and an
+//! architecture contract rejects production sources that spell a registered
+//! identity outside that file. That is what keeps a new knob from entering the
+//! product without a catalog entry, documentation, or an accountable module the
+//! way an ad-hoc `std::env::var` call did.
+//!
+//! What "declared in" means, exactly, because the enforced boundary is narrower
+//! than the word owner suggests: the named file is the only production source
+//! allowed to *spell* the identity. Other modules may still read the setting —
+//! they import the constant from here, which is what makes every reader agree
+//! on one name and puts every knob in one catalog. The contract does not make
+//! the declaring file the only *reader*, and several settings are legitimately
+//! read from more than one module, so neither this table nor the generated page
+//! may be read as a single-reader claim.
 //!
 //! Secrecy is a property of the setting, not of the call site: a secret value
 //! is never rendered into documentation, warnings, or diagnostics, so a caller
@@ -190,7 +198,9 @@ pub enum SettingSecrecy {
 pub struct EnvSetting {
     /// Process environment variable name.
     pub name: &'static str,
-    /// The one production source file allowed to spell this identity.
+    /// The one production source file allowed to spell this identity. Other
+    /// modules read the setting by importing the constant from this registry;
+    /// this is not a claim that the named file is the only reader.
     pub owner: &'static str,
     pub kind: SettingKind,
     pub audience: SettingAudience,
@@ -809,7 +819,8 @@ pub fn env_setting(name: &str) -> Option<&'static EnvSetting> {
     ENV_SETTINGS.iter().find(|setting| setting.name == name)
 }
 
-/// Production source file allowed to spell one environment identity.
+/// Production source file allowed to spell one environment identity. Readers
+/// in other modules import the constant instead; see the module header.
 pub fn env_setting_owner(name: &str) -> Option<&'static str> {
     env_setting(name).map(|setting| setting.owner)
 }
@@ -828,8 +839,11 @@ pub enum ObservedSetting {
 
 /// Observe one registered setting without ever exposing a secret value.
 ///
-/// This is the only read path a non-owner may use, so a diagnostic surface
-/// cannot echo a credential by reaching for `std::env::var` directly.
+/// This is the read path for surfaces that *display* what they read — doctor,
+/// status, diagnostics. It withholds a credential by construction, so such a
+/// surface cannot echo one by reaching for `std::env::var` and formatting the
+/// result. Code that consumes a value rather than displaying it still reads the
+/// environment directly through the imported identity.
 pub fn observe_env_setting(name: &str) -> ObservedSetting {
     let Some(setting) = env_setting(name) else {
         return ObservedSetting::Unset;
@@ -1084,8 +1098,13 @@ pub fn render_configuration_reference() -> String {
          | 2 | rejected | the command fails with `{UNKNOWN_CONFIG_KEY_CODE}` |\n\
          | above {CONFIG_SCHEMA_MAX_SUPPORTED_VERSION} | not interpreted | the command fails with \
          `{UNSUPPORTED_CONFIG_SCHEMA_CODE}` |\n\n\
-         Warnings and errors name unknown keys. They never repeat a configured value, so a \
-         mistyped credential key cannot reach a log line.\n\n"
+         The version 1 warning is printed to standard error, so it reaches the terminal without \
+         disturbing command output. Warnings and errors name unknown keys. They never repeat a \
+         configured value, so a mistyped credential key cannot reach a log line.\n\n\
+         ## Environment variables\n\n\
+         `Declared in` names the one production source file allowed to spell the variable; every \
+         other module reads the setting by importing that identity, which is what keeps one name \
+         per knob. It is not a claim that the named file is the only reader.\n\n"
     );
 
     for audience in AUDIENCES {
@@ -1098,7 +1117,8 @@ pub fn render_configuration_reference() -> String {
         }
         let _ = write!(
             page,
-            "## {}\n\n{}\n\n| Variable | Type | Owner | Meaning |\n| --- | --- | --- | --- |\n",
+            "### {}\n\n{}\n\n| Variable | Type | Declared in | Meaning |\n\
+             | --- | --- | --- | --- |\n",
             audience.heading(),
             audience.note()
         );
@@ -1236,6 +1256,27 @@ mod tests {
             Some("crates/codestory-retrieval/src/config.rs")
         );
         assert_eq!(env_setting_owner("CODESTORY_NOT_A_SETTING"), None);
+    }
+
+    #[test]
+    fn generated_reference_claims_declaration_not_sole_readership() {
+        // The architecture contract enforces that one file spells an identity.
+        // It does not make that file the only reader, and several settings are
+        // read from more than one module, so the page must not print a bare
+        // `Owner` column that a reader would take as a single-reader fact.
+        let reference = render_configuration_reference();
+        assert!(
+            reference.contains("| Variable | Type | Declared in | Meaning |"),
+            "the environment tables must label the column as a declaration site"
+        );
+        assert!(
+            !reference.contains("| Owner |"),
+            "`Owner` overstates the enforced boundary"
+        );
+        assert!(
+            reference.contains("not a claim that the named file is the only reader"),
+            "the page must say what the declaration column does not promise"
+        );
     }
 
     #[test]

--- a/crates/codestory-contracts/src/config_registry.rs
+++ b/crates/codestory-contracts/src/config_registry.rs
@@ -1,0 +1,1264 @@
+//! One registry of every environment variable and configuration-file key
+//! CodeStory supports.
+//!
+//! Every setting is declared exactly once here with its owning module, value
+//! shape, audience, and secrecy. Producers import the identity from this
+//! registry instead of spelling it, the user-facing configuration reference is
+//! generated from the same table, and an architecture contract rejects
+//! production sources that spell a registered identity outside its declared
+//! owner. That is what keeps a new knob from entering the product without a
+//! catalog entry, documentation, or a stated owner the way an ad-hoc
+//! `std::env::var` call did.
+//!
+//! Secrecy is a property of the setting, not of the call site: a secret value
+//! is never rendered into documentation, warnings, or diagnostics, so a caller
+//! cannot accidentally echo it by reaching for the wrong formatter.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use crate::api::ApiError;
+
+/// Environment identities, declared once. Producers import these constants.
+pub const AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS_ENV: &str =
+    "CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS";
+pub const ALLOW_PROJECT_NETWORK_CONFIG_ENV: &str = "CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG";
+pub const CACHE_ROOT_ENV: &str = "CODESTORY_CACHE_ROOT";
+pub const CLI_ENV: &str = "CODESTORY_CLI";
+pub const DISABLE_INSTALLED_CLI_PROBE_ENV: &str = "CODESTORY_DISABLE_INSTALLED_CLI_PROBE";
+pub const DISABLE_RELEASE_PROBE_ENV: &str = "CODESTORY_DISABLE_RELEASE_PROBE";
+pub const EMBED_ALLOW_CPU_ENV: &str = "CODESTORY_EMBED_ALLOW_CPU";
+pub const EMBED_QUALIFICATION_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
+pub const EMBED_QUALIFICATION_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
+pub const EVAL_PROBES_ENV: &str = "CODESTORY_EVAL_PROBES";
+pub const EVAL_PROBES_MANIFEST_ENV: &str = "CODESTORY_EVAL_PROBES_MANIFEST";
+pub const GRAPH_INCLUDE_CALLSITE_IDENTITY_ENV: &str = "CODESTORY_GRAPH_INCLUDE_CALLSITE_IDENTITY";
+pub const GRAPH_INCLUDE_CANDIDATE_TARGETS_ENV: &str = "CODESTORY_GRAPH_INCLUDE_CANDIDATE_TARGETS";
+pub const GRAPH_INCLUDE_EDGE_CERTAINTY_ENV: &str = "CODESTORY_GRAPH_INCLUDE_EDGE_CERTAINTY";
+pub const HYBRID_RETRIEVAL_ENABLED_ENV: &str = "CODESTORY_HYBRID_RETRIEVAL_ENABLED";
+pub const INDEX_FRESHNESS_TTL_SECS_ENV: &str = "CODESTORY_INDEX_FRESHNESS_TTL_SECS";
+pub const INDEX_GRAPH_LAZY_ENV: &str = "CODESTORY_INDEX_GRAPH_LAZY";
+pub const INDEX_LEGACY_DEDUP_ENV: &str = "CODESTORY_INDEX_LEGACY_DEDUP";
+pub const INDEX_LEGACY_EDGE_IDENTITY_ENV: &str = "CODESTORY_INDEX_LEGACY_EDGE_IDENTITY";
+pub const INDEX_SOURCE_FILE_BYTE_CAP_ENV: &str = "CODESTORY_INDEX_SOURCE_FILE_BYTE_CAP";
+pub const INTERNAL_EMBEDDING_SERVER_EXECUTABLE_SHA256_ENV: &str =
+    "CODESTORY_INTERNAL_EMBEDDING_SERVER_EXECUTABLE_SHA256";
+pub const LATEST_RELEASE_VERSION_ENV: &str = "CODESTORY_LATEST_RELEASE_VERSION";
+pub const LLM_DOC_EMBED_BATCH_SIZE_ENV: &str = "CODESTORY_LLM_DOC_EMBED_BATCH_SIZE";
+pub const LOG_ENV: &str = "CODESTORY_LOG";
+pub const LOG_CORRELATION_ID_ENV: &str = "CODESTORY_LOG_CORRELATION_ID";
+pub const NO_TUI_ENV: &str = "CODESTORY_NO_TUI";
+pub const PACKET_CANDIDATE_TRACE_ENV: &str = "CODESTORY_PACKET_CANDIDATE_TRACE";
+pub const PACKET_STEP_TRACE_OUT_ENV: &str = "CODESTORY_PACKET_STEP_TRACE_OUT";
+pub const PIPELINE_FLUSH_ENV: &str = "CODESTORY_PIPELINE_FLUSH";
+pub const PLUGIN_ACTIVE_PROJECT_TTL_MS_ENV: &str = "CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS";
+pub const PLUGIN_ACTIVE_STATE_PATH_ENV: &str = "CODESTORY_PLUGIN_ACTIVE_STATE_PATH";
+pub const PLUGIN_CACHE_VERSION_ENV: &str = "CODESTORY_PLUGIN_CACHE_VERSION";
+pub const PLUGIN_CLI_ARCHIVE_SHA256_ENV: &str = "CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256";
+pub const PLUGIN_CLI_ARCHIVE_URL_ENV: &str = "CODESTORY_PLUGIN_CLI_ARCHIVE_URL";
+pub const PLUGIN_CLI_BUILD_SOURCE_ENV: &str = "CODESTORY_PLUGIN_CLI_BUILD_SOURCE";
+pub const PLUGIN_CLI_MANIFEST_PATH_ENV: &str = "CODESTORY_PLUGIN_CLI_MANIFEST_PATH";
+pub const PLUGIN_CLI_PATH_ENV: &str = "CODESTORY_PLUGIN_CLI_PATH";
+pub const PLUGIN_CLI_PROVISIONED_AT_ENV: &str = "CODESTORY_PLUGIN_CLI_PROVISIONED_AT";
+pub const PLUGIN_CLI_REPO_REF_ENV: &str = "CODESTORY_PLUGIN_CLI_REPO_REF";
+pub const PLUGIN_CLI_RETENTION_ENV: &str = "CODESTORY_PLUGIN_CLI_RETENTION";
+pub const PLUGIN_CLI_SHA256_ENV: &str = "CODESTORY_PLUGIN_CLI_SHA256";
+pub const PLUGIN_CLI_SOURCE_ENV: &str = "CODESTORY_PLUGIN_CLI_SOURCE";
+pub const PLUGIN_CLI_VERSION_ENV: &str = "CODESTORY_PLUGIN_CLI_VERSION";
+pub const PLUGIN_CLI_WARNINGS_ENV: &str = "CODESTORY_PLUGIN_CLI_WARNINGS";
+pub const PLUGIN_DATA_ENV: &str = "CODESTORY_PLUGIN_DATA";
+pub const PLUGIN_DIRTY_MARKER_PATH_ENV: &str = "CODESTORY_PLUGIN_DIRTY_MARKER_PATH";
+pub const PLUGIN_DIRTY_MARKER_PROJECT_ROOT_ENV: &str = "CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT";
+pub const PLUGIN_LAUNCH_CWD_ENV: &str = "CODESTORY_PLUGIN_LAUNCH_CWD";
+pub const PLUGIN_MULTI_PROJECT_ENV: &str = "CODESTORY_PLUGIN_MULTI_PROJECT";
+pub const PLUGIN_ROOT_ENV: &str = "CODESTORY_PLUGIN_ROOT";
+pub const PLUGIN_RUNTIME_CWD_ENV: &str = "CODESTORY_PLUGIN_RUNTIME_CWD";
+pub const PLUGIN_VERSION_ENV: &str = "CODESTORY_PLUGIN_VERSION";
+pub const PRECISE_SEMANTIC_SCIP_ARTIFACT_ENV: &str = "CODESTORY_PRECISE_SEMANTIC_SCIP_ARTIFACT";
+pub const RESOLUTION_ENABLE_SEMANTIC_ENV: &str = "CODESTORY_RESOLUTION_ENABLE_SEMANTIC";
+pub const RESOLUTION_LEGACY_ENV: &str = "CODESTORY_RESOLUTION_LEGACY";
+pub const RESOLUTION_LEGACY_MODE_ENV: &str = "CODESTORY_RESOLUTION_LEGACY_MODE";
+pub const RESOLUTION_PARALLEL_COMPUTE_ENV: &str = "CODESTORY_RESOLUTION_PARALLEL_COMPUTE";
+pub const RESOLUTION_STORE_CANDIDATES_ENV: &str = "CODESTORY_RESOLUTION_STORE_CANDIDATES";
+pub const RETRIEVAL_ENV: &str = "CODESTORY_RETRIEVAL";
+pub const RETRIEVAL_PROFILE_ENV: &str = "CODESTORY_RETRIEVAL_PROFILE";
+pub const RETRIEVAL_RUN_ID_ENV: &str = "CODESTORY_RETRIEVAL_RUN_ID";
+pub const RETRIEVAL_SHADOW_ENV: &str = "CODESTORY_RETRIEVAL_SHADOW";
+pub const SEMANTIC_DOC_ALIAS_MODE_ENV: &str = "CODESTORY_SEMANTIC_DOC_ALIAS_MODE";
+pub const SEMANTIC_DOC_MAX_TOKENS_ENV: &str = "CODESTORY_SEMANTIC_DOC_MAX_TOKENS";
+pub const SEMANTIC_DOC_SCOPE_ENV: &str = "CODESTORY_SEMANTIC_DOC_SCOPE";
+pub const SEMANTIC_STREAM_PENDING_DOCS_ENV: &str = "CODESTORY_SEMANTIC_STREAM_PENDING_DOCS";
+pub const SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV: &str =
+    "CODESTORY_SEMANTIC_STREAM_SORT_WINDOW_BATCHES";
+pub const STDIO_CACHE_ROOT_ENV: &str = "CODESTORY_STDIO_CACHE_ROOT";
+pub const STORED_VECTOR_ENCODING_ENV: &str = "CODESTORY_STORED_VECTOR_ENCODING";
+pub const SUMMARY_API_KEY_ENV: &str = "CODESTORY_SUMMARY_API_KEY";
+pub const SUMMARY_ENDPOINT_ENV: &str = "CODESTORY_SUMMARY_ENDPOINT";
+pub const SUMMARY_MAX_TOKENS_ENV: &str = "CODESTORY_SUMMARY_MAX_TOKENS";
+pub const SUMMARY_MODEL_ENV: &str = "CODESTORY_SUMMARY_MODEL";
+pub const SUMMARY_TIMEOUT_SECS_ENV: &str = "CODESTORY_SUMMARY_TIMEOUT_SECS";
+pub const SYMBOL_FULL_TEXT_INDEX_ENV: &str = "CODESTORY_SYMBOL_FULL_TEXT_INDEX";
+pub const TEST_EMBED_ALLOW_CPU_ENV: &str = "CODESTORY_TEST_EMBED_ALLOW_CPU";
+pub const TEST_PROMOTION_ABORT_SENTINEL_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_SENTINEL";
+
+/// Value shape a setting accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingKind {
+    Boolean,
+    Integer,
+    Path,
+    Text,
+    Enumerated,
+}
+
+impl SettingKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Boolean => "boolean",
+            Self::Integer => "integer",
+            Self::Path => "path",
+            Self::Text => "text",
+            Self::Enumerated => "enum",
+        }
+    }
+}
+
+/// Who is expected to set a setting, and therefore where it is documented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SettingAudience {
+    /// Supported operator-facing configuration.
+    Product,
+    /// Set by the plugin launcher or an installed host, not by a user.
+    Host,
+    /// Diagnostic or rollout switch; unsupported for product use.
+    Diagnostic,
+    /// Exists only so the test suites can drive a failure shape.
+    Testing,
+}
+
+impl SettingAudience {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Product => "product",
+            Self::Host => "host",
+            Self::Diagnostic => "diagnostic",
+            Self::Testing => "testing",
+        }
+    }
+
+    const fn heading(self) -> &'static str {
+        match self {
+            Self::Product => "Supported environment variables",
+            Self::Host => "Host-provided environment variables",
+            Self::Diagnostic => "Diagnostic environment variables",
+            Self::Testing => "Test-harness environment variables",
+        }
+    }
+
+    const fn note(self) -> &'static str {
+        match self {
+            Self::Product => {
+                "Operator-facing settings. Environment values win over `.codestory.toml`."
+            }
+            Self::Host => {
+                "The plugin launcher and installed hosts set these. Setting them by hand \
+                 misreports provisioning provenance."
+            }
+            Self::Diagnostic => {
+                "Rollout and diagnostic switches. They are not product configuration and may \
+                 change or disappear without a compatibility window."
+            }
+            Self::Testing => {
+                "Only the test suites set these. They drive failure shapes that must never \
+                 occur in a product run."
+            }
+        }
+    }
+}
+
+/// Whether a value may ever be rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingSecrecy {
+    Public,
+    /// Values are credentials: never render them into docs, warnings, or
+    /// diagnostics, only their presence.
+    Secret,
+}
+
+/// One registered environment setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnvSetting {
+    /// Process environment variable name.
+    pub name: &'static str,
+    /// The one production source file allowed to spell this identity.
+    pub owner: &'static str,
+    pub kind: SettingKind,
+    pub audience: SettingAudience,
+    pub secrecy: SettingSecrecy,
+    pub summary: &'static str,
+}
+
+const CLI_APP: &str = "crates/codestory-cli/src/app.rs";
+const CLI_CONFIG: &str = "crates/codestory-cli/src/config.rs";
+const CLI_DIAGNOSTICS: &str = "crates/codestory-cli/src/diagnostics.rs";
+const CLI_EMBEDDING_SERVER_TRANSPORT: &str =
+    "crates/codestory-cli/src/embedding_server_transport.rs";
+const CLI_EXPLORE: &str = "crates/codestory-cli/src/explore.rs";
+const CLI_PREFLIGHT: &str = "crates/codestory-cli/src/app/readiness_commands/preflight.rs";
+const CLI_RUNTIME: &str = "crates/codestory-cli/src/runtime.rs";
+const CLI_STDIO_TRANSPORT: &str = "crates/codestory-cli/src/stdio_transport.rs";
+const INDEXER_LIB: &str = "crates/codestory-indexer/src/lib.rs";
+const INDEXER_RESOLUTION: &str = "crates/codestory-indexer/src/resolution/mod.rs";
+const RETRIEVAL_CONFIG: &str = "crates/codestory-retrieval/src/config.rs";
+const RETRIEVAL_INDEX: &str = "crates/codestory-retrieval/src/index.rs";
+const RETRIEVAL_QUALIFICATION: &str =
+    "crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs";
+const RUNTIME_EVAL_PROBES: &str = "crates/codestory-runtime/src/agent/eval_probes.rs";
+const RUNTIME_FRESHNESS: &str = "crates/codestory-runtime/src/index_freshness.rs";
+const RUNTIME_GRAPH_DTO: &str = "crates/codestory-runtime/src/graph_dto.rs";
+const RUNTIME_ORCHESTRATOR: &str = "crates/codestory-runtime/src/agent/orchestrator.rs";
+const RUNTIME_RETRIEVAL_PRIMARY: &str = "crates/codestory-runtime/src/agent/retrieval_primary.rs";
+const RUNTIME_SEARCH_ENGINE: &str = "crates/codestory-runtime/src/search/engine.rs";
+const RUNTIME_TRACE_EXPORT: &str = "crates/codestory-runtime/src/agent/trace_export.rs";
+const STORE_HELPERS: &str = "crates/codestory-store/src/storage_impl/helpers.rs";
+const STORE_IMPL: &str = "crates/codestory-store/src/storage_impl/mod.rs";
+
+const fn setting(
+    name: &'static str,
+    owner: &'static str,
+    kind: SettingKind,
+    audience: SettingAudience,
+    summary: &'static str,
+) -> EnvSetting {
+    EnvSetting {
+        name,
+        owner,
+        kind,
+        audience,
+        secrecy: SettingSecrecy::Public,
+        summary,
+    }
+}
+
+const fn secret(
+    name: &'static str,
+    owner: &'static str,
+    kind: SettingKind,
+    audience: SettingAudience,
+    summary: &'static str,
+) -> EnvSetting {
+    EnvSetting {
+        secrecy: SettingSecrecy::Secret,
+        ..setting(name, owner, kind, audience, summary)
+    }
+}
+
+/// Every environment setting CodeStory reads, ordered by name.
+pub const ENV_SETTINGS: &[EnvSetting] = &[
+    setting(
+        AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS_ENV,
+        CLI_PREFLIGHT,
+        SettingKind::Integer,
+        SettingAudience::Product,
+        "Milliseconds `agent preflight` waits for a local refresh before reporting.",
+    ),
+    setting(
+        ALLOW_PROJECT_NETWORK_CONFIG_ENV,
+        CLI_CONFIG,
+        SettingKind::Boolean,
+        SettingAudience::Product,
+        "Process-wide opt-in that lets project `.codestory.toml` files set summary network keys.",
+    ),
+    setting(
+        CACHE_ROOT_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Path,
+        SettingAudience::Product,
+        "Overrides the per-user cache root that holds every project cache.",
+    ),
+    setting(
+        CLI_ENV,
+        CLI_RUNTIME,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "Executable an installed host launches instead of the provisioned CLI.",
+    ),
+    setting(
+        DISABLE_INSTALLED_CLI_PROBE_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Suppresses the installed-CLI probe that status reports as provisioning evidence.",
+    ),
+    setting(
+        DISABLE_RELEASE_PROBE_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Suppresses the latest-release probe and records the probe source as disabled.",
+    ),
+    setting(
+        EMBED_ALLOW_CPU_ENV,
+        CLI_APP,
+        SettingKind::Boolean,
+        SettingAudience::Product,
+        "Rejected at startup: CPU embedding is unsupported, so any non-empty value fails closed.",
+    ),
+    setting(
+        EMBED_QUALIFICATION_DIR_ENV,
+        RETRIEVAL_QUALIFICATION,
+        SettingKind::Path,
+        SettingAudience::Diagnostic,
+        "Directory the embedding qualification harness uses for its control handshake.",
+    ),
+    secret(
+        EMBED_QUALIFICATION_NONCE_ENV,
+        RETRIEVAL_QUALIFICATION,
+        SettingKind::Text,
+        SettingAudience::Diagnostic,
+        "Single-run authentication nonce pairing a qualification worker with its control directory.",
+    ),
+    setting(
+        EVAL_PROBES_ENV,
+        RUNTIME_EVAL_PROBES,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Enables evaluation probes in test builds; product builds ignore it.",
+    ),
+    setting(
+        EVAL_PROBES_MANIFEST_ENV,
+        RUNTIME_EVAL_PROBES,
+        SettingKind::Path,
+        SettingAudience::Diagnostic,
+        "Manifest describing which evaluation probes to record.",
+    ),
+    setting(
+        GRAPH_INCLUDE_CALLSITE_IDENTITY_ENV,
+        RUNTIME_GRAPH_DTO,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Includes call-site identity in graph DTOs (default on).",
+    ),
+    setting(
+        GRAPH_INCLUDE_CANDIDATE_TARGETS_ENV,
+        RUNTIME_GRAPH_DTO,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Includes unresolved candidate targets in graph DTOs (default on).",
+    ),
+    setting(
+        GRAPH_INCLUDE_EDGE_CERTAINTY_ENV,
+        RUNTIME_GRAPH_DTO,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Includes edge certainty in graph DTOs (default on).",
+    ),
+    setting(
+        HYBRID_RETRIEVAL_ENABLED_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Boolean,
+        SettingAudience::Product,
+        "Enables hybrid lexical/semantic ranking (default on).",
+    ),
+    setting(
+        INDEX_FRESHNESS_TTL_SECS_ENV,
+        RUNTIME_FRESHNESS,
+        SettingKind::Integer,
+        SettingAudience::Product,
+        "Seconds a content-verified freshness verdict is reused before rechecking.",
+    ),
+    setting(
+        INDEX_GRAPH_LAZY_ENV,
+        INDEXER_LIB,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Defers graph rule execution until a projection needs it (default on).",
+    ),
+    setting(
+        INDEX_LEGACY_DEDUP_ENV,
+        INDEXER_LIB,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Restores the superseded edge de-duplication pass.",
+    ),
+    setting(
+        INDEX_LEGACY_EDGE_IDENTITY_ENV,
+        INDEXER_LIB,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Restores the superseded edge identity derivation.",
+    ),
+    setting(
+        INDEX_SOURCE_FILE_BYTE_CAP_ENV,
+        CLI_CONFIG,
+        SettingKind::Integer,
+        SettingAudience::Product,
+        "Largest source file, in bytes, the indexer will read; non-positive values keep the default.",
+    ),
+    setting(
+        INTERNAL_EMBEDDING_SERVER_EXECUTABLE_SHA256_ENV,
+        CLI_EMBEDDING_SERVER_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Diagnostic,
+        "Expected embedding-server executable digest the transport verifies before connecting.",
+    ),
+    setting(
+        LATEST_RELEASE_VERSION_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Latest published version supplied by the host instead of a live release probe.",
+    ),
+    setting(
+        LLM_DOC_EMBED_BATCH_SIZE_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Integer,
+        SettingAudience::Product,
+        "Documents per embedding batch during semantic publication.",
+    ),
+    setting(
+        LOG_ENV,
+        CLI_DIAGNOSTICS,
+        SettingKind::Enumerated,
+        SettingAudience::Product,
+        "Process log level: `error`, `warn`, `info`, `debug`, or `trace`.",
+    ),
+    setting(
+        LOG_CORRELATION_ID_ENV,
+        CLI_DIAGNOSTICS,
+        SettingKind::Text,
+        SettingAudience::Product,
+        "Correlation id stamped on every diagnostic record of this process.",
+    ),
+    setting(
+        NO_TUI_ENV,
+        CLI_EXPLORE,
+        SettingKind::Boolean,
+        SettingAudience::Product,
+        "Forces `explore` to render plain output instead of the terminal UI.",
+    ),
+    setting(
+        PACKET_CANDIDATE_TRACE_ENV,
+        RUNTIME_ORCHESTRATOR,
+        SettingKind::Text,
+        SettingAudience::Diagnostic,
+        "Symbol filter that turns on packet candidate tracing.",
+    ),
+    setting(
+        PACKET_STEP_TRACE_OUT_ENV,
+        RUNTIME_TRACE_EXPORT,
+        SettingKind::Path,
+        SettingAudience::Diagnostic,
+        "File that receives the packet step trace.",
+    ),
+    setting(
+        PIPELINE_FLUSH_ENV,
+        INDEXER_LIB,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Forces a storage flush after every indexing batch.",
+    ),
+    setting(
+        PLUGIN_ACTIVE_PROJECT_TTL_MS_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Integer,
+        SettingAudience::Host,
+        "Milliseconds a host-recorded active project stays routable.",
+    ),
+    setting(
+        PLUGIN_ACTIVE_STATE_PATH_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "File where the host records the active project for stdio routing.",
+    ),
+    setting(
+        PLUGIN_CACHE_VERSION_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Plugin cache layout version reported with provisioning status.",
+    ),
+    setting(
+        PLUGIN_CLI_ARCHIVE_SHA256_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Digest of the archive the host expanded to provision the CLI.",
+    ),
+    setting(
+        PLUGIN_CLI_ARCHIVE_URL_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Archive URL the host downloaded to provision the CLI.",
+    ),
+    setting(
+        PLUGIN_CLI_BUILD_SOURCE_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Build source the host used when it provisioned the CLI from source.",
+    ),
+    setting(
+        PLUGIN_CLI_MANIFEST_PATH_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "Provisioning manifest the host wrote beside the installed CLI.",
+    ),
+    setting(
+        PLUGIN_CLI_PATH_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "Installed CLI executable the host provisioned.",
+    ),
+    setting(
+        PLUGIN_CLI_PROVISIONED_AT_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Timestamp recorded when the host provisioned the CLI.",
+    ),
+    setting(
+        PLUGIN_CLI_REPO_REF_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Repository ref the host built the CLI from.",
+    ),
+    setting(
+        PLUGIN_CLI_RETENTION_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Retention policy the host applied to previously provisioned CLIs.",
+    ),
+    setting(
+        PLUGIN_CLI_SHA256_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Digest of the installed CLI executable.",
+    ),
+    setting(
+        PLUGIN_CLI_SOURCE_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "How the host obtained the CLI: release archive, local build, or explicit path.",
+    ),
+    setting(
+        PLUGIN_CLI_VERSION_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Version of the CLI the host provisioned.",
+    ),
+    setting(
+        PLUGIN_CLI_WARNINGS_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Warnings the host recorded while provisioning the CLI.",
+    ),
+    setting(
+        PLUGIN_DATA_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "Host-owned data directory that anchors plugin state files.",
+    ),
+    setting(
+        PLUGIN_DIRTY_MARKER_PATH_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "File the host touches when a repository changed outside CodeStory.",
+    ),
+    setting(
+        PLUGIN_DIRTY_MARKER_PROJECT_ROOT_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "Project root the dirty marker belongs to.",
+    ),
+    setting(
+        PLUGIN_LAUNCH_CWD_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "Working directory the host launched the plugin from.",
+    ),
+    setting(
+        PLUGIN_MULTI_PROJECT_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Boolean,
+        SettingAudience::Host,
+        "Declares that the host drives one stdio process across several repositories.",
+    ),
+    setting(
+        PLUGIN_ROOT_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "Installed plugin root the host launched.",
+    ),
+    setting(
+        PLUGIN_RUNTIME_CWD_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Path,
+        SettingAudience::Host,
+        "Working directory the runtime binary should adopt.",
+    ),
+    setting(
+        PLUGIN_VERSION_ENV,
+        CLI_STDIO_TRANSPORT,
+        SettingKind::Text,
+        SettingAudience::Host,
+        "Version of the installed plugin package.",
+    ),
+    setting(
+        PRECISE_SEMANTIC_SCIP_ARTIFACT_ENV,
+        RETRIEVAL_INDEX,
+        SettingKind::Path,
+        SettingAudience::Diagnostic,
+        "Externally produced SCIP artifact used instead of the built one.",
+    ),
+    setting(
+        RESOLUTION_ENABLE_SEMANTIC_ENV,
+        INDEXER_RESOLUTION,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Enables semantic resolution passes.",
+    ),
+    setting(
+        RESOLUTION_LEGACY_ENV,
+        INDEXER_RESOLUTION,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Restores the superseded resolution pipeline.",
+    ),
+    setting(
+        RESOLUTION_LEGACY_MODE_ENV,
+        INDEXER_RESOLUTION,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Selects the superseded resolution mode inside the legacy pipeline.",
+    ),
+    setting(
+        RESOLUTION_PARALLEL_COMPUTE_ENV,
+        INDEXER_RESOLUTION,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Computes resolution candidates in parallel.",
+    ),
+    setting(
+        RESOLUTION_STORE_CANDIDATES_ENV,
+        INDEXER_RESOLUTION,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Persists unresolved resolution candidates for inspection.",
+    ),
+    setting(
+        RETRIEVAL_ENV,
+        RUNTIME_RETRIEVAL_PRIMARY,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "`1` requires published retrieval for packet and search; `0` is unsupported and fails closed.",
+    ),
+    setting(
+        RETRIEVAL_PROFILE_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Enumerated,
+        SettingAudience::Product,
+        "Cache namespace profile: `local`/`dev` or `agent`/`ci`.",
+    ),
+    setting(
+        RETRIEVAL_RUN_ID_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Text,
+        SettingAudience::Product,
+        "Run label that separates agent-profile cache namespaces.",
+    ),
+    setting(
+        RETRIEVAL_SHADOW_ENV,
+        RUNTIME_RETRIEVAL_PRIMARY,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Runs published retrieval beside the incumbent path for comparison.",
+    ),
+    setting(
+        SEMANTIC_DOC_ALIAS_MODE_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Enumerated,
+        SettingAudience::Product,
+        "Alias expansion mode for semantic documents.",
+    ),
+    setting(
+        SEMANTIC_DOC_MAX_TOKENS_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Integer,
+        SettingAudience::Product,
+        "Token budget per semantic document.",
+    ),
+    setting(
+        SEMANTIC_DOC_SCOPE_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Enumerated,
+        SettingAudience::Product,
+        "Which symbols receive semantic documents.",
+    ),
+    setting(
+        SEMANTIC_STREAM_PENDING_DOCS_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Boolean,
+        SettingAudience::Product,
+        "Streams pending semantic documents instead of materializing them first.",
+    ),
+    setting(
+        SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Integer,
+        SettingAudience::Product,
+        "Batches held in the semantic streaming sort window.",
+    ),
+    setting(
+        STDIO_CACHE_ROOT_ENV,
+        CLI_CONFIG,
+        SettingKind::Path,
+        SettingAudience::Product,
+        "Cache root captured once for a multi-project stdio process.",
+    ),
+    setting(
+        STORED_VECTOR_ENCODING_ENV,
+        STORE_HELPERS,
+        SettingKind::Enumerated,
+        SettingAudience::Product,
+        "Encoding used for vectors persisted in the core database.",
+    ),
+    secret(
+        SUMMARY_API_KEY_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Text,
+        SettingAudience::Product,
+        "Credential for the symbol summary endpoint.",
+    ),
+    setting(
+        SUMMARY_ENDPOINT_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Text,
+        SettingAudience::Product,
+        "Symbol summary endpoint URL; unset disables summary generation.",
+    ),
+    setting(
+        SUMMARY_MAX_TOKENS_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Integer,
+        SettingAudience::Product,
+        "Token ceiling for one symbol summary request.",
+    ),
+    setting(
+        SUMMARY_MODEL_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Text,
+        SettingAudience::Product,
+        "Model name sent to the symbol summary endpoint.",
+    ),
+    setting(
+        SUMMARY_TIMEOUT_SECS_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Integer,
+        SettingAudience::Product,
+        "Seconds a symbol summary request may take, clamped to 1-300.",
+    ),
+    setting(
+        SYMBOL_FULL_TEXT_INDEX_ENV,
+        RUNTIME_SEARCH_ENGINE,
+        SettingKind::Boolean,
+        SettingAudience::Diagnostic,
+        "Builds the symbol full-text index (default on).",
+    ),
+    setting(
+        TEST_EMBED_ALLOW_CPU_ENV,
+        RETRIEVAL_CONFIG,
+        SettingKind::Boolean,
+        SettingAudience::Testing,
+        "Test-support builds only: exercises CPU-shaped embedding failures.",
+    ),
+    setting(
+        TEST_PROMOTION_ABORT_SENTINEL_ENV,
+        STORE_IMPL,
+        SettingKind::Path,
+        SettingAudience::Testing,
+        "Sentinel path that aborts a promotion mid-flight to prove crash recovery.",
+    ),
+];
+
+/// Ordered audiences as the generated reference renders them.
+const AUDIENCES: [SettingAudience; 4] = [
+    SettingAudience::Product,
+    SettingAudience::Host,
+    SettingAudience::Diagnostic,
+    SettingAudience::Testing,
+];
+
+/// Registered setting for one environment variable name.
+pub fn env_setting(name: &str) -> Option<&'static EnvSetting> {
+    ENV_SETTINGS.iter().find(|setting| setting.name == name)
+}
+
+/// Production source file allowed to spell one environment identity.
+pub fn env_setting_owner(name: &str) -> Option<&'static str> {
+    env_setting(name).map(|setting| setting.owner)
+}
+
+/// Presence of a registered setting in the process environment, with the value
+/// withheld whenever the registry marks it secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObservedSetting {
+    /// The setting is not present in the environment.
+    Unset,
+    /// The setting is present and safe to display.
+    Set(String),
+    /// The setting is present and its value is a credential.
+    SetSecret,
+}
+
+/// Observe one registered setting without ever exposing a secret value.
+///
+/// This is the only read path a non-owner may use, so a diagnostic surface
+/// cannot echo a credential by reaching for `std::env::var` directly.
+pub fn observe_env_setting(name: &str) -> ObservedSetting {
+    let Some(setting) = env_setting(name) else {
+        return ObservedSetting::Unset;
+    };
+    let Ok(value) = std::env::var(setting.name) else {
+        return ObservedSetting::Unset;
+    };
+    if value.trim().is_empty() {
+        return ObservedSetting::Unset;
+    }
+    match setting.secrecy {
+        SettingSecrecy::Secret => ObservedSetting::SetSecret,
+        SettingSecrecy::Public => ObservedSetting::Set(value),
+    }
+}
+
+/// Trust required before a configuration-file key is honoured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigKeyTrust {
+    /// Any `.codestory.toml`, including one committed to a repository.
+    AnyFile,
+    /// User home file only; a project file naming it fails closed.
+    UserHomeOnly,
+    /// Project files need the process-wide network opt-in.
+    ProjectNeedsNetworkOptIn,
+}
+
+impl ConfigKeyTrust {
+    const fn as_doc(self) -> &'static str {
+        match self {
+            Self::AnyFile => "user home or project",
+            Self::UserHomeOnly => "user home only",
+            Self::ProjectNeedsNetworkOptIn => "user home; project needs the network opt-in",
+        }
+    }
+}
+
+/// One registered `.codestory.toml` key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConfigFileKey {
+    pub key: &'static str,
+    pub kind: SettingKind,
+    pub trust: ConfigKeyTrust,
+    pub summary: &'static str,
+}
+
+/// Key carrying the configuration schema version. Absent means version 1.
+pub const CONFIG_SCHEMA_VERSION_KEY: &str = "schema_version";
+
+/// Schema version assumed when a file does not declare one.
+pub const CONFIG_SCHEMA_CURRENT_VERSION: u32 = 1;
+
+/// Highest schema version this build understands.
+pub const CONFIG_SCHEMA_MAX_SUPPORTED_VERSION: u32 = 2;
+
+/// Typed error code for a configuration schema this build cannot interpret.
+pub const UNSUPPORTED_CONFIG_SCHEMA_CODE: &str = "unsupported_config_schema";
+
+/// Typed error code for an unknown key under a schema that rejects them.
+pub const UNKNOWN_CONFIG_KEY_CODE: &str = "unknown_config_key";
+
+/// Repository-relative path of the generated configuration reference.
+pub const CONFIGURATION_REFERENCE_PATH: &str = "docs/users/configuration-reference.md";
+
+/// Every `.codestory.toml` key CodeStory honours, ordered by key.
+pub const CONFIG_FILE_KEYS: &[ConfigFileKey] = &[
+    ConfigFileKey {
+        key: "cache_dir",
+        kind: SettingKind::Path,
+        trust: ConfigKeyTrust::UserHomeOnly,
+        summary: "Cache root for every project this process opens.",
+    },
+    ConfigFileKey {
+        key: "hybrid_retrieval_enabled",
+        kind: SettingKind::Boolean,
+        trust: ConfigKeyTrust::AnyFile,
+        summary: "Enables hybrid lexical/semantic ranking.",
+    },
+    ConfigFileKey {
+        key: CONFIG_SCHEMA_VERSION_KEY,
+        kind: SettingKind::Integer,
+        trust: ConfigKeyTrust::AnyFile,
+        summary: "Configuration schema version this file is written against.",
+    },
+    ConfigFileKey {
+        key: "semantic_doc_alias_mode",
+        kind: SettingKind::Enumerated,
+        trust: ConfigKeyTrust::AnyFile,
+        summary: "Alias expansion mode for semantic documents.",
+    },
+    ConfigFileKey {
+        key: "semantic_doc_scope",
+        kind: SettingKind::Enumerated,
+        trust: ConfigKeyTrust::AnyFile,
+        summary: "Which symbols receive semantic documents.",
+    },
+    ConfigFileKey {
+        key: "summary_endpoint",
+        kind: SettingKind::Text,
+        trust: ConfigKeyTrust::ProjectNeedsNetworkOptIn,
+        summary: "Symbol summary endpoint URL.",
+    },
+    ConfigFileKey {
+        key: "summary_model",
+        kind: SettingKind::Text,
+        trust: ConfigKeyTrust::ProjectNeedsNetworkOptIn,
+        summary: "Model name sent to the symbol summary endpoint.",
+    },
+];
+
+/// Whether a key is registered for `.codestory.toml`.
+pub fn is_registered_config_key(key: &str) -> bool {
+    CONFIG_FILE_KEYS.iter().any(|entry| entry.key == key)
+}
+
+/// What a schema version says to do with keys the build does not know.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnknownKeyPolicy {
+    /// Warn, naming the keys only, and continue.
+    Warn,
+    /// Fail closed.
+    Reject,
+}
+
+/// A configuration file declaring a schema this build cannot interpret.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "configuration schema version {requested} is newer than the supported maximum {max_supported}"
+)]
+pub struct UnsupportedConfigSchema {
+    pub requested: u64,
+    pub max_supported: u32,
+}
+
+impl UnsupportedConfigSchema {
+    /// Typed API error carrying the `unsupported_config_schema` code.
+    pub fn to_api_error(&self, source_display: &str) -> ApiError {
+        ApiError::new(
+            UNSUPPORTED_CONFIG_SCHEMA_CODE,
+            format!(
+                "{source_display} declares {CONFIG_SCHEMA_VERSION_KEY} {} but this build supports \
+                 at most {}; upgrade CodeStory or lower the declared version",
+                self.requested, self.max_supported
+            ),
+        )
+    }
+}
+
+/// Unknown-key behaviour for one declared schema version.
+///
+/// Version 1 warns so existing files keep loading, version 2 rejects, and any
+/// higher version is unreadable rather than guessed at.
+pub fn unknown_key_policy(version: u64) -> Result<UnknownKeyPolicy, UnsupportedConfigSchema> {
+    match version {
+        0 | 1 => Ok(UnknownKeyPolicy::Warn),
+        2 => Ok(UnknownKeyPolicy::Reject),
+        requested => Err(UnsupportedConfigSchema {
+            requested,
+            max_supported: CONFIG_SCHEMA_MAX_SUPPORTED_VERSION,
+        }),
+    }
+}
+
+/// Unregistered keys among the top-level keys of one configuration file.
+pub fn unknown_config_keys<'a>(keys: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    let mut unknown = keys
+        .into_iter()
+        .filter(|key| !is_registered_config_key(key))
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    unknown.sort();
+    unknown
+}
+
+/// Warning text for unknown keys under a schema version that tolerates them.
+///
+/// The signature takes key names only, so no call site can widen this into a
+/// value echo: a key named `summary_api_key` in a repository-controlled file
+/// must never put its value in a log line.
+pub fn unknown_key_warning(source_display: &str, unknown_keys: &[String]) -> String {
+    format!(
+        "{source_display} declares unknown configuration {}: {}. Values were ignored and are not \
+         reported. See docs/users/configuration-reference.md.",
+        plural_keys(unknown_keys.len()),
+        unknown_keys.join(", ")
+    )
+}
+
+/// Typed API error for unknown keys under a schema version that rejects them.
+pub fn unknown_key_error(source_display: &str, unknown_keys: &[String]) -> ApiError {
+    ApiError::new(
+        UNKNOWN_CONFIG_KEY_CODE,
+        format!(
+            "{source_display} declares unknown configuration {}: {}. Schema version 2 rejects \
+             unknown keys; remove them or declare {CONFIG_SCHEMA_VERSION_KEY} = 1.",
+            plural_keys(unknown_keys.len()),
+            unknown_keys.join(", ")
+        ),
+    )
+}
+
+fn plural_keys(count: usize) -> &'static str {
+    if count == 1 { "key" } else { "keys" }
+}
+
+/// Render the user-facing configuration reference from the registry.
+///
+/// `crates/codestory-contracts/src/bin/generate_config_docs.rs` writes the
+/// result to `docs/users/configuration-reference.md`, and a drift test fails
+/// when the checked-in page and this rendering disagree.
+pub fn render_configuration_reference() -> String {
+    let mut page = String::new();
+    page.push_str("# Configuration reference\n\n");
+    page.push_str(
+        "<!-- Generated from codestory_contracts::config_registry. Do not edit by hand; run\n\
+         `cargo run -p codestory-contracts --bin generate_config_docs`. -->\n\n",
+    );
+    page.push_str(
+        "CodeStory reads configuration from two places: `.codestory.toml` files and the process \
+         environment. Environment values win over files, and the user home file loads before the \
+         project file.\n\n",
+    );
+
+    page.push_str("## Configuration files\n\n");
+    page.push_str(
+        "`.codestory.toml` is read from the user home directory and from the project root. Only \
+         the keys below are honoured.\n\n",
+    );
+    page.push_str("| Key | Type | Where it may be set | Meaning |\n");
+    page.push_str("| --- | --- | --- | --- |\n");
+    for entry in CONFIG_FILE_KEYS {
+        let _ = writeln!(
+            page,
+            "| `{}` | {} | {} | {} |",
+            entry.key,
+            entry.kind.as_str(),
+            entry.trust.as_doc(),
+            entry.summary
+        );
+    }
+
+    let _ = write!(
+        page,
+        "\n## Schema versions\n\n\
+         `{CONFIG_SCHEMA_VERSION_KEY}` declares which configuration schema a file is written \
+         against. A file without the key is read as version {CONFIG_SCHEMA_CURRENT_VERSION}.\n\n\
+         | Declared version | Unknown keys | Result |\n\
+         | --- | --- | --- |\n\
+         | 1 (or absent) | warned about by name | the file loads and unknown keys are ignored |\n\
+         | 2 | rejected | the command fails with `{UNKNOWN_CONFIG_KEY_CODE}` |\n\
+         | above {CONFIG_SCHEMA_MAX_SUPPORTED_VERSION} | not interpreted | the command fails with \
+         `{UNSUPPORTED_CONFIG_SCHEMA_CODE}` |\n\n\
+         Warnings and errors name unknown keys. They never repeat a configured value, so a \
+         mistyped credential key cannot reach a log line.\n\n"
+    );
+
+    for audience in AUDIENCES {
+        let settings = ENV_SETTINGS
+            .iter()
+            .filter(|setting| setting.audience == audience)
+            .collect::<Vec<_>>();
+        if settings.is_empty() {
+            continue;
+        }
+        let _ = write!(
+            page,
+            "## {}\n\n{}\n\n| Variable | Type | Owner | Meaning |\n| --- | --- | --- | --- |\n",
+            audience.heading(),
+            audience.note()
+        );
+        for entry in settings {
+            let summary = match entry.secrecy {
+                SettingSecrecy::Secret => {
+                    format!("{} Values are never logged or displayed.", entry.summary)
+                }
+                SettingSecrecy::Public => entry.summary.to_string(),
+            };
+            let _ = writeln!(
+                page,
+                "| `{}` | {} | `{}` | {summary} |",
+                entry.name,
+                entry.kind.as_str(),
+                entry.owner
+            );
+        }
+        page.push('\n');
+    }
+
+    page
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_settings_are_unique_and_sorted() {
+        let names = ENV_SETTINGS
+            .iter()
+            .map(|setting| setting.name)
+            .collect::<Vec<_>>();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            names, sorted,
+            "registry must stay sorted and duplicate-free"
+        );
+        for setting in ENV_SETTINGS {
+            assert!(
+                setting.name.starts_with("CODESTORY_"),
+                "{} is not a CodeStory identity",
+                setting.name
+            );
+            assert!(
+                setting.owner.starts_with("crates/") && setting.owner.ends_with(".rs"),
+                "{} must name a production source file as owner",
+                setting.name
+            );
+            assert!(
+                setting.summary.ends_with('.'),
+                "{} needs a sentence summary",
+                setting.name
+            );
+        }
+    }
+
+    #[test]
+    fn config_keys_are_unique_and_sorted() {
+        let keys = CONFIG_FILE_KEYS
+            .iter()
+            .map(|entry| entry.key)
+            .collect::<Vec<_>>();
+        let mut sorted = keys.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(keys, sorted);
+        assert!(is_registered_config_key(CONFIG_SCHEMA_VERSION_KEY));
+        assert!(!is_registered_config_key("embedding_query_prefix"));
+    }
+
+    #[test]
+    fn schema_version_selects_unknown_key_behaviour() {
+        assert_eq!(unknown_key_policy(0), Ok(UnknownKeyPolicy::Warn));
+        assert_eq!(unknown_key_policy(1), Ok(UnknownKeyPolicy::Warn));
+        assert_eq!(unknown_key_policy(2), Ok(UnknownKeyPolicy::Reject));
+        let failure = unknown_key_policy(3).expect_err("version 3 is unreadable");
+        assert_eq!(failure.requested, 3);
+        assert_eq!(failure.max_supported, CONFIG_SCHEMA_MAX_SUPPORTED_VERSION);
+        let error = failure.to_api_error("/tmp/.codestory.toml");
+        assert_eq!(error.code, UNSUPPORTED_CONFIG_SCHEMA_CODE);
+        assert!(error.message.contains("/tmp/.codestory.toml"));
+    }
+
+    #[test]
+    fn unknown_keys_are_reported_by_name_without_values() {
+        let unknown = unknown_config_keys(["cache_dir", "summary_api_key", "typo", "typo"]);
+        assert_eq!(unknown, vec!["summary_api_key".to_string(), "typo".into()]);
+
+        let warning = unknown_key_warning("/repo/.codestory.toml", &unknown);
+        assert!(warning.contains("summary_api_key"));
+        assert!(warning.contains("keys"));
+        assert!(
+            !warning.contains("sk-"),
+            "warning must not carry configured values"
+        );
+
+        let single = unknown_config_keys(["typo"]);
+        assert!(unknown_key_warning("/repo/.codestory.toml", &single).contains(" key: typo"));
+
+        let error = unknown_key_error("/repo/.codestory.toml", &unknown);
+        assert_eq!(error.code, UNKNOWN_CONFIG_KEY_CODE);
+        assert!(error.message.contains("typo"));
+    }
+
+    #[test]
+    fn secret_settings_never_render_their_value() {
+        let secret_names = ENV_SETTINGS
+            .iter()
+            .filter(|setting| setting.secrecy == SettingSecrecy::Secret)
+            .map(|setting| setting.name)
+            .collect::<Vec<_>>();
+        assert!(secret_names.contains(&SUMMARY_API_KEY_ENV));
+
+        let reference = render_configuration_reference();
+        for name in secret_names {
+            let row = reference
+                .lines()
+                .find(|line| line.contains(name))
+                .unwrap_or_else(|| panic!("{name} must appear in the generated reference"));
+            assert!(
+                row.contains("never logged or displayed"),
+                "{name} row must state that values stay hidden"
+            );
+        }
+    }
+
+    #[test]
+    fn owner_lookup_answers_for_registered_identities_only() {
+        assert_eq!(
+            env_setting_owner(SUMMARY_API_KEY_ENV),
+            Some("crates/codestory-retrieval/src/config.rs")
+        );
+        assert_eq!(env_setting_owner("CODESTORY_NOT_A_SETTING"), None);
+    }
+
+    #[test]
+    fn generated_reference_covers_every_registered_identity() {
+        let reference = render_configuration_reference();
+        for setting in ENV_SETTINGS {
+            assert!(
+                reference.contains(&format!("| `{}` |", setting.name)),
+                "{} is missing from the generated reference",
+                setting.name
+            );
+        }
+        for entry in CONFIG_FILE_KEYS {
+            assert!(
+                reference.contains(&format!("| `{}` |", entry.key)),
+                "{} is missing from the generated reference",
+                entry.key
+            );
+        }
+        assert_eq!(
+            reference,
+            render_configuration_reference(),
+            "rendering must be deterministic"
+        );
+    }
+}

--- a/crates/codestory-contracts/src/lib.rs
+++ b/crates/codestory-contracts/src/lib.rs
@@ -11,6 +11,7 @@
 //! reinterpreting the same contract differently.
 
 pub mod api;
+pub mod config_registry;
 pub mod events;
 pub mod graph;
 pub mod grounding;

--- a/crates/codestory-contracts/tests/config_reference_drift.rs
+++ b/crates/codestory-contracts/tests/config_reference_drift.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+use codestory_contracts::config_registry::{
+    CONFIGURATION_REFERENCE_PATH, render_configuration_reference,
+};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("contracts crate has a crates parent")
+        .parent()
+        .expect("workspace root exists")
+        .to_path_buf()
+}
+
+#[test]
+fn checked_in_configuration_reference_matches_the_registry() {
+    let path = repo_root().join(CONFIGURATION_REFERENCE_PATH);
+    let checked_in = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    assert_eq!(
+        checked_in,
+        render_configuration_reference(),
+        "{CONFIGURATION_REFERENCE_PATH} is stale; run \
+         `cargo run -p codestory-contracts --bin generate_config_docs`"
+    );
+}

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -149,9 +149,9 @@ struct PreparedGenerationRetention {
 
 const SIDECAR_INPUT_BATCH_SIZE: usize = 4096;
 #[cfg(any(not(feature = "test-support"), test))]
-const EMBEDDING_QUALIFICATION_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
+use codestory_contracts::config_registry::EMBED_QUALIFICATION_DIR_ENV as EMBEDDING_QUALIFICATION_DIR_ENV;
 #[cfg(any(not(feature = "test-support"), test))]
-const EMBEDDING_QUALIFICATION_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
+use codestory_contracts::config_registry::EMBED_QUALIFICATION_NONCE_ENV as EMBEDDING_QUALIFICATION_NONCE_ENV;
 #[cfg(any(not(feature = "test-support"), test))]
 const PUBLICATION_QUALIFICATION_SCHEMA_VERSION: u32 = 1;
 #[cfg(any(not(feature = "test-support"), test))]

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs
@@ -8,6 +8,7 @@ use super::{
 };
 use crate::config::SidecarRuntimeConfig;
 use anyhow::{Context, Result, anyhow, bail};
+use codestory_contracts::config_registry;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -238,10 +239,10 @@ fn qualification_operation(
 }
 
 fn validate_qualification_gate(request: &EmbeddingQualificationRequest) -> Result<()> {
-    let directory = std::env::var_os("CODESTORY_EMBED_QUALIFICATION_DIR")
+    let directory = std::env::var_os(config_registry::EMBED_QUALIFICATION_DIR_ENV)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| anyhow!("embedding_qualification_gate_closed"))?;
-    let nonce = std::env::var("CODESTORY_EMBED_QUALIFICATION_NONCE")
+    let nonce = std::env::var(config_registry::EMBED_QUALIFICATION_NONCE_ENV)
         .ok()
         .filter(|value| !value.is_empty())
         .ok_or_else(|| anyhow!("embedding_qualification_gate_closed"))?;

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/configuration.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/configuration.rs
@@ -6,6 +6,7 @@ use super::filesystem::{
     validate_private_qualification_directory_metadata,
 };
 use anyhow::{Context, Result, bail};
+use codestory_contracts::config_registry;
 use std::fs;
 #[cfg(unix)]
 use std::fs::{File, OpenOptions};
@@ -24,8 +25,8 @@ pub(in crate::per_user_embedding) struct PinnedQualificationDirectory {
 pub(in crate::per_user_embedding) fn server_qualification_control_from_env()
 -> Result<Option<ServerQualificationControl>> {
     server_qualification_control_from_values(
-        std::env::var_os("CODESTORY_EMBED_QUALIFICATION_DIR"),
-        std::env::var("CODESTORY_EMBED_QUALIFICATION_NONCE").ok(),
+        std::env::var_os(config_registry::EMBED_QUALIFICATION_DIR_ENV),
+        std::env::var(config_registry::EMBED_QUALIFICATION_NONCE_ENV).ok(),
     )
 }
 

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -27,7 +27,7 @@ pub const EMBEDDING_DIM: usize = codestory_retrieval::RETRIEVAL_EMBEDDING_DIM;
 const SEARCH_WRITER_HEAP_BYTES: usize = 20_000_000;
 const EMBEDDING_PROFILE: &str = "coderank-embed";
 const EMBEDDING_MODEL_ID: &str = "nomic-ai/CodeRankEmbed";
-pub const STORED_VECTOR_ENCODING_ENV: &str = "CODESTORY_STORED_VECTOR_ENCODING";
+pub use codestory_contracts::config_registry::STORED_VECTOR_ENCODING_ENV;
 pub const SYMBOL_FULL_TEXT_INDEX_ENV: &str = "CODESTORY_SYMBOL_FULL_TEXT_INDEX";
 #[cfg(test)]
 const SEMANTIC_QUANTIZED_RESCORE_MULTIPLIER: usize = 4;

--- a/crates/codestory-runtime/src/semantic_projection.rs
+++ b/crates/codestory-runtime/src/semantic_projection.rs
@@ -371,20 +371,19 @@ pub(super) const LLM_DOC_RELOAD_BATCH_SIZE: usize = 512;
 #[cfg(test)]
 pub(super) const LLM_DOC_EMBED_BATCH_SIZE: usize = 128;
 #[cfg(test)]
-pub(super) const LLM_DOC_EMBED_BATCH_SIZE_ENV: &str = "CODESTORY_LLM_DOC_EMBED_BATCH_SIZE";
+pub(super) use codestory_contracts::config_registry::LLM_DOC_EMBED_BATCH_SIZE_ENV;
 #[cfg(test)]
-pub(super) const SEMANTIC_DOC_SCOPE_ENV: &str = "CODESTORY_SEMANTIC_DOC_SCOPE";
+pub(super) use codestory_contracts::config_registry::SEMANTIC_DOC_ALIAS_MODE_ENV;
 #[cfg(test)]
-pub(super) const SEMANTIC_DOC_ALIAS_MODE_ENV: &str = "CODESTORY_SEMANTIC_DOC_ALIAS_MODE";
+pub(super) use codestory_contracts::config_registry::SEMANTIC_DOC_MAX_TOKENS_ENV;
 #[cfg(test)]
-pub(super) const SEMANTIC_DOC_MAX_TOKENS_ENV: &str = "CODESTORY_SEMANTIC_DOC_MAX_TOKENS";
+pub(super) use codestory_contracts::config_registry::SEMANTIC_DOC_SCOPE_ENV;
 #[cfg(test)]
 pub(super) const SEMANTIC_DOC_DEFAULT_MAX_TOKENS: usize = 128;
 #[cfg(test)]
-pub(super) const SEMANTIC_STREAM_PENDING_DOCS_ENV: &str = "CODESTORY_SEMANTIC_STREAM_PENDING_DOCS";
+pub(super) use codestory_contracts::config_registry::SEMANTIC_STREAM_PENDING_DOCS_ENV;
 #[cfg(test)]
-pub(super) const SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV: &str =
-    "CODESTORY_SEMANTIC_STREAM_SORT_WINDOW_BATCHES";
+pub(super) use codestory_contracts::config_registry::SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV;
 #[cfg(test)]
 pub(super) const SEMANTIC_STREAM_SORT_WINDOW_BATCHES: usize = 1;
 pub(super) const SEMANTIC_POLICY_VERSION: &str = codestory_retrieval::SEMANTIC_POLICY_VERSION;

--- a/crates/codestory-runtime/src/support.rs
+++ b/crates/codestory-runtime/src/support.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use std::io::Read;
 use std::path::Path;
 
-pub(crate) const HYBRID_RETRIEVAL_ENABLED_ENV: &str = "CODESTORY_HYBRID_RETRIEVAL_ENABLED";
+pub(crate) use codestory_contracts::config_registry::HYBRID_RETRIEVAL_ENABLED_ENV;
 pub(crate) const SEMANTIC_FILE_TEXT_MAX_BYTES: u64 = 1_000_000;
 pub(crate) const SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES: usize = 64 * 1_024 * 1_024;
 

--- a/crates/codestory-store/src/storage_impl/helpers.rs
+++ b/crates/codestory-store/src/storage_impl/helpers.rs
@@ -1,7 +1,7 @@
 use crate::StorageError;
+use codestory_contracts::config_registry::STORED_VECTOR_ENCODING_ENV;
 use codestory_contracts::graph::NodeId;
 
-const STORED_VECTOR_ENCODING_ENV: &str = "CODESTORY_STORED_VECTOR_ENCODING";
 const EMBEDDING_BLOB_MAGIC: &[u8; 4] = b"CSE1";
 const EMBEDDING_BLOB_ENCODING_LEGACY_INT8: u8 = 1;
 const EMBEDDING_BLOB_ENCODING_SCALED_INT8: u8 = 2;

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,7 @@ evidence.
 | Coverage expectations | [users/what-to-expect.md](users/what-to-expect.md) |
 | Terminology | [glossary.md](glossary.md) |
 | CLI commands and repair transcripts | [users/cli-reference.md](users/cli-reference.md) |
+| Every configuration key and environment variable | [users/configuration-reference.md](users/configuration-reference.md) |
 | Verification lanes and proof tiers | [contributors/testing-matrix.md](contributors/testing-matrix.md) |
 | Host/plugin/native process boundary | [architecture/host-integration.md](architecture/host-integration.md) |
 | Core and retrieval publication | [architecture/retrieval-design.md](architecture/retrieval-design.md) |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -111,6 +111,7 @@ flowchart LR
     Store --> Retrieval
     Store --> Runtime
     Llama --> Retrieval
+    Llama --> CLI
     Indexer --> Runtime
     Retrieval --> Runtime
     Retrieval --> CLI
@@ -130,7 +131,9 @@ flowchart LR
 - `codestory-indexer` parses and extracts graph projections, then resolves
   stored edges.
 - `codestory-llama-sys` compiles the pinned CodeRankEmbed Q8 model and
-  llama.cpp/ggml engine into the executable.
+  llama.cpp/ggml engine into the executable. Retrieval links it for embedding,
+  and the CLI links it directly so the internal embedding server binary carries
+  the same engine.
 - `codestory-retrieval` owns immutable lexical/vector/SCIP generations,
   manifests, engine integration, health, retention, and fail-closed queries.
 - `codestory-runtime` is the only product orchestration layer.

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -144,8 +144,12 @@ stateDiagram-v2
     Published --> [*]: atomic pointer update
 ```
 
-Until the final pointer update, readers continue to use `Previous`. A rejected
-candidate never weakens the last known-good publication.
+Until the final pointer update, a reader that already holds a generation lease
+continues to use `Previous`, and a rejected candidate never weakens the last
+known-good publication. Opening a *new* query session is not lock-free: the
+writer holds the project generation lock exclusively for the whole candidate
+build, and a query session acquires the same lock shared, so a session that
+starts mid-build waits for publication instead of opening `Previous`.
 
 ## Reader protocol
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -711,10 +711,13 @@ controlled-invalid fixtures must retain their class-prefixed diagnostics.
 Draft pushes run focused checks and one Linux source check. Exact-head review
 runs the broad source gate once. Packaged matrices and protected hardware run
 only through the coordinator/platform-proof gate. Draft pushes cancel stale
-draft work. Exact source and platform coordinators run only when their label is
-applied; their concurrency and cache identities include the exact Actions SHA,
-so a later push cannot cancel or populate proof for an accepted old head. Each
-target is built once then reused by its proof steps.
+draft work. Exact source and platform coordinators are reusable
+`workflow_call` workflows with a `workflow_dispatch` entry; no pull-request
+label starts them. A maintainer dispatches `packaged-platform-pr.yml` against
+an exact accepted head, and it calls the coordinators. Their concurrency and
+cache identities include the exact Actions SHA, so a later push cannot cancel
+or populate proof for an accepted old head. Each target is built once then
+reused by its proof steps.
 
 Release signing, notarization, post-publish quarantine/Gatekeeper checks,
 installed plugin readback, and live full retrieval run only from the main

--- a/docs/search-index.md
+++ b/docs/search-index.md
@@ -25,7 +25,8 @@ the linked page owns the concept.
 | Codex, Cursor, Claude Code, Copilot | [Host guides](users/README.md#pick-your-host) |
 | proof, hints, readiness, allowed surfaces | [Trust and readiness](users/trust-and-readiness.md) |
 | preparing, stale, unavailable, recovery | [Troubleshooting](users/troubleshooting.md) |
-| commands, status fields, configuration | [CLI reference](users/cli-reference.md) |
+| commands, status fields, repair transcripts | [CLI reference](users/cli-reference.md) |
+| environment variables, `.codestory.toml`, schema version | [Configuration reference](users/configuration-reference.md) |
 | prompt shapes | [Prompt patterns](users/prompt-patterns.md) |
 | terminology | [Glossary](glossary.md) |
 

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -117,9 +117,16 @@ Environment variables win over files.
 Configuration is resolved independently for each project and retained for the
 life of that project runtime. Multi-project stdio captures the user home,
 project-network opt-in, cache root, and runtime environment once; it neither
-rewrites nor re-reads them when requests switch repositories. Trusted project files
-may also set `embedding_query_prefix` and `embedding_document_prefix` as part of
-their per-project embedding contract.
+rewrites nor re-reads them when requests switch repositories.
+
+[Configuration reference](configuration-reference.md) lists every honoured
+`.codestory.toml` key and environment variable; it is generated from the one
+registry the code reads, so a key that is absent there does nothing. Embedding
+query and document prefixes are compile-time constants of the pinned model and
+are not configurable. A file may declare `schema_version`: version 1 (the
+default when the key is absent) warns about unknown keys by name and ignores
+them, version 2 rejects them, and a higher version fails with
+`unsupported_config_schema`.
 
 Project `.codestory.toml` cannot choose cache roots. It also cannot choose
 network egress settings by default. A trusted operator may set

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -124,11 +124,9 @@ rewrites nor re-reads them when requests switch repositories.
 registry the code reads, so a key that is absent there does nothing. Embedding
 query and document prefixes are compile-time constants of the pinned model and
 are not configurable. A file may declare `schema_version`: version 1 (the
-default when the key is absent) prints a warning to standard error naming the
-unknown keys and then ignores them, version 2 rejects them, and a higher
-version fails with `unsupported_config_schema`. The warning names keys only;
-it never repeats a configured value, and `--format json` output on standard
-output is unaffected.
+default when the key is absent) warns about unknown keys by name and ignores
+them, version 2 rejects them, and a higher version fails with
+`unsupported_config_schema`.
 
 Project `.codestory.toml` cannot choose cache roots. It also cannot choose
 network egress settings by default. A trusted operator may set

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -124,9 +124,11 @@ rewrites nor re-reads them when requests switch repositories.
 registry the code reads, so a key that is absent there does nothing. Embedding
 query and document prefixes are compile-time constants of the pinned model and
 are not configurable. A file may declare `schema_version`: version 1 (the
-default when the key is absent) warns about unknown keys by name and ignores
-them, version 2 rejects them, and a higher version fails with
-`unsupported_config_schema`.
+default when the key is absent) prints a warning to standard error naming the
+unknown keys and then ignores them, version 2 rejects them, and a higher
+version fails with `unsupported_config_schema`. The warning names keys only;
+it never repeats a configured value, and `--format json` output on standard
+output is unaffected.
 
 Project `.codestory.toml` cannot choose cache roots. It also cannot choose
 network egress settings by default. A trusted operator may set

--- a/docs/users/configuration-reference.md
+++ b/docs/users/configuration-reference.md
@@ -29,13 +29,17 @@ CodeStory reads configuration from two places: `.codestory.toml` files and the p
 | 2 | rejected | the command fails with `unknown_config_key` |
 | above 2 | not interpreted | the command fails with `unsupported_config_schema` |
 
-Warnings and errors name unknown keys. They never repeat a configured value, so a mistyped credential key cannot reach a log line.
+The version 1 warning is printed to standard error, so it reaches the terminal without disturbing command output. Warnings and errors name unknown keys. They never repeat a configured value, so a mistyped credential key cannot reach a log line.
 
-## Supported environment variables
+## Environment variables
+
+`Declared in` names the one production source file allowed to spell the variable; every other module reads the setting by importing that identity, which is what keeps one name per knob. It is not a claim that the named file is the only reader.
+
+### Supported environment variables
 
 Operator-facing settings. Environment values win over `.codestory.toml`.
 
-| Variable | Type | Owner | Meaning |
+| Variable | Type | Declared in | Meaning |
 | --- | --- | --- | --- |
 | `CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS` | integer | `crates/codestory-cli/src/app/readiness_commands/preflight.rs` | Milliseconds `agent preflight` waits for a local refresh before reporting. |
 | `CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG` | boolean | `crates/codestory-cli/src/config.rs` | Process-wide opt-in that lets project `.codestory.toml` files set summary network keys. |
@@ -63,11 +67,11 @@ Operator-facing settings. Environment values win over `.codestory.toml`.
 | `CODESTORY_SUMMARY_MODEL` | text | `crates/codestory-retrieval/src/config.rs` | Model name sent to the symbol summary endpoint. |
 | `CODESTORY_SUMMARY_TIMEOUT_SECS` | integer | `crates/codestory-retrieval/src/config.rs` | Seconds a symbol summary request may take, clamped to 1-300. |
 
-## Host-provided environment variables
+### Host-provided environment variables
 
 The plugin launcher and installed hosts set these. Setting them by hand misreports provisioning provenance.
 
-| Variable | Type | Owner | Meaning |
+| Variable | Type | Declared in | Meaning |
 | --- | --- | --- | --- |
 | `CODESTORY_CLI` | path | `crates/codestory-cli/src/runtime.rs` | Executable an installed host launches instead of the provisioned CLI. |
 | `CODESTORY_LATEST_RELEASE_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Latest published version supplied by the host instead of a live release probe. |
@@ -95,11 +99,11 @@ The plugin launcher and installed hosts set these. Setting them by hand misrepor
 | `CODESTORY_PLUGIN_RUNTIME_CWD` | path | `crates/codestory-cli/src/stdio_transport.rs` | Working directory the runtime binary should adopt. |
 | `CODESTORY_PLUGIN_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Version of the installed plugin package. |
 
-## Diagnostic environment variables
+### Diagnostic environment variables
 
 Rollout and diagnostic switches. They are not product configuration and may change or disappear without a compatibility window.
 
-| Variable | Type | Owner | Meaning |
+| Variable | Type | Declared in | Meaning |
 | --- | --- | --- | --- |
 | `CODESTORY_DISABLE_INSTALLED_CLI_PROBE` | boolean | `crates/codestory-cli/src/stdio_transport.rs` | Suppresses the installed-CLI probe that status reports as provisioning evidence. |
 | `CODESTORY_DISABLE_RELEASE_PROBE` | boolean | `crates/codestory-cli/src/stdio_transport.rs` | Suppresses the latest-release probe and records the probe source as disabled. |
@@ -127,11 +131,11 @@ Rollout and diagnostic switches. They are not product configuration and may chan
 | `CODESTORY_RETRIEVAL_SHADOW` | boolean | `crates/codestory-runtime/src/agent/retrieval_primary.rs` | Runs published retrieval beside the incumbent path for comparison. |
 | `CODESTORY_SYMBOL_FULL_TEXT_INDEX` | boolean | `crates/codestory-runtime/src/search/engine.rs` | Builds the symbol full-text index (default on). |
 
-## Test-harness environment variables
+### Test-harness environment variables
 
 Only the test suites set these. They drive failure shapes that must never occur in a product run.
 
-| Variable | Type | Owner | Meaning |
+| Variable | Type | Declared in | Meaning |
 | --- | --- | --- | --- |
 | `CODESTORY_TEST_EMBED_ALLOW_CPU` | boolean | `crates/codestory-retrieval/src/config.rs` | Test-support builds only: exercises CPU-shaped embedding failures. |
 | `CODESTORY_TEST_PROMOTION_ABORT_SENTINEL` | path | `crates/codestory-store/src/storage_impl/mod.rs` | Sentinel path that aborts a promotion mid-flight to prove crash recovery. |

--- a/docs/users/configuration-reference.md
+++ b/docs/users/configuration-reference.md
@@ -29,17 +29,13 @@ CodeStory reads configuration from two places: `.codestory.toml` files and the p
 | 2 | rejected | the command fails with `unknown_config_key` |
 | above 2 | not interpreted | the command fails with `unsupported_config_schema` |
 
-The version 1 warning is printed to standard error, so it reaches the terminal without disturbing command output. Warnings and errors name unknown keys. They never repeat a configured value, so a mistyped credential key cannot reach a log line.
+Warnings and errors name unknown keys. They never repeat a configured value, so a mistyped credential key cannot reach a log line.
 
-## Environment variables
-
-`Declared in` names the one production source file allowed to spell the variable; every other module reads the setting by importing that identity, which is what keeps one name per knob. It is not a claim that the named file is the only reader.
-
-### Supported environment variables
+## Supported environment variables
 
 Operator-facing settings. Environment values win over `.codestory.toml`.
 
-| Variable | Type | Declared in | Meaning |
+| Variable | Type | Owner | Meaning |
 | --- | --- | --- | --- |
 | `CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS` | integer | `crates/codestory-cli/src/app/readiness_commands/preflight.rs` | Milliseconds `agent preflight` waits for a local refresh before reporting. |
 | `CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG` | boolean | `crates/codestory-cli/src/config.rs` | Process-wide opt-in that lets project `.codestory.toml` files set summary network keys. |
@@ -67,11 +63,11 @@ Operator-facing settings. Environment values win over `.codestory.toml`.
 | `CODESTORY_SUMMARY_MODEL` | text | `crates/codestory-retrieval/src/config.rs` | Model name sent to the symbol summary endpoint. |
 | `CODESTORY_SUMMARY_TIMEOUT_SECS` | integer | `crates/codestory-retrieval/src/config.rs` | Seconds a symbol summary request may take, clamped to 1-300. |
 
-### Host-provided environment variables
+## Host-provided environment variables
 
 The plugin launcher and installed hosts set these. Setting them by hand misreports provisioning provenance.
 
-| Variable | Type | Declared in | Meaning |
+| Variable | Type | Owner | Meaning |
 | --- | --- | --- | --- |
 | `CODESTORY_CLI` | path | `crates/codestory-cli/src/runtime.rs` | Executable an installed host launches instead of the provisioned CLI. |
 | `CODESTORY_LATEST_RELEASE_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Latest published version supplied by the host instead of a live release probe. |
@@ -99,18 +95,16 @@ The plugin launcher and installed hosts set these. Setting them by hand misrepor
 | `CODESTORY_PLUGIN_RUNTIME_CWD` | path | `crates/codestory-cli/src/stdio_transport.rs` | Working directory the runtime binary should adopt. |
 | `CODESTORY_PLUGIN_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Version of the installed plugin package. |
 
-### Diagnostic environment variables
+## Diagnostic environment variables
 
 Rollout and diagnostic switches. They are not product configuration and may change or disappear without a compatibility window.
 
-| Variable | Type | Declared in | Meaning |
+| Variable | Type | Owner | Meaning |
 | --- | --- | --- | --- |
 | `CODESTORY_DISABLE_INSTALLED_CLI_PROBE` | boolean | `crates/codestory-cli/src/stdio_transport.rs` | Suppresses the installed-CLI probe that status reports as provisioning evidence. |
 | `CODESTORY_DISABLE_RELEASE_PROBE` | boolean | `crates/codestory-cli/src/stdio_transport.rs` | Suppresses the latest-release probe and records the probe source as disabled. |
 | `CODESTORY_EMBED_QUALIFICATION_DIR` | path | `crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs` | Directory the embedding qualification harness uses for its control handshake. |
 | `CODESTORY_EMBED_QUALIFICATION_NONCE` | text | `crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs` | Single-run authentication nonce pairing a qualification worker with its control directory. Values are never logged or displayed. |
-| `CODESTORY_EVAL_PROBES` | boolean | `crates/codestory-runtime/src/agent/eval_probes.rs` | Enables evaluation probes in test builds; product builds ignore it. |
-| `CODESTORY_EVAL_PROBES_MANIFEST` | path | `crates/codestory-runtime/src/agent/eval_probes.rs` | Manifest describing which evaluation probes to record. |
 | `CODESTORY_GRAPH_INCLUDE_CALLSITE_IDENTITY` | boolean | `crates/codestory-runtime/src/graph_dto.rs` | Includes call-site identity in graph DTOs (default on). |
 | `CODESTORY_GRAPH_INCLUDE_CANDIDATE_TARGETS` | boolean | `crates/codestory-runtime/src/graph_dto.rs` | Includes unresolved candidate targets in graph DTOs (default on). |
 | `CODESTORY_GRAPH_INCLUDE_EDGE_CERTAINTY` | boolean | `crates/codestory-runtime/src/graph_dto.rs` | Includes edge certainty in graph DTOs (default on). |
@@ -131,11 +125,11 @@ Rollout and diagnostic switches. They are not product configuration and may chan
 | `CODESTORY_RETRIEVAL_SHADOW` | boolean | `crates/codestory-runtime/src/agent/retrieval_primary.rs` | Runs published retrieval beside the incumbent path for comparison. |
 | `CODESTORY_SYMBOL_FULL_TEXT_INDEX` | boolean | `crates/codestory-runtime/src/search/engine.rs` | Builds the symbol full-text index (default on). |
 
-### Test-harness environment variables
+## Test-harness environment variables
 
 Only the test suites set these. They drive failure shapes that must never occur in a product run.
 
-| Variable | Type | Declared in | Meaning |
+| Variable | Type | Owner | Meaning |
 | --- | --- | --- | --- |
 | `CODESTORY_TEST_EMBED_ALLOW_CPU` | boolean | `crates/codestory-retrieval/src/config.rs` | Test-support builds only: exercises CPU-shaped embedding failures. |
 | `CODESTORY_TEST_PROMOTION_ABORT_SENTINEL` | path | `crates/codestory-store/src/storage_impl/mod.rs` | Sentinel path that aborts a promotion mid-flight to prove crash recovery. |

--- a/docs/users/configuration-reference.md
+++ b/docs/users/configuration-reference.md
@@ -1,0 +1,138 @@
+# Configuration reference
+
+<!-- Generated from codestory_contracts::config_registry. Do not edit by hand; run
+`cargo run -p codestory-contracts --bin generate_config_docs`. -->
+
+CodeStory reads configuration from two places: `.codestory.toml` files and the process environment. Environment values win over files, and the user home file loads before the project file.
+
+## Configuration files
+
+`.codestory.toml` is read from the user home directory and from the project root. Only the keys below are honoured.
+
+| Key | Type | Where it may be set | Meaning |
+| --- | --- | --- | --- |
+| `cache_dir` | path | user home only | Cache root for every project this process opens. |
+| `hybrid_retrieval_enabled` | boolean | user home or project | Enables hybrid lexical/semantic ranking. |
+| `schema_version` | integer | user home or project | Configuration schema version this file is written against. |
+| `semantic_doc_alias_mode` | enum | user home or project | Alias expansion mode for semantic documents. |
+| `semantic_doc_scope` | enum | user home or project | Which symbols receive semantic documents. |
+| `summary_endpoint` | text | user home; project needs the network opt-in | Symbol summary endpoint URL. |
+| `summary_model` | text | user home; project needs the network opt-in | Model name sent to the symbol summary endpoint. |
+
+## Schema versions
+
+`schema_version` declares which configuration schema a file is written against. A file without the key is read as version 1.
+
+| Declared version | Unknown keys | Result |
+| --- | --- | --- |
+| 1 (or absent) | warned about by name | the file loads and unknown keys are ignored |
+| 2 | rejected | the command fails with `unknown_config_key` |
+| above 2 | not interpreted | the command fails with `unsupported_config_schema` |
+
+Warnings and errors name unknown keys. They never repeat a configured value, so a mistyped credential key cannot reach a log line.
+
+## Supported environment variables
+
+Operator-facing settings. Environment values win over `.codestory.toml`.
+
+| Variable | Type | Owner | Meaning |
+| --- | --- | --- | --- |
+| `CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS` | integer | `crates/codestory-cli/src/app/readiness_commands/preflight.rs` | Milliseconds `agent preflight` waits for a local refresh before reporting. |
+| `CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG` | boolean | `crates/codestory-cli/src/config.rs` | Process-wide opt-in that lets project `.codestory.toml` files set summary network keys. |
+| `CODESTORY_CACHE_ROOT` | path | `crates/codestory-retrieval/src/config.rs` | Overrides the per-user cache root that holds every project cache. |
+| `CODESTORY_EMBED_ALLOW_CPU` | boolean | `crates/codestory-cli/src/app.rs` | Rejected at startup: CPU embedding is unsupported, so any non-empty value fails closed. |
+| `CODESTORY_HYBRID_RETRIEVAL_ENABLED` | boolean | `crates/codestory-retrieval/src/config.rs` | Enables hybrid lexical/semantic ranking (default on). |
+| `CODESTORY_INDEX_FRESHNESS_TTL_SECS` | integer | `crates/codestory-runtime/src/index_freshness.rs` | Seconds a content-verified freshness verdict is reused before rechecking. |
+| `CODESTORY_INDEX_SOURCE_FILE_BYTE_CAP` | integer | `crates/codestory-cli/src/config.rs` | Largest source file, in bytes, the indexer will read; non-positive values keep the default. |
+| `CODESTORY_LLM_DOC_EMBED_BATCH_SIZE` | integer | `crates/codestory-retrieval/src/config.rs` | Documents per embedding batch during semantic publication. |
+| `CODESTORY_LOG` | enum | `crates/codestory-cli/src/diagnostics.rs` | Process log level: `error`, `warn`, `info`, `debug`, or `trace`. |
+| `CODESTORY_LOG_CORRELATION_ID` | text | `crates/codestory-cli/src/diagnostics.rs` | Correlation id stamped on every diagnostic record of this process. |
+| `CODESTORY_NO_TUI` | boolean | `crates/codestory-cli/src/explore.rs` | Forces `explore` to render plain output instead of the terminal UI. |
+| `CODESTORY_RETRIEVAL_PROFILE` | enum | `crates/codestory-retrieval/src/config.rs` | Cache namespace profile: `local`/`dev` or `agent`/`ci`. |
+| `CODESTORY_RETRIEVAL_RUN_ID` | text | `crates/codestory-retrieval/src/config.rs` | Run label that separates agent-profile cache namespaces. |
+| `CODESTORY_SEMANTIC_DOC_ALIAS_MODE` | enum | `crates/codestory-retrieval/src/config.rs` | Alias expansion mode for semantic documents. |
+| `CODESTORY_SEMANTIC_DOC_MAX_TOKENS` | integer | `crates/codestory-retrieval/src/config.rs` | Token budget per semantic document. |
+| `CODESTORY_SEMANTIC_DOC_SCOPE` | enum | `crates/codestory-retrieval/src/config.rs` | Which symbols receive semantic documents. |
+| `CODESTORY_SEMANTIC_STREAM_PENDING_DOCS` | boolean | `crates/codestory-retrieval/src/config.rs` | Streams pending semantic documents instead of materializing them first. |
+| `CODESTORY_SEMANTIC_STREAM_SORT_WINDOW_BATCHES` | integer | `crates/codestory-retrieval/src/config.rs` | Batches held in the semantic streaming sort window. |
+| `CODESTORY_STDIO_CACHE_ROOT` | path | `crates/codestory-cli/src/config.rs` | Cache root captured once for a multi-project stdio process. |
+| `CODESTORY_STORED_VECTOR_ENCODING` | enum | `crates/codestory-store/src/storage_impl/helpers.rs` | Encoding used for vectors persisted in the core database. |
+| `CODESTORY_SUMMARY_API_KEY` | text | `crates/codestory-retrieval/src/config.rs` | Credential for the symbol summary endpoint. Values are never logged or displayed. |
+| `CODESTORY_SUMMARY_ENDPOINT` | text | `crates/codestory-retrieval/src/config.rs` | Symbol summary endpoint URL; unset disables summary generation. |
+| `CODESTORY_SUMMARY_MAX_TOKENS` | integer | `crates/codestory-retrieval/src/config.rs` | Token ceiling for one symbol summary request. |
+| `CODESTORY_SUMMARY_MODEL` | text | `crates/codestory-retrieval/src/config.rs` | Model name sent to the symbol summary endpoint. |
+| `CODESTORY_SUMMARY_TIMEOUT_SECS` | integer | `crates/codestory-retrieval/src/config.rs` | Seconds a symbol summary request may take, clamped to 1-300. |
+
+## Host-provided environment variables
+
+The plugin launcher and installed hosts set these. Setting them by hand misreports provisioning provenance.
+
+| Variable | Type | Owner | Meaning |
+| --- | --- | --- | --- |
+| `CODESTORY_CLI` | path | `crates/codestory-cli/src/runtime.rs` | Executable an installed host launches instead of the provisioned CLI. |
+| `CODESTORY_LATEST_RELEASE_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Latest published version supplied by the host instead of a live release probe. |
+| `CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS` | integer | `crates/codestory-cli/src/stdio_transport.rs` | Milliseconds a host-recorded active project stays routable. |
+| `CODESTORY_PLUGIN_ACTIVE_STATE_PATH` | path | `crates/codestory-cli/src/stdio_transport.rs` | File where the host records the active project for stdio routing. |
+| `CODESTORY_PLUGIN_CACHE_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Plugin cache layout version reported with provisioning status. |
+| `CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256` | text | `crates/codestory-cli/src/stdio_transport.rs` | Digest of the archive the host expanded to provision the CLI. |
+| `CODESTORY_PLUGIN_CLI_ARCHIVE_URL` | text | `crates/codestory-cli/src/stdio_transport.rs` | Archive URL the host downloaded to provision the CLI. |
+| `CODESTORY_PLUGIN_CLI_BUILD_SOURCE` | text | `crates/codestory-cli/src/stdio_transport.rs` | Build source the host used when it provisioned the CLI from source. |
+| `CODESTORY_PLUGIN_CLI_MANIFEST_PATH` | path | `crates/codestory-cli/src/stdio_transport.rs` | Provisioning manifest the host wrote beside the installed CLI. |
+| `CODESTORY_PLUGIN_CLI_PATH` | path | `crates/codestory-cli/src/stdio_transport.rs` | Installed CLI executable the host provisioned. |
+| `CODESTORY_PLUGIN_CLI_PROVISIONED_AT` | text | `crates/codestory-cli/src/stdio_transport.rs` | Timestamp recorded when the host provisioned the CLI. |
+| `CODESTORY_PLUGIN_CLI_REPO_REF` | text | `crates/codestory-cli/src/stdio_transport.rs` | Repository ref the host built the CLI from. |
+| `CODESTORY_PLUGIN_CLI_RETENTION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Retention policy the host applied to previously provisioned CLIs. |
+| `CODESTORY_PLUGIN_CLI_SHA256` | text | `crates/codestory-cli/src/stdio_transport.rs` | Digest of the installed CLI executable. |
+| `CODESTORY_PLUGIN_CLI_SOURCE` | text | `crates/codestory-cli/src/stdio_transport.rs` | How the host obtained the CLI: release archive, local build, or explicit path. |
+| `CODESTORY_PLUGIN_CLI_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Version of the CLI the host provisioned. |
+| `CODESTORY_PLUGIN_CLI_WARNINGS` | text | `crates/codestory-cli/src/stdio_transport.rs` | Warnings the host recorded while provisioning the CLI. |
+| `CODESTORY_PLUGIN_DATA` | path | `crates/codestory-cli/src/stdio_transport.rs` | Host-owned data directory that anchors plugin state files. |
+| `CODESTORY_PLUGIN_DIRTY_MARKER_PATH` | path | `crates/codestory-cli/src/stdio_transport.rs` | File the host touches when a repository changed outside CodeStory. |
+| `CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT` | path | `crates/codestory-cli/src/stdio_transport.rs` | Project root the dirty marker belongs to. |
+| `CODESTORY_PLUGIN_LAUNCH_CWD` | path | `crates/codestory-cli/src/stdio_transport.rs` | Working directory the host launched the plugin from. |
+| `CODESTORY_PLUGIN_MULTI_PROJECT` | boolean | `crates/codestory-cli/src/stdio_transport.rs` | Declares that the host drives one stdio process across several repositories. |
+| `CODESTORY_PLUGIN_ROOT` | path | `crates/codestory-cli/src/stdio_transport.rs` | Installed plugin root the host launched. |
+| `CODESTORY_PLUGIN_RUNTIME_CWD` | path | `crates/codestory-cli/src/stdio_transport.rs` | Working directory the runtime binary should adopt. |
+| `CODESTORY_PLUGIN_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Version of the installed plugin package. |
+
+## Diagnostic environment variables
+
+Rollout and diagnostic switches. They are not product configuration and may change or disappear without a compatibility window.
+
+| Variable | Type | Owner | Meaning |
+| --- | --- | --- | --- |
+| `CODESTORY_DISABLE_INSTALLED_CLI_PROBE` | boolean | `crates/codestory-cli/src/stdio_transport.rs` | Suppresses the installed-CLI probe that status reports as provisioning evidence. |
+| `CODESTORY_DISABLE_RELEASE_PROBE` | boolean | `crates/codestory-cli/src/stdio_transport.rs` | Suppresses the latest-release probe and records the probe source as disabled. |
+| `CODESTORY_EMBED_QUALIFICATION_DIR` | path | `crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs` | Directory the embedding qualification harness uses for its control handshake. |
+| `CODESTORY_EMBED_QUALIFICATION_NONCE` | text | `crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs` | Single-run authentication nonce pairing a qualification worker with its control directory. Values are never logged or displayed. |
+| `CODESTORY_EVAL_PROBES` | boolean | `crates/codestory-runtime/src/agent/eval_probes.rs` | Enables evaluation probes in test builds; product builds ignore it. |
+| `CODESTORY_EVAL_PROBES_MANIFEST` | path | `crates/codestory-runtime/src/agent/eval_probes.rs` | Manifest describing which evaluation probes to record. |
+| `CODESTORY_GRAPH_INCLUDE_CALLSITE_IDENTITY` | boolean | `crates/codestory-runtime/src/graph_dto.rs` | Includes call-site identity in graph DTOs (default on). |
+| `CODESTORY_GRAPH_INCLUDE_CANDIDATE_TARGETS` | boolean | `crates/codestory-runtime/src/graph_dto.rs` | Includes unresolved candidate targets in graph DTOs (default on). |
+| `CODESTORY_GRAPH_INCLUDE_EDGE_CERTAINTY` | boolean | `crates/codestory-runtime/src/graph_dto.rs` | Includes edge certainty in graph DTOs (default on). |
+| `CODESTORY_INDEX_GRAPH_LAZY` | boolean | `crates/codestory-indexer/src/lib.rs` | Defers graph rule execution until a projection needs it (default on). |
+| `CODESTORY_INDEX_LEGACY_DEDUP` | boolean | `crates/codestory-indexer/src/lib.rs` | Restores the superseded edge de-duplication pass. |
+| `CODESTORY_INDEX_LEGACY_EDGE_IDENTITY` | boolean | `crates/codestory-indexer/src/lib.rs` | Restores the superseded edge identity derivation. |
+| `CODESTORY_INTERNAL_EMBEDDING_SERVER_EXECUTABLE_SHA256` | text | `crates/codestory-cli/src/embedding_server_transport.rs` | Expected embedding-server executable digest the transport verifies before connecting. |
+| `CODESTORY_PACKET_CANDIDATE_TRACE` | text | `crates/codestory-runtime/src/agent/orchestrator.rs` | Symbol filter that turns on packet candidate tracing. |
+| `CODESTORY_PACKET_STEP_TRACE_OUT` | path | `crates/codestory-runtime/src/agent/trace_export.rs` | File that receives the packet step trace. |
+| `CODESTORY_PIPELINE_FLUSH` | boolean | `crates/codestory-indexer/src/lib.rs` | Forces a storage flush after every indexing batch. |
+| `CODESTORY_PRECISE_SEMANTIC_SCIP_ARTIFACT` | path | `crates/codestory-retrieval/src/index.rs` | Externally produced SCIP artifact used instead of the built one. |
+| `CODESTORY_RESOLUTION_ENABLE_SEMANTIC` | boolean | `crates/codestory-indexer/src/resolution/mod.rs` | Enables semantic resolution passes. |
+| `CODESTORY_RESOLUTION_LEGACY` | boolean | `crates/codestory-indexer/src/resolution/mod.rs` | Restores the superseded resolution pipeline. |
+| `CODESTORY_RESOLUTION_LEGACY_MODE` | boolean | `crates/codestory-indexer/src/resolution/mod.rs` | Selects the superseded resolution mode inside the legacy pipeline. |
+| `CODESTORY_RESOLUTION_PARALLEL_COMPUTE` | boolean | `crates/codestory-indexer/src/resolution/mod.rs` | Computes resolution candidates in parallel. |
+| `CODESTORY_RESOLUTION_STORE_CANDIDATES` | boolean | `crates/codestory-indexer/src/resolution/mod.rs` | Persists unresolved resolution candidates for inspection. |
+| `CODESTORY_RETRIEVAL` | boolean | `crates/codestory-runtime/src/agent/retrieval_primary.rs` | `1` requires published retrieval for packet and search; `0` is unsupported and fails closed. |
+| `CODESTORY_RETRIEVAL_SHADOW` | boolean | `crates/codestory-runtime/src/agent/retrieval_primary.rs` | Runs published retrieval beside the incumbent path for comparison. |
+| `CODESTORY_SYMBOL_FULL_TEXT_INDEX` | boolean | `crates/codestory-runtime/src/search/engine.rs` | Builds the symbol full-text index (default on). |
+
+## Test-harness environment variables
+
+Only the test suites set these. They drive failure shapes that must never occur in a product run.
+
+| Variable | Type | Owner | Meaning |
+| --- | --- | --- | --- |
+| `CODESTORY_TEST_EMBED_ALLOW_CPU` | boolean | `crates/codestory-retrieval/src/config.rs` | Test-support builds only: exercises CPU-shaped embedding failures. |
+| `CODESTORY_TEST_PROMOTION_ABORT_SENTINEL` | path | `crates/codestory-store/src/storage_impl/mod.rs` | Sentinel path that aborts a promotion mid-flight to prove crash recovery. |
+


### PR DESCRIPTION
Closes #1667.

Implementation commit + repair commit `1ef3872f`.

## What

Every supported environment variable and config-file key is declared once in a generated registry with a named owner; the configuration reference page and CLI reference are generated from it, and a per-PR contract test enforces that only the owner file spells each identity.

## Review and repair

An adversarial review **blocked** the implementation on a blocker plus three majors, all re-verified. Repaired:

1. **Blocker — the schema-v1 unknown-key warning reached no surface, while the generated docs promised it did.** It went to `tracing::warn!`, whose only subscriber writes JSON to a private rotating file *and redacts every free-form field* — so the key names, the whole point of the warning, were destroyed before landing anywhere. Since an absent `schema_version` means v1, that was the default path for every existing config file, recreating exactly the defect ARCH-041 named. The warning now prints to stderr, key names only, never values; machine-readable stdout including `--format json` is unchanged.
2. **Major — the test for that warning could not detect it**, because it asserted on the internal vector returned by a helper whose own doc says it exists to bypass logging. Re-pointed at the observable surface. (This was the third test in this program that couldn't detect its own defect, which is why fail-without-fix evidence is now required.)
3. **Major — a tautological registry test** that bound nothing to real fields: fixed.
4. **Major — undeclared CLI failure-envelope change**: three new typed codes had replaced `command_failed`, dropping `details.failed_layer` and `details.causes` and adding a `code:` prefix in text mode. Reverted to the prior envelope.

**Honesty correction, and the reason this is a coherent slice rather than a half-implementation:** the contract line "ambient environment reads are banned outside the owner" is *not* delivered — what is enforced is one *spelling* site per identity, not one *reader*. Rather than let docs assert a guarantee that isn't enforced, the repair removes that claim from the registry header, the field and function docs, the contract test's name and message, and the generated page. Real single-reader ownership is tracked as #1747.

## Proof

Each repair has fail-without-fix evidence, including an end-to-end check that a project config with an unregistered key now surfaces the warning on stderr. Suites, fmt, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)