### PR TITLE
[v0.17 SRC-C] Repair signature identity and parser projections in one rebaseline window

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -7,7 +7,11 @@ use codestory_store::FileInfo;
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 2;
+// Bumped to 3 with the position-free callable projection format: a cached
+// artifact from version 2 carries node ids minted from declaration lines and
+// projection rows whose `signature_hash` still binds a position, so reusing one
+// would mix two identity formats inside a single file.
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 3;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -105,7 +109,9 @@ impl CachedStructuralArtifact {
     }
 }
 
-pub(crate) const STRUCTURAL_ARTIFACT_CACHE_VERSION: u32 = 2;
+// Bumped to 3 alongside the index artifact cache: the SQL, HTML, and callable
+// projection changes in this wave all reach structural artifacts too.
+pub(crate) const STRUCTURAL_ARTIFACT_CACHE_VERSION: u32 = 3;
 
 pub(crate) fn build_structural_artifact_cache_key(
     cache_path: &Path,

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -21,7 +21,7 @@ use codestory_store::{
     IndexArtifactCacheReader, IndexArtifactCacheWrite, StorageError, Store as Storage,
 };
 use crossbeam_channel::{Receiver, SendTimeoutError, bounded};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -12281,19 +12281,39 @@ fn kotlin_property_belongs_to_owner(property: TsNode<'_>, owner_node: TsNode<'_>
     false
 }
 
+/// Property bindings declared in a Kotlin class's primary constructor.
+///
+/// The surface used to be the class text up to its first `{`, scanned from the
+/// first `(`. An annotated declaration puts that `(` inside the annotation:
+/// `@Table(name = "users") data class User(val id: Long)` yielded `name =
+/// "users"` and the class lost every primary-constructor binding (CR-009). The
+/// grammar keeps `primary_constructor` as its own child, after `modifiers`.
 fn kotlin_primary_constructor_property_bindings(
     owner_node: TsNode<'_>,
     source: &str,
     context: &KotlinReceiverContext<'_>,
 ) -> Vec<(String, OptionalReceiverOwnerBinding)> {
-    let Some(owner_surface) = trimmed_node_text(owner_node, source) else {
-        return Vec::new();
-    };
-    let head = owner_surface
-        .split('{')
-        .next()
-        .unwrap_or(owner_surface.as_str());
-    let Some(parameters) = signature_parameter_surface_text(head) else {
+    let mut cursor = owner_node.walk();
+    let parameters = owner_node
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "primary_constructor")
+        .and_then(callable_parameter_list_node)
+        .and_then(|node| trimmed_node_text(node, source))
+        .map(|text| {
+            text.strip_prefix('(')
+                .and_then(|inner| inner.strip_suffix(')'))
+                .unwrap_or(text.as_str())
+                .to_string()
+        })
+        .or_else(|| {
+            let owner_surface = trimmed_node_text(owner_node, source)?;
+            let head = owner_surface
+                .split('{')
+                .next()
+                .unwrap_or(owner_surface.as_str());
+            signature_parameter_surface_text(head)
+        });
+    let Some(parameters) = parameters else {
         return Vec::new();
     };
     split_top_level_parameters(&parameters)
@@ -14495,17 +14515,65 @@ fn collect_colon_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<
     receiver_types
 }
 
+/// Drop the annotations a parameter declaration carries before its type.
+///
+/// `f(@RequestParam("id") String id)` records the owner type of `id` as
+/// `@RequestParam`, because the leading annotation is just another
+/// whitespace-separated token and `normalize_type_surface` truncates it at the
+/// `(` (CR-009). Token filtering is not enough: `@RequestParam(value = "id")`
+/// spans four tokens. Skip each leading `@Name` and, when it is followed by an
+/// argument list, everything up to that list's matching `)`.
+fn strip_leading_parameter_annotations(parameter: &str) -> &str {
+    let mut rest = parameter.trim_start();
+    while let Some(after_at) = rest.strip_prefix('@') {
+        let name_len = after_at
+            .find(|ch: char| !(ch.is_alphanumeric() || ch == '_' || ch == '.'))
+            .unwrap_or(after_at.len());
+        if name_len == 0 {
+            break;
+        }
+        let after_name = after_at[name_len..].trim_start();
+        let Some(arguments) = after_name.strip_prefix('(') else {
+            rest = after_name;
+            continue;
+        };
+        let mut depth = 1usize;
+        let mut consumed = None;
+        for (index, ch) in arguments.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        consumed = Some(index + ch.len_utf8());
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        // An unbalanced annotation argument list is malformed input; leaving
+        // the text untouched keeps the caller's existing behaviour rather than
+        // inventing a truncation.
+        let Some(consumed) = consumed else {
+            break;
+        };
+        rest = arguments[consumed..].trim_start();
+    }
+    rest
+}
+
 fn collect_prefix_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
     let mut receiver_types = HashMap::new();
     let Some(parameters) = signature_parameter_surface(callable, source) else {
         return receiver_types;
     };
     for parameter in split_top_level_parameters(&parameters) {
-        let parameter = parameter
-            .split('=')
-            .next()
-            .unwrap_or(parameter.as_str())
-            .trim();
+        // Annotations come off before the default-value split: an annotation
+        // argument list can itself contain `=`, as in `@RequestParam(value =
+        // "id")`, and splitting first would cut the declaration in half.
+        let parameter = strip_leading_parameter_annotations(&parameter);
+        let parameter = parameter.split('=').next().unwrap_or(parameter).trim();
         let tokens = parameter
             .split_whitespace()
             .filter(|token| !matches!(*token, "final" | "const" | "var" | "required"))
@@ -14666,7 +14734,48 @@ fn dart_import_alias_name(statement: &str) -> Option<String> {
     None
 }
 
+/// The grammar's own parameter-list node for a callable, when it has one.
+///
+/// Every vendored grammar that models parameters exposes the list either
+/// through a `parameters` field or as a distinctly named child; only the
+/// declarator-nested C family and a few looser grammars leave nothing to find.
+fn callable_parameter_list_node<'tree>(callable: TsNode<'tree>) -> Option<TsNode<'tree>> {
+    if let Some(parameters) = callable.child_by_field_name("parameters") {
+        return Some(parameters);
+    }
+    let mut cursor = callable.walk();
+    callable.named_children(&mut cursor).find(|child| {
+        matches!(
+            child.kind(),
+            "function_value_parameters"
+                | "formal_parameters"
+                | "parameter_list"
+                | "parameters"
+                | "class_parameters"
+        )
+    })
+}
+
+/// The text between a callable's parameter parentheses.
+///
+/// The scan used to start from the first `(` in the callable's own text, which
+/// for Java `method_declaration` and Kotlin `function_declaration` includes the
+/// leading modifier list: `@GetMapping("/users") String list()` handed back
+/// `"/users"` as the parameter list, and `@Throws(IOException::class)` handed
+/// back a bogus `IOException::class` receiver binding (CR-009). The grammar
+/// already separates modifiers from parameters, so ask it first and keep the
+/// text scan only for grammars that expose no parameter node.
 fn signature_parameter_surface(callable: TsNode<'_>, source: &str) -> Option<String> {
+    if let Some(parameters) = callable_parameter_list_node(callable)
+        && let Some(text) = trimmed_node_text(parameters, source)
+    {
+        return Some(
+            text.strip_prefix('(')
+                .and_then(|inner| inner.strip_suffix(')'))
+                .unwrap_or(text.as_str())
+                .to_string(),
+        );
+    }
     let text = trimmed_node_text(callable, source)?;
     let start = text.find('(')?;
     let mut depth = 0usize;
@@ -14924,27 +15033,41 @@ fn normalize_js_ts_private_receiver_surface(receiver: &str) -> String {
         .join(".")
 }
 
+/// Receiver and member of one Kotlin member call, read from the grammar.
+///
+/// The text scan this replaces cut the callee at the first `(` and then split
+/// on the last `.` of what remained, which is wrong for the two most idiomatic
+/// Kotlin call shapes (CR-010). A trailing lambda has no parentheses at all, so
+/// `user.apply { this.name = n }` split on the dot inside the lambda body and
+/// produced the receiver `user.apply { this`. A chain such as
+/// `repo.findAll().filter { … }` truncated at the first `(` and reported the
+/// outer `.filter` call as `repo.findAll`, duplicating the inner call and
+/// losing the outer one. `call_expression` keeps its callee as its first child
+/// and a member callee is a `navigation_expression`, so both shapes read
+/// directly off the tree.
 fn kotlin_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
     if node.kind() != "call_expression" {
         return None;
     }
-    let text = trimmed_node_text(node, source)?;
-    let callable = text
-        .split('(')
-        .next()
-        .unwrap_or(text.as_str())
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    let separator = callable.rfind('.')?;
-    let receiver = callable[..separator].trim().trim_end_matches('?').trim();
-    let method = callable[separator + 1..]
-        .trim()
-        .trim_start_matches('?')
-        .trim();
+    let mut cursor = node.walk();
+    let callee = node.named_children(&mut cursor).next()?;
+    if callee.kind() != "navigation_expression" {
+        return None;
+    }
+    let mut callee_cursor = callee.walk();
+    let callee_children = callee
+        .named_children(&mut callee_cursor)
+        .collect::<Vec<_>>();
+    let receiver = callee_children.first()?;
+    let member = callee_children.last()?;
+    if receiver.id() == member.id() {
+        return None;
+    }
+    let receiver_text = trimmed_node_text(*receiver, source)?;
+    let member_text = trimmed_node_text(*member, source)?;
     Some((
-        normalized_kotlin_receiver_surface(receiver)?,
-        normalize_parameter_name(method)?,
+        normalized_kotlin_receiver_surface(receiver_text.trim_end_matches('?'))?,
+        normalize_parameter_name(member_text.trim_start_matches('?'))?,
     ))
 }
 
