### PR TITLE
[v0.17 EV-9] Add validated rollback activation and derived-cache reset

### DIFF
--- a/.github/workflows/retrieval-engine-smoke.yml
+++ b/.github/workflows/retrieval-engine-smoke.yml
@@ -183,7 +183,12 @@ jobs:
         run: cargo test --locked -p codestory-cli --test packet_search_eval
 
       - name: Retrieval crate unit tests
-        run: cargo test --locked -p codestory-retrieval
+        run: |
+          cargo test --locked -p codestory-retrieval
+          # Rollback activation fixtures need an admissible embedding device,
+          # which only exists under test-support (EV-9, #1652). Without this
+          # invocation the whole module is compiled out of the PR lane.
+          cargo test --locked -p codestory-retrieval --features test-support --lib rollback::
 
       - name: Architecture ownership contract tests
         run: cargo test --locked -p codestory-cli --test architecture_contracts

--- a/crates/codestory-cli/src/app/diagnostics/doctor.rs
+++ b/crates/codestory-cli/src/app/diagnostics/doctor.rs
@@ -37,7 +37,8 @@ pub(in crate::app) fn build_doctor_output(
     );
     let readiness_lanes =
         build_readiness_lanes_for_runtime(runtime, &readiness, None, Some(&readiness_sidecar));
-    let next_commands = readiness::compatibility_next_commands(&readiness);
+    let mut next_commands = readiness::compatibility_next_commands(&readiness);
+    let retained_rollback = observe_retained_rollback(runtime);
     let mut checks = Vec::new();
     checks.push(doctor_check(
         "project",
@@ -75,6 +76,14 @@ pub(in crate::app) fn build_doctor_output(
         )
     });
     checks.push(doctor_sidecar_check(&readiness_sidecar));
+    if let Some(check) = doctor_rollback_check(
+        &project,
+        &sidecar_retrieval,
+        retained_rollback.as_ref(),
+        &mut next_commands,
+    ) {
+        checks.push(check);
+    }
     if let Some(retrieval) = retrieval.as_ref()
         && retrieval.stored_embedding.is_some()
     {
@@ -119,6 +128,155 @@ pub(in crate::app) fn build_doctor_output(
         checks,
         next_commands,
         environment,
+    }
+}
+
+/// Observe the retained rollback pointer without mutating anything.
+///
+/// Doctor is an observational surface: a failure to read the pointer must
+/// leave doctor reporting everything else rather than failing the command, and
+/// the read itself goes through the strictly non-mutating observation entry
+/// point so inspecting a project can never migrate or recover it.
+fn observe_retained_rollback(
+    runtime: &RuntimeContext,
+) -> Option<codestory_retrieval::RetainedRollbackObservation> {
+    codestory_retrieval::observe_retained_rollback_generation(
+        &runtime.project_root,
+        &runtime.storage_path,
+        &runtime.sidecar,
+    )
+    .ok()
+    .flatten()
+}
+
+/// Report the rollback lever, and recommend it only when it could help.
+///
+/// Doctor stays read-only: this appends a command for the operator to run, it
+/// never activates anything. The recommendation is suppressed while retrieval
+/// is live-ready, because rolling a healthy generation back is a regression,
+/// not a repair.
+fn doctor_rollback_check(
+    project: &str,
+    sidecar_retrieval: &RetrievalStatusOutput,
+    retained: Option<&codestory_retrieval::RetainedRollbackObservation>,
+    next_commands: &mut Vec<String>,
+) -> Option<crate::args::DoctorCheckOutput> {
+    let retained = retained?;
+    let generation = retained.rollback_generation.as_deref()?;
+    if doctor_sidecar_status_is_live_ready(sidecar_retrieval) {
+        return Some(doctor_check(
+            "retrieval_rollback",
+            "ok",
+            format!(
+                "Retrieval is live-ready; verified rollback generation `{generation}` stays retained."
+            ),
+        ));
+    }
+    let command = format!("codestory-cli retrieval activate-rollback --project {project}");
+    let message = format!(
+        "Retrieval is not live-ready and verified rollback generation `{generation}` is retained. Validate it with `{command} --dry-run`, then run `{command}` to make it current."
+    );
+    if !next_commands.iter().any(|existing| existing == &command) {
+        next_commands.insert(0, command);
+    }
+    Some(doctor_check("retrieval_rollback", "warn", message))
+}
+
+#[cfg(test)]
+mod rollback_recommendation_tests {
+    use super::*;
+    use crate::app::diagnostics::sidecar::doctor_sidecar_status_from_report;
+
+    /// A real production status report, not a hand-built DTO: an absent
+    /// manifest is what a project with unusable retrieval actually renders.
+    fn unavailable_status() -> RetrievalStatusOutput {
+        let layout = codestory_retrieval::SidecarLayout::from_env();
+        doctor_sidecar_status_from_report(
+            codestory_retrieval::probe_sidecar_health(&layout, "doctor-rollback-fixture", None),
+            None,
+        )
+    }
+
+    fn live_ready_status() -> RetrievalStatusOutput {
+        let mut status = unavailable_status();
+        status.retrieval_mode = "full".into();
+        status.degraded_reason = None;
+        status
+    }
+
+    fn retained(generation: &str) -> codestory_retrieval::RetainedRollbackObservation {
+        codestory_retrieval::RetainedRollbackObservation {
+            project_id: "doctor-rollback-fixture".into(),
+            current_generation: Some("doctor-rollback-fixture-current".into()),
+            rollback_generation: Some(generation.into()),
+            rollback_verified_at_epoch_ms: 7,
+        }
+    }
+
+    #[test]
+    fn a_retained_rollback_is_recommended_when_retrieval_is_not_live_ready() {
+        let mut next_commands = vec!["codestory-cli index --project /repo --refresh full".into()];
+        let observed = retained("doctor-rollback-fixture-previous");
+
+        let check = doctor_rollback_check(
+            "/repo",
+            &unavailable_status(),
+            Some(&observed),
+            &mut next_commands,
+        )
+        .expect("a retained rollback must be reported");
+
+        assert_eq!(check.name, "retrieval_rollback");
+        assert_eq!(check.status, "warn");
+        assert!(
+            check.message.contains("doctor-rollback-fixture-previous"),
+            "the check must name the retained generation: {}",
+            check.message
+        );
+        assert_eq!(
+            next_commands.first().map(String::as_str),
+            Some("codestory-cli retrieval activate-rollback --project /repo"),
+            "the lever must be the first thing doctor tells the operator to run: {next_commands:?}"
+        );
+        assert_eq!(
+            next_commands.len(),
+            2,
+            "the existing repair guidance must survive: {next_commands:?}"
+        );
+    }
+
+    #[test]
+    fn a_live_ready_retrieval_reports_the_rollback_without_recommending_it() {
+        let mut next_commands = vec!["codestory-cli ready --project /repo --goal agent".into()];
+        let observed = retained("doctor-rollback-fixture-previous");
+
+        let check = doctor_rollback_check(
+            "/repo",
+            &live_ready_status(),
+            Some(&observed),
+            &mut next_commands,
+        )
+        .expect("a retained rollback must still be reported");
+
+        assert_eq!(check.status, "ok");
+        assert_eq!(
+            next_commands,
+            vec!["codestory-cli ready --project /repo --goal agent".to_string()],
+            "rolling a healthy generation back is a regression, not a repair"
+        );
+    }
+
+    #[test]
+    fn no_retained_rollback_produces_no_check_and_no_recommendation() {
+        let mut next_commands = vec!["codestory-cli index --project /repo --refresh full".into()];
+
+        let check = doctor_rollback_check("/repo", &unavailable_status(), None, &mut next_commands);
+
+        assert!(check.is_none(), "there is no lever to report");
+        assert_eq!(
+            next_commands,
+            vec!["codestory-cli index --project /repo --refresh full".to_string()]
+        );
     }
 }
 

--- a/crates/codestory-cli/src/app/lifecycle.rs
+++ b/crates/codestory-cli/src/app/lifecycle.rs
@@ -110,6 +110,8 @@ pub(super) fn run_cache(cmd: CacheCommand) -> Result<()> {
         CacheAction::Identity(cmd) => run_cache_identity(cmd),
         CacheAction::Rehydrate(cmd) => run_cache_rehydrate(cmd),
         CacheAction::Clean(cmd) => run_cache_clean(cmd),
+
+        CacheAction::Reset(cmd) => crate::cache_reset::run_cache_reset(cmd),
     }
 }
 

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -720,6 +720,11 @@ pub(crate) enum CacheAction {
         about = "Report, and optionally reclaim, cache state no live workspace or model can claim."
     )]
     Clean(CacheCleanCommand),
+    #[command(
+        about = "Quarantine this project's derived cache so it can be rebuilt.",
+        long_about = "Quarantine this project's derived cache so it can be rebuilt.\n\nDerived state is moved into a quarantine directory beside the cache, never deleted, and user-authored annotations are preserved in place. Use this after rolling a CodeStory release back onto a cache written by a newer schema; the reindex step is printed on completion."
+    )]
+    Reset(CacheResetCommand),
 }
 
 #[derive(Args, Debug)]
@@ -737,6 +742,56 @@ pub(crate) struct CacheCleanCommand {
         help = "Write command output to this file instead of stdout. The parent directory must already exist."
     )]
     pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("cache_reset_intent")
+        .args(["confirm", "dry_run"])
+        .required(true)
+))]
+pub(crate) struct CacheResetCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(
+        long,
+        required = true,
+        help = "Required scope acknowledgement. Only derived cache state is reset; user-authored annotations are preserved."
+    )]
+    pub(crate) derived_only: bool,
+    #[arg(
+        long,
+        help = "Move the derived cache into quarantine. Exactly one of --confirm or --dry-run is required."
+    )]
+    pub(crate) confirm: bool,
+    #[arg(
+        long,
+        help = "Print the quarantine plan without moving anything. Exactly one of --confirm or --dry-run is required."
+    )]
+    pub(crate) dry_run: bool,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+/// JSON contract for `cache reset`.
+pub(crate) struct CacheResetOutput {
+    pub(crate) project: String,
+    pub(crate) storage_path: String,
+    /// Only `derived_only` exists. The field is emitted so a later scope can
+    /// be told apart by machine readers without a schema guess.
+    pub(crate) scope: &'static str,
+    pub(crate) applied: bool,
+    pub(crate) quarantine_dir: String,
+    pub(crate) quarantined: Vec<String>,
+    pub(crate) preserved: Vec<String>,
+    pub(crate) next_commands: Vec<String>,
 }
 
 #[derive(Args, Debug)]
@@ -817,6 +872,39 @@ pub(crate) enum RetrievalAction {
     RepublishProjections(RetrievalRepublishProjectionsCommand),
     /// Execute a standalone query against published retrieval artifacts.
     Query(RetrievalQueryCommand),
+    /// Validate the retained rollback generation and make it current.
+    ///
+    /// Retention keeps one deeply verified previous generation. Activation
+    /// re-proves it against live state before moving the pointer and refuses
+    /// with a typed code when it no longer proves out.
+    ActivateRollback(RetrievalActivateRollbackCommand),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct RetrievalActivateRollbackCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(
+        long,
+        help = "Validate the retained rollback generation without changing the current pointer."
+    )]
+    pub(crate) dry_run: bool,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+/// JSON contract for `retrieval activate-rollback`.
+pub(crate) struct RetrievalActivateRollbackOutput {
+    pub(crate) project: String,
+    pub(crate) outcome: codestory_retrieval::RollbackActivationOutcome,
+    pub(crate) next_commands: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -2574,6 +2662,98 @@ mod tests {
             panic!("expected cache clean command");
         };
         assert!(applied.apply);
+    }
+
+    #[test]
+    fn cache_reset_refuses_to_parse_without_an_explicit_scope_and_intent() {
+        // Quarantining a cache is destructive-looking even though it only
+        // moves files, so neither the scope nor the intent may be implicit.
+        let missing_everything = Cli::try_parse_from(["codestory-cli", "cache", "reset"])
+            .expect_err("cache reset must not parse bare");
+        assert!(
+            missing_everything.to_string().contains("--derived-only"),
+            "the scope acknowledgement must be named: {missing_everything}"
+        );
+
+        let missing_intent =
+            Cli::try_parse_from(["codestory-cli", "cache", "reset", "--derived-only"])
+                .expect_err("cache reset must not parse without an intent");
+        let rendered = missing_intent.to_string();
+        assert!(
+            rendered.contains("--confirm") && rendered.contains("--dry-run"),
+            "the required intent flags must be named: {rendered}"
+        );
+
+        let both = Cli::try_parse_from([
+            "codestory-cli",
+            "cache",
+            "reset",
+            "--derived-only",
+            "--confirm",
+            "--dry-run",
+        ])
+        .expect_err("cache reset must not accept both intents at once");
+        assert!(
+            both.to_string().contains("cannot be used with"),
+            "confirm and dry-run must be mutually exclusive: {both}"
+        );
+
+        let parsed = Cli::try_parse_from([
+            "codestory-cli",
+            "cache",
+            "reset",
+            "--derived-only",
+            "--confirm",
+        ])
+        .expect("an explicit scope and intent must parse");
+        let Command::Cache(cache) = parsed.command else {
+            panic!("expected the cache command");
+        };
+        let CacheAction::Reset(reset) = cache.action else {
+            panic!("expected the reset action");
+        };
+        assert!(reset.derived_only);
+        assert!(reset.confirm);
+        assert!(!reset.dry_run);
+    }
+
+    #[test]
+    fn retrieval_activate_rollback_defaults_to_applying_and_accepts_dry_run() {
+        let applied = Cli::try_parse_from([
+            "codestory-cli",
+            "retrieval",
+            "activate-rollback",
+            "--project",
+            "/repo",
+        ])
+        .expect("activate-rollback must parse");
+        let Command::Retrieval(retrieval) = applied.command else {
+            panic!("expected the retrieval command");
+        };
+        let RetrievalAction::ActivateRollback(activate) = retrieval.action else {
+            panic!("expected the activate-rollback action");
+        };
+        assert!(
+            !activate.dry_run,
+            "activation applies unless validation-only is requested"
+        );
+
+        let validated = Cli::try_parse_from([
+            "codestory-cli",
+            "retrieval",
+            "activate-rollback",
+            "--project",
+            "/repo",
+            "--dry-run",
+        ])
+        .expect("activate-rollback --dry-run must parse");
+        let Command::Retrieval(retrieval) = validated.command else {
+            panic!("expected the retrieval command");
+        };
+        let RetrievalAction::ActivateRollback(activate) = retrieval.action else {
+            panic!("expected the activate-rollback action");
+        };
+        assert!(activate.dry_run);
     }
 
     #[test]

