### PR TITLE
[v0.17 LINT-2] Clear the release-gate clippy failures on dev

### DIFF
--- a/crates/codestory-cli/src/app/diagnostics/doctor.rs
+++ b/crates/codestory-cli/src/app/diagnostics/doctor.rs
@@ -182,104 +182,6 @@ fn doctor_rollback_check(
     Some(doctor_check("retrieval_rollback", "warn", message))
 }
 
-#[cfg(test)]
-mod rollback_recommendation_tests {
-    use super::*;
-    use crate::app::diagnostics::sidecar::doctor_sidecar_status_from_report;
-
-    /// A real production status report, not a hand-built DTO: an absent
-    /// manifest is what a project with unusable retrieval actually renders.
-    fn unavailable_status() -> RetrievalStatusOutput {
-        let layout = codestory_retrieval::SidecarLayout::from_env();
-        doctor_sidecar_status_from_report(
-            codestory_retrieval::probe_sidecar_health(&layout, "doctor-rollback-fixture", None),
-            None,
-        )
-    }
-
-    fn live_ready_status() -> RetrievalStatusOutput {
-        let mut status = unavailable_status();
-        status.retrieval_mode = "full".into();
-        status.degraded_reason = None;
-        status
-    }
-
-    fn retained(generation: &str) -> codestory_retrieval::RetainedRollbackObservation {
-        codestory_retrieval::RetainedRollbackObservation {
-            project_id: "doctor-rollback-fixture".into(),
-            current_generation: Some("doctor-rollback-fixture-current".into()),
-            rollback_generation: Some(generation.into()),
-            rollback_verified_at_epoch_ms: 7,
-        }
-    }
-
-    #[test]
-    fn a_retained_rollback_is_recommended_when_retrieval_is_not_live_ready() {
-        let mut next_commands = vec!["codestory-cli index --project /repo --refresh full".into()];
-        let observed = retained("doctor-rollback-fixture-previous");
-
-        let check = doctor_rollback_check(
-            "/repo",
-            &unavailable_status(),
-            Some(&observed),
-            &mut next_commands,
-        )
-        .expect("a retained rollback must be reported");
-
-        assert_eq!(check.name, "retrieval_rollback");
-        assert_eq!(check.status, "warn");
-        assert!(
-            check.message.contains("doctor-rollback-fixture-previous"),
-            "the check must name the retained generation: {}",
-            check.message
-        );
-        assert_eq!(
-            next_commands.first().map(String::as_str),
-            Some("codestory-cli retrieval activate-rollback --project /repo"),
-            "the lever must be the first thing doctor tells the operator to run: {next_commands:?}"
-        );
-        assert_eq!(
-            next_commands.len(),
-            2,
-            "the existing repair guidance must survive: {next_commands:?}"
-        );
-    }
-
-    #[test]
-    fn a_live_ready_retrieval_reports_the_rollback_without_recommending_it() {
-        let mut next_commands = vec!["codestory-cli ready --project /repo --goal agent".into()];
-        let observed = retained("doctor-rollback-fixture-previous");
-
-        let check = doctor_rollback_check(
-            "/repo",
-            &live_ready_status(),
-            Some(&observed),
-            &mut next_commands,
-        )
-        .expect("a retained rollback must still be reported");
-
-        assert_eq!(check.status, "ok");
-        assert_eq!(
-            next_commands,
-            vec!["codestory-cli ready --project /repo --goal agent".to_string()],
-            "rolling a healthy generation back is a regression, not a repair"
-        );
-    }
-
-    #[test]
-    fn no_retained_rollback_produces_no_check_and_no_recommendation() {
-        let mut next_commands = vec!["codestory-cli index --project /repo --refresh full".into()];
-
-        let check = doctor_rollback_check("/repo", &unavailable_status(), None, &mut next_commands);
-
-        assert!(check.is_none(), "there is no lever to report");
-        assert_eq!(
-            next_commands,
-            vec!["codestory-cli index --project /repo --refresh full".to_string()]
-        );
-    }
-}
-
 pub(in crate::app::diagnostics) fn doctor_env_check_message(name: &str, value: &str) -> String {
     let trimmed = value.trim();
     if name.ends_with("_URL") || trimmed.contains("://") {
@@ -652,4 +554,102 @@ pub(in crate::app) fn index_next_commands(
         "codestory-cli context --project {project} --query \"<concrete target>\""
     ));
     commands
+}
+
+#[cfg(test)]
+mod rollback_recommendation_tests {
+    use super::*;
+    use crate::app::diagnostics::sidecar::doctor_sidecar_status_from_report;
+
+    /// A real production status report, not a hand-built DTO: an absent
+    /// manifest is what a project with unusable retrieval actually renders.
+    fn unavailable_status() -> RetrievalStatusOutput {
+        let layout = codestory_retrieval::SidecarLayout::from_env();
+        doctor_sidecar_status_from_report(
+            codestory_retrieval::probe_sidecar_health(&layout, "doctor-rollback-fixture", None),
+            None,
+        )
+    }
+
+    fn live_ready_status() -> RetrievalStatusOutput {
+        let mut status = unavailable_status();
+        status.retrieval_mode = "full".into();
+        status.degraded_reason = None;
+        status
+    }
+
+    fn retained(generation: &str) -> codestory_retrieval::RetainedRollbackObservation {
+        codestory_retrieval::RetainedRollbackObservation {
+            project_id: "doctor-rollback-fixture".into(),
+            current_generation: Some("doctor-rollback-fixture-current".into()),
+            rollback_generation: Some(generation.into()),
+            rollback_verified_at_epoch_ms: 7,
+        }
+    }
+
+    #[test]
+    fn a_retained_rollback_is_recommended_when_retrieval_is_not_live_ready() {
+        let mut next_commands = vec!["codestory-cli index --project /repo --refresh full".into()];
+        let observed = retained("doctor-rollback-fixture-previous");
+
+        let check = doctor_rollback_check(
+            "/repo",
+            &unavailable_status(),
+            Some(&observed),
+            &mut next_commands,
+        )
+        .expect("a retained rollback must be reported");
+
+        assert_eq!(check.name, "retrieval_rollback");
+        assert_eq!(check.status, "warn");
+        assert!(
+            check.message.contains("doctor-rollback-fixture-previous"),
+            "the check must name the retained generation: {}",
+            check.message
+        );
+        assert_eq!(
+            next_commands.first().map(String::as_str),
+            Some("codestory-cli retrieval activate-rollback --project /repo"),
+            "the lever must be the first thing doctor tells the operator to run: {next_commands:?}"
+        );
+        assert_eq!(
+            next_commands.len(),
+            2,
+            "the existing repair guidance must survive: {next_commands:?}"
+        );
+    }
+
+    #[test]
+    fn a_live_ready_retrieval_reports_the_rollback_without_recommending_it() {
+        let mut next_commands = vec!["codestory-cli ready --project /repo --goal agent".into()];
+        let observed = retained("doctor-rollback-fixture-previous");
+
+        let check = doctor_rollback_check(
+            "/repo",
+            &live_ready_status(),
+            Some(&observed),
+            &mut next_commands,
+        )
+        .expect("a retained rollback must still be reported");
+
+        assert_eq!(check.status, "ok");
+        assert_eq!(
+            next_commands,
+            vec!["codestory-cli ready --project /repo --goal agent".to_string()],
+            "rolling a healthy generation back is a regression, not a repair"
+        );
+    }
+
+    #[test]
+    fn no_retained_rollback_produces_no_check_and_no_recommendation() {
+        let mut next_commands = vec!["codestory-cli index --project /repo --refresh full".into()];
+
+        let check = doctor_rollback_check("/repo", &unavailable_status(), None, &mut next_commands);
+
+        assert!(check.is_none(), "there is no lever to report");
+        assert_eq!(
+            next_commands,
+            vec!["codestory-cli index --project /repo --refresh full".to_string()]
+        );
+    }
 }

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -2862,7 +2862,10 @@ mod tests {
             packet_claim_family(&receipt),
             Some("planned state-write evidence")
         );
