### PR TITLE
[v0.17 READY-C] Seal generation health receipts and repair damaged reuse

### DIFF
--- a/crates/codestory-contracts/src/lib.rs
+++ b/crates/codestory-contracts/src/lib.rs
@@ -20,4 +20,5 @@ pub mod language_support;
 pub mod owned_artifacts;
 pub mod query;
 pub mod trail;
+pub mod validation_receipts;
 pub mod workspace;

--- a/crates/codestory-contracts/src/validation_receipts.rs
+++ b/crates/codestory-contracts/src/validation_receipts.rs
@@ -1,0 +1,606 @@
+//! Sealed validation receipts.
+//!
+//! A receipt records that one expensive validation of an *immutable* artifact
+//! succeeded. It is only reusable while the native identity of every file the
+//! validation examined is byte-for-byte the same observation it was sealed to:
+//! same presence, same length, same modification and inode-change instants,
+//! same device/inode, same read-only bit. Replacement, truncation, in-place
+//! rewriting, and the appearance of a SQLite sidecar all break the seal, so a
+//! generation that was damaged after its first validation re-validates instead
+//! of hiding behind the earlier verdict.
+//!
+//! Two rules are structural rather than conventional:
+//!
+//! * **Success only.** A failing validation never produces a receipt, and it
+//!   removes any receipt the key already had.
+//! * **Facts, not verdicts.** A receipt caches what the artifact *is* — the
+//!   content-derived value the validation computed. Admission decisions that
+//!   depend on caller expectations stay outside the receipt and re-run every
+//!   time.
+//!
+//! Receipts are process-local. They are an optimization over re-reading bytes
+//! this process already read; they are never persisted and never shared.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::Hash;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Sentinel for a native timestamp the platform does not report.
+///
+/// A fixed sentinel keeps seal comparison total: two observations of the same
+/// file on the same platform always agree, and a platform that gains support
+/// mid-process simply invalidates once.
+const TIMESTAMP_UNAVAILABLE: i128 = i128::MIN;
+
+/// Why an artifact could not be sealed.
+///
+/// An unsealable artifact is not an error for the caller: the validation still
+/// runs, it just cannot be turned into a receipt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtifactSealError {
+    /// The path exists but is not a regular file.
+    NotRegularFile { path: PathBuf },
+    /// Native metadata could not be read.
+    Unreadable { path: PathBuf, detail: String },
+}
+
+impl ArtifactSealError {
+    /// Stable machine code for this failure.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NotRegularFile { .. } => "artifact_seal_not_regular_file",
+            Self::Unreadable { .. } => "artifact_seal_unreadable",
+        }
+    }
+}
+
+impl fmt::Display for ArtifactSealError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotRegularFile { path } => {
+                write!(formatter, "{} is not a regular file", path.display())
+            }
+            Self::Unreadable { path, detail } => {
+                write!(
+                    formatter,
+                    "native metadata for {} is unreadable: {detail}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ArtifactSealError {}
+
+/// Native identity of one artifact at a single observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactSeal {
+    path: PathBuf,
+    presence: SealPresence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SealPresence {
+    /// The artifact did not exist. Absence is part of the seal: a sidecar that
+    /// appears after validation invalidates the receipt.
+    Absent,
+    Present {
+        len: u64,
+        modified_nanos: i128,
+        created_nanos: i128,
+        /// Unix device id, `0` where the platform does not report one.
+        device: u64,
+        /// Unix inode number, `0` where the platform does not report one.
+        inode: u64,
+        /// Unix inode-change instant. This is what catches an in-place rewrite
+        /// that restores the modification time afterwards.
+        inode_change_nanos: i128,
+        readonly: bool,
+    },
+}
+
+impl ArtifactSeal {
+    /// Observe the native identity of `path` right now.
+    ///
+    /// A missing path seals as absent. Anything that exists but is not a
+    /// regular file — a directory, a symlink standing in for the artifact, a
+    /// device node — is refused rather than sealed.
+    pub fn observe(path: &Path) -> Result<Self, ArtifactSealError> {
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.is_file() => Ok(Self {
+                path: path.to_path_buf(),
+                presence: SealPresence::Present {
+                    len: metadata.len(),
+                    modified_nanos: metadata
+                        .modified()
+                        .map_or(TIMESTAMP_UNAVAILABLE, system_time_nanos),
+                    created_nanos: metadata
+                        .created()
+                        .map_or(TIMESTAMP_UNAVAILABLE, system_time_nanos),
+                    device: native_device(&metadata),
+                    inode: native_inode(&metadata),
+                    inode_change_nanos: native_inode_change_nanos(&metadata),
+                    readonly: metadata.permissions().readonly(),
+                },
+            }),
+            Ok(_) => Err(ArtifactSealError::NotRegularFile {
+                path: path.to_path_buf(),
+            }),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self {
+                path: path.to_path_buf(),
+                presence: SealPresence::Absent,
+            }),
+            Err(error) => Err(ArtifactSealError::Unreadable {
+                path: path.to_path_buf(),
+                detail: error.to_string(),
+            }),
+        }
+    }
+
+    /// The artifact this seal describes.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Whether the artifact existed as a regular file when it was sealed.
+    pub fn is_present(&self) -> bool {
+        matches!(self.presence, SealPresence::Present { .. })
+    }
+
+    /// Observe every artifact in order, or report the first that cannot be
+    /// sealed.
+    pub fn observe_all(paths: &[PathBuf]) -> Result<Vec<Self>, ArtifactSealError> {
+        paths.iter().map(|path| Self::observe(path)).collect()
+    }
+}
+
+fn system_time_nanos(time: SystemTime) -> i128 {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(elapsed) => elapsed.as_nanos() as i128,
+        Err(error) => -(error.duration().as_nanos() as i128),
+    }
+}
+
+#[cfg(unix)]
+fn native_device(metadata: &std::fs::Metadata) -> u64 {
+    std::os::unix::fs::MetadataExt::dev(metadata)
+}
+
+#[cfg(not(unix))]
+fn native_device(_metadata: &std::fs::Metadata) -> u64 {
+    0
+}
+
+#[cfg(unix)]
+fn native_inode(metadata: &std::fs::Metadata) -> u64 {
+    std::os::unix::fs::MetadataExt::ino(metadata)
+}
+
+#[cfg(not(unix))]
+fn native_inode(_metadata: &std::fs::Metadata) -> u64 {
+    0
+}
+
+#[cfg(unix)]
+fn native_inode_change_nanos(metadata: &std::fs::Metadata) -> i128 {
+    use std::os::unix::fs::MetadataExt;
+    i128::from(metadata.ctime()) * 1_000_000_000 + i128::from(metadata.ctime_nsec())
+}
+
+#[cfg(not(unix))]
+fn native_inode_change_nanos(_metadata: &std::fs::Metadata) -> i128 {
+    TIMESTAMP_UNAVAILABLE
+}
+
+/// Per-key receipt accounting, for tests and diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ReceiptStats {
+    /// Successful validations that produced a receipt for this key.
+    pub validations: u64,
+    /// Times the sealed receipt answered instead of re-validating.
+    pub reuses: u64,
+    /// Times a stored receipt was discarded because its seal no longer held.
+    pub invalidations: u64,
+}
+
+struct Receipt<V> {
+    seals: Vec<ArtifactSeal>,
+    value: V,
+    stats: ReceiptStats,
+}
+
+/// A bounded, process-local cache of sealed validation receipts.
+///
+/// Construct one `static` per validation family. `capacity` bounds the number
+/// of live receipts; reaching it clears the cache rather than guessing which
+/// generation is still interesting, which keeps the memory bound hard and the
+/// eviction rule deterministic.
+pub struct SealedReceiptCache<K, V> {
+    capacity: usize,
+    entries: OnceLock<Mutex<HashMap<K, Receipt<V>>>>,
+}
+
+impl<K, V> SealedReceiptCache<K, V> {
+    /// A cache holding at most `capacity` receipts.
+    pub const fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            entries: OnceLock::new(),
+        }
+    }
+}
+
+impl<K, V> SealedReceiptCache<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    fn entries(&self) -> &Mutex<HashMap<K, Receipt<V>>> {
+        self.entries.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// Answer from a sealed receipt when one still holds, otherwise run
+    /// `validate` and seal its success.
+    ///
+    /// `artifacts` is the complete set of files the verdict depends on. The
+    /// seal is taken before validation and re-taken after it; a file that
+    /// changed while the validation ran is never sealed, so a receipt can only
+    /// describe a state the validation actually observed end to end.
+    ///
+    /// A failed validation removes any receipt for `key` and is never cached.
+    pub fn validate_sealed<E>(
+        &self,
+        key: K,
+        artifacts: &[PathBuf],
+        validate: impl FnOnce() -> Result<V, E>,
+    ) -> Result<V, E> {
+        let observed = ArtifactSeal::observe_all(artifacts).ok();
+        let mut carried = ReceiptStats::default();
+        if let Some(observed) = observed.as_ref() {
+            let mut entries = self.locked_entries();
+            if let Some(receipt) = entries.get_mut(&key) {
+                if &receipt.seals == observed {
+                    receipt.stats.reuses += 1;
+                    return Ok(receipt.value.clone());
+                }
+                carried = receipt.stats;
+                carried.invalidations += 1;
+                // Fail closed: a receipt whose seal no longer holds is gone
+                // before the replacement verdict exists.
+                entries.remove(&key);
+            }
+        }
+
+        let value = match validate() {
+            Ok(value) => value,
+            Err(error) => {
+                self.locked_entries().remove(&key);
+                return Err(error);
+            }
+        };
+
+        if let Some(observed) = observed
+            && ArtifactSeal::observe_all(artifacts).is_ok_and(|after| after == observed)
+        {
+            carried.validations += 1;
+            let mut entries = self.locked_entries();
+            if entries.len() >= self.capacity && !entries.contains_key(&key) {
+                entries.clear();
+            }
+            entries.insert(
+                key,
+                Receipt {
+                    seals: observed,
+                    value: value.clone(),
+                    stats: carried,
+                },
+            );
+        }
+        Ok(value)
+    }
+
+    /// Accounting for `key`, or `None` when no receipt is held.
+    pub fn stats(&self, key: &K) -> Option<ReceiptStats> {
+        self.locked_entries().get(key).map(|entry| entry.stats)
+    }
+
+    /// Number of receipts currently held.
+    pub fn len(&self) -> usize {
+        self.locked_entries().len()
+    }
+
+    /// Whether no receipt is currently held.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Drop every receipt.
+    pub fn clear(&self) {
+        self.locked_entries().clear();
+    }
+
+    fn locked_entries(&self) -> std::sync::MutexGuard<'_, HashMap<K, Receipt<V>>> {
+        // A poisoned receipt cache is recoverable: the worst a torn map can do
+        // is cost a re-validation, and refusing to validate would be worse.
+        self.entries()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::fs::{File, FileTimes};
+    use std::time::Duration;
+
+    fn write(path: &Path, body: &str) {
+        std::fs::write(path, body).expect("write artifact");
+    }
+
+    fn set_modified(path: &Path, nanos_since_epoch: u64) {
+        let file = File::options()
+            .write(true)
+            .open(path)
+            .expect("open artifact to set times");
+        file.set_times(
+            FileTimes::new()
+                .set_modified(UNIX_EPOCH + Duration::from_nanos(nanos_since_epoch))
+                .set_accessed(UNIX_EPOCH + Duration::from_nanos(nanos_since_epoch)),
+        )
+        .expect("set artifact times");
+    }
+
+    struct CountingValidator {
+        runs: Cell<u64>,
+    }
+
+    impl CountingValidator {
+        fn new() -> Self {
+            Self { runs: Cell::new(0) }
+        }
+
+        fn ok(&self, value: &str) -> Result<String, String> {
+            self.runs.set(self.runs.get() + 1);
+            Ok(value.to_string())
+        }
+
+        fn err(&self) -> Result<String, String> {
+            self.runs.set(self.runs.get() + 1);
+            Err("validation failed".into())
+        }
+    }
+
+    #[test]
+    fn an_unchanged_artifact_is_validated_once_and_reused() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let artifact = dir.path().join("shard.sqlite3");
+        write(&artifact, "generation-a");
+        let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
+        let validator = CountingValidator::new();
+        let artifacts = vec![artifact.clone()];
+
+        let first = cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("verdict-a"))
+            .expect("first validation");
+        let second = cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("verdict-b"))
+            .expect("second validation");
+
+        assert_eq!(first, "verdict-a");
+        assert_eq!(
+            second, "verdict-a",
+            "the sealed receipt must answer, not a fresh validation"
+        );
+        assert_eq!(validator.runs.get(), 1);
+        assert_eq!(
+            cache.stats(&artifact),
+            Some(ReceiptStats {
+                validations: 1,
+                reuses: 1,
+                invalidations: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn in_place_corruption_that_restores_the_modification_time_still_breaks_the_seal() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let artifact = dir.path().join("shard.sqlite3");
+        write(&artifact, "generation-a");
+        let pinned_modified = 1_700_000_000_000_000_000;
+        set_modified(&artifact, pinned_modified);
+        let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
+        let validator = CountingValidator::new();
+        let artifacts = vec![artifact.clone()];
+
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("healthy"))
+            .expect("seal the healthy generation");
+
+        // Same path, same inode, same length, and the modification time is put
+        // back exactly where it was: only the native inode-change instant
+        // records that the bytes were rewritten.
+        write(&artifact, "generation-X");
+        set_modified(&artifact, pinned_modified);
+
+        let after = cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("damaged"))
+            .expect("re-validate after in-place corruption");
+
+        assert_eq!(
+            after, "damaged",
+            "corrupted bytes must not be answered from the earlier receipt"
+        );
+        assert_eq!(validator.runs.get(), 2);
+        assert_eq!(
+            cache.stats(&artifact),
+            Some(ReceiptStats {
+                validations: 2,
+                reuses: 0,
+                invalidations: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn replacing_the_artifact_with_identical_bytes_breaks_the_seal() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let artifact = dir.path().join("shard.sqlite3");
+        let replacement = dir.path().join("shard.sqlite3.new");
+        write(&artifact, "generation-a");
+        let pinned_modified = 1_700_000_000_000_000_000;
+        set_modified(&artifact, pinned_modified);
+        let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
+        let validator = CountingValidator::new();
+        let artifacts = vec![artifact.clone()];
+
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("healthy"))
+            .expect("seal the healthy generation");
+
+        write(&replacement, "generation-a");
+        set_modified(&replacement, pinned_modified);
+        std::fs::rename(&replacement, &artifact).expect("replace artifact");
+
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("rebuilt"))
+            .expect("re-validate after replacement");
+
+        assert_eq!(
+            validator.runs.get(),
+            2,
+            "a replaced file is a different artifact even when its bytes match"
+        );
+    }
+
+    #[test]
+    fn a_sidecar_appearing_beside_the_artifact_breaks_the_seal() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let artifact = dir.path().join("shard.sqlite3");
+        let sidecar = dir.path().join("shard.sqlite3-wal");
+        write(&artifact, "generation-a");
+        let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
+        let validator = CountingValidator::new();
+        let artifacts = vec![artifact.clone(), sidecar.clone()];
+
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("healthy"))
+            .expect("seal with the sidecar absent");
+        write(&sidecar, "uncommitted pages");
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("healthy"))
+            .expect("re-validate with the sidecar present");
+
+        assert_eq!(validator.runs.get(), 2);
+        assert_eq!(
+            cache.stats(&artifact).map(|stats| stats.invalidations),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn a_failed_validation_is_never_sealed_and_evicts_the_earlier_receipt() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let artifact = dir.path().join("shard.sqlite3");
+        write(&artifact, "generation-a");
+        let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
+        let validator = CountingValidator::new();
+        let artifacts = vec![artifact.clone()];
+
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("healthy"))
+            .expect("seal the healthy generation");
+        write(&artifact, "generation-a-damaged");
+
+        let first_failure = cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.err())
+            .expect_err("damaged generation fails validation");
+        assert_eq!(first_failure, "validation failed");
+        assert_eq!(cache.stats(&artifact), None, "failures leave no receipt");
+
+        let second_failure = cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.err())
+            .expect_err("a repeated failure re-runs validation");
+        assert_eq!(second_failure, "validation failed");
+        assert_eq!(validator.runs.get(), 3);
+        assert_eq!(cache.stats(&artifact), None);
+    }
+
+    #[test]
+    fn an_artifact_that_changes_during_validation_is_not_sealed() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let artifact = dir.path().join("shard.sqlite3");
+        write(&artifact, "generation-a");
+        let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
+        let validator = CountingValidator::new();
+        let artifacts = vec![artifact.clone()];
+
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || {
+                let verdict = validator.ok("healthy");
+                write(&artifact, "generation-a-rewritten-mid-validation");
+                verdict
+            })
+            .expect("validation succeeds against the bytes it read");
+
+        assert_eq!(
+            cache.stats(&artifact),
+            None,
+            "a verdict about bytes that no longer exist must not be sealed"
+        );
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("healthy"))
+            .expect("second validation");
+        assert_eq!(validator.runs.get(), 2);
+    }
+
+    #[test]
+    fn an_unsealable_artifact_validates_without_caching() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let artifact = dir.path().join("shard.sqlite3");
+        std::fs::create_dir(&artifact).expect("create directory where a file belongs");
+        let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
+        let validator = CountingValidator::new();
+        let artifacts = vec![artifact.clone()];
+
+        assert_eq!(
+            ArtifactSeal::observe(&artifact)
+                .expect_err("a directory cannot be sealed")
+                .code(),
+            "artifact_seal_not_regular_file"
+        );
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("verdict"))
+            .expect("first validation");
+        cache
+            .validate_sealed(artifact.clone(), &artifacts, || validator.ok("verdict"))
+            .expect("second validation");
+
+        assert_eq!(validator.runs.get(), 2);
+        assert_eq!(cache.stats(&artifact), None);
+    }
+
+    #[test]
+    fn the_receipt_cache_holds_at_most_its_capacity() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(2);
+        let validator = CountingValidator::new();
+        for index in 0..5 {
+            let artifact = dir.path().join(format!("shard-{index}.sqlite3"));
+            write(&artifact, "generation");
+            cache
+                .validate_sealed(artifact.clone(), std::slice::from_ref(&artifact), || {
+                    validator.ok("verdict")
+                })
+                .expect("validate");
+            assert!(cache.len() <= 2, "receipt cache exceeded its capacity");
+        }
+        assert_eq!(validator.runs.get(), 5);
+    }
+}

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -516,11 +516,13 @@ fn has_real_scip_artifact(project_dir: &Path, generation: &str) -> bool {
     project_dir
         .join(crate::scip_index::SCIP_SYMBOLS_FILE)
         .is_file()
-        && project_dir
-            .join(crate::scip_index::SCIP_INDEX_FILE)
-            .is_file()
+        // `index.scip` is parsed and bound to this generation's revision.
+        // Existence alone let a corrupt-but-present marker publish clean.
+        && crate::scip_index::parse_scip_index_marker(project_dir, &revision).is_ok()
         && project_dir.join("revision.txt").is_file()
-        && !project_dir.join("index.scip.stub").is_file()
+        && !project_dir
+            .join(crate::scip_index::SCIP_STUB_MARKER_FILE)
+            .is_file()
         && crate::scip_index::load_fresh_scip_symbols(project_dir, &revision, generation)
             .ok()
             .flatten()

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -671,7 +671,7 @@ pub fn finalize_index_for_runtime_with_progress_and_cancel(
                 expected_points: sidecar_input.projection_count,
             };
             let semantic_point_count = semantic_ready_point_count(&previous_semantic);
-            if status.retrieval_mode == "full" && semantic_point_count.is_some() {
+            if unchanged_generation_is_reusable(&status, semantic_point_count) {
                 let mut manifest = previous.clone();
                 if let Some(generation) = manifest.sidecar_generation.clone() {
                     let scip_dir = layout.scip_project_dir(&generation);
@@ -1261,6 +1261,23 @@ fn sidecar_disk_bytes(
     )
 }
 
+/// Whether an unchanged sidecar generation may be republished as-is.
+///
+/// `status.retrieval_mode` is overridden to `"full"` whenever the stored
+/// manifest classifies full, and every published manifest does, so it can
+/// never refuse reuse — it was a tautology at this decision point.
+/// [`RetrievalStatusReport::is_live_ready`] additionally requires the live
+/// lexical, semantic, and graph verdicts the probe just computed, so a
+/// generation damaged after publication falls through to the in-place rebuild
+/// instead of being reused and then rejected at the publication fence with no
+/// path back to a healthy state.
+fn unchanged_generation_is_reusable(
+    status: &crate::health::RetrievalStatusReport,
+    semantic_point_count: Option<u64>,
+) -> bool {
+    status.is_live_ready() && semantic_point_count.is_some()
+}
+
 fn semantic_ready_point_count(semantic: &SemanticGeneration<'_>) -> Option<u64> {
     let expected = u64::try_from(semantic.expected_points).ok()?;
     let health = EmbeddedVectorIndex::health(
@@ -1827,7 +1844,10 @@ fn prepare_generation_retention(
                     context.embedding_device,
                     context.runtime,
                 );
-                if status.retrieval_mode != "full" {
+                // Same manifest override as the reuse branch: a rollback
+                // pointer must name a generation whose artifacts are live
+                // healthy right now, not one whose manifest says so.
+                if !status.is_live_ready() {
                     bail!(
                         "rollback generation is not full: {} {:?}",
                         status.retrieval_mode,
@@ -3846,6 +3866,204 @@ mod tests {
             "git {} failed: {}",
             args.join(" "),
             String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// The explicit-CPU device a zero-dense generation is admitted under.
+    fn cpu_explicit_device() -> crate::embeddings::EmbeddingDeviceReadiness {
+        crate::embeddings::EmbeddingDeviceReadiness {
+            requested_policy: "cpu_explicit",
+            observed_state: "cpu_explicit",
+            observation_source: "per_user_server",
+            detected_provider: None,
+            detected_gpu: None,
+            accelerator_requested: false,
+            accelerator_request_provider: None,
+            accelerator_request_device: None,
+            cpu_allowed: true,
+            full_retrieval_allowed: true,
+            degraded_reason: None,
+        }
+    }
+
+    struct HealthyGeneration {
+        _project: TempDir,
+        _data: TempDir,
+        layout: SidecarLayout,
+        manifest: RetrievalIndexManifest,
+        generation: String,
+        scip_dir: PathBuf,
+        lexical_data_dir: PathBuf,
+    }
+
+    /// Publish one complete, live-healthy zero-dense generation on disk:
+    /// a real lexical shard, real SCIP artifacts, and the manifest a finalize
+    /// pass would have committed for them.
+    fn publish_healthy_generation(project_id: &str) -> HealthyGeneration {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "pub fn handler() {}").expect("source");
+        let data = TempDir::new().expect("data");
+        let layout = SidecarLayout {
+            lexical_data_dir: data.path().join("lexical"),
+            semantic_data_dir: data.path().join("semantic"),
+            scip_artifacts_root: data.path().join("scip"),
+            state_file: data.path().join("state.json"),
+        };
+        layout.ensure_data_dirs().expect("data dirs");
+        let manifest = crate::test_support::retrieval_manifest_fixture(project_id, "input-hash");
+        let generation = manifest
+            .sidecar_generation
+            .clone()
+            .expect("fixture generation");
+        let fingerprint =
+            crate::lexical_index::lexical_input_fingerprint(project.path(), None).expect("scan");
+        crate::lexical_index::build_lexical_shard(
+            project.path(),
+            None,
+            &layout.lexical_data_dir,
+            &generation,
+            &fingerprint,
+            "input-hash",
+        )
+        .expect("build lexical shard");
+
+        let revision = manifest.scip_revision.clone().expect("fixture revision");
+        let scip_dir = layout.scip_project_dir(&generation);
+        std::fs::create_dir_all(&scip_dir).expect("scip dir");
+        let scip_symbols = vec![crate::scip_index::ScipSymbolRecord {
+            node_id: Some("1".into()),
+            path: "lib.rs".into(),
+            symbol: "handler".into(),
+            start_line: 1,
+            end_line: 1,
+        }];
+        // A graph-projection artifact is only fresh when it carries proof
+        // records, so the fixture publishes the definition proof for its one
+        // symbol. Without it the generation is stale, not live-healthy, and
+        // the reuse assertions below would prove nothing.
+        let scip_proofs = scip_symbols
+            .iter()
+            .map(|symbol: &crate::scip_index::ScipSymbolRecord| {
+                crate::scip_index::ScipProofRecord {
+                    role: crate::scip_index::SCIP_DEFINITION_ROLE.into(),
+                    path: symbol.path.clone(),
+                    symbol: symbol.symbol.clone(),
+                    start_line: symbol.start_line,
+                    start_character_utf16: 0,
+                    end_line: symbol.end_line,
+                    end_character_utf16: 0,
+                    target_symbol: None,
+                    node_id: symbol.node_id.clone(),
+                    target_node_id: None,
+                }
+            })
+            .collect();
+        let symbols = crate::scip_index::ScipSymbolsIndex {
+            generation: generation.clone(),
+            revision: revision.clone(),
+            contract: crate::scip_index::ScipProofAdapterContract::graph_projection(&revision),
+            symbols: scip_symbols,
+            proofs: scip_proofs,
+        };
+        std::fs::write(
+            scip_dir.join(crate::scip_index::SCIP_SYMBOLS_FILE),
+            serde_json::to_vec_pretty(&symbols).expect("serialize symbols"),
+        )
+        .expect("write symbols");
+        std::fs::write(scip_dir.join("revision.txt"), format!("{revision}\n")).expect("revision");
+        crate::scip_index::write_scip_index_marker(&scip_dir, &revision).expect("marker");
+
+        let lexical_data_dir = layout.lexical_data_dir.clone();
+        HealthyGeneration {
+            _project: project,
+            _data: data,
+            layout,
+            manifest,
+            generation,
+            scip_dir,
+            lexical_data_dir,
+        }
+    }
+
+    fn probe(
+        fixture: &HealthyGeneration,
+        project_id: &str,
+    ) -> crate::health::RetrievalStatusReport {
+        probe_sidecar_health_for_runtime(
+            &fixture.layout,
+            project_id,
+            Some(fixture.manifest.clone()),
+            &cpu_explicit_device(),
+            &SidecarRuntimeConfig::local(),
+        )
+    }
+
+    #[test]
+    fn reuse_refuses_a_generation_whose_graph_artifact_was_damaged_after_publication() {
+        let fixture = publish_healthy_generation("reuse-scip");
+        // A zero-dense generation renders exactly this semantic count; holding
+        // it fixed leaves the live artifact verdict as the only variable.
+        let semantic_point_count = Some(0);
+
+        let healthy = probe(&fixture, "reuse-scip");
+        assert!(
+            unchanged_generation_is_reusable(&healthy, semantic_point_count),
+            "an intact generation must still be reused: {:?}",
+            healthy.degraded_reason
+        );
+
+        std::fs::write(
+            fixture.scip_dir.join(crate::scip_index::SCIP_INDEX_FILE),
+            b"\0\0\0\0",
+        )
+        .expect("damage the graph marker in place");
+
+        let damaged = probe(&fixture, "reuse-scip");
+
+        assert_eq!(
+            damaged.retrieval_mode, "full",
+            "the manifest still classifies full, which is why the old gate could never refuse"
+        );
+        assert_eq!(
+            damaged.degraded_reason.as_deref(),
+            Some("scip_index_marker_header_unrecognized")
+        );
+        assert!(
+            !unchanged_generation_is_reusable(&damaged, semantic_point_count),
+            "a damaged graph lane must fall through to the rebuild"
+        );
+        assert!(
+            !damaged.is_live_ready(),
+            "the rollback verification fence reads the same predicate, so a damaged \
+             generation cannot be recorded as a verified rollback target either"
+        );
+    }
+
+    #[test]
+    fn reuse_refuses_a_generation_whose_lexical_shard_was_damaged_after_publication() {
+        let fixture = publish_healthy_generation("reuse-lexical");
+        let semantic_point_count = Some(0);
+        assert!(unchanged_generation_is_reusable(
+            &probe(&fixture, "reuse-lexical"),
+            semantic_point_count
+        ));
+
+        let shard =
+            crate::lexical_index::shard_dir_for(&fixture.lexical_data_dir, &fixture.generation)
+                .join(crate::lexical_index::LEXICAL_INDEX_FILE);
+        crate::lexical_index::make_test_file_writable(&shard);
+        std::fs::write(&shard, b"not sqlite").expect("damage the lexical shard in place");
+
+        let damaged = probe(&fixture, "reuse-lexical");
+
+        assert_eq!(damaged.retrieval_mode, "full");
+        assert_eq!(
+            damaged.degraded_reason.as_deref(),
+            Some("lexical_shard_unavailable")
+        );
+        assert!(
+            !unchanged_generation_is_reusable(&damaged, semantic_point_count),
+            "a damaged lexical shard must fall through to the rebuild"
         );
     }
 }

--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -2,6 +2,8 @@
 
 use anyhow::{Context, Result, bail};
 use codestory_contracts::api::SearchTargetDto;
+use codestory_contracts::owned_artifacts::sqlite_file_with_sidecars;
+use codestory_contracts::validation_receipts::SealedReceiptCache;
 use codestory_store::{FileRole, Store, SymbolSearchDoc};
 use codestory_workspace::paths::sqlite_open_path;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
@@ -18,6 +20,28 @@ const LEGACY_STUB_MARKER: &str = ".zoekt-stub";
 const MAX_FILE_BYTES: u64 = 1_000_000;
 const MAX_CANDIDATES: usize = 4_096;
 const COVERAGE_PATH_SAMPLE: usize = 32;
+
+/// How many published lexical generations may hold a sealed health receipt at
+/// once.
+///
+/// A runtime works on one project generation at a time and keeps at most the
+/// outgoing one alive beside it, so the live cardinality is a handful; the
+/// bound exists to make the memory ceiling hard, not to force turnover. A
+/// receipt is one metadata row, so the whole cache at capacity is tens of
+/// kilobytes. Reaching the bound clears the cache, which costs a re-scan and
+/// never changes a verdict.
+const LEXICAL_SHARD_RECEIPT_CAPACITY: usize = 256;
+
+/// Sealed deep-verification receipts for immutable lexical shards.
+///
+/// The receipt records what a shard *is* — its self-consistent metadata row —
+/// after a full integrity pass. It never records whether that shard satisfies
+/// a particular caller's expectations; those comparisons are cheap and re-run
+/// on every probe. The seal covers the shard database and every SQLite sidecar
+/// identity the registry owns, so an in-place rewrite, a replacement, or a
+/// stray write-ahead log invalidates the receipt instead of hiding behind it.
+static LEXICAL_SHARD_RECEIPTS: SealedReceiptCache<PathBuf, LexicalShardMetadata> =
+    SealedReceiptCache::new(LEXICAL_SHARD_RECEIPT_CAPACITY);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct LexicalCoverage {
@@ -212,12 +236,14 @@ pub fn build_lexical_shard(
             expected,
             |visit| scan_lexical_documents(project_root, storage_path, storage_path, visit),
         )?;
-        validate_lexical_database(
-            &temp_path,
+        // The staged file is about to be renamed away, so its verdict is not
+        // receiptable: seal the published identity, never the temporary one.
+        let staged = verify_lexical_database_contents(&temp_path)?;
+        match_lexical_shard_expectations(
+            &staged,
             project_id,
             sidecar_input_hash,
             Some((expected.file_count, expected.hash.as_str())),
-            true,
         )?;
         publish_immutable_lexical_database(&temp_path, &index_path)?;
         Ok(rebuilt)
@@ -298,7 +324,6 @@ pub fn shard_has_lexical_index(shard_dir: &Path, expected_sidecar_input_hash: &s
         project_id,
         expected_sidecar_input_hash,
         None,
-        false,
     )
     .is_ok()
 }
@@ -315,7 +340,6 @@ pub fn shard_matches_lexical_input(
         sidecar_generation,
         expected_sidecar_input_hash,
         Some((expected_file_count, expected_hash)),
-        true,
     )
     .is_ok()
 }
@@ -330,9 +354,19 @@ pub fn lexical_shard_coverage(
         sidecar_generation,
         expected_sidecar_input_hash,
         None,
-        false,
     )?
     .coverage)
+}
+
+/// Sealed-receipt accounting for one shard, for tests that must prove the deep
+/// verification ran exactly as often as the seal allowed.
+#[cfg(test)]
+pub(crate) fn lexical_shard_receipt_stats(
+    lexical_data_dir: &Path,
+    sidecar_generation: &str,
+) -> Option<codestory_contracts::validation_receipts::ReceiptStats> {
+    LEXICAL_SHARD_RECEIPTS
+        .stats(&shard_dir_for(lexical_data_dir, sidecar_generation).join(LEXICAL_INDEX_FILE))
 }
 
 #[cfg(test)]
@@ -656,47 +690,56 @@ where
     Ok(actual)
 }
 
+/// Deep-verify one immutable lexical shard, reusing a sealed receipt when the
+/// shard's native identity is unchanged, then check the caller's expectations
+/// against the receipted metadata.
+///
+/// The two halves are deliberately separate. The deep half scans the whole FTS
+/// mirror and is a fact about the artifact, so it is receiptable. The
+/// expectation half is three string comparisons that depend on the caller, so
+/// it runs every time and can never be answered from a receipt.
 fn validate_lexical_database(
     path: &Path,
     expected_project_id: &str,
     expected_sidecar_input_hash: &str,
     expected_lexical: Option<(u32, &str)>,
-    quick_check: bool,
 ) -> Result<LexicalShardMetadata> {
+    let metadata = LEXICAL_SHARD_RECEIPTS.validate_sealed(
+        path.to_path_buf(),
+        &sqlite_file_with_sidecars(path),
+        || verify_lexical_database_contents(path),
+    )?;
+    match_lexical_shard_expectations(
+        &metadata,
+        expected_project_id,
+        expected_sidecar_input_hash,
+        expected_lexical,
+    )?;
+    Ok(metadata)
+}
+
+/// The receiptable half: everything that depends only on the shard's own bytes.
+///
+/// `quick_check` is unconditional here. It used to be opt-in so that the cheap
+/// callers could skip it, but with the verdict sealed to native identity the
+/// page-level check is paid once per generation, and the strongest verdict is
+/// the only one worth sealing.
+fn verify_lexical_database_contents(path: &Path) -> Result<LexicalShardMetadata> {
     if !path.is_file() {
         bail!("lexical SQLite shard is missing");
     }
     let connection = open_read_only(path)?;
-    validate_open_database(
-        &connection,
-        expected_project_id,
-        expected_sidecar_input_hash,
-        expected_lexical,
-        quick_check,
-        &|| false,
-    )
+    verify_open_database_contents(&connection, &|| false)
 }
 
-fn validate_open_database(
+fn verify_open_database_contents(
     connection: &Connection,
-    expected_project_id: &str,
-    expected_sidecar_input_hash: &str,
-    expected_lexical: Option<(u32, &str)>,
-    quick_check: bool,
     cancelled: &dyn Fn() -> bool,
 ) -> Result<LexicalShardMetadata> {
-    let metadata = validate_open_database_metadata(
-        connection,
-        expected_project_id,
-        expected_sidecar_input_hash,
-        expected_lexical,
-        cancelled,
-    )?;
-    if quick_check {
-        let check: String = connection.query_row("PRAGMA quick_check(1)", [], |row| row.get(0))?;
-        if check != "ok" {
-            bail!("lexical SQLite shard failed quick_check: {check}");
-        }
+    let metadata = read_open_database_metadata(connection, cancelled)?;
+    let check: String = connection.query_row("PRAGMA quick_check(1)", [], |row| row.get(0))?;
+    if check != "ok" {
+        bail!("lexical SQLite shard failed quick_check: {check}");
     }
     let actual_count: u32 =
         connection.query_row("SELECT count(*) FROM lexical_documents", [], |row| {
@@ -751,6 +794,24 @@ fn validate_open_database_metadata(
     expected_lexical: Option<(u32, &str)>,
     cancelled: &dyn Fn() -> bool,
 ) -> Result<LexicalShardMetadata> {
+    let metadata = read_open_database_metadata(connection, cancelled)?;
+    match_lexical_shard_expectations(
+        &metadata,
+        expected_project_id,
+        expected_sidecar_input_hash,
+        expected_lexical,
+    )?;
+    Ok(metadata)
+}
+
+/// Read the shard's own metadata row and check it is internally consistent.
+///
+/// Nothing here depends on the caller, which is what makes the verdict
+/// receiptable.
+fn read_open_database_metadata(
+    connection: &Connection,
+    cancelled: &dyn Fn() -> bool,
+) -> Result<LexicalShardMetadata> {
     if cancelled() {
         bail!("lexical search cancelled");
     }
@@ -803,12 +864,6 @@ fn validate_open_database_metadata(
     if version != LEXICAL_INDEX_VERSION {
         bail!("lexical SQLite shard version is not current");
     }
-    if metadata.project_id != expected_project_id {
-        bail!("lexical SQLite shard project id does not match its generation directory");
-    }
-    if metadata.sidecar_input_hash != expected_sidecar_input_hash {
-        bail!("lexical SQLite shard does not match the sidecar input hash");
-    }
     if metadata.binding_sha256
         != metadata_binding(
             &metadata.project_id,
@@ -820,12 +875,28 @@ fn validate_open_database_metadata(
     {
         bail!("lexical SQLite shard metadata binding is invalid");
     }
+    Ok(metadata)
+}
+
+/// The caller-dependent half: never receipted, always re-checked.
+fn match_lexical_shard_expectations(
+    metadata: &LexicalShardMetadata,
+    expected_project_id: &str,
+    expected_sidecar_input_hash: &str,
+    expected_lexical: Option<(u32, &str)>,
+) -> Result<()> {
+    if metadata.project_id != expected_project_id {
+        bail!("lexical SQLite shard project id does not match its generation directory");
+    }
+    if metadata.sidecar_input_hash != expected_sidecar_input_hash {
+        bail!("lexical SQLite shard does not match the sidecar input hash");
+    }
     if let Some((file_count, lexical_hash)) = expected_lexical
         && (metadata.file_count != file_count || metadata.lexical_hash != lexical_hash)
     {
         bail!("lexical SQLite shard does not match current lexical input");
     }
-    Ok(metadata)
+    Ok(())
 }
 
 fn open_read_only(path: &Path) -> Result<Connection> {
@@ -1991,14 +2062,18 @@ mod tests {
             let mut deep_validation_micros = Vec::new();
             for _ in 0..7 {
                 let started = std::time::Instant::now();
-                validate_lexical_database(
-                    &index_path,
+                // Measure the uncached scan on purpose: the sealed receipt
+                // would answer every repeat and report the cost of a HashMap
+                // lookup instead of the corpus pass this fixture reports.
+                let metadata =
+                    verify_lexical_database_contents(&index_path).expect("deep validation");
+                match_lexical_shard_expectations(
+                    &metadata,
                     &generation,
                     "benchmark-input",
                     Some((fingerprint.file_count, fingerprint.hash.as_str())),
-                    true,
                 )
-                .expect("deep validation");
+                .expect("deep validation expectations");
                 deep_validation_micros.push(started.elapsed().as_micros() as u64);
             }
 
@@ -2109,5 +2184,157 @@ mod tests {
         });
         hits.truncate(limit);
         hits
+    }
+
+    fn shard_modified_nanos(index: &Path) -> u64 {
+        std::fs::metadata(index)
+            .expect("shard metadata")
+            .modified()
+            .expect("shard mtime")
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("shard mtime after epoch")
+            .as_nanos() as u64
+    }
+
+    fn restore_shard_modified_nanos(index: &Path, nanos: u64) {
+        let file = std::fs::File::options()
+            .write(true)
+            .open(index)
+            .expect("open shard to restore times");
+        let restored = std::time::UNIX_EPOCH + std::time::Duration::from_nanos(nanos);
+        file.set_times(
+            std::fs::FileTimes::new()
+                .set_modified(restored)
+                .set_accessed(restored),
+        )
+        .expect("restore shard times");
+    }
+
+    #[test]
+    fn repeated_probes_of_one_generation_deep_scan_the_shard_once() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "pub fn handler() {}").expect("source");
+        let data = TempDir::new().expect("data");
+        let shard = build(project.path(), data.path(), "receipt-reuse", "input");
+        let fingerprint = lexical_input_fingerprint(project.path(), None).expect("fingerprint");
+        assert_eq!(
+            lexical_shard_receipt_stats(data.path(), "receipt-reuse"),
+            None,
+            "publishing a shard must not seal a receipt; only a read path may"
+        );
+
+        // Exactly the pair a single health probe performs, then the finalize
+        // fence's stricter check over the same generation.
+        assert!(shard_has_lexical_index(&shard, "input"));
+        lexical_shard_coverage(data.path(), "receipt-reuse", "input").expect("coverage");
+        assert!(shard_matches_lexical_input(
+            data.path(),
+            "receipt-reuse",
+            fingerprint.file_count,
+            &fingerprint.hash,
+            "input",
+        ));
+
+        let stats = lexical_shard_receipt_stats(data.path(), "receipt-reuse")
+            .expect("a successful deep verification seals a receipt");
+        assert_eq!(
+            (stats.validations, stats.reuses, stats.invalidations),
+            (1, 2, 0),
+            "three probes of one unchanged generation must scan the FTS mirror once"
+        );
+    }
+
+    #[test]
+    fn a_sealed_receipt_cannot_hide_in_place_corruption_of_its_shard() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "fn handler() {}").expect("source");
+        std::fs::write(project.path().join("other.rs"), "fn unrelated() {}").expect("source");
+        let data = TempDir::new().expect("data");
+        let shard = build(project.path(), data.path(), "receipt-seal", "input");
+        let index = shard.join(LEXICAL_INDEX_FILE);
+
+        lexical_shard_coverage(data.path(), "receipt-seal", "input")
+            .expect("healthy generation verifies");
+        assert!(
+            lexical_shard_receipt_stats(data.path(), "receipt-seal").is_some(),
+            "the healthy verdict must be sealed, or corruption below proves nothing"
+        );
+
+        // Rewrite the shard where it lies, keeping the forged text the same
+        // length as the document it shadows, then put the modification time
+        // back: exactly what a restore-in-place or a torn write leaves behind,
+        // and invisible to a length-and-mtime check.
+        let published = std::fs::metadata(&index).expect("shard metadata");
+        let modified = shard_modified_nanos(&index);
+        let length = published.len();
+        let permissions = published.permissions();
+        make_test_file_writable(&index);
+        let connection = Connection::open(&index).expect("open writable");
+        connection
+            .execute(
+                "UPDATE lexical_fts SET content = 'fn unrelated() {;'
+                 WHERE rowid = (SELECT id FROM lexical_documents WHERE path = 'other.rs')",
+                [],
+            )
+            .expect("forge FTS row");
+        drop(connection);
+        restore_shard_modified_nanos(&index, modified);
+        std::fs::set_permissions(&index, permissions.clone()).expect("restore shard permissions");
+        let corrupted = std::fs::metadata(&index).expect("shard metadata");
+        assert_eq!(
+            shard_modified_nanos(&index),
+            modified,
+            "the corruption must be invisible to a modification-time check"
+        );
+        assert_eq!(
+            corrupted.len(),
+            length,
+            "the corruption must be invisible to a file-length check"
+        );
+        assert_eq!(
+            corrupted.permissions().readonly(),
+            permissions.readonly(),
+            "the corruption must be invisible to a permission check"
+        );
+
+        let after = lexical_shard_coverage(data.path(), "receipt-seal", "input");
+
+        assert!(
+            after.is_err(),
+            "the sealed receipt answered for bytes that no longer exist: {after:?}"
+        );
+        assert!(
+            format!("{:#}", after.expect_err("corrupt shard"))
+                .contains("FTS rows do not match immutable documents"),
+            "the re-run deep scan must report the corruption it found"
+        );
+        assert!(!shard_has_lexical_index(&shard, "input"));
+        assert_eq!(
+            lexical_shard_receipt_stats(data.path(), "receipt-seal"),
+            None,
+            "a failed verification must leave no receipt behind"
+        );
+    }
+
+    #[test]
+    fn rebuilding_a_damaged_generation_in_place_reseals_it_as_healthy() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "fn handler() {}").expect("source");
+        let data = TempDir::new().expect("data");
+        let shard = build(project.path(), data.path(), "receipt-repair", "input");
+        let index = shard.join(LEXICAL_INDEX_FILE);
+        lexical_shard_coverage(data.path(), "receipt-repair", "input").expect("healthy");
+
+        make_test_file_writable(&index);
+        std::fs::write(&index, b"not sqlite").expect("corrupt shard");
+        assert!(lexical_shard_coverage(data.path(), "receipt-repair", "input").is_err());
+
+        // The same generation id rebuilt in place: this is the self-repair the
+        // finalize fall-through reaches.
+        let _repaired = build(project.path(), data.path(), "receipt-repair", "input");
+
+        lexical_shard_coverage(data.path(), "receipt-repair", "input")
+            .expect("the repaired generation verifies again");
+        assert!(shard_has_lexical_index(&shard, "input"));
     }
 }

--- a/crates/codestory-retrieval/src/scip_client.rs
+++ b/crates/codestory-retrieval/src/scip_client.rs
@@ -1,7 +1,8 @@
 use crate::config::SidecarLayout;
 use crate::scip_index::{
-    SCIP_GRAPH_PROJECTION_PROVENANCE, SCIP_INDEX_FILE, SCIP_SYMBOLS_FILE, ScipSymbolLookup,
-    ScipSymbolRecord, load_fresh_scip_symbols, load_scip_symbols, reference_defect,
+    SCIP_GRAPH_PROJECTION_PROVENANCE, SCIP_STUB_MARKER_FILE, SCIP_SYMBOLS_FILE,
+    ScipIndexMarkerError, ScipSymbolLookup, ScipSymbolRecord, load_fresh_scip_symbols,
+    load_scip_symbols, parse_scip_index_marker, reference_defect,
 };
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -11,6 +12,9 @@ use std::path::Path;
 /// enters fusion with.
 const SCIP_ADJACENCY_ANCHOR_LIMIT: usize = 4;
 const SCIP_ADJACENCY_SCORE: f32 = 0.65;
+
+/// Artifact status meaning "the graph lane is ready to serve".
+const SCIP_READY_STATUS: &str = "ready";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScipAvailability {
@@ -52,26 +56,27 @@ impl ScipClient {
                 detail: "scip project dir exists but empty (indexers not run)".into(),
             };
         }
-        if project_dir.join("index.scip.stub").is_file() {
+        if project_dir.join(SCIP_STUB_MARKER_FILE).is_file() {
             return ScipHealthProbe {
                 availability: ScipAvailability::Unavailable {
                     reason: "scip_stub".into(),
                 },
                 artifact_count: artifacts,
-                detail: "stub SCIP artifacts only (index.scip.stub present)".into(),
+                detail: format!("stub SCIP artifacts only ({SCIP_STUB_MARKER_FILE} present)"),
             };
         }
         let revision = read_scip_revision(&project_dir).unwrap_or_else(|| "stub-v1".into());
         let artifact_status = scip_artifact_status(&project_dir, &revision, generation);
         let is_stub_revision = revision == "stub-v1" || artifact_status == "scip_stub";
         ScipHealthProbe {
+            // Only the ready status admits the lane. Every other status — the
+            // ones that existed and the ones content validation added — is
+            // reported as its own unavailable reason.
             availability: if is_stub_revision {
                 ScipAvailability::Unavailable {
                     reason: "scip_stub".into(),
                 }
-            } else if artifact_status == "scip_stale"
-                || artifact_status == "scip_imported_diagnostic_only"
-            {
+            } else if artifact_status != SCIP_READY_STATUS {
                 ScipAvailability::Unavailable {
                     reason: artifact_status.into(),
                 }
@@ -492,11 +497,20 @@ fn read_scip_revision(dir: &Path) -> Option<String> {
 
 fn scip_artifact_status(project_dir: &Path, revision: &str, generation: &str) -> &'static str {
     if !project_dir.join(SCIP_SYMBOLS_FILE).is_file()
-        || !project_dir.join(SCIP_INDEX_FILE).is_file()
         || !project_dir.join("revision.txt").is_file()
-        || project_dir.join("index.scip.stub").is_file()
+        || project_dir.join(SCIP_STUB_MARKER_FILE).is_file()
     {
         return "scip_stub";
+    }
+    // A present `index.scip` is not evidence until it parses and names this
+    // revision. Each defect reports its own typed code so the generation falls
+    // through to a rebuild carrying why, instead of publishing as a healthy
+    // graph lane. Absence keeps its existing stub reason.
+    if let Err(error) = parse_scip_index_marker(project_dir, revision) {
+        return match error {
+            ScipIndexMarkerError::Missing => "scip_stub",
+            damaged => damaged.code(),
+        };
     }
     load_scip_symbols(project_dir)
         .ok()
@@ -507,7 +521,7 @@ fn scip_artifact_status(project_dir: &Path, revision: &str, generation: &str) ->
                 return "scip_stale";
             }
             if index.contract.evidence_source == SCIP_GRAPH_PROJECTION_PROVENANCE {
-                "ready"
+                SCIP_READY_STATUS
             } else {
                 "scip_imported_diagnostic_only"
             }
@@ -519,10 +533,11 @@ mod tests {
     use super::*;
     use crate::candidate::{CandidateHit, CandidateSource};
     use crate::scip_index::{
-        SCIP_DEFINITION_ROLE, SCIP_IMPORTED_PROOF_PROVENANCE,
+        SCIP_DEFINITION_ROLE, SCIP_IMPORTED_PROOF_PROVENANCE, SCIP_INDEX_FILE,
         SCIP_PRECISE_SEMANTIC_IMPORT_PUBLIC_PROVENANCE, SCIP_REFERENCE_ROLE, ScipPackageIdentity,
-        ScipProofAdapterContract, ScipProofRecord, ScipSymbolsIndex,
+        ScipProofAdapterContract, ScipProofRecord, ScipSymbolsIndex, write_scip_index_marker,
     };
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use tempfile::TempDir;
 
@@ -548,7 +563,7 @@ mod tests {
         .expect("write symbols");
         std::fs::write(project_dir.join("revision.txt"), format!("{revision}\n"))
             .expect("revision");
-        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n").expect("index");
+        write_scip_index_marker(project_dir, revision).expect("index marker");
     }
 
     fn graph_definition_proofs(symbols: &[ScipSymbolRecord]) -> Vec<ScipProofRecord> {
@@ -808,7 +823,7 @@ mod tests {
         let project_dir = layout.scip_project_dir(project_id);
         std::fs::create_dir_all(&project_dir).expect("scip dir");
         std::fs::write(project_dir.join("revision.txt"), "graph-test\n").expect("revision");
-        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n").expect("index");
+        write_scip_index_marker(&project_dir, "graph-test").expect("index marker");
 
         let probe = ScipClient::health_probe(&layout, project_id);
 
@@ -1199,5 +1214,99 @@ mod tests {
         )
         .expect_err("adjacency scan should observe cancellation");
         assert!(error.to_string().contains("cancelled"), "{error}");
+    }
+
+    fn graph_projection_fixture(root: &TempDir, revision: &str) -> (SidecarLayout, PathBuf) {
+        let layout = adjacency_layout(root);
+        let project_dir = layout.scip_project_dir("project");
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+        let symbols = vec![ScipSymbolRecord {
+            node_id: Some("1".into()),
+            path: "src/lib.rs".into(),
+            symbol: "alpha".into(),
+            start_line: 1,
+            end_line: 1,
+        }];
+        let proofs = graph_definition_proofs(&symbols);
+        write_scip_index(
+            &project_dir,
+            "project",
+            revision,
+            ScipProofAdapterContract::graph_projection(revision),
+            symbols,
+            proofs,
+        );
+        (layout, project_dir)
+    }
+
+    #[test]
+    fn a_truncated_index_scip_marker_cannot_report_a_ready_graph_lane() {
+        let root = TempDir::new().expect("root");
+        let (layout, project_dir) = graph_projection_fixture(&root, "graph-test");
+        assert_eq!(
+            ScipClient::health_probe(&layout, "project").availability,
+            ScipAvailability::Ready {
+                revision: "graph-test".into()
+            },
+            "the intact fixture must be ready, or the corruption below proves nothing"
+        );
+
+        // Present, non-empty, and completely useless: exactly the artifact the
+        // old `.is_file()` check published as healthy.
+        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "\0\0\0\0").expect("truncate marker");
+
+        assert_eq!(
+            ScipClient::health_probe(&layout, "project").availability,
+            ScipAvailability::Unavailable {
+                reason: "scip_index_marker_header_unrecognized".into()
+            }
+        );
+    }
+
+    #[test]
+    fn an_index_scip_marker_from_another_generation_cannot_report_a_ready_graph_lane() {
+        let root = TempDir::new().expect("root");
+        let (layout, project_dir) = graph_projection_fixture(&root, "graph-test");
+
+        write_scip_index_marker(&project_dir, "graph-someone-else").expect("stale marker");
+
+        assert_eq!(
+            ScipClient::health_probe(&layout, "project").availability,
+            ScipAvailability::Unavailable {
+                reason: "scip_index_marker_revision_mismatch".into()
+            }
+        );
+    }
+
+    #[test]
+    fn an_index_scip_marker_without_a_revision_line_cannot_report_a_ready_graph_lane() {
+        let root = TempDir::new().expect("root");
+        let (layout, project_dir) = graph_projection_fixture(&root, "graph-test");
+
+        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n")
+            .expect("header-only marker");
+
+        assert_eq!(
+            ScipClient::health_probe(&layout, "project").availability,
+            ScipAvailability::Unavailable {
+                reason: "scip_index_marker_revision_missing".into()
+            }
+        );
+    }
+
+    #[test]
+    fn a_deleted_index_scip_marker_still_reports_as_a_stub() {
+        let root = TempDir::new().expect("root");
+        let (layout, project_dir) = graph_projection_fixture(&root, "graph-test");
+
+        std::fs::remove_file(project_dir.join(SCIP_INDEX_FILE)).expect("remove marker");
+
+        assert_eq!(
+            ScipClient::health_probe(&layout, "project").availability,
+            ScipAvailability::Unavailable {
+                reason: "scip_stub".into()
+            },
+            "absence keeps its existing reason; only present-but-damaged is new"
+        );
     }
 }

--- a/crates/codestory-retrieval/src/scip_index.rs
+++ b/crates/codestory-retrieval/src/scip_index.rs
@@ -18,7 +18,139 @@ pub const SCIP_GRAPH_PROJECTION_PROVENANCE: &str = "scip_graph_projection";
 pub const SCIP_DEFINITION_ROLE: &str = "definition";
 pub const SCIP_REFERENCE_ROLE: &str = "reference";
 const SCIP_POSITION_ENCODING: &str = "line_one_based_utf16_column_zero_based";
-const STUB_MARKER: &str = "index.scip.stub";
+/// Marker written beside stubbed SCIP artifacts. One spelling, so a probe and a
+/// producer cannot disagree about what "stubbed" looks like on disk.
+pub const SCIP_STUB_MARKER_FILE: &str = "index.scip.stub";
+
+/// Header of the graph-projection `index.scip` marker.
+const SCIP_INDEX_MARKER_HEADER: &str = "codestory-scip-v1";
+/// Header of the imported precise-semantic `index.scip` marker.
+const SCIP_IMPORT_MARKER_HEADER: &str = "codestory-precise-semantic-import-v1";
+/// Every header a readable `index.scip` marker may carry.
+const SCIP_INDEX_MARKER_HEADERS: [&str; 2] = [SCIP_INDEX_MARKER_HEADER, SCIP_IMPORT_MARKER_HEADER];
+/// The marker is a two-line contract. Anything materially larger is not the
+/// artifact this product wrote, and is refused without reading it.
+const SCIP_INDEX_MARKER_MAX_BYTES: u64 = 4_096;
+const SCIP_INDEX_MARKER_REVISION_PREFIX: &str = "revision=";
+
+/// Why a present `index.scip` is not the artifact its generation claims.
+///
+/// Existence used to be the whole check, so a truncated, empty, or
+/// leftover-from-another-generation marker published as a healthy graph lane.
+/// Each variant is a distinct, typed reason a generation is damaged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ScipIndexMarkerError {
+    /// No marker file at all.
+    Missing,
+    /// Present but its bytes could not be read as a marker.
+    Unreadable { detail: String },
+    /// Present but far larger than the marker contract allows.
+    Oversized { bytes: u64 },
+    /// Present but its first line is not a marker header this product writes.
+    HeaderUnrecognized,
+    /// Present, headed correctly, but carrying no revision line.
+    RevisionMissing,
+    /// Present and parsable, but describing a different generation.
+    RevisionMismatch { expected: String, found: String },
+}
+
+impl ScipIndexMarkerError {
+    /// Stable machine code for this defect.
+    pub(crate) fn code(&self) -> &'static str {
+        match self {
+            Self::Missing => "scip_index_marker_missing",
+            Self::Unreadable { .. } => "scip_index_marker_unreadable",
+            Self::Oversized { .. } => "scip_index_marker_oversized",
+            Self::HeaderUnrecognized => "scip_index_marker_header_unrecognized",
+            Self::RevisionMissing => "scip_index_marker_revision_missing",
+            Self::RevisionMismatch { .. } => "scip_index_marker_revision_mismatch",
+        }
+    }
+}
+
+/// A parsed, revision-matched `index.scip` marker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScipIndexMarker {
+    pub(crate) header: &'static str,
+    pub(crate) revision: String,
+}
+
+/// Write the graph-projection marker for `revision`.
+pub(crate) fn write_scip_index_marker(project_dir: &Path, revision: &str) -> Result<()> {
+    std::fs::write(
+        project_dir.join(SCIP_INDEX_FILE),
+        format!("{SCIP_INDEX_MARKER_HEADER}\n{SCIP_INDEX_MARKER_REVISION_PREFIX}{revision}\n"),
+    )
+    .context("write index.scip marker")
+}
+
+/// Write the imported precise-semantic marker for `revision`.
+fn write_scip_import_marker(import_dir: &Path, revision: &str) -> Result<()> {
+    std::fs::write(
+        import_dir.join(SCIP_INDEX_FILE),
+        format!("{SCIP_IMPORT_MARKER_HEADER}\n{SCIP_INDEX_MARKER_REVISION_PREFIX}{revision}\n"),
+    )
+    .context("write precise semantic import marker")
+}
+
+/// Parse `index.scip` and bind it to `expected_revision`.
+///
+/// This replaces the previous `.is_file()` test. A marker that exists but does
+/// not parse, or parses to a different revision, is a damaged generation — the
+/// caller must fall through to a rebuild rather than publish it as healthy.
+pub(crate) fn parse_scip_index_marker(
+    project_dir: &Path,
+    expected_revision: &str,
+) -> Result<ScipIndexMarker, ScipIndexMarkerError> {
+    let path = project_dir.join(SCIP_INDEX_FILE);
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ScipIndexMarkerError::Missing);
+        }
+        Err(error) => {
+            return Err(ScipIndexMarkerError::Unreadable {
+                detail: error.to_string(),
+            });
+        }
+    };
+    if !metadata.is_file() {
+        return Err(ScipIndexMarkerError::Missing);
+    }
+    if metadata.len() > SCIP_INDEX_MARKER_MAX_BYTES {
+        return Err(ScipIndexMarkerError::Oversized {
+            bytes: metadata.len(),
+        });
+    }
+    let body =
+        std::fs::read_to_string(&path).map_err(|error| ScipIndexMarkerError::Unreadable {
+            detail: error.to_string(),
+        })?;
+    let mut lines = body.lines().map(str::trim);
+    let header = lines
+        .next()
+        .and_then(|line| {
+            SCIP_INDEX_MARKER_HEADERS
+                .into_iter()
+                .find(|header| *header == line)
+        })
+        .ok_or(ScipIndexMarkerError::HeaderUnrecognized)?;
+    let revision = lines
+        .find_map(|line| line.strip_prefix(SCIP_INDEX_MARKER_REVISION_PREFIX))
+        .map(str::trim)
+        .filter(|revision| !revision.is_empty())
+        .ok_or(ScipIndexMarkerError::RevisionMissing)?;
+    if revision != expected_revision {
+        return Err(ScipIndexMarkerError::RevisionMismatch {
+            expected: expected_revision.to_string(),
+            found: revision.to_string(),
+        });
+    }
+    Ok(ScipIndexMarker {
+        header,
+        revision: revision.to_string(),
+    })
+}
 
 /// Graph edge kinds that carry a real reference from one emitted symbol to
 /// another. `MEMBER` is containment rather than a reference and `UNKNOWN` is
@@ -568,14 +700,7 @@ pub fn import_precise_semantic_scip_artifact(
         format!("{}\n", index.revision),
     )
     .context("write precise semantic import revision")?;
-    std::fs::write(
-        import_dir.join(SCIP_INDEX_FILE),
-        format!(
-            "codestory-precise-semantic-import-v1\nrevision={}\n",
-            index.revision
-        ),
-    )
-    .context("write precise semantic import marker")?;
+    write_scip_import_marker(import_dir, &index.revision)?;
     Ok(PreciseSemanticImportStatus {
         status: "fresh".into(),
         reason: None,
@@ -673,13 +798,11 @@ pub fn emit_scip_artifacts_from_store(
         .context("write symbols.index.json")?;
     std::fs::write(project_dir.join("revision.txt"), format!("{revision}\n"))
         .context("write scip revision")?;
-    // Minimal marker so health treats graph lane as backed by a real artifact file.
-    std::fs::write(
-        project_dir.join(SCIP_INDEX_FILE),
-        format!("codestory-scip-v1\nrevision={revision}\n"),
-    )
-    .context("write index.scip marker")?;
-    let stub = project_dir.join(STUB_MARKER);
+    // Minimal marker so health treats graph lane as backed by a real artifact
+    // file. Health parses it and binds it to this revision, so it is evidence
+    // rather than a presence flag.
+    write_scip_index_marker(project_dir, &revision)?;
+    let stub = project_dir.join(SCIP_STUB_MARKER_FILE);
     if stub.is_file() {
         std::fs::remove_file(stub).context("remove scip stub marker")?;
     }

--- a/crates/codestory-retrieval/src/test_support.rs
+++ b/crates/codestory-retrieval/src/test_support.rs
@@ -148,11 +148,8 @@ pub fn publish_zero_dense_pinned_query_fixture(
         serde_json::to_vec_pretty(&index).context("serialize pinned query fixture SCIP index")?,
     )
     .context("write pinned query fixture SCIP index")?;
-    std::fs::write(
-        scip_dir.join(crate::scip_index::SCIP_INDEX_FILE),
-        format!("codestory-scip-v1\nrevision={revision}\n"),
-    )
-    .context("write pinned query fixture SCIP marker")?;
+    crate::scip_index::write_scip_index_marker(&scip_dir, &revision)
+        .context("write pinned query fixture SCIP marker")?;
     std::fs::write(scip_dir.join("revision.txt"), format!("{revision}\n"))
         .context("write pinned query fixture SCIP revision")?;
     manifest.scip_revision = Some(revision);


### PR DESCRIPTION
Closes #1654.

Generation health receipts are sealed and damaged reuse is repaired rather than silently admitted.

## Review

**Merge with follow-up**, two majors surviving verification, both filed rather than blocking:

1. **Sealed receipts cannot detect in-place corruption or replacement on Windows**, so a corrupted generation can still satisfy its receipt there.
2. **Both reuse-gating behavior changes can be reverted with the entire suite staying green** — the gates are correct but unpinned, the same class of gap that has cost this program repeatedly.

Neither is a merge blocker: the shipped behavior is right and strictly safer than what it replaces. Both are tracked so the guarantees get pinned rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)