### PR TITLE
[v0.17 S3-KOTLIN] Extract Kotlin language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3936,12 +3936,15 @@ fn ansi_highlight_snippet(path: &str, snippet: &str) -> String {
 }
 
 fn ansi_highlight_line(language: &str, line: &str) -> String {
-    let comment_marker = match language {
-        "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
-        "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "kotlin"
-        | "csharp" | "cpp" | "dart" | "php" | "swift" => Some("//"),
-        _ => None,
-    };
+    // Registry first; the arms below are the languages whose per-language
+    // extraction package has not landed yet (ARCH-012 roster burn-down).
+    let comment_marker = codestory_contracts::language_support::line_comment_for_language(language)
+        .or(match language {
+            "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
+            "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
+            | "cpp" | "dart" | "php" | "swift" => Some("//"),
+            _ => None,
+        });
     let Some(marker) = comment_marker else {
         return ansi_highlight_code(language, line);
     };
@@ -4109,12 +4112,18 @@ fn snippet_language(path: &str) -> &'static str {
         .unwrap_or_default()
         .to_ascii_lowercase();
 
+    // Component dialects come from the companion-extension registry; `tsx` and
+    // `jsx` stay local because they are highlighter dialects, not registered
+    // surfaces (both route to typescript/javascript in the language registry).
+    if let Some(surface) =
+        codestory_contracts::language_support::companion_surface_language(&extension)
+    {
+        return surface;
+    }
+
     match extension.as_str() {
         "tsx" => "tsx",
         "jsx" => "jsx",
-        "svelte" => "svelte",
-        "vue" => "vue",
-        "astro" => "astro",
         "json" => "json",
         "toml" => "toml",
         "md" | "mdx" => "markdown",
@@ -5559,6 +5568,104 @@ mod tests {
 
         let bash = ansi_highlight_snippet("scripts/bootstrap.sh", "echo ok # comment");
         assert!(bash.contains("\x1b[90m# comment\x1b[0m"), "{bash:?}");
+    }
+
+    /// Kotlin's comment marker now comes from the language registry rather than
+    /// the local roster, and every other language must be unmoved.
+    ///
+    /// Asserting only "Kotlin still dims `//`" would pass with the registry
+    /// lookup deleted, because the local roster used to answer for Kotlin too.
+    /// The table below is the pre-move roster restated, so a registry row that
+    /// contradicted a consumer would fail here rather than change rendering.
+    #[test]
+    fn comment_markers_stay_identical_after_the_registry_lookup() {
+        const EXPECTED: &[(&str, Option<&str>)] = &[
+            ("kotlin", Some("//")),
+            ("bash", Some("#")),
+            ("python", Some("#")),
+            ("ruby", Some("#")),
+            ("toml", Some("#")),
+            ("yaml", Some("#")),
+            ("rust", Some("//")),
+            ("typescript", Some("//")),
+            ("tsx", Some("//")),
+            ("javascript", Some("//")),
+            ("jsx", Some("//")),
+            ("go", Some("//")),
+            ("java", Some("//")),
+            ("csharp", Some("//")),
+            ("cpp", Some("//")),
+            ("dart", Some("//")),
+            ("php", Some("//")),
+            ("swift", Some("//")),
+            // Deliberately absent from the roster before and after the move.
+            ("c", None),
+            ("html", None),
+            ("css", None),
+            ("sql", None),
+            ("markdown", None),
+            ("json", None),
+            ("vue", None),
+            ("svelte", None),
+            ("astro", None),
+            ("", None),
+        ];
+        for (language, marker) in EXPECTED {
+            let highlighted = ansi_highlight_line(language, "value // slash # hash");
+            match marker {
+                Some("//") => assert!(
+                    highlighted.contains("\x1b[90m// slash # hash\x1b[0m"),
+                    "{language} should dim from the first `//`: {highlighted:?}"
+                ),
+                Some("#") => assert!(
+                    highlighted.contains("\x1b[90m# hash\x1b[0m"),
+                    "{language} should dim from the first `#`: {highlighted:?}"
+                ),
+                Some(other) => panic!("unexpected marker {other}"),
+                None => assert!(
+                    !highlighted.contains("\x1b[90m"),
+                    "{language} must not dim a comment: {highlighted:?}"
+                ),
+            }
+        }
+
+        // The registry is the source for Kotlin: it must agree with the marker
+        // the roster used to hold.
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("kotlin"),
+            Some("//")
+        );
+        let kotlin = ansi_highlight_snippet("app/Main.kt", "val ok = true // comment");
+        assert!(kotlin.contains("\x1b[90m// comment\x1b[0m"), "{kotlin:?}");
+    }
+
+    /// Component dialects resolve through the companion-extension registry and
+    /// every other snippet language is unchanged.
+    #[test]
+    fn snippet_languages_stay_identical_after_the_registry_lookup() {
+        for (path, expected) in [
+            ("app/Component.vue", "vue"),
+            ("app/Component.svelte", "svelte"),
+            ("app/Page.astro", "astro"),
+            ("app/View.tsx", "tsx"),
+            ("app/View.jsx", "jsx"),
+            ("data/config.json", "json"),
+            ("Cargo.toml", "toml"),
+            ("docs/guide.md", "markdown"),
+            ("docs/guide.mdx", "markdown"),
+            ("ci/build.yml", "yaml"),
+            ("ci/build.yaml", "yaml"),
+            ("app/Main.kt", "kotlin"),
+            ("app/Main.kts", "kotlin"),
+            ("src/lib.rs", "rust"),
+            ("src/app.ts", "typescript"),
+            // No public profile and no companion row: no highlighting.
+            ("app/Page.cshtml", ""),
+            ("styles/app.scss", ""),
+            ("notes.txt", ""),
+        ] {
+            assert_eq!(snippet_language(path), expected, "{path}");
+        }
     }
 
     #[test]

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -369,6 +369,125 @@ pub const LANGUAGE_SUPPORT_PROFILES: &[LanguageSupportProfile] = &[
     structural_profile("cargo_manifest", &[]),
 ];
 
+/// Extension that rides along with a registered language without being a claim
+/// of its own.
+///
+/// Template dialects (`.vue`, `.svelte`, `.astro`, `.cshtml`) and style
+/// preprocessor extensions (`.scss`, `.sass`, `.less`) used to be hand-repeated
+/// at every call site that cared: the workspace's source-group compatibility
+/// map, the indexer's template blanking pipeline, the indexer's text-only
+/// language projection, and the CLI's snippet highlighter (ARCH-012). They live
+/// here instead so those sites agree.
+///
+/// This is deliberately a sibling table, not more rows in
+/// [`LANGUAGE_SUPPORT_PROFILES`]. Adding `.vue` there would silently widen
+/// [`supported_extensions`], [`language_name_for_path`] and
+/// [`is_structural_source_path`], which decide what the product indexes and
+/// what claim tier it advertises. A companion extension makes no claim: it only
+/// records which registered languages already accept it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompanionExtensionProfile {
+    /// Extension without a leading dot, lowercase.
+    pub extension: &'static str,
+    /// Surface language reported for the file, when the extension names a
+    /// dialect of its own. `None` means the file is only ever attributed to the
+    /// language that owns it (Razor is C#, SCSS is CSS).
+    pub surface_language: Option<&'static str>,
+    /// Language source groups whose discovery accepts this extension.
+    ///
+    /// Entries are language names, either from [`LANGUAGE_SUPPORT_PROFILES`] or
+    /// from `surface_language` itself. They are not claim tiers.
+    pub source_group_languages: &'static [&'static str],
+}
+
+pub const COMPANION_EXTENSION_PROFILES: &[CompanionExtensionProfile] = &[
+    CompanionExtensionProfile {
+        extension: "vue",
+        surface_language: Some("vue"),
+        source_group_languages: &["javascript", "typescript", "vue"],
+    },
+    CompanionExtensionProfile {
+        extension: "svelte",
+        surface_language: Some("svelte"),
+        source_group_languages: &["javascript", "typescript", "svelte"],
+    },
+    CompanionExtensionProfile {
+        extension: "astro",
+        surface_language: Some("astro"),
+        source_group_languages: &["javascript", "typescript", "astro"],
+    },
+    CompanionExtensionProfile {
+        extension: "cshtml",
+        surface_language: None,
+        source_group_languages: &["csharp"],
+    },
+    CompanionExtensionProfile {
+        extension: "lua",
+        surface_language: None,
+        source_group_languages: &["lua"],
+    },
+    CompanionExtensionProfile {
+        extension: "scss",
+        surface_language: None,
+        source_group_languages: &["css"],
+    },
+    CompanionExtensionProfile {
+        extension: "sass",
+        surface_language: None,
+        source_group_languages: &["css"],
+    },
+    CompanionExtensionProfile {
+        extension: "less",
+        surface_language: None,
+        source_group_languages: &["css"],
+    },
+];
+
+/// Look up a companion extension profile.
+pub fn companion_extension_profile(ext: &str) -> Option<&'static CompanionExtensionProfile> {
+    let ext = ext.trim().trim_start_matches('.');
+    COMPANION_EXTENSION_PROFILES
+        .iter()
+        .find(|profile| profile.extension.eq_ignore_ascii_case(ext))
+}
+
+/// Surface language for a companion extension, when it names its own dialect.
+pub fn companion_surface_language(ext: &str) -> Option<&'static str> {
+    companion_extension_profile(ext).and_then(|profile| profile.surface_language)
+}
+
+/// Line-comment marker for a language whose extraction rules have been
+/// registered.
+///
+/// Comment syntax is presentation, not evidence, which is why it is a sibling
+/// table rather than a field on [`LanguageSupportProfile`] — every field there
+/// is a claim-tier fact and must not be diluted by a rendering detail.
+///
+/// A language appears here only once its per-language extraction package has
+/// landed (S3, #1676 onward). Until then the consumer's own match arm owns it,
+/// and consumers therefore read this table first and fall back to that arm.
+/// Populating the table ahead of the migration would change rendering for
+/// languages whose consumer roster deliberately differs from their real syntax.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LanguageCommentProfile {
+    pub language_name: &'static str,
+    pub line_comment: &'static str,
+}
+
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
+    language_name: "kotlin",
+    line_comment: "//",
+}];
+
+/// Line-comment marker for a registered language name.
+pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
+    let language_name = language_name.trim();
+    LANGUAGE_COMMENT_PROFILES
+        .iter()
+        .find(|profile| profile.language_name.eq_ignore_ascii_case(language_name))
+        .map(|profile| profile.line_comment)
+}
+
 const fn parser_profile(
     language_name: &'static str,
     extensions: &'static [&'static str],
@@ -1023,6 +1142,124 @@ mod tests {
         );
         assert_eq!(profile.evidence_tier, LanguageEvidenceTier::StructuralOnly);
         assert!(profile.extensions.is_empty());
+    }
+
+    /// Companion extensions must stay out of the claim registry.
+    ///
+    /// The whole reason this is a sibling table is that a companion extension
+    /// must not widen what the product indexes or what tier it advertises. If a
+    /// future edit moved `.vue` or `.scss` into `LANGUAGE_SUPPORT_PROFILES`,
+    /// `supported_extensions`, `language_name_for_path` and
+    /// `is_structural_source_path` would all start answering for it.
+    #[test]
+    fn companion_extensions_make_no_public_language_claim() {
+        for profile in COMPANION_EXTENSION_PROFILES {
+            assert_eq!(
+                language_support_profile_for_ext(profile.extension),
+                None,
+                "companion extension `{}` must not carry a public claim tier",
+                profile.extension
+            );
+            assert!(
+                !is_structural_source_path(&format!("src/file.{}", profile.extension)),
+                "companion extension `{}` must not be a structural source path",
+                profile.extension
+            );
+            assert!(
+                !profile.source_group_languages.is_empty(),
+                "companion extension `{}` needs at least one source group",
+                profile.extension
+            );
+        }
+
+        let mut seen = HashSet::new();
+        for profile in COMPANION_EXTENSION_PROFILES {
+            assert!(
+                seen.insert(profile.extension),
+                "companion extension `{}` is declared twice",
+                profile.extension
+            );
+            assert_eq!(
+                profile.extension.to_ascii_lowercase(),
+                profile.extension,
+                "companion extensions are stored lowercase"
+            );
+        }
+    }
+
+    /// Only the three blanked component dialects report a surface language.
+    ///
+    /// `template_surface_language` in the indexer routes on exactly this set,
+    /// and `semantic::detect_language` reports whatever it returns. Giving
+    /// Razor or SCSS a surface here would start attributing those files to a
+    /// language that has no parser behind it.
+    #[test]
+    fn only_component_dialects_carry_a_surface_language() {
+        let surfaces = COMPANION_EXTENSION_PROFILES
+            .iter()
+            .filter_map(|profile| {
+                profile
+                    .surface_language
+                    .map(|surface| (profile.extension, surface))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            surfaces,
+            vec![("vue", "vue"), ("svelte", "svelte"), ("astro", "astro")]
+        );
+        assert_eq!(companion_surface_language(".VUE"), Some("vue"));
+        assert_eq!(companion_surface_language("cshtml"), None);
+        assert_eq!(companion_surface_language("scss"), None);
+        assert_eq!(companion_surface_language("kt"), None);
+    }
+
+    /// Every source group a companion extension names must be a real language.
+    ///
+    /// A typo here would silently drop the extension out of discovery for that
+    /// source group rather than fail.
+    #[test]
+    fn companion_source_groups_name_real_languages() {
+        let surface_names = COMPANION_EXTENSION_PROFILES
+            .iter()
+            .filter_map(|profile| profile.surface_language)
+            .collect::<HashSet<_>>();
+        for profile in COMPANION_EXTENSION_PROFILES {
+            for language in profile.source_group_languages {
+                assert!(
+                    language_support_profile_for_language_name(language).is_some()
+                        || surface_names.contains(language)
+                        // `lua` has no registered profile at all; it exists
+                        // only as a workspace source-group compatibility name.
+                        || *language == "lua",
+                    "`{}` names unknown source group `{language}`",
+                    profile.extension
+                );
+            }
+        }
+    }
+
+    /// Comment rows exist only for languages whose extraction package landed.
+    #[test]
+    fn comment_profiles_cover_only_migrated_languages() {
+        let names = LANGUAGE_COMMENT_PROFILES
+            .iter()
+            .map(|profile| profile.language_name)
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["kotlin"]);
+        for profile in LANGUAGE_COMMENT_PROFILES {
+            assert!(
+                language_support_profile_for_language_name(profile.language_name).is_some(),
+                "`{}` has no public language profile",
+                profile.language_name
+            );
+            assert!(
+                !profile.line_comment.is_empty(),
+                "`{}` needs a line-comment marker",
+                profile.language_name
+            );
+        }
+        assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("swift"), None);
     }
 
     #[test]

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -1,9 +1,9 @@
 use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