-        assert_eq!(packet_supported_claim_family_count(&[receipt.clone()]), 1);
+        assert_eq!(
+            packet_supported_claim_family_count(std::slice::from_ref(&receipt)),
+            1
+        );
         assert!(packet_route_claim_node_ids("RequestedEndpoint", &[], &receipt).is_empty());
         assert!(!packet_route_claim_binds_stage(
             &["RequestedEndpoint".to_string()],

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -237,6 +237,10 @@ impl ActivationSnapshot {
     }
 }
 
+/// Test-only handshake a spawned activation worker waits on before starting.
+#[cfg(any(test, feature = "test-support"))]
+type WorkerStartGate = Arc<(Mutex<bool>, Condvar)>;
+
 #[derive(Debug, Clone)]
 pub struct ActivationRun {
     pub snapshot: ActivationSnapshot,
@@ -352,7 +356,7 @@ struct ActivationCoordinator {
     #[cfg(any(test, feature = "test-support"))]
     worker_start_count: AtomicU64,
     #[cfg(any(test, feature = "test-support"))]
-    worker_start_gate: Mutex<Option<Arc<(Mutex<bool>, Condvar)>>>,
+    worker_start_gate: Mutex<Option<WorkerStartGate>>,
     #[cfg(any(test, feature = "test-support"))]
     native_preparation_count: AtomicU64,
     #[cfg(any(test, feature = "test-support"))]


### PR DESCRIPTION
Closes #1776.

The release choreography's broad source proof runs `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (`source-proof.yml:613`). Three warnings on dev are errors under that flag, so **the gate could not pass in its current state** — worth knowing before the freeze rather than at it.

- `services.rs` — named the test-only worker start gate as `WorkerStartGate` (`type_complexity`)
- `packet_sufficiency.rs` — `std::slice::from_ref` instead of cloning a single receipt
- `doctor.rs` — moved the test module past the 373 lines that followed it

No behavior change; all three are lint-shape only. Found by a rebase agent running the full gate locally — no per-PR lane runs this configuration, which is the same coverage gap that let #1761 through earlier today.

## Proof

`cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: **0 errors** (was 3). `codestory-runtime --lib` 1065 passed, `codestory-cli --lib` 346 passed, `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)