### PR TITLE
[v0.17 LINT-1] Assert the rehydrate reuse condition directly

### DIFF
--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -1118,13 +1118,12 @@ mod tests {
         })
         .expect("rehydrate");
 
-        assert_ne!(
-            output
+        assert!(
+            !output
                 .reason
                 .as_deref()
                 .unwrap_or_default()
                 .contains("Partial"),
-            true,
             "a restored tracked source must not make the inventory partial: {output:?}"
         );
         let manifest =


### PR DESCRIPTION
Closes #1761.

Replaces `assert_ne!(cond, true, ..)` with a direct `assert!(!cond, ..)` in the SRC-B2a rehydrate gate test. `clippy::bool_assert_comparison` rejects the former under `-D warnings`.

Found by a WIN-LINK-SRC agent running `cargo clippy --workspace --all-targets --all-features` — a configuration no per-PR lane runs, which is why it reached dev. Mine, from #1741.

`cargo test -p codestory-runtime --lib cache_rehydrate` 12 passed; clippy clean for the crate; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)