### PR TITLE
[v0.17 WIRE] Version the public publication and protocol compatibility contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,29 @@
 - If moving bookmarks to their new home is interrupted — a full disk, a closed
   laptop — the bookmarks you already had stay visible instead of appearing to
   have vanished, and the move finishes the next time you make a change.
+- A host is no longer told CodeStory speaks a protocol revision it does not
+  implement. The MCP handshake used to repeat back whichever revision the host
+  asked for, which read as agreement. It now answers with a revision CodeStory
+  actually implements and reports what was asked for, what was agreed, and
+  everything supported.
+- Every CodeStory response now says which response contract produced it, and the
+  handshake says it first, so a tool that reads CodeStory output knows the
+  vocabulary before it reads a single result. The contract is version 2: tool
+  arguments are checked against the published tool list and refused instead of
+  being quietly repaired, so a tool written against version 1 can see requests it
+  believes are valid rejected. A response with no version stamp is the old
+  unversioned one.
+- Pointing `CODESTORY_CLI` at a build that does not match the installed plugin
+  now stops the session with a plain reason instead of mixing two contracts.
+  Nothing that build produces reaches the host, and CodeStory's own diagnostics
+  explain why. This was the one supported way to end up with a mismatched pair
+  and the only place it could be caught.
+- Evidence that arrives without saying whether it was resolvable, where it came
+  from, or whether its retrieval stage finished is now refused instead of being
+  read as resolvable, parser-backed and complete.
+- The same word spelled two ways across CodeStory's own output — `Full` and
+  `full`, `Public` and `public` — is now accepted either way when read back.
+  What CodeStory writes is unchanged.
 
 ## 0.16.3
 

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -530,9 +530,16 @@ impl RuntimeContext {
     }
 }
 
-/// Additive public response-envelope contract. Missing remains legacy v0 until W7.7 completes
-/// protocol negotiation and fail-closed defaults around this stamp.
-pub(crate) const CODESTORY_PUBLICATION_META_SCHEMA_VERSION: u32 = 1;
+/// Public response-envelope contract version. `codestory_contracts::wire` owns
+/// the value and documents each revision; a missing stamp stays legacy v0.
+pub(crate) const CODESTORY_PUBLICATION_META_SCHEMA_VERSION: u32 =
+    codestory_contracts::wire::PUBLICATION_STAMP_SCHEMA_VERSION;
+
+/// Oldest reader schema that can still interpret this stamp. Published so a
+/// consumer decides from the payload instead of guessing that every bump is
+/// additive.
+pub(crate) const CODESTORY_PUBLICATION_META_MINIMUM_COMPATIBLE_SCHEMA_VERSION: u32 =
+    codestory_contracts::wire::MINIMUM_COMPATIBLE_PUBLICATION_STAMP_SCHEMA_VERSION;
 
 pub(crate) fn codestory_publication_contract_runtime_meta() -> serde_json::Value {
     let active_cli_version = env!("CARGO_PKG_VERSION");
@@ -597,6 +604,8 @@ pub(crate) fn codestory_publication_meta(
     };
     serde_json::json!({
         "schema_version": CODESTORY_PUBLICATION_META_SCHEMA_VERSION,
+        "minimum_compatible_schema_version":
+            CODESTORY_PUBLICATION_META_MINIMUM_COMPATIBLE_SCHEMA_VERSION,
         "served_from": served_from,
         "publication": core_publication,
         "core_publication": core_publication,
@@ -1308,11 +1317,16 @@ mod tests {
             value.pointer("/_meta/codestory_publication/served_from"),
             Some(&serde_json::json!("contract_only"))
         );
+        // Literal, not the constant: the CLI JSON envelope publishes the same
+        // number the stdio and HTTP adapters do, and a consumer pinned to it
+        // must see the bump rather than a self-referential comparison.
         assert_eq!(
             value.pointer("/_meta/codestory_publication/schema_version"),
-            Some(&serde_json::json!(
-                CODESTORY_PUBLICATION_META_SCHEMA_VERSION
-            ))
+            Some(&serde_json::json!(2))
+        );
+        assert_eq!(
+            value.pointer("/_meta/codestory_publication/minimum_compatible_schema_version"),
+            Some(&serde_json::json!(2))
         );
         assert_eq!(
             value.pointer("/_meta/codestory_publication/contract_runtime/cli_version"),

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1912,24 +1912,32 @@ fn compact_stdio_status(runtime: &RuntimeContext, status: &serde_json::Value) ->
     })
 }
 
+/// Render one `tools/call` outcome.
+///
+/// The publication stamp is not optional: every successful tool payload that an
+/// out-of-repo consumer can read — including the packet vocabulary EV-5 added,
+/// where `proof_status: "reported"` names a carrier lead rather than proof —
+/// must arrive with the schema version that defines that vocabulary.
 fn stdio_jsonrpc_tool_call_from_legacy(
     id: serde_json::Value,
     response: serde_json::Value,
-    publication_meta: Option<serde_json::Value>,
+    publication_meta: serde_json::Value,
     tool_name: &str,
 ) -> serde_json::Value {
     if let Some(result) = response.get("result") {
         let mut success = stdio_tool_call_success(tool_name, result.clone());
-        if let Some(publication_meta) = publication_meta
-            && let Some(success) = success.as_object_mut()
-        {
-            let meta = success
-                .entry("_meta")
-                .or_insert_with(|| serde_json::json!({}));
-            if let Some(meta) = meta.as_object_mut() {
-                meta.insert("codestory_publication".to_string(), publication_meta);
-            }
+        let success_object = success
+            .as_object_mut()
+            .expect("tools/call success payload is an object");
+        let meta = success_object
+            .entry("_meta")
+            .or_insert_with(|| serde_json::json!({}));
+        if !meta.is_object() {
+            *meta = serde_json::json!({});
         }
+        meta.as_object_mut()
+            .expect("tools/call metadata is an object")
+            .insert("codestory_publication".to_string(), publication_meta);
         return stdio_jsonrpc_success(id, success);
     }
     if let Some(error) = response.get("error") {
@@ -1981,7 +1989,7 @@ fn stdio_served_publication_meta(
     retrieval_publication: Option<&serde_json::Value>,
     operation_id: Option<&str>,
     attempt: Option<u32>,
-) -> Option<serde_json::Value> {
+) -> serde_json::Value {
     let status = state.status_cache.as_ref().map(|cached| &cached.value);
     let refreshing = status
         .and_then(|status| status.pointer("/local_refresh/state"))
@@ -2004,7 +2012,7 @@ fn stdio_served_publication_meta(
             "started_at_epoch_ms": status.and_then(|status| status.pointer("/local_refresh/started_at_epoch_ms"))
         });
     }
-    Some(meta)
+    meta
 }
 
 fn stdio_response_retrieval_publication(
@@ -2503,14 +2511,25 @@ fn stdio_json_text(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
 }
 
+/// Build the `initialize` result.
+///
+/// Two contracts land here. The protocol revision is *negotiated* against the
+/// revisions this build implements instead of echoed, so a client can no longer
+/// read its own request back as a compatibility guarantee. And the result
+/// carries the same `_meta.codestory_publication` stamp every publication-backed
+/// response carries, so a pinned launcher — including one pointed at a
+/// different binary through the documented `CODESTORY_CLI` override — learns the
+/// response-schema version at session start rather than after the first
+/// `tools/call`.
 fn stdio_initialize_result_json(request: &serde_json::Value) -> serde_json::Value {
-    let protocol_version = request
-        .pointer("/params/protocolVersion")
-        .and_then(|value| value.as_str())
-        .unwrap_or("2024-11-05");
+    let negotiation = codestory_contracts::wire::negotiate_mcp_protocol_version(
+        request
+            .pointer("/params/protocolVersion")
+            .and_then(|value| value.as_str()),
+    );
     let version = env!("CARGO_PKG_VERSION");
     serde_json::json!({
-        "protocolVersion": protocol_version,
+        "protocolVersion": negotiation.negotiated,
         "name": "codestory",
         "version": version,
         "serverInfo": {
@@ -2528,6 +2547,16 @@ fn stdio_initialize_result_json(request: &serde_json::Value) -> serde_json::Valu
             "prompts": {
                 "listChanged": false
             }
+        },
+        "_meta": {
+            "codestory_publication": crate::runtime::codestory_publication_meta(
+                None,
+                None,
+                None,
+                None,
+                false,
+            ),
+            "codestory_protocol": negotiation,
         }
     })
 }
@@ -8497,9 +8526,7 @@ version = "0.11.20"
         );
         assert_eq!(
             response.pointer("/result/_meta/codestory_publication/schema_version"),
-            Some(&json!(
-                crate::runtime::CODESTORY_PUBLICATION_META_SCHEMA_VERSION
-            ))
+            Some(&json!(2))
         );
         assert_eq!(
             response.pointer("/result/_meta/codestory_publication/contract_runtime/cli_version"),
@@ -8540,11 +8567,18 @@ version = "0.11.20"
         )
         .expect("canonical CLI/HTTP envelope");
 
+        // The payload above carries `proof_status: "reported"`, the value EV-5
+        // added. The literal is deliberate: a consumer told "schema 2" is being
+        // told which vocabulary this word belongs to, so the number cannot be
+        // allowed to drift behind a self-referential constant.
         assert_eq!(
             response.pointer("/result/_meta/codestory_publication/schema_version"),
-            Some(&json!(
-                crate::runtime::CODESTORY_PUBLICATION_META_SCHEMA_VERSION
-            ))
+            Some(&json!(2))
+        );
+        assert_eq!(
+            response
+                .pointer("/result/_meta/codestory_publication/minimum_compatible_schema_version"),
+            Some(&json!(2))
         );
         assert_eq!(
             response.pointer("/result/_meta/codestory_publication/core_publication"),
@@ -8592,6 +8626,65 @@ version = "0.11.20"
         assert_eq!(direct["pinned_pair_matches"], serde_json::Value::Null);
         assert_eq!(mismatch["pinned_pair_matches"], json!(false));
         assert_eq!(matched["pinned_pair_matches"], json!(true));
+    }
+
+    #[test]
+    fn stdio_initialize_negotiates_instead_of_echoing_and_stamps_the_contract() {
+        let initialize = |params: serde_json::Value| {
+            stdio_initialize_result_json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": params
+            }))
+        };
+
+        let agreed = initialize(json!({"protocolVersion": "2024-11-05"}));
+        assert_eq!(agreed["protocolVersion"], json!("2024-11-05"));
+        assert_eq!(
+            agreed["_meta"]["codestory_protocol"]["status"],
+            json!("agreed")
+        );
+
+        let unsupported = initialize(json!({"protocolVersion": "2025-06-18"}));
+        assert_eq!(
+            unsupported["protocolVersion"],
+            json!("2024-11-05"),
+            "an unimplemented revision must not be echoed as supported"
+        );
+        assert_eq!(
+            unsupported["_meta"]["codestory_protocol"],
+            json!({
+                "requested": "2025-06-18",
+                "negotiated": "2024-11-05",
+                "supported": ["2024-11-05"],
+                "status": "unsupported_client_revision",
+                "compatible": false
+            })
+        );
+
+        let defaulted = initialize(json!({}));
+        assert_eq!(defaulted["protocolVersion"], json!("2024-11-05"));
+        assert_eq!(
+            defaulted["_meta"]["codestory_protocol"]["status"],
+            json!("defaulted")
+        );
+
+        // The launcher reads this stamp out of the frame it suppresses, so it
+        // must be the same contract-only stamp every other adapter publishes.
+        let stamp = &agreed["_meta"]["codestory_publication"];
+        assert_eq!(stamp["schema_version"], json!(2));
+        assert_eq!(stamp["minimum_compatible_schema_version"], json!(2));
+        assert_eq!(stamp["served_from"], json!("contract_only"));
+        assert_eq!(
+            stamp["contract_runtime"]["cli_version"],
+            json!(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(
+            stamp,
+            &crate::runtime::codestory_publication_meta(None, None, None, None, false),
+            "initialize must not invent a second stamp shape"
+        );
     }
 
     #[test]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -965,7 +965,7 @@ fn initialize_preserves_id_and_reports_server_info_and_capabilities() {
     assert_eq!(
         result.get("protocolVersion"),
         Some(&json!("2024-11-05")),
-        "initialize should echo the requested protocol version: {response}"
+        "initialize should agree to a supported protocol version: {response}"
     );
     assert!(
         result
@@ -988,6 +988,153 @@ fn initialize_preserves_id_and_reports_server_info_and_capabilities() {
     assert!(
         result.get("capabilities").is_some(),
         "initialize should report server capabilities: {response}"
+    );
+}
+
+/// CR-064 + ARCH-035. `initialize` is the first frame an out-of-repo consumer
+/// sees, so it is where the session's two compatibility identities must be
+/// truthful: the protocol revision the server actually implements, and the
+/// response-schema version that defines the vocabulary of everything after it.
+#[test]
+fn initialize_negotiates_the_protocol_revision_and_stamps_the_wire_contract() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let agreed = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init-agreed",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "contract-test", "version": "0"}
+            }
+        }),
+    );
+    let agreed = assert_success_envelope(&agreed, json!("init-agreed"));
+    assert_eq!(agreed.get("protocolVersion"), Some(&json!("2024-11-05")));
+    assert_eq!(
+        agreed.pointer("/_meta/codestory_protocol"),
+        Some(&json!({
+            "requested": "2024-11-05",
+            "negotiated": "2024-11-05",
+            "supported": ["2024-11-05"],
+            "status": "agreed",
+            "compatible": true
+        })),
+    );
+    assert_eq!(
+        agreed.pointer("/_meta/codestory_publication/schema_version"),
+        Some(&json!(2)),
+        "the session-start stamp publishes the v0.17.0 response schema: {agreed}"
+    );
+    assert_eq!(
+        agreed.pointer("/_meta/codestory_publication/minimum_compatible_schema_version"),
+        Some(&json!(2)),
+    );
+    assert_eq!(
+        agreed.pointer("/_meta/codestory_publication/served_from"),
+        Some(&json!("contract_only")),
+        "initialize serves no publication and must not claim one: {agreed}"
+    );
+    assert_eq!(
+        agreed.pointer("/_meta/codestory_publication/contract_runtime/cli_version"),
+        Some(&json!(env!("CARGO_PKG_VERSION"))),
+    );
+
+    let unsupported = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init-unsupported",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "contract-test", "version": "0"}
+            }
+        }),
+    );
+    let unsupported = assert_success_envelope(&unsupported, json!("init-unsupported"));
+    assert_eq!(
+        unsupported.get("protocolVersion"),
+        Some(&json!("2024-11-05")),
+        "an unimplemented revision must not be echoed back as supported: {unsupported}"
+    );
+    assert_eq!(
+        unsupported.pointer("/_meta/codestory_protocol"),
+        Some(&json!({
+            "requested": "2025-06-18",
+            "negotiated": "2024-11-05",
+            "supported": ["2024-11-05"],
+            "status": "unsupported_client_revision",
+            "compatible": false
+        })),
+    );
+
+    let defaulted = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init-defaulted",
+            "method": "initialize",
+            "params": {"capabilities": {}}
+        }),
+    );
+    let defaulted = assert_success_envelope(&defaulted, json!("init-defaulted"));
+    assert_eq!(defaulted.get("protocolVersion"), Some(&json!("2024-11-05")));
+    assert_eq!(
+        defaulted.pointer("/_meta/codestory_protocol/status"),
+        Some(&json!("defaulted")),
+    );
+    assert_eq!(
+        defaulted.pointer("/_meta/codestory_protocol/requested"),
+        Some(&Value::Null),
+    );
+}
+
+/// ARCH-035 + EV-5. `proof_status: "reported"` is a v2 vocabulary value: it
+/// names a carrier lead that failed its typed proof contract. An out-of-repo
+/// reader may only interpret it when the response says which schema produced
+/// it, so every publication-backed tool payload carries the stamp.
+#[test]
+fn tool_results_carry_the_publication_schema_that_defines_their_vocabulary() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+    initialize_stdio_server(&mut server, "init-stamp");
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-stamp",
+            "method": "tools/call",
+            "params": {
+                "name": "ground",
+                "arguments": {
+                    "project": fixture.workspace.path(),
+                    "budget": "strict"
+                }
+            }
+        }),
+    );
+    assert_tool_success(&response, json!("ground-stamp"));
+    let result = assert_success_envelope(&response, json!("ground-stamp"));
+    assert_eq!(
+        result.pointer("/_meta/codestory_publication/schema_version"),
+        Some(&json!(2)),
+        "a served payload must name the schema its vocabulary belongs to: {response}"
+    );
+    assert_eq!(
+        result.pointer("/_meta/codestory_publication/minimum_compatible_schema_version"),
+        Some(&json!(2)),
+    );
+    assert_eq!(
+        result.pointer("/_meta/codestory_publication/served_from"),
+        Some(&json!("complete_publication")),
+        "a served payload must name the publication it came from: {response}"
     );
 }
 

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -63,11 +63,18 @@ pub struct IndexPublicationDto {
     pub published_at_epoch_ms: i64,
 }
 