--- a/crates/codestory-cli/src/cache_reset.rs
+++ b/crates/codestory-cli/src/cache_reset.rs
@@ -1,0 +1,408 @@
+//! Guided derived-only cache reset.
+//!
+//! Forward-only migrations fail closed on a database written by a newer
+//! CodeStory: an older binary can neither read it nor repair it through
+//! `--refresh full`, which also fails closed. Failing closed is the
+//! data-integrity-correct choice — the alternative destroys a newer database —
+//! but until now the only recovery was out of band: delete the cache by hand,
+//! or reinstall the newer release.
+//!
+//! This is the in-band recovery. It moves the derived cache into a quarantine
+//! directory beside it, never deletes, never opens the database (so a
+//! schema-too-new store is reachable), and preserves user-authored annotation
+//! state in place. The reindex step that rebuilds what was quarantined is
+//! named in the output.
+//!
+//! Every identity it moves and every identity it preserves comes from
+//! `codestory_contracts::owned_artifacts`, so a future owned artifact cannot
+//! be silently left behind — or silently destroyed — by this path.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use codestory_contracts::bounded_locks::{self, FileLockKind, LockDeadline};
+use codestory_contracts::owned_artifacts;
+
+use crate::args::{CacheResetCommand, CacheResetOutput};
+use crate::output::emit;
+use crate::runtime::RuntimeContext;
+
+/// Wait budget for the promotion exclusion the reset holds.
+///
+/// A legitimate holder is a whole publication or promotion pass, so this
+/// matches the publication budget every other waiter behind such a pass uses.
+const RESET_LOCK_WAIT: Duration = bounded_locks::PUBLICATION_LOCK_WAIT;
+
+pub(crate) fn run_cache_reset(cmd: CacheResetCommand) -> Result<()> {
+    crate::ensure_dot_only_for_trail(cmd.format, "cache reset")?;
+    crate::preflight_output_file(cmd.output_file.as_deref())?;
+    // clap requires exactly one of --confirm/--dry-run, so this is a guard
+    // against a future argument edit silently making both optional.
+    if cmd.confirm == cmd.dry_run {
+        bail!("Pass exactly one of --confirm or --dry-run to `cache reset`.");
+    }
+    if !cmd.derived_only {
+        bail!("`cache reset` only supports --derived-only.");
+    }
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let output = plan_and_maybe_apply(&runtime.project_root, &runtime.storage_path, cmd.confirm)?;
+    let markdown = render_cache_reset_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
+fn plan_and_maybe_apply(
+    project_root: &Path,
+    storage_path: &Path,
+    apply: bool,
+) -> Result<CacheResetOutput> {
+    let project = crate::display::clean_path_string(&project_root.to_string_lossy());
+    let plan = derived_reset_plan(storage_path);
+    let quarantine_dir =
+        owned_artifacts::derived_reset_quarantine_root(storage_path).join(quarantine_slot_name());
+    let preserved = present_annotation_identities(storage_path);
+    let mut output = CacheResetOutput {
+        project,
+        storage_path: crate::display::clean_path_string(&storage_path.to_string_lossy()),
+        scope: "derived_only",
+        applied: false,
+        quarantine_dir: crate::display::clean_path_string(&quarantine_dir.to_string_lossy()),
+        quarantined: plan
+            .iter()
+            .map(|path| display_name(storage_path, path))
+            .collect(),
+        preserved: preserved
+            .iter()
+            .map(|path| display_name(storage_path, path))
+            .collect(),
+        next_commands: reset_next_commands(&output_project_arg(project_root)),
+    };
+    if !apply {
+        return Ok(output);
+    }
+    let moved = apply_derived_reset(storage_path, &plan, &quarantine_dir)?;
+    output.applied = true;
+    output.quarantined = moved
+        .iter()
+        .map(|path| display_name(storage_path, path))
+        .collect();
+    // Re-observe rather than trusting the pre-move plan: the whole point of
+    // the command is that annotation state is still there afterwards.
+    output.preserved = present_annotation_identities(storage_path)
+        .iter()
+        .map(|path| display_name(storage_path, path))
+        .collect();
+    Ok(output)
+}
+
+/// Derived identities that currently exist, in a stable order.
+fn derived_reset_plan(storage_path: &Path) -> Vec<PathBuf> {
+    let mut plan: Vec<PathBuf> = owned_artifacts::derived_reset_file_identities(storage_path)
+        .into_iter()
+        .filter(|path| path.is_file() || path.is_symlink())
+        .collect();
+    plan.extend(
+        owned_artifacts::derived_reset_directory_identities(storage_path)
+            .into_iter()
+            .filter(|path| path.is_dir()),
+    );
+    plan.sort();
+    plan.dedup();
+    plan
+}
+
+fn present_annotation_identities(storage_path: &Path) -> Vec<PathBuf> {
+    let cache_root = storage_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut preserved: Vec<PathBuf> = owned_artifacts::annotation_owned_file_identities(cache_root)
+        .into_iter()
+        .filter(|path| path.exists())
+        .collect();
+    preserved.sort();
+    preserved
+}
+
+fn apply_derived_reset(
+    storage_path: &Path,
+    plan: &[PathBuf],
+    quarantine_dir: &Path,
+) -> Result<Vec<PathBuf>> {
+    let cache_root = storage_path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(cache_root)
+        .with_context(|| format!("create cache root {}", cache_root.display()))?;
+    let lock_path = owned_artifacts::promotion_sibling_path(
+        storage_path,
+        owned_artifacts::PROMOTION_LOCK_SUFFIX,
+    );
+    let lock_file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("open promotion lock {}", lock_path.display()))?;
+    bounded_locks::acquire_with_deadline(
+        &lock_file,
+        FileLockKind::Exclusive,
+        LockDeadline::after(RESET_LOCK_WAIT),
+        None,
+    )
+    .with_context(|| {
+        format!(
+            "acquire the promotion lock for the derived cache reset at {}",
+            lock_path.display()
+        )
+    })?;
+    let result = move_plan_into_quarantine(storage_path, plan, quarantine_dir);
+    let _ = bounded_locks::release(&lock_file);
+    result
+}
+
+fn move_plan_into_quarantine(
+    storage_path: &Path,
+    plan: &[PathBuf],
+    quarantine_dir: &Path,
+) -> Result<Vec<PathBuf>> {
+    fs::create_dir_all(quarantine_dir)
+        .with_context(|| format!("create quarantine directory {}", quarantine_dir.display()))?;
+    let mut moved = Vec::new();
+    for source in plan {
+        if !source.exists() {
+            continue;
+        }
+        let destination = quarantine_dir.join(display_name(storage_path, source));
+        fs::rename(source, &destination).with_context(|| {
+            format!(
+                "quarantine {} into {}",
+                source.display(),
+                destination.display()
+            )
+        })?;
+        moved.push(source.clone());
+    }
+    Ok(moved)
+}
+
+/// Name a cache-root-relative identity for both the report and the quarantine
+/// destination, so the quarantine is a flat mirror of what was moved.
+fn display_name(storage_path: &Path, path: &Path) -> String {
+    let cache_root = storage_path.parent().unwrap_or_else(|| Path::new("."));
+    path.strip_prefix(cache_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Name one quarantine slot so repeated resets never collide and the newest
+/// sorts last.
+fn quarantine_slot_name() -> String {
+    let epoch_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis())
+        .unwrap_or_default();
+    format!("{epoch_ms:013}")
+}
+
+fn output_project_arg(project_root: &Path) -> String {
+    crate::display::clean_path_string(&project_root.to_string_lossy())
+}
+
+fn reset_next_commands(project: &str) -> Vec<String> {
+    vec![
+        format!("codestory-cli index --project \"{project}\" --refresh full"),
+        format!("codestory-cli retrieval index --project \"{project}\" --refresh full"),
+        format!("codestory-cli doctor --project \"{project}\" --format markdown"),
+    ]
+}
+
+fn render_cache_reset_markdown(output: &CacheResetOutput) -> String {
+    let mut markdown = format!(
+        "# Derived cache reset\n\n- project: `{}`\n- storage_path: `{}`\n- scope: `{}`\n- applied: {}\n- quarantine_dir: `{}`\n",
+        output.project, output.storage_path, output.scope, output.applied, output.quarantine_dir
+    );
+    markdown.push_str("\n## Quarantined derived state\n\n");
+    if output.quarantined.is_empty() {
+        markdown.push_str("- none present\n");
+    } else {
+        for name in &output.quarantined {
+            markdown.push_str(&format!("- `{name}`\n"));
+        }
+    }
+    markdown.push_str("\n## Preserved user state\n\n");
+    if output.preserved.is_empty() {
+        markdown.push_str("- no annotation sidecar present\n");
+    } else {
+        for name in &output.preserved {
+            markdown.push_str(&format!("- `{name}`\n"));
+        }
+    }
+    if !output.applied {
+        markdown.push_str(
+            "\nPlan only: nothing was moved. Rerun with `--confirm` instead of `--dry-run` to quarantine.\n",
+        );
+    }
+    markdown.push_str("\n## Reindex\n\n");
+    for command in &output.next_commands {
+        markdown.push_str(&format!("- `{command}`\n"));
+    }
+    markdown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    struct CacheFixture {
+        _root: TempDir,
+        project_root: PathBuf,
+        storage_path: PathBuf,
+        annotations: PathBuf,
+    }
+
+    /// A cache root holding derived core state plus a user annotation sidecar.
+    fn seed_cache() -> CacheFixture {
+        let root = TempDir::new().expect("fixture root");
+        let project_root = root.path().join("project");
+        let cache_root = root.path().join("cache");
+        fs::create_dir_all(&project_root).expect("create project");
+        fs::create_dir_all(&cache_root).expect("create cache root");
+        let storage_path = cache_root.join("codestory.db");
+        fs::write(&storage_path, b"core database bytes").expect("write core database");
+        fs::write(cache_root.join("codestory.db-wal"), b"wal").expect("write wal");
+        fs::write(
+            cache_root.join("codestory.sqlite.backup"),
+            b"rollback backup",
+        )
+        .expect("write rollback backup");
+        fs::write(cache_root.join("local-refresh-status.json"), b"{}")
+            .expect("write refresh state");
+        fs::create_dir_all(cache_root.join("codestory.search")).expect("create search tree");
+        fs::write(cache_root.join("codestory.search").join("shard"), b"shard")
+            .expect("write search shard");
+        let annotations = cache_root.join("annotations.sqlite3");
+        fs::write(&annotations, b"user bookmarks").expect("write annotation sidecar");
+        fs::write(
+            cache_root.join("annotations.sqlite3-wal"),
+            b"annotation wal",
+        )
+        .expect("write annotation wal");
+        CacheFixture {
+            _root: root,
+            project_root,
+            storage_path,
+            annotations,
+        }
+    }
+
+    #[test]
+    fn confirmed_reset_quarantines_derived_state_and_preserves_annotations() {
+        let fixture = seed_cache();
+
+        let output = plan_and_maybe_apply(&fixture.project_root, &fixture.storage_path, true)
+            .expect("reset");
+
+        assert!(output.applied);
+        assert!(
+            !fixture.storage_path.exists(),
+            "the core database must leave the live cache location"
+        );
+        assert!(
+            !fixture
+                .storage_path
+                .parent()
+                .expect("cache root")
+                .join("codestory.search")
+                .exists(),
+            "the derived search tree must leave the live cache location"
+        );
+        assert_eq!(
+            fs::read(&fixture.annotations).expect("annotation sidecar still readable"),
+            b"user bookmarks",
+            "user-authored annotations must survive a derived-only reset byte for byte"
+        );
+        assert!(
+            fixture
+                .annotations
+                .parent()
+                .expect("cache root")
+                .join("annotations.sqlite3-wal")
+                .exists(),
+            "annotation SQLite siblings must survive too"
+        );
+        let quarantined = Path::new(&output.quarantine_dir);
+        assert_eq!(
+            fs::read(quarantined.join("codestory.db")).expect("quarantined core database"),
+            b"core database bytes",
+            "the reset must move derived state, not destroy it"
+        );
+        assert!(quarantined.join("codestory.search").join("shard").is_file());
+        assert_eq!(
+            output.preserved,
+            vec![
+                "annotations.sqlite3".to_string(),
+                "annotations.sqlite3-wal".to_string()
+            ]
+        );
+        assert!(
+            output
+                .next_commands
+                .iter()
+                .any(|command| command.contains("--refresh full")),
+            "the reset must name the reindex step: {:?}",
+            output.next_commands
+        );
+    }
+
+    #[test]
+    fn dry_run_reports_the_plan_without_moving_anything() {
+        let fixture = seed_cache();
+
+        let output = plan_and_maybe_apply(&fixture.project_root, &fixture.storage_path, false)
+            .expect("plan");
+
+        assert!(!output.applied);
+        assert!(
+            fixture.storage_path.is_file(),
+            "a dry run must leave the derived cache in place"
+        );
+        assert!(
+            !Path::new(&output.quarantine_dir).exists(),
+            "a dry run must not create the quarantine directory"
+        );
+        assert!(
+            output.quarantined.contains(&"codestory.db".to_string()),
+            "the plan must name the derived state it would move: {:?}",
+            output.quarantined
+        );
+        assert!(
+            !output
+                .quarantined
+                .iter()
+                .any(|name| name.starts_with("annotations.sqlite3")),
+            "the plan must never list user annotation state: {:?}",
+            output.quarantined
+        );
+    }
+
+    #[test]
+    fn reset_does_not_open_or_migrate_the_core_database() {
+        // A schema-too-new database is the exact case this command exists for,
+        // so it must be reachable without a store open. Bytes that no SQLite
+        // build can open stand in for a database this binary must not touch.
+        let fixture = seed_cache();
+        fs::write(&fixture.storage_path, b"not a sqlite database at all")
+            .expect("write unopenable core database");
+
+        let output = plan_and_maybe_apply(&fixture.project_root, &fixture.storage_path, true)
+            .expect("reset");
+
+        assert!(output.applied);
+        assert_eq!(
+            fs::read(Path::new(&output.quarantine_dir).join("codestory.db"))
+                .expect("quarantined core database"),
+            b"not a sqlite database at all",
+            "the reset must move the database untouched, not open or migrate it"
+        );
+    }
+}

--- a/crates/codestory-cli/src/cache_reset.rs
+++ b/crates/codestory-cli/src/cache_reset.rs
@@ -13,6 +13,10 @@
 //! state in place. The reindex step that rebuilds what was quarantined is
 //! named in the output.
 //!
+//! It holds the same writer exclusions an indexing run holds, for the whole
+//! move, so it cannot move the cache out from under a live indexer or
+//! publisher.
+//!
 //! Every identity it moves and every identity it preserves comes from
 //! `codestory_contracts::owned_artifacts`, so a future owned artifact cannot
 //! be silently left behind — or silently destroyed — by this path.
@@ -29,10 +33,11 @@ use crate::args::{CacheResetCommand, CacheResetOutput};
 use crate::output::emit;
 use crate::runtime::RuntimeContext;
 
-/// Wait budget for the promotion exclusion the reset holds.
+/// Wait budget for each writer exclusion the reset holds.
 ///
-/// A legitimate holder is a whole publication or promotion pass, so this
-/// matches the publication budget every other waiter behind such a pass uses.
+/// A legitimate holder is a whole indexing, publication, or promotion pass, so
+/// this matches the publication budget every other waiter behind such a pass
+/// uses.
 const RESET_LOCK_WAIT: Duration = bounded_locks::PUBLICATION_LOCK_WAIT;
 
 pub(crate) fn run_cache_reset(cmd: CacheResetCommand) -> Result<()> {
@@ -130,32 +135,58 @@ fn apply_derived_reset(
     let cache_root = storage_path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(cache_root)
         .with_context(|| format!("create cache root {}", cache_root.display()))?;
-    let lock_path = owned_artifacts::promotion_sibling_path(
-        storage_path,
-        owned_artifacts::PROMOTION_LOCK_SUFFIX,
-    );
-    let lock_file = fs::OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)
-        .with_context(|| format!("open promotion lock {}", lock_path.display()))?;
-    bounded_locks::acquire_with_deadline(
-        &lock_file,
-        FileLockKind::Exclusive,
-        LockDeadline::after(RESET_LOCK_WAIT),
-        None,
-    )
-    .with_context(|| {
-        format!(
-            "acquire the promotion lock for the derived cache reset at {}",
-            lock_path.display()
-        )
-    })?;
-    let result = move_plan_into_quarantine(storage_path, plan, quarantine_dir);
-    let _ = bounded_locks::release(&lock_file);
-    result
+    let _exclusion = ResetExclusion::acquire(storage_path)?;
+    move_plan_into_quarantine(storage_path, plan, quarantine_dir)
+}
+
+/// Every writer exclusion the reset holds for the whole move.
+///
+/// The promotion lock alone is not enough: a publisher holds it only for the
+/// publish critical section, so an indexing run that is between publishes owns
+/// none of it while it keeps writing the cache this reset is moving. The
+/// index-writer lock is the one a run holds end to end, so the reset takes
+/// both, outermost first, in the order an indexing run takes them.
+struct ResetExclusion {
+    held: Vec<fs::File>,
+}
+
+impl ResetExclusion {
+    fn acquire(storage_path: &Path) -> Result<Self> {
+        let mut exclusion = Self { held: Vec::new() };
+        for lock_path in owned_artifacts::derived_reset_held_lock_paths(storage_path) {
+            let lock_file = fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)
+                .with_context(|| format!("open cache lock {}", lock_path.display()))?;
+            bounded_locks::acquire_with_deadline(
+                &lock_file,
+                FileLockKind::Exclusive,
+                LockDeadline::after(RESET_LOCK_WAIT),
+                None,
+            )
+            .with_context(|| {
+                format!(
+                    "acquire {} exclusively for the derived cache reset",
+                    lock_path.display()
+                )
+            })?;
+            // Push after the acquisition so a refusal releases only what this
+            // reset actually took.
+            exclusion.held.push(lock_file);
+        }
+        Ok(exclusion)
+    }
+}
+
+impl Drop for ResetExclusion {
+    fn drop(&mut self) {
+        for lock_file in self.held.iter().rev() {
+            let _ = bounded_locks::release(lock_file);
+        }
+    }
 }
 
 fn move_plan_into_quarantine(
@@ -251,13 +282,23 @@ fn render_cache_reset_markdown(output: &CacheResetOutput) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::args::{OutputFormat, ProjectArgs};
+    use std::sync::mpsc;
     use tempfile::TempDir;
 
     struct CacheFixture {
         _root: TempDir,
         project_root: PathBuf,
+        cache_root: PathBuf,
+        /// Outside the cache root, so emitting the report cannot itself change
+        /// what the reset observes.
+        output_dir: PathBuf,
         storage_path: PathBuf,
         annotations: PathBuf,
+        /// Spelled here rather than derived from the registry so a registry
+        /// edit cannot move the expectation along with the behaviour.
+        index_writer_lock: PathBuf,
+        promotion_lock: PathBuf,
     }
 
     /// A cache root holding derived core state plus a user annotation sidecar.
@@ -265,8 +306,10 @@ mod tests {
         let root = TempDir::new().expect("fixture root");
         let project_root = root.path().join("project");
         let cache_root = root.path().join("cache");
+        let output_dir = root.path().join("reports");
         fs::create_dir_all(&project_root).expect("create project");
         fs::create_dir_all(&cache_root).expect("create cache root");
+        fs::create_dir_all(&output_dir).expect("create report directory");
         let storage_path = cache_root.join("codestory.db");
         fs::write(&storage_path, b"core database bytes").expect("write core database");
         fs::write(cache_root.join("codestory.db-wal"), b"wal").expect("write wal");
@@ -287,12 +330,189 @@ mod tests {
             b"annotation wal",
         )
         .expect("write annotation wal");
+        // Both writer locks exist in any cache an indexing run has touched, so
+        // the fixture carries them: whether the reset moves them decides
+        // whether a peer can take a fresh lock at the live path mid-reset.
+        let index_writer_lock = cache_root.join("codestory.index-writer.lock");
+        let promotion_lock = cache_root.join("codestory.db.promotion.lock");
+        fs::write(&index_writer_lock, b"").expect("write index writer lock");
+        fs::write(&promotion_lock, b"").expect("write promotion lock");
         CacheFixture {
             _root: root,
             project_root,
+            cache_root,
+            output_dir,
             storage_path,
             annotations,
+            index_writer_lock,
+            promotion_lock,
         }
+    }
+
+    /// The command as the CLI dispatches it, writing JSON to `output_file`.
+    fn boundary_command(
+        fixture: &CacheFixture,
+        confirm: bool,
+        output_file: &Path,
+    ) -> CacheResetCommand {
+        CacheResetCommand {
+            project: ProjectArgs {
+                project: fixture.project_root.clone(),
+                cache_dir: Some(fixture.cache_root.clone()),
+            },
+            derived_only: true,
+            confirm,
+            dry_run: !confirm,
+            format: OutputFormat::Json,
+            output_file: Some(output_file.to_path_buf()),
+        }
+    }
+
+    fn emitted_output(output_file: &Path) -> serde_json::Value {
+        serde_json::from_str(&fs::read_to_string(output_file).expect("read emitted output"))
+            .expect("parse emitted output")
+    }
+
+    fn open_peer_lock(path: &Path) -> fs::File {
+        fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(path)
+            .expect("open peer lock")
+    }
+
+    /// How long a peer keeps its lock while the command boundary runs.
+    ///
+    /// The whole move is a handful of renames, so a reset that is not excluded
+    /// finishes many times over inside this window. A reset that is excluded
+    /// cannot finish inside it at any speed, which is what makes the
+    /// observation one-sided rather than a race.
+    const PEER_HOLD: Duration = Duration::from_millis(500);
+
+    /// Drive `cache reset --confirm` at the command boundary while a peer owns
+    /// `lock_path` the way a live indexing run or publication owns it, and
+    /// report whether the derived cache was still in place when the peer let
+    /// go.
+    fn reset_under_peer_lock(
+        fixture: &CacheFixture,
+        lock_path: &Path,
+    ) -> (bool, serde_json::Value) {
+        let peer = open_peer_lock(lock_path);
+        assert!(
+            bounded_locks::try_acquire(&peer, FileLockKind::Exclusive).expect("peer lock attempt"),
+            "the peer must own {} before the reset starts",
+            lock_path.display()
+        );
+        let output_file = fixture.output_dir.join("reset.json");
+        let command = boundary_command(fixture, true, &output_file);
+        let (started, start_signal) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            started
+                .send(())
+                .expect("signal that the reset thread began");
+            run_cache_reset(command)
+        });
+        start_signal.recv().expect("the reset thread must begin");
+        std::thread::sleep(PEER_HOLD);
+
+        let derived_still_live = fixture.storage_path.is_file();
+        bounded_locks::release(&peer).expect("release the peer lock");
+        drop(peer);
+        worker
+            .join()
+            .expect("join the reset thread")
+            .expect("the reset must succeed once the peer releases");
+        (derived_still_live, emitted_output(&output_file))
+    }
+
+    #[test]
+    fn the_command_boundary_resets_a_database_no_build_can_open() {
+        // The command exists for a cache this binary refuses to open, so the
+        // boundary itself — not just the layer under it — must reach the move
+        // without a store open. Bytes no SQLite build can open stand in for
+        // that cache: anything that opens the database on the way in turns the
+        // command into the failure it is supposed to recover from.
+        let _env_lock = crate::config::config_env_test_lock();
+        let fixture = seed_cache();
+        fs::write(&fixture.storage_path, b"not a sqlite database at all")
+            .expect("write unopenable core database");
+        let output_file = fixture.output_dir.join("reset.json");
+
+        run_cache_reset(boundary_command(&fixture, true, &output_file))
+            .expect("the command boundary must reach a cache it cannot open");
+
+        let output = emitted_output(&output_file);
+        assert_eq!(output["applied"], serde_json::Value::Bool(true));
+        assert!(
+            !fixture.storage_path.exists(),
+            "the derived cache must leave the live location"
+        );
+        let quarantine = PathBuf::from(
+            output["quarantine_dir"]
+                .as_str()
+                .expect("quarantine_dir is a string"),
+        );
+        assert_eq!(
+            fs::read(quarantine.join("codestory.db")).expect("quarantined core database"),
+            b"not a sqlite database at all",
+            "the reset must move the database untouched, not open or migrate it"
+        );
+        assert_eq!(
+            fs::read(&fixture.annotations).expect("annotation sidecar still readable"),
+            b"user bookmarks",
+            "user-authored annotations must survive the command boundary too"
+        );
+    }
+
+    #[test]
+    fn the_command_boundary_waits_out_an_indexing_run_that_owns_the_writer_lock() {
+        // The promotion lock is held only for the publish critical section, so
+        // it does not exclude an indexing run that is between publishes — and
+        // that run keeps writing the very cache this reset moves. The
+        // index-writer lock is the one a run holds end to end.
+        let _env_lock = crate::config::config_env_test_lock();
+        let fixture = seed_cache();
+
+        let (derived_still_live, output) =
+            reset_under_peer_lock(&fixture, &fixture.index_writer_lock);
+
+        assert!(
+            derived_still_live,
+            "the reset must not move the cache out from under an indexing run that owns the writer lock"
+        );
+        assert_eq!(output["applied"], serde_json::Value::Bool(true));
+        assert!(
+            !fixture.storage_path.exists(),
+            "the reset must complete once the indexing run releases"
+        );
+        assert!(
+            fixture.index_writer_lock.exists(),
+            "the writer lock must stay at the live path; quarantining it lets the next run take a fresh lock mid-reset"
+        );
+    }
+
+    #[test]
+    fn the_command_boundary_waits_out_a_publication_that_owns_the_promotion_lock() {
+        let _env_lock = crate::config::config_env_test_lock();
+        let fixture = seed_cache();
+
+        let (derived_still_live, output) = reset_under_peer_lock(&fixture, &fixture.promotion_lock);
+
+        assert!(
+            derived_still_live,
+            "the reset must not move the cache out from under a publication that owns the promotion lock"
+        );
+        assert_eq!(output["applied"], serde_json::Value::Bool(true));
+        assert!(
+            !fixture.storage_path.exists(),
+            "the reset must complete once the publication releases"
+        );
+        assert!(
+            fixture.promotion_lock.exists(),
+            "the promotion lock must stay at the live path; quarantining it drops the exclusion a waiting publisher is behind"
+        );
     }
 
     #[test]
