### PR TITLE
[v0.17 S4a] Extract the first agent-planning slice behind the pinned-reader trait

### DIFF
--- a/.github/scripts/cargo-build-artifacts.mjs
+++ b/.github/scripts/cargo-build-artifacts.mjs
@@ -23,7 +23,12 @@ const SHIPPING_BINARIES = [
     targetName: "codestory-cli-runtime",
   },
 ];
+// Every crate feature that swaps product behavior for test behavior, and so must be absent from
+// the graph the shipped binaries are built from. A crate that grows such a feature has to be
+// added here: the gate proves the feature is off, and it also proves the crate is in the shipping
+// graph at all, so an omission here is an unproved crate rather than a passing one.
 const FORBIDDEN_SHIPPING_FEATURES = new Map([
+  ["codestory-agent", new Set(["test-support"])],
   ["codestory-retrieval", new Set(["benchmark-support", "test-support"])],
   ["codestory-runtime", new Set(["benchmark-support", "test-support"])],
 ]);

--- a/.github/scripts/cargo-build-artifacts.test.mjs
+++ b/.github/scripts/cargo-build-artifacts.test.mjs
@@ -105,7 +105,12 @@ function fixture({
     executable: artifact.executable,
     fresh: false,
   }));
-  for (const packageName of ["codestory-retrieval", "codestory-runtime"]) {
+  // Every crate the shipping feature gate speaks for has to be in the graph it inspects.
+  for (const packageName of [
+    "codestory-agent",
+    "codestory-retrieval",
+    "codestory-runtime",
+  ]) {
     const manifest = writePackageManifest(packageName);
     messages.push({
       reason: "compiler-artifact",
@@ -343,6 +348,42 @@ test("rejects retrieval benchmark or test support in the shipping graph", async 
       );
     });
   }
+});
+
+test("rejects agent test support in the shipping graph", () => {
+  // `codestory-agent/test-support` compiles the eval/holdout probe hooks that used to ride
+  // `#[cfg(test)]` inside codestory-runtime. Product builds never enable it, and the gate is
+  // what makes "never" checkable rather than asserted (#1673).
+  const input = fixture();
+  featureMessage(input, "codestory-agent").features = ["test-support"];
+  refreshCargoJson(input);
+
+  assert.throws(
+    () =>
+      assertShippingFeatureContract({
+        jsonLines: input.jsonLines,
+        workspaceRoot: input.root,
+      }),
+    /forbidden feature codestory-agent\/test-support/u,
+  );
+});
+
+test("refuses a shipping graph that never mentions a gated crate", () => {
+  // Absence is the failure the gate has to notice: a crate that vanishes from the graph produces
+  // no feature evidence, and "no evidence of the feature" must not read as "feature off".
+  const input = fixture();
+  const agent = featureMessage(input, "codestory-agent");
+  input.messages.splice(input.messages.indexOf(agent), 1);
+  refreshCargoJson(input);
+
+  assert.throws(
+    () =>
+      assertShippingFeatureContract({
+        jsonLines: input.jsonLines,
+        workspaceRoot: input.root,
+      }),
+    /shipping Cargo graph omitted feature evidence for codestory-agent/u,
+  );
 });
 
 test("rejects runtime benchmark or test support in the shipping graph", async (t) => {

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -154,7 +154,7 @@ export function retrievalGeneralizationSuitePolicyViolations(
   )].map((match) => match[1]);
   const expectedFilesystemMemberCounts = {
     existsSync: 1,
-    mkdirSync: 6,
+    mkdirSync: 7,
     mkdtempSync: 1,
     // Two of these read the shipped pending inventory and the registry document it points at,
     // so the claim-profile ratchet is checked against the tree that ships, not a synthetic one.
@@ -172,8 +172,8 @@ export function retrievalGeneralizationSuitePolicyViolations(
     );
   }
   const fixtureFilesystemShapeIsExact =
-    fsReferenceCount === 23
-    && filesystemMemberReferences.length === 21
+    fsReferenceCount === 24
+    && filesystemMemberReferences.length === 22
     && Object.entries(expectedFilesystemMemberCounts).every(
       ([name, count]) => (filesystemMemberCounts.get(name) ?? 0) === count,
     )
@@ -183,6 +183,7 @@ export function retrievalGeneralizationSuitePolicyViolations(
       "fs.writeFileSync(destination, contents);",
       "fs.mkdirSync(rustRoot, { recursive: true });",
       "fs.mkdirSync(retrievalRoot, { recursive: true });",
+      "fs.mkdirSync(agentRoot, { recursive: true });",
       "fs.mkdirSync(extraRustRoot);",
       "fs.mkdirSync(nonRustRoot);",
       "fs.mkdirSync(taskRoot);",
@@ -207,7 +208,7 @@ export function retrievalGeneralizationSuitePolicyViolations(
   const fixturePathReferenceShapeIsExact =
     repositoryRootReferenceCount === 14
     && fixtureRootReferenceCount === 10
-    && productionRepositoryRootReferenceCount === 4;
+    && productionRepositoryRootReferenceCount === 5;
   const protectedRetrievalWorkflow = `.github/workflows/${retrievalFile}`;
   const retainedDynamicImportFixtures = [
     "await import(harness);",

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -30,6 +30,9 @@ on:
       - scripts/codestory-release-claims.mjs
       - scripts/codestory-release-closeout.mjs
       - scripts/codestory-release-evidence-gate.mjs
+      - scripts/native-fingerprint.mjs
+      - scripts/bump-version.mjs
+      - scripts/lib/workspace-members.mjs
       - scripts/tests/codestory-release-claims.test.mjs
       - scripts/tests/codestory-release-closeout.test.mjs
       - scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -103,6 +106,9 @@ on:
       - scripts/codestory-release-claims.mjs
       - scripts/codestory-release-closeout.mjs
       - scripts/codestory-release-evidence-gate.mjs
+      - scripts/native-fingerprint.mjs
+      - scripts/bump-version.mjs
+      - scripts/lib/workspace-members.mjs
       - scripts/tests/codestory-release-claims.test.mjs
       - scripts/tests/codestory-release-closeout.test.mjs
       - scripts/tests/codestory-release-evidence-gate.test.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ pages, runbooks, and workflows own detailed mechanics.
   publication.
 - `codestory-retrieval`: lexical, semantic, and SCIP artifacts; immutable
   sidecar generations; manifests; health; and fail-closed query execution.
+- `codestory-agent`: packet planning only -- prompt terms, flow requirements,
+  evidence roles and carriers, citation scoring, and the query plan. It depends
+  on `codestory-contracts` alone and reads pinned runtime state only through the
+  `PinnedReader` trait, so it can never activate, store, execute retrieval,
+  retry a publication, or move readiness.
 - `codestory-runtime`: the only product orchestration layer. Indexing,
   grounding, search, packet construction, and agent flows belong here.
 - `codestory-cli`: command and transport parsing, output rendering, process

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codestory-agent"
+version = "0.16.3"
+dependencies = [
+ "codestory-contracts",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "codestory-bench"
 version = "0.16.3"
 dependencies = [
@@ -676,6 +685,7 @@ name = "codestory-runtime"
 version = "0.16.3"
 dependencies = [
  "anyhow",
+ "codestory-agent",
  "codestory-contracts",
  "codestory-indexer",
  "codestory-retrieval",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/codestory-store",
     "crates/codestory-indexer",
     "crates/codestory-retrieval",
+    "crates/codestory-agent",
     "crates/codestory-runtime",
     "crates/codestory-cli",
     "crates/codestory-bench",
@@ -21,6 +22,7 @@ codestory-workspace = { path = "crates/codestory-workspace" }
 codestory-store = { path = "crates/codestory-store" }
 codestory-indexer = { path = "crates/codestory-indexer" }
 codestory-retrieval = { path = "crates/codestory-retrieval" }
+codestory-agent = { path = "crates/codestory-agent" }
 codestory-runtime = { path = "crates/codestory-runtime" }
 codestory-cli = { path = "crates/codestory-cli" }
 

--- a/crates/codestory-agent/Cargo.toml
+++ b/crates/codestory-agent/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "codestory-agent"
+version = "0.16.3"
+edition = "2024"
+
+[features]
+# Compiles the eval/holdout probe hooks that used to ride `#[cfg(test)]` inside
+# `codestory-runtime`. `codestory-runtime` turns it on as a dev-dependency so its
+# own unit tests keep seeing the same hooks they saw before the extraction; no
+# product build enables it.
+test-support = []
+
+[dependencies]
+codestory-contracts = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/codestory-agent/src/eval_probes.rs
+++ b/crates/codestory-agent/src/eval_probes.rs
@@ -8,19 +8,19 @@ use std::sync::OnceLock;
 use codestory_contracts::api::AgentCitationDto;
 use serde::Deserialize;
 
-#[cfg(test)]
-pub(crate) const EVAL_PROBES_ENV: &str = "CODESTORY_EVAL_PROBES";
+#[cfg(any(test, feature = "test-support"))]
+pub const EVAL_PROBES_ENV: &str = "CODESTORY_EVAL_PROBES";
 const EVAL_PROBE_MANIFEST_ENV: &str = "CODESTORY_EVAL_PROBES_MANIFEST";
 
 thread_local! {
     static EVAL_PROBES_TEST_OVERRIDE_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
-pub(crate) fn eval_probes_enabled() -> bool {
+pub fn eval_probes_enabled() -> bool {
     eval_probes_enabled_for_build()
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 fn eval_probes_enabled_for_build() -> bool {
     if EVAL_PROBES_TEST_OVERRIDE_DEPTH.get() > 0 {
         return true;
@@ -33,19 +33,19 @@ fn eval_probes_enabled_for_build() -> bool {
     })
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "test-support")))]
 fn eval_probes_enabled_for_build() -> bool {
     false
 }
 
-#[cfg(test)]
-pub(crate) fn push_eval_probes_test_override() {
+#[cfg(any(test, feature = "test-support"))]
+pub fn push_eval_probes_test_override() {
     let depth = EVAL_PROBES_TEST_OVERRIDE_DEPTH.get();
     EVAL_PROBES_TEST_OVERRIDE_DEPTH.set(depth.saturating_add(1));
 }
 
-#[cfg(test)]
-pub(crate) fn pop_eval_probes_test_override() {
+#[cfg(any(test, feature = "test-support"))]
+pub fn pop_eval_probes_test_override() {
     let depth = EVAL_PROBES_TEST_OVERRIDE_DEPTH.get();
     debug_assert!(depth > 0, "eval probe test override underflow");
     EVAL_PROBES_TEST_OVERRIDE_DEPTH.set(depth.saturating_sub(1));
@@ -126,7 +126,7 @@ fn term_matches(terms: &[String], expected: &str) -> bool {
         .any(|value| value.eq_ignore_ascii_case(expected))
 }
 
-pub(crate) fn push_eval_flow_hint_packet_queries(terms: &[String], queries: &mut Vec<String>) {
+pub fn push_eval_flow_hint_packet_queries(terms: &[String], queries: &mut Vec<String>) {
     if !eval_probes_enabled() {
         return;
     }
@@ -139,7 +139,7 @@ pub(crate) fn push_eval_flow_hint_packet_queries(terms: &[String], queries: &mut
     }
 }
 
-pub(crate) fn push_eval_required_probe_queries(terms: &[String], queries: &mut Vec<String>) {
+pub fn push_eval_required_probe_queries(terms: &[String], queries: &mut Vec<String>) {
     if !eval_probes_enabled() {
         return;
     }
@@ -152,10 +152,7 @@ pub(crate) fn push_eval_required_probe_queries(terms: &[String], queries: &mut V
     }
 }
 
-pub(crate) fn push_prompt_concept_derived_symbol_probes(
-    terms: &[String],
-    queries: &mut Vec<String>,
-) {
+pub fn push_prompt_concept_derived_symbol_probes(terms: &[String], queries: &mut Vec<String>) {
     if !eval_probes_enabled() {
         return;
     }
@@ -209,7 +206,7 @@ pub(crate) fn push_prompt_concept_derived_symbol_probes(
     }
 }
 
-pub(crate) fn push_prompt_named_file_probe_queries(terms: &[String], queries: &mut Vec<String>) {
+pub fn push_prompt_named_file_probe_queries(terms: &[String], queries: &mut Vec<String>) {
     if !eval_probes_enabled() {
         return;
     }
@@ -292,7 +289,7 @@ pub(crate) fn push_prompt_named_file_probe_queries(terms: &[String], queries: &m
     }
 }
 
-pub(crate) fn source_derived_claims_for_citation(
+pub fn source_derived_claims_for_citation(
     prompt: &str,
     citation: &AgentCitationDto,
     source: &str,
@@ -348,11 +345,7 @@ pub(crate) fn source_derived_claims_for_citation(
     claims
 }
 
-pub(crate) fn eval_citation_rank_adjustment(
-    normalized_display: &str,
-    path: &str,
-    score: f32,
-) -> f32 {
+pub fn eval_citation_rank_adjustment(normalized_display: &str, path: &str, score: f32) -> f32 {
     if !eval_probes_enabled() {
         return score;
     }
@@ -365,7 +358,7 @@ pub(crate) fn eval_citation_rank_adjustment(
     adjusted
 }
 
-pub(crate) fn eval_flow_template_claims(
+pub fn eval_flow_template_claims(
     normalized_prompt: &str,
     citations: &[AgentCitationDto],
 ) -> Vec<(String, AgentCitationDto)> {
@@ -477,7 +470,7 @@ pub(crate) fn eval_flow_template_claims(
     claims
 }
 
-pub(crate) fn push_eval_architecture_flow_probe_terms(lower_prompt: &str, terms: &mut Vec<String>) {
+pub fn push_eval_architecture_flow_probe_terms(lower_prompt: &str, terms: &mut Vec<String>) {
     if !eval_probes_enabled() {
         return;
     }
@@ -526,10 +519,7 @@ pub(crate) fn push_eval_architecture_flow_probe_terms(lower_prompt: &str, terms:
     }
 }
 
-pub(crate) fn eval_supporting_claim_flow_sentence(
-    normalized_prompt: &str,
-    focus: &str,
-) -> Option<String> {
+pub fn eval_supporting_claim_flow_sentence(normalized_prompt: &str, focus: &str) -> Option<String> {
     if !eval_probes_enabled() {
         return None;
     }
@@ -559,7 +549,7 @@ pub(crate) fn eval_supporting_claim_flow_sentence(
     None
 }
 
-pub(crate) fn eval_citation_shaped_claim(
+pub fn eval_citation_shaped_claim(
     citation: &AgentCitationDto,
     prompt: &str,
     display_path: &str,

--- a/crates/codestory-agent/src/lib.rs
+++ b/crates/codestory-agent/src/lib.rs
@@ -1,0 +1,28 @@
+//! Packet planning, extracted from `codestory-runtime`.
+//!
+//! This crate decides *what to ask for*: the terms a prompt carries, the flow
+//! requirements a task class implies, the evidence roles and carriers a
+//! citation can play, and the deduplicated query plan that comes out the other
+//! side. It owns none of the machinery that answers those questions.
+//!
+//! Specifically, nothing here may activate a publication, open or write
+//! storage, execute retrieval, retry a publication, or move readiness. The only
+//! runtime state planning may see is what the host already pinned, and it sees
+//! that exclusively through [`pinned_reader::PinnedReader`]. The crate DAG
+//! enforces the rule from below — `codestory-agent` depends on
+//! `codestory-contracts` and nothing else in this workspace — and
+//! `codestory-cli`'s architecture contracts enforce it from above.
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod eval_probes;
+pub mod packet_citations;
+pub mod packet_evidence_carriers;
+pub mod packet_evidence_roles;
+pub mod packet_flow_requirements;
+pub mod packet_scoring;
+pub mod packet_terms;
+pub mod pinned_reader;
+pub mod planning;
+pub mod text;
+
+pub use pinned_reader::{ContinuationRefusal, PinnedReader, admit_continuation_probe};

--- a/crates/codestory-agent/src/packet_citations.rs
+++ b/crates/codestory-agent/src/packet_citations.rs
@@ -1,7 +1,7 @@
-use crate::agent::packet_scoring::{normalize_identifier, packet_display_path};
+use crate::packet_scoring::{normalize_identifier, packet_display_path};
 use codestory_contracts::api::AgentCitationDto;
 
-pub(crate) fn packet_citation_matching_display<'a>(
+pub fn packet_citation_matching_display<'a>(
     citations: &'a [AgentCitationDto],
     display_needle: &str,
 ) -> Option<&'a AgentCitationDto> {
@@ -11,7 +11,7 @@ pub(crate) fn packet_citation_matching_display<'a>(
         .find(|citation| normalize_identifier(&citation.display_name) == needle)
 }
 
-pub(crate) fn packet_citation_matching_path_and_display<'a>(
+pub fn packet_citation_matching_path_and_display<'a>(
     citations: &'a [AgentCitationDto],
     path_needle: &str,
     display_needle: &str,
@@ -30,7 +30,7 @@ pub(crate) fn packet_citation_matching_path_and_display<'a>(
     })
 }
 
-pub(crate) fn packet_command_crate_sources_contain_all(
+pub fn packet_command_crate_sources_contain_all(
     citations: &[AgentCitationDto],
     crate_segment: &str,
     groups: &[&[&str]],
@@ -54,7 +54,7 @@ pub(crate) fn packet_command_crate_sources_contain_all(
         })
 }
 
-pub(crate) fn packet_citation_path_contains_crate_segment(
+pub fn packet_citation_path_contains_crate_segment(
     citation: &AgentCitationDto,
     crate_segment: &str,
 ) -> bool {
@@ -77,7 +77,7 @@ pub(crate) fn packet_citation_path_contains_crate_segment(
         .unwrap_or(false)
 }
 
-pub(crate) fn packet_citation_source_text(citation: &AgentCitationDto) -> Option<String> {
+pub fn packet_citation_source_text(citation: &AgentCitationDto) -> Option<String> {
     let path = citation.file_path.as_deref()?;
     std::fs::read_to_string(path).ok()
 }

--- a/crates/codestory-agent/src/packet_evidence_carriers.rs
+++ b/crates/codestory-agent/src/packet_evidence_carriers.rs
@@ -53,11 +53,13 @@
 //! and output methods hang off the site object itself, so the subject is read from the name where
 //! every other carrier here reads it.
 
-use crate::agent::packet_scoring::{normalize_identifier, packet_display_path};
+use crate::packet_scoring::{normalize_identifier, packet_display_path};
 use codestory_contracts::api::{AgentCitationDto, NodeKind};
 
 fn terminal(citation: &AgentCitationDto) -> String {
-    normalize_identifier(&crate::terminal_symbol_segment(&citation.display_name))
+    normalize_identifier(&crate::text::terminal_symbol_segment(
+        &citation.display_name,
+    ))
 }
 
 /// The last `::`/`.`/`/` segment of a symbol name with its original casing intact. Case carries
@@ -197,7 +199,7 @@ fn names_token_prefix(citation: &AgentCitationDto, prefixes: &[&str]) -> bool {
 /// library rather than the word "client", and nothing in a name separates it from a
 /// `FrameKind.request` somewhere else in the repository. It is recorded as a family in
 /// `COMPOUND_EVIDENCE_SURFACE` rather than left for the next reviewer to find again.
-pub(crate) fn citation_owns_client_request_method(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_client_request_method(citation: &AgentCitationDto) -> bool {
     matches!(citation.kind, NodeKind::FUNCTION | NodeKind::METHOD)
         && belongs_to_http_client(citation)
         && matches!(
@@ -234,7 +236,7 @@ fn belongs_to_http_client(citation: &AgentCitationDto) -> bool {
 }
 
 /// The step that turns a configured request into a transport-ready one.
-pub(crate) fn citation_owns_client_request_finalization(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_client_request_finalization(citation: &AgentCitationDto) -> bool {
     if !owns_behavior(citation) || !belongs_to_http_client(citation) {
         return false;
     }
@@ -244,7 +246,7 @@ pub(crate) fn citation_owns_client_request_finalization(citation: &AgentCitation
 }
 
 /// The boundary where a transport response becomes a value the caller can read.
-pub(crate) fn citation_owns_client_response_materialization(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_client_response_materialization(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && names_token(citation, &["response", "responses"])
         && (names_token(
@@ -299,7 +301,7 @@ fn names_a_hook(citation: &AgentCitationDto) -> bool {
         .is_some_and(|next| next.is_ascii_uppercase())
 }
 
-pub(crate) fn citation_owns_hook_public_export(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_hook_public_export(citation: &AgentCitationDto) -> bool {
     matches!(citation.kind, NodeKind::FUNCTION | NodeKind::METHOD)
         && is_script_surface(citation)
         && names_a_hook(citation)
@@ -309,7 +311,7 @@ pub(crate) fn citation_owns_hook_public_export(citation: &AgentCitationDto) -> b
 /// Serializing *the cache key*. Being a `serialize*` function on a script surface is the shape of
 /// every `serializeSettings`, `serializeForm` and `serializeQueryString` ever written; the
 /// requirement is about the key, so the key has to be named.
-pub(crate) fn citation_owns_hook_key_serialization(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_hook_key_serialization(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && is_script_surface(citation)
         && names_token(citation, &["key", "keys"])
@@ -320,7 +322,7 @@ pub(crate) fn citation_owns_hook_key_serialization(citation: &AgentCitationDto) 
 /// The helper that holds cache state, not any method that touches a cache. `Cache.put` and
 /// `Cache.get` are the cache's own API on every cache in every repository; this requirement is the
 /// hook library's helper *around* one, so the anchor has to name the helper.
-pub(crate) fn citation_owns_hook_cache_helper(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_hook_cache_helper(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && is_script_surface(citation)
         && names_token(citation, &["cache", "caches"])
@@ -330,7 +332,7 @@ pub(crate) fn citation_owns_hook_cache_helper(citation: &AgentCitationDto) -> bo
         ) || names_token_prefix(citation, &["make", "creat", "init"]))
 }
 
-pub(crate) fn citation_owns_hook_mutation_flow(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_hook_mutation_flow(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && is_script_surface(citation)
         && names_token_prefix(citation, &["mutat"])
@@ -359,7 +361,7 @@ fn is_stylesheet(citation: &AgentCitationDto) -> bool {
     path_has_any_extension(citation, &[".css", ".scss", ".sass", ".less"])
 }
 
-pub(crate) fn citation_owns_html_app_shell(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_html_app_shell(citation: &AgentCitationDto) -> bool {
     is_markup_document(citation)
         && names_token(
             citation,
@@ -369,15 +371,15 @@ pub(crate) fn citation_owns_html_app_shell(citation: &AgentCitationDto) -> bool 
         )
 }
 
-pub(crate) fn citation_owns_css_structure(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_css_structure(citation: &AgentCitationDto) -> bool {
     is_stylesheet(citation)
 }
 
-pub(crate) fn citation_owns_css_animation_entrypoint(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_css_animation_entrypoint(citation: &AgentCitationDto) -> bool {
     is_stylesheet(citation) && names_token(citation, &["import", "use", "forward"])
 }
 
-pub(crate) fn citation_owns_css_animation_structure(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_css_animation_structure(citation: &AgentCitationDto) -> bool {
     is_stylesheet(citation)
         // Sibling of `css_animation_entrypoint`. `@import "animations/base"` names the animation
         // directory, so without this an import closed the structure requirement too.
@@ -464,7 +466,7 @@ fn is_form_constraint_markup(citation: &AgentCitationDto) -> bool {
     is_markup_document(citation) && names_or_path_token(citation, FORM_SUBSYSTEM_WORDS)
 }
 
-pub(crate) fn citation_owns_form_native_constraint(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_form_native_constraint(citation: &AgentCitationDto) -> bool {
     (is_form_validation_surface(citation) || is_form_constraint_markup(citation))
         && names_token(
             citation,
@@ -481,7 +483,7 @@ pub(crate) fn citation_owns_form_native_constraint(citation: &AgentCitationDto) 
         )
 }
 
-pub(crate) fn citation_owns_form_custom_validation(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_form_custom_validation(citation: &AgentCitationDto) -> bool {
     is_form_validation_surface(citation)
         && (names_token(
             citation,
@@ -495,7 +497,7 @@ pub(crate) fn citation_owns_form_custom_validation(citation: &AgentCitationDto) 
         ) || names_token_prefix(citation, &["customvalid", "checkvalid", "reportvalid"]))
 }
 
-pub(crate) fn citation_owns_form_submit_guard(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_form_submit_guard(citation: &AgentCitationDto) -> bool {
     is_form_validation_surface(citation)
         && (names_token(citation, &["submit", "submits", "preventdefault"])
             || names_token_prefix(citation, &["submitt"]))
@@ -513,7 +515,7 @@ fn is_shell_script(citation: &AgentCitationDto) -> bool {
         || path.ends_with("install")
 }
 
-pub(crate) fn citation_owns_shell_installer_bootstrap(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_shell_installer_bootstrap(citation: &AgentCitationDto) -> bool {
     is_shell_script(citation)
         && names_token_prefix(
             citation,
@@ -521,13 +523,13 @@ pub(crate) fn citation_owns_shell_installer_bootstrap(citation: &AgentCitationDt
         )
 }
 
-pub(crate) fn citation_owns_shell_function_dispatch(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_shell_function_dispatch(citation: &AgentCitationDto) -> bool {
     is_shell_script(citation)
         && (names_token(citation, &["use", "run", "exec", "case"])
             || names_token_prefix(citation, &["dispatch", "command", "exec"]))
 }
 
-pub(crate) fn citation_owns_shell_completion(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_shell_completion(citation: &AgentCitationDto) -> bool {
     is_shell_script(citation)
         && names_token_prefix(citation, &["completion", "compgen", "complete", "alias"])
 }
@@ -586,7 +588,7 @@ fn names_io_operation(citation: &AgentCitationDto) -> bool {
 }
 
 /// The buffer itself — where bytes live between a source and a sink.
-pub(crate) fn citation_owns_buffer_storage(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_buffer_storage(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && names_buffer(citation)
         && !names_io_operation(citation)
@@ -601,7 +603,7 @@ pub(crate) fn citation_owns_buffer_storage(citation: &AgentCitationDto) -> bool 
 /// citation combine with unrelated database and telemetry operations to close the whole flow.
 /// The positive surface remains operations named on the storage object itself, which carry both
 /// factors in one citation.
-pub(crate) fn citation_owns_buffer_read_write(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_buffer_read_write(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation) && names_io_operation(citation) && names_the_buffer_itself(citation)
 }
 
@@ -627,7 +629,7 @@ fn belongs_to_logging(citation: &AgentCitationDto) -> bool {
 /// `createUserRecord` that happens to sit in `src/logging/` is still a database row, and letting
 /// the directory supply the subsystem is how an off-subject symbol inside a flow's own folder
 /// closes that flow's requirement.
-pub(crate) fn citation_owns_log_record_creation(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_log_record_creation(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation) && {
         let tokens = name_tokens(citation);
         has_token(&tokens, &["log", "logs", "logger", "loggers", "logging"])
@@ -650,7 +652,7 @@ pub(crate) fn citation_owns_log_record_creation(citation: &AgentCitationDto) -> 
 /// one as a record-pipeline subject let an HTTP handler combine with real record-creation evidence
 /// and close the whole logging flow. A proof-bearing handler anchor therefore says both whose
 /// handler it is and which processing step it owns.
-pub(crate) fn citation_owns_log_handler_processing(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_log_handler_processing(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation) && belongs_to_logging(citation) && {
         let tokens = name_tokens(citation);
         let names_a_handler = has_token(&tokens, &["handler", "handlers"]);
@@ -726,7 +728,7 @@ fn belongs_to_site_build(citation: &AgentCitationDto) -> bool {
 /// it is gone with the directory. It cannot narrow anything now: "site" was itself the first entry
 /// in that list, so every name `belongs_to_site_build` accepts satisfies it. Leaving it in would
 /// read as a second factor and be none.
-pub(crate) fn citation_owns_site_lifecycle(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_site_lifecycle(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation) && belongs_to_site_build(citation) && {
         let tokens = name_tokens(citation);
         has_token(
@@ -737,7 +739,7 @@ pub(crate) fn citation_owns_site_lifecycle(citation: &AgentCitationDto) -> bool 
     }
 }
 
-pub(crate) fn citation_owns_site_terminal(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_site_terminal(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && belongs_to_site_build(citation)
         // Sibling of `site_lifecycle`, which excludes these same three stems, so one anchor cannot
@@ -799,7 +801,7 @@ fn names_mapper_configuration(citation: &AgentCitationDto) -> bool {
     names_token_prefix(citation, &["config", "profile", "option"])
 }
 
-pub(crate) fn citation_owns_mapper_configuration(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_mapper_configuration(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && belongs_to_object_mapper(citation)
         && names_mapper_configuration(citation)
@@ -809,7 +811,7 @@ pub(crate) fn citation_owns_mapper_configuration(citation: &AgentCitationDto) ->
 /// The plan a mapper executes. "mapper" and "mapping" are absent from the step list on purpose:
 /// they are what `belongs_to_object_mapper` already asks for, so listing them here let a symbol
 /// named nothing but `Mapper` satisfy both of this carrier's factors at once.
-pub(crate) fn citation_owns_mapper_execution(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_mapper_execution(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && belongs_to_object_mapper(citation)
         && !names_mapper_configuration(citation)
@@ -852,7 +854,7 @@ fn belongs_to_runtime_formatting(citation: &AgentCitationDto) -> bool {
 }
 
 /// The type-erased argument store a runtime formatter reads from.
-pub(crate) fn citation_owns_format_arguments(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_format_arguments(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation) && {
         let tokens = name_tokens(citation);
         has_token(&tokens, RUNTIME_FORMAT_ARGUMENT_WORDS)
@@ -867,7 +869,7 @@ pub(crate) fn citation_owns_format_arguments(citation: &AgentCitationDto) -> boo
 /// The error/fallback path a runtime formatter takes when an argument cannot be formatted. This is
 /// the only carrier for `FlowRole::ErrorOrFallback`; without it the role would ask for evidence no
 /// packet could ever cite.
-pub(crate) fn citation_owns_formatter_fallback(citation: &AgentCitationDto) -> bool {
+pub fn citation_owns_formatter_fallback(citation: &AgentCitationDto) -> bool {
     owns_behavior(citation)
         && belongs_to_runtime_formatting(citation)
         && names_token_prefix(
@@ -894,7 +896,7 @@ pub(crate) fn citation_owns_formatter_fallback(citation: &AgentCitationDto) -> b
 // ---------------------------------------------------------------------------
 
 /// Indexing: discovering files, extracting symbols, and persisting them.
-pub(crate) fn flow_belongs_to_indexing(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_indexing(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -921,7 +923,7 @@ pub(crate) fn flow_belongs_to_indexing(citation: &AgentCitationDto) -> bool {
 }
 
 /// A server receiving and routing an inbound request.
-pub(crate) fn flow_belongs_to_server_request(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_server_request(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -965,7 +967,7 @@ pub(crate) fn flow_belongs_to_server_request(citation: &AgentCitationDto) -> boo
 }
 
 /// A client assembling and issuing an outbound request.
-pub(crate) fn flow_belongs_to_client_request(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_client_request(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -997,7 +999,7 @@ pub(crate) fn flow_belongs_to_client_request(citation: &AgentCitationDto) -> boo
 }
 
 /// Where a request leaves the process and a response comes back.
-pub(crate) fn flow_belongs_to_request_terminal(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_request_terminal(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -1022,7 +1024,7 @@ pub(crate) fn flow_belongs_to_request_terminal(citation: &AgentCitationDto) -> b
 }
 
 /// A URL session and the delegate callbacks it drives.
-pub(crate) fn flow_belongs_to_url_session(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_url_session(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -1048,7 +1050,7 @@ pub(crate) fn flow_belongs_to_url_session(citation: &AgentCitationDto) -> bool {
 }
 
 /// Bringing a command server up.
-pub(crate) fn flow_belongs_to_command_server(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_command_server(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -1067,7 +1069,7 @@ pub(crate) fn flow_belongs_to_command_server(citation: &AgentCitationDto) -> boo
 }
 
 /// The loop that waits for readiness and fires callbacks.
-pub(crate) fn flow_belongs_to_event_loop(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_event_loop(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -1078,7 +1080,7 @@ pub(crate) fn flow_belongs_to_event_loop(citation: &AgentCitationDto) -> bool {
 }
 
 /// Reading a command off the wire.
-pub(crate) fn flow_belongs_to_network_input(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_network_input(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -1103,7 +1105,7 @@ pub(crate) fn flow_belongs_to_network_input(citation: &AgentCitationDto) -> bool
 /// "dispatch"/"dispatcher" are absent: the role classifier grants `RequestDispatch` and
 /// `CommandDispatch` from that same word, so listing it here let one word answer both "is this the
 /// command subsystem" and "is this its dispatch step". A command dispatcher says "command".
-pub(crate) fn flow_belongs_to_command_dispatch(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_command_dispatch(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -1113,7 +1115,7 @@ pub(crate) fn flow_belongs_to_command_dispatch(citation: &AgentCitationDto) -> b
 }
 
 /// Planning and running a search.
-pub(crate) fn flow_belongs_to_search(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_search(citation: &AgentCitationDto) -> bool {
     names_token(
         citation,
         &[
@@ -1125,7 +1127,7 @@ pub(crate) fn flow_belongs_to_search(citation: &AgentCitationDto) -> bool {
 
 /// A schema requirement is proved by the schema file, so here the file *is* the subsystem: a `.sql`
 /// anchor has no identifier of its own to scope by.
-pub(crate) fn flow_belongs_to_sql_schema(citation: &AgentCitationDto) -> bool {
+pub fn flow_belongs_to_sql_schema(citation: &AgentCitationDto) -> bool {
     path_has_any_extension(citation, &[".sql"])
 }
 

--- a/crates/codestory-agent/src/packet_evidence_roles.rs
+++ b/crates/codestory-agent/src/packet_evidence_roles.rs
@@ -1,11 +1,11 @@
-use crate::agent::packet_scoring::{
+use crate::packet_scoring::{
     normalize_identifier, packet_display_name_is_test_like, packet_display_path,
 };
-use crate::retrieval_file_role_from_path;
+use crate::text::retrieval_file_role_from_path;
 use codestory_contracts::api::{AgentCitationDto, NodeKind, SearchHitOrigin};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum PacketEvidenceRole {
+pub enum PacketEvidenceRole {
     SqlTableDefinition,
     SqlRelationshipConstraint,
     SqlSchemaFile,
@@ -37,16 +37,16 @@ pub(crate) enum PacketEvidenceRole {
     SourceEvidence,
 }
 
-pub(crate) fn packet_citation_owns_request_pipeline(citation: &AgentCitationDto) -> bool {
+pub fn packet_citation_owns_request_pipeline(citation: &AgentCitationDto) -> bool {
     matches!(citation.kind, NodeKind::FUNCTION | NodeKind::METHOD)
-        && crate::terminal_symbol_segment(&citation.display_name) == "request"
+        && crate::text::terminal_symbol_segment(&citation.display_name) == "request"
 }
 
-pub(crate) fn packet_citation_owns_interceptor_management(citation: &AgentCitationDto) -> bool {
+pub fn packet_citation_owns_interceptor_management(citation: &AgentCitationDto) -> bool {
     let owner_kind = matches!(citation.kind, NodeKind::STRUCT | NodeKind::CLASS)
         || (citation.kind == NodeKind::METHOD
             && matches!(
-                crate::terminal_symbol_segment(&citation.display_name).as_str(),
+                crate::text::terminal_symbol_segment(&citation.display_name).as_str(),
                 "constructor" | "init" | "new"
             ));
     if !owner_kind {
@@ -59,7 +59,7 @@ pub(crate) fn packet_citation_owns_interceptor_management(citation: &AgentCitati
             .any(|owner| display.contains(owner))
 }
 
-pub(crate) fn packet_citation_owns_transport_adapter(citation: &AgentCitationDto) -> bool {
+pub fn packet_citation_owns_transport_adapter(citation: &AgentCitationDto) -> bool {
     if !matches!(
         citation.kind,
         NodeKind::FUNCTION | NodeKind::METHOD | NodeKind::CLASS | NodeKind::STRUCT
@@ -70,7 +70,9 @@ pub(crate) fn packet_citation_owns_transport_adapter(citation: &AgentCitationDto
     if !display.contains("adapter") {
         return false;
     }
-    let terminal = normalize_identifier(&crate::terminal_symbol_segment(&citation.display_name));
+    let terminal = normalize_identifier(&crate::text::terminal_symbol_segment(
+        &citation.display_name,
+    ));
     if matches!(citation.kind, NodeKind::CLASS | NodeKind::STRUCT) {
         // A type whose name merely ends in "adapter" is `ArrayAdapter`, `ListAdapter`,
         // `RecyclerViewAdapter` — the most populated class-name suffix in mobile and UI code, and
@@ -101,7 +103,7 @@ pub(crate) fn packet_citation_owns_transport_adapter(citation: &AgentCitationDto
 }
 
 impl PacketEvidenceRole {
-    pub(crate) fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::SqlTableDefinition => "sql table definition",
             Self::SqlRelationshipConstraint => "sql relationship constraint",
@@ -135,12 +137,12 @@ impl PacketEvidenceRole {
         }
     }
 
-    pub(crate) fn is_low_priority_cap_role(self) -> bool {
+    pub fn is_low_priority_cap_role(self) -> bool {
         matches!(self, Self::TestsAndRegressionCoverage)
     }
 }
 
-pub(crate) fn packet_evidence_role(citation: &AgentCitationDto) -> Option<PacketEvidenceRole> {
+pub fn packet_evidence_role(citation: &AgentCitationDto) -> Option<PacketEvidenceRole> {
     if citation.kind == NodeKind::FILE && citation.origin == SearchHitOrigin::TextMatch {
         return None;
     }
@@ -326,7 +328,7 @@ pub(crate) fn packet_evidence_role(citation: &AgentCitationDto) -> Option<Packet
     } else if path.contains("/collections/") {
         Some(PacketEvidenceRole::CollectionConfiguration)
     } else if matches!(citation.kind, NodeKind::FUNCTION | NodeKind::METHOD)
-        && retrieval_file_role_from_path(&path) == crate::RetrievalFileRole::Source
+        && retrieval_file_role_from_path(&path) == crate::text::RetrievalFileRole::Source
     {
         Some(PacketEvidenceRole::SourceEvidence)
     } else {
@@ -334,7 +336,7 @@ pub(crate) fn packet_evidence_role(citation: &AgentCitationDto) -> Option<Packet
     }
 }
 
-pub(crate) fn packet_claim_key_for_citation(
+pub fn packet_claim_key_for_citation(
     role: PacketEvidenceRole,
     citation: &AgentCitationDto,
 ) -> String {

--- a/crates/codestory-agent/src/packet_flow_requirements.rs
+++ b/crates/codestory-agent/src/packet_flow_requirements.rs
@@ -1,6 +1,6 @@
 //! Generic packet flow requirements shared by planning, probes, and sufficiency.
 
-use crate::agent::packet_evidence_carriers::{
+use crate::packet_evidence_carriers::{
     citation_owns_buffer_read_write, citation_owns_buffer_storage,
     citation_owns_client_request_finalization, citation_owns_client_request_method,
     citation_owns_client_response_materialization, citation_owns_css_animation_entrypoint,
@@ -19,10 +19,10 @@ use crate::agent::packet_evidence_carriers::{
     flow_belongs_to_network_input, flow_belongs_to_request_terminal, flow_belongs_to_search,
     flow_belongs_to_server_request, flow_belongs_to_sql_schema, flow_belongs_to_url_session,
 };
-use crate::agent::packet_evidence_roles::{
+use crate::packet_evidence_roles::{
     PacketEvidenceRole, packet_citation_owns_interceptor_management, packet_evidence_role,
 };
-use crate::agent::packet_terms::{
+use crate::packet_terms::{
     packet_terms_have_any, packet_terms_indicate_buffered_io_flow,
     packet_terms_indicate_client_send_flow, packet_terms_indicate_command_dispatch_flow,
     packet_terms_indicate_command_event_loop_flow,
@@ -51,7 +51,7 @@ const BEHAVIORAL_OWNER_NODE_KINDS: &[NodeKind] = &[
 const SQL_SCHEMA_NODE_KINDS: &[NodeKind] = &[NodeKind::FILE, NodeKind::ANNOTATION];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum FlowRole {
+pub enum FlowRole {
     Entrypoint,
     Registration,
     Configuration,
@@ -63,8 +63,8 @@ pub(crate) enum FlowRole {
 }
 
 impl FlowRole {
-    #[cfg(test)]
-    pub(crate) const fn role_id(self) -> &'static str {
+    #[cfg(any(test, feature = "test-support"))]
+    pub const fn role_id(self) -> &'static str {
         match self {
             Self::Entrypoint => "entrypoint",
             Self::Registration => "registration",
@@ -77,7 +77,7 @@ impl FlowRole {
         }
     }
 
-    pub(crate) const fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
             Self::Entrypoint => "entrypoint",
             Self::Registration => "registration",
@@ -92,7 +92,7 @@ impl FlowRole {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CoverageMode {
+pub enum CoverageMode {
     RequiresResolvedSourceOrGraph,
     AllowsSourceRange,
     AllowsLexicalSource,
@@ -106,7 +106,7 @@ pub(crate) enum CoverageMode {
 /// close the other. An evidence predicate belongs to a single requirement and reads only the
 /// citation, never the claim's wording.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum EvidencePredicate {
+pub enum EvidencePredicate {
     /// Covered by a citation the evidence-role classifier places in this part of the flow *and*
     /// that belongs to the subsystem this flow is about.
     ///
@@ -127,7 +127,7 @@ pub(crate) enum EvidencePredicate {
 }
 
 impl EvidencePredicate {
-    pub(crate) fn citation_proves(self, citation: &AgentCitationDto) -> bool {
+    pub fn citation_proves(self, citation: &AgentCitationDto) -> bool {
         match self {
             Self::CitedRoles { subsystem, roles } => {
                 subsystem(citation)
@@ -140,7 +140,7 @@ impl EvidencePredicate {
 
     /// Secondary node-kind policy for role-based predicates. Carrier predicates already encode
     /// their own structural contract and return an empty list to mean "predicate-owned".
-    pub(crate) fn allowed_node_kinds(self) -> &'static [NodeKind] {
+    pub fn allowed_node_kinds(self) -> &'static [NodeKind] {
         let Self::CitedRoles { roles, .. } = self else {
             return &[];
         };
@@ -207,7 +207,7 @@ fn role_survives_without_its_path(
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct FlowRequirement {
+pub struct FlowRequirement {
     pub id: &'static str,
     pub role: FlowRole,
     pub query_seeds: &'static [&'static str],
@@ -216,13 +216,13 @@ pub(crate) struct FlowRequirement {
 }
 
 impl FlowRequirement {
-    #[cfg(test)]
-    pub(crate) const fn role_id(&self) -> &'static str {
+    #[cfg(any(test, feature = "test-support"))]
+    pub const fn role_id(&self) -> &'static str {
         self.role.role_id()
     }
 }
 
-pub(crate) fn packet_flow_requirements_for_terms(
+pub fn packet_flow_requirements_for_terms(
     terms: &[String],
     task_class: PacketTaskClassDto,
 ) -> Vec<FlowRequirement> {
@@ -299,7 +299,7 @@ pub(crate) fn packet_flow_requirements_for_terms(
     dedupe_requirements(requirements)
 }
 
-pub(crate) fn packet_flow_requirement_queries_for_terms(
+pub fn packet_flow_requirement_queries_for_terms(
     terms: &[String],
     task_class: PacketTaskClassDto,
 ) -> Vec<String> {
@@ -961,7 +961,7 @@ const SEARCH_EXECUTION_FLOW: &[FlowRequirement] = &[
 /// a group and a `FlowRole` are the ones that must stay separable by evidence, so tests need the
 /// grouping and not just a flat list.
 #[cfg(test)]
-pub(crate) fn all_flow_requirement_groups() -> Vec<(&'static str, Vec<FlowRequirement>)> {
+pub fn all_flow_requirement_groups() -> Vec<(&'static str, Vec<FlowRequirement>)> {
     let mut client_dispatch = CLIENT_REQUEST_DISPATCH_FLOW.to_vec();
     client_dispatch.push(REQUEST_INTERCEPTOR_REQUIREMENT);
     vec![
@@ -1015,7 +1015,7 @@ pub(crate) fn all_flow_requirement_groups() -> Vec<(&'static str, Vec<FlowRequir
 }
 
 #[cfg(test)]
-pub(crate) fn all_flow_requirements() -> Vec<FlowRequirement> {
+pub fn all_flow_requirements() -> Vec<FlowRequirement> {
     all_flow_requirement_groups()
         .into_iter()
         .flat_map(|(_, requirements)| requirements)
@@ -1025,7 +1025,7 @@ pub(crate) fn all_flow_requirements() -> Vec<FlowRequirement> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::packet_terms::packet_probe_terms;
+    use crate::packet_terms::packet_probe_terms;
     use codestory_contracts::api::{NodeId, NodeKind, SearchHitOrigin};
     use std::collections::BTreeMap;
 

--- a/crates/codestory-agent/src/packet_scoring.rs
+++ b/crates/codestory-agent/src/packet_scoring.rs
@@ -1,8 +1,8 @@
 //! Packet citation scoring helpers for batch retrieval ranking.
 
-#[cfg(test)]
-use super::eval_probes::eval_citation_rank_adjustment;
-use crate::agent::packet_terms::{
+#[cfg(any(test, feature = "test-support"))]
+use crate::eval_probes::eval_citation_rank_adjustment;
+use crate::packet_terms::{
     packet_terms_indicate_buffered_io_flow, packet_terms_indicate_client_send_flow,
     packet_terms_indicate_form_validation_flow,
     packet_terms_indicate_html_css_template_structure_flow,
@@ -16,7 +16,7 @@ use crate::agent::packet_terms::{
     packet_terms_indicate_stylesheet_animation_flow,
     packet_terms_indicate_url_session_request_flow,
 };
-use crate::retrieval_file_role_from_path;
+use crate::text::retrieval_file_role_from_path;
 use codestory_contracts::api::{
     AgentCitationDto, NodeKind, PacketBudgetLimitsDto, SearchHitOrigin,
 };
@@ -28,7 +28,7 @@ use std::cmp::Ordering;
 /// ranking term, so they are decorated before the sort rather than recomputed
 /// inside the comparator. The comparator itself is unchanged — a NaN rank still
 /// compares equal, and the stable sort keeps input order for equal ranks.
-pub(crate) fn sort_by_cached_rank_desc<T>(values: &mut Vec<T>, mut rank: impl FnMut(&T) -> f32) {
+pub fn sort_by_cached_rank_desc<T>(values: &mut Vec<T>, mut rank: impl FnMut(&T) -> f32) {
     let mut decorated = std::mem::take(values)
         .into_iter()
         .map(|value| {
@@ -41,16 +41,16 @@ pub(crate) fn sort_by_cached_rank_desc<T>(values: &mut Vec<T>, mut rank: impl Fn
 }
 
 /// Citations merged from each packet retrieval stage before the final budget cap.
-pub(crate) fn packet_stage_citation_carry_limit(limits: &PacketBudgetLimitsDto) -> usize {
+pub fn packet_stage_citation_carry_limit(limits: &PacketBudgetLimitsDto) -> usize {
     limits.max_anchors.clamp(8, 16) as usize
 }
 
 /// Candidate hits fetched per planned subquery or anchor-probe batch query.
-pub(crate) fn packet_subquery_hit_limit(limits: &PacketBudgetLimitsDto) -> usize {
+pub fn packet_subquery_hit_limit(limits: &PacketBudgetLimitsDto) -> usize {
     limits.max_anchors.clamp(8, 20) as usize
 }
 
-pub(crate) fn packet_citation_key(citation: &AgentCitationDto) -> String {
+pub fn packet_citation_key(citation: &AgentCitationDto) -> String {
     format!(
         "{}\t{}\t{}",
         citation.node_id.0,
@@ -58,7 +58,7 @@ pub(crate) fn packet_citation_key(citation: &AgentCitationDto) -> String {
         citation.line.unwrap_or_default()
     )
 }
-pub(crate) fn packet_citation_rank(
+pub fn packet_citation_rank(
     citation: &AgentCitationDto,
     terms: &[String],
     prefer_primary_sources: bool,
@@ -200,7 +200,7 @@ pub(crate) fn packet_citation_rank(
         score += packet_shell_install_dispatch_rank_bonus(&normalized_display, &path);
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     {
         score = eval_citation_rank_adjustment(&normalized_display, &path, score);
     }
@@ -267,7 +267,7 @@ fn packet_concrete_module_file_citation(
 }
 
 /// Rank citations for role-backed claim carry: prefer primary-source flow evidence over tests.
-pub(crate) fn packet_claim_carry_rank(
+pub fn packet_claim_carry_rank(
     citation: &AgentCitationDto,
     terms: &[String],
     prefer_primary_sources: bool,
@@ -291,11 +291,11 @@ pub(crate) fn packet_claim_carry_rank(
     score
 }
 
-pub(crate) fn packet_low_signal_display_name(normalized_display: &str) -> bool {
+pub fn packet_low_signal_display_name(normalized_display: &str) -> bool {
     matches!(normalized_display, "current" | "actual" | "existing")
 }
 
-pub(crate) fn packet_display_name_is_import_literal(display: &str) -> bool {
+pub fn packet_display_name_is_import_literal(display: &str) -> bool {
     let trimmed = display.trim();
     (trimmed.starts_with('\'') && trimmed.ends_with('\''))
         || (trimmed.starts_with('"') && trimmed.ends_with('"'))
@@ -304,7 +304,7 @@ pub(crate) fn packet_display_name_is_import_literal(display: &str) -> bool {
         || trimmed.starts_with("\\\\?\\")
 }
 
-pub(crate) fn packet_display_name_is_test_like(display: &str) -> bool {
+pub fn packet_display_name_is_test_like(display: &str) -> bool {
     let trimmed = display.trim();
     let display = trimmed.to_ascii_lowercase();
     let local_name = display.rsplit("::").next().unwrap_or(display.as_str());
@@ -422,7 +422,7 @@ fn packet_request_dispatch_anchor_rank_bonus(
     } else if role.is_non_primary() {
         bonus -= 10.0;
     }
-    if role == crate::RetrievalFileRole::Source
+    if role == crate::text::RetrievalFileRole::Source
         && packet_application_router_response_source_anchor(display, normalized_display, path)
     {
         bonus += 8.0;
@@ -1178,12 +1178,12 @@ const PACKET_QUERY_STOP_TERMS: &[&str] = &[
     "support",
 ];
 
-pub(crate) fn packet_query_stop_term(term: &str) -> bool {
+pub fn packet_query_stop_term(term: &str) -> bool {
     let lower = term.to_ascii_lowercase();
     PACKET_QUERY_STOP_TERMS.contains(&lower.as_str())
 }
 
-pub(crate) fn packet_adjacent_query_stop_term(term: &str) -> bool {
+pub fn packet_adjacent_query_stop_term(term: &str) -> bool {
     matches!(
         term.to_ascii_lowercase().as_str(),
         "actual"
@@ -1208,13 +1208,13 @@ pub(crate) fn packet_adjacent_query_stop_term(term: &str) -> bool {
     )
 }
 
-pub(crate) fn packet_terms_contain(terms: &[String], needle: &str) -> bool {
+pub fn packet_terms_contain(terms: &[String], needle: &str) -> bool {
     terms
         .iter()
         .any(|term| term.eq_ignore_ascii_case(needle) || normalize_identifier(term) == needle)
 }
 
-pub(crate) fn normalize_identifier(value: &str) -> String {
+pub fn normalize_identifier(value: &str) -> String {
     value
         .chars()
         .filter(|ch| ch.is_ascii_alphanumeric())
@@ -1222,7 +1222,7 @@ pub(crate) fn normalize_identifier(value: &str) -> String {
         .collect()
 }
 
-pub(crate) fn packet_display_path(path: &str) -> String {
+pub fn packet_display_path(path: &str) -> String {
     let normalized = path.trim_start_matches("\\\\?\\").replace('\\', "/");
     if let Some(path) = path_after_named_repo_root(&normalized) {
         return path;

--- a/crates/codestory-agent/src/packet_terms.rs
+++ b/crates/codestory-agent/src/packet_terms.rs
@@ -1,8 +1,8 @@
-use crate::agent::packet_scoring::normalize_identifier;
-use crate::{is_non_primary_source_term, query_mentions_non_primary_source};
+use crate::packet_scoring::normalize_identifier;
+use crate::text::{is_non_primary_source_term, query_mentions_non_primary_source};
 use std::collections::HashSet;
 
-pub(crate) fn prompt_search_terms(prompt: &str) -> Vec<String> {
+pub fn prompt_search_terms(prompt: &str) -> Vec<String> {
     const STOPWORDS: &[&str] = &[
         "a",
         "actual",
@@ -80,7 +80,7 @@ pub(crate) fn prompt_search_terms(prompt: &str) -> Vec<String> {
     terms
 }
 
-pub(crate) fn packet_probe_terms(question: &str) -> Vec<String> {
+pub fn packet_probe_terms(question: &str) -> Vec<String> {
     let include_non_primary_terms = query_mentions_non_primary_source(question);
     let brand_terms = brand_phrase_noise_terms(question);
     let mut terms = prompt_search_terms(question)
@@ -185,20 +185,20 @@ fn title_case_brand_token_term(token: &str) -> Option<String> {
     }
 }
 
-pub(crate) fn packet_terms_have(terms: &[String], needle: &str) -> bool {
+pub fn packet_terms_have(terms: &[String], needle: &str) -> bool {
     let normalized_needle = normalize_identifier(needle);
     terms.iter().any(|value| {
         value.eq_ignore_ascii_case(needle) || normalize_identifier(value) == normalized_needle
     })
 }
 
-pub(crate) fn packet_terms_have_any(terms: &[String], needles: &[&str]) -> bool {
+pub fn packet_terms_have_any(terms: &[String], needles: &[&str]) -> bool {
     needles
         .iter()
         .any(|needle| packet_terms_have(terms, needle))
 }
 
-pub(crate) fn packet_terms_indicate_indexing_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_indexing_flow(terms: &[String]) -> bool {
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
 
     has_any(&["index", "indexed", "indexer", "indexing"])
@@ -222,7 +222,7 @@ pub(crate) fn packet_terms_indicate_indexing_flow(terms: &[String]) -> bool {
         ])
 }
 
-pub(crate) fn packet_terms_indicate_request_dispatch_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_request_dispatch_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     let explicit_client_transport = has_any(&[
@@ -248,7 +248,7 @@ pub(crate) fn packet_terms_indicate_request_dispatch_flow(terms: &[String]) -> b
             && has_any(&["adapter", "adapters", "dispatch", "dispatches", "transport"]))
 }
 
-pub(crate) fn packet_terms_indicate_server_request_dispatch_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_server_request_dispatch_flow(terms: &[String]) -> bool {
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     let server_or_protocol = has_any(&["wsgi", "asgi", "server", "servers"]);
     let request_flow = has_any(&["request", "requests"]) && has_any(&["dispatch", "dispatches"]);
@@ -270,7 +270,7 @@ pub(crate) fn packet_terms_indicate_server_request_dispatch_flow(terms: &[String
             && !packet_terms_indicate_server_route_dispatch_flow(terms))
 }
 
-pub(crate) fn packet_terms_indicate_server_route_dispatch_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_server_route_dispatch_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     has_any(&["route", "routes", "router"])
@@ -286,7 +286,7 @@ pub(crate) fn packet_terms_indicate_server_route_dispatch_flow(terms: &[String])
             || has_any(&["engine", "method", "methods"]))
 }
 
-pub(crate) fn packet_terms_indicate_javascript_route_source_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_javascript_route_source_flow(terms: &[String]) -> bool {
     packet_terms_indicate_server_route_dispatch_flow(terms)
         && packet_terms_have_any(
             terms,
@@ -305,7 +305,7 @@ pub(crate) fn packet_terms_indicate_javascript_route_source_flow(terms: &[String
         )
 }
 
-pub(crate) fn packet_terms_indicate_route_tree_dispatch_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_route_tree_dispatch_flow(terms: &[String]) -> bool {
     packet_terms_indicate_server_route_dispatch_flow(terms)
         && packet_terms_have_any(
             terms,
@@ -323,7 +323,7 @@ pub(crate) fn packet_terms_indicate_route_tree_dispatch_flow(terms: &[String]) -
         )
 }
 
-pub(crate) fn packet_terms_indicate_buffered_io_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_buffered_io_flow(terms: &[String]) -> bool {
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     has_any(&["buffer", "buffers", "buffered"])
         && (has_any(&["source", "sources", "sink", "sinks"])
@@ -331,7 +331,7 @@ pub(crate) fn packet_terms_indicate_buffered_io_flow(terms: &[String]) -> bool {
                 && has_any(&["byte", "bytes", "stream", "streams", "wrapper", "wrappers"])))
 }
 
-pub(crate) fn packet_terms_indicate_site_build_phase_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_site_build_phase_flow(terms: &[String]) -> bool {
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     let build_intent = has_any(&[
         "build",
@@ -357,7 +357,7 @@ pub(crate) fn packet_terms_indicate_site_build_phase_flow(terms: &[String]) -> b
     build_intent && site_intent && covered_phases >= 2
 }
 
-pub(crate) fn packet_terms_indicate_log_record_handler_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_log_record_handler_flow(terms: &[String]) -> bool {
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     let logger_or_log_call = has_any(&["log", "logger", "logging", "message", "messages"]);
     let compound_log_record_intent = terms.iter().any(|term| {
@@ -380,7 +380,7 @@ pub(crate) fn packet_terms_indicate_log_record_handler_flow(terms: &[String]) ->
     logger_or_log_call && record_intent && handler_intent
 }
 
-pub(crate) fn packet_terms_indicate_mapper_configuration_plan_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_mapper_configuration_plan_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     let mapper_intent = has_any(&["mapper", "mappers", "mapping", "map", "maps"]);
@@ -420,7 +420,7 @@ pub(crate) fn packet_terms_indicate_mapper_configuration_plan_flow(terms: &[Stri
         && (runtime_api_intent || source_destination_intent || plan_intent || has("objects"))
 }
 
-pub(crate) fn packet_terms_indicate_prepared_session_adapter_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_prepared_session_adapter_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     (has("prepared") || has("prepare"))
@@ -429,7 +429,7 @@ pub(crate) fn packet_terms_indicate_prepared_session_adapter_flow(terms: &[Strin
         && has_any(&["adapter", "adapters", "send", "sends", "transport"])
 }
 
-pub(crate) fn packet_terms_indicate_search_execution_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_search_execution_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     has("search")
@@ -445,7 +445,7 @@ pub(crate) fn packet_terms_indicate_search_execution_flow(terms: &[String]) -> b
         ])
 }
 
-pub(crate) fn packet_terms_indicate_stylesheet_animation_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_stylesheet_animation_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     let css_signal = has("css")
@@ -481,7 +481,7 @@ pub(crate) fn packet_terms_indicate_stylesheet_animation_flow(terms: &[String]) 
     css_signal && animation_signal && source_shape_signal
 }
 
-pub(crate) fn packet_terms_indicate_html_css_template_structure_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_html_css_template_structure_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     let html_signal = has("html") || has_any(&["markup", "document", "shell"]);
@@ -505,7 +505,7 @@ pub(crate) fn packet_terms_indicate_html_css_template_structure_flow(terms: &[St
     html_signal && css_signal && structure_signal
 }
 
-pub(crate) fn packet_terms_indicate_sql_schema_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_sql_schema_flow(terms: &[String]) -> bool {
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     has_any(&["sql", "schema", "schemas", "table", "tables"])
         && has_any(&[
@@ -522,7 +522,7 @@ pub(crate) fn packet_terms_indicate_sql_schema_flow(terms: &[String]) -> bool {
         && has_any(&["table", "tables", "create", "schema", "schemas"])
 }
 
-pub(crate) fn packet_terms_indicate_hook_cache_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_hook_cache_flow(terms: &[String]) -> bool {
     let hook_signal = packet_terms_have_any(terms, &["hook", "hooks"])
         || terms.iter().any(|term| {
             let normalized = normalize_identifier(term);
@@ -549,7 +549,7 @@ pub(crate) fn packet_terms_indicate_hook_cache_flow(terms: &[String]) -> bool {
     hook_signal && cache_or_public_api_intent
 }
 
-pub(crate) fn packet_terms_indicate_client_send_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_client_send_flow(terms: &[String]) -> bool {
     let explicit_client_or_http_intent =
         packet_terms_have_any(terms, &["client", "clients", "http", "httpclient"]);
     let request_intent = packet_terms_have_any(terms, &["request", "requests"]);
@@ -564,7 +564,7 @@ pub(crate) fn packet_terms_indicate_client_send_flow(terms: &[String]) -> bool {
         || (request_intent && send_or_transport_intent)
 }
 
-pub(crate) fn packet_terms_indicate_form_validation_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_form_validation_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
 
@@ -576,14 +576,14 @@ pub(crate) fn packet_terms_indicate_form_validation_flow(terms: &[String]) -> bo
             || has_any(&["required", "min", "max"]))
 }
 
-pub(crate) fn packet_terms_indicate_event_loop_command_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_event_loop_command_flow(terms: &[String]) -> bool {
     packet_terms_indicate_command_server_bootstrap_flow(terms)
         || packet_terms_indicate_command_event_loop_flow(terms)
         || packet_terms_indicate_network_command_input_flow(terms)
         || packet_terms_indicate_command_dispatch_flow(terms)
 }
 
-pub(crate) fn packet_terms_indicate_command_server_bootstrap_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_command_server_bootstrap_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     let has_any = |needles: &[&str]| packet_terms_have_any(terms, needles);
     has_any(&["command", "commands"])
@@ -600,18 +600,18 @@ pub(crate) fn packet_terms_indicate_command_server_bootstrap_flow(terms: &[Strin
             || (has("event") && has("loop")))
 }
 
-pub(crate) fn packet_terms_indicate_command_event_loop_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_command_event_loop_flow(terms: &[String]) -> bool {
     let has = |term: &str| packet_terms_have(terms, term);
     packet_terms_have_any(terms, &["command", "commands"])
         && (has("eventloop") || (has("event") && has("loop")))
 }
 
-pub(crate) fn packet_terms_indicate_network_command_input_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_network_command_input_flow(terms: &[String]) -> bool {
     packet_terms_have_any(terms, &["network", "socket", "client", "input"])
         && packet_terms_have_any(terms, &["command", "commands"])
 }
 
-pub(crate) fn packet_terms_indicate_command_dispatch_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_command_dispatch_flow(terms: &[String]) -> bool {
     packet_terms_have_any(terms, &["command", "commands"])
         && packet_terms_have_any(
             terms,
@@ -634,7 +634,7 @@ pub(crate) fn packet_terms_indicate_command_dispatch_flow(terms: &[String]) -> b
         )
 }
 
-pub(crate) fn packet_terms_indicate_url_session_request_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_url_session_request_flow(terms: &[String]) -> bool {
     let explicit_url_session_lifecycle = packet_terms_have_any(
         terms,
         &[
@@ -666,7 +666,7 @@ pub(crate) fn packet_terms_indicate_url_session_request_flow(terms: &[String]) -
         )
 }
 
-pub(crate) fn packet_terms_indicate_shell_version_use_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_shell_version_use_flow(terms: &[String]) -> bool {
     packet_terms_have_any(
         terms,
         &[
@@ -678,7 +678,7 @@ pub(crate) fn packet_terms_indicate_shell_version_use_flow(terms: &[String]) -> 
 /// A shell-install prompt needs an actual shell signal. "command"/"function" alone also describe a
 /// command server, and a shell requirement raised over a command-server prompt is unclosable: no
 /// citation in such a repository is a shell script, so the packet would report partial forever.
-pub(crate) fn packet_terms_indicate_shell_install_dispatch_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_shell_install_dispatch_flow(terms: &[String]) -> bool {
     packet_terms_have_any(terms, &["bash", "shell", "sh", "zsh", "script", "scripts"])
         && packet_terms_have_any(
             terms,
@@ -699,7 +699,7 @@ pub(crate) fn packet_terms_indicate_shell_install_dispatch_flow(terms: &[String]
         && packet_terms_have_any(terms, &["dispatch", "dispatches", "function", "commands"])
 }
 
-pub(crate) fn packet_terms_indicate_string_predicate_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_string_predicate_flow(terms: &[String]) -> bool {
     packet_terms_have_any(
         terms,
         &["string", "strings", "charsequence", "charsequences", "text"],
@@ -717,7 +717,7 @@ pub(crate) fn packet_terms_indicate_string_predicate_flow(terms: &[String]) -> b
     )
 }
 
-pub(crate) fn packet_terms_indicate_runtime_formatting_flow(terms: &[String]) -> bool {
+pub fn packet_terms_indicate_runtime_formatting_flow(terms: &[String]) -> bool {
     packet_terms_have_any(
         terms,
         &["format", "formats", "formatting", "vformat", "format_to"],

--- a/crates/codestory-agent/src/pinned_reader.rs
+++ b/crates/codestory-agent/src/pinned_reader.rs
@@ -1,0 +1,396 @@
+//! The read-only seam between packet planning and the runtime that pins state.
+//!
+//! `codestory-agent` plans; it never activates, stores, executes retrieval,
+//! retries a publication, or moves readiness. Everything it needs to know about
+//! what the *current* public operation pinned arrives through [`PinnedReader`],
+//! whose every method is an owned read of an identity the runtime already
+//! selected. There is deliberately no method that hands back a store, a
+//! session, a controller, or anything else that could be written through.
+//!
+//! A reader that answers `None` means "the runtime is not holding that pin
+//! right now", and every decision below treats that as a refusal. Losing a pin
+//! can never widen what a continuation is allowed to reuse.
+
+use codestory_contracts::api::{PACKET_PROBE_CONTRACT_VERSION, PacketProbeRejectionCodeDto};
+
+/// Read-only view of the identities pinned by the public operation in flight.
+pub trait PinnedReader {
+    /// Identity of the project the current operation pinned, or `None` when no
+    /// project is open.
+    fn pinned_project_id(&self) -> Option<String>;
+
+    /// Core generation the current operation pinned, or `None` when no core
+    /// publication is selected.
+    fn pinned_core_generation_id(&self) -> Option<String>;
+
+    /// Retrieval generation the current operation pinned, or `None` when no
+    /// retrieval publication is selected.
+    fn pinned_retrieval_generation(&self) -> Option<String>;
+}
+
+/// Why a continuation probe may not be reused against the pinned state.
+///
+/// Each variant carries exactly one rejection code and one message, so the
+/// wire-visible refusal is a property of the decision rather than of the caller
+/// that renders it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContinuationRefusal {
+    /// The continuation was minted against a different probe contract.
+    IncompatibleContract { requested: u32 },
+    /// No project is open, so nothing can be continued.
+    NoOpenProject,
+    /// The continuation belongs to a project other than the pinned one.
+    ProjectChanged,
+    /// The pinned core generation is not the one the continuation was minted
+    /// against (including the case where no core publication is selected).
+    CoreGenerationChanged,
+    /// The continuation named a retrieval generation that is not the pinned one
+    /// (including the case where no retrieval publication is selected).
+    RetrievalGenerationChanged,
+    /// The continuation carries no query to continue.
+    EmptyQuery,
+}
+
+impl ContinuationRefusal {
+    /// The wire rejection code for this refusal.
+    pub fn code(&self) -> PacketProbeRejectionCodeDto {
+        match self {
+            Self::IncompatibleContract { .. } => {
+                PacketProbeRejectionCodeDto::IncompatibleContinuation
+            }
+            Self::NoOpenProject
+            | Self::ProjectChanged
+            | Self::CoreGenerationChanged
+            | Self::RetrievalGenerationChanged => PacketProbeRejectionCodeDto::StaleContinuation,
+            Self::EmptyQuery => PacketProbeRejectionCodeDto::MalformedProbe,
+        }
+    }
+
+    /// The wire rejection message for this refusal.
+    pub fn message(&self) -> String {
+        match self {
+            Self::IncompatibleContract { requested } => format!(
+                "continuation contract {requested} is incompatible with {PACKET_PROBE_CONTRACT_VERSION}"
+            ),
+            Self::NoOpenProject => "continuation requires an open project".to_string(),
+            Self::ProjectChanged => "continuation belongs to a different project".to_string(),
+            Self::CoreGenerationChanged => {
+                "continuation core generation is no longer selected".to_string()
+            }
+            Self::RetrievalGenerationChanged => {
+                "continuation retrieval generation is no longer selected".to_string()
+            }
+            Self::EmptyQuery => "continuation query must not be empty".to_string(),
+        }
+    }
+}
+
+/// Decide whether a continuation probe may be planned against the pinned state.
+///
+/// Returns the trimmed continuation query on admission. The checks run in
+/// pin-widening order — contract, project, core generation, retrieval
+/// generation, query — so a caller learns the outermost reason first and the
+/// reader is never asked for a pin the previous check already refused.
+pub fn admit_continuation_probe(
+    reader: &dyn PinnedReader,
+    contract_version: u32,
+    project_id: &str,
+    core_generation_id: &str,
+    retrieval_generation: Option<&str>,
+    query: &str,
+) -> Result<String, ContinuationRefusal> {
+    if contract_version != PACKET_PROBE_CONTRACT_VERSION {
+        return Err(ContinuationRefusal::IncompatibleContract {
+            requested: contract_version,
+        });
+    }
+    let Some(pinned_project_id) = reader.pinned_project_id() else {
+        return Err(ContinuationRefusal::NoOpenProject);
+    };
+    if pinned_project_id != project_id {
+        return Err(ContinuationRefusal::ProjectChanged);
+    }
+    if reader
+        .pinned_core_generation_id()
+        .is_none_or(|pinned| pinned != core_generation_id)
+    {
+        return Err(ContinuationRefusal::CoreGenerationChanged);
+    }
+    if let Some(expected) = retrieval_generation
+        && reader
+            .pinned_retrieval_generation()
+            .is_none_or(|pinned| pinned != expected)
+    {
+        return Err(ContinuationRefusal::RetrievalGenerationChanged);
+    }
+    let query = query.trim();
+    if query.is_empty() {
+        return Err(ContinuationRefusal::EmptyQuery);
+    }
+    Ok(query.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// A reader that answers exactly what the runtime's `ControllerPinnedReader`
+    /// answers — three owned identities, each absent when the corresponding pin
+    /// is not held — and records the order it was asked in.
+    struct RecordingReader {
+        project_id: Option<&'static str>,
+        core_generation_id: Option<&'static str>,
+        retrieval_generation: Option<&'static str>,
+        reads: RefCell<Vec<&'static str>>,
+    }
+
+    impl RecordingReader {
+        fn pinned() -> Self {
+            Self {
+                project_id: Some("project-a"),
+                core_generation_id: Some("core-7"),
+                retrieval_generation: Some("retrieval-7"),
+                reads: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn reads(&self) -> Vec<&'static str> {
+            self.reads.borrow().clone()
+        }
+    }
+
+    impl PinnedReader for RecordingReader {
+        fn pinned_project_id(&self) -> Option<String> {
+            self.reads.borrow_mut().push("project");
+            self.project_id.map(str::to_string)
+        }
+
+        fn pinned_core_generation_id(&self) -> Option<String> {
+            self.reads.borrow_mut().push("core");
+            self.core_generation_id.map(str::to_string)
+        }
+
+        fn pinned_retrieval_generation(&self) -> Option<String> {
+            self.reads.borrow_mut().push("retrieval");
+            self.retrieval_generation.map(str::to_string)
+        }
+    }
+
+    fn admit(
+        reader: &RecordingReader,
+        contract_version: u32,
+        project_id: &str,
+        core_generation_id: &str,
+        retrieval_generation: Option<&str>,
+        query: &str,
+    ) -> Result<String, ContinuationRefusal> {
+        admit_continuation_probe(
+            reader,
+            contract_version,
+            project_id,
+            core_generation_id,
+            retrieval_generation,
+            query,
+        )
+    }
+
+    #[test]
+    fn a_continuation_matching_every_pin_is_admitted_with_a_trimmed_query() {
+        let reader = RecordingReader::pinned();
+        assert_eq!(
+            admit(
+                &reader,
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-a",
+                "core-7",
+                Some("retrieval-7"),
+                "  AppController::open  ",
+            ),
+            Ok("AppController::open".to_string())
+        );
+        assert_eq!(reader.reads(), ["project", "core", "retrieval"]);
+    }
+
+    /// One row of the refusal decision table: the pinned state, the continuation
+    /// as it arrived, and the exact wire pair it must produce.
+    type RefusalCase = (
+        RecordingReader,
+        u32,
+        &'static str,
+        &'static str,
+        Option<&'static str>,
+        &'static str,
+        PacketProbeRejectionCodeDto,
+        String,
+    );
+
+    #[test]
+    fn every_refusal_carries_its_own_rejection_code_and_wire_message() {
+        let pinned = || RecordingReader::pinned();
+        let no_project = || RecordingReader {
+            project_id: None,
+            ..RecordingReader::pinned()
+        };
+        let no_core = || RecordingReader {
+            core_generation_id: None,
+            ..RecordingReader::pinned()
+        };
+        let no_retrieval = || RecordingReader {
+            retrieval_generation: None,
+            ..RecordingReader::pinned()
+        };
+
+        let cases: Vec<RefusalCase> = vec![
+            (
+                pinned(),
+                PACKET_PROBE_CONTRACT_VERSION + 1,
+                "project-a",
+                "core-7",
+                None,
+                "query",
+                PacketProbeRejectionCodeDto::IncompatibleContinuation,
+                format!(
+                    "continuation contract {} is incompatible with {PACKET_PROBE_CONTRACT_VERSION}",
+                    PACKET_PROBE_CONTRACT_VERSION + 1
+                ),
+            ),
+            (
+                no_project(),
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-a",
+                "core-7",
+                None,
+                "query",
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation requires an open project".to_string(),
+            ),
+            (
+                pinned(),
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-b",
+                "core-7",
+                None,
+                "query",
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation belongs to a different project".to_string(),
+            ),
+            (
+                pinned(),
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-a",
+                "core-6",
+                None,
+                "query",
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation core generation is no longer selected".to_string(),
+            ),
+            (
+                no_core(),
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-a",
+                "core-7",
+                None,
+                "query",
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation core generation is no longer selected".to_string(),
+            ),
+            (
+                pinned(),
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-a",
+                "core-7",
+                Some("retrieval-6"),
+                "query",
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation retrieval generation is no longer selected".to_string(),
+            ),
+            (
+                no_retrieval(),
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-a",
+                "core-7",
+                Some("retrieval-7"),
+                "query",
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation retrieval generation is no longer selected".to_string(),
+            ),
+            (
+                pinned(),
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-a",
+                "core-7",
+                Some("retrieval-7"),
+                "   ",
+                PacketProbeRejectionCodeDto::MalformedProbe,
+                "continuation query must not be empty".to_string(),
+            ),
+        ];
+
+        for (reader, contract, project, core, retrieval, query, code, message) in cases {
+            let refusal = admit(&reader, contract, project, core, retrieval, query)
+                .expect_err("this continuation must be refused");
+            assert_eq!(refusal.code(), code, "code for {refusal:?}");
+            assert_eq!(refusal.message(), message, "message for {refusal:?}");
+        }
+    }
+
+    #[test]
+    fn a_refused_continuation_never_reads_a_pin_past_the_check_that_refused_it() {
+        let reader = RecordingReader::pinned();
+        admit(
+            &reader,
+            PACKET_PROBE_CONTRACT_VERSION + 1,
+            "project-a",
+            "core-7",
+            Some("retrieval-7"),
+            "query",
+        )
+        .expect_err("an incompatible contract is refused before any pin is read");
+        assert_eq!(reader.reads(), Vec::<&str>::new());
+
+        let reader = RecordingReader::pinned();
+        admit(
+            &reader,
+            PACKET_PROBE_CONTRACT_VERSION,
+            "project-b",
+            "core-7",
+            Some("retrieval-7"),
+            "query",
+        )
+        .expect_err("a foreign project is refused before the generations are read");
+        assert_eq!(reader.reads(), ["project"]);
+
+        let reader = RecordingReader::pinned();
+        admit(
+            &reader,
+            PACKET_PROBE_CONTRACT_VERSION,
+            "project-a",
+            "core-6",
+            Some("retrieval-7"),
+            "query",
+        )
+        .expect_err("a stale core generation is refused before retrieval is read");
+        assert_eq!(reader.reads(), ["project", "core"]);
+    }
+
+    #[test]
+    fn a_continuation_that_names_no_retrieval_generation_never_reads_that_pin() {
+        let reader = RecordingReader {
+            retrieval_generation: None,
+            ..RecordingReader::pinned()
+        };
+        assert_eq!(
+            admit(
+                &reader,
+                PACKET_PROBE_CONTRACT_VERSION,
+                "project-a",
+                "core-7",
+                None,
+                "query",
+            ),
+            Ok("query".to_string())
+        );
+        assert_eq!(reader.reads(), ["project", "core"]);
+    }
+}

--- a/crates/codestory-agent/src/planning.rs
+++ b/crates/codestory-agent/src/planning.rs
@@ -3,14 +3,14 @@
 use codestory_contracts::api::{PacketPlanDto, PacketPlanQueryDto};
 use std::collections::HashSet;
 
-pub(crate) const PACKET_EXACT_SYMBOL_QUERY_PURPOSE: &str =
+pub const PACKET_EXACT_SYMBOL_QUERY_PURPOSE: &str =
     "case-sensitive exact symbol identity from task wording";
 
-pub(crate) fn packet_plan_query_is_exact_symbol_identity(query: &PacketPlanQueryDto) -> bool {
+pub fn packet_plan_query_is_exact_symbol_identity(query: &PacketPlanQueryDto) -> bool {
     query.purpose == PACKET_EXACT_SYMBOL_QUERY_PURPOSE
 }
 
-pub(crate) fn normalize_packet_subquery(query: &str) -> String {
+pub fn normalize_packet_subquery(query: &str) -> String {
     query
         .split_whitespace()
         .filter(|term| !PACKET_SUBQUERY_STOP_WORDS.contains(term))
@@ -24,7 +24,7 @@ const PACKET_SUBQUERY_STOP_WORDS: &[&str] = &[
     "when", "which", "that", "this", "these", "those", "does", "do", "is", "are", "was", "were",
 ];
 
-pub(crate) fn dedupe_packet_plan_queries(plan: &mut PacketPlanDto) {
+pub fn dedupe_packet_plan_queries(plan: &mut PacketPlanDto) {
     let mut seen = HashSet::<String>::new();
     let mut deduped = Vec::with_capacity(plan.queries.len());
     for query in plan.queries.drain(..) {

--- a/crates/codestory-agent/src/text.rs
+++ b/crates/codestory-agent/src/text.rs
@@ -1,0 +1,230 @@
+//! Pure lexical and path classification used by packet planning.
+//!
+//! These helpers were `codestory-runtime`'s `symbol_query` internals. They read
+//! nothing: no controller, no store, no publication, no filesystem. Planning
+//! needs them on every prompt, so they move with planning rather than staying
+//! behind a runtime import that would make `codestory-agent` depend on the
+//! crate it was extracted from.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetrievalFileRole {
+    Source,
+    Test,
+    Docs,
+    Benchmark,
+    Generated,
+    Vendor,
+}
+
+impl RetrievalFileRole {
+    pub fn is_non_primary(self) -> bool {
+        !matches!(self, Self::Source)
+    }
+}
+
+pub fn normalize_symbol_query(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+pub fn terminal_symbol_segment(value: &str) -> String {
+    value
+        .rsplit([':', '.', '/', '\\'])
+        .next()
+        .map(normalize_symbol_query)
+        .unwrap_or_default()
+}
+
+pub fn retrieval_file_role_from_path(path: &str) -> RetrievalFileRole {
+    let normalized_raw = normalize_retrieval_path(path);
+    let normalized = strip_materialized_repo_cache_prefix(&normalized_raw).to_string();
+    let marked = format!("/{normalized}");
+    let file_name = normalized.rsplit('/').next().unwrap_or(normalized.as_str());
+
+    if path_contains_any(
+        &marked,
+        &[
+            "/node_modules/",
+            "/src/external/",
+            "/external/",
+            "/deps/",
+            "/vendor/",
+            "/vendors/",
+            "/third_party/",
+            "/third-party/",
+        ],
+    ) {
+        return RetrievalFileRole::Vendor;
+    }
+
+    if path_contains_any(&marked, &["/target/", "/dist/", "/build/", "/generated/"])
+        || marked.contains("/schema/typescript/")
+        || marked.contains(".generated.")
+        || file_name.contains("generated")
+        || file_name.ends_with(".g.cs")
+    {
+        return RetrievalFileRole::Generated;
+    }
+
+    if path_contains_any(
+        &marked,
+        &["/benches/", "/bench/", "/benchmarks/", "/benchmark/"],
+    ) || (marked.contains("/scripts/")
+        && (marked.contains("bench") || marked.contains("benchmark")))
+    {
+        return RetrievalFileRole::Benchmark;
+    }
+
+    if path_contains_any(
+        &marked,
+        &[
+            "/bin/test/",
+            "/test/data/",
+            "/tests/",
+            "/test/",
+            "/spec/",
+            "/fixtures/",
+            "/fixture/",
+            "/examples/",
+            "/example/",
+            "/__tests__/",
+            "/__test__/",
+            "-test-client/",
+            "_test_client/",
+        ],
+    ) || file_name.contains(".test.")
+        || file_name.contains(".spec.")
+        || file_name.ends_with("_test.rs")
+        || file_name.ends_with("_tests.rs")
+        || file_name.ends_with("_test.py")
+        || file_name.ends_with("_tests.py")
+        || file_name.ends_with("_test.ts")
+        || file_name.ends_with("_tests.ts")
+        || file_name.ends_with("_test.tsx")
+        || file_name.ends_with("_tests.tsx")
+        || file_name.ends_with("test.java")
+        || file_name.ends_with("tests.java")
+    {
+        return RetrievalFileRole::Test;
+    }
+
+    if path_contains_any(&marked, &["/docs/", "/doc/"])
+        || matches!(file_name, "readme.md" | "changelog.md")
+    {
+        return RetrievalFileRole::Docs;
+    }
+
+    RetrievalFileRole::Source
+}
+
+fn normalize_retrieval_path(path: &str) -> String {
+    path.trim_start_matches("\\\\?\\")
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_ascii_lowercase()
+}
+
+fn strip_materialized_repo_cache_prefix(path: &str) -> &str {
+    let mut best_match: Option<(usize, &str)> = None;
+    for marker in ["/source/repos/", "source/repos/", "/repos/", "repos/"] {
+        let Some(index) = path.rfind(marker) else {
+            continue;
+        };
+        let after_marker = &path[index + marker.len()..];
+        if let Some((_, repo_relative)) = after_marker.split_once('/')
+            && !repo_relative.is_empty()
+            && best_match
+                .as_ref()
+                .is_none_or(|(best_index, _)| index > *best_index)
+        {
+            best_match = Some((index, repo_relative));
+        }
+    }
+    best_match
+        .map(|(_, repo_relative)| repo_relative)
+        .unwrap_or(path)
+}
+
+fn path_contains_any(path: &str, markers: &[&str]) -> bool {
+    markers.iter().any(|marker| path.contains(marker))
+}
+
+pub fn terms_contain_phrase(terms: &[String], phrase: &[&str]) -> bool {
+    terms
+        .windows(phrase.len())
+        .any(|window| window.iter().map(String::as_str).eq(phrase.iter().copied()))
+}
+
+pub fn query_mentions_non_primary_source(query: &str) -> bool {
+    let terms = query
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+        .map(|term| term.to_ascii_lowercase())
+        .filter(|term| !term.is_empty())
+        .collect::<Vec<_>>();
+
+    terms.iter().enumerate().any(|(index, term)| {
+        is_non_primary_source_term(term) && !is_non_primary_source_exclusion_context(&terms, index)
+    })
+}
+
+pub fn is_non_primary_source_term(term: &str) -> bool {
+    matches!(
+        term,
+        "test"
+            | "tests"
+            | "testing"
+            | "doc"
+            | "docs"
+            | "documentation"
+            | "example"
+            | "examples"
+            | "sample"
+            | "samples"
+            | "script"
+            | "scripts"
+            | "bench"
+            | "benchmark"
+            | "benchmarks"
+            | "fixture"
+            | "fixtures"
+            | "external"
+            | "vendor"
+            | "vendors"
+            | "vendored"
+            | "generated"
+            | "thirdparty"
+            | "third_party"
+            | "third-party"
+    )
+}
+
+fn is_non_primary_source_exclusion_context(terms: &[String], index: usize) -> bool {
+    let start = index.saturating_sub(8);
+    let end = (index + 9).min(terms.len());
+    terms[start..end].iter().any(|term| {
+        matches!(
+            term.as_str(),
+            "avoid"
+                | "demote"
+                | "demotes"
+                | "demoted"
+                | "downrank"
+                | "downranking"
+                | "exclude"
+                | "excluding"
+                | "hide"
+                | "ignore"
+                | "omit"
+                | "pollute"
+                | "pollution"
+                | "precision"
+                | "primary"
+                | "prod"
+                | "production"
+                | "role"
+                | "roles"
+                | "skip"
+                | "without"
+        )
+    })
+}

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -296,6 +296,154 @@ fn indexer_crate_stays_decoupled_from_runtime_and_cli() {
     );
 }
 
+/// Packet planning lives in `codestory-agent`, and the crate DAG is what keeps
+/// it from growing the powers it was extracted away from.
+///
+/// The dependency half is the load-bearing one: a planning crate that cannot
+/// name `codestory-store`, `codestory-retrieval`, `codestory-indexer`,
+/// `codestory-workspace`, or `codestory-runtime` cannot open storage, execute
+/// retrieval, activate or retry a publication, or move readiness, because none
+/// of those types exist for it. Everything it may know about pinned runtime
+/// state arrives through `codestory_agent::PinnedReader`, which the runtime
+/// implements.
+///
+/// The location half stops the extraction from being quietly undone: a planning
+/// module copied back under `crates/codestory-runtime/src/agent/` would regain
+/// the whole runtime namespace without anyone editing a manifest.
+#[test]
+fn agent_planning_crate_owns_planning_and_depends_on_contracts_only() {
+    let dependencies = dependency_names("crates/codestory-agent/Cargo.toml");
+    let workspace_dependencies = dependencies
+        .iter()
+        .filter(|name| name.starts_with("codestory-"))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        workspace_dependencies,
+        BTreeSet::from(["codestory-contracts".to_string()]),
+        "codestory-agent plans against the contract types only; it reaches pinned \
+         runtime state through PinnedReader, never through a producer crate"
+    );
+
+    for module in [
+        "packet_citations.rs",
+        "packet_evidence_carriers.rs",
+        "packet_evidence_roles.rs",
+        "packet_flow_requirements.rs",
+        "packet_scoring.rs",
+        "packet_terms.rs",
+        "pinned_reader.rs",
+        "planning.rs",
+        "text.rs",
+    ] {
+        assert!(
+            repo_root()
+                .join("crates/codestory-agent/src")
+                .join(module)
+                .is_file(),
+            "planning module {module} belongs to codestory-agent"
+        );
+        assert!(
+            !repo_root()
+                .join("crates/codestory-runtime/src/agent")
+                .join(module)
+                .is_file(),
+            "planning module {module} must not exist a second time inside the runtime crate"
+        );
+    }
+
+    // Planning reads. It never writes persisted state, and it never takes the
+    // advisory locks that guard state it does not own.
+    let agent_source = production_source(&read_source_tree("crates/codestory-agent/src"));
+    for forbidden in [
+        "fs::write",
+        "fs::create_dir",
+        "fs::remove_file",
+        "fs::remove_dir",
+        "fs::rename",
+        "OpenOptions",
+        "bounded_locks",
+        "owned_artifacts",
+    ] {
+        assert!(
+            !agent_source.contains(forbidden),
+            "codestory-agent must not spell {forbidden}: planning owns no persisted state"
+        );
+    }
+}
+
+/// The eval/holdout probe hooks used to ride `#[cfg(test)]` inside
+/// `codestory-runtime`, so a runtime unit test saw them and a product build did
+/// not. They now live in `codestory-agent`, where `#[cfg(test)]` means "the
+/// agent crate's own tests" and would silently switch the hooks off for every
+/// runtime test that used to have them — quietly moving fidelity/eval output.
+///
+/// The `test-support` feature restores the old truth table, and this pins both
+/// halves of it: `codestory-runtime` turns the feature on for its tests, and no
+/// product dependency edge turns it on at all.
+#[test]
+fn agent_eval_hooks_stay_on_for_runtime_tests_and_off_for_product_builds() {
+    let agent_manifest = manifest("crates/codestory-agent/Cargo.toml");
+    assert!(
+        agent_manifest
+            .get("features")
+            .and_then(|features| features.get("test-support"))
+            .is_some(),
+        "codestory-agent must declare the test-support feature the eval hooks hang from"
+    );
+
+    let runtime_manifest = manifest("crates/codestory-runtime/Cargo.toml");
+    let dev_features = runtime_manifest
+        .get("dev-dependencies")
+        .and_then(|table| table.get("codestory-agent"))
+        .and_then(|entry| entry.get("features"))
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    assert!(
+        dev_features.contains("test-support"),
+        "codestory-runtime's tests must compile codestory-agent with test-support, or the eval \
+         probe hooks that used to be cfg(test) inside the runtime disappear from them"
+    );
+
+    for consumer in [
+        "crates/codestory-runtime/Cargo.toml",
+        "crates/codestory-cli/Cargo.toml",
+        "crates/codestory-bench/Cargo.toml",
+    ] {
+        let consumer_manifest = manifest(consumer);
+        let features = consumer_manifest
+            .get("dependencies")
+            .and_then(|table| table.get("codestory-agent"))
+            .and_then(|entry| entry.get("features"))
+            .and_then(Value::as_array)
+            .map(|values| values.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+            .unwrap_or_default();
+        assert!(
+            !features.contains(&"test-support"),
+            "{consumer} must not enable codestory-agent/test-support on a product dependency edge"
+        );
+    }
+
+    // The hook itself has to hang from that feature, not from a bare cfg(test)
+    // that no longer reaches the runtime's test build.
+    let packet_scoring = read("crates/codestory-agent/src/packet_scoring.rs");
+    assert!(
+        packet_scoring.contains(
+            "#[cfg(any(test, feature = \"test-support\"))]\nuse crate::eval_probes::eval_citation_rank_adjustment;"
+        ) && packet_scoring.contains(
+            "    #[cfg(any(test, feature = \"test-support\"))]\n    {\n        score = eval_citation_rank_adjustment("
+        ),
+        "the citation rank eval hook must be gated on test-support, not on cfg(test) alone"
+    );
+}
+
 #[test]
 fn runtime_crate_depends_on_v2_surfaces_only() {
     let dependencies = dependency_names("crates/codestory-runtime/Cargo.toml");
@@ -1128,6 +1276,7 @@ fn production_sources() -> Vec<(String, String)> {
         "crates/codestory-store/src",
         "crates/codestory-indexer/src",
         "crates/codestory-retrieval/src",
+        "crates/codestory-agent/src",
         "crates/codestory-runtime/src",
         "crates/codestory-cli/src",
     ];
@@ -1146,7 +1295,7 @@ fn production_sources() -> Vec<(String, String)> {
             // production (its `evalOnlyProductionFiles` set) and bans product
             // paths from depending on it, so it cannot also be a production
             // surface here: the two boundaries must name the same thing.
-            if relative == "crates/codestory-runtime/src/agent/eval_probes.rs"
+            if relative == "crates/codestory-agent/src/eval_probes.rs"
                 || relative.split('/').any(|part| part == "tests")
                 || relative.ends_with("/tests.rs")
                 || relative.ends_with("/test_support.rs")
@@ -1611,6 +1760,7 @@ fn owned_artifact_identities_are_declared_only_in_the_registry() {
     let producer_crates = [
         "crates/codestory-workspace/src",
         "crates/codestory-store/src",
+        "crates/codestory-agent/src",
         "crates/codestory-runtime/src",
         "crates/codestory-cli/src",
         "crates/codestory-retrieval/src",

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -9,6 +9,7 @@ test-support = []
 
 [dependencies]
 anyhow = { workspace = true }
+codestory-agent = { workspace = true }
 codestory-contracts = { workspace = true }
 codestory-indexer = { workspace = true }
 codestory-retrieval = { workspace = true }
@@ -27,6 +28,7 @@ ureq = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+codestory-agent = { workspace = true, features = ["test-support"] }
 codestory-retrieval = { workspace = true, features = ["test-support"] }
 rusqlite = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/codestory-runtime/src/agent/mod.rs
+++ b/crates/codestory-runtime/src/agent/mod.rs
@@ -1,38 +1,40 @@
 pub(crate) mod citation;
-#[cfg(test)]
-pub(crate) mod eval_probes;
 pub(crate) mod nucleo_policy;
 pub(crate) mod orchestrator;
 pub(crate) mod packet_batch;
 pub(crate) mod packet_budget;
 pub(crate) mod packet_capping;
-pub(crate) mod packet_citations;
 pub(crate) mod packet_claim_profile_registry;
+
 pub(crate) mod packet_claim_profiles;
 pub(crate) mod packet_claims;
 pub(crate) mod packet_command_profiles;
 pub(crate) mod packet_degradation;
 pub(crate) mod packet_evidence;
-pub(crate) mod packet_evidence_carriers;
-pub(crate) mod packet_evidence_roles;
-pub(crate) mod packet_flow_requirements;
 pub(crate) mod packet_freshness;
 pub(crate) mod packet_obligations;
 pub(crate) mod packet_plan;
 pub(crate) mod packet_probe;
 pub(crate) mod packet_profile_telemetry;
 pub(crate) mod packet_required_probes;
-pub(crate) mod packet_scoring;
 pub(crate) mod packet_search;
 pub(crate) mod packet_source_patterns;
 pub(crate) mod packet_sufficiency;
-pub(crate) mod packet_terms;
 pub(crate) mod packet_trace;
-pub(crate) mod planning;
 pub(crate) mod profiles;
 pub(crate) mod retrieval_primary;
 pub(crate) mod trace;
 pub(crate) mod trace_export;
+
+// Planning lives in `codestory-agent`. These aliases keep the runtime's own
+// module paths spelling the same names they always did, so the extraction is a
+// crate move rather than a rename of every call site.
+#[cfg(test)]
+pub(crate) use codestory_agent::eval_probes;
+pub(crate) use codestory_agent::{
+    packet_citations, packet_evidence_roles, packet_flow_requirements, packet_scoring,
+    packet_terms, planning,
+};
 
 pub(crate) use orchestrator::{agent_ask, agent_packet};
 pub use trace_export::packet_step_trace_json;

--- a/crates/codestory-runtime/src/agent/packet_probe.rs
+++ b/crates/codestory-runtime/src/agent/packet_probe.rs
@@ -2,11 +2,12 @@ use crate::AppController;
 use crate::agent::citation::to_citation_from_hit;
 use crate::agent::retrieval_primary::active_pinned_retrieval_publication;
 use crate::target_resolution::{TargetResolution, TargetSelection, search_hit_matches_exact_file};
+use codestory_agent::{PinnedReader, admit_continuation_probe};
 use codestory_contracts::api::{
-    AgentCitationDto, NodeId, NodeKind, PACKET_PROBE_CONTRACT_VERSION, PacketEvidenceResolutionDto,
-    PacketEvidenceTierDto, PacketProbeAmbiguityCandidateDto, PacketProbeDto,
-    PacketProbeRejectionCodeDto, PacketProbeRejectionDto, PacketProbeResolutionDto,
-    PacketProbeResolutionStatusDto, SearchHit, SearchHitOrigin,
+    AgentCitationDto, NodeId, NodeKind, PacketEvidenceResolutionDto, PacketEvidenceTierDto,
+    PacketProbeAmbiguityCandidateDto, PacketProbeDto, PacketProbeRejectionCodeDto,
+    PacketProbeRejectionDto, PacketProbeResolutionDto, PacketProbeResolutionStatusDto, SearchHit,
+    SearchHitOrigin,
 };
 use codestory_workspace::{
     ProjectRelativePathResolution, project_identity_v3, resolve_project_relative_path,
@@ -513,6 +514,36 @@ fn probe_status_for_hit(
     }
 }
 
+/// The runtime's implementation of planning's read-only seam.
+///
+/// Every method is an owned read of an identity the current public operation
+/// already pinned. Nothing here opens storage, activates a publication, or
+/// retries one, and a missing pin is reported as `None` so the planning side
+/// refuses rather than guesses.
+struct ControllerPinnedReader<'a> {
+    controller: &'a AppController,
+}
+
+impl PinnedReader for ControllerPinnedReader<'_> {
+    fn pinned_project_id(&self) -> Option<String> {
+        self.controller
+            .require_project_root()
+            .ok()
+            .map(|root| project_identity_v3(&root).project_id)
+    }
+
+    fn pinned_core_generation_id(&self) -> Option<String> {
+        self.controller
+            .active_core_publication()
+            .map(|publication| publication.generation_id)
+    }
+
+    fn pinned_retrieval_generation(&self) -> Option<String> {
+        active_pinned_retrieval_publication(self.controller)
+            .map(|publication| publication.retrieval_generation)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn resolve_continuation_probe(
     controller: &AppController,
@@ -525,64 +556,20 @@ fn resolve_continuation_probe(
     symbol_id: Option<&str>,
     query: &str,
 ) -> PacketProbeResolutionDto {
-    if contract_version != PACKET_PROBE_CONTRACT_VERSION {
-        return rejected_resolution(
-            input_index,
-            probe,
-            PacketProbeRejectionCodeDto::IncompatibleContinuation,
-            format!(
-                "continuation contract {contract_version} is incompatible with {}",
-                PACKET_PROBE_CONTRACT_VERSION
-            ),
-        );
-    }
-    let Ok(project_root) = controller.require_project_root() else {
-        return rejected_resolution(
-            input_index,
-            probe,
-            PacketProbeRejectionCodeDto::StaleContinuation,
-            "continuation requires an open project",
-        );
+    let query = match admit_continuation_probe(
+        &ControllerPinnedReader { controller },
+        contract_version,
+        project_id,
+        core_generation_id,
+        retrieval_generation,
+        query,
+    ) {
+        Ok(query) => query,
+        Err(refusal) => {
+            return rejected_resolution(input_index, probe, refusal.code(), refusal.message());
+        }
     };
-    if project_id != project_identity_v3(&project_root).project_id {
-        return rejected_resolution(
-            input_index,
-            probe,
-            PacketProbeRejectionCodeDto::StaleContinuation,
-            "continuation belongs to a different project",
-        );
-    }
-    if controller
-        .active_core_publication()
-        .is_none_or(|publication| publication.generation_id != core_generation_id)
-    {
-        return rejected_resolution(
-            input_index,
-            probe,
-            PacketProbeRejectionCodeDto::StaleContinuation,
-            "continuation core generation is no longer selected",
-        );
-    }
-    if let Some(expected) = retrieval_generation
-        && active_pinned_retrieval_publication(controller)
-            .is_none_or(|publication| publication.retrieval_generation != expected)
-    {
-        return rejected_resolution(
-            input_index,
-            probe,
-            PacketProbeRejectionCodeDto::StaleContinuation,
-            "continuation retrieval generation is no longer selected",
-        );
-    }
-    let query = query.trim();
-    if query.is_empty() {
-        return rejected_resolution(
-            input_index,
-            probe,
-            PacketProbeRejectionCodeDto::MalformedProbe,
-            "continuation query must not be empty",
-        );
-    }
+    let query = query.as_str();
     if let Some(symbol_id) = symbol_id {
         let mut resolution = resolve_symbol_id_probe(controller, input_index, probe, symbol_id);
         if resolution.status == PacketProbeResolutionStatusDto::IndexedSymbol {
@@ -702,6 +689,7 @@ fn display_relative_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codestory_contracts::api::PACKET_PROBE_CONTRACT_VERSION;
     use codestory_contracts::graph::{Node, NodeId as CoreNodeId, NodeKind as CoreNodeKind};
     use codestory_store::{FileInfo, FileRole, Store};
     use std::path::PathBuf;
@@ -1165,6 +1153,123 @@ mod tests {
                     .as_ref()
                     .map(|rejection| rejection.code),
                 Some(PacketProbeRejectionCodeDto::StaleContinuation)
+            );
+        }
+    }
+
+    /// Continuation admission moved into `codestory-agent` behind `PinnedReader`,
+    /// so the runtime now *renders* a refusal the planning crate decided. This
+    /// pins the rendered wire pair — code and message — at the layer a caller
+    /// actually receives it, for every refusal a real controller can reach.
+    #[test]
+    fn continuation_refusals_render_the_same_wire_code_and_message_as_before_extraction() {
+        let project = TempDir::new().expect("project");
+        let controller = controller_with_empty_store(&project);
+        let project_id = project_identity_v3(project.path()).project_id;
+        let rootless = AppController::new();
+
+        let continuation = |contract_version: u32,
+                            project_id: &str,
+                            core_generation_id: &str,
+                            retrieval_generation: Option<&str>,
+                            query: &str| {
+            PacketProbeDto::Continuation {
+                contract_version,
+                project_id: project_id.to_string(),
+                core_generation_id: core_generation_id.to_string(),
+                retrieval_generation: retrieval_generation.map(str::to_string),
+                symbol_id: None,
+                query: query.to_string(),
+            }
+        };
+
+        let resolutions = resolve_packet_probes(
+            &controller,
+            vec![
+                continuation(
+                    PACKET_PROBE_CONTRACT_VERSION + 1,
+                    &project_id,
+                    "generation",
+                    None,
+                    "AppController",
+                ),
+                continuation(
+                    PACKET_PROBE_CONTRACT_VERSION,
+                    "different-project",
+                    "generation",
+                    None,
+                    "AppController",
+                ),
+                continuation(
+                    PACKET_PROBE_CONTRACT_VERSION,
+                    &project_id,
+                    "stale-generation",
+                    Some("retrieval-generation"),
+                    "AppController",
+                ),
+            ],
+        );
+        let rootless_resolutions = resolve_packet_probes(
+            &rootless,
+            vec![continuation(
+                PACKET_PROBE_CONTRACT_VERSION,
+                &project_id,
+                "generation",
+                None,
+                "AppController",
+            )],
+        );
+
+        let rendered = |resolution: &PacketProbeResolutionDto| {
+            let rejection = resolution
+                .rejection
+                .as_ref()
+                .expect("a refused continuation carries a rejection");
+            (rejection.code, rejection.message.clone())
+        };
+
+        assert_eq!(
+            rendered(&resolutions[0]),
+            (
+                PacketProbeRejectionCodeDto::IncompatibleContinuation,
+                format!(
+                    "continuation contract {} is incompatible with {PACKET_PROBE_CONTRACT_VERSION}",
+                    PACKET_PROBE_CONTRACT_VERSION + 1
+                )
+            )
+        );
+        assert_eq!(
+            rendered(&resolutions[1]),
+            (
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation belongs to a different project".to_string()
+            )
+        );
+        // No core publication is pinned here, so the core check refuses before
+        // the retrieval generation this probe also names is ever consulted.
+        assert_eq!(
+            rendered(&resolutions[2]),
+            (
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation core generation is no longer selected".to_string()
+            )
+        );
+        assert_eq!(
+            rendered(&rootless_resolutions[0]),
+            (
+                PacketProbeRejectionCodeDto::StaleContinuation,
+                "continuation requires an open project".to_string()
+            )
+        );
+        for resolution in resolutions.iter().chain(rootless_resolutions.iter()) {
+            assert_eq!(
+                resolution.status,
+                PacketProbeResolutionStatusDto::Rejected,
+                "a refused continuation must not resolve to a reusable probe"
+            );
+            assert!(
+                resolution.normalized_query.is_none() && resolution.symbol_id.is_none(),
+                "a refused continuation must not carry a query or symbol forward"
             );
         }
     }

--- a/crates/codestory-runtime/src/symbol_query.rs
+++ b/crates/codestory-runtime/src/symbol_query.rs
@@ -1,4 +1,15 @@
 use crate::root_rank::{CallDegrees, EntryEvidence, degree_tier};
+// Lexical and path classification moved to `codestory-agent` with the planning
+// modules that call it on every prompt; the runtime keeps the same names here
+// so `crate::retrieval_file_role_from_path` and friends still resolve.
+use codestory_agent::text::terms_contain_phrase;
+pub use codestory_agent::text::{
+    RetrievalFileRole, normalize_symbol_query, retrieval_file_role_from_path,
+    terminal_symbol_segment,
+};
+pub(crate) use codestory_agent::text::{
+    is_non_primary_source_term, query_mentions_non_primary_source,
+};
 use codestory_contracts::api::{NodeId, NodeKind, SearchHit, SearchHitOrigin};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -138,34 +149,6 @@ impl OrientationEvidence {
             .filter(|subsystem| !subsystem.is_empty())
             .collect()
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RetrievalFileRole {
-    Source,
-    Test,
-    Docs,
-    Benchmark,
-    Generated,
-    Vendor,
-}
-
-impl RetrievalFileRole {
-    pub fn is_non_primary(self) -> bool {
-        !matches!(self, Self::Source)
-    }
-}
-
-pub fn normalize_symbol_query(value: &str) -> String {
-    value.trim().to_ascii_lowercase()
-}
-
-pub fn terminal_symbol_segment(value: &str) -> String {
-    value
-        .rsplit([':', '.', '/', '\\'])
-        .next()
-        .map(normalize_symbol_query)
-        .unwrap_or_default()
 }
 
 pub fn leading_symbol_segment(value: &str) -> String {
@@ -413,88 +396,6 @@ fn qualified_symbol_query_parts(query: &str) -> Option<(&str, &str)> {
     Some((prefix, terminal))
 }
 
-pub fn retrieval_file_role_from_path(path: &str) -> RetrievalFileRole {
-    let normalized_raw = normalize_retrieval_path(path);
-    let normalized = strip_materialized_repo_cache_prefix(&normalized_raw).to_string();
-    let marked = format!("/{normalized}");
-    let file_name = normalized.rsplit('/').next().unwrap_or(normalized.as_str());
-
-    if path_contains_any(
-        &marked,
-        &[
-            "/node_modules/",
-            "/src/external/",
-            "/external/",
-            "/deps/",
-            "/vendor/",
-            "/vendors/",
-            "/third_party/",
-            "/third-party/",
-        ],
-    ) {
-        return RetrievalFileRole::Vendor;
-    }
-
-    if path_contains_any(&marked, &["/target/", "/dist/", "/build/", "/generated/"])
-        || marked.contains("/schema/typescript/")
-        || marked.contains(".generated.")
-        || file_name.contains("generated")
-        || file_name.ends_with(".g.cs")
-    {
-        return RetrievalFileRole::Generated;
-    }
-
-    if path_contains_any(
-        &marked,
-        &["/benches/", "/bench/", "/benchmarks/", "/benchmark/"],
-    ) || (marked.contains("/scripts/")
-        && (marked.contains("bench") || marked.contains("benchmark")))
-    {
-        return RetrievalFileRole::Benchmark;
-    }
-
-    if path_contains_any(
-        &marked,
-        &[
-            "/bin/test/",
-            "/test/data/",
-            "/tests/",
-            "/test/",
-            "/spec/",
-            "/fixtures/",
-            "/fixture/",
-            "/examples/",
-            "/example/",
-            "/__tests__/",
-            "/__test__/",
-            "-test-client/",
-            "_test_client/",
-        ],
-    ) || file_name.contains(".test.")
-        || file_name.contains(".spec.")
-        || file_name.ends_with("_test.rs")
-        || file_name.ends_with("_tests.rs")
-        || file_name.ends_with("_test.py")
-        || file_name.ends_with("_tests.py")
-        || file_name.ends_with("_test.ts")
-        || file_name.ends_with("_tests.ts")
-        || file_name.ends_with("_test.tsx")
-        || file_name.ends_with("_tests.tsx")
-        || file_name.ends_with("test.java")
-        || file_name.ends_with("tests.java")
-    {
-        return RetrievalFileRole::Test;
-    }
-
-    if path_contains_any(&marked, &["/docs/", "/doc/"])
-        || matches!(file_name, "readme.md" | "changelog.md")
-    {
-        return RetrievalFileRole::Docs;
-    }
-
-    RetrievalFileRole::Source
-}
-
 pub fn retrieval_file_role_for_hit(hit: &SearchHit) -> RetrievalFileRole {
     if hit.display_name.starts_with("tests::") {
         return RetrievalFileRole::Test;
@@ -503,39 +404,6 @@ pub fn retrieval_file_role_for_hit(hit: &SearchHit) -> RetrievalFileRole {
         .as_deref()
         .map(retrieval_file_role_from_path)
         .unwrap_or(RetrievalFileRole::Source)
-}
-
-fn normalize_retrieval_path(path: &str) -> String {
-    path.trim_start_matches("\\\\?\\")
-        .replace('\\', "/")
-        .trim_start_matches("./")
-        .trim_start_matches('/')
-        .to_ascii_lowercase()
-}
-
-fn strip_materialized_repo_cache_prefix(path: &str) -> &str {
-    let mut best_match: Option<(usize, &str)> = None;
-    for marker in ["/source/repos/", "source/repos/", "/repos/", "repos/"] {
-        let Some(index) = path.rfind(marker) else {
-            continue;
-        };
-        let after_marker = &path[index + marker.len()..];
-        if let Some((_, repo_relative)) = after_marker.split_once('/')
-            && !repo_relative.is_empty()
-            && best_match
-                .as_ref()
-                .is_none_or(|(best_index, _)| index > *best_index)
-        {
-            best_match = Some((index, repo_relative));
-        }
-    }
-    best_match
-        .map(|(_, repo_relative)| repo_relative)
-        .unwrap_or(path)
-}
-
-fn path_contains_any(path: &str, markers: &[&str]) -> bool {
-    markers.iter().any(|marker| path.contains(marker))
 }
 
 pub fn compare_ranked_hits<T: Ord>(
@@ -728,12 +596,6 @@ fn path_term_match_bucket(query: &str, hit: &SearchHit, is_exact_match: bool) ->
     u8::from(terms.iter().any(|term| normalized_path.contains(term)))
 }
 
-fn terms_contain_phrase(terms: &[String], phrase: &[&str]) -> bool {
-    terms
-        .windows(phrase.len())
-        .any(|window| window.iter().map(String::as_str).eq(phrase.iter().copied()))
-}
-
 fn query_entrypoint_intent_bucket(query: &str, display_name: &str, is_exact_match: bool) -> u8 {
     if is_exact_match {
         return 0;
@@ -754,80 +616,6 @@ fn query_entrypoint_intent_bucket(query: &str, display_name: &str, is_exact_matc
                     .iter()
                     .any(|term| matches!(term.as_str(), "url" | "env" | "environment"))),
     )
-}
-
-pub(crate) fn query_mentions_non_primary_source(query: &str) -> bool {
-    let terms = query
-        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
-        .map(|term| term.to_ascii_lowercase())
-        .filter(|term| !term.is_empty())
-        .collect::<Vec<_>>();
-
-    terms.iter().enumerate().any(|(index, term)| {
-        is_non_primary_source_term(term) && !is_non_primary_source_exclusion_context(&terms, index)
-    })
-}
-
-pub(crate) fn is_non_primary_source_term(term: &str) -> bool {
-    matches!(
-        term,
-        "test"
-            | "tests"
-            | "testing"
-            | "doc"
-            | "docs"
-            | "documentation"
-            | "example"
-            | "examples"
-            | "sample"
-            | "samples"
-            | "script"
-            | "scripts"
-            | "bench"
-            | "benchmark"
-            | "benchmarks"
-            | "fixture"
-            | "fixtures"
-            | "external"
-            | "vendor"
-            | "vendors"
-            | "vendored"
-            | "generated"
-            | "thirdparty"
-            | "third_party"
-            | "third-party"
-    )
-}
-
-fn is_non_primary_source_exclusion_context(terms: &[String], index: usize) -> bool {
-    let start = index.saturating_sub(8);
-    let end = (index + 9).min(terms.len());
-    terms[start..end].iter().any(|term| {
-        matches!(
-            term.as_str(),
-            "avoid"
-                | "demote"
-                | "demotes"
-                | "demoted"
-                | "downrank"
-                | "downranking"
-                | "exclude"
-                | "excluding"
-                | "hide"
-                | "ignore"
-                | "omit"
-                | "pollute"
-                | "pollution"
-                | "precision"
-                | "primary"
-                | "prod"
-                | "production"
-                | "role"
-                | "roles"
-                | "skip"
-                | "without"
-        )
-    })
 }
 
 pub(crate) fn is_non_primary_source_hit(hit: &SearchHit) -> bool {

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -83,7 +83,7 @@ and `retrieval_mode=full` does not replace live engine and publication checks.
 
 ## Workspace crates
 
-The workspace has nine crates: eight product layers and one measurement crate.
+The workspace has ten crates: nine product layers and one measurement crate.
 
 ```mermaid
 flowchart LR
@@ -93,6 +93,7 @@ flowchart LR
     Indexer["indexer"]
     Llama["llama-sys"]
     Retrieval["retrieval"]
+    Agent["agent"]
     Runtime["runtime"]
     CLI["cli"]
     Bench["bench"]
@@ -101,6 +102,7 @@ flowchart LR
     Contracts --> Store
     Contracts --> Indexer
     Contracts --> Retrieval
+    Contracts --> Agent
     Contracts --> Runtime
     Contracts --> CLI
     Workspace --> Indexer
@@ -114,6 +116,7 @@ flowchart LR
     Llama --> CLI
     Indexer --> Runtime
     Retrieval --> Runtime
+    Agent --> Runtime
     Retrieval --> CLI
     Runtime --> CLI
     Workspace -.-> Bench
@@ -136,12 +139,17 @@ flowchart LR
   the same engine.
 - `codestory-retrieval` owns immutable lexical/vector/SCIP generations,
   manifests, engine integration, health, retention, and fail-closed queries.
+- `codestory-agent` owns packet planning: prompt terms, flow requirements,
+  evidence roles and carriers, citation scoring, and the deduplicated query
+  plan. It owns no activation, storage, retrieval execution, publication retry,
+  or mutable readiness authority, and it reads pinned runtime state only through
+  the `PinnedReader` trait the runtime implements.
 - `codestory-runtime` is the only product orchestration layer.
 - `codestory-cli` parses and renders CLI, HTTP, and stdio adapters.
 - `codestory-bench` measures product paths without defining product behavior.
 
 The intended direction is
-`contracts -> workspace/store/indexer/llama-sys/retrieval -> runtime -> cli`.
+`contracts -> workspace/store/indexer/llama-sys/retrieval/agent -> runtime -> cli`.
 The exact dependency edges are shown above; bench may depend on product crates
 for measurement.
 

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -28,6 +28,7 @@ const WORKSPACE_MEMBERS = [
   "codestory-store",
   "codestory-indexer",
   "codestory-retrieval",
+  "codestory-agent",
   "codestory-runtime",
   "codestory-cli",
   "codestory-bench",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -16,23 +16,18 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parsePublishedArchiveDigests } from "./lib/pinned-archive-digests.mjs";
+import { workspaceMemberNames } from "./lib/workspace-members.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 
-/// Every codestory-* crate, in workspace order.
-const WORKSPACE_MEMBERS = [
-  "codestory-llama-sys",
-  "codestory-contracts",
-  "codestory-workspace",
-  "codestory-store",
-  "codestory-indexer",
-  "codestory-retrieval",
-  "codestory-agent",
-  "codestory-runtime",
-  "codestory-cli",
-  "codestory-bench",
-];
+/// Every codestory-* crate, in workspace order, read from the workspace itself.
+///
+/// Derived rather than listed so that adding a crate cannot leave one version surface behind:
+/// `check-codestory-release.py` and `native-fingerprint.mjs` read the same membership (#1673).
+const WORKSPACE_MEMBERS = workspaceMemberNames(
+  readFileSync(path.join(repositoryRoot, "Cargo.toml"), "utf8"),
+);
 
 const PLUGIN_MANIFESTS = [
   "plugins/codestory/.codex-plugin/plugin.json",

--- a/scripts/lib/retrieval-generalization-lint.mjs
+++ b/scripts/lib/retrieval-generalization-lint.mjs
@@ -529,10 +529,12 @@ const guardedStructuralScanDirs = readdirSync(
 // ban, so a ranking module added tomorrow is covered on the day it is written
 // rather than on the day someone remembers to list it.
 const requiredScanDirs = [
+  path.join(productionRepoRoot, "crates", "codestory-agent", "src"),
   path.join(productionRepoRoot, "crates", "codestory-runtime", "src"),
   path.join(productionRepoRoot, "crates", "codestory-retrieval", "src"),
 ];
 const guardedRequiredScanDirs = [
+  path.join(repoRoot, "crates", "codestory-agent", "src"),
   path.join(repoRoot, "crates", "codestory-runtime", "src"),
   path.join(repoRoot, "crates", "codestory-retrieval", "src"),
 ];
@@ -686,7 +688,7 @@ metadata.structuralScanDirs = structuralScanDirs.map((root) => path.resolve(root
 
 const evalOnlyProductionFiles = new Set(
   (evalOnlyProductionPaths ?? [
-    path.join(productionRepoRoot, "crates", "codestory-runtime", "src", "agent", "eval_probes.rs"),
+    path.join(productionRepoRoot, "crates", "codestory-agent", "src", "eval_probes.rs"),
   ]).map((filePath) => path.resolve(filePath)),
 );
 
@@ -721,9 +723,8 @@ const benchmarkEvalProbeManifestPath = path.join(benchmarkTaskRoot, "eval-probes
 const benchmarkEvalProbeSourcePath = path.join(
   repoRoot,
   "crates",
-  "codestory-runtime",
+  "codestory-agent",
   "src",
-  "agent",
   "eval_probes.rs",
 );
 const evalCorpusRoots = [

--- a/scripts/lib/workspace-members.mjs
+++ b/scripts/lib/workspace-members.mjs
@@ -1,0 +1,62 @@
+// The workspace member crates, read from the one file Cargo itself reads them from.
+//
+// Several release surfaces need to know "every codestory crate that carries a version": the bump
+// writes each one's `[package] version`, the native fingerprint has to normalize exactly those
+// lines back out, and `check-codestory-release.py` validates them. Each of those used to keep its
+// own hand-written list, so adding a crate to the workspace meant remembering three unrelated
+// files. The fingerprint's copy was the dangerous one -- forgetting it does not fail anything, it
+// just makes a version-only bump look like a source change and silently voids accelerator evidence
+// reuse (#1673). Deriving the list here removes the place the drift could hide.
+
+const WORKSPACE_TABLE = /^\[workspace\]\s*$/mu;
+const MEMBERS_ARRAY = /^members\s*=\s*\[([^\]]*)\]/mu;
+const QUOTED = /"([^"]+)"/gu;
+
+/// The `[workspace] members` paths declared by a root `Cargo.toml`, in manifest order.
+///
+/// Takes the manifest source rather than a directory on purpose: the fingerprint has to read the
+/// membership recorded at the git ref it is hashing, not whatever the working tree happens to say.
+export function parseWorkspaceMembers(manifestSource) {
+  const tableStart = manifestSource.search(WORKSPACE_TABLE);
+  if (tableStart < 0) throw new Error("root Cargo.toml declares no [workspace] table");
+  // Stop at the next table header so `[workspace.dependencies]` and friends cannot contribute.
+  const fromTable = manifestSource.slice(tableStart);
+  const nextTable = fromTable.slice(1).search(/^\[/mu);
+  const table = nextTable < 0 ? fromTable : fromTable.slice(0, nextTable + 1);
+
+  const declared = MEMBERS_ARRAY.exec(table);
+  if (!declared) throw new Error("root Cargo.toml [workspace] declares no members array");
+  const members = [...declared[1].matchAll(QUOTED)].map(([, member]) => member);
+  if (members.length === 0) throw new Error("root Cargo.toml [workspace] members is empty");
+
+  const seen = new Set();
+  for (const member of members) {
+    if (member.startsWith("/") || member.includes("..") || member.endsWith("/")) {
+      throw new Error(`root Cargo.toml [workspace] member ${member} is not a repository path`);
+    }
+    if (seen.has(member)) {
+      throw new Error(`root Cargo.toml [workspace] lists ${member} twice`);
+    }
+    seen.add(member);
+  }
+  return members;
+}
+
+/// The repository-relative manifest path of every workspace member.
+export function workspaceMemberManifests(manifestSource) {
+  return parseWorkspaceMembers(manifestSource).map((member) => `${member}/Cargo.toml`);
+}
+
+/// The crate name of every workspace member, taken from its directory.
+///
+/// Every member of this workspace lives at `crates/<crate-name>`; a member that does not is a
+/// layout change the version surfaces have to be taught about rather than guess at.
+export function workspaceMemberNames(manifestSource) {
+  return parseWorkspaceMembers(manifestSource).map((member) => {
+    const name = /^crates\/([A-Za-z0-9_-]+)$/u.exec(member)?.[1];
+    if (!name) {
+      throw new Error(`workspace member ${member} does not live at crates/<crate-name>`);
+    }
+    return name;
+  });
+}

--- a/scripts/native-fingerprint.mjs
+++ b/scripts/native-fingerprint.mjs
@@ -16,6 +16,8 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { workspaceMemberManifests } from "./lib/workspace-members.mjs";
+
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 /// Everything that shapes the built native artifacts.
@@ -31,25 +33,30 @@ const NATIVE_PATHS = [
   ".github/scripts/install-windows-vulkan-sdk.ps1",
 ];
 
-/// Files whose version-bump lines are normalized rather than hashed raw.
-const VERSION_STAMPED = new Set([
-  "Cargo.lock",
-  "crates/codestory-llama-sys/model-contract.json",
-  ...[
-    "codestory-llama-sys",
-    "codestory-contracts",
-    "codestory-workspace",
-    "codestory-store",
-    "codestory-indexer",
-    "codestory-retrieval",
-    "codestory-runtime",
-    "codestory-cli",
-    "codestory-bench",
-  ].map((crate) => `crates/${crate}/Cargo.toml`),
-]);
+/// Files the bump rewrites that are not crate manifests.
+const VERSION_STAMPED_FIXED = ["Cargo.lock", "crates/codestory-llama-sys/model-contract.json"];
+
+/// The root manifest, which names the crates whose version lines are normalized.
+const WORKSPACE_MANIFEST = "Cargo.toml";
 
 function git(args) {
   return execFileSync("git", args, { cwd: repositoryRoot, encoding: "utf8", maxBuffer: 1 << 28 });
+}
+
+/// Files whose version-bump lines are normalized rather than hashed raw, at one ref.
+///
+/// The crate manifests are derived from that ref's own `[workspace] members` rather than listed
+/// here, because a hand list is the one failure this fingerprint cannot survive: `bump-version.mjs`
+/// rewrites the `[package] version` of every workspace member, so a member missing from this set
+/// gets its version line hashed raw and a pure version bump stops fingerprinting equal. Nothing
+/// fails when that happens -- the release lane just quietly loses the accelerator-evidence reuse
+/// this file exists to justify (#1673). Reading membership at the ref, not from the working tree,
+/// keeps historical refs hashing exactly as they did when they were released.
+function versionStampedPaths(workspaceManifestSource) {
+  return new Set([
+    ...VERSION_STAMPED_FIXED,
+    ...workspaceMemberManifests(workspaceManifestSource),
+  ]);
 }
 
 /// Strip exactly the lines the version bump rewrites; everything else stays byte-exact.
@@ -88,10 +95,23 @@ function main() {
     process.exit(1);
   }
 
+  const workspaceManifest = listing.find(({ relative }) => relative === WORKSPACE_MANIFEST);
+  if (!workspaceManifest) {
+    console.error(`::error::native fingerprint saw no ${WORKSPACE_MANIFEST} at ${ref}`);
+    process.exit(1);
+  }
+  let versionStamped;
+  try {
+    versionStamped = versionStampedPaths(git(["cat-file", "blob", workspaceManifest.objectId]));
+  } catch (error) {
+    console.error(`::error::native fingerprint cannot read the crate set at ${ref}: ${error.message}`);
+    process.exit(1);
+  }
+
   const hash = createHash("sha256");
   hash.update("codestory-native-fingerprint-v1\0");
   for (const { mode, objectId, relative } of listing) {
-    if (VERSION_STAMPED.has(relative)) {
+    if (versionStamped.has(relative)) {
       const content = git(["cat-file", "blob", objectId]);
       hash.update(`${mode} ${relative}\0`);
       hash.update(normalizeVersionStamp(relative, content));

--- a/scripts/retrieval-generalization-pending.json
+++ b/scripts/retrieval-generalization-pending.json
@@ -111,14 +111,14 @@
         "runmain": 2
       }
     },
-    "crates/codestory-runtime/src/agent/packet_evidence_carriers.rs": {
+    "crates/codestory-agent/src/packet_evidence_carriers.rs": {
       "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
       "reason": "The stylesheet carrier lists the words a CSS animation is written with, and one of them collides with a benchmark marker: `animated` is the class name Animate.css and its imitators ship, so a stylesheet whose only anchor is that class would stop closing the animation structure step without it. It goes when a stylesheet requirement is decided from the at-rules the indexer already extracts rather than from a word list.",
       "markers": {
         "animated": 1
       }
     },
-    "crates/codestory-runtime/src/agent/packet_evidence_roles.rs": {
+    "crates/codestory-agent/src/packet_evidence_roles.rs": {
       "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
       "reason": "Evidence-role assignment matches holdout file names to decide whether a citation is a route, a client, or a model. The role has to come from the indexed symbol kind instead.",
       "markers": {
@@ -135,7 +135,7 @@
         "source_group": 1
       }
     },
-    "crates/codestory-runtime/src/agent/packet_flow_requirements.rs": {
+    "crates/codestory-agent/src/packet_flow_requirements.rs": {
       "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
       "reason": "Flow requirements enumerate holdout DOM and validation identifiers to decide a flow is covered. Deriving the requirement from the question's own terms is the replacement.",
       "markers": {
@@ -198,7 +198,7 @@
         "wsgiapp": 1
       }
     },
-    "crates/codestory-runtime/src/agent/packet_scoring.rs": {
+    "crates/codestory-agent/src/packet_scoring.rs": {
       "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
       "reason": "Citation ranking contains explicit per-file boosts for holdout paths, including path.ends_with checks on corpus file names. This is the largest single benchmark-shaped surface left and the ranking has to be rebuilt on structural signals.",
       "markers": {
@@ -297,7 +297,7 @@
         "wsgiapp": 1
       }
     },
-    "crates/codestory-runtime/src/agent/packet_terms.rs": {
+    "crates/codestory-agent/src/packet_terms.rs": {
       "issue": "https://github.com/TheGreenCedar/CodeStory/issues/1573",
       "reason": "Prompt term expansion carries holdout language and API vocabulary. It is the packet-path twin of the search-plan term tables this branch removes and needs the same treatment with packet quality evidence.",
       "markers": {

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -39,6 +39,7 @@ function fixtureRoot(version) {
     "codestory-store",
     "codestory-indexer",
     "codestory-retrieval",
+    "codestory-agent",
     "codestory-runtime",
     "codestory-cli",
     "codestory-bench",

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -14,10 +14,15 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { parsePublishedArchiveDigests } from "../lib/pinned-archive-digests.mjs";
+import { workspaceMemberNames } from "../lib/workspace-members.mjs";
 
 const repositoryRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
+);
+/// The fixture carries the real workspace's crates so a new crate cannot slip past these tests.
+const workspaceCrates = workspaceMemberNames(
+  readFileSync(path.join(repositoryRoot, "Cargo.toml"), "utf8"),
 );
 const testPython = ["python", "python3"].find((candidate) => {
   try {
@@ -32,18 +37,13 @@ assert.ok(testPython, "bump-version tests require Python with tomllib");
 /// A minimal tree carrying every surface the script owns.
 function fixtureRoot(version) {
   const root = mkdtempSync(path.join(tmpdir(), "codestory-bump-"));
-  const crates = [
-    "codestory-llama-sys",
-    "codestory-contracts",
-    "codestory-workspace",
-    "codestory-store",
-    "codestory-indexer",
-    "codestory-retrieval",
-    "codestory-agent",
-    "codestory-runtime",
-    "codestory-cli",
-    "codestory-bench",
-  ];
+  const crates = workspaceCrates;
+  writeFileSync(
+    path.join(root, "Cargo.toml"),
+    `[workspace]\nresolver = "2"\nmembers = [\n${crates
+      .map((crate) => `    "crates/${crate}",\n`)
+      .join("")}]\n`,
+  );
   for (const crate of crates) {
     const directory = path.join(root, "crates", crate);
     mkdirSync(directory, { recursive: true });
@@ -109,10 +109,12 @@ function fixtureRoot(version) {
     path.join(root, "scripts/bump-version.mjs"),
   );
   mkdirSync(path.join(root, "scripts/lib"), { recursive: true });
-  cpSync(
-    path.join(repositoryRoot, "scripts/lib/pinned-archive-digests.mjs"),
-    path.join(root, "scripts/lib/pinned-archive-digests.mjs"),
-  );
+  for (const module of ["pinned-archive-digests.mjs", "workspace-members.mjs"]) {
+    cpSync(
+      path.join(repositoryRoot, "scripts/lib", module),
+      path.join(root, "scripts/lib", module),
+    );
+  }
   mkdirSync(path.join(root, ".github/scripts"), { recursive: true });
   cpSync(
     path.join(repositoryRoot, ".github/scripts/check-codestory-release.py"),

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -18,6 +25,7 @@ import {
   validateReleaseClaimGraph,
   verifyReuseBinding,
 } from "../codestory-release-claims.mjs";
+import { workspaceMemberManifests } from "../lib/workspace-members.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const fixtureRoot = path.join(root, "scripts/tests/fixtures/release-claims");
@@ -1425,6 +1433,192 @@ test("reuse bindings verify tree identity and fingerprint equality against real 
     }),
     /is not an ancestor of the release commit/u,
   );
+});
+
+/// The unstamped native input the fingerprint must keep hashing byte-for-byte.
+const UNSTAMPED_NATIVE_CONTROL = ".cargo/config.toml";
+
+function gitIn(repository, args) {
+  const result = spawnSync("git", args, { cwd: repository, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+  }
+  return result.stdout.trim();
+}
+
+/// Materialize this repository's release version surfaces at `ref` into a throwaway git repository.
+///
+/// Built from the real tree rather than a stand-in workspace on purpose: the whole failure mode
+/// under test is a crate the fingerprint's stamped set never heard of, so the crates have to be
+/// whichever crates this commit actually declares. The two scripts are copied in because each
+/// resolves its repository from its own location.
+function versionSurfaceRepository(ref) {
+  const repository = mkdtempSync(path.join(os.tmpdir(), "codestory-fingerprint-"));
+  const show = (relative) =>
+    gitIn(root, ["--no-pager", "show", `${ref}:${relative}`]) + "\n";
+  const surfaces = [
+    "Cargo.toml",
+    "Cargo.lock",
+    "CHANGELOG.md",
+    UNSTAMPED_NATIVE_CONTROL,
+    "crates/codestory-llama-sys/model-contract.json",
+    "plugins/codestory/cli-version.json",
+    "plugins/codestory/.codex-plugin/plugin.json",
+    "plugins/codestory/.claude-plugin/plugin.json",
+    "plugins/codestory/.github/plugin/plugin.json",
+    ...workspaceMemberManifests(show("Cargo.toml")),
+  ];
+  for (const relative of surfaces) {
+    const absolute = path.join(repository, relative);
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, show(relative));
+  }
+  mkdirSync(path.join(repository, "scripts/lib"), { recursive: true });
+  for (const script of [
+    "bump-version.mjs",
+    "native-fingerprint.mjs",
+    "lib/pinned-archive-digests.mjs",
+    "lib/workspace-members.mjs",
+  ]) {
+    cpSync(path.join(root, "scripts", script), path.join(repository, "scripts", script));
+  }
+  gitIn(repository, ["init", "--quiet", "--initial-branch", "main"]);
+  gitIn(repository, ["config", "user.email", "fingerprint@codestory.test"]);
+  gitIn(repository, ["config", "user.name", "fingerprint test"]);
+  gitIn(repository, ["config", "commit.gpgsign", "false"]);
+  return repository;
+}
+
+function commitEverything(repository, message) {
+  gitIn(repository, ["add", "--all"]);
+  gitIn(repository, ["commit", "--quiet", "--allow-empty", "--message", message]);
+  return gitIn(repository, ["rev-parse", "HEAD"]);
+}
+
+function nativeFingerprint(repository, ref) {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(repository, "scripts/native-fingerprint.mjs"), "--ref", ref],
+    { cwd: repository, encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, `native fingerprint failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function runBump(repository, args) {
+  return spawnSync(
+    process.execPath,
+    [path.join(repository, "scripts/bump-version.mjs"), ...args],
+    { cwd: repository, encoding: "utf8" },
+  );
+}
+
+test("a version-only release bump leaves the native fingerprint unchanged", () => {
+  // release-claims.json binds `native_fingerprint` admissibility to this equality, and
+  // `evidence_policy.native_reuse = "version_only_delta"` is the whole justification for
+  // inheriting the previous release's accelerator evidence. Nothing fails loudly when the
+  // equality stops holding -- the reuse claim simply stops matching and the native proof
+  // silently reruns from scratch -- so it is proved here, on the real crate set, in the suite
+  // pull requests run (#1673).
+  const repository = versionSurfaceRepository("HEAD");
+  try {
+    const members = workspaceMemberManifests(
+      readFileSync(path.join(repository, "Cargo.toml"), "utf8"),
+    );
+    assert.ok(members.length > 0, "the workspace must declare crates to prove anything about");
+    const before = commitEverything(repository, "release surfaces before the bump");
+    const beforePrint = nativeFingerprint(repository, before);
+    assert.match(beforePrint, /^[0-9a-f]{64}$/u);
+
+    // The real version owner writes every text surface and then stops at `cargo update`, which
+    // cannot run against a manifest-only checkout. Cargo's own effect on the lock -- the recorded
+    // version of each workspace crate -- is applied here in its place, and the owner's own
+    // `--check` then certifies that the result is a complete release bump and nothing more.
+    runBump(repository, ["--version", "0.17.0"]);
+    const lockPath = path.join(repository, "Cargo.lock");
+    writeFileSync(
+      lockPath,
+      readFileSync(lockPath, "utf8").replace(
+        /(name = "codestory-[a-z-]+"\nversion = ")[^"]+(")/gu,
+        "$10.17.0$2",
+      ),
+    );
+    const certified = runBump(repository, ["--version", "0.17.0", "--check"]);
+    assert.equal(
+      certified.status,
+      0,
+      `the bump left a surface behind: ${certified.stdout}${certified.stderr}`,
+    );
+
+    const after = commitEverything(repository, "version-only release bump");
+    assert.notEqual(
+      gitIn(repository, ["rev-parse", `${after}^{tree}`]),
+      gitIn(repository, ["rev-parse", `${before}^{tree}`]),
+      "the bump must actually have changed the tree",
+    );
+    assert.equal(
+      nativeFingerprint(repository, after),
+      beforePrint,
+      "a version-only bump moved the native fingerprint, voiding accelerator evidence reuse",
+    );
+  } finally {
+    rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test("every workspace crate is version-normalized and content-bound by the fingerprint", () => {
+  // Per crate, so the failure names the crate that drifted: bumping only its `[package] version`
+  // must be invisible to the fingerprint. Two counter-probes keep that from being satisfied by a
+  // fingerprint that had stopped looking -- a manifest's non-version content and an unstamped
+  // native input both still have to move it.
+  const repository = versionSurfaceRepository("HEAD");
+  try {
+    const base = commitEverything(repository, "release surfaces");
+    const basePrint = nativeFingerprint(repository, base);
+    const probe = (relative, edit, message) => {
+      const absolute = path.join(repository, relative);
+      writeFileSync(absolute, edit(readFileSync(absolute, "utf8")));
+      const commit = commitEverything(repository, message);
+      const print = nativeFingerprint(repository, commit);
+      gitIn(repository, ["reset", "--hard", "--quiet", base]);
+      return print;
+    };
+    const members = workspaceMemberManifests(
+      readFileSync(path.join(repository, "Cargo.toml"), "utf8"),
+    );
+
+    for (const manifest of members) {
+      assert.equal(
+        probe(
+          manifest,
+          (source) =>
+            source.replace(/(^\[package\][\s\S]*?^version\s*=\s*")[^"]+(")/mu, "$10.17.0$2"),
+          `bump ${manifest}`,
+        ),
+        basePrint,
+        `${manifest} is not version-normalized, so a version bump voids accelerator reuse`,
+      );
+    }
+
+    // Normalization is a line, not a licence to stop hashing the file.
+    const counterProbe = members.at(-1);
+    assert.notEqual(
+      probe(
+        counterProbe,
+        (source) => `${source}\n[package.metadata.probe]\nseen = true\n`,
+        `edit ${counterProbe}`,
+      ),
+      basePrint,
+      `${counterProbe} does not bind its own content into the fingerprint`,
+    );
+    assert.notEqual(
+      probe(UNSTAMPED_NATIVE_CONTROL, (source) => `${source}\n# probe\n`, "edit cargo config"),
+      basePrint,
+      `${UNSTAMPED_NATIVE_CONTROL} does not bind its content into the fingerprint`,
+    );
+  } finally {
+    rmSync(repository, { recursive: true, force: true });
+  }
 });
 
 test("a reuse binding may equate only identities its own construction determines", () => {

--- a/scripts/tests/lint-retrieval-generalization.test.mjs
+++ b/scripts/tests/lint-retrieval-generalization.test.mjs
@@ -361,11 +361,22 @@ test("the full hostile matrix shares one policy load and never writes into the c
     "codestory-retrieval",
     "src",
   );
+  // Packet planning moved to its own crate; it carries the same full ban set as
+  // the runtime and retrieval slices it was cut out of, so the hostile matrix
+  // has to stand up that root as well or the lint fails closed on a missing
+  // required scan path before it reaches a single finding.
+  const agentRoot = path.join(
+    productionRepositoryRoot,
+    "crates",
+    "codestory-agent",
+    "src",
+  );
   const extraRustRoot = path.join(fixtureRoot, "extra-rust");
   const nonRustRoot = path.join(fixtureRoot, "non-rust");
   const taskRoot = path.join(fixtureRoot, "tasks");
   fs.mkdirSync(rustRoot, { recursive: true });
   fs.mkdirSync(retrievalRoot, { recursive: true });
+  fs.mkdirSync(agentRoot, { recursive: true });
   fs.mkdirSync(extraRustRoot);
   fs.mkdirSync(nonRustRoot);
   fs.mkdirSync(taskRoot);
@@ -839,8 +850,8 @@ pub const PLANTED_TERMS: &[(&str, &str)] = &[
     }
     assert.deepEqual(
       result.scanDirs,
-      [rustRoot, retrievalRoot, extraRustRoot],
-      "the canonical runtime/retrieval defaults must remain present before the additive extra root",
+      [agentRoot, rustRoot, retrievalRoot, extraRustRoot],
+      "the canonical agent/runtime/retrieval defaults must remain present before the additive extra root",
     );
     assert.ok(
       findingFor(result, "deep/new/ranking_scope_probe_generated.rs"),


### PR DESCRIPTION
Closes #1790. **#1673 stays open** — the rest of the agent module remains in `codestory-runtime`; this is the largest coherent behavior-preserving slice.

## Review and repair

The review found a release-lane defect that would have surfaced at the freeze, not before:

**Adding `codestory-agent` to the version-bump list without adding it to the fingerprint's version-normalized set silently voids the accelerator-evidence reuse binding.** `scripts/native-fingerprint.mjs` hashes everything under `crates` but normalizes version lines only for nine hand-enumerated manifests; `bump-version.mjs` was updated to rewrite every workspace member. So the v0.17.0 bump would edit a manifest whose version line is hashed raw — exactly what that file's own header says it exists to prevent. `release-claims.json` binds `native_fingerprint` admissibility to that equality, so the previous release's accelerator evidence would have become inadmissible and the native proof would have re-run from scratch. Nothing fails loudly; the claim just stops matching.

Repaired by **deriving the version-stamped set from `WORKSPACE_MEMBERS`** rather than adding one more hand-maintained entry, so the two lists cannot drift again, plus a test proving a version-only bump leaves the fingerprint unchanged. The `test-support` feature gate flagged alongside it is also closed.

**Declared residual:** `scripts/tests/bump-version.test.mjs` is invoked by no workflow (pre-existing), so that fixture change is verified locally only — though `bump-version.mjs` itself is now exercised end-to-end by the claims suite, which does run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