@@ -15771,6 +15894,68 @@ fn canonicalize_nodes(
     canonicalize_nodes_with_file_identity(file_name, file_name, final_nodes, canonical_roles)
 }
 
+/// Separator between a qualified name and its declaration ordinal.
+///
+/// A colon would read as the old line-number suffix; `#` makes the ordinal
+/// unmistakable in stored ids, logs, and citations.
+const DECLARATION_ORDINAL_SEPARATOR: char = '#';
+
+fn node_needs_declaration_ordinal(node: &Node) -> bool {
+    !is_type_like_kind(node.kind) && node.kind != NodeKind::FILE
+}
+
+fn preserved_canonical_id(node: &Node) -> Option<&str> {
+    node.canonical_id.as_deref().filter(|value| {
+        value.starts_with("openapi:endpoint:")
+            || value.starts_with("route_endpoint:")
+            || value.starts_with("tauri:command:")
+            || value.starts_with("payload:collection:")
+    })
+}
+
+/// Declaration ordinals for every qualified name that needs a discriminator.
+///
+/// Two callables in one file can share a qualified name — Java and C++
+/// overloads, an unresolved call placeholder beside the function it names, a
+/// local rebound in two sibling scopes. The discriminator used to be the
+/// declaration's own `start_line`, which made every identity in the file a
+/// function of its position: inserting a line above a function renamed it, so
+/// incremental indexing could only replace the whole file (CR-008) and every
+/// annotation anchored to it was destroyed (ARCH-001).
+///
+/// The ordinal is the rank of the declaration's line among the distinct lines
+/// that share its qualified name, so it is invariant under any edit that moves
+/// declarations without reordering them. Declarations that share a line still
+/// share an id, exactly as the line-suffixed form grouped them: this is a
+/// relabelling of the same groups, not a regrouping.
+fn declaration_ordinals(nodes: &[Node]) -> HashMap<String, BTreeMap<u32, usize>> {
+    let mut lines_by_name: HashMap<String, BTreeSet<u32>> = HashMap::new();
+    for node in nodes {
+        if preserved_canonical_id(node).is_some() || !node_needs_declaration_ordinal(node) {
+            continue;
+        }
+        let qualified_name = node
+            .qualified_name
+            .clone()
+            .unwrap_or_else(|| node.serialized_name.clone());
+        lines_by_name
+            .entry(qualified_name)
+            .or_default()
+            .insert(node.start_line.unwrap_or(1));
+    }
+    lines_by_name
+        .into_iter()
+        .map(|(qualified_name, lines)| {
+            let ordinals = lines
+                .into_iter()
+                .enumerate()
+                .map(|(ordinal, line)| (line, ordinal))
+                .collect::<BTreeMap<_, _>>();
+            (qualified_name, ordinals)
+        })
+        .collect()
+}
+
 fn canonicalize_nodes_with_file_identity(
     file_name: &str,
     file_identity: &str,
@@ -15779,6 +15964,7 @@ fn canonicalize_nodes_with_file_identity(
 ) -> (Vec<Node>, HashMap<NodeId, NodeId>) {
     let mut id_remap = HashMap::<NodeId, NodeId>::new();
     let mut grouped_nodes = BTreeMap::<String, Vec<Node>>::new();
+    let ordinals_by_name = declaration_ordinals(&final_nodes);
 
     for mut node in final_nodes {
         let qualified_name = node
@@ -15787,15 +15973,7 @@ fn canonicalize_nodes_with_file_identity(
             .unwrap_or_else(|| node.serialized_name.clone());
         node.qualified_name = Some(qualified_name.clone());
 
-        let canonical_id = node
-            .canonical_id
-            .as_deref()
-            .filter(|value| {
-                value.starts_with("openapi:endpoint:")
-                    || value.starts_with("route_endpoint:")
-                    || value.starts_with("tauri:command:")
-                    || value.starts_with("payload:collection:")
-            })
+        let canonical_id = preserved_canonical_id(&node)
             .map(str::to_string)
             .unwrap_or_else(|| {
                 if is_type_like_kind(node.kind) {
@@ -15804,7 +15982,11 @@ fn canonicalize_nodes_with_file_identity(
                     format!("{file_identity}:{file_identity}:1")
                 } else {
                     let start_line = node.start_line.unwrap_or(1);
-                    format!("{}:{}:{}", file_name, qualified_name, start_line)
+                    let ordinal = ordinals_by_name
+                        .get(&qualified_name)
+                        .and_then(|ordinals| ordinals.get(&start_line).copied())
+                        .unwrap_or(0);
+                    format!("{file_name}:{qualified_name}{DECLARATION_ORDINAL_SEPARATOR}{ordinal}")
                 }
             });
         grouped_nodes.entry(canonical_id).or_default().push(node);
@@ -21108,7 +21290,7 @@ pub(crate) fn build_callable_projection_states(
         ) {
             continue;
         }
-        let (Some(file_id), Some(start_line), Some(start_col), Some(end_line)) = (
+        let (Some(file_id), Some(start_line), Some(_start_col), Some(end_line)) = (
             node.file_node_id,
             node.start_line,
             node.start_col,
@@ -21123,13 +21305,15 @@ pub(crate) fn build_callable_projection_states(
                 .as_deref()
                 .unwrap_or(node.serialized_name.as_str())
         );
-        let signature_hash = hash_parts([
-            symbol_key.as_str(),
-            &start_line.to_string(),
-            &start_col.to_string(),
-        ]);
+        let signature_hash = callable_signature_hash(&symbol_key);
 
-        let mut body_parts = callable_edge_projection_parts(edges_by_source.get(&node.id));
+        let mut body_parts = vec![
+            format!("extent:{start_line}:{end_line}"),
+            format!("identity:{}", node.id.0),
+        ];
+        body_parts.extend(callable_edge_projection_parts(
+            edges_by_source.get(&node.id),
+        ));
         body_parts.extend(callable_occurrence_projection_parts(
             occurrences_by_file.get(&file_id),
             node,
@@ -21158,15 +21342,23 @@ pub(crate) fn build_callable_projection_states(
     }
 
     if let Some(file_node) = nodes.iter().find(|node| node.kind == NodeKind::FILE) {
+        let repaired_callables = CallableProjectionExtents::from_states(&states);
         states.push(CallableProjectionState {
             file_id: file_node.id.0,
             symbol_key: FILE_STRUCTURAL_SYMBOL_KEY.to_string(),
             node_id: file_node.id,
-            signature_hash: hash_parts([FILE_STRUCTURAL_SYMBOL_KEY]),
+            signature_hash: callable_signature_hash(FILE_STRUCTURAL_SYMBOL_KEY),
             // The file structural row is not a callable, so it carries no
             // normalized signature and can never satisfy a rebind probe.
             normalized_signature: None,
-            body_hash: structural_projection_hash(file_node.id, nodes, edges, &node_by_id),
+            body_hash: structural_projection_hash(
+                file_node.id,
+                nodes,
+                edges,
+                occurrences,
+                &node_by_id,
+                &repaired_callables,
+            ),
             start_line: 1,
             end_line: file_node.end_line.unwrap_or(1),
         });
@@ -21293,13 +21485,50 @@ fn callable_relative_occurrence_parts(
     occurrence_parts
 }
 
+/// Stamp distinguishing one callable-projection identity format from the next.
+///
+/// A stored row whose stamp differs was produced by a different definition of
+/// "changed", so it cannot be compared field by field. Bumping the stamp is the
+/// declared way to force exactly one full re-projection wave per file and then
+/// return to incremental updates; it is the only reason `signature_hash` ever
+/// changes for a symbol that kept its key.
+const CALLABLE_PROJECTION_FORMAT_STAMP: &str = "callable-projection-format:2";
+
+/// Identity of one projection row: the state the delta path cannot repair.
+///
+/// `signature_hash` used to bind `start_line` and `start_col`, so inserting a
+/// line above any function flipped it and routed the whole file to
+/// `FullReplace` (CR-008) — which deletes the file's nodes and, with them,
+/// everything anchored to those nodes. Position is not identity: it is
+/// projection *content*, carried in `body_hash` and in the row's own
+/// `start_line`/`end_line` columns, both of which the delta path rewrites.
+/// What remains here is the symbol key and the format stamp.
+fn callable_signature_hash(symbol_key: &str) -> i64 {
+    hash_parts([CALLABLE_PROJECTION_FORMAT_STAMP, symbol_key])
+}
+
+/// The edge kinds the caller-scoped delta cleanup rewrites.
+///
+/// `Store::delete_projection_for_callers` deletes exactly the call and usage
+/// edges a changed caller sources in its own file. Anything else the caller
+/// sources survives that cleanup, so it belongs to the file-structural fence
+/// instead — this predicate is the single definition all three sites read.
+fn edge_is_caller_scoped_repairable(kind: EdgeKind) -> bool {
+    matches!(kind, EdgeKind::CALL | EdgeKind::USAGE)
+}
+
+/// Every edge the delta cleanup would remove for this caller.
+///
+/// A caller whose outgoing edges changed is only safe to repair incrementally
+/// if the cleanup deletes the same edges this hash counted; an edge the hash
+/// counts but the cleanup skips is an edge whose stale row survives the repair.
 fn callable_edge_projection_parts(source_edges: Option<&Vec<&Edge>>) -> Vec<String> {
     let Some(source_edges) = source_edges else {
         return Vec::new();
     };
     let mut edge_parts = source_edges
         .iter()
-        .filter(|edge| !is_structural_projection_edge(edge.kind))
+        .filter(|edge| edge_is_caller_scoped_repairable(edge.kind))
         .map(|edge| {
             format!(
                 "{}:{}:{}:{}",
@@ -21314,6 +21543,15 @@ fn callable_edge_projection_parts(source_edges: Option<&Vec<&Edge>>) -> Vec<Stri
     edge_parts
 }
 
+/// The edge kinds that describe a symbol's place in the file's structure
+/// rather than the work its body does.
+///
+/// Distinct from `edge_is_caller_scoped_repairable`, and the two must not be
+/// collapsed into one another: that predicate names the edges the delta
+/// cleanup rewrites, so it fences incremental repair, while this one excludes
+/// structure from a callable's *shape*, so it feeds the normalized signature
+/// the annotation rebind ladder matches on. They answer different questions
+/// and are free to disagree about a kind that is neither CALL nor USAGE.
 fn is_structural_projection_edge(kind: EdgeKind) -> bool {
     matches!(
         kind,
@@ -21362,11 +21600,92 @@ fn occurrence_belongs_to_callable_body(
         && occurrence.element_id != node.id.0
 }
 
+/// Everything in a file that no callable row owns.
+///
+/// The delta path repairs exactly two things: the rows of the callers it was
+/// given, and the node table (upserted by id, so positions self-heal for any
+/// node whose id is stable). This hash is the fence around the rest, and it is
+/// deliberately built as the complement of what
+/// `Store::delete_projection_for_callers` deletes:
+///
+/// - **node identity** for every node in the file. Some collectors still mint
+///   ids from a line and column, so a shifted declaration becomes a *different*
+///   node; a delta would insert the new row and leave the old one behind.
+///   Hashing the id makes any identity churn a full replacement, which is the
+///   only repair that removes the abandoned rows.
+/// - **unowned edges**, with their line. An edge whose source is not a callable
+///   of this file is never deleted by the caller-scoped cleanup, and edge rows
+///   are insert-or-ignore, so a moved edge would keep its old line forever.
+/// - **unowned occurrences**, with their span. Occurrence rows carry no id at
+///   all, so a moved occurrence that is not deleted becomes a duplicate row
+///   rather than an updated one.
+///
+/// Callables contribute only their identity here: their positions, edges, and
+/// body occurrences live in their own rows, which the delta path rewrites.
+/// The callables that actually have a projection row, and their extents.
+///
+/// Ownership must be read off the rows that exist, not off the node kinds: a
+/// callable the projection skipped (no recorded column, say) repairs nothing,
+/// so everything inside it still belongs to the file fence.
+struct CallableProjectionExtents {
+    node_ids: HashSet<NodeId>,
+    /// Extents sorted by start line, with the running maximum end line, so a
+    /// containment probe can stop before scanning every callable in the file.
+    sorted_extents: Vec<(u32, u32)>,
+    prefix_max_end: Vec<u32>,
+}
+
+impl CallableProjectionExtents {
+    fn from_states(states: &[CallableProjectionState]) -> Self {
+        let node_ids = states.iter().map(|state| state.node_id).collect();
+        let mut sorted_extents = states
+            .iter()
+            .map(|state| (state.start_line, state.end_line))
+            .collect::<Vec<_>>();
+        sorted_extents.sort_unstable();
+        let mut prefix_max_end = Vec::with_capacity(sorted_extents.len());
+        let mut running_max = 0;
+        for (_, end_line) in &sorted_extents {
+            running_max = running_max.max(*end_line);
+            prefix_max_end.push(running_max);
+        }
+        Self {
+            node_ids,
+            sorted_extents,
+            prefix_max_end,
+        }
+    }
+
+    fn owns_node(&self, node_id: NodeId) -> bool {
+        self.node_ids.contains(&node_id)
+    }
+
+    /// Mirror of the occurrence predicate in `delete_projection_for_callers`:
+    /// an occurrence is repairable when it is a callable's own definition or
+    /// falls inside a callable's recorded extent.
+    fn owns_occurrence(&self, occurrence: &Occurrence) -> bool {
+        if self.node_ids.contains(&NodeId(occurrence.element_id)) {
+            return true;
+        }
+        let candidates = self
+            .sorted_extents
+            .partition_point(|(start_line, _)| *start_line <= occurrence.location.start_line);
+        if candidates == 0 || self.prefix_max_end[candidates - 1] < occurrence.location.end_line {
+            return false;
+        }
+        self.sorted_extents[..candidates]
+            .iter()
+            .any(|(_, end_line)| *end_line >= occurrence.location.end_line)
+    }
+}
+
 fn structural_projection_hash(
     file_id: NodeId,
     nodes: &[Node],
     edges: &[Edge],
+    occurrences: &[Occurrence],
     node_by_id: &HashMap<NodeId, &Node>,
+    repaired_callables: &CallableProjectionExtents,
 ) -> i64 {
     let mut parts = Vec::new();
 
@@ -21374,28 +21693,24 @@ fn structural_projection_hash(
         if node.id == file_id {
             continue;
         }
-        if is_callable_kind(node.kind) {
-            parts.push(format!(
-                "callable:{}:{}",
-                node.kind as i32,
-                node.qualified_name
-                    .as_deref()
-                    .unwrap_or(node.serialized_name.as_str())
-            ));
-            continue;
-        }
+        let qualified_name = node
+            .qualified_name
+            .as_deref()
+            .unwrap_or(node.serialized_name.as_str());
+        let role = if is_callable_kind(node.kind) {
+            "callable"
+        } else {
+            "node"
+        };
         parts.push(format!(
-            "node:{}:{}:{}",
-            node.kind as i32,
-            node.qualified_name
-                .as_deref()
-                .unwrap_or(node.serialized_name.as_str()),
-            node.start_line.unwrap_or(0)
+            "{role}:{}:{qualified_name}:{}",
+            node.kind as i32, node.id.0
         ));
     }
 
     for edge in edges {
-        if matches!(edge.kind, EdgeKind::CALL | EdgeKind::USAGE) {
+        if edge_is_caller_scoped_repairable(edge.kind) && repaired_callables.owns_node(edge.source)
+        {
             continue;
         }
         let source_name = node_by_id
@@ -21415,8 +21730,27 @@ fn structural_projection_hash(
             })
             .unwrap_or_default();
         parts.push(format!(
-            "edge:{}:{}:{}",
-            edge.kind as i32, source_name, target_name
+            "edge:{}:{source_name}:{target_name}:{}",
+            edge.kind as i32,
+            edge.line.unwrap_or(0)
+        ));
+    }
+
+    for occurrence in occurrences {
+        if occurrence.location.file_node_id != file_id {
+            continue;
+        }
+        if repaired_callables.owns_occurrence(occurrence) {
+            continue;
+        }
+        parts.push(format!(
+            "occurrence:{}:{}:{}:{}:{}:{}",
+            occurrence.element_id,
+            occurrence.kind as i32,
+            occurrence.location.start_line,
+            occurrence.location.start_col,
+            occurrence.location.end_line,
+            occurrence.location.end_col
         ));
     }
 
@@ -21561,6 +21895,160 @@ mod tests {
     use rusqlite::types::Value;
     use std::collections::HashSet;
     use tempfile::tempdir;
+
+    /// A file whose only structural node is a position-derived one: a shape
+    /// several collectors produce today, because `structural_node_id` mixes the
+    /// declaration's line and column into the id.
+    fn projection_for_positioned_structural_node(
+        structural_id: i64,
+        structural_line: u32,
+        callable_start: u32,
+    ) -> Vec<CallableProjectionState> {
+        let file_id = NodeId(1);
+        let nodes = vec![
+            Node {
+                id: file_id,
+                kind: NodeKind::FILE,
+                serialized_name: "app.sql".to_string(),
+                qualified_name: Some("app.sql".to_string()),
+                start_line: Some(1),
+                start_col: Some(1),
+                end_line: Some(40),
+                end_col: Some(1),
+                ..Default::default()
+            },
+            Node {
+                id: NodeId(2),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "run".to_string(),
+                qualified_name: Some("run".to_string()),
+                file_node_id: Some(file_id),
+                start_line: Some(callable_start),
+                start_col: Some(1),
+                end_line: Some(callable_start + 4),
+                end_col: Some(1),
+                ..Default::default()
+            },
+            Node {
+                id: NodeId(structural_id),
+                kind: NodeKind::CLASS,
+                serialized_name: "public.users".to_string(),
+                qualified_name: Some("public.users".to_string()),
+                file_node_id: Some(file_id),
+                start_line: Some(structural_line),
+                start_col: Some(1),
+                end_line: Some(structural_line),
+                end_col: Some(12),
+                ..Default::default()
+            },
+        ];
+        // The structural node's only occurrence sits inside the callable, so
+        // the occurrence fence cannot see it move; node identity is the sole
+        // remaining signal that the row was replaced rather than repositioned.
+        let occurrences = vec![Occurrence {
+            element_id: structural_id,
+            kind: OccurrenceKind::DEFINITION,
+            location: SourceLocation {
+                file_node_id: file_id,
+                start_line: callable_start + 1,
+                start_col: 1,
+                end_line: callable_start + 1,
+                end_col: 12,
+            },
+        }];
+        build_callable_projection_states(&nodes, &[], &occurrences)
+    }
+
+    #[test]
+    fn a_replaced_node_identity_forces_a_full_replacement() {
+        let before = projection_for_positioned_structural_node(30, 3, 10);
+        let unchanged = projection_for_positioned_structural_node(30, 3, 10);
+        assert!(
+            matches!(
+                classify_projection_update(&before, &unchanged),
+                ProjectionUpdateMode::NoChanges
+            ),
+            "an unchanged file must not be reprojected"
+        );
+
+        // Same kind, same qualified name, same everything a caller-scoped
+        // repair would rewrite — only the id differs, which is what a
+        // position-derived collector emits after a shift. The old row is
+        // keyed by the old id and nothing would ever delete it.
+        let reidentified = projection_for_positioned_structural_node(31, 3, 10);
+        assert!(
+            matches!(
+                classify_projection_update(&before, &reidentified),
+                ProjectionUpdateMode::FullReplace
+            ),
+            "a node that changed identity must not be repaired incrementally: {:?}",
+            classify_projection_update(&before, &reidentified)
+        );
+    }
+
+    /// A callable that projects nothing: no outgoing edges, no body
+    /// occurrences. Only its own extent distinguishes one position from
+    /// another, and the stored row's `start_line`/`end_line` are what the
+    /// occurrence cleanup later reads to decide what a delta may delete.
+    fn projection_for_empty_stub(start_line: u32) -> Vec<CallableProjectionState> {
+        let file_id = NodeId(1);
+        let nodes = vec![
+            Node {
+                id: file_id,
+                kind: NodeKind::FILE,
+                serialized_name: "app.rs".to_string(),
+                qualified_name: Some("app.rs".to_string()),
+                start_line: Some(1),
+                start_col: Some(1),
+                end_line: Some(40),
+                end_col: Some(1),
+                ..Default::default()
+            },
+            Node {
+                id: NodeId(2),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "stub".to_string(),
+                qualified_name: Some("stub".to_string()),
+                file_node_id: Some(file_id),
+                start_line: Some(start_line),
+                start_col: Some(1),
+                end_line: Some(start_line + 1),
+                end_col: Some(1),
+                ..Default::default()
+            },
+        ];
+        build_callable_projection_states(&nodes, &[], &[])
+    }
+
+    #[test]
+    fn a_moved_stub_is_still_reprojected() {
+        let before = projection_for_empty_stub(10);
+        assert!(
+            matches!(
+                classify_projection_update(&before, &projection_for_empty_stub(10)),
+                ProjectionUpdateMode::NoChanges
+            ),
+            "an unchanged stub must not be reprojected"
+        );
+        let mode = classify_projection_update(&before, &projection_for_empty_stub(12));
+        assert!(
+            matches!(mode, ProjectionUpdateMode::Delta { ref changed_callers }
+                if changed_callers == &vec![NodeId(2)]),
+            "a stub that moved must still have its stored extent rewritten, got {mode:?}"
+        );
+    }
+
+    #[test]
+    fn a_callable_that_only_moved_is_repaired_in_place() {
+        let before = projection_for_positioned_structural_node(30, 3, 10);
+        let moved = projection_for_positioned_structural_node(30, 3, 12);
+        let mode = classify_projection_update(&before, &moved);
+        assert!(
+            matches!(mode, ProjectionUpdateMode::Delta { ref changed_callers }
+                if changed_callers == &vec![NodeId(2)]),
+            "a callable that only moved must be repaired caller-scoped, got {mode:?}"
+        );
+    }
 
     fn projection_snapshot(storage: &Storage) -> Result<Vec<(String, Vec<Vec<Value>>)>> {
         const QUERIES: [(&str, &str); 8] = [
@@ -23735,7 +24223,10 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             "structural_json_collector",
         )
         .expect("current structural cache key");
-        assert!(current_key.starts_with("v2:"));
+        assert!(current_key.starts_with(&format!(
+            "v{}:",
+            crate::cache::STRUCTURAL_ARTIFACT_CACHE_VERSION
+        )));
 
         let indexer = WorkspaceIndexer::new(dir.path().to_path_buf());
         let symbol_table = Arc::new(SymbolTable::new());
@@ -23753,7 +24244,7 @@ fn checked_foreign(value: Option<i32>) -> Option<i32> {
             )
         };
         let Ok(PreparedIndexWork::Structural(legacy_input)) = legacy_prepared else {
-            panic!("v1 cache must not satisfy the v2 structural cache lookup");
+            panic!("a superseded cache version must not satisfy the current lookup");
         };
         let legacy_result = indexer.execute_prepared_structural_index(&legacy_input);
         assert_eq!(legacy_stats.artifact_cache_hits, 0);

--- a/crates/codestory-indexer/src/structural/html.rs
+++ b/crates/codestory-indexer/src/structural/html.rs
@@ -5,7 +5,7 @@ use crate::structural::blanking::{
 };
 use crate::{get_language_for_ext, index_file};
 use codestory_contracts::graph::{EdgeId, EdgeKind, NodeId, NodeKind};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use super::common::{
@@ -20,8 +20,15 @@ pub(crate) fn collect_html_entities(
     storage: &mut IntermediateStorage,
 ) {
     let path_key = path.to_string_lossy();
-    let mut region_nodes: HashMap<u32, NodeId> = HashMap::new();
+    // Anchor parents are persisted inside `structural_edge_id`, so an arbitrary
+    // choice is not merely cosmetic: it makes the emitted edge set differ
+    // between two indexings of identical bytes (CR-013). `HashMap::values()`
+    // yields `RandomState` order, so both lookups below moved with the hash
+    // seed. Keyed maps ordered by line make the nearest enclosing region — the
+    // parent the old `.last()` was reaching for — a deterministic choice.
+    let mut region_nodes: BTreeMap<u32, NodeId> = BTreeMap::new();
     let mut id_nodes: HashMap<String, NodeId> = HashMap::new();
+    let mut id_nodes_by_line: BTreeMap<u32, NodeId> = BTreeMap::new();
 
     for (line_idx, line_text) in source.lines().enumerate() {
         let line_number = line_idx as u32 + 1;
@@ -44,7 +51,8 @@ pub(crate) fn collect_html_entities(
                 StructuralSourceSpan::token(line_number, id_start, id.len()),
             );
             id_nodes.insert(id.clone(), node_id);
-            if let Some(region_id) = region_nodes.values().last().copied() {
+            id_nodes_by_line.entry(line_number).or_insert(node_id);
+            if let Some(region_id) = nearest_at_or_above(&region_nodes, line_number) {
                 push_member_edge(storage, file_id, region_id, node_id, line_number);
             } else {
                 push_member_edge(storage, file_id, file_id, node_id, line_number);
@@ -67,10 +75,8 @@ pub(crate) fn collect_html_entities(
                     end_col: Some(class_name.len().max(1) as u32),
                 });
             }
-            let host_id = region_nodes
-                .get(&line_number)
-                .copied()
-                .or_else(|| id_nodes.values().copied().next())
+            let host_id = nearest_at_or_above(&region_nodes, line_number)
+                .or_else(|| nearest_at_or_above(&id_nodes_by_line, line_number))
                 .unwrap_or(file_id);
             push_usage_edge(storage, file_id, host_id, css_id, line_number);
         }
@@ -88,6 +94,11 @@ pub(crate) fn collect_html_entities(
     }
 
     delegate_script_blocks(path, source, file_id, storage);
+}
+
+/// The entry whose line is closest to `line` without passing it.
+fn nearest_at_or_above(nodes: &BTreeMap<u32, NodeId>, line: u32) -> Option<NodeId> {
+    nodes.range(..=line).next_back().map(|(_, id)| *id)
 }
 
 fn maybe_region_node(
@@ -296,15 +307,45 @@ fn merge_delegated_script_graph(
     }
 }
 
+/// True when `index` begins an attribute name rather than ending one.
+///
+/// The scan looks for a literal `id=` or `class=`, which also matches the tail
+/// of `data-testid=`, `data-id=`, `uid=`, and every other attribute whose name
+/// merely ends in those letters (CR-012). HTML attribute names are separated
+/// from what precedes them by whitespace, the opening `<tag`, or a quote that
+/// closed the previous value, so anything that could continue a name — an
+/// ASCII alphanumeric, `-`, `_`, `:`, `.`, or `@` — disqualifies the match.
+fn starts_attribute_name(line: &str, index: usize) -> bool {
+    let Some(previous) = line[..index].chars().next_back() else {
+        return true;
+    };
+    !(previous.is_ascii_alphanumeric() || matches!(previous, '-' | '_' | ':' | '.' | '@' | '$'))
+}
+
+fn find_attribute_start(lower: &str, line: &str, from: usize, name: &str) -> Option<usize> {
+    let spaced = format!("{name} =");
+    let equals = format!("{name}=");
+    let mut search = from;
+    while search <= lower.len() {
+        let rel = lower[search..]
+            .find(&equals)
+            .into_iter()
+            .chain(lower[search..].find(&spaced))
+            .min()?;
+        let index = search + rel;
+        if starts_attribute_name(line, index) {
+            return Some(index);
+        }
+        search = index + name.len();
+    }
+    None
+}
+
 fn extract_html_ids(line: &str) -> Vec<(String, usize)> {
     let mut ids = Vec::new();
     let lower = line.to_ascii_lowercase();
     let mut search = 0usize;
-    while let Some(rel) = lower[search..]
-        .find("id=")
-        .or_else(|| lower[search..].find("id ="))
-    {
-        let idx = search + rel;
+    while let Some(idx) = find_attribute_start(&lower, line, search, "id") {
         let rest = &line[idx..];
         if let Some((value, value_start)) = extract_attr_value(rest)
             && !value.is_empty()
@@ -320,11 +361,7 @@ fn extract_html_classes(line: &str) -> Vec<String> {
     let mut classes = Vec::new();
     let lower = line.to_ascii_lowercase();
     let mut search = 0usize;
-    while let Some(rel) = lower[search..]
-        .find("class=")
-        .or_else(|| lower[search..].find("class ="))
-    {
-        let idx = search + rel;
+    while let Some(idx) = find_attribute_start(&lower, line, search, "class") {
         let rest = &line[idx..];
         if let Some((value, _)) = extract_attr_value(rest) {
             for class_name in value.split_whitespace() {
@@ -391,5 +428,132 @@ mod tests {
                 .iter()
                 .any(|n| n.canonical_id.as_deref() == Some("css:class:layout"))
         );
+    }
+
+    fn collect(source: &str) -> IntermediateStorage {
+        let mut storage = IntermediateStorage::default();
+        collect_html_entities(Path::new("index.html"), source, NodeId(99), &mut storage);
+        storage
+    }
+
+    fn canonical_ids(storage: &IntermediateStorage) -> Vec<String> {
+        let mut ids = storage
+            .nodes
+            .iter()
+            .filter_map(|node| node.canonical_id.clone())
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+
+    #[test]
+    fn only_a_real_id_attribute_mints_an_entity() {
+        let storage = collect(
+            r#"<main id="app">
+  <button data-testid="login-submit" data-id="row-7" class="btn">Go</button>
+  <input uid="u-1" aria-labelledby="app" id="search">
+</main>"#,
+        );
+        let ids = canonical_ids(&storage);
+        for expected in ["html:id:app", "html:id:search"] {
+            assert!(
+                ids.contains(&expected.to_string()),
+                "`{expected}` is a real id attribute: {ids:?}"
+            );
+        }
+        for forbidden in [
+            "html:id:login-submit",
+            "html:id:row-7",
+            "html:id:u-1",
+            "html:id:app-labelled",
+        ] {
+            assert!(
+                !ids.contains(&forbidden.to_string()),
+                "`{forbidden}` comes from an attribute that merely ends in `id`: {ids:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_real_class_attribute_mints_a_css_usage() {
+        let storage = collect(
+            r#"<main class="layout">
+  <div data-class="ghost" ng-class="dynamic">x</div>
+</main>"#,
+        );
+        let ids = canonical_ids(&storage);
+        assert!(ids.contains(&"css:class:layout".to_string()), "{ids:?}");
+        for forbidden in ["css:class:ghost", "css:class:dynamic"] {
+            assert!(
+                !ids.contains(&forbidden.to_string()),
+                "`{forbidden}` comes from an attribute that merely ends in `class`: {ids:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn anchor_parents_are_the_nearest_enclosing_region_on_every_run() {
+        // Two regions and two ids, so the parent choice is ambiguous unless it
+        // is anchored: the old `HashMap::values().last()` picked whichever the
+        // hash seed happened to yield.
+        let source = r#"<section id="first">
+  <p>one</p>
+</section>
+<article id="second">
+  <p class="two">two</p>
+</article>"#;
+        let baseline = collect(source);
+        let region_by_id = baseline
+            .nodes
+            .iter()
+            .filter_map(|node| Some((node.id, node.canonical_id.clone()?)))
+            .collect::<std::collections::HashMap<_, _>>();
+        let describe = |storage: &IntermediateStorage| {
+            let mut rows = storage
+                .edges
+                .iter()
+                .map(|edge| {
+                    format!(
+                        "{:?}:{}->{}",
+                        edge.kind,
+                        region_by_id
+                            .get(&edge.source)
+                            .cloned()
+                            .unwrap_or_else(|| edge.source.0.to_string()),
+                        region_by_id
+                            .get(&edge.target)
+                            .cloned()
+                            .unwrap_or_else(|| edge.target.0.to_string())
+                    )
+                })
+                .collect::<Vec<_>>();
+            rows.sort();
+            rows
+        };
+
+        let baseline_edges = describe(&baseline);
+        assert!(
+            baseline_edges
+                .iter()
+                .any(|row| row == "MEMBER:html:region:index.html:1->html:id:first"),
+            "the id on the section line belongs to that section: {baseline_edges:?}"
+        );
+        assert!(
+            baseline_edges
+                .iter()
+                .any(|row| row == "MEMBER:html:region:index.html:4->html:id:second"),
+            "the id on the article line belongs to that article: {baseline_edges:?}"
+        );
+
+        // Repeated indexing of identical bytes must emit an identical edge set;
+        // the parent is baked into `structural_edge_id`, so drift here is
+        // persisted churn.
+        for _ in 0..16 {
+            assert_eq!(
+                describe(&collect(source)),
+                baseline_edges,
+                "identical source must produce an identical edge set"
+            );
+        }
     }
 }

--- a/crates/codestory-indexer/src/structural/sql.rs
+++ b/crates/codestory-indexer/src/structural/sql.rs
@@ -21,12 +21,85 @@ struct LocatedQualifiedName {
     len: usize,
 }
 
+/// Blank out SQL comments while preserving every byte offset.
+///
+/// The collector is line-oriented and records exact byte spans, so comments are
+/// overwritten with spaces rather than removed: `-- CREATE TABLE old_users (id
+/// INT);` used to mint a real table node with a MEMBER edge and inline column
+/// fields, and prose like `-- create table statements below` used to mint a
+/// table called `statements` (CR-011). Quoting is tracked so a `--` or `/*`
+/// inside a string literal or a quoted identifier is left alone, and block
+/// comments carry their state across lines.
+fn mask_sql_comments(source: &str) -> String {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Scan {
+        Code,
+        Quoted(u8),
+        BlockComment,
+    }
+
+    let bytes = source.as_bytes();
+    // Every byte of a masked run is overwritten, so a multi-byte character
+    // inside a comment becomes that many spaces and the result stays valid
+    // UTF-8 at exactly the original length.
+    let mut output = bytes.to_vec();
+    let mut state = Scan::Code;
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        let next = bytes.get(index + 1).copied();
+        match state {
+            Scan::Code => match (byte, next) {
+                (b'-', Some(b'-')) => {
+                    while index < bytes.len() && bytes[index] != b'\n' {
+                        output[index] = b' ';
+                        index += 1;
+                    }
+                }
+                (b'/', Some(b'*')) => {
+                    state = Scan::BlockComment;
+                    output[index] = b' ';
+                    output[index + 1] = b' ';
+                    index += 2;
+                }
+                (b'\'', _) | (b'"', _) | (b'`', _) => {
+                    state = Scan::Quoted(byte);
+                    index += 1;
+                }
+                _ => index += 1,
+            },
+            Scan::Quoted(quote) => {
+                if byte == quote {
+                    state = Scan::Code;
+                }
+                index += 1;
+            }
+            Scan::BlockComment => {
+                if byte == b'*' && next == Some(b'/') {
+                    output[index] = b' ';
+                    output[index + 1] = b' ';
+                    state = Scan::Code;
+                    index += 2;
+                } else {
+                    if byte != b'\n' && byte != b'\r' {
+                        output[index] = b' ';
+                    }
+                    index += 1;
+                }
+            }
+        }
+    }
+    String::from_utf8(output).unwrap_or_else(|_| source.to_string())
+}
+
 pub(crate) fn collect_sql_entities(
     path: &Path,
     source: &str,
     file_id: NodeId,
     storage: &mut IntermediateStorage,
 ) {
+    let masked = mask_sql_comments(source);
+    let source = masked.as_str();
     let default_schema = infer_default_schema(source);
     let schema_nodes = collect_schemas(source, file_id, storage, &default_schema);
     let mut tables: HashMap<String, NodeId> = HashMap::new();
@@ -199,10 +272,38 @@ fn default_schema_node(file_id: NodeId, storage: &mut IntermediateStorage, schem
     push_synthetic_structural_node(storage, file_id, NodeKind::NAMESPACE, schema, &canonical)
 }
 
+/// Byte offsets on this line at which a SQL statement can begin.
+///
+/// One offset for the first non-whitespace byte, and one after every `;`.
+/// Anything else on the line is inside a statement.
+fn statement_start_offsets(line: &str) -> Vec<usize> {
+    let mut offsets = vec![skip_ascii_whitespace(line, 0)];
+    for (index, byte) in line.as_bytes().iter().enumerate() {
+        if *byte == b';' {
+            offsets.push(skip_ascii_whitespace(line, index + 1));
+        }
+    }
+    offsets.retain(|offset| *offset < line.len());
+    offsets
+}
+
+/// Locate `keyword` only where a statement starts.
+///
+/// The lookup used to be an unanchored `find`, so any line mentioning the
+/// keyword produced a schema object: a string literal holding dynamic DDL, a
+/// `COMMENT ON` body, a continuation line quoting the phrase (CR-011). Comment
+/// masking removes one source of those; anchoring removes the rest. `CREATE
+/// INDEX` is unaffected — `parse_create_index` was already anchored separately.
 fn parse_qualified_name_after_keyword(line: &str, keyword: &str) -> Option<LocatedQualifiedName> {
     let lower = line.to_ascii_lowercase();
     let keyword_lower = keyword.to_ascii_lowercase();
-    let idx = lower.find(&keyword_lower)?;
+    let idx = statement_start_offsets(line).into_iter().find(|offset| {
+        lower[*offset..].starts_with(&keyword_lower)
+            && line
+                .as_bytes()
+                .get(offset + keyword.len())
+                .is_none_or(|byte| byte.is_ascii_whitespace() || *byte == b'(')
+    })?;
     let mut start = skip_ascii_whitespace(line, idx + keyword.len());
     if line[start..]
         .to_ascii_uppercase()
@@ -445,6 +546,118 @@ CREATE INDEX users_email_idx ON app.users (email);
         assert_eq!(
             &source.lines().next().unwrap().as_bytes()[start..end],
             b"app"
+        );
+    }
+
+    fn canonical_ids(storage: &IntermediateStorage) -> Vec<String> {
+        let mut ids = storage
+            .nodes
+            .iter()
+            .filter_map(|node| node.canonical_id.clone())
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+
+    fn collect(source: &str) -> IntermediateStorage {
+        let mut storage = IntermediateStorage::default();
+        collect_sql_entities(Path::new("schema.sql"), source, NodeId(7), &mut storage);
+        storage
+    }
+
+    #[test]
+    fn commented_out_and_quoted_ddl_produce_no_schema_objects() {
+        let live = collect("CREATE TABLE app.users (id INT, email TEXT);\n");
+        let live_ids = canonical_ids(&live);
+        assert!(
+            live_ids.contains(&"sql:table:app.users".to_string()),
+            "live DDL must still be collected: {live_ids:?}"
+        );
+        assert!(
+            live_ids.contains(&"sql:column:app.users.id".to_string()),
+            "live inline columns must still be collected: {live_ids:?}"
+        );
+
+        let commented = collect(concat!(
+            "-- CREATE TABLE app.old_users (id INT);\n",
+            "-- create table statements below\n",
+            "/* CREATE TABLE app.block_users (id INT);\n",
+            "   CREATE VIEW app.block_view AS SELECT 1; */\n",
+            "EXECUTE 'CREATE TABLE app.dynamic_users (id INT)';\n",
+            "COMMENT ON TABLE app.users IS 'CREATE FUNCTION app.fake()';\n",
+        ));
+        let commented_ids = canonical_ids(&commented);
+        for forbidden in [
+            "sql:table:app.old_users",
+            "sql:table:public.statements",
+            "sql:table:app.block_users",
+            "sql:view:app.block_view",
+            "sql:table:app.dynamic_users",
+            "sql:func:app.fake",
+        ] {
+            assert!(
+                !commented_ids.contains(&forbidden.to_string()),
+                "`{forbidden}` must not be minted from a comment or a string literal: \
+                 {commented_ids:?}"
+            );
+        }
+        assert!(
+            !commented
+                .nodes
+                .iter()
+                .any(|node| node.kind == NodeKind::FIELD),
+            "no inline columns may be minted from commented-out DDL: {commented_ids:?}"
+        );
+    }
+
+    #[test]
+    fn a_trailing_comment_does_not_hide_the_statement_it_follows() {
+        let storage = collect(
+            "CREATE TABLE app.users (id INT); -- CREATE TABLE app.ghost (id INT);\n\
+             CREATE TABLE app.orders (id INT); /* note */\n",
+        );
+        let ids = canonical_ids(&storage);
+        assert!(ids.contains(&"sql:table:app.users".to_string()), "{ids:?}");
+        assert!(ids.contains(&"sql:table:app.orders".to_string()), "{ids:?}");
+        assert!(!ids.contains(&"sql:table:app.ghost".to_string()), "{ids:?}");
+    }
+
+    #[test]
+    fn comment_masking_preserves_every_byte_offset() {
+        let source = "CREATE TABLE app.users (id INT); -- naïve note\n/* ünicode */\n";
+        let masked = mask_sql_comments(source);
+        assert_eq!(masked.len(), source.len());
+        assert_eq!(masked.lines().count(), source.lines().count());
+        assert!(masked.starts_with("CREATE TABLE app.users (id INT);"));
+        assert!(
+            masked
+                .lines()
+                .next()
+                .expect("first line")
+                .trim_end()
+                .ends_with(';'),
+            "the comment tail must be blanked, not shortened: {masked:?}"
+        );
+        assert!(
+            masked
+                .lines()
+                .nth(1)
+                .expect("second line")
+                .trim()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_quoted_comment_marker_is_not_a_comment() {
+        let masked = mask_sql_comments("SELECT '-- not a comment' AS note; -- real\n");
+        assert!(
+            masked.contains("'-- not a comment'"),
+            "string literals keep their contents: {masked:?}"
+        );
+        assert!(
+            !masked.contains("real"),
+            "the real comment is still blanked: {masked:?}"
         );
     }
 }

--- a/crates/codestory-indexer/tests/call_resolution_common_methods.rs
+++ b/crates/codestory-indexer/tests/call_resolution_common_methods.rs
@@ -13128,3 +13128,204 @@ fn test_comprehensive_polymorphic_call_resolution_fixtures() -> anyhow::Result<(
 
     Ok(())
 }
+
+#[test]
+fn test_java_argument_carrying_method_annotation_keeps_parameter_receiver_types()
+-> anyhow::Result<()> {
+    // The parameter surface used to be scanned from the first `(` in the
+    // method's own text, and a leading annotation with an argument list puts
+    // that `(` inside the annotation (CR-009). `@GetMapping("/dispatch")`
+    // yielded `"/dispatch"` as the parameter list, so the receiver map came out
+    // empty and `listener.handleEvent()` never resolved.
+    let source = r#"
+class Listener {
+    void handleEvent() {}
+}
+
+class AuditListener {
+    void handleEvent() {}
+}
+
+class Bus {
+    @GetMapping("/dispatch")
+    @Transactional(readOnly = true)
+    void dispatchTo(Listener listener) {
+        listener.handleEvent();
+    }
+}
+"#;
+
+    let (nodes, edges) = index_single_file("Bus.java", source)?;
+    assert_resolved_call_to_method_owner(
+        "java annotated method",
+        &nodes,
+        &edges,
+        "dispatchTo",
+        "Listener",
+        "handleEvent",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "java annotated method",
+        &nodes,
+        &edges,
+        "dispatchTo",
+        "AuditListener",
+        "handleEvent",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_java_parameter_annotation_does_not_become_the_receiver_owner_type() -> anyhow::Result<()> {
+    // `f(@RequestParam("id") Listener listener)` recorded the owner type of
+    // `listener` as `@RequestParam`, because the annotation is just another
+    // whitespace-separated token and the type surface truncates at its `(`.
+    let source = r#"
+class Listener {
+    void handleEvent() {}
+}
+
+class AuditListener {
+    void handleEvent() {}
+}
+
+class Bus {
+    void dispatchTo(@RequestParam(value = "id") final Listener listener) {
+        listener.handleEvent();
+    }
+}
+"#;
+
+    let (nodes, edges) = index_single_file("Bus.java", source)?;
+    assert_resolved_call_to_method_owner(
+        "java annotated parameter",
+        &nodes,
+        &edges,
+        "dispatchTo",
+        "Listener",
+        "handleEvent",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "java annotated parameter",
+        &nodes,
+        &edges,
+        "dispatchTo",
+        "AuditListener",
+        "handleEvent",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_kotlin_argument_carrying_annotations_keep_parameter_and_property_bindings()
+-> anyhow::Result<()> {
+    // Two separate CR-009 failures on one path: `@Throws(IOException::class)`
+    // on a function turned `IOException::class` into the parameter surface, and
+    // `@Table(name = "users")` on a data class swallowed the whole primary
+    // constructor, so the class lost every property binding.
+    let source = r#"
+package app
+
+class Repository {
+    fun save() {}
+}
+
+class Audit {
+    fun save() {}
+}
+
+@Table(name = "users")
+data class User(private val repository: Repository) {
+    fun persist() {
+        repository.save()
+    }
+}
+
+class Bus {
+    @Throws(IllegalStateException::class)
+    fun dispatchTo(repository: Repository) {
+        repository.save()
+    }
+}
+"#;
+
+    let (nodes, edges) = index_single_file("App.kt", source)?;
+    assert_resolved_call_to_method_owner(
+        "kotlin annotated data class",
+        &nodes,
+        &edges,
+        "persist",
+        "Repository",
+        "save",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "kotlin annotated data class",
+        &nodes,
+        &edges,
+        "persist",
+        "Audit",
+        "save",
+    );
+    assert_resolved_call_to_method_owner(
+        "kotlin annotated function",
+        &nodes,
+        &edges,
+        "dispatchTo",
+        "Repository",
+        "save",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "kotlin annotated function",
+        &nodes,
+        &edges,
+        "dispatchTo",
+        "Audit",
+        "save",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_kotlin_trailing_lambda_call_keeps_its_receiver() -> anyhow::Result<()> {
+    // A trailing lambda has no argument parentheses, so cutting the callee at
+    // the first `(` and splitting on the last `.` reached into the lambda body:
+    // `repository.forEach { it.hashCode() }` produced the receiver
+    // `repository.forEach { it` and the member `hashCode`, and the real call to
+    // `forEach` was lost (CR-010).
+    let source = r#"
+package app
+
+class Repository {
+    fun forEach(block: (Int) -> Unit) {}
+}
+
+class Audit {
+    fun forEach(block: (Int) -> Unit) {}
+}
+
+class Bus {
+    fun run(repository: Repository) {
+        repository.forEach { it.hashCode() }
+    }
+}
+"#;
+
+    let (nodes, edges) = index_single_file("Bus.kt", source)?;
+    assert_resolved_call_to_method_owner(
+        "kotlin trailing lambda",
+        &nodes,
+        &edges,
+        "run",
+        "Repository",
+        "forEach",
+    );
+    assert_no_resolved_call_to_method_owner(
+        "kotlin trailing lambda",
+        &nodes,
+        &edges,
+        "run",
+        "Audit",
+        "forEach",
+    );
+    Ok(())
+}

--- a/crates/codestory-indexer/tests/projection_identity.rs
+++ b/crates/codestory-indexer/tests/projection_identity.rs
@@ -1,0 +1,288 @@
+//! Callable projection identity across position-shifting edits (W4.6/CR-008).
+//!
+//! Every assertion here reads rows the production incremental path actually
+//! wrote: node identities, occurrence spans, edge lines, and the bookmark table
+//! that a whole-file replacement destroys.
+
+use codestory_contracts::events::EventBus;
+use codestory_contracts::graph::{EdgeKind, NodeKind};
+use codestory_indexer::WorkspaceIndexer;
+use codestory_store::Store as Storage;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn reindex(root: &Path, storage: &mut Storage, path: &Path) -> anyhow::Result<()> {
+    let indexer = WorkspaceIndexer::new(root.to_path_buf());
+    let event_bus = EventBus::new();
+    let refresh_info = codestory_workspace::RefreshInfo {
+        mode: codestory_workspace::BuildMode::Incremental,
+        files_to_index: vec![path.to_path_buf()],
+        files_to_remove: vec![],
+        existing_file_ids: HashMap::new(),
+    };
+    indexer.run_incremental(storage, &refresh_info, &event_bus, None)?;
+    Ok(())
+}
+
+fn node_id_by_name(storage: &Storage, name: &str, kind: NodeKind) -> anyhow::Result<i64> {
+    let matches = storage
+        .get_nodes()?
+        .into_iter()
+        .filter(|node| node.serialized_name == name && node.kind == kind)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one `{name}` of kind {kind:?}, got {:?}",
+        matches
+            .iter()
+            .map(|node| (node.id.0, node.start_line))
+            .collect::<Vec<_>>()
+    );
+    Ok(matches[0].id.0)
+}
+
+fn occurrence_spans(storage: &Storage, file_id: i64) -> anyhow::Result<Vec<(i64, u32, u32)>> {
+    let mut rows = storage
+        .get_occurrences_for_file(codestory_contracts::graph::NodeId(file_id))?
+        .into_iter()
+        .map(|occ| {
+            (
+                occ.element_id,
+                occ.location.start_line,
+                occ.location.start_col,
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort();
+    Ok(rows)
+}
+
+fn file_node_id(storage: &Storage) -> anyhow::Result<i64> {
+    Ok(storage
+        .get_nodes()?
+        .into_iter()
+        .find(|node| node.kind == NodeKind::FILE)
+        .expect("file node")
+        .id
+        .0)
+}
+
+const RUST_BEFORE: &str = r#"use std::fmt::Debug;
+
+struct Thing {
+    value: i32,
+}
+
+fn helper(a: i32) -> i32 {
+    a + 1
+}
+
+fn caller() -> i32 {
+    let t = Thing { value: 1 };
+    helper(t.value)
+}
+"#;
+
+const RUST_AFTER_SHIFT: &str = r#"use std::fmt::Debug;
+
+struct Thing {
+    value: i32,
+}
+
+// a comment inserted above the first function
+fn helper(a: i32) -> i32 {
+    a + 1
+}
+
+fn caller() -> i32 {
+    let t = Thing { value: 1 };
+    helper(t.value)
+}
+"#;
+
+#[test]
+fn position_shift_keeps_callable_identity_and_its_annotations() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let path = root.join("lib.rs");
+    fs::write(&path, RUST_BEFORE)?;
+    let mut storage = Storage::new_in_memory()?;
+    reindex(root, &mut storage, &path)?;
+
+    let helper_before = node_id_by_name(&storage, "helper", NodeKind::FUNCTION)?;
+    let caller_before = node_id_by_name(&storage, "caller", NodeKind::FUNCTION)?;
+    let category = storage.create_bookmark_category("review")?;
+    let bookmark = storage.add_bookmark(
+        category,
+        codestory_contracts::graph::NodeId(helper_before),
+        Some("look here"),
+    )?;
+
+    fs::write(&path, RUST_AFTER_SHIFT)?;
+    reindex(root, &mut storage, &path)?;
+
+    // Identity survives the shift, so anything anchored to it survives too.
+    assert_eq!(
+        node_id_by_name(&storage, "helper", NodeKind::FUNCTION)?,
+        helper_before,
+        "a callable that only moved must keep its identity"
+    );
+    assert_eq!(
+        node_id_by_name(&storage, "caller", NodeKind::FUNCTION)?,
+        caller_before
+    );
+    let bookmarks = storage.get_bookmarks(Some(category))?;
+    assert_eq!(
+        bookmarks.len(),
+        1,
+        "a position-shifting edit must not delete user annotations: {bookmarks:?}"
+    );
+    assert_eq!(bookmarks[0].id, bookmark);
+    assert_eq!(bookmarks[0].node_id.0, helper_before);
+
+    // The projection is repaired, not merely preserved: positions move with the
+    // source and no stale duplicate survives.
+    let file_id = file_node_id(&storage)?;
+    let spans = occurrence_spans(&storage, file_id)?;
+    assert!(
+        spans.contains(&(helper_before, 8, 1)),
+        "helper's definition occurrence must follow it to line 8: {spans:?}"
+    );
+    assert!(
+        !spans
+            .iter()
+            .any(|(element, line, _)| *element == helper_before && *line == 7),
+        "the pre-shift occurrence must not survive as a duplicate: {spans:?}"
+    );
+    let mut seen = spans.clone();
+    seen.dedup();
+    assert_eq!(
+        seen.len(),
+        spans.len(),
+        "duplicate occurrence rows: {spans:?}"
+    );
+
+    let nodes = storage.get_nodes()?;
+    assert_eq!(
+        nodes
+            .iter()
+            .filter(|node| node.serialized_name == "helper")
+            .count(),
+        2,
+        "the function and its one call placeholder, and no orphaned copies: {:?}",
+        nodes
+            .iter()
+            .map(|node| (node.serialized_name.as_str(), node.id.0, node.start_line))
+            .collect::<Vec<_>>()
+    );
+    let helper_node = nodes
+        .iter()
+        .find(|node| node.id.0 == helper_before)
+        .expect("helper node");
+    assert_eq!(
+        helper_node.start_line,
+        Some(8),
+        "the surviving node row carries the new position"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_moved_call_edge_carries_its_new_line() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let path = root.join("lib.rs");
+    fs::write(&path, RUST_BEFORE)?;
+    let mut storage = Storage::new_in_memory()?;
+    reindex(root, &mut storage, &path)?;
+    fs::write(&path, RUST_AFTER_SHIFT)?;
+    reindex(root, &mut storage, &path)?;
+
+    let nodes = storage.get_nodes()?;
+    let caller = nodes
+        .iter()
+        .find(|node| node.serialized_name == "caller" && node.kind == NodeKind::FUNCTION)
+        .expect("caller node");
+    let call_lines = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL && edge.source == caller.id)
+        .map(|edge| edge.line)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        call_lines,
+        vec![Some(14)],
+        "exactly one call edge, on the line the call now occupies"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_shifted_occurrence_no_callable_owns_forces_a_full_replacement() -> anyhow::Result<()> {
+    // Occurrence rows carry no id, so an occurrence the caller-scoped cleanup
+    // does not delete becomes a duplicate rather than an updated row. The
+    // struct field's occurrence sits outside every callable, so nothing but the
+    // file fence can see it move.
+    let dir = tempdir()?;
+    let root = dir.path();
+    let path = root.join("lib.rs");
+    fs::write(&path, RUST_BEFORE)?;
+    let mut storage = Storage::new_in_memory()?;
+    reindex(root, &mut storage, &path)?;
+    let field = storage
+        .get_nodes()?
+        .into_iter()
+        .find(|node| node.serialized_name == "Thing::value")
+        .expect("field node");
+
+    // Insert above everything, so the field itself moves.
+    fs::write(&path, format!("// header\n{RUST_BEFORE}"))?;
+    reindex(root, &mut storage, &path)?;
+
+    let file_id = file_node_id(&storage)?;
+    let field_spans = occurrence_spans(&storage, file_id)?
+        .into_iter()
+        .filter(|(element, _, _)| *element == field.id.0)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        field_spans,
+        vec![(field.id.0, 5, 5)],
+        "the field's occurrence must move once, not be duplicated"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_body_edit_still_replaces_the_symbols_it_removes() -> anyhow::Result<()> {
+    // Fail-closed control: relaxing the position trigger must not relax
+    // deletion. A callable that disappears is still fully replaced.
+    let dir = tempdir()?;
+    let root = dir.path();
+    let path = root.join("lib.rs");
+    fs::write(&path, RUST_BEFORE)?;
+    let mut storage = Storage::new_in_memory()?;
+    reindex(root, &mut storage, &path)?;
+    assert!(
+        storage
+            .get_nodes()?
+            .iter()
+            .any(|node| node.serialized_name == "helper" && node.kind == NodeKind::FUNCTION)
+    );
+
+    fs::write(
+        &path,
+        "use std::fmt::Debug;\n\nstruct Thing {\n    value: i32,\n}\n\nfn caller() -> i32 {\n    let t = Thing { value: 1 };\n    t.value\n}\n",
+    )?;
+    reindex(root, &mut storage, &path)?;
+    assert!(
+        !storage
+            .get_nodes()?
+            .iter()
+            .any(|node| node.serialized_name == "helper"),
+        "a deleted callable must not survive an incremental refresh"
+    );
+    Ok(())
+}

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -7783,6 +7783,11 @@ impl Storage {
             }
         }
 
+        // The caller-scoped repair owns exactly the call and usage edges this
+        // file records for the caller. `callable_edge_projection_parts` in the
+        // indexer counts the same two kinds, and anything else is fenced by the
+        // file-structural row instead; the three definitions have to agree or a
+        // delta leaves a row nothing rewrote.
         let removed_edges = tx.execute(
             &format!(
                 "DELETE FROM edge


### PR DESCRIPTION
Closes #1657. **This unblocks the sixteen S3 language packages (#1676–#1691).**

## What

W4.6 went deeper than the review knew. `signature_hash` was positional — but so was *identity*: the canonical node id was `{file}:{qualified_name}:{start_line}`, so inserting one comment above a function changed the id of that function, its caller, its locals, and its unresolved-call placeholder. Fixing only the hash would have taken the delta path with stale node ids and orphaned rows. The discriminator is now a within-file **ordinal** (`{file}:{qualified_name}#{ordinal}`) — a relabelling of the same merge groups, so overloads and same-named locals stay distinct while a line insertion changes nothing. Position moved into `body_hash` with an explicit extent term, so a stub that projects nothing is still reprojected when it moves.

W4.7 point fixes: Java/Kotlin parameter surfaces read the grammar's parameter node rather than the first `(`; Kotlin primary constructors read `primary_constructor`; parameter-level annotations are stripped before the type and default-value split; SQL comments are blanked byte-for-byte with quoting tracked and DDL anchored to statement starts; HTML `id=`/`class=` require an attribute-name boundary with anchor parents from line-ordered maps.

Both artifact cache versions go 2 → 3 (one projection-format bump); the version is mixed into the hash *and* prefixed onto the key, so a v2 artifact can never satisfy a v3 lookup.

## Review

**Merge with follow-up.** The reviewer ran five mutations against production code — reverting the canonical id, the signature hash, the occurrence fence, the HTML ordering, and the Kotlin grammar path — and every one was caught by an assertion reading rows the incremental path actually wrote. They could construct no mutation that kept the suite green while breaking a claimed contract, and called it the strongest test evidence in the program.

**One major, and it corrects this PR's own framing:** the commit's declared remainder says files whose unowned rows move still take FullReplace, illustrated as "Go-style file → symbol MEMBER edges". That understates it badly. An unowned occurrence is *any* import, top-level constant, field, or class/struct/interface header — so a header-comment insertion still destroys every bookmark in almost any real file, measured across Java, C#, Kotlin, Python, TypeScript, Ruby, PHP and C++. Go free functions happen to work. Filed as follow-up; stated here rather than left in the commit's gloss.

Baseline movement is in the declared W4 window with a 17-row per-category cause table where every moved row names its defect id and every unmoved row says why it is insensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)