-    GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, KOTLIN_GRAPH_QUERY, LanguageConfig,
-    LanguageRuleset, PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY,
-    RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, make_language_config,
+    GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
+    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
+    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
+    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -14,6 +14,18 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
     let profile = language_support_profile_for_ext(&ext)?;
     if profile.support_mode != LanguageSupportMode::ParserBackedGraph {
         return None;
+    }
+
+    // Registry first: a migrated language owns its parser config. The arms
+    // below are the languages whose S3 package has not landed yet.
+    if let Some(extraction) = languages::extraction_for_ext(&ext) {
+        return Some(make_language_config(
+            (extraction.parser_language)(),
+            extraction.language_name,
+            extraction.graph_query,
+            extraction.tags_query,
+            extraction.ruleset,
+        ));
     }
 
     match (profile.language_name, ext.as_str()) {
@@ -29,7 +41,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("ruby", _) => Some(ruby()),
         ("php", _) => Some(php()),
         ("csharp", _) => Some(csharp()),
-        ("kotlin", _) => Some(kotlin()),
         ("swift", _) => Some(swift()),
         ("dart", _) => Some(dart()),
         ("bash", _) => Some(bash()),
@@ -154,16 +165,6 @@ fn csharp() -> LanguageConfig {
         CSHARP_GRAPH_QUERY,
         None,
         LanguageRuleset::CSharp,
-    )
-}
-
-fn kotlin() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_kotlin_ng::LANGUAGE.into(),
-        "kotlin",
-        KOTLIN_GRAPH_QUERY,
-        None,
-        LanguageRuleset::Kotlin,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/kotlin.rs
+++ b/crates/codestory-indexer/src/languages/kotlin.rs
@@ -1,0 +1,690 @@
+//! Kotlin extraction rules.
+//!
+//! Kotlin's graph extraction lives here: the tree-sitter rule file, the
+//! compiled-rule cache, the member-call callsite marker, and the receiver-call
+//! resolution engine that turns `repo.save(...)` into an edge aimed at
+//! `Repository.save`. Every language-keyed dispatch in the crate reaches it
+//! through [`super::EXTRACTIONS`] rather than by spelling `"kotlin"`.
+//!
+//! Two Kotlin surfaces are deliberately *not* here yet, and both are shared
+//! seams rather than Kotlin content:
+//!
+//! * `lib.rs::collect_ktor_route` and its `"kotlin"` arm in the framework-route
+//!   scanner. The per-language route collectors take non-uniform arguments and
+//!   a per-framework `has_<framework>` precondition, so routing them through
+//!   the registry is one change for all sixteen languages, not part of Kotlin's
+//!   rollback unit.
+//! * `LanguageRuleset::Kotlin`, which stays in `lib.rs` because the enum is the
+//!   compiled-rule cache key for every language at once.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both Kotlin fixtures so the move stays output-equal.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, ImportedTypeBinding, LanguageRuleset, ManualReceiverCallSpec,
+    ManualReceiverSource, OptionalReceiverOwnerBinding, ReceiverCallSiteKey,
+    callable_parameter_list_node, collect_colon_parameter_types,
+    collect_receiver_call_specs_in_callable, declaration_name, enclosing_node_with_kind,
+    member_call_method_col, node_is_same_or_ancestor, normalize_parameter_name,
+    normalize_type_surface, parameter_name_before_colon, parameter_type_after_colon,
+    receiver_call_belongs_to_callable, receiver_callsite_key, same_ts_span,
+    split_top_level_parameters, trimmed_node_text, ts_node_graph_span, walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from Kotlin member-call syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:kotlin-member-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/kotlin.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for Kotlin.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["kotlin"],
+    language_name: "kotlin",
+    extensions: &["kt", "kts"],
+    ruleset: LanguageRuleset::Kotlin,
+    parser_language: kotlin_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    receiver_call_specs: Some(receiver_call_specs),
+    member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
+    graph_call_syntax: Some("kotlin_member"),
+    // A `function_declaration` whose owner is type-like is a method in Kotlin;
+    // the projection promotes FUNCTION to METHOD for exactly these languages.
+    promotes_type_member_functions_to_methods: true,
+    qualified_name_delimiter: ".",
+    route_comments_are_c_style: true,
+    uses_generic_semantic_resolver: true,
+    semantic_family: "kotlin",
+};
+
+fn kotlin_language() -> tree_sitter::Language {
+    tree_sitter_kotlin_ng::LANGUAGE.into()
+}
+
+/// Manual receiver-call edges for one parsed Kotlin file.
+///
+/// Was `lib.rs::collect_kotlin_receiver_call_edges`.
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let root = tree.root_node();
+    let top_level_type_names = collect_kotlin_top_level_type_binding_names(root, source);
+    let has_wildcard_import = has_kotlin_wildcard_import(root, source);
+    let imported_type_bindings =
+        collect_kotlin_imported_type_bindings(root, source, &top_level_type_names);
+    walk_tree_nodes(tree.root_node(), &mut |callable| {
+        if callable.kind() != "function_declaration" {
+            return;
+        }
+        let Some(source_name) = declaration_name(callable, source) else {
+            return;
+        };
+        let source_span = ts_node_graph_span(callable);
+        let parameter_receiver_types = collect_colon_parameter_types(callable, source);
+        let mut local_receiver_callsites = HashSet::new();
+        collect_kotlin_precise_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: &source_name,
+                span: source_span,
+            },
+            KotlinReceiverContext {
+                parameter_receiver_types: &parameter_receiver_types,
+                imported_type_bindings: &imported_type_bindings,
+                top_level_type_names: &top_level_type_names,
+                has_wildcard_import,
+            },
+            &mut local_receiver_callsites,
+            &mut edges,
+        );
+        if !parameter_receiver_types.is_empty() {
+            let start = edges.len();
+            collect_receiver_call_specs_in_callable(
+                callable,
+                source,
+                ManualReceiverSource {
+                    name: &source_name,
+                    span: source_span,
+                },
+                &parameter_receiver_types,
+                member_call,
+                false,
+                &mut edges,
+            );
+            let mut parameter_specs = edges.split_off(start);
+            parameter_specs
+                .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
+            for spec in &mut parameter_specs {
+                if let Some(binding) = imported_type_bindings.get(&spec.owner_name) {
+                    spec.owner_name = binding.owner_name.clone();
+                    spec.owner_module = Some(binding.module_name.clone());
+                } else if has_wildcard_import && !top_level_type_names.contains(&spec.owner_name) {
+                    spec.owner_module = Some("*".to_string());
+                }
+            }
+            edges.extend(parameter_specs);
+        }
+    });
+    edges
+}
+
+struct KotlinReceiverContext<'a> {
+    parameter_receiver_types: &'a HashMap<String, String>,
+    imported_type_bindings: &'a HashMap<String, ImportedTypeBinding>,
+    top_level_type_names: &'a HashSet<String>,
+    has_wildcard_import: bool,
+}
+
+fn collect_kotlin_precise_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    context: KotlinReceiverContext<'_>,
+    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let method_col = member_call_method_col(node, source, &method_name);
+        let callsite_key = ReceiverCallSiteKey {
+            receiver_name: receiver_name.clone(),
+            method_name: method_name.clone(),
+            line: Some(node.start_position().row as u32 + 1),
+            method_col,
+        };
+
+        if let Some(owner) =
+            kotlin_visible_local_receiver_owner(callable, node, &receiver_name, source, &context)
+        {
+            local_receiver_callsites.insert(callsite_key);
+            if let Some((owner_name, owner_module)) = owner {
+                edges.push(ManualReceiverCallSpec {
+                    source_name: call_source.name.to_string(),
+                    source_span: call_source.span,
+                    receiver_name,
+                    owner_name,
+                    owner_module,
+                    method_name,
+                    method_col,
+                    line: Some(node.start_position().row as u32 + 1),
+                    allow_global_fallback: false,
+                });
+            }
+            return;
+        }
+
+        let owner =
+            if let Some(owner) = kotlin_self_receiver_owner(callable, &receiver_name, source) {
+                Some(owner)
+            } else if !context
+                .parameter_receiver_types
+                .contains_key(&receiver_name)
+            {
+                kotlin_property_receiver_owner(callable, &receiver_name, source, &context)
+            } else {
+                None
+            };
+        let Some((owner_name, owner_module)) = owner else {
+            return;
+        };
+        edges.push(ManualReceiverCallSpec {
+            source_name: call_source.name.to_string(),
+            source_span: call_source.span,
+            receiver_name,
+            owner_name,
+            owner_module,
+            method_name,
+            method_col,
+            line: Some(node.start_position().row as u32 + 1),
+            allow_global_fallback: false,
+        });
+    });
+}
+
+fn kotlin_self_receiver_owner(
+    callable: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+) -> OptionalReceiverOwnerBinding {
+    if receiver_name != "this" {
+        return None;
+    }
+    let owner_node =
+        enclosing_node_with_kind(callable, &["class_declaration", "object_declaration"])?;
+    let owner_name = declaration_name(owner_node, source)?;
+    Some((owner_name, None))
+}
+
+fn kotlin_visible_local_receiver_owner(
+    callable: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    context: &KotlinReceiverContext<'_>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(callable, &mut |node| {
+        if !kotlin_local_declaration_candidate(node) {
+            return;
+        }
+        if !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > call_node.start_byte()
+        {
+            return;
+        }
+        let Some(surface) = trimmed_node_text(node, source) else {
+            return;
+        };
+        let Some((binding_name, owner)) = kotlin_local_receiver_binding(&surface, context) else {
+            return;
+        };
+        if binding_name != receiver_name || !kotlin_local_binding_visible_at_call(node, call_node) {
+            return;
+        }
+        visible_bindings.push((node.end_byte(), owner));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner)| owner)
+}
+
+fn kotlin_property_receiver_owner(
+    callable: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    context: &KotlinReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let field_name = receiver_name
+        .strip_prefix("this.")
+        .unwrap_or(receiver_name)
+        .trim();
+    if field_name == "this" || field_name.contains('.') {
+        return None;
+    }
+    let owner_node =
+        enclosing_node_with_kind(callable, &["class_declaration", "object_declaration"])?;
+    let mut property_bindings = Vec::new();
+    for (binding_name, owner) in
+        kotlin_primary_constructor_property_bindings(owner_node, source, context)
+    {
+        if binding_name == field_name
+            && let Some(owner) = owner
+        {
+            property_bindings.push(owner);
+        }
+    }
+    walk_tree_nodes(owner_node, &mut |node| {
+        if node.kind() != "property_declaration"
+            || !kotlin_property_belongs_to_owner(node, owner_node)
+        {
+            return;
+        }
+        for (binding_name, owner) in
+            kotlin_property_declaration_receiver_bindings(node, source, context)
+        {
+            if binding_name == field_name
+                && let Some(owner) = owner
+            {
+                property_bindings.push(owner);
+            }
+        }
+    });
+    property_bindings.sort();
+    property_bindings.dedup();
+    if property_bindings.len() == 1 {
+        Some(property_bindings.remove(0))
+    } else {
+        None
+    }
+}
+
+fn kotlin_property_belongs_to_owner(property: TsNode<'_>, owner_node: TsNode<'_>) -> bool {
+    let mut current = property.parent();
+    while let Some(candidate) = current {
+        if same_ts_span(candidate, owner_node) {
+            return true;
+        }
+        if candidate.kind() == "function_declaration"
+            || matches!(candidate.kind(), "class_declaration" | "object_declaration")
+        {
+            return false;
+        }
+        current = candidate.parent();
+    }
+    false
+}
+
+/// Property bindings declared in a Kotlin class's primary constructor.
+///
+/// The surface used to be the class text up to its first `{`, scanned from the
+/// first `(`. An annotated declaration puts that `(` inside the annotation:
+/// `@Table(name = "users") data class User(val id: Long)` yielded `name =
+/// "users"` and the class lost every primary-constructor binding (CR-009). The
+/// grammar keeps `primary_constructor` as its own child, after `modifiers`.
+fn kotlin_primary_constructor_property_bindings(
+    owner_node: TsNode<'_>,
+    source: &str,
+    context: &KotlinReceiverContext<'_>,
+) -> Vec<(String, OptionalReceiverOwnerBinding)> {
+    let mut cursor = owner_node.walk();
+    let parameters = owner_node
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "primary_constructor")
+        .and_then(callable_parameter_list_node)
+        .and_then(|node| trimmed_node_text(node, source))
+        .map(|text| {
+            text.strip_prefix('(')
+                .and_then(|inner| inner.strip_suffix(')'))
+                .unwrap_or(text.as_str())
+                .to_string()
+        })
+        .or_else(|| {
+            let owner_surface = trimmed_node_text(owner_node, source)?;
+            let head = owner_surface
+                .split('{')
+                .next()
+                .unwrap_or(owner_surface.as_str());
+            signature_parameter_surface_text(head)
+        });
+    let Some(parameters) = parameters else {
+        return Vec::new();
+    };
+    split_top_level_parameters(&parameters)
+        .into_iter()
+        .filter_map(|parameter| {
+            let (name_side, type_side) = parameter.split_once(':')?;
+            if !kotlin_property_parameter_name_side(name_side) {
+                return None;
+            }
+            let binding_name = parameter_name_before_colon(name_side)?;
+            let owner =
+                kotlin_receiver_owner_from_type(&parameter_type_after_colon(type_side), context);
+            Some((binding_name, owner))
+        })
+        .collect()
+}
+
+fn signature_parameter_surface_text(text: &str) -> Option<String> {
+    let start = text.find('(')?;
+    let mut depth = 0usize;
+    let mut parameter_start = None;
+    for (index, ch) in text.char_indices().skip_while(|(index, _)| *index < start) {
+        match ch {
+            '(' => {
+                depth = depth.saturating_add(1);
+                if depth == 1 {
+                    parameter_start = Some(index + ch.len_utf8());
+                }
+            }
+            ')' => {
+                if depth == 1 {
+                    let parameter_start = parameter_start?;
+                    return Some(text[parameter_start..index].to_string());
+                }
+                depth = depth.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn kotlin_property_parameter_name_side(name_side: &str) -> bool {
+    name_side
+        .split_whitespace()
+        .any(|token| matches!(token, "val" | "var"))
+}
+
+fn kotlin_property_declaration_receiver_bindings(
+    node: TsNode<'_>,
+    source: &str,
+    context: &KotlinReceiverContext<'_>,
+) -> Vec<(String, OptionalReceiverOwnerBinding)> {
+    trimmed_node_text(node, source)
+        .as_deref()
+        .and_then(|surface| kotlin_typed_property_binding(surface, context))
+        .into_iter()
+        .collect()
+}
+
+fn kotlin_local_declaration_candidate(node: TsNode<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "property_declaration" | "variable_declaration" | "local_declaration"
+    )
+}
+
+fn kotlin_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
+    let Some(binding_scope) = kotlin_lexical_scope(binding) else {
+        return false;
+    };
+    let Some(call_scope) = kotlin_lexical_scope(call_node) else {
+        return false;
+    };
+    node_is_same_or_ancestor(binding_scope, call_scope)
+}
+
+fn kotlin_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
+    enclosing_node_with_kind(node, &["block", "function_body"])
+}
+
+fn kotlin_local_receiver_binding(
+    surface: &str,
+    context: &KotlinReceiverContext<'_>,
+) -> Option<(String, OptionalReceiverOwnerBinding)> {
+    let surface = surface.trim().trim_end_matches(';').trim();
+    let rest = surface
+        .strip_prefix("val ")
+        .or_else(|| surface.strip_prefix("var "))?
+        .trim();
+    let (binding_surface, value_surface) = rest.split_once('=')?;
+    let binding_name = binding_surface
+        .split(':')
+        .next()
+        .unwrap_or(binding_surface)
+        .split_whitespace()
+        .next()
+        .and_then(normalize_parameter_name)?;
+    let constructor_surface = value_surface.trim();
+    let Some((constructor_name, _)) = constructor_surface.split_once('(') else {
+        return Some((binding_name, None));
+    };
+    let constructor_name = constructor_name.trim();
+    if constructor_name.contains('.') || constructor_name.contains("::") {
+        return Some((binding_name, None));
+    }
+    let Some(owner_name) = normalize_type_surface(constructor_name) else {
+        return Some((binding_name, None));
+    };
+    if !owner_name
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_uppercase())
+    {
+        return Some((binding_name, None));
+    }
+    let owner = kotlin_receiver_owner_from_constructor_name(&owner_name, context);
+    Some((binding_name, owner))
+}
+
+fn kotlin_receiver_owner_from_constructor_name(
+    constructor_name: &str,
+    context: &KotlinReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    if context.top_level_type_names.contains(constructor_name) {
+        return Some((constructor_name.to_string(), None));
+    }
+    if let Some(binding) = context.imported_type_bindings.get(constructor_name) {
+        return Some((
+            binding.owner_name.clone(),
+            Some(binding.module_name.clone()),
+        ));
+    }
+    Some((constructor_name.to_string(), None))
+}
+
+fn kotlin_typed_property_binding(
+    surface: &str,
+    context: &KotlinReceiverContext<'_>,
+) -> Option<(String, OptionalReceiverOwnerBinding)> {
+    let surface = surface
+        .split('=')
+        .next()
+        .unwrap_or(surface)
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    let rest = surface
+        .rsplit_once(" val ")
+        .map(|(_, rest)| rest)
+        .or_else(|| surface.rsplit_once(" var ").map(|(_, rest)| rest))
+        .or_else(|| surface.strip_prefix("val "))
+        .or_else(|| surface.strip_prefix("var "))?
+        .trim();
+    let (name_side, type_side) = rest.split_once(':')?;
+    let binding_name = parameter_name_before_colon(name_side)?;
+    let owner = kotlin_receiver_owner_from_type(&parameter_type_after_colon(type_side), context);
+    Some((binding_name, owner))
+}
+
+fn kotlin_receiver_owner_from_type(
+    raw_type: &str,
+    context: &KotlinReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let owner_name = normalize_type_surface(raw_type)?;
+    if context.top_level_type_names.contains(&owner_name) {
+        return Some((owner_name, None));
+    }
+    if let Some(binding) = context.imported_type_bindings.get(&owner_name) {
+        return Some((
+            binding.owner_name.clone(),
+            Some(binding.module_name.clone()),
+        ));
+    }
+    if context.has_wildcard_import {
+        return Some((owner_name, Some("*".to_string())));
+    }
+    Some((owner_name, None))
+}
+
+fn collect_kotlin_imported_type_bindings(
+    root: TsNode<'_>,
+    source: &str,
+    top_level_bindings: &HashSet<String>,
+) -> HashMap<String, ImportedTypeBinding> {
+    let mut bindings = HashMap::new();
+    let mut duplicates = HashSet::new();
+    let mut cursor = root.walk();
+
+    for statement in root.named_children(&mut cursor) {
+        if statement.kind() != "import" {
+            continue;
+        }
+        let Some((owner_name, local_name, module_name)) =
+            kotlin_import_type_binding_names(statement, source)
+        else {
+            continue;
+        };
+        if top_level_bindings.contains(&local_name) || duplicates.contains(&local_name) {
+            continue;
+        }
+        if bindings.contains_key(&local_name) {
+            bindings.remove(&local_name);
+            duplicates.insert(local_name);
+            continue;
+        }
+        bindings.insert(
+            local_name,
+            ImportedTypeBinding {
+                module_name,
+                owner_name,
+            },
+        );
+    }
+
+    bindings
+}
+
+fn has_kotlin_wildcard_import(root: TsNode<'_>, source: &str) -> bool {
+    let mut cursor = root.walk();
+    root.named_children(&mut cursor)
+        .filter(|statement| statement.kind() == "import")
+        .filter_map(|statement| trimmed_node_text(statement, source))
+        .any(|surface| {
+            surface
+                .strip_prefix("import")
+                .map(|rest| rest.trim().trim_end_matches(';').trim().ends_with(".*"))
+                .unwrap_or(false)
+        })
+}
+
+fn collect_kotlin_top_level_type_binding_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if matches!(
+            child.kind(),
+            "class_declaration" | "object_declaration" | "type_alias"
+        ) && let Some(name) = declaration_name(child, source)
+        {
+            names.insert(name);
+        }
+    }
+    names
+}
+
+fn kotlin_import_type_binding_names(
+    statement: TsNode<'_>,
+    source: &str,
+) -> Option<(String, String, String)> {
+    let surface = trimmed_node_text(statement, source)?;
+    let rest = surface
+        .strip_prefix("import")?
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    if rest.is_empty() || rest.ends_with(".*") || rest.contains('*') {
+        return None;
+    }
+
+    let (module_surface, alias_surface) = rest
+        .rsplit_once(" as ")
+        .map(|(module, alias)| (module.trim(), Some(alias.trim())))
+        .unwrap_or((rest, None));
+    if !module_surface.contains('.') || module_surface.split_whitespace().count() != 1 {
+        return None;
+    }
+    let owner_name = module_surface
+        .rsplit('.')
+        .next()
+        .and_then(normalize_parameter_name)?;
+    let local_name = alias_surface
+        .and_then(normalize_parameter_name)
+        .unwrap_or_else(|| owner_name.clone());
+    Some((owner_name, local_name, module_surface.to_string()))
+}
+/// Receiver and member of one Kotlin member call, read from the grammar.
+///
+/// The text scan this replaces cut the callee at the first `(` and then split
+/// on the last `.` of what remained, which is wrong for the two most idiomatic
+/// Kotlin call shapes (CR-010). A trailing lambda has no parentheses at all, so
+/// `user.apply { this.name = n }` split on the dot inside the lambda body and
+/// produced the receiver `user.apply { this`. A chain such as
+/// `repo.findAll().filter { … }` truncated at the first `(` and reported the
+/// outer `.filter` call as `repo.findAll`, duplicating the inner call and
+/// losing the outer one. `call_expression` keeps its callee as its first child
+/// and a member callee is a `navigation_expression`, so both shapes read
+/// directly off the tree.
+fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let mut cursor = node.walk();
+    let callee = node.named_children(&mut cursor).next()?;
+    if callee.kind() != "navigation_expression" {
+        return None;
+    }
+    let mut callee_cursor = callee.walk();
+    let callee_children = callee
+        .named_children(&mut callee_cursor)
+        .collect::<Vec<_>>();
+    let receiver = callee_children.first()?;
+    let member = callee_children.last()?;
+    if receiver.id() == member.id() {
+        return None;
+    }
+    let receiver_text = trimmed_node_text(*receiver, source)?;
+    let member_text = trimmed_node_text(*member, source)?;
+    Some((
+        normalized_kotlin_receiver_surface(receiver_text.trim_end_matches('?'))?,
+        normalize_parameter_name(member_text.trim_start_matches('?'))?,
+    ))
+}
+
+fn normalized_kotlin_receiver_surface(raw: &str) -> Option<String> {
+    let receiver = raw.trim().trim_end_matches('?').trim();
+    if receiver.contains('.') {
+        let cleaned = receiver
+            .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '.')
+            .trim();
+        let valid = cleaned
+            .split('.')
+            .all(|part| normalize_parameter_name(part).is_some());
+        return (valid && !cleaned.is_empty()).then(|| cleaned.to_string());
+    }
+    normalize_parameter_name(receiver)
+}

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -1,0 +1,240 @@
+//! Per-language extraction rules, one module per language, behind a registry.
+//!
+//! ARCH-012: the indexer used to spread each language across a dozen
+//! hand-maintained name rosters — parser configs, compiled-rule caches,
+//! receiver-call dispatch, name-projection flags, comment style, resolver
+//! selection, family buckets — so adding or auditing a language meant finding
+//! every match arm that spelled its name. A migrated language instead owns one
+//! module here and appears exactly once, as one [`LanguageExtraction`] row in
+//! [`EXTRACTIONS`]; every consumer iterates the registry.
+//!
+//! The migration is one language per rollback unit (Kotlin first, then #1677
+//! through #1691). Until a language has moved, its rows stay in the residual
+//! `match` at each call site, and each consumer therefore reads
+//! "registry first, residual match second". That ordering is behaviour-neutral
+//! because the registry and the residual match are disjoint by construction —
+//! `registry_rows_do_not_shadow_unmigrated_languages` proves it — and the last
+//! package to land deletes the residual arms entirely.
+
+pub(crate) mod kotlin;
+
+use std::sync::OnceLock;
+
+use tree_sitter::{Language, Tree};
+
+use crate::{CompiledLanguageRules, LanguageRuleset, ManualReceiverCallSpec};
+
+/// Everything the indexer knows about one migrated language.
+///
+/// Each field replaces one hand-kept roster entry. A new language fills the
+/// struct once instead of editing the dispatches this struct feeds.
+pub(crate) struct LanguageExtraction {
+    /// Every language name this row answers to in the indexer's language-keyed
+    /// dispatches. Normally one name; TSX exists as its own dispatch name while
+    /// still reporting `typescript` as its public `language_name`.
+    pub(crate) dispatch_names: &'static [&'static str],
+    /// Public registry name from `codestory_contracts::language_support`.
+    pub(crate) language_name: &'static str,
+    /// Extensions this row serves. Must be a subset of the contracts registry's
+    /// extensions for `language_name`; the drift test below enforces it.
+    pub(crate) extensions: &'static [&'static str],
+    /// Discriminant used by the compiled-rule cache.
+    pub(crate) ruleset: LanguageRuleset,
+    /// Tree-sitter grammar constructor.
+    pub(crate) parser_language: fn() -> Language,
+    /// Graph DSL rule file contents.
+    pub(crate) graph_query: &'static str,
+    /// Optional tags query contents.
+    pub(crate) tags_query: Option<&'static str>,
+    /// Process-wide cache for the compiled graph/tags rules.
+    pub(crate) compiled_rules: &'static OnceLock<Result<CompiledLanguageRules, String>>,
+    /// Manual receiver-call collector, when the language has one.
+    pub(crate) receiver_call_specs: Option<fn(&Tree, &str) -> Vec<ManualReceiverCallSpec>>,
+    /// Callsite marker for edges produced from member-call syntax.
+    pub(crate) member_callsite_marker: Option<&'static str>,
+    /// `call_syntax` value the rule file emits for that marker.
+    pub(crate) graph_call_syntax: Option<&'static str>,
+    /// Member functions of a type-like owner project as METHOD, not FUNCTION.
+    pub(crate) promotes_type_member_functions_to_methods: bool,
+    /// Separator between an owner and its member in qualified names.
+    pub(crate) qualified_name_delimiter: &'static str,
+    /// Framework-route text scanning strips `//` and `/* */` comments.
+    pub(crate) route_comments_are_c_style: bool,
+    /// Whether the language resolves through the shared name-only resolver.
+    /// `false` means `semantic::dedicated_semantic_resolver` still constructs
+    /// it, because those resolver types are private to that module.
+    pub(crate) uses_generic_semantic_resolver: bool,
+    /// Bucket used to keep semantic candidates inside one language family.
+    pub(crate) semantic_family: &'static str,
+}
+
+/// Every language whose extraction rules have moved into this module tree.
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+
+/// Look a row up by any of its dispatch names.
+pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {
+    EXTRACTIONS
+        .iter()
+        .find(|extraction| extraction.dispatch_names.contains(&language_name))
+}
+
+/// Look a row up by file extension. The extension is expected to be already
+/// normalized (no leading dot, lowercase).
+pub(crate) fn extraction_for_ext(ext: &str) -> Option<&'static LanguageExtraction> {
+    EXTRACTIONS
+        .iter()
+        .find(|extraction| extraction.extensions.contains(&ext))
+}
+
+/// Look a row up by its compiled-rule discriminant.
+pub(crate) fn extraction_for_ruleset(
+    ruleset: LanguageRuleset,
+) -> Option<&'static LanguageExtraction> {
+    EXTRACTIONS
+        .iter()
+        .find(|extraction| extraction.ruleset == ruleset)
+}
+
+/// Callsite marker for a `call_syntax` value emitted by a migrated rule file.
+pub(crate) fn member_callsite_marker_for_call_syntax(call_syntax: &str) -> Option<&'static str> {
+    EXTRACTIONS
+        .iter()
+        .find(|extraction| extraction.graph_call_syntax == Some(call_syntax))
+        .and_then(|extraction| extraction.member_callsite_marker)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::language_support::{
+        LanguageSupportMode, language_support_profile_for_ext,
+        language_support_profile_for_language_name,
+    };
+    use std::collections::HashSet;
+
+    /// Every registry row must agree with the public language registry.
+    ///
+    /// A row that claimed an extension the contracts registry routes elsewhere
+    /// would silently steal files from another language's parser.
+    #[test]
+    fn registry_rows_agree_with_the_public_language_registry() {
+        for extraction in EXTRACTIONS {
+            assert!(
+                !extraction.extensions.is_empty(),
+                "{} must claim at least one extension",
+                extraction.language_name
+            );
+            for extension in extraction.extensions {
+                let profile = language_support_profile_for_ext(extension)
+                    .unwrap_or_else(|| panic!("`{extension}` has no public language profile"));
+                assert_eq!(
+                    profile.language_name, extraction.language_name,
+                    "`{extension}` is routed to {} by the public registry",
+                    profile.language_name
+                );
+                assert_eq!(
+                    profile.support_mode,
+                    LanguageSupportMode::ParserBackedGraph,
+                    "`{extension}` is not a parser-backed claim",
+                );
+            }
+            assert!(
+                !extraction.dispatch_names.is_empty(),
+                "{} must answer to at least one dispatch name",
+                extraction.language_name
+            );
+            for dispatch_name in extraction.dispatch_names {
+                // A dispatch name is either this row's own registry name, or a
+                // finer-grained indexer-only name that the public registry does
+                // not know (TSX). Anything else means the row would answer for
+                // some *other* language's dispatches.
+                assert!(
+                    *dispatch_name == extraction.language_name
+                        || language_support_profile_for_language_name(dispatch_name).is_none(),
+                    "{} claims dispatch name `{dispatch_name}`, which the public registry \
+                     assigns to another language",
+                    extraction.language_name
+                );
+            }
+            assert_eq!(
+                extraction.member_callsite_marker.is_some(),
+                extraction.graph_call_syntax.is_some(),
+                "{} must pair its callsite marker with the rule file's call_syntax",
+                extraction.language_name
+            );
+        }
+    }
+
+    /// Registry rows and the residual `match` arms must stay disjoint.
+    ///
+    /// Every consumer reads "registry first, residual match second". If a
+    /// language were listed in both, the registry answer would silently shadow
+    /// the residual arm and a behavioural difference between them would become
+    /// invisible. Uniqueness inside the registry is the enforceable half of
+    /// that; the residual half is enforced by each consumer's own test.
+    #[test]
+    fn registry_rows_do_not_shadow_unmigrated_languages() {
+        let mut dispatch_names = HashSet::new();
+        let mut extensions = HashSet::new();
+        let mut rulesets = Vec::new();
+        let mut call_syntaxes = HashSet::new();
+        for extraction in EXTRACTIONS {
+            for name in extraction.dispatch_names {
+                assert!(
+                    dispatch_names.insert(*name),
+                    "dispatch name `{name}` is claimed twice"
+                );
+            }
+            for extension in extraction.extensions {
+                assert!(
+                    extensions.insert(*extension),
+                    "extension `{extension}` is claimed twice"
+                );
+            }
+            assert!(
+                !rulesets.contains(&extraction.ruleset),
+                "ruleset {:?} is claimed twice",
+                extraction.ruleset
+            );
+            rulesets.push(extraction.ruleset);
+            if let Some(call_syntax) = extraction.graph_call_syntax {
+                assert!(
+                    call_syntaxes.insert(call_syntax),
+                    "call_syntax `{call_syntax}` is claimed twice"
+                );
+            }
+        }
+    }
+
+    /// The Kotlin row must keep the exact projection facts it had while it was
+    /// spread across `lib.rs`. These four values used to live in four separate
+    /// match statements; a wrong value here is a silent projection change that
+    /// no threshold test would catch.
+    #[test]
+    fn kotlin_row_keeps_the_projection_facts_it_had_in_the_god_file() {
+        let kotlin = extraction_for_language("kotlin").expect("kotlin row");
+        assert!(kotlin.promotes_type_member_functions_to_methods);
+        assert_eq!(kotlin.qualified_name_delimiter, ".");
+        assert!(kotlin.route_comments_are_c_style);
+        assert_eq!(kotlin.semantic_family, "kotlin");
+        assert!(kotlin.uses_generic_semantic_resolver);
+        assert_eq!(
+            kotlin.member_callsite_marker,
+            Some("syntax:kotlin-member-call")
+        );
+        assert_eq!(
+            member_callsite_marker_for_call_syntax("kotlin_member"),
+            Some("syntax:kotlin-member-call")
+        );
+        assert!(kotlin.receiver_call_specs.is_some());
+        assert!(kotlin.tags_query.is_none());
+        assert_eq!(
+            extraction_for_ext("kt").map(|row| row.language_name),
+            Some("kotlin")
+        );
+        assert_eq!(
+            extraction_for_ext("kts").map(|row| row.language_name),
+            Some("kotlin")
+        );
+    }
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -43,6 +43,7 @@ pub mod compilation_database;
 mod framework_routes;
 pub mod intermediate_storage;
 mod language_configs;