@@ -330,6 +550,13 @@ mod tests {
                 .exists(),
             "annotation SQLite siblings must survive too"
         );
+        for held in [&fixture.index_writer_lock, &fixture.promotion_lock] {
+            assert!(
+                held.exists(),
+                "{} is an exclusion the reset holds and must stay at the live path",
+                held.display()
+            );
+        }
         let quarantined = Path::new(&output.quarantine_dir);
         assert_eq!(
             fs::read(quarantined.join("codestory.db")).expect("quarantined core database"),

--- a/crates/codestory-cli/src/lib.rs
+++ b/crates/codestory-cli/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod app;
 mod args;
+mod cache_reset;
 mod config;
 mod diagnostics;
 mod display;

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -8,7 +8,8 @@ use codestory_retrieval::{
 };
 
 use crate::args::{
-    CliSidecarProfile, OutputFormat, RefreshMode, RetrievalAction, RetrievalCommand,
+    CliSidecarProfile, OutputFormat, RefreshMode, RetrievalAction,
+    RetrievalActivateRollbackCommand, RetrievalActivateRollbackOutput, RetrievalCommand,
     RetrievalIndexCommand, RetrievalInventoryCommand, RetrievalQueryCommand,
     RetrievalRepublishProjectionsCommand, RetrievalStatusCommand,
 };
@@ -24,7 +25,87 @@ pub(crate) fn run_retrieval(cmd: RetrievalCommand) -> Result<()> {
             run_retrieval_republish_projections(republish_cmd)
         }
         RetrievalAction::Query(query_cmd) => run_retrieval_query(query_cmd),
+        RetrievalAction::ActivateRollback(activate_cmd) => {
+            run_retrieval_activate_rollback(activate_cmd)
+        }
     }