+/// Mode the served publication was produced by.
+///
+/// Emission stays `snake_case`. The PascalCase aliases accept the spelling the
+/// mirrored `IndexMode` request enum emits on the same wire surfaces.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum IndexPublicationModeDto {
+    #[serde(alias = "Full")]
     Full,
+    #[serde(alias = "Incremental")]
     Incremental,
+    #[serde(alias = "SemanticProjection")]
     SemanticProjection,
 }
 
@@ -1704,12 +1711,20 @@ pub enum CanonicalRouteKind {
     Hierarchy,
 }
 
+/// Canonical member visibility.
+///
+/// Emission stays `snake_case`. The PascalCase aliases accept the spelling the
+/// mirrored `MemberAccess` enum emits on the same wire surfaces.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CanonicalMemberVisibility {
+    #[serde(alias = "Public")]
     Public,
+    #[serde(alias = "Protected")]
     Protected,
+    #[serde(alias = "Private")]
     Private,
+    #[serde(alias = "Default")]
     Default,
 }
 
@@ -2152,11 +2167,14 @@ pub struct AgentCitationDto {
     pub file_path: Option<String>,
     pub line: Option<u32>,
     pub score: f32,
-    #[serde(default = "default_search_hit_origin")]
+    // `origin` and `resolvable` are required on decode. An absent provenance or
+    // resolvability field once decoded to "indexed symbol" and "resolvable",
+    // which is the wrong direction for evidence: a truncated or older payload
+    // would have claimed parser-backed, followable evidence the producer never
+    // sent. A reader that did not receive the field must fail, not assume.
     pub origin: SearchHitOrigin,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target: Option<SearchTargetDto>,
-    #[serde(default = "default_citation_resolvable")]
     pub resolvable: bool,
     #[serde(default)]
     pub subgraph_id: Option<String>,
@@ -2176,14 +2194,6 @@ pub struct AgentCitationDto {
     pub coverage_role: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eligible_for_sufficiency: Option<bool>,
-}
-
-const fn default_search_hit_origin() -> SearchHitOrigin {
-    SearchHitOrigin::IndexedSymbol
-}
-
-const fn default_citation_resolvable() -> bool {
-    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
@@ -2291,12 +2301,10 @@ pub struct RetrievalStageTimingDto {
     pub degraded: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stub_reason: Option<String>,
-    #[serde(default = "completed_stage_status")]
+    // Required on decode. Defaulting an absent status to "completed" claimed a
+    // finished stage beside a populated `cancel_reason`; a stage whose outcome
+    // was not transmitted has no known outcome.
     pub completion_status: String,
-}
-
-fn completed_stage_status() -> String {
-    "completed".into()
 }
 
 fn is_false(value: &bool) -> bool {
@@ -3939,6 +3947,111 @@ mod packet_tests {
         let omitted = serde_json::to_value(omitted).expect("serialize omitted comment");
         assert!(omitted.get("comment").is_none());
         assert!(omitted.get("category_id").is_none());
+    }
+
+    fn citation_json() -> serde_json::Value {
+        serde_json::json!({
+            "node_id": "node-1",
+            "display_name": "handle_request",
+            "kind": "FUNCTION",
+            "file_path": "src/lib.rs",
+            "line": 10,
+            "score": 1.0,
+            "origin": "text_match",
+            "resolvable": false
+        })
+    }
+
+    #[test]
+    fn absent_citation_provenance_and_resolvability_fail_closed() {
+        // CR-055: the previous defaults decoded an absent field to
+        // "indexed symbol" and "resolvable", inventing parser-backed,
+        // followable evidence the producer never sent.
+        let complete: AgentCitationDto =
+            serde_json::from_value(citation_json()).expect("complete citation decodes");
+        assert_eq!(complete.origin, SearchHitOrigin::TextMatch);
+        assert!(!complete.resolvable);
+
+        for field in ["origin", "resolvable"] {
+            let mut partial = citation_json();
+            partial
+                .as_object_mut()
+                .expect("citation object")
+                .remove(field);
+            let error = serde_json::from_value::<AgentCitationDto>(partial)
+                .expect_err("an absent evidence field must not decode to a permissive default");
+            assert!(
+                error.to_string().contains(field),
+                "the decode failure must name the absent field: {error}"
+            );
+        }
+    }
+
+    fn stage_timing_json() -> serde_json::Value {
+        serde_json::json!({
+            "stage": "stage2_semantic",
+            "elapsed_ms": 40,
+            "cancel_reason": "deadline_exceeded",
+            "completion_status": "cancelled"
+        })
+    }
+
+    #[test]
+    fn absent_stage_completion_status_fails_closed() {
+        // CR-055: defaulting to "completed" claimed a finished stage beside a
+        // populated cancel_reason.
+        let complete: RetrievalStageTimingDto =
+            serde_json::from_value(stage_timing_json()).expect("complete stage decodes");
+        assert_eq!(complete.completion_status, "cancelled");
+
+        let mut partial = stage_timing_json();
+        partial
+            .as_object_mut()
+            .expect("stage object")
+            .remove("completion_status");
+        let error = serde_json::from_value::<RetrievalStageTimingDto>(partial)
+            .expect_err("an absent stage completion status must not decode as completed");
+        assert!(
+            error.to_string().contains("completion_status"),
+            "the decode failure must name the absent field: {error}"
+        );
+    }
+
+    #[test]
+    fn mirrored_publication_mode_accepts_both_casings_and_emits_one() {
+        // CR-032: the same vocabulary is spelled two ways across mirrored wire
+        // fields. Deserialize accepts both; emission is unchanged.
+        for spelling in ["semantic_projection", "SemanticProjection"] {
+            let parsed: IndexPublicationModeDto =
+                serde_json::from_value(serde_json::json!(spelling))
+                    .unwrap_or_else(|error| panic!("decode {spelling}: {error}"));
+            assert_eq!(parsed, IndexPublicationModeDto::SemanticProjection);
+        }
+        assert_eq!(
+            serde_json::to_value(IndexPublicationModeDto::SemanticProjection)
+                .expect("serialize publication mode"),
+            serde_json::json!("semantic_projection"),
+            "emission must stay snake_case"
+        );
+
+        for spelling in ["protected", "Protected"] {
+            let parsed: CanonicalMemberVisibility =
+                serde_json::from_value(serde_json::json!(spelling))
+                    .unwrap_or_else(|error| panic!("decode {spelling}: {error}"));
+            assert_eq!(parsed, CanonicalMemberVisibility::Protected);
+        }
+        assert_eq!(
+            serde_json::to_value(CanonicalMemberVisibility::Protected)
+                .expect("serialize member visibility"),
+            serde_json::json!("protected"),
+            "emission must stay snake_case"
+        );
+
+        assert!(
+            serde_json::from_value::<IndexPublicationModeDto>(serde_json::json!("SEMANTIC"))
+                .is_err(),
+            "aliases add the mirrored spelling only, not arbitrary casing"
+        );
     }
 }
 

--- a/crates/codestory-contracts/src/api/types.rs
+++ b/crates/codestory-contracts/src/api/types.rs
@@ -21,9 +21,16 @@ macro_rules! impl_mirrored_enum_conversions {
     };
 }
 
+/// Requested indexing mode.
+///
+/// Emission stays PascalCase. The `snake_case` aliases accept the spelling the
+/// mirrored `IndexPublicationModeDto` emits on the same wire surfaces, so a
+/// caller that read one vocabulary can write the other without a rename.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type)]
 pub enum IndexMode {
+    #[serde(alias = "full")]
     Full,
+    #[serde(alias = "incremental")]
     Incremental,
 }
 
@@ -184,12 +191,20 @@ impl_mirrored_enum_conversions!(
     [Horizontal, Vertical,]
 );
 
+/// Declared member access.
+///
+/// Emission stays PascalCase. The `snake_case` aliases accept the spelling the
+/// mirrored `CanonicalMemberVisibility` emits on the same wire surfaces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type, Default)]
 pub enum MemberAccess {
     #[default]
+    #[serde(alias = "public")]
     Public,
+    #[serde(alias = "protected")]
     Protected,
+    #[serde(alias = "private")]
     Private,
+    #[serde(alias = "default")]
     Default,
 }
 
@@ -198,3 +213,45 @@ impl_mirrored_enum_conversions!(
     crate::graph::AccessKind,
     [Public, Protected, Private, Default,]
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mirrored_request_enums_accept_both_casings_and_emit_one() {
+        // CR-032: `IndexMode` and `MemberAccess` emit PascalCase while their
+        // mirrored response enums emit snake_case for the same vocabulary. The
+        // aliases let a caller write back what it read; emission is unchanged.
+        for spelling in ["Incremental", "incremental"] {
+            let parsed: IndexMode = serde_json::from_value(serde_json::json!(spelling))
+                .unwrap_or_else(|error| panic!("decode {spelling}: {error}"));
+            assert_eq!(parsed, IndexMode::Incremental);
+        }
+        assert_eq!(
+            serde_json::to_value(IndexMode::Incremental).expect("serialize index mode"),
+            serde_json::json!("Incremental"),
+            "emission must stay PascalCase"
+        );
+
+        let request: crate::api::StartIndexingRequest =
+            serde_json::from_str(r#"{"mode":"full"}"#).expect("snake_case request mode decodes");
+        assert_eq!(request.mode, IndexMode::Full);
+
+        for spelling in ["Private", "private"] {
+            let parsed: MemberAccess = serde_json::from_value(serde_json::json!(spelling))
+                .unwrap_or_else(|error| panic!("decode {spelling}: {error}"));
+            assert_eq!(parsed, MemberAccess::Private);
+        }
+        assert_eq!(
+            serde_json::to_value(MemberAccess::Private).expect("serialize member access"),
+            serde_json::json!("Private"),
+            "emission must stay PascalCase"
+        );
+
+        assert!(
+            serde_json::from_value::<IndexMode>(serde_json::json!("INCREMENTAL")).is_err(),
+            "aliases add the mirrored spelling only, not arbitrary casing"
+        );
+    }
+}

--- a/crates/codestory-contracts/src/lib.rs
+++ b/crates/codestory-contracts/src/lib.rs
@@ -21,4 +21,6 @@ pub mod owned_artifacts;
 pub mod query;
 pub mod trail;
 pub mod validation_receipts;
+
+pub mod wire;
 pub mod workspace;

--- a/crates/codestory-contracts/src/wire.rs
+++ b/crates/codestory-contracts/src/wire.rs
@@ -1,0 +1,289 @@
+//! Public publication and protocol compatibility contract.
+//!
+//! Two identities cross the CodeStory process boundary on every MCP session and
+//! neither can be inferred from the payload itself:
+//!
+//! * the `_meta.codestory_publication` **stamp schema version**, which tells a
+//!   reader which response vocabulary and which request-validation rules the
+//!   producer is running, and
+//! * the **MCP protocol revisions** this build actually implements.
+//!
+//! The packaged plugin ships pinned to one CLI, so in a released pair these
+//! values always agree. The documented `CODESTORY_CLI` override is the one
+//! supported channel that can put a different CLI behind the same launcher, and
+//! the stamp is the only detector that channel leaves available. Everything in
+//! this module is therefore a compatibility surface: changing a value here
+//! changes what an out-of-repo consumer is entitled to believe.
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version stamped into `_meta.codestory_publication`.
+///
+/// * **v0** — the stamp is absent. Readers must treat a missing stamp as v0 and
+///   must not infer any newer guarantee from its absence.
+/// * **v1** — the additive stamp: publication identities, `served_from`, and
+///   `contract_runtime`. Tool arguments were repaired before dispatch, so a
+///   request that violated the published catalog could still be served.
+/// * **v2** — `tools/call` arguments are validated strictly against the
+///   published catalog and rejected with JSON-RPC `-32602` instead of being
+///   repaired, and `initialize` negotiates the protocol revision instead of
+///   echoing whatever the client asked for.
+pub const PUBLICATION_STAMP_SCHEMA_VERSION: u32 = 2;
+
+/// Oldest reader schema version that can still interpret a payload stamped with
+/// [`PUBLICATION_STAMP_SCHEMA_VERSION`] without misreading it.
+///
+/// v2 is deliberately not backward compatible with a v1 reader. A v1 client was
+/// written against a server that repaired malformed tool arguments; the same
+/// client against a v2 server receives `-32602` for requests it believes are
+/// valid. Consumers must compare against this bound rather than assuming the
+/// stamp is purely additive.
+pub const MINIMUM_COMPATIBLE_PUBLICATION_STAMP_SCHEMA_VERSION: u32 = 2;
+
+/// Schema version a reader must assume when `_meta.codestory_publication` is
+/// absent from a response that should carry it.
+pub const LEGACY_PUBLICATION_STAMP_SCHEMA_VERSION: u32 = 0;
+
+/// MCP protocol revisions this build implements, newest-preferred first.
+///
+/// Advertising a revision here is a claim that the server honours it. The list
+/// stays deliberately short: an unimplemented revision echoed back to a client
+/// is a false compatibility claim, which is the defect this contract closes.
+pub const SUPPORTED_MCP_PROTOCOL_VERSIONS: &[&str] = &["2024-11-05"];
+
+/// Revision the server answers with when the client offers nothing usable.
+pub const PREFERRED_MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// Outcome of one `initialize` protocol-revision negotiation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpProtocolNegotiationStatus {
+    /// The client named a revision this build implements; it is echoed.
+    Agreed,
+    /// The client named no revision. The server default applies and nothing was
+    /// rejected.
+    Defaulted,
+    /// The client named a revision this build does not implement. The server
+    /// answers with its own revision so the client can decide, and never
+    /// claims the requested revision is supported.
+    UnsupportedClientRevision,
+}
+
+impl McpProtocolNegotiationStatus {
+    /// Whether the negotiated revision is one the client can rely on.
+    ///
+    /// `Defaulted` is compatible: the client asserted no requirement. Only a
+    /// revision the client explicitly asked for and this build does not
+    /// implement is incompatible.
+    pub const fn compatible(self) -> bool {
+        matches!(self, Self::Agreed | Self::Defaulted)
+    }
+}
+
+/// Negotiated protocol revision published on the `initialize` result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpProtocolNegotiationDto {
+    /// Exactly what the client asked for, or `None` when it named nothing.
+    pub requested: Option<String>,
+    /// Revision the server will speak for this session.
+    pub negotiated: String,
+    /// Every revision this build implements.
+    pub supported: Vec<String>,
+    pub status: McpProtocolNegotiationStatus,
+    /// Convenience mirror of [`McpProtocolNegotiationStatus::compatible`] for
+    /// JSON consumers that cannot match on the enum.
+    pub compatible: bool,
+}
+
+/// Negotiate one MCP protocol revision against [`SUPPORTED_MCP_PROTOCOL_VERSIONS`].
+///
+/// Never echoes an unsupported revision. A client that asked for something this
+/// build does not implement receives the server's own revision plus
+/// [`McpProtocolNegotiationStatus::UnsupportedClientRevision`], which is the
+/// signal it needs to refuse the session.
+pub fn negotiate_mcp_protocol_version(requested: Option<&str>) -> McpProtocolNegotiationDto {
+    let requested = requested
+        .map(str::trim)
+        .filter(|requested| !requested.is_empty());
+    let (negotiated, status) = match requested {
+        None => (
+            PREFERRED_MCP_PROTOCOL_VERSION,
+            McpProtocolNegotiationStatus::Defaulted,
+        ),
+        Some(requested) => match SUPPORTED_MCP_PROTOCOL_VERSIONS
+            .iter()
+            .find(|supported| **supported == requested)
+        {
+            Some(supported) => (*supported, McpProtocolNegotiationStatus::Agreed),
+            None => (
+                PREFERRED_MCP_PROTOCOL_VERSION,
+                McpProtocolNegotiationStatus::UnsupportedClientRevision,
+            ),
+        },
+    };
+    McpProtocolNegotiationDto {
+        requested: requested.map(str::to_string),
+        negotiated: negotiated.to_string(),
+        supported: SUPPORTED_MCP_PROTOCOL_VERSIONS
+            .iter()
+            .map(|version| (*version).to_string())
+            .collect(),
+        status,
+        compatible: status.compatible(),
+    }
+}
+
+/// Why a reader refused a publication stamp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublicationStampSkew {
+    /// `_meta.codestory_publication` is absent: a legacy v0 producer.
+    LegacyV0,
+    /// The stamp exists but carries no readable `schema_version`.
+    Malformed,
+    /// The producer is older than this reader's minimum.
+    ProducerTooOld,
+    /// The producer declares a minimum this reader does not meet, or a schema
+    /// version this reader has never heard of.
+    ProducerTooNew,
+}
+
+impl PublicationStampSkew {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyV0 => "legacy_v0",
+            Self::Malformed => "malformed",
+            Self::ProducerTooOld => "producer_too_old",
+            Self::ProducerTooNew => "producer_too_new",
+        }
+    }
+}
+
+/// Decide whether a reader running [`PUBLICATION_STAMP_SCHEMA_VERSION`] may act
+/// on a payload stamped `observed` and declaring `observed_minimum`.
+///
+/// Fail-closed: an absent stamp, an unreadable version, or a version outside
+/// the mutually supported window is refused. `None` is the legacy v0 case and
+/// is never silently upgraded.
+///
+/// This is the rule the packaged launcher applies to the runtime's `initialize`
+/// result, mirrored there in JavaScript because it runs before the native
+/// process is trusted. Publishing it here keeps the decision owned by the
+/// contract rather than by the reader that happens to run first.
+pub fn classify_publication_stamp(
+    observed: Option<u32>,
+    observed_minimum: Option<u32>,
+) -> Result<u32, PublicationStampSkew> {
+    let Some(observed) = observed else {
+        return Err(PublicationStampSkew::LegacyV0);
+    };
+    if observed == LEGACY_PUBLICATION_STAMP_SCHEMA_VERSION {
+        return Err(PublicationStampSkew::LegacyV0);
+    }
+    if observed > PUBLICATION_STAMP_SCHEMA_VERSION {
+        return Err(PublicationStampSkew::ProducerTooNew);
+    }
+    if observed < MINIMUM_COMPATIBLE_PUBLICATION_STAMP_SCHEMA_VERSION {
+        return Err(PublicationStampSkew::ProducerTooOld);
+    }
+    // A producer may raise its own floor ahead of ours; honour the stricter of
+    // the two rather than assuming our version is enough.
+    if observed_minimum.is_some_and(|minimum| minimum > PUBLICATION_STAMP_SCHEMA_VERSION) {
+        return Err(PublicationStampSkew::ProducerTooNew);
+    }
+    Ok(observed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_revision_is_agreed_and_echoed() {
+        let negotiation = negotiate_mcp_protocol_version(Some("2024-11-05"));
+
+        assert_eq!(negotiation.negotiated, "2024-11-05");
+        assert_eq!(negotiation.status, McpProtocolNegotiationStatus::Agreed);
+        assert!(negotiation.compatible);
+        assert_eq!(negotiation.requested.as_deref(), Some("2024-11-05"));
+    }
+
+    #[test]
+    fn unsupported_revision_answers_with_the_server_revision() {
+        let negotiation = negotiate_mcp_protocol_version(Some("2025-06-18"));
+
+        assert_eq!(
+            negotiation.negotiated, "2024-11-05",
+            "an unimplemented revision must never be echoed back as supported"
+        );
+        assert_eq!(
+            negotiation.status,
+            McpProtocolNegotiationStatus::UnsupportedClientRevision
+        );
+        assert!(!negotiation.compatible);
+        assert_eq!(negotiation.requested.as_deref(), Some("2025-06-18"));
+    }
+
+    #[test]
+    fn absent_revision_defaults_without_claiming_a_client_revision() {
+        for requested in [None, Some(""), Some("   ")] {
+            let negotiation = negotiate_mcp_protocol_version(requested);
+
+            assert_eq!(negotiation.negotiated, "2024-11-05");
+            assert_eq!(negotiation.status, McpProtocolNegotiationStatus::Defaulted);
+            assert!(negotiation.compatible);
+            assert_eq!(negotiation.requested, None);
+        }
+    }
+
+    #[test]
+    fn missing_stamp_is_legacy_v0_and_never_upgraded() {
+        assert_eq!(
+            classify_publication_stamp(None, None),
+            Err(PublicationStampSkew::LegacyV0)
+        );
+        assert_eq!(
+            classify_publication_stamp(Some(LEGACY_PUBLICATION_STAMP_SCHEMA_VERSION), None),
+            Err(PublicationStampSkew::LegacyV0)
+        );
+    }
+
+    #[test]
+    fn stamp_window_is_closed_on_both_sides() {
+        assert_eq!(
+            classify_publication_stamp(Some(1), None),
+            Err(PublicationStampSkew::ProducerTooOld)
+        );
+        assert_eq!(
+            classify_publication_stamp(Some(PUBLICATION_STAMP_SCHEMA_VERSION + 1), None),
+            Err(PublicationStampSkew::ProducerTooNew)
+        );
+        assert_eq!(
+            classify_publication_stamp(
+                Some(PUBLICATION_STAMP_SCHEMA_VERSION),
+                Some(PUBLICATION_STAMP_SCHEMA_VERSION + 1)
+            ),
+            Err(PublicationStampSkew::ProducerTooNew),
+            "a producer floor above this reader must be refused, not ignored"
+        );
+        assert_eq!(
+            classify_publication_stamp(
+                Some(PUBLICATION_STAMP_SCHEMA_VERSION),
+                Some(MINIMUM_COMPATIBLE_PUBLICATION_STAMP_SCHEMA_VERSION)
+            ),
+            Ok(PUBLICATION_STAMP_SCHEMA_VERSION)
+        );
+    }
+
+    #[test]
+    fn published_stamp_bounds_are_the_documented_values() {
+        assert_eq!(
+            PUBLICATION_STAMP_SCHEMA_VERSION, 2,
+            "the v0.17.0 wire contract publishes stamp schema 2"
+        );
+        assert_eq!(MINIMUM_COMPATIBLE_PUBLICATION_STAMP_SCHEMA_VERSION, 2);
+        assert_eq!(LEGACY_PUBLICATION_STAMP_SCHEMA_VERSION, 0);
+        assert_eq!(SUPPORTED_MCP_PROTOCOL_VERSIONS, &["2024-11-05"]);
+        assert_eq!(PREFERRED_MCP_PROTOCOL_VERSION, "2024-11-05");
+    }
+}

--- a/docs/architecture/host-integration.md
+++ b/docs/architecture/host-integration.md
@@ -44,6 +44,32 @@ override. A declared but invalid receipt, or a receipt combined with the raw
 `CODESTORY_CLI` override, fails closed and cannot fall through to managed
 release provisioning.
 
+## Wire compatibility
+
+`codestory_contracts::wire` owns two identities the launcher and the native
+process must agree on: the `_meta.codestory_publication` schema version and the
+MCP protocol revisions the executable implements. The generated MCP catalog
+records both, read back out of the real binary, so the launcher's mirrored
+constants are pinned to the CLI it ships with.
+
+`initialize` negotiates. The server answers with a revision it implements and
+reports the requested revision, the negotiated revision, the supported set, and
+whether they agree in `_meta.codestory_protocol`. It never echoes an
+unimplemented revision back as supported.
+
+The launcher answers `initialize` for the host and suppresses the native
+process's own answer, so it is the only reader of that answer. It compares the
+negotiated revision and the publication schema version against its pinned
+contract. A stamp that is absent (legacy v0), unreadable, older than the
+launcher's minimum, or newer than it understands refuses the handoff: the
+runtime is shut down, every delegated request already in flight is answered with
+a typed `runtime_wire_contract_skew` failure, nothing that runtime wrote is
+relayed to the host, and the fail-open diagnostic reports the skew as the
+degraded reason. Provisioning applies the same check
+before staging an archive. Released pairs always match; the documented
+`CODESTORY_CLI` override is the one supported way to skew them, and this
+comparison is the only detector that channel leaves available.
+
 ## Request routing
 
 Every tool and resource request includes an absolute `project` root. The

--- a/docs/architecture/host-integration.md
+++ b/docs/architecture/host-integration.md
@@ -58,7 +58,16 @@ whether they agree in `_meta.codestory_protocol`. It never echoes an
 unimplemented revision back as supported.
 
 The launcher answers `initialize` for the host and suppresses the native
-process's own answer, so it is the only reader of that answer. It compares the
+process's own answer, so the answer the host reads at handshake is the
+launcher's. It stamps that answer with its own `_meta.codestory_publication`:
+the same schema and minimum-compatible versions the launcher pins, with
+`served_from=contract_only` because no publication identity exists at session
+start, and a `contract_runtime` recording the launcher's half of the pinned pair
+(`pinned_pair_matches` is `null` while no CLI is resolved, which is "cannot
+compare", not "mismatch"). Without that stamp the packaged handshake would read
+as a legacy v0 producer whatever the pinned runtime implements.
+
+Being the only reader of the native answer, the launcher compares the
 negotiated revision and the publication schema version against its pinned
 contract. A stamp that is absent (legacy v0), unreadable, older than the
 launcher's minimum, or newer than it understands refuses the handoff: the

--- a/plugins/codestory/generated-mcp-catalog.json
+++ b/plugins/codestory/generated-mcp-catalog.json
@@ -1,4 +1,12 @@
 {
+  "wireContract": {
+    "publicationStampSchemaVersion": 2,
+    "minimumCompatiblePublicationStampSchemaVersion": 2,
+    "supportedMcpProtocolVersions": [
+      "2024-11-05"
+    ],
+    "preferredMcpProtocolVersion": "2024-11-05"
+  },
   "tools": [
     {
       "annotations": {

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -2097,6 +2097,54 @@ function publicationStampSkew(stamp) {
   return null;
 }
 
+function publicationStampText(value) {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text ? text : null;
+}
+
+// Mirrors `codestory_cli::runtime::codestory_publication_meta` for the one frame
+// the packaged path never delegates. The launcher answers `initialize` itself
+// and suppresses the runtime's own answer, so this is the only stamp a host
+// behind `plugins/codestory/.mcp.json` can read at handshake; without it the
+// packaged handshake is indistinguishable from a legacy v0 producer no matter
+// which contract the pinned runtime implements. The launcher authors the frame,
+// so the stamp describes the launcher's own knowledge: no publication identity
+// exists at session start, hence `served_from=contract_only`.
+function failOpenPublicationStamp(status) {
+  const plugin = isPlainObject(status?.plugin_runtime) ? status.plugin_runtime : {};
+  const cliVersion = publicationStampText(status?.cli_version);
+  // The launcher-provided half of the pinned pair: exactly the value
+  // `stdioRuntimeEnv` hands the runtime as `CODESTORY_PLUGIN_CLI_VERSION`.
+  const pluginCliVersion = publicationStampText(plugin.plugin_cli_version);
+  // `launcher` is the existing source token for "the launcher itself, with no
+  // resolved CLI behind it"; the fallback stays inside that vocabulary rather
+  // than inventing a value a consumer has never been told about.
+  const cliSource = publicationStampText(plugin.cli_source) || 'launcher';
+  return {
+    schema_version: publicationStampSchemaVersion,
+    minimum_compatible_schema_version: minimumCompatiblePublicationStampSchemaVersion,
+    served_from: 'contract_only',
+    publication: null,
+    core_publication: null,
+    retrieval_publication: null,
+    contract_runtime: {
+      cli_version: cliVersion,
+      plugin_version: publicationStampText(plugin.plugin_version),
+      plugin_cli_version: pluginCliVersion,
+      cli_source: cliSource,
+      // `null` is "cannot compare", not "mismatch": the launcher answers
+      // `initialize` before any runtime is required to exist, so an unresolved
+      // CLI must not be reported as a failed pin.
+      pinned_pair_matches: pluginCliVersion === null || cliVersion === null
+        ? null
+        : pluginCliVersion === cliVersion,
+      known_override_skew_channel: Boolean(publicationStampText(process.env.CODESTORY_CLI))
+        || cliSource === 'local_dev_override',
+    },
+    operation: { operation_id: null, attempt: null },
+  };
+}
+
 // The pair check the `CODESTORY_CLI` override otherwise bypasses: the runtime's
 // own `initialize` result must agree with the revision the launcher already
 // promised the host and must stamp a publication schema this launcher can read.
@@ -3206,6 +3254,10 @@ function pluginRuntimeForResolved(resolved) {
     cli_source: resolved.source,
     cli_path: resolved.path,
     cli_sha256: resolved.sha256,
+    // The launcher-provided half of the pinned pair, identical to the
+    // `CODESTORY_PLUGIN_CLI_VERSION` the runtime stamps back as
+    // `contract_runtime.plugin_cli_version`.
+    plugin_cli_version: resolved.cliVersion || resolved.version || null,
     build_source: resolved.buildSource,
     repo_ref: resolved.repoRef,
     source_package_sha256: resolved.sourcePackageSha256 || null,
@@ -4119,7 +4171,10 @@ function runFailOpenMcp(status, options = {}) {
           prompts: { listChanged: true },
         },
         serverInfo: { name: 'codestory', version: resolvedVersionForStatus(liveStatus) },
-        _meta: { codestory_protocol: negotiatedProtocol },
+        _meta: {
+          codestory_publication: failOpenPublicationStamp(liveStatus),
+          codestory_protocol: negotiatedProtocol,
+        },
       });
     } else if (request.method === 'tools/list') {
       response = jsonrpcResult(request.id, { tools });
@@ -4519,6 +4574,7 @@ if (require.main === module) {
       probeResolvedCli,
       probeManagedCliStdio,
       negotiateMcpProtocolVersion,
+      failOpenPublicationStamp,
       publicationStampSkew,
       runtimeWireContractSkew,
       supportedMcpProtocolVersions,

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -74,7 +74,16 @@ const managedCliProbeStdoutMaxBytes = 64 * 1024;
 const managedCliProbeStderrMaxBytes = 4 * 1024;
 const managedCliProbeTerminationGraceMs = 500;
 const managedCliProbeForceKillGraceMs = 1000;
+// Wire compatibility contract. `codestory_contracts::wire` owns these values;
+// the generated MCP catalog records the same three read back out of the real
+// binary, and `launcher wire contract matches the generated catalog` in the
+// plugin test suite pins the launcher copy to that recording. The launcher must
+// not depend on the catalog at run time: a packaging failure that loses the
+// catalog must not also lose the skew detector.
 const managedCliMcpProtocolVersion = '2024-11-05';
+const supportedMcpProtocolVersions = Object.freeze(['2024-11-05']);
+const publicationStampSchemaVersion = 2;
+const minimumCompatiblePublicationStampSchemaVersion = 2;
 const runtimeStderrObservedBytesCap = 16 * 1024 * 1024;
 const runtimeStderrObservedChunksCap = 65_535;
 const failOpenMaxFrameBytes = 1024 * 1024;
@@ -2045,6 +2054,61 @@ function isPlainObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+// Mirrors codestory_contracts::wire::negotiate_mcp_protocol_version. The
+// launcher answers `initialize` itself and suppresses the CLI's answer, so an
+// echoed revision here would be a false compatibility claim the host can never
+// see corrected.
+function negotiateMcpProtocolVersion(requested) {
+  const asked = typeof requested === 'string' ? requested.trim() : '';
+  if (!asked) {
+    return {
+      requested: null,
+      negotiated: managedCliMcpProtocolVersion,
+      supported: [...supportedMcpProtocolVersions],
+      status: 'defaulted',
+      compatible: true,
+    };
+  }
+  const agreed = supportedMcpProtocolVersions.includes(asked);
+  return {
+    requested: asked,
+    negotiated: agreed ? asked : managedCliMcpProtocolVersion,
+    supported: [...supportedMcpProtocolVersions],
+    status: agreed ? 'agreed' : 'unsupported_client_revision',
+    compatible: agreed,
+  };
+}
+
+// Mirrors codestory_contracts::wire::classify_publication_stamp. Returns a skew
+// token, or null when the stamp is inside the mutually supported window.
+function publicationStampSkew(stamp) {
+  if (!isPlainObject(stamp)) return 'publication_stamp_legacy_v0';
+  const observed = stamp.schema_version;
+  if (!Number.isSafeInteger(observed) || observed < 0) return 'publication_stamp_malformed';
+  if (observed === 0) return 'publication_stamp_legacy_v0';
+  if (observed > publicationStampSchemaVersion) return 'publication_stamp_producer_too_new';
+  if (observed < minimumCompatiblePublicationStampSchemaVersion) {
+    return 'publication_stamp_producer_too_old';
+  }
+  const producerMinimum = stamp.minimum_compatible_schema_version;
+  if (Number.isSafeInteger(producerMinimum) && producerMinimum > publicationStampSchemaVersion) {
+    return 'publication_stamp_producer_too_new';
+  }
+  return null;
+}
+
+// The pair check the `CODESTORY_CLI` override otherwise bypasses: the runtime's
+// own `initialize` result must agree with the revision the launcher already
+// promised the host and must stamp a publication schema this launcher can read.
+function runtimeWireContractSkew(response, negotiatedProtocolVersion) {
+  if (!isPlainObject(response)) return 'initialize_response_invalid';
+  if (response.error !== undefined) return 'initialize_rejected';
+  const result = response.result;
+  if (!isPlainObject(result)) return 'initialize_result_invalid';
+  if (result.protocolVersion !== negotiatedProtocolVersion) return 'protocol_version_skew';
+  return publicationStampSkew(result._meta?.codestory_publication);
+}
+
 function probeManagedCliStdio(cliPath, timeoutMs = 5000, options = {}) {
   return new Promise((resolve, reject) => {
     const spawnChild = options.spawn || spawn;
@@ -2128,6 +2192,14 @@ function probeManagedCliStdio(cliPath, timeoutMs = 5000, options = {}) {
         typeof response.result.serverInfo.version !== 'string' || !response.result.serverInfo.version.trim()
       ) {
         terminate(new Error('managed_cli_stdio_initialize_incompatible'));
+        return;
+      }
+      // Provisioning is where the pinned pair is established, so an archive
+      // whose runtime publishes a wire contract this launcher cannot read is
+      // never staged.
+      const stampSkew = publicationStampSkew(response.result._meta?.codestory_publication);
+      if (stampSkew) {
+        terminate(new Error(`managed_cli_stdio_initialize_wire_contract:${stampSkew}`));
         return;
       }
       terminate(null);
@@ -3684,6 +3756,10 @@ const runtimeFailureReasons = new Map([
   ['runtime_stdio_child_exit', 'CodeStory stdio handoff exited before completing the request.'],
   ['runtime_stdio_child_spawn', 'CodeStory stdio handoff failed to start.'],
   ['runtime_stdio_child_stdin', 'CodeStory stdio handoff stdin failed.'],
+  [
+    'runtime_wire_contract_skew',
+    'CodeStory stdio handoff published a wire contract this plugin cannot read.',
+  ],
 ]);
 
 function runtimeFailureCode(value) {
@@ -3818,6 +3894,7 @@ function runFailOpenMcp(status, options = {}) {
   let handoff = null;
   let handoffWrite = null;
   let initializeRequest = null;
+  let negotiatedProtocol = null;
   let initializedNotification = null;
   let runtimeReadyNotified = false;
   let stdinEnded = false;
@@ -3925,6 +4002,9 @@ function runFailOpenMcp(status, options = {}) {
       let suppressInitialize = Boolean(initializeRequest);
       handoff.stdout.setEncoding('utf8');
       handoff.stdout.on('data', (chunk) => {
+        // A failed handoff stops relaying immediately. Chunks that arrive after
+        // the failure carry results from a runtime the launcher already refused.
+        if (handoffFailureHandled) return;
         stdout += chunk;
         const lines = stdout.split(/\r?\n/u);
         stdout = lines.pop() || '';
@@ -3938,6 +4018,18 @@ function runFailOpenMcp(status, options = {}) {
           }
           if (suppressInitialize && parsed?.id === initializeRequest.id) {
             suppressInitialize = false;
+            // The host never sees this frame — the launcher already answered
+            // `initialize`. That makes the launcher the only reader of the
+            // runtime's own compatibility claim, and the only place a
+            // `CODESTORY_CLI` override can be caught at session runtime.
+            const skew = runtimeWireContractSkew(
+              parsed,
+              negotiatedProtocol?.negotiated ?? managedCliMcpProtocolVersion,
+            );
+            if (skew) {
+              failHandoff('runtime_wire_contract_skew', { errorCode: skew });
+              return;
+            }
             continue;
           }
           if (parsed?.id !== undefined) delegatedRequestIds.delete(JSON.stringify(parsed.id));
@@ -4018,14 +4110,16 @@ function runFailOpenMcp(status, options = {}) {
     let response;
     if (request.method === 'initialize') {
       const liveStatus = currentStatus();
+      negotiatedProtocol = negotiateMcpProtocolVersion(request.params?.protocolVersion);
       response = jsonrpcResult(request.id, {
-        protocolVersion: request.params?.protocolVersion || '2024-11-05',
+        protocolVersion: negotiatedProtocol.negotiated,
         capabilities: {
           tools: { listChanged: true },
           resources: { subscribe: false, listChanged: true },
           prompts: { listChanged: true },
         },
         serverInfo: { name: 'codestory', version: resolvedVersionForStatus(liveStatus) },
+        _meta: { codestory_protocol: negotiatedProtocol },
       });
     } else if (request.method === 'tools/list') {
       response = jsonrpcResult(request.id, { tools });
@@ -4245,9 +4339,11 @@ async function main() {
       onRuntimeFailure: (failure) => {
         const failed = ready;
         ready = null;
-        const reason = failure.stdinError
-          ? 'runtime_stdio_child_stdin'
-          : failure.spawnError ? 'managed_cli_handoff_unspawnable' : 'runtime_stdio_child_exit';
+        const reason = failure.reasonCode === 'runtime_wire_contract_skew'
+          ? 'runtime_wire_contract_skew'
+          : failure.stdinError
+            ? 'runtime_stdio_child_stdin'
+            : failure.spawnError ? 'managed_cli_handoff_unspawnable' : 'runtime_stdio_child_exit';
         status = fallbackDiagnostic(failed, {
           status: failure.code ?? null,
           error: failure.reason,
@@ -4297,9 +4393,11 @@ async function main() {
     startRuntime: () => spawnStdioRuntime(resolved, runtimeCwd, ['pipe', 'pipe', 'pipe']),
     onRuntimeFailure: (failure) => {
       handoffReady = false;
-      const reason = failure.stdinError
-        ? 'runtime_stdio_child_stdin'
-        : failure.spawnError ? `${resolved.source}_cli_unspawnable` : 'runtime_stdio_child_exit';
+      const reason = failure.reasonCode === 'runtime_wire_contract_skew'
+        ? 'runtime_wire_contract_skew'
+        : failure.stdinError
+          ? 'runtime_stdio_child_stdin'
+          : failure.spawnError ? `${resolved.source}_cli_unspawnable` : 'runtime_stdio_child_exit';
       const error = failure.code != null
         ? `codestory-cli serve --stdio exited with status ${failure.code}`
         : failure.reason;
@@ -4420,6 +4518,13 @@ if (require.main === module) {
       processStartIdentity,
       probeResolvedCli,
       probeManagedCliStdio,
+      negotiateMcpProtocolVersion,
+      publicationStampSkew,
+      runtimeWireContractSkew,
+      supportedMcpProtocolVersions,
+      managedCliMcpProtocolVersion,
+      publicationStampSchemaVersion,
+      minimumCompatiblePublicationStampSchemaVersion,
       provisionManagedCli,
       quarantineManagedCliVersion,
       releaseManagedCliLock,

--- a/plugins/codestory/skills/codestory-grounding/references/packet.md
+++ b/plugins/codestory/skills/codestory-grounding/references/packet.md
@@ -54,7 +54,8 @@ Use `<codestory-cli> <command> --help` for the complete option set.
 - The Markdown Packet Claims section uses fixed-width status markers: `P` proven, `R`
   reported lead, `L` likely, `D` diagnostic, and `U` unsupported or unclassified. Only `P`
   claims may be repeated as supported facts; the structured ledger remains authoritative.
-- CLI JSON, HTTP, and MCP consumers can detect the additive `reported` proof-status value through
-  `_meta.codestory_publication.schema_version` and should also inspect
-  `contract_runtime.pinned_pair_matches`. A configured `CODESTORY_CLI` override is surfaced as
-  `contract_runtime.known_override_skew_channel`.
+- CLI JSON, HTTP, and MCP consumers detect the `reported` proof-status value through
+  `_meta.codestory_publication.schema_version`, which is `2` for this contract, and should also
+  inspect `contract_runtime.pinned_pair_matches`. A configured `CODESTORY_CLI` override is
+  surfaced as `contract_runtime.known_override_skew_channel`. The stamp rides on the `initialize`
+  result too, so the version is known before the first tool call.

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -96,6 +96,10 @@ The `initialize` result carries the same stamp plus `_meta.codestory_protocol`,
 which reports the requested revision, the negotiated revision, every revision the
 server implements, and whether the two agree. The server answers with a revision
 it actually implements; it never echoes an unsupported one back as supported.
+Through the packaged plugin the launcher answers `initialize` for the host, so
+the handshake stamp is the launcher's: it is always `served_from=contract_only`
+and reports the response contract version and the pinned pair, never a
+publication identity. Read publication identities from a tool result.
 
 Local navigation is useful while broad search prepares, but it is not full
 retrieval proof. Trust a broad result only when the requested tool succeeds

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -78,12 +78,24 @@ complete core and retrieval publication identities used by the runtime-owned
 operation. Treat that metadata as the response's evidence boundary rather than
 re-reading status around the call.
 
-The envelope also carries `schema_version` and `contract_runtime`. The latter
-records the active CLI, the launcher-provided plugin/CLI pair, whether that pair
-matches, and whether the explicit `CODESTORY_CLI` skew channel is active. A
-missing schema version is the legacy v0 envelope. CLI JSON, HTTP, and MCP use the
-same stamp. When neither a core nor retrieval identity exists, the stamp remains
-present with `served_from=contract_only`; it must not claim a complete publication.
+The envelope also carries `schema_version`, `minimum_compatible_schema_version`,
+and `contract_runtime`. The last records the active CLI, the launcher-provided
+plugin/CLI pair, whether that pair matches, and whether the explicit
+`CODESTORY_CLI` skew channel is active. A missing schema version is the legacy v0
+envelope. CLI JSON, HTTP, and MCP use the same stamp. When neither a core nor
+retrieval identity exists, the stamp remains present with
+`served_from=contract_only`; it must not claim a complete publication.
+
+Schema version 2 is the v0.17.0 contract. It is not a purely additive bump:
+`tools/call` arguments are validated against the published catalog and rejected
+with JSON-RPC `-32602` instead of being repaired, so a client written against
+schema 1 can see valid-looking requests refused. Compare against
+`minimum_compatible_schema_version` rather than assuming forward compatibility.
+
+The `initialize` result carries the same stamp plus `_meta.codestory_protocol`,
+which reports the requested revision, the negotiated revision, every revision the
+server implements, and whether the two agree. The server answers with a revision
+it actually implements; it never echoes an unsupported one back as supported.
 
 Local navigation is useful while broad search prepares, but it is not full
 retrieval proof. Trust a broad result only when the requested tool succeeds

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -153,6 +153,105 @@ test("fail-open tool schemas are the generated canonical MCP catalog", async () 
   );
 });
 
+test("launcher wire contract matches the generated catalog read from the real CLI", async () => {
+  // The launcher must not read the catalog at run time to find its skew
+  // detector, so the constants are mirrored. This is the pin that keeps the
+  // mirror honest: the catalog half is generated from the real binary.
+  const catalog = JSON.parse(await readFile(join(pluginRoot, "generated-mcp-catalog.json"), "utf8"));
+  assert.deepEqual(catalog.wireContract, {
+    publicationStampSchemaVersion: launcherTest.publicationStampSchemaVersion,
+    minimumCompatiblePublicationStampSchemaVersion:
+      launcherTest.minimumCompatiblePublicationStampSchemaVersion,
+    supportedMcpProtocolVersions: [...launcherTest.supportedMcpProtocolVersions],
+    preferredMcpProtocolVersion: launcherTest.managedCliMcpProtocolVersion,
+  });
+  assert.equal(catalog.wireContract.publicationStampSchemaVersion, 2);
+  assert.deepEqual(catalog.wireContract.supportedMcpProtocolVersions, ["2024-11-05"]);
+});
+
+test("launcher negotiates the MCP protocol revision instead of echoing it", () => {
+  // CR-064: echoing an unimplemented revision hands the host a compatibility
+  // claim nothing behind the launcher honours.
+  assert.deepEqual(launcherTest.negotiateMcpProtocolVersion("2024-11-05"), {
+    requested: "2024-11-05",
+    negotiated: "2024-11-05",
+    supported: ["2024-11-05"],
+    status: "agreed",
+    compatible: true,
+  });
+  assert.deepEqual(launcherTest.negotiateMcpProtocolVersion("2025-03-26"), {
+    requested: "2025-03-26",
+    negotiated: "2024-11-05",
+    supported: ["2024-11-05"],
+    status: "unsupported_client_revision",
+    compatible: false,
+  });
+  for (const absent of [undefined, null, "", "   ", 7]) {
+    assert.deepEqual(
+      launcherTest.negotiateMcpProtocolVersion(absent),
+      {
+        requested: null,
+        negotiated: "2024-11-05",
+        supported: ["2024-11-05"],
+        status: "defaulted",
+        compatible: true,
+      },
+      `absent revision ${JSON.stringify(absent)} must default without claiming a client revision`,
+    );
+  }
+});
+
+test("launcher classifies the runtime initialize contract fail-closed", () => {
+  const stamped = (stamp) => ({
+    jsonrpc: "2.0",
+    id: "initialize",
+    result: {
+      protocolVersion: "2024-11-05",
+      _meta: { codestory_publication: stamp },
+    },
+  });
+
+  assert.equal(
+    launcherTest.runtimeWireContractSkew(
+      stamped({ schema_version: 2, minimum_compatible_schema_version: 2 }),
+      "2024-11-05",
+    ),
+    null,
+  );
+  assert.equal(
+    launcherTest.runtimeWireContractSkew(
+      { jsonrpc: "2.0", id: "initialize", result: { protocolVersion: "2024-11-05" } },
+      "2024-11-05",
+    ),
+    "publication_stamp_legacy_v0",
+    "a runtime that predates the stamp is legacy v0, not silently current",
+  );
+  assert.equal(
+    launcherTest.runtimeWireContractSkew(stamped({ schema_version: 1 }), "2024-11-05"),
+    "publication_stamp_producer_too_old",
+  );
+  assert.equal(
+    launcherTest.runtimeWireContractSkew(
+      stamped({ schema_version: 2, minimum_compatible_schema_version: 2 }),
+      "2025-03-26",
+    ),
+    "protocol_version_skew",
+    "the runtime must speak the revision the launcher already promised the host",
+  );
+  assert.equal(
+    launcherTest.runtimeWireContractSkew(
+      { jsonrpc: "2.0", id: "initialize", error: { code: -32600, message: "no" } },
+      "2024-11-05",
+    ),
+    "initialize_rejected",
+  );
+  assert.equal(launcherTest.runtimeWireContractSkew("not-json-rpc", "2024-11-05"), "initialize_response_invalid");
+  assert.equal(
+    launcherTest.runtimeWireContractSkew({ jsonrpc: "2.0", id: "initialize" }, "2024-11-05"),
+    "initialize_result_invalid",
+  );
+});
+
 test("fail-open relay bounds hostile frames and survives null input and a missing catalog", async () => {
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const status = {
@@ -648,7 +747,7 @@ async function waitForPath(pathname, timeoutMs = 10000) {
 async function writeFakeCli(cliPath) {
   const script = [
     "const fs=require('fs');const args=process.argv.slice(1);",
-    "if(process.env.CODESTORY_PLUGIN_PROVISIONING_PROBE==='1'&&args[0]==='serve'){let input='';process.stdin.on('data',chunk=>{input+=chunk;const newline=input.indexOf('\\n');if(newline<0)return;const request=JSON.parse(input.slice(0,newline));process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{protocolVersion:request.params.protocolVersion,capabilities:{},serverInfo:{name:'fixture',version:'1'}}})+'\\n',()=>process.exit(0))})}",
+    "if(process.env.CODESTORY_PLUGIN_PROVISIONING_PROBE==='1'&&args[0]==='serve'){let input='';process.stdin.on('data',chunk=>{input+=chunk;const newline=input.indexOf('\\n');if(newline<0)return;const request=JSON.parse(input.slice(0,newline));process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{protocolVersion:request.params.protocolVersion,capabilities:{},serverInfo:{name:'fixture',version:'1'},_meta:{codestory_publication:{schema_version:Number(process.env.CODESTORY_TEST_STAMP_SCHEMA_VERSION||'2'),minimum_compatible_schema_version:2}}}})+'\\n',()=>process.exit(0))})}",
     "else if(args[0]==='--version'){if(process.env.CODESTORY_PLUGIN_PROVISIONING_PROBE==='1'&&process.env.CODESTORY_TEST_PROBE_LOG)fs.appendFileSync(process.env.CODESTORY_TEST_PROBE_LOG,'probe\\n');const delay=Number(process.env.CODESTORY_TEST_PROBE_DELAY_MS||0);if(delay>0)Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,delay);console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}",
     "else{fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,warnings:process.env.CODESTORY_PLUGIN_CLI_WARNINGS,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,retention:process.env.CODESTORY_PLUGIN_CLI_RETENTION,args}))}",
   ].join("");
@@ -676,7 +775,7 @@ async function writeLifecycleCli(cliPath) {
     "if(args[0]!=='serve')process.exit(2);",
     "let initialized=false;let notified=false;let input='';",
     "process.stdin.setEncoding('utf8');",
-    "process.stdin.on('data',chunk=>{input+=chunk;const lines=input.split(/\\r?\\n/u);input=lines.pop()||'';for(const line of lines){if(!line)continue;const request=JSON.parse(line);if(request.method==='initialize'){initialized=true;process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{protocolVersion:request.params.protocolVersion,capabilities:{tools:{listChanged:false},resources:{listChanged:false},prompts:{listChanged:false}},serverInfo:{name:'fixture',version:'1'}}})+'\\n')}else if(request.method==='notifications/initialized'){notified=true}else if(request.method==='tools/list'){if(!initialized||!notified)process.exit(42);fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({initialized,notified,args}));process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{tools:[]}})+'\\n')}else if(request.method==='resources/list'){process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{resources:[]}})+'\\n',()=>process.exit(17))}}});",
+    "process.stdin.on('data',chunk=>{input+=chunk;const lines=input.split(/\\r?\\n/u);input=lines.pop()||'';for(const line of lines){if(!line)continue;const request=JSON.parse(line);if(request.method==='initialize'){initialized=true;process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{protocolVersion:'2024-11-05',capabilities:{tools:{listChanged:false},resources:{listChanged:false},prompts:{listChanged:false}},serverInfo:{name:'fixture',version:'1'},_meta:{codestory_publication:{schema_version:Number(process.env.CODESTORY_TEST_STAMP_SCHEMA_VERSION||'2'),minimum_compatible_schema_version:2}}}})+'\\n')}else if(request.method==='notifications/initialized'){notified=true}else if(request.method==='tools/list'){if(!initialized||!notified)process.exit(42);fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({initialized,notified,args}));process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{tools:[]}})+'\\n')}else if(request.method==='resources/list'){process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{resources:[]}})+'\\n',()=>process.exit(17))}}});",
   ].join("");
   if (process.platform === "win32") {
     await writeFile(cliPath, `@echo off\r\n"${process.execPath}" -e "${script}" -- %*\r\n`, "utf8");
@@ -2101,16 +2200,49 @@ test("managed cli staging uses direct executables and requires the exact MCP con
   assert.equal(spawnOptions.shell, false);
 });
 
-test("managed cli staging escalates and awaits a stubborn child", async () => {
-  const compatible = {
+function compatibleProbeResult(stamp = { schema_version: 2, minimum_compatible_schema_version: 2 }) {
+  return {
     jsonrpc: "2.0",
     id: "managed-cli-staging",
     result: {
       protocolVersion: "2024-11-05",
       capabilities: {},
       serverInfo: { name: "fixture", version: "1" },
+      ...(stamp === null ? {} : { _meta: { codestory_publication: stamp } }),
     },
   };
+}
+
+test("managed cli staging refuses to stage a runtime whose publication stamp it cannot read", async () => {
+  // ARCH-035: provisioning establishes the pinned pair, so a runtime that
+  // publishes a stamp outside the launcher's window never becomes the staged
+  // CLI. `null` is the legacy v0 producer that predates the stamp entirely.
+  const cases = [
+    [null, "publication_stamp_legacy_v0"],
+    [{ schema_version: 0 }, "publication_stamp_legacy_v0"],
+    [{ schema_version: "2" }, "publication_stamp_malformed"],
+    [{ schema_version: 1 }, "publication_stamp_producer_too_old"],
+    [{ schema_version: 3 }, "publication_stamp_producer_too_new"],
+    [
+      { schema_version: 2, minimum_compatible_schema_version: 3 },
+      "publication_stamp_producer_too_new",
+    ],
+  ];
+  for (const [stamp, expected] of cases) {
+    await assert.rejects(
+      launcherTest.probeManagedCliStdio("fixture", 100, {
+        spawn: () => fakeProbeChild(compatibleProbeResult(stamp)),
+        terminationGraceMs: 5,
+        forceKillGraceMs: 20,
+      }),
+      new RegExp(`managed_cli_stdio_initialize_wire_contract:${expected}$`, "u"),
+      `stamp ${JSON.stringify(stamp)} must be refused as ${expected}`,
+    );
+  }
+});
+
+test("managed cli staging escalates and awaits a stubborn child", async () => {
+  const compatible = compatibleProbeResult();
   const child = fakeProbeChild(compatible);
   await launcherTest.probeManagedCliStdio("fixture", 100, {
     spawn: () => child,
@@ -3287,7 +3419,7 @@ test("projectless mcp hands off to stdio without active project state", async ()
         "      if (!line.trim()) continue;",
         "      const request = JSON.parse(line);",
       "      if (request.method === 'initialize') {",
-      "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { serverInfo: { name: 'codestory' } } }) + '\\n');",
+      "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { protocolVersion: process.env.TEST_PROTOCOL_VERSION || '2024-11-05', serverInfo: { name: 'codestory' }, _meta: { codestory_publication: { schema_version: Number(process.env.TEST_STAMP_SCHEMA_VERSION || '2'), minimum_compatible_schema_version: 2 } } } }) + '\\n');",
       "      } else if (request.method === 'tools/list') {",
       "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'ground' }] } }) + '\\n');",
       "      } else if (request.method === 'tools/call' && request.params && request.params.name === 'ground') {",
@@ -3726,9 +3858,12 @@ test("mcp launcher starts the multi-project stdio runtime through its bridge", a
         "          jsonrpc: '2.0',",
         "          id: request.id,",
         "          result: {",
-        "            protocolVersion: request.params.protocolVersion,",
+        // A v2 runtime negotiates: it answers with the revision it implements,
+        // never the one the client asked for.
+        "            protocolVersion: process.env.TEST_PROTOCOL_VERSION || '2024-11-05',",
         "            capabilities: {},",
         "            serverInfo: { name: 'codestory', version },",
+        "            _meta: { codestory_publication: { schema_version: Number(process.env.TEST_STAMP_SCHEMA_VERSION || '2'), minimum_compatible_schema_version: 2 } },",
         "          },",
         "        }));",
         "      } else if (request.method === 'tools/list') {",
@@ -3806,6 +3941,178 @@ test("mcp launcher starts the multi-project stdio runtime through its bridge", a
       ]);
     }));
   } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("CODESTORY_CLI override that publishes an unreadable wire contract is refused at session runtime", async () => {
+  // ARCH-035: the launcher answers `initialize` itself and suppresses the
+  // runtime's answer, so the runtime's own compatibility claim reaches nobody
+  // else. Under `CODESTORY_CLI` there is no pinned pair, no archive digest and
+  // no catalog drift check left — this stamp comparison is the whole detector.
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-wire-skew-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "skewed-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "skewed-codestory-cli.cmd" : "skewed-codestory-cli",
+  );
+  const servedFile = join(dataDir, "runtime-served.txt");
+  let child;
+
+  try {
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] !== 'serve') process.exit(2);",
+        "let buffer = '';",
+        "process.stdin.setEncoding('utf8');",
+        // Outlive the launcher closing our stdin so the delayed reply below is
+        // actually produced; the launcher must refuse to relay it.
+        "process.stdin.on('end', () => setTimeout(() => process.exit(0), 400));",
+        "process.stdin.on('data', (chunk) => {",
+        "  buffer += chunk;",
+        "  const lines = buffer.split(/\\r?\\n/u);",
+        "  buffer = lines.pop() || '';",
+        "  for (const line of lines) {",
+        "    if (!line.trim()) continue;",
+        "    const request = JSON.parse(line);",
+        "    if (request.method === 'initialize') {",
+        "      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'codestory', version: '0' }, _meta: { codestory_publication: { schema_version: 1 } } } }) + '\\n');",
+        "    } else if (request.method === 'tools/list') {",
+        // Answer in a later chunk so the reply lands after the launcher has
+        // already refused this runtime: the relay must stay shut, not just
+        // drop the rest of the chunk that carried the initialize frame.
+        "      setTimeout(() => {",
+        "        fs.writeFileSync(process.env.TEST_SERVED, 'runtime-answered');",
+        "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'skewed-runtime' }] } }) + '\\n');",
+        "      }, 50);",
+        "    }",
+        "  }",
+        "});",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    child = spawn(process.execPath, [launcher], {
+      cwd: dataDir,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_SERVED: servedFile,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const pending = new Map();
+    const received = new Map();
+    const hostFrames = [];
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      for (;;) {
+        const newline = stdout.indexOf("\n");
+        if (newline < 0) break;
+        const line = stdout.slice(0, newline).trim();
+        stdout = stdout.slice(newline + 1);
+        if (!line) continue;
+        hostFrames.push(line);
+        const response = JSON.parse(line);
+        if (response.id === undefined) continue;
+        if (pending.has(response.id)) pending.get(response.id)(response);
+        else received.set(response.id, response);
+      }
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    const sendRequest = async (request) => {
+      const waiter = received.has(request.id)
+        ? Promise.resolve(received.get(request.id))
+        : new Promise((resolve) => pending.set(request.id, resolve));
+      child.stdin.write(`${JSON.stringify(request)}\n`);
+      return Promise.race([
+        waiter,
+        new Promise((_, reject) => setTimeout(
+          () => reject(new Error(`timed out waiting for ${request.id}: ${stderr}`)),
+          8000,
+        )),
+      ]);
+    };
+
+    const init = await sendRequest({
+      jsonrpc: "2.0",
+      id: "init",
+      method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "t", version: "1" } },
+    });
+    assert.equal(
+      init.result.protocolVersion,
+      "2024-11-05",
+      "the launcher must answer with the revision it implements, not the one requested",
+    );
+    assert.deepEqual(init.result._meta.codestory_protocol, {
+      requested: "2025-03-26",
+      negotiated: "2024-11-05",
+      supported: ["2024-11-05"],
+      status: "unsupported_client_revision",
+      compatible: false,
+    });
+
+    const delegated = await sendRequest({ jsonrpc: "2.0", id: "tools", method: "tools/list" });
+    assert.equal(
+      delegated.result,
+      undefined,
+      `a skewed runtime must not serve a delegated request: ${JSON.stringify(delegated)}`,
+    );
+    assert.equal(delegated.error.code, -32000);
+    assert.match(delegated.error.message, /reason_code=runtime_wire_contract_skew/u);
+    assert.match(delegated.error.message, /error_code=publication_stamp_producer_too_old/u);
+
+    const diagnostic = await sendRequest({
+      jsonrpc: "2.0",
+      id: "status",
+      method: "resources/read",
+      params: { uri: launcherTest.projectBoundResourceUri("codestory://status", dataDir) },
+    });
+    const status = JSON.parse(diagnostic.result.contents[0].text);
+    assert.equal(status.degraded_reason, "runtime_wire_contract_skew");
+    assert.equal(status.readiness[0].status, "unavailable");
+    assert.equal(status.allowed_surfaces.ground.allowed, false);
+
+    // The refused runtime did produce a `tools/list` answer — the request was
+    // already in flight when its initialize frame arrived. The contract is that
+    // none of it reaches the host.
+    for (let waited = 0; waited < 2000 && !fs.existsSync(servedFile); waited += 25) {
+      await delay(25);
+    }
+    await delay(100);
+    assert.equal(fs.existsSync(servedFile), true, "the fixture must have produced a reply to suppress");
+    assert.equal(
+      hostFrames.some((frame) => frame.includes("skewed-runtime")),
+      false,
+      `a refused runtime's output must never reach the host: ${hostFrames.join("\n")}`,
+    );
+  } finally {
+    if (child) {
+      child.stdin.end();
+      await Promise.race([once(child, "exit"), delay(2000)]);
+      if (child.exitCode === null && child.signalCode === null) child.kill();
+    }
     await rm(dataDir, { recursive: true, force: true });
   }
 });

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -3817,6 +3817,124 @@ test("mcp launcher owns initialize before handing off to the native runtime", as
   }
 });
 
+test("packaged initialize handshake carries the publication stamp the host reads", async () => {
+  // The launcher answers `initialize` itself and suppresses the runtime's own
+  // answer, so the runtime-side `initialize` stamp is invisible to a host wired
+  // through `plugins/codestory/.mcp.json`. This drives the packaged launcher as
+  // a process — the only path the plugin configures — and pins the claim the
+  // CHANGELOG and the shipped grounding skills make: the version is known at
+  // handshake, before the first tool call.
+  const version = await readPluginVersion();
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const initialize = {
+    jsonrpc: "2.0",
+    id: "initialize",
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "plugin-static", version: "1" },
+    },
+  };
+  const packagedInitializeResult = (env, cwd) => {
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd,
+      env,
+      input: `${JSON.stringify(initialize)}\n`,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const response = JSON.parse(result.stdout.trim().split(/\r?\n/u)[0]);
+    assert.equal(response.id, "initialize");
+    return response.result;
+  };
+
+  // The documented `CODESTORY_CLI` override: a runtime is available and the
+  // launcher is about to hand the session off, yet the handshake it already
+  // answered is still the only stamp the host will ever see.
+  const overrideDataDir = await mkdtemp(join(tmpdir(), "codestory-handshake-stamp-"));
+  const overrideBinDir = await mkdtemp(join(tmpdir(), "codestory-handshake-stamp-bin-"));
+  try {
+    const cliPath = await writeNodeCli(
+      overrideBinDir,
+      [
+        "const args = process.argv.slice(2);",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'serve') { setInterval(() => {}, 1000); }",
+        "else process.exit(2);",
+      ].join("\n"),
+    );
+    const overrideResult = packagedInitializeResult({
+      ...process.env,
+      CODESTORY_CLI: cliPath,
+      PLUGIN_DATA: overrideDataDir,
+      TEST_CODESTORY_VERSION: version,
+    }, overrideDataDir);
+
+    const stamp = overrideResult._meta?.codestory_publication;
+    assert.ok(
+      stamp,
+      "the packaged handshake must carry _meta.codestory_publication, not only _meta.codestory_protocol",
+    );
+    assert.deepEqual(stamp, {
+      schema_version: 2,
+      minimum_compatible_schema_version: 2,
+      served_from: "contract_only",
+      publication: null,
+      core_publication: null,
+      retrieval_publication: null,
+      contract_runtime: {
+        cli_version: version,
+        plugin_version: version,
+        plugin_cli_version: version,
+        cli_source: "local_dev_override",
+        pinned_pair_matches: true,
+        known_override_skew_channel: true,
+      },
+      operation: { operation_id: null, attempt: null },
+    });
+    // The launcher's own fail-closed reader must accept the launcher's own
+    // handshake: a stamp the pinned reader would refuse is not a stamp.
+    assert.equal(launcherTest.publicationStampSkew(stamp), null);
+    assert.equal(overrideResult._meta.codestory_protocol.negotiated, "2024-11-05");
+  } finally {
+    await rm(overrideDataDir, { recursive: true, force: true });
+    await rm(overrideBinDir, { recursive: true, force: true });
+  }
+
+  // Fail-open, no runtime at all: the host still learns the response contract
+  // it is talking to instead of reading an unstamped legacy v0 handshake.
+  const failOpenDataDir = await mkdtemp(join(tmpdir(), "codestory-handshake-stamp-failopen-"));
+  try {
+    const failOpenResult = packagedInitializeResult({
+      PLUGIN_DATA: "",
+      COPILOT_PLUGIN_DATA: "",
+      CODESTORY_PLUGIN_DATA: failOpenDataDir,
+      CODESTORY_PLUGIN_DISABLE_PROVISION: "1",
+      PATH: "",
+      ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+    }, repoRoot);
+
+    const stamp = failOpenResult._meta?.codestory_publication;
+    assert.ok(stamp, "the fail-open handshake must carry the stamp too");
+    assert.equal(stamp.schema_version, 2);
+    assert.equal(stamp.minimum_compatible_schema_version, 2);
+    assert.equal(stamp.served_from, "contract_only");
+    assert.equal(launcherTest.publicationStampSkew(stamp), null);
+    assert.equal(stamp.contract_runtime.cli_source, "managed_unavailable");
+    assert.equal(stamp.contract_runtime.cli_version, null);
+    assert.equal(
+      stamp.contract_runtime.pinned_pair_matches,
+      null,
+      "an unresolved CLI cannot be reported as a failed pin",
+    );
+    assert.equal(stamp.contract_runtime.known_override_skew_channel, false);
+  } finally {
+    await rm(failOpenDataDir, { recursive: true, force: true });
+  }
+});
+
 test("mcp launcher starts the multi-project stdio runtime through its bridge", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();

--- a/scripts/generate-codestory-skill-syntax.mjs
+++ b/scripts/generate-codestory-skill-syntax.mjs
@@ -80,12 +80,28 @@ function mcpCatalog() {
       .filter((response) => response.id !== undefined)
       .map((response) => [response.id, response]),
   );
-  for (const id of [2, 3, 4, 5]) {
+  for (const id of [1, 2, 3, 4, 5]) {
     if (responses.get(id)?.error || !responses.get(id)?.result) {
       throw new Error(`Canonical MCP catalog request ${id} failed: ${JSON.stringify(responses.get(id))}`);
     }
   }
+  const initialize = responses.get(1).result;
+  const stamp = initialize._meta?.codestory_publication;
+  const protocol = initialize._meta?.codestory_protocol;
+  if (!stamp || !protocol) {
+    throw new Error(
+      "Canonical MCP initialize result is missing its wire contract stamp: expected _meta.codestory_publication and _meta.codestory_protocol.",
+    );
+  }
   return {
+    // Read out of the real binary so the launcher's mirrored wire constants are
+    // pinned to the CLI they ship with instead of hand-copied.
+    wireContract: {
+      publicationStampSchemaVersion: stamp.schema_version,
+      minimumCompatiblePublicationStampSchemaVersion: stamp.minimum_compatible_schema_version,
+      supportedMcpProtocolVersions: protocol.supported,
+      preferredMcpProtocolVersion: protocol.negotiated,
+    },
     tools: responses.get(2).result.tools,
     resources: responses.get(3).result.resources,
     resourceTemplates: responses.get(4).result.resourceTemplates,


### PR DESCRIPTION
Closes #1668.

Versions the public publication and protocol compatibility contract, including API #1666's deliberate breaking change (previously-repaired MCP arguments now fail `-32602`).

## Review and repair

The review **blocked** this on shipped documentation asserting a behavior the product did not have: the packaged launcher's `initialize` answered with protocol negotiation and **no publication stamp**, while the commit body, `CHANGELOG.md`, and two shipped skill docs all said the handshake carries it. Through the plugin — the only wiring `.mcp.json` configures — the host never saw it.

Repaired at the source rather than by correcting the four texts: the packaged handshake now carries the stamp, proved by a test driving the packaged path rather than the runtime's own `initialize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
