### PR TITLE
[v0.17 PERF-R] Seal storage and model validation receipts to native identity

### DIFF
--- a/crates/codestory-llama-sys/src/lib.rs
+++ b/crates/codestory-llama-sys/src/lib.rs
@@ -2206,19 +2206,175 @@ fn tokenize(
     Ok(tokens)
 }
 
-fn verified_model_file(path: &Path) -> Result<bool, EngineError> {
-    let metadata = match fs::symlink_metadata(path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(cache_error(error)),
-    };
-    if !metadata.file_type().is_file() || metadata.len() != MODEL_SIZE {
-        return Ok(false);
-    }
-    Ok(sha256_file(path)? == MODEL_SHA256)
+/// Native filesystem identity of one materialized artifact.
+///
+/// Replacement moves the device/inode pair, truncation or growth moves the
+/// length, and an in-place rewrite moves the modification and inode-change
+/// timestamps. A verdict sealed to this value therefore cannot outlive the
+/// bytes it was issued for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NativeArtifactIdentity {
+    length: u64,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    modified_seconds: i64,
+    #[cfg(unix)]
+    modified_nanoseconds: i64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+    /// Portable stand-in for the inode pair where no inode is exposed: a
+    /// replaced file carries a new creation time, and a rewritten one carries a
+    /// new modification time.
+    #[cfg(not(unix))]
+    created: SystemTime,
+    #[cfg(not(unix))]
+    modified: SystemTime,
 }
 