+}
+
+fn run_retrieval_activate_rollback(cmd: RetrievalActivateRollbackCommand) -> Result<()> {
+    preflight_output(cmd.output_file.as_deref())?;
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let outcome = codestory_retrieval::activate_retained_rollback_generation(
+        &runtime.project_root,
+        &runtime.storage_path,
+        &runtime.sidecar,
+        !cmd.dry_run,
+    )
+    .map_err(annotate_rollback_activation_error)?;
+    let project = crate::display::clean_path_string(&runtime.project_root.to_string_lossy());
+    let next_commands = rollback_activation_next_commands(&project, &outcome);
+    let markdown = render_rollback_activation_markdown(&project, &outcome, &next_commands);
+    let payload = RetrievalActivateRollbackOutput {
+        project,
+        outcome,
+        next_commands,
+    };
+    emit(cmd.format, &payload, markdown, cmd.output_file.as_deref())
+}
+
+/// Carry the typed refusal code into the CLI error chain.
+///
+/// The refusal is the product answer, not an internal failure, so the code has
+/// to survive into stderr and into any wrapping context a caller adds.
+fn annotate_rollback_activation_error(
+    error: codestory_retrieval::RollbackActivationError,
+) -> anyhow::Error {
+    let code = error.code();
+    anyhow::anyhow!("{error}").context(format!("retrieval activate-rollback refused: {code}"))
+}
+
+fn rollback_activation_next_commands(
+    project: &str,
+    outcome: &codestory_retrieval::RollbackActivationOutcome,
+) -> Vec<String> {
+    if outcome.applied {
+        return vec![
+            format!("codestory-cli doctor --project \"{project}\" --format markdown"),
+            format!("codestory-cli retrieval inventory --project \"{project}\" --apply"),
+        ];
+    }
+    vec![format!(
+        "codestory-cli retrieval activate-rollback --project \"{project}\""
+    )]
+}
+
+fn render_rollback_activation_markdown(
+    project: &str,
+    outcome: &codestory_retrieval::RollbackActivationOutcome,
+    next_commands: &[String],
+) -> String {
+    let mut markdown = format!(
+        "# Retrieval rollback activation\n\n- project: `{project}`\n- project_id: `{}`\n- applied: {}\n- previous_generation: `{}`\n- activated_generation: `{}`\n- activated_semantic_generation: `{}`\n- activated_retrieval_mode: `{}`\n- rollback_pointer_retained: {}\n",
+        outcome.project_id,
+        outcome.applied,
+        outcome
+            .previous_generation
+            .as_deref()
+            .unwrap_or("<missing>"),
+        outcome.activated_generation,
+        outcome.activated_semantic_generation,
+        outcome.activated_retrieval_mode,
+        outcome.rollback_pointer_retained,
+    );
+    if !outcome.applied {
+        markdown.push_str(
+            "\nValidation only: the current retrieval generation was not changed. Rerun without `--dry-run` to activate.\n",
+        );
+    }
+    markdown.push_str("\n## Next\n\n");
+    for command in next_commands {
+        markdown.push_str(&format!("- `{command}`\n"));
+    }
+    markdown
 }
 
 fn run_retrieval_republish_projections(cmd: RetrievalRepublishProjectionsCommand) -> Result<()> {

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -999,6 +999,8 @@ pub(crate) fn api_error_in_chain(error: &anyhow::Error) -> Option<&ApiError> {
 fn map_api_error_with_project(error: ApiError, project: Option<&Path>) -> anyhow::Error {
     let message = if api_error_is_cache_busy(&error) {
         cache_busy_message(project)
+    } else if api_error_is_schema_too_new(&error) {
+        schema_too_new_message(&error, project)
     } else {
         let mut message = format!("{}: {}", error.code, error.message);
         if let Some((minimum_next, full_repair)) = api_error_repair_groups(&error) {
@@ -1062,6 +1064,32 @@ fn api_error_is_cache_busy(error: &ApiError) -> bool {
 fn is_cache_busy_text(text: &str) -> bool {
     let text = text.to_ascii_lowercase();
     text.contains("database is locked") || text.contains("sqlite_busy")
+}
+
+fn api_error_is_schema_too_new(error: &ApiError) -> bool {
+    is_schema_too_new_text(&format!("{} {}", error.code, error.message))
+}
+
+fn is_schema_too_new_text(text: &str) -> bool {
+    text.to_ascii_lowercase()
+        .contains("unsupported database schema version")
+}
+
+/// Name the executable downgrade path on a schema-too-new cache.
+///
+/// Migrations are forward-only, so an older CodeStory refuses a newer cache
+/// and the advertised `--refresh full` repair refuses it too. Without this the
+/// operator is told only that the cache is unsupported, with no in-band way
+/// out. The reset is a move, not a delete, and preserves annotations, so it is
+/// safe to recommend directly.
+fn schema_too_new_message(error: &ApiError, project: Option<&Path>) -> String {
+    let project = project
+        .map(quote_command_path)
+        .unwrap_or_else(|| "<repo>".to_string());
+    format!(
+        "{}: {}\n\nThis CodeStory build is older than the cache it was pointed at. Migrations are forward-only, so `--refresh full` refuses it too. Quarantine the derived cache (annotations are preserved, nothing is deleted) and rebuild:\n\nMinimum next:\n  codestory-cli cache reset --project {project} --derived-only --dry-run\n  codestory-cli cache reset --project {project} --derived-only --confirm\n  codestory-cli index --project {project} --refresh full\n\nAdditional checks:\n  codestory-cli doctor --project {project} --format markdown",
+        error.code, error.message
+    )
 }
 
 fn cache_busy_message(project: Option<&Path>) -> String {
@@ -1186,6 +1214,68 @@ mod tests {
             "codestory-cli ready --project {project} --goal agent"
         )));
         assert!(human.contains(&format!("codestory-cli doctor --project {project}")));
+    }
+
+    #[test]
+    fn a_schema_too_new_cache_names_the_derived_reset_recovery() {
+        // ARCH-020: migrations are forward-only, so an older CodeStory refuses
+        // a cache a newer release wrote, and the advertised `--refresh full`
+        // repair refuses it too. The operator was told the cache was
+        // unsupported and nothing else. This drives the real production path —
+        // a real store, its version stamped past what this build supports,
+        // opened through the same `RuntimeContext` every command uses — and
+        // pins that the executable recovery reaches the operator.
+        let _env_lock = crate::config::config_env_test_lock();
+        let temp = tempdir().expect("temp dir");
+        let project = temp.path().join("repo");
+        let cache = temp.path().join("cache");
+        fs::create_dir_all(&project).expect("create project");
+        fs::create_dir_all(&cache).expect("create cache");
+        fs::write(project.join("lib.rs"), "pub fn alpha() {}\n").expect("seed source");
+        let args = ProjectArgs {
+            project: project.clone(),
+            cache_dir: Some(cache),
+        };
+        let seed = RuntimeContext::new_inspect_only(&args).expect("resolve runtime paths");
+        seed.ensure_open(RefreshMode::Full)
+            .expect("publish a cache this build supports");
+        let storage_path = seed.storage_path.clone();
+        drop(seed);
+
+        // Stamp the cache one version past whatever this build wrote, which is
+        // exactly the shape a rolled-back CLI meets in the field.
+        let stamp = rusqlite::Connection::open(&storage_path).expect("open cache for stamping");
+        let supported: i64 = stamp
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("read the supported schema version");
+        assert!(supported > 0, "the seeded cache must record a version");
+        stamp
+            .pragma_update(None, "user_version", supported + 1)
+            .expect("stamp a newer schema version");
+        drop(stamp);
+
+        let runtime = RuntimeContext::new_inspect_only(&args).expect("resolve runtime paths");
+        let error = runtime
+            .open_project_summary()
+            .expect_err("a newer schema must fail closed");
+
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("Unsupported database schema version"),
+            "the fail-closed reason must survive into the CLI message: {rendered}"
+        );
+        assert!(
+            rendered.contains("cache reset"),
+            "a schema-too-new cache must name the derived reset: {rendered}"
+        );
+        assert!(
+            rendered.contains("--derived-only --confirm"),
+            "the recovery must be executable, not a hint: {rendered}"
+        );
+        assert!(
+            rendered.contains("--refresh full"),
+            "the recovery must name the reindex step that follows: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -1189,6 +1189,7 @@ fn owned_artifact_identities_are_declared_only_in_the_registry() {
         "annotations.pre-migration.json",
         "embedded-models",
         ".materialize.lock",
+        "derived-reset-quarantine",
     ];
     let producer_crates = [
         "crates/codestory-workspace/src",

--- a/crates/codestory-contracts/src/owned_artifacts.rs
+++ b/crates/codestory-contracts/src/owned_artifacts.rs
@@ -154,6 +154,11 @@ pub fn annotations_migration_backup_path(storage_path: &Path) -> PathBuf {
     cache_root_for(storage_path).join(ANNOTATIONS_MIGRATION_BACKUP_FILE)
 }
 
+/// The index-writer lock one storage file's indexing runs hold end to end.
+pub fn index_writer_lock_path(storage_path: &Path) -> PathBuf {
+    storage_path.with_extension(INDEX_WRITER_LOCK_EXTENSION)
+}
+
 /// Exact owned file identities beside one storage file: the database and its
 /// sidecars, the index-writer lock, promotion siblings, the rollback backup
 /// and its sidecars, the search directory locks, the local-refresh files, and
@@ -162,7 +167,7 @@ pub fn storage_owned_file_identities(storage_path: &Path) -> Vec<PathBuf> {
     let cache_root = cache_root_for(storage_path);
     let rollback_backup = storage_path.with_extension(ROLLBACK_BACKUP_EXTENSION);
     let mut files = sqlite_file_with_sidecars(storage_path);
-    files.push(storage_path.with_extension(INDEX_WRITER_LOCK_EXTENSION));
+    files.push(index_writer_lock_path(storage_path));
     files.extend(
         PROMOTION_SIBLING_SUFFIXES
             .iter()
@@ -203,19 +208,36 @@ pub fn derived_reset_quarantine_root(storage_path: &Path) -> PathBuf {
     cache_root_for(storage_path).join(DERIVED_RESET_QUARANTINE_DIR)
 }
 
+/// Exclusions the guided reset holds for the whole move, in acquisition order.
+///
+/// An indexing run holds the index-writer lock for its entire pass and takes
+/// the promotion lock inside it, so the reset must take them in the same order
+/// or the two paths can deadlock against each other. The promotion lock alone
+/// excludes only the publish critical section, which is a few milliseconds of
+/// a minutes-long index run — a reset that took only that lock would move the
+/// cache out from under a live indexer.
+pub fn derived_reset_held_lock_paths(storage_path: &Path) -> [PathBuf; 2] {
+    [
+        index_writer_lock_path(storage_path),
+        promotion_sibling_path(storage_path, PROMOTION_LOCK_SUFFIX),
+    ]
+}
+
 /// Derived file identities the guided reset quarantines.
 ///
-/// This is every file identity the storage file owns, minus two exclusions.
-/// The annotation sidecar family is user-owned state and is preserved in
-/// place. The promotion lock is the exclusion the reset itself holds while it
-/// runs, and an empty coordination file carries no derived state, so moving it
-/// would only drop the exclusion a concurrent publisher is waiting on.
+/// This is every file identity the storage file owns, minus two exclusion
+/// families. The annotation sidecar family is user-owned state and is
+/// preserved in place. The locks in [`derived_reset_held_lock_paths`] are the
+/// exclusions the reset itself holds while it runs, and an empty coordination
+/// file carries no derived state, so moving one would only drop the exclusion
+/// a concurrent publisher or indexer is waiting on — or let a new indexer take
+/// a fresh lock file at the old path and start writing mid-reset.
 pub fn derived_reset_file_identities(storage_path: &Path) -> Vec<PathBuf> {
     let preserved = annotation_owned_file_identities(cache_root_for(storage_path));
-    let held_lock = promotion_sibling_path(storage_path, PROMOTION_LOCK_SUFFIX);
+    let held = derived_reset_held_lock_paths(storage_path);
     storage_owned_file_identities(storage_path)
         .into_iter()
-        .filter(|path| *path != held_lock && !preserved.contains(path))
+        .filter(|path| !held.contains(path) && !preserved.contains(path))
         .collect()
 }
 
@@ -312,15 +334,25 @@ mod tests {
                 annotation.display()
             );
         }
-        assert!(
-            !contains("/cache/custom-core.db.promotion.lock"),
-            "the reset holds the promotion lock; quarantining it would drop the exclusion"
+        assert_eq!(
+            derived_reset_held_lock_paths(storage),
+            [
+                PathBuf::from("/cache/custom-core.index-writer.lock"),
+                PathBuf::from("/cache/custom-core.db.promotion.lock"),
+            ],
+            "the reset must exclude an indexing run, not only a publish, and must take the two locks in the order an indexer takes them"
         );
+        for held in derived_reset_held_lock_paths(storage) {
+            assert!(
+                !derived.contains(&held),
+                "{} is the exclusion the reset holds; quarantining it would let a peer take a fresh lock at the live path mid-reset",
+                held.display()
+            );
+        }
         for required in [
             "/cache/custom-core.db",
             "/cache/custom-core.db-wal",
             "/cache/custom-core.db-shm",
-            "/cache/custom-core.index-writer.lock",
             "/cache/custom-core.db.promotion.prepared.json",
             "/cache/custom-core.db.promotion.committed.json",
             "/cache/custom-core.db.promotion.cleanup-blocked",

--- a/crates/codestory-contracts/src/owned_artifacts.rs
+++ b/crates/codestory-contracts/src/owned_artifacts.rs
@@ -88,6 +88,11 @@ pub fn embedded_model_directory(cache_root: &Path, digest: &str) -> PathBuf {
     embedded_model_digest_root(cache_root).join(digest)
 }
 
+/// Directory the guided derived-cache reset moves quarantined derived state
+/// into, inside the cache root that holds the storage file. The reset moves
+/// rather than deletes, so the name is an owned identity like any other.
+pub const DERIVED_RESET_QUARANTINE_DIR: &str = "derived-reset-quarantine";
+
 fn cache_root_for(storage_path: &Path) -> &Path {
     storage_path
         .parent()
@@ -179,6 +184,50 @@ pub fn storage_owned_file_identities(storage_path: &Path) -> Vec<PathBuf> {
     files
 }
 
+/// One promotion sibling path for a storage file.
+pub fn promotion_sibling_path(storage_path: &Path, suffix: &str) -> PathBuf {
+    path_with_display_suffix(storage_path, suffix)
+}
+
+/// The annotations sidecar and its SQLite siblings in one cache root.
+///
+/// These hold user-authored state. Nothing that reclaims derived output may
+/// move or remove them, which is why they are named separately from the rest
+/// of the owned set rather than filtered at each call site.
+pub fn annotation_owned_file_identities(cache_root: &Path) -> Vec<PathBuf> {
+    sqlite_file_with_sidecars(&cache_root.join(ANNOTATIONS_SIDECAR_FILE))
+}
+
+/// Root the guided derived-cache reset quarantines into for one storage file.
+pub fn derived_reset_quarantine_root(storage_path: &Path) -> PathBuf {
+    cache_root_for(storage_path).join(DERIVED_RESET_QUARANTINE_DIR)
+}
+
+/// Derived file identities the guided reset quarantines.
+///
+/// This is every file identity the storage file owns, minus two exclusions.
+/// The annotation sidecar family is user-owned state and is preserved in
+/// place. The promotion lock is the exclusion the reset itself holds while it
+/// runs, and an empty coordination file carries no derived state, so moving it
+/// would only drop the exclusion a concurrent publisher is waiting on.
+pub fn derived_reset_file_identities(storage_path: &Path) -> Vec<PathBuf> {
+    let preserved = annotation_owned_file_identities(cache_root_for(storage_path));
+    let held_lock = promotion_sibling_path(storage_path, PROMOTION_LOCK_SUFFIX);
+    storage_owned_file_identities(storage_path)
+        .into_iter()
+        .filter(|path| *path != held_lock && !preserved.contains(path))
+        .collect()
+}
+
+/// Derived directory identities the guided reset quarantines: the search trees
+/// owned by one storage file.
+pub fn derived_reset_directory_identities(storage_path: &Path) -> Vec<PathBuf> {
+    SEARCH_DIRECTORY_SUFFIXES
+        .iter()
+        .map(|suffix| search_directory_for_storage(storage_path, suffix))
+        .collect()
+}
+
 /// Build the staged snapshot path for one live database and unique parts.
 pub fn staged_snapshot_path(live_path: &Path, pid: u32, epoch_ns: u128) -> PathBuf {
     cache_root_for(live_path).join(format!(
@@ -248,6 +297,56 @@ mod tests {
         expect("/cache/annotations.sqlite3");
         expect("/cache/annotations.sqlite3-shm");
         expect("/cache/annotations.pre-migration.json");
+    }
+
+    #[test]
+    fn derived_reset_quarantines_the_core_cache_and_preserves_annotations() {
+        let storage = Path::new("/cache/custom-core.db");
+        let derived = derived_reset_file_identities(storage);
+        let contains = |name: &str| derived.iter().any(|file| file == Path::new(name));
+
+        for annotation in annotation_owned_file_identities(Path::new("/cache")) {
+            assert!(
+                !derived.contains(&annotation),
+                "{} is user-owned annotation state and must never be quarantined",
+                annotation.display()
+            );
+        }
+        assert!(
+            !contains("/cache/custom-core.db.promotion.lock"),
+            "the reset holds the promotion lock; quarantining it would drop the exclusion"
+        );
+        for required in [
+            "/cache/custom-core.db",
+            "/cache/custom-core.db-wal",
+            "/cache/custom-core.db-shm",
+            "/cache/custom-core.index-writer.lock",
+            "/cache/custom-core.db.promotion.prepared.json",
+            "/cache/custom-core.db.promotion.committed.json",
+            "/cache/custom-core.db.promotion.cleanup-blocked",
+            "/cache/custom-core.sqlite.backup",
+            "/cache/custom-core.search.lock",
+            "/cache/custom-core.search-generations.lock",
+            "/cache/local-refresh-status.json",
+            "/cache/local-refresh.lock",
+            "/cache/local-refresh-state.guard",
+        ] {
+            assert!(
+                contains(required),
+                "{required} must be quarantined by the reset"
+            );
+        }
+        assert_eq!(
+            derived_reset_directory_identities(storage),
+            vec![
+                PathBuf::from("/cache/custom-core.search"),
+                PathBuf::from("/cache/custom-core.search-generations"),
+            ]
+        );
+        assert_eq!(
+            derived_reset_quarantine_root(storage),
+            Path::new("/cache").join(DERIVED_RESET_QUARANTINE_DIR)
+        );
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -1524,7 +1524,7 @@ fn promote_retrieval_manifest_with_cancel<T>(
     Ok(prepared)
 }
 
-fn publish_derived_retention_marker(
+pub(crate) fn publish_derived_retention_marker(
     storage: &Store,
     layout: &SidecarLayout,
     workspace_id: &str,

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -34,6 +34,7 @@ mod query;
 mod query_features;
 mod ranker;
 mod retention;
+mod rollback;
 mod scip_client;
 mod scip_index;
 mod sidecar;
@@ -156,6 +157,11 @@ pub use retention::{
     GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport, GenerationRetentionLock,
     GenerationRetentionPlan, MarkerRetirement, ObservedRetentionLock, RETENTION_MARKER_SCHEMA_V1,
     RETENTION_MARKER_SCHEMA_V2, global_generation_gc_state_file,
+};
+pub use rollback::{
+    RetainedRollbackObservation, RollbackActivationError, RollbackActivationOutcome,
+    RollbackActivationRefusal, activate_retained_rollback_generation,
+    observe_retained_rollback_generation,
 };
 pub use scip_client::ScipClient;
 pub use sidecar::{

--- a/crates/codestory-retrieval/src/rollback.rs
+++ b/crates/codestory-retrieval/src/rollback.rs
@@ -1,0 +1,723 @@
+//! Validated activation of the retained retrieval rollback generation.
+//!
+//! Retention already keeps one *verified* previous generation beside the
+//! current pointer, in the same SQLite row, so a reader observes either the
+//! complete old pair or the complete new pair. Until now no code path could
+//! select it: a corrupt or unusable current generation could only be repaired
+//! by rebuilding, which is minutes to hours of work for a lever the product
+//! already paid to retain.
+//!
+//! Activation re-proves the retained candidate against live state before it
+//! moves the pointer, at the same bar retention used to call it verified —
+//! current sidecar-generation contract, deep vector-evidence validation
+//! against the live complete core publication, and a live-ready health probe.
+//! A candidate that no longer proves out is refused with a typed code and the
+//! current pointer is left exactly where it was: this lever can only ever
+//! narrow what is served, never widen it.
+
+use std::fmt;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use codestory_store::{RetrievalIndexManifest, RetrievalIndexRollbackRecord, Store};
+use serde::Serialize;
+use tracing::warn;
+
+use crate::config::SidecarRuntimeConfig;
+use crate::embedding_server_compat::ProductEmbeddingIdentity;
+use crate::embeddings::EmbeddingDeviceReadiness;
+use crate::generation::manifest_has_current_sidecar_contract;
+use crate::health::probe_sidecar_health_for_runtime;
+use crate::index::sidecar_project_id_for_runtime;
+
+/// Why validated rollback activation left the current pointer alone.
+///
+/// Every variant is a refusal to serve something new, never a refusal that
+/// removes an existing capability, so callers can report all of them as
+/// "nothing changed" without inspecting the code.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum RollbackActivationRefusal {
+    /// No retrieval publication row exists for this project id.
+    NoPublication,
+    /// The publication row carries no retained rollback pointer.
+    NoRetainedRollback,
+    /// The retained rollback manifest no longer satisfies the current
+    /// sidecar-generation contract, so nothing downstream would admit it.
+    RollbackContractMissing { sidecar_generation: Option<String> },
+    /// The core publication is missing or incomplete, so no retrieval
+    /// generation can be bound to it.
+    CorePublicationIncomplete,
+    /// The retained generation's vector bytes, producer evidence, or anchor
+    /// coverage no longer validate against the live core publication.
+    RollbackEvidenceInvalid { reason: String },
+    /// The retained generation does not probe as a live-ready full retrieval
+    /// mode with the artifacts currently on disk.
+    RollbackNotLiveReady {
+        retrieval_mode: String,
+        degraded_reason: Option<String>,
+    },
+    /// The publication pair changed between validation and activation, so the
+    /// validated candidate is no longer the one that would be written.
+    PublicationRaced,
+}
+
+impl RollbackActivationRefusal {
+    /// Stable machine code for this refusal.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NoPublication => "no_publication",
+            Self::NoRetainedRollback => "no_retained_rollback",
+            Self::RollbackContractMissing { .. } => "rollback_contract_missing",
+            Self::CorePublicationIncomplete => "core_publication_incomplete",
+            Self::RollbackEvidenceInvalid { .. } => "rollback_evidence_invalid",
+            Self::RollbackNotLiveReady { .. } => "rollback_not_live_ready",
+            Self::PublicationRaced => "publication_raced",
+        }
+    }
+}
+
+impl fmt::Display for RollbackActivationRefusal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoPublication => {
+                write!(
+                    formatter,
+                    "{}: this project has published no retrieval generation",
+                    self.code()
+                )
+            }
+            Self::NoRetainedRollback => write!(
+                formatter,
+                "{}: no verified rollback generation is retained beside the current pointer",
+                self.code()
+            ),
+            Self::RollbackContractMissing { sidecar_generation } => write!(
+                formatter,
+                "{}: retained rollback generation {} does not satisfy the current sidecar generation contract",
+                self.code(),
+                sidecar_generation.as_deref().unwrap_or("<missing>")
+            ),
+            Self::CorePublicationIncomplete => write!(
+                formatter,
+                "{}: no complete core publication is available to bind a retrieval generation to",
+                self.code()
+            ),
+            Self::RollbackEvidenceInvalid { reason } => {
+                write!(formatter, "{}: {reason}", self.code())
+            }
+            Self::RollbackNotLiveReady {
+                retrieval_mode,
+                degraded_reason,
+            } => write!(
+                formatter,
+                "{}: retained rollback generation probes as {retrieval_mode} ({})",
+                self.code(),
+                degraded_reason.as_deref().unwrap_or("no degraded reason")
+            ),
+            Self::PublicationRaced => write!(
+                formatter,
+                "{}: the retrieval publication changed while the rollback candidate was being validated",
+                self.code()
+            ),
+        }
+    }
+}
+
+/// Typed failure surface for rollback activation.
+#[derive(Debug)]
+pub enum RollbackActivationError {
+    /// Activation completed its checks and declined; nothing was written.
+    Refused(RollbackActivationRefusal),
+    /// Activation could not complete its checks.
+    Failed(anyhow::Error),
+}
+
+impl RollbackActivationError {
+    /// Stable machine code for this failure.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Refused(refusal) => refusal.code(),
+            Self::Failed(_) => "rollback_activation_failed",
+        }
+    }
+}
+
+impl From<RollbackActivationRefusal> for RollbackActivationError {
+    fn from(value: RollbackActivationRefusal) -> Self {
+        Self::Refused(value)
+    }
+}
+
+impl fmt::Display for RollbackActivationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Refused(refusal) => write!(formatter, "{refusal}"),
+            Self::Failed(error) => write!(formatter, "{error:#}"),
+        }
+    }
+}
+
+impl std::error::Error for RollbackActivationError {}
+
+/// What validated rollback activation observed, and whether it applied.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RollbackActivationOutcome {
+    pub project_id: String,
+    /// `false` for a validation-only run: every check ran, nothing was written.
+    pub applied: bool,
+    pub previous_generation: Option<String>,
+    pub previous_semantic_generation: String,
+    pub activated_generation: String,
+    pub activated_semantic_generation: String,
+    pub activated_built_at_epoch_ms: i64,
+    pub rollback_verified_at_epoch_ms: i64,
+    /// Activation consumes the retained pointer: the generation it replaced is
+    /// the one the operator is stepping away from, so it is not re-armed as a
+    /// rollback target.
+    pub rollback_pointer_retained: bool,
+    pub activated_retrieval_mode: String,
+}
+
+/// The retained rollback pointer as an observational surface sees it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RetainedRollbackObservation {
+    pub project_id: String,
+    pub current_generation: Option<String>,
+    pub rollback_generation: Option<String>,
+    pub rollback_verified_at_epoch_ms: i64,
+}
+
+/// Observe whether a rollback generation is retained for this project.
+///
+/// Strictly non-mutating: a status or doctor surface must be able to mention
+/// the lever without becoming the thing that migrates, recovers, or activates
+/// anything. It deliberately does not validate the candidate — that is
+/// [`activate_retained_rollback_generation`]'s job, and doing it here would
+/// make an observational call pay for deep artifact validation.
+pub fn observe_retained_rollback_generation(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<Option<RetainedRollbackObservation>> {
+    if !storage_path.is_file() {
+        return Ok(None);
+    }
+    let project_id = sidecar_project_id_for_runtime(project_root, runtime)
+        .context("resolve project id for retained rollback observation")?;
+    let storage = Store::open_observational(storage_path)
+        .context("open storage observationally for retained rollback observation")?;
+    let Some((current, rollback)) = storage
+        .get_retrieval_index_publication(&project_id)
+        .context("load the retrieval publication pair")?
+    else {
+        return Ok(None);
+    };
+    let Some(rollback) = rollback else {
+        return Ok(None);
+    };
+    Ok(Some(RetainedRollbackObservation {
+        project_id,
+        current_generation: current.sidecar_generation,
+        rollback_generation: rollback.manifest.sidecar_generation,
+        rollback_verified_at_epoch_ms: rollback.verified_at_epoch_ms,
+    }))
+}
+
+/// Validate and (when `apply`) activate the retained rollback generation.
+///
+/// With `apply == false` every check runs and nothing is written, so an
+/// observational surface can report whether the lever would work without
+/// becoming a mutating surface itself.
+pub fn activate_retained_rollback_generation(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+    apply: bool,
+) -> Result<RollbackActivationOutcome, RollbackActivationError> {
+    let snapshot = crate::embeddings::embedding_engine_snapshot_for_runtime(runtime);
+    activate_retained_rollback_generation_with_embedding(
+        project_root,
+        storage_path,
+        runtime,
+        &snapshot.device,
+        snapshot.identity.as_ref(),
+        apply,
+    )
+}
+
+pub(crate) fn activate_retained_rollback_generation_with_embedding(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+    embedding_device: &EmbeddingDeviceReadiness,
+    live_identity: Option<&ProductEmbeddingIdentity>,
+    apply: bool,
+) -> Result<RollbackActivationOutcome, RollbackActivationError> {
+    let project_id = sidecar_project_id_for_runtime(project_root, runtime)
+        .context("resolve project id for rollback activation")
+        .map_err(RollbackActivationError::Failed)?;
+    let validated = validate_retained_rollback(
+        storage_path,
+        runtime,
+        embedding_device,
+        live_identity,
+        &project_id,
+    )?;
+    let mut outcome = RollbackActivationOutcome {
+        project_id: project_id.clone(),
+        applied: false,
+        previous_generation: validated.current.sidecar_generation.clone(),
+        previous_semantic_generation: validated.current.semantic_generation.clone(),
+        activated_generation: validated
+            .rollback
+            .manifest
+            .sidecar_generation
+            .clone()
+            .unwrap_or_default(),
+        activated_semantic_generation: validated.rollback.manifest.semantic_generation.clone(),
+        activated_built_at_epoch_ms: validated.rollback.manifest.built_at_epoch_ms,
+        rollback_verified_at_epoch_ms: validated.rollback.verified_at_epoch_ms,
+        rollback_pointer_retained: !apply,
+        activated_retrieval_mode: validated.retrieval_mode,
+    };
+    if !apply {
+        return Ok(outcome);
+    }
+
+    let mut storage = Store::open(storage_path)
+        .context("open storage to activate the retained rollback generation")
+        .map_err(RollbackActivationError::Failed)?;
+    let mut publication = storage
+        .write_transaction()
+        .context("lock the retrieval publication for rollback activation")
+        .map_err(RollbackActivationError::Failed)?;
+    let observed = publication
+        .storage()
+        .get_retrieval_index_publication(&project_id)
+        .context("re-read the retrieval publication under the activation transaction")
+        .map_err(RollbackActivationError::Failed)?;
+    match observed {
+        Some((current, Some(rollback)))
+            if current == validated.current && rollback == validated.rollback => {}
+        _ => return Err(RollbackActivationRefusal::PublicationRaced.into()),
+    }
+    publication
+        .storage_mut()
+        .publish_retrieval_index_publication(&validated.rollback.manifest, None)
+        .context("write the activated rollback generation as the current pointer")
+        .map_err(RollbackActivationError::Failed)?;
+    publication
+        .finish()
+        .context("commit the rollback activation")
+        .map_err(RollbackActivationError::Failed)?;
+    refresh_retention_marker_after_activation(
+        &storage,
+        runtime,
+        project_root,
+        &project_id,
+        &validated.rollback.manifest,
+    );
+    outcome.applied = true;
+    outcome.rollback_pointer_retained = false;
+    Ok(outcome)
+}
+
+struct ValidatedRollback {
+    current: RetrievalIndexManifest,
+    rollback: RetrievalIndexRollbackRecord,
+    retrieval_mode: String,
+}
+
+fn validate_retained_rollback(
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+    embedding_device: &EmbeddingDeviceReadiness,
+    live_identity: Option<&ProductEmbeddingIdentity>,
+    project_id: &str,
+) -> Result<ValidatedRollback, RollbackActivationError> {
+    // Validation is strictly observational: an operator inspecting the lever
+    // must never up-migrate or recover a database as a side effect.
+    let storage = Store::open_observational(storage_path)
+        .context("open storage observationally for rollback validation")
+        .map_err(RollbackActivationError::Failed)?;
+    let publication = storage
+        .get_retrieval_index_publication(project_id)
+        .context("load the retrieval publication pair")
+        .map_err(RollbackActivationError::Failed)?;
+    let Some((current, rollback)) = publication else {
+        return Err(RollbackActivationRefusal::NoPublication.into());
+    };
+    let Some(rollback) = rollback else {
+        return Err(RollbackActivationRefusal::NoRetainedRollback.into());
+    };
+    let candidate = rollback.manifest.clone();
+    if !manifest_has_current_sidecar_contract(project_id, &candidate) {
+        return Err(RollbackActivationRefusal::RollbackContractMissing {
+            sidecar_generation: candidate.sidecar_generation.clone(),
+        }
+        .into());
+    }
+    let core_publication = storage
+        .get_complete_index_publication()
+        .context("load the complete core publication for rollback validation")
+        .map_err(RollbackActivationError::Failed)?;
+    let Some(core_publication) = core_publication else {
+        return Err(RollbackActivationRefusal::CorePublicationIncomplete.into());
+    };
+    crate::embedded_vector::validate_generation_evidence_for_publication(
+        &runtime.layout,
+        &storage,
+        &candidate,
+        &core_publication,
+        runtime,
+        embedding_device,
+        live_identity,
+    )
+    .map_err(|error| RollbackActivationRefusal::RollbackEvidenceInvalid {
+        reason: format!("{error:#}"),
+    })?;
+    let status = probe_sidecar_health_for_runtime(
+        &runtime.layout,
+        project_id,
+        Some(candidate.clone()),
+        embedding_device,
+        runtime,
+    );
+    if !status.is_live_ready() {
+        return Err(RollbackActivationRefusal::RollbackNotLiveReady {
+            retrieval_mode: status.retrieval_mode,
+            degraded_reason: status.degraded_reason,
+        }
+        .into());
+    }
+    Ok(ValidatedRollback {
+        current,
+        rollback,
+        retrieval_mode: status.retrieval_mode,
+    })
+}
+
+/// Re-derive the generation retention marker from the committed publication.
+///
+/// A stale marker only ever over-protects generations, so a failure here is a
+/// warning rather than a failed activation: the pointer swap is already
+/// durable and correct.
+fn refresh_retention_marker_after_activation(
+    storage: &Store,
+    runtime: &SidecarRuntimeConfig,
+    project_root: &Path,
+    project_id: &str,
+    activated: &RetrievalIndexManifest,
+) {
+    let Some(workspace_id) = runtime
+        .project_identity
+        .as_ref()
+        .map(|identity| identity.workspace_id.as_str())
+    else {
+        return;
+    };
+    if let Err(error) = crate::index::publish_derived_retention_marker(
+        storage,
+        &runtime.layout,
+        workspace_id,
+        project_root,
+        project_id,
+    ) {
+        warn!(
+            project_id = %project_id,
+            sidecar_generation = ?activated.sidecar_generation,
+            error = %format!("{error:#}"),
+            "rollback activation committed but the retention marker was not refreshed"
+        );
+    }
+}
+
+// The fixtures below need a device the product would admit for full
+// retrieval, which only exists under `test-support`; the per-PR lane runs this
+// module with that feature explicitly.
+#[cfg(all(test, feature = "test-support"))]
+mod tests {
+    use super::*;
+    use crate::test_support::{env_lock, publish_zero_dense_pinned_query_fixture};
+    use codestory_store::{IndexPublicationMode, IndexPublicationRecord};
+    use std::io::Write as _;
+    use tempfile::TempDir;
+
+    struct Fixture {
+        _project: TempDir,
+        _storage_dir: TempDir,
+        _cache: TempDir,
+        project_root: std::path::PathBuf,
+        storage_path: std::path::PathBuf,
+        runtime: SidecarRuntimeConfig,
+        current: RetrievalIndexManifest,
+        rollback: RetrievalIndexRollbackRecord,
+    }
+
+    /// Publish two distinct live-ready retrieval generations against one core
+    /// publication and arm the older one as the retained rollback pointer.
+    fn publish_current_over_rollback() -> Fixture {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let cache = TempDir::new().expect("cache");
+        let storage_path = storage_dir.path().join("codestory.db");
+        std::fs::write(project.path().join("lib.rs"), "pub fn alpha() {}\n").expect("seed source");
+        let store = Store::open(&storage_path).expect("open storage");
+        store
+            .put_index_publication(&IndexPublicationRecord {
+                generation: 1,
+                generation_id: "11111111-1111-4111-8111-111111111111".into(),
+                run_id: "run-one".into(),
+                mode: IndexPublicationMode::Full,
+                published_at_epoch_ms: 1,
+            })
+            .expect("publish core identity");
+        drop(store);
+        let runtime = crate::config::with_test_cache_root(cache.path(), || {
+            SidecarRuntimeConfig::for_project_profile(
+                Some(project.path()),
+                crate::SidecarProfile::Local,
+            )
+        });
+        let older =
+            publish_zero_dense_pinned_query_fixture(project.path(), &storage_path, &runtime)
+                .expect("publish rollback candidate generation");
+        // A second lexical input over the same core publication produces a
+        // distinct sidecar generation, which is exactly the shape retention
+        // retains: two generations bound to one core publication.
+        std::fs::write(project.path().join("beta.rs"), "pub fn beta() {}\n")
+            .expect("second source");
+        let newer =
+            publish_zero_dense_pinned_query_fixture(project.path(), &storage_path, &runtime)
+                .expect("publish current generation");
+        assert_ne!(
+            older.sidecar_generation, newer.sidecar_generation,
+            "fixture must produce two distinct generations"
+        );
+        let rollback = RetrievalIndexRollbackRecord {
+            manifest: older,
+            verified_at_epoch_ms: 4_242,
+        };
+        let mut store = Store::open(&storage_path).expect("open storage for pointer pair");
+        store
+            .publish_retrieval_index_publication(&newer, Some(&rollback))
+            .expect("arm the retained rollback pointer");
+        drop(store);
+        Fixture {
+            project_root: project.path().to_path_buf(),
+            storage_path,
+            runtime,
+            current: newer,
+            rollback,
+            _project: project,
+            _storage_dir: storage_dir,
+            _cache: cache,
+        }
+    }
+
+    fn activate(
+        fixture: &Fixture,
+        apply: bool,
+    ) -> Result<RollbackActivationOutcome, RollbackActivationError> {
+        let device = crate::embeddings::embedding_device_readiness_for_runtime(&fixture.runtime);
+        activate_retained_rollback_generation_with_embedding(
+            &fixture.project_root,
+            &fixture.storage_path,
+            &fixture.runtime,
+            &device,
+            None,
+            apply,
+        )
+    }
+
+    fn stored_publication(
+        fixture: &Fixture,
+    ) -> (RetrievalIndexManifest, Option<RetrievalIndexRollbackRecord>) {
+        let store = Store::open_observational(&fixture.storage_path).expect("open storage");
+        store
+            .get_retrieval_index_publication(&fixture.current.project_id)
+            .expect("read publication")
+            .expect("publication exists")
+    }
+
+    #[test]
+    fn activation_promotes_the_verified_rollback_generation_and_consumes_the_pointer() {
+        let _env = env_lock();
+        let fixture = publish_current_over_rollback();
+
+        let outcome = activate(&fixture, true).expect("verified rollback must activate");
+
+        assert!(outcome.applied, "activation must report that it wrote");
+        assert_eq!(
+            outcome.activated_generation,
+            fixture
+                .rollback
+                .manifest
+                .sidecar_generation
+                .clone()
+                .expect("rollback generation")
+        );
+        assert_eq!(
+            outcome.previous_generation,
+            fixture.current.sidecar_generation
+        );
+        assert_eq!(outcome.activated_retrieval_mode, "full");
+        let (current, rollback) = stored_publication(&fixture);
+        assert_eq!(
+            current, fixture.rollback.manifest,
+            "the retained rollback generation must become the current pointer"
+        );
+        assert_eq!(
+            rollback, None,
+            "activation must consume the retained rollback pointer"
+        );
+    }
+
+    #[test]
+    fn validation_only_activation_never_writes_the_publication() {
+        let _env = env_lock();
+        let fixture = publish_current_over_rollback();
+
+        let outcome = activate(&fixture, false).expect("validation-only run must succeed");
+
+        assert!(
+            !outcome.applied,
+            "validation-only run must not report a write"
+        );
+        assert!(
+            outcome.rollback_pointer_retained,
+            "validation-only run must leave the retained pointer armed"
+        );
+        let (current, rollback) = stored_publication(&fixture);
+        assert_eq!(
+            current, fixture.current,
+            "validation-only run must leave the current pointer alone"
+        );
+        assert_eq!(
+            rollback,
+            Some(fixture.rollback.clone()),
+            "validation-only run must leave the rollback pointer alone"
+        );
+    }
+
+    #[test]
+    fn corrupt_rollback_vector_bytes_refuse_activation_and_keep_the_current_generation() {
+        let _env = env_lock();
+        let fixture = publish_current_over_rollback();
+        let vector_path = crate::embedded_vector::index_path(
+            &fixture.runtime.layout,
+            &fixture.rollback.manifest.semantic_generation,
+        );
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&vector_path)
+            .expect("open retained rollback vector database")
+            .write_all(b"corrupt")
+            .expect("corrupt retained rollback vector bytes");
+
+        let error = activate(&fixture, true).expect_err("corrupt rollback must be refused");
+
+        assert_eq!(error.code(), "rollback_evidence_invalid", "{error}");
+        let (current, rollback) = stored_publication(&fixture);
+        assert_eq!(
+            current, fixture.current,
+            "a refused activation must leave the current pointer alone"
+        );
+        assert_eq!(
+            rollback,
+            Some(fixture.rollback.clone()),
+            "a refused activation must leave the retained pointer alone"
+        );
+    }
+
+    #[test]
+    fn missing_rollback_lexical_shard_refuses_activation_as_not_live_ready() {
+        let _env = env_lock();
+        let fixture = publish_current_over_rollback();
+        let shard = crate::lexical_index::shard_dir_for(
+            &fixture.runtime.layout.lexical_data_dir,
+            fixture
+                .rollback
+                .manifest
+                .sidecar_generation
+                .as_deref()
+                .expect("rollback generation"),
+        );
+        let index = shard.join(crate::lexical_index::LEXICAL_INDEX_FILE);
+        crate::lexical_index::make_test_file_writable(&index);
+        std::fs::remove_file(&index).expect("remove retained rollback lexical shard");
+
+        let error = activate(&fixture, true).expect_err("unusable rollback must be refused");
+
+        assert_eq!(error.code(), "rollback_not_live_ready", "{error}");
+        let (current, rollback) = stored_publication(&fixture);
+        assert_eq!(current, fixture.current);
+        assert_eq!(rollback, Some(fixture.rollback.clone()));
+    }
+
+    #[test]
+    fn observation_reports_the_retained_pointer_and_leaves_the_cache_untouched() {
+        let _env = env_lock();
+        let fixture = publish_current_over_rollback();
+        let before = std::fs::read(&fixture.storage_path).expect("read cache before observing");
+
+        let observed = observe_retained_rollback_generation(
+            &fixture.project_root,
+            &fixture.storage_path,
+            &fixture.runtime,
+        )
+        .expect("observation must succeed")
+        .expect("a retained rollback must be observed");
+
+        assert_eq!(observed.project_id, fixture.current.project_id);
+        assert_eq!(
+            observed.current_generation,
+            fixture.current.sidecar_generation
+        );
+        assert_eq!(
+            observed.rollback_generation,
+            fixture.rollback.manifest.sidecar_generation
+        );
+        assert_eq!(observed.rollback_verified_at_epoch_ms, 4_242);
+        assert_eq!(
+            std::fs::read(&fixture.storage_path).expect("read cache after observing"),
+            before,
+            "an observational read must not change a byte of the cache"
+        );
+
+        let mut store = Store::open(&fixture.storage_path).expect("open storage");
+        store
+            .publish_retrieval_index_publication(&fixture.current, None)
+            .expect("clear the retained rollback pointer");
+        drop(store);
+        assert_eq!(
+            observe_retained_rollback_generation(
+                &fixture.project_root,
+                &fixture.storage_path,
+                &fixture.runtime,
+            )
+            .expect("observation must succeed"),
+            None,
+            "with no retained pointer there is no lever to report"
+        );
+    }
+
+    #[test]
+    fn a_publication_without_a_retained_rollback_refuses_activation() {
+        let _env = env_lock();
+        let fixture = publish_current_over_rollback();
+        let mut store = Store::open(&fixture.storage_path).expect("open storage");
+        store
+            .publish_retrieval_index_publication(&fixture.current, None)
+            .expect("clear the retained rollback pointer");
+        drop(store);
+
+        let error = activate(&fixture, true).expect_err("missing rollback must be refused");
+
+        assert_eq!(error.code(), "no_retained_rollback", "{error}");
+        let (current, rollback) = stored_publication(&fixture);
+        assert_eq!(current, fixture.current);
+        assert_eq!(rollback, None);
+    }
+}

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -10577,3 +10577,96 @@ fn promoted_receipt_reuse_is_sealed_to_the_restored_bytes() -> Result<(), Storag
     cleanup_sqlite_sidecars(&live_path)?;
     Ok(())
 }
+
+/// Read the durable schema shape a connection currently has.
+///
+/// `sqlite_master` is the only place both construction paths converge, so it
+/// is the only honest comparison surface for schema drift. Autoindexes are
+/// derived from the table SQL already present in the same dump, so including
+/// them would double-count rather than add signal.
+///
+/// Runs of whitespace are collapsed. SQLite stores the DDL text verbatim, and
+/// `create_tables` and the migration ladder indent the same table differently;
+/// that is layout, not shape. Everything that decides whether two caches are
+/// interchangeable — table set, index set, column names, types, defaults,
+/// constraints, and their order — survives the collapse.
+fn normalize_schema_sql(sql: &str) -> String {
+    sql.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn sqlite_master_shape(conn: &rusqlite::Connection) -> Vec<(String, String, String, String)> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT type, name, tbl_name, COALESCE(sql, '')
+             FROM sqlite_master
+             WHERE name NOT LIKE 'sqlite_autoindex_%'
+             ORDER BY type, name, tbl_name",
+        )
+        .expect("prepare sqlite_master read");
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                normalize_schema_sql(&row.get::<_, String>(3)?),
+            ))
+        })
+        .expect("query sqlite_master");
+    rows.map(|row| row.expect("read sqlite_master row"))
+        .collect()
+}
+
+#[test]
+fn a_replayed_migration_ladder_produces_the_same_schema_as_a_fresh_create() {
+    // ARCH-020: the CREATE TABLE definitions in `schema.rs` and the migration
+    // ladder are two sources of truth for one schema, and they have already
+    // drifted once. `init` stamps `user_version` to the current version before
+    // migrations run, so a freshly created database executes *no* migration —
+    // the ladder is only ever exercised on an upgraded cache, which is exactly
+    // where nothing was comparing the two shapes.
+    //
+    // This pins the drift direction that strands a rolled-back CLI: a
+    // conditional migration that changes the schema beyond what CREATE TABLE
+    // produces. Rewinding `user_version` replays the whole ladder over a
+    // freshly created database; the resulting `sqlite_master` must equal the
+    // fresh one, which also proves every migration is idempotent against the
+    // shape `schema.rs` ships.
+    //
+    // Scope, stated honestly: the tail of the ladder runs unconditionally on
+    // every open, so those steps already shape a fresh database and cannot
+    // drift from it. What this covers is the version-gated body — the steps a
+    // fresh create skips and only an upgraded cache ever runs.
+    let fresh_dir = tempfile::tempdir().expect("fresh schema directory");
+    let fresh_path = fresh_dir.path().join("codestory.db");
+    let fresh = Storage::open(&fresh_path).expect("create a fresh database");
+    let fresh_shape = sqlite_master_shape(fresh.get_connection());
+    drop(fresh);
+    assert!(
+        !fresh_shape.is_empty(),
+        "a fresh database must define a schema to compare"
+    );
+
+    let replay_dir = tempfile::tempdir().expect("replay schema directory");
+    let replay_path = replay_dir.path().join("codestory.db");
+    drop(Storage::open(&replay_path).expect("create the database to replay onto"));
+    let rewind = rusqlite::Connection::open(&replay_path).expect("open for version rewind");
+    rewind
+        .pragma_update(None, "user_version", 1i64)
+        .expect("rewind the recorded schema version");
+    drop(rewind);
+
+    let replayed = Storage::open(&replay_path).expect("replay the full migration ladder");
+    let replayed_shape = sqlite_master_shape(replayed.get_connection());
+    drop(replayed);
+
+    assert_eq!(
+        Storage::database_schema_version(&replay_path).expect("read replayed schema version"),
+        CURRENT_SCHEMA_VERSION,
+        "the replayed ladder must land on the current schema version"
+    );
+    assert_eq!(
+        replayed_shape, fresh_shape,
+        "the migration ladder and the CREATE TABLE definitions must agree; a fresh cache and a migrated cache have drifted"
+    );
+}

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -217,6 +217,20 @@ fn storage_owned_discovery_files(storage_path: &Path) -> Vec<PathBuf> {
     codestory_contracts::owned_artifacts::storage_owned_file_identities(storage_path)
 }
 
