### PR TITLE
[v0.17 PERF-Qa] Land the selective store lookups

### DIFF
--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -64,7 +64,7 @@ use crate::agent::packet_required_probes::{
 #[cfg(test)]
 use crate::agent::packet_scoring::packet_citation_key;
 use crate::agent::packet_scoring::{
-    normalize_identifier, packet_citation_rank, packet_display_path,
+    normalize_identifier, packet_citation_rank, packet_display_path, sort_by_cached_rank_desc,
 };
 use crate::agent::packet_source_patterns::packet_sql_identifier_after;
 use crate::agent::packet_sufficiency::build_packet_sufficiency_with_obligation_context;
@@ -730,10 +730,8 @@ fn hybrid_weights_are_lexical_only(weights: Option<&AgentHybridWeightsDto>) -> b
 fn rank_packet_evidence(question: &str, answer: &mut AgentAnswerDto) {
     let terms = packet_rank_terms(question);
     let prefer_primary_sources = !query_mentions_non_primary_source(question);
-    answer.citations.sort_by(|left, right| {
-        packet_citation_rank(right, &terms, prefer_primary_sources)
-            .partial_cmp(&packet_citation_rank(left, &terms, prefer_primary_sources))
-            .unwrap_or(Ordering::Equal)
+    sort_by_cached_rank_desc(&mut answer.citations, |citation| {
+        packet_citation_rank(citation, &terms, prefer_primary_sources)
     });
 }
 

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -5,7 +5,7 @@ use super::citation::to_citation_from_hit;
 use super::packet_required_probes::packet_sufficiency_required_probe_queries_from_terms;
 use super::packet_scoring::{
     normalize_identifier, packet_citation_key, packet_citation_rank,
-    packet_stage_citation_carry_limit, packet_subquery_hit_limit,
+    packet_stage_citation_carry_limit, packet_subquery_hit_limit, sort_by_cached_rank_desc,
 };
 use super::packet_terms::packet_probe_terms;
 use super::packet_trace::{
@@ -20,7 +20,6 @@ use codestory_contracts::api::{
     PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto, PacketTaskClassDto, SearchHit,
     SearchHitOrigin, SearchMatchQualityDto,
 };
-use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::time::Instant;
@@ -443,10 +442,8 @@ pub(crate) fn run_packet_anchor_expansion(
                     .filter(|hit| packet_anchor_hit_is_relevant(&query, hit))
                     .map(|hit| to_citation_from_hit(hit, None, None, include_evidence))
                     .collect::<Vec<_>>();
-                citations.sort_by(|left, right| {
-                    packet_citation_rank(right, rank_terms, true)
-                        .partial_cmp(&packet_citation_rank(left, rank_terms, true))
-                        .unwrap_or(Ordering::Equal)
+                sort_by_cached_rank_desc(&mut citations, |citation| {
+                    packet_citation_rank(citation, rank_terms, true)
                 });
                 for citation in citations.into_iter().take(stage_carry_limit) {
                     if citation_keys.insert(packet_citation_key(&citation)) {

--- a/crates/codestory-runtime/src/agent/packet_claims.rs
+++ b/crates/codestory-runtime/src/agent/packet_claims.rs
@@ -18,7 +18,7 @@ use crate::agent::packet_plan::packet_rank_terms;
 use crate::agent::packet_profile_telemetry::{PacketClaimSource, PacketClaimTelemetry};
 use crate::agent::packet_scoring::{
     normalize_identifier, packet_adjacent_query_stop_term, packet_claim_carry_rank,
-    packet_display_path, packet_query_stop_term,
+    packet_display_path, packet_query_stop_term, sort_by_cached_rank_desc,
 };
 use crate::agent::packet_terms::{packet_probe_terms, packet_terms_indicate_sql_schema_flow};
 use crate::query_mentions_non_primary_source;
@@ -26,7 +26,6 @@ use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, PacketClaimDto, PacketEvidenceResolutionDto,
     PacketEvidenceTierDto, PacketProofStatusDto,
 };
-use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fmt::Write as _;
 
@@ -686,14 +685,8 @@ pub(crate) fn append_ranked_citation_claims(
     seen_claims: &mut HashSet<String>,
 ) {
     let mut ordered_citations = citations.to_vec();
-    ordered_citations.sort_by(|left, right| {
-        packet_claim_carry_rank(right, rank_terms, prefer_primary_sources)
-            .partial_cmp(&packet_claim_carry_rank(
-                left,
-                rank_terms,
-                prefer_primary_sources,
-            ))
-            .unwrap_or(Ordering::Equal)
+    sort_by_cached_rank_desc(&mut ordered_citations, |citation| {
+        packet_claim_carry_rank(citation, rank_terms, prefer_primary_sources)
     });
     for citation in &ordered_citations {
         if let Some(shaped) = packet_citation_shaped_claim(citation, prompt) {

--- a/crates/codestory-runtime/src/agent/packet_scoring.rs
+++ b/crates/codestory-runtime/src/agent/packet_scoring.rs
@@ -20,6 +20,25 @@ use crate::retrieval_file_role_from_path;
 use codestory_contracts::api::{
     AgentCitationDto, NodeKind, PacketBudgetLimitsDto, SearchHitOrigin,
 };
+use std::cmp::Ordering;
+
+/// Sort descending on a rank that is evaluated exactly once per element.
+///
+/// `packet_citation_rank` and `packet_claim_carry_rank` allocate and rescan every
+/// ranking term, so they are decorated before the sort rather than recomputed
+/// inside the comparator. The comparator itself is unchanged — a NaN rank still
+/// compares equal, and the stable sort keeps input order for equal ranks.
+pub(crate) fn sort_by_cached_rank_desc<T>(values: &mut Vec<T>, mut rank: impl FnMut(&T) -> f32) {
+    let mut decorated = std::mem::take(values)
+        .into_iter()
+        .map(|value| {
+            let rank = rank(&value);
+            (value, rank)
+        })
+        .collect::<Vec<_>>();
+    decorated.sort_by(|(_, left), (_, right)| right.partial_cmp(left).unwrap_or(Ordering::Equal));
+    *values = decorated.into_iter().map(|(value, _)| value).collect();
+}
 
 /// Citations merged from each packet retrieval stage before the final budget cap.
 pub(crate) fn packet_stage_citation_carry_limit(limits: &PacketBudgetLimitsDto) -> usize {
@@ -1268,6 +1287,86 @@ fn path_after_named_repo_root(normalized: &str) -> Option<String> {
 mod tests {
     use super::*;
     use codestory_contracts::api::NodeId;
+
+    #[test]
+    fn cached_rank_sort_evaluates_once_and_keeps_equal_and_nan_order() {
+        let mut evaluations = 0usize;
+        let mut values = vec![
+            ("equal-a", 2.0_f32),
+            ("equal-b", 2.0),
+            ("low", 1.0),
+            ("high", 3.0),
+        ];
+        sort_by_cached_rank_desc(&mut values, |(_, rank)| {
+            evaluations += 1;
+            *rank
+        });
+        assert_eq!(evaluations, values.len());
+        assert_eq!(
+            values.iter().map(|(label, _)| *label).collect::<Vec<_>>(),
+            vec!["high", "equal-a", "equal-b", "low"],
+            "equal ranks must keep input order"
+        );
+
+        for mut values in [
+            vec![("nan", f32::NAN), ("finite", 2.0_f32)],
+            vec![("finite", 2.0_f32), ("nan", f32::NAN)],
+        ] {
+            let expected = values.iter().map(|(label, _)| *label).collect::<Vec<_>>();
+            sort_by_cached_rank_desc(&mut values, |(_, rank)| *rank);
+            assert_eq!(
+                values.iter().map(|(label, _)| *label).collect::<Vec<_>>(),
+                expected,
+                "a NaN rank must stay comparator-equal and stable"
+            );
+        }
+    }
+
+    #[test]
+    fn cached_rank_sort_permutes_exactly_like_the_recomputing_comparator() {
+        // The zero-movement claim rests on this: the decorated sort must be a
+        // permutation-for-permutation replacement of the comparator that
+        // recomputed the rank on every comparison.
+        let ranks = [
+            3.0_f32,
+            f32::NAN,
+            3.0,
+            -100.0,
+            0.0,
+            f32::NAN,
+            12.5,
+            -0.0,
+            12.5,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            1.0,
+            1.0,
+            1.0,
+        ];
+        for window in 1..=ranks.len() {
+            for offset in 0..=(ranks.len() - window) {
+                let labelled = ranks[offset..offset + window]
+                    .iter()
+                    .enumerate()
+                    .map(|(index, rank)| (index, *rank))
+                    .collect::<Vec<_>>();
+
+                let mut previous = labelled.clone();
+                previous.sort_by(|(_, left), (_, right)| {
+                    right.partial_cmp(left).unwrap_or(Ordering::Equal)
+                });
+
+                let mut current = labelled;
+                sort_by_cached_rank_desc(&mut current, |(_, rank)| *rank);
+
+                assert_eq!(
+                    current.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+                    previous.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+                    "cached-rank sort moved rows for window={window} offset={offset}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_like_display_names_include_go_style_pascal_names() {

--- a/crates/codestory-runtime/src/agent/packet_trace.rs
+++ b/crates/codestory-runtime/src/agent/packet_trace.rs
@@ -3,14 +3,13 @@
 #![allow(clippy::items_after_test_module)]
 
 use super::citation::to_citation_from_hit;
-use super::packet_scoring::{packet_citation_key, packet_citation_rank};
+use super::packet_scoring::{packet_citation_key, packet_citation_rank, sort_by_cached_rank_desc};
 use super::trace::field;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentResponseBlockDto, AgentResponseSectionDto, AgentRetrievalStepDto,
     AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto, AgentRetrievalSummaryFieldDto,
     PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto, SearchHit,
 };
-use std::cmp::Ordering;
 use std::collections::HashSet;
 
 fn sanitize_section_id(value: &str) -> String {
@@ -58,10 +57,8 @@ pub(crate) fn merge_packet_fused_subquery_batch(
             .iter()
             .map(|hit| to_citation_from_hit(hit, None, None, include_evidence))
             .collect::<Vec<_>>();
-        citations.sort_by(|left, right| {
-            packet_citation_rank(right, rank_terms, true)
-                .partial_cmp(&packet_citation_rank(left, rank_terms, true))
-                .unwrap_or(Ordering::Equal)
+        sort_by_cached_rank_desc(&mut citations, |citation| {
+            packet_citation_rank(citation, rank_terms, true)
         });
         for citation in citations.into_iter().take(stage_carry_limit) {
             if citation_keys.insert(packet_citation_key(&citation)) {

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1624,6 +1624,39 @@ fn candidate_path_resolvable(project_root: &Path, file_path: &str) -> bool {
             .any(|path| path.exists())
 }
 
+/// Order the resolvable candidates ahead of the unresolvable ones, by score.
+///
+/// `path_resolvable` stats the filesystem, so it is decorated once per surviving
+/// candidate instead of once per comparison, and the resolved verdict is handed
+/// back for the unresolved-candidate label. The comparator is unchanged, so a
+/// NaN score still compares equal and stable sorting keeps input order for ties.
+fn ordered_sidecar_candidates<F>(
+    candidates: &[CandidateHit],
+    mut path_resolvable: F,
+) -> Vec<(usize, &CandidateHit, bool)>
+where
+    F: FnMut(&CandidateHit) -> bool,
+{
+    let mut ordered = candidates
+        .iter()
+        .enumerate()
+        .filter(|(_, candidate)| !is_phantom_sidecar_hit(candidate))
+        .map(|(index, candidate)| {
+            let resolvable = path_resolvable(candidate);
+            (index, candidate, resolvable)
+        })
+        .collect::<Vec<_>>();
+    ordered.sort_by(|(_, left, left_resolvable), (_, right, right_resolvable)| {
+        right_resolvable.cmp(left_resolvable).then(
+            right
+                .score
+                .partial_cmp(&left.score)
+                .unwrap_or(std::cmp::Ordering::Equal),
+        )
+    });
+    ordered
+}
+
 fn candidate_path_text_is_path_like(path: &str) -> bool {
     let trimmed = path.trim();
     !trimmed.is_empty()
@@ -1818,23 +1851,11 @@ fn resolve_sidecar_candidates_in_storage(
     let mut unresolved_candidates = Vec::new();
     let mut attempted_candidate_indices = HashSet::new();
     let mut seen = HashSet::new();
-    let mut ordered: Vec<(usize, &CandidateHit)> = candidates
-        .iter()
-        .enumerate()
-        .filter(|(_, candidate)| !is_phantom_sidecar_hit(candidate))
-        .collect();
-    ordered.sort_by(|(_, left), (_, right)| {
-        let left_resolvable = candidate_path_resolvable(project_root, &left.file_path);
-        let right_resolvable = candidate_path_resolvable(project_root, &right.file_path);
-        right_resolvable.cmp(&left_resolvable).then(
-            right
-                .score
-                .partial_cmp(&left.score)
-                .unwrap_or(std::cmp::Ordering::Equal),
-        )
+    let ordered = ordered_sidecar_candidates(candidates, |candidate| {
+        candidate_path_resolvable(project_root, &candidate.file_path)
     });
 
-    for (candidate_index, candidate) in ordered {
+    for (candidate_index, candidate, path_resolvable) in ordered {
         if hits.len() >= max_results {
             break;
         }
@@ -1843,7 +1864,7 @@ fn resolve_sidecar_candidates_in_storage(
         let Some(node_id) =
             resolve_candidate_node_id(storage, node_names, project_root, &rel_path, candidate)
         else {
-            let label = if candidate_path_resolvable(project_root, &candidate.file_path) {
+            let label = if path_resolvable {
                 "node_unresolved"
             } else {
                 "path_unresolvable"
@@ -2360,6 +2381,111 @@ mod tests {
             ),
             "source-root path should resolve through src/test/java"
         );
+    }
+
+    #[test]
+    fn sidecar_candidate_order_evaluates_path_resolution_once_per_candidate() {
+        let candidates = vec![
+            CandidateHit::lexical_stub("ok/equal-a.rs", 1.0),
+            CandidateHit::lexical_stub("ok/equal-b.rs", 1.0),
+            CandidateHit::lexical_stub("missing/high.rs", 100.0),
+            CandidateHit::lexical_stub("lexical:phantom", 500.0),
+        ];
+        let mut evaluations = 0usize;
+        let ordered = ordered_sidecar_candidates(&candidates, |candidate| {
+            evaluations += 1;
+            candidate.file_path.starts_with("ok/")
+        });
+        assert_eq!(
+            evaluations, 3,
+            "path resolution must run once per surviving candidate"
+        );
+        assert_eq!(
+            ordered
+                .iter()
+                .map(|(index, candidate, resolvable)| (
+                    *index,
+                    candidate.file_path.as_str(),
+                    *resolvable
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                (0, "ok/equal-a.rs", true),
+                (1, "ok/equal-b.rs", true),
+                (2, "missing/high.rs", false),
+            ],
+            "resolvability stays the primary key and equal scores keep input order"
+        );
+
+        let nan_candidates = vec![
+            CandidateHit::lexical_stub("ok/nan.rs", f32::NAN),
+            CandidateHit::lexical_stub("ok/finite.rs", 2.0),
+        ];
+        let ordered = ordered_sidecar_candidates(&nan_candidates, |_| true);
+        assert_eq!(
+            ordered
+                .iter()
+                .map(|(_, candidate, _)| candidate.file_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ok/nan.rs", "ok/finite.rs"],
+            "a NaN score must stay comparator-equal and stable"
+        );
+    }
+
+    #[test]
+    fn sidecar_candidate_order_matches_the_recomputing_comparator() {
+        // The zero-movement claim rests on this: decorating the resolvable
+        // verdict must be a permutation-for-permutation replacement of the
+        // comparator that stat'ed the filesystem on every comparison.
+        let scores = [
+            1.0_f32,
+            f32::NAN,
+            1.0,
+            50.0,
+            -3.0,
+            f32::NAN,
+            0.0,
+            50.0,
+            f32::INFINITY,
+        ];
+        let resolvable = |path: &str| path.starts_with("ok/");
+        for window in 1..=scores.len() {
+            for offset in 0..=(scores.len() - window) {
+                let candidates = scores[offset..offset + window]
+                    .iter()
+                    .enumerate()
+                    .map(|(index, score)| {
+                        let prefix = if index.is_multiple_of(3) { "ok" } else { "no" };
+                        CandidateHit::lexical_stub(format!("{prefix}/candidate-{index}.rs"), *score)
+                    })
+                    .collect::<Vec<_>>();
+
+                let mut previous = candidates.iter().enumerate().collect::<Vec<_>>();
+                previous.sort_by(|(_, left), (_, right)| {
+                    let left_resolvable = resolvable(&left.file_path);
+                    let right_resolvable = resolvable(&right.file_path);
+                    right_resolvable.cmp(&left_resolvable).then(
+                        right
+                            .score
+                            .partial_cmp(&left.score)
+                            .unwrap_or(std::cmp::Ordering::Equal),
+                    )
+                });
+
+                let current = ordered_sidecar_candidates(&candidates, |candidate| {
+                    resolvable(&candidate.file_path)
+                });
+
+                assert_eq!(
+                    current
+                        .iter()
+                        .map(|(index, _, _)| *index)
+                        .collect::<Vec<_>>(),
+                    previous.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+                    "candidate order moved for window={window} offset={offset}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/codestory-runtime/src/controller_symbols.rs
+++ b/crates/codestory-runtime/src/controller_symbols.rs
@@ -18,6 +18,22 @@ use codestory_contracts::api::{
 use codestory_contracts::graph::Node as GraphNode;
 use std::collections::{HashMap, HashSet};
 
+/// Copy only the cached display names the caller can still read back.
+///
+/// Consumers look names up by candidate ID, so the copy is bounded by the
+/// candidate set instead of by the size of the indexed symbol table.
+pub(crate) fn node_names_for_ids<I>(
+    node_names: &HashMap<codestory_contracts::graph::NodeId, String>,
+    ids: I,
+) -> HashMap<codestory_contracts::graph::NodeId, String>
+where
+    I: IntoIterator<Item = codestory_contracts::graph::NodeId>,
+{
+    ids.into_iter()
+        .filter_map(|id| node_names.get(&id).map(|name| (id, name.clone())))
+        .collect()
+}
+
 impl AppController {
     pub(crate) fn cached_labels<I>(
         &self,
@@ -27,9 +43,7 @@ impl AppController {
         I: IntoIterator<Item = codestory_contracts::graph::NodeId>,
     {
         let s = self.state.lock();
-        ids.into_iter()
-            .filter_map(|id| s.node_names.get(&id).cloned().map(|name| (id, name)))
-            .collect()
+        node_names_for_ids(&s.node_names, ids)
     }
 
     pub(crate) fn file_path_for_node(
@@ -82,16 +96,12 @@ impl AppController {
         }))
     }
 
-    pub(crate) fn symbol_summary_for_node(
+    fn symbol_summary_for_node(
         storage: &Storage,
         labels_by_id: &HashMap<codestory_contracts::graph::NodeId, String>,
         node: codestory_contracts::graph::Node,
+        has_children: bool,
     ) -> Result<SymbolSummaryDto, ApiError> {
-        let has_children = !storage
-            .get_children_symbols(node.id)
-            .map_err(|e| ApiError::internal(format!("Failed to load child symbols: {e}")))?
-            .is_empty();
-
         let label = labels_by_id
             .get(&node.id)
             .cloned()
@@ -104,6 +114,29 @@ impl AppController {
             file_path: Self::file_path_for_node(storage, &node)?,
             has_children,
         })
+    }
+
+    /// Render symbol summaries for an already sorted, deduped, truncated list.
+    ///
+    /// Child presence is one batched lookup for the whole rendered window, so
+    /// the batch is bounded by what the response actually carries.
+    pub(crate) fn symbol_summaries_for_nodes(
+        storage: &Storage,
+        labels_by_id: &HashMap<codestory_contracts::graph::NodeId, String>,
+        nodes: Vec<codestory_contracts::graph::Node>,
+    ) -> Result<Vec<SymbolSummaryDto>, ApiError> {
+        let node_ids = nodes.iter().map(|node| node.id).collect::<Vec<_>>();
+        let node_ids_with_children = storage
+            .node_ids_with_child_symbols(&node_ids)
+            .map_err(|e| ApiError::internal(format!("Failed to load child symbols: {e}")))?;
+
+        nodes
+            .into_iter()
+            .map(|node| {
+                let has_children = node_ids_with_children.contains(&node.id);
+                Self::symbol_summary_for_node(storage, labels_by_id, node, has_children)
+            })
+            .collect()
     }
 
     pub(crate) fn dedupe_symbol_nodes(
@@ -145,10 +178,9 @@ impl AppController {
             let engine = s.search_engine.as_mut().ok_or_else(|| {
                 ApiError::invalid_argument("Search engine not initialized. Open a project first.")
             })?;
-            (
-                engine.search_symbol_with_scores(query),
-                s.node_names.clone(),
-            )
+            let matches = engine.search_symbol_with_scores(query);
+            let node_names = node_names_for_ids(&s.node_names, matches.iter().map(|(id, _)| *id));
+            (matches, node_names)
         };
 
         let mut hits = matches
@@ -190,10 +222,7 @@ impl AppController {
             roots.truncate(limit);
         }
 
-        roots
-            .into_iter()
-            .map(|node| Self::symbol_summary_for_node(&storage, &labels_by_id, node))
-            .collect()
+        Self::symbol_summaries_for_nodes(&storage, &labels_by_id, roots)
     }
 
     pub fn list_children_symbols(
@@ -211,10 +240,7 @@ impl AppController {
 
         let labels_by_id = self.cached_labels(children.iter().map(|node| node.id));
         children = Self::dedupe_symbol_nodes(children, &labels_by_id);
-        children
-            .into_iter()
-            .map(|node| Self::symbol_summary_for_node(&storage, &labels_by_id, node))
-            .collect()
+        Self::symbol_summaries_for_nodes(&storage, &labels_by_id, children)
     }
 
     /// Build an answer from indexed source and sidecar-primary retrieval.
@@ -395,13 +421,11 @@ impl AppController {
         storage: &Storage,
         route_node: &GraphNode,
     ) -> Option<RouteEndpointHandlerDto> {
-        let edges = storage.get_edges().ok()?;
+        let edges = storage
+            .get_raw_call_edges_by_effective_source(route_node.id)
+            .ok()?;
         let mut candidates = edges
             .into_iter()
-            .filter(|edge| {
-                edge.kind == codestory_contracts::graph::EdgeKind::CALL
-                    && edge.effective_source() == route_node.id
-            })
             .filter_map(|edge| {
                 let target = storage.get_node(edge.effective_target()).ok().flatten()?;
                 let terminal = target

--- a/crates/codestory-runtime/src/grounding.rs
+++ b/crates/codestory-runtime/src/grounding.rs
@@ -1380,8 +1380,8 @@ impl AppController {
         let children = Self::dedupe_symbol_nodes(children, &labels_by_id)
             .into_iter()
             .take(16)
-            .map(|child| Self::symbol_summary_for_node(&storage, &labels_by_id, child))
-            .collect::<Result<Vec<_>, ApiError>>()?;
+            .collect::<Vec<_>>();
+        let children = Self::symbol_summaries_for_nodes(&storage, &labels_by_id, children)?;
 
         let related_hits = self
             .resolve_indexed_symbol_candidates(&node.display_name, 6)?

--- a/crates/codestory-runtime/src/tests/search_scoring.rs
+++ b/crates/codestory-runtime/src/tests/search_scoring.rs
@@ -1,25 +1,25 @@
 use super::{
-    AgentHybridWeightsDto, AppController, CancellationToken, CoreNodeId, EnvGuard,
-    GroundingBudgetDto, HYBRID_RETRIEVAL_ENABLED_ENV, HashMap, HybridSearchConfig,
+    AgentHybridWeightsDto, AppController, CancellationToken, CoreNodeId, Edge, EdgeId, EdgeKind,
+    EnvGuard, GroundingBudgetDto, HYBRID_RETRIEVAL_ENABLED_ENV, HashMap, HybridSearchConfig,
     IndexFreshnessStatusDto, IndexMode, Node, NodeId, NodeKind, Occurrence, OccurrenceKind,
     OpenProjectRequest, Path, PathBuf, PublicationTestAction, PublicationTestBoundary,
-    RetrievalModeDto, SEMANTIC_DOC_ALIAS_MODE_ENV, SEMANTIC_DOC_MAX_TOKENS_ENV, SearchEngine,
-    SearchGenerationCatalogGuard, SearchGenerationCompletion, SearchHit, SearchRepoTextMode,
-    SearchRequest, SearchSymbolProjection, SemanticProjectionStats, SnapshotStore, SourceLocation,
-    Storage, apply_hybrid_limits, arm_publication_test_fault,
-    assert_mandatory_retrieval_unavailable, assert_no_staged_publication_artifacts,
-    build_persisted_search_state_from_canonical_symbols, build_search_state, compare_search_hits,
-    copy_tictactoe_workspace, current_epoch_ms, dedupe_inexact_search_hits_by_display_key,
-    default_source_policy_identity, finalize_staged_semantic_docs,
-    flush_pending_dense_anchor_inputs, fs, hybrid_search_config_for_request, hybrid_test_env,
-    insert_semantic_fixture_nodes, llm_symbol_doc_hash, load_persisted_search_state,
-    merge_search_hits_by_node_id, normalized_hybrid_weights, pending_semantic_doc_for_test,
-    persisted_search_generation_names, primary_source_retention_threshold, process_env_test_lock,
-    project_identity_v3, prune_search_generations, rebuild_search_state_from_storage,
-    search_generation_completion_path, search_index_generation_root,
-    search_index_path_for_publication, search_index_storage_path, semantic_doc_text_for_test,
-    semantic_projection_republish_for_runtime, tempdir, test_index_publication,
-    test_retrieval_manifest, test_sidecar_runtime_from_env, unbounded,
+    ResolutionCertainty, RetrievalModeDto, SEMANTIC_DOC_ALIAS_MODE_ENV,
+    SEMANTIC_DOC_MAX_TOKENS_ENV, SearchEngine, SearchGenerationCatalogGuard,
+    SearchGenerationCompletion, SearchHit, SearchRepoTextMode, SearchRequest,
+    SearchSymbolProjection, SemanticProjectionStats, SnapshotStore, SourceLocation, Storage,
+    apply_hybrid_limits, arm_publication_test_fault, assert_mandatory_retrieval_unavailable,
+    assert_no_staged_publication_artifacts, build_persisted_search_state_from_canonical_symbols,
+    build_search_state, compare_search_hits, copy_tictactoe_workspace, current_epoch_ms,
+    dedupe_inexact_search_hits_by_display_key, default_source_policy_identity,
+    finalize_staged_semantic_docs, flush_pending_dense_anchor_inputs, fs,
+    hybrid_search_config_for_request, hybrid_test_env, insert_semantic_fixture_nodes,
+    llm_symbol_doc_hash, load_persisted_search_state, merge_search_hits_by_node_id,
+    normalized_hybrid_weights, pending_semantic_doc_for_test, persisted_search_generation_names,
+    primary_source_retention_threshold, process_env_test_lock, project_identity_v3,
+    prune_search_generations, rebuild_search_state_from_storage, search_generation_completion_path,
+    search_index_generation_root, search_index_path_for_publication, search_index_storage_path,
+    semantic_doc_text_for_test, semantic_projection_republish_for_runtime, tempdir,
+    test_index_publication, test_retrieval_manifest, test_sidecar_runtime_from_env, unbounded,
     write_search_generation_completion, write_semantic_fixture,
 };
 use codestory_contracts::bounded_locks::{self, FileLockKind};
@@ -275,6 +275,218 @@ fn build_search_hit_adjusts_route_scores_by_extraction_provenance() {
     let mut hits = [text_only, ast.clone()];
     hits.sort_by(|left, right| compare_search_hits("/api/users", left, right));
     assert_eq!(hits.first().map(|hit| &hit.node_id), Some(&ast.node_id));
+}
+
+#[test]
+fn canonical_and_openapi_route_metadata_keep_uncertain_resolved_handlers() {
+    let route_canonical_id = format!(
+        "route_endpoint:{}",
+        serde_json::json!({
+            "kind": "framework_route",
+            "framework": "express",
+            "method": "GET",
+            "path": "/api/users",
+            "provenance": ["framework:express"],
+        })
+    );
+    let mut storage = Storage::new_in_memory().expect("storage");
+    storage
+        .insert_nodes_batch(&[
+            Node {
+                id: CoreNodeId(100),
+                kind: NodeKind::FILE,
+                serialized_name: "src/routes.ts".to_string(),
+                ..Default::default()
+            },
+            Node {
+                id: CoreNodeId(101),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "GET /api/users".to_string(),
+                canonical_id: Some(route_canonical_id),
+                file_node_id: Some(CoreNodeId(100)),
+                start_line: Some(10),
+                ..Default::default()
+            },
+            Node {
+                id: CoreNodeId(102),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "POST /api/users".to_string(),
+                canonical_id: Some("openapi:endpoint:POST /api/users".to_string()),
+                file_node_id: Some(CoreNodeId(100)),
+                start_line: Some(20),
+                ..Default::default()
+            },
+            // The raw call targets are the router verbs the handler filter drops.
+            Node {
+                id: CoreNodeId(103),
+                kind: NodeKind::METHOD,
+                serialized_name: "get".to_string(),
+                ..Default::default()
+            },
+            Node {
+                id: CoreNodeId(104),
+                kind: NodeKind::METHOD,
+                serialized_name: "post".to_string(),
+                ..Default::default()
+            },
+            Node {
+                id: CoreNodeId(105),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "list_users".to_string(),
+                qualified_name: Some("handlers::list_users".to_string()),
+                file_node_id: Some(CoreNodeId(100)),
+                start_line: Some(40),
+                ..Default::default()
+            },
+            Node {
+                id: CoreNodeId(106),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "create_user".to_string(),
+                qualified_name: Some("handlers::create_user".to_string()),
+                file_node_id: Some(CoreNodeId(100)),
+                start_line: Some(50),
+                ..Default::default()
+            },
+        ])
+        .expect("insert route graph");
+    storage
+        .insert_edges_batch(&[
+            Edge {
+                id: EdgeId(1),
+                source: CoreNodeId(101),
+                target: CoreNodeId(103),
+                kind: EdgeKind::CALL,
+                resolved_target: Some(CoreNodeId(105)),
+                confidence: Some(0.25),
+                certainty: Some(ResolutionCertainty::Uncertain),
+                ..Default::default()
+            },
+            Edge {
+                id: EdgeId(2),
+                source: CoreNodeId(102),
+                target: CoreNodeId(104),
+                kind: EdgeKind::CALL,
+                resolved_target: Some(CoreNodeId(106)),
+                confidence: Some(0.2),
+                certainty: Some(ResolutionCertainty::Uncertain),
+                ..Default::default()
+            },
+        ])
+        .expect("insert route handler edges");
+
+    for route_id in [CoreNodeId(101), CoreNodeId(102)] {
+        let trail_edges = storage
+            .get_edges_for_node_ids(&[route_id])
+            .expect("trail edge lookup");
+        assert!(
+            trail_edges[&route_id]
+                .iter()
+                .all(|edge| edge.resolved_target.is_none()),
+            "the trail accessor must remain an invalid substitute for raw route metadata"
+        );
+    }
+
+    let controller = AppController::new();
+    for (route_id, expected_handler) in [
+        (CoreNodeId(101), NodeId("105".to_string())),
+        (CoreNodeId(102), NodeId("106".to_string())),
+    ] {
+        let route = storage
+            .get_node(route_id)
+            .expect("load route")
+            .expect("route node");
+        let metadata = controller
+            .route_endpoint_metadata(&storage, &route, Some("src/routes.ts"), "route")
+            .expect("route metadata");
+        let handler = metadata.handler.expect("resolved handler");
+        assert_eq!(handler.node_id, expected_handler);
+        assert_eq!(handler.certainty.as_deref(), Some("uncertain"));
+        assert_eq!(handler.file_path.as_deref(), Some("src/routes.ts"));
+        assert!(
+            metadata
+                .provenance
+                .iter()
+                .any(|entry| entry == "graph:handler_edge")
+        );
+    }
+}
+
+#[test]
+fn symbol_summaries_batch_child_presence_for_the_rendered_window() {
+    let mut storage = Storage::new_in_memory().expect("storage");
+    storage
+        .insert_nodes_batch(&[
+            Node {
+                id: CoreNodeId(1),
+                kind: NodeKind::CLASS,
+                serialized_name: "WithChild".to_string(),
+                ..Default::default()
+            },
+            Node {
+                id: CoreNodeId(2),
+                kind: NodeKind::CLASS,
+                serialized_name: "Childless".to_string(),
+                ..Default::default()
+            },
+            Node {
+                id: CoreNodeId(3),
+                kind: NodeKind::METHOD,
+                serialized_name: "child".to_string(),
+                ..Default::default()
+            },
+        ])
+        .expect("insert nodes");
+    storage
+        .insert_edges_batch(&[Edge {
+            id: EdgeId(1),
+            source: CoreNodeId(1),
+            target: CoreNodeId(3),
+            kind: EdgeKind::MEMBER,
+            ..Default::default()
+        }])
+        .expect("insert member edge");
+
+    let nodes = [CoreNodeId(1), CoreNodeId(2), CoreNodeId(3)]
+        .into_iter()
+        .map(|id| storage.get_node(id).expect("load node").expect("node"))
+        .collect::<Vec<_>>();
+    let labels = HashMap::from([(CoreNodeId(1), "WithChild".to_string())]);
+    let summaries = AppController::symbol_summaries_for_nodes(&storage, &labels, nodes.clone())
+        .expect("symbol summaries");
+
+    assert_eq!(summaries.len(), nodes.len());
+    for (summary, node) in summaries.iter().zip(nodes.iter()) {
+        assert_eq!(
+            summary.has_children,
+            !storage
+                .get_children_symbols(node.id)
+                .expect("children")
+                .is_empty(),
+            "batched child presence diverged for {:?}",
+            node.id
+        );
+    }
+    assert_eq!(summaries[0].label, "WithChild");
+    assert_eq!(summaries[1].label, "Childless");
+}
+
+#[test]
+fn indexed_symbol_name_lookup_is_bounded_by_the_candidate_ids() {
+    let node_names = HashMap::from([
+        (CoreNodeId(1), "one".to_string()),
+        (CoreNodeId(2), "two".to_string()),
+        (CoreNodeId(3), "three".to_string()),
+    ]);
+
+    let bounded =
+        crate::controller_symbols::node_names_for_ids(&node_names, [CoreNodeId(2), CoreNodeId(9)]);
+
+    assert_eq!(
+        bounded,
+        HashMap::from([(CoreNodeId(2), "two".to_string())]),
+        "only the candidate ids may be copied out of the symbol-name table"
+    );
+    assert!(crate::controller_symbols::node_names_for_ids(&node_names, []).is_empty());
 }
 
 #[test]

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -61,6 +61,25 @@ const EDGE_SELECT_BASE: &str = "SELECT e.id, e.source_node_id, e.target_node_id,
                  FROM edge e
                  JOIN node t ON t.id = e.target_node_id
                  LEFT JOIN node f ON f.id = e.file_node_id";
+/// `COALESCE(resolved_source_node_id, source_node_id) = ?1` is spelled as two
+/// branches because only a branch is index-seekable; the branches stay disjoint
+/// on `resolved_source_node_id IS NULL`, so their union is exactly the edges
+/// whose `Edge::effective_source` is `?1`. Both branches pin their index because
+/// an unpinned planner reads `resolved_source_node_id IS NULL` as the more
+/// selective term and seeks every unresolved CALL edge in the repository.
+/// `raw_call_edges_by_effective_source_plan_seeks_both_branches` holds the shape.
+/// Every pinned index is created for any live store (schema.rs:396,415).
+const RAW_CALL_EDGES_BY_EFFECTIVE_SOURCE_SQL: &str = "SELECT e.id, e.source_node_id, e.target_node_id, e.kind, e.file_node_id, e.line, e.resolved_source_node_id, e.resolved_target_node_id, e.confidence, e.callsite_identity, e.certainty, e.candidate_target_node_ids
+     FROM edge e INDEXED BY idx_edge_resolved_source
+     WHERE e.resolved_source_node_id = ?1
+       AND e.kind = ?2
+     UNION ALL
+     SELECT e.id, e.source_node_id, e.target_node_id, e.kind, e.file_node_id, e.line, e.resolved_source_node_id, e.resolved_target_node_id, e.confidence, e.callsite_identity, e.certainty, e.candidate_target_node_ids
+     FROM edge e INDEXED BY idx_edge_kind_source
+     WHERE e.kind = ?2
+       AND e.source_node_id = ?1
+       AND e.resolved_source_node_id IS NULL
+     ORDER BY id ASC";
 pub const BUILD_EDGE_SEED_BATCH_SIZE: usize = 200;
 const EDGE_NODE_LOOKUP_BATCH_SIZE: usize = BUILD_EDGE_SEED_BATCH_SIZE;
 const NODE_LOOKUP_BATCH_SIZE: usize = 200;
@@ -6426,6 +6445,28 @@ impl Storage {
         Ok(edges)
     }
 
+    /// Reads the CALL edges whose effective source is `source_node_id`, unpolicied.
+    ///
+    /// Route metadata reports the persisted resolution of a handler call, so this
+    /// accessor deliberately skips the trail policy that
+    /// [`Self::get_edges_for_node_ids`] applies: that policy clears
+    /// `resolved_target`, `confidence`, and `certainty` on uncertain and
+    /// common-unqualified calls, which are exactly the fields the route handler
+    /// DTO reports. Every other field, and the edge-ID row order, match filtering
+    /// [`Self::get_edges`] by `Edge::effective_source`.
+    pub fn get_raw_call_edges_by_effective_source(
+        &self,
+        source_node_id: NodeId,
+    ) -> Result<Vec<Edge>, StorageError> {
+        let mut stmt = self.conn.prepare(RAW_CALL_EDGES_BY_EFFECTIVE_SOURCE_SQL)?;
+        let mut rows = stmt.query(params![source_node_id.0, EdgeKind::CALL as i32])?;
+        let mut edges = Vec::new();
+        while let Some(row) = rows.next()? {
+            edges.push(Self::edge_from_row(row)?);
+        }
+        Ok(edges)
+    }
+
     pub fn get_edges_for_node_ids(
         &self,
         node_ids: &[NodeId],
@@ -11225,6 +11266,60 @@ impl Storage {
             nodes.push(Self::node_from_row(row)?);
         }
         Ok(nodes)
+    }
+
+    /// Returns the subset of `node_ids` that has at least one child symbol.
+    ///
+    /// Membership is exactly `!get_children_symbols(id).is_empty()`, so the
+    /// `node` join stays: a MEMBER edge whose target row is absent yields no
+    /// child there and must yield no presence here. Input IDs carry set
+    /// semantics and each SQLite bind-limit chunk runs one statement, replacing
+    /// one materialising child query per rendered symbol.
+    pub fn node_ids_with_child_symbols(
+        &self,
+        node_ids: &[NodeId],
+    ) -> Result<HashSet<NodeId>, StorageError> {
+        if node_ids.is_empty() {
+            return Ok(HashSet::new());
+        }
+
+        let variable_limit = usize::try_from(self.conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)?)
+            .map_err(|_| {
+                StorageError::Other(
+                    "SQLite reported a negative bind-variable limit for child-presence lookup"
+                        .to_string(),
+                )
+            })?;
+        if variable_limit == 0 {
+            return Err(StorageError::Other(
+                "SQLite bind-variable limit 0 cannot support child-presence lookup".to_string(),
+            ));
+        }
+
+        let mut unique_node_ids = node_ids.to_vec();
+        unique_node_ids.sort_unstable_by_key(|node_id| node_id.0);
+        unique_node_ids.dedup();
+
+        let kind_member = codestory_contracts::graph::EdgeKind::MEMBER as i32;
+        let mut with_children = HashSet::new();
+        for batch in unique_node_ids.chunks(variable_limit) {
+            let placeholders = question_placeholders(batch.len());
+            // The MEMBER kind is an inlined enum discriminant so a chunk binds
+            // exactly `variable_limit` values.
+            let query = format!(
+                "SELECT DISTINCT e.source_node_id
+                 FROM edge e
+                 JOIN node n ON n.id = e.target_node_id
+                 WHERE e.source_node_id IN ({placeholders})
+                   AND e.kind = {kind_member}"
+            );
+            let mut stmt = self.conn.prepare(&query)?;
+            let mut rows = stmt.query(params_from_iter(batch.iter().map(|id| id.0)))?;
+            while let Some(row) = rows.next()? {
+                with_children.insert(NodeId(row.get(0)?));
+            }
+        }
+        Ok(with_children)
     }
 
     /// Return store counts, preferring ready summary snapshots when available.

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -9564,3 +9564,404 @@ fn test_grounding_edge_digests_ignore_ambiguous_resolved_targets() -> Result<(),
 
     Ok(())
 }
+
+#[test]
+fn raw_call_edges_by_effective_source_match_the_broad_edge_filter() -> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::FILE,
+            serialized_name: "src/routes.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(10),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "route".to_string(),
+            file_node_id: Some(NodeId(1)),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(11),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "raw_caller".to_string(),
+            file_node_id: Some(NodeId(1)),
+            ..Default::default()
+        },
+        Node {
+            // A very common unqualified call name, so trail policy clears any
+            // resolution below `Certain`.
+            id: NodeId(20),
+            kind: NodeKind::METHOD,
+            serialized_name: "insert".to_string(),
+            file_node_id: Some(NodeId(1)),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(21),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "handler".to_string(),
+            file_node_id: Some(NodeId(1)),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(22),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "other".to_string(),
+            file_node_id: Some(NodeId(1)),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_edges_batch(&[
+        // Unresolved source, so the effective source is the raw source.
+        Edge {
+            id: EdgeId(1),
+            source: NodeId(10),
+            target: NodeId(21),
+            kind: EdgeKind::CALL,
+            file_node_id: Some(NodeId(1)),
+            line: Some(7),
+            resolved_target: Some(NodeId(21)),
+            confidence: Some(0.42),
+            callsite_identity: Some("routes.rs:7:handler".to_string()),
+            certainty: Some(ResolutionCertainty::Uncertain),
+            candidate_targets: vec![NodeId(21), NodeId(22)],
+            ..Default::default()
+        },
+        // A resolved source rewrites the effective source onto the route node.
+        Edge {
+            id: EdgeId(2),
+            source: NodeId(11),
+            target: NodeId(20),
+            kind: EdgeKind::CALL,
+            resolved_source: Some(NodeId(10)),
+            resolved_target: Some(NodeId(20)),
+            confidence: Some(0.8),
+            certainty: Some(ResolutionCertainty::Probable),
+            ..Default::default()
+        },
+        // Same raw source, but the resolved source moves it elsewhere.
+        Edge {
+            id: EdgeId(3),
+            source: NodeId(10),
+            target: NodeId(22),
+            kind: EdgeKind::CALL,
+            resolved_source: Some(NodeId(11)),
+            ..Default::default()
+        },
+        // Right source, wrong kind.
+        Edge {
+            id: EdgeId(4),
+            source: NodeId(10),
+            target: NodeId(21),
+            kind: EdgeKind::MEMBER,
+            ..Default::default()
+        },
+        // A later unresolved-branch edge, so the two branches interleave by id.
+        Edge {
+            id: EdgeId(5),
+            source: NodeId(10),
+            target: NodeId(22),
+            kind: EdgeKind::CALL,
+            resolved_target: Some(NodeId(21)),
+            certainty: Some(ResolutionCertainty::Certain),
+            confidence: Some(0.99),
+            ..Default::default()
+        },
+    ])?;
+
+    let expected = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL && edge.effective_source() == NodeId(10))
+        .collect::<Vec<_>>();
+    let selective = storage.get_raw_call_edges_by_effective_source(NodeId(10))?;
+    assert_eq!(
+        selective, expected,
+        "selective route lookup diverged from the broad edge filter"
+    );
+    assert_eq!(
+        selective.iter().map(|edge| edge.id).collect::<Vec<_>>(),
+        vec![EdgeId(1), EdgeId(2), EdgeId(5)],
+        "selective route lookup lost deterministic edge-id order across branches"
+    );
+
+    // The trail accessor is not a substitute: its policy clears exactly the
+    // resolution fields the route-handler DTO reports, for both the uncertain
+    // call and the probable common-name call.
+    let trail_edges = storage.get_edges_for_node_id(NodeId(10))?;
+    for edge_id in [EdgeId(1), EdgeId(2)] {
+        let policied = trail_edges
+            .iter()
+            .find(|edge| edge.id == edge_id)
+            .unwrap_or_else(|| panic!("trail lookup returns {edge_id:?}"));
+        assert_eq!(policied.resolved_target, None, "{edge_id:?}");
+        assert_eq!(policied.certainty, None, "{edge_id:?}");
+        assert_eq!(policied.confidence, None, "{edge_id:?}");
+    }
+    let raw_uncertain = selective
+        .iter()
+        .find(|edge| edge.id == EdgeId(1))
+        .expect("raw lookup returns the uncertain call");
+    assert_eq!(raw_uncertain.resolved_target, Some(NodeId(21)));
+    assert_eq!(
+        raw_uncertain.certainty,
+        Some(ResolutionCertainty::Uncertain)
+    );
+    assert_eq!(raw_uncertain.confidence, Some(0.42));
+    let raw_common = selective
+        .iter()
+        .find(|edge| edge.id == EdgeId(2))
+        .expect("raw lookup returns the resolved-source call");
+    assert_eq!(raw_common.resolved_target, Some(NodeId(20)));
+    assert_eq!(raw_common.certainty, Some(ResolutionCertainty::Probable));
+    assert_eq!(raw_common.confidence, Some(0.8));
+
+    assert!(
+        storage
+            .get_raw_call_edges_by_effective_source(NodeId(22))?
+            .is_empty()
+    );
+    Ok(())
+}
+
+#[test]
+fn raw_route_edge_lookup_costs_less_vm_work_than_the_broad_edge_scan() -> Result<(), StorageError> {
+    const REPRESENTATIVE_NODE_COUNT: i64 = 12_000;
+    const REPRESENTATIVE_EDGE_COUNT: i64 = 48_000;
+    const ROUTE_NODE_ID: i64 = 7;
+
+    let storage = Storage::new_in_memory()?;
+    let call_kind = EdgeKind::CALL as i32;
+    storage.conn.execute_batch(&format!(
+        "WITH RECURSIVE sequence(value) AS (
+             SELECT 1
+             UNION ALL
+             SELECT value + 1 FROM sequence WHERE value < {REPRESENTATIVE_NODE_COUNT}
+         )
+         INSERT INTO node(id, kind, serialized_name)
+         SELECT value, 3, printf('node-%d', value) FROM sequence;
+         WITH RECURSIVE sequence(value) AS (
+             SELECT 1
+             UNION ALL
+             SELECT value + 1 FROM sequence WHERE value < {REPRESENTATIVE_EDGE_COUNT}
+         )
+         INSERT INTO edge(
+             id,
+             source_node_id,
+             target_node_id,
+             kind,
+             resolved_source_node_id
+         )
+         SELECT
+             value,
+             (value % {REPRESENTATIVE_NODE_COUNT}) + 1,
+             ((value * 17) % {REPRESENTATIVE_NODE_COUNT}) + 1,
+             {call_kind},
+             CASE WHEN value % 3 = 0 THEN ((value * 19) % {REPRESENTATIVE_NODE_COUNT}) + 1 END
+         FROM sequence;"
+    ))?;
+
+    let plan = storage
+        .conn
+        .prepare(&format!(
+            "EXPLAIN QUERY PLAN {RAW_CALL_EDGES_BY_EFFECTIVE_SOURCE_SQL}"
+        ))?
+        .query_map(rusqlite::params![ROUTE_NODE_ID, call_kind], |row| {
+            row.get::<_, String>(3)
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    assert!(
+        plan.iter()
+            .any(|line| line.contains("idx_edge_resolved_source")),
+        "route lookup lost the resolved-source index: {plan:?}"
+    );
+    assert!(
+        plan.iter()
+            .any(|line| line.contains("idx_edge_kind_source")),
+        "route lookup lost the kind/source index: {plan:?}"
+    );
+    assert!(
+        plan.iter().all(|line| !line.contains("SCAN e")),
+        "route lookup still scans the edge table: {plan:?}"
+    );
+
+    let count_vm_steps = |run: &dyn Fn() -> Result<Vec<Edge>, StorageError>| {
+        let callbacks = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&callbacks);
+        storage.conn.progress_handler(
+            100,
+            Some(move || {
+                counter.fetch_add(1, AtomicOrdering::Relaxed);
+                false
+            }),
+        )?;
+        let edges = run()?;
+        storage.conn.progress_handler(0, None::<fn() -> bool>)?;
+        Ok::<_, StorageError>((edges, callbacks.load(AtomicOrdering::Relaxed)))
+    };
+
+    let (broad_edges, broad_callbacks) = count_vm_steps(&|| {
+        Ok(storage
+            .get_edges()?
+            .into_iter()
+            .filter(|edge| {
+                edge.kind == EdgeKind::CALL && edge.effective_source() == NodeId(ROUTE_NODE_ID)
+            })
+            .collect())
+    })?;
+    let (selective_edges, selective_callbacks) =
+        count_vm_steps(&|| storage.get_raw_call_edges_by_effective_source(NodeId(ROUTE_NODE_ID)))?;
+
+    assert!(
+        !selective_edges.is_empty(),
+        "representative fixture produced no route edges"
+    );
+    assert_eq!(
+        selective_edges, broad_edges,
+        "selective route lookup diverged from the broad scan on the representative fixture"
+    );
+    assert!(
+        broad_callbacks > selective_callbacks.saturating_mul(5),
+        "representative route lookup VM work did not improve enough: broad={broad_callbacks}, selective={selective_callbacks}"
+    );
+    eprintln!(
+        "raw route edge representative proof: nodes={REPRESENTATIVE_NODE_COUNT} edges={REPRESENTATIVE_EDGE_COUNT} broad_callbacks={broad_callbacks} selective_callbacks={selective_callbacks}"
+    );
+    Ok(())
+}
+
+#[test]
+fn node_ids_with_child_symbols_matches_per_node_children() -> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::CLASS,
+            serialized_name: "WithChild".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(2),
+            kind: NodeKind::CLASS,
+            serialized_name: "Childless".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(3),
+            kind: NodeKind::METHOD,
+            serialized_name: "child".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(4),
+            kind: NodeKind::CLASS,
+            serialized_name: "OnlyCalls".to_string(),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_edges_batch(&[
+        Edge {
+            id: EdgeId(1),
+            source: NodeId(1),
+            target: NodeId(3),
+            kind: EdgeKind::MEMBER,
+            ..Default::default()
+        },
+        Edge {
+            id: EdgeId(2),
+            source: NodeId(4),
+            target: NodeId(3),
+            kind: EdgeKind::CALL,
+            ..Default::default()
+        },
+    ])?;
+
+    let candidates = [NodeId(1), NodeId(2), NodeId(3), NodeId(4), NodeId(1)];
+    let batched = storage.node_ids_with_child_symbols(&candidates)?;
+    for node_id in candidates {
+        assert_eq!(
+            batched.contains(&node_id),
+            !storage.get_children_symbols(node_id)?.is_empty(),
+            "batched child presence diverged from per-node children for {node_id:?}"
+        );
+    }
+    assert!(storage.node_ids_with_child_symbols(&[])?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn node_ids_with_child_symbols_runs_one_statement_per_bind_limit_chunk() -> Result<(), StorageError>
+{
+    let mut storage = Storage::new_in_memory()?;
+    let parents = (1..=5_i64).collect::<Vec<_>>();
+    storage.insert_nodes_batch(
+        &parents
+            .iter()
+            .map(|id| Node {
+                id: NodeId(*id),
+                kind: NodeKind::CLASS,
+                serialized_name: format!("Parent{id}"),
+                ..Default::default()
+            })
+            .chain(std::iter::once(Node {
+                id: NodeId(100),
+                kind: NodeKind::METHOD,
+                serialized_name: "member".to_string(),
+                ..Default::default()
+            }))
+            .collect::<Vec<_>>(),
+    )?;
+    storage.insert_edges_batch(
+        &parents
+            .iter()
+            .filter(|id| **id % 2 == 1)
+            .map(|id| Edge {
+                id: EdgeId(*id),
+                source: NodeId(*id),
+                target: NodeId(100),
+                kind: EdgeKind::MEMBER,
+                ..Default::default()
+            })
+            .collect::<Vec<_>>(),
+    )?;
+
+    let node_ids = parents.iter().map(|id| NodeId(*id)).collect::<Vec<_>>();
+    let unchunked = storage.node_ids_with_child_symbols(&node_ids)?;
+    assert_eq!(
+        unchunked,
+        [NodeId(1), NodeId(3), NodeId(5)].into_iter().collect()
+    );
+
+    let previous_limit = storage.conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)?;
+    storage
+        .conn
+        .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 2)?;
+    let prepares = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&prepares);
+    storage
+        .conn
+        .authorizer(Some(move |context: AuthContext<'_>| {
+            if matches!(context.action, AuthAction::Select) {
+                counter.fetch_add(1, AtomicOrdering::Relaxed);
+            }
+            Authorization::Allow
+        }))?;
+    let chunked = storage.node_ids_with_child_symbols(&node_ids);
+    storage
+        .conn
+        .authorizer(None::<fn(AuthContext<'_>) -> Authorization>)?;
+    storage
+        .conn
+        .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, previous_limit)?;
+    let chunked = chunked?;
+
+    assert_eq!(chunked, unchunked);
+    assert_eq!(
+        prepares.load(AtomicOrdering::Relaxed),
+        3,
+        "five candidates at a bind limit of two must run exactly three statements"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Closes #1752. Bottom of the storage stack (PERF-Q → ANNO-B).

## What

Broad store reads are replaced with selective lookups, building on ANNO-A's canonical anchors and batched accessors.

## Review

Layer-scoped review: **merge with follow-up**. Two findings to know about, neither a blocker:

- `get_raw_call_edges_by_effective_source` uses `INDEXED BY`, which is a hard requirement rather than a hint — it fails at `prepare()` if `idx_edge_resolved_source` or `idx_edge_kind_source` is absent. The review checked migration and rehydrate states; tracked as follow-up.
- The bounded indexed-symbol name lookup is delivered at one of two sites; the hotter site still clones. Follow-up.

**Why this closes a child and not #1661:** the parent requires a same-publication schema-v2 before/after report recording zero verdict, count, and cause movement. That needs a live run, and the issue explicitly says a `packet_search_eval` pass is *not* that proof — so it cannot be produced from source. #1661 stays open until the receipt exists. No packet or search baseline moved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)