+/// Observe the native identity of an already-stat'ed artifact.
+///
+/// A platform or filesystem that cannot supply a complete identity yields
+/// `None`, which denies every receipt and falls back to re-hashing.
+fn native_artifact_identity(metadata: &fs::Metadata) -> Option<NativeArtifactIdentity> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Some(NativeArtifactIdentity {
+            length: metadata.len(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+            changed_seconds: metadata.ctime(),
+            changed_nanoseconds: metadata.ctime_nsec(),
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        Some(NativeArtifactIdentity {
+            length: metadata.len(),
+            created: metadata.created().ok()?,
+            modified: metadata.modified().ok()?,
+        })
+    }
+}
+
+/// One process-local integrity verdict sealed to a native artifact identity.
+///
+/// Only successful verifications are ever sealed; a mismatch clears the seal so
+/// a failed verdict is never reused. The seal is advisory: honoring it skips a
+/// digest pass, and every path that cannot honor it re-hashes.
+#[derive(Debug)]
+struct SealedIntegrityReceipt {
+    path: PathBuf,
+    identity: NativeArtifactIdentity,
+}
+
+#[derive(Debug)]
+struct IntegrityReceiptCell(Mutex<Option<SealedIntegrityReceipt>>);
+
+impl IntegrityReceiptCell {
+    const fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    /// Whether the sealed verdict still covers this exact path and identity.
+    ///
+    /// A poisoned cell honors nothing, so a panic under the lock degrades to
+    /// re-hashing rather than to trusting an unknown verdict.
+    fn honors(&self, path: &Path, identity: &NativeArtifactIdentity) -> bool {
+        self.0.lock().is_ok_and(|sealed| {
+            sealed
+                .as_ref()
+                .is_some_and(|sealed| sealed.path == path && &sealed.identity == identity)
+        })
+    }
+
+    fn seal(&self, path: &Path, identity: NativeArtifactIdentity) {
+        if let Ok(mut cell) = self.0.lock() {
+            *cell = Some(SealedIntegrityReceipt {
+                path: path.to_path_buf(),
+                identity,
+            });
+        }
+    }
+
+    fn clear(&self) {
+        if let Ok(mut cell) = self.0.lock() {
+            *cell = None;
+        }
+    }
+}
+
+static MATERIALIZED_MODEL_RECEIPT: IntegrityReceiptCell = IntegrityReceiptCell::new();
+
+fn verified_model_file(path: &Path) -> Result<bool, EngineError> {
+    verified_sealed_artifact(path, MODEL_SIZE, MODEL_SHA256, &MATERIALIZED_MODEL_RECEIPT)
+}
+
+/// Verify one artifact against its expected length and digest, reusing a
+/// process-local receipt when the file's native identity has not moved.
+///
+/// The steady-state cost of a honored receipt is one `stat`. Every other
+/// outcome — a missing file, a length change, a replaced inode, an in-place
+/// rewrite, a file that moved under the digest pass, or an unavailable native
+/// identity — re-hashes and reseals only on success.
+fn verified_sealed_artifact(
+    path: &Path,
+    expected_length: u64,
+    expected_digest: &str,
+    receipt: &IntegrityReceiptCell,
+) -> Result<bool, EngineError> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            receipt.clear();
+            return Ok(false);
+        }
+        Err(error) => return Err(cache_error(error)),
+    };
+    if !metadata.file_type().is_file() || metadata.len() != expected_length {
+        receipt.clear();
+        return Ok(false);
+    }
+    let before = native_artifact_identity(&metadata);
+    if let Some(identity) = before.as_ref()
+        && receipt.honors(path, identity)
+    {
+        return Ok(true);
+    }
+    receipt.clear();
+    if sha256_file(path)? != expected_digest {
+        return Ok(false);
+    }
+    // Seal only an identity that held still across the digest pass: bytes read
+    // from a file that moved underneath the read were never proven.
+    let after = fs::symlink_metadata(path)
+        .ok()
+        .filter(|metadata| metadata.file_type().is_file())
+        .as_ref()
+        .and_then(native_artifact_identity);
+    if let Some(identity) = after
+        && before.as_ref() == Some(&identity)
+    {
+        receipt.seal(path, identity);
+    }
+    Ok(true)
+}
+
+/// Whole-file digest passes performed by this process, so a receipt test can
+/// prove the pass it claims to have skipped was in fact skipped.
+#[cfg(test)]
+static ARTIFACT_DIGEST_PASSES: AtomicU64 = AtomicU64::new(0);
+
 fn sha256_file(path: &Path) -> Result<String, EngineError> {
+    #[cfg(test)]
+    ARTIFACT_DIGEST_PASSES.fetch_add(1, Ordering::Relaxed);
     let mut reader = BufReader::new(File::open(path).map_err(cache_error)?);
     let mut hasher = Sha256::new();
     let mut buffer = vec![0_u8; 1024 * 1024];
@@ -2898,5 +3054,176 @@ mod tests {
             worker_alive: true,
             load_error: None,
         }
+    }
+
+    /// `ARTIFACT_DIGEST_PASSES` is process-wide, so digest-pass observations
+    /// run one at a time.
+    static DIGEST_PASS_OBSERVATION: Mutex<()> = Mutex::new(());
+
+    struct SealedArtifactFixture {
+        _observation: std::sync::MutexGuard<'static, ()>,
+        _directory: tempfile::TempDir,
+        path: PathBuf,
+        bytes: Vec<u8>,
+        digest: String,
+        receipt: IntegrityReceiptCell,
+    }
+
+    impl SealedArtifactFixture {
+        fn new(name: &str) -> Self {
+            let observation = DIGEST_PASS_OBSERVATION
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let directory = tempfile::tempdir().expect("sealed artifact fixture directory");
+            let path = directory.path().join(name);
+            let bytes = (0..64_u32)
+                .flat_map(|value| value.to_le_bytes())
+                .collect::<Vec<u8>>();
+            fs::write(&path, &bytes).expect("write sealed artifact fixture");
+            let digest = format!("{:x}", Sha256::digest(&bytes));
+            Self {
+                _observation: observation,
+                _directory: directory,
+                path,
+                bytes,
+                digest,
+                receipt: IntegrityReceiptCell::new(),
+            }
+        }
+
+        fn verify(&self) -> Result<bool, EngineError> {
+            verified_sealed_artifact(
+                &self.path,
+                self.bytes.len() as u64,
+                &self.digest,
+                &self.receipt,
+            )
+        }
+
+        /// Run one verification and report how many whole-file digest passes it
+        /// performed.
+        fn verify_counting_digest_passes(&self) -> (bool, u64) {
+            let before = ARTIFACT_DIGEST_PASSES.load(Ordering::Relaxed);
+            let verified = self.verify().expect("verify sealed artifact");
+            (
+                verified,
+                ARTIFACT_DIGEST_PASSES
+                    .load(Ordering::Relaxed)
+                    .saturating_sub(before),
+            )
+        }
+
+        /// Rewrite the artifact in place, keeping its length and inode.
+        fn rewrite_in_place(&self, bytes: &[u8]) {
+            assert_eq!(
+                bytes.len(),
+                self.bytes.len(),
+                "in-place rewrite keeps length"
+            );
+            let mut file = OpenOptions::new()
+                .write(true)
+                .open(&self.path)
+                .expect("open sealed artifact for in-place rewrite");
+            file.write_all(bytes).expect("rewrite sealed artifact");
+            file.sync_all().expect("sync in-place rewrite");
+        }
+    }
+
+    #[test]
+    fn model_integrity_receipt_skips_the_digest_pass_until_native_identity_moves() {
+        let fixture = SealedArtifactFixture::new("receipt-reuse.gguf");
+
+        let (first, first_passes) = fixture.verify_counting_digest_passes();
+        assert!(first, "an intact artifact verifies");
+        assert_eq!(first_passes, 1, "the first verification hashes the file");
+
+        let (second, second_passes) = fixture.verify_counting_digest_passes();
+        assert!(second, "the sealed receipt still verifies");
+        assert_eq!(
+            second_passes, 0,
+            "a receipt sealed to an unmoved native identity costs one stat"
+        );
+
+        // Native replacement: identical bytes, new inode.
+        let replacement = fixture.path.with_extension("replacement");
+        fs::write(&replacement, &fixture.bytes).expect("stage replacement artifact");
+        fs::rename(&replacement, &fixture.path).expect("replace sealed artifact");
+
+        let (third, third_passes) = fixture.verify_counting_digest_passes();
+        assert!(third, "the replacement carries the same verified bytes");
+        assert_eq!(
+            third_passes, 1,
+            "a replaced artifact is re-hashed even when the bytes match"
+        );
+    }
+
+    #[test]
+    fn model_integrity_receipt_never_survives_in_place_corruption_or_caches_failure() {
+        let fixture = SealedArtifactFixture::new("receipt-corruption.gguf");
+        assert!(fixture.verify().expect("seal the intact artifact"));
+
+        let mut corrupted = fixture.bytes.clone();
+        corrupted[7] ^= 0xff;
+        fixture.rewrite_in_place(&corrupted);
+
+        let (verified, passes) = fixture.verify_counting_digest_passes();
+        assert!(
+            !verified,
+            "an in-place rewrite must not be served by the sealed receipt"
+        );
+        assert_eq!(passes, 1, "the moved identity forces a fresh digest pass");
+
+        let (repeated, repeated_passes) = fixture.verify_counting_digest_passes();
+        assert!(!repeated, "the corrupt artifact still fails");
+        assert_eq!(
+            repeated_passes, 1,
+            "a failed verdict is never sealed, so it is re-proven every time"
+        );
+
+        fixture.rewrite_in_place(&fixture.bytes);
+        let (repaired, repaired_passes) = fixture.verify_counting_digest_passes();
+        assert!(repaired, "restored bytes verify again");
+        assert_eq!(
+            repaired_passes, 1,
+            "repair is proven by hashing, not assumed"
+        );
+    }
+
+    #[test]
+    fn model_integrity_receipt_is_cleared_when_the_artifact_disappears_or_changes_length() {
+        let fixture = SealedArtifactFixture::new("receipt-length.gguf");
+        assert!(fixture.verify().expect("seal the intact artifact"));
+
+        let mut longer = fixture.bytes.clone();
+        longer.push(0);
+        fs::write(&fixture.path, &longer).expect("grow sealed artifact");
+        assert!(
+            !fixture.verify().expect("length drift is observable"),
+            "a length change fails the verification"
+        );
+
+        fs::write(&fixture.path, &fixture.bytes).expect("shrink sealed artifact back");
+        let (recovered, recovered_passes) = fixture.verify_counting_digest_passes();
+        assert!(recovered, "the original bytes verify again");
+        assert_eq!(
+            recovered_passes, 1,
+            "a length that moved and returned is re-proven, never served from the seal"
+        );
+
+        fs::remove_file(&fixture.path).expect("remove sealed artifact");
+        assert!(
+            !fixture
+                .verify()
+                .expect("a missing artifact is not an error"),
+            "a missing artifact fails the verification"
+        );
+
+        fs::write(&fixture.path, &fixture.bytes).expect("restore sealed artifact");
+        let (restored, restored_passes) = fixture.verify_counting_digest_passes();
+        assert!(restored, "the restored artifact verifies");
+        assert_eq!(
+            restored_passes, 1,
+            "the cleared receipt cannot admit the restored file without hashing"
+        );
     }
 }

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -23,7 +23,7 @@ use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -902,10 +902,14 @@ fn read_structural_text_unit_rollback_identity(
     let Some(identity) = identity else {
         return Ok(None);
     };
-    let (unit_count, unit_digest, unit_versions) = structural_text_unit_content_summary(&conn)?;
-    let (projection_count, projection_digest, projection_versions) =
-        structural_text_projection_content_summary(&conn)?;
-    validate_structural_text_projection_rows(&conn)?;
+    let StructuralTextContentScan {
+        unit_count,
+        unit_digest,
+        unit_versions,
+        projection_count,
+        projection_digest,
+        projection_versions,
+    } = scan_structural_text_content(&conn)?;
     validate_structural_text_artifact_cache_rows(&conn).map_err(|error| {
         promotion_error(format!(
             "Structural artifact cache rollback identity does not match {}: {error}",
@@ -989,6 +993,139 @@ fn require_candidate_structural_text_identity(
         )));
     }
     require_recorded_structural_text_identity(path, publication, expected, role)
+}
+
+/// Byte extent of the SQLite database header.
+const SQLITE_DATABASE_HEADER_BYTES: usize = 100;
+
+/// Header slots SQLite rewrites as bookkeeping when it commits or completes a
+/// `sqlite3_backup`, and which therefore carry no database content: the file
+/// change counter (24..28), the schema cookie (40..44), and the version-valid-for
+/// counter (92..96). Every other byte of the file, header included, participates.
+const SQLITE_VOLATILE_HEADER_SLOTS: [(usize, usize); 3] = [(24, 28), (40, 44), (92, 96)];
+
+/// Rollback-journal sidecars that can hold database content outside the main
+/// file. `-shm` is excluded on purpose: it is a rebuildable wal-index, never
+/// content.
+const SQLITE_CONTENT_SIDECAR_SUFFIXES: [&str; 2] = ["-wal", "-journal"];
+
+/// Whole-database byte identity for one promotion artifact.
+///
+/// This is content evidence, not a handle: two databases with the same image
+/// hold the same pages, so a validation that passed on one is a validation of
+/// the other. It is deliberately opaque so no caller can manufacture one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PromotionDatabaseImage([u8; 32]);
+
+/// Digest the whole database file, masking only the header slots SQLite itself
+/// rewrites.
+///
+/// `None` means the image is not provable — a hot `-wal` or `-journal` sidecar
+/// puts content outside the main file, and a file shorter than the header is not
+/// a database. An unprovable image never admits reuse; it forces full
+/// revalidation.
+fn promotion_database_image(path: &Path) -> Result<Option<PromotionDatabaseImage>, StorageError> {
+    for suffix in SQLITE_CONTENT_SIDECAR_SUFFIXES {
+        let sidecar = sqlite_sidecar_path(path, suffix);
+        match fs::metadata(&sidecar) {
+            Ok(metadata) if metadata.len() > 0 => return Ok(None),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(promotion_path_error("inspect", &sidecar, error)),
+        }
+    }
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(promotion_path_error("open", path, error)),
+    };
+    let mut reader = BufReader::new(file);
+    let mut header = [0_u8; SQLITE_DATABASE_HEADER_BYTES];
+    match reader.read_exact(&mut header) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(promotion_path_error("read", path, error)),
+    }
+    for (start, end) in SQLITE_VOLATILE_HEADER_SLOTS {
+        header[start..end].fill(0);
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(header);
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| promotion_path_error("read", path, error))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(Some(PromotionDatabaseImage(hasher.finalize().into())))
+}
+
+/// How the post-restore fence was satisfied for one promotion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromotedValidation {
+    /// The restored file is byte-identical to the validated candidate, so the
+    /// candidate's receipt covers it.
+    ReusedCandidateReceipt,
+    /// The restored file could not be proven identical, so it was validated in
+    /// full.
+    Revalidated,
+}
+
+impl PromotedValidation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReusedCandidateReceipt => "reused_candidate_receipt",
+            Self::Revalidated => "revalidated",
+        }
+    }
+}
+
+/// Fence the restored live database before the promotion may commit.
+///
+/// The publication identity is always read back from the promoted file. The
+/// deep source-policy and structural-text validations are reused from the staged
+/// candidate only when the restored file's whole-database image equals the image
+/// sealed to that candidate's validation — which proves the two files hold the
+/// same pages, so re-deriving the same verdict from them is redundant work. A
+/// missing image on either side, or any difference at all, revalidates in full.
+fn validate_promoted_live_database(
+    live_path: &Path,
+    staged_path: &Path,
+    candidate: &IndexPublicationRecord,
+    candidate_source_policy: &Option<SourcePolicyExclusionRollbackIdentity>,
+    candidate_structural_text: &Option<StructuralTextUnitRollbackIdentity>,
+    candidate_image: Option<PromotionDatabaseImage>,
+) -> Result<PromotedValidation, StorageError> {
+    let published =
+        require_complete_promotion_database_identity(live_path, "Promoted live database")?;
+    if &published != candidate {
+        return Err(promotion_error(format!(
+            "Promoted live database identity does not match staged candidate {}",
+            staged_path.display()
+        )));
+    }
+    if let Some(candidate_image) = candidate_image
+        && promotion_database_image(live_path)? == Some(candidate_image)
+    {
+        return Ok(PromotedValidation::ReusedCandidateReceipt);
+    }
+    require_candidate_source_policy_identity(
+        live_path,
+        &published,
+        candidate_source_policy,
+        "Promoted live database",
+    )?;
+    require_candidate_structural_text_identity(
+        live_path,
+        &published,
+        candidate_structural_text,
+        "Promoted live database",
+    )?;
+    Ok(PromotedValidation::Revalidated)
 }
 
 fn promotion_lock_path(path: &Path) -> PathBuf {
@@ -2564,6 +2701,158 @@ fn hash_structural_text_unit_part(hasher: &mut Sha256, value: &[u8]) {
     hasher.update(value);
 }
 
+/// Everything a structural validation receipt needs from the unit and
+/// projection tables.
+#[derive(Debug)]
+struct StructuralTextContentScan {
+    unit_count: u64,
+    unit_digest: String,
+    unit_versions: HashSet<u32>,
+    projection_count: u64,
+    projection_digest: String,
+    projection_versions: HashSet<u32>,
+}
+
+/// Per-file unit evidence accumulated while the unit table is scanned.
+struct StructuralTextFileUnits {
+    count: u64,
+    digest: Sha256,
+}
+
+/// Read the structural unit and projection evidence in one ordered scan per
+/// table.
+///
+/// The publication summary and the per-file unit digests come from the same
+/// `structural_text_unit` cursor, and the projection summary and the per-file
+/// comparison come from the same `structural_text_projection` cursor, so a
+/// validation costs one pass over each table instead of two. Both digests keep
+/// the exact bytes their producers hashed: the publication summary hashes the
+/// stored column text, and the per-file digest hashes the decoded unit the way
+/// [`structural_text_unit_digest`] does. Neither validation is skipped.
+fn scan_structural_text_content(
+    conn: &Connection,
+) -> Result<StructuralTextContentScan, StorageError> {
+    let mut stmt = conn.prepare(
+        "SELECT node_id, file_id, placement_id, content_hash, source_content_hash,
+                descriptor_version, producer, evidence_tier, resolution, language,
+                kind, start_line, start_col, end_line, end_col, file_role
+         FROM structural_text_unit ORDER BY node_id ASC",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut unit_hasher = Sha256::new();
+    unit_hasher.update(STRUCTURAL_TEXT_UNIT_DIGEST_DOMAIN);
+    let mut unit_count = 0_u64;
+    let mut unit_versions = HashSet::new();
+    let mut units_by_file = HashMap::<i64, StructuralTextFileUnits>::new();
+    while let Some(row) = rows.next()? {
+        let descriptor_version = u32::try_from(row.get::<_, i64>(5)?).map_err(|_| {
+            StorageError::Other("structural text unit descriptor version is invalid".into())
+        })?;
+        unit_versions.insert(descriptor_version);
+        let file_id = row.get::<_, i64>(1)?;
+        let file_role = row.get::<_, String>(15)?;
+        let values = [
+            row.get::<_, i64>(0)?.to_string(),
+            file_id.to_string(),
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            descriptor_version.to_string(),
+            row.get::<_, String>(6)?,
+            row.get::<_, String>(7)?,
+            row.get::<_, String>(8)?,
+            row.get::<_, String>(9)?,
+            row.get::<_, i64>(10)?.to_string(),
+            row.get::<_, i64>(11)?.to_string(),
+            row.get::<_, i64>(12)?.to_string(),
+            row.get::<_, i64>(13)?.to_string(),
+            row.get::<_, i64>(14)?.to_string(),
+            file_role.clone(),
+        ];
+        for value in &values {
+            hash_structural_text_unit_part(&mut unit_hasher, value.as_bytes());
+        }
+        unit_count = unit_count.saturating_add(1);
+
+        // The per-file digest is the producer's digest, so it hashes the
+        // decoded unit: an out-of-range kind or span is rejected here exactly as
+        // decoding a row would reject it, and the role is the decoded role.
+        let unit = structural_text_unit_from_row(row)?;
+        let file = units_by_file
+            .entry(file_id)
+            .or_insert_with(|| StructuralTextFileUnits {
+                count: 0,
+                digest: new_structural_text_file_unit_digest(),
+            });
+        file.count = file.count.saturating_add(1);
+        hash_structural_text_unit_fields(&mut file.digest, &unit);
+    }
+    drop(rows);
+    drop(stmt);
+
+    let mut stmt = conn.prepare(
+        "SELECT file_id, source_content_hash, descriptor_version, producer,
+                language, file_role, unit_count, unit_digest
+         FROM structural_text_projection ORDER BY file_id ASC",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut projection_hasher = Sha256::new();
+    projection_hasher.update(b"codestory-structural-text-projection-publication-v1\0");
+    let mut projection_count = 0_u64;
+    let mut projection_versions = HashSet::new();
+    while let Some(row) = rows.next()? {
+        let descriptor_version = u32::try_from(row.get::<_, i64>(2)?).map_err(|_| {
+            StorageError::Other("structural text projection descriptor version is invalid".into())
+        })?;
+        projection_versions.insert(descriptor_version);
+        let file_id = row.get::<_, i64>(0)?;
+        let declared_unit_count = u64::try_from(row.get::<_, i64>(6)?).unwrap_or(0);
+        let declared_unit_digest = row.get::<_, String>(7)?;
+        let values = [
+            file_id.to_string(),
+            row.get::<_, String>(1)?,
+            descriptor_version.to_string(),
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, String>(5)?,
+            row.get::<_, i64>(6)?.to_string(),
+            declared_unit_digest.clone(),
+        ];
+        for value in &values {
+            hash_structural_text_unit_part(&mut projection_hasher, value.as_bytes());
+        }
+        projection_count = projection_count.saturating_add(1);
+
+        let observed = units_by_file
+            .remove(&file_id)
+            .unwrap_or_else(|| StructuralTextFileUnits {
+                count: 0,
+                digest: new_structural_text_file_unit_digest(),
+            });
+        if declared_unit_count != observed.count
+            || declared_unit_digest != format!("{:x}", observed.digest.finalize())
+        {
+            return Err(StorageError::Other(format!(
+                "structural text projection {file_id} does not match its unit set"
+            )));
+        }
+    }
+    if !units_by_file.is_empty() {
+        return Err(StorageError::Other(
+            "structural text units exist without owning projections".into(),
+        ));
+    }
+
+    Ok(StructuralTextContentScan {
+        unit_count,
+        unit_digest: format!("{:x}", unit_hasher.finalize()),
+        unit_versions,
+        projection_count,
+        projection_digest: format!("{:x}", projection_hasher.finalize()),
+        projection_versions,
+    })
+}
+
 fn structural_text_unit_content_summary(
     conn: &Connection,
 ) -> Result<(u64, String, HashSet<u32>), StorageError> {
@@ -2619,26 +2908,37 @@ pub fn structural_text_unit_digest(units: &[StructuralTextUnit]) -> String {
     structural_text_unit_digest_ordered(&units)
 }
 
-fn structural_text_unit_digest_ordered(units: &[&StructuralTextUnit]) -> String {
+const STRUCTURAL_TEXT_FILE_UNIT_DIGEST_DOMAIN: &[u8] = b"codestory-structural-text-file-units-v1\0";
+
+fn new_structural_text_file_unit_digest() -> Sha256 {
     let mut hasher = Sha256::new();
-    hasher.update(b"codestory-structural-text-file-units-v1\0");
+    hasher.update(STRUCTURAL_TEXT_FILE_UNIT_DIGEST_DOMAIN);
+    hasher
+}
+
+fn hash_structural_text_unit_fields(hasher: &mut Sha256, unit: &StructuralTextUnit) {
+    hash_structural_text_unit_part(hasher, unit.node_id.0.to_string().as_bytes());
+    hash_structural_text_unit_part(hasher, unit.file_id.to_string().as_bytes());
+    hash_structural_text_unit_part(hasher, unit.placement_id.as_bytes());
+    hash_structural_text_unit_part(hasher, unit.content_hash.as_bytes());
+    hash_structural_text_unit_part(hasher, unit.source_content_hash.as_bytes());
+    hash_structural_text_unit_part(hasher, unit.descriptor_version.to_string().as_bytes());
+    hash_structural_text_unit_part(hasher, unit.producer.as_bytes());
+    hash_structural_text_unit_part(hasher, unit.evidence_tier.as_bytes());
+    hash_structural_text_unit_part(hasher, unit.resolution.as_bytes());
+    hash_structural_text_unit_part(hasher, unit.language.as_bytes());
+    hash_structural_text_unit_part(hasher, (unit.kind as i32).to_string().as_bytes());
+    hash_structural_text_unit_part(hasher, unit.start_line.to_string().as_bytes());
+    hash_structural_text_unit_part(hasher, unit.start_col.to_string().as_bytes());
+    hash_structural_text_unit_part(hasher, unit.end_line.to_string().as_bytes());
+    hash_structural_text_unit_part(hasher, unit.end_col.to_string().as_bytes());
+    hash_structural_text_unit_part(hasher, unit.file_role.as_str().as_bytes());
+}
+
+fn structural_text_unit_digest_ordered(units: &[&StructuralTextUnit]) -> String {
+    let mut hasher = new_structural_text_file_unit_digest();
     for unit in units {
-        hash_structural_text_unit_part(&mut hasher, unit.node_id.0.to_string().as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.file_id.to_string().as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.placement_id.as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.content_hash.as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.source_content_hash.as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.descriptor_version.to_string().as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.producer.as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.evidence_tier.as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.resolution.as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.language.as_bytes());
-        hash_structural_text_unit_part(&mut hasher, (unit.kind as i32).to_string().as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.start_line.to_string().as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.start_col.to_string().as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.end_line.to_string().as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.end_col.to_string().as_bytes());
-        hash_structural_text_unit_part(&mut hasher, unit.file_role.as_str().as_bytes());
+        hash_structural_text_unit_fields(&mut hasher, unit);
     }
     format!("{:x}", hasher.finalize())
 }
@@ -2692,40 +2992,38 @@ fn structural_text_artifact_cache_key_is_valid(cache_key: &str) -> bool {
         && !identity.is_empty()
 }
 
+/// Validate every cached structural artifact against its verified projection in
+/// one ordered scan of the cache table.
+///
+/// The outer join carries the orphan check that used to need a second pass: a
+/// cache row whose projection is absent still arrives, and it is rejected on the
+/// same terms as before.
 fn validate_structural_text_artifact_cache_rows(conn: &Connection) -> Result<(), StorageError> {
-    let orphaned_rows = conn.query_row(
-        "SELECT COUNT(*)
-         FROM structural_text_artifact_cache c
-         LEFT JOIN structural_text_projection p ON p.file_id = c.file_id
-         WHERE p.file_id IS NULL",
-        [],
-        |row| row.get::<_, i64>(0),
-    )?;
-    if orphaned_rows != 0 {
-        return Err(StorageError::Other(
-            "structural artifact cache contains rows without verified projections".into(),
-        ));
-    }
     let mut stmt = conn.prepare(
         "SELECT c.file_id, c.cache_key, c.source_content_hash,
                 c.descriptor_version, c.producer, c.artifact_digest, c.artifact_blob,
-                p.source_content_hash, p.descriptor_version, p.producer
+                p.file_id, p.source_content_hash, p.descriptor_version, p.producer
          FROM structural_text_artifact_cache c
-         INNER JOIN structural_text_projection p ON p.file_id = c.file_id
+         LEFT JOIN structural_text_projection p ON p.file_id = c.file_id
          ORDER BY c.file_id ASC",
     )?;
     let mut rows = stmt.query([])?;
     while let Some(row) = rows.next()? {
         let file_id = row.get::<_, i64>(0)?;
+        if row.get::<_, Option<i64>>(7)?.is_none() {
+            return Err(StorageError::Other(
+                "structural artifact cache contains rows without verified projections".into(),
+            ));
+        }
         let cache_key = row.get::<_, String>(1)?;
         let source_content_hash = row.get::<_, String>(2)?;
         let descriptor_version = row.get::<_, i64>(3)?;
         let producer = row.get::<_, String>(4)?;
         let artifact_digest = row.get::<_, String>(5)?;
         let artifact_blob = row.get::<_, Vec<u8>>(6)?;
-        let projection_source_content_hash = row.get::<_, String>(7)?;
-        let projection_descriptor_version = row.get::<_, i64>(8)?;
-        let projection_producer = row.get::<_, String>(9)?;
+        let projection_source_content_hash = row.get::<_, String>(8)?;
+        let projection_descriptor_version = row.get::<_, i64>(9)?;
+        let projection_producer = row.get::<_, String>(10)?;
         let expected_digest = format!("{:x}", Sha256::digest(&artifact_blob));
         if source_content_hash != projection_source_content_hash
             || descriptor_version != projection_descriptor_version
@@ -5532,6 +5830,7 @@ impl Storage {
         durations.lock_recovery = lock_recovery_started.elapsed();
 
         let candidate_validation_started = Instant::now();
+        let candidate_image_before_validation = promotion_database_image(staged_path)?;
         let candidate = require_complete_promotion_database_identity(
             staged_path,
             "Staged promotion candidate",
@@ -5552,6 +5851,16 @@ impl Storage {
                 staged_path.display()
             )));
         }
+        // A receipt may only seal bytes the validation above actually read, so
+        // the image is taken on both sides of it. A staged file that moved under
+        // its own validation seals nothing and the promoted copy is revalidated.
+        let candidate_image = match (
+            candidate_image_before_validation,
+            promotion_database_image(staged_path)?,
+        ) {
+            (Some(before), Some(after)) if before == after => Some(after),
+            _ => None,
+        };
         let candidate_bytes = database_logical_bytes_at_path(staged_path)?;
         durations.candidate_validation = candidate_validation_started.elapsed();
 
@@ -5687,33 +5996,25 @@ impl Storage {
         durations.staged_to_live_restore = staged_to_live_restore_started.elapsed();
 
         let promoted_validation_started = Instant::now();
-        let published =
-            require_complete_promotion_database_identity(live_path, "Promoted live database")?;
-        if published != candidate {
-            let _ = rollback_prepared_promotion(live_path, &prepared);
-            return Err(promotion_error(format!(
-                "Promoted live database identity does not match staged candidate {}",
-                staged_path.display()
-            )));
-        }
-        if let Err(error) = require_candidate_source_policy_identity(
+        let promoted_validation = match validate_promoted_live_database(
             live_path,
-            &published,
+            staged_path,
+            &candidate,
             &candidate_source_policy,
-            "Promoted live database",
-        ) {
-            let _ = rollback_prepared_promotion(live_path, &prepared);
-            return Err(error);
-        }
-        if let Err(error) = require_candidate_structural_text_identity(
-            live_path,
-            &published,
             &candidate_structural_text,
-            "Promoted live database",
+            candidate_image,
         ) {
-            let _ = rollback_prepared_promotion(live_path, &prepared);
-            return Err(error);
-        }
+            Ok(promoted_validation) => promoted_validation,
+            Err(error) => {
+                let _ = rollback_prepared_promotion(live_path, &prepared);
+                return Err(error);
+            }
+        };
+        tracing::debug!(
+            live_path = %live_path.display(),
+            promoted_validation = promoted_validation.as_str(),
+            "promotion fenced the restored live database"
+        );
         durations.promoted_validation = promoted_validation_started.elapsed();
 
         let committed_journal_started = Instant::now();

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -10201,5 +10201,379 @@ fn annotation_uniqueness_probes_never_read_more_rows_than_the_decision_needs()
         2,
         "a crowded name must not stream the whole workspace into the rebind ladder"
     );
+
+    Ok(())
+}
+
+/// Seed one promotion-ready database whose structural evidence spans several
+/// files, each with several units, one projection, and one bound cache row.
+fn seed_structural_promotion_corpus(path: &Path, generation: i64) -> Result<(), StorageError> {
+    const FILE_COUNT: i64 = 4;
+    const UNITS_PER_FILE: i64 = 3;
+
+    let mut storage = Storage::open(path)?;
+    let mut files = Vec::new();
+    let mut file_content_hashes = Vec::new();
+    let mut nodes = Vec::new();
+    let mut units = Vec::new();
+    let mut projections = Vec::new();
+    for index in 0..FILE_COUNT {
+        let file_id = generation * 100 + index + 1;
+        let source_hash = format!("{file_id:064x}");
+        files.push(FileInfo {
+            id: file_id,
+            path: PathBuf::from(format!("src/module_{file_id}.rs")),
+            language: "rust".to_string(),
+            modification_time: file_id,
+            indexed: true,
+            complete: true,
+            line_count: 64,
+            file_role: FileRole::Source,
+        });
+        file_content_hashes.push(FileContentHash {
+            file_id,
+            content_hash: source_hash.clone(),
+        });
+        let first_unit = units.len();
+        for offset in 0..UNITS_PER_FILE {
+            let node_id = file_id * 10 + offset;
+            nodes.push(Node {
+                id: NodeId(node_id),
+                kind: NodeKind::FUNCTION,
+                serialized_name: format!("module_{file_id}::f{offset}"),
+                ..Default::default()
+            });
+            units.push(structural_unit_fixture(node_id, file_id, &source_hash));
+        }
+        projections.push(StructuralTextProjection {
+            file_id,
+            source_content_hash: source_hash,
+            descriptor_version: STRUCTURAL_TEXT_UNIT_DESCRIPTOR_VERSION,
+            producer: "fixture".to_string(),
+            language: "rust".to_string(),
+            file_role: FileRole::Source,
+            unit_count: UNITS_PER_FILE as u64,
+            unit_digest: structural_text_unit_digest(&units[first_unit..]),
+        });
+    }
+    let cache_writes = files
+        .iter()
+        .map(|file| StructuralTextArtifactCacheWrite {
+            path: &file.path,
+            file_id: file.id,
+            cache_key: "v1:fixture",
+            artifact_blob: b"verified structural artifact",
+        })
+        .collect::<Vec<_>>();
+    storage.flush_projection_batch(ProjectionBatch {
+        files: &files,
+        file_content_hashes: &file_content_hashes,
+        nodes: &nodes,
+        structural_text_units: &units,
+        structural_text_projections: &projections,
+        structural_text_cache_writes: &cache_writes,
+        edges: &[],
+        occurrences: &[],
+        component_access: &[],
+        callable_projection_states: &[],
+        file_errors: &[],
+    })?;
+    let publication = IndexPublicationRecord {
+        generation: generation.max(0) as u64,
+        generation_id: format!("generation-{generation}"),
+        run_id: format!("run-{generation}"),
+        mode: IndexPublicationMode::Full,
+        published_at_epoch_ms: generation.max(0),
+    };
+    storage.put_index_publication(&publication)?;
+    storage.publish_structural_text_unit_generation(&publication)?;
+    storage.publish_source_policy_exclusion_generation(
+        &publication,
+        "test-project",
+        "test-workspace",
+        source_policy_identity(
+            OVERSIZED_SOURCE_POLICY_VERSION,
+            DEFAULT_SOURCE_FILE_BYTE_CAP,
+            codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
+        ),
+        &[],
+    )?;
+    storage.finalize_staged_snapshot()
+}
+
+#[test]
+fn structural_content_scan_reproduces_the_separate_summaries_and_per_file_digests()
+-> Result<(), StorageError> {
+    let path = unique_temp_db_path("structural-content-scan-equivalence");
+    seed_structural_promotion_corpus(&path, 7)?;
+    let storage = Storage::open(&path)?;
+    let conn = storage.get_connection();
+
+    let (unit_count, unit_digest, unit_versions) = structural_text_unit_content_summary(conn)?;
+    let (projection_count, projection_digest, projection_versions) =
+        structural_text_projection_content_summary(conn)?;
+    validate_structural_text_projection_rows(conn)?;
+
+    let scan = scan_structural_text_content(conn)?;
+
+    assert_eq!(scan.unit_count, unit_count);
+    assert_eq!(scan.unit_digest, unit_digest);
+    assert_eq!(scan.unit_versions, unit_versions);
+    assert_eq!(scan.projection_count, projection_count);
+    assert_eq!(scan.projection_digest, projection_digest);
+    assert_eq!(scan.projection_versions, projection_versions);
+    assert_eq!(scan.unit_count, 12, "the fixture publishes twelve units");
+    assert_eq!(
+        scan.projection_count, 4,
+        "the fixture publishes four projections"
+    );
+
+    drop(storage);
+    cleanup_sqlite_sidecars(&path)?;
+    Ok(())
+}
+
+#[test]
+fn structural_content_scan_rejects_a_projection_that_no_longer_owns_its_units()
+-> Result<(), StorageError> {
+    let path = unique_temp_db_path("structural-content-scan-lost-unit");
+    seed_structural_promotion_corpus(&path, 8)?;
+    let storage = Storage::open(&path)?;
+    let conn = storage.get_connection();
+    let (file_id, node_id) = conn.query_row(
+        "SELECT file_id, node_id FROM structural_text_unit ORDER BY node_id ASC LIMIT 1",
+        [],
+        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+    )?;
+    conn.execute(
+        "DELETE FROM structural_text_unit WHERE node_id = ?1",
+        params![node_id],
+    )?;
+
+    let error = scan_structural_text_content(conn)
+        .expect_err("a projection that lost a unit must not validate");
+
+    assert_eq!(
+        error.to_string(),
+        format!("Other error: structural text projection {file_id} does not match its unit set"),
+        "the merged scan must report the same defect the separate pass reported"
+    );
+    assert_eq!(
+        validate_structural_text_projection_rows(conn)
+            .expect_err("the separate pass agrees")
+            .to_string(),
+        error.to_string()
+    );
+
+    drop(storage);
+    cleanup_sqlite_sidecars(&path)?;
+    Ok(())
+}
+
+#[test]
+fn structural_content_scan_rejects_units_without_an_owning_projection() -> Result<(), StorageError>
+{
+    let path = unique_temp_db_path("structural-content-scan-orphan-units");
+    seed_structural_promotion_corpus(&path, 9)?;
+    let storage = Storage::open(&path)?;
+    let conn = storage.get_connection();
+    let file_id = conn.query_row(
+        "SELECT file_id FROM structural_text_projection ORDER BY file_id ASC LIMIT 1",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    conn.execute(
+        "DELETE FROM structural_text_projection WHERE file_id = ?1",
+        params![file_id],
+    )?;
+
+    let error = scan_structural_text_content(conn).expect_err("orphaned units must not validate");
+
+    assert_eq!(
+        error.to_string(),
+        "Other error: structural text units exist without owning projections"
+    );
+
+    drop(storage);
+    cleanup_sqlite_sidecars(&path)?;
+    Ok(())
+}
+
+#[test]
+fn promotion_database_image_covers_content_and_ignores_only_sqlite_bookkeeping()
+-> Result<(), StorageError> {
+    let staged_path = unique_temp_db_path("promotion-image-source");
+    let live_path = unique_temp_db_path("promotion-image-destination");
+    seed_structural_promotion_corpus(&staged_path, 11)?;
+    seed_structural_promotion_corpus(&live_path, 12)?;
+
+    let staged_image = promotion_database_image(&staged_path)?.expect("staged image is provable");
+    assert_ne!(
+        promotion_database_image(&live_path)?.expect("live image is provable"),
+        staged_image,
+        "two different databases must not share an image"
+    );
+
+    let mut live_conn = Connection::open(sqlite_path::open_path(&live_path))?;
+    live_conn.restore(
+        MAIN_DB,
+        sqlite_path::open_path(&staged_path),
+        None::<fn(rusqlite::backup::Progress)>,
+    )?;
+    drop(live_conn);
+
+    assert_ne!(
+        fs::read(&staged_path).expect("read staged bytes"),
+        fs::read(&live_path).expect("read live bytes"),
+        "a restore leaves SQLite's own header counters different, which is why \
+         the image masks exactly those slots"
+    );
+    assert_eq!(
+        promotion_database_image(&live_path)?.expect("restored image is provable"),
+        staged_image,
+        "a faithful page-level restore carries the candidate's content"
+    );
+
+    let restored = fs::read(&live_path).expect("read live bytes");
+    let reimage = |mutate: &dyn Fn(&mut Vec<u8>)| -> Result<PromotionDatabaseImage, StorageError> {
+        let mut bytes = restored.clone();
+        mutate(&mut bytes);
+        fs::write(&live_path, &bytes).expect("write mutated live bytes");
+        Ok(promotion_database_image(&live_path)?.expect("mutated image is provable"))
+    };
+
+    // Only the three bookkeeping slots are outside the image.
+    for (start, end) in SQLITE_VOLATILE_HEADER_SLOTS {
+        assert_eq!(
+            reimage(&|bytes| bytes[start..end].iter_mut().for_each(|byte| *byte ^= 0xff))?,
+            staged_image,
+            "header slot {start}..{end} is SQLite bookkeeping, not content"
+        );
+    }
+    // Every other header byte is content: the page size, the text encoding, the
+    // freelist head, the user version and the application id all participate.
+    for offset in [16, 28, 32, 44, 56, 60, 68, 96] {
+        assert_ne!(
+            reimage(&|bytes| bytes[offset] ^= 0xff)?,
+            staged_image,
+            "header byte {offset} must participate in the image"
+        );
+    }
+    // And so does one byte of page content well past the header.
+    let content_offset = restored.len() / 2;
+    assert_ne!(
+        reimage(&|bytes| bytes[content_offset] ^= 0xff)?,
+        staged_image,
+        "byte drift in the pages must break the image"
+    );
+
+    cleanup_sqlite_sidecars(&staged_path)?;
+    cleanup_sqlite_sidecars(&live_path)?;
+    Ok(())
+}
+
+#[test]
+fn promotion_database_image_is_unprovable_when_content_sits_outside_the_main_file()
+-> Result<(), StorageError> {
+    let path = unique_temp_db_path("promotion-image-hot-sidecar");
+    seed_structural_promotion_corpus(&path, 13)?;
+    let sealed = promotion_database_image(&path)?.expect("sealed image is provable");
+
+    for suffix in ["-wal", "-journal"] {
+        let sidecar = sqlite_sidecar_path(&path, suffix);
+        fs::write(&sidecar, b"pending frames").expect("stage a hot sidecar");
+        assert_eq!(
+            promotion_database_image(&path)?,
+            None,
+            "{suffix} content outside the main file must leave the image unprovable"
+        );
+        fs::remove_file(&sidecar).expect("remove the hot sidecar");
+    }
+    assert_eq!(
+        promotion_database_image(&path)?,
+        Some(sealed),
+        "removing the sidecars restores the same image"
+    );
+
+    cleanup_sqlite_sidecars(&path)?;
+    Ok(())
+}
+
+#[test]
+fn promoted_receipt_reuse_is_sealed_to_the_restored_bytes() -> Result<(), StorageError> {
+    let staged_path = unique_temp_db_path("promoted-receipt-staged");
+    let live_path = unique_temp_db_path("promoted-receipt-live");
+    seed_structural_promotion_corpus(&staged_path, 21)?;
+    seed_structural_promotion_corpus(&live_path, 22)?;
+
+    let candidate =
+        require_complete_promotion_database_identity(&staged_path, "Staged promotion candidate")?;
+    let candidate_source_policy =
+        read_source_policy_exclusion_rollback_identity(&staged_path, &candidate)?;
+    let candidate_structural_text =
+        read_structural_text_unit_rollback_identity(&staged_path, &candidate)?;
+    let candidate_image = promotion_database_image(&staged_path)?.expect("candidate image");
+
+    let mut live_conn = Connection::open(sqlite_path::open_path(&live_path))?;
+    live_conn.restore(
+        MAIN_DB,
+        sqlite_path::open_path(&staged_path),
+        None::<fn(rusqlite::backup::Progress)>,
+    )?;
+    drop(live_conn);
+
+    assert_eq!(
+        validate_promoted_live_database(
+            &live_path,
+            &staged_path,
+            &candidate,
+            &candidate_source_policy,
+            &candidate_structural_text,
+            Some(candidate_image),
+        )?,
+        PromotedValidation::ReusedCandidateReceipt,
+        "a restore proven byte-identical to the validated candidate reuses its receipt"
+    );
+    assert_eq!(
+        validate_promoted_live_database(
+            &live_path,
+            &staged_path,
+            &candidate,
+            &candidate_source_policy,
+            &candidate_structural_text,
+            None,
+        )?,
+        PromotedValidation::Revalidated,
+        "without a candidate image the promoted copy is validated in full"
+    );
+
+    // In-place corruption after the restore leaves the publication identity
+    // untouched, so only the deep validation can catch it. The receipt must not
+    // be reusable here.
+    corrupt_test_structural_cache(&live_path, "blob")?;
+    assert_ne!(
+        promotion_database_image(&live_path)?.expect("corrupted image"),
+        candidate_image,
+        "in-place corruption must break the seal"
+    );
+    let error = validate_promoted_live_database(
+        &live_path,
+        &staged_path,
+        &candidate,
+        &candidate_source_policy,
+        &candidate_structural_text,
+        Some(candidate_image),
+    )
+    .expect_err("a corrupted restore must fail the post-restore fence");
+    assert!(
+        error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("structural artifact cache"),
+        "unexpected fence error: {error}"
+    );
+
+    cleanup_sqlite_sidecars(&staged_path)?;
+    cleanup_sqlite_sidecars(&live_path)?;
     Ok(())
 }


### PR DESCRIPTION
Closes #1662.

Storage and model validation receipts are sealed to native identity, so a receipt cannot be replayed against a database or model it did not validate. One ordered scan per table for the store validation receipt; restored-copy reuse is gated on independent whole-database byte identity.

## Review

Independently reviewed against the contract: **merge with follow-up**, no blocking or major findings surviving verification. Two flags were raised and both downgraded to minor on re-examination: the one-ordered-scan property is delivered on one of three validation paths, and the before/after candidate-image pairing (the guard on the now-default reuse path) deserves a direct test. Both are follow-up work, neither blocks.

No baseline moved; no version surface touched; no workflow change, so no `release-claims.json` mirroring owed.

## Proof

10 tests, each with fail-without-fix evidence recorded by the implementer. Owning-crate suites, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)