### PR TITLE
[v0.17 EV-4a] Land the four EV-4 source mechanisms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,24 @@
 - When a question names more files than fit in the follow-up list, the missing
   parts of the flow are no longer pushed out of it. Follow-ups for requested
   files and for unproven steps now alternate, so both survive the limit.
+- Meaning-based search now says nothing rather than something unrelated. It
+  always returned a full page of results, so a question with no close match got
+  the least-distant files in the codebase, ranked as though they were relevant —
+  and those crowded out the exact matches. Results it cannot claim are related
+  are left out, and a result's reported meaning score is now the similarity that
+  was actually measured instead of a minimum every result was given.
+- Two functions with the same name in one file are both returned. One of them
+  used to absorb the other, keeping the higher score and the wrong line number,
+  so overloads and repeated local names went missing from results.
+- Searching for `Foo` and then `foo` no longer returns the first search's
+  results for the second. Answers are remembered per exact query, so the hits,
+  the echoed query, and the exact-match labels match what you typed.
+- Questions are routed by how they are written, not by their punctuation. A
+  capitalised first word or a closing full stop made an ordinary question look
+  like a symbol name and halved how much of the codebase was searched, and a
+  bare filename was only recognised for three languages. Every language
+  CodeStory supports is now recognised, and only a genuine mid-word capital or
+  qualifier marks a query as a symbol.
 
 ## 0.16.3
 

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2933,19 +2933,9 @@ fn handle_stdio_search(
         .map(|value| value.clamp(1, 50) as u32)
         .unwrap_or(10);
     let publication = stdio_active_product_publication(runtime);
-    let cache_key = publication
-        .clone()
-        .map(|publication| StdioSearchFragmentCacheKey {
-            publication,
-            query: query.trim().to_ascii_lowercase(),
-            repo_text: match repo_text {
-                SearchRepoTextMode::On => "on",
-                SearchRepoTextMode::Off => "off",
-                SearchRepoTextMode::Auto => "auto",
-            }
-            .to_string(),
-            limit_per_source,
-        });
+    let cache_key = publication.clone().map(|publication| {
+        stdio_search_fragment_cache_key(publication, &query, repo_text, limit_per_source)
+    });
     if let (Some(cache_key), Some(publication)) = (cache_key.as_ref(), publication.as_ref())
         && let Some(cached) = state.search_cache.get(cache_key)
         && let Some(cached) =
@@ -2985,6 +2975,31 @@ fn handle_stdio_search(
 }
 
 const STDIO_SEARCH_FRAGMENT_CACHE_CAPACITY: usize = 64;
+
+/// Cache identity for one search fragment.
+///
+/// The query is trimmed but never case-folded: retrieval embeds and
+/// fingerprints the exact string, shape classification observes case, and
+/// search exactness is case-sensitive, so a case-folded key would serve one
+/// casing's hits, echoed query, and exactness metadata to the other.
+fn stdio_search_fragment_cache_key(
+    publication: StdioProductPublicationKey,
+    query: &str,
+    repo_text: SearchRepoTextMode,
+    limit_per_source: u32,
+) -> StdioSearchFragmentCacheKey {
+    StdioSearchFragmentCacheKey {
+        publication,
+        query: query.trim().to_string(),
+        repo_text: match repo_text {
+            SearchRepoTextMode::On => "on",
+            SearchRepoTextMode::Off => "off",
+            SearchRepoTextMode::Auto => "auto",
+        }
+        .to_string(),
+        limit_per_source,
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StdioSearchFragmentCacheKey {
@@ -6731,6 +6746,41 @@ version = "0.11.20"
                 ..key.clone()
             }),
             None
+        );
+    }
+
+    #[test]
+    fn stdio_search_fragment_cache_separates_case_distinct_queries() {
+        let mut cache = StdioSearchFragmentCache::default();
+        let upper = stdio_search_fragment_cache_key(
+            product_publication(1),
+            "  SearchWorker  ",
+            SearchRepoTextMode::Auto,
+            10,
+        );
+        let lower = stdio_search_fragment_cache_key(
+            product_publication(1),
+            "searchworker",
+            SearchRepoTextMode::Auto,
+            10,
+        );
+        assert_eq!(upper.query, "SearchWorker", "the key must stay trimmed");
+
+        cache.insert(upper.clone(), json!({"result": {"hits": ["exact"]}}));
+
+        assert_eq!(
+            cache.get(&lower),
+            None,
+            "a case-distinct query must not be served another casing's answer"
+        );
+        assert_eq!(
+            cache.get(&stdio_search_fragment_cache_key(
+                product_publication(1),
+                "SearchWorker",
+                SearchRepoTextMode::Auto,
+                10,
+            )),
+            Some(json!({"result": {"hits": ["exact"]}}))
         );
     }
 