+mod languages;
 pub mod resolution;
 pub mod semantic;
 pub mod structural;
@@ -65,7 +66,6 @@ pub(crate) const RUBY_MEMBER_CALLSITE_MARKER: &str = "syntax:ruby-member-call";
 pub(crate) const PHP_MEMBER_CALLSITE_MARKER: &str = "syntax:php-member-call";
 pub(crate) const JS_MEMBER_CALLSITE_MARKER: &str = "syntax:js-member-call";
 pub(crate) const TS_MEMBER_CALLSITE_MARKER: &str = "syntax:ts-member-call";
-pub(crate) const KOTLIN_MEMBER_CALLSITE_MARKER: &str = "syntax:kotlin-member-call";
 pub(crate) const DART_MEMBER_CALLSITE_MARKER: &str = "syntax:dart-member-call";
 pub(crate) const SWIFT_MEMBER_CALLSITE_MARKER: &str = "syntax:swift-member-call";
 pub(crate) const RECEIVER_OWNER_CALLSITE_PREFIX: &str = "receiver-owner:";
@@ -142,12 +142,11 @@ const GO_GRAPH_QUERY: &str = include_str!("../rules/go.scm");
 const RUBY_GRAPH_QUERY: &str = include_str!("../rules/ruby.scm");
 const PHP_GRAPH_QUERY: &str = include_str!("../rules/php.scm");
 const CSHARP_GRAPH_QUERY: &str = include_str!("../rules/csharp.scm");
