### PR TITLE
[v0.17 CONFIG-B] Enforce single-reader ownership for registered settings

### DIFF
--- a/crates/codestory-cli/src/app/diagnostics/doctor.rs
+++ b/crates/codestory-cli/src/app/diagnostics/doctor.rs
@@ -95,23 +95,23 @@ pub(in crate::app) fn build_doctor_output(
 
     // Reported settings are observed through the registry so a secret-marked
     // value can never reach a doctor line, whatever this list grows to hold.
-    let environment = [
-        config_registry::EMBED_ALLOW_CPU_ENV,
-        config_registry::STORED_VECTOR_ENCODING_ENV,
-        config_registry::HYBRID_RETRIEVAL_ENABLED_ENV,
-        config_registry::SEMANTIC_DOC_ALIAS_MODE_ENV,
-    ]
-    .into_iter()
-    .map(|name| match config_registry::observe_env_setting(name) {
-        ObservedSetting::Set(value) => {
-            doctor_check(name, "ok", doctor_env_check_message(name, &value))
-        }
-        ObservedSetting::SetSecret => doctor_check(name, "ok", "set; value withheld".to_string()),
-        ObservedSetting::Unset => {
-            doctor_check(name, "info", "not set; using runtime defaults".to_string())
-        }
-    })
-    .collect::<Vec<_>>();
+    // The list itself lives in the registry too: naming these identities here
+    // would make doctor a second reader of four settings other modules own.
+    let environment = config_registry::REPORTED_ENV_SETTINGS
+        .iter()
+        .copied()
+        .map(|name| match config_registry::observe_env_setting(name) {
+            ObservedSetting::Set(value) => {
+                doctor_check(name, "ok", doctor_env_check_message(name, &value))
+            }
+            ObservedSetting::SetSecret => {
+                doctor_check(name, "ok", "set; value withheld".to_string())
+            }
+            ObservedSetting::Unset => {
+                doctor_check(name, "info", "not set; using runtime defaults".to_string())
+            }
+        })
+        .collect::<Vec<_>>();
 
     DoctorOutput {
         project: project.clone(),

--- a/crates/codestory-cli/src/embedding_qualification/worker.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker.rs
@@ -1,8 +1,8 @@
 use self::gate::{
     current_process_start_identity, project_identity_sha256, qualification_nonce,
-    read_private_request, required_absolute_directory, sha256_bytes, validate_direct_child,
-    validate_gate_path, validate_private_directory, validate_worker_project, wait_for_gate,
-    worker_error, write_atomic_json,
+    read_private_request, required_absolute_qualification_directory, sha256_bytes,
+    validate_direct_child, validate_gate_path, validate_private_directory, validate_worker_project,
+    wait_for_gate, worker_error, write_atomic_json,
 };
 use self::operations::{
     run_activate_probe, run_cold_race_protocol_exchange, run_dead_client_load,
@@ -23,8 +23,6 @@ use codestory_retrieval::{
 use std::sync::Arc;
 use std::time::Duration;
 
-use codestory_contracts::config_registry::EMBED_QUALIFICATION_DIR_ENV as QUALIFICATION_DIR_ENV;
-
 mod gate;
 mod operations;
 mod protocol;
@@ -38,7 +36,7 @@ pub(super) fn run(command: InternalEmbeddingQualificationCommand) -> Result<()> 
     if request.schema_version != EMBEDDING_QUALIFICATION_WORKER_SCHEMA_VERSION {
         bail!("embedding_qualification_worker_schema_invalid");
     }
-    let directory = required_absolute_directory(QUALIFICATION_DIR_ENV)?;
+    let directory = required_absolute_qualification_directory()?;
     validate_private_directory(&directory)?;
     validate_direct_child(&command.request, &directory, true)?;
     validate_direct_child(&command.output, &directory, false)?;

--- a/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result, bail};
-use codestory_contracts::config_registry::EMBED_QUALIFICATION_NONCE_ENV as QUALIFICATION_NONCE_ENV;
 use codestory_retrieval::{
     AwakeMonotonicClock, EmbeddingQualificationWorkerError as WorkerError, ProcessStartProbe,
     SidecarRuntimeConfig, embedding_retry_state,
@@ -63,8 +62,9 @@ pub(super) fn validate_direct_child(
     Ok(canonical_path)
 }
 
-pub(super) fn required_absolute_directory(name: &str) -> Result<PathBuf> {
-    let value = std::env::var_os(name)
+pub(super) fn required_absolute_qualification_directory() -> Result<PathBuf> {
+    let value = codestory_retrieval::qualification_gate_environment()
+        .directory
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .ok_or_else(|| anyhow::anyhow!("embedding_qualification_gate_closed"))?;
@@ -149,8 +149,8 @@ pub(super) fn sha256_bytes(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 pub(super) fn qualification_nonce() -> Result<String> {
-    std::env::var(QUALIFICATION_NONCE_ENV)
-        .ok()
+    codestory_retrieval::qualification_gate_environment()
+        .nonce_string()
         .filter(|nonce| {
             !nonce.is_empty()
                 && nonce.len() <= 128

--- a/crates/codestory-cli/src/embedding_server_transport.rs
+++ b/crates/codestory-cli/src/embedding_server_transport.rs
@@ -1901,10 +1901,8 @@ mod platform {
     }
 
     fn runtime_paths() -> Result<RuntimePaths> {
-        match (
-            std::env::var_os(QUALIFICATION_DIR_ENV),
-            std::env::var_os(QUALIFICATION_NONCE_ENV),
-        ) {
+        let gate = codestory_retrieval::qualification_gate_environment();
+        match (gate.directory, gate.nonce) {
             (None, None) => platform_runtime_paths(),
             (Some(dir), Some(nonce)) => qualification_runtime_paths(
                 PathBuf::from(dir),
@@ -3865,10 +3863,8 @@ mod platform {
     }
 
     fn qualification_namespace_salt() -> Result<String> {
-        match (
-            std::env::var_os(QUALIFICATION_DIR_ENV),
-            std::env::var_os(QUALIFICATION_NONCE_ENV),
-        ) {
+        let gate = codestory_retrieval::qualification_gate_environment();
+        match (gate.directory, gate.nonce) {
             (None, None) => Ok("production".into()),
             (Some(dir), Some(nonce)) => {
                 let dir = PathBuf::from(dir);

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -536,16 +536,18 @@ pub(crate) const CODESTORY_PUBLICATION_META_SCHEMA_VERSION: u32 = 1;
 
 pub(crate) fn codestory_publication_contract_runtime_meta() -> serde_json::Value {
     let active_cli_version = env!("CARGO_PKG_VERSION");
-    let plugin_cli_version = publication_env_nonempty(config_registry::PLUGIN_CLI_VERSION_ENV);
-    let plugin_version = publication_env_nonempty(config_registry::PLUGIN_VERSION_ENV);
-    let cli_source = publication_env_nonempty(config_registry::PLUGIN_CLI_SOURCE_ENV)
+    // The plugin identities are declared to stdio_transport.rs, which reads
+    // them; this stamp consumes that value rather than reading them again.
+    let host = crate::stdio_transport::host_provisioning_identity();
+    let cli_source = host
+        .cli_source
         .unwrap_or_else(|| "direct_cli_launch".to_string());
     let override_configured = publication_env_nonempty(config_registry::CLI_ENV).is_some()
         || cli_source == "local_dev_override";
     codestory_publication_contract_runtime_meta_from(
         active_cli_version,
-        plugin_version,
-        plugin_cli_version,
+        host.plugin_version,
+        host.plugin_cli_version,
         cli_source,
         override_configured,
     )

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -5844,6 +5844,31 @@ fn env_nonempty(name: &str) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+/// What the host declared about the pair it provisioned.
+///
+/// The plugin identities are declared to this file, so this is where they are
+/// read. `runtime.rs` builds the `_meta.codestory_publication` stamp from this
+/// value instead of reading the same three variables with its own copy of
+/// `env_nonempty` — the skew detector and the status surface have to be looking
+/// at the same provisioning, or the stamp reports a pairing status the status
+/// report contradicts.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct HostProvisioningIdentity {
+    pub(crate) plugin_version: Option<String>,
+    pub(crate) plugin_cli_version: Option<String>,
+    /// `None` when the host declared nothing; callers supply their own label
+    /// for a direct launch.
+    pub(crate) cli_source: Option<String>,
+}
+
+pub(crate) fn host_provisioning_identity() -> HostProvisioningIdentity {
+    HostProvisioningIdentity {
+        plugin_version: env_nonempty("CODESTORY_PLUGIN_VERSION"),
+        plugin_cli_version: env_nonempty("CODESTORY_PLUGIN_CLI_VERSION"),
+        cli_source: env_nonempty("CODESTORY_PLUGIN_CLI_SOURCE"),
+    }
+}
+
 fn sha256_file(path: &Path) -> Result<String> {
     let mut file = File::open(path).with_context(|| format!("open {}", path.display()))?;
     let mut hasher = Sha256::new();

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -1135,6 +1135,345 @@ fn config_registry_owners_name_real_production_files() {
     }
 }
 
+#[test]
+fn registered_settings_are_read_only_by_their_declared_owner() {
+    // CONFIG-B: the sibling contract above stops a *second spelling* of an
+    // identity. It does not stop a second reading, and those are different
+    // failures: a non-owner that imports the registry constant spells the
+    // identity once and still decides for itself what the value means. That is
+    // how CODESTORY_SEMANTIC_DOC_MAX_TOKENS=0 was 16 tokens to retrieval and
+    // 128 to the runtime at the same instant.
+    //
+    // A read is an identity in *expression* position: the registry constant, an
+    // `as` alias of it, or a file-local `const` bound to it, appearing anywhere
+    // outside an import, a comment, or a string. Passing it to a helper counts —
+    // `env_flag_enabled(HYBRID_RETRIEVAL_ENABLED_ENV, true)` reads the setting
+    // just as surely as `std::env::var` does, and the whole point is that no
+    // indirection buys a second interpretation. Naming an identity inside a
+    // message stays legal: it tells an operator which variable to set and reads
+    // nothing.
+    //
+    // `production_sources` strips only the trailing `#[cfg(test)] mod tests`,
+    // so an inline test-only reader inside a production file is in scope on
+    // purpose. Those are the worst kind: the runtime's semantic prefilter read
+    // this setting only under `cfg(test)` and taught its own tests an encoding
+    // vocabulary the store has never written.
+    //
+    // Scope, stated so it is not mistaken for more: the six product crates
+    // `production_sources` walks. A harness outside them that *sets* a variable
+    // for a child process (codestory-bench does, for the qualification gate) is
+    // producing an environment, not interpreting one, and is not governed here.
+    // Should a product crate ever need to write one, the owner should expose the
+    // writer, and this contract will say so by failing.
+    let registry = read("crates/codestory-contracts/src/config_registry.rs");
+    let declared = registry_identity_constants(&registry)
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    let mut violations = Vec::new();
+    for (relative, source) in production_sources() {
+        let masked = mask_comments_and_strings(&source);
+        let bindings = registered_identity_bindings(&declared, &masked);
+        if bindings.is_empty() {
+            continue;
+        }
+        let imports = import_line_numbers(&masked);
+        for (line_number, line) in masked.lines().enumerate() {
+            if imports.contains(&(line_number + 1)) {
+                continue;
+            }
+            for (token, identity) in &bindings {
+                if !contains_word(line, token) {
+                    continue;
+                }
+                let owner = codestory_contracts::config_registry::env_setting_owner(identity)
+                    .expect("binding resolves to a registered identity");
+                if owner == relative {
+                    continue;
+                }
+                violations.push(format!(
+                    "{relative}:{} reads {identity} (as `{token}`); the registry declares \
+                     {owner} as its single reader. Consume that module's typed value instead \
+                     of reading the setting here.",
+                    line_number + 1
+                ));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "a registered setting may be read only by its declared owner:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn every_registered_identity_has_exactly_one_registry_constant() {
+    // The read contract resolves identities through the registry's own
+    // constants, so a setting reachable only by a literal would be invisible to
+    // it. Both directions are checked: a constant with no entry, and an entry
+    // with no constant.
+    let registry = read("crates/codestory-contracts/src/config_registry.rs");
+    let declared = registry_identity_constants(&registry);
+    let mut by_identity: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for (constant, identity) in &declared {
+        assert!(
+            codestory_contracts::config_registry::env_setting(identity).is_some(),
+            "{constant} declares {identity}, which is not in ENV_SETTINGS"
+        );
+        by_identity
+            .entry(identity.as_str())
+            .or_default()
+            .push(constant.as_str());
+    }
+    for setting in codestory_contracts::config_registry::ENV_SETTINGS {
+        let constants = by_identity.get(setting.name).cloned().unwrap_or_default();
+        assert_eq!(
+            constants.len(),
+            1,
+            "{} needs exactly one registry constant, found {constants:?}",
+            setting.name
+        );
+    }
+}
+
+/// Registry constant name to environment identity, read from the registry
+/// source so the registry stays the one place a knob is declared.
+fn registry_identity_constants(registry_source: &str) -> Vec<(String, String)> {
+    let mut declared = Vec::new();
+    let normalized = registry_source.replace(['\n', '\r'], " ");
+    let mut rest = normalized.as_str();
+    while let Some(index) = rest.find("pub const ") {
+        rest = &rest[index + "pub const ".len()..];
+        let Some((name, tail)) = rest.split_once(':') else {
+            break;
+        };
+        let name = name.trim();
+        if !name.ends_with("_ENV") {
+            continue;
+        }
+        let Some((_, tail)) = tail.split_once('=') else {
+            break;
+        };
+        let tail = tail.trim_start();
+        let Some(value) = tail.strip_prefix('"').and_then(|tail| {
+            tail.split_once('"')
+                .map(|(value, _)| value)
+                .filter(|value| value.starts_with("CODESTORY_"))
+        }) else {
+            continue;
+        };
+        declared.push((name.to_string(), value.to_string()));
+    }
+    declared
+}
+
+/// Names that resolve to a registered identity inside one source file: the
+/// registry constants themselves, `as` aliases of them, and file-local `const`
+/// bindings to them.
+fn registered_identity_bindings(
+    declared: &BTreeMap<String, String>,
+    masked_source: &str,
+) -> BTreeMap<String, String> {
+    let registered = |identity: &String| {
+        codestory_contracts::config_registry::env_setting(identity)
+            .is_some()
+            .then(|| identity.clone())
+    };
+    let mut bindings = BTreeMap::new();
+    for (constant, identity) in declared {
+        if contains_word(masked_source, constant)
+            && let Some(identity) = registered(identity)
+        {
+            bindings.insert(constant.clone(), identity);
+        }
+    }
+    for (alias, constant) in aliased_names(masked_source) {
+        if let Some(identity) = declared.get(&constant).and_then(registered) {
+            bindings.insert(alias, identity);
+        }
+    }
+    bindings
+}
+
+/// `<CONSTANT> as <ALIAS>` in an import, and `const <ALIAS>: &str = ...::<CONSTANT>;`.
+fn aliased_names(masked_source: &str) -> Vec<(String, String)> {
+    let mut aliases = Vec::new();
+    let words = masked_source
+        .split(|character: char| !(character.is_alphanumeric() || character == '_'))
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    for window in words.windows(3) {
+        if window[1] == "as" && window[0].ends_with("_ENV") {
+            aliases.push((window[2].to_string(), window[0].to_string()));
+        }
+    }
+    for window in words.windows(6) {
+        // `const NAME : & str = config_registry :: CONSTANT ;` reduces to the
+        // words `const NAME str config_registry CONSTANT`, so match on the
+        // const keyword and the trailing `_ENV` word.
+        if window[0] == "const"
+            && window.contains(&"str")
+            && let Some(constant) = window.iter().rev().find(|word| word.ends_with("_ENV"))
+            && *constant != window[1]
+        {
+            aliases.push((window[1].to_string(), (*constant).to_string()));
+        }
+    }
+    aliases
+}
+
+/// 1-based line numbers occupied by `use` items.
+fn import_line_numbers(masked_source: &str) -> BTreeSet<usize> {
+    let mut lines = BTreeSet::new();
+    let mut inside_import = false;
+    for (index, line) in masked_source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        let starts_import = trimmed.starts_with("use ")
+            || trimmed.starts_with("pub use ")
+            || trimmed.starts_with("pub(crate) use ")
+            || trimmed.starts_with("pub(super) use ")
+            || (trimmed.starts_with("pub(in ")
+                && trimmed
+                    .split_once(") ")
+                    .is_some_and(|(_, rest)| rest.starts_with("use ")));
+        if !inside_import && !starts_import {
+            continue;
+        }
+        lines.insert(index + 1);
+        inside_import = !line.trim_end().ends_with(';');
+    }
+    lines
+}
+
+fn contains_word(haystack: &str, word: &str) -> bool {
+    let mut offset = 0;
+    while let Some(index) = haystack[offset..].find(word) {
+        let start = offset + index;
+        let end = start + word.len();
+        let before_is_word = haystack[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|character| character.is_alphanumeric() || character == '_');
+        let after_is_word = haystack[end..]
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_alphanumeric() || character == '_');
+        if !before_is_word && !after_is_word {
+            return true;
+        }
+        offset = end;
+    }
+    false
+}
+
+/// Blank out comments and string literals, preserving byte offsets and line
+/// breaks so a violation still reports the line it was found on. Prose that
+/// names a variable and messages that tell an operator to set one are not
+/// reads, and must not be mistaken for them.
+fn mask_comments_and_strings(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut masked = bytes.to_vec();
+    // Blanking whole comment and literal spans byte by byte keeps every offset
+    // and line break where it was, and stays valid UTF-8 because the spans
+    // always start and end on character boundaries.
+    let blank = |masked: &mut Vec<u8>, from: usize, to: usize| {
+        for byte in &mut masked[from..to.min(bytes.len())] {
+            if *byte != b'\n' {
+                *byte = b' ';
+            }
+        }
+    };
+    let is_word_byte = |byte: u8| byte.is_ascii_alphanumeric() || byte == b'_' || !byte.is_ascii();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                let end = bytes[index..]
+                    .iter()
+                    .position(|byte| *byte == b'\n')
+                    .map_or(bytes.len(), |offset| index + offset);
+                blank(&mut masked, index, end);
+                index = end;
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                let mut depth = 1_usize;
+                let mut cursor = index + 2;
+                while cursor < bytes.len() && depth > 0 {
+                    if bytes[cursor] == b'/' && bytes.get(cursor + 1) == Some(&b'*') {
+                        depth += 1;
+                        cursor += 2;
+                    } else if bytes[cursor] == b'*' && bytes.get(cursor + 1) == Some(&b'/') {
+                        depth -= 1;
+                        cursor += 2;
+                    } else {
+                        cursor += 1;
+                    }
+                }
+                blank(&mut masked, index, cursor);
+                index = cursor;
+            }
+            b'\'' => {
+                // A char or byte literal, or a lifetime. Only the literals hide
+                // a quote that would otherwise open a phantom string.
+                let end = match (bytes.get(index + 1), bytes.get(index + 2)) {
+                    (Some(b'\\'), _) => bytes[index + 2..]
+                        .iter()
+                        .position(|byte| *byte == b'\'')
+                        .map(|offset| index + 3 + offset),
+                    (Some(_), Some(b'\'')) => Some(index + 3),
+                    _ => None,
+                };
+                match end {
+                    Some(end) => {
+                        blank(&mut masked, index, end);
+                        index = end;
+                    }
+                    None => index += 1,
+                }
+            }
+            b'r' | b'b' if index == 0 || !is_word_byte(bytes[index - 1]) => {
+                let mut cursor = index + 1;
+                if bytes.get(cursor) == Some(&b'r') && bytes[index] == b'b' {
+                    cursor += 1;
+                }
+                let mut hashes = 0;
+                while bytes.get(cursor) == Some(&b'#') {
+                    hashes += 1;
+                    cursor += 1;
+                }
+                if bytes.get(cursor) != Some(&b'"') {
+                    index += 1;
+                    continue;
+                }
+                let terminator = format!("\"{}", "#".repeat(hashes));
+                let end = source
+                    .get(cursor + 1..)
+                    .and_then(|rest| rest.find(&terminator))
+                    .map_or(bytes.len(), |offset| cursor + 1 + offset + terminator.len());
+                blank(&mut masked, index, end);
+                index = end;
+            }
+            b'"' => {
+                let mut cursor = index + 1;
+                while cursor < bytes.len() {
+                    match bytes[cursor] {
+                        b'\\' => cursor += 2,
+                        b'"' => {
+                            cursor += 1;
+                            break;
+                        }
+                        _ => cursor += 1,
+                    }
+                }
+                blank(&mut masked, index, cursor);
+                index = cursor.min(bytes.len());
+            }
+            _ => index += 1,
+        }
+    }
+    String::from_utf8(masked).expect("blanking whole spans preserves UTF-8")
+}
+
 /// `CODESTORY_*` identities spelled in production, mapped to the files that
 /// spell them.
 fn production_environment_identities() -> BTreeMap<String, BTreeSet<String>> {

--- a/crates/codestory-contracts/src/config_registry.rs
+++ b/crates/codestory-contracts/src/config_registry.rs
@@ -10,6 +10,21 @@
 //! catalog entry, documentation, or a stated owner the way an ad-hoc
 //! `std::env::var` call did.
 //!
+//! The owner is the single reader, and that is enforced, not merely intended:
+//! the same architecture contract rejects any production file other than the
+//! owner that uses a registered identity in expression position — spelling it,
+//! importing the constant and passing it to `std::env::var`, or handing it to a
+//! helper that reads on its behalf. A non-owner consumes the owner's typed
+//! value instead. That is the difference between one name for a setting and one
+//! meaning for it: while two modules could each read
+//! `CODESTORY_STORED_VECTOR_ENCODING`, one could clamp, default, or reject a
+//! value the other accepted, and the setting meant two things at once.
+//!
+//! Two things deliberately stay legal for a non-owner, because neither reads a
+//! value: naming an identity inside a message so an operator learns which
+//! variable to set, and [`observe_env_setting`], the registry's own read path
+//! for surfaces that display presence rather than act on it.
+//!
 //! Secrecy is a property of the setting, not of the call site: a secret value
 //! is never rendered into documentation, warnings, or diagnostics, so a caller
 //! cannot accidentally echo it by reaching for the wrong formatter.
@@ -30,8 +45,6 @@ pub const DISABLE_RELEASE_PROBE_ENV: &str = "CODESTORY_DISABLE_RELEASE_PROBE";
 pub const EMBED_ALLOW_CPU_ENV: &str = "CODESTORY_EMBED_ALLOW_CPU";
 pub const EMBED_QUALIFICATION_DIR_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_DIR";
 pub const EMBED_QUALIFICATION_NONCE_ENV: &str = "CODESTORY_EMBED_QUALIFICATION_NONCE";
-pub const EVAL_PROBES_ENV: &str = "CODESTORY_EVAL_PROBES";
-pub const EVAL_PROBES_MANIFEST_ENV: &str = "CODESTORY_EVAL_PROBES_MANIFEST";
 pub const GRAPH_INCLUDE_CALLSITE_IDENTITY_ENV: &str = "CODESTORY_GRAPH_INCLUDE_CALLSITE_IDENTITY";
 pub const GRAPH_INCLUDE_CANDIDATE_TARGETS_ENV: &str = "CODESTORY_GRAPH_INCLUDE_CANDIDATE_TARGETS";
 pub const GRAPH_INCLUDE_EDGE_CERTAINTY_ENV: &str = "CODESTORY_GRAPH_INCLUDE_EDGE_CERTAINTY";
@@ -190,7 +203,10 @@ pub enum SettingSecrecy {
 pub struct EnvSetting {
     /// Process environment variable name.
     pub name: &'static str,
-    /// The one production source file allowed to spell this identity.
+    /// The one production source file that reads this setting.
+    ///
+    /// No other production file may spell the identity or use the registry
+    /// constant in expression position; consumers take the owner's typed value.
     pub owner: &'static str,
     pub kind: SettingKind,
     pub audience: SettingAudience,
@@ -794,7 +810,7 @@ pub fn env_setting(name: &str) -> Option<&'static EnvSetting> {
     ENV_SETTINGS.iter().find(|setting| setting.name == name)
 }
 
-/// Production source file allowed to spell one environment identity.
+/// The one production source file that reads one environment identity.
 pub fn env_setting_owner(name: &str) -> Option<&'static str> {
     env_setting(name).map(|setting| setting.owner)
 }
@@ -811,10 +827,26 @@ pub enum ObservedSetting {
     SetSecret,
 }
 
+/// Settings the diagnostic surfaces report on, in report order.
+///
+/// The list lives here rather than in the reporting file for the same reason
+/// the owner is the single reader: a diagnostic that named these identities
+/// itself would be a second module deciding what four settings mean, and it
+/// would need to name identities four other modules own. Observation is a
+/// registry act, so the registry holds the list.
+pub const REPORTED_ENV_SETTINGS: &[&str] = &[
+    EMBED_ALLOW_CPU_ENV,
+    STORED_VECTOR_ENCODING_ENV,
+    HYBRID_RETRIEVAL_ENABLED_ENV,
+    SEMANTIC_DOC_ALIAS_MODE_ENV,
+];
+
 /// Observe one registered setting without ever exposing a secret value.
 ///
 /// This is the only read path a non-owner may use, so a diagnostic surface
-/// cannot echo a credential by reaching for `std::env::var` directly.
+/// cannot echo a credential by reaching for `std::env::var` directly. It
+/// reports presence, never an interpretation: a surface that needs to act on a
+/// setting takes the owner's typed value instead.
 pub fn observe_env_setting(name: &str) -> ObservedSetting {
     let Some(setting) = env_setting(name) else {
         return ObservedSetting::Unset;
@@ -1073,6 +1105,13 @@ pub fn render_configuration_reference() -> String {
          mistyped credential key cannot reach a log line.\n\n"
     );
 
+    page.push_str(
+        "## Environment variables\n\n\
+         The owner column names the one source file that reads a variable. A build check \
+         rejects any other production file that reads it, so a setting has one meaning: no \
+         second module can clamp, default, or reject a value the owner accepted.\n\n",
+    );
+
     for audience in AUDIENCES {
         let settings = ENV_SETTINGS
             .iter()
@@ -1083,7 +1122,7 @@ pub fn render_configuration_reference() -> String {
         }
         let _ = write!(
             page,
-            "## {}\n\n{}\n\n| Variable | Type | Owner | Meaning |\n| --- | --- | --- | --- |\n",
+            "### {}\n\n{}\n\n| Variable | Type | Owner | Meaning |\n| --- | --- | --- | --- |\n",
             audience.heading(),
             audience.note()
         );
@@ -1212,6 +1251,35 @@ mod tests {
                 "{name} row must state that values stay hidden"
             );
         }
+    }
+
+    #[test]
+    fn generated_reference_states_the_enforced_single_reader_rule() {
+        // The claim is only allowed on the page because a contract enforces it
+        // (`registered_settings_are_read_only_by_their_owner` in
+        // `codestory-cli/tests/architecture_contracts.rs`). If that contract is
+        // ever deleted, this sentence has to go with it.
+        let reference = render_configuration_reference();
+        assert!(
+            reference.contains(
+                "The owner column names the one source file that reads a variable. A build check \
+                 rejects any other production file that reads it"
+            ),
+            "the environment section must state the enforced single-reader rule"
+        );
+    }
+
+    #[test]
+    fn reported_settings_are_registered_and_reported_once() {
+        let mut seen = BTreeSet::new();
+        for name in REPORTED_ENV_SETTINGS {
+            assert!(
+                env_setting(name).is_some(),
+                "{name} is reported by diagnostics but is not registered"
+            );
+            assert!(seen.insert(*name), "{name} is reported twice");
+        }
+        assert!(seen.contains(&STORED_VECTOR_ENCODING_ENV));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -389,6 +389,44 @@ impl SidecarRuntimeConfig {
     }
 }
 
+/// Hybrid ranking stays on unless a value explicitly turns it off.
+const HYBRID_RETRIEVAL_ENABLED_DEFAULT: bool = true;
+
+/// The retrieval-owned runtime settings, read from the live process
+/// environment.
+///
+/// This file is the declared owner of every setting in
+/// [`RetrievalRuntimeConfig`], so it is the only one that may read them.
+/// Modules that used to interpret the same variables — the runtime's semantic
+/// projection and search publication — call this instead, which is what makes a
+/// clamp or a default apply once rather than twice with two answers.
+///
+/// Unlike [`sidecar_process_defaults`] this does not freeze: it observes the
+/// environment as it stands at the call. Callers holding a
+/// [`SidecarRuntimeConfig`] should read `runtime.retrieval` from it rather than
+/// call here; this exists for the callers that have no configured runtime in
+/// hand.
+pub fn retrieval_runtime_config_from_process_env() -> RetrievalRuntimeConfig {
+    retrieval_runtime_config(
+        &SidecarRuntimeDefaults::from_process_env(),
+        &SidecarRuntimeOverrides::default(),
+    )
+}
+
+/// Whether hybrid lexical/semantic ranking is enabled for this process.
+///
+/// Narrower than [`retrieval_runtime_config_from_process_env`] because the
+/// query path asks per request; it resolves the value through the same
+/// interpretation, so the two can never disagree.
+pub fn hybrid_retrieval_enabled_from_process_env() -> bool {
+    parse_optional_bool(
+        std::env::var("CODESTORY_HYBRID_RETRIEVAL_ENABLED")
+            .ok()
+            .as_deref(),
+    )
+    .unwrap_or(HYBRID_RETRIEVAL_ENABLED_DEFAULT)
+}
+
 fn retrieval_runtime_config(
     defaults: &SidecarRuntimeDefaults,
     overrides: &SidecarRuntimeOverrides,
@@ -396,7 +434,7 @@ fn retrieval_runtime_config(
     RetrievalRuntimeConfig {
         hybrid_enabled: default_optional_bool(defaults, "CODESTORY_HYBRID_RETRIEVAL_ENABLED")
             .or(overrides.hybrid_retrieval_enabled)
-            .unwrap_or(true),
+            .unwrap_or(HYBRID_RETRIEVAL_ENABLED_DEFAULT),
         semantic_doc_scope: default_nonempty(defaults, "CODESTORY_SEMANTIC_DOC_SCOPE")
             .or_else(|| overrides.semantic_doc_scope.clone())
             .unwrap_or_else(|| "durable".to_string()),
@@ -465,13 +503,17 @@ fn default_nonempty(defaults: &SidecarRuntimeDefaults, name: &str) -> Option<Str
 }
 
 fn default_optional_bool(defaults: &SidecarRuntimeDefaults, name: &str) -> Option<bool> {
-    defaults
-        .get(name)
-        .and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
-            "1" | "true" | "yes" | "on" => Some(true),
-            "0" | "false" | "no" | "off" => Some(false),
-            _ => None,
-        })
+    parse_optional_bool(defaults.get(name))
+}
+
+/// One interpretation of a boolean setting, shared by every entry point in this
+/// file so a caller cannot get a different answer by asking a different way.
+fn parse_optional_bool(value: Option<&str>) -> Option<bool> {
+    value.and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    })
 }
 
 fn default_bounded_usize(

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -204,10 +204,9 @@ struct PublicationQualificationHook {
 impl PublicationQualificationHook {
     #[cfg(not(feature = "test-support"))]
     fn from_environment() -> Result<Option<Self>> {
-        Self::from_environment_values(
-            std::env::var_os(EMBEDDING_QUALIFICATION_DIR_ENV),
-            std::env::var(EMBEDDING_QUALIFICATION_NONCE_ENV).ok(),
-        )
+        let gate = crate::per_user_embedding::qualification_gate_environment();
+        let nonce = gate.nonce_string();
+        Self::from_environment_values(gate.directory, nonce)
     }
 
     fn from_environment_values(

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -59,7 +59,8 @@ pub use codestory_llama_sys::{
 pub use config::{
     DEFAULT_AGENT_RUN_ID, EmbeddingRuntimeConfig, RetrievalRuntimeConfig, SidecarLayout,
     SidecarProcessDefaults, SidecarProfile, SidecarRuntimeConfig, SidecarRuntimeDefaults,
-    SidecarRuntimeOverrides, SummaryRuntimeConfig, sidecar_process_defaults, user_cache_root,
+    SidecarRuntimeOverrides, SummaryRuntimeConfig, hybrid_retrieval_enabled_from_process_env,
+    retrieval_runtime_config_from_process_env, sidecar_process_defaults, user_cache_root,
 };
 #[cfg(feature = "test-support")]
 pub use config::{
@@ -134,9 +135,10 @@ pub use per_user_embedding::{
     PER_USER_EMBEDDING_SERVER_IDLE_TIMEOUT_MS, PER_USER_EMBEDDING_SERVER_PROOF_MARKER,
     PER_USER_EMBEDDING_SERVER_SNAPSHOT_SCHEMA_VERSION, PerUserEmbeddingClient,
     PerUserEmbeddingError, PerUserEmbeddingResidencyLease, PerUserEmbeddingServerConfig,
-    embedding_capacity_pressure, embedding_qualification_watchdog_marker_filename,
-    embedding_retry_state, install_embedding_client_transport,
-    install_embedding_client_transport_factory, run_per_user_embedding_qualification,
+    QualificationGateEnvironment, embedding_capacity_pressure,
+    embedding_qualification_watchdog_marker_filename, embedding_retry_state,
+    install_embedding_client_transport, install_embedding_client_transport_factory,
+    qualification_gate_environment, run_per_user_embedding_qualification,
     run_per_user_embedding_server,
 };
 pub use planner::{PlannedStage, RetrievalPlan, RetrievalStageKind, plan_query};

--- a/crates/codestory-retrieval/src/per_user_embedding.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding.rs
@@ -22,6 +22,7 @@ pub use client::{
 pub use qualification_control::{
     EmbeddingQualificationAttemptResult, EmbeddingQualificationOperationResult,
     EmbeddingQualificationParameters, EmbeddingQualificationRequest, EmbeddingQualificationResult,
+    QualificationGateEnvironment, qualification_gate_environment,
     run_per_user_embedding_qualification,
 };
 pub use qualification_worker::{

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control.rs
@@ -32,6 +32,44 @@ pub(super) use server::{
     write_server_qualification_event,
 };
 
+/// The qualification gate credentials, exactly as the process environment
+/// carries them.
+///
+/// The gate spans four processes — the CLI that spawns a qualification run, the
+/// worker it spawns, the embedding server, and this control path — and each
+/// applies its own admission rules to the same pair. Those rules differ on
+/// purpose (the worker demands an absolute existing directory; the server
+/// pins it by native identity), but the *reading* is one act, and this is where
+/// it happens: `CODESTORY_EMBED_QUALIFICATION_DIR` and
+/// `CODESTORY_EMBED_QUALIFICATION_NONCE` are declared to this file and read
+/// nowhere else. Values are returned unvalidated and untrimmed so every
+/// consumer keeps the validation it already had.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QualificationGateEnvironment {
+    /// Raw `CODESTORY_EMBED_QUALIFICATION_DIR`.
+    pub directory: Option<std::ffi::OsString>,
+    /// Raw `CODESTORY_EMBED_QUALIFICATION_NONCE`.
+    pub nonce: Option<std::ffi::OsString>,
+}
+
+impl QualificationGateEnvironment {
+    /// The nonce as `std::env::var` would have produced it: absent when unset
+    /// or not valid Unicode.
+    pub fn nonce_string(&self) -> Option<String> {
+        self.nonce
+            .as_ref()
+            .and_then(|nonce| nonce.clone().into_string().ok())
+    }
+}
+
+/// Read the qualification gate credentials from the process environment.
+pub fn qualification_gate_environment() -> QualificationGateEnvironment {
+    QualificationGateEnvironment {
+        directory: std::env::var_os(config_registry::EMBED_QUALIFICATION_DIR_ENV),
+        nonce: std::env::var_os(config_registry::EMBED_QUALIFICATION_NONCE_ENV),
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EmbeddingQualificationRequest {
@@ -239,11 +277,13 @@ fn qualification_operation(
 }
 
 fn validate_qualification_gate(request: &EmbeddingQualificationRequest) -> Result<()> {
-    let directory = std::env::var_os(config_registry::EMBED_QUALIFICATION_DIR_ENV)
+    let gate = qualification_gate_environment();
+    let raw_nonce = gate.nonce_string();
+    let directory = gate
+        .directory
         .filter(|value| !value.is_empty())
         .ok_or_else(|| anyhow!("embedding_qualification_gate_closed"))?;
-    let nonce = std::env::var(config_registry::EMBED_QUALIFICATION_NONCE_ENV)
-        .ok()
+    let nonce = raw_nonce
         .filter(|value| !value.is_empty())
         .ok_or_else(|| anyhow!("embedding_qualification_gate_closed"))?;
     if !PathBuf::from(directory).is_dir() || request.nonce_sha256 != hex_sha256(nonce.as_bytes()) {

--- a/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/configuration.rs
+++ b/crates/codestory-retrieval/src/per_user_embedding/qualification_control/server/configuration.rs
@@ -5,8 +5,8 @@ use super::filesystem::{
     NativeFileIdentity, native_file_identity, native_path_identity,
     validate_private_qualification_directory_metadata,
 };
+use crate::per_user_embedding::qualification_control::qualification_gate_environment;
 use anyhow::{Context, Result, bail};
-use codestory_contracts::config_registry;
 use std::fs;
 #[cfg(unix)]
 use std::fs::{File, OpenOptions};
@@ -24,10 +24,9 @@ pub(in crate::per_user_embedding) struct PinnedQualificationDirectory {
 
 pub(in crate::per_user_embedding) fn server_qualification_control_from_env()
 -> Result<Option<ServerQualificationControl>> {
-    server_qualification_control_from_values(
-        std::env::var_os(config_registry::EMBED_QUALIFICATION_DIR_ENV),
-        std::env::var(config_registry::EMBED_QUALIFICATION_NONCE_ENV).ok(),
-    )
+    let gate = qualification_gate_environment();
+    let nonce = gate.nonce_string();
+    server_qualification_control_from_values(gate.directory, nonce)
 }
 
 pub(in crate::per_user_embedding) fn server_qualification_control_from_values(

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -29,7 +29,8 @@ pub const EMBEDDING_DIM: usize = codestory_retrieval::RETRIEVAL_EMBEDDING_DIM;
 const SEARCH_WRITER_HEAP_BYTES: usize = 20_000_000;
 const EMBEDDING_PROFILE: &str = "coderank-embed";
 const EMBEDDING_MODEL_ID: &str = "nomic-ai/CodeRankEmbed";
-pub use codestory_contracts::config_registry::STORED_VECTOR_ENCODING_ENV;
+#[cfg(test)]
+use codestory_contracts::config_registry::STORED_VECTOR_ENCODING_ENV;
 pub const SYMBOL_FULL_TEXT_INDEX_ENV: &str = "CODESTORY_SYMBOL_FULL_TEXT_INDEX";
 #[cfg(test)]
 const SEMANTIC_QUANTIZED_RESCORE_MULTIPLIER: usize = 4;
@@ -161,62 +162,37 @@ impl HybridSearchConfig {
     }
 }
 
-#[cfg(test)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StoredVectorEncoding {
-    Float32,
-    Int8,
-    Uint8,
-    Binary,
-    Ubinary,
-}
-
-#[cfg(test)]
-impl StoredVectorEncoding {
-    fn from_env() -> Result<Self> {
-        match std::env::var(STORED_VECTOR_ENCODING_ENV)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str()
-        {
-            "" | "float32" | "none" => Ok(Self::Float32),
-            "int8" => Ok(Self::Int8),
-            "uint8" => Ok(Self::Uint8),
-            "binary" => Ok(Self::Binary),
-            "ubinary" => Ok(Self::Ubinary),
-            other => bail!("unsupported stored vector encoding `{other}`"),
-        }
-    }
-
-    fn quantize(self, values: &[f32]) -> Option<QuantizedEmbedding> {
-        match self {
-            Self::Float32 => None,
-            Self::Int8 => Some(QuantizedEmbedding::Int8(
-                values
-                    .iter()
-                    .map(|value| (value * 127.0).round().clamp(-127.0, 127.0) as i8)
-                    .collect(),
-            )),
-            Self::Uint8 => Some(QuantizedEmbedding::Uint8(
-                values
-                    .iter()
-                    .map(|value| ((value + 1.0) * 127.5).round().clamp(0.0, 255.0) as u8)
-                    .collect(),
-            )),
-            Self::Binary => Some(QuantizedEmbedding::Binary(pack_sign_bits(values))),
-            Self::Ubinary => Some(QuantizedEmbedding::Ubinary(pack_sign_bits(values))),
-        }
-    }
-}
-
+/// In-memory mirror of a vector the store persisted quantized.
+///
+/// The prefilter can only model encodings the store can actually write, and the
+/// store writes exactly float32 or compact scaled int8 — so the encoding this
+/// path branches on is [`codestory_store::StoredVectorEncoding`], read once by
+/// its owner, rather than a second interpretation of
+/// `CODESTORY_STORED_VECTOR_ENCODING` here. The interpretation this replaces
+/// accepted `uint8`, `binary` and `ubinary` and rejected anything else, none of
+/// which the store has ever honoured: it would have quantized the prefilter to
+/// a width the persisted blobs were not in, and failed a run for a value the
+/// encoder silently treats as float32.
 #[cfg(test)]
 #[derive(Debug, Clone)]
 enum QuantizedEmbedding {
     Int8(Vec<i8>),
-    Uint8(Vec<u8>),
-    Binary(PackedSignBits),
-    Ubinary(PackedSignBits),
+}
+
+#[cfg(test)]
+fn quantize_for_prefilter(
+    encoding: codestory_store::StoredVectorEncoding,
+    values: &[f32],
+) -> Option<QuantizedEmbedding> {
+    match encoding {
+        codestory_store::StoredVectorEncoding::Float32 => None,
+        codestory_store::StoredVectorEncoding::Int8 => Some(QuantizedEmbedding::Int8(
+            values
+                .iter()
+                .map(|value| (value * 127.0).round().clamp(-127.0, 127.0) as i8)
+                .collect(),
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -228,83 +204,8 @@ impl QuantizedEmbedding {
                 .zip(values)
                 .map(|(query, doc)| query * (*doc as f32 / 127.0))
                 .sum(),
-            Self::Uint8(values) if values.len() == query.len() => query
-                .iter()
-                .zip(values)
-                .map(|(query, doc)| query * ((*doc as f32 / 127.5) - 1.0))
-                .sum(),
-            Self::Binary(bits) => signed_binary_cosine(query, bits),
-            Self::Ubinary(bits) => unsigned_binary_cosine(query, bits),
-            _ => 0.0,
+            Self::Int8(_) => 0.0,
         }
-    }
-}
-
-#[cfg(test)]
-#[derive(Debug, Clone)]
-struct PackedSignBits {
-    bytes: Vec<u8>,
-    len: usize,
-    positives: usize,
-}
-
-#[cfg(test)]
-fn pack_sign_bits(values: &[f32]) -> PackedSignBits {
-    let mut bits = PackedSignBits {
-        bytes: vec![0; values.len().div_ceil(8)],
-        len: values.len(),
-        positives: 0,
-    };
-    for (index, value) in values.iter().enumerate() {
-        if *value >= 0.0 {
-            bits.bytes[index / 8] |= 1 << (index % 8);
-            bits.positives += 1;
-        }
-    }
-    bits
-}
-
-#[cfg(test)]
-fn sign_bit(bits: &PackedSignBits, index: usize) -> bool {
-    bits.bytes
-        .get(index / 8)
-        .is_some_and(|byte| byte & (1 << (index % 8)) != 0)
-}
-
-#[cfg(test)]
-fn signed_binary_cosine(query: &[f32], bits: &PackedSignBits) -> f32 {
-    if query.len() != bits.len || bits.len == 0 {
-        return 0.0;
-    }
-    query
-        .iter()
-        .enumerate()
-        .map(|(index, value)| {
-            if (*value >= 0.0) == sign_bit(bits, index) {
-                1_i32
-            } else {
-                -1
-            }
-        })
-        .sum::<i32>() as f32
-        / bits.len as f32
-}
-
-#[cfg(test)]
-fn unsigned_binary_cosine(query: &[f32], bits: &PackedSignBits) -> f32 {
-    if query.len() != bits.len || bits.len == 0 {
-        return 0.0;
-    }
-    let positives = query.iter().filter(|value| **value >= 0.0).count();
-    let intersection = query
-        .iter()
-        .enumerate()
-        .filter(|(index, value)| **value >= 0.0 && sign_bit(bits, *index))
-        .count();
-    if positives == 0 || bits.positives == 0 {
-        0.0
-    } else {
-        intersection as f32 / ((positives * bits.positives) as f32).sqrt()
     }
 }
 
@@ -377,7 +278,7 @@ pub struct SearchEngine {
     quantized_llm_docs: HashMap<NodeId, QuantizedEmbedding>,
     embedding_runtime: Option<EmbeddingRuntime>,
     #[cfg(test)]
-    stored_vector_encoding: StoredVectorEncoding,
+    stored_vector_encoding: codestory_store::StoredVectorEncoding,
     full_text_index_enabled: bool,
     #[cfg(test)]
     query_embedding_cache: HashMap<String, Vec<f32>>,
@@ -646,7 +547,7 @@ impl SearchEngine {
             quantized_llm_docs: HashMap::new(),
             embedding_runtime: None,
             #[cfg(test)]
-            stored_vector_encoding: StoredVectorEncoding::from_env()?,
+            stored_vector_encoding: codestory_store::stored_vector_encoding(),
             full_text_index_enabled: symbol_full_text_index_enabled_from_env(),
             #[cfg(test)]
             query_embedding_cache: HashMap::new(),
@@ -876,7 +777,9 @@ impl SearchEngine {
         let node_id = doc.node_id;
         #[cfg(test)]
         {
-            if let Some(quantized) = self.stored_vector_encoding.quantize(&doc.embedding) {
+            if let Some(quantized) =
+                quantize_for_prefilter(self.stored_vector_encoding, &doc.embedding)
+            {
                 self.quantized_llm_docs.insert(node_id, quantized);
             } else {
                 self.quantized_llm_docs.remove(&node_id);
@@ -1281,7 +1184,7 @@ pub(crate) struct HybridSearchState {
     symbols: Arc<Vec<(Utf32String, NodeId)>>,
     llm_docs: Arc<HashMap<NodeId, LlmSearchDoc>>,
     quantized_llm_docs: Arc<HashMap<NodeId, QuantizedEmbedding>>,
-    stored_vector_encoding: StoredVectorEncoding,
+    stored_vector_encoding: codestory_store::StoredVectorEncoding,
 }
 
 #[cfg(test)]
@@ -1322,7 +1225,9 @@ impl HybridSearchState {
             return Vec::new();
         }
 
-        let mut scored = if self.stored_vector_encoding == StoredVectorEncoding::Float32 {
+        let mut scored = if self.stored_vector_encoding
+            == codestory_store::StoredVectorEncoding::Float32
+        {
             self.llm_docs
                 .par_iter()
                 .map(|(_, doc)| {
@@ -2122,7 +2027,10 @@ mod tests {
         let _guard = EnvGuard::set(STORED_VECTOR_ENCODING_ENV, "int8");
 
         let mut engine = SearchEngine::new(None)?;
-        assert_eq!(engine.stored_vector_encoding, StoredVectorEncoding::Int8);
+        assert_eq!(
+            engine.stored_vector_encoding,
+            codestory_store::StoredVectorEncoding::Int8
+        );
         engine.index_nodes(vec![
             (NodeId(20), "auth_policy".to_string()),
             (NodeId(21), "theme_tokens".to_string()),
@@ -2165,6 +2073,44 @@ mod tests {
 
         assert!(!hits.is_empty());
         assert_eq!(hits[0].node_id, NodeId(20));
+        Ok(())
+    }
+
+    #[test]
+    fn quantized_prefilter_matches_what_the_store_actually_persisted() -> Result<()> {
+        let _lock = crate::process_env_test_lock();
+        // The store is the declared reader of CODESTORY_STORED_VECTOR_ENCODING
+        // and writes float32 for any value it does not recognise, so the
+        // prefilter must model float32 too. When the runtime read the variable
+        // itself it accepted `uint8` as a fourth encoding and quantized the
+        // in-memory vectors to a width no persisted blob was ever in; the
+        // durable bytes and the prefilter disagreed about the same setting.
+        let _guard = EnvGuard::set(STORED_VECTOR_ENCODING_ENV, "uint8");
+        assert_eq!(
+            codestory_store::stored_vector_encoding(),
+            codestory_store::StoredVectorEncoding::Float32,
+            "the store writes float32 for an unrecognised encoding"
+        );
+
+        let mut engine = SearchEngine::new(None)?;
+        assert_eq!(
+            engine.stored_vector_encoding,
+            codestory_store::StoredVectorEncoding::Float32
+        );
+        engine.set_embedding_runtime(EmbeddingRuntime::test_runtime());
+        engine.index_llm_symbol_docs(vec![LlmSearchDoc {
+            node_id: NodeId(40),
+            file_role: RetrievalFileRole::Source,
+            doc_text: "authorization policy permission validation".to_string(),
+            embedding: embed_text_with_hash_projection(
+                "authorization policy permission validation",
+                EMBEDDING_DIM,
+            ),
+        }]);
+        assert!(
+            engine.quantized_llm_docs.is_empty(),
+            "float32 storage must leave the prefilter on full-precision vectors"
+        );
         Ok(())
     }
 

--- a/crates/codestory-runtime/src/search_publication.rs
+++ b/crates/codestory-runtime/src/search_publication.rs
@@ -14,9 +14,7 @@ use super::{
     test_sidecar_runtime_from_env,
 };
 #[cfg(test)]
-use crate::semantic_projection::{
-    LLM_DOC_EMBED_BATCH_SIZE, LLM_DOC_EMBED_BATCH_SIZE_ENV, current_embedding_contract_from_env,
-};
+use crate::semantic_projection::current_embedding_contract_from_env;
 use crate::semantic_projection::{
     SEARCH_SYMBOL_STREAM_BATCH_SIZE, SearchStateBuildStats, current_embedding_contract_for_runtime,
     load_persisted_semantic_docs_for_runtime,
@@ -599,13 +597,14 @@ pub(super) fn load_persisted_search_state_for_runtime(
     })
 }
 
+/// Documents per embedding batch, as the setting's owner reads it.
+///
+/// `CODESTORY_LLM_DOC_EMBED_BATCH_SIZE` is declared to
+/// `codestory-retrieval/src/config.rs` and read there; publication takes the
+/// clamped value rather than parsing the variable again.
 #[cfg(test)]
 pub(super) fn llm_doc_embed_batch_size() -> usize {
-    std::env::var(LLM_DOC_EMBED_BATCH_SIZE_ENV)
-        .ok()
-        .and_then(|raw| raw.trim().parse::<usize>().ok())
-        .map(|value| value.clamp(1, 2_048))
-        .unwrap_or(LLM_DOC_EMBED_BATCH_SIZE)
+    codestory_retrieval::retrieval_runtime_config_from_process_env().llm_doc_embed_batch_size
 }
 
 #[cfg(test)]

--- a/crates/codestory-runtime/src/search_runtime.rs
+++ b/crates/codestory-runtime/src/search_runtime.rs
@@ -1,10 +1,10 @@
 pub(crate) use crate::search::engine::SearchEngine;
 pub use crate::search::engine::{
     EmbeddingProfileContract, EmbeddingRuntimeAvailability, HybridSearchConfig, HybridSearchHit,
-    LlmSearchDoc, STORED_VECTOR_ENCODING_ENV, embedding_profile_contract_from_config,
-    embedding_profile_contract_from_env, embedding_runtime_availability_from_config,
-    embedding_runtime_availability_from_env,
+    LlmSearchDoc, embedding_profile_contract_from_config, embedding_profile_contract_from_env,
+    embedding_runtime_availability_from_config, embedding_runtime_availability_from_env,
 };
+pub use codestory_contracts::config_registry::STORED_VECTOR_ENCODING_ENV;
 
 pub mod embedding {
     pub use crate::search::engine::EmbeddingRuntime;
@@ -19,7 +19,7 @@ pub mod lexical {
 }
 
 pub mod model_config {
-    pub use crate::search::engine::STORED_VECTOR_ENCODING_ENV;
+    pub use codestory_contracts::config_registry::STORED_VECTOR_ENCODING_ENV;
 }
 
 pub mod semantic {

--- a/crates/codestory-runtime/src/semantic_projection.rs
+++ b/crates/codestory-runtime/src/semantic_projection.rs
@@ -369,8 +369,6 @@ pub(super) const SEMANTIC_NODE_STREAM_BATCH_SIZE: usize = 4_096;
 pub(super) const SEMANTIC_EDGE_STREAM_BATCH_SIZE: usize = 4_096;
 pub(super) const LLM_DOC_RELOAD_BATCH_SIZE: usize = 512;
 #[cfg(test)]
-pub(super) const LLM_DOC_EMBED_BATCH_SIZE: usize = 128;
-#[cfg(test)]
 pub(super) use codestory_contracts::config_registry::LLM_DOC_EMBED_BATCH_SIZE_ENV;
 #[cfg(test)]
 pub(super) use codestory_contracts::config_registry::SEMANTIC_DOC_ALIAS_MODE_ENV;
@@ -384,8 +382,6 @@ pub(super) const SEMANTIC_DOC_DEFAULT_MAX_TOKENS: usize = 128;
 pub(super) use codestory_contracts::config_registry::SEMANTIC_STREAM_PENDING_DOCS_ENV;
 #[cfg(test)]
 pub(super) use codestory_contracts::config_registry::SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV;
-#[cfg(test)]
-pub(super) const SEMANTIC_STREAM_SORT_WINDOW_BATCHES: usize = 1;
 pub(super) const SEMANTIC_POLICY_VERSION: &str = codestory_retrieval::SEMANTIC_POLICY_VERSION;
 pub(super) const LEGACY_SEMANTIC_PROJECTION_SCHEMA_VERSION: u32 = 29;
 pub(super) const LEGACY_OVERSIZED_SOURCE_POLICY_VERSION: &str = "oversized-source-v1";
@@ -556,9 +552,23 @@ pub(super) fn semantic_doc_stats_match_contract(
         && stats.semantic_policy_version.as_deref() == Some(SEMANTIC_POLICY_VERSION)
 }
 
+/// The retrieval-owned semantic settings for this process.
+///
+/// Every `*_from_env` accessor below goes through here. The settings are
+/// declared to `codestory-retrieval/src/config.rs`, which reads and clamps
+/// them; the runtime interprets the resulting *values*, never the variables. A
+/// second parse here is how a clamp drifts: this file used to reject
+/// `CODESTORY_SEMANTIC_DOC_MAX_TOKENS=0` back to the default while the owner
+/// clamped it to the floor of 16, so the same environment described two
+/// different token budgets depending on which code asked.
+#[cfg(test)]
+fn retrieval_settings() -> codestory_retrieval::RetrievalRuntimeConfig {
+    codestory_retrieval::retrieval_runtime_config_from_process_env()
+}
+
 #[cfg(test)]
 pub(super) fn semantic_doc_scope_from_env() -> SemanticDocScope {
-    semantic_doc_scope_from_value(&std::env::var(SEMANTIC_DOC_SCOPE_ENV).unwrap_or_default())
+    semantic_doc_scope_from_value(&retrieval_settings().semantic_doc_scope)
 }
 
 pub(super) fn semantic_doc_scope_from_value(value: &str) -> SemanticDocScope {
@@ -570,9 +580,7 @@ pub(super) fn semantic_doc_scope_from_value(value: &str) -> SemanticDocScope {
 
 #[cfg(test)]
 pub(super) fn semantic_doc_alias_mode_from_env() -> SemanticDocAliasMode {
-    semantic_doc_alias_mode_from_value(
-        &std::env::var(SEMANTIC_DOC_ALIAS_MODE_ENV).unwrap_or_default(),
-    )
+    semantic_doc_alias_mode_from_value(&retrieval_settings().semantic_doc_alias_mode)
 }
 
 pub(super) fn semantic_doc_alias_mode_from_value(value: &str) -> SemanticDocAliasMode {
@@ -589,33 +597,17 @@ pub(super) fn semantic_doc_alias_mode_from_value(value: &str) -> SemanticDocAlia
 
 #[cfg(test)]
 pub(super) fn semantic_doc_max_tokens_from_env() -> usize {
-    std::env::var(SEMANTIC_DOC_MAX_TOKENS_ENV)
-        .ok()
-        .and_then(|raw| raw.trim().parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .map(|value| value.clamp(16, 8_192))
-        .unwrap_or(SEMANTIC_DOC_DEFAULT_MAX_TOKENS)
+    retrieval_settings().semantic_doc_max_tokens
 }
 
 #[cfg(test)]
 pub(super) fn stream_pending_llm_symbol_docs_from_env() -> bool {
-    !matches!(
-        std::env::var(SEMANTIC_STREAM_PENDING_DOCS_ENV)
-            .unwrap_or_else(|_| "true".to_string())
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    retrieval_settings().stream_pending_docs
 }
 
 #[cfg(test)]
 pub(super) fn semantic_stream_sort_window_batches_from_env() -> usize {
-    std::env::var(SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV)
-        .ok()
-        .and_then(|raw| raw.trim().parse::<usize>().ok())
-        .map(|value| value.clamp(1, 16))
-        .unwrap_or(SEMANTIC_STREAM_SORT_WINDOW_BATCHES)
+    retrieval_settings().stream_sort_window_batches
 }
 
 pub(super) fn llm_indexable_kind_for_scope(

--- a/crates/codestory-runtime/src/support.rs
+++ b/crates/codestory-runtime/src/support.rs
@@ -12,19 +12,16 @@ pub(crate) use codestory_contracts::config_registry::HYBRID_RETRIEVAL_ENABLED_EN
 pub(crate) const SEMANTIC_FILE_TEXT_MAX_BYTES: u64 = 1_000_000;
 pub(crate) const SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES: usize = 64 * 1_024 * 1_024;
 
+/// Whether hybrid lexical/semantic ranking is on for this process.
+///
+/// `CODESTORY_HYBRID_RETRIEVAL_ENABLED` is declared to
+/// `codestory-retrieval/src/config.rs`, which is where the value is read and
+/// interpreted; the runtime asks rather than parsing the variable a second
+/// time. Query paths that already hold a `SidecarRuntimeConfig` should prefer
+/// `runtime.retrieval.hybrid_enabled`, which additionally honours the
+/// `.codestory.toml` override.
 pub(crate) fn hybrid_retrieval_enabled() -> bool {
-    env_flag_enabled(HYBRID_RETRIEVAL_ENABLED_ENV, true)
-}
-
-fn env_flag_enabled(var_name: &str, default: bool) -> bool {
-    match std::env::var(var_name) {
-        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
-            "1" | "true" | "yes" | "on" => true,
-            "0" | "false" | "no" | "off" => false,
-            _ => default,
-        },
-        Err(_) => default,
-    }
+    codestory_retrieval::hybrid_retrieval_enabled_from_process_env()
 }
 
 #[cfg(test)]

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -626,6 +626,45 @@ fn semantic_doc_token_budget_defaults_to_safe_window() {
     assert!(semantic_doc_shape_contract().contains("max_tokens=128"));
 }
 
+#[test]
+fn semantic_doc_token_budget_matches_the_owning_module_at_the_clamp_floor() {
+    let _lock = process_env_test_lock();
+    // The setting is declared to codestory-retrieval/src/config.rs, which
+    // clamps a below-floor request up to 16. The runtime used to read the
+    // variable itself and reject a zero back to the 128-token default, so the
+    // same environment described a 16-token budget to publication planning and
+    // a 128-token budget to the projection that wrote the docs.
+    let _env = EnvGuard::set(SEMANTIC_DOC_MAX_TOKENS_ENV, "0");
+
+    let owner = codestory_retrieval::retrieval_runtime_config_from_process_env();
+    assert_eq!(owner.semantic_doc_max_tokens, 16);
+    assert_eq!(semantic_doc_max_tokens_from_env(), 16);
+}
+
+#[test]
+fn hybrid_retrieval_flag_matches_the_owning_module() {
+    let _lock = process_env_test_lock();
+    // CODESTORY_HYBRID_RETRIEVAL_ENABLED is declared to
+    // codestory-retrieval/src/config.rs. The runtime's query path asks that
+    // module rather than parsing the variable with its own boolean vocabulary.
+    let _env = EnvGuard::set(HYBRID_RETRIEVAL_ENABLED_ENV, "off");
+    assert!(!crate::hybrid_retrieval_enabled());
+    assert_eq!(
+        crate::hybrid_retrieval_enabled(),
+        codestory_retrieval::retrieval_runtime_config_from_process_env().hybrid_enabled
+    );
+
+    let _env = EnvGuard::set(HYBRID_RETRIEVAL_ENABLED_ENV, "sometimes");
+    assert!(
+        crate::hybrid_retrieval_enabled(),
+        "an unreadable value falls back to the owner's default"
+    );
+    assert_eq!(
+        crate::hybrid_retrieval_enabled(),
+        codestory_retrieval::retrieval_runtime_config_from_process_env().hybrid_enabled
+    );
+}
+
 fn pending_semantic_doc_for_test(node_id: i64, doc_text: &str) -> PendingLlmSymbolDoc {
     PendingLlmSymbolDoc {
         node_id: CoreNodeId(node_id),

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -43,10 +43,11 @@ pub use storage_impl::{
     STRUCTURAL_TEXT_UNIT_MIGRATION_STATE_NATIVE, STRUCTURAL_TEXT_UNIT_PUBLICATION_SCHEMA_VERSION,
     SearchSymbolProjection, SearchSymbolProjectionDetail, SourcePolicyExclusionManifest,
     SourcePolicyExclusionPolicyIdentity, SourcePolicyExclusionRecord, Storage as Store,
-    StorageError, StorageOpenMode, StorageStats, StructuralTextArtifactCacheWrite,
-    StructuralTextProjection, StructuralTextPublicationCompatibility, StructuralTextUnit,
+    StorageError, StorageOpenMode, StorageStats, StoredVectorEncoding,
+    StructuralTextArtifactCacheWrite, StructuralTextProjection,
+    StructuralTextPublicationCompatibility, StructuralTextUnit,
     StructuralTextUnitPublicationManifest, SymbolSearchDoc, SymbolSummaryRecord,
-    structural_text_unit_digest,
+    stored_vector_encoding, structural_text_unit_digest,
 };
 
 impl Store {

--- a/crates/codestory-store/src/storage_impl/helpers.rs
+++ b/crates/codestory-store/src/storage_impl/helpers.rs
@@ -9,10 +9,27 @@ const EMBEDDING_BLOB_ENCODING_COMPACT_SCALED_INT8: u8 = 3;
 const EMBEDDING_BLOB_HEADER_LEN: usize = 9;
 const EMBEDDING_BLOB_SCALED_INT8_HEADER_LEN: usize = 13;
 
+/// Encoding used for vectors persisted in the core database.
+///
+/// The store writes the blobs, so the store decides what
+/// `CODESTORY_STORED_VECTOR_ENCODING` means, and it is the only module that
+/// reads the setting. Anything that needs to know how vectors are stored —
+/// notably the runtime's quantized semantic prefilter — takes this typed value
+/// rather than interpreting the raw string a second time. The two variants are
+/// the whole vocabulary: a value the store does not recognise is float32,
+/// because that is what the encoder then writes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EmbeddingBlobEncoding {
+pub enum StoredVectorEncoding {
     Float32,
     Int8,
+}
+
+/// The stored vector encoding this process is configured for.
+pub fn stored_vector_encoding() -> StoredVectorEncoding {
+    match std::env::var(STORED_VECTOR_ENCODING_ENV) {
+        Ok(raw) if raw.trim().eq_ignore_ascii_case("int8") => StoredVectorEncoding::Int8,
+        _ => StoredVectorEncoding::Float32,
+    }
 }
 
 pub(crate) fn numbered_placeholders(start: usize, count: usize) -> String {
@@ -55,20 +72,13 @@ pub(crate) fn deserialize_candidate_targets(
 }
 
 pub(crate) fn encode_embedding_blob(values: &[f32]) -> Vec<u8> {
-    encode_embedding_blob_with_encoding(values, embedding_blob_encoding_from_env())
+    encode_embedding_blob_with_encoding(values, stored_vector_encoding())
 }
 
-fn encode_embedding_blob_with_encoding(values: &[f32], encoding: EmbeddingBlobEncoding) -> Vec<u8> {
+fn encode_embedding_blob_with_encoding(values: &[f32], encoding: StoredVectorEncoding) -> Vec<u8> {
     match encoding {
-        EmbeddingBlobEncoding::Float32 => encode_float32_embedding_blob(values),
-        EmbeddingBlobEncoding::Int8 => encode_int8_embedding_blob(values),
-    }
-}
-
-fn embedding_blob_encoding_from_env() -> EmbeddingBlobEncoding {
-    match std::env::var(STORED_VECTOR_ENCODING_ENV) {
-        Ok(raw) if raw.trim().eq_ignore_ascii_case("int8") => EmbeddingBlobEncoding::Int8,
-        _ => EmbeddingBlobEncoding::Float32,
+        StoredVectorEncoding::Float32 => encode_float32_embedding_blob(values),
+        StoredVectorEncoding::Int8 => encode_int8_embedding_blob(values),
     }
 }
 
@@ -206,7 +216,7 @@ mod tests {
     fn test_decode_legacy_float32_embedding_blob() {
         let values = [0.25, -0.5, 0.75];
 
-        let encoded = encode_embedding_blob_with_encoding(&values, EmbeddingBlobEncoding::Float32);
+        let encoded = encode_embedding_blob_with_encoding(&values, StoredVectorEncoding::Float32);
         let decoded = decode_embedding_blob(&encoded).expect("decode legacy f32 blob");
 
         assert_eq!(encoded.len(), values.len() * std::mem::size_of::<f32>());
@@ -217,7 +227,7 @@ mod tests {
     fn test_int8_embedding_blob_is_compact_and_normalized() {
         let values = [0.6, -0.8, 0.0];
 
-        let encoded = encode_embedding_blob_with_encoding(&values, EmbeddingBlobEncoding::Int8);
+        let encoded = encode_embedding_blob_with_encoding(&values, StoredVectorEncoding::Int8);
         let decoded = decode_embedding_blob(&encoded).expect("decode int8 blob");
         let norm = decoded
             .iter()

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -45,6 +45,8 @@ use helpers::{
     numbered_placeholders, question_placeholders, serialize_candidate_targets,
 };
 
+pub use helpers::{StoredVectorEncoding, stored_vector_encoding};
+
 const SCHEMA_VERSION: u32 = 31;
 // Reserved outside the sequential migration range so a future real schema version cannot
 // accidentally be treated as an interrupted run from this release.

--- a/docs/users/configuration-reference.md
+++ b/docs/users/configuration-reference.md
@@ -31,7 +31,11 @@ CodeStory reads configuration from two places: `.codestory.toml` files and the p
 
 Warnings and errors name unknown keys. They never repeat a configured value, so a mistyped credential key cannot reach a log line.
 
-## Supported environment variables
+## Environment variables
+
+The owner column names the one source file that reads a variable. A build check rejects any other production file that reads it, so a setting has one meaning: no second module can clamp, default, or reject a value the owner accepted.
+
+### Supported environment variables
 
 Operator-facing settings. Environment values win over `.codestory.toml`.
 
@@ -63,7 +67,7 @@ Operator-facing settings. Environment values win over `.codestory.toml`.
 | `CODESTORY_SUMMARY_MODEL` | text | `crates/codestory-retrieval/src/config.rs` | Model name sent to the symbol summary endpoint. |
 | `CODESTORY_SUMMARY_TIMEOUT_SECS` | integer | `crates/codestory-retrieval/src/config.rs` | Seconds a symbol summary request may take, clamped to 1-300. |
 
-## Host-provided environment variables
+### Host-provided environment variables
 
 The plugin launcher and installed hosts set these. Setting them by hand misreports provisioning provenance.
 
@@ -95,7 +99,7 @@ The plugin launcher and installed hosts set these. Setting them by hand misrepor
 | `CODESTORY_PLUGIN_RUNTIME_CWD` | path | `crates/codestory-cli/src/stdio_transport.rs` | Working directory the runtime binary should adopt. |
 | `CODESTORY_PLUGIN_VERSION` | text | `crates/codestory-cli/src/stdio_transport.rs` | Version of the installed plugin package. |
 
-## Diagnostic environment variables
+### Diagnostic environment variables
 
 Rollout and diagnostic switches. They are not product configuration and may change or disappear without a compatibility window.
 
@@ -125,7 +129,7 @@ Rollout and diagnostic switches. They are not product configuration and may chan
 | `CODESTORY_RETRIEVAL_SHADOW` | boolean | `crates/codestory-runtime/src/agent/retrieval_primary.rs` | Runs published retrieval beside the incumbent path for comparison. |
 | `CODESTORY_SYMBOL_FULL_TEXT_INDEX` | boolean | `crates/codestory-runtime/src/search/engine.rs` | Builds the symbol full-text index (default on). |
 
-## Test-harness environment variables
+### Test-harness environment variables
 
 Only the test suites set these. They drive failure shapes that must never occur in a product run.
 


### PR DESCRIPTION
Closes #1747.

Registered settings are now read through one owning accessor: non-owners consume the owner's typed value instead of re-reading the raw setting, and the contract test enforces **reads**, not merely spellings. The known divergent readers are fixed — `CODESTORY_STORED_VECTOR_ENCODING` (runtime `search/engine.rs` vs store `storage_impl/helpers.rs`), plus runtime `semantic_projection.rs` and `search_publication.rs` reading retrieval-owned settings.

This completes what CONFIG (#1667) honestly declined to claim: that PR stripped the single-owner assertion from the registry header, the docs and the generated page because only spellings were enforced. With reads enforced, the claim is earned rather than restored by assertion.

## Review

**Merge with follow-up** — no blocking or major findings survived verification. The reviewer constructed a second independent reader of a registered setting and confirmed the contract test fails on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)