### PR TITLE
[v0.17 LOW] Retire low-risk debt and freeze its absence with ratchets

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -586,16 +586,18 @@ function calleeInputSpecifications(workflow) {
   return specifications;
 }
 
-const dispatchForwardedPattern
-  = /^\$\{\{\s*inputs\.([A-Za-z_][A-Za-z0-9_-]*)\s*\|\|\s*''\s*\}\}$/u;
-
 // Classify what a caller can make each callee input be. A literal is fixed for
-// every run of that caller; a dispatch input forwarded verbatim is chosen by
-// whoever dispatches; anything else is treated as free so this check never
+// every run of that caller; ANY interpolated value is free, so this check never
 // invents reachability the caller cannot actually deliver.
-function callerInputBindings(callerWorkflow, callerJob, specifications) {
+//
+// There used to be a `${{ inputs.x || '' }}` regex here that separated a
+// verbatim-forwarded dispatch input from every other expression -- and then set
+// both to the same free binding. The two branches were identical, so the regex
+// decided nothing while the comment above it claimed a distinction the code did
+// not make. Freeness is the conservative answer for every expression, which is
+// what this now says once.
+export function callerInputBindings(callerJob, specifications) {
   const supplied = object(callerJob.with);
-  const dispatchInputs = object(at(callerWorkflow, "on", "workflow_dispatch", "inputs"));
   const bindings = new Map();
   for (const [name, specification] of specifications) {
     const domain = specification.boolean ? [true, false] : ["", "supplied-by-dispatch"];
@@ -604,17 +606,8 @@ function callerInputBindings(callerWorkflow, callerJob, specifications) {
       continue;
     }
     const value = supplied[name];
-    if (typeof value !== "string") {
+    if (typeof value !== "string" || !value.includes("${{")) {
       bindings.set(name, { fixed: true, values: [value] });
-      continue;
-    }
-    if (!value.includes("${{")) {
-      bindings.set(name, { fixed: true, values: [value] });
-      continue;
-    }
-    const forwarded = value.match(dispatchForwardedPattern);
-    if (forwarded !== null && forwarded[1] in dispatchInputs) {
-      bindings.set(name, { fixed: false, values: domain });
       continue;
     }
     bindings.set(name, { fixed: false, values: domain });
@@ -4563,7 +4556,6 @@ function validatePackagedProof(workflows, violations, graph) {
   const coordinator = workflows.get(coordinatorFile);
   const coordinatorPackaged = object(at(coordinator, "jobs", "packaged-proof"));
   const bindings = callerInputBindings(
-    object(coordinator),
     coordinatorPackaged,
     calleeInputSpecifications(workflow),
   );
@@ -9792,6 +9784,19 @@ export function shellDependentBindingViolations(workflows) {
 /// Scoped to `run:` steps. The optional cache restores are `uses:` steps whose miss is the normal
 /// path and carries no outcome to require -- their non-blocking-ness is separately required, and
 /// this rule must not contradict that.
+/// Every `if:` removed, at any depth. A condition decides whether something
+/// runs; it can never make a run fail, which is why neither the job-level nor
+/// the step-level successor may be found in one.
+function withoutConditions(value) {
+  if (Array.isArray(value)) return value.map(withoutConditions);
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== "if")
+      .map(([key, nested]) => [key, withoutConditions(nested)]),
+  );
+}
+
 export function absorbedFailureViolations(workflows) {
   const violations = [];
   const absorbs = value => value !== undefined && value !== false;
@@ -9811,12 +9816,26 @@ export function absorbedFailureViolations(workflows) {
             frozenCandidateQualityWorkflowRef.lastIndexOf("/") + 1,
           )
           && jobId === "quality";
+        // Reading the outcome is not requiring it one level up either, and the
+        // job-level rule used to accept exactly the `if:`-only read the
+        // step-level rule below deliberately refuses -- it scanned every string
+        // under `jobs`, including the absorbing job's own text and every
+        // condition. A successor is a *downstream, blocking* job that receives
+        // `needs.<id>.result` somewhere other than a condition, where a script
+        // can still test it and exit non-zero.
+        const requiredDownstream = Object.entries(object(workflow.jobs)).some(
+          ([otherId, rawOther]) => {
+            if (otherId === jobId) return false;
+            const other = object(rawOther);
+            if (absorbs(other["continue-on-error"])) return false;
+            return scalarStrings(withoutConditions(other)).some(
+              text => text.includes(`needs.${jobId}.result`),
+            );
+          },
+        );
         add(
           violations,
-          isOptionalFrozenCandidateQuality
-            || scalarStrings(workflow.jobs).some(
-              text => text.includes(`needs.${jobId}.result`),
-            ),
+          isOptionalFrozenCandidateQuality || requiredDownstream,
           `${file} jobs.${jobId} absorbs its own failure and must have needs.${jobId}.result required`,
         );
       }

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -23,6 +23,7 @@ import {
 import {
   absorbedFailureViolations,
   annotationScopeViolations,
+  callerInputBindings,
   basicWorkflowViolations,
   benchmarkDependencyIsolationViolations,
   crateDurabilityFile,
@@ -7268,6 +7269,127 @@ test("a script that absorbs its own failure must hand that failure to something 
         + " needs.plugin-static.result required",
     ]);
   });
+
+  // The job-level rule accepted exactly the `if:`-only read the step-level rule above
+  // deliberately refuses, and it scanned the absorbing job's own text too, so a job could
+  // satisfy the rule by mentioning its own name. Both readings are the same mistake: a
+  // condition decides whether a reader runs, and a skipped reader is not a failed run.
+  const absorbingCoordinator = () => {
+    const workflows = loadWorkflows();
+    workflows.get("plugin-static.yml").jobs["plugin-static"]["continue-on-error"] = true;
+    return workflows;
+  };
+  const jobViolation = "plugin-static.yml jobs.plugin-static absorbs its own failure and must have"
+    + " needs.plugin-static.result required";
+
+  await t.test("a downstream if: does not make an absorbed job failure required", () => {
+    const workflows = absorbingCoordinator();
+    workflows.get("plugin-static.yml").jobs.reader = {
+      needs: ["plugin-static"],
+      "runs-on": "ubuntu-latest",
+      if: "needs.plugin-static.result == 'success'",
+      steps: [{ name: "Report", shell: "bash", run: "echo reported\n" }],
+    };
+    assert.deepEqual(absorbedFailureViolations(workflows), [jobViolation]);
+  });
+
+  await t.test("a step-level if: inside the reader is no better", () => {
+    const workflows = absorbingCoordinator();
+    workflows.get("plugin-static.yml").jobs.reader = {
+      needs: ["plugin-static"],
+      "runs-on": "ubuntu-latest",
+      steps: [{
+        name: "Report",
+        if: "needs.plugin-static.result == 'success'",
+        shell: "bash",
+        run: "echo reported\n",
+      }],
+    };
+    assert.deepEqual(absorbedFailureViolations(workflows), [jobViolation]);
+  });
+
+  await t.test("the absorbing job cannot answer for itself", () => {
+    const workflows = absorbingCoordinator();
+    workflows.get("plugin-static.yml").jobs["plugin-static"].steps.push({
+      name: "Mention the result",
+      shell: "bash",
+      run: "echo needs.plugin-static.result\n",
+    });
+    assert.deepEqual(absorbedFailureViolations(workflows), [jobViolation]);
+  });
+
+  await t.test("a reader that absorbs its own failure is not a successor", () => {
+    const workflows = absorbingCoordinator();
+    workflows.get("plugin-static.yml").jobs.reader = {
+      needs: ["plugin-static"],
+      "runs-on": "ubuntu-latest",
+      "continue-on-error": true,
+      steps: [{
+        name: "Require the coordinator",
+        shell: "bash",
+        env: { COORDINATOR: "${{ needs.plugin-static.result }}" },
+        run: 'test "$COORDINATOR" = success\n',
+      }],
+    };
+    assert.match(absorbedFailureViolations(workflows).join("\n"), /jobs\.plugin-static absorbs/u);
+  });
+
+  // And the shape that is allowed, one level up: a blocking downstream job that receives the
+  // result where a script can test it and exit non-zero.
+  await t.test("a blocking downstream job that can fail on the result is a successor", () => {
+    const workflows = absorbingCoordinator();
+    workflows.get("plugin-static.yml").jobs.reader = {
+      needs: ["plugin-static"],
+      "runs-on": "ubuntu-latest",
+      steps: [{
+        name: "Require the coordinator",
+        shell: "bash",
+        env: { COORDINATOR: "${{ needs.plugin-static.result }}" },
+        run: 'test "$COORDINATOR" = success\n',
+      }],
+    };
+    assert.deepEqual(absorbedFailureViolations(workflows), []);
+  });
+});
+
+// A caller can pin a callee input to a literal, or it can hand over an expression. Only the
+// first is fixed for every run of that caller; everything interpolated is free, because this
+// check must never invent reachability the caller cannot actually deliver.
+//
+// There used to be a `${{ inputs.x || '' }}` regex separating a verbatim-forwarded dispatch
+// input from every other expression -- and both branches then produced the same free binding.
+// The regex decided nothing, so the guard was exactly as lax as "any expression is free" while
+// its comment claimed a narrower rule. This pins the behaviour that is actually correct, so
+// reintroducing a special case that treats some expressions as fixed fails here.
+test("every interpolated caller input is free and only literals are fixed", () => {
+  const specifications = new Map([
+    ["forwarded", { boolean: false, default: "" }],
+    ["computed", { boolean: false, default: "" }],
+    ["flag", { boolean: true, default: false }],
+    ["pinned", { boolean: false, default: "" }],
+    ["omitted", { boolean: false, default: "fallback" }],
+    ["omitted_flag", { boolean: true, default: false }],
+  ]);
+  const bindings = callerInputBindings({
+    with: {
+      forwarded: "${{ inputs.forwarded || '' }}",
+      computed: "${{ github.event.pull_request.head.sha }}",
+      flag: "${{ github.event_name == 'workflow_dispatch' }}",
+      pinned: "release",
+    },
+  }, specifications);
+
+  const free = { fixed: false, values: ["", "supplied-by-dispatch"] };
+  assert.deepEqual(bindings.get("forwarded"), free);
+  assert.deepEqual(bindings.get("computed"), free);
+  assert.deepEqual(bindings.get("flag"), { fixed: false, values: [true, false] });
+  assert.deepEqual(bindings.get("pinned"), { fixed: true, values: ["release"] });
+  assert.deepEqual(bindings.get("omitted"), { fixed: true, values: ["fallback"] });
+  assert.deepEqual(bindings.get("omitted_flag"), { fixed: true, values: [false] });
+
+  // The retired regex must not come back as a distinction the bindings do not make.
+  const source = readFileSync(path.join(root, ".github", "scripts", "check-workflow-policy.mjs"), "utf8");
+  assert.equal(source.includes("dispatchForwardedPattern"), false, "the dead forwarding branch is retired");
 });
 
 // Routing a dispatched value through `env:` removes it from the script's text -- and from the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ codestory-indexer = { path = "crates/codestory-indexer" }
 codestory-retrieval = { path = "crates/codestory-retrieval" }
 codestory-runtime = { path = "crates/codestory-runtime" }
 codestory-cli = { path = "crates/codestory-cli" }
-codestory-bench = { path = "crates/codestory-bench" }
 
 # Parsing (tree-sitter)
 tree-sitter = "0.26.11"
@@ -86,14 +85,12 @@ gix = { version = "=0.86.0", default-features = false, features = ["parallel", "
 tempfile = "3.10"
 toml = "0.8"
 sha2 = "0.10"
-ring = "0.17.14"
 ureq = "2.12"
 windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }
 llama-cpp-2 = { version = "=0.1.151", default-features = false }
 llama-cpp-sys-2 = { version = "=0.1.151", default-features = false }
 
 criterion = "0.8.2"
-proptest = "1.5"
 
 [profile.dev]
 opt-level = 0 # keep your own code fast-to-compile

--- a/crates/codestory-cli/src/app/diagnostics.rs
+++ b/crates/codestory-cli/src/app/diagnostics.rs
@@ -8,6 +8,6 @@ pub(crate) use readiness::build_readiness_lanes_for_runtime;
 pub(crate) use sidecar::{build_summary_readiness, doctor_sidecar_status};
 
 #[cfg(test)]
-pub(super) use doctor::{index_next_commands, semantic_contract_check};
+pub(super) use doctor::{index_next_commands, redact_urls_in_text, semantic_contract_check};
 #[cfg(test)]
 pub(super) use readiness::{agent_readiness_sidecar_runtime, readiness_lane_output};

--- a/crates/codestory-cli/src/app/diagnostics/doctor.rs
+++ b/crates/codestory-cli/src/app/diagnostics/doctor.rs
@@ -133,7 +133,7 @@ pub(in crate::app::diagnostics) fn doctor_env_check_message(name: &str, value: &
     format!("set to `{trimmed}`")
 }
 
-pub(in crate::app::diagnostics) fn redact_urls_in_text(text: &str) -> String {
+pub(in crate::app) fn redact_urls_in_text(text: &str) -> String {
     text.split_whitespace()
         .map(redact_url_token)
         .collect::<Vec<_>>()
@@ -141,12 +141,19 @@ pub(in crate::app::diagnostics) fn redact_urls_in_text(text: &str) -> String {
 }
 
 pub(in crate::app::diagnostics) fn redact_url_token(token: &str) -> String {
+    // The scheme boundary is the byte *after* the last non-scheme character,
+    // which is `index + ch.len_utf8()`, not `index + 1`: a multi-byte
+    // character before `://` (a fallback message can carry any UTF-8 the
+    // sidecar produced) made the old arithmetic land inside that character and
+    // panic on the `token[..prefix_len]` slice below.
     let prefix_len = token
         .find("://")
         .and_then(|scheme_end| {
             token[..scheme_end]
-                .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.')))
-                .map(|index| index + 1)
+                .char_indices()
+                .rev()
+                .find(|(_, ch)| !(ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.')))
+                .map(|(index, ch)| index + ch.len_utf8())
                 .or(Some(0))
         })
         .unwrap_or(token.len());

--- a/crates/codestory-cli/src/app/drill/execution.rs
+++ b/crates/codestory-cli/src/app/drill/execution.rs
@@ -25,6 +25,21 @@ use codestory_contracts::api::{
 use std::collections::HashSet;
 use std::time::Instant;
 
+/// The deprecation notice `drill --jobs` carries for its final release.
+///
+/// The flag never scheduled anything — the evidence packet owns drill batching
+/// — so the honest statement is that it is ignored, said once, on the error
+/// stream, without changing the report or the exit status.
+pub(super) const DEPRECATED_DRILL_JOBS_WARNING: &str = "[drill] --jobs is deprecated and ignored: the evidence packet owns drill scheduling. \
+     It is removed next release; drop it from pinned invocations. \
+     `drill-suite --jobs` is unaffected.";
+
+fn warn_on_deprecated_drill_jobs(jobs: Option<usize>) {
+    if jobs.is_some() {
+        eprintln!("{DEPRECATED_DRILL_JOBS_WARNING}");
+    }
+}
+
 pub(in crate::app) fn run_drill(cmd: DrillCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "drill")?;
     let operation = execute_drill(&cmd)?;
@@ -96,7 +111,7 @@ fn prepare_drill(cmd: &DrillCommand) -> Result<PreparedDrill> {
 pub(super) fn execute_drill(
     cmd: &DrillCommand,
 ) -> Result<codestory_runtime::PublicOperation<DrillOutput>> {
-    let _ = cmd.jobs; // retained CLI compatibility; packet owns internal batch scheduling
+    warn_on_deprecated_drill_jobs(cmd.jobs);
     let total_timer = Instant::now();
     let PreparedDrill {
         runtime,

--- a/crates/codestory-cli/src/app/drill/suite.rs
+++ b/crates/codestory-cli/src/app/drill/suite.rs
@@ -146,12 +146,7 @@ pub(super) fn execute_codestory_real_repo_drill_suite(
         display::clean_path_string(&cmd.output_dir.to_string_lossy())
     ));
     let suite_jobs = drill_suite_case_jobs(cmd.jobs, cmd.refresh, total_cases);
-    let drill_jobs = if suite_jobs > 1 {
-        1
-    } else {
-        drill_read_only_jobs(cmd.jobs, cmd.refresh)
-    };
-    let repos = run_drill_suite_cases(cmd, cases, suite_jobs, drill_jobs);
+    let repos = run_drill_suite_cases(cmd, cases, suite_jobs);
 
     let degraded_count = drill_suite_verdict_count(&repos, "degraded");
     let blocked_count = drill_suite_verdict_count(&repos, "blocked");
@@ -193,16 +188,13 @@ pub(super) fn run_drill_suite_cases(
     cmd: &DrillSuiteCommand,
     cases: Vec<DrillSuiteCase>,
     jobs: usize,
-    drill_jobs: usize,
 ) -> Vec<DrillSuiteRepoOutput> {
     let total_cases = cases.len();
     if jobs <= 1 || total_cases <= 1 {
         return cases
             .iter()
             .enumerate()
-            .map(|(case_index, case)| {
-                run_drill_suite_case(cmd, case_index, total_cases, case, drill_jobs)
-            })
+            .map(|(case_index, case)| run_drill_suite_case(cmd, case_index, total_cases, case))
             .collect();
     }
 
@@ -216,7 +208,7 @@ pub(super) fn run_drill_suite_cases(
                 chunk
                     .iter()
                     .map(|(case_index, case)| {
-                        let repo = run_drill_suite_case(cmd, *case_index, total_cases, case, 1);
+                        let repo = run_drill_suite_case(cmd, *case_index, total_cases, case);
                         (*case_index, repo)
                     })
                     .collect::<Vec<_>>()
@@ -241,7 +233,6 @@ pub(super) fn run_drill_suite_case(
     case_index: usize,
     total_cases: usize,
     case: &DrillSuiteCase,
-    drill_jobs: usize,
 ) -> DrillSuiteRepoOutput {
     let progress_index = case_index + 1;
     let repo_output_dir = cmd.output_dir.join(format!("{}-drill", case.slug));
@@ -268,7 +259,9 @@ pub(super) fn run_drill_suite_case(
         profile: None,
         run_id: None,
         format: cmd.format,
-        jobs: drill_jobs,
+        // The suite schedules cases itself; the deprecated per-drill flag is
+        // never synthesized, so an internal case never prints its warning.
+        jobs: None,
     };
     match execute_drill(&drill_cmd).and_then(|operation| {
         write_drill_outputs(cmd.format, &repo_output_dir, &operation)?;

--- a/crates/codestory-cli/src/app/tests/contracts.rs
+++ b/crates/codestory-cli/src/app/tests/contracts.rs
@@ -2,6 +2,7 @@ use super::test_support::{
     sample_graph_edge, sample_graph_node, sample_node_details, test_search_hit_defaults,
 };
 use crate::app::artifacts::ensure_dot_only_for_trail;
+use crate::app::diagnostics::redact_urls_in_text;
 use crate::app::rendering::hide_speculative_trail_edges;
 use crate::app::resolution::{quote_command_path, quote_command_value};
 use crate::app::source_commands::render_affected_invocation;
@@ -381,6 +382,21 @@ fn embedding_preflight_preserves_typed_capacity_for_json_failures() {
             .and_then(|details| details.embedding_capacity.as_ref())
             .map(|pressure| pressure.retry_condition.as_str()),
         Some("a query slot becomes available")
+    );
+}
+
+#[test]
+fn doctor_redaction_survives_multi_byte_text_before_a_url_scheme() {
+    // `build_doctor_output` runs every sidecar `fallback_message` through
+    // `redact_urls_in_text`, and that message is arbitrary UTF-8 the sidecar
+    // wrote. Finding the scheme start with `byte_index + 1` landed inside a
+    // multi-byte character and panicked the whole `doctor` command instead of
+    // redacting. The credential must be gone and the surrounding text intact.
+    let message = "semantic fallback: endpoint »http://user:secret@embed.internal:9000/v1« refused";
+
+    assert_eq!(
+        redact_urls_in_text(message),
+        "semantic fallback: endpoint »http://embed.internal:9000/v1« refused"
     );
 }
 

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -994,14 +994,23 @@ pub(crate) struct DrillCommand {
     pub(crate) run_id: Option<String>,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
     pub(crate) format: OutputFormat,
+    /// Deprecated no-op, retained for one release so pinned invocations keep
+    /// parsing.
+    ///
+    /// The evidence packet owns internal batch scheduling, so a single drill
+    /// has no anchor or bridge worker pool to size — `execute_drill` discarded
+    /// this value while help and the grounding skill advertised it as a real
+    /// control. It is hidden from help and warns when supplied this release;
+    /// removal is next release. `drill-suite --jobs` is a different flag and
+    /// still schedules cases.
     #[arg(
         long,
         value_name = "N",
-        default_value_t = 1,
         value_parser = parse_positive_usize,
-        help = "Read-only anchor and bridge evidence workers for --refresh none drills. Defaults to 1."
+        hide = true,
+        help = "Deprecated and ignored; the evidence packet owns drill scheduling. Removed next release."
     )]
-    pub(crate) jobs: usize,
+    pub(crate) jobs: Option<usize>,
 }
 
 #[derive(Args, Debug)]
@@ -2706,7 +2715,6 @@ mod tests {
         assert!(help.contains("--output-dir <DIR>"));
         assert!(help.contains("--label <LABEL>"));
         assert!(help.contains("--question <QUESTION>"));
-        assert!(help.contains("--jobs <N>"));
         assert!(help.contains("--profile <PROFILE>"));
         assert!(help.contains("--run-id <ID>"));
         assert!(help.contains("Stored in the report only; it is not interpreted"));
@@ -2764,8 +2772,18 @@ mod tests {
         assert!(!help.contains("--ledger"));
     }
 
+    /// `drill --jobs` is a deprecated no-op in its final release: it must still
+    /// parse so pinned invocations keep working, must no longer be advertised
+    /// in help, and must be distinguishable from "not supplied" so the run can
+    /// say it is being ignored. Removal is next release.
     #[test]
-    fn drill_jobs_parse_with_conservative_default() {
+    fn deprecated_drill_jobs_stays_parseable_but_unadvertised() {
+        let help = render_subcommand_help("drill");
+        assert!(
+            !help.contains("--jobs"),
+            "a flag that schedules nothing must not be advertised: {help}"
+        );
+
         let drill = Cli::try_parse_from([
             "codestory-cli",
             "drill",
@@ -2774,9 +2792,9 @@ mod tests {
             "--output-dir",
             "target/drill/test",
         ])
-        .expect("drill default jobs");
+        .expect("drill without the deprecated flag");
         match drill.command {
-            Command::Drill(cmd) => assert_eq!(cmd.jobs, 1),
+            Command::Drill(cmd) => assert_eq!(cmd.jobs, None),
             _ => panic!("expected drill command"),
         }
 
@@ -2790,9 +2808,9 @@ mod tests {
             "--jobs",
             "4",
         ])
-        .expect("drill explicit jobs");
+        .expect("a pinned invocation must keep parsing for one more release");
         match drill.command {
-            Command::Drill(cmd) => assert_eq!(cmd.jobs, 4),
+            Command::Drill(cmd) => assert_eq!(cmd.jobs, Some(4)),
             _ => panic!("expected drill command"),
         }
 

--- a/crates/codestory-cli/src/http_transport.rs
+++ b/crates/codestory-cli/src/http_transport.rs
@@ -7,7 +7,7 @@ use std::{
     collections::HashMap,
     io::{Read, Write},
     net::{IpAddr, TcpStream},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use crate::args;
@@ -23,6 +23,17 @@ const BROWSER_REFERENCES_DEPTH: u32 = 0;
 const BROWSER_REFERENCES_MAX_NODES: u32 = 120;
 pub(crate) const BROWSER_SYMBOLS_DEFAULT_LIMIT: u32 = 300;
 pub(crate) const BROWSER_SYMBOLS_MAX_LIMIT: u32 = 2_000;
+
+/// How long one peer may take to finish sending its request headers.
+///
+/// Optional HTTP serving is loopback-only, explicitly invoked, and serial, so
+/// this is the whole time any single peer can occupy the serving thread before
+/// `/health` and every other route answer again.
+const HTTP_REQUEST_HEADER_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Polling granularity inside [`HTTP_REQUEST_HEADER_DEADLINE`], never a bound
+/// on the request: each read window restarts, the deadline does not.
+const HTTP_REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct HttpServePolicy {
@@ -40,11 +51,23 @@ pub(crate) fn handle_http_request(
     mut stream: TcpStream,
     policy: HttpServePolicy,
 ) -> Result<()> {
-    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let header_deadline = Instant::now() + HTTP_REQUEST_HEADER_DEADLINE;
     let mut request_bytes = Vec::with_capacity(1024);
     let mut buffer = [0u8; 1024];
     let mut headers_complete = false;
+    let mut deadline_exceeded = false;
     loop {
+        // The per-read timeout alone bounded nothing: this accept loop is
+        // serial, and a peer that sent one byte just inside every read window
+        // held the only serving thread for as long as it liked, so `/health`
+        // never answered. The whole-request deadline is what actually bounds
+        // the peer; the per-read timeout stays as its polling granularity.
+        let remaining = header_deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            deadline_exceeded = true;
+            break;
+        }
+        stream.set_read_timeout(Some(remaining.min(HTTP_REQUEST_READ_TIMEOUT)))?;
         let read = match stream.read(&mut buffer) {
             Ok(read) => read,
             Err(error)
@@ -53,7 +76,7 @@ pub(crate) fn handle_http_request(
                     std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
                 ) =>
             {
-                break;
+                continue;
             }
             Err(error) => return Err(error.into()),
         };
@@ -68,6 +91,17 @@ pub(crate) fn handle_http_request(
         if request_bytes.len() >= 8192 {
             break;
         }
+    }
+    if deadline_exceeded {
+        return write_http_error_json(
+            &mut stream,
+            408,
+            "http_request_deadline_exceeded",
+            format!(
+                "Request headers did not arrive within {} seconds.",
+                HTTP_REQUEST_HEADER_DEADLINE.as_secs()
+            ),
+        );
     }
     if !headers_complete {
         return write_http_json(

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -1179,3 +1179,147 @@ fn packet_profile_telemetry_travels_on_a_typed_field_not_the_evidence_annotation
         );
     }
 }
+
+/// `[workspace.dependencies]` is a shared version register, not a parking lot.
+///
+/// An entry no member consumes still reads as a supported, version-pinned
+/// dependency of this workspace while pinning nothing: `proptest` sat there
+/// consumed by zero crates, and `ring` outlived the one crate that used it. The
+/// dead entry is the debt; this is the ratchet that keeps it retired.
+#[test]
+fn every_workspace_dependency_is_consumed_by_a_member() {
+    fn consumes(table: &Value, name: &str) -> bool {
+        let Some(table) = table.as_table() else {
+            return false;
+        };
+        table.iter().any(|(key, value)| {
+            (key == name
+                && value
+                    .get("workspace")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false))
+                || consumes(value, name)
+        })
+    }
+
+    let workspace = manifest("Cargo.toml");
+    let declared = workspace
+        .get("workspace")
+        .and_then(|workspace| workspace.get("dependencies"))
+        .and_then(Value::as_table)
+        .expect("workspace dependencies");
+    let members = workspace_members()
+        .into_iter()
+        .map(|member| manifest(&format!("{member}/Cargo.toml")))
+        .collect::<Vec<_>>();
+
+    let unconsumed = declared
+        .keys()
+        .filter(|name| !members.iter().any(|member| consumes(member, name)))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    assert!(
+        unconsumed.is_empty(),
+        "workspace dependencies no member declares with `workspace = true`: {}",
+        unconsumed.join(", ")
+    );
+}
+
+/// Every constant `codestory-llama-sys`'s build script compiles into the crate
+/// must be read by workspace code.
+///
+/// The frozen constant set is calibrated evidence, and emitting values from it
+/// that nothing reads presents unread numbers as shipped runtime behaviour —
+/// the election-backoff and bulk-replay-budget constants were exactly that, and
+/// three model/native identity constants sat beside them. Deleting the emission
+/// changes no calibrated value: the constant-set JSON is untouched and the
+/// build script still enforces the invariants those values exist for.
+#[test]
+fn generated_embedding_constants_are_all_read_by_workspace_code() {
+    let build_script = read("crates/codestory-llama-sys/build.rs");
+    let emitted = build_script
+        .match_indices("pub const ")
+        .chain(build_script.match_indices("pub static "))
+        .filter_map(|(index, keyword)| {
+            build_script[index + keyword.len()..]
+                .split(|ch: char| !(ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_'))
+                .next()
+                .filter(|name| !name.is_empty())
+                .map(str::to_owned)
+        })
+        .collect::<BTreeSet<String>>();
+    assert!(
+        emitted.contains("PER_USER_EMBEDDING_CONNECT_TIMEOUT_MS")
+            && emitted.contains("MODEL_SHA256"),
+        "the emitted-constant scan must actually find the generated constants: {emitted:?}"
+    );
+
+    let mut corpus = String::new();
+    for member in workspace_members() {
+        for directory in ["src", "tests", "benches", "examples"] {
+            if repo_root().join(&member).join(directory).is_dir() {
+                corpus.push_str(&read_source_tree(&format!("{member}/{directory}")));
+                corpus.push('\n');
+            }
+        }
+    }
+
+    let unread = emitted
+        .iter()
+        .filter(|name| !corpus.contains(name.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert!(
+        unread.is_empty(),
+        "generated constants no workspace source reads: {}",
+        unread.join(", ")
+    );
+}
+
+// The build-script decision itself, compiled from the same file `build.rs`
+// includes. A build script is reachable from no test target, which is how this
+// gate came to read Cargo's `DEBUG` (debug info) instead of `PROFILE` (profile
+// identity) with nothing failing.
+mod model_source_gate {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../codestory-llama-sys/model_source_gate.rs"
+    ));
+
+    pub(super) fn requires_embedded_model(profile: Option<&str>) -> bool {
+        profile_requires_embedded_model(profile)
+    }
+}
+
+/// A release build with no embedded model must fail, and must keep failing when
+/// somebody turns on release debug info.
+///
+/// `[profile.release] debug = 1` for symbolication sets `DEBUG` to a
+/// non-`"false"` value while `PROFILE` stays `release`. Keying the gate on
+/// `DEBUG` therefore let a release build produce a binary with no embedded
+/// model and say nothing.
+#[test]
+fn the_release_model_embedding_gate_keys_on_the_profile_not_debug_info() {
+    assert!(model_source_gate::requires_embedded_model(Some("release")));
+    for permitted in [Some("debug"), Some("test"), Some("bench"), None] {
+        assert!(
+            !model_source_gate::requires_embedded_model(permitted),
+            "{permitted:?} is not a shipping profile"
+        );
+    }
+
+    let build_script = read("crates/codestory-llama-sys/build.rs");
+    assert!(
+        build_script.contains("env::var(\"PROFILE\")"),
+        "the gate must read the profile identity"
+    );
+    assert!(
+        !build_script.contains("\"DEBUG\""),
+        "the gate must not read the debug-info setting"
+    );
+    assert!(
+        build_script.contains("profile_requires_embedded_model(profile.as_deref())"),
+        "the gate must route the profile through the shared decision this test compiles"
+    );
+}

--- a/crates/codestory-cli/tests/cli_error_contracts.rs
+++ b/crates/codestory-cli/tests/cli_error_contracts.rs
@@ -300,6 +300,64 @@ fn top_level_help_names_command_purposes() {
     }
 }
 
+/// `drill --jobs` never scheduled anything, and help plus the grounding skill
+/// advertised it as a real control. For its final release it must keep parsing
+/// so pinned invocations do not break, and it must say plainly that it is
+/// ignored — supplying it is the only thing that prints the notice.
+#[test]
+fn deprecated_drill_jobs_warns_when_supplied_and_stays_silent_otherwise() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    let output_dir = tempdir().expect("drill output dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    let notice = "--jobs is deprecated and ignored";
+
+    let with_flag = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "drill",
+            "--refresh",
+            "none",
+            "--anchors",
+            "AppController",
+            "--output-dir",
+            &output_dir.path().to_string_lossy(),
+            "--jobs",
+            "4",
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&with_flag.stderr);
+    assert!(
+        stderr.contains(notice),
+        "supplying the deprecated flag must say it is ignored:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("removed next release"),
+        "the notice must name the removal release:\n{stderr}"
+    );
+
+    let without_flag = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "drill",
+            "--refresh",
+            "none",
+            "--anchors",
+            "AppController",
+            "--output-dir",
+            &output_dir.path().to_string_lossy(),
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&without_flag.stderr);
+    assert!(
+        !stderr.contains(notice),
+        "a run that never mentioned --jobs must not be warned:\n{stderr}"
+    );
+}
+
 #[test]
 fn product_cli_rejects_the_removed_cpu_embedding_selector() {
     let output = test_support::cli_command()

--- a/crates/codestory-cli/tests/http_transport_contracts.rs
+++ b/crates/codestory-cli/tests/http_transport_contracts.rs
@@ -430,6 +430,79 @@ fn http_serve_rejects_non_loopback_host_and_origin_headers() {
     );
 }
 
+/// One slow peer must not own the only serving thread.
+///
+/// Optional HTTP serving accepts serially, so the bound that matters is on the
+/// whole request, not on one read. A peer dribbling a byte just inside every
+/// read window renewed the per-read timeout forever and `/health` never
+/// answered; the whole-request deadline ends that peer with a typed 408 and
+/// hands the thread back.
+#[test]
+fn a_dribbling_peer_cannot_hold_the_serial_http_loop_past_the_request_deadline() {
+    let fixture = indexed_fixture();
+    let (_server, addr) = spawn_http_server(&fixture);
+
+    let mut slow = TcpStream::connect(&addr).expect("connect slow peer");
+    slow.set_read_timeout(Some(Duration::from_secs(30)))
+        .expect("slow peer read timeout");
+    write!(slow, "GET /health HTTP/1.1\r\nHost: {addr}\r\n").expect("slow peer preamble");
+    slow.flush().expect("flush slow peer preamble");
+
+    // Never send the blank line that ends the headers, and keep the connection
+    // demonstrably live with a byte well inside the 2s read window.
+    let dribbler = {
+        let mut slow = slow.try_clone().expect("clone slow peer");
+        thread::spawn(move || {
+            for _ in 0..30 {
+                if write!(slow, "X").is_err() || slow.flush().is_err() {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(500));
+            }
+        })
+    };
+
+    let started = Instant::now();
+    let mut response_bytes = Vec::new();
+    let mut chunk = [0u8; 1024];
+    loop {
+        match slow.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => response_bytes.extend_from_slice(&chunk[..read]),
+            Err(error) if error.kind() == std::io::ErrorKind::ConnectionReset => break,
+            Err(error) => panic!("slow peer read: {error}"),
+        }
+        if response_bytes
+            .windows(4)
+            .any(|window| window == b"\r\n\r\n")
+        {
+            break;
+        }
+    }
+    let elapsed = started.elapsed();
+    let response = String::from_utf8_lossy(&response_bytes).to_string();
+    let _ = dribbler.join();
+
+    assert!(
+        response.starts_with("HTTP/1.1 408 "),
+        "slow peer should be ended with a typed request-deadline status after {elapsed:?}: \
+         {response:?}"
+    );
+    assert!(
+        response.contains("http_request_deadline_exceeded"),
+        "the 408 must carry its typed code: {response:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "the whole-request deadline should end the peer promptly, took {elapsed:?}"
+    );
+
+    // The serving thread is back: the route the slow peer was blocking answers.
+    let health = http_get(&addr, "/health").expect("health after the slow peer");
+    assert_eq!(health.status, 200, "{}", health.body);
+    assert_eq!(health.body["ok"], true, "{}", health.body);
+}
+
 fn get_json(addr: &str, target: &str) -> Value {
     let response = http_get(addr, target).unwrap_or_else(|error| panic!("GET {target}: {error}"));
     assert_eq!(

--- a/crates/codestory-llama-sys/build.rs
+++ b/crates/codestory-llama-sys/build.rs
@@ -41,22 +41,31 @@ struct ModelContract {
     license_source_url: String,
 }
 
+/// The constant-set values this build script turns into compiled constants.
+///
+/// Every field here is read by product code. The constant set also carries
+/// `bulk_replay_success_budget_ms` and the `election_backoff_policy` pair;
+/// those are deliberately *not* fields, because no product code reads them —
+/// they survive only as build-time invariant inputs (the bulk deadline must
+/// cover one successful replay; election backoff must be ordered), which
+/// `load_embedding_server_constants` asserts before this struct is built.
+/// Emitting them as constants nothing reads is the ARCH-024 debt, and
+/// `generated_embedding_constants_are_all_read_by_product_code` fails if it
+/// returns.
 struct EmbeddingServerConstants {
     frozen: bool,
     connect_timeout_ms: u64,
     spawn_convergence_timeout_ms: u64,
     retry_after_ms: u64,
     query_request_deadline_ms: u64,
-    bulk_replay_success_budget_ms: u64,
     bulk_request_deadline_ms: u64,
     hard_native_no_progress_ms: u64,
     watchdog_cadence_ms: u64,
-    election_initial_backoff_ms: Option<u64>,
-    election_maximum_backoff_ms: Option<u64>,
 }
 
 fn main() {
     println!("cargo:rerun-if-env-changed=CODESTORY_EMBED_MODEL_SOURCE");
+    println!("cargo:rerun-if-changed=model_source_gate.rs");
     println!("cargo:rerun-if-changed={MODEL_CONTRACT_FILE}");
     println!("cargo:rerun-if-changed=model_staging.rs");
     println!("cargo:rerun-if-changed=native_staging.rs");
@@ -118,8 +127,6 @@ fn main() {
             "pub const MODEL_FILE_NAME: &str = {:?};\n\
              pub const MODEL_SIZE: u64 = {};\n\
              pub const MODEL_SHA256: &str = {:?};\n\
-             pub const LLAMA_CPP_CRATE_VERSION: &str = {:?};\n\
-             pub const LLAMA_CPP_SOURCE_COMMIT: &str = {:?};\n\
              const EMBEDDING_DIMENSION: usize = {};\n\
              pub const MODEL_TOKENIZER_SHA256: &str = {:?};\n\
              pub const MODEL_CONFIG_SHA256: &str = {:?};\n\
@@ -135,7 +142,6 @@ fn main() {
              pub const NATIVE_ENGINE_LINKAGE: &str = {engine_linkage:?};\n\
              pub const NATIVE_ENGINE_BACKEND_LOADING: &str = {backend_loading:?};\n\
              pub const NATIVE_ENGINE_COMPILED_BACKENDS: &[&str] = &{compiled_backends:?};\n\
-             pub const NATIVE_ENGINE_GENERATION_ID: &str = {native_generation_id:?};\n\
              pub static NATIVE_ENGINE_GENERATION_MARKER: &[u8] = {native_generation_marker:?}.as_bytes();\n\
              pub const NATIVE_ENGINE_EMBEDDING_CONTRACT_SHA256: &str = {embedding_contract_sha256:?};\n\
              pub const GGML_BUILD_IDENTITY: &str = {ggml_build_identity:?};\n\
@@ -143,8 +149,6 @@ fn main() {
             contract.file_name,
             contract.size,
             contract.sha256,
-            contract.llama_cpp_crate_version,
-            contract.llama_cpp_source_commit,
             contract.dimension,
             contract.tokenizer_sha256,
             contract.config_sha256,
@@ -170,12 +174,9 @@ fn main() {
              pub const PER_USER_EMBEDDING_SPAWN_CONVERGENCE_TIMEOUT_MS: u64 = {spawn_convergence_timeout_ms};\n\
              pub const PER_USER_EMBEDDING_RETRY_AFTER_MS: u64 = {retry_after_ms};\n\
              pub const PER_USER_EMBEDDING_QUERY_REQUEST_DEADLINE_MS: u64 = {query_request_deadline_ms};\n\
-             pub const PER_USER_EMBEDDING_BULK_REPLAY_SUCCESS_BUDGET_MS: u64 = {bulk_replay_success_budget_ms};\n\
              pub const PER_USER_EMBEDDING_BULK_REQUEST_DEADLINE_MS: u64 = {bulk_request_deadline_ms};\n\
              pub const PER_USER_EMBEDDING_HARD_NATIVE_NO_PROGRESS_MS: u64 = {hard_native_no_progress_ms};\n\
              pub const PER_USER_EMBEDDING_WATCHDOG_CADENCE_MS: u64 = {watchdog_cadence_ms};\n\
-             pub const PER_USER_EMBEDDING_ELECTION_INITIAL_BACKOFF_MS: Option<u64> = {election_initial_backoff_ms:?};\n\
-             pub const PER_USER_EMBEDDING_ELECTION_MAXIMUM_BACKOFF_MS: Option<u64> = {election_maximum_backoff_ms:?};\n\
              #[used]\n\
              pub static EMBEDDING_SERVER_PROOF_MARKER: &[u8] = {embedding_server_proof_marker:?}.as_bytes();\n",
             constant_set_frozen = embedding_server_constants.frozen,
@@ -185,17 +186,11 @@ fn main() {
             retry_after_ms = embedding_server_constants.retry_after_ms,
             query_request_deadline_ms =
                 embedding_server_constants.query_request_deadline_ms,
-            bulk_replay_success_budget_ms =
-                embedding_server_constants.bulk_replay_success_budget_ms,
             bulk_request_deadline_ms =
                 embedding_server_constants.bulk_request_deadline_ms,
             hard_native_no_progress_ms =
                 embedding_server_constants.hard_native_no_progress_ms,
             watchdog_cadence_ms = embedding_server_constants.watchdog_cadence_ms,
-            election_initial_backoff_ms =
-                embedding_server_constants.election_initial_backoff_ms,
-            election_maximum_backoff_ms =
-                embedding_server_constants.election_maximum_backoff_ms,
         ),
     )
     .expect("write embedding server proof contract");
@@ -375,12 +370,9 @@ fn load_embedding_server_constants(path: &str) -> EmbeddingServerConstants {
         spawn_convergence_timeout_ms,
         retry_after_ms,
         query_request_deadline_ms,
-        bulk_replay_success_budget_ms,
         bulk_request_deadline_ms,
         hard_native_no_progress_ms,
         watchdog_cadence_ms,
-        election_initial_backoff_ms,
-        election_maximum_backoff_ms,
     }
 }
 
@@ -739,11 +731,14 @@ fn ordered_contract_digest(domain: &str, values: &[&str]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+include!("model_source_gate.rs");
+
 fn resolve_model_source() -> Option<PathBuf> {
     if let Some(source) = env::var_os("CODESTORY_EMBED_MODEL_SOURCE") {
         return Some(PathBuf::from(source));
     }
-    if env::var("DEBUG").as_deref() != Ok("false") {
+    let profile = env::var("PROFILE").ok();
+    if !profile_requires_embedded_model(profile.as_deref()) {
         return None;
     }
 

--- a/crates/codestory-llama-sys/model_source_gate.rs
+++ b/crates/codestory-llama-sys/model_source_gate.rs
@@ -1,0 +1,25 @@
+// The one decision that says whether a build may proceed without an embedded
+// model, kept in a dependency-free file so the build script and the contract
+// ratchet compile the *same* definition.
+//
+// `build.rs` `include!`s this file; so does
+// `crates/codestory-cli/tests/architecture_contracts.rs`. A build script is
+// otherwise unreachable from any test target, which is how the gate came to key
+// on Cargo's `DEBUG` (the debug-info setting) instead of `PROFILE` (the profile
+// identity) with nothing failing: a routine `[profile.release] debug = 1` for
+// symbolication set `DEBUG` to a non-`"false"` value and silently produced a
+// release build with no embedded model.
+//
+// This file is `include!`d, not declared as a module, so it must stay free of
+// inner attributes and inner doc comments.
+
+/// True when the profile Cargo reports is one whose artifacts ship, so a build
+/// without `CODESTORY_EMBED_MODEL_SOURCE` must fail rather than quietly omit
+/// the model.
+///
+/// Cargo sets `PROFILE` to `release` for release-rooted profiles and `debug`
+/// otherwise. `None` means the variable was absent or not UTF-8, which is not a
+/// shipping build.
+fn profile_requires_embedded_model(profile: Option<&str>) -> bool {
+    matches!(profile, Some("release"))
+}

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -4,9 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
-use std::time::Duration;
-#[cfg(any(test, feature = "test-support"))]
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 pub const DEFAULT_AGENT_RUN_ID: &str = "shared-agent";
 
@@ -584,7 +582,97 @@ fn uncached_user_cache_root() -> PathBuf {
     }
     ProjectDirs::from("dev", "codestory", "codestory")
         .map(|dirs| dirs.cache_dir().to_path_buf())
-        .unwrap_or_else(|| std::env::temp_dir().join("codestory").join("cache"))
+        .unwrap_or_else(temporary_cache_root)
+}
+
+/// The per-user name the temporary-directory cache fallback claims.
+///
+/// Unix `/tmp` is shared, so the name carries the effective uid; Windows and
+/// the remaining platforms get a per-user temporary directory from the OS, so
+/// the bare name is already private there.
+fn temporary_cache_root_name() -> String {
+    #[cfg(unix)]
+    {
+        format!("codestory-cache-{}", unsafe { libc::geteuid() })
+    }
+    #[cfg(not(unix))]
+    {
+        "codestory-cache".to_string()
+    }
+}
+
+/// Cache root used only when no home directory resolves.
+///
+/// The old fallback was the fixed `<temp>/codestory/cache`. Nothing created it
+/// privately and nothing checked who owned it, so on a shared Unix host any
+/// local user could pre-create that exact path and then read the full source
+/// text every sidecar and index database writes underneath it — the 0600 socket
+/// discipline next door made the asymmetry plain.
+///
+/// The replacement never uses a directory it did not itself create privately:
+/// the per-user name is claimed with mode 0700, an existing name is accepted
+/// only when [`private_cache_directory`] confirms this user owns it with no
+/// group or other access, and an occupied or untrusted name is refused in
+/// favour of an unpredictable private directory rather than shared. If even
+/// that cannot be created the uncreated unpredictable path is returned, so
+/// downstream writes fail on a path an attacker cannot have staged instead of
+/// succeeding into one they can read.
+fn temporary_cache_root() -> PathBuf {
+    let temporary = std::env::temp_dir();
+    let shared = temporary.join(temporary_cache_root_name());
+    if private_cache_directory(&shared).is_ok() {
+        return shared;
+    }
+    let nonce = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let unpredictable = temporary.join(format!(
+        "{}-{}-{nonce}",
+        temporary_cache_root_name(),
+        std::process::id()
+    ));
+    let _ = private_cache_directory(&unpredictable);
+    unpredictable
+}
+
+/// Make `path` a directory this user owns privately, or report why it is not.
+///
+/// Creating it is the ordinary case and is exclusive: the directory is created
+/// with mode 0700 on Unix, so no other user ever sees it in a permissive state.
+/// An existing name is not trusted for being there — it is accepted only after
+/// `symlink_metadata` shows a real directory (never a symlink) owned by the
+/// effective uid with `mode & 0o077 == 0`.
+fn private_cache_directory(path: &Path) -> std::io::Result<()> {
+    let mut builder = std::fs::DirBuilder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    match builder.create(path) {
+        Ok(()) => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error),
+    }
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "codestory_cache_root_untrusted",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.uid() != unsafe { libc::geteuid() } || metadata.mode() & 0o077 != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "codestory_cache_root_untrusted",
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(not(test))]
@@ -726,6 +814,78 @@ pub fn dir_size_bytes(path: &Path) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The temporary-directory cache fallback holds sidecar and index databases
+    /// that contain full source text, so it may only ever be a directory this
+    /// user owns privately. A world-writable directory already sitting at the
+    /// fallback name is exactly the ARCH-027 attack: a local user pre-creates
+    /// the fixed path and reads whatever the next indexing run writes into it.
+    #[test]
+    fn temporary_cache_fallback_refuses_a_directory_another_user_could_have_staged() {
+        let temporary = tempfile::tempdir().expect("temporary root");
+
+        let fresh = temporary.path().join("fresh");
+        private_cache_directory(&fresh).expect("fresh fallback is claimed privately");
+        assert!(fresh.is_dir());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&fresh)
+                    .expect("fresh fallback metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+        }
+
+        // Claiming a name that is already a private directory of ours is the
+        // ordinary second run and must keep working.
+        private_cache_directory(&fresh).expect("private fallback is reused");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let staged = temporary.path().join("staged");
+            std::fs::create_dir(&staged).expect("staged directory");
+            std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o777))
+                .expect("stage a world-writable directory");
+            let refusal =
+                private_cache_directory(&staged).expect_err("staged fallback must be refused");
+            assert_eq!(refusal.kind(), std::io::ErrorKind::PermissionDenied);
+            assert_eq!(refusal.to_string(), "codestory_cache_root_untrusted");
+
+            let link = temporary.path().join("link");
+            std::os::unix::fs::symlink(&fresh, &link).expect("symlinked fallback");
+            let refusal =
+                private_cache_directory(&link).expect_err("symlinked fallback must be refused");
+            assert_eq!(refusal.kind(), std::io::ErrorKind::PermissionDenied);
+            assert_eq!(refusal.to_string(), "codestory_cache_root_untrusted");
+        }
+    }
+
+    /// The fallback name must be per-user on the shared Unix temporary
+    /// directory, and the root it hands back must always be a directory this
+    /// process created privately — never the bare `<temp>/codestory/cache`.
+    #[test]
+    fn temporary_cache_root_is_per_user_and_privately_created() {
+        let root = temporary_cache_root();
+
+        assert!(root.starts_with(std::env::temp_dir()));
+        assert_ne!(root, std::env::temp_dir().join("codestory").join("cache"));
+        assert!(root.is_dir(), "{} should exist", root.display());
+        private_cache_directory(&root).expect("returned root is privately owned");
+        #[cfg(unix)]
+        assert!(
+            root.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name
+                    .starts_with(&format!("codestory-cache-{}", unsafe { libc::geteuid() }))),
+            "{} should carry the effective uid",
+            root.display()
+        );
+    }
 
     fn defaults(cache_root: &Path, values: &[(&str, &str)]) -> SidecarProcessDefaults {
         SidecarProcessDefaults::new(

--- a/crates/codestory-retrieval/src/per_user_embedding/server/state.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/server/state.rs
@@ -358,12 +358,14 @@ impl PerUserEmbeddingServerState {
     }
 
     pub(in crate::per_user_embedding) fn finish_request(&self, key: &str) {
-        if let Ok(mut active) = self.active.lock() {
-            active.remove(key);
-        }
-        if let Ok(mut cancellations) = self.cancellations.lock() {
-            cancellations.remove(key);
-        }
+        self.active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(key);
+        self.cancellations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(key);
         self.restart_idle_window();
         self.bump_event();
     }
@@ -373,8 +375,24 @@ impl PerUserEmbeddingServerState {
             .store(self.clock.now_ns(), Ordering::Release);
     }
 
+    /// Whether nothing is in flight, so the idle window may retire the process.
+    ///
+    /// Lock poisoning is recovered here rather than read as work. Every
+    /// *serving* path still refuses a poisoned lock — `engine`,
+    /// `register_request`, and the admission accounting all fail closed with a
+    /// typed `..._poisoned` error, and this function grants nothing. Treating
+    /// poison as "busy" was the only reachable consequence, and it was a
+    /// zombie: one panicked worker made every later idle check false, so a
+    /// server that could no longer serve also never exited its idle window and
+    /// kept holding its socket and its native engine until the machine
+    /// rebooted.
     pub(in crate::per_user_embedding) fn true_idle(&self) -> bool {
-        if self.active.lock().map_or(true, |active| !active.is_empty()) {
+        if !self
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty()
+        {
             return false;
         }
         if self.request_admission.snapshot() != ServerRequestAdmissionDepths::default() {
@@ -390,9 +408,12 @@ impl PerUserEmbeddingServerState {
     }
 
     pub(in crate::per_user_embedding) fn begin_draining_if_idle(&self) -> bool {
-        let Ok(_admission) = self.admission_gate.lock() else {
-            return false;
-        };
+        // Same reasoning as `true_idle`: a poisoned admission gate must not be
+        // the reason a server that cannot serve refuses to drain.
+        let _admission = self
+            .admission_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if self
             .draining
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)

--- a/crates/codestory-retrieval/src/per_user_embedding/tests/server_admission.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/tests/server_admission.rs
@@ -33,6 +33,57 @@ fn request_deadline_covers_pre_engine_work_and_cancels_abandoned_context() {
     assert!(context.is_cancelled());
 }
 
+/// A panicked worker must not turn the server into a zombie.
+///
+/// Poisoning is recoverable state, not work in flight. Reading a poisoned
+/// request map as "busy" meant one panic anywhere under that lock made every
+/// later idle check false: the server could no longer finish a request, could
+/// no longer drain, and therefore never exited its idle window — it held the
+/// socket and the native engine open indefinitely. Serving still fails closed;
+/// only retirement is allowed to proceed.
+#[test]
+fn a_poisoned_request_map_still_lets_the_idle_window_retire_the_server() {
+    let state = test_server_state();
+    let key = "connection:poisoned";
+    state.active.lock().expect("active map").insert(
+        key.to_string(),
+        ActiveServerRequest {
+            request_id: "poisoned".into(),
+            scope_id: "scope".into(),
+            request_class: EmbeddingRequestClass::Query,
+            phase: "running".into(),
+            started_ns: 0,
+        },
+    );
+
+    let poisoner = Arc::clone(&state);
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _active = poisoner.active.lock().expect("active map");
+        let _gate = poisoner.admission_gate.lock().expect("admission gate");
+        panic!("intentional: a worker dies holding the request map and the admission gate");
+    }));
+    assert!(state.active.is_poisoned());
+    assert!(state.admission_gate.is_poisoned());
+
+    state.finish_request(key);
+    assert!(
+        state
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty(),
+        "a poisoned map must still lose the finished request"
+    );
+    assert!(
+        state.true_idle(),
+        "a poisoned lock is recoverable state, not work in flight"
+    );
+    assert!(
+        state.begin_draining_if_idle(),
+        "a server that can no longer serve must still be able to retire"
+    );
+}
+
 #[test]
 fn idle_admission_closes_before_a_new_request_can_enter() {
     let state = test_server_state();

--- a/crates/codestory-runtime/src/grounding.rs
+++ b/crates/codestory-runtime/src/grounding.rs
@@ -1620,11 +1620,30 @@ fn path_supports_brace_balanced_function_fallback(path: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// String state the brace scanner has to carry across a newline.
+///
+/// Only the two forms that legally span lines in the languages this fallback
+/// accepts. A `'`-delimited literal stays line-local because Rust lifetimes
+/// (`&'a str`) open one that never closes, and persisting that would swallow
+/// the rest of the file; a `"`-delimited literal stays line-local for the same
+/// containment reason.
+#[derive(Clone, Copy)]
+enum MultilineStringState {
+    None,
+    /// A JavaScript/TypeScript template literal or a Go raw string literal.
+    Backtick,
+    /// A Rust raw string literal, closed by `"` followed by `hashes` `#`.
+    RustRaw {
+        hashes: usize,
+    },
+}
+
 fn brace_balanced_body_end_line(source: &str, start_line: u32) -> Option<u32> {
     let start_index = start_line.checked_sub(1)? as usize;
     let mut depth = 0usize;
     let mut saw_opening_brace = false;
     let mut in_block_comment = false;
+    let mut multiline_string = MultilineStringState::None;
 
     for (offset, line) in source
         .lines()
@@ -1637,6 +1656,7 @@ fn brace_balanced_body_end_line(source: &str, start_line: u32) -> Option<u32> {
             &mut depth,
             &mut saw_opening_brace,
             &mut in_block_comment,
+            &mut multiline_string,
         );
         if saw_opening_brace && depth == 0 {
             return Some((offset + 1) as u32);
@@ -1650,23 +1670,56 @@ fn brace_balanced_body_end_line(source: &str, start_line: u32) -> Option<u32> {
     None
 }
 
+/// Scan one line for braces, carrying block-comment and multiline-string state.
+///
+/// `multiline_string` is why this takes state rather than rediscovering it:
+/// string state used to be line-local, so a `}` inside a JavaScript template
+/// literal or a Rust raw string that spans lines was counted as real, closed
+/// the inferred function early, and the snippet was still reported as
+/// `scope=function_body` with a `brace_balanced_fallback` range — a truncated
+/// body presented as a whole one.
 fn scan_braces_in_line(
     line: &str,
     depth: &mut usize,
     saw_opening_brace: &mut bool,
     in_block_comment: &mut bool,
+    multiline_string: &mut MultilineStringState,
 ) {
-    let mut chars = line.chars().peekable();
+    let chars: Vec<char> = line.chars().collect();
+    let mut index = 0usize;
     let mut string_delimiter: Option<char> = None;
     let mut escaped = false;
 
-    while let Some(ch) = chars.next() {
+    while index < chars.len() {
+        let ch = chars[index];
+        index += 1;
+
         if *in_block_comment {
-            if ch == '*' && chars.peek() == Some(&'/') {
-                chars.next();
+            if ch == '*' && chars.get(index) == Some(&'/') {
+                index += 1;
                 *in_block_comment = false;
             }
             continue;
+        }
+        match *multiline_string {
+            MultilineStringState::Backtick => {
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == '`' {
+                    *multiline_string = MultilineStringState::None;
+                }
+                continue;
+            }
+            MultilineStringState::RustRaw { hashes } => {
+                if ch == '"' && chars[index..].iter().take_while(|c| **c == '#').count() >= hashes {
+                    index += hashes;
+                    *multiline_string = MultilineStringState::None;
+                }
+                continue;
+            }
+            MultilineStringState::None => {}
         }
         if let Some(delimiter) = string_delimiter {
             if escaped {
@@ -1683,17 +1736,28 @@ fn scan_braces_in_line(
             continue;
         }
         if ch == '/' {
-            match chars.peek() {
+            match chars.get(index) {
                 Some('/') => break,
                 Some('*') => {
-                    chars.next();
+                    index += 1;
                     *in_block_comment = true;
                     continue;
                 }
                 _ => {}
             }
         }
-        if matches!(ch, '"' | '\'' | '`') {
+        if ch == '`' {
+            *multiline_string = MultilineStringState::Backtick;
+            escaped = false;
+            continue;
+        }
+        if let Some(hashes) = rust_raw_string_open_hashes(&chars, index - 1) {
+            // Skip `r`, the opening hashes, and the quote.
+            index += hashes + 1;
+            *multiline_string = MultilineStringState::RustRaw { hashes };
+            continue;
+        }
+        if matches!(ch, '"' | '\'') {
             string_delimiter = Some(ch);
             continue;
         }
@@ -1708,6 +1772,34 @@ fn scan_braces_in_line(
     }
 }
 
+/// The `#` count of a Rust raw string literal opening at `index`, if one does.
+///
+/// Accepts `r"`, `r#"`, `r##"`, and the byte-string forms `br"`/`br#"`, and
+/// only at an identifier boundary so an ordinary `r` inside a word (`for`,
+/// `error`) never opens a literal.
+fn rust_raw_string_open_hashes(chars: &[char], index: usize) -> Option<usize> {
+    if chars.get(index) != Some(&'r') {
+        return None;
+    }
+    let boundary = match index.checked_sub(1).map(|previous| chars[previous]) {
+        None => true,
+        // `br"..."` is the byte-string spelling of the same literal.
+        Some('b') => index
+            .checked_sub(2)
+            .is_none_or(|previous| !is_rust_identifier_char(chars[previous])),
+        Some(previous) => !is_rust_identifier_char(previous),
+    };
+    if !boundary {
+        return None;
+    }
+    let hashes = chars[index + 1..].iter().take_while(|c| **c == '#').count();
+    (chars.get(index + 1 + hashes) == Some(&'"')).then_some(hashes)
+}
+
+fn is_rust_identifier_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1716,6 +1808,50 @@ mod tests {
         SourceLocation,
     };
     use tempfile::tempdir;
+
+    /// The inferred function body must end at the real closing brace, not at
+    /// the first `}` that happens to sit inside a string spanning lines.
+    ///
+    /// `snippet_function_body_context` publishes this end line as a
+    /// `brace_balanced_fallback` range under `scope=function_body`, so an early
+    /// end is a truncated body presented as a whole one — with no truncation
+    /// flag, because nothing was truncated: the range itself was wrong.
+    #[test]
+    fn brace_balanced_body_end_ignores_braces_inside_multiline_strings() {
+        let template_literal = concat!(
+            "export function render(rows) {\n",
+            "  const markup = `\n",
+            "}\n",
+            "`;\n",
+            "  return markup;\n",
+            "}\n",
+        );
+        assert_eq!(brace_balanced_body_end_line(template_literal, 1), Some(6));
+
+        let rust_raw_string = concat!(
+            "fn render() -> String {\n",
+            "    let markup = r#\"\n",
+            "}\n",
+            "\"#;\n",
+            "    markup.to_string()\n",
+            "}\n",
+        );
+        assert_eq!(brace_balanced_body_end_line(rust_raw_string, 1), Some(6));
+
+        // Positive control: nothing about ordinary bodies moved, including the
+        // single-line strings, char literals, and lifetimes that must stay
+        // line-local.
+        let ordinary = concat!(
+            "fn render<'a>(rows: &'a [Row]) -> String {\n",
+            "    let separator = \"}\";\n",
+            "    if rows.is_empty() {\n",
+            "        return separator.to_string();\n",
+            "    }\n",
+            "    rows.len().to_string()\n",
+            "}\n",
+        );
+        assert_eq!(brace_balanced_body_end_line(ordinary, 1), Some(7));
+    }
 
     fn insert_file_node(
         storage: &mut Storage,

--- a/plugins/codestory/skills/codestory-grounding/references/drill.md
+++ b/plugins/codestory/skills/codestory-grounding/references/drill.md
@@ -35,9 +35,6 @@ The report includes:
 
 # JSON-first run for automation, while still writing Markdown too
 <codestory-cli> drill --project <target-workspace> --refresh none --anchors EntryPoint,Coordinator,BackingStore --output-dir target/drill/entrypoint-flow --format json
-
-# Optional read-only anchor and bridge workers against an already-fresh local index
-<codestory-cli> drill --project <target-workspace> --refresh none --anchors EntryPoint,Coordinator,BackingStore --output-dir target/drill/entrypoint-flow --format json --jobs 4
 ```
 
 ## Interpretation
@@ -54,10 +51,10 @@ Consumer summaries inspect direct incoming production consumers for the selected
 
 If `drill-summary.json` reports stale freshness, refresh the index before promoting claims. If retrieval is not full or semantic diagnostics report degraded state, wait for a complete publication or run the maintainer-directed rebuild before trusting broad natural-language recall; use symbol, trail, snippet, and source-truth files deliberately while broad retrieval is unavailable.
 
-`--jobs` is default-off and read-only. Use it only with `--refresh none` after
-the index is fresh, and measure the run: multi-case suites can benefit from
-parallel case execution, while single-case anchor resolution and bridge checks
-may be limited by storage and graph traversal contention on some repos.
+`drill --jobs` is deprecated, hidden, and ignored: the evidence packet owns
+drill scheduling, so a single drill has no worker pool to size. Supplying it
+prints a notice and changes nothing, and it is removed next release. Case-level
+parallelism lives on `drill-suite --jobs`.
 
 The optional `question_search` artifact and any `question_supplemental_searches` are intentionally partial discovery evidence. They can add public page, component, collection, and store files to the source-truth checklist when the broad question points there, but they do not prove the architecture by themselves. Use them to avoid missing verification files, then rely on each anchor's symbol/trail/explore/snippet artifacts and focused source reads before promoting claims.
 


### PR DESCRIPTION
Closes #1669.

Low-risk debt retired, with a ratchet behind each retirement so the debt cannot return silently.

## Review

**Merge with follow-up** — no blocking or major findings survived verification. The reviewer checked that each retirement has a ratchet that actually fails when the debt is reintroduced, rather than a deletion with no guard, and that no frozen release constant was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)