--- a/crates/codestory-retrieval/src/candidate.rs
+++ b/crates/codestory-retrieval/src/candidate.rs
@@ -64,6 +64,25 @@ pub fn phantom_sidecar_candidates_only(candidates: &[CandidateHit]) -> bool {
     !candidates.is_empty() && candidates.iter().all(is_phantom_sidecar_hit)
 }
 
+/// Identity two lane candidates must share before fusion may collapse them.
+///
+/// A resolved node id is the strongest identity a lane can offer, so two
+/// candidates that both carry one are the same evidence only when the ids
+/// match: the schema permits duplicate display names in one file, and
+/// overloads or repeated local names are distinct nodes at distinct lines.
+/// When at least one lane left the candidate unresolved there is no id to
+/// compare, so identity falls back to the definition site itself.
+pub fn fused_candidate_identity_matches(left: &CandidateHit, right: &CandidateHit) -> bool {
+    match (left.node_id.as_deref(), right.node_id.as_deref()) {
+        (Some(left_node_id), Some(right_node_id)) => left_node_id == right_node_id,
+        _ => {
+            left.file_path == right.file_path
+                && left.symbol_name == right.symbol_name
+                && left.start_line == right.start_line
+        }
+    }
+}
+
 impl CandidateHit {
     pub fn lexical_stub(file_path: impl Into<String>, score: f32) -> Self {
         Self {
@@ -109,5 +128,55 @@ impl CandidateHit {
         if !self.provenance.iter().any(|existing| existing == &label) {
             self.provenance.push(label);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn overload(node_id: &str, start_line: u32) -> CandidateHit {
+        let mut hit = CandidateHit::with_source(
+            "src/search.rs",
+            Some("search".into()),
+            0.5,
+            CandidateSource::Lexical,
+        );
+        hit.node_id = Some(node_id.into());
+        hit.start_line = Some(start_line);
+        hit
+    }
+
+    #[test]
+    fn distinct_nodes_sharing_a_name_and_file_are_not_the_same_candidate() {
+        assert!(!fused_candidate_identity_matches(
+            &overload("11", 40),
+            &overload("12", 120)
+        ));
+    }
+
+    #[test]
+    fn same_node_id_matches_across_lanes_that_spell_the_symbol_differently() {
+        let mut lexical = overload("11", 40);
+        let mut dense = overload("11", 40);
+        dense.source = CandidateSource::Semantic;
+        dense.symbol_name = Some("core::search".into());
+        dense.start_line = None;
+        lexical.symbol_name = Some("search".into());
+
+        assert!(fused_candidate_identity_matches(&lexical, &dense));
+    }
+
+    #[test]
+    fn unresolved_candidates_fall_back_to_the_definition_site() {
+        let mut anchored = overload("11", 40);
+        anchored.node_id = None;
+        let mut same_site = anchored.clone();
+        same_site.source = CandidateSource::Scip;
+        let mut other_site = anchored.clone();
+        other_site.start_line = Some(120);
+
+        assert!(fused_candidate_identity_matches(&anchored, &same_site));
+        assert!(!fused_candidate_identity_matches(&anchored, &other_site));
     }
 }

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -30,6 +30,14 @@ const VECTOR_GENERATION_MANIFEST_FILE: &str = "vector-generation-manifest.json";
 const VECTOR_GENERATION_MANIFEST_SCHEMA_VERSION: u32 = 1;
 const VECTOR_DIGEST_DOMAIN: &[u8] = b"codestory-vector-digest-v1\0";
 const VECTOR_NORM_TOLERANCE: f64 = 1.0e-3;
+/// Share of the lane's own best similarity a neighbour must reach to be
+/// reported as dense evidence.
+///
+/// The rule is stated against this query's own best hit rather than an
+/// absolute cosine, so it carries no corpus, repository, or model-scale
+/// assumption: a neighbour less than half as similar as the best vector the
+/// lane found is one the lane's own evidence argues against.
+const DENSE_ABSTENTION_RELATIVE_MARGIN: f32 = 0.5;
 type ScoredHit = (
     f32,
     String,
@@ -1396,6 +1404,7 @@ fn search_database(
         }
     }
     scored.sort_unstable_by(compare_scored_hits);
+    retain_dense_evidence(&mut scored);
     Ok(scored
         .into_iter()
         .map(
@@ -1420,6 +1429,25 @@ fn search_database(
             },
         )
         .collect())
+}
+
+/// Drop the neighbours this lane cannot claim are related, leaving the whole
+/// stage empty when none survive.
+///
+/// A bounded scan always fills its window: without this the top `limit`
+/// vectors are reported even at zero or negative cosine, so a query with no
+/// dense evidence still emits a full set of confident-looking anchors.
+/// Requires `scored` sorted by descending similarity.
+fn retain_dense_evidence(scored: &mut Vec<ScoredHit>) {
+    let Some(best) = scored.first().map(|hit| hit.0) else {
+        return;
+    };
+    if best <= 0.0 {
+        scored.clear();
+        return;
+    }
+    let floor = best * DENSE_ABSTENTION_RELATIVE_MARGIN;
+    scored.retain(|hit| hit.0 > 0.0 && hit.0 >= floor);
 }
 
 fn compare_scored_hits(left: &ScoredHit, right: &ScoredHit) -> Ordering {
@@ -1793,6 +1821,65 @@ mod tests {
                 2,
             )
             .ready
+        );
+    }
+
+    #[test]
+    fn dense_search_abstains_instead_of_filling_its_window_with_unrelated_vectors() {
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let points = [
+            point("related", vec![1.0, 0.0]),
+            point("near", vec![0.707_106_77, 0.707_106_77]),
+            point("distant", vec![0.258_819_04, 0.965_925_8]),
+            point("opposed", vec![-1.0, 0.0]),
+        ];
+        EmbeddedVectorIndex::build_with_points(
+            &layout,
+            "codestory_abstention_deadbeefdeadbeef",
+            "abstention-deadbeefdeadbeef",
+            "input",
+            "backend",
+            2,
+            |visit| {
+                for point in points {
+                    visit(point)?;
+                }
+                Ok(())
+            },
+        )
+        .expect("build");
+        let path = index_path(&layout, "codestory_abstention_deadbeefdeadbeef");
+
+        let hits = search_database(
+            &path,
+            "abstention-deadbeefdeadbeef",
+            "input",
+            &[1.0, 0.0],
+            4,
+            || false,
+        )
+        .expect("search");
+        assert_eq!(
+            hits.iter()
+                .map(|hit| hit.node_id.as_deref().unwrap_or_default())
+                .collect::<Vec<_>>(),
+            vec!["related", "near"],
+            "the window must not be padded with vectors the lane cannot claim"
+        );
+
+        let abstained = search_database(
+            &path,
+            "abstention-deadbeefdeadbeef",
+            "input",
+            &[0.0, -1.0],
+            4,
+            || false,
+        )
+        .expect("search");
+        assert!(
+            abstained.is_empty(),
+            "no positively related vector must yield no dense evidence: {abstained:?}"
         );
     }
 

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -1,7 +1,7 @@
 use crate::cache::RetrievalCache;
 #[cfg(test)]
 use crate::cache::RetrievalCacheKey;
-use crate::candidate::CandidateHit;
+use crate::candidate::{CandidateHit, fused_candidate_identity_matches};
 use crate::health::{
     probe_sidecar_health, probe_sidecar_health_for_runtime,
     probe_sidecar_health_with_embedding_device,
@@ -930,9 +930,9 @@ fn stage_stub_metadata(hits: &[CandidateHit]) -> (Option<String>, bool) {
 fn merge_candidates(acc: &mut Vec<CandidateHit>, incoming: Vec<CandidateHit>) -> usize {
     let mut added = 0usize;
     for hit in incoming {
-        let duplicate = acc.iter_mut().find(|existing| {
-            existing.file_path == hit.file_path && existing.symbol_name == hit.symbol_name
-        });
+        let duplicate = acc
+            .iter_mut()
+            .find(|existing| fused_candidate_identity_matches(existing, &hit));
         if let Some(existing) = duplicate {
             existing.score = existing.score.max(hit.score);
             if existing.node_id.is_none() {
@@ -2178,6 +2178,56 @@ mod tests {
         assert!(rank_features.lexical >= 0.85);
         assert!(rank_features.semantic >= 0.85);
         assert_eq!(rank_features.scip_distance, 0.0);
+    }
+
+    #[test]
+    fn executor_keeps_distinct_same_name_nodes_from_one_file() {
+        let query = "resolve";
+        let mut first = CandidateHit::with_source(
+            "src/store/resolve.rs",
+            Some("resolve".into()),
+            0.80,
+            CandidateSource::Lexical,
+        );
+        first.node_id = Some("11".into());
+        first.start_line = Some(40);
+        let mut second = CandidateHit::with_source(
+            "src/store/resolve.rs",
+            Some("resolve".into()),
+            0.62,
+            CandidateSource::Lexical,
+        );
+        second.node_id = Some("12".into());
+        second.start_line = Some(120);
+        let mock = MockSidecarSearch {
+            lexical: Mutex::new(HashMap::from([(query.into(), vec![first, second])])),
+            ..Default::default()
+        };
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(mock),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: Arc::new(HashMap::new()),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+
+        let result = executor.execute(query, Some(800)).expect("query");
+
+        let mut recalled: Vec<(&str, Option<u32>)> = result
+            .hits
+            .iter()
+            .filter(|hit| hit.file_path == "src/store/resolve.rs")
+            .map(|hit| (hit.node_id.as_deref().unwrap_or_default(), hit.start_line))
+            .collect();
+        recalled.sort_unstable();
+        assert_eq!(
+            recalled,
+            vec![("11", Some(40)), ("12", Some(120))],
+            "overloads must stay distinct evidence instead of collapsing onto one line: {:?}",
+            result.hits
+        );
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/query_features.rs
+++ b/crates/codestory-retrieval/src/query_features.rs
@@ -27,9 +27,7 @@ pub fn classify_query(query: &str) -> QueryFeatures {
     let token_count = tokens.len().max(1);
 
     let has_path_separators = trimmed.contains('/') || trimmed.contains('\\');
-    let has_camel_case_token = tokens.iter().any(|token| {
-        token.chars().any(char::is_uppercase) && token.chars().any(char::is_lowercase)
-    });
+    let has_camel_case_token = tokens.iter().any(|token| has_internal_camel_hump(token));
     let has_snake_case_token = tokens.iter().any(|token| {
         token.contains('_')
             && token
@@ -37,13 +35,10 @@ pub fn classify_query(query: &str) -> QueryFeatures {
                 .filter(|c| c.is_ascii_alphabetic())
                 .all(|c| c.is_ascii_lowercase() || c == '_')
     });
-    let looks_like_qualified_symbol = tokens
-        .iter()
-        .any(|token| token.contains('.') || token.contains("::"));
+    let looks_like_qualified_symbol = tokens.iter().any(|token| is_qualified_symbol(token));
 
-    let path_like = has_path_separators
-        || (token_count == 1
-            && (trimmed.ends_with(".rs") || trimmed.ends_with(".ts") || trimmed.ends_with(".tsx")));
+    let path_like =
+        has_path_separators || (token_count == 1 && has_supported_file_extension(trimmed));
     let symbol_like = looks_like_qualified_symbol
         || has_camel_case_token
         || has_snake_case_token
@@ -86,6 +81,60 @@ pub fn classify_query(query: &str) -> QueryFeatures {
     }
 }
 
+/// A camel hump is an interior lowercase-to-uppercase transition.
+///
+/// Any capitalised word satisfies "has an uppercase and a lowercase letter", so
+/// that weaker test reads a sentence-leading `How` or `Explain` as a symbol and
+/// demotes the natural-language profile that owns broad recall.
+fn has_internal_camel_hump(token: &str) -> bool {
+    token
+        .chars()
+        .zip(token.chars().skip(1))
+        .any(|(previous, current)| previous.is_lowercase() && current.is_uppercase())
+}
+
+/// A qualifier only counts between two name characters.
+///
+/// Sentence punctuation puts a trailing `.` on ordinary prose, which otherwise
+/// reads as a qualified symbol and misroutes the whole query.
+fn is_qualified_symbol(token: &str) -> bool {
+    let characters: Vec<char> = token.chars().collect();
+    characters
+        .iter()
+        .enumerate()
+        .skip(1)
+        .take(characters.len().saturating_sub(2))
+        .any(|(index, current)| {
+            let separator_len = match (*current, characters.get(index + 1)) {
+                ('.', _) => 1,
+                (':', Some(':')) => 2,
+                _ => return false,
+            };
+            let Some(following) = characters.get(index + separator_len) else {
+                return false;
+            };
+            is_name_character(characters[index - 1]) && is_name_character(*following)
+        })
+}
+
+fn is_name_character(character: char) -> bool {
+    character.is_alphanumeric() || character == '_'
+}
+
+/// A bare filename is path-like only when the registry claims its extension.
+///
+/// Spelling a few extensions inline routed every other language's bare
+/// filename into the symbol profile, which costs the path-shaped plan.
+fn has_supported_file_extension(token: &str) -> bool {
+    let Some((stem, extension)) = token.rsplit_once('.') else {
+        return false;
+    };
+    if stem.is_empty() || extension.is_empty() {
+        return false;
+    }
+    codestory_contracts::language_support::language_support_profile_for_ext(extension).is_some()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,5 +157,60 @@ mod tests {
     fn classifies_natural_language() {
         let features = classify_query("how does packet retrieval work");
         assert_eq!(features.shape, QueryShape::NaturalLanguage);
+    }
+
+    #[test]
+    fn sentence_capitalisation_and_punctuation_stay_natural_language() {
+        for query in [
+            "How does packet retrieval work",
+            "Explain how the worker pool drains requests.",
+            "Where is the request deadline enforced?",
+        ] {
+            let features = classify_query(query);
+            assert!(
+                !features.has_camel_case_token,
+                "{query} has no interior camel hump"
+            );
+            assert!(
+                !features.looks_like_qualified_symbol,
+                "{query} has no interior qualifier"
+            );
+            assert_eq!(
+                features.shape,
+                QueryShape::NaturalLanguage,
+                "{query} must keep the natural-language plan"
+            );
+        }
+    }
+
+    #[test]
+    fn interior_camel_hump_and_qualifier_still_read_as_symbols() {
+        let features = classify_query("SearchWorker");
+        assert!(features.has_camel_case_token);
+        assert_eq!(features.shape, QueryShape::SymbolLike);
+
+        let features = classify_query("worker.spawn");
+        assert!(features.looks_like_qualified_symbol);
+        assert_eq!(features.shape, QueryShape::SymbolLike);
+
+        let features = classify_query("Explain how SearchWorker drains requests");
+        assert!(features.has_camel_case_token);
+        assert_eq!(features.shape, QueryShape::Mixed);
+    }
+
+    #[test]
+    fn bare_filenames_are_path_like_for_every_registered_extension() {
+        for query in ["worker.py", "Worker.java", "worker.go", "worker.rs"] {
+            assert_eq!(
+                classify_query(query).shape,
+                QueryShape::PathLike,
+                "{query} is a bare filename of a supported language"
+            );
+        }
+        assert_eq!(
+            classify_query("worker.spawn").shape,
+            QueryShape::SymbolLike,
+            "an unregistered suffix stays a qualified symbol"
+        );
     }
 }

--- a/crates/codestory-retrieval/src/ranker.rs
+++ b/crates/codestory-retrieval/src/ranker.rs
@@ -166,8 +166,12 @@ fn build_rank_features(candidate: &CandidateHit, query_tokens: &[String]) -> Ran
         candidate.score * 0.6
     };
 
+    // No floor: a dense lane that retained a weakly related vector must report
+    // the similarity it actually measured. Flooring it made an irrelevant
+    // neighbour outscore the minimum rank score on the strength of the floor
+    // alone.
     let semantic = if has_semantic {
-        candidate.score.max(0.4)
+        candidate.score
     } else {
         candidate.score * 0.25
     };
@@ -179,11 +183,7 @@ fn build_rank_features(candidate: &CandidateHit, query_tokens: &[String]) -> Ran
     };
 
     let file_role_prior = file_role_prior(effective_file_role(candidate));
-    let definition_quality = if candidate.symbol_name.is_some() {
-        0.85
-    } else {
-        0.45
-    };
+    let definition_quality = definition_quality(candidate);
     let token_overlap = token_overlap_score(query_tokens, &path_lower, &symbol_lower);
 
     RankFeatures {
@@ -194,6 +194,18 @@ fn build_rank_features(candidate: &CandidateHit, query_tokens: &[String]) -> Ran
         definition_quality,
         token_overlap,
     }
+}
+
+/// Definition quality claims a definition, so a bare display name cannot earn
+/// it: only a candidate resolved to an indexed node or anchored to a line has
+/// a definition site to report.
+fn definition_quality(candidate: &CandidateHit) -> f32 {
+    let named = candidate
+        .symbol_name
+        .as_deref()
+        .is_some_and(|symbol_name| !symbol_name.trim().is_empty());
+    let anchored = candidate.node_id.is_some() || candidate.start_line.is_some();
+    if named && anchored { 0.85 } else { 0.45 }
 }
 
 fn export_rank_features(candidate: &CandidateHit, mut features: RankFeatures) -> RankFeatures {
@@ -693,6 +705,10 @@ mod tests {
         let features = classify_query("primary button layout css class");
         let mut structural = CandidateHit::lexical_stub("src/ui/primary.css", 0.7);
         structural.symbol_name = Some("primary".to_string());
+        // A lexical symbol document always resolves to an indexed node, which is
+        // what earns the candidate its definition-quality feature.
+        structural.node_id = Some("41".to_string());
+        structural.start_line = Some(12);
         structural.source = CandidateSource::Lexical;
         let mut graph = CandidateHit::lexical_stub("src/ui/components.rs", 0.72);
         graph.source = CandidateSource::Lexical;
@@ -942,6 +958,68 @@ mod tests {
         assert_eq!(rank_features.lexical, 0.85);
         assert_eq!(rank_features.semantic, 0.85);
         assert_eq!(rank_features.scip_distance, 0.0);
+    }
+
+    #[test]
+    fn ranker_reports_the_measured_dense_similarity_without_a_floor() {
+        let features = classify_query("how does the request deadline reach a worker");
+        let mut weak_dense = CandidateHit::with_source(
+            "docs/notes/glossary.md",
+            Some("glossary".into()),
+            0.02,
+            CandidateSource::Semantic,
+        );
+        weak_dense.node_id = Some("91".into());
+        weak_dense.provenance = vec!["dense_anchor".into()];
+        let strong_lexical = CandidateHit::lexical_stub("src/worker/deadline.rs", 0.81);
+
+        let ranked = rank_candidates(&features, vec![weak_dense, strong_lexical]);
+
+        let dense = ranked
+            .iter()
+            .find(|hit| hit.file_path == "docs/notes/glossary.md");
+        assert!(
+            dense.is_none_or(
+                |hit| hit.rank_features.as_ref().expect("rank features").semantic < 0.4
+            ),
+            "a barely related vector must not report a floored dense feature: {ranked:#?}"
+        );
+        assert_eq!(
+            ranked.first().map(|hit| hit.file_path.as_str()),
+            Some("src/worker/deadline.rs"),
+            "measured lexical evidence must outrank an unrelated vector: {ranked:#?}"
+        );
+    }
+
+    #[test]
+    fn ranker_reserves_definition_quality_for_anchored_definitions() {
+        let features = classify_query("how does the worker drain requests");
+        let unanchored = CandidateHit::with_source(
+            "src/worker/pool.rs",
+            Some("worker pool overview".into()),
+            0.6,
+            CandidateSource::Semantic,
+        );
+        let mut anchored = unanchored.clone();
+        anchored.node_id = Some("77".into());
+        anchored.start_line = Some(31);
+
+        let unanchored_quality = rank_candidates(&features, vec![unanchored])[0]
+            .rank_features
+            .as_ref()
+            .expect("rank features")
+            .definition_quality;
+        let anchored_quality = rank_candidates(&features, vec![anchored])[0]
+            .rank_features
+            .as_ref()
+            .expect("rank features")
+            .definition_quality;
+
+        assert_eq!(anchored_quality, 0.85);
+        assert_eq!(
+            unanchored_quality, 0.45,
+            "a display name with no definition site is not definition evidence"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1751. Bottom of the stdio stack (EV-4 → RUN-B → API).

## What

Four causal boundaries from the retained review evidence:

1. **Fusion identity (CR-024)** — merging keyed on `(file_path, symbol_name)`, so overloads and repeated local names in one file collapsed onto the first candidate, which then carried the maximum score and another node's provenance at the wrong line. Now keyed on node id where both lanes resolved one, otherwise path + symbol + start line.
2. **Case-preserving stdio cache key (CR-025)** — the key was lowercased, so after `Foo` a same-publication `foo` was served the first result set with the wrong query echoed back and the wrong exactness metadata, while retrieval embeds and classifies the exact string.
3. **Query shape (CR-023)** — any token with one uppercase and one lowercase letter counted as camel case, so a sentence-leading `How`/`Where` demoted a pure prompt from NaturalLanguage to Mixed, halving the lexical stage top-k. Camel detection now requires an interior lower→upper transition, a qualifier must sit between name characters, and path-likeness derives from the language-support registry instead of an inlined extension triple.
4. **Abstention honesty (CR-021)** — the bounded scalar scan always filled its window, returning top-`limit` vectors at zero or negative cosine, which the ranker then floored to 0.4 semantic and 0.85 definition quality against final minimums of 0.04–0.08. Non-positive cosine is no longer evidence, the reported meaning score is the measured similarity, and definition quality requires an anchor.

## Review

Independently reviewed at layer scope: **merge with follow-up**. No baseline moved (baselines, approved-baselines, corpus contracts and fixtures all untouched); the generalization lint passes with unchanged counts; the vector schema is untouched so an existing 0.16.3 cache keeps working; the stdio cache is in-memory so nothing persisted can be corrupted. Every mechanism has a test proven to fail without it — the agent reverted all five production edits and observed exactly nine failures with the positive control still passing.

**Why this closes a child and not #1245:** the parent's remaining Done-when lines — reproducing the retained misses, focused causal evidence, and three cold repeats at ≥0.70 recall and coverage — need the protected measurement, which no source package may dispatch. Two review findings say the same thing from the other side: the `DENSE_ABSTENTION_RELATIVE_MARGIN = 0.5` is justified by prose rather than measurement, and its test does not exercise the 0.45–0.55 band where the rule binds. #1245 stays open until the measurement clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)