### PR TITLE
[v0.17 LIFE] Make cache inventory observational and cleanup proof-owned

### DIFF
--- a/crates/codestory-cli/src/app/lifecycle.rs
+++ b/crates/codestory-cli/src/app/lifecycle.rs
@@ -109,7 +109,81 @@ pub(super) fn run_cache(cmd: CacheCommand) -> Result<()> {
     match cmd.action {
         CacheAction::Identity(cmd) => run_cache_identity(cmd),
         CacheAction::Rehydrate(cmd) => run_cache_rehydrate(cmd),
+        CacheAction::Clean(cmd) => run_cache_clean(cmd),
     }
+}
+
+fn run_cache_clean(cmd: args::CacheCleanCommand) -> Result<()> {
+    ensure_dot_only_for_trail(cmd.format, "cache clean")?;
+    preflight_output_file(cmd.output_file.as_deref())?;
+    crate::sidecar_runtime::prepare_cache_access();
+    if cmd.apply {
+        let report = codestory_retrieval::apply_cache_clean().context("cache clean apply")?;
+        let markdown = render_cache_clean_report_markdown(&report);
+        return emit(cmd.format, &report, markdown, cmd.output_file.as_deref());
+    }
+    let plan = codestory_retrieval::plan_cache_clean().context("cache clean plan")?;
+    let markdown = render_cache_clean_plan_markdown(&plan);
+    emit(cmd.format, &plan, markdown, cmd.output_file.as_deref())
+}
+
+fn render_cache_clean_plan_markdown(plan: &codestory_retrieval::CacheCleanPlan) -> String {
+    let mut markdown = String::new();
+    let _ = writeln!(markdown, "# Cache Clean");
+    let _ = writeln!(markdown, "dry_run: `{}`", plan.dry_run);
+    let _ = writeln!(markdown, "cache_root: `{}`", plan.cache_root);
+    let _ = writeln!(
+        markdown,
+        "current_model_digest: `{}`",
+        plan.current_model_digest
+    );
+    let _ = writeln!(markdown, "reclaimable_bytes: {}", plan.reclaimable_bytes);
+    let _ = writeln!(markdown, "\n## Candidates");
+    for candidate in &plan.candidates {
+        let _ = writeln!(
+            markdown,
+            "- `{}` ({} bytes): {}",
+            candidate.relative_path, candidate.bytes, candidate.proof
+        );
+    }
+    let _ = writeln!(markdown, "\n## Retained");
+    for retained in &plan.retained {
+        let _ = writeln!(
+            markdown,
+            "- `{}` [{}]: {}",
+            retained.relative_path,
+            retained.reason.as_str(),
+            retained.detail
+        );
+    }
+    if !plan.errors.is_empty() {
+        let _ = writeln!(markdown, "\n## Errors");
+        for error in &plan.errors {
+            let _ = writeln!(markdown, "- {error}");
+        }
+    }
+    markdown
+}
+
+fn render_cache_clean_report_markdown(report: &codestory_retrieval::CacheCleanReport) -> String {
+    let mut markdown = render_cache_clean_plan_markdown(&report.plan);
+    let _ = writeln!(markdown, "\n## Removed");
+    let _ = writeln!(markdown, "removed_bytes: {}", report.removed_bytes);
+    for removal in &report.removals {
+        let _ = writeln!(
+            markdown,
+            "- `{}` removed={} bytes={}{}",
+            removal.relative_path,
+            removal.removed,
+            removal.bytes,
+            removal
+                .error
+                .as_deref()
+                .map(|error| format!(" error={error}"))
+                .unwrap_or_default()
+        );
+    }
+    markdown
 }
 
 fn run_cache_identity(cmd: args::CacheIdentityCommand) -> Result<()> {

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -716,6 +716,27 @@ pub(crate) enum CacheAction {
     Identity(CacheIdentityCommand),
     #[command(about = "Rehydrate a compatible cache from another worktree.")]
     Rehydrate(CacheRehydrateCommand),
+    #[command(
+        about = "Report, and optionally reclaim, cache state no live workspace or model can claim."
+    )]
+    Clean(CacheCleanCommand),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct CacheCleanCommand {
+    #[arg(
+        long,
+        help = "Reclaim the proven candidates in the plan. Omit for a dry-run plan that leaves the cache tree untouched."
+    )]
+    pub(crate) apply: bool,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -2528,6 +2549,31 @@ mod tests {
             .find_subcommand_mut(name)
             .expect("subcommand should exist");
         subcommand.render_long_help().to_string()
+    }
+
+    /// Reclaiming cache state is opt-in. A `cache clean` invocation that
+    /// forgets `--apply` must produce a plan, never a deletion.
+    #[test]
+    fn cache_clean_reclaims_nothing_without_an_explicit_apply() {
+        let planned = Cli::try_parse_from(["codestory-cli", "cache", "clean"])
+            .expect("cache clean should parse without flags");
+        let Command::Cache(CacheCommand {
+            action: CacheAction::Clean(planned),
+        }) = planned.command
+        else {
+            panic!("expected cache clean command");
+        };
+        assert!(!planned.apply, "cache clean must default to a dry-run plan");
+
+        let applied = Cli::try_parse_from(["codestory-cli", "cache", "clean", "--apply"])
+            .expect("cache clean --apply should parse");
+        let Command::Cache(CacheCommand {
+            action: CacheAction::Clean(applied),
+        }) = applied.command
+        else {
+            panic!("expected cache clean command");
+        };
+        assert!(applied.apply);
     }
 
     #[test]

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -1187,6 +1187,8 @@ fn owned_artifact_identities_are_declared_only_in_the_registry() {
         "local-refresh-state.guard",
         "annotations.sqlite3",
         "annotations.pre-migration.json",
+        "embedded-models",
+        ".materialize.lock",
     ];
     let producer_crates = [
         "crates/codestory-workspace/src",
@@ -1195,6 +1197,7 @@ fn owned_artifact_identities_are_declared_only_in_the_registry() {
         "crates/codestory-cli/src",
         "crates/codestory-retrieval/src",
         "crates/codestory-indexer/src",
+        "crates/codestory-llama-sys/src",
     ];
     for dir in producer_crates {
         let mut files = Vec::new();

--- a/crates/codestory-contracts/src/owned_artifacts.rs
+++ b/crates/codestory-contracts/src/owned_artifacts.rs
@@ -64,6 +64,30 @@ pub const CACHE_ROOT_OWNED_FILE_NAMES: [&str; 3] = [
     LOCAL_REFRESH_STATE_GUARD_FILE,
 ];
 
+/// Content-addressed materialization tree for the embedded embedding model,
+/// rooted at the process cache root rather than beside any storage file.
+///
+/// The digest segment names one immutable model revision, so a cleanup pass
+/// can only prove a sibling superseded by comparing it against the digest the
+/// running executable was compiled with. Both segments live here so the
+/// producer and the cleanup planner cannot drift.
+pub const EMBEDDED_MODEL_CACHE_DIR: &str = "embedded-models";
+pub const EMBEDDED_MODEL_DIGEST_DIR: &str = "sha256";
+/// Advisory lock beside one materialized model revision.
+pub const EMBEDDED_MODEL_MATERIALIZE_LOCK_FILE: &str = ".materialize.lock";
+
+/// Root holding one directory per content-addressed model digest.
+pub fn embedded_model_digest_root(cache_root: &Path) -> PathBuf {
+    cache_root
+        .join(EMBEDDED_MODEL_CACHE_DIR)
+        .join(EMBEDDED_MODEL_DIGEST_DIR)
+}
+
+/// Directory holding the materialized model for one digest.
+pub fn embedded_model_directory(cache_root: &Path, digest: &str) -> PathBuf {
+    embedded_model_digest_root(cache_root).join(digest)
+}
+
 fn cache_root_for(storage_path: &Path) -> &Path {
     storage_path
         .parent()

--- a/crates/codestory-llama-sys/src/lib.rs
+++ b/crates/codestory-llama-sys/src/lib.rs
@@ -10,6 +10,9 @@ pub use admission::{
 
 use admission::EmbeddingAdmissionTracker;
 use codestory_contracts::bounded_locks::{self, FileLockKind, LockDeadline, acquire_with_deadline};
+use codestory_contracts::owned_artifacts::{
+    EMBEDDED_MODEL_MATERIALIZE_LOCK_FILE, embedded_model_directory,
+};
 use crossbeam_channel::{Receiver, Sender, TryRecvError, after, bounded, select_biased, unbounded};
 use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::context::params::{LlamaAttentionType, LlamaContextParams, LlamaPoolingType};
@@ -1934,17 +1937,14 @@ pub fn materialize_embedded_model(cache_root: &Path) -> Result<MaterializedModel
         )));
     }
 
-    let directory = cache_root
-        .join("embedded-models")
-        .join("sha256")
-        .join(MODEL_SHA256);
+    let directory = embedded_model_directory(cache_root, MODEL_SHA256);
     fs::create_dir_all(&directory).map_err(cache_error)?;
     let lock = OpenOptions::new()
         .create(true)
         .truncate(false)
         .read(true)
         .write(true)