+/// Owned directory trees discovery must never walk into as user source.
+///
+/// The quarantine tree belongs here for the same reason the search trees do:
+/// the guided derived-cache reset moves owned artifacts into it rather than
+/// deleting them, so every one of those files stays on disk inside the cache
+/// root under a name discovery has never seen.
+fn storage_owned_discovery_directory_roots(storage_path: &Path) -> Vec<PathBuf> {
+    vec![
+        legacy_search_directory_for_storage(storage_path),
+        search_generation_directory_for_storage(storage_path),
+        codestory_contracts::owned_artifacts::derived_reset_quarantine_root(storage_path),
+    ]
+}
+
 fn storage_owned_staged_discovery_files(storage_path: &Path) -> io::Result<Vec<PathBuf>> {
     let parent = storage_parent_for_observation(storage_path);
     let entries = match fs::read_dir(parent) {
@@ -459,8 +473,8 @@ impl WorkspaceManifest {
         }
     }
 
-    /// Open a workspace while excluding the exact CodeStory core/search
-    /// artifacts owned by `storage_path`.
+    /// Open a workspace while excluding the exact CodeStory core, search, and
+    /// quarantined-reset artifacts owned by `storage_path`.
     pub fn open_with_storage_owned_exclusions(
         root_path: PathBuf,
         storage_path: &Path,
@@ -470,10 +484,9 @@ impl WorkspaceManifest {
         manifest
             .discovery_owned_storage_paths
             .push(storage_path.to_path_buf());
-        manifest.exclude_discovery_directory_roots([
-            legacy_search_directory_for_storage(storage_path),
-            search_generation_directory_for_storage(storage_path),
-        ]);
+        manifest.exclude_discovery_directory_roots(storage_owned_discovery_directory_roots(
+            storage_path,
+        ));
         Ok(manifest)
     }
 
@@ -3162,7 +3175,8 @@ mod tests {
         assert_eq!(files.len(), 256);
         assert_eq!(
             manifest.discovery_exclusion_observation_count(),
-            storage_owned_discovery_files(&storage_path).len() + 2
+            storage_owned_discovery_files(&storage_path).len()
+                + storage_owned_discovery_directory_roots(&storage_path).len()
         );
         Ok(())
     }
@@ -3210,6 +3224,49 @@ mod tests {
                 .iter()
                 .all(|owned| !inventory.files.contains(owned))
         );
+        Ok(())
+    }
+
+    #[test]
+    fn quarantined_derived_reset_state_stays_out_of_source_discovery() -> Result<()> {
+        // The guided derived-cache reset moves owned artifacts into a
+        // quarantine tree inside the cache root instead of deleting them, so
+        // every file it reclaimed is still on disk under a name discovery has
+        // never seen. Unless the quarantine root is an owned directory
+        // identity, the next inventory adopts the whole reclaimed cache as
+        // user source.
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        let storage_path = root.join(".cache/custom-core.db");
+        let quarantine =
+            codestory_contracts::owned_artifacts::derived_reset_quarantine_root(&storage_path)
+                .join("0001700000000");
+        fs::create_dir_all(quarantine.join("custom-core.search"))?;
+        let quarantined = [
+            quarantine.join("custom-core.db"),
+            quarantine.join("custom-core.db-wal"),
+            quarantine.join("local-refresh-status.json"),
+            quarantine.join("custom-core.search").join("meta.json"),
+        ];
+        for path in &quarantined {
+            fs::write(path, b"quarantined derived state\n")?;
+        }
+        let user_source = root.join("src/lib.rs");
+        fs::create_dir_all(user_source.parent().expect("user source parent"))?;
+        fs::write(&user_source, "pub fn keep() {}\n")?;
+
+        let manifest = WorkspaceManifest::open_with_storage_owned_exclusions(root, &storage_path)?;
+        let inventory = manifest.source_inventory()?;
+
+        assert_eq!(inventory.outcome, WorkspaceInventoryOutcome::Complete);
+        assert!(inventory.files.contains(&user_source));
+        for path in &quarantined {
+            assert!(
+                !inventory.files.contains(path),
+                "{} was quarantined by the derived-cache reset and must never be discovered as user source",
+                path.display()
+            );
+        }
         Ok(())
     }
 

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -91,6 +91,58 @@ refresh cannot converge. Verify the path is under the active CodeStory cache
 root, preserve the old directory until the replacement is healthy, and never
 clean a user cache merely to make tests pass.
 
+## Roll a retrieval generation back
+
+CodeStory retains one deeply verified previous retrieval generation beside the
+current one. When broad retrieval stops being live-ready but the retained
+generation still proves out, activate it instead of rebuilding:
+
+```sh
+codestory-cli retrieval activate-rollback --project <repo> --dry-run
+codestory-cli retrieval activate-rollback --project <repo>
+```
+
+`--dry-run` runs every validation and changes nothing. Activation re-proves the
+retained generation against the live core publication and the artifacts on disk
+before it moves the pointer, so it can only ever refuse — with a typed code such
+as `rollback_evidence_invalid` or `rollback_not_live_ready` — never serve
+something the normal publication fence would have rejected. Activation consumes
+the retained pointer: the generation you stepped away from is not re-armed as a
+rollback target.
+
+`doctor` reports the retained generation and recommends this command when
+retrieval is not live-ready. `doctor` never activates anything itself.
+
+## Downgrade to an older CodeStory
+
+Schema migrations are forward-only. An older CodeStory pointed at a cache a
+newer release wrote fails closed with `Unsupported database schema version`, and
+`--refresh full` fails closed on it too. That is deliberate: the alternative is
+destroying a newer database. The executable recovery is to quarantine the
+derived cache and rebuild it.
+
+```sh
+codestory-cli cache reset --project <repo> --derived-only --dry-run
+codestory-cli cache reset --project <repo> --derived-only --confirm
+codestory-cli index --project <repo> --refresh full
+codestory-cli retrieval index --project <repo> --refresh full
+codestory-cli doctor --project <repo> --format markdown
+```
+
+`cache reset` requires `--derived-only` and exactly one of `--dry-run` or
+`--confirm`. It moves derived state — the core database and its SQLite
+siblings, the rollback backup, promotion journals, the search trees, and
+local-refresh state — into a timestamped `derived-reset-quarantine/` directory
+inside the same cache root. Nothing is deleted, so a mistaken reset is
+recoverable by moving the quarantined files back. It never opens the database,
+which is what makes it usable against a schema it cannot read.
+
+User-authored annotations live in a sidecar beside the cache and are preserved
+in place; the command reports exactly what it moved and what it preserved.
+Retrieval generations are reclaimed separately by
+`codestory-cli retrieval inventory --project <repo> --apply` once the rebuild
+has published a new generation.
+
 ## Index and ground
 
 ```sh
@@ -145,6 +197,8 @@ Embedding never uses a network endpoint. Put `cache_dir` in user home `.codestor
 | Change impact | `affected` with `--stdin` from `git diff` | Pick focused tests; not a test run |
 | Readiness | `agent preflight --format json` | `codestory://status{?project}` when MCP is live |
 | Broad evidence | `retrieval status --format json` | `packet` or `search` only after `full` mode |
+| Broad retrieval broke and a rollback is retained | `retrieval activate-rollback --project <repo> --dry-run` | Rerun without `--dry-run` once validation passes |
+| Rolled back CodeStory onto a newer cache | `cache reset --project <repo> --derived-only --dry-run` | `--confirm`, then `index --refresh full` |
 
 ## Managed search internals
 

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -139,6 +139,11 @@ which is what makes it usable against a schema it cannot read.
 
 User-authored annotations live in a sidecar beside the cache and are preserved
 in place; the command reports exactly what it moved and what it preserved.
+The reset holds this project's index-writer and promotion locks for the whole
+move, so a concurrent indexing run or publication either finishes first or is
+refused with `cache_busy`; if neither releases within the wait budget the reset
+itself refuses and moves nothing.
+
 Retrieval generations are reclaimed separately by
 `codestory-cli retrieval inventory --project <repo> --apply` once the rebuild
 has published a new generation.


### PR DESCRIPTION
Closes #1652.

Rollback activation and derived-cache reset — the only two ARCH-003 levers in scope per the maintainer decision. No lexical-only degraded serving mode was built, and the review confirmed none exists in the diff.

## Review and repair

The review's blocker ("reset preserves user annotations is not delivered") was **refuted** on verification — the claim holds. Two real gaps were repaired:

- **The safety claims were untested at the command boundary.** `run_cache_reset` is the layer that must not open the database — the entire reason the command is reachable on a schema this build refuses — but every test entered one layer below, so inserting a store open there kept the suite green while making the command useless in its only scenario. Same shape for the promotion-lock exclusion: no test created contention, so deleting the lock acquisition left everything passing. Both are now pinned at the command boundary and proved with those exact mutations.
- **The quarantine directory was not registered** as an owned artifact, so it could be discovered as user source. Registered.

**Declared residual:** the promotion lock is held only during the publish critical section, so a concurrent indexer holding the index-writer lock is not excluded — and that lock file is itself moved by the plan. The window is now declared rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)