### PR TITLE
[v0.17 EV-7ba] Arm the filesystem observer and stamp the ready lease with its epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "glob",
  "ignore",
  "libc",
+ "notify",
  "remove_dir_all",
  "serde",
  "serde_json",

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -28,5 +28,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 codestory-retrieval = { workspace = true, features = ["test-support"] }
+codestory-workspace = { workspace = true, features = ["test-support"] }
 rusqlite = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/codestory-runtime/src/affected.rs
+++ b/crates/codestory-runtime/src/affected.rs
@@ -2196,12 +2196,14 @@ impl AppController {
         let workspace = runtime_workspace_manifest(root, &storage_path)
             .map_err(|error| ApiError::internal(format!("Failed to open project: {error}")))?;
         let mut path_identities = AffectedOperationIdentityIndex::native();
+        // `affected` reports what an existing publication covers; it never creates observers.
         let freshness = index_freshness_observation_from_storage_with_identities(
             root,
             &workspace,
             &storage,
             &self.source_index_policy,
             &mut path_identities,
+            crate::index_freshness::FreshnessObservation::Unobserved,
         );
         let identity_matches = match_affected_file_identities(
             root,

--- a/crates/codestory-runtime/src/controller_core.rs
+++ b/crates/codestory-runtime/src/controller_core.rs
@@ -1,6 +1,7 @@
 use crate::browser::ReadOnlyBrowserService;
 use crate::index_freshness::{
-    index_freshness_from_storage_with_policy, open_existing_storage_for_read, open_storage_for_read,
+    FreshnessObservation, FreshnessObservationPolicy, index_freshness_from_storage_with_policy,
+    open_existing_storage_for_read, open_storage_for_read,
 };
 use crate::search_publication::{
     load_persisted_search_state_for_runtime, retrieval_state_from_storage_for_runtime,
@@ -12,8 +13,8 @@ use crate::services::{
 use crate::workspace_state::runtime_workspace_manifest;
 use crate::{
     ACTIVE_CORE_READ, ActiveCoreRead, ActiveCoreReadGuard, AppController, AppState, ReadStorage,
-    RuntimeProcessConfig, SidecarQueryCacheState, Storage, clear_search_engine,
-    publish_search_engine,
+    RuntimeProcessConfig, SidecarQueryCacheState, SourceObserverState, Storage,
+    clear_search_engine, publish_search_engine,
 };
 use codestory_contracts::api::{
     ApiError, AppEventPayload, IndexFreshnessDto, ProjectSummary, RetrievalStateDto,
@@ -23,7 +24,7 @@ use codestory_workspace::SourceIndexPolicy;
 use crossbeam_channel::{Receiver, unbounded};
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -67,6 +68,7 @@ impl AppController {
             })),
             sidecar_query_cache: Arc::new(Mutex::new(SidecarQueryCacheState::new())),
             canonical_symbol_names: Arc::new(Mutex::new(Default::default())),
+            source_observer: Arc::new(Mutex::new(SourceObserverState::default())),
             events_tx,
             events_rx,
             runtime_config: Arc::new(config),
@@ -260,17 +262,28 @@ impl AppController {
         result
     }
 
-    pub(crate) fn index_freshness_uncached(&self) -> Result<IndexFreshnessDto, ApiError> {
+    pub(crate) fn index_freshness_uncached(
+        &self,
+        observation: FreshnessObservationPolicy,
+    ) -> Result<IndexFreshnessDto, ApiError> {
         let root = self.require_project_root()?;
         let storage = self.open_storage_for_freshness()?;
         let storage_path = self.require_storage_path()?;
         let workspace = runtime_workspace_manifest(&root, &storage_path)
             .map_err(|error| ApiError::internal(format!("Failed to open project: {error}")))?;
+        let session = match observation {
+            FreshnessObservationPolicy::Unobserved => None,
+            FreshnessObservationPolicy::ObserveSourceRoot => self.source_observer_session(&root),
+        };
         Ok(index_freshness_from_storage_with_policy(
             &root,
             &workspace,
             &storage,
             &self.source_index_policy,
+            session.as_deref().map_or(
+                FreshnessObservation::Unobserved,
+                FreshnessObservation::Observed,
+            ),
         ))
     }
 
@@ -285,9 +298,89 @@ impl AppController {
     /// preserves both mtime and byte length is invisible to metadata, and the
     /// content hash is the only mechanism that catches it. Callers guarding the
     /// *end* of an operation use this entry point so the hash runs again.
-    pub(crate) fn index_freshness_reverified(&self) -> Result<IndexFreshnessDto, ApiError> {
+    ///
+    /// The observation policy is passed straight through: dropping the memo
+    /// governs what the scan is allowed to remember, arming the observer
+    /// governs what the scan is allowed to miss, and the end-of-operation
+    /// refusal needs both.
+    pub(crate) fn index_freshness_reverified(
+        &self,
+        observation: FreshnessObservationPolicy,
+    ) -> Result<IndexFreshnessDto, ApiError> {
         codestory_workspace::reverify_source_freshness_from_content();
-        self.index_freshness_uncached()
+        self.index_freshness_uncached(observation)
+    }
+
+    /// Arm, or reuse, the filesystem observer over `root`.
+    ///
+    /// Arming is the expensive half — a recursive watch over the working tree — so one session
+    /// serves every observed read of the same root. A session that has already lost coverage is
+    /// kept rather than replaced: it seals indeterminate from then on, which is exactly the
+    /// unobserved fallback, and re-arming on every read would pay the watch cost repeatedly on a
+    /// host that is producing more churn than the notifier can carry.
+    pub(crate) fn source_observer_session(
+        &self,
+        root: &Path,
+    ) -> Option<Arc<codestory_workspace::filesystem_observer::FilesystemObserverSession>> {
+        use codestory_workspace::filesystem_observer::FilesystemObserverSession;
+
+        let mut state = self.source_observer.lock();
+        if state.root.as_deref() != Some(root) {
+            *state = SourceObserverState {
+                root: Some(root.to_path_buf()),
+                #[cfg(any(test, feature = "test-support"))]
+                arm_requests: state.arm_requests,
+                ..SourceObserverState::default()
+            };
+        }
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            state.arm_requests = state.arm_requests.saturating_add(1);
+        }
+        if let Some(session) = state.session.as_ref() {
+            return Some(Arc::clone(session));
+        }
+        if state.refused.is_some() {
+            return None;
+        }
+        match FilesystemObserverSession::arm(root) {
+            Ok(session) => {
+                let session = Arc::new(session);
+                state.session = Some(Arc::clone(&session));
+                Some(session)
+            }
+            Err(gap) => {
+                tracing::debug!(
+                    root = %root.display(),
+                    gap = gap.id(),
+                    detail = %gap.detail(),
+                    "filesystem observation unavailable; freshness falls back to the scan verdict"
+                );
+                state.refused = Some(gap);
+                None
+            }
+        }
+    }
+
+    /// Install a caller-driven observer session so a test can script the racing window.
+    #[cfg(any(test, feature = "test-support"))]
+    #[allow(dead_code)]
+    pub(crate) fn install_source_observer_for_test(
+        &self,
+        root: &Path,
+        session: Arc<codestory_workspace::filesystem_observer::FilesystemObserverSession>,
+    ) {
+        let mut state = self.source_observer.lock();
+        state.root = Some(root.to_path_buf());
+        state.session = Some(session);
+        state.refused = None;
+    }
+
+    /// How many times a read asked this controller for an observer session.
+    #[cfg(any(test, feature = "test-support"))]
+    #[allow(dead_code)]
+    pub(crate) fn source_observer_requests_for_test(&self) -> u64 {
+        self.source_observer.lock().arm_requests
     }
 
     pub(crate) fn clear_search_state(&self) {

--- a/crates/codestory-runtime/src/controller_core.rs
+++ b/crates/codestory-runtime/src/controller_core.rs
@@ -12,9 +12,9 @@ use crate::services::{
 };
 use crate::workspace_state::runtime_workspace_manifest;
 use crate::{
-    ACTIVE_CORE_READ, ActiveCoreRead, ActiveCoreReadGuard, AppController, AppState, ReadStorage,
-    RuntimeProcessConfig, SidecarQueryCacheState, SourceObserverState, Storage,
-    clear_search_engine, publish_search_engine,
+    ACTIVE_CORE_READ, ActiveCoreRead, ActiveCoreReadGuard, AppController, AppState,
+    ObservedSourceEpoch, ReadStorage, RuntimeProcessConfig, SidecarQueryCacheState,
+    SourceObserverState, Storage, clear_search_engine, publish_search_engine,
 };
 use codestory_contracts::api::{
     ApiError, AppEventPayload, IndexFreshnessDto, ProjectSummary, RetrievalStateDto,
@@ -324,6 +324,7 @@ impl AppController {
     ) -> Option<Arc<codestory_workspace::filesystem_observer::FilesystemObserverSession>> {
         use codestory_workspace::filesystem_observer::FilesystemObserverSession;
 
+        let storage_path = self.require_storage_path().ok();
         let mut state = self.source_observer.lock();
         if state.root.as_deref() != Some(root) {
             *state = SourceObserverState {
@@ -343,7 +344,19 @@ impl AppController {
         if state.refused.is_some() {
             return None;
         }
-        match FilesystemObserverSession::arm(root) {
+        // The recursive watch cannot be narrowed at the kernel, so the storage cache — which this
+        // process itself writes on every read — is excluded on arrival alongside the discovery
+        // exclusions the filter already carries.
+        let mut scope =
+            codestory_workspace::filesystem_observer::ObservedScopeFilter::source_default();
+        if let Some(storage_root) = storage_path
+            .as_deref()
+            .and_then(Path::parent)
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            scope = scope.ignoring_root(storage_root);
+        }
+        match FilesystemObserverSession::arm_with_scope(root, scope) {
             Ok(session) => {
                 let session = Arc::new(session);
                 state.session = Some(Arc::clone(&session));
@@ -360,6 +373,24 @@ impl AppController {
                 None
             }
         }
+    }
+
+    /// What the observer over `root` can say about the working tree at this instant.
+    ///
+    /// This is the value a ready lease carries so a later probe has something that *moves* when
+    /// the tree does. `None` means the observer cannot back a claim about this root at all — no
+    /// notifier, an unsupported filesystem, or a session that has already taken a sticky loss —
+    /// and a lease stamped `None` keeps exactly the EV-7 answer it had before.
+    pub(crate) fn observed_source_epoch(&self, root: &Path) -> Option<ObservedSourceEpoch> {
+        let session = self.source_observer_session(root)?;
+        if session.gap().is_some() {
+            return None;
+        }
+        Some(ObservedSourceEpoch {
+            session_id: session.identity().session_id().to_string(),
+            backend: session.identity().backend().id(),
+            epoch: session.epoch(),
+        })
     }
 
     /// Install a caller-driven observer session so a test can script the racing window.

--- a/crates/codestory-runtime/src/controller_indexing.rs
+++ b/crates/codestory-runtime/src/controller_indexing.rs
@@ -1,9 +1,9 @@
 use crate::index_commit::{IndexWriterGuard, index_publication_dto};
 use crate::index_coverage::indexed_files_from_storage;
 use crate::index_freshness::{
-    CachedIndexFreshness, index_freshness_cache_ttl_secs, index_freshness_from_storage_with_policy,
-    open_storage_for_read, storage_fingerprint, workspace_member_index_summaries,
-    workspace_member_storage_summaries,
+    CachedIndexFreshness, FreshnessObservation, index_freshness_cache_ttl_secs,
+    index_freshness_from_storage_with_policy, open_storage_for_read, storage_fingerprint,
+    workspace_member_index_summaries, workspace_member_storage_summaries,
 };
 use crate::index_full::index_full_for_runtime;
 use crate::index_incremental::{
@@ -1134,6 +1134,7 @@ impl AppController {
                 workspace,
                 storage,
                 &self.source_index_policy,
+                FreshnessObservation::Unobserved,
             );
         }
         let ttl = Duration::from_secs(index_freshness_cache_ttl_secs());
@@ -1150,11 +1151,14 @@ impl AppController {
             }
         }
 
+        // The cached project summary feeds observational surfaces. They read what already
+        // exists and never create observers.
         let freshness = index_freshness_from_storage_with_policy(
             root,
             workspace,
             storage,
             &self.source_index_policy,
+            FreshnessObservation::Unobserved,
         );
         let mut state = self.state.lock();
         state.index_freshness_cache = Some(CachedIndexFreshness {

--- a/crates/codestory-runtime/src/index_freshness.rs
+++ b/crates/codestory-runtime/src/index_freshness.rs
@@ -7,6 +7,9 @@ use super::{
     clamp_usize_to_u32, runtime_relative_path, source_policy_exclusion_candidate,
     validate_source_policy_exclusions, validate_structural_text_units,
 };
+use codestory_workspace::filesystem_observer::{
+    FilesystemObserverCoverage, FilesystemObserverSession, ProvenCoverage,
+};
 #[cfg(test)]
 use std::cell::RefCell;
 use std::io;
@@ -36,6 +39,25 @@ fn run_after_index_freshness_fence_test_hook() {
     if let Some(hook) = hook {
         hook();
     }
+}
+
+/// Whether a freshness read may arm a filesystem observer around its discovery scan.
+///
+/// Observational surfaces — `status`, `doctor`, dry-run inventory — read what already exists and
+/// never create observers, so they pass [`Self::Unobserved`]. Reads that authorise serving arm
+/// one, because their verdict is the thing an observer can keep honest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FreshnessObservationPolicy {
+    Unobserved,
+    ObserveSourceRoot,
+}
+
+/// The observation a single freshness check runs inside.
+pub(super) enum FreshnessObservation<'a> {
+    /// No observer. The scan verdict is exactly what EV-7 computed, with its existing bounds.
+    Unobserved,
+    /// An armed session over the project root, sealed around the discovery scan.
+    Observed(&'a FilesystemObserverSession),
 }
 
 /// A freshness check that produced no verdict, carrying why.
@@ -134,6 +156,7 @@ pub(super) fn index_freshness_observation_from_storage(
     workspace: &WorkspaceManifest,
     storage: &Storage,
     policy: &SourceIndexPolicy,
+    observation: FreshnessObservation<'_>,
 ) -> IndexFreshnessObservation {
     let mut identities = AffectedOperationIdentityIndex::native();
     index_freshness_observation_from_storage_with_identities(
@@ -142,6 +165,7 @@ pub(super) fn index_freshness_observation_from_storage(
         storage,
         policy,
         &mut identities,
+        observation,
     )
 }
 
@@ -472,6 +496,7 @@ pub(super) fn index_freshness_observation_from_storage_with_identities<R>(
     storage: &Storage,
     policy: &SourceIndexPolicy,
     identities: &mut AffectedOperationIdentityIndex<R>,
+    observation: FreshnessObservation<'_>,
 ) -> IndexFreshnessObservation
 where
     R: FnMut(&Path) -> io::Result<WorkspacePathIdentity>,
@@ -517,7 +542,19 @@ where
             ));
         }
     };
-    let planned = match plan_index_freshness(workspace, &inventory, policy) {
+    // The observer is armed before the scan and sealed after it, so its window is exactly the
+    // stretch during which the scan's answer could go out of date underneath it.
+    let (planned, coverage) = match observation {
+        FreshnessObservation::Unobserved => {
+            (plan_index_freshness(workspace, &inventory, policy), None)
+        }
+        FreshnessObservation::Observed(session) => {
+            let (planned, coverage) =
+                session.observe_window(|| plan_index_freshness(workspace, &inventory, policy));
+            (planned, Some(coverage))
+        }
+    };
+    let planned = match planned {
         Ok(planned) => planned,
         Err(reason) => {
             return IndexFreshnessObservation::incomplete(not_checked_index_freshness(
@@ -530,7 +567,7 @@ where
     let changes = classify_index_freshness_changes(root, &inventory, &planned);
     let identity =
         account_index_freshness_identities(&planned, &inventory.removed_paths, identities);
-    let status = if changes.changed_file_count == 0
+    let mut status = if changes.changed_file_count == 0
         && changes.new_file_count == 0
         && changes.removed_file_count == 0
     {
@@ -543,18 +580,37 @@ where
         .saturating_sub(changes.removed_file_count)
         .saturating_add(changes.new_file_count);
 
+    let mut changed_file_count = changes.changed_file_count;
+    let mut samples = changes.samples;
+    let mut reason = None;
+    if status == IndexFreshnessStatusDto::Fresh
+        && let Some(escalation) = observer_escalation(
+            root,
+            &inventory,
+            &planned,
+            coverage
+                .as_ref()
+                .and_then(FilesystemObserverCoverage::proven),
+        )
+    {
+        status = IndexFreshnessStatusDto::Stale;
+        changed_file_count = escalation.changed_file_count;
+        samples = escalation.samples;
+        reason = Some(escalation.reason);
+    }
+
     IndexFreshnessObservation {
         freshness: IndexFreshnessDto {
             status,
-            changed_file_count: changes.changed_file_count,
+            changed_file_count,
             new_file_count: changes.new_file_count,
             removed_file_count: changes.removed_file_count,
             checked_file_count,
             indexed_file_count: inventory.indexed_file_count,
             duration_ms: clamp_u128_to_u32(started_at.elapsed().as_millis()),
-            reason: None,
+            reason,
             not_checked_cause: None,
-            samples: changes.samples,
+            samples,
         },
         inventory_complete: identity.gap_count == 0,
         admitted_identities: identity.admitted_identities,
@@ -564,13 +620,140 @@ where
     }
 }
 
+/// A `Fresh` verdict the observer proved was answered about a tree that moved.
+struct ObserverEscalation {
+    reason: String,
+    samples: Vec<IndexFreshnessSampleDto>,
+    changed_file_count: u32,
+}
+
+/// Decide what a sealed observation window adds to a `Fresh` scan verdict.
+///
+/// The observer may only ever move the verdict toward less certainty, so this returns `Some`
+/// exactly when the window proves the scan raced a change it cannot have accounted for, and
+/// `None` in every other case — including every case where the observer knows nothing. An
+/// indeterminate window (no observer, unsupported filesystem, dropped events, exhausted budget)
+/// leaves the EV-7 verdict standing untouched; that fallback is the floor, not a degraded mode.
+///
+/// Only paths discovery itself admitted are considered. A repository builds, checks out branches,
+/// and writes caches while a scan runs, and treating `target/` or `.git/` churn as source drift
+/// would leave freshness permanently escalated for no reason a caller could act on.
+fn observer_escalation(
+    root: &Path,
+    inventory: &IndexFreshnessInventory,
+    planned: &IndexFreshnessPlan,
+    coverage: Option<&ProvenCoverage>,
+) -> Option<ObserverEscalation> {
+    let coverage = coverage?;
+    if coverage.is_quiet() {
+        return None;
+    }
+
+    let mut admitted_files = HashMap::<PathBuf, &Path>::new();
+    let mut admitted_directories = HashSet::<PathBuf>::new();
+    for path in planned
+        .plan
+        .existing_file_ids
+        .keys()
+        .chain(planned.plan.files_to_index.iter())
+    {
+        let Some(relative) = codestory_workspace::workspace_relative_path(root, path) else {
+            continue;
+        };
+        for ancestor in relative.ancestors().skip(1) {
+            if !admitted_directories.insert(ancestor.to_path_buf()) {
+                break;
+            }
+        }
+        admitted_files.insert(relative, path.as_path());
+    }
+    let stored_by_relative_path = inventory
+        .refresh_inputs
+        .stored_files
+        .iter()
+        .filter_map(|file| {
+            codestory_workspace::workspace_relative_path(root, &file.path)
+                .map(|relative| (relative, file))
+        })
+        .collect::<HashMap<_, _>>();
+
+    let mut escalating = Vec::new();
+    // A file-scoped mutation names one path, so rehashing it settles whether the scan's answer
+    // for that path is still true.
+    let mut contested = Vec::new();
+    for observed in coverage.dirty_paths() {
+        let Some(relative) = codestory_workspace::workspace_relative_path(root, observed) else {
+            continue;
+        };
+        let Some(indexed_path) = admitted_files.get(&relative) else {
+            continue;
+        };
+        contested.push((relative, *indexed_path));
+    }
+    if !contested.is_empty() {
+        // The operation-scoped verdict memo already holds an answer for these paths: the scan
+        // this window just sealed recorded one, taken *before* the mutation the observer is
+        // reporting. Letting the memo answer here would have the escalation agree with the very
+        // verdict it exists to falsify, and same-mtime same-length drift — the one shape only a
+        // content read sees — would pass. Drop it so the re-check below re-reads content, on the
+        // same terms as the post-build refusal. Nothing is dropped on a quiet window, so the
+        // memo still spans an operation whose observer saw no admitted path move.
+        codestory_workspace::reverify_source_freshness_from_content();
+    }
+    for (relative, indexed_path) in contested {
+        let drifted = match stored_by_relative_path.get(&relative) {
+            Some(stored) => codestory_workspace::stored_file_requires_reindex(indexed_path, stored),
+            // Discovery admitted a path it has no stored record for, which is drift by itself.
+            None => true,
+        };
+        if drifted {
+            escalating.push((IndexFreshnessChangeKindDto::Changed, relative));
+        }
+    }
+    // A directory-scoped mutation names no file, so nothing short of rescanning that scope can
+    // settle it. Escalating is the only answer that stays correct without a hidden broad pass.
+    for observed in coverage.rescan_roots() {
+        let Some(relative) = codestory_workspace::workspace_relative_path(root, observed) else {
+            continue;
+        };
+        if admitted_directories.contains(&relative) {
+            escalating.push((IndexFreshnessChangeKindDto::Changed, relative));
+        }
+    }
+    if escalating.is_empty() {
+        return None;
+    }
+
+    escalating.sort_by(|left, right| left.1.cmp(&right.1));
+    escalating.dedup_by(|left, right| left.1 == right.1);
+    let changed_file_count = clamp_usize_to_u32(escalating.len());
+    let samples = escalating
+        .into_iter()
+        .take(INDEX_FRESHNESS_SAMPLE_LIMIT)
+        .map(|(kind, relative)| IndexFreshnessSampleDto {
+            kind,
+            path: relative.to_string_lossy().to_string(),
+        })
+        .collect();
+    Some(ObserverEscalation {
+        reason: format!(
+            "source_changed_during_freshness_scan_observed_by_{}",
+            coverage.identity().backend().id()
+        ),
+        samples,
+        changed_file_count,
+    })
+}
+
 pub(super) fn index_freshness_from_storage_with_policy(
     root: &Path,
     workspace: &WorkspaceManifest,
     storage: &Storage,
     policy: &SourceIndexPolicy,
+    observation: FreshnessObservation<'_>,
 ) -> IndexFreshnessDto {
-    index_freshness_observation_from_storage(root, workspace, storage, policy).freshness
+    index_freshness_observation_from_storage(root, workspace, storage, policy, observation)
+        .freshness
 }
 
 #[cfg(test)]
@@ -584,6 +767,7 @@ pub(super) fn index_freshness_from_storage(
         workspace,
         storage,
         &SourceIndexPolicy::default(),
+        FreshnessObservation::Unobserved,
     )
 }
 

--- a/crates/codestory-runtime/src/index_freshness.rs
+++ b/crates/codestory-runtime/src/index_freshness.rs
@@ -583,6 +583,16 @@ where
     let mut changed_file_count = changes.changed_file_count;
     let mut samples = changes.samples;
     let mut reason = None;
+    if let Some(gap) = coverage.as_ref().and_then(FilesystemObserverCoverage::gap) {
+        // The only symptom of a self-disabling observer is that reads keep saying `Fresh`. An
+        // operator asking why a repository is never observed needs the gap id to answer it.
+        tracing::debug!(
+            root = %root.display(),
+            gap = gap.id(),
+            detail = %gap.detail(),
+            "freshness observation sealed indeterminate; the scan verdict stands unchanged"
+        );
+    }
     if status == IndexFreshnessStatusDto::Fresh
         && let Some(escalation) = observer_escalation(
             root,

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -575,10 +575,25 @@ pub struct AppController {
     sidecar_query_cache: Arc<Mutex<SidecarQueryCacheState>>,
     pub(crate) canonical_symbol_names:
         Arc<Mutex<crate::agent::retrieval_primary::CanonicalSymbolNamesState>>,
+    source_observer: Arc<Mutex<SourceObserverState>>,
     events_tx: Sender<AppEventPayload>,
     events_rx: Receiver<AppEventPayload>,
     runtime_config: Arc<codestory_retrieval::SidecarRuntimeConfig>,
     source_index_policy: Arc<SourceIndexPolicy>,
+}
+
+/// The filesystem observer this controller has armed, if any.
+///
+/// One session per project root per process. `refused` records a root the platform declined so
+/// the controller does not re-probe an unsupported filesystem on every serving read; that answer
+/// cannot change while the root stays put.
+#[derive(Default)]
+pub(crate) struct SourceObserverState {
+    root: Option<PathBuf>,
+    session: Option<Arc<codestory_workspace::filesystem_observer::FilesystemObserverSession>>,
+    refused: Option<codestory_workspace::filesystem_observer::FilesystemObserverGap>,
+    #[cfg(any(test, feature = "test-support"))]
+    arm_requests: u64,
 }
 
 #[derive(Debug)]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -596,6 +596,19 @@ pub(crate) struct SourceObserverState {
     arm_requests: u64,
 }
 
+/// What one armed observer session said about a root at a single moment.
+///
+/// The session id pins *which* observer made the claim, because a re-armed session knows nothing
+/// about the window before it. The epoch is the part that moves: it counts every mutation the
+/// scope filter admitted, so two readings that agree are a positive statement that no admitted
+/// path changed in between.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ObservedSourceEpoch {
+    session_id: String,
+    backend: &'static str,
+    epoch: codestory_workspace::filesystem_observer::ObserverEpoch,
+}
+
 #[derive(Debug)]
 pub(crate) struct SidecarQueryCacheState {
     generation: u64,

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -13,6 +13,7 @@ use codestory_contracts::api::{
 };
 
 use crate::AppController;
+use crate::ObservedSourceEpoch;
 use crate::index_freshness::FreshnessObservationPolicy;
 use codestory_indexer::CancellationToken;
 use codestory_store::{IndexPublicationRecord, Store};
@@ -314,6 +315,17 @@ struct ReadyLease {
     core_publication: IndexPublicationDto,
     retrieval: codestory_retrieval::ReadyRetrievalIdentity,
     source: ReadySourceIdentity,
+    /// The observer session and epoch the source snapshot was taken under.
+    ///
+    /// Everything else in this lease is a pointer that a source write does not move: the core
+    /// publication is unchanged because the database is unchanged, the retrieval manifest is
+    /// unchanged for the same reason, and `source` is a DTO frozen at one instant. That is the
+    /// window EV-78 left open and the reason this package exists — so the lease has to carry the
+    /// one value that *does* move when the working tree does.
+    ///
+    /// `None` on a host the observer cannot watch. The lease then means exactly what it meant
+    /// before this package: EV-7's bounded scan, revalidated by the serving reads.
+    source_observer: Option<ObservedSourceEpoch>,
 }
 
 #[derive(Debug, Clone)]
@@ -976,10 +988,39 @@ impl ActivationService {
         ReadyLeaseProbe {
             admissible: configuration_matches
                 && lease.source.is_admissible_snapshot()
+                && self.ready_lease_source_observer_unchanged(lease.source_observer.as_ref())
                 && retrieval_matches
                 && core_matches,
             retained_core_publication,
         }
+    }
+
+    /// Whether the working tree has stood still since the lease recorded its source snapshot.
+    ///
+    /// The lease probe is the one readiness gate that never re-scans: it compares stored
+    /// identities, and a source write moves none of them. Comparing observer epochs is what makes
+    /// the stored snapshot falsifiable at all — the epoch advances the moment an admitted path is
+    /// written, which is precisely the post-scan window the lease used to keep re-admitting.
+    ///
+    /// A lease minted without an observer compares nothing and stays admissible. Refusing those
+    /// would re-activate on every request on WSL drive mounts and network shares, which is the
+    /// availability cost the typed-unknown fallback exists to refuse.
+    fn ready_lease_source_observer_unchanged(
+        &self,
+        recorded: Option<&ObservedSourceEpoch>,
+    ) -> bool {
+        let Some(recorded) = recorded else {
+            return true;
+        };
+        let Ok(project_root) = self.controller.require_project_root() else {
+            return false;
+        };
+        // A re-armed session, or one that has taken a sticky loss, cannot speak for the window
+        // the lease was minted in. Refusing costs one re-activation and then converges: the next
+        // lease is minted without an observer and falls back to the floor.
+        self.controller
+            .observed_source_epoch(&project_root)
+            .is_some_and(|observed| observed == *recorded)
     }
 
     fn begin_activation_locked(
@@ -1374,6 +1415,10 @@ impl ActivationService {
                 "retrieval publication is not live-ready after activation",
             ));
         }
+        // Read the epoch *before* the scan, not after: a mutation that lands while the scan runs
+        // has to fall outside the lease's recorded epoch, or the lease would vouch for the very
+        // window the observer just proved was contested.
+        let source_observer = self.controller.observed_source_epoch(&project_root);
         let source_freshness = self
             .controller
             .index_freshness_uncached(FreshnessObservationPolicy::ObserveSourceRoot)?;
@@ -1423,6 +1468,7 @@ impl ActivationService {
             core_publication: revalidated_core,
             retrieval,
             source: ReadySourceIdentity::from(&source_freshness),
+            source_observer,
         });
         operation.set_capability(true, ActivationCapabilityState::Ready);
         Ok(())
@@ -2766,6 +2812,10 @@ mod activation_tests {
             .retained_core_publication(&storage_path)
             .expect("read ready core")
             .expect("complete ready core");
+        let source_observer = service
+            .controller
+            .observed_source_epoch(project.path())
+            .expect("a local temporary project must be observable");
         let source_freshness = service
             .controller
             .index_freshness_uncached(FreshnessObservationPolicy::ObserveSourceRoot)
@@ -2786,6 +2836,7 @@ mod activation_tests {
             core_publication: core_publication.clone(),
             retrieval,
             source: ReadySourceIdentity::from(&source_freshness),
+            source_observer: Some(source_observer),
         };
         assert!(lease.source.is_admissible_snapshot());
         {
@@ -3215,6 +3266,124 @@ mod activation_tests {
             !service
                 .probe_ready_lease(&fixture.storage_path, &invalid_source_snapshot)
                 .admissible
+        );
+    }
+
+    /// An observer that escalates every window it seals, moving nothing on disk.
+    ///
+    /// The event is directory-scoped, so it names no file to rehash: the scan verdict stays
+    /// `Fresh` on its own and only the escalation can refuse. Anything these tests turn red is
+    /// therefore the consequence of the escalation and not the arming.
+    fn install_escalating_observer(controller: &AppController) -> PathBuf {
+        let root = controller
+            .require_project_root()
+            .expect("the fixture binds a project root");
+        let scoped_root = root.clone();
+        let session = crate::tests::freshness_observer_tests::scripted_session(&root, move |_| {
+            vec![
+                codestory_workspace::filesystem_observer::ObservedFilesystemEvent::Mutated {
+                    path: scoped_root.clone(),
+                    scope: codestory_workspace::filesystem_observer::MutationScope::Directory,
+                },
+            ]
+        });
+        controller.install_source_observer_for_test(&root, Arc::new(session));
+        root
+    }
+
+    #[test]
+    fn an_escalated_verdict_refuses_ready_lease_publication() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.activation_service();
+        service.use_published_retrieval_fixture_for_test();
+        let project_root = install_escalating_observer(&service.controller);
+        let operation = ActivationOperation {
+            service: service.clone(),
+            operation_id: "activation-observed-source-drift".to_string(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let error = service
+            .activate_once(&operation, project_root, fixture.storage_path.clone())
+            .expect_err("a source tree that moved under the scan must not be leased as ready");
+
+        assert_eq!(
+            error.code, "publication_changed",
+            "ready-lease validation is a serving read; an observed race has to refuse it"
+        );
+        let state = service
+            .coordinator
+            .state
+            .lock()
+            .expect("activation coordinator");
+        assert_eq!(
+            state.ready_lease.as_ref(),
+            Some(&fixture.lease),
+            "a refused validation must not replace the lease it refused to renew"
+        );
+    }
+
+    #[test]
+    fn a_source_mutation_after_the_lease_was_minted_refuses_ready_reuse() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.activation_service();
+        let root = service
+            .controller
+            .require_project_root()
+            .expect("the fixture binds a project root");
+        let quiet = Arc::new(AtomicBool::new(true));
+        let gate = Arc::clone(&quiet);
+        let written = root.join("metadata.rs");
+        let session = crate::tests::freshness_observer_tests::scripted_session(&root, move |_| {
+            if gate.load(Ordering::Acquire) {
+                return Vec::new();
+            }
+            vec![
+                codestory_workspace::filesystem_observer::ObservedFilesystemEvent::Mutated {
+                    path: written.clone(),
+                    scope: codestory_workspace::filesystem_observer::MutationScope::File,
+                },
+            ]
+        });
+        service
+            .controller
+            .install_source_observer_for_test(&root, Arc::new(session));
+
+        let mut lease = fixture.lease.clone();
+        lease.source_observer = service.controller.observed_source_epoch(&root);
+        assert!(
+            lease.source_observer.is_some(),
+            "an armed session must be able to stamp the lease it authorises"
+        );
+        assert!(
+            service
+                .probe_ready_lease(&fixture.storage_path, &lease)
+                .admissible,
+            "a still working tree keeps the lease it earned"
+        );
+
+        // The write EV-78 could not see: the database does not move, so every other identity in
+        // the lease still matches and the probe never re-scans.
+        quiet.store(false, Ordering::Release);
+        assert!(
+            !service
+                .probe_ready_lease(&fixture.storage_path, &lease)
+                .admissible,
+            "a source write after the lease was minted must end the reuse window"
+        );
+    }
+
+    #[test]
+    fn a_lease_minted_without_an_observer_keeps_the_unobserved_floor() {
+        let fixture = ready_activation_fixture();
+        let service = fixture.runtime.activation_service();
+        let mut unobservable = fixture.lease.clone();
+        unobservable.source_observer = None;
+        assert!(
+            service
+                .probe_ready_lease(&fixture.storage_path, &unobservable)
+                .admissible,
+            "a host the observer cannot watch keeps exactly the EV-7 answer it had before"
         );
     }
 

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -13,6 +13,7 @@ use codestory_contracts::api::{
 };
 
 use crate::AppController;
+use crate::index_freshness::FreshnessObservationPolicy;
 use codestory_indexer::CancellationToken;
 use codestory_store::{IndexPublicationRecord, Store};
 use serde::Serialize;
@@ -1254,7 +1255,10 @@ impl ActivationService {
         let mut summary = self
             .controller
             .open_project_summary_with_storage_path(project_root.clone(), storage_path.clone())?;
-        summary.freshness = Some(self.controller.index_freshness_uncached()?);
+        summary.freshness = Some(
+            self.controller
+                .index_freshness_uncached(FreshnessObservationPolicy::Unobserved)?,
+        );
 
         operation.set_stage(ActivationStage::CoreFreshness);
         let core_stale = summary.publication.is_none()
@@ -1283,7 +1287,10 @@ impl ActivationService {
                 project_root.clone(),
                 storage_path.clone(),
             )?;
-            summary.freshness = Some(self.controller.index_freshness_uncached()?);
+            summary.freshness = Some(
+                self.controller
+                    .index_freshness_uncached(FreshnessObservationPolicy::Unobserved)?,
+            );
         }
         let local_ready = summary.publication.is_some()
             && summary.stats.node_count > 0
@@ -1367,7 +1374,9 @@ impl ActivationService {
                 "retrieval publication is not live-ready after activation",
             ));
         }
-        let source_freshness = self.controller.index_freshness_uncached()?;
+        let source_freshness = self
+            .controller
+            .index_freshness_uncached(FreshnessObservationPolicy::ObserveSourceRoot)?;
         if !index_freshness_admits_operation(&source_freshness) {
             return Err(ApiError::new(
                 "publication_changed",
@@ -1772,7 +1781,9 @@ impl PublicOperationService {
         let _source_freshness_scope = codestory_workspace::SourceFreshnessScope::enter();
         for attempt in 1..=2 {
             let result = self.controller.with_complete_core_snapshot(|publication| {
-                let freshness = self.controller.index_freshness_uncached()?;
+                let freshness = self
+                    .controller
+                    .index_freshness_uncached(FreshnessObservationPolicy::ObserveSourceRoot)?;
                 if !index_freshness_admits_operation(&freshness)
                     && !self.retained_core_allows(operation, publication)
                 {
@@ -1801,7 +1812,13 @@ impl PublicOperationService {
                     // including a mutation that preserved both mtime and byte
                     // length. Only re-hashing content sees that, so the
                     // operation-scoped verdict memo must not answer here.
-                    let after = self.controller.index_freshness_reverified()?;
+                    // Observed as well, because the re-read is still a scan with
+                    // a window of its own: the memo drop makes the scan see
+                    // drift that landed before it started, and the observer
+                    // makes it refuse drift that lands while it runs.
+                    let after = self.controller.index_freshness_reverified(
+                        FreshnessObservationPolicy::ObserveSourceRoot,
+                    )?;
                     if !index_freshness_admits_operation(&after)
                         && !self.retained_core_allows(operation, publication)
                     {
@@ -2751,7 +2768,7 @@ mod activation_tests {
             .expect("complete ready core");
         let source_freshness = service
             .controller
-            .index_freshness_uncached()
+            .index_freshness_uncached(FreshnessObservationPolicy::ObserveSourceRoot)
             .expect("verify ready source snapshot");
         assert!(index_freshness_admits_operation(&source_freshness));
         let retrieval = codestory_retrieval::ready_retrieval_identity_for_runtime(
@@ -2873,7 +2890,7 @@ mod activation_tests {
             .runtime
             .activation_service()
             .controller
-            .index_freshness_uncached()
+            .index_freshness_uncached(FreshnessObservationPolicy::Unobserved)
             .expect("observe indexed inventory")
             .indexed_file_count;
         assert!(

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -113,6 +113,8 @@ use tempfile::{TempDir, tempdir};
 #[path = "tests/activation_coverage_tests.rs"]
 mod activation_coverage_tests;
 
+#[path = "tests/freshness_observer.rs"]
+mod freshness_observer_tests;
 #[path = "tests/repo_text.rs"]
 mod repo_text_tests;
 #[path = "tests/search_intent.rs"]

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -114,7 +114,7 @@ use tempfile::{TempDir, tempdir};
 mod activation_coverage_tests;
 
 #[path = "tests/freshness_observer.rs"]
-mod freshness_observer_tests;
+pub(crate) mod freshness_observer_tests;
 #[path = "tests/repo_text.rs"]
 mod repo_text_tests;
 #[path = "tests/search_intent.rs"]

--- a/crates/codestory-runtime/src/tests/freshness_observer.rs
+++ b/crates/codestory-runtime/src/tests/freshness_observer.rs
@@ -40,7 +40,7 @@ impl ObserverEventSource for ScriptedObserver {
     }
 }
 
-fn scripted_session(
+pub(crate) fn scripted_session(
     root: &Path,
     script: impl FnMut(usize) -> Vec<ObservedFilesystemEvent> + Send + 'static,
 ) -> FilesystemObserverSession {
@@ -164,6 +164,45 @@ fn a_write_that_races_the_scan_is_reported_stale_instead_of_fresh() {
 }
 
 #[test]
+fn the_scan_runs_inside_the_window_the_observer_sealed() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let racing_path = project.source.clone();
+    // Every other case in this file scripts events by drain index, and a drain index cannot tell
+    // arm-then-scan apart from scan-then-arm: the seal drains either way. This one moves the
+    // working tree at the instant the window opens and reports nothing at all, so the only thing
+    // that can turn the verdict is the scan reading bytes the window opened over. A scan that
+    // already finished before the window opened reads the published bytes and answers `Fresh`.
+    let session = scripted_session(project.root(), move |drain| {
+        if drain == 0 {
+            std::fs::write(&racing_path, "pub fn wrote_at_the_seam() {}\n").expect("seam write");
+        }
+        Vec::new()
+    });
+
+    let freshness = project.freshness(FreshnessObservation::Observed(&session));
+    assert_eq!(
+        freshness.status,
+        IndexFreshnessStatusDto::Stale,
+        "the scan must run inside the window, so a write that lands as the window opens is one \
+         the scan itself has to read"
+    );
+    assert_eq!(freshness.changed_file_count, 1);
+    assert_eq!(
+        freshness.reason, None,
+        "the scan caught this one on its own; nothing was escalated"
+    );
+    assert_eq!(
+        freshness
+            .samples
+            .iter()
+            .map(|sample| sample.path.as_str())
+            .collect::<Vec<_>>(),
+        vec![Path::new("src").join("lib.rs").to_string_lossy().as_ref()]
+    );
+}
+
+#[test]
 fn a_dirty_path_whose_bytes_did_not_move_stays_fresh() {
     let _env = hybrid_test_env();
     let project = ObservedProject::publish();
@@ -251,8 +290,11 @@ fn churn_outside_the_admitted_tree_never_escalates() {
     let project = ObservedProject::publish();
     let build_output = project.root().join("target");
     let git_directory = project.root().join(".git");
+    let attachments = project.root().join("attachments");
     // A build and a checkout running alongside a scan must not leave freshness permanently
-    // escalated over paths discovery never admitted.
+    // escalated over paths discovery never admitted. `attachments/` is the case the observer's own
+    // scope filter does not cover: it is an ordinary directory the session accounts for, and only
+    // the plan knows discovery admitted nothing inside it.
     let session = scripted_session(project.root(), move |drain| {
         if drain == 0 {
             return Vec::new();
@@ -265,6 +307,8 @@ fn churn_outside_the_admitted_tree_never_escalates() {
             ),
             mutated(&git_directory, MutationScope::Directory),
             mutated(&git_directory.join("index"), MutationScope::File),
+            mutated(&attachments, MutationScope::Directory),
+            mutated(&attachments.join("photo.bin"), MutationScope::File),
         ]
     });
 
@@ -330,6 +374,42 @@ fn a_window_that_lost_events_falls_back_to_the_scan_verdict() {
 }
 
 #[test]
+fn a_session_that_lost_coverage_stamps_no_certainty_on_a_ready_lease() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let covered = Arc::new(AtomicBool::new(true));
+    let gate = Arc::clone(&covered);
+    let session = scripted_session(project.root(), move |_| {
+        if gate.load(std::sync::atomic::Ordering::Acquire) {
+            return Vec::new();
+        }
+        vec![ObservedFilesystemEvent::CoverageLost {
+            detail: "queue overflow".to_string(),
+        }]
+    });
+    project
+        .controller
+        .install_source_observer_for_test(project.root(), Arc::new(session));
+    assert!(
+        project
+            .controller
+            .observed_source_epoch(project.root())
+            .is_some(),
+        "a covering session is what lets a lease carry a falsifiable source claim"
+    );
+
+    // Losing coverage does not degrade the verdict — the scan verdict is the declared floor — but
+    // it must degrade the *lease*, which would otherwise keep quoting an epoch the observer can no
+    // longer stand behind.
+    covered.store(false, std::sync::atomic::Ordering::Release);
+    assert_eq!(
+        project.controller.observed_source_epoch(project.root()),
+        None,
+        "an epoch from a session that admits it missed something is not evidence"
+    );
+}
+
+#[test]
 fn serving_reads_arm_an_observer_and_observational_reads_do_not() {
     let _env = hybrid_test_env();
     let project = ObservedProject::publish();
@@ -358,6 +438,80 @@ fn serving_reads_arm_an_observer_and_observational_reads_do_not() {
     assert!(
         project.controller.source_observer_requests_for_test() > 0,
         "the admission that authorises serving must be the one that arms the observer"
+    );
+}
+
+/// A session that escalates every window it seals, without moving a single byte on disk.
+///
+/// A directory-scoped mutation names no file to rehash, so the scan verdict stays `Fresh` on its
+/// own and the observer is the only thing that can refuse. That is what makes these tests measure
+/// the consequence rather than the arming: nothing but the escalation can turn them red.
+fn escalating_session(root: &Path, quiet_drains: usize) -> FilesystemObserverSession {
+    let source_directory = root.join("src");
+    scripted_session(root, move |drain| {
+        if drain < quiet_drains {
+            return Vec::new();
+        }
+        vec![mutated(&source_directory, MutationScope::Directory)]
+    })
+}
+
+#[test]
+fn an_escalated_verdict_refuses_the_public_operation_before_its_body_runs() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let session = escalating_session(project.root(), 1);
+    project
+        .controller
+        .install_source_observer_for_test(project.root(), Arc::new(session));
+
+    let service = crate::services::PublicOperationService::new(project.controller.clone());
+    let builds = std::cell::Cell::new(0usize);
+    let error = service
+        .run_with_cancel("symbols", Arc::new(AtomicBool::new(false)), || {
+            builds.set(builds.get() + 1);
+            Ok(())
+        })
+        .expect_err("an observer-escalated verdict must refuse the operation, not just be counted");
+
+    assert_eq!(
+        error.code, "project_unavailable",
+        "the admission before the operation body is the one that has to refuse"
+    );
+    assert_eq!(
+        builds.get(),
+        0,
+        "a refusal that lets the response get built is not a refusal"
+    );
+}
+
+#[test]
+fn an_escalated_verdict_refuses_the_public_operation_after_its_body_runs() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    // Quiet across the first admission's window (its arm and its seal), then escalating: the
+    // mutation lands while the operation body is running, which only the read after the body can
+    // catch.
+    let session = escalating_session(project.root(), 2);
+    project
+        .controller
+        .install_source_observer_for_test(project.root(), Arc::new(session));
+
+    let service = crate::services::PublicOperationService::new(project.controller.clone());
+    let builds = std::cell::Cell::new(0usize);
+    let error = service
+        .run_with_cancel("symbols", Arc::new(AtomicBool::new(false)), || {
+            builds.set(builds.get() + 1);
+            Ok(())
+        })
+        .expect_err("a response built over a tree that moved under it must not be served");
+
+    assert_eq!(error.code, "project_unavailable");
+    assert_eq!(
+        builds.get(),
+        1,
+        "the first attempt ran and was refused after the fact; its bounded retry was refused \
+         before running again"
     );
 }
 

--- a/crates/codestory-runtime/src/tests/freshness_observer.rs
+++ b/crates/codestory-runtime/src/tests/freshness_observer.rs
@@ -1,0 +1,424 @@
+//! Freshness verdicts under an armed filesystem observer.
+//!
+//! The property under test is one-directional: observation may turn a `Fresh` verdict the scan
+//! could not have known was wrong into `Stale`, and may never do anything else. Every case where
+//! the observer knows less than it would like — dropped events, an unsupported filesystem, no
+//! observer at all — must leave the EV-7 scan verdict exactly as it was.
+
+use super::{hybrid_test_env, test_sidecar_runtime_from_env};
+use crate::index_freshness::{
+    FreshnessObservation, FreshnessObservationPolicy, index_freshness_from_storage_with_policy,
+};
+use crate::{AppController, SourceIndexPolicy, Storage, WorkspaceManifest};
+use codestory_contracts::api::{
+    IndexFreshnessChangeKindDto, IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode,
+};
+use codestory_workspace::filesystem_observer::{
+    FilesystemObserverSession, MutationScope, ObservedFilesystemEvent, ObserverEventSource,
+};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use tempfile::{TempDir, tempdir};
+
+/// An event source whose script runs on each drain, so a test can move the working tree at the
+/// exact point in the window a real writer would have.
+struct ScriptedObserver {
+    drains: usize,
+    script: Arc<Mutex<dyn FnMut(usize) -> Vec<ObservedFilesystemEvent> + Send>>,
+}
+
+impl ObserverEventSource for ScriptedObserver {
+    fn drain(&mut self) -> Vec<ObservedFilesystemEvent> {
+        let index = self.drains;
+        self.drains += 1;
+        let mut script = self
+            .script
+            .lock()
+            .expect("scripted observer script poisoned");
+        (script)(index)
+    }
+}
+
+fn scripted_session(
+    root: &Path,
+    script: impl FnMut(usize) -> Vec<ObservedFilesystemEvent> + Send + 'static,
+) -> FilesystemObserverSession {
+    FilesystemObserverSession::arm_with_source(
+        root,
+        Box::new(ScriptedObserver {
+            drains: 0,
+            script: Arc::new(Mutex::new(script)),
+        }),
+    )
+}
+
+/// A published project with one indexed source file whose scan verdict is `Fresh`.
+struct ObservedProject {
+    workspace: TempDir,
+    storage_path: PathBuf,
+    controller: AppController,
+    source: PathBuf,
+}
+
+impl ObservedProject {
+    fn publish() -> Self {
+        let workspace = tempdir().expect("workspace");
+        let source_directory = workspace.path().join("src");
+        std::fs::create_dir(&source_directory).expect("source directory");
+        let source = source_directory.join("lib.rs");
+        std::fs::write(&source, "pub fn published() {}\n").expect("published source");
+        let storage_path = workspace.path().join(".cache/codestory.db");
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("baseline publication");
+        Self {
+            workspace,
+            storage_path,
+            controller,
+            source,
+        }
+    }
+
+    fn root(&self) -> &Path {
+        self.workspace.path()
+    }
+
+    fn freshness(&self, observation: FreshnessObservation<'_>) -> IndexFreshnessDto {
+        let manifest = WorkspaceManifest::open_with_storage_owned_exclusions(
+            self.workspace.path().to_path_buf(),
+            &self.storage_path,
+        )
+        .expect("workspace manifest");
+        let storage = Storage::open(&self.storage_path).expect("published storage");
+        index_freshness_from_storage_with_policy(
+            self.workspace.path(),
+            &manifest,
+            &storage,
+            &SourceIndexPolicy::default(),
+            observation,
+        )
+    }
+}
+
+fn mutated(path: &Path, scope: MutationScope) -> ObservedFilesystemEvent {
+    ObservedFilesystemEvent::Mutated {
+        path: path.to_path_buf(),
+        scope,
+    }
+}
+
+#[test]
+fn an_unobserved_scan_reports_the_published_tree_as_fresh() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let freshness = project.freshness(FreshnessObservation::Unobserved);
+    assert_eq!(freshness.status, IndexFreshnessStatusDto::Fresh);
+    assert_eq!(freshness.reason, None);
+}
+
+#[test]
+fn a_write_that_races_the_scan_is_reported_stale_instead_of_fresh() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let racing_path = project.source.clone();
+    // The scan runs inside the window and finds the published bytes. The write lands afterwards,
+    // which is exactly the state a writer that beat the walker to a directory leaves behind.
+    let session = scripted_session(project.root(), move |drain| {
+        if drain == 0 {
+            return Vec::new();
+        }
+        std::fs::write(&racing_path, "pub fn racing() {}\n").expect("racing write");
+        vec![mutated(&racing_path, MutationScope::File)]
+    });
+
+    let freshness = project.freshness(FreshnessObservation::Observed(&session));
+    assert_eq!(
+        freshness.status,
+        IndexFreshnessStatusDto::Stale,
+        "a scan that raced a tracked write must not authorise its own verdict"
+    );
+    assert_eq!(
+        freshness.reason.as_deref(),
+        Some("source_changed_during_freshness_scan_observed_by_injected")
+    );
+    assert_eq!(freshness.changed_file_count, 1);
+    assert_eq!(
+        freshness
+            .samples
+            .iter()
+            .map(|sample| (sample.kind, sample.path.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(
+            IndexFreshnessChangeKindDto::Changed,
+            Path::new("src").join("lib.rs").to_string_lossy().as_ref()
+        )]
+    );
+}
+
+#[test]
+fn a_dirty_path_whose_bytes_did_not_move_stays_fresh() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let quiet_path = project.source.clone();
+    // Notifiers report metadata touches and rewrites of identical bytes. Rehashing the named path
+    // against the planner's own predicate is what keeps those from reading as drift.
+    let session = scripted_session(project.root(), move |drain| {
+        if drain == 0 {
+            return Vec::new();
+        }
+        vec![mutated(&quiet_path, MutationScope::File)]
+    });
+
+    let freshness = project.freshness(FreshnessObservation::Observed(&session));
+    assert_eq!(freshness.status, IndexFreshnessStatusDto::Fresh);
+    assert_eq!(freshness.reason, None);
+    assert_eq!(freshness.changed_file_count, 0);
+}
+
+/// The operation-scoped freshness memo and this observer meet inside the escalation, which
+/// settles a dirty path by re-applying the planner's own predicate — and that predicate is
+/// memoized. The scan this window just sealed recorded a verdict for the very path the observer
+/// is reporting, taken before the racing write. If the memo answered here the escalation would
+/// agree with the verdict it exists to falsify, and the one drift shape metadata cannot see would
+/// be served.
+#[test]
+fn a_same_mtime_same_length_race_escalates_from_content_inside_an_armed_memo_scope() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let racing_path = project.source.clone();
+    let published = std::fs::metadata(&racing_path).expect("stat the published source");
+    let published_len = published.len();
+    let published_mtime = published.modified().expect("published modification time");
+    let session = scripted_session(project.root(), move |drain| {
+        if drain == 0 {
+            return Vec::new();
+        }
+        // Same byte length, same modification time, different bytes: exactly the drift no
+        // metadata comparison can see, landing after the scan already answered `Fresh`.
+        std::fs::write(&racing_path, "pub fn publishee() {}\n").expect("racing write");
+        std::fs::File::options()
+            .write(true)
+            .open(&racing_path)
+            .expect("reopen the raced source")
+            .set_modified(published_mtime)
+            .expect("restore the modification time");
+        let observed = std::fs::metadata(&racing_path).expect("stat the raced source");
+        assert_eq!(
+            observed.len(),
+            published_len,
+            "the race must preserve the byte length to exercise the guard"
+        );
+        assert_eq!(
+            observed.modified().expect("raced modification time"),
+            published_mtime,
+            "the race must preserve the modification time to exercise the guard"
+        );
+        vec![mutated(&racing_path, MutationScope::File)]
+    });
+
+    let _memo = codestory_workspace::SourceFreshnessScope::enter();
+    // Warm the memo the way a public operation's pre-body admission does.
+    assert_eq!(
+        project.freshness(FreshnessObservation::Unobserved).status,
+        IndexFreshnessStatusDto::Fresh
+    );
+
+    let freshness = project.freshness(FreshnessObservation::Observed(&session));
+    assert_eq!(
+        freshness.status,
+        IndexFreshnessStatusDto::Stale,
+        "the escalation has to re-read content; a memoized verdict only describes the instant \
+         before the race"
+    );
+    assert_eq!(
+        freshness.reason.as_deref(),
+        Some("source_changed_during_freshness_scan_observed_by_injected")
+    );
+    assert_eq!(freshness.changed_file_count, 1);
+}
+
+#[test]
+fn churn_outside_the_admitted_tree_never_escalates() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let build_output = project.root().join("target");
+    let git_directory = project.root().join(".git");
+    // A build and a checkout running alongside a scan must not leave freshness permanently
+    // escalated over paths discovery never admitted.
+    let session = scripted_session(project.root(), move |drain| {
+        if drain == 0 {
+            return Vec::new();
+        }
+        vec![
+            mutated(&build_output, MutationScope::Directory),
+            mutated(
+                &build_output.join("debug").join("main.rs"),
+                MutationScope::File,
+            ),
+            mutated(&git_directory, MutationScope::Directory),
+            mutated(&git_directory.join("index"), MutationScope::File),
+        ]
+    });
+
+    let freshness = project.freshness(FreshnessObservation::Observed(&session));
+    assert_eq!(freshness.status, IndexFreshnessStatusDto::Fresh);
+    assert_eq!(freshness.reason, None);
+}
+
+#[test]
+fn a_directory_event_inside_the_admitted_tree_escalates_without_a_broad_pass() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let source_directory = project.root().join("src");
+    // A create, rename, or removal names no file the caller can rehash. Escalating is the only
+    // answer that stays correct without silently re-walking the repository.
+    let session = scripted_session(project.root(), move |drain| {
+        if drain == 0 {
+            return Vec::new();
+        }
+        vec![mutated(&source_directory, MutationScope::Directory)]
+    });
+
+    let freshness = project.freshness(FreshnessObservation::Observed(&session));
+    assert_eq!(freshness.status, IndexFreshnessStatusDto::Stale);
+    assert_eq!(
+        freshness
+            .samples
+            .iter()
+            .map(|sample| sample.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["src"]
+    );
+}
+
+#[test]
+fn a_window_that_lost_events_falls_back_to_the_scan_verdict() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let racing_path = project.source.clone();
+    // The same racing write as the escalation case, but the notifier admits it dropped events.
+    // EV-7 is the floor: the scan verdict stands untouched, which is the availability cost the
+    // typed-unknown fallback deliberately accepts rather than forcing a broad pass per operation.
+    let session = scripted_session(project.root(), move |drain| {
+        if drain == 0 {
+            return Vec::new();
+        }
+        std::fs::write(&racing_path, "pub fn racing() {}\n").expect("racing write");
+        vec![
+            ObservedFilesystemEvent::CoverageLost {
+                detail: "queue overflow".to_string(),
+            },
+            mutated(&racing_path, MutationScope::File),
+        ]
+    });
+
+    let freshness = project.freshness(FreshnessObservation::Observed(&session));
+    assert_eq!(
+        freshness.status,
+        IndexFreshnessStatusDto::Fresh,
+        "an indeterminate window may not manufacture a verdict the observer did not prove"
+    );
+    assert_eq!(freshness.reason, None);
+}
+
+#[test]
+fn serving_reads_arm_an_observer_and_observational_reads_do_not() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+
+    project
+        .controller
+        .index_freshness()
+        .expect("observational freshness");
+    project
+        .controller
+        .open_project_summary_with_storage_path(
+            project.root().to_path_buf(),
+            project.storage_path.clone(),
+        )
+        .expect("observational project summary");
+    assert_eq!(
+        project.controller.source_observer_requests_for_test(),
+        0,
+        "status, doctor, and summary reads observe what exists and never create observers"
+    );
+
+    let service = crate::services::PublicOperationService::new(project.controller.clone());
+    service
+        .run_with_cancel("symbols", Arc::new(AtomicBool::new(false)), || Ok(()))
+        .expect("public operation over a fresh publication");
+    assert!(
+        project.controller.source_observer_requests_for_test() > 0,
+        "the admission that authorises serving must be the one that arms the observer"
+    );
+}
+
+#[test]
+fn one_session_serves_every_observed_read_of_the_same_root() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let root = project.root().to_path_buf();
+    let first = project
+        .controller
+        .source_observer_session(&root)
+        .expect("a local temporary directory must be observable");
+    let second = project
+        .controller
+        .source_observer_session(&root)
+        .expect("the armed session must be reused");
+    assert_eq!(
+        first.identity(),
+        second.identity(),
+        "re-arming per read would pay the recursive watch cost on every operation"
+    );
+    assert!(Arc::ptr_eq(&first, &second));
+}
+
+#[test]
+fn the_observed_policy_is_what_reaches_the_freshness_check() {
+    let _env = hybrid_test_env();
+    let project = ObservedProject::publish();
+    let racing_path = project.source.clone();
+    let session = scripted_session(project.root(), move |drain| {
+        if drain == 0 {
+            return Vec::new();
+        }
+        std::fs::write(&racing_path, "pub fn racing() {}\n").expect("racing write");
+        vec![mutated(&racing_path, MutationScope::File)]
+    });
+    project
+        .controller
+        .install_source_observer_for_test(project.root(), Arc::new(session));
+
+    let unobserved = project
+        .controller
+        .index_freshness_uncached(FreshnessObservationPolicy::Unobserved)
+        .expect("unobserved freshness");
+    assert_eq!(
+        unobserved.status,
+        IndexFreshnessStatusDto::Fresh,
+        "the unobserved policy must not reach the armed session"
+    );
+
+    let observed = project
+        .controller
+        .index_freshness_uncached(FreshnessObservationPolicy::ObserveSourceRoot)
+        .expect("observed freshness");
+    assert_eq!(
+        observed.status,
+        IndexFreshnessStatusDto::Stale,
+        "the controller must hand the armed session to the freshness check"
+    );
+    assert_eq!(
+        observed.reason.as_deref(),
+        Some("source_changed_during_freshness_scan_observed_by_injected")
+    );
+}

--- a/crates/codestory-runtime/src/tests/search_scoring.rs
+++ b/crates/codestory-runtime/src/tests/search_scoring.rs
@@ -2340,7 +2340,9 @@ fn staged_recovery_search_failure_preserves_the_marked_live_database() {
         .index_freshness()
         .expect("cached recovery freshness");
     let uncached = controller
-        .index_freshness_uncached()
+        .index_freshness_uncached(
+            crate::index_freshness::FreshnessObservationPolicy::ObserveSourceRoot,
+        )
         .expect("uncached recovery freshness");
     for freshness in [&cached, &uncached] {
         assert_eq!(freshness.status, IndexFreshnessStatusDto::Stale);

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -13,6 +13,7 @@ fs_at = { workspace = true }
 glob = { workspace = true }
 gix = { workspace = true }
 ignore = { workspace = true }
+notify = { workspace = true }
 remove_dir_all = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/codestory-workspace/src/filesystem_observer.rs
+++ b/crates/codestory-workspace/src/filesystem_observer.rs
@@ -1,0 +1,1384 @@
+//! Cross-platform filesystem observation that may only ever upgrade certainty.
+//!
+//! A freshness check that walks the working tree and compares content hashes answers a question
+//! about a *moving* target: a source file written after the walk passed its directory is reported
+//! as unchanged. This module closes that window by arming a platform change notifier **before**
+//! the scan starts and sealing it after the scan finishes, so the check learns whether anything
+//! mutated while it was looking.
+//!
+//! The one invariant every part of this module exists to hold is that observation may only ever
+//! *upgrade* certainty. It can prove a scan raced a mutation; it can never prove a scan did not.
+//! Whenever the observer cannot account for the whole window — the backend refused to arm, the
+//! root sits on a filesystem whose notifications are not trustworthy (WSL interop, network
+//! mounts), the kernel queue dropped events, or the accumulation budget was exhausted — the
+//! window seals [`FilesystemObserverCoverage::Indeterminate`] with a typed gap and the caller
+//! keeps whatever verdict it computed without the observer. That fallback is the permanent floor
+//! beneath this module, not a temporary state.
+//!
+//! Losses are sticky. Once a session has missed anything it can never seal `Proven` again,
+//! because a backend that dropped one event has no way to tell the caller what it dropped.
+//! Recovering certainty requires arming a new session, which carries a new identity.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+use uuid::Uuid;
+
+/// Monotone count of mutations one armed session has absorbed since arming.
+///
+/// Two observations of the same session at the same epoch saw the same filesystem: the counter
+/// advances on every mutation the backend reports, so an unchanged epoch is a positive statement
+/// that nothing was observed in between.
+pub type ObserverEpoch = u64;
+
+/// Paths one session accumulates inside a single window before it declares a hole.
+///
+/// The bound exists so a runaway writer cannot grow observer state without limit. Exhausting it
+/// is a loss of coverage like any other: the window seals indeterminate and the caller falls back.
+pub const FILESYSTEM_OBSERVER_DIRTY_PATH_CAP: usize = 4_096;
+
+/// Which notifier produced a session's events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilesystemObserverBackend {
+    /// The platform change notifier selected for this host.
+    Native,
+    /// A caller-supplied event source. Only reachable from tests.
+    Injected,
+}
+
+impl FilesystemObserverBackend {
+    /// Stable machine-readable identity for lease and diagnostic text.
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Injected => "injected",
+        }
+    }
+}
+
+/// Stable identity of one armed observation session.
+///
+/// The session id changes on every arming, so a caller that recorded an identity can tell a
+/// re-armed observer (which knows nothing about the window before it) from the one it trusted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilesystemObserverIdentity {
+    backend: FilesystemObserverBackend,
+    root: PathBuf,
+    session_id: String,
+}
+
+impl FilesystemObserverIdentity {
+    /// The notifier behind this session.
+    pub fn backend(&self) -> FilesystemObserverBackend {
+        self.backend
+    }
+
+    /// The root this session watches, exactly as the caller spelled it.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Unique per arming. A new session never reuses an earlier id.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+}
+
+/// A filesystem whose change notification cannot carry a freshness claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedFilesystemKind {
+    /// A remote mount. Notifications describe local activity only, so remote writes are invisible.
+    NetworkMount,
+    /// A Windows Subsystem for Linux interop mount, where events cross a translation layer.
+    WindowsSubsystemForLinuxInterop,
+    /// A userspace filesystem whose notification support is defined by the driver, not the kernel.
+    UserspaceMount,
+}
+
+impl UnsupportedFilesystemKind {
+    /// Stable machine-readable identity for gap text and typed output fields.
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::NetworkMount => "network_mount",
+            Self::WindowsSubsystemForLinuxInterop => "wsl_interop_mount",
+            Self::UserspaceMount => "userspace_mount",
+        }
+    }
+}
+
+/// Why an observation window proves nothing about drift.
+///
+/// Every variant means the same thing to a caller — fall back to the unobserved verdict — but
+/// they are distinct because an operator diagnosing "why is this repository never observed"
+/// needs to know whether the notifier is missing, the filesystem is unsupported, or the host is
+/// simply producing more churn than the session budget allows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilesystemObserverGap {
+    /// The platform notifier could not be created or could not watch the root.
+    BackendUnavailable { detail: String },
+    /// The root sits on a filesystem whose change notification is not trustworthy.
+    UnsupportedFilesystem {
+        kind: UnsupportedFilesystemKind,
+        detail: String,
+    },
+    /// The notifier reported that it dropped events; the window has a hole of unknown size.
+    EventQueueOverflow { detail: String },
+    /// The notifier reported a hard error after arming.
+    BackendFailed { detail: String },
+    /// One window accumulated more distinct paths than [`FILESYSTEM_OBSERVER_DIRTY_PATH_CAP`].
+    ObservationBudgetExhausted { limit: usize },
+    /// Another window over the same session overlapped this one, so neither owns its accounting.
+    ConcurrentObservation,
+}
+
+impl FilesystemObserverGap {
+    /// Stable machine-readable identity for gap text and typed output fields.
+    pub fn id(&self) -> &'static str {
+        match self {
+            Self::BackendUnavailable { .. } => "observer_backend_unavailable",
+            Self::UnsupportedFilesystem { .. } => "observer_unsupported_filesystem",
+            Self::EventQueueOverflow { .. } => "observer_event_queue_overflow",
+            Self::BackendFailed { .. } => "observer_backend_failed",
+            Self::ObservationBudgetExhausted { .. } => "observer_budget_exhausted",
+            Self::ConcurrentObservation => "observer_concurrent_observation",
+        }
+    }
+
+    /// Operator-facing detail. Never used for control flow.
+    pub fn detail(&self) -> String {
+        match self {
+            Self::BackendUnavailable { detail } | Self::BackendFailed { detail } => detail.clone(),
+            Self::UnsupportedFilesystem { kind, detail } => {
+                format!("{} ({detail})", kind.id())
+            }
+            Self::EventQueueOverflow { detail } => detail.clone(),
+            Self::ObservationBudgetExhausted { limit } => {
+                format!("observation exceeded {limit} distinct paths")
+            }
+            Self::ConcurrentObservation => {
+                "another observation window overlapped this one".to_string()
+            }
+        }
+    }
+}
+
+/// What a mutation implies about the scope a caller must re-examine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MutationScope {
+    /// One file's bytes or metadata changed. Rehashing that path settles it.
+    File,
+    /// A directory's membership changed. Only rescanning that scope settles it.
+    Directory,
+}
+
+/// One mutation, or one loss of coverage, as reported by a notifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObservedFilesystemEvent {
+    /// A path changed.
+    Mutated { path: PathBuf, scope: MutationScope },
+    /// The notifier dropped events it cannot describe.
+    CoverageLost { detail: String },
+    /// The notifier failed after arming.
+    Failed { detail: String },
+}
+
+/// A window the observer covered end to end.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvenCoverage {
+    identity: FilesystemObserverIdentity,
+    armed_epoch: ObserverEpoch,
+    sealed_epoch: ObserverEpoch,
+    dirty_paths: BTreeSet<PathBuf>,
+    rescan_roots: BTreeSet<PathBuf>,
+}
+
+impl ProvenCoverage {
+    /// Identity of the session that covered the window.
+    pub fn identity(&self) -> &FilesystemObserverIdentity {
+        &self.identity
+    }
+
+    /// Mutation count at the moment the window opened, before the caller's scan ran.
+    pub fn armed_epoch(&self) -> ObserverEpoch {
+        self.armed_epoch
+    }
+
+    /// Mutation count at the moment the window closed.
+    pub fn sealed_epoch(&self) -> ObserverEpoch {
+        self.sealed_epoch
+    }
+
+    /// No mutation at all was observed while the caller's scan ran.
+    pub fn is_quiet(&self) -> bool {
+        self.armed_epoch == self.sealed_epoch
+    }
+
+    /// Files whose bytes or metadata changed during the window. Rehash these.
+    pub fn dirty_paths(&self) -> &BTreeSet<PathBuf> {
+        &self.dirty_paths
+    }
+
+    /// Directories whose membership changed during the window. Rescan these scopes.
+    pub fn rescan_roots(&self) -> &BTreeSet<PathBuf> {
+        &self.rescan_roots
+    }
+}
+
+/// The result of one observation window.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilesystemObserverCoverage {
+    /// The observer accounted for the whole window and names every mutation inside it.
+    Proven(ProvenCoverage),
+    /// Nothing may be concluded from this window.
+    Indeterminate { gap: FilesystemObserverGap },
+}
+
+impl FilesystemObserverCoverage {
+    /// The coverage that was proven, or `None` when the window sealed indeterminate.
+    pub fn proven(&self) -> Option<&ProvenCoverage> {
+        match self {
+            Self::Proven(coverage) => Some(coverage),
+            Self::Indeterminate { .. } => None,
+        }
+    }
+
+    /// The gap, when the window sealed indeterminate.
+    pub fn gap(&self) -> Option<&FilesystemObserverGap> {
+        match self {
+            Self::Proven(_) => None,
+            Self::Indeterminate { gap } => Some(gap),
+        }
+    }
+}
+
+/// A source of filesystem events for one armed session.
+///
+/// Implementors must report every loss they know about; a source that silently swallows a
+/// dropped event turns an indeterminate window into a false proof, which is the one failure this
+/// module cannot tolerate.
+pub trait ObserverEventSource: Send {
+    /// Take everything queued since the previous call. Must not block.
+    fn drain(&mut self) -> Vec<ObservedFilesystemEvent>;
+}
+
+struct SessionState {
+    epoch: ObserverEpoch,
+    dirty: BTreeSet<PathBuf>,
+    rescan: BTreeSet<PathBuf>,
+    gap: Option<FilesystemObserverGap>,
+    open_windows: usize,
+    contended: bool,
+    source: Box<dyn ObserverEventSource>,
+}
+
+/// One armed observation of one root.
+///
+/// Arm it, run the authoritative scan inside [`FilesystemObserverSession::observe_window`], and
+/// read the sealed coverage. There is deliberately no way to seal a window that was not opened
+/// before the scan: the ordering the whole design depends on is enforced by the call shape rather
+/// than by a comment.
+pub struct FilesystemObserverSession {
+    identity: FilesystemObserverIdentity,
+    canonical_root: PathBuf,
+    state: Mutex<SessionState>,
+}
+
+impl std::fmt::Debug for FilesystemObserverSession {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FilesystemObserverSession")
+            .field("identity", &self.identity)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FilesystemObserverSession {
+    /// Arm the platform notifier over `root`.
+    ///
+    /// Fails closed with a typed gap when the filesystem is unsupported or the notifier refuses.
+    pub fn arm(root: &Path) -> Result<Self, FilesystemObserverGap> {
+        Self::arm_with_filesystem(root, &probe_host_filesystem(root))
+    }
+
+    /// Arm the platform notifier over `root` against a filesystem description the caller already
+    /// has.
+    ///
+    /// The support check runs first and refuses before any notifier is created, so an unsupported
+    /// root costs nothing and can never end up half-armed.
+    pub fn arm_with_filesystem(
+        root: &Path,
+        observed: &ObservedFilesystem,
+    ) -> Result<Self, FilesystemObserverGap> {
+        classify_observed_filesystem(root, observed)?;
+        let source = native_event_source(root)?;
+        Ok(Self::from_source(
+            FilesystemObserverBackend::Native,
+            root,
+            Box::new(source),
+        ))
+    }
+
+    /// Arm a session over a caller-supplied event source.
+    ///
+    /// Test-only: production always arms the platform notifier through [`Self::arm`].
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn arm_with_source(root: &Path, source: Box<dyn ObserverEventSource>) -> Self {
+        Self::from_source(FilesystemObserverBackend::Injected, root, source)
+    }
+
+    fn from_source(
+        backend: FilesystemObserverBackend,
+        root: &Path,
+        source: Box<dyn ObserverEventSource>,
+    ) -> Self {
+        let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        Self {
+            identity: FilesystemObserverIdentity {
+                backend,
+                root: root.to_path_buf(),
+                session_id: Uuid::new_v4().to_string(),
+            },
+            canonical_root,
+            state: Mutex::new(SessionState {
+                epoch: 0,
+                dirty: BTreeSet::new(),
+                rescan: BTreeSet::new(),
+                gap: None,
+                open_windows: 0,
+                contended: false,
+                source,
+            }),
+        }
+    }
+
+    /// Identity of this armed session.
+    pub fn identity(&self) -> &FilesystemObserverIdentity {
+        &self.identity
+    }
+
+    /// Mutations absorbed so far, after taking whatever the notifier has queued.
+    ///
+    /// Reading the epoch outside a window is only meaningful for diagnostics; a freshness claim
+    /// must come from a sealed window.
+    pub fn epoch(&self) -> ObserverEpoch {
+        let mut state = self.lock();
+        self.absorb(&mut state);
+        state.epoch
+    }
+
+    /// The sticky gap this session has fallen into, if any.
+    pub fn gap(&self) -> Option<FilesystemObserverGap> {
+        let mut state = self.lock();
+        self.absorb(&mut state);
+        state.gap.clone()
+    }
+
+    /// Run `scan` inside an observation window and report what the observer saw while it ran.
+    ///
+    /// Everything queued before the window is absorbed and discarded first, so the sealed
+    /// coverage describes the scan's window and nothing else. `scan` always runs, including when
+    /// the session is already indeterminate — the observer never decides whether the caller's own
+    /// work happens.
+    pub fn observe_window<T>(&self, scan: impl FnOnce() -> T) -> (T, FilesystemObserverCoverage) {
+        let armed_epoch = {
+            let mut state = self.lock();
+            self.absorb(&mut state);
+            if state.open_windows == 0 {
+                state.dirty.clear();
+                state.rescan.clear();
+            } else {
+                // Two windows sharing one accumulator can each attribute the other's quiet
+                // stretches to itself. Neither may claim proof.
+                state.contended = true;
+            }
+            state.open_windows += 1;
+            state.epoch
+        };
+        let value = scan();
+        let coverage = {
+            let mut state = self.lock();
+            self.absorb(&mut state);
+            state.open_windows = state.open_windows.saturating_sub(1);
+            let contended = state.contended;
+            if state.open_windows == 0 {
+                state.contended = false;
+            }
+            match (contended, state.gap.clone()) {
+                (_, Some(gap)) => FilesystemObserverCoverage::Indeterminate { gap },
+                (true, None) => FilesystemObserverCoverage::Indeterminate {
+                    gap: FilesystemObserverGap::ConcurrentObservation,
+                },
+                (false, None) => FilesystemObserverCoverage::Proven(ProvenCoverage {
+                    identity: self.identity.clone(),
+                    armed_epoch,
+                    sealed_epoch: state.epoch,
+                    dirty_paths: state.dirty.clone(),
+                    rescan_roots: state.rescan.clone(),
+                }),
+            }
+        };
+        (value, coverage)
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, SessionState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn absorb(&self, state: &mut SessionState) {
+        for event in state.source.drain() {
+            self.apply(state, event);
+        }
+    }
+
+    fn apply(&self, state: &mut SessionState, event: ObservedFilesystemEvent) {
+        match event {
+            ObservedFilesystemEvent::Mutated { path, scope } => {
+                state.epoch = state.epoch.saturating_add(1);
+                let path = self.rebase_observed_path(path);
+                let set = match scope {
+                    MutationScope::File => &mut state.dirty,
+                    MutationScope::Directory => &mut state.rescan,
+                };
+                if set.len() >= FILESYSTEM_OBSERVER_DIRTY_PATH_CAP && !set.contains(&path) {
+                    state
+                        .gap
+                        .get_or_insert(FilesystemObserverGap::ObservationBudgetExhausted {
+                            limit: FILESYSTEM_OBSERVER_DIRTY_PATH_CAP,
+                        });
+                    return;
+                }
+                set.insert(path);
+            }
+            ObservedFilesystemEvent::CoverageLost { detail } => {
+                state
+                    .gap
+                    .get_or_insert(FilesystemObserverGap::EventQueueOverflow { detail });
+            }
+            ObservedFilesystemEvent::Failed { detail } => {
+                state
+                    .gap
+                    .get_or_insert(FilesystemObserverGap::BackendFailed { detail });
+            }
+        }
+    }
+
+    /// Re-root an observed path onto the spelling the caller armed with.
+    ///
+    /// Platform notifiers report resolved paths. On hosts where the watched root reaches the
+    /// volume through a symlink — `/tmp` and `/var` on macOS are the everyday case — every
+    /// observed path would otherwise fail to line up with the paths the caller's scan produced,
+    /// and every mutation would be silently discarded as out of scope.
+    fn rebase_observed_path(&self, path: PathBuf) -> PathBuf {
+        if self.canonical_root == self.identity.root {
+            return path;
+        }
+        match path.strip_prefix(&self.canonical_root) {
+            Ok(suffix) => self.identity.root.join(suffix),
+            Err(_) => path,
+        }
+    }
+}
+
+/// Map one notifier event onto the mutations a caller must account for.
+///
+/// A dropped-event flag outranks everything else in the same event: the notifier is telling the
+/// caller that it cannot describe what happened, and no path list alongside it makes the window
+/// whole again.
+///
+/// Anything the notifier could not classify is treated as a directory-scoped mutation rather
+/// than a file-scoped one, because rescanning a scope is the answer that stays correct when the
+/// event turns out to have been a create, a rename, or a removal.
+pub fn classify_notify_event(event: &notify::Event) -> Vec<ObservedFilesystemEvent> {
+    use notify::event::{CreateKind, EventKind, ModifyKind, RemoveKind};
+
+    if event.need_rescan() {
+        return vec![ObservedFilesystemEvent::CoverageLost {
+            detail: "platform notifier reported dropped events".to_string(),
+        }];
+    }
+
+    let mut observed = Vec::new();
+    for path in &event.paths {
+        match event.kind {
+            // Opening, reading, or closing a file is not a mutation.
+            EventKind::Access(_) => {}
+            EventKind::Create(CreateKind::Folder) | EventKind::Remove(RemoveKind::Folder) => {
+                observed.push(ObservedFilesystemEvent::Mutated {
+                    path: path.clone(),
+                    scope: MutationScope::Directory,
+                });
+                observed.push(ObservedFilesystemEvent::Mutated {
+                    path: parent_or_self(path),
+                    scope: MutationScope::Directory,
+                });
+            }
+            EventKind::Create(_)
+            | EventKind::Remove(_)
+            | EventKind::Modify(ModifyKind::Name(_)) => {
+                // The directory listing changed, and a scan that already passed this directory
+                // cannot know whether it saw the entry before or after.
+                observed.push(ObservedFilesystemEvent::Mutated {
+                    path: parent_or_self(path),
+                    scope: MutationScope::Directory,
+                });
+            }
+            EventKind::Modify(_) => observed.push(ObservedFilesystemEvent::Mutated {
+                path: path.clone(),
+                scope: MutationScope::File,
+            }),
+            EventKind::Any | EventKind::Other => {
+                observed.push(ObservedFilesystemEvent::Mutated {
+                    path: parent_or_self(path),
+                    scope: MutationScope::Directory,
+                });
+            }
+        }
+    }
+    observed
+}
+
+fn parent_or_self(path: &Path) -> PathBuf {
+    path.parent()
+        .map_or_else(|| path.to_path_buf(), Path::to_path_buf)
+}
+
+struct NativeEventSource {
+    _watcher: notify::RecommendedWatcher,
+    events: Receiver<Result<notify::Event, notify::Error>>,
+}
+
+impl ObserverEventSource for NativeEventSource {
+    fn drain(&mut self) -> Vec<ObservedFilesystemEvent> {
+        let mut observed = Vec::new();
+        loop {
+            match self.events.try_recv() {
+                Ok(Ok(event)) => observed.extend(classify_notify_event(&event)),
+                Ok(Err(error)) => observed.push(ObservedFilesystemEvent::Failed {
+                    detail: format!("platform notifier error: {error}"),
+                }),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    observed.push(ObservedFilesystemEvent::Failed {
+                        detail: "platform notifier channel closed".to_string(),
+                    });
+                    break;
+                }
+            }
+        }
+        observed
+    }
+}
+
+fn native_event_source(root: &Path) -> Result<NativeEventSource, FilesystemObserverGap> {
+    use notify::{RecursiveMode, Watcher};
+
+    let (sender, events) = std::sync::mpsc::channel();
+    let mut watcher = notify::recommended_watcher(move |event| {
+        let _ = sender.send(event);
+    })
+    .map_err(|error| FilesystemObserverGap::BackendUnavailable {
+        detail: format!("failed to create platform notifier: {error}"),
+    })?;
+    watcher
+        .watch(root, RecursiveMode::Recursive)
+        .map_err(|error| FilesystemObserverGap::BackendUnavailable {
+            detail: format!("failed to watch {}: {error}", root.display()),
+        })?;
+    Ok(NativeEventSource {
+        _watcher: watcher,
+        events,
+    })
+}
+
+/// Classify a filesystem type name against the notification support CodeStory requires.
+///
+/// The name is whatever the host calls the filesystem: `f_fstypename` on macOS, the mount-table
+/// type on Linux. Suffixed names (`fuse.sshfs`) are classified by their suffix first, so a
+/// network filesystem tunnelled through FUSE is recognised as remote rather than merely
+/// userspace.
+pub fn classify_filesystem_type_name(name: &str) -> Option<UnsupportedFilesystemKind> {
+    const NETWORK: &[&str] = &[
+        "nfs",
+        "nfs3",
+        "nfs4",
+        "cifs",
+        "smb",
+        "smb2",
+        "smb3",
+        "smbfs",
+        "afpfs",
+        "afp",
+        "afs",
+        "ncpfs",
+        "glusterfs",
+        "ceph",
+        "webdav",
+        "davfs",
+        "davfs2",
+        "sshfs",
+        "ftpfs",
+        "curlftpfs",
+        "s3fs",
+    ];
+    const WSL_INTEROP: &[&str] = &["9p", "v9fs", "drvfs", "drvfs2", "lxfs", "plan9"];
+
+    let name = name.trim().to_ascii_lowercase();
+    if name.is_empty() {
+        return None;
+    }
+    let suffix = name.rsplit('.').next().unwrap_or(name.as_str());
+    for candidate in [name.as_str(), suffix] {
+        if NETWORK.contains(&candidate) {
+            return Some(UnsupportedFilesystemKind::NetworkMount);
+        }
+        if WSL_INTEROP.contains(&candidate) {
+            return Some(UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop);
+        }
+    }
+    // `macfuse`, `osxfuse`, `fuse`, `fuseblk`, `fuse.<driver>`: the driver, not the kernel,
+    // decides what notification these deliver, so no claim may rest on them.
+    if name == "fuseblk" || name.ends_with("fuse") || name.starts_with("fuse.") {
+        return Some(UnsupportedFilesystemKind::UserspaceMount);
+    }
+    None
+}
+
+/// Classify the mount that owns `root` from a Linux `/proc/self/mountinfo` table.
+///
+/// The deepest mount point that contains the root wins, because a repository under an NFS mount
+/// nested inside a local filesystem is on NFS.
+pub fn classify_mount_table(
+    root: &Path,
+    mountinfo: &str,
+) -> Option<(UnsupportedFilesystemKind, String)> {
+    let mut best: Option<(usize, String)> = None;
+    for line in mountinfo.lines() {
+        let Some((before, after)) = line.split_once(" - ") else {
+            continue;
+        };
+        let mount_point = before.split_whitespace().nth(4)?;
+        let mount_point = decode_mountinfo_field(mount_point);
+        let Some(filesystem_type) = after.split_whitespace().next() else {
+            continue;
+        };
+        if !root.starts_with(&mount_point) {
+            continue;
+        }
+        let depth = Path::new(&mount_point).components().count();
+        if best.as_ref().is_none_or(|(best, _)| depth >= *best) {
+            best = Some((depth, filesystem_type.to_string()));
+        }
+    }
+    let (_, filesystem_type) = best?;
+    classify_filesystem_type_name(&filesystem_type).map(|kind| (kind, filesystem_type))
+}
+
+fn decode_mountinfo_field(field: &str) -> String {
+    let mut decoded = String::with_capacity(field.len());
+    let mut characters = field.chars();
+    while let Some(character) = characters.next() {
+        if character != '\\' {
+            decoded.push(character);
+            continue;
+        }
+        let escape = characters.by_ref().take(3).collect::<String>();
+        match u8::from_str_radix(&escape, 8) {
+            Ok(value) => decoded.push(char::from(value)),
+            Err(_) => {
+                decoded.push('\\');
+                decoded.push_str(&escape);
+            }
+        }
+    }
+    decoded
+}
+
+/// Classify a Linux root reached through WSL's Windows-drive interop.
+///
+/// The mount table already catches WSL 2, whose drive mounts are 9p. WSL 1 presents its own
+/// filesystem driver under names the table may not carry, so the kernel release string plus the
+/// `/mnt/<drive>` shape stands in for it.
+pub fn classify_wsl_interop(
+    os_release: Option<&str>,
+    root: &Path,
+) -> Option<UnsupportedFilesystemKind> {
+    let os_release = os_release?.to_ascii_lowercase();
+    if !os_release.contains("microsoft") && !os_release.contains("wsl") {
+        return None;
+    }
+    let mut components = root.components();
+    if components.next() != Some(std::path::Component::RootDir) {
+        return None;
+    }
+    if components.next()?.as_os_str() != "mnt" {
+        return None;
+    }
+    let drive = components.next()?.as_os_str().to_str()?;
+    let mut characters = drive.chars();
+    let letter = characters.next()?;
+    if characters.next().is_some() || !letter.is_ascii_alphabetic() {
+        return None;
+    }
+    Some(UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop)
+}
+
+/// Classify a Windows root by path shape alone.
+///
+/// UNC roots name a server, and `\\wsl$\` and `\\wsl.localhost\` reach a Linux filesystem through
+/// a translation layer. Neither delivers change notification a freshness claim can rest on. The
+/// `\\?\` and `\\.\` prefixes are local device namespaces and are left to the drive checks.
+pub fn classify_windows_path_shape(root: &Path) -> Option<UnsupportedFilesystemKind> {
+    let spelling = root.to_string_lossy().to_ascii_lowercase();
+    let spelling = spelling.replace('/', "\\");
+    if spelling.starts_with("\\\\wsl$\\") || spelling.starts_with("\\\\wsl.localhost\\") {
+        return Some(UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop);
+    }
+    if spelling.starts_with("\\\\?\\unc\\") {
+        return Some(UnsupportedFilesystemKind::NetworkMount);
+    }
+    if spelling.starts_with("\\\\")
+        && !spelling.starts_with("\\\\?\\")
+        && !spelling.starts_with("\\\\.\\")
+    {
+        return Some(UnsupportedFilesystemKind::NetworkMount);
+    }
+    None
+}
+
+fn unsupported(kind: UnsupportedFilesystemKind, detail: String) -> FilesystemObserverGap {
+    FilesystemObserverGap::UnsupportedFilesystem { kind, detail }
+}
+
+/// Whatever this host can say about the filesystem under a root.
+///
+/// Platforms disagree about which of these they expose — macOS names the filesystem directly,
+/// Linux describes it through the mount table and kernel release, Windows says nothing beyond the
+/// path shape — so every field is optional and the classification simply uses what it is given.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObservedFilesystem {
+    /// The host's name for the filesystem under the root.
+    pub type_name: Option<String>,
+    /// The kernel release string.
+    pub os_release: Option<String>,
+    /// A Linux `/proc/self/mountinfo` table.
+    pub mount_table: Option<String>,
+}
+
+/// Decide whether a root's filesystem can carry a freshness claim.
+///
+/// Every signal is checked, not just the first one the platform happens to provide: a WSL 2 drive
+/// mount is both a `9p` mount-table entry and a `/mnt/<drive>` path under a Microsoft kernel, and
+/// a host that reports only one of those must still be refused.
+pub fn classify_observed_filesystem(
+    root: &Path,
+    observed: &ObservedFilesystem,
+) -> Result<(), FilesystemObserverGap> {
+    if let Some(kind) = classify_windows_path_shape(root) {
+        return Err(unsupported(kind, "unsupported windows root".to_string()));
+    }
+    if let Some(kind) = classify_wsl_interop(observed.os_release.as_deref(), root) {
+        return Err(unsupported(kind, "windows drive interop mount".to_string()));
+    }
+    if let Some(type_name) = observed.type_name.as_deref()
+        && let Some(kind) = classify_filesystem_type_name(type_name)
+    {
+        return Err(unsupported(kind, type_name.to_string()));
+    }
+    if let Some(mount_table) = observed.mount_table.as_deref()
+        && let Some((kind, type_name)) = classify_mount_table(root, mount_table)
+    {
+        return Err(unsupported(kind, type_name));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn probe_host_filesystem(_root: &Path) -> ObservedFilesystem {
+    ObservedFilesystem {
+        type_name: None,
+        os_release: std::fs::read_to_string("/proc/sys/kernel/osrelease").ok(),
+        mount_table: std::fs::read_to_string("/proc/self/mountinfo").ok(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn probe_host_filesystem(root: &Path) -> ObservedFilesystem {
+    ObservedFilesystem {
+        type_name: observed_filesystem_type_name(root),
+        os_release: None,
+        mount_table: None,
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn probe_host_filesystem(_root: &Path) -> ObservedFilesystem {
+    // Windows is fully covered by the path-shape rules, which run for every host.
+    ObservedFilesystem::default()
+}
+
+#[cfg(target_os = "macos")]
+fn observed_filesystem_type_name(root: &Path) -> Option<String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let path = CString::new(root.as_os_str().as_bytes()).ok()?;
+    // SAFETY: `path` is a NUL-terminated C string that outlives the call, and `statfs` only
+    // writes into the zeroed output record it is handed.
+    let mut record: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(path.as_ptr(), &mut record) } != 0 {
+        return None;
+    }
+    let bytes = record
+        .f_fstypename
+        .iter()
+        .take_while(|byte| **byte != 0)
+        .map(|byte| *byte as u8)
+        .collect::<Vec<_>>();
+    String::from_utf8(bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{
+        AccessKind, CreateKind, DataChange, EventKind, ModifyKind, RemoveKind, RenameMode,
+    };
+    use std::sync::mpsc::{Sender, channel};
+    use std::time::{Duration, Instant};
+
+    struct ScriptedSource {
+        events: Receiver<ObservedFilesystemEvent>,
+    }
+
+    impl ObserverEventSource for ScriptedSource {
+        fn drain(&mut self) -> Vec<ObservedFilesystemEvent> {
+            let mut observed = Vec::new();
+            while let Ok(event) = self.events.try_recv() {
+                observed.push(event);
+            }
+            observed
+        }
+    }
+
+    fn scripted(root: &Path) -> (FilesystemObserverSession, Sender<ObservedFilesystemEvent>) {
+        let (sender, events) = channel();
+        let session =
+            FilesystemObserverSession::arm_with_source(root, Box::new(ScriptedSource { events }));
+        (session, sender)
+    }
+
+    fn mutated(path: &str, scope: MutationScope) -> ObservedFilesystemEvent {
+        ObservedFilesystemEvent::Mutated {
+            path: PathBuf::from(path),
+            scope,
+        }
+    }
+
+    #[test]
+    fn a_quiet_window_seals_proven_and_names_no_drift() {
+        let (session, _sender) = scripted(Path::new("/repo"));
+        let (value, coverage) = session.observe_window(|| 7);
+        assert_eq!(value, 7);
+        let proven = coverage.proven().expect("a quiet window must seal proven");
+        assert!(proven.is_quiet());
+        assert_eq!(proven.armed_epoch(), proven.sealed_epoch());
+        assert!(proven.dirty_paths().is_empty());
+        assert!(proven.rescan_roots().is_empty());
+        assert_eq!(proven.identity(), session.identity());
+    }
+
+    #[test]
+    fn a_mutation_during_the_window_is_named_and_advances_the_epoch() {
+        let (session, sender) = scripted(Path::new("/repo"));
+        let (_, coverage) = session.observe_window(|| {
+            sender
+                .send(mutated("/repo/src/lib.rs", MutationScope::File))
+                .expect("scripted source must accept the event");
+            sender
+                .send(mutated("/repo/src", MutationScope::Directory))
+                .expect("scripted source must accept the event");
+        });
+        let proven = coverage.proven().expect("no loss was reported");
+        assert!(!proven.is_quiet());
+        assert_eq!(proven.sealed_epoch(), proven.armed_epoch() + 2);
+        assert_eq!(
+            proven.dirty_paths().iter().collect::<Vec<_>>(),
+            vec![&PathBuf::from("/repo/src/lib.rs")]
+        );
+        assert_eq!(
+            proven.rescan_roots().iter().collect::<Vec<_>>(),
+            vec![&PathBuf::from("/repo/src")]
+        );
+    }
+
+    #[test]
+    fn mutations_before_the_window_never_enter_it() {
+        let (session, sender) = scripted(Path::new("/repo"));
+        sender
+            .send(mutated("/repo/src/before.rs", MutationScope::File))
+            .expect("scripted source must accept the event");
+        let (_, coverage) = session.observe_window(|| {});
+        let proven = coverage.proven().expect("no loss was reported");
+        assert!(
+            proven.is_quiet(),
+            "a pre-window mutation must be absorbed before the window opens"
+        );
+        assert!(proven.dirty_paths().is_empty());
+        assert!(
+            proven.armed_epoch() > 0,
+            "the absorbed mutation must still advance the session epoch"
+        );
+    }
+
+    #[test]
+    fn a_path_dirtied_before_and_again_inside_the_window_is_still_reported() {
+        // Accumulating across windows and diffing the sets would hide exactly this case.
+        let (session, sender) = scripted(Path::new("/repo"));
+        sender
+            .send(mutated("/repo/src/lib.rs", MutationScope::File))
+            .expect("scripted source must accept the event");
+        let (_, coverage) = session.observe_window(|| {
+            sender
+                .send(mutated("/repo/src/lib.rs", MutationScope::File))
+                .expect("scripted source must accept the event");
+        });
+        let proven = coverage.proven().expect("no loss was reported");
+        assert_eq!(
+            proven.dirty_paths().iter().collect::<Vec<_>>(),
+            vec![&PathBuf::from("/repo/src/lib.rs")],
+            "the second mutation belongs to this window"
+        );
+        assert!(!proven.is_quiet());
+    }
+
+    #[test]
+    fn a_dropped_event_seals_indeterminate_and_stays_that_way() {
+        let (session, sender) = scripted(Path::new("/repo"));
+        let (_, coverage) = session.observe_window(|| {
+            sender
+                .send(ObservedFilesystemEvent::CoverageLost {
+                    detail: "queue overflow".to_string(),
+                })
+                .expect("scripted source must accept the event");
+        });
+        assert_eq!(
+            coverage.gap().map(FilesystemObserverGap::id),
+            Some("observer_event_queue_overflow")
+        );
+
+        let (_, later) = session.observe_window(|| {});
+        assert!(
+            later.proven().is_none(),
+            "a session that lost coverage can never prove a later window"
+        );
+        assert_eq!(
+            later.gap().map(FilesystemObserverGap::id),
+            Some("observer_event_queue_overflow")
+        );
+    }
+
+    #[test]
+    fn a_backend_failure_seals_indeterminate() {
+        let (session, sender) = scripted(Path::new("/repo"));
+        let (_, coverage) = session.observe_window(|| {
+            sender
+                .send(ObservedFilesystemEvent::Failed {
+                    detail: "watch descriptor exhausted".to_string(),
+                })
+                .expect("scripted source must accept the event");
+        });
+        assert_eq!(
+            coverage.gap().map(FilesystemObserverGap::id),
+            Some("observer_backend_failed")
+        );
+    }
+
+    #[test]
+    fn exhausting_the_path_budget_seals_indeterminate() {
+        let (session, sender) = scripted(Path::new("/repo"));
+        let (_, coverage) = session.observe_window(|| {
+            for index in 0..=FILESYSTEM_OBSERVER_DIRTY_PATH_CAP {
+                sender
+                    .send(mutated(
+                        &format!("/repo/src/file{index}.rs"),
+                        MutationScope::File,
+                    ))
+                    .expect("scripted source must accept the event");
+            }
+        });
+        assert_eq!(
+            coverage.gap().map(FilesystemObserverGap::id),
+            Some("observer_budget_exhausted")
+        );
+    }
+
+    #[test]
+    fn overlapping_windows_both_seal_indeterminate() {
+        let (session, sender) = scripted(Path::new("/repo"));
+        let mut inner = None;
+        let (_, outer) = session.observe_window(|| {
+            sender
+                .send(mutated("/repo/src/lib.rs", MutationScope::File))
+                .expect("scripted source must accept the event");
+            let (_, coverage) = session.observe_window(|| {});
+            inner = Some(coverage);
+        });
+        assert_eq!(
+            inner.as_ref().and_then(FilesystemObserverCoverage::gap),
+            Some(&FilesystemObserverGap::ConcurrentObservation)
+        );
+        assert_eq!(
+            outer.gap(),
+            Some(&FilesystemObserverGap::ConcurrentObservation)
+        );
+    }
+
+    #[test]
+    fn contention_clears_once_every_window_closes() {
+        let (session, _sender) = scripted(Path::new("/repo"));
+        let (_, outer) = session.observe_window(|| {
+            let _ = session.observe_window(|| {});
+        });
+        assert!(outer.proven().is_none());
+        let (_, later) = session.observe_window(|| {});
+        assert!(
+            later.proven().is_some(),
+            "overlap is a per-window fact, not a permanent loss"
+        );
+    }
+
+    #[test]
+    fn a_file_write_is_file_scoped_and_a_create_is_directory_scoped() {
+        let write = notify::Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content)))
+            .add_path(PathBuf::from("/repo/src/lib.rs"));
+        assert_eq!(
+            classify_notify_event(&write),
+            vec![mutated("/repo/src/lib.rs", MutationScope::File)]
+        );
+
+        let create = notify::Event::new(EventKind::Create(CreateKind::File))
+            .add_path(PathBuf::from("/repo/src/new.rs"));
+        assert_eq!(
+            classify_notify_event(&create),
+            vec![mutated("/repo/src", MutationScope::Directory)],
+            "a created entry changes the directory listing a scan may already have read"
+        );
+
+        let removed = notify::Event::new(EventKind::Remove(RemoveKind::File))
+            .add_path(PathBuf::from("/repo/src/old.rs"));
+        assert_eq!(
+            classify_notify_event(&removed),
+            vec![mutated("/repo/src", MutationScope::Directory)]
+        );
+
+        let renamed = notify::Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
+            .add_path(PathBuf::from("/repo/src/from.rs"))
+            .add_path(PathBuf::from("/repo/src/to.rs"));
+        assert_eq!(
+            classify_notify_event(&renamed),
+            vec![
+                mutated("/repo/src", MutationScope::Directory),
+                mutated("/repo/src", MutationScope::Directory),
+            ]
+        );
+    }
+
+    #[test]
+    fn reading_a_file_is_not_a_mutation() {
+        let read = notify::Event::new(EventKind::Access(AccessKind::Read))
+            .add_path(PathBuf::from("/repo/src/lib.rs"));
+        assert_eq!(classify_notify_event(&read), Vec::new());
+    }
+
+    #[test]
+    fn an_unclassified_event_is_treated_as_a_directory_rescan() {
+        let unknown =
+            notify::Event::new(EventKind::Any).add_path(PathBuf::from("/repo/src/lib.rs"));
+        assert_eq!(
+            classify_notify_event(&unknown),
+            vec![mutated("/repo/src", MutationScope::Directory)]
+        );
+    }
+
+    #[test]
+    fn a_rescan_flag_outranks_every_path_in_the_same_event() {
+        let mut event =
+            notify::Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content)))
+                .add_path(PathBuf::from("/repo/src/lib.rs"));
+        event = event.set_flag(notify::event::Flag::Rescan);
+        assert_eq!(
+            classify_notify_event(&event),
+            vec![ObservedFilesystemEvent::CoverageLost {
+                detail: "platform notifier reported dropped events".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn network_and_interop_filesystems_are_classified_apart_from_local_ones() {
+        for (name, expected) in [
+            ("nfs", Some(UnsupportedFilesystemKind::NetworkMount)),
+            ("nfs4", Some(UnsupportedFilesystemKind::NetworkMount)),
+            ("cifs", Some(UnsupportedFilesystemKind::NetworkMount)),
+            ("smbfs", Some(UnsupportedFilesystemKind::NetworkMount)),
+            ("fuse.sshfs", Some(UnsupportedFilesystemKind::NetworkMount)),
+            (
+                "9p",
+                Some(UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop),
+            ),
+            (
+                "drvfs",
+                Some(UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop),
+            ),
+            ("fuse", Some(UnsupportedFilesystemKind::UserspaceMount)),
+            ("macfuse", Some(UnsupportedFilesystemKind::UserspaceMount)),
+            ("apfs", None),
+            ("ext4", None),
+            ("btrfs", None),
+            ("xfs", None),
+            ("ntfs", None),
+            ("overlay", None),
+            ("", None),
+        ] {
+            assert_eq!(
+                classify_filesystem_type_name(name),
+                expected,
+                "filesystem type {name} was classified wrongly"
+            );
+        }
+    }
+
+    #[test]
+    fn the_deepest_mount_that_contains_the_root_decides() {
+        let mountinfo = concat!(
+            "23 28 0:21 / / rw,relatime shared:1 - ext4 /dev/sda1 rw\n",
+            "31 23 0:26 / /work rw,relatime shared:2 - nfs4 fileserver:/work rw\n",
+            "32 31 0:27 / /work/local rw,relatime shared:3 - ext4 /dev/sdb1 rw\n",
+        );
+        assert_eq!(
+            classify_mount_table(Path::new("/work/project"), mountinfo),
+            Some((UnsupportedFilesystemKind::NetworkMount, "nfs4".to_string()))
+        );
+        assert_eq!(
+            classify_mount_table(Path::new("/work/local/project"), mountinfo),
+            None,
+            "a local mount nested inside a network mount is still local"
+        );
+        assert_eq!(classify_mount_table(Path::new("/home/me"), mountinfo), None);
+    }
+
+    #[test]
+    fn a_mount_point_with_an_escaped_space_still_matches() {
+        let mountinfo =
+            "40 23 0:44 / /mnt/my\\040share rw,relatime shared:9 - cifs //server/share rw\n";
+        assert_eq!(
+            classify_mount_table(Path::new("/mnt/my share/repo"), mountinfo),
+            Some((UnsupportedFilesystemKind::NetworkMount, "cifs".to_string()))
+        );
+    }
+
+    #[test]
+    fn wsl_drive_interop_is_recognised_from_the_kernel_release() {
+        let release = Some("5.15.90.1-microsoft-standard-WSL2");
+        assert_eq!(
+            classify_wsl_interop(release, Path::new("/mnt/c/Users/me/repo")),
+            Some(UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop)
+        );
+        assert_eq!(
+            classify_wsl_interop(release, Path::new("/home/me/repo")),
+            None,
+            "the Linux filesystem inside WSL observes normally"
+        );
+        assert_eq!(
+            classify_wsl_interop(release, Path::new("/mnt/storage/repo")),
+            None,
+            "only single-letter drive mounts are interop mounts"
+        );
+        assert_eq!(
+            classify_wsl_interop(Some("6.1.0-generic"), Path::new("/mnt/c/repo")),
+            None,
+            "a non-WSL kernel has no drive interop"
+        );
+        assert_eq!(classify_wsl_interop(None, Path::new("/mnt/c/repo")), None);
+    }
+
+    #[test]
+    fn unc_and_wsl_windows_roots_are_unsupported_but_local_drives_are_not() {
+        assert_eq!(
+            classify_windows_path_shape(Path::new(r"\\wsl$\Ubuntu\home\me\repo")),
+            Some(UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop)
+        );
+        assert_eq!(
+            classify_windows_path_shape(Path::new(r"\\wsl.localhost\Ubuntu\home\me\repo")),
+            Some(UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop)
+        );
+        assert_eq!(
+            classify_windows_path_shape(Path::new(r"\\fileserver\share\repo")),
+            Some(UnsupportedFilesystemKind::NetworkMount)
+        );
+        assert_eq!(
+            classify_windows_path_shape(Path::new(r"\\?\UNC\fileserver\share\repo")),
+            Some(UnsupportedFilesystemKind::NetworkMount)
+        );
+        assert_eq!(
+            classify_windows_path_shape(Path::new(r"\\?\C:\repo")),
+            None,
+            "the extended-length local prefix is not a network root"
+        );
+        assert_eq!(classify_windows_path_shape(Path::new(r"C:\repo")), None);
+    }
+
+    #[test]
+    fn arming_refuses_an_unsupported_filesystem_before_it_creates_a_notifier() {
+        // The root is a perfectly observable local directory. Only the filesystem description
+        // says otherwise, which is what an NFS or WSL drive mount looks like to `arm`.
+        let root = tempfile::tempdir().expect("temporary root");
+        for (observed, expected) in [
+            (
+                ObservedFilesystem {
+                    type_name: Some("nfs4".to_string()),
+                    ..ObservedFilesystem::default()
+                },
+                UnsupportedFilesystemKind::NetworkMount,
+            ),
+            (
+                ObservedFilesystem {
+                    mount_table: Some(format!(
+                        "23 28 0:21 / / rw shared:1 - ext4 /dev/sda1 rw\n\
+                         31 23 0:26 / {} rw shared:2 - cifs //server/share rw\n",
+                        root.path().display()
+                    )),
+                    ..ObservedFilesystem::default()
+                },
+                UnsupportedFilesystemKind::NetworkMount,
+            ),
+            (
+                ObservedFilesystem {
+                    os_release: Some("5.15.90.1-microsoft-standard-WSL2".to_string()),
+                    ..ObservedFilesystem::default()
+                },
+                UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop,
+            ),
+        ] {
+            let root = if expected == UnsupportedFilesystemKind::WindowsSubsystemForLinuxInterop {
+                PathBuf::from("/mnt/c/Users/me/repo")
+            } else {
+                root.path().to_path_buf()
+            };
+            let gap = FilesystemObserverSession::arm_with_filesystem(&root, &observed)
+                .expect_err("an unsupported filesystem must refuse to arm");
+            assert_eq!(
+                gap,
+                FilesystemObserverGap::UnsupportedFilesystem {
+                    kind: expected,
+                    detail: match (&observed.type_name, &observed.mount_table) {
+                        (Some(name), _) => name.clone(),
+                        (None, Some(_)) => "cifs".to_string(),
+                        (None, None) => "windows drive interop mount".to_string(),
+                    },
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn arming_accepts_a_local_filesystem() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let session = FilesystemObserverSession::arm_with_filesystem(
+            root.path(),
+            &ObservedFilesystem {
+                type_name: Some("apfs".to_string()),
+                os_release: Some("6.1.0-generic".to_string()),
+                mount_table: Some("23 28 0:21 / / rw shared:1 - ext4 /dev/sda1 rw\n".to_string()),
+            },
+        )
+        .expect("a local filesystem must arm");
+        assert_eq!(
+            session.identity().backend(),
+            FilesystemObserverBackend::Native
+        );
+    }
+
+    #[test]
+    fn every_gap_carries_a_distinct_stable_identity() {
+        let gaps = [
+            FilesystemObserverGap::BackendUnavailable {
+                detail: String::new(),
+            },
+            FilesystemObserverGap::UnsupportedFilesystem {
+                kind: UnsupportedFilesystemKind::NetworkMount,
+                detail: String::new(),
+            },
+            FilesystemObserverGap::EventQueueOverflow {
+                detail: String::new(),
+            },
+            FilesystemObserverGap::BackendFailed {
+                detail: String::new(),
+            },
+            FilesystemObserverGap::ObservationBudgetExhausted { limit: 1 },
+            FilesystemObserverGap::ConcurrentObservation,
+        ];
+        let identities = gaps
+            .iter()
+            .map(FilesystemObserverGap::id)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(identities.len(), gaps.len());
+    }
+
+    #[test]
+    fn the_native_observer_reports_a_write_that_races_a_scan() {
+        // The scripted source hands the session paths the test chose. Only a real notifier over a
+        // real directory proves the session lines observed paths up with the caller's spelling,
+        // which on macOS reaches the temporary directory through a symlink.
+        let root = tempfile::tempdir().expect("temporary root");
+        let source = root.path().join("src");
+        std::fs::create_dir(&source).expect("source directory");
+        std::fs::write(source.join("lib.rs"), "fn existing() {}\n").expect("seed file");
+
+        let session = match FilesystemObserverSession::arm(root.path()) {
+            Ok(session) => session,
+            Err(gap) => panic!(
+                "the host must observe a temporary directory: {}",
+                gap.detail()
+            ),
+        };
+        assert_eq!(
+            session.identity().backend(),
+            FilesystemObserverBackend::Native
+        );
+
+        let target = source.join("lib.rs");
+        let (_, coverage) = session.observe_window(|| {
+            // Stand in for the authoritative scan: write while the window is open, then wait for
+            // the notifier to deliver rather than assuming a delivery latency.
+            std::fs::write(&target, "fn racing() {}\n").expect("racing write");
+            let deadline = Instant::now() + Duration::from_secs(20);
+            while Instant::now() < deadline && session.epoch() == 0 {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        });
+
+        let proven = coverage
+            .proven()
+            .expect("a local temporary directory must observe without loss");
+        assert!(
+            !proven.is_quiet(),
+            "the write inside the window must advance the epoch"
+        );
+        let observed = proven
+            .dirty_paths()
+            .iter()
+            .chain(proven.rescan_roots().iter())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        assert!(
+            observed.contains(&target) || observed.contains(&source),
+            "observed paths {observed:?} must be spelled under the armed root {}",
+            root.path().display()
+        );
+    }
+}

--- a/crates/codestory-workspace/src/filesystem_observer.rs
+++ b/crates/codestory-workspace/src/filesystem_observer.rs
@@ -15,9 +15,18 @@
 //! keeps whatever verdict it computed without the observer. That fallback is the permanent floor
 //! beneath this module, not a temporary state.
 //!
-//! Losses are sticky. Once a session has missed anything it can never seal `Proven` again,
-//! because a backend that dropped one event has no way to tell the caller what it dropped.
-//! Recovering certainty requires arming a new session, which carries a new identity.
+//! Backend losses are sticky. Once a notifier has told a session it missed something, that
+//! session can never seal `Proven` again: a backend that dropped one event has no way to say what
+//! it dropped, and on inotify the descriptors for subtrees created during the overflow were never
+//! installed. Recovering certainty requires arming a new session, which carries a new identity.
+//!
+//! Losses the session inflicts on *itself* are not sticky, because it knows exactly what they
+//! cost. An overflowed per-window accumulator and an overlapping window each seal one window
+//! indeterminate and clear when every window closes: the accumulator is per-window by
+//! construction and the next caller re-reads the tree anyway, so nothing carries forward.
+//!
+//! Churn is filtered on arrival by [`ObservedScopeFilter`] rather than downstream, so a build
+//! writing `target/` cannot spend the observation budget of a scan it was never going to affect.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -36,8 +45,21 @@ pub type ObserverEpoch = u64;
 /// Paths one session accumulates inside a single window before it declares a hole.
 ///
 /// The bound exists so a runaway writer cannot grow observer state without limit. Exhausting it
-/// is a loss of coverage like any other: the window seals indeterminate and the caller falls back.
+/// seals *that* window indeterminate and the caller falls back — but unlike a dropped kernel
+/// event it is not a permanent loss. The accumulator is per-window by construction, and the next
+/// window's caller re-reads the tree anyway, so the session recovers as soon as a window closes.
 pub const FILESYSTEM_OBSERVER_DIRTY_PATH_CAP: usize = 4_096;
+
+/// Directory names whose churn under a watched root can never be admitted source.
+///
+/// A recursive watch over a project root sees everything: a build writing `target/`, a checkout
+/// rewriting `.git/`, a package install unpacking `node_modules/`. None of it can ever reach a
+/// freshness verdict, because discovery excludes those trees by default — so charging them
+/// against the observation budget spends the whole window's accounting on paths the caller is
+/// about to throw away. The names mirror `default_source_exclude_patterns`, which is what
+/// discovery actually applies.
+const OBSERVER_IGNORED_DIRECTORY_NAMES: &[&str] =
+    &[".git", "node_modules", "target", "dist", "build"];
 
 /// Which notifier produced a session's events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -164,6 +186,70 @@ impl FilesystemObserverGap {
     }
 }
 
+/// Which observed paths one session accounts for at all.
+///
+/// The filter runs *before* anything is charged: an ignored path advances no epoch, occupies no
+/// accumulator slot, and consumes no budget. That ordering is the whole point. A recursive watch
+/// cannot be narrowed at the kernel, so the only place churn can be dropped is on arrival, and
+/// dropping it after the budget has already been spent would let a single `cargo build` overlapping
+/// one scan exhaust a 4096-path window on paths the escalation logic discards anyway.
+///
+/// Dropping is safe in exactly one direction: a path this filter refuses can never be admitted
+/// source, so refusing it can only ever *lower* the number of mutations a window reports. It can
+/// never manufacture a mutation, and it can never hide one a caller could have acted on.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObservedScopeFilter {
+    ignored_directory_names: BTreeSet<String>,
+    ignored_roots: BTreeSet<PathBuf>,
+}
+
+impl ObservedScopeFilter {
+    /// Account for every path under the watched root.
+    pub fn observe_everything() -> Self {
+        Self::default()
+    }
+
+    /// Account for everything discovery could admit, and nothing else.
+    pub fn source_default() -> Self {
+        Self {
+            ignored_directory_names: OBSERVER_IGNORED_DIRECTORY_NAMES
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
+            ignored_roots: BTreeSet::new(),
+        }
+    }
+
+    /// Also ignore one absolute subtree, such as the storage-owned cache directory.
+    #[must_use]
+    pub fn ignoring_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.ignored_roots.insert(root.into());
+        self
+    }
+
+    /// Whether `path` under `root` can possibly name something discovery admitted.
+    pub fn admits(&self, root: &Path, path: &Path) -> bool {
+        let Ok(relative) = path.strip_prefix(root) else {
+            // A recursive watch reports nothing outside its root; anything that arrives anyway
+            // names no file inside the project and can carry no verdict.
+            return false;
+        };
+        if self
+            .ignored_roots
+            .iter()
+            .any(|ignored| path.starts_with(ignored))
+        {
+            return false;
+        }
+        !relative.components().any(|component| {
+            component
+                .as_os_str()
+                .to_str()
+                .is_some_and(|name| self.ignored_directory_names.contains(name))
+        })
+    }
+}
+
 /// What a mutation implies about the scope a caller must re-examine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MutationScope {
@@ -210,7 +296,10 @@ impl ProvenCoverage {
         self.sealed_epoch
     }
 
-    /// No mutation at all was observed while the caller's scan ran.
+    /// No mutation the scope filter admits was observed while the caller's scan ran.
+    ///
+    /// Churn the filter refuses — `target/`, `.git/`, the storage cache — never counted, so a
+    /// build running alongside a scan still leaves the window quiet.
     pub fn is_quiet(&self) -> bool {
         self.armed_epoch == self.sealed_epoch
     }
@@ -267,7 +356,15 @@ struct SessionState {
     epoch: ObserverEpoch,
     dirty: BTreeSet<PathBuf>,
     rescan: BTreeSet<PathBuf>,
+    /// Losses the session can never come back from. A backend that dropped one event cannot say
+    /// what it dropped, and on inotify the descriptors for subtrees created during the overflow
+    /// were never installed, so nothing later re-establishes coverage.
     gap: Option<FilesystemObserverGap>,
+    /// The current window overflowed its own accumulator. Cleared when every window closes,
+    /// because the accumulator is per-window and the next caller re-reads the tree regardless.
+    budget_exhausted: bool,
+    /// How many windows this session has overflowed. Diagnostic only, never control flow.
+    budget_exhaustions: u64,
     open_windows: usize,
     contended: bool,
     source: Box<dyn ObserverEventSource>,
@@ -282,6 +379,7 @@ struct SessionState {
 pub struct FilesystemObserverSession {
     identity: FilesystemObserverIdentity,
     canonical_root: PathBuf,
+    scope: ObservedScopeFilter,
     state: Mutex<SessionState>,
 }
 
@@ -299,7 +397,15 @@ impl FilesystemObserverSession {
     ///
     /// Fails closed with a typed gap when the filesystem is unsupported or the notifier refuses.
     pub fn arm(root: &Path) -> Result<Self, FilesystemObserverGap> {
-        Self::arm_with_filesystem(root, &probe_host_filesystem(root))
+        Self::arm_with_scope(root, ObservedScopeFilter::source_default())
+    }
+
+    /// Arm the platform notifier over `root`, accounting only for paths `scope` admits.
+    pub fn arm_with_scope(
+        root: &Path,
+        scope: ObservedScopeFilter,
+    ) -> Result<Self, FilesystemObserverGap> {
+        Self::arm_with_filesystem_and_scope(root, &probe_host_filesystem(root), scope)
     }
 
     /// Arm the platform notifier over `root` against a filesystem description the caller already
@@ -311,12 +417,22 @@ impl FilesystemObserverSession {
         root: &Path,
         observed: &ObservedFilesystem,
     ) -> Result<Self, FilesystemObserverGap> {
+        Self::arm_with_filesystem_and_scope(root, observed, ObservedScopeFilter::source_default())
+    }
+
+    /// Arm against a caller-supplied filesystem description and scope filter.
+    pub fn arm_with_filesystem_and_scope(
+        root: &Path,
+        observed: &ObservedFilesystem,
+        scope: ObservedScopeFilter,
+    ) -> Result<Self, FilesystemObserverGap> {
         classify_observed_filesystem(root, observed)?;
         let source = native_event_source(root)?;
         Ok(Self::from_source(
             FilesystemObserverBackend::Native,
             root,
             Box::new(source),
+            scope,
         ))
     }
 
@@ -325,13 +441,29 @@ impl FilesystemObserverSession {
     /// Test-only: production always arms the platform notifier through [`Self::arm`].
     #[cfg(any(test, feature = "test-support"))]
     pub fn arm_with_source(root: &Path, source: Box<dyn ObserverEventSource>) -> Self {
-        Self::from_source(FilesystemObserverBackend::Injected, root, source)
+        Self::from_source(
+            FilesystemObserverBackend::Injected,
+            root,
+            source,
+            ObservedScopeFilter::source_default(),
+        )
+    }
+
+    /// Arm a session over a caller-supplied event source and scope filter.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn arm_with_source_and_scope(
+        root: &Path,
+        source: Box<dyn ObserverEventSource>,
+        scope: ObservedScopeFilter,
+    ) -> Self {
+        Self::from_source(FilesystemObserverBackend::Injected, root, source, scope)
     }
 
     fn from_source(
         backend: FilesystemObserverBackend,
         root: &Path,
         source: Box<dyn ObserverEventSource>,
+        scope: ObservedScopeFilter,
     ) -> Self {
         let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
         Self {
@@ -341,11 +473,14 @@ impl FilesystemObserverSession {
                 session_id: Uuid::new_v4().to_string(),
             },
             canonical_root,
+            scope,
             state: Mutex::new(SessionState {
                 epoch: 0,
                 dirty: BTreeSet::new(),
                 rescan: BTreeSet::new(),
                 gap: None,
+                budget_exhausted: false,
+                budget_exhaustions: 0,
                 open_windows: 0,
                 contended: false,
                 source,
@@ -356,6 +491,20 @@ impl FilesystemObserverSession {
     /// Identity of this armed session.
     pub fn identity(&self) -> &FilesystemObserverIdentity {
         &self.identity
+    }
+
+    /// Which observed paths this session accounts for.
+    pub fn scope(&self) -> &ObservedScopeFilter {
+        &self.scope
+    }
+
+    /// How many windows this session has overflowed its per-window path budget.
+    ///
+    /// Exhaustion is otherwise invisible from outside — the symptom is that reads keep returning
+    /// whatever the unobserved scan said — so an operator asking "why is this repository never
+    /// observed" needs a number to look at.
+    pub fn budget_exhaustion_count(&self) -> u64 {
+        self.lock().budget_exhaustions
     }
 
     /// Mutations absorbed so far, after taking whatever the notifier has queued.
@@ -369,6 +518,9 @@ impl FilesystemObserverSession {
     }
 
     /// The sticky gap this session has fallen into, if any.
+    ///
+    /// Per-window losses — an overflowed accumulator, an overlapping window — are not sticky and
+    /// never appear here; they are reported by the window that suffered them and nowhere else.
     pub fn gap(&self) -> Option<FilesystemObserverGap> {
         let mut state = self.lock();
         self.absorb(&mut state);
@@ -388,6 +540,7 @@ impl FilesystemObserverSession {
             if state.open_windows == 0 {
                 state.dirty.clear();
                 state.rescan.clear();
+                state.budget_exhausted = false;
             } else {
                 // Two windows sharing one accumulator can each attribute the other's quiet
                 // stretches to itself. Neither may claim proof.
@@ -402,15 +555,22 @@ impl FilesystemObserverSession {
             self.absorb(&mut state);
             state.open_windows = state.open_windows.saturating_sub(1);
             let contended = state.contended;
+            let exhausted = state.budget_exhausted;
             if state.open_windows == 0 {
                 state.contended = false;
+                state.budget_exhausted = false;
             }
-            match (contended, state.gap.clone()) {
-                (_, Some(gap)) => FilesystemObserverCoverage::Indeterminate { gap },
-                (true, None) => FilesystemObserverCoverage::Indeterminate {
+            match (contended, exhausted, state.gap.clone()) {
+                (_, _, Some(gap)) => FilesystemObserverCoverage::Indeterminate { gap },
+                (true, _, None) => FilesystemObserverCoverage::Indeterminate {
                     gap: FilesystemObserverGap::ConcurrentObservation,
                 },
-                (false, None) => FilesystemObserverCoverage::Proven(ProvenCoverage {
+                (false, true, None) => FilesystemObserverCoverage::Indeterminate {
+                    gap: FilesystemObserverGap::ObservationBudgetExhausted {
+                        limit: FILESYSTEM_OBSERVER_DIRTY_PATH_CAP,
+                    },
+                },
+                (false, false, None) => FilesystemObserverCoverage::Proven(ProvenCoverage {
                     identity: self.identity.clone(),
                     armed_epoch,
                     sealed_epoch: state.epoch,
@@ -437,18 +597,22 @@ impl FilesystemObserverSession {
     fn apply(&self, state: &mut SessionState, event: ObservedFilesystemEvent) {
         match event {
             ObservedFilesystemEvent::Mutated { path, scope } => {
-                state.epoch = state.epoch.saturating_add(1);
                 let path = self.rebase_observed_path(path);
+                // Admission first, budget second. A path no caller can act on must not advance
+                // the epoch, must not occupy an accumulator slot, and must not spend the window.
+                if !self.scope.admits(&self.identity.root, &path) {
+                    return;
+                }
+                state.epoch = state.epoch.saturating_add(1);
                 let set = match scope {
                     MutationScope::File => &mut state.dirty,
                     MutationScope::Directory => &mut state.rescan,
                 };
                 if set.len() >= FILESYSTEM_OBSERVER_DIRTY_PATH_CAP && !set.contains(&path) {
-                    state
-                        .gap
-                        .get_or_insert(FilesystemObserverGap::ObservationBudgetExhausted {
-                            limit: FILESYSTEM_OBSERVER_DIRTY_PATH_CAP,
-                        });
+                    if !state.budget_exhausted {
+                        state.budget_exhausted = true;
+                        state.budget_exhaustions = state.budget_exhaustions.saturating_add(1);
+                    }
                     return;
                 }
                 set.insert(path);
@@ -1013,6 +1177,111 @@ mod tests {
         assert_eq!(
             coverage.gap().map(FilesystemObserverGap::id),
             Some("observer_budget_exhausted")
+        );
+    }
+
+    #[test]
+    fn an_exhausted_budget_is_a_per_window_loss_the_next_window_recovers_from() {
+        // The permanently-disabled observer is the failure this guards: a single build overlapping
+        // one scan must not silently switch the feature off for the rest of the process.
+        let (session, sender) = scripted(Path::new("/repo"));
+        let (_, exhausted) = session.observe_window(|| {
+            for index in 0..=FILESYSTEM_OBSERVER_DIRTY_PATH_CAP {
+                sender
+                    .send(mutated(
+                        &format!("/repo/src/file{index}.rs"),
+                        MutationScope::File,
+                    ))
+                    .expect("scripted source must accept the event");
+            }
+        });
+        assert_eq!(
+            exhausted.gap().map(FilesystemObserverGap::id),
+            Some("observer_budget_exhausted")
+        );
+        assert_eq!(session.budget_exhaustion_count(), 1);
+        assert_eq!(
+            session.gap(),
+            None,
+            "overflowing our own accumulator is not a backend loss and must not stick"
+        );
+
+        let (_, recovered) = session.observe_window(|| {
+            sender
+                .send(mutated("/repo/src/lib.rs", MutationScope::File))
+                .expect("scripted source must accept the event");
+        });
+        let proven = recovered
+            .proven()
+            .expect("the window after an overflow accounts for itself completely");
+        assert_eq!(
+            proven.dirty_paths().iter().collect::<Vec<_>>(),
+            vec![&PathBuf::from("/repo/src/lib.rs")]
+        );
+        assert_eq!(session.budget_exhaustion_count(), 1);
+    }
+
+    #[test]
+    fn ignored_churn_never_reaches_the_epoch_or_the_budget() {
+        // A build and a checkout produce more paths than the whole budget. Charging them before
+        // the admission filter would seal every overlapping window indeterminate.
+        let (session, sender) = scripted(Path::new("/repo"));
+        let (_, coverage) = session.observe_window(|| {
+            for index in 0..=FILESYSTEM_OBSERVER_DIRTY_PATH_CAP {
+                sender
+                    .send(mutated(
+                        &format!("/repo/target/debug/artifact{index}.o"),
+                        MutationScope::File,
+                    ))
+                    .expect("scripted source must accept the event");
+                sender
+                    .send(mutated(
+                        &format!("/repo/.git/objects/{index}"),
+                        MutationScope::File,
+                    ))
+                    .expect("scripted source must accept the event");
+                sender
+                    .send(mutated(
+                        &format!("/repo/node_modules/dep{index}/index.js"),
+                        MutationScope::File,
+                    ))
+                    .expect("scripted source must accept the event");
+            }
+            sender
+                .send(mutated("/repo/src/lib.rs", MutationScope::File))
+                .expect("scripted source must accept the event");
+        });
+        let proven = coverage
+            .proven()
+            .expect("churn discovery excludes may not exhaust the observation budget");
+        assert_eq!(session.budget_exhaustion_count(), 0);
+        assert_eq!(
+            proven.dirty_paths().iter().collect::<Vec<_>>(),
+            vec![&PathBuf::from("/repo/src/lib.rs")],
+            "only paths discovery could admit are accounted for"
+        );
+        assert_eq!(
+            proven.sealed_epoch(),
+            proven.armed_epoch() + 1,
+            "ignored churn advances no epoch, so a lease cannot be invalidated by a build"
+        );
+    }
+
+    #[test]
+    fn an_ignored_root_covers_the_storage_cache_the_runtime_owns() {
+        let scope = ObservedScopeFilter::source_default().ignoring_root("/repo/.cache");
+        assert!(scope.admits(Path::new("/repo"), Path::new("/repo/src/lib.rs")));
+        assert!(scope.admits(Path::new("/repo"), Path::new("/repo")));
+        assert!(!scope.admits(Path::new("/repo"), Path::new("/repo/.cache/codestory.db")));
+        assert!(!scope.admits(Path::new("/repo"), Path::new("/repo/target/debug/main")));
+        assert!(!scope.admits(Path::new("/repo"), Path::new("/repo/a/.git/index")));
+        assert!(
+            !scope.admits(Path::new("/repo"), Path::new("/elsewhere/lib.rs")),
+            "a recursive watch reports nothing outside its root; anything that arrives is noise"
+        );
+        assert!(
+            ObservedScopeFilter::observe_everything()
+                .admits(Path::new("/repo"), Path::new("/repo/target/debug/main"))
         );
     }
 

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -27,6 +27,7 @@ use std::path::{Component, Path, PathBuf};
 use uuid::Uuid;
 
 pub mod atomic_file;
+pub mod filesystem_observer;
 pub mod locking;
 pub mod owned_deletion;
 pub mod paths;
@@ -1631,6 +1632,16 @@ fn observed_file_metadata(path: &Path) -> Result<ObservedFileMetadata> {
         modified_ms: clamp_system_time_to_epoch_millis(modified),
         len: metadata.len(),
     })
+}
+
+/// Re-verify one stored file against the bytes on disk right now.
+///
+/// This is the exact predicate refresh planning applies during discovery, exposed so a caller
+/// that learned a specific path was written *after* the plan was built can settle that path
+/// without re-walking the tree. Sharing the predicate is the point: a second, similar-looking
+/// comparison would be free to disagree with the planner about what counts as drift.
+pub fn stored_file_requires_reindex(path: &Path, file: &StoredFileState) -> bool {
+    stored_file_needs_index(path, file)
 }
 
 fn stored_file_needs_index(path: &Path, file: &StoredFileState) -> bool {


### PR DESCRIPTION
Closes #1787. **#1651 stays open** — see Declared remainder.

## What

A cross-platform filesystem observer that arms **before** the authoritative freshness scan and may only ever upgrade certainty. Dirty paths are rehashed through the planner's own predicate (so no second predicate can drift from it), directory-scoped mutations inside admitted scopes escalate, and the `ReadyLease` now carries an observer epoch so a mutation racing the lease scan refuses reuse.

## Review and repair

The review found five majors. All addressed, each with mutation evidence:

1. **The arm-before-scan ordering was unpinned at the call site.** Inverting it — running the scan outside the window, then sealing an empty one — destroyed the feature and left all 31 tests green, because the scripted observer fires by drain index rather than by position relative to the scan. The new test emits *no* event at all: the racing write lands at arm time, so only a scan that genuinely runs inside the window can see it. Under the exact inversion it fails `left: Fresh / right: Stale`.
2. **The three declared serving-read sites were pinned only by a counter of arm requests** — each could be reverted individually with the suite green, and nothing asserted that an escalated verdict actually *refuses* anything. All three now pinned by consequence, each with its own mutation, using a directory-scoped mutation that moves no byte so only the escalation can turn them red.
3. **Clause 2 was unimplemented and undeclared** — the lease-reuse window the commit's own opening names as the motivating bug. Now delivered: the lease records session, backend and epoch, captured before the lease scan; reuse is refused when the epoch advances, the session re-arms, or coverage is lost. The previously-orphaned `ObserverEpoch` surface finally has a production consumer.
4. **The budget was spent on churn the escalation later discards, and exhaustion was permanently sticky** — a `cargo build` overlapping one scan blew the 4096-path cap on `target/` files and silently disabled the observer for the process, with reads simply continuing to say fresh. Scope filtering now runs *before* the budget, exhaustion is per-window and counted, and a sealed-indeterminate window emits a diagnostic. Backend losses stay sticky by design.
5. **The safety claim, resolved explicitly rather than left implicit.** On observer loss the fallback is EV-78's existing typed-unknown floor, not a new refusal. The reasoning is now in the commit body: refusing would permanently lock out every NFS mount, every WSL drive mount, and every host whose notifier declines. Epic #1179 stages this package "behind typed-unknown fallback"; #1651's literal Done-when reads stricter. That divergence is named, not papered over.

## Declared remainder (why this closes a child)

Clause 5 (the 25,000-file cap) and therefore clause 1's "complete" scan; clause 4 substituted; clause 6's literal reading. All carried on #1651 with their exposure stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