-const KOTLIN_GRAPH_QUERY: &str = include_str!("../rules/kotlin.scm");
 const SWIFT_GRAPH_QUERY: &str = include_str!("../rules/swift.scm");
 const DART_GRAPH_QUERY: &str = include_str!("../rules/dart.scm");
 const BASH_GRAPH_QUERY: &str = include_str!("../rules/bash.scm");
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LanguageRuleset {
     Python,
     Java,
@@ -279,6 +278,16 @@ impl LanguageConfig {
 
 impl LanguageRuleset {
     fn compiled_rules(&self, language: Language) -> Result<&'static CompiledLanguageRules> {
+        // Registry first: a migrated language carries its rule file and cache in
+        // `languages::<lang>`. The arms below are the not-yet-migrated residue.
+        if let Some(extraction) = languages::extraction_for_ruleset(*self) {
+            return compiled_rules_cache(
+                language,
+                extraction.graph_query,
+                extraction.tags_query,
+                extraction.compiled_rules,
+            );
+        }
         match self {
             LanguageRuleset::Python => {
                 compiled_rules_cache(language, PYTHON_GRAPH_QUERY, None, &PYTHON_RULES)
@@ -318,9 +327,12 @@ impl LanguageRuleset {
             LanguageRuleset::CSharp => {
                 compiled_rules_cache(language, CSHARP_GRAPH_QUERY, None, &CSHARP_RULES)
             }
-            LanguageRuleset::Kotlin => {
-                compiled_rules_cache(language, KOTLIN_GRAPH_QUERY, None, &KOTLIN_RULES)
-            }
+            // Answered by the registry above; the arm only exists because the
+            // match must stay exhaustive. Failing closed here rather than
+            // panicking keeps a future registry mistake a typed indexing error.
+            LanguageRuleset::Kotlin => Err(anyhow!(
+                "kotlin compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::Swift => {
                 compiled_rules_cache(language, SWIFT_GRAPH_QUERY, None, &SWIFT_RULES)
             }
@@ -372,7 +384,6 @@ static GO_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new
 static RUBY_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static PHP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CSHARP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static KOTLIN_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static SWIFT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static DART_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static BASH_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
@@ -7552,6 +7563,13 @@ fn language_receiver_call_specs(
     tree: &Tree,
     source: &str,
 ) -> Vec<ManualReceiverCallSpec> {
+    // Registry first; the arms below are the languages that have not moved yet.
+    if let Some(extraction) = languages::extraction_for_language(language_name) {
+        return match extraction.receiver_call_specs {
+            Some(collect) => collect(tree, source),
+            None => Vec::new(),
+        };
+    }
     match language_name {
         "javascript" => collect_javascript_receiver_call_edges(tree, source),
         "python" => collect_python_receiver_call_edges(tree, source),
@@ -7561,7 +7579,6 @@ fn language_receiver_call_specs(
         "ruby" => collect_ruby_receiver_call_edges(tree, source),
         "php" => collect_php_receiver_call_edges(tree, source),
         "csharp" => collect_csharp_receiver_call_edges(tree, source),
-        "kotlin" => collect_kotlin_receiver_call_edges(tree, source),
         "cpp" => collect_cpp_receiver_call_edges(tree, source),
         "swift" => collect_swift_receiver_call_edges(tree, source),
         "dart" => collect_dart_receiver_call_edges(tree, source),
@@ -12027,374 +12044,6 @@ fn csharp_plain_namespace_import_type_module(
     Some(format!("{namespace_name}.{owner_name}"))
 }
 
-fn collect_kotlin_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let root = tree.root_node();
-    let top_level_type_names = collect_kotlin_top_level_type_binding_names(root, source);
-    let has_wildcard_import = has_kotlin_wildcard_import(root, source);
-    let imported_type_bindings =
-        collect_kotlin_imported_type_bindings(root, source, &top_level_type_names);
-    walk_tree_nodes(tree.root_node(), &mut |callable| {
-        if callable.kind() != "function_declaration" {
-            return;
-        }
-        let Some(source_name) = declaration_name(callable, source) else {
-            return;
-        };
-        let source_span = ts_node_graph_span(callable);
-        let parameter_receiver_types = collect_colon_parameter_types(callable, source);
-        let mut local_receiver_callsites = HashSet::new();
-        collect_kotlin_precise_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: &source_name,
-                span: source_span,
-            },
-            KotlinReceiverContext {
-                parameter_receiver_types: &parameter_receiver_types,
-                imported_type_bindings: &imported_type_bindings,
-                top_level_type_names: &top_level_type_names,
-                has_wildcard_import,
-            },
-            &mut local_receiver_callsites,
-            &mut edges,
-        );
-        if !parameter_receiver_types.is_empty() {
-            let start = edges.len();
-            collect_receiver_call_specs_in_callable(
-                callable,
-                source,
-                ManualReceiverSource {
-                    name: &source_name,
-                    span: source_span,
-                },
-                &parameter_receiver_types,
-                kotlin_member_call,
-                false,
-                &mut edges,
-            );
-            let mut parameter_specs = edges.split_off(start);
-            parameter_specs
-                .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
-            for spec in &mut parameter_specs {
-                if let Some(binding) = imported_type_bindings.get(&spec.owner_name) {
-                    spec.owner_name = binding.owner_name.clone();
-                    spec.owner_module = Some(binding.module_name.clone());
-                } else if has_wildcard_import && !top_level_type_names.contains(&spec.owner_name) {
-                    spec.owner_module = Some("*".to_string());
-                }
-            }
-            edges.extend(parameter_specs);
-        }
-    });
-    edges
-}
-
-struct KotlinReceiverContext<'a> {
-    parameter_receiver_types: &'a HashMap<String, String>,
-    imported_type_bindings: &'a HashMap<String, ImportedTypeBinding>,
-    top_level_type_names: &'a HashSet<String>,
-    has_wildcard_import: bool,
-}
-
-fn collect_kotlin_precise_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    context: KotlinReceiverContext<'_>,
-    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = kotlin_member_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let method_col = member_call_method_col(node, source, &method_name);
-        let callsite_key = ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
-            method_col,
-        };
-
-        if let Some(owner) =
-            kotlin_visible_local_receiver_owner(callable, node, &receiver_name, source, &context)
-        {
-            local_receiver_callsites.insert(callsite_key);
-            if let Some((owner_name, owner_module)) = owner {
-                edges.push(ManualReceiverCallSpec {
-                    source_name: call_source.name.to_string(),
-                    source_span: call_source.span,
-                    receiver_name,
-                    owner_name,
-                    owner_module,
-                    method_name,
-                    method_col,
-                    line: Some(node.start_position().row as u32 + 1),
-                    allow_global_fallback: false,
-                });
-            }
-            return;
-        }
-
-        let owner =
-            if let Some(owner) = kotlin_self_receiver_owner(callable, &receiver_name, source) {
-                Some(owner)
-            } else if !context
-                .parameter_receiver_types
-                .contains_key(&receiver_name)
-            {
-                kotlin_property_receiver_owner(callable, &receiver_name, source, &context)
-            } else {
-                None
-            };
-        let Some((owner_name, owner_module)) = owner else {
-            return;
-        };
-        edges.push(ManualReceiverCallSpec {
-            source_name: call_source.name.to_string(),
-            source_span: call_source.span,
-            receiver_name,
-            owner_name,
-            owner_module,
-            method_name,
-            method_col,
-            line: Some(node.start_position().row as u32 + 1),
-            allow_global_fallback: false,
-        });
-    });
-}
-
-fn kotlin_self_receiver_owner(
-    callable: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-) -> OptionalReceiverOwnerBinding {
-    if receiver_name != "this" {
-        return None;
-    }
-    let owner_node =
-        enclosing_node_with_kind(callable, &["class_declaration", "object_declaration"])?;
-    let owner_name = declaration_name(owner_node, source)?;
-    Some((owner_name, None))
-}
-
-fn kotlin_visible_local_receiver_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    context: &KotlinReceiverContext<'_>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if !kotlin_local_declaration_candidate(node) {
-            return;
-        }
-        if !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
-        {
-            return;
-        }
-        let Some(surface) = trimmed_node_text(node, source) else {
-            return;
-        };
-        let Some((binding_name, owner)) = kotlin_local_receiver_binding(&surface, context) else {
-            return;
-        };
-        if binding_name != receiver_name || !kotlin_local_binding_visible_at_call(node, call_node) {
-            return;
-        }
-        visible_bindings.push((node.end_byte(), owner));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner)| owner)
-}
-
-fn kotlin_property_receiver_owner(
-    callable: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    context: &KotlinReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let field_name = receiver_name
-        .strip_prefix("this.")
-        .unwrap_or(receiver_name)
-        .trim();
-    if field_name == "this" || field_name.contains('.') {
-        return None;
-    }
-    let owner_node =
-        enclosing_node_with_kind(callable, &["class_declaration", "object_declaration"])?;
-    let mut property_bindings = Vec::new();
-    for (binding_name, owner) in
-        kotlin_primary_constructor_property_bindings(owner_node, source, context)
-    {
-        if binding_name == field_name
-            && let Some(owner) = owner
-        {
-            property_bindings.push(owner);
-        }
-    }
-    walk_tree_nodes(owner_node, &mut |node| {
-        if node.kind() != "property_declaration"
-            || !kotlin_property_belongs_to_owner(node, owner_node)
-        {
-            return;
-        }
-        for (binding_name, owner) in
-            kotlin_property_declaration_receiver_bindings(node, source, context)
-        {
-            if binding_name == field_name
-                && let Some(owner) = owner
-            {
-                property_bindings.push(owner);
-            }
-        }
-    });
-    property_bindings.sort();
-    property_bindings.dedup();
-    if property_bindings.len() == 1 {
-        Some(property_bindings.remove(0))
-    } else {
-        None
-    }
-}
-
-fn kotlin_property_belongs_to_owner(property: TsNode<'_>, owner_node: TsNode<'_>) -> bool {
-    let mut current = property.parent();
-    while let Some(candidate) = current {
-        if same_ts_span(candidate, owner_node) {
-            return true;
-        }
-        if candidate.kind() == "function_declaration"
-            || matches!(candidate.kind(), "class_declaration" | "object_declaration")
-        {
-            return false;
-        }
-        current = candidate.parent();
-    }
-    false
-}
-
-/// Property bindings declared in a Kotlin class's primary constructor.
-///
-/// The surface used to be the class text up to its first `{`, scanned from the
-/// first `(`. An annotated declaration puts that `(` inside the annotation:
-/// `@Table(name = "users") data class User(val id: Long)` yielded `name =
-/// "users"` and the class lost every primary-constructor binding (CR-009). The
-/// grammar keeps `primary_constructor` as its own child, after `modifiers`.
-fn kotlin_primary_constructor_property_bindings(
-    owner_node: TsNode<'_>,
-    source: &str,
-    context: &KotlinReceiverContext<'_>,
-) -> Vec<(String, OptionalReceiverOwnerBinding)> {
-    let mut cursor = owner_node.walk();
-    let parameters = owner_node
-        .named_children(&mut cursor)
-        .find(|child| child.kind() == "primary_constructor")
-        .and_then(callable_parameter_list_node)
-        .and_then(|node| trimmed_node_text(node, source))
-        .map(|text| {
-            text.strip_prefix('(')
-                .and_then(|inner| inner.strip_suffix(')'))
-                .unwrap_or(text.as_str())
-                .to_string()
-        })
-        .or_else(|| {
-            let owner_surface = trimmed_node_text(owner_node, source)?;
-            let head = owner_surface
-                .split('{')
-                .next()
-                .unwrap_or(owner_surface.as_str());
-            signature_parameter_surface_text(head)
-        });
-    let Some(parameters) = parameters else {
-        return Vec::new();
-    };
-    split_top_level_parameters(&parameters)
-        .into_iter()
-        .filter_map(|parameter| {
-            let (name_side, type_side) = parameter.split_once(':')?;
-            if !kotlin_property_parameter_name_side(name_side) {
-                return None;
-            }
-            let binding_name = parameter_name_before_colon(name_side)?;
-            let owner =
-                kotlin_receiver_owner_from_type(&parameter_type_after_colon(type_side), context);
-            Some((binding_name, owner))
-        })
-        .collect()
-}
-
-fn signature_parameter_surface_text(text: &str) -> Option<String> {
-    let start = text.find('(')?;
-    let mut depth = 0usize;
-    let mut parameter_start = None;
-    for (index, ch) in text.char_indices().skip_while(|(index, _)| *index < start) {
-        match ch {
-            '(' => {
-                depth = depth.saturating_add(1);
-                if depth == 1 {
-                    parameter_start = Some(index + ch.len_utf8());
-                }
-            }
-            ')' => {
-                if depth == 1 {
-                    let parameter_start = parameter_start?;
-                    return Some(text[parameter_start..index].to_string());
-                }
-                depth = depth.saturating_sub(1);
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
-fn kotlin_property_parameter_name_side(name_side: &str) -> bool {
-    name_side
-        .split_whitespace()
-        .any(|token| matches!(token, "val" | "var"))
-}
-
-fn kotlin_property_declaration_receiver_bindings(
-    node: TsNode<'_>,
-    source: &str,
-    context: &KotlinReceiverContext<'_>,
-) -> Vec<(String, OptionalReceiverOwnerBinding)> {
-    trimmed_node_text(node, source)
-        .as_deref()
-        .and_then(|surface| kotlin_typed_property_binding(surface, context))
-        .into_iter()
-        .collect()
-}
-
-fn kotlin_local_declaration_candidate(node: TsNode<'_>) -> bool {
-    matches!(
-        node.kind(),
-        "property_declaration" | "variable_declaration" | "local_declaration"
-    )
-}
-
-fn kotlin_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
-    let Some(binding_scope) = kotlin_lexical_scope(binding) else {
-        return false;
-    };
-    let Some(call_scope) = kotlin_lexical_scope(call_node) else {
-        return false;
-    };
-    node_is_same_or_ancestor(binding_scope, call_scope)
-}
-
-fn kotlin_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
-    enclosing_node_with_kind(node, &["block", "function_body"])
-}
-
 fn node_is_same_or_ancestor(ancestor: TsNode<'_>, node: TsNode<'_>) -> bool {
     let mut current = Some(node);
     while let Some(candidate) = current {
@@ -12404,202 +12053,6 @@ fn node_is_same_or_ancestor(ancestor: TsNode<'_>, node: TsNode<'_>) -> bool {
         current = candidate.parent();
     }
     false
-}
-
-fn kotlin_local_receiver_binding(
-    surface: &str,
-    context: &KotlinReceiverContext<'_>,
-) -> Option<(String, OptionalReceiverOwnerBinding)> {
-    let surface = surface.trim().trim_end_matches(';').trim();
-    let rest = surface
-        .strip_prefix("val ")
-        .or_else(|| surface.strip_prefix("var "))?
-        .trim();
-    let (binding_surface, value_surface) = rest.split_once('=')?;
-    let binding_name = binding_surface
-        .split(':')
-        .next()
-        .unwrap_or(binding_surface)
-        .split_whitespace()
-        .next()
-        .and_then(normalize_parameter_name)?;
-    let constructor_surface = value_surface.trim();
-    let Some((constructor_name, _)) = constructor_surface.split_once('(') else {
-        return Some((binding_name, None));
-    };
-    let constructor_name = constructor_name.trim();
-    if constructor_name.contains('.') || constructor_name.contains("::") {
-        return Some((binding_name, None));
-    }
-    let Some(owner_name) = normalize_type_surface(constructor_name) else {
-        return Some((binding_name, None));
-    };
-    if !owner_name
-        .chars()
-        .next()
-        .is_some_and(|first| first.is_ascii_uppercase())
-    {
-        return Some((binding_name, None));
-    }
-    let owner = kotlin_receiver_owner_from_constructor_name(&owner_name, context);
-    Some((binding_name, owner))
-}
-
-fn kotlin_receiver_owner_from_constructor_name(
-    constructor_name: &str,
-    context: &KotlinReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    if context.top_level_type_names.contains(constructor_name) {
-        return Some((constructor_name.to_string(), None));
-    }
-    if let Some(binding) = context.imported_type_bindings.get(constructor_name) {
-        return Some((
-            binding.owner_name.clone(),
-            Some(binding.module_name.clone()),
-        ));
-    }
-    Some((constructor_name.to_string(), None))
-}
-
-fn kotlin_typed_property_binding(
-    surface: &str,
-    context: &KotlinReceiverContext<'_>,
-) -> Option<(String, OptionalReceiverOwnerBinding)> {
-    let surface = surface
-        .split('=')
-        .next()
-        .unwrap_or(surface)
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    let rest = surface
-        .rsplit_once(" val ")
-        .map(|(_, rest)| rest)
-        .or_else(|| surface.rsplit_once(" var ").map(|(_, rest)| rest))
-        .or_else(|| surface.strip_prefix("val "))
-        .or_else(|| surface.strip_prefix("var "))?
-        .trim();
-    let (name_side, type_side) = rest.split_once(':')?;
-    let binding_name = parameter_name_before_colon(name_side)?;
-    let owner = kotlin_receiver_owner_from_type(&parameter_type_after_colon(type_side), context);
-    Some((binding_name, owner))
-}
-
-fn kotlin_receiver_owner_from_type(
-    raw_type: &str,
-    context: &KotlinReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let owner_name = normalize_type_surface(raw_type)?;
-    if context.top_level_type_names.contains(&owner_name) {
-        return Some((owner_name, None));
-    }
-    if let Some(binding) = context.imported_type_bindings.get(&owner_name) {
-        return Some((
-            binding.owner_name.clone(),
-            Some(binding.module_name.clone()),
-        ));
-    }
-    if context.has_wildcard_import {
-        return Some((owner_name, Some("*".to_string())));
-    }
-    Some((owner_name, None))
-}
-
-fn collect_kotlin_imported_type_bindings(
-    root: TsNode<'_>,
-    source: &str,
-    top_level_bindings: &HashSet<String>,
-) -> HashMap<String, ImportedTypeBinding> {
-    let mut bindings = HashMap::new();
-    let mut duplicates = HashSet::new();
-    let mut cursor = root.walk();
-
-    for statement in root.named_children(&mut cursor) {
-        if statement.kind() != "import" {
-            continue;
-        }
-        let Some((owner_name, local_name, module_name)) =
-            kotlin_import_type_binding_names(statement, source)
-        else {
-            continue;
-        };
-        if top_level_bindings.contains(&local_name) || duplicates.contains(&local_name) {
-            continue;
-        }
-        if bindings.contains_key(&local_name) {
-            bindings.remove(&local_name);
-            duplicates.insert(local_name);
-            continue;
-        }
-        bindings.insert(
-            local_name,
-            ImportedTypeBinding {
-                module_name,
-                owner_name,
-            },
-        );
-    }
-
-    bindings
-}
-
-fn has_kotlin_wildcard_import(root: TsNode<'_>, source: &str) -> bool {
-    let mut cursor = root.walk();
-    root.named_children(&mut cursor)
-        .filter(|statement| statement.kind() == "import")
-        .filter_map(|statement| trimmed_node_text(statement, source))
-        .any(|surface| {
-            surface
-                .strip_prefix("import")
-                .map(|rest| rest.trim().trim_end_matches(';').trim().ends_with(".*"))
-                .unwrap_or(false)
-        })
-}
-
-fn collect_kotlin_top_level_type_binding_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
-    let mut names = HashSet::new();
-    let mut cursor = root.walk();
-    for child in root.named_children(&mut cursor) {
-        if matches!(
-            child.kind(),
-            "class_declaration" | "object_declaration" | "type_alias"
-        ) && let Some(name) = declaration_name(child, source)
-        {
-            names.insert(name);
-        }
-    }
-    names
-}
-
-fn kotlin_import_type_binding_names(
-    statement: TsNode<'_>,
-    source: &str,
-) -> Option<(String, String, String)> {
-    let surface = trimmed_node_text(statement, source)?;
-    let rest = surface
-        .strip_prefix("import")?
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    if rest.is_empty() || rest.ends_with(".*") || rest.contains('*') {
-        return None;
-    }
-
-    let (module_surface, alias_surface) = rest
-        .rsplit_once(" as ")
-        .map(|(module, alias)| (module.trim(), Some(alias.trim())))
-        .unwrap_or((rest, None));
-    if !module_surface.contains('.') || module_surface.split_whitespace().count() != 1 {
-        return None;
-    }
-    let owner_name = module_surface
-        .rsplit('.')
-        .next()
-        .and_then(normalize_parameter_name)?;
-    let local_name = alias_surface
-        .and_then(normalize_parameter_name)
-        .unwrap_or_else(|| owner_name.clone());
-    Some((owner_name, local_name, module_surface.to_string()))
 }
 
 fn collect_cpp_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
@@ -15033,58 +14486,6 @@ fn normalize_js_ts_private_receiver_surface(receiver: &str) -> String {
         .join(".")
 }
 
-/// Receiver and member of one Kotlin member call, read from the grammar.
-///
-/// The text scan this replaces cut the callee at the first `(` and then split
-/// on the last `.` of what remained, which is wrong for the two most idiomatic
-/// Kotlin call shapes (CR-010). A trailing lambda has no parentheses at all, so
-/// `user.apply { this.name = n }` split on the dot inside the lambda body and
-/// produced the receiver `user.apply { this`. A chain such as
-/// `repo.findAll().filter { … }` truncated at the first `(` and reported the
-/// outer `.filter` call as `repo.findAll`, duplicating the inner call and
-/// losing the outer one. `call_expression` keeps its callee as its first child
-/// and a member callee is a `navigation_expression`, so both shapes read
-/// directly off the tree.
-fn kotlin_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if node.kind() != "call_expression" {
-        return None;
-    }
-    let mut cursor = node.walk();
-    let callee = node.named_children(&mut cursor).next()?;
-    if callee.kind() != "navigation_expression" {
-        return None;
-    }
-    let mut callee_cursor = callee.walk();
-    let callee_children = callee
-        .named_children(&mut callee_cursor)
-        .collect::<Vec<_>>();
-    let receiver = callee_children.first()?;
-    let member = callee_children.last()?;
-    if receiver.id() == member.id() {
-        return None;
-    }
-    let receiver_text = trimmed_node_text(*receiver, source)?;
-    let member_text = trimmed_node_text(*member, source)?;
-    Some((
-        normalized_kotlin_receiver_surface(receiver_text.trim_end_matches('?'))?,
-        normalize_parameter_name(member_text.trim_start_matches('?'))?,
-    ))
-}
-
-fn normalized_kotlin_receiver_surface(raw: &str) -> Option<String> {
-    let receiver = raw.trim().trim_end_matches('?').trim();
-    if receiver.contains('.') {
-        let cleaned = receiver
-            .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '.')
-            .trim();
-        let valid = cleaned
-            .split('.')
-            .all(|part| normalize_parameter_name(part).is_some());
-        return (valid && !cleaned.is_empty()).then(|| cleaned.to_string());
-    }
-    normalize_parameter_name(receiver)
-}
-
 fn cpp_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
     if node.kind() != "call_expression" {
         return None;
@@ -15779,10 +15180,17 @@ fn queue_qualified_child_names(
 }
 
 fn promotes_type_member_functions_to_methods(language_name: &str) -> bool {
-    matches!(language_name, "kotlin" | "swift" | "dart")
+    // Registry first; `swift` and `dart` are the unmigrated residue.
+    if let Some(extraction) = languages::extraction_for_language(language_name) {
+        return extraction.promotes_type_member_functions_to_methods;
+    }
+    matches!(language_name, "swift" | "dart")
 }
 
 fn qualified_name_delimiter(language_name: &str) -> &'static str {
+    if let Some(extraction) = languages::extraction_for_language(language_name) {
+        return extraction.qualified_name_delimiter;
+    }
     match language_name {
         "rust" | "cpp" | "c" => "::",
         _ => ".",
@@ -16850,16 +16258,18 @@ pub fn is_text_only_candidate_path(path: &Path) -> bool {
 }
 
 fn text_only_language_name(path: &Path) -> &'static str {
-    match path
+    let extension = path
         .extension()
         .and_then(|value| value.to_str())
         .unwrap_or_default()
-        .to_ascii_lowercase()
-        .as_str()
+        .to_ascii_lowercase();
+    // Component dialects come from the companion-extension registry.
+    if let Some(surface) =
+        codestory_contracts::language_support::companion_surface_language(&extension)
     {
-        "svelte" => "svelte",
-        "vue" => "vue",
-        "astro" => "astro",
+        return surface;
+    }
+    match extension.as_str() {
         "go" => "go",
         "rb" => "ruby",
         "php" => "php",
@@ -17636,6 +17046,9 @@ fn route_code_lines(language_name: &str, source: &str) -> Vec<String> {
 }
 
 fn route_language_uses_c_style_comments(language_name: &str) -> bool {
+    if let Some(extraction) = languages::extraction_for_language(language_name) {
+        return extraction.route_comments_are_c_style;
+    }
     matches!(
         language_name,
         "javascript"
@@ -17645,7 +17058,6 @@ fn route_language_uses_c_style_comments(language_name: &str) -> bool {
             | "go"
             | "php"
             | "csharp"
-            | "kotlin"
             | "dart"
             | "vue"
             | "astro"
@@ -20781,20 +20193,28 @@ pub fn index_file(
                     }
                     "call_syntax" => {
                         if let Ok(raw) = val.as_str() {
-                            callsite_marker = match raw.trim() {
-                                "python_attribute" => Some(PYTHON_ATTRIBUTE_CALLSITE_MARKER),
-                                "cpp_member" => Some(CPP_MEMBER_CALLSITE_MARKER),
-                                "go_selector" => Some(GO_SELECTOR_CALLSITE_MARKER),
-                                "java_member" => Some(JAVA_MEMBER_CALLSITE_MARKER),
-                                "csharp_member" => Some(CSHARP_MEMBER_CALLSITE_MARKER),
-                                "php_member" => Some(PHP_MEMBER_CALLSITE_MARKER),
-                                "js_member" => Some(JS_MEMBER_CALLSITE_MARKER),
-                                "ts_member" => Some(TS_MEMBER_CALLSITE_MARKER),
-                                "kotlin_member" => Some(KOTLIN_MEMBER_CALLSITE_MARKER),
-                                "dart_member" => Some(DART_MEMBER_CALLSITE_MARKER),
-                                "swift_member" => Some(SWIFT_MEMBER_CALLSITE_MARKER),
-                                _ => callsite_marker,
-                            };
+                            let raw = raw.trim();
+                            // Registry first; the arms below are the languages
+                            // whose markers have not moved into `languages`.
+                            callsite_marker =
+                                match languages::member_callsite_marker_for_call_syntax(raw) {
+                                    Some(marker) => Some(marker),
+                                    None => match raw {
+                                        "python_attribute" => {
+                                            Some(PYTHON_ATTRIBUTE_CALLSITE_MARKER)
+                                        }
+                                        "cpp_member" => Some(CPP_MEMBER_CALLSITE_MARKER),
+                                        "go_selector" => Some(GO_SELECTOR_CALLSITE_MARKER),
+                                        "java_member" => Some(JAVA_MEMBER_CALLSITE_MARKER),
+                                        "csharp_member" => Some(CSHARP_MEMBER_CALLSITE_MARKER),
+                                        "php_member" => Some(PHP_MEMBER_CALLSITE_MARKER),
+                                        "js_member" => Some(JS_MEMBER_CALLSITE_MARKER),
+                                        "ts_member" => Some(TS_MEMBER_CALLSITE_MARKER),
+                                        "dart_member" => Some(DART_MEMBER_CALLSITE_MARKER),
+                                        "swift_member" => Some(SWIFT_MEMBER_CALLSITE_MARKER),
+                                        _ => callsite_marker,
+                                    },
+                                };
                         }
                     }
                     _ => {}
@@ -26295,8 +25715,20 @@ class Test {
         assert_eq!(tsx.graph_query, TSX_GRAPH_QUERY);
         assert_eq!(tsx.tags_query, Some(TSX_TAGS_QUERY));
 
+        // Kotlin's rule file moved into `languages::kotlin`; the config must
+        // still come back through the same extension lookup.
         let kotlin = get_language_for_ext("kt").expect("kotlin config");
-        assert_eq!(kotlin.graph_query, KOTLIN_GRAPH_QUERY);
+        assert_eq!(kotlin.language_name, "kotlin");
+        assert_eq!(
+            kotlin.graph_query,
+            languages::extraction_for_ext("kt")
+                .expect("kotlin registry row")
+                .graph_query
+        );
+        assert!(kotlin.graph_query.contains("kotlin_member"));
+        assert!(kotlin.tags_query.is_none());
+        let kotlin_script = get_language_for_ext("kts").expect("kotlin script config");
+        assert_eq!(kotlin_script.graph_query, kotlin.graph_query);
 
         let swift = get_language_for_ext("swift").expect("swift config");
         assert_eq!(swift.graph_query, SWIFT_GRAPH_QUERY);
@@ -28313,6 +27745,37 @@ func (r *Route) Get(name string) interface{} { return r.namedRoutes[name] }
             mux_library_routes.is_empty(),
             "plain mux library methods should not be indexed as framework routes: {mux_library_routes:?}"
         );
+    }
+
+    /// Kotlin route scanning keeps stripping C-style comments after the
+    /// language's comment style moved into the extraction registry.
+    ///
+    /// `route_comments_are_c_style` is now a registry field rather than a name
+    /// in a `matches!` roster. Asserting the field's value alone would be a
+    /// tautology, so this drives the behaviour it controls: a commented-out
+    /// ktor route must not become a product route claim.
+    #[test]
+    fn kotlin_route_scanning_still_strips_c_style_comments() {
+        let source = r#"
+import io.ktor.server.routing.*
+fun Application.module() {
+  routing {
+    get("/ktor/live") { }
+    // get("/ktor/line-commented") { }
+    /*
+    post("/ktor/block-commented") { }
+    */
+  }
+}
+"#;
+        let routes = collect_framework_routes(Path::new("Routing.kt"), "kotlin", source);
+        let paths = routes
+            .iter()
+            .map(|route| route.path.as_str())
+            .collect::<HashSet<_>>();
+        assert!(paths.contains("/ktor/live"), "{routes:?}");
+        assert!(!paths.contains("/ktor/line-commented"), "{routes:?}");
+        assert!(!paths.contains("/ktor/block-commented"), "{routes:?}");
     }
 
     #[test]

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1357,7 +1357,7 @@ fn is_kotlin_member_call_placeholder(edge_kind: EdgeKind, callsite_identity: Opt
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::KOTLIN_MEMBER_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::kotlin::MEMBER_CALLSITE_MARKER)
     })
 }
 

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -379,7 +379,24 @@ pub(crate) fn detect_resolver_language(path: Option<&str>) -> Option<&'static st
 }
 
 fn semantic_resolver_for_path(path: Option<&str>) -> Option<SemanticResolverKind> {
-    match detect_resolver_language(path)? {
+    let language = detect_resolver_language(path)?;
+    // Registry first; the arms below are the languages that have not moved into
+    // `crate::languages` yet.
+    if let Some(extraction) = crate::languages::extraction_for_language(language) {
+        if extraction.uses_generic_semantic_resolver {
+            return Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
+                extraction.language_name,
+            )));
+        }
+        // The dedicated resolver types are private to this module, so the
+        // registry records the choice and the residual match builds it.
+        return dedicated_semantic_resolver(extraction.language_name);
+    }
+    dedicated_semantic_resolver(language)
+}
+
+fn dedicated_semantic_resolver(language: &str) -> Option<SemanticResolverKind> {
+    match language {
         "c" => Some(SemanticResolverKind::C(CSemanticResolver)),
         "cpp" => Some(SemanticResolverKind::Cpp(CppSemanticResolver)),
         "javascript" | "vue" | "svelte" | "astro" => {
@@ -393,9 +410,6 @@ fn semantic_resolver_for_path(path: Option<&str>) -> Option<SemanticResolverKind
         "ruby" => Some(SemanticResolverKind::Ruby(RubySemanticResolver)),
         "php" => Some(SemanticResolverKind::Php(PhpSemanticResolver)),
         "csharp" => Some(SemanticResolverKind::CSharp(CSharpSemanticResolver)),
-        "kotlin" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
-            "kotlin",
-        ))),
         "swift" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
             "swift",
         ))),
