### PR TITLE
[v0.17 REL-CI] Generate and drive the release graph with authenticated receipts (first slice)

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -8,6 +8,8 @@ import { loadReleaseClaimGraph } from "../../scripts/codestory-release-claims.mj
 import {
   LOST_RUNNER_ANNOTATION,
   MAXIMUM_RUN_ATTEMPTS,
+  RERUN_DISPATCH_SCHEMA,
+  RERUN_PLAN_SCHEMA,
 } from "./lost-runner-recovery.mjs";
 import {
   LINK_PHASE as WINDOWS_LINK_PHASE,
@@ -9961,12 +9963,35 @@ export function annotationScopeViolations(workflows) {
 export function lostRunnerRecoveryViolations(workflows, graph) {
   const violations = [];
   const policy = graph.non_claim_policy;
+  const rerunPolicy = object(graph.workflow_policy.lost_runner_rerun);
   const rerunFile = "lost-runner-rerun.yml";
   const rerun = workflows.get(rerunFile);
   add(
     violations,
     MAXIMUM_RUN_ATTEMPTS === policy.maximum_run_attempts,
     `${rerunFile} recovery bound must equal the release claim graph maximum_run_attempts`,
+  );
+  add(
+    violations,
+    rerunPolicy.workflow === rerunFile
+      && rerunPolicy.job === "rerun-lost-jobs"
+      && rerunPolicy.recovery_contract === policy.recovery_contract,
+    "the release claim graph lost_runner_rerun block must name the recovery workflow and contract",
+  );
+  add(
+    violations,
+    rerunPolicy.plan_schema === RERUN_PLAN_SCHEMA
+      && rerunPolicy.dispatch_schema === RERUN_DISPATCH_SCHEMA,
+    "the release claim graph must record the recovery plan and dispatch receipt schemas the contract emits",
+  );
+  // Two facts the recovery cannot be reasoned about without: which execution of a job the plan
+  // reads, and what one refused re-dispatch does to the others.
+  add(
+    violations,
+    rerunPolicy.selection === "latest_execution_per_job_name"
+      && rerunPolicy.dispatch_tolerance === "per_job_id"
+      && rerunPolicy.dispatch_failure === "fail_only_when_no_job_was_accepted",
+    "the release claim graph must declare latest-execution rerun selection and per-id dispatch tolerance",
   );
   add(
     violations,
@@ -10007,16 +10032,25 @@ export function lostRunnerRecoveryViolations(workflows, graph) {
     ]);
     requireStepRun(violations, rerunFile, job, "Plan the bounded rerun", [
       "node .github/scripts/lost-runner-recovery.mjs plan-rerun",
+      `--out ${rerunPolicy.plan_file}`,
     ]);
-    const dispatch = namedStep(job, "Re-dispatch only the lost jobs");
+    const dispatchStep = String(rerunPolicy.dispatch_step ?? "");
+    const dispatch = namedStep(job, dispatchStep);
     add(
       violations,
       dispatch?.if === "steps.plan.outputs.rerun == 'true'",
       `${rerunFile} re-dispatch must be gated on the classified recovery plan`,
     );
-    requireStepRun(violations, rerunFile, job, "Re-dispatch only the lost jobs", [
-      "actions/jobs/$job_id/rerun",
+    requireStepRun(violations, rerunFile, job, dispatchStep, [
+      String(rerunPolicy.dispatch_command ?? ""),
+      `--plan ${rerunPolicy.plan_file}`,
+      `--out ${rerunPolicy.dispatch_file}`,
     ]);
+    // The hosts share one machine, so a single incident loses two of them at once. A shell loop
+    // calling the API directly stops at the first refusal under `set -e` and abandons the recovery
+    // the remaining ids are still owed, so the step must delegate to the contract that records a
+    // per-id outcome and fails only when nothing at all was accepted.
+    forbidStepRun(violations, rerunFile, job, dispatchStep, ["gh api", "for job_id in"]);
     // Re-running every failed job would sweep an assertion failure back into the queue alongside
     // the lost one; the plan names ids, so the API call must be the per-job endpoint.
     add(

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -7825,11 +7825,31 @@ test("lost-runner recovery stays automatic, bounded, and blind to job names", ()
     ["blanket failed-job rerun", workflows => {
       const step = workflows.get(rerunFile).jobs["rerun-lost-jobs"].steps
         .find(({ name }) => name === "Re-dispatch only the lost jobs");
-      step.run = step.run.replace(
-        "actions/jobs/$job_id/rerun",
-        "actions/runs/$FAILED_RUN_ID/rerun-failed-jobs",
-      );
+      step.run = 'gh api --method POST "repos/$GITHUB_REPOSITORY/actions/runs/$FAILED_RUN_ID/rerun-failed-jobs"\n';
     }],
+    // The hosts share one machine, so one incident loses two of them at once. A loop that calls
+    // the API directly stops at the first refusal under `set -e` and abandons the rest of the
+    // recovery, which is the shape the tolerant dispatcher replaced.
+    ["shell-loop re-dispatch with no per-id tolerance", workflows => {
+      const step = workflows.get(rerunFile).jobs["rerun-lost-jobs"].steps
+        .find(({ name }) => name === "Re-dispatch only the lost jobs");
+      step.run = [
+        "set -euo pipefail",
+        'test -n "$JOB_IDS"',
+        'for job_id in $JOB_IDS; do',
+        '  gh api --method POST "repos/$GITHUB_REPOSITORY/actions/jobs/$job_id/rerun"',
+        "done",
+        "",
+      ].join("\n");
+    }, /must not run for job_id in/u],
+    ["re-dispatch that records no per-id receipt", workflows => {
+      const step = workflows.get(rerunFile).jobs["rerun-lost-jobs"].steps
+        .find(({ name }) => name === "Re-dispatch only the lost jobs");
+      step.run = step.run.replace(
+        /\s*--out target\/lost-runner\/rerun-dispatch\.json/u,
+        "",
+      );
+    }, /must run --out target\/lost-runner\/rerun-dispatch\.json/u],
     ["ungated re-dispatch", workflows => {
       delete workflows.get(rerunFile).jobs["rerun-lost-jobs"].steps
         .find(({ name }) => name === "Re-dispatch only the lost jobs").if;
@@ -7893,10 +7913,14 @@ test("lost-runner recovery stays automatic, bounded, and blind to job names", ()
       });
     }],
   ];
-  for (const [label, mutate] of mutations) {
+  for (const [label, mutate, expected] of mutations) {
     const workflows = loadWorkflows();
     mutate(workflows);
-    assert.notDeepEqual(validateWorkflows(workflows), [], label);
+    const violations = validateWorkflows(workflows);
+    assert.notDeepEqual(violations, [], label);
+    // Some mutations name the rule that has to catch them, so a rule that stopped looking cannot
+    // hide behind an unrelated violation the same edit happened to trip.
+    if (expected) assert.match(violations.join("\n"), expected, label);
   }
 
   // A recovery bound that drifts from the release claim graph is caught even when the workflows
@@ -7907,6 +7931,22 @@ test("lost-runner recovery stays automatic, bounded, and blind to job names", ()
   const rephrased = structuredClone(graph);
   rephrased.non_claim_policy.annotation = "The runner went away.";
   assert.notDeepEqual(lostRunnerRecoveryViolations(loadWorkflows(), rephrased), []);
+
+  // The two recovery properties a reader cannot recover from the YAML alone -- which execution of
+  // a job the plan reads, and what one refused re-dispatch does to the others -- are graph facts,
+  // so the graph losing them is a violation even with the workflows untouched.
+  for (const drift of [
+    (value) => { value.workflow_policy.lost_runner_rerun.selection = "every_collected_execution"; },
+    (value) => { value.workflow_policy.lost_runner_rerun.dispatch_tolerance = "abort_on_first_refusal"; },
+    (value) => { value.workflow_policy.lost_runner_rerun.dispatch_failure = "never_fail"; },
+    (value) => { value.workflow_policy.lost_runner_rerun.plan_schema = "codestory.lost-runner-rerun-plan/v1"; },
+    (value) => { value.workflow_policy.lost_runner_rerun.dispatch_schema = "codestory.something-else/v1"; },
+    (value) => { value.workflow_policy.lost_runner_rerun.recovery_contract = ".github/scripts/other.mjs"; },
+  ]) {
+    const mutated = structuredClone(graph);
+    drift(mutated);
+    assert.notDeepEqual(lostRunnerRecoveryViolations(loadWorkflows(), mutated), []);
+  }
 });
 
 // Catalog publication is delivery, not a release gate. Relaxing a gate is exactly where a vacuous

--- a/.github/scripts/lost-runner-recovery.mjs
+++ b/.github/scripts/lost-runner-recovery.mjs
@@ -13,6 +13,7 @@
 // on every step and a log blob. This module keys on the signature, never on job names, so that a
 // renamed or newly added proof job cannot silently become retryable.
 
+import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync, appendFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,8 +29,16 @@ export const MAXIMUM_RUN_ATTEMPTS = 2;
 
 export const RUNNER_COMMUNICATION_LOSS = "runner_communication_loss";
 export const JOB_ASSERTION_FAILURE = "job_assertion_failure";
-export const RERUN_PLAN_SCHEMA = "codestory.lost-runner-rerun-plan/v1";
+export const RERUN_PLAN_SCHEMA = "codestory.lost-runner-rerun-plan/v2";
 export const NON_CLAIM_PLAN_SCHEMA = "codestory.accelerator-non-claim-plan/v1";
+export const RERUN_DISPATCH_SCHEMA = "codestory.lost-runner-rerun-dispatch/v1";
+
+/// Why an execution that failed is not in the re-dispatch list. Every failed execution the planner
+/// saw carries exactly one of these, so a reader of the plan never has to infer an omission.
+export const RETRY_REQUESTED = "retry_requested";
+export const RECOVERY_BOUND_REACHED = "recovery_bound_reached";
+export const SUPERSEDED_BY_LATER_EXECUTION = "superseded_by_later_execution";
+export const NOT_A_RUNNER_COMMUNICATION_LOSS = "not_a_runner_communication_loss";
 
 function fail(message) {
   throw new Error(message);
@@ -127,8 +136,40 @@ function distinctExecutions(jobs) {
   return [...byId.values()];
 }
 
-function failedJobs(jobs) {
-  return distinctExecutions(jobs).filter((job) => String(job?.conclusion ?? "") === "failure");
+/// Order two executions of the same job name. Actions allocates job ids in creation order inside a
+/// run, so the execution a re-dispatch created always ranks above the execution it replaced --
+/// whether or not the carried-forward row is re-listed under the newer attempt number. Ranking on
+/// the attempt alone answers wrongly under that second listing shape.
+function ranksAbove(candidate, incumbent, name) {
+  const candidateAttempt = positiveInteger(candidate?.run_attempt, `${name} run attempt`);
+  const incumbentAttempt = positiveInteger(incumbent?.run_attempt, `${name} run attempt`);
+  if (candidateAttempt !== incumbentAttempt) return candidateAttempt > incumbentAttempt;
+  return positiveInteger(candidate?.id, `${name} job id`)
+    > positiveInteger(incumbent?.id, `${name} job id`);
+}
+
+/// The newest execution of every job name, and the executions it superseded.
+///
+/// Recovery decisions are about *what the job is doing now*, so they are made from the newest
+/// execution only. Deciding from every execution ever collected kept a job that a later attempt
+/// already recovered in the plan forever, and named its stale, already-consumed job id.
+function latestExecutionsByName(jobs) {
+  const byName = new Map();
+  for (const job of distinctExecutions(jobs)) {
+    const name = leafJobName(job?.name);
+    const previous = byName.get(name);
+    if (previous === undefined) {
+      byName.set(name, { name, latest: job, superseded: [] });
+      continue;
+    }
+    if (ranksAbove(job, previous.latest, name)) {
+      previous.superseded.push(previous.latest);
+      previous.latest = job;
+    } else {
+      previous.superseded.push(job);
+    }
+  }
+  return [...byName.values()];
 }
 
 /// How many *executions* of one job name were lost to their runner, across every attempt collected.
@@ -147,38 +188,111 @@ export function countLostExecutions(jobs, jobName) {
     .length;
 }
 
+function executionReference(job, name) {
+  return {
+    id: positiveInteger(job?.id, `${name} job id`),
+    run_attempt: String(positiveInteger(job?.run_attempt, `${name} run attempt`)),
+    conclusion: job?.conclusion === null || job?.conclusion === undefined
+      ? null
+      : String(job.conclusion),
+  };
+}
+
 /// Decide which individual jobs to re-dispatch. Only jobs carrying the lost-runner signature are
 /// ever re-dispatched -- the plan names them one by one instead of asking Actions to rerun every
 /// failed job, so a proof that failed its own assertions is left exactly as it is and keeps the run
 /// red. No approval gate is consulted: recovery is a machine decision or it does not happen.
 ///
-/// The bound is per job, not per run: see `countLostExecutions`.
+/// Selection reads each job name's *newest* execution and nothing else. An execution a later
+/// execution superseded is already spent: re-dispatching its id asks Actions to re-run a job the
+/// run has moved past, and when the newest execution succeeded there is nothing to recover at all.
+/// Both of those used to be in the plan, so a run that failed for an unrelated reason re-dispatched
+/// an already-recovered host and led the request with a stale id.
+///
+/// The recovery bound is per job, not per run: see `countLostExecutions`.
 export function planLostRunnerRerun({ runAttempt, runConclusion, jobs }) {
   const attempt = positiveInteger(runAttempt, "run attempt");
-  const classified = failedJobs(jobs).map(classifyJobFailure);
-  const withRecoveries = classified.map((job) => ({
-    ...job,
-    lost_executions: countLostExecutions(jobs, job.name),
-  }));
-  const lost = withRecoveries.filter(({ signature }) => signature === RUNNER_COMMUNICATION_LOSS);
-  const notRetried = withRecoveries.filter(({ signature }) => signature !== RUNNER_COMMUNICATION_LOSS);
-  const retryable = lost.filter(({ lost_executions: spent }) => spent < MAXIMUM_RUN_ATTEMPTS);
+  const rows = [];
+  for (const { name, latest, superseded } of latestExecutionsByName(jobs)) {
+    const spent = countLostExecutions(jobs, name);
+    for (const stale of superseded) {
+      if (String(stale?.conclusion ?? "") !== "failure") continue;
+      rows.push({
+        ...classifyJobFailure(stale),
+        lost_executions: spent,
+        retry_decision: SUPERSEDED_BY_LATER_EXECUTION,
+        superseded_by: executionReference(latest, name),
+      });
+    }
+    if (String(latest?.conclusion ?? "") !== "failure") continue;
+    const classified = classifyJobFailure(latest);
+    const decision = classified.signature !== RUNNER_COMMUNICATION_LOSS
+      ? NOT_A_RUNNER_COMMUNICATION_LOSS
+      : spent < MAXIMUM_RUN_ATTEMPTS
+        ? RETRY_REQUESTED
+        : RECOVERY_BOUND_REACHED;
+    rows.push({ ...classified, lost_executions: spent, retry_decision: decision });
+  }
+  const lost = rows.filter(({ retry_decision: decision }) =>
+    decision === RETRY_REQUESTED || decision === RECOVERY_BOUND_REACHED);
+  const notRetried = rows.filter(({ retry_decision: decision }) =>
+    decision !== RETRY_REQUESTED && decision !== RECOVERY_BOUND_REACHED);
+  const retryable = rows.filter(({ retry_decision: decision }) => decision === RETRY_REQUESTED);
   const reason = String(runConclusion ?? "") !== "failure"
     ? "run_did_not_fail"
     : lost.length === 0
       ? "no_runner_communication_loss"
       : retryable.length === 0
         ? "recovery_bound_reached"
-        : "runner_communication_loss";
+        : RUNNER_COMMUNICATION_LOSS;
   return {
     schema: RERUN_PLAN_SCHEMA,
-    rerun: reason === "runner_communication_loss",
+    rerun: reason === RUNNER_COMMUNICATION_LOSS,
     reason,
     run_attempt: attempt,
     maximum_run_attempts: MAXIMUM_RUN_ATTEMPTS,
-    rerun_job_ids: reason === "runner_communication_loss" ? retryable.map(({ id }) => id) : [],
+    rerun_job_ids: reason === RUNNER_COMMUNICATION_LOSS
+      ? retryable.map(({ id }) => id).sort((left, right) => left - right)
+      : [],
     lost_jobs: lost,
     not_retried_jobs: notRetried,
+  };
+}
+
+/// Ask Actions to re-run each named job, one id at a time, and record what each id answered.
+///
+/// The bound this has to respect is that one refused id may not consume the recovery of the others.
+/// The release owns one host per accelerator and the hosts share a machine, so a run can lose two
+/// of them at once; a sequential loop that stops at the first non-zero exit would then recover the
+/// lowest-numbered job and silently abandon the rest. Every id therefore gets its own attempt and
+/// its own recorded outcome, and the command fails only when the recovery as a whole did not
+/// happen -- no id succeeded even though ids were named.
+export function planRerunDispatch({ jobIds, dispatch }) {
+  const ids = list(jobIds, "rerun job ids").map((id) => positiveInteger(id, "rerun job id"));
+  const results = ids.map((id) => {
+    const outcome = dispatch(id);
+    return {
+      job_id: id,
+      dispatched: outcome.dispatched === true,
+      detail: text(outcome.detail, `job ${id} dispatch detail`),
+    };
+  });
+  const dispatched = results.filter(({ dispatched: ok }) => ok);
+  const refused = results.filter(({ dispatched: ok }) => !ok);
+  return {
+    schema: RERUN_DISPATCH_SCHEMA,
+    requested_job_ids: ids,
+    dispatched_job_ids: dispatched.map(({ job_id: id }) => id),
+    refused_job_ids: refused.map(({ job_id: id }) => id),
+    results,
+    recovered: ids.length > 0 && dispatched.length > 0,
+    reason: ids.length === 0
+      ? "no_job_requested"
+      : dispatched.length === 0
+        ? "every_job_refused"
+        : refused.length === 0
+          ? "every_job_dispatched"
+          : "partially_dispatched",
   };
 }
 
@@ -286,6 +400,26 @@ function emitOutputs(entries) {
   }
 }
 
+/// One re-dispatch request. A refusal is data -- the receipt says which id Actions declined and
+/// what it said -- and never an exception, because the ids after it still have their own recovery
+/// owed to them.
+function rerunJobThroughGh(repository, jobId) {
+  const result = spawnSync(
+    "gh",
+    ["api", "--method", "POST", `repos/${repository}/actions/jobs/${jobId}/rerun`],
+    { encoding: "utf8" },
+  );
+  if (result.error) {
+    return { dispatched: false, detail: `gh_not_invoked: ${result.error.message}` };
+  }
+  if (result.status === 0) return { dispatched: true, detail: "accepted" };
+  const stderr = String(result.stderr ?? "").replace(/\s+/gu, " ").trim().slice(0, 200);
+  return {
+    dispatched: false,
+    detail: `refused_exit_${String(result.status)}: ${stderr === "" ? "no stderr" : stderr}`,
+  };
+}
+
 function parseArgs(argv) {
   const command = argv.shift();
   const values = {};
@@ -310,6 +444,33 @@ function main() {
     writeJson(values.out ?? "target/lost-runner/rerun-plan.json", plan);
     emitOutputs({ rerun: String(plan.rerun), job_ids: plan.rerun_job_ids.join(" ") });
     console.log(JSON.stringify(plan, null, 2));
+    return;
+  }
+  if (command === "dispatch-rerun") {
+    const plan = readJson(values.plan);
+    if (plan.schema !== RERUN_PLAN_SCHEMA) {
+      fail(`rerun plan must carry ${RERUN_PLAN_SCHEMA}`);
+    }
+    if (plan.rerun !== true) fail("dispatch-rerun refuses a plan that did not ask for a rerun");
+    const repository = text(
+      values.repository ?? process.env.GITHUB_REPOSITORY,
+      "repository",
+    );
+    const receipt = planRerunDispatch({
+      jobIds: plan.rerun_job_ids,
+      dispatch: (jobId) => rerunJobThroughGh(repository, jobId),
+    });
+    writeJson(values.out ?? "target/lost-runner/rerun-dispatch.json", receipt);
+    emitOutputs({
+      recovered: String(receipt.recovered),
+      dispatched_job_ids: receipt.dispatched_job_ids.join(" "),
+      refused_job_ids: receipt.refused_job_ids.join(" "),
+    });
+    console.log(JSON.stringify(receipt, null, 2));
+    for (const row of receipt.results.filter(({ dispatched }) => !dispatched)) {
+      console.error(`::error::Actions refused the rerun of job ${row.job_id}: ${row.detail}`);
+    }
+    if (!receipt.recovered) process.exitCode = 1;
     return;
   }
   if (command === "plan-non-claim") {

--- a/.github/scripts/lost-runner-recovery.test.mjs
+++ b/.github/scripts/lost-runner-recovery.test.mjs
@@ -9,11 +9,18 @@ import {
   JOB_ASSERTION_FAILURE,
   LOST_RUNNER_ANNOTATION,
   MAXIMUM_RUN_ATTEMPTS,
+  NOT_A_RUNNER_COMMUNICATION_LOSS,
+  RECOVERY_BOUND_REACHED,
+  RERUN_DISPATCH_SCHEMA,
+  RERUN_PLAN_SCHEMA,
+  RETRY_REQUESTED,
   RUNNER_COMMUNICATION_LOSS,
+  SUPERSEDED_BY_LATER_EXECUTION,
   classifyJobFailure,
   countLostExecutions,
   planAcceleratorNonClaim,
   planLostRunnerRerun,
+  planRerunDispatch,
 } from "./lost-runner-recovery.mjs";
 
 const script = fileURLToPath(new URL("./lost-runner-recovery.mjs", import.meta.url));
@@ -154,7 +161,9 @@ test("only lost jobs are re-dispatched and the recovery bound counts recoveries"
   assert.equal(assertionOnly.reason, "no_runner_communication_loss");
   assert.deepEqual(assertionOnly.rerun_job_ids, []);
 
-  // The bound is two lost executions of the same job: the second loss gets no third try.
+  // The bound is two lost executions of the same job: the second loss gets no third try. The
+  // decision is reported against the execution that is current -- the attempt-1 execution the
+  // re-dispatch already consumed is reported as superseded, never as a second pending decision.
   const bounded = planLostRunnerRerun({
     runAttempt: MAXIMUM_RUN_ATTEMPTS,
     runConclusion: "failure",
@@ -162,7 +171,14 @@ test("only lost jobs are re-dispatched and the recovery bound counts recoveries"
   });
   assert.equal(bounded.rerun, false);
   assert.equal(bounded.reason, "recovery_bound_reached");
-  assert.deepEqual(bounded.lost_jobs.map(({ lost_executions: spent }) => spent), [2, 2]);
+  assert.deepEqual(bounded.lost_jobs.map(({ id }) => id), [42]);
+  assert.deepEqual(bounded.lost_jobs.map(({ retry_decision: decision }) => decision), [
+    RECOVERY_BOUND_REACHED,
+  ]);
+  assert.deepEqual(bounded.lost_jobs.map(({ lost_executions: spent }) => spent), [2]);
+  assert.deepEqual(bounded.not_retried_jobs.map(({ id, retry_decision: decision }) => [id, decision]), [
+    [41, SUPERSEDED_BY_LATER_EXECUTION],
+  ]);
 
   // A run that reached attempt 2 for an unrelated reason has still never re-dispatched this host,
   // and the first loss of its runner is owed its one automatic recovery. Reading the run-attempt
@@ -194,6 +210,246 @@ test("only lost jobs are re-dispatched and the recovery bound counts recoveries"
   const green = planLostRunnerRerun({ runAttempt: 1, runConclusion: "success", jobs: [lostJob()] });
   assert.equal(green.rerun, false);
   assert.equal(green.reason, "run_did_not_fail");
+});
+
+// The Metal host is a second name in the same run, used wherever the point is that one host's
+// decision must not be read off another host's rows.
+function metalLostJob(overrides = {}) {
+  return lostJob({
+    id: 51,
+    name: "macos-metal-proof / Packaged Apple Silicon Metal engine",
+    ...overrides,
+  });
+}
+
+test("a job a later execution already recovered is out of the plan, and its stale id is never named", () => {
+  // The recovery worked: the host was lost at attempt 1 and reported at attempt 2. Another job
+  // then failed its own assertions, so the run as a whole is red and the planner runs again.
+  const recovered = planLostRunnerRerun({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    runConclusion: "failure",
+    jobs: [
+      lostJob(),
+      lostJob({
+        id: 43,
+        run_attempt: String(MAXIMUM_RUN_ATTEMPTS),
+        conclusion: "success",
+        annotations: [],
+        log_uploaded: true,
+        steps: [{ name: "Prove offline Linux Vulkan retrieval", conclusion: "success" }],
+      }),
+      assertionJob({ id: 77, name: "windows-vulkan-proof / Packaged Windows Vulkan engine" }),
+    ],
+  });
+  assert.equal(recovered.rerun, false);
+  assert.equal(recovered.reason, "no_runner_communication_loss");
+  assert.deepEqual(recovered.rerun_job_ids, []);
+  assert.deepEqual(recovered.lost_jobs, []);
+  const stale = recovered.not_retried_jobs.find(({ id }) => id === 41);
+  assert.equal(stale.retry_decision, SUPERSEDED_BY_LATER_EXECUTION);
+  assert.deepEqual(stale.superseded_by, { id: 43, run_attempt: "2", conclusion: "success" });
+  // The assertion failure that made the run red is still reported, and still not retried.
+  const refused = recovered.not_retried_jobs.find(({ id }) => id === 77);
+  assert.equal(refused.retry_decision, NOT_A_RUNNER_COMMUNICATION_LOSS);
+  assert.equal(refused.signature, JOB_ASSERTION_FAILURE);
+
+  // Actions also lists a carried-forward job under the newer attempt number, so the attempt alone
+  // cannot order two executions of one name. Job ids are allocated in creation order inside a run,
+  // so the execution the re-dispatch created is the higher id even when both read attempt 2.
+  const sameAttemptListing = planLostRunnerRerun({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    runConclusion: "failure",
+    jobs: [
+      lostJob({ run_attempt: String(MAXIMUM_RUN_ATTEMPTS) }),
+      lostJob({
+        id: 43,
+        run_attempt: String(MAXIMUM_RUN_ATTEMPTS),
+        conclusion: "success",
+        annotations: [],
+        log_uploaded: true,
+        steps: [{ name: "Prove offline Linux Vulkan retrieval", conclusion: "success" }],
+      }),
+      assertionJob({ id: 77, name: "windows-vulkan-proof / Packaged Windows Vulkan engine" }),
+    ],
+  });
+  assert.equal(sameAttemptListing.rerun, false);
+  assert.deepEqual(sameAttemptListing.rerun_job_ids, []);
+  assert.equal(
+    sameAttemptListing.not_retried_jobs.find(({ id }) => id === 41).retry_decision,
+    SUPERSEDED_BY_LATER_EXECUTION,
+  );
+
+  // The host was lost, re-dispatched, and then disagreed with the product on its own terms. The
+  // stale lost execution must not put the assertion failure back into the queue: a proof that ran
+  // and refused to pass is never re-dispatched, whatever an earlier execution of it looked like.
+  const recoveredIntoAssertionFailure = planLostRunnerRerun({
+    runAttempt: MAXIMUM_RUN_ATTEMPTS,
+    runConclusion: "failure",
+    jobs: [lostJob(), assertionJob({ id: 43, run_attempt: String(MAXIMUM_RUN_ATTEMPTS) })],
+  });
+  assert.equal(recoveredIntoAssertionFailure.rerun, false);
+  assert.equal(recoveredIntoAssertionFailure.reason, "no_runner_communication_loss");
+  assert.deepEqual(recoveredIntoAssertionFailure.rerun_job_ids, []);
+  assert.deepEqual(
+    recoveredIntoAssertionFailure.not_retried_jobs
+      .map(({ id, retry_decision: decision }) => [id, decision]),
+    [[41, SUPERSEDED_BY_LATER_EXECUTION], [43, NOT_A_RUNNER_COMMUNICATION_LOSS]],
+  );
+
+  // Two hosts lost in the same incident are both owed a recovery, and the request names the
+  // execution each of them is actually sitting in.
+  const both = planLostRunnerRerun({
+    runAttempt: 1,
+    runConclusion: "failure",
+    jobs: [lostJob(), metalLostJob()],
+  });
+  assert.equal(both.rerun, true);
+  assert.deepEqual(both.rerun_job_ids, [41, 51]);
+  assert.deepEqual(both.lost_jobs.map(({ retry_decision: decision }) => decision), [
+    RETRY_REQUESTED,
+    RETRY_REQUESTED,
+  ]);
+  assert.equal(both.schema, RERUN_PLAN_SCHEMA);
+});
+
+test("one refused re-dispatch does not consume the recovery the other lost hosts are owed", () => {
+  const attempted = [];
+  const partial = planRerunDispatch({
+    jobIds: [41, 51],
+    dispatch: (jobId) => {
+      attempted.push(jobId);
+      return jobId === 41
+        ? { dispatched: false, detail: "refused_exit_1: HTTP 403" }
+        : { dispatched: true, detail: "accepted" };
+    },
+  });
+  // Every named id got its own request: the refusal of the first did not end the loop.
+  assert.deepEqual(attempted, [41, 51]);
+  assert.equal(partial.schema, RERUN_DISPATCH_SCHEMA);
+  assert.equal(partial.recovered, true);
+  assert.equal(partial.reason, "partially_dispatched");
+  assert.deepEqual(partial.dispatched_job_ids, [51]);
+  assert.deepEqual(partial.refused_job_ids, [41]);
+  assert.equal(partial.results.find(({ job_id: id }) => id === 41).detail, "refused_exit_1: HTTP 403");
+
+  const none = planRerunDispatch({
+    jobIds: [41, 51],
+    dispatch: () => ({ dispatched: false, detail: "refused_exit_1: HTTP 403" }),
+  });
+  assert.equal(none.recovered, false);
+  assert.equal(none.reason, "every_job_refused");
+  assert.deepEqual(none.dispatched_job_ids, []);
+
+  const all = planRerunDispatch({
+    jobIds: [41, 51],
+    dispatch: () => ({ dispatched: true, detail: "accepted" }),
+  });
+  assert.equal(all.recovered, true);
+  assert.equal(all.reason, "every_job_dispatched");
+});
+
+function stubbedGh(script) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codestory-gh-stub-"));
+  const binary = path.join(directory, "gh");
+  writeFileSync(binary, script, { mode: 0o755 });
+  return { directory, log: path.join(directory, "calls.txt") };
+}
+
+function runDispatchCli(plan, ghScript) {
+  const { directory, log } = stubbedGh(ghScript);
+  const planPath = path.join(directory, "rerun-plan.json");
+  const outPath = path.join(directory, "rerun-dispatch.json");
+  const outputsPath = path.join(directory, "outputs.txt");
+  writeFileSync(planPath, JSON.stringify(plan));
+  writeFileSync(outputsPath, "");
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "dispatch-rerun",
+      "--plan", planPath,
+      "--repository", "TheGreenCedar/CodeStory",
+      "--out", outPath,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${directory}${path.delimiter}${process.env.PATH}`,
+        GITHUB_OUTPUT: outputsPath,
+        CODESTORY_GH_STUB_LOG: log,
+      },
+    },
+  );
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    receipt: existsSync(outPath) ? JSON.parse(readFileSync(outPath, "utf8")) : undefined,
+    outputs: readFileSync(outputsPath, "utf8"),
+    calls: existsSync(log) ? readFileSync(log, "utf8").trim().split("\n") : [],
+  };
+}
+
+test("the dispatch CLI asks Actions for every lost job separately and records what each answered", () => {
+  const plan = {
+    schema: RERUN_PLAN_SCHEMA,
+    rerun: true,
+    reason: RUNNER_COMMUNICATION_LOSS,
+    rerun_job_ids: [41, 51],
+  };
+  // The first id is refused the way Actions refuses a job it will not re-run; the second must
+  // still be asked for, and the recovery as a whole must count as having happened.
+  const partial = runDispatchCli(
+    plan,
+    [
+      "#!/usr/bin/env bash",
+      'printf "%s\\n" "$*" >> "$CODESTORY_GH_STUB_LOG"',
+      'case "$*" in',
+      '  *"/jobs/41/rerun"*) echo "HTTP 403: cannot re-run this job" >&2; exit 1 ;;',
+      '  *) echo "{}" ;;',
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  assert.equal(partial.status, 0);
+  // The per-job endpoint, named id by id: re-running every failed job would sweep an assertion
+  // failure back into the queue alongside the lost one.
+  assert.deepEqual(partial.calls, [
+    "api --method POST repos/TheGreenCedar/CodeStory/actions/jobs/41/rerun",
+    "api --method POST repos/TheGreenCedar/CodeStory/actions/jobs/51/rerun",
+  ]);
+  assert.equal(partial.receipt.recovered, true);
+  assert.deepEqual(partial.receipt.dispatched_job_ids, [51]);
+  assert.match(partial.receipt.results.find(({ job_id: id }) => id === 41).detail, /HTTP 403/u);
+  assert.match(partial.outputs, /recovered=true/u);
+  assert.match(partial.outputs, /dispatched_job_ids=51/u);
+
+  // Nothing was recovered, so the recovery workflow itself has to go red.
+  const refused = runDispatchCli(
+    plan,
+    ["#!/usr/bin/env bash", 'printf "%s\\n" "$*" >> "$CODESTORY_GH_STUB_LOG"', "exit 1", ""].join("\n"),
+  );
+  assert.equal(refused.status, 1);
+  assert.equal(refused.calls.length, 2);
+  assert.equal(refused.receipt.recovered, false);
+  assert.equal(refused.receipt.reason, "every_job_refused");
+
+  // A plan that did not ask for a rerun can never be turned into re-dispatch requests.
+  const notPlanned = runDispatchCli(
+    { ...plan, rerun: false, reason: "no_runner_communication_loss", rerun_job_ids: [] },
+    ["#!/usr/bin/env bash", 'printf "%s\\n" "$*" >> "$CODESTORY_GH_STUB_LOG"', "echo '{}'", ""].join("\n"),
+  );
+  assert.notEqual(notPlanned.status, 0);
+  assert.deepEqual(notPlanned.calls, []);
+  assert.match(notPlanned.stderr, /did not ask for a rerun/u);
+
+  // A plan written by an older contract is refused rather than reinterpreted.
+  const staleSchema = runDispatchCli(
+    { ...plan, schema: "codestory.lost-runner-rerun-plan/v1" },
+    ["#!/usr/bin/env bash", 'printf "%s\\n" "$*" >> "$CODESTORY_GH_STUB_LOG"', "echo '{}'", ""].join("\n"),
+  );
+  assert.notEqual(staleSchema.status, 0);
+  assert.deepEqual(staleSchema.calls, []);
 });
 
 test("a non-claim is reachable only from a spent retry bound on a lost runner", () => {

--- a/.github/workflows/lost-runner-rerun.yml
+++ b/.github/workflows/lost-runner-rerun.yml
@@ -63,18 +63,20 @@ jobs:
             --input target/lost-runner/rerun-input.json \
             --out target/lost-runner/rerun-plan.json
 
+      # One refused id may not consume the recovery of the others: the hosts share a machine, so a
+      # single incident can lose two of them at once. The dispatcher asks for every named id
+      # separately, records what each one answered, and fails only when no id was accepted at all.
       - name: Re-dispatch only the lost jobs
         if: steps.plan.outputs.rerun == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          JOB_IDS: ${{ steps.plan.outputs.job_ids }}
         shell: bash
         run: |
           set -euo pipefail
-          test -n "$JOB_IDS"
-          for job_id in $JOB_IDS; do
-            gh api --method POST "repos/$GITHUB_REPOSITORY/actions/jobs/$job_id/rerun"
-          done
+          node .github/scripts/lost-runner-recovery.mjs dispatch-rerun \
+            --plan target/lost-runner/rerun-plan.json \
+            --repository "$GITHUB_REPOSITORY" \
+            --out target/lost-runner/rerun-dispatch.json
 
       - name: Upload the recovery decision
         if: always()

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "c4af376cab0fa2ed87b6990c1af19d6b287afd1d37f40c28ea8d1e2cacb45ee9",
+    "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "c4af376cab0fa2ed87b6990c1af19d6b287afd1d37f40c28ea8d1e2cacb45ee9",
+        "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "c4af376cab0fa2ed87b6990c1af19d6b287afd1d37f40c28ea8d1e2cacb45ee9",
+        "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "ddc025969a97d5fdebd13f494f8553ab69c1527bd0f60d2733446e80406c48fc",
+  "candidate_sha256": "f0d2542d39094d6907be637c865f9a22cacc2c2b5073e3f99979282dd4c21e4c",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "c4af376cab0fa2ed87b6990c1af19d6b287afd1d37f40c28ea8d1e2cacb45ee9",
+      "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "c4af376cab0fa2ed87b6990c1af19d6b287afd1d37f40c28ea8d1e2cacb45ee9",
+      "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "c4af376cab0fa2ed87b6990c1af19d6b287afd1d37f40c28ea8d1e2cacb45ee9",
+    "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -610,6 +610,25 @@ every attempt of the run to make that count possible, and counts a job Actions
 carried forward unchanged once. Jobs that failed on their own assertions are
 not named in the rerun request and stay red.
 
+Which execution the plan reads, and what one refused re-dispatch does to the
+others, are both declared in `workflow_policy.lost_runner_rerun`:
+
+- `selection: latest_execution_per_job_name`. The plan decides from each job
+  name's **newest** execution and reports the executions it superseded with
+  `retry_decision: superseded_by_later_execution`. A host that was lost and
+  then reported on a later attempt is therefore out of the plan entirely, and
+  its stale, already-consumed job id is never named. Executions are ordered by
+  run attempt and then by job id, because Actions allocates job ids in creation
+  order inside a run and also re-lists a carried-forward job under the newer
+  attempt number -- the attempt alone cannot order the two.
+- `dispatch_tolerance: per_job_id`. The hosts share one machine, so one incident
+  can lose two of them at once. `lost-runner-recovery.mjs dispatch-rerun` asks
+  Actions for every named id separately, records what each one answered in
+  `rerun-dispatch.json` (schema `codestory.lost-runner-rerun-dispatch/v1`), and
+  fails only when **no** id was accepted. A shell loop under `set -e` used to
+  abandon the ids after the first refusal, and workflow policy now refuses a
+  dispatch step that calls the API itself.
+
 If a host is lost twice, `release.yml`'s `accelerator-non-claim` job records a
 **populated non-claim** for that host in place of the cells that host would
 have produced. It mirrors the package manifest's own shape:

--- a/release-claims.json
+++ b/release-claims.json
@@ -1520,6 +1520,20 @@
         }
       ]
     },
+    "lost_runner_rerun": {
+      "workflow": "lost-runner-rerun.yml",
+      "job": "rerun-lost-jobs",
+      "recovery_contract": ".github/scripts/lost-runner-recovery.mjs",
+      "plan_schema": "codestory.lost-runner-rerun-plan/v2",
+      "plan_file": "target/lost-runner/rerun-plan.json",
+      "dispatch_schema": "codestory.lost-runner-rerun-dispatch/v1",
+      "dispatch_file": "target/lost-runner/rerun-dispatch.json",
+      "dispatch_step": "Re-dispatch only the lost jobs",
+      "dispatch_command": "node .github/scripts/lost-runner-recovery.mjs dispatch-rerun",
+      "selection": "latest_execution_per_job_name",
+      "dispatch_tolerance": "per_job_id",
+      "dispatch_failure": "fail_only_when_no_job_was_accepted"
+    },
     "artifact_workflows": [
       "source-proof.yml",
       "release-candidate-evidence.yml",

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "c4af376cab0fa2ed87b6990c1af19d6b287afd1d37f40c28ea8d1e2cacb45ee9",
+      "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
Closes #1785. **#1670 stays open** — Five of the six sub-contracts remain and nothing partial landed for any of them; the issue stays open with the remainder named below.

## What landed

The declared replacement for the ad-hoc dispatch path, with the receipt shape the rest of the package will build on.

## Review

**Merge with follow-up**, no blocking or major findings surviving verification. Three flags were downgraded to minor: the commit's model of Actions job listing makes an untouched non-claim planner harder to reason about, and two halves of the declared replacement rule (a ban on that step running `gh api`, and the graph-declared dispatch command) survive deletion with the suite green — real test gaps, tracked rather than blocking, because the shipped behavior is correct.

The reviewer was asked explicitly whether this slice is coherent alone or a fragment that should wait, and judged it safe to land on its own.

## Remaining on #1670

W8.2 stable-only versions at every entrypoint, plus four further sub-contracts. **REL-MAN (#1671) stacks behind this and must merge before the release freeze** — that dependency is now the critical path to the freeze step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