-        .open(directory.join(".materialize.lock"))
+        .open(directory.join(EMBEDDED_MODEL_MATERIALIZE_LOCK_FILE))
         .map_err(cache_error)?;
     acquire_with_deadline(
         &lock,

--- a/crates/codestory-retrieval/src/cache_clean.rs
+++ b/crates/codestory-retrieval/src/cache_clean.rs
@@ -1,0 +1,955 @@
+//! Proof-owned cleanup for cache-root state no live workspace or running
+//! executable can still claim.
+//!
+//! Generation retention already reclaims superseded generations inside one
+//! project's sidecar tree. Two things sit outside it and were never reclaimed:
+//! the per-project cache directory of a worktree that no longer exists, and the
+//! content-addressed model tree of a model revision this executable was not
+//! built with.
+//!
+//! Both are removed only against positive proof, never against a heuristic.
+//! A project cache is removable only when a schema-2 retention marker
+//! registered a project root that is now provably gone; a model tree is
+//! removable only when its digest differs from the digest compiled into this
+//! binary. Everything else is reported as retained with a typed reason, so the
+//! plan reads as an audit rather than as a list of guesses.
+
+use crate::config::{SidecarRuntimeConfig, user_cache_root};
+use crate::retention::{
+    GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionLock, MarkerRetirement, RetentionDirEntry,
+    classify_retention_entry, directory_size, global_generation_gc_state_file, read_marker_path,
+    retention_dir,
+};
+use anyhow::{Context, Result};
+use codestory_contracts::owned_artifacts::{ANNOTATIONS_SIDECAR_FILE, embedded_model_digest_root};
+use codestory_workspace::owned_deletion::OwnedDeletionRoot;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Wire version of the plan and report documents.
+pub const CACHE_CLEAN_SCHEMA_VERSION: u32 = 1;
+
+/// A workspace cache directory is named by the 16-hex workspace identity.
+/// Anything else under the cache root is a different artifact family and is
+/// never a project-cache candidate.
+const WORKSPACE_ID_HEX_LEN: usize = 16;
+/// Content-addressed model directories are named by a SHA-256 digest.
+const MODEL_DIGEST_HEX_LEN: usize = 64;
+
+/// What kind of proof made one entry removable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheCleanKind {
+    /// A per-project cache directory whose registered workspace is gone.
+    AbandonedProjectCache,
+    /// A materialized model tree for a digest this executable does not use.
+    SupersededModelDigest,
+}
+
+/// Why one entry was left in place. Every refusal is typed so an operator can
+/// tell "nothing to do" apart from "refused for cause".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheCleanRefusal {
+    /// The registered project root still exists.
+    LiveWorkspace,
+    /// No schema-2 registration exists for this cache, so abandonment cannot
+    /// be proven. Covers both a missing marker and a schema-1 marker.
+    UnregisteredWorkspace,
+    /// The registered project root could not be observed either way.
+    UnprovenWorkspace,
+    /// The digest this executable was built with.
+    CurrentModelDigest,
+    /// Inside a CodeStory-owned tree but not a shape this planner recognizes.
+    UnrecognizedEntry,
+    /// A proven-abandoned cache still holds the annotations sidecar. Its
+    /// contents are authored, not derived, so a lost workspace cannot
+    /// regenerate them and cleanup will not take them.
+    AnnotationsPresent,
+    /// The entry could not be measured or inspected safely.
+    UnsafeEntry,
+}
+
+impl CacheCleanRefusal {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LiveWorkspace => "live_workspace",
+            Self::UnregisteredWorkspace => "unregistered_workspace",
+            Self::UnprovenWorkspace => "unproven_workspace",
+            Self::CurrentModelDigest => "current_model_digest",
+            Self::UnrecognizedEntry => "unrecognized_entry",
+            Self::AnnotationsPresent => "annotations_present",
+            Self::UnsafeEntry => "unsafe_entry",
+        }
+    }
+}
+
+/// One removable entry and the proof that made it removable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheCleanCandidate {
+    pub kind: CacheCleanKind,
+    /// Path relative to the cache root; also the owned deletion key.
+    pub relative_path: String,
+    pub bytes: u64,
+    pub proof: String,
+}
+
+/// One entry deliberately left in place.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheCleanRetained {
+    pub relative_path: String,
+    pub reason: CacheCleanRefusal,
+    pub detail: String,
+}
+
+/// The auditable cleanup plan. Building it never writes to the cache tree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheCleanPlan {
+    pub schema_version: u32,
+    pub dry_run: bool,
+    pub cache_root: String,
+    pub current_model_digest: String,
+    pub reclaimable_bytes: u64,
+    pub candidates: Vec<CacheCleanCandidate>,
+    pub retained: Vec<CacheCleanRetained>,
+    pub errors: Vec<String>,
+}
+
+/// One attempted removal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheCleanRemoval {
+    pub kind: CacheCleanKind,
+    pub relative_path: String,
+    pub bytes: u64,
+    pub removed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// The result of applying a plan re-derived under the cleanup lock.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheCleanReport {
+    pub schema_version: u32,
+    pub dry_run: bool,
+    pub plan: CacheCleanPlan,
+    pub removed_bytes: u64,
+    pub removals: Vec<CacheCleanRemoval>,
+    pub errors: Vec<String>,
+}
+
+/// Plan cleanup for the process cache root without touching it.
+pub fn plan_cache_clean() -> Result<CacheCleanPlan> {
+    let cache_root = user_cache_root();
+    Ok(build_cache_clean_plan(&cache_root))
+}
+
+/// Apply cleanup for the process cache root.
+///
+/// The plan is re-derived while holding the global generation cleanup lock, so
+/// a publication that started after an operator read the dry run cannot have
+/// its evidence deleted underneath it.
+pub fn apply_cache_clean() -> Result<CacheCleanReport> {
+    let cache_root = user_cache_root();
+    let runtime = SidecarRuntimeConfig::local();
+    let _global_gc_lock = GenerationRetentionLock::acquire(
+        &global_generation_gc_state_file(&runtime),
+        GLOBAL_GENERATION_GC_LOCK_SCOPE,
+    )
+    .context("coordinate cache cleanup with generation publication")?;
+    let mut plan = build_cache_clean_plan(&cache_root);
+    plan.dry_run = false;
+    Ok(apply_cache_clean_plan(&cache_root, plan))
+}
+
+fn apply_cache_clean_plan(cache_root: &Path, plan: CacheCleanPlan) -> CacheCleanReport {
+    let mut removals = Vec::new();
+    let mut removed_bytes = 0_u64;
+    let mut errors = plan.errors.clone();
+    match OwnedDeletionRoot::open(cache_root) {
+        Ok(deletion) => {
+            for candidate in &plan.candidates {
+                let relative = PathBuf::from(&candidate.relative_path);
+                match deletion.remove(&relative) {
+                    Ok(true) => {
+                        removed_bytes = removed_bytes.saturating_add(candidate.bytes);
+                        removals.push(CacheCleanRemoval {
+                            kind: candidate.kind,
+                            relative_path: candidate.relative_path.clone(),
+                            bytes: candidate.bytes,
+                            removed: true,
+                            error: None,
+                        });
+                    }
+                    Ok(false) => removals.push(CacheCleanRemoval {
+                        kind: candidate.kind,
+                        relative_path: candidate.relative_path.clone(),
+                        bytes: 0,
+                        removed: false,
+                        error: Some("entry disappeared before removal".into()),
+                    }),
+                    Err(error) => {
+                        let message = format!("remove {}: {error}", candidate.relative_path);
+                        errors.push(message.clone());
+                        removals.push(CacheCleanRemoval {
+                            kind: candidate.kind,
+                            relative_path: candidate.relative_path.clone(),
+                            bytes: 0,
+                            removed: false,
+                            error: Some(message),
+                        });
+                    }
+                }
+            }
+        }
+        Err(error) => errors.push(format!(
+            "open owned cache root {}: {error}",
+            cache_root.display()
+        )),
+    }
+    CacheCleanReport {
+        schema_version: CACHE_CLEAN_SCHEMA_VERSION,
+        dry_run: false,
+        plan,
+        removed_bytes,
+        removals,
+        errors,
+    }
+}
+
+/// Registration evidence for one workspace cache, read from the retention
+/// marker directory.
+struct WorkspaceRegistration {
+    retirement: MarkerRetirement,
+    project_root: Option<String>,
+}
+
+fn build_cache_clean_plan(cache_root: &Path) -> CacheCleanPlan {
+    let mut errors = Vec::new();
+    let mut candidates = Vec::new();
+    let mut retained = Vec::new();
+    let registrations = read_workspace_registrations(cache_root, &mut errors);
+    plan_project_caches(
+        cache_root,
+        &registrations,
+        &mut candidates,
+        &mut retained,
+        &mut errors,
+    );
+    plan_model_digests(cache_root, &mut candidates, &mut retained, &mut errors);
+    candidates.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    retained.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    let reclaimable_bytes = candidates.iter().fold(0_u64, |total, candidate| {
+        total.saturating_add(candidate.bytes)
+    });
+    CacheCleanPlan {
+        schema_version: CACHE_CLEAN_SCHEMA_VERSION,
+        dry_run: true,
+        cache_root: cache_root.display().to_string(),
+        current_model_digest: codestory_llama_sys::MODEL_SHA256.to_string(),
+        reclaimable_bytes,
+        candidates,
+        retained,
+        errors,
+    }
+}
+
+/// Read every retention marker under the local-profile state file and index it
+/// by the workspace it registers.
+fn read_workspace_registrations(
+    cache_root: &Path,
+    errors: &mut Vec<String>,
+) -> BTreeMap<String, WorkspaceRegistration> {
+    let mut registrations = BTreeMap::new();
+    let marker_dir = retention_dir(&local_state_file(cache_root));
+    let entries = match std::fs::read_dir(&marker_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return registrations,
+        Err(error) => {
+            errors.push(format!(
+                "read retention marker directory {}: {error}",
+                marker_dir.display()
+            ));
+            return registrations;
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                errors.push(format!(
+                    "read retention marker entry in {}: {error}",
+                    marker_dir.display()
+                ));
+                continue;
+            }
+        };
+        let path = entry.path();
+        if classify_retention_entry(&path) != RetentionDirEntry::Marker {
+            continue;
+        }
+        match read_marker_path(&path) {
+            Ok(Some(marker)) => {
+                let retirement = marker.retirement();
+                registrations.insert(
+                    marker.workspace_id.clone(),
+                    WorkspaceRegistration {
+                        retirement,
+                        project_root: marker.owner.map(|owner| owner.project_root),
+                    },
+                );
+            }
+            Ok(None) => {}
+            Err(error) => errors.push(format!(
+                "read retention marker {}: {error:#}",
+                path.display()
+            )),
+        }
+    }
+    registrations
+}
+
+/// The local profile roots its retention state directly in the cache root, so
+/// every workspace registration for this machine sits under one marker
+/// directory regardless of which project wrote it.
+fn local_state_file(cache_root: &Path) -> PathBuf {
+    cache_root.join(crate::config::RETRIEVAL_STATE_FILE)
+}
+
+fn plan_project_caches(
+    cache_root: &Path,
+    registrations: &BTreeMap<String, WorkspaceRegistration>,
+    candidates: &mut Vec<CacheCleanCandidate>,
+    retained: &mut Vec<CacheCleanRetained>,
+    errors: &mut Vec<String>,
+) {
+    let entries = match std::fs::read_dir(cache_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => {
+            errors.push(format!("read cache root {}: {error}", cache_root.display()));
+            return;
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                errors.push(format!(
+                    "read cache entry under {}: {error}",
+                    cache_root.display()
+                ));
+                continue;
+            }
+        };
+        let path = entry.path();
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        if !is_workspace_cache_name(&name) {
+            continue;
+        }
+        match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() && !file_type.is_symlink() => {}
+            Ok(_) => {
+                retained.push(CacheCleanRetained {
+                    relative_path: name,
+                    reason: CacheCleanRefusal::UnsafeEntry,
+                    detail: "workspace cache entry is not a direct directory".into(),
+                });
+                continue;
+            }
+            Err(error) => {
+                errors.push(format!("read cache entry type {}: {error}", path.display()));
+                continue;
+            }
+        }
+
+        let Some(registration) = registrations.get(&name) else {
+            retained.push(CacheCleanRetained {
+                relative_path: name,
+                reason: CacheCleanRefusal::UnregisteredWorkspace,
+                detail: "no schema 2 retention marker registers this workspace cache".into(),
+            });
+            continue;
+        };
+        let refusal = match registration.retirement {
+            MarkerRetirement::RetiredWorkspace => None,
+            MarkerRetirement::LiveWorkspace => Some(CacheCleanRefusal::LiveWorkspace),
+            MarkerRetirement::UnprovenWorkspace => Some(CacheCleanRefusal::UnprovenWorkspace),
+            MarkerRetirement::UnregisteredWorkspace => {
+                Some(CacheCleanRefusal::UnregisteredWorkspace)
+            }
+        };
+        if let Some(reason) = refusal {
+            retained.push(CacheCleanRetained {
+                relative_path: name,
+                reason,
+                detail: format!(
+                    "registered project root {} is {}",
+                    registration.project_root.as_deref().unwrap_or("unrecorded"),
+                    registration.retirement.as_str()
+                ),
+            });
+            continue;
+        }
+
+        // Authored annotations are the one artifact in a cache directory that
+        // a vanished workspace cannot reproduce, so proven abandonment is not
+        // enough to take them.
+        if path.join(ANNOTATIONS_SIDECAR_FILE).exists() {
+            retained.push(CacheCleanRetained {
+                relative_path: name,
+                reason: CacheCleanRefusal::AnnotationsPresent,
+                detail: "abandoned cache still holds authored annotations".into(),
+            });
+            continue;
+        }
+
+        match directory_size(&path) {
+            Ok(bytes) => candidates.push(CacheCleanCandidate {
+                kind: CacheCleanKind::AbandonedProjectCache,
+                relative_path: name,
+                bytes,
+                proof: format!(
+                    "registered project root {} no longer exists",
+                    registration.project_root.as_deref().unwrap_or("unrecorded")
+                ),
+            }),
+            Err(error) => {
+                errors.push(format!("measure cache {}: {error:#}", path.display()));
+                retained.push(CacheCleanRetained {
+                    relative_path: name,
+                    reason: CacheCleanRefusal::UnsafeEntry,
+                    detail: format!("cache directory could not be measured: {error:#}"),
+                });
+            }
+        }
+    }
+}
+
+fn plan_model_digests(
+    cache_root: &Path,
+    candidates: &mut Vec<CacheCleanCandidate>,
+    retained: &mut Vec<CacheCleanRetained>,
+    errors: &mut Vec<String>,
+) {
+    let digest_root = embedded_model_digest_root(cache_root);
+    let current = codestory_llama_sys::MODEL_SHA256;
+    let entries = match std::fs::read_dir(&digest_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => {
+            errors.push(format!(
+                "read model digest root {}: {error}",
+                digest_root.display()
+            ));
+            return;
+        }
+    };
+    let relative_of = |name: &str| {
+        digest_root
+            .strip_prefix(cache_root)
+            .map(|relative| relative.join(name))
+            .unwrap_or_else(|_| PathBuf::from(name))
+            .display()
+            .to_string()
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                errors.push(format!(
+                    "read model digest entry in {}: {error}",
+                    digest_root.display()
+                ));
+                continue;
+            }
+        };
+        let path = entry.path();
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let relative = relative_of(&name);
+        match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() && !file_type.is_symlink() => {}
+            Ok(_) => {
+                retained.push(CacheCleanRetained {
+                    relative_path: relative,
+                    reason: CacheCleanRefusal::UnsafeEntry,
+                    detail: "model digest entry is not a direct directory".into(),
+                });
+                continue;
+            }
+            Err(error) => {
+                errors.push(format!(
+                    "read model digest type {}: {error}",
+                    path.display()
+                ));
+                continue;
+            }
+        }
+        if !is_model_digest_name(&name) {
+            retained.push(CacheCleanRetained {
+                relative_path: relative,
+                reason: CacheCleanRefusal::UnrecognizedEntry,
+                detail: "directory name is not a SHA-256 digest".into(),
+            });
+            continue;
+        }
+        // Without a compiled digest there is nothing to compare against, so
+        // every revision stays.
+        if current.is_empty() || name == current {
+            retained.push(CacheCleanRetained {
+                relative_path: relative,
+                reason: CacheCleanRefusal::CurrentModelDigest,
+                detail: "digest matches the model compiled into this executable".into(),
+            });
+            continue;
+        }
+        match directory_size(&path) {
+            Ok(bytes) => candidates.push(CacheCleanCandidate {
+                kind: CacheCleanKind::SupersededModelDigest,
+                relative_path: relative,
+                bytes,
+                proof: format!("digest differs from the compiled model digest {current}"),
+            }),
+            Err(error) => {
+                errors.push(format!(
+                    "measure model digest {}: {error:#}",
+                    path.display()
+                ));
+                retained.push(CacheCleanRetained {
+                    relative_path: relative,
+                    reason: CacheCleanRefusal::UnsafeEntry,
+                    detail: format!("model digest directory could not be measured: {error:#}"),
+                });
+            }
+        }
+    }
+}
+
+fn is_workspace_cache_name(name: &str) -> bool {
+    name.len() == WORKSPACE_ID_HEX_LEN && name.bytes().all(is_lowercase_hex)
+}
+
+fn is_model_digest_name(name: &str) -> bool {
+    name.len() == MODEL_DIGEST_HEX_LEN && name.bytes().all(is_lowercase_hex)
+}
+
+const fn is_lowercase_hex(byte: u8) -> bool {
+    byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{SidecarLayout, with_test_cache_root};
+    use crate::retention::{GenerationRetentionMarker, write_retention_marker};
+    use codestory_store::RetrievalIndexManifest;
+    use sha2::{Digest, Sha256};
+    use std::collections::BTreeMap;
+    use tempfile::{TempDir, tempdir};
+
+    const OTHER_DIGEST: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+
+    fn snapshot_tree(root: &Path) -> BTreeMap<String, String> {
+        let mut entries = BTreeMap::new();
+        collect_tree(root, root, &mut entries);
+        entries
+    }
+
+    fn collect_tree(root: &Path, dir: &Path, entries: &mut BTreeMap<String, String>) {
+        let Ok(read_dir) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .expect("entry is below the snapshot root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let metadata = std::fs::symlink_metadata(&path).expect("inspect snapshot entry");
+            if metadata.is_dir() {
+                entries.insert(format!("{relative}/"), "<dir>".to_string());
+                collect_tree(root, &path, entries);
+            } else {
+                let bytes = std::fs::read(&path).expect("read snapshot entry");
+                let digest = Sha256::digest(&bytes);
+                entries.insert(relative, format!("{}:{digest:x}", bytes.len()));
+            }
+        }
+    }
+
+    fn manifest(project_id: &str, suffix: &str) -> RetrievalIndexManifest {
+        RetrievalIndexManifest {
+            project_id: project_id.into(),
+            lexical_version: "v1".into(),
+            semantic_generation: format!("codestory_{project_id}_{suffix}"),
+            scip_revision: Some(format!("graph-{suffix}")),
+            built_at_epoch_ms: 1,
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+            embedding_dim: Some(768),
+            sidecar_schema_version: Some(2),
+            sidecar_input_hash: Some(suffix.repeat(4)),
+            sidecar_generation: Some(format!("{project_id}-{suffix}")),
+            projection_count: Some(1),
+            symbol_doc_count: Some(1),
+            dense_projection_count: Some(1),
+            semantic_policy_version: Some(crate::generation::SEMANTIC_POLICY_VERSION.into()),
+            graph_artifact_hash: Some("graph".into()),
+            dense_reason_counts_json: Some("{}".into()),
+            precise_semantic_import_status: None,
+            precise_semantic_import_reason: None,
+            precise_semantic_import_revision: None,
+            precise_semantic_import_producer: None,
+        }
+    }
+
+    fn state_file_for(cache_root: &Path) -> PathBuf {
+        local_state_file(cache_root)
+    }
+
+    /// A per-project cache with a byte of content, registered to `worktree`.
+    fn register_project_cache(
+        cache_root: &Path,
+        workspace_id: &str,
+        worktree: &Path,
+        suffix: &str,
+    ) {
+        let dir = cache_root.join(workspace_id);
+        std::fs::create_dir_all(&dir).expect("project cache dir");
+        std::fs::write(dir.join("codestory.db"), vec![b'x'; 16]).expect("project cache store");
+        let marker = GenerationRetentionMarker::next(
+            workspace_id,
+            worktree,
+            manifest("repo-v1-project", suffix),
+            None,
+            1,
+        )
+        .expect("registration marker");
+        write_retention_marker(&state_file_for(cache_root), &marker).expect("write marker");
+    }
+
+    fn write_model_digest(cache_root: &Path, digest: &str, bytes: usize) {
+        let dir = embedded_model_digest_root(cache_root).join(digest);
+        std::fs::create_dir_all(&dir).expect("model digest dir");
+        std::fs::write(dir.join("model.gguf"), vec![b'm'; bytes]).expect("model bytes");
+    }
+
+    fn retained_reason(plan: &CacheCleanPlan, relative: &str) -> Option<CacheCleanRefusal> {
+        plan.retained
+            .iter()
+            .find(|entry| entry.relative_path == relative)
+            .map(|entry| entry.reason)
+    }
+
+    fn candidate_kinds(plan: &CacheCleanPlan) -> Vec<(String, CacheCleanKind)> {
+        plan.candidates
+            .iter()
+            .map(|candidate| (candidate.relative_path.clone(), candidate.kind))
+            .collect()
+    }
+
+    struct Fixture {
+        cache: TempDir,
+        _worktrees: TempDir,
+        live_workspace: String,
+        dead_workspace: String,
+        unregistered_workspace: String,
+    }
+
+    /// One cache root holding, side by side: a live registered workspace, a
+    /// registered workspace whose worktree was deleted, an unregistered
+    /// workspace, the current model digest, and a superseded one.
+    fn fixture() -> Fixture {
+        let cache = tempdir().expect("cache root");
+        let worktrees = tempdir().expect("worktrees");
+        let live_root = worktrees.path().join("live");
+        let dead_root = worktrees.path().join("dead");
+        std::fs::create_dir_all(&live_root).expect("live worktree");
+        std::fs::create_dir_all(&dead_root).expect("dead worktree");
+        let live_workspace = "aaaa000000000001".to_string();
+        let dead_workspace = "bbbb000000000002".to_string();
+        let unregistered_workspace = "cccc000000000003".to_string();
+        register_project_cache(
+            cache.path(),
+            &live_workspace,
+            &live_root,
+            "aaaaaaaaaaaaaaaa",
+        );
+        register_project_cache(
+            cache.path(),
+            &dead_workspace,
+            &dead_root,
+            "bbbbbbbbbbbbbbbb",
+        );
+        let unregistered = cache.path().join(&unregistered_workspace);
+        std::fs::create_dir_all(&unregistered).expect("unregistered cache");
+        std::fs::write(unregistered.join("codestory.db"), b"unregistered")
+            .expect("unregistered store");
+        write_model_digest(cache.path(), codestory_llama_sys::MODEL_SHA256, 8);
+        write_model_digest(cache.path(), OTHER_DIGEST, 12);
+        std::fs::remove_dir_all(&dead_root).expect("retire the dead worktree");
+        Fixture {
+            cache,
+            _worktrees: worktrees,
+            live_workspace,
+            dead_workspace,
+            unregistered_workspace,
+        }
+    }
+
+    #[test]
+    fn a_dry_run_plan_leaves_the_cache_tree_byte_identical() {
+        let fixture = fixture();
+        let before = snapshot_tree(fixture.cache.path());
+
+        let plan = with_test_cache_root(fixture.cache.path(), || {
+            plan_cache_clean().expect("cache clean plan")
+        });
+
+        assert_eq!(
+            before,
+            snapshot_tree(fixture.cache.path()),
+            "planning cleanup must not add, remove, or rewrite one byte"
+        );
+        assert!(plan.dry_run);
+        assert!(plan.reclaimable_bytes > 0);
+    }
+
+    #[test]
+    fn only_a_retired_registration_and_a_superseded_digest_are_candidates() {
+        let fixture = fixture();
+
+        let plan = with_test_cache_root(fixture.cache.path(), || {
+            plan_cache_clean().expect("cache clean plan")
+        });
+
+        let superseded = format!("embedded-models/sha256/{OTHER_DIGEST}");
+        assert_eq!(
+            candidate_kinds(&plan),
+            vec![
+                (
+                    fixture.dead_workspace.clone(),
+                    CacheCleanKind::AbandonedProjectCache
+                ),
+                (superseded.clone(), CacheCleanKind::SupersededModelDigest),
+            ]
+        );
+        assert_eq!(
+            retained_reason(&plan, &fixture.live_workspace),
+            Some(CacheCleanRefusal::LiveWorkspace)
+        );
+        assert_eq!(
+            retained_reason(&plan, &fixture.unregistered_workspace),
+            Some(CacheCleanRefusal::UnregisteredWorkspace)
+        );
+        assert_eq!(
+            retained_reason(
+                &plan,
+                &format!(
+                    "embedded-models/sha256/{}",
+                    codestory_llama_sys::MODEL_SHA256
+                )
+            ),
+            Some(CacheCleanRefusal::CurrentModelDigest)
+        );
+        assert!(plan.errors.is_empty(), "{:?}", plan.errors);
+    }
+
+    #[test]
+    fn apply_removes_the_proven_candidates_and_nothing_else() {
+        let fixture = fixture();
+        let cache_root = fixture.cache.path().to_path_buf();
+
+        let report = with_test_cache_root(&cache_root, || {
+            apply_cache_clean().expect("cache clean apply")
+        });
+
+        assert!(!report.dry_run);
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(
+            report
+                .removals
+                .iter()
+                .map(|removal| (removal.relative_path.as_str(), removal.removed))
+                .collect::<Vec<_>>(),
+            vec![
+                (fixture.dead_workspace.as_str(), true),
+                (
+                    format!("embedded-models/sha256/{OTHER_DIGEST}").as_str(),
+                    true
+                ),
+            ]
+        );
+        assert!(!cache_root.join(&fixture.dead_workspace).exists());
+        assert!(
+            !embedded_model_digest_root(&cache_root)
+                .join(OTHER_DIGEST)
+                .exists()
+        );
+        assert!(cache_root.join(&fixture.live_workspace).is_dir());
+        assert!(cache_root.join(&fixture.unregistered_workspace).is_dir());
+        assert!(
+            embedded_model_digest_root(&cache_root)
+                .join(codestory_llama_sys::MODEL_SHA256)
+                .is_dir()
+        );
+    }
+
+    /// Annotations are authored, not derived. A workspace that no longer
+    /// exists cannot regenerate them, so proven abandonment is not licence to
+    /// take them.
+    #[test]
+    fn a_retired_cache_holding_annotations_is_not_removed() {
+        let fixture = fixture();
+        let cache_root = fixture.cache.path().to_path_buf();
+        std::fs::write(
+            cache_root
+                .join(&fixture.dead_workspace)
+                .join(ANNOTATIONS_SIDECAR_FILE),
+            b"authored annotations",
+        )
+        .expect("annotations sidecar");
+
+        let report = with_test_cache_root(&cache_root, || {
+            apply_cache_clean().expect("cache clean apply")
+        });
+
+        assert!(
+            cache_root
+                .join(&fixture.dead_workspace)
+                .join(ANNOTATIONS_SIDECAR_FILE)
+                .exists(),
+            "cleanup must never take authored annotations"
+        );
+        assert_eq!(
+            retained_reason(&report.plan, &fixture.dead_workspace),
+            Some(CacheCleanRefusal::AnnotationsPresent)
+        );
+        assert_eq!(
+            report
+                .removals
+                .iter()
+                .map(|removal| removal.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![format!("embedded-models/sha256/{OTHER_DIGEST}").as_str()]
+        );
+    }
+
+    /// A schema-1 marker registers nothing, so its cache can never be proven
+    /// abandoned no matter how long the worktree has been gone.
+    #[test]
+    fn a_schema_1_registration_never_makes_a_cache_removable() {
+        let cache = tempdir().expect("cache root");
+        let workspace_id = "dddd000000000004";
+        let dir = cache.path().join(workspace_id);
+        std::fs::create_dir_all(&dir).expect("project cache dir");
+        std::fs::write(dir.join("codestory.db"), b"legacy").expect("store");
+        let legacy = GenerationRetentionMarker {
+            schema_version: crate::retention::RETENTION_MARKER_SCHEMA_V1,
+            workspace_id: workspace_id.into(),
+            project_id: "repo-v1-project".into(),
+            active: manifest("repo-v1-project", "aaaaaaaaaaaaaaaa"),
+            rollback: None,
+            updated_at_epoch_ms: 1,
+            owner: None,
+            generation: None,
+            heartbeat_epoch_ms: None,
+        };
+        let state_file = state_file_for(cache.path());
+        crate::retention::ensure_retention_dir(&state_file).expect("retention dir");
+        std::fs::write(
+            crate::retention::retention_marker_path(&state_file, workspace_id)
+                .expect("marker path"),
+            serde_json::to_vec(&legacy).expect("serialize legacy marker"),
+        )
+        .expect("write legacy marker");
+
+        let plan = with_test_cache_root(cache.path(), || {
+            plan_cache_clean().expect("cache clean plan")
+        });
+
+        assert!(candidate_kinds(&plan).is_empty(), "{:?}", plan.candidates);
+        assert_eq!(
+            retained_reason(&plan, workspace_id),
+            Some(CacheCleanRefusal::UnregisteredWorkspace)
+        );
+    }
+
+    /// An unplugged drive or unmounted share makes the whole ancestor path
+    /// disappear, which looks exactly like a deleted worktree if only the leaf
+    /// is checked. An absent volume is not evidence of abandonment.
+    #[test]
+    fn a_registration_whose_whole_ancestor_path_vanished_is_not_proven_abandoned() {
+        let cache = tempdir().expect("cache root");
+        let mount = tempdir().expect("mount point");
+        let volume = mount.path().join("volume");
+        let worktree = volume.join("project");
+        std::fs::create_dir_all(&worktree).expect("worktree on the volume");
+        let workspace_id = "eeee000000000005";
+        register_project_cache(cache.path(), workspace_id, &worktree, "aaaaaaaaaaaaaaaa");
+        std::fs::remove_dir_all(&volume).expect("unmount the volume");
+
+        let plan = with_test_cache_root(cache.path(), || {
+            plan_cache_clean().expect("cache clean plan")
+        });
+
+        assert!(candidate_kinds(&plan).is_empty(), "{:?}", plan.candidates);
+        assert_eq!(
+            retained_reason(&plan, workspace_id),
+            Some(CacheCleanRefusal::UnprovenWorkspace)
+        );
+    }
+
+    #[test]
+    fn a_non_digest_directory_under_the_model_root_is_never_a_candidate() {
+        let cache = tempdir().expect("cache root");
+        let stray = embedded_model_digest_root(cache.path()).join("scratch");
+        std::fs::create_dir_all(&stray).expect("stray dir");
+        std::fs::write(stray.join("note"), b"not a digest").expect("stray file");
+
+        let plan = with_test_cache_root(cache.path(), || {
+            plan_cache_clean().expect("cache clean plan")
+        });
+
+        assert!(candidate_kinds(&plan).is_empty(), "{:?}", plan.candidates);
+        assert_eq!(
+            retained_reason(&plan, "embedded-models/sha256/scratch"),
+            Some(CacheCleanRefusal::UnrecognizedEntry)
+        );
+    }
+
+    /// The sidecar artifact roots share the cache root with per-project
+    /// caches. Only the 16-hex workspace shape may ever be considered.
+    #[test]
+    fn sidecar_artifact_roots_are_not_project_cache_candidates() {
+        let cache = tempdir().expect("cache root");
+        let layout = SidecarLayout {
+            lexical_data_dir: cache.path().join("lexical"),
+            semantic_data_dir: cache.path().join("semantic"),
+            scip_artifacts_root: cache.path().join("scip"),
+            state_file: state_file_for(cache.path()),
+        };
+        for dir in [
+            &layout.lexical_data_dir,
+            &layout.semantic_data_dir,
+            &layout.scip_artifacts_root,
+            &cache.path().join("retrieval"),
+        ] {
+            std::fs::create_dir_all(dir).expect("artifact root");
+            std::fs::write(dir.join("data"), b"artifact").expect("artifact bytes");
+        }
+
+        let plan = with_test_cache_root(cache.path(), || {
+            plan_cache_clean().expect("cache clean plan")
+        });
+
+        assert!(candidate_kinds(&plan).is_empty(), "{:?}", plan.candidates);
+        assert!(plan.retained.is_empty(), "{:?}", plan.retained);
+    }
+}

--- a/crates/codestory-retrieval/src/cache_clean.rs
+++ b/crates/codestory-retrieval/src/cache_clean.rs
@@ -1,5 +1,4 @@
-//! Proof-owned cleanup for cache-root state no live workspace or running
-//! executable can still claim.
+//! Proof-owned cleanup for cache-root state no live workspace can still claim.
 //!
 //! Generation retention already reclaims superseded generations inside one
 //! project's sidecar tree. Two things sit outside it and were never reclaimed:
@@ -9,10 +8,24 @@
 //!
 //! Both are removed only against positive proof, never against a heuristic.
 //! A project cache is removable only when a schema-2 retention marker
-//! registered a project root that is now provably gone; a model tree is
+//! registered a project root that is now provably gone *and* the directory was
+//! read end to end without finding one authored annotation; a model tree is
 //! removable only when its digest differs from the digest compiled into this
-//! binary. Everything else is reported as retained with a typed reason, so the
-//! plan reads as an audit rather than as a list of guesses.
+//! binary and no peer holds its materialization lock. Everything else is
+//! reported as retained with a typed reason, so the plan reads as an audit
+//! rather than as a list of guesses.
+//!
+//! Two proof limits are deliberate and named rather than implied:
+//!
+//! - A model tree proves "not the revision this executable was built with" and
+//!   "not being materialized right now". It does not prove that no separately
+//!   installed CodeStory executable is running with that revision mapped.
+//!   Reclamation is still safe on POSIX, where unlinking an open file leaves
+//!   the mapping intact, and fails loudly on Windows, where the open handle
+//!   refuses the delete; a peer never observes a truncated model.
+//! - Absence of authored annotations must be *read*, never inferred from a
+//!   missing file. Anything this reader cannot open, parse, or enumerate
+//!   leaves the cache in place.
 
 use crate::config::{SidecarRuntimeConfig, user_cache_root};
 use crate::retention::{
@@ -20,11 +33,17 @@ use crate::retention::{
     classify_retention_entry, directory_size, global_generation_gc_state_file, read_marker_path,
     retention_dir,
 };
-use anyhow::{Context, Result};
-use codestory_contracts::owned_artifacts::{ANNOTATIONS_SIDECAR_FILE, embedded_model_digest_root};
+use anyhow::{Context, Result, anyhow};
+use codestory_contracts::bounded_locks::{self, FileLockKind};
+use codestory_contracts::owned_artifacts::{
+    ANNOTATIONS_SIDECAR_FILE, EMBEDDED_MODEL_MATERIALIZE_LOCK_FILE, ROLLBACK_BACKUP_EXTENSION,
+    SQLITE_SIDECAR_SUFFIXES, embedded_model_digest_root,
+};
+use codestory_store::Store;
 use codestory_workspace::owned_deletion::OwnedDeletionRoot;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
 /// Wire version of the plan and report documents.
@@ -63,10 +82,17 @@ pub enum CacheCleanRefusal {
     CurrentModelDigest,
     /// Inside a CodeStory-owned tree but not a shape this planner recognizes.
     UnrecognizedEntry,
-    /// A proven-abandoned cache still holds the annotations sidecar. Its
-    /// contents are authored, not derived, so a lost workspace cannot
-    /// regenerate them and cleanup will not take them.
+    /// A proven-abandoned cache holds authored annotations, in the versioned
+    /// sidecar or in the core store's own `bookmark_category` /
+    /// `bookmark_node` tables. Their contents are authored, not derived, so a
+    /// lost workspace cannot regenerate them and cleanup will not take them.
     AnnotationsPresent,
+    /// A proven-abandoned cache could not be *read* well enough to prove it
+    /// holds no authored annotation. Absence is never inferred from a missing
+    /// file, so an unreadable or unopenable cache is refused.
+    AnnotationsUnproven,
+    /// A model tree whose materialization lock a peer currently holds.
+    ModelTreeInUse,
     /// The entry could not be measured or inspected safely.
     UnsafeEntry,
 }
@@ -80,6 +106,8 @@ impl CacheCleanRefusal {
             Self::CurrentModelDigest => "current_model_digest",
             Self::UnrecognizedEntry => "unrecognized_entry",
             Self::AnnotationsPresent => "annotations_present",
+            Self::AnnotationsUnproven => "annotations_unproven",
+            Self::ModelTreeInUse => "model_tree_in_use",
             Self::UnsafeEntry => "unsafe_entry",
         }
     }
@@ -396,14 +424,26 @@ fn plan_project_caches(
 
         // Authored annotations are the one artifact in a cache directory that
         // a vanished workspace cannot reproduce, so proven abandonment is not
-        // enough to take them.
-        if path.join(ANNOTATIONS_SIDECAR_FILE).exists() {
-            retained.push(CacheCleanRetained {
-                relative_path: name,
-                reason: CacheCleanRefusal::AnnotationsPresent,
-                detail: "abandoned cache still holds authored annotations".into(),
-            });
-            continue;
+        // enough to take them. Presence is read out of the directory, never
+        // inferred from one file name, and anything unreadable refuses.
+        match observe_authored_annotations(&path) {
+            AnnotationEvidence::ProvenAbsent => {}
+            AnnotationEvidence::Present(detail) => {
+                retained.push(CacheCleanRetained {
+                    relative_path: name,
+                    reason: CacheCleanRefusal::AnnotationsPresent,
+                    detail,
+                });
+                continue;
+            }
+            AnnotationEvidence::Unproven(detail) => {
+                retained.push(CacheCleanRetained {
+                    relative_path: name,
+                    reason: CacheCleanRefusal::AnnotationsUnproven,
+                    detail,
+                });
+                continue;
+            }
         }
 
         match directory_size(&path) {
@@ -425,6 +465,247 @@ fn plan_project_caches(
                 });
             }
         }
+    }
+}
+
+/// What one cache directory proves about authored annotations.
+///
+/// Annotations live in two places at once during the sidecar cutover: the
+/// versioned annotations sidecar, and the core store's own `bookmark_category`
+/// and `bookmark_node` tables for every cache that has not cut over yet. The
+/// cutover is lazy -- it happens on an annotation write or a core-replacing
+/// operation -- and an abandoned worktree is by definition never re-opened, so
+/// its cache is the one population that can *never* have cut over. Testing for
+/// the sidecar file therefore proves nothing about exactly the caches this
+/// planner is allowed to delete.
+#[derive(Debug)]
+enum AnnotationEvidence {
+    /// Every annotation-bearing artifact under the directory was read and
+    /// holds no authored row.
+    ProvenAbsent,
+    /// Authored annotations exist here.
+    Present(String),
+    /// Absence could not be proven, so the cache stays.
+    Unproven(String),
+}
+
+/// Read one cache directory end to end for authored annotations.
+///
+/// Observation only: stores are opened through the non-mutating observer, so
+/// planning cannot migrate, recover, or create a sidecar in a cache this
+/// process does not own.
+fn observe_authored_annotations(cache_dir: &Path) -> AnnotationEvidence {
+    let mut unproven = None;
+    if let Some(present) = scan_annotation_evidence(cache_dir, &mut unproven) {
+        return AnnotationEvidence::Present(present);
+    }
+    match unproven {
+        Some(detail) => AnnotationEvidence::Unproven(detail),
+        None => AnnotationEvidence::ProvenAbsent,
+    }
+}
+
+/// Walk one directory, returning `Some(detail)` as soon as authored
+/// annotations are found.
+///
+/// Every entry this reader cannot interpret is recorded in `unproven` instead
+/// of being skipped, so a directory it could not fully read never reads as
+/// empty. The walk is the same shape the byte measurement already performs, so
+/// it costs one extra pass over metadata the planner reads anyway.
+fn scan_annotation_evidence(dir: &Path, unproven: &mut Option<String>) -> Option<String> {
+    let mut paths = Vec::new();
+    match std::fs::read_dir(dir) {
+        Ok(entries) => {
+            for entry in entries {
+                match entry {
+                    Ok(entry) => paths.push(entry.path()),
+                    Err(error) => record_unproven(
+                        unproven,
+                        format!("read entry under {}: {error}", dir.display()),
+                    ),
+                }
+            }
+        }
+        Err(error) => {
+            record_unproven(
+                unproven,
+                format!("read directory {}: {error}", dir.display()),
+            );
+            return None;
+        }
+    }
+    paths.sort();
+    for path in paths {
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                record_unproven(unproven, format!("inspect {}: {error}", path.display()));
+                continue;
+            }
+        };
+        if metadata.file_type().is_symlink() {
+            record_unproven(
+                unproven,
+                format!("cache holds a linked entry {}", path.display()),
+            );
+            continue;
+        }
+        if metadata.is_dir() {
+            if let Some(found) = scan_annotation_evidence(&path, unproven) {
+                return Some(found);
+            }
+            continue;
+        }
+        if !metadata.is_file() {
+            record_unproven(
+                unproven,
+                format!("cache holds an unsupported entry {}", path.display()),
+            );
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            record_unproven(
+                unproven,
+                format!("cache holds an unreadable entry name in {}", dir.display()),
+            );
+            continue;
+        };
+        if is_annotations_sidecar_name(name) {
+            // This binary does not own the sidecar schema, so its rows cannot
+            // be counted here. Refusing on presence is the fail-closed
+            // direction: it can only keep a cache, never take one.
+            return Some(format!(
+                "the authored annotations sidecar {} is present",
+                path.display()
+            ));
+        }
+        if let Some(main) = orphaned_sqlite_sidecar_owner(&path, name) {
+            record_unproven(
+                unproven,
+                format!(
+                    "{} is a SQLite sidecar whose database {} is missing",
+                    path.display(),
+                    main.display()
+                ),
+            );
+            continue;
+        }
+        if !is_core_store_name(name) {
+            continue;
+        }
+        match observe_legacy_annotation_rows(&path) {
+            Ok(0) => {}
+            Ok(rows) => {
+                return Some(format!(
+                    "{} holds {rows} authored annotation rows in the core bookmark tables",
+                    path.display()
+                ));
+            }
+            Err(error) => record_unproven(
+                unproven,
+                format!(
+                    "core store {} could not be read for authored annotations: {error:#}",
+                    path.display()
+                ),
+            ),
+        }
+    }
+    None
+}
+
+/// Keep the first reason absence could not be proven. One is enough to refuse,
+/// and the first entry in a sorted walk is stable across platforms.
+fn record_unproven(slot: &mut Option<String>, detail: String) {
+    if slot.is_none() {
+        *slot = Some(detail);
+    }
+}
+
+/// Count the authored rows in the core store's legacy annotation tables.
+fn observe_legacy_annotation_rows(path: &Path) -> Result<u64> {
+    let store = Store::open_observational(path)
+        .map_err(|error| anyhow!("open observationally: {error}"))?;
+    let categories = store
+        .get_bookmark_categories()
+        .map_err(|error| anyhow!("read bookmark categories: {error}"))?;
+    let bookmarks = store
+        .get_bookmarks(None)
+        .map_err(|error| anyhow!("read bookmarks: {error}"))?;
+    Ok(categories.len() as u64 + bookmarks.len() as u64)
+}
+
+fn is_annotations_sidecar_name(name: &str) -> bool {
+    name == ANNOTATIONS_SIDECAR_FILE
+        || SQLITE_SIDECAR_SUFFIXES
+            .iter()
+            .any(|suffix| name.strip_suffix(suffix) == Some(ANNOTATIONS_SIDECAR_FILE))
+}
+
+/// The database a `-wal`, `-shm`, or `-journal` file belongs to, when that
+/// database is not present. Orphaned sidecars are evidence this reader cannot
+/// interpret rather than derived bytes it may drop.
+fn orphaned_sqlite_sidecar_owner(path: &Path, name: &str) -> Option<PathBuf> {
+    let base = SQLITE_SIDECAR_SUFFIXES
+        .iter()
+        .find_map(|suffix| name.strip_suffix(suffix))?;
+    let main = path.with_file_name(base);
+    (!main.is_file()).then_some(main)
+}
+
+/// Whether one file name in a cache directory can carry the core schema, and
+/// with it the legacy `bookmark_category` and `bookmark_node` tables. The
+/// rollback backup counts: it is a whole core database, and deleting the
+/// directory takes it too.
+fn is_core_store_name(name: &str) -> bool {
+    if name.ends_with(&format!(".{ROLLBACK_BACKUP_EXTENSION}")) {
+        return true;
+    }
+    Path::new(name)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| CORE_STORE_EXTENSIONS.contains(&extension))
+}
+
+/// Extensions a core SQLite database is written with anywhere in the cache
+/// root: the live store, staged snapshots, and rehydration copies.
+const CORE_STORE_EXTENSIONS: [&str; 3] = ["db", "sqlite", "sqlite3"];
+
+/// Whether a peer currently holds one model tree's materialization lock.
+enum ModelTreeLock {
+    Free,
+    Held,
+    Unobservable(String),
+}
+
+/// Observe the materialization lock beside one model tree without creating it.
+///
+/// A dry-run plan must not be the reason the lock file first exists, so the
+/// file is opened read-only and a missing file reads as "no holder".
+fn observe_model_tree_lock(directory: &Path) -> ModelTreeLock {
+    let lock_path = directory.join(EMBEDDED_MODEL_MATERIALIZE_LOCK_FILE);
+    let file = match File::open(&lock_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return ModelTreeLock::Free,
+        Err(error) => {
+            return ModelTreeLock::Unobservable(format!(
+                "open materialization lock {}: {error}",
+                lock_path.display()
+            ));
+        }
+    };
+    match bounded_locks::try_acquire(&file, FileLockKind::Shared) {
+        Ok(true) => match bounded_locks::release(&file) {
+            Ok(()) => ModelTreeLock::Free,
+            Err(error) => ModelTreeLock::Unobservable(format!(
+                "release materialization lock {}: {error}",
+                lock_path.display()
+            )),
+        },
+        Ok(false) => ModelTreeLock::Held,
+        Err(error) => ModelTreeLock::Unobservable(format!(
+            "observe materialization lock {}: {error}",
+            lock_path.display()
+        )),
     }
 }
 