@@ -573,6 +587,9 @@ fn tail_component(value: &str) -> Option<&str> {
 }
 
 fn language_family_bucket(language: &'static str) -> &'static str {
+    if let Some(extraction) = crate::languages::extraction_for_language(language) {
+        return extraction.semantic_family;
+    }
     match language {
         "c" | "cpp" => "native",
         "javascript" | "typescript" | "vue" | "svelte" | "astro" => "webscript",
@@ -583,7 +600,6 @@ fn language_family_bucket(language: &'static str) -> &'static str {
         "ruby" => "ruby",
         "php" => "php",
         "csharp" => "csharp",
-        "kotlin" => "kotlin",
         "swift" => "swift",
         "dart" => "dart",
         "bash" => "bash",
@@ -799,6 +815,57 @@ mod tests {
             out.is_empty(),
             "unexpected cross-language candidates: {out:?}"
         );
+        Ok(())
+    }
+
+    /// Kotlin keeps its own semantic family after the bucket moved into the
+    /// extraction registry.
+    ///
+    /// The bucket is what stops a Kotlin caller from resolving onto a
+    /// same-named JavaScript declaration. Asserting the registry field's value
+    /// would be a tautology, so this drives the filter: the Kotlin caller must
+    /// see the Kotlin candidate and only the Kotlin candidate. Both halves
+    /// matter — a wrong bucket that merged Kotlin into `webscript` would flip
+    /// exactly these two assertions in opposite directions.
+    #[test]
+    fn kotlin_keeps_its_own_semantic_family_after_the_registry_move() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        create_node_table(&conn)?;
+        insert_file_node(&conn, 1, "Caller.kt")?;
+        insert_file_node(&conn, 2, "helper.js")?;
+        insert_file_node(&conn, 3, "Helper.kt")?;
+        for (id, file_id) in [(20_i64, 2_i64), (21_i64, 3_i64)] {
+            conn.execute(
+                "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    id,
+                    NodeKind::FUNCTION as i32,
+                    "persistRecord",
+                    "persistRecord",
+                    file_id,
+                    5_i64
+                ],
+            )?;
+        }
+
+        let index = SemanticCandidateIndex::load(&conn, &[NodeKind::FUNCTION as i32])?;
+        let out = resolve_call_candidates(
+            &index,
+            &[NodeKind::FUNCTION as i32],
+            "persistRecord",
+            Some(1),
+            detect_language(Some("Caller.kt")),
+            0.82,
+            0.70,
+        )?;
+
+        let ids = out
+            .iter()
+            .map(|candidate| candidate.target_node_id)
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![21_i64], "kotlin caller candidates: {out:?}");
+        assert_eq!(language_family_bucket("kotlin"), "kotlin");
         Ok(())
     }
 

--- a/crates/codestory-indexer/src/template_pipeline.rs
+++ b/crates/codestory-indexer/src/template_pipeline.rs
@@ -42,26 +42,22 @@ pub struct TemplatePrepareResult {
     pub style_blocks: Vec<StyleBlockRange>,
 }
 
+/// Surface language of a template file, from the companion-extension registry.
+///
+/// The extension list used to be repeated here and at three other call sites
+/// (ARCH-012). `codestory_contracts::language_support` owns it now.
+pub fn template_surface_language(path: &Path) -> Option<&'static str> {
+    let ext = path.extension().and_then(|value| value.to_str())?;
+    codestory_contracts::language_support::companion_surface_language(ext)
+}
+
 pub fn template_kind_for_path(path: &Path) -> Option<TemplateKind> {
-    let ext = path
-        .extension()
-        .and_then(|value| value.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    match ext.as_str() {
+    match template_surface_language(path)? {
         "vue" => Some(TemplateKind::Vue),
         "svelte" => Some(TemplateKind::Svelte),
         "astro" => Some(TemplateKind::Astro),
         _ => None,
     }
-}
-
-pub fn template_surface_language(path: &Path) -> Option<&'static str> {
-    template_kind_for_path(path).map(|kind| match kind {
-        TemplateKind::Vue => "vue",
-        TemplateKind::Svelte => "svelte",
-        TemplateKind::Astro => "astro",
-    })
 }
 
 pub fn prepare_template_source(kind: TemplateKind, source: &str) -> TemplatePrepareResult {
@@ -393,6 +389,42 @@ mod tests {
     use super::*;
     use crate::{get_language_for_ext, index_file};
     use std::path::Path;
+
+    /// Template routing must stay the exact three-dialect set it was before it
+    /// started reading the companion-extension registry.
+    ///
+    /// Widening it would send new file types through script blanking, and
+    /// `semantic::detect_language` reports whatever `template_surface_language`
+    /// returns, so a stray row here would attribute files to a language with no
+    /// parser behind it.
+    #[test]
+    fn template_routing_covers_exactly_the_blanked_component_dialects() {
+        for (path, kind, surface) in [
+            ("app/Widget.vue", Some(TemplateKind::Vue), Some("vue")),
+            ("app/Widget.VUE", Some(TemplateKind::Vue), Some("vue")),
+            (
+                "app/Widget.svelte",
+                Some(TemplateKind::Svelte),
+                Some("svelte"),
+            ),
+            ("app/Page.astro", Some(TemplateKind::Astro), Some("astro")),
+            ("app/Page.cshtml", None, None),
+            ("styles/app.scss", None, None),
+            ("styles/app.sass", None, None),
+            ("styles/app.less", None, None),
+            ("scripts/tool.lua", None, None),
+            ("app/Main.kt", None, None),
+            ("app/main.js", None, None),
+            ("Makefile", None, None),
+        ] {
+            assert_eq!(template_kind_for_path(Path::new(path)), kind, "{path}");
+            assert_eq!(
+                template_surface_language(Path::new(path)),
+                surface,
+                "{path}"
+            );
+        }
+    }
 
     fn symbol_line_col(result: &crate::IndexResult, name: &str) -> Option<(u32, u32)> {
         result

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/kotlin_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/kotlin_fidelity.txt
@@ -1,0 +1,49 @@
+node CLASS name=ConsoleNotifier qn=app.ConsoleNotifier canonical=<ROOT>/fidelity.kt:app.ConsoleNotifier line=9 col=1 end=13:2 file=FILE:<ROOT>/fidelity.kt@1
+node CLASS name=Event qn=app.Event canonical=<ROOT>/fidelity.kt:app.Event line=21 col=1 end=21:30 file=FILE:<ROOT>/fidelity.kt@1
+node CLASS name=Notifier qn=Notifier canonical=<ROOT>/fidelity.kt:Notifier line=9 col=25 end=9:33 file=FILE:<ROOT>/fidelity.kt@1
+node CLASS name=Repository qn=app.Repository canonical=<ROOT>/fidelity.kt:app.Repository line=15 col=1 end=19:2 file=FILE:<ROOT>/fidelity.kt@1
+node CLASS name=Workflow qn=app.Workflow canonical=<ROOT>/fidelity.kt:app.Workflow line=23 col=1 end=33:2 file=FILE:<ROOT>/fidelity.kt@1
+node FILE name=<ROOT>/fidelity.kt qn=<ROOT>/fidelity.kt canonical=<ROOT>/fidelity.kt:<ROOT>/fidelity.kt:1 line=1 col=1 end=39:0 file=FILE:<ROOT>/fidelity.kt@1
+node FUNCTION name=orchestrateKotlin qn=orchestrateKotlin canonical=<ROOT>/fidelity.kt:orchestrateKotlin#0 line=35 col=1 end=39:2 file=FILE:<ROOT>/fidelity.kt@1
+node INTERFACE name=Notifier qn=app.Notifier canonical=<ROOT>/fidelity.kt:app.Notifier line=5 col=1 end=7:2 file=FILE:<ROOT>/fidelity.kt@1
+node METHOD name=ConsoleNotifier.notify qn=app.ConsoleNotifier.notify canonical=<ROOT>/fidelity.kt:app.ConsoleNotifier.notify#0 line=10 col=5 end=12:6 file=FILE:<ROOT>/fidelity.kt@1
+node METHOD name=Notifier.notify qn=app.Notifier.notify canonical=<ROOT>/fidelity.kt:app.Notifier.notify#0 line=6 col=5 end=6:29 file=FILE:<ROOT>/fidelity.kt@1
+node METHOD name=Repository.save qn=app.Repository.save canonical=<ROOT>/fidelity.kt:app.Repository.save#0 line=16 col=5 end=18:6 file=FILE:<ROOT>/fidelity.kt@1
+node METHOD name=Workflow.decorate qn=app.Workflow.decorate canonical=<ROOT>/fidelity.kt:app.Workflow.decorate#0 line=30 col=5 end=32:6 file=FILE:<ROOT>/fidelity.kt@1
+node METHOD name=Workflow.run qn=app.Workflow.run canonical=<ROOT>/fidelity.kt:app.Workflow.run#0 line=24 col=5 end=28:6 file=FILE:<ROOT>/fidelity.kt@1
+node MODULE name=app qn=app canonical=<ROOT>/fidelity.kt:app#0 line=1 col=1 end=1:12 file=FILE:<ROOT>/fidelity.kt@1
+node MODULE name=kotlin.math.abs qn=kotlin.math.abs canonical=<ROOT>/fidelity.kt:kotlin.math.abs#0 line=3 col=8 end=3:23 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.kt:ConsoleNotifier#0 line=37 col=34 end=37:49 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=Event qn=Event canonical=<ROOT>/fidelity.kt:Event#0 line=37 col=18 end=37:23 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=Repository qn=Repository canonical=<ROOT>/fidelity.kt:Repository#0 line=37 col=53 end=37:63 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=Workflow qn=Workflow canonical=<ROOT>/fidelity.kt:Workflow#0 line=36 col=20 end=36:28 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=abs qn=abs canonical=<ROOT>/fidelity.kt:abs#0 line=38 col=5 end=38:8 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.kt:decorate#0 line=27 col=9 end=27:17 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.kt:notify#0 line=25 col=18 end=25:24 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=println qn=println canonical=<ROOT>/fidelity.kt:println#0 line=11 col=9 end=11:16 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=println qn=println canonical=<ROOT>/fidelity.kt:println#1 line=17 col=9 end=17:16 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.kt:run#0 line=37 col=14 end=37:17 file=FILE:<ROOT>/fidelity.kt@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.kt:save#0 line=26 col=20 end=26:24 file=FILE:<ROOT>/fidelity.kt@1
+edge CALL src=FUNCTION:orchestrateKotlin@35 dst=METHOD:Workflow.run@24 resolved_src=FUNCTION:orchestrateKotlin@35 resolved_dst=METHOD:Workflow.run@24 line=37 confidence=1.0000 certainty=Certain callsite=h0:37:1:h1 candidates=[]
+edge CALL src=FUNCTION:orchestrateKotlin@35 dst=UNKNOWN:ConsoleNotifier@37 resolved_src=FUNCTION:orchestrateKotlin@35 resolved_dst=- line=37 confidence=- certainty=- callsite=h0:37:1:h2 candidates=[]
+edge CALL src=FUNCTION:orchestrateKotlin@35 dst=UNKNOWN:Event@37 resolved_src=FUNCTION:orchestrateKotlin@35 resolved_dst=- line=37 confidence=- certainty=- callsite=h0:37:1:h3 candidates=[]
+edge CALL src=FUNCTION:orchestrateKotlin@35 dst=UNKNOWN:Repository@37 resolved_src=FUNCTION:orchestrateKotlin@35 resolved_dst=- line=37 confidence=- certainty=- callsite=h0:37:1:h4 candidates=[]
+edge CALL src=FUNCTION:orchestrateKotlin@35 dst=UNKNOWN:Workflow@36 resolved_src=FUNCTION:orchestrateKotlin@35 resolved_dst=- line=36 confidence=- certainty=- callsite=h0:36:1:h5 candidates=[]
+edge CALL src=FUNCTION:orchestrateKotlin@35 dst=UNKNOWN:abs@38 resolved_src=FUNCTION:orchestrateKotlin@35 resolved_dst=- line=38 confidence=- certainty=- callsite=h0:38:1:h6 candidates=[]
+edge CALL src=METHOD:ConsoleNotifier.notify@10 dst=UNKNOWN:println@11 resolved_src=METHOD:ConsoleNotifier.notify@10 resolved_dst=- line=11 confidence=- certainty=- callsite=h0:11:1:h7 candidates=[]
+edge CALL src=METHOD:Repository.save@16 dst=UNKNOWN:println@17 resolved_src=METHOD:Repository.save@16 resolved_dst=- line=17 confidence=- certainty=- callsite=h0:17:1:h8 candidates=[]
+edge CALL src=METHOD:Workflow.run@24 dst=METHOD:Notifier.notify@6 resolved_src=METHOD:Workflow.run@24 resolved_dst=METHOD:Notifier.notify@6 line=25 confidence=1.0000 certainty=Certain callsite=h0:25:1:h9 candidates=[]
+edge CALL src=METHOD:Workflow.run@24 dst=METHOD:Repository.save@16 resolved_src=METHOD:Workflow.run@24 resolved_dst=METHOD:Repository.save@16 line=26 confidence=1.0000 certainty=Certain callsite=h0:26:1:h10 candidates=[]
+edge CALL src=METHOD:Workflow.run@24 dst=UNKNOWN:decorate@27 resolved_src=METHOD:Workflow.run@24 resolved_dst=METHOD:Workflow.decorate@30 line=27 confidence=0.9500 certainty=Certain callsite=h0:27:1:h11 candidates=[]
+edge IMPORT src=MODULE:kotlin.math.abs@3 dst=MODULE:kotlin.math.abs@3 resolved_src=MODULE:kotlin.math.abs@3 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ConsoleNotifier@9 dst=CLASS:Notifier@9 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@9 dst=METHOD:ConsoleNotifier.notify@10 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@15 dst=METHOD:Repository.save@16 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@23 dst=METHOD:Workflow.decorate@30 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@23 dst=METHOD:Workflow.run@24 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Notifier@5 dst=METHOD:Notifier.notify@6 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:app@1 dst=CLASS:ConsoleNotifier@9 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:app@1 dst=CLASS:Event@21 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:app@1 dst=CLASS:Repository@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:app@1 dst=CLASS:Workflow@23 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:app@1 dst=INTERFACE:Notifier@5 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/kotlin_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/kotlin_tictactoe.txt
@@ -1,0 +1,115 @@
+node CLASS name=ArtificialPlayer qn=tictactoe.ArtificialPlayer canonical=game.kt:tictactoe.ArtificialPlayer line=46 col=1 end=58:2 file=FILE:game.kt@1
+node CLASS name=Field qn=tictactoe.Field canonical=game.kt:tictactoe.Field line=19 col=1 end=34:2 file=FILE:game.kt@1
+node CLASS name=GameObject qn=GameObject canonical=game.kt:GameObject line=19 col=15 end=19:25 file=FILE:game.kt@1
+node CLASS name=GameObject qn=tictactoe.GameObject canonical=game.kt:tictactoe.GameObject line=15 col=1 end=17:2 file=FILE:game.kt@1
+node CLASS name=HumanPlayer qn=tictactoe.HumanPlayer canonical=game.kt:tictactoe.HumanPlayer line=40 col=1 end=44:2 file=FILE:game.kt@1
+node CLASS name=Player qn=Player canonical=game.kt:Player line=40 col=21 end=40:27 file=FILE:game.kt@1
+node CLASS name=TicTacToe qn=tictactoe.TicTacToe canonical=game.kt:tictactoe.TicTacToe line=60 col=1 end=68:2 file=FILE:game.kt@1
+node FILE name=game.kt qn=game.kt canonical=game.kt:game.kt:1 line=1 col=1 end=73:0 file=FILE:game.kt@1
+node FUNCTION name=main qn=main canonical=game.kt:main#0 line=70 col=1 end=73:2 file=FILE:game.kt@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.kt:numberIn#0 line=5 col=1 end=5:24 file=FILE:game.kt@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.kt:numberOut#0 line=7 col=1 end=9:2 file=FILE:game.kt@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.kt:stringOut#0 line=11 col=1 end=13:2 file=FILE:game.kt@1
+node INTERFACE name=Player qn=tictactoe.Player canonical=game.kt:tictactoe.Player line=36 col=1 end=38:2 file=FILE:game.kt@1
+node METHOD name=ArtificialPlayer.minMax qn=tictactoe.ArtificialPlayer.minMax canonical=game.kt:tictactoe.ArtificialPlayer.minMax#0 line=47 col=5 end=52:6 file=FILE:game.kt@1
+node METHOD name=ArtificialPlayer.turn qn=tictactoe.ArtificialPlayer.turn canonical=game.kt:tictactoe.ArtificialPlayer.turn#0 line=54 col=5 end=57:6 file=FILE:game.kt@1
+node METHOD name=Field.makeMove qn=tictactoe.Field.makeMove canonical=game.kt:tictactoe.Field.makeMove#0 line=26 col=5 end=33:6 file=FILE:game.kt@1
+node METHOD name=Field.sameInRow qn=tictactoe.Field.sameInRow canonical=game.kt:tictactoe.Field.sameInRow#0 line=22 col=5 end=24:6 file=FILE:game.kt@1
+node METHOD name=GameObject.announce qn=tictactoe.GameObject.announce canonical=game.kt:tictactoe.GameObject.announce#0 line=16 col=5 end=16:22 file=FILE:game.kt@1
+node METHOD name=HumanPlayer.turn qn=tictactoe.HumanPlayer.turn canonical=game.kt:tictactoe.HumanPlayer.turn#0 line=41 col=5 end=43:6 file=FILE:game.kt@1
+node METHOD name=Player.turn qn=tictactoe.Player.turn canonical=game.kt:tictactoe.Player.turn#0 line=37 col=5 end=37:48 file=FILE:game.kt@1
+node METHOD name=TicTacToe.run qn=tictactoe.TicTacToe.run canonical=game.kt:tictactoe.TicTacToe.run#0 line=63 col=5 end=67:6 file=FILE:game.kt@1
+node MODULE name=kotlin.random.Random qn=kotlin.random.Random canonical=game.kt:kotlin.random.Random#0 line=3 col=8 end=3:28 file=FILE:game.kt@1
+node MODULE name=tictactoe qn=tictactoe canonical=game.kt:tictactoe#0 line=1 col=1 end=1:18 file=FILE:game.kt@1
+node UNKNOWN name=Field qn=Field canonical=game.kt:Field#0 line=61 col=17 end=61:22 file=FILE:game.kt@1
+node UNKNOWN name=TicTacToe qn=TicTacToe canonical=game.kt:TicTacToe#0 line=71 col=16 end=71:25 file=FILE:game.kt@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.kt:makeMove#0 line=42 col=22 end=42:30 file=FILE:game.kt@1
+node UNKNOWN name=minMax qn=minMax canonical=game.kt:minMax#0 line=51 col=16 end=51:22 file=FILE:game.kt@1
+node UNKNOWN name=minMax qn=minMax canonical=game.kt:minMax#1 line=55 col=9 end=55:15 file=FILE:game.kt@1
+node UNKNOWN name=nextInt qn=nextInt canonical=game.kt:nextInt#0 line=66 col=16 end=66:23 file=FILE:game.kt@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.kt:numberIn#1 line=64 col=9 end=64:17 file=FILE:game.kt@1
+node UNKNOWN name=println qn=println canonical=game.kt:println#0 line=8 col=5 end=8:12 file=FILE:game.kt@1
+node UNKNOWN name=println qn=println canonical=game.kt:println#1 line=12 col=5 end=12:12 file=FILE:game.kt@1
+node UNKNOWN name=run qn=run canonical=game.kt:run#0 line=72 col=10 end=72:13 file=FILE:game.kt@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.kt:sameInRow#0 line=31 col=9 end=31:18 file=FILE:game.kt@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.kt:stringOut#1 line=65 col=9 end=65:18 file=FILE:game.kt@1
+edge CALL src=FUNCTION:main@70 dst=METHOD:TicTacToe.run@63 resolved_src=- resolved_dst=METHOD:TicTacToe.run@63 line=72 confidence=1.0000 certainty=Certain callsite=h0:72:1:h1 candidates=[]
+edge CALL src=FUNCTION:main@70 dst=UNKNOWN:TicTacToe@71 resolved_src=- resolved_dst=- line=71 confidence=- certainty=- callsite=h0:71:1:h2 candidates=[]
+edge CALL src=FUNCTION:numberOut@7 dst=UNKNOWN:println@8 resolved_src=- resolved_dst=- line=8 confidence=- certainty=- callsite=h0:8:1:h3 candidates=[]
+edge CALL src=FUNCTION:stringOut@11 dst=UNKNOWN:println@12 resolved_src=- resolved_dst=- line=12 confidence=- certainty=- callsite=h0:12:1:h4 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@47 dst=UNKNOWN:minMax@51 resolved_src=- resolved_dst=- line=51 confidence=- certainty=- callsite=h0:51:1:h5 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@54 dst=UNKNOWN:minMax@55 resolved_src=- resolved_dst=- line=55 confidence=- certainty=- callsite=h0:55:1:h6 candidates=[]
+edge CALL src=METHOD:Field.makeMove@26 dst=UNKNOWN:sameInRow@31 resolved_src=- resolved_dst=- line=31 confidence=- certainty=- callsite=h0:31:1:h7 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@41 dst=METHOD:Field.makeMove@26 resolved_src=- resolved_dst=METHOD:Field.makeMove@26 line=42 confidence=1.0000 certainty=Certain callsite=h0:42:1:h8 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@63 dst=UNKNOWN:nextInt@66 resolved_src=- resolved_dst=- line=66 confidence=- certainty=- callsite=h0:66:1:h9|syntax:kotlin-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@63 dst=UNKNOWN:numberIn@64 resolved_src=- resolved_dst=- line=64 confidence=- certainty=- callsite=h0:64:1:h10 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@63 dst=UNKNOWN:stringOut@65 resolved_src=- resolved_dst=- line=65 confidence=- certainty=- callsite=h0:65:1:h11 candidates=[]
+edge IMPORT src=MODULE:kotlin.random.Random@3 dst=MODULE:kotlin.random.Random@3 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ArtificialPlayer@46 dst=CLASS:Player@40 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@19 dst=CLASS:GameObject@19 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:HumanPlayer@40 dst=CLASS:Player@40 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:TicTacToe@60 dst=CLASS:GameObject@19 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@46 dst=METHOD:ArtificialPlayer.minMax@47 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@46 dst=METHOD:ArtificialPlayer.turn@54 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@19 dst=METHOD:Field.makeMove@26 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@19 dst=METHOD:Field.sameInRow@22 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:GameObject@15 dst=METHOD:GameObject.announce@16 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@40 dst=METHOD:HumanPlayer.turn@41 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@60 dst=METHOD:TicTacToe.run@63 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Player@36 dst=METHOD:Player.turn@37 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:tictactoe@1 dst=CLASS:ArtificialPlayer@46 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:tictactoe@1 dst=CLASS:Field@19 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:tictactoe@1 dst=CLASS:GameObject@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:tictactoe@1 dst=CLASS:HumanPlayer@40 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:tictactoe@1 dst=CLASS:TicTacToe@60 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=MODULE:tictactoe@1 dst=INTERFACE:Player@36 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.kt language=kotlin lines=73 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@46 kind=DEFINITION span=46:1-58:2
+occurrence element=CLASS:Field@19 kind=DEFINITION span=19:1-34:2
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=15:1-17:2
+occurrence element=CLASS:GameObject@19 kind=DEFINITION span=19:15-19:25
+occurrence element=CLASS:GameObject@19 kind=DEFINITION span=60:19-60:29
+occurrence element=CLASS:HumanPlayer@40 kind=DEFINITION span=40:1-44:2
+occurrence element=CLASS:Player@40 kind=DEFINITION span=40:21-40:27
+occurrence element=CLASS:Player@40 kind=DEFINITION span=46:26-46:32
+occurrence element=CLASS:TicTacToe@60 kind=DEFINITION span=60:1-68:2
+occurrence element=FUNCTION:main@70 kind=DEFINITION span=70:1-73:2
+occurrence element=FUNCTION:numberIn@5 kind=DEFINITION span=5:1-5:24
+occurrence element=FUNCTION:numberOut@7 kind=DEFINITION span=7:1-9:2
+occurrence element=FUNCTION:stringOut@11 kind=DEFINITION span=11:1-13:2
+occurrence element=INTERFACE:Player@36 kind=DEFINITION span=36:1-38:2
+occurrence element=METHOD:ArtificialPlayer.minMax@47 kind=DEFINITION span=47:5-52:6
+occurrence element=METHOD:ArtificialPlayer.turn@54 kind=DEFINITION span=54:5-57:6
+occurrence element=METHOD:Field.makeMove@26 kind=DEFINITION span=26:5-33:6
+occurrence element=METHOD:Field.sameInRow@22 kind=DEFINITION span=22:5-24:6
+occurrence element=METHOD:GameObject.announce@16 kind=DEFINITION span=16:5-16:22
+occurrence element=METHOD:HumanPlayer.turn@41 kind=DEFINITION span=41:5-43:6
+occurrence element=METHOD:Player.turn@37 kind=DEFINITION span=37:5-37:48
+occurrence element=METHOD:TicTacToe.run@63 kind=DEFINITION span=63:5-67:6
+occurrence element=MODULE:kotlin.random.Random@3 kind=DEFINITION span=3:8-3:28
+occurrence element=MODULE:tictactoe@1 kind=DEFINITION span=1:1-1:18
+occurrence element=UNKNOWN:Field@61 kind=DEFINITION span=61:17-61:22
+occurrence element=UNKNOWN:TicTacToe@71 kind=DEFINITION span=71:16-71:25
+occurrence element=UNKNOWN:makeMove@42 kind=DEFINITION span=42:22-42:30
+occurrence element=UNKNOWN:minMax@51 kind=DEFINITION span=51:16-51:22
+occurrence element=UNKNOWN:minMax@55 kind=DEFINITION span=55:9-55:15
+occurrence element=UNKNOWN:nextInt@66 kind=DEFINITION span=66:16-66:23
+occurrence element=UNKNOWN:numberIn@64 kind=DEFINITION span=64:9-64:17
+occurrence element=UNKNOWN:println@12 kind=DEFINITION span=12:5-12:12
+occurrence element=UNKNOWN:println@8 kind=DEFINITION span=8:5-8:12
+occurrence element=UNKNOWN:run@72 kind=DEFINITION span=72:10-72:13
+occurrence element=UNKNOWN:sameInRow@31 kind=DEFINITION span=31:9-31:18
+occurrence element=UNKNOWN:stringOut@65 kind=DEFINITION span=65:9-65:18
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "13:main", node_id: NodeId(-3269461739909379704), signature_hash: -4671339478033693080, normalized_signature: Some("shape:-2692651601011948422"), body_hash: -8673273081720969995, start_line: 70, end_line: 73 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "13:numberIn", node_id: NodeId(3089308516238638639), signature_hash: 2477812878330356949, normalized_signature: Some("outline:-1793518511152586733"), body_hash: 7459896940976823828, start_line: 5, end_line: 5 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "13:numberOut", node_id: NodeId(-3709840166360608430), signature_hash: -1579019679195996938, normalized_signature: Some("shape:-1605510924220694893"), body_hash: 2936401094215417944, start_line: 7, end_line: 9 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "13:stringOut", node_id: NodeId(-4149573940085942370), signature_hash: -5818630870471287222, normalized_signature: Some("shape:1309767868204554717"), body_hash: -4220344892772128265, start_line: 11, end_line: 13 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "14:tictactoe.ArtificialPlayer.minMax", node_id: NodeId(-5761633344270872004), signature_hash: 7923513529814909507, normalized_signature: Some("shape:1015635496070560885"), body_hash: 4242977279514388040, start_line: 47, end_line: 52 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "14:tictactoe.ArtificialPlayer.turn", node_id: NodeId(5137820935137696609), signature_hash: 7173012715314331748, normalized_signature: Some("shape:8113778084223192606"), body_hash: 3184914660125496680, start_line: 54, end_line: 57 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "14:tictactoe.Field.makeMove", node_id: NodeId(-7313089341527803310), signature_hash: 5427009982719951223, normalized_signature: Some("shape:5939635087886849543"), body_hash: 8577733092547693783, start_line: 26, end_line: 33 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "14:tictactoe.Field.sameInRow", node_id: NodeId(-3798522297738322762), signature_hash: 13991502958346549, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -3596774140282798074, start_line: 22, end_line: 24 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "14:tictactoe.GameObject.announce", node_id: NodeId(6989368840253805161), signature_hash: -8484686843331876212, normalized_signature: Some("outline:-5083272169020481154"), body_hash: 5649390043764946485, start_line: 16, end_line: 16 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "14:tictactoe.HumanPlayer.turn", node_id: NodeId(6083351942803539678), signature_hash: 8396526627782628803, normalized_signature: Some("shape:8849405336717584789"), body_hash: 86375802672240801, start_line: 41, end_line: 43 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "14:tictactoe.Player.turn", node_id: NodeId(1806542613209924669), signature_hash: 3751145040262998084, normalized_signature: Some("outline:-5083272169020481154"), body_hash: -3888748658543768978, start_line: 37, end_line: 37 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "14:tictactoe.TicTacToe.run", node_id: NodeId(3180349830509067196), signature_hash: 7756538164283989331, normalized_signature: Some("shape:6107906801655771678"), body_hash: 2516058718679896838, start_line: 63, end_line: 67 }
+callable_state CallableProjectionState { file_id: -3740202488659960972, symbol_key: "__file_structural__", node_id: NodeId(-3740202488659960972), signature_hash: 553768115714561381, normalized_signature: None, body_hash: 741816125663691004, start_line: 1, end_line: 73 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -1,0 +1,419 @@
+//! Byte-exact projection snapshots for languages whose extraction rules have
+//! been moved out of the indexer god file into `src/languages/<lang>.rs`.
+//!
+//! `fidelity_regression` and `tictactoe_language_coverage` are threshold tests:
+//! they assert minimum counts and the presence of required names, so a move
+//! that silently *added* nodes, dropped a callsite marker, changed a qualified
+//! name, or lost a resolved owner still passes them. This file pins the whole
+//! rendered projection of the same two fixtures instead, which is what the S3
+//! contract actually requires ("outputs equal before and after the move").
+//!
+//! Two indexing paths are captured on purpose, because they exercise different
+//! halves of a language's rules:
+//!
+//! * the `fidelity_lab` fixture through the full store pipeline
+//!   (`WorkspaceIndexer::run_incremental`), which runs call resolution and so
+//!   covers the manual receiver-call engine and its resolved owners; and
+//! * the `tictactoe` fixture through raw `index_file`, which covers the
+//!   tree-sitter rule file, occurrences, and component access without any
+//!   resolution on top.
+//!
+//! Sibling packages (#1677-#1691) add one `SnapshotCase` row plus two golden
+//! files; they do not change this harness. To produce a new golden, run the
+//! failing assertion and copy its `left` value into the fixture — the goldens
+//! are never written by the test itself, so a regression cannot bless itself.
+
+use anyhow::{Result, anyhow};
+use codestory_contracts::events::EventBus;
+use codestory_contracts::graph::{AccessKind, Edge, Node, NodeId};
+use codestory_indexer::{IndexResult, WorkspaceIndexer, get_language_for_ext, index_file};
+use codestory_store::Store as Storage;
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+struct SnapshotCase {
+    /// Registry language name, used only for failure messages.
+    language: &'static str,
+    /// Extension routed through the language registry.
+    extension: &'static str,
+    fidelity_filename: &'static str,
+    fidelity_source: &'static str,
+    fidelity_golden: &'static str,
+    tictactoe_filename: &'static str,
+    tictactoe_source: &'static str,
+    tictactoe_golden: &'static str,
+}
+
+const CASES: &[SnapshotCase] = &[SnapshotCase {
+    language: "kotlin",
+    extension: "kt",
+    fidelity_filename: "fidelity.kt",
+    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+    tictactoe_filename: "game.kt",
+    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+}];
+
+#[test]
+fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {
+    for case in CASES {
+        let (nodes, edges, root) =
+            index_through_store(case.fidelity_filename, case.fidelity_source)?;
+        let rendered = render_resolved_projection(&nodes, &edges, &root);
+        assert_eq!(
+            rendered.trim_end(),
+            case.fidelity_golden.trim_end(),
+            "{} fidelity_lab projection changed; the S3 move must be output-equal",
+            case.language
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn moved_language_rules_keep_the_tictactoe_projection_byte_identical() -> Result<()> {
+    for case in CASES {
+        let result = index_raw(
+            case.extension,
+            case.tictactoe_filename,
+            case.tictactoe_source,
+        )?;
+        let rendered = render_index_result(&result);
+        assert_eq!(
+            rendered.trim_end(),
+            case.tictactoe_golden.trim_end(),
+            "{} tictactoe projection changed; the S3 move must be output-equal",
+            case.language
+        );
+    }
+    Ok(())
+}
+
+/// The golden files must actually describe the fixture, not an empty run.
+///
+/// A snapshot harness whose fixture silently stopped producing a graph would
+/// otherwise keep comparing two empty strings forever.
+#[test]
+fn snapshot_goldens_are_non_trivial() {
+    for case in CASES {
+        let fidelity_edges = case
+            .fidelity_golden
+            .lines()
+            .filter(|line| line.starts_with("edge "))
+            .count();
+        let tictactoe_edges = case
+            .tictactoe_golden
+            .lines()
+            .filter(|line| line.starts_with("edge "))
+            .count();
+        assert!(
+            case.fidelity_golden
+                .lines()
+                .filter(|line| line.starts_with("node "))
+                .count()
+                >= 10
+                && fidelity_edges >= 5,
+            "{} fidelity golden is too small to prove anything",
+            case.language
+        );
+        assert!(
+            case.tictactoe_golden
+                .lines()
+                .filter(|line| line.starts_with("node "))
+                .count()
+                >= 15
+                && tictactoe_edges >= 12,
+            "{} tictactoe golden is too small to prove anything",
+            case.language
+        );
+    }
+}
+
+/// Index one file through the full store pipeline.
+///
+/// The third element is the temporary root, which appears inside canonical ids
+/// and file-node names and must be normalized out before comparison.
+fn index_through_store(filename: &str, contents: &str) -> Result<(Vec<Node>, Vec<Edge>, String)> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join(filename);
+    fs::write(&file_path, contents)?;
+
+    let mut storage = Storage::new_in_memory()?;
+    let indexer = WorkspaceIndexer::new(root.to_path_buf());
+    let event_bus = EventBus::new();
+
+    let refresh_info = codestory_workspace::RefreshInfo {
+        mode: codestory_workspace::BuildMode::Incremental,
+        files_to_index: vec![file_path],
+        files_to_remove: vec![],
+        existing_file_ids: HashMap::new(),
+    };
+
+    indexer.run_incremental(&mut storage, &refresh_info, &event_bus, None)?;
+
+    let errors = storage.get_errors(None)?;
+    anyhow::ensure!(
+        errors.is_empty(),
+        "indexing errors for `{filename}`: {errors:?}"
+    );
+
+    Ok((
+        storage.get_nodes()?,
+        storage.get_edges()?,
+        root.to_string_lossy().replace('\\', "/"),
+    ))
+}
+
+fn index_raw(extension: &str, filename: &str, source: &str) -> Result<IndexResult> {
+    let language_config = get_language_for_ext(extension)
+        .ok_or_else(|| anyhow!("no language mapping for extension `{extension}`"))?;
+    index_file(Path::new(filename), source, &language_config, None, None)
+        .map_err(|error| anyhow!("indexing failed for `{filename}`: {error}"))
+}
+
+/// Node identity independent of assignment order.
+///
+/// Snapshotting raw `NodeId`s would make the golden depend on hash-map
+/// iteration order rather than on the extraction rules.
+fn node_label(nodes: &HashMap<NodeId, &Node>, id: NodeId) -> String {
+    match nodes.get(&id) {
+        Some(node) => format!(
+            "{:?}:{}@{}",
+            node.kind,
+            node.serialized_name,
+            node.start_line.unwrap_or(0)
+        ),
+        None => format!("<missing:{}>", id.0),
+    }
+}
+
+/// Replace the run-specific temporary root so the golden is stable, then sort.
+///
+/// Normalization has to happen before the sort: the temporary directory name is
+/// random, and sorting raw lines would let it decide the order of any two lines
+/// that only differ inside a path.
+fn emit_sorted(lines: Vec<String>, temp_root: &str, out: &mut String) {
+    let mut lines = lines
+        .into_iter()
+        .map(|line| {
+            let line = line.replace('\\', "/");
+            if temp_root.is_empty() {
+                line
+            } else {
+                line.replace(temp_root, "<ROOT>")
+            }
+        })
+        .collect::<Vec<_>>();
+    lines.sort();
+    for line in lines {
+        out.push_str(&line);
+        out.push('\n');
+    }
+}
+
+fn render_nodes(nodes: &[Node], temp_root: &str, out: &mut String) {
+    let by_id: HashMap<NodeId, &Node> = nodes.iter().map(|node| (node.id, node)).collect();
+    let lines = nodes
+        .iter()
+        .map(|node| {
+            format!(
+                "node {:?} name={} qn={} canonical={} line={} col={} end={}:{} file={}",
+                node.kind,
+                node.serialized_name,
+                node.qualified_name.as_deref().unwrap_or("-"),
+                node.canonical_id.as_deref().unwrap_or("-"),
+                node.start_line.unwrap_or(0),
+                node.start_col.unwrap_or(0),
+                node.end_line.unwrap_or(0),
+                node.end_col.unwrap_or(0),
+                node.file_node_id
+                    .map(|id| node_label(&by_id, id))
+                    .unwrap_or_else(|| "-".to_string()),
+            )
+        })
+        .collect::<Vec<_>>();
+    emit_sorted(lines, temp_root, out);
+}
+
+fn render_edges(nodes: &[Node], edges: &[Edge], temp_root: &str, out: &mut String) {
+    let by_id: HashMap<NodeId, &Node> = nodes.iter().map(|node| (node.id, node)).collect();
+    let lines = edges
+        .iter()
+        .map(|edge| {
+            format!(
+                "edge {:?} src={} dst={} resolved_src={} resolved_dst={} line={} confidence={} certainty={} callsite={} candidates=[{}]",
+                edge.kind,
+                node_label(&by_id, edge.source),
+                node_label(&by_id, edge.target),
+                edge.resolved_source
+                    .map(|id| node_label(&by_id, id))
+                    .unwrap_or_else(|| "-".to_string()),
+                edge.resolved_target
+                    .map(|id| node_label(&by_id, id))
+                    .unwrap_or_else(|| "-".to_string()),
+                edge.line.unwrap_or(0),
+                edge.confidence
+                    .map(|value| format!("{value:.4}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                edge.certainty
+                    .map(|value| format!("{value:?}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                edge.callsite_identity.as_deref().unwrap_or("-"),
+                {
+                    let mut candidates = edge
+                        .candidate_targets
+                        .iter()
+                        .map(|id| node_label(&by_id, *id))
+                        .collect::<Vec<_>>();
+                    candidates.sort();
+                    candidates.join(",")
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut rendered = String::new();
+    emit_sorted(lines, temp_root, &mut rendered);
+    out.push_str(&normalize_callsite_hashes(&rendered));
+}
+
+/// Replace the 64-bit hash components of `callsite_identity` with dense tokens.
+///
+/// The identity is `<file-hash>:<line>:<col>:<callsite-hash>` and both hashes
+/// are derived from the file's *absolute* path, which is a fresh temporary
+/// directory on every run. Masking the raw values keeps the golden stable while
+/// preserving everything the contract cares about: how many distinct callsite
+/// identities exist, which edges share one (a collision would show up as a
+/// repeated token), and the line and column they carry.
+fn normalize_callsite_hashes(rendered: &str) -> String {
+    let mut assigned: Vec<String> = Vec::new();
+    let mut out = String::new();
+    for line in rendered.lines() {
+        let Some((head, rest)) = line.split_once("callsite=") else {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        };
+        let (identity, tail) = rest.split_once(' ').unwrap_or((rest, ""));
+        let masked = identity
+            .split(':')
+            .map(|component| {
+                // A syntax marker rides the last component as `<hash>|syntax:...`;
+                // mask the hash and keep the marker verbatim, because the marker
+                // is exactly the per-language fact this snapshot must pin.
+                let (number, suffix) = match component.split_once('|') {
+                    Some((number, suffix)) => (number, Some(suffix)),
+                    None => (component, None),
+                };
+                let masked = match number.parse::<i64>() {
+                    Ok(value) if value.abs() >= 1_000_000_000 => {
+                        let index = match assigned.iter().position(|seen| seen == number) {
+                            Some(index) => index,
+                            None => {
+                                assigned.push(number.to_string());
+                                assigned.len() - 1
+                            }
+                        };
+                        format!("h{index}")
+                    }
+                    _ => number.to_string(),
+                };
+                match suffix {
+                    Some(suffix) => format!("{masked}|{suffix}"),
+                    None => masked,
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(":");
+        out.push_str(head);
+        out.push_str("callsite=");
+        out.push_str(&masked);
+        if !tail.is_empty() {
+            out.push(' ');
+            out.push_str(tail);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn render_resolved_projection(nodes: &[Node], edges: &[Edge], temp_root: &str) -> String {
+    let mut out = String::new();
+    render_nodes(nodes, temp_root, &mut out);
+    render_edges(nodes, edges, temp_root, &mut out);
+    out
+}
+
+fn render_index_result(result: &IndexResult) -> String {
+    let mut out = String::new();
+    render_nodes(&result.nodes, "", &mut out);
+    render_edges(&result.nodes, &result.edges, "", &mut out);
+
+    let by_id: HashMap<NodeId, &Node> = result.nodes.iter().map(|node| (node.id, node)).collect();
+
+    let files = result
+        .files
+        .iter()
+        .map(|file| {
+            format!(
+                "file path={} language={} lines={} complete={} role={:?}",
+                file.path.to_string_lossy().replace('\\', "/"),
+                file.language,
+                file.line_count,
+                file.complete,
+                file.file_role,
+            )
+        })
+        .collect::<Vec<_>>();
+    emit_sorted(files, "", &mut out);
+
+    let occurrences = result
+        .occurrences
+        .iter()
+        .map(|occurrence| {
+            format!(
+                "occurrence element={} kind={:?} span={}:{}-{}:{}",
+                node_label(&by_id, NodeId(occurrence.element_id)),
+                occurrence.kind,
+                occurrence.location.start_line,
+                occurrence.location.start_col,
+                occurrence.location.end_line,
+                occurrence.location.end_col,
+            )
+        })
+        .collect::<Vec<_>>();
+    emit_sorted(occurrences, "", &mut out);
+
+    let access = result
+        .component_access
+        .iter()
+        .map(|(id, access): &(NodeId, AccessKind)| {
+            format!("access node={} kind={access:?}", node_label(&by_id, *id))
+        })
+        .collect::<Vec<_>>();
+    emit_sorted(access, "", &mut out);
+
+    let anchors = result
+        .impl_anchor_node_ids
+        .iter()
+        .map(|id| format!("impl_anchor node={}", node_label(&by_id, *id)))
+        .collect::<Vec<_>>();
+    emit_sorted(anchors, "", &mut out);
+
+    let states = result
+        .callable_projection_states
+        .iter()
+        .map(|state| {
+            let mut line = String::new();
+            let _ = write!(line, "callable_state {state:?}");
+            line
+        })
+        .collect::<Vec<_>>();
+    emit_sorted(states, "", &mut out);
+
+    out
+}

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -2032,6 +2032,14 @@ fn source_group_accepts_registry_language(language: &Language, registry_language
             | (&Language::Kotlin, "kotlin")
             | (&Language::Swift, "swift")
             | (&Language::Dart, "dart")
+            // Companion-extension source groups. These names never come back
+            // from `language_support_profile_for_ext`, so they cannot widen
+            // `registry_extension_matches_source_group`; they exist so the
+            // companion table can name a source group by language name.
+            | (&Language::Lua, "lua")
+            | (&Language::Svelte, "svelte")
+            | (&Language::Vue, "vue")
+            | (&Language::Astro, "astro")
             | (&Language::Sql, "sql")
             | (&Language::Html, "html")
             | (&Language::Css, "css")
@@ -2045,17 +2053,20 @@ fn source_group_accepts_registry_language(language: &Language, registry_language
     )
 }
 
+/// Template and style extensions that a registered language's source group
+/// accepts without being a public claim of their own.
+///
+/// The (language, extension) cross product used to be spelled out here and
+/// repeated in the indexer and the CLI (ARCH-012); the extension table now
+/// lives in `codestory_contracts::language_support`.
 fn compatibility_extension_matches_source_group(extension: &str, language: &Language) -> bool {
-    matches!(
-        (language, extension),
-        (&Language::JavaScript, "svelte" | "vue" | "astro")
-            | (&Language::TypeScript, "svelte" | "vue" | "astro")
-            | (&Language::CSharp, "cshtml")
-            | (&Language::Lua, "lua")
-            | (&Language::Css, "scss" | "sass" | "less")
-            | (&Language::Svelte, "svelte")
-            | (&Language::Vue, "vue")
-            | (&Language::Astro, "astro")
+    codestory_contracts::language_support::companion_extension_profile(extension).is_some_and(
+        |profile| {
+            profile
+                .source_group_languages
+                .iter()
+                .any(|group| source_group_accepts_registry_language(language, group))
+        },
     )
 }
 
@@ -3481,6 +3492,98 @@ mod tests {
                 matches_source_group_language(Path::new(&file_name), &language),
                 "compatibility-only source extension should stay accepted by workspace discovery: {extension}"
             );
+        }
+    }
+
+    /// The registry-driven companion match must accept exactly the pairs the
+    /// hand-written cross product accepted — no more, no fewer.
+    ///
+    /// The positive direction alone is not enough: routing this through a
+    /// registry could widen discovery (a `.scss` file entering the JavaScript
+    /// source group, say), and discovery admission decides what gets indexed.
+    /// The expected set below is the pre-move table restated literally.
+    #[test]
+    fn companion_extension_source_groups_match_the_hand_written_cross_product() {
+        const EXPECTED: &[(&str, &[&str])] = &[
+            ("vue", &["JavaScript", "TypeScript", "Vue"]),
+            ("svelte", &["JavaScript", "TypeScript", "Svelte"]),
+            ("astro", &["JavaScript", "TypeScript", "Astro"]),
+            ("cshtml", &["CSharp"]),
+            ("lua", &["Lua"]),
+            ("scss", &["Css"]),
+            ("sass", &["Css"]),
+            ("less", &["Css"]),
+        ];
+        let all_languages = [
+            ("Cxx", Language::Cxx),
+            ("Java", Language::Java),
+            ("Python", Language::Python),
+            ("Rust", Language::Rust),
+            ("JavaScript", Language::JavaScript),
+            ("TypeScript", Language::TypeScript),
+            ("Go", Language::Go),
+            ("Ruby", Language::Ruby),
+            ("Php", Language::Php),
+            ("CSharp", Language::CSharp),
+            ("Kotlin", Language::Kotlin),
+            ("Swift", Language::Swift),
+            ("Dart", Language::Dart),
+            ("Lua", Language::Lua),
+            ("Sql", Language::Sql),
+            ("Html", Language::Html),
+            ("Css", Language::Css),
+            ("Bash", Language::Bash),
+            ("Shell", Language::Shell),
+            ("PowerShell", Language::PowerShell),
+            ("Markdown", Language::Markdown),
+            ("Yaml", Language::Yaml),
+            ("Toml", Language::Toml),
+            ("Json", Language::Json),
+            ("Svelte", Language::Svelte),
+            ("Vue", Language::Vue),
+            ("Astro", Language::Astro),
+        ];
+
+        let declared = codestory_contracts::language_support::COMPANION_EXTENSION_PROFILES
+            .iter()
+            .map(|profile| profile.extension)
+            .collect::<Vec<_>>();
+        let expected_extensions = EXPECTED
+            .iter()
+            .map(|(extension, _)| *extension)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            declared, expected_extensions,
+            "the companion registry gained or lost an extension"
+        );
+
+        for (extension, accepted) in EXPECTED {
+            for (name, language) in &all_languages {
+                let expected = accepted.contains(name);
+                assert_eq!(
+                    compatibility_extension_matches_source_group(extension, language),
+                    expected,
+                    "`{extension}` in the {name} source group"
+                );
+                // The same answer must hold through the public entry point, so
+                // the registry cannot leak in via the other branch either.
+                let file_name = format!("main.{extension}");
+                assert_eq!(
+                    matches_source_group_language(Path::new(&file_name), language),
+                    expected,
+                    "`main.{extension}` discovered for {name}"
+                );
+            }
+        }
+
+        // Extensions outside the companion table stay outside it.
+        for extension in ["kt", "rs", "txt", "cshtmlx", ""] {
+            for (_, language) in &all_languages {
+                assert!(
+                    !compatibility_extension_matches_source_group(extension, language),
+                    "`{extension}` must not be a companion extension"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1676. **This is the S3 pattern-setter — fifteen sibling packages (#1677–#1691) follow the structure it establishes.**

## What moved

Kotlin's graph extraction leaves `crates/codestory-indexer/src/lib.rs` for `crates/codestory-indexer/src/languages/kotlin.rs`: the rule include, the compiled-rule cache, the callsite marker, the parser config, and the 23-function receiver-call resolution engine. `lib.rs` is 757 lines lighter.

**The move is proven mechanical**: a `diff` of the moved bodies against the deleted lines, ignoring blank lines, is empty. The only textual changes are two entry-point renames and one `pub(crate)`. Function accounting: exactly 23 disappeared from `lib.rs`, all Kotlin-named, and `kotlin.rs` has those 23 plus a grammar constructor.

A `LanguageExtraction` registry replaces the hand-kept rosters, and every dispatch site now reads registry-first with the residual `match` behind it — behaviour-neutral at each step because the two are disjoint, and the sixteenth package deletes the residual arms.

Template/style and comment tables are **siblings** of `LANGUAGE_SUPPORT_PROFILES`, not rows in it. That is load-bearing: adding `.vue` or `.scss` to the profile table would silently widen `supported_extensions`, `language_name_for_path` and `is_structural_source_path` — the functions deciding what the product indexes and what claim tier it advertises. A contracts test pins that companion extensions carry no public claim tier.

## Proof, and a gap it exposed

Two byte-identical projection snapshots (fidelity lab, tictactoe) are the equality proof the contract asks for; goldens were captured before the edit and diffed after.

Five mutations were applied and observed. Two of them — flipping `promotes_type_member_functions_to_methods` and changing `qualified_name_delimiter` — **failed the new snapshots while `fidelity_regression` stayed green**. That matters for the fifteen siblings: the pre-existing threshold suite alone would not have caught either regression, and for the delimiter no pre-existing test catches it at all. The snapshot rows are what make these rollback units safe.

## For the siblings

The commit body carries a literal file-by-file pattern: module layout, the one-line registration, all 15 `LanguageExtraction` fields, the registry-first/residual-match rule, and the seven files a sibling touches. It also flags a trap: the CLI comment roster and the indexer route-comment roster genuinely disagree today and must **not** be unified — they are separate facts with separate owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