@@ -507,12 +788,33 @@ fn plan_model_digests(
             });
             continue;
         }
+        match observe_model_tree_lock(&path) {
+            ModelTreeLock::Free => {}
+            ModelTreeLock::Held => {
+                retained.push(CacheCleanRetained {
+                    relative_path: relative,
+                    reason: CacheCleanRefusal::ModelTreeInUse,
+                    detail: "a peer holds this model tree's materialization lock".into(),
+                });
+                continue;
+            }
+            ModelTreeLock::Unobservable(detail) => {
+                retained.push(CacheCleanRetained {
+                    relative_path: relative,
+                    reason: CacheCleanRefusal::UnsafeEntry,
+                    detail,
+                });
+                continue;
+            }
+        }
         match directory_size(&path) {
             Ok(bytes) => candidates.push(CacheCleanCandidate {
                 kind: CacheCleanKind::SupersededModelDigest,
                 relative_path: relative,
                 bytes,
-                proof: format!("digest differs from the compiled model digest {current}"),
+                proof: format!(
+                    "digest differs from the compiled model digest {current} and no peer holds its materialization lock"
+                ),
             }),
             Err(error) => {
                 errors.push(format!(
@@ -546,6 +848,7 @@ mod tests {
     use super::*;
     use crate::config::{SidecarLayout, with_test_cache_root};
     use crate::retention::{GenerationRetentionMarker, write_retention_marker};
+    use codestory_contracts::graph::{Node, NodeId, NodeKind};
     use codestory_store::RetrievalIndexManifest;
     use sha2::{Digest, Sha256};
     use std::collections::BTreeMap;
@@ -613,7 +916,47 @@ mod tests {
         local_state_file(cache_root)
     }
 
-    /// A per-project cache with a byte of content, registered to `worktree`.
+    /// A real, current-schema core store holding no authored annotation. The
+    /// planner reads this database, so a stand-in byte blob would prove
+    /// nothing about the guard under test.
+    fn write_derived_core_store(path: &Path) {
+        let store = Store::open(path).expect("create core store");
+        drop(store);
+        assert_eq!(
+            observe_legacy_annotation_rows(path).expect("observe a freshly created core store"),
+            0
+        );
+    }
+
+    /// The same core store with a user-authored bookmark in it: a category and
+    /// a bookmark on a node, in `bookmark_category` and `bookmark_node`.
+    fn author_bookmark_in_core_store(path: &Path) {
+        let store = Store::open(path).expect("open core store");
+        store
+            .insert_node(&Node {
+                id: NodeId(1),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "n:auth.rs:login".into(),
+                qualified_name: Some("auth::login".into()),
+                canonical_id: Some("auth::login".into()),
+                file_node_id: None,
+                start_line: Some(1),
+                start_col: Some(0),
+                end_line: Some(9),
+                end_col: Some(1),
+            })
+            .expect("insert bookmarked node");
+        let category = store
+            .create_bookmark_category("Onboarding")
+            .expect("authored bookmark category");
+        store
+            .add_bookmark(category, NodeId(1), Some("start here"))
+            .expect("authored bookmark");
+        drop(store);
+    }
+
+    /// A per-project cache holding a real core store, registered to
+    /// `worktree`.
     fn register_project_cache(
         cache_root: &Path,
         workspace_id: &str,
@@ -622,7 +965,7 @@ mod tests {
     ) {
         let dir = cache_root.join(workspace_id);
         std::fs::create_dir_all(&dir).expect("project cache dir");
-        std::fs::write(dir.join("codestory.db"), vec![b'x'; 16]).expect("project cache store");
+        write_derived_core_store(&dir.join("codestory.db"));
         let marker = GenerationRetentionMarker::next(
             workspace_id,
             worktree,
@@ -838,6 +1181,186 @@ mod tests {
                 .map(|removal| removal.relative_path.as_str())
                 .collect::<Vec<_>>(),
             vec![format!("embedded-models/sha256/{OTHER_DIGEST}").as_str()]
+        );
+    }
+
+    /// The regression this guard exists for. Bookmarks are authored in the
+    /// core store's own `bookmark_category` and `bookmark_node` tables, and
+    /// the annotations sidecar only appears once a cache cuts over. An
+    /// abandoned worktree is never re-opened, so it can never cut over: its
+    /// cache is exactly the population where the sidecar file is guaranteed
+    /// absent while authored bookmarks are present. Testing for the file
+    /// deleted them.
+    #[test]
+    fn a_retired_cache_with_authored_bookmarks_in_core_legacy_tables_is_not_removed() {
+        let fixture = fixture();
+        let cache_root = fixture.cache.path().to_path_buf();
+        let dead_cache = cache_root.join(&fixture.dead_workspace);
+        author_bookmark_in_core_store(&dead_cache.join("codestory.db"));
+        assert!(
+            !dead_cache.join(ANNOTATIONS_SIDECAR_FILE).exists(),
+            "the population under test is precisely the one with no sidecar"
+        );
+
+        let report = with_test_cache_root(&cache_root, || {
+            apply_cache_clean().expect("cache clean apply")
+        });
+
+        assert!(
+            dead_cache.join("codestory.db").is_file(),
+            "cleanup must never take a cache holding authored bookmarks"
+        );
+        let surviving = Store::open_observational(dead_cache.join("codestory.db"))
+            .expect("re-observe the surviving core store");
+        assert_eq!(
+            surviving
+                .get_bookmark_categories()
+                .expect("surviving categories")
+                .len(),
+            1
+        );
+        assert_eq!(
+            surviving.get_bookmarks(None).expect("surviving bookmarks")[0]
+                .comment
+                .as_deref(),
+            Some("start here")
+        );
+        assert_eq!(
+            retained_reason(&report.plan, &fixture.dead_workspace),
+            Some(CacheCleanRefusal::AnnotationsPresent)
+        );
+        assert_eq!(
+            report
+                .removals
+                .iter()
+                .map(|removal| removal.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![format!("embedded-models/sha256/{OTHER_DIGEST}").as_str()]
+        );
+    }
+
+    /// Absence of authored annotations must be read, never inferred. A core
+    /// store this binary cannot open proves nothing, so the cache stays.
+    #[test]
+    fn a_retired_cache_whose_core_store_cannot_be_observed_is_not_removed() {
+        let fixture = fixture();
+        let cache_root = fixture.cache.path().to_path_buf();
+        let dead_cache = cache_root.join(&fixture.dead_workspace);
+        std::fs::write(dead_cache.join("codestory.db"), vec![b'x'; 16])
+            .expect("unopenable core store");
+
+        let report = with_test_cache_root(&cache_root, || {
+            apply_cache_clean().expect("cache clean apply")
+        });
+
+        assert!(
+            dead_cache.is_dir(),
+            "an unreadable cache must never be deleted"
+        );
+        assert_eq!(
+            retained_reason(&report.plan, &fixture.dead_workspace),
+            Some(CacheCleanRefusal::AnnotationsUnproven)
+        );
+        assert_eq!(
+            report
+                .removals
+                .iter()
+                .map(|removal| removal.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![format!("embedded-models/sha256/{OTHER_DIGEST}").as_str()]
+        );
+    }
+
+    /// An orphaned WAL is evidence this reader cannot interpret, not derived
+    /// bytes it may drop.
+    #[test]
+    fn a_retired_cache_holding_an_orphaned_sqlite_sidecar_is_not_removed() {
+        let fixture = fixture();
+        let cache_root = fixture.cache.path().to_path_buf();
+        let dead_cache = cache_root.join(&fixture.dead_workspace);
+        std::fs::remove_file(dead_cache.join("codestory.db")).expect("drop the core store");
+        std::fs::write(dead_cache.join("codestory.db-wal"), b"orphan frames")
+            .expect("orphaned write-ahead log");
+
+        let plan = with_test_cache_root(&cache_root, || {
+            plan_cache_clean().expect("cache clean plan")
+        });
+
+        assert_eq!(
+            retained_reason(&plan, &fixture.dead_workspace),
+            Some(CacheCleanRefusal::AnnotationsUnproven)
+        );
+    }
+
+    /// A model tree a peer is materializing right now is not reclaimable, and
+    /// observing that must not create the lock file.
+    #[test]
+    fn a_superseded_model_tree_whose_materialization_lock_is_held_is_not_removed() {
+        let fixture = fixture();
+        let cache_root = fixture.cache.path().to_path_buf();
+        let superseded = embedded_model_digest_root(&cache_root).join(OTHER_DIGEST);
+        let lock_path = superseded.join(EMBEDDED_MODEL_MATERIALIZE_LOCK_FILE);
+        std::fs::write(&lock_path, b"").expect("materialization lock file");
+        let holder = File::options()
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .expect("open the materialization lock");
+        assert!(
+            bounded_locks::try_acquire(&holder, FileLockKind::Exclusive)
+                .expect("hold the materialization lock"),
+            "the peer must actually hold the lock"
+        );
+
+        let report = with_test_cache_root(&cache_root, || {
+            apply_cache_clean().expect("cache clean apply")
+        });
+
+        assert!(
+            superseded.is_dir(),
+            "a model tree a peer is materializing must not be reclaimed"
+        );
+        assert_eq!(
+            retained_reason(
+                &report.plan,
+                &format!("embedded-models/sha256/{OTHER_DIGEST}")
+            ),
+            Some(CacheCleanRefusal::ModelTreeInUse)
+        );
+        assert_eq!(
+            report
+                .removals
+                .iter()
+                .map(|removal| removal.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![fixture.dead_workspace.as_str()]
+        );
+        bounded_locks::release(&holder).expect("release the materialization lock");
+    }
+
+    /// Observation never creates the lock file a dry run only wanted to read.
+    #[test]
+    fn planning_does_not_create_a_model_materialization_lock() {
+        let cache = tempdir().expect("cache root");
+        write_model_digest(cache.path(), OTHER_DIGEST, 12);
+        let lock_path = embedded_model_digest_root(cache.path())
+            .join(OTHER_DIGEST)
+            .join(EMBEDDED_MODEL_MATERIALIZE_LOCK_FILE);
+
+        let plan = with_test_cache_root(cache.path(), || {
+            plan_cache_clean().expect("cache clean plan")
+        });
+
+        assert!(
+            !lock_path.exists(),
+            "a dry-run plan must not be the reason the lock file exists"
+        );
+        assert_eq!(
+            candidate_kinds(&plan),
+            vec![(
+                format!("embedded-models/sha256/{OTHER_DIGEST}"),
+                CacheCleanKind::SupersededModelDigest
+            )]
         );
     }
 

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -12,7 +12,7 @@ pub const DEFAULT_AGENT_RUN_ID: &str = "shared-agent";
 
 const LOCAL_RETRIEVAL_NAMESPACE: &str = "codestory-v3";
 const AGENT_RETRIEVAL_NAMESPACE_PREFIX: &str = "codestory-agent-v3-";
-const RETRIEVAL_STATE_FILE: &str = "retrieval-generations-v1.state";
+pub(crate) const RETRIEVAL_STATE_FILE: &str = "retrieval-generations-v1.state";
 const RETRIEVAL_ARTIFACTS_DIR: &str = "retrieval";
 const RUNTIME_ENV_KEYS: &[&str] = &[
     "CODESTORY_RETRIEVAL_PROFILE",

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -1422,6 +1422,7 @@ fn persist_finalized_manifest(
         &storage,
         retention_context.layout,
         retention_context.workspace_id,
+        project_root,
         &project_id,
     ) {
         Ok(()) => None,
@@ -1527,6 +1528,7 @@ fn publish_derived_retention_marker(
     storage: &Store,
     layout: &SidecarLayout,
     workspace_id: &str,
+    project_root: &Path,
     project_id: &str,
 ) -> Result<()> {
     let (active, rollback) = storage
@@ -1535,6 +1537,7 @@ fn publish_derived_retention_marker(
         .context("committed retrieval publication is missing")?;
     let marker = GenerationRetentionMarker::next(
         workspace_id,
+        project_root,
         active,
         rollback,
         Utc::now().timestamp_millis(),
@@ -3386,6 +3389,7 @@ mod tests {
         let state_file = storage_dir.path().join("state/retrieval-sidecars.json");
         let marker = GenerationRetentionMarker::next(
             "workspace",
+            storage_dir.path(),
             old_manifest.clone(),
             Some(RetrievalIndexRollbackRecord {
                 manifest: rollback_manifest,
@@ -3621,8 +3625,14 @@ mod tests {
         std::fs::write(&marker_blocker, b"not a directory").expect("marker blocker");
         let mut blocked_layout = runtime.layout.clone();
         blocked_layout.state_file = marker_blocker.join("retrieval.state");
-        publish_derived_retention_marker(&storage, &blocked_layout, "workspace", "proj")
-            .expect_err("derived marker failure happens after SQLite commit");
+        publish_derived_retention_marker(
+            &storage,
+            &blocked_layout,
+            "workspace",
+            storage_dir.path(),
+            "proj",
+        )
+        .expect_err("derived marker failure happens after SQLite commit");
         assert_eq!(
             storage
                 .get_retrieval_index_publication("proj")

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -5,7 +5,7 @@ use crate::generation::{
 use crate::retention::{
     FsGenerationRemover, GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport,
     GenerationRetentionLock, GenerationRetentionPlan, GenerationRetentionState,
-    apply_generation_retention, global_generation_gc_state_file,
+    ObservedRetentionLock, apply_generation_retention, global_generation_gc_state_file,
     plan_generation_retention_with_unrooted_state, scan_retention_protection,
 };
 use anyhow::{Context, Result};
@@ -86,10 +86,12 @@ fn generation_retention_plan_for_storage(
 fn inventory_retention_view(
     runtime: &SidecarRuntimeConfig,
     project_id: &str,
-) -> Result<(Option<GenerationRetentionLock>, GenerationRetentionState)> {
-    let lock = GenerationRetentionLock::try_acquire_shared(&runtime.layout.state_file, project_id)
+) -> Result<(ObservedRetentionLock, GenerationRetentionState)> {
+    // Observation only: a dry-run inventory must not be the reason the
+    // retention directory or its lock file first exists.
+    let lock = GenerationRetentionLock::observe_shared(&runtime.layout.state_file, project_id)
         .context("observe retrieval generation inventory lock")?;
-    let state = if lock.is_some() {
+    let state = if lock.is_quiescent() {
         GenerationRetentionState::Reclaimable
     } else {
         GenerationRetentionState::Building
@@ -128,7 +130,10 @@ fn build_generation_retention_plan(
     let mut protection =
         scan_retention_protection(cache_root, Some(storage_path), &layout.state_file);
     let manifest = if storage_path.is_file() {
-        match Store::open(storage_path) {
+        // Planning retention is observation, including of the caller's own
+        // store: a plan must never be the thing that migrates or recovers the
+        // database it is reasoning about.
+        match Store::open_observational(storage_path) {
             Ok(store) => match store.get_retrieval_index_manifest(project_id) {
                 Ok(Some(manifest)) => {
                     record_manifest_freshness(
@@ -149,9 +154,10 @@ fn build_generation_retention_plan(
                 }
             },
             Err(error) => {
+                protection.protection_incomplete = true;
                 protection
                     .errors
-                    .push(format!("open active storage for retention: {error:#}"));
+                    .push(format!("observe active storage for retention: {error:#}"));
                 None
             }
         }
@@ -202,5 +208,146 @@ fn record_manifest_freshness(
         errors.push(format!(
             "active retrieval manifest is stale; pruning suppressed: {reason}"
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::with_test_cache_root;
+    use sha2::{Digest, Sha256};
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    /// Every path below `root`, mapped to the exact bytes it holds. A missing
+    /// entry, an added entry, or one changed byte all show up as an inequality.
+    fn snapshot_tree(root: &Path) -> BTreeMap<String, String> {
+        let mut entries = BTreeMap::new();
+        collect_tree(root, root, &mut entries);
+        entries
+    }
+
+    fn collect_tree(root: &Path, dir: &Path, entries: &mut BTreeMap<String, String>) {
+        let Ok(read_dir) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .expect("entry is below the snapshot root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let metadata = std::fs::symlink_metadata(&path).expect("inspect snapshot entry");
+            if metadata.is_dir() {
+                entries.insert(format!("{relative}/"), "<dir>".to_string());
+                collect_tree(root, &path, entries);
+            } else {
+                let bytes = std::fs::read(&path).expect("read snapshot entry");
+                let digest = Sha256::digest(&bytes);
+                entries.insert(relative, format!("{}:{digest:x}", bytes.len()));
+            }
+        }
+    }
+
+    fn create_store(path: &Path) {
+        std::fs::create_dir_all(path.parent().expect("storage parent"))
+            .expect("create storage parent");
+        let store = Store::open(path).expect("create store");
+        drop(store);
+    }
+
+    fn schema_version(path: &Path) -> i64 {
+        let connection = rusqlite::Connection::open(path).expect("open sqlite");
+        let version = connection
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("read user_version");
+        drop(connection);
+        version
+    }
+
+    fn set_schema_version(path: &Path, version: i64) {
+        let connection = rusqlite::Connection::open(path).expect("open sqlite");
+        connection
+            .pragma_update(None, "user_version", version)
+            .expect("write user_version");
+        drop(connection);
+    }
+
+    /// A version-skewed neighbour: another project's cache left at the schema
+    /// an older binary wrote. The activating open path would migrate it in
+    /// place; an inventory has no right to.
+    fn skewed_neighbour_cache(cache_root: &Path, name: &str) -> PathBuf {
+        let storage = cache_root.join(name).join("codestory.db");
+        create_store(&storage);
+        let current = schema_version(&storage);
+        set_schema_version(&storage, current - 1);
+        storage
+    }
+
+    #[test]
+    fn dry_run_inventory_leaves_the_cache_tree_byte_identical() {
+        let cache = tempdir().expect("cache root");
+        let project = tempdir().expect("project root");
+        let workspace_id = codestory_workspace::workspace_id_v3_for_root(project.path());
+        let active_storage = cache.path().join(&workspace_id).join("codestory.db");
+        create_store(&active_storage);
+        let neighbour = skewed_neighbour_cache(cache.path(), "00112233445566aa");
+        let active_schema = schema_version(&active_storage);
+
+        let before = snapshot_tree(cache.path());
+        let report = with_test_cache_root(cache.path(), || {
+            sidecar_inventory_with_storage(project.path(), &active_storage)
+                .expect("dry-run inventory")
+        });
+        let after = snapshot_tree(cache.path());
+
+        assert_eq!(
+            before, after,
+            "a dry-run inventory must not add, remove, or rewrite one byte of the cache tree"
+        );
+        assert_eq!(
+            schema_version(&neighbour),
+            active_schema - 1,
+            "the neighbour cache must still be at the schema its owner left it on"
+        );
+        let plan = report
+            .generation_retention
+            .as_ref()
+            .expect("inventory reports a retention plan");
+        assert!(
+            plan.pruning_suppressed,
+            "a cache holding an unobservable neighbour must not prune"
+        );
+        assert!(
+            plan.errors
+                .iter()
+                .any(|error| error.contains("observe retrieval manifests in")
+                    && error.contains("00112233445566aa")),
+            "the skewed neighbour must be reported as unobservable, got {:?}",
+            plan.errors
+        );
+    }
+
+    #[test]
+    fn dry_run_inventory_does_not_create_the_retention_lock_it_observes() {
+        let cache = tempdir().expect("cache root");
+        let project = tempdir().expect("project root");
+        let workspace_id = codestory_workspace::workspace_id_v3_for_root(project.path());
+        let active_storage = cache.path().join(&workspace_id).join("codestory.db");
+        create_store(&active_storage);
+        let retention_dir = cache.path().join("retention");
+
+        with_test_cache_root(cache.path(), || {
+            sidecar_inventory_with_storage(project.path(), &active_storage)
+                .expect("dry-run inventory")
+        });
+
+        assert!(
+            !retention_dir.exists(),
+            "observing the retention lock must not be what creates {}",
+            retention_dir.display()
+        );
     }
 }

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -10,6 +10,7 @@
 //! checks and revalidate generations before serving cached retrieval results.
 
 mod cache;
+mod cache_clean;
 mod candidate;
 mod capabilities;
 mod config;
@@ -42,6 +43,11 @@ mod sidecar_search;
 pub mod test_support;
 
 pub use cache::{RetrievalCache, RetrievalCacheKey};
+pub use cache_clean::{
+    CACHE_CLEAN_SCHEMA_VERSION, CacheCleanCandidate, CacheCleanKind, CacheCleanPlan,
+    CacheCleanRefusal, CacheCleanRemoval, CacheCleanReport, CacheCleanRetained, apply_cache_clean,
+    plan_cache_clean,
+};
 pub use candidate::{CandidateHit, CandidateSource, RankFeatures};
 pub use candidate::{is_phantom_sidecar_hit, phantom_sidecar_candidates_only};
 pub use capabilities::SidecarCapabilities;
@@ -148,7 +154,8 @@ pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
 pub use retention::{
     GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport, GenerationRetentionLock,
-    GenerationRetentionPlan, global_generation_gc_state_file,
+    GenerationRetentionPlan, MarkerRetirement, ObservedRetentionLock, RETENTION_MARKER_SCHEMA_V1,
+    RETENTION_MARKER_SCHEMA_V2, global_generation_gc_state_file,
 };
 pub use scip_client::ScipClient;
 pub use sidecar::{

--- a/crates/codestory-retrieval/src/retention.rs
+++ b/crates/codestory-retrieval/src/retention.rs
@@ -13,8 +13,23 @@ use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-const RETENTION_SCHEMA_VERSION: u32 = 1;
+/// Marker schema 1: no workspace registration, so its roots can never be
+/// proven retired. Still read so a peer running an older binary keeps pinning
+/// the generations it is serving.
+pub const RETENTION_MARKER_SCHEMA_V1: u32 = 1;
+/// Marker schema 2 adds the workspace registration (`owner`), the canonical
+/// generation it pins, and a heartbeat, which is what lets a dead worktree be
+/// retired instead of pinning its generations forever.
+pub const RETENTION_MARKER_SCHEMA_V2: u32 = 2;
+/// The schema this binary writes. Readers accept every schema in
+/// [`RETENTION_MARKER_SCHEMA_V1`]..=[`RETENTION_MARKER_SCHEMA_V2`].
+const RETENTION_SCHEMA_VERSION: u32 = RETENTION_MARKER_SCHEMA_V2;
 const RETENTION_DIR: &str = "retention";
+/// Extensions the retention directory is allowed to contain. Anything else is
+/// evidence this reader does not understand, so it protects instead of being
+/// skipped: a future marker encoding must not silently read as "no roots".
+const RETENTION_MARKER_EXTENSION: &str = "json";
+const RETENTION_LOCK_EXTENSION: &str = "lock";
 pub const GLOBAL_GENERATION_GC_LOCK_SCOPE: &str = "global_generation_gc";
 
 pub fn global_generation_gc_state_file(runtime: &SidecarRuntimeConfig) -> PathBuf {
@@ -31,6 +46,18 @@ pub fn global_generation_gc_state_file(runtime: &SidecarRuntimeConfig) -> PathBu
     base.join("generation-retention-coordination.state")
 }
 
+/// Workspace registration carried by a schema-2 marker.
+///
+/// `project_root` is the registration itself: without it a marker's roots can
+/// never be proven retired, which is why a schema-1 marker stays protected
+/// forever. `workspace_id` is repeated here so a registration copied into the
+/// wrong marker file fails validation rather than retiring another workspace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetentionMarkerOwner {
+    pub workspace_id: String,
+    pub project_root: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GenerationRetentionMarker {
     pub schema_version: u32,
@@ -40,11 +67,24 @@ pub struct GenerationRetentionMarker {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rollback: Option<RetrievalIndexRollbackRecord>,
     pub updated_at_epoch_ms: i64,
+    /// Schema 2 only. Absent in a schema-1 marker, which dual-read still
+    /// accepts as an unretirable root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<RetentionMarkerOwner>,
+    /// Schema 2 only: the canonical generation this marker pins, recorded so a
+    /// reader can report the pin without re-deriving it from the manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<String>,
+    /// Schema 2 only: last time the registering workspace refreshed this
+    /// marker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heartbeat_epoch_ms: Option<i64>,
 }
 
 impl GenerationRetentionMarker {
     pub fn next(
         workspace_id: &str,
+        project_root: &Path,
         active: RetrievalIndexManifest,
         verified_previous: Option<RetrievalIndexRollbackRecord>,
         updated_at_epoch_ms: i64,
@@ -57,6 +97,10 @@ impl GenerationRetentionMarker {
                     .ok()
                     .is_some_and(|generation| generation != active_generation)
         });
+        let project_root = project_root
+            .to_str()
+            .context("workspace registration requires a UTF-8 project root")?
+            .to_string();
         let marker = Self {
             schema_version: RETENTION_SCHEMA_VERSION,
             workspace_id: workspace_id.to_string(),
@@ -64,9 +108,76 @@ impl GenerationRetentionMarker {
             active,
             rollback,
             updated_at_epoch_ms,
+            owner: Some(RetentionMarkerOwner {
+                workspace_id: workspace_id.to_string(),
+                project_root,
+            }),
+            generation: Some(active_generation),
+            heartbeat_epoch_ms: Some(updated_at_epoch_ms),
         };
         validate_marker(&marker)?;
         Ok(marker)
+    }
+
+    /// Whether this marker's roots may be retired without further evidence.
+    ///
+    /// Only a schema-2 registration whose recorded project root has since
+    /// disappeared qualifies. Every other shape — schema 1, an unreadable
+    /// root, or a root that still exists — keeps protecting.
+    pub fn retirement(&self) -> MarkerRetirement {
+        let Some(owner) = self.owner.as_ref() else {
+            return MarkerRetirement::UnregisteredWorkspace;
+        };
+        let project_root = Path::new(&owner.project_root);
+        match std::fs::symlink_metadata(project_root) {
+            Ok(_) => return MarkerRetirement::LiveWorkspace,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return MarkerRetirement::UnprovenWorkspace,
+        }
+        // A missing leaf under a directory that is still there is a deleted
+        // worktree. A missing leaf whose parent is also gone is indistinguishable
+        // from an unplugged drive or an unmounted network share, and an absent
+        // volume is not evidence that the workspace was abandoned.
+        let Some(parent) = project_root
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        else {
+            return MarkerRetirement::UnprovenWorkspace;
+        };
+        match std::fs::symlink_metadata(parent) {
+            Ok(metadata) if metadata.is_dir() => MarkerRetirement::RetiredWorkspace,
+            Ok(_) | Err(_) => MarkerRetirement::UnprovenWorkspace,
+        }
+    }
+}
+
+/// Why one marker's roots do or do not still protect their generations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MarkerRetirement {
+    /// Schema-1 marker: no registration exists, so retirement is unprovable.
+    UnregisteredWorkspace,
+    /// The registered project root still exists.
+    LiveWorkspace,
+    /// The registered project root could not be observed at all.
+    UnprovenWorkspace,
+    /// The registered project root is provably gone.
+    RetiredWorkspace,
+}
+
+impl MarkerRetirement {
+    /// A marker stops rooting its generations only under proven retirement.
+    pub const fn still_protects(self) -> bool {
+        !matches!(self, Self::RetiredWorkspace)
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UnregisteredWorkspace => "unregistered_workspace",
+            Self::LiveWorkspace => "live_workspace",
+            Self::UnprovenWorkspace => "unproven_workspace",
+            Self::RetiredWorkspace => "retired_workspace",
+        }
     }
 }
 
@@ -132,6 +243,34 @@ impl GenerationRetentionLock {
         }
     }
 
+    /// Observe the retention lock without creating it.
+    ///
+    /// A read-only pass may not be the reason a retention directory or lock
+    /// file first appears: an inventory that reports what exists must leave the
+    /// cache tree exactly as it found it. A lock file that does not exist
+    /// cannot be held by anyone, which is [`ObservedRetentionLock::Absent`].
+    pub fn observe_shared(state_file: &Path, scope_id: &str) -> Result<ObservedRetentionLock> {
+        let path = retention_lock_path(state_file, scope_id)?;
+        let file = match OpenOptions::new().read(true).write(true).open(&path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(ObservedRetentionLock::Absent);
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("observe generation retention lock {}", path.display())
+                });
+            }
+        };
+        match bounded_locks::try_acquire(&file, FileLockKind::Shared) {
+            Ok(true) => Ok(ObservedRetentionLock::Acquired(Self { file })),
+            Ok(false) => Ok(ObservedRetentionLock::Contended),
+            Err(error) => Err(anyhow::Error::new(error)).with_context(|| {
+                format!("try lock shared generation retention {}", path.display())
+            }),
+        }
+    }
+
     /// Every blocking retention acquisition goes through one absolute deadline:
     /// a sibling publication holding this lock must never be able to stall an
     /// unrelated query, eviction, or shutdown for longer than the caller's
@@ -170,6 +309,24 @@ impl GenerationRetentionLock {
 impl Drop for GenerationRetentionLock {
     fn drop(&mut self) {
         let _ = bounded_locks::release(&self.file);
+    }
+}
+
+/// What a non-creating observation of a retention lock found.
+#[derive(Debug)]
+pub enum ObservedRetentionLock {
+    /// No lock file exists, so no publication can be holding one.
+    Absent,
+    /// Held shared for as long as this value lives.
+    Acquired(GenerationRetentionLock),
+    /// A peer holds it exclusively right now.
+    Contended,
+}
+
+impl ObservedRetentionLock {
+    /// Whether the observation proves no exclusive holder was present.
+    pub const fn is_quiescent(&self) -> bool {
+        matches!(self, Self::Absent | Self::Acquired(_))
     }
 }
 
@@ -265,7 +422,26 @@ pub struct RetentionProtectionScan {
     pub rollback: Vec<RetrievalIndexManifest>,
     pub storage_paths_scanned: Vec<PathBuf>,
     pub marker_paths_scanned: Vec<PathBuf>,
+    /// Markers whose registered workspace is provably gone, so their roots
+    /// were deliberately not collected.
+    #[serde(default)]
+    pub retired_marker_paths: Vec<PathBuf>,
+    /// Set whenever some protection evidence could not be interpreted: an
+    /// unreadable or unknown-schema marker, an unrecognized entry in the
+    /// retention directory, a marker directory that could not be enumerated,
+    /// or a store this binary refuses to observe. It is the typed reason to
+    /// suppress pruning, so protection never depends on a caller happening to
+    /// treat a free-text error as fatal.
+    #[serde(default)]
+    pub protection_incomplete: bool,
     pub errors: Vec<String>,
+}
+
+impl RetentionProtectionScan {
+    fn record_incomplete(&mut self, message: String) {
+        self.protection_incomplete = true;
+        self.errors.push(message);
+    }
 }
 
 pub fn scan_retention_protection(
@@ -274,9 +450,15 @@ pub fn scan_retention_protection(
     state_file: &Path,
 ) -> RetentionProtectionScan {
     let mut scan = RetentionProtectionScan::default();
-    let storage_paths = storage_paths_for_scan(cache_root, active_storage_path, &mut scan.errors);
+    let storage_paths = storage_paths_for_scan(cache_root, active_storage_path, &mut scan);
     for storage_path in storage_paths {
-        match Store::open(&storage_path).and_then(|store| store.list_retrieval_index_publications())
+        // Observation only. The live open path recovers interrupted
+        // promotions, converts the journal to WAL, and runs the migration
+        // ladder, so a scan of another project's cache would rewrite a
+        // database this process does not own. An observer that refuses is
+        // reported as unreadable protection evidence instead.
+        match Store::open_observational(&storage_path)
+            .and_then(|store| store.list_retrieval_index_publications())
         {
             Ok(publications) => {
                 let manifests = publications
@@ -295,8 +477,8 @@ pub fn scan_retention_protection(
                 scan.active.extend(manifests);
                 scan.rollback.extend(rollbacks);
             }
-            Err(error) => scan.errors.push(format!(
-                "scan retrieval manifests in {}: {error}",
+            Err(error) => scan.record_incomplete(format!(
+                "observe retrieval manifests in {}: {error}",
                 storage_path.display()
             )),
         }
@@ -305,7 +487,7 @@ pub fn scan_retention_protection(
     let marker_dir = retention_dir(state_file);
     match std::fs::symlink_metadata(&marker_dir) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
-            scan.errors.push(format!(
+            scan.record_incomplete(format!(
                 "retention marker path is not a direct directory: {}",
                 marker_dir.display()
             ));
@@ -316,7 +498,7 @@ pub fn scan_retention_protection(
                     let entry = match entry {
                         Ok(entry) => entry,
                         Err(error) => {
-                            scan.errors.push(format!(
+                            scan.record_incomplete(format!(
                                 "read retention marker entry in {}: {error}",
                                 marker_dir.display()
                             ));
@@ -324,13 +506,21 @@ pub fn scan_retention_protection(
                         }
                     };
                     let path = entry.path();
-                    if path.extension().and_then(|value| value.to_str()) != Some("json") {
-                        continue;
+                    match classify_retention_entry(&path) {
+                        RetentionDirEntry::Marker => {}
+                        RetentionDirEntry::Ignorable => continue,
+                        RetentionDirEntry::Unrecognized => {
+                            scan.record_incomplete(format!(
+                                "retention directory holds evidence this reader cannot interpret: {}",
+                                path.display()
+                            ));
+                            continue;
+                        }
                     }
                     let file_type = match entry.file_type() {
                         Ok(file_type) => file_type,
                         Err(error) => {
-                            scan.errors.push(format!(
+                            scan.record_incomplete(format!(
                                 "read retention marker type {}: {error}",
                                 path.display()
                             ));
@@ -338,7 +528,7 @@ pub fn scan_retention_protection(
                         }
                     };
                     if file_type.is_symlink() || !file_type.is_file() {
-                        scan.errors.push(format!(
+                        scan.record_incomplete(format!(
                             "retention marker is not a direct regular file: {}",
                             path.display()
                         ));
@@ -346,6 +536,11 @@ pub fn scan_retention_protection(
                     }
                     match read_marker_path(&path) {
                         Ok(Some(marker)) => {
+                            let retirement = marker.retirement();
+                            if !retirement.still_protects() {
+                                scan.retired_marker_paths.push(path);
+                                continue;
+                            }
                             scan.marker_paths_scanned.push(path);
                             scan.active.push(marker.active);
                             if let Some(rollback) = marker.rollback {
@@ -353,20 +548,20 @@ pub fn scan_retention_protection(
                             }
                         }
                         Ok(None) => {}
-                        Err(error) => scan.errors.push(format!(
+                        Err(error) => scan.record_incomplete(format!(
                             "scan retention marker {}: {error:#}",
                             path.display()
                         )),
                     }
                 }
             }
-            Err(error) => scan.errors.push(format!(
+            Err(error) => scan.record_incomplete(format!(
                 "read retention marker directory {}: {error}",
                 marker_dir.display()
             )),
         },
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => scan.errors.push(format!(
+        Err(error) => scan.record_incomplete(format!(
             "inspect retention marker directory {}: {error}",
             marker_dir.display()
         )),
@@ -529,7 +724,10 @@ pub(crate) fn plan_generation_retention_with_unrooted_state(
         builders.entry(generation.clone()).or_default();
     }
 
-    let effective_unrooted_state = if errors.is_empty() {
+    // Unreadable protection evidence is its own reason to stop, independent of
+    // the free-text error list: a marker this reader cannot interpret may be
+    // rooting the very generation about to be reclaimed.
+    let effective_unrooted_state = if errors.is_empty() && !protection.protection_incomplete {
         unrooted_state
     } else {
         GenerationRetentionState::Building
@@ -810,14 +1008,44 @@ impl BundleBuilder {
     }
 }
 
-fn retention_dir(state_file: &Path) -> PathBuf {
+/// What one entry inside the retention directory means to this reader.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RetentionDirEntry {
+    /// A marker file to parse.
+    Marker,
+    /// A lock file or an in-flight atomic temporary: never protection
+    /// evidence, so skipping it loses nothing.
+    Ignorable,
+    /// Something inside a CodeStory-owned evidence directory that this reader
+    /// does not understand — treated as missing protection, not as absence.
+    Unrecognized,
+}
+
+pub(crate) fn classify_retention_entry(path: &Path) -> RetentionDirEntry {
+    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+        return RetentionDirEntry::Unrecognized;
+    };
+    // `write_file_atomic` publishes through a dot-prefixed sibling, and a
+    // crashed writer can leave one behind. Hidden files are likewise not
+    // retention evidence.
+    if name.starts_with('.') {
+        return RetentionDirEntry::Ignorable;
+    }
+    match path.extension().and_then(|value| value.to_str()) {
+        Some(RETENTION_MARKER_EXTENSION) => RetentionDirEntry::Marker,
+        Some(RETENTION_LOCK_EXTENSION) => RetentionDirEntry::Ignorable,
+        _ => RetentionDirEntry::Unrecognized,
+    }
+}
+
+pub(crate) fn retention_dir(state_file: &Path) -> PathBuf {
     state_file
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join(RETENTION_DIR)
 }
 
-fn ensure_retention_dir(state_file: &Path) -> Result<PathBuf> {
+pub(crate) fn ensure_retention_dir(state_file: &Path) -> Result<PathBuf> {
     let path = retention_dir(state_file);
     match std::fs::symlink_metadata(&path) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
@@ -859,14 +1087,51 @@ fn validate_retention_component(component: &str) -> Result<()> {
 }
 
 fn validate_marker(marker: &GenerationRetentionMarker) -> Result<()> {
-    if marker.schema_version != RETENTION_SCHEMA_VERSION {
-        bail!("unsupported generation retention marker schema");
+    // Dual-read: a peer on the previous binary still writes schema 1 and must
+    // keep pinning what it serves, so both schemas parse. Anything outside the
+    // known range is evidence this reader cannot interpret and is refused, so
+    // the caller protects instead of ignoring it.
+    match marker.schema_version {
+        RETENTION_MARKER_SCHEMA_V1 => {
+            if marker.owner.is_some()
+                || marker.generation.is_some()
+                || marker.heartbeat_epoch_ms.is_some()
+            {
+                bail!("schema 1 generation retention marker carries schema 2 registration fields");
+            }
+        }
+        RETENTION_MARKER_SCHEMA_V2 => {
+            let owner = marker
+                .owner
+                .as_ref()
+                .context("schema 2 generation retention marker is missing its workspace owner")?;
+            if owner.workspace_id != marker.workspace_id {
+                bail!(
+                    "generation retention marker owner workspace does not match marker workspace"
+                );
+            }
+
+            if owner.project_root.is_empty() {
+                bail!("generation retention marker owner has an empty project root");
+            }
+            marker
+                .heartbeat_epoch_ms
+                .context("schema 2 generation retention marker is missing its heartbeat")?;
+        }
+        _ => bail!("unsupported generation retention marker schema"),
     }
     validate_retention_component(&marker.workspace_id)?;
     if marker.project_id != marker.active.project_id {
         bail!("generation retention marker active project does not match marker project");
     }
     let active_generation = canonical_manifest_generation(&marker.active)?;
+    if marker
+        .generation
+        .as_ref()
+        .is_some_and(|generation| generation != &active_generation)
+    {
+        bail!("generation retention marker generation does not match its active manifest");
+    }
     if let Some(rollback) = marker.rollback.as_ref() {
         if rollback.manifest.project_id != marker.project_id {
             bail!("generation retention rollback project does not match marker project");
@@ -878,7 +1143,7 @@ fn validate_marker(marker: &GenerationRetentionMarker) -> Result<()> {
     Ok(())
 }
 
-fn read_marker_path(path: &Path) -> Result<Option<GenerationRetentionMarker>> {
+pub(crate) fn read_marker_path(path: &Path) -> Result<Option<GenerationRetentionMarker>> {
     if !path.exists() {
         return Ok(None);
     }
@@ -921,17 +1186,20 @@ fn canonical_suffix(suffix: &str) -> Option<&str> {
     .then_some(suffix)
 }
 
+/// Every store that may hold protection evidence. A candidate this scan cannot
+/// even enumerate is missing evidence, so it marks the scan incomplete rather
+/// than shrinking the protected set silently.
 fn storage_paths_for_scan(
     cache_root: &Path,
     active_storage_path: Option<&Path>,
-    errors: &mut Vec<String>,
+    scan: &mut RetentionProtectionScan,
 ) -> BTreeSet<PathBuf> {
     let mut paths = BTreeSet::new();
     if let Some(path) = active_storage_path {
-        insert_direct_storage_path(path, "active storage", &mut paths, errors);
+        insert_direct_storage_path(path, "active storage", &mut paths, scan);
     }
     let flat = cache_root.join("codestory.db");
-    insert_direct_storage_path(&flat, "flat cache storage", &mut paths, errors);
+    insert_direct_storage_path(&flat, "flat cache storage", &mut paths, scan);
     if !cache_root.exists() {
         return paths;
     }
@@ -943,7 +1211,7 @@ fn storage_paths_for_scan(
                         let file_type = match entry.file_type() {
                             Ok(file_type) => file_type,
                             Err(error) => {
-                                errors.push(format!(
+                                scan.record_incomplete(format!(
                                     "read cache entry type {}: {error}",
                                     entry.path().display()
                                 ));
@@ -951,7 +1219,7 @@ fn storage_paths_for_scan(
                             }
                         };
                         if file_type.is_symlink() {
-                            errors.push(format!(
+                            scan.record_incomplete(format!(
                                 "cache scan refuses linked entry {}",
                                 entry.path().display()
                             ));
@@ -965,17 +1233,17 @@ fn storage_paths_for_scan(
                             &path,
                             "project cache storage",
                             &mut paths,
-                            errors,
+                            scan,
                         );
                     }
-                    Err(error) => errors.push(format!(
+                    Err(error) => scan.record_incomplete(format!(
                         "read cache entry under {}: {error}",
                         cache_root.display()
                     )),
                 }
             }
         }
-        Err(error) => errors.push(format!(
+        Err(error) => scan.record_incomplete(format!(
             "read cache root {} for retention manifests: {error}",
             cache_root.display()
         )),
@@ -987,17 +1255,21 @@ fn insert_direct_storage_path(
     path: &Path,
     label: &str,
     paths: &mut BTreeSet<PathBuf>,
-    errors: &mut Vec<String>,
+    scan: &mut RetentionProtectionScan,
 ) {
     match std::fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => errors.push(
-            format!("{label} is not a direct regular file: {}", path.display()),
-        ),
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => scan
+            .record_incomplete(format!(
+                "{label} is not a direct regular file: {}",
+                path.display()
+            )),
         Ok(_) => {
             paths.insert(path.to_path_buf());
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => errors.push(format!("inspect {label} {}: {error}", path.display())),
+        Err(error) => {
+            scan.record_incomplete(format!("inspect {label} {}: {error}", path.display()))
+        }
     }
 }
 
@@ -1232,7 +1504,7 @@ fn direct_directory_exists_or_missing(root: &Path, label: &str, errors: &mut Vec
     }
 }
 
-fn directory_size(path: &Path) -> Result<u64> {
+pub(crate) fn directory_size(path: &Path) -> Result<u64> {
     let metadata = std::fs::symlink_metadata(path)
         .with_context(|| format!("inspect directory {}", path.display()))?;
     if metadata.file_type().is_symlink() || !metadata.is_dir() {
@@ -1462,6 +1734,7 @@ mod tests {
         ] {
             let marker = GenerationRetentionMarker::next(
                 workspace,
+                root.path(),
                 manifest(project, active, 10),
                 Some(RetrievalIndexRollbackRecord {
                     manifest: manifest(project, rollback, 5),
@@ -1747,6 +2020,7 @@ mod tests {
 
     #[test]
     fn marker_update_preserves_only_a_freshly_verified_rollback() {
+        let root = tempdir().expect("root");
         let project = "repo-v1-project";
         let active = manifest(project, "aaaaaaaaaaaaaaaa", 10);
         let rollback = RetrievalIndexRollbackRecord {
@@ -1758,6 +2032,7 @@ mod tests {
 
         let refreshed = GenerationRetentionMarker::next(
             "workspace_1",
+            root.path(),
             refreshed_active,
             Some(rollback.clone()),
             21,
@@ -1773,6 +2048,7 @@ mod tests {
         let state_file = root.path().join("retrieval-sidecars.json");
         let marker = GenerationRetentionMarker::next(
             "workspace_1",
+            root.path(),
             manifest("repo-v1-project", "aaaaaaaaaaaaaaaa", 1),
             None,
             2,
@@ -1790,6 +2066,7 @@ mod tests {
         assert_eq!(scan.active.len(), 1);
         assert_eq!(scan.errors.len(), 1);
         assert!(scan.errors[0].contains("bad.json"));
+        assert!(scan.protection_incomplete);
     }
 
     /// A second OS process holds the retention lock for longer than the
@@ -1925,6 +2202,295 @@ mod tests {
         assert!(
             waited >= DEFAULT_LOCK_WAIT,
             "the wait gave up after {waited:?}, inside the {DEFAULT_LOCK_WAIT:?} foreground budget, so a legitimate publication would be refused"
+        );
+    }
+
+    /// A peer already running the schema-2 writer publishes a marker into the
+    /// shared retention directory. Before dual-read this reader rejected the
+    /// unknown schema outright, so the peer's live generation became an
+    /// unrooted reclaim candidate and the whole project stopped pruning.
+    #[test]
+    fn a_schema_2_marker_from_a_peer_roots_its_generation_for_a_dual_reading_scanner() {
+        let root = tempdir().expect("root");
+        let peer_workspace_root = root.path().join("peer-worktree");
+        std::fs::create_dir_all(&peer_workspace_root).expect("peer worktree");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let peer = "aaaaaaaaaaaaaaaa";
+        let stale = "cccccccccccccccc";
+        write_bundle(&layout, project, peer, [1, 1, 1]);
+        write_bundle(&layout, project, stale, [1, 1, 1]);
+        let state_file = layout.state_file.clone();
+        let marker = GenerationRetentionMarker::next(
+            "workspace_peer",
+            &peer_workspace_root,
+            manifest(project, peer, 10),
+            None,
+            10,
+        )
+        .expect("schema 2 marker");
+        assert_eq!(marker.schema_version, RETENTION_MARKER_SCHEMA_V2);
+        write_retention_marker(&state_file, &marker).expect("write marker");
+
+        let protection = scan_retention_protection(root.path(), None, &state_file);
+        let plan = plan_generation_retention(&layout, project, &protection);
+
+        assert!(
+            !protection.protection_incomplete,
+            "a schema 2 marker is readable evidence, not a gap: {:?}",
+            protection.errors
+        );
+        assert_eq!(
+            plan.bundles
+                .iter()
+                .map(|bundle| (bundle.generation.as_str(), bundle.state))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "repo-v1-project-aaaaaaaaaaaaaaaa",
+                    GenerationRetentionState::Active
+                ),
+                (
+                    "repo-v1-project-cccccccccccccccc",
+                    GenerationRetentionState::Reclaimable
+                ),
+            ]
+        );
+        assert!(!plan.pruning_suppressed);
+    }
+
+    /// Dual-read runs the other way too: a peer still on the previous binary
+    /// writes schema 1, and its generation must keep its pin.
+    #[test]
+    fn a_schema_1_marker_still_roots_its_generation() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let legacy = "bbbbbbbbbbbbbbbb";
+        write_bundle(&layout, project, legacy, [1, 1, 1]);
+        let state_file = layout.state_file.clone();
+        let legacy_marker = GenerationRetentionMarker {
+            schema_version: RETENTION_MARKER_SCHEMA_V1,
+            workspace_id: "workspace_legacy".into(),
+            project_id: project.into(),
+            active: manifest(project, legacy, 10),
+            rollback: None,
+            updated_at_epoch_ms: 10,
+            owner: None,
+            generation: None,
+            heartbeat_epoch_ms: None,
+        };
+        ensure_retention_dir(&state_file).expect("retention dir");
+        std::fs::write(
+            retention_marker_path(&state_file, "workspace_legacy").expect("marker path"),
+            serde_json::to_vec(&legacy_marker).expect("serialize legacy marker"),
+        )
+        .expect("write legacy marker");
+
+        let protection = scan_retention_protection(root.path(), None, &state_file);
+        let plan = plan_generation_retention(&layout, project, &protection);
+
+        assert!(!protection.protection_incomplete, "{:?}", protection.errors);
+        assert_eq!(
+            plan.bundles
+                .iter()
+                .map(|bundle| (bundle.generation.as_str(), bundle.state))
+                .collect::<Vec<_>>(),
+            vec![(
+                "repo-v1-project-bbbbbbbbbbbbbbbb",
+                GenerationRetentionState::Active
+            )]
+        );
+        assert_eq!(
+            legacy_marker.retirement(),
+            MarkerRetirement::UnregisteredWorkspace
+        );
+    }
+
+    /// The point of the registration: a worktree that has been deleted stops
+    /// pinning, while a worktree that still exists keeps its pin no matter how
+    /// old its marker is.
+    #[test]
+    fn a_deleted_worktree_releases_its_generation_while_a_live_one_keeps_it() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let live_root = root.path().join("live-worktree");
+        let dead_root = root.path().join("dead-worktree");
+        std::fs::create_dir_all(&live_root).expect("live worktree");
+        std::fs::create_dir_all(&dead_root).expect("dead worktree");
+        let live = "aaaaaaaaaaaaaaaa";
+        let dead = "dddddddddddddddd";
+        write_bundle(&layout, project, live, [1, 1, 1]);
+        write_bundle(&layout, project, dead, [1, 1, 1]);
+        let state_file = layout.state_file.clone();
+        for (workspace, worktree, suffix, age) in [
+            ("workspace_live", &live_root, live, 1),
+            ("workspace_dead", &dead_root, dead, 9_999),
+        ] {
+            let marker = GenerationRetentionMarker::next(
+                workspace,
+                worktree,
+                manifest(project, suffix, age),
+                None,
+                age,
+            )
+            .expect("marker");
+            write_retention_marker(&state_file, &marker).expect("write marker");
+        }
+        std::fs::remove_dir_all(&dead_root).expect("retire the dead worktree");
+
+        let protection = scan_retention_protection(root.path(), None, &state_file);
+        let plan = plan_generation_retention(&layout, project, &protection);
+
+        assert!(!protection.protection_incomplete, "{:?}", protection.errors);
+        assert_eq!(
+            protection
+                .retired_marker_paths
+                .iter()
+                .filter_map(|path| path.file_name().and_then(|name| name.to_str()))
+                .collect::<Vec<_>>(),
+            vec!["workspace_dead.json"]
+        );
+        assert_eq!(
+            plan.bundles
+                .iter()
+                .map(|bundle| (bundle.generation.as_str(), bundle.state))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "repo-v1-project-aaaaaaaaaaaaaaaa",
+                    GenerationRetentionState::Active
+                ),
+                (
+                    "repo-v1-project-dddddddddddddddd",
+                    GenerationRetentionState::Reclaimable
+                ),
+            ]
+        );
+    }
+
+    /// A future marker encoding this reader does not recognize sits in the
+    /// same owned directory. Skipping it reads as "no roots", which is the one
+    /// interpretation that deletes a live pin, so it must protect instead.
+    #[test]
+    fn an_unrecognized_retention_entry_protects_instead_of_being_skipped() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let live_root = root.path().join("live-worktree");
+        std::fs::create_dir_all(&live_root).expect("live worktree");
+        let pinned = "aaaaaaaaaaaaaaaa";
+        let other = "cccccccccccccccc";
+        write_bundle(&layout, project, pinned, [1, 1, 1]);
+        write_bundle(&layout, project, other, [1, 1, 1]);
+        let state_file = layout.state_file.clone();
+        let marker = GenerationRetentionMarker::next(
+            "workspace_live",
+            &live_root,
+            manifest(project, pinned, 10),
+            None,
+            10,
+        )
+        .expect("marker");
+        write_retention_marker(&state_file, &marker).expect("write marker");
+        // A marker written in an encoding a later release introduces.
+        std::fs::write(
+            retention_dir(&state_file).join("workspace_future.marker3"),
+            b"opaque",
+        )
+        .expect("future marker");
+
+        let protection = scan_retention_protection(root.path(), None, &state_file);
+        let plan = plan_generation_retention(&layout, project, &protection);
+
+        assert!(
+            protection.protection_incomplete,
+            "an entry this reader cannot interpret is missing protection, not absent protection"
+        );
+        assert!(
+            protection
+                .errors
+                .iter()
+                .any(|error| error.contains("workspace_future.marker3")),
+            "{:?}",
+            protection.errors
+        );
+        assert!(plan.pruning_suppressed);
+        assert_eq!(
+            plan.bundles
+                .iter()
+                .find(|bundle| bundle.generation.ends_with(other))
+                .map(|bundle| bundle.state),
+            Some(GenerationRetentionState::Building),
+            "no generation may be reclaimable while protection evidence is unreadable"
+        );
+    }
+
+    /// Lock files and crashed atomic-write temporaries share the directory and
+    /// are not protection evidence, so they must not wedge pruning forever.
+    #[test]
+    fn locks_and_abandoned_temporaries_are_not_unreadable_protection() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let live_root = root.path().join("live-worktree");
+        std::fs::create_dir_all(&live_root).expect("live worktree");
+        write_bundle(&layout, project, "aaaaaaaaaaaaaaaa", [1, 1, 1]);
+        let state_file = layout.state_file.clone();
+        let marker = GenerationRetentionMarker::next(
+            "workspace_live",
+            &live_root,
+            manifest(project, "aaaaaaaaaaaaaaaa", 10),
+            None,
+            10,
+        )
+        .expect("marker");
+        write_retention_marker(&state_file, &marker).expect("write marker");
+        let dir = retention_dir(&state_file);
+        std::fs::write(dir.join("repo-v1-project.lock"), b"").expect("lock file");
+        std::fs::write(
+            dir.join(".generation-retention.4242.7.tmp"),
+            b"abandoned partial write",
+        )
+        .expect("abandoned temporary");
+
+        let protection = scan_retention_protection(root.path(), None, &state_file);
+
+        assert!(
+            !protection.protection_incomplete,
+            "locks and temporaries are not evidence: {:?}",
+            protection.errors
+        );
+        assert!(protection.errors.is_empty(), "{:?}", protection.errors);
+    }
+
+    /// A schema-2 marker whose registration was copied from another workspace
+    /// would retire the wrong cache, so it is refused rather than trusted.
+    #[test]
+    fn a_marker_registration_for_another_workspace_is_refused() {
+        let root = tempdir().expect("root");
+        let project = "repo-v1-project";
+        let mut marker = GenerationRetentionMarker::next(
+            "workspace_1",
+            root.path(),
+            manifest(project, "aaaaaaaaaaaaaaaa", 1),
+            None,
+            2,
+        )
+        .expect("marker");
+        marker.owner = Some(RetentionMarkerOwner {
+            workspace_id: "workspace_2".into(),
+            project_root: root.path().display().to_string(),
+        });
+
+        let error = validate_marker(&marker).expect_err("mismatched registration is refused");
+
+        assert!(
+            error
+                .to_string()
+                .contains("owner workspace does not match marker workspace"),
+            "{error:#}"
         );
     }
 }


### PR DESCRIPTION
Closes #1665.

## Review and repair

The review **blocked** this on unrecoverable user-data loss:

**`cache clean --apply` would have deleted authored bookmarks.** The guard against destroying live annotations checked whether `annotations.sqlite3` exists — but bookmarks live in core's own `bookmark_category`/`bookmark_node` tables, and the sidecar cutover is lazy. An abandoned worktree is by definition never reopened, so it is exactly the population that can never have cut over: the sidecar is absent, the guard cannot fire, and the command deletes the whole cache directory including `codestory.db` — the only copy of the user's bookmarks and their comments — while reporting it as proof-owned cleanup.

Repaired so the guard proves annotation *absence* (sidecar **or** core legacy tables) and fails closed when it cannot prove it: an unreadable or unopenable cache is never reclaimed.

**Declared residual:** model-tree reclamation still proves "not this binary's digest" rather than "no running executable" — the materialization lock is only held during materialization, so a peer already running with an older digest mapped holds nothing. Now stated in the module docs rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)