### PR TITLE
[v0.17 REL-MANa] Split the provision-proof lanes and bind the native release manifest

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -2343,6 +2343,8 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       "scripts/tests/codestory-release-closeout.test.mjs",
       "scripts/tests/codestory-release-evidence-gate.test.mjs",
       "scripts/tests/fixtures/release-claims/**",
+      ".github/scripts/publish-marketplace-catalog.mjs",
+      ".github/scripts/publish-marketplace-catalog.test.mjs",
       "benchmarks/release-evidence/**",
       ".github/workflows/**",
       ".github/workflows/release.yml",
@@ -2359,7 +2361,11 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       "scripts/prepare-embedded-model.mjs",
       "scripts/tests/prepare-embedded-model.test.mjs",
       "scripts/prove-plugin-pinned-provision.mjs",
+      "scripts/build-release-manifest.mjs",
       "scripts/lib/wait-for-managed-runtime.mjs",
+      "scripts/lib/pinned-archive-digests.mjs",
+      "scripts/lib/provision-proof-lanes.mjs",
+      "scripts/lib/release-manifest.mjs",
       "scripts/tests/prove-plugin-pinned-provision.test.mjs",
       "crates/codestory-llama-sys/model-contract.json",
       "crates/codestory-llama-sys/build.rs",
@@ -2393,6 +2399,7 @@ function validatePluginAndDraftWorkflows(workflows, violations, graph) {
       "node --test scripts/tests/prove-plugin-pinned-provision.test.mjs",
     ]);
     requireStepRun(violations, pluginFile, job, "Check release claim and evidence contracts", [
+      ".github/scripts/publish-marketplace-catalog.test.mjs",
       "scripts/tests/release-evidence-runner-contract.test.mjs",
     ]);
     requireStepRun(violations, pluginFile, job, "Check workflow syntax", [
@@ -2940,8 +2947,12 @@ function catalogDeliveryOutcomeViolations(file, job, delivery) {
     '[ "$TOKEN_OUTCOME" = "success" ]',
     '[ "$PUBLISH_OUTCOME" = "success" ]',
     `printf '%s' "$PUBLISHED_REVISION" | grep -Eq '^[0-9a-f]{40}$'`,
-    'echo "catalog_published=$catalog_published" >> "$GITHUB_OUTPUT"',
-    'echo "marketplace_revision=$marketplace_revision" >> "$GITHUB_OUTPUT"',
+    'echo "catalog_published=$catalog_published"',
+    'echo "marketplace_revision=$marketplace_revision"',
+    // The delivery state and the rollback target leave this step through one grouped redirect,
+    // so the redirect itself is pinned: the echoes alone would be satisfied by a step that
+    // computed the state and wrote it nowhere.
+    '} >> "$GITHUB_OUTPUT"',
     "::warning::Catalog publication deferred",
     "recover with $RECOVERY_WORKFLOW",
     // The recovery workflow mints the SAME credential from the SAME environment, so it recovers
@@ -2955,6 +2966,31 @@ function catalogDeliveryOutcomeViolations(file, job, delivery) {
     object(job.outputs).catalog_published === "${{ steps.delivery.outputs.catalog_published }}"
       && object(job.outputs).marketplace_revision === "${{ steps.delivery.outputs.marketplace_revision }}",
     `${file} marketplace publication must publish the recorded delivery state, not the raw push result`,
+  );
+  // The rollback target. A catalog move with no recorded predecessor is a move nobody can undo, so
+  // every name the graph declares has to leave the push step, be written by the delivery step, and
+  // leave the job -- a break anywhere in that chain loses the only record of what to restore.
+  for (const name of list(object(delivery.recovery).previous_pin_outputs)) {
+    add(
+      violations,
+      object(job.outputs)[name] === `\${{ steps.delivery.outputs.${name} }}`,
+      `${file} marketplace publication must publish the recorded ${name}`,
+    );
+    add(
+      violations,
+      executableRunText(String(deliveryOutcome?.run ?? "")).includes(`echo "${name}=`),
+      `${file} catalog delivery outcome must record ${name}`,
+    );
+  }
+  add(
+    violations,
+    object(deliveryOutcome?.env).PREVIOUS_REVISION
+        === "${{ steps.publish.outputs.previous_marketplace_revision }}"
+      && object(deliveryOutcome?.env).PREVIOUS_PLUGIN_SHA
+        === "${{ steps.publish.outputs.previous_plugin_sha }}"
+      && object(deliveryOutcome?.env).PREVIOUS_PLUGIN_VERSION
+        === "${{ steps.publish.outputs.previous_plugin_version }}",
+    `${file} catalog delivery outcome must read the rollback target the catalog move recorded`,
   );
   // A retry would collapse distinguishable failures into one opaque one and could publish on a
   // second attempt after the first was already recorded, so this job gets exactly one attempt.
@@ -3055,10 +3091,17 @@ function validateReleaseCoordinator(workflows, violations, graph) {
   ]);
   requireStepRun(violations, releaseFile, policy, "Check release claim and evidence contracts", [
     ".github/scripts/build-marketplace-fixture.test.mjs",
+    // The catalog publisher records the pin a rollback would restore and refuses to move a
+    // catalog it cannot name a rollback target for. Both are release behaviour, so the suite
+    // runs on the release lane's own policy job.
+    ".github/scripts/publish-marketplace-catalog.test.mjs",
     "scripts/tests/codestory-release-claims.test.mjs",
     "scripts/tests/codestory-release-cell-manifest.test.mjs",
     "scripts/tests/codestory-release-closeout.test.mjs",
     "scripts/tests/codestory-release-evidence-gate.test.mjs",
+    // The publish job generates the release manifest with scripts/build-release-manifest.mjs, so
+    // the suite that proves the generator refuses drifted archives runs before any proof does.
+    "scripts/tests/prove-plugin-pinned-provision.test.mjs",
   ]);
   requireStepRun(violations, releaseFile, policy, "Enforce workflow policy", [
     "node .github/scripts/check-workflow-policy.mjs",
@@ -3451,6 +3494,28 @@ function validateReleaseCoordinator(workflows, violations, graph) {
     "node scripts/codestory-release-claims.mjs release-platform-notes",
     "--ledger target/release-closeout/pre_publish/ledger.json",
   ]);
+  // The native lane's archive digests. The frozen source cannot carry them, so they are generated
+  // here from the built archives and shipped with the release. The generation has to happen after
+  // the checksums exist -- it cross-checks against them -- and before the release is created, or
+  // the launcher fetches a manifest that describes bytes nobody published.
+  requireStepRun(violations, releaseFile, publish, "Generate the release manifest", [
+    "node scripts/build-release-manifest.mjs",
+    '--version "$VERSION"',
+    '--tag "$TAG"',
+    '--commit "$GITHUB_SHA"',
+    "--assets target/release-assets",
+    "--output target/release-assets/codestory-release-manifest.json",
+  ]);
+  requireStepEnv(violations, releaseFile, publish, "Generate the release manifest", {
+    TAG: "${{ needs.preflight.outputs.tag }}",
+    VERSION: "${{ needs.preflight.outputs.version }}",
+  });
+  add(
+    violations,
+    stepIndex(publish, "Combine and verify checksums") < stepIndex(publish, "Generate the release manifest")
+      && stepIndex(publish, "Generate the release manifest") < stepIndex(publish, "Create GitHub release"),
+    `${releaseFile} must generate the release manifest from verified checksums before creating the release`,
+  );
   // The ledger the README tells readers to consult has to be reachable from the release itself.
   requireStepRun(violations, releaseFile, publish, "Ship the accepted closeout summary with the release", [
     "target/release-closeout/pre_publish/summary.json",
@@ -10515,8 +10580,12 @@ export function validatePluginRelease(workflows, violations, graph) {
   requireStepRun(violations, file, object(jobs["plugin-proof"]), "Check the pinned provision proof", [
     "node --test scripts/tests/prove-plugin-pinned-provision.test.mjs",
   ]);
+  // The lane is stated, never defaulted. The native lane's pin lawfully carries no archive
+  // digests, so a plugin-lane gate that stopped naming its lane could silently become one that
+  // proves nothing about the source pin it exists to enforce.
   requireStepRun(violations, file, object(jobs["plugin-proof"]), "Provision the pinned CLI end to end", [
     "scripts/prove-plugin-pinned-provision.mjs",
+    "--lane plugin",
   ]);
   requireStepRun(violations, file, object(jobs.publish), "Re-verify main before tagging", [
     "repos/$GITHUB_REPOSITORY/git/ref/heads/main",
@@ -10610,7 +10679,7 @@ export function validatePluginRelease(workflows, violations, graph) {
   );
 }
 
-export function validateMarketplaceSync(workflows, violations) {
+export function validateMarketplaceSync(workflows, violations, graph) {
   const file = "marketplace-sync.yml";
   const workflow = workflows.get(file);
   if (!workflow) {
@@ -10754,6 +10823,52 @@ export function validateMarketplaceSync(workflows, violations) {
     stepIndex(job, checkout) > stepIndex(job, guard),
     `${file} must validate the dispatched commit before checking it out`,
   );
+  // A catalog moved by this workflow is a RECOVERY, not the publication that shipped the plugin.
+  // The two stay distinguishable only if this lane records its own identity, and the rollback it
+  // performs is only undoable if the pin it replaced is recorded with it.
+  const recovery = object(object(graph?.workflow_policy?.catalog_delivery).recovery);
+  const recoveryStep = "Record catalog recovery identity";
+  requireStepRun(violations, file, job, "Point the catalog at the published release", [
+    "publish-marketplace-catalog.mjs",
+    '--github-output "$GITHUB_OUTPUT"',
+  ]);
+  add(
+    violations,
+    namedStep(job, "Point the catalog at the published release")?.id === "publish",
+    `${file} catalog push must publish its recorded pin under the id the identity step reads`,
+  );
+  add(
+    violations,
+    object(namedStep(job, recoveryStep)?.env).CATALOG_DELIVERY === recovery.id,
+    `${file} must record the ${recovery.id} delivery identity the release claim graph declares`,
+  );
+  for (const name of list(recovery.previous_pin_outputs)) {
+    add(
+      violations,
+      scalarStrings(object(namedStep(job, recoveryStep)?.env)).includes(
+        `\${{ steps.publish.outputs.${name} }}`,
+      ),
+      `${file} ${recoveryStep} must carry the recorded ${name}`,
+    );
+  }
+  requireStepRun(violations, file, job, recoveryStep, [
+    // A recovery that cannot name the immutable catalog revision it produced has not recorded a
+    // distinguishable identity, only a claim that one happened.
+    `printf '%s' "$MARKETPLACE_REVISION" | grep -Eq '^[0-9a-f]{40}$'`,
+    'echo "Catalog delivery state: $CATALOG_DELIVERY',
+  ]);
+  add(
+    violations,
+    stepIndex(job, recoveryStep) > stepIndex(job, "Point the catalog at the published release"),
+    `${file} must record the recovery identity from the catalog move it actually performed`,
+  );
+  for (const state of list(object(graph?.workflow_policy?.catalog_delivery).states)) {
+    add(
+      violations,
+      object(state).id !== recovery.id,
+      `${file} recovery identity must not reuse the ${object(state).id} delivery state`,
+    );
+  }
 }
 
 export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repositoryRoot)) {
@@ -10794,7 +10909,7 @@ export function validateWorkflows(workflows, graph = loadReleaseClaimGraph(repos
   violations.push(...reusableWorkflowPermissionViolations(workflows));
   validateCargoTestFilters(workflows, violations);
   validatePluginRelease(workflows, violations, graph);
-  validateMarketplaceSync(workflows, violations);
+  validateMarketplaceSync(workflows, violations, graph);
   validateLockedSetupSurfaces(violations);
   validateIssueWorkflows(workflows, violations);
   validatePluginAndDraftWorkflows(workflows, violations, graph);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -6844,14 +6844,14 @@ test("marketplace sync keeps dispatch inputs out of script text", async (t) => {
         uses: `actions/github-script@${fullSha}`,
         with: { script: 'console.log("${{ inputs.commit }}")' },
       });
-    }, /jobs\.sync\.steps\.5 must not splice a dispatch input into an action input/u],
+    }, /jobs\.sync\.steps\.6 must not splice a dispatch input into an action input/u],
     ["a pinned action takes the unvalidated spelling of the input", workflow => {
       workflow.jobs.sync.steps.push({
         name: "Report the dispatched commit",
         uses: `actions/github-script@${fullSha}`,
         with: { script: 'console.log("${{ github.event.inputs.commit }}")' },
       });
-    }, /jobs\.sync\.steps\.5 must not splice a dispatch input into an action input/u],
+    }, /jobs\.sync\.steps\.6 must not splice a dispatch input into an action input/u],
     // `$NAME` and `${NAME}` are the same read, so a binding assertion that only sees the bare form
     // is evaded by writing the brace form and deleting the bindings.
     ["a brace-form read loses both of its env bindings", workflow => {
@@ -6871,7 +6871,7 @@ test("marketplace sync keeps dispatch inputs out of script text", async (t) => {
         env: { INPUT_COMMIT: "${{ github.event.inputs.commit }}" },
         run: "echo bound\n",
       });
-    }, /jobs\.sync\.steps\.5 must bind INPUT_COMMIT/u],
+    }, /jobs\.sync\.steps\.6 must bind INPUT_COMMIT/u],
     // Job-level `env:` is below every step's own binding check, so the unvalidated spelling is
     // refused by name wherever it appears rather than only where a step declares it.
     ["the unvalidated spelling hides in job-level env", workflow => {
@@ -8121,7 +8121,16 @@ function runCatalogDeliveryOutcome(environment, [file, jobName] = catalogOutcome
   const step = draftStep(loadWorkflows().get(file).jobs[jobName], "Record catalog delivery outcome");
   // Every GitHub expression in this step lives in env, so the body is executable bash.
   assert.ok(!step.run.includes("${{"), "delivery outcome body must not embed workflow expressions");
-  return runStepBash(step.run, { RECOVERY_WORKFLOW: step.env.RECOVERY_WORKFLOW, ...environment });
+  // The workflow declares every one of these in `env:`, so they exist -- possibly empty -- for the
+  // real step. Defaulting them here keeps the harness's environment the one the workflow provides
+  // rather than a laxer one.
+  return runStepBash(step.run, {
+    RECOVERY_WORKFLOW: step.env.RECOVERY_WORKFLOW,
+    PREVIOUS_REVISION: "",
+    PREVIOUS_PLUGIN_SHA: "",
+    PREVIOUS_PLUGIN_VERSION: "",
+    ...environment,
+  });
 }
 
 function runCatalogDeliveryState(environment, [file, jobName] = catalogStateLanes[0]) {
@@ -8144,19 +8153,37 @@ function repositoryHead() {
 
 test("a release records catalog publication only when the catalog push actually landed", () => {
   const revision = "a".repeat(40);
+  const previousRevision = "b".repeat(40);
+  const previousSha = "c".repeat(40);
+  // The rollback target the catalog move recorded. It is the pin the catalog was serving, so it
+  // must survive into the job's outputs whether the move landed or not -- a published run needs it
+  // to restore, and a deferred run needs it to say what the catalog is still serving.
+  const previousPin = {
+    PREVIOUS_REVISION: previousRevision,
+    PREVIOUS_PLUGIN_SHA: previousSha,
+    PREVIOUS_PLUGIN_VERSION: "0.16.2",
+  };
+  const recordedPin = {
+    previous_marketplace_revision: previousRevision,
+    previous_plugin_sha: previousSha,
+    previous_plugin_version: "0.16.2",
+  };
 
   for (const lane of catalogOutcomeLanes) {
     const published = runCatalogDeliveryOutcome({
       TOKEN_OUTCOME: "success",
       PUBLISH_OUTCOME: "success",
       PUBLISHED_REVISION: revision,
+      ...previousPin,
     }, lane);
     assert.equal(published.status, 0, published.stderr);
     assert.deepEqual(published.outputs, {
       catalog_published: "true",
       marketplace_revision: revision,
+      ...recordedPin,
     }, lane.join("/"));
     assert.doesNotMatch(published.stdout, /::warning::/u, lane.join("/"));
+    assert.match(published.summary, /Rollback target: codestory 0\.16\.2 at c{40}/u, lane.join("/"));
   }
 
   // Each of these is a real way this job has failed or could fail. None may report published, and
@@ -8183,17 +8210,37 @@ test("a release records catalog publication only when the catalog push actually 
   ];
   for (const lane of catalogOutcomeLanes) {
     for (const [label, environment] of deferrals) {
-      const deferred = runCatalogDeliveryOutcome(environment, lane);
+      const deferred = runCatalogDeliveryOutcome({ ...previousPin, ...environment }, lane);
       const where = `${lane.join("/")}: ${label}`;
       assert.equal(deferred.status, 0, `${where}: ${deferred.stderr}`);
       assert.deepEqual(deferred.outputs, {
         catalog_published: "false",
         marketplace_revision: "",
+        ...recordedPin,
       }, where);
       assert.match(deferred.stdout, /::warning::Catalog publication deferred/u, where);
       assert.match(deferred.stdout, /marketplace-sync\.yml/u, where);
       assert.match(deferred.summary, /DEFERRED/u, where);
+      // A deferred run never announces a rollback target: the catalog did not move, so there is
+      // nothing to restore and nothing may read as if there were.
+      assert.doesNotMatch(deferred.summary, /Rollback target/u, where);
     }
+
+    // The credential never minted, so the push step was skipped and recorded no pin at all. The
+    // absent pin must travel as absent rather than be filled in with something invented.
+    const unrecorded = runCatalogDeliveryOutcome({
+      TOKEN_OUTCOME: "failure",
+      PUBLISH_OUTCOME: "",
+      PUBLISHED_REVISION: "",
+    }, lane);
+    assert.equal(unrecorded.status, 0, unrecorded.stderr);
+    assert.deepEqual(unrecorded.outputs, {
+      catalog_published: "false",
+      marketplace_revision: "",
+      previous_marketplace_revision: "",
+      previous_plugin_sha: "",
+      previous_plugin_version: "",
+    }, lane.join("/"));
   }
 });
 

--- a/.github/scripts/publish-marketplace-catalog.mjs
+++ b/.github/scripts/publish-marketplace-catalog.mjs
@@ -84,19 +84,43 @@ if (entry.source?.url !== SOURCE_URL || entry.source?.path !== "plugins/codestor
   fail(`${CATALOG} codestory entry does not point at this repository's plugin directory`);
 }
 
+// What the catalog served before this run touched it. Recorded BEFORE the push, because a
+// rollback needs a target and the live catalog stops being able to answer that question the
+// moment this script succeeds. Refused rather than recorded empty: a catalog move whose previous
+// pin cannot be named is a move nobody can undo, and this job is `continue-on-error`, so refusing
+// leaves the catalog serving the release it already served -- the safe direction.
+const previousSha = String(entry.source.sha ?? "");
+const previousVersion = String(entry.version ?? "");
+if (!/^[0-9a-f]{40}$/u.test(previousSha)) {
+  fail(`${CATALOG} codestory entry pins ${JSON.stringify(entry.source.sha ?? null)}, which is not a rollback target`);
+}
+if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/u.test(previousVersion)) {
+  fail(`${CATALOG} codestory entry names version ${JSON.stringify(entry.version ?? null)}, which is not a rollback target`);
+}
+const previousRevision = git("rev-parse", "HEAD");
+
 const output = (revision, published) => {
   console.log(
     published
       ? `Catalog now pins codestory ${args.version} at ${commit} (${revision}).`
       : `Catalog already pins codestory ${args.version} at ${commit} (${revision}); nothing to push.`,
   );
+  console.log(
+    `Previous catalog pin: codestory ${previousVersion} at ${previousSha} (catalog ${previousRevision}).`,
+  );
   if (args.github_output) {
-    appendFileSync(args.github_output, `marketplace_revision=${revision}\n`);
+    appendFileSync(
+      args.github_output,
+      `marketplace_revision=${revision}\n`
+        + `previous_marketplace_revision=${previousRevision}\n`
+        + `previous_plugin_sha=${previousSha}\n`
+        + `previous_plugin_version=${previousVersion}\n`,
+    );
   }
 };
 
 if (entry.source.sha === commit && entry.version === args.version) {
-  output(git("rev-parse", "HEAD"), false);
+  output(previousRevision, false);
   process.exit(0);
 }
 

--- a/.github/scripts/publish-marketplace-catalog.test.mjs
+++ b/.github/scripts/publish-marketplace-catalog.test.mjs
@@ -1,0 +1,203 @@
+// Drive the real catalog publisher against real Git repositories.
+//
+// The marketplace is a second repository reached over https, so the script's clone URL is fixed.
+// `url.<base>.insteadOf` in a scratch global config redirects that exact URL to a local bare repo,
+// which lets the whole script run -- clone, edit, commit, push -- with nothing stubbed out. The
+// assertions are made against the bare repo's own contents, not against the script's stdout.
+
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const publisher = path.join(scriptsDir, "publish-marketplace-catalog.mjs");
+const CATALOG = ".agents/plugins/marketplace.json";
+const SOURCE_URL = "https://github.com/TheGreenCedar/CodeStory.git";
+const TOKEN = "test-token";
+const CLONE_URL = `https://x-access-token:${TOKEN}@github.com/TheGreenCedar/AgentPluginMarketplace.git`;
+
+function git(cwd, ...args) {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+}
+
+function commitAll(repo, message) {
+  git(repo, "add", "-A");
+  git(repo, "-c", "user.email=t@t.invalid", "-c", "user.name=t", "commit", "--message", message);
+  return git(repo, "rev-parse", "HEAD");
+}
+
+/// A source repository whose plugin manifest carries each version at its own commit, which is what
+/// the publisher checks before it is willing to pin a commit.
+function sourceRepository(root, versions) {
+  const repo = path.join(root, "source");
+  fs.mkdirSync(path.join(repo, "plugins/codestory/.codex-plugin"), { recursive: true });
+  git(root, "init", "--quiet", repo);
+  const commits = {};
+  for (const version of versions) {
+    fs.writeFileSync(
+      path.join(repo, "plugins/codestory/.codex-plugin/plugin.json"),
+      `${JSON.stringify({ name: "codestory", version }, null, 2)}\n`,
+    );
+    commits[version] = commitAll(repo, `codestory ${version}`);
+  }
+  return { repo, commits };
+}
+
+function marketplaceRepository(root, entry) {
+  const work = path.join(root, "marketplace-work");
+  const bare = path.join(root, "marketplace.git");
+  fs.mkdirSync(path.join(work, path.dirname(CATALOG)), { recursive: true });
+  git(root, "init", "--quiet", work);
+  fs.writeFileSync(
+    path.join(work, CATALOG),
+    `${JSON.stringify({ plugins: [entry] }, null, 2)}\n`,
+  );
+  commitAll(work, "seed catalog");
+  git(root, "init", "--bare", "--quiet", bare);
+  git(work, "remote", "add", "origin", bare);
+  git(work, "push", "--quiet", "origin", "HEAD:main");
+  git(bare, "symbolic-ref", "HEAD", "refs/heads/main");
+  return bare;
+}
+
+function catalogEntry(version, sha) {
+  return {
+    name: "codestory",
+    version,
+    source: { url: SOURCE_URL, path: "plugins/codestory", sha },
+  };
+}
+
+function readCatalog(bare) {
+  return JSON.parse(execFileSync("git", ["-C", bare, "show", "main:" + CATALOG], { encoding: "utf8" }));
+}
+
+function scratch() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-catalog-"));
+  const configPath = path.join(root, "gitconfig");
+  fs.writeFileSync(configPath, `[url "file://${path.join(root, "marketplace.git")}"]\n\tinsteadOf = ${CLONE_URL}\n`);
+  return { root, configPath };
+}
+
+function runPublisher({ root, configPath }, repo, { commit, version }) {
+  const outputPath = path.join(root, `output-${Math.random().toString(36).slice(2)}.txt`);
+  fs.writeFileSync(outputPath, "");
+  const result = spawnSync(
+    process.execPath,
+    [
+      publisher,
+      "--source-repository",
+      repo,
+      "--commit",
+      commit,
+      "--version",
+      version,
+      "--github-output",
+      outputPath,
+    ],
+    {
+      encoding: "utf8",
+      env: { ...process.env, GH_TOKEN: TOKEN, GIT_CONFIG_GLOBAL: configPath, GIT_CONFIG_NOSYSTEM: "1" },
+    },
+  );
+  const outputs = Object.fromEntries(
+    fs
+      .readFileSync(outputPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const index = line.indexOf("=");
+        return [line.slice(0, index), line.slice(index + 1)];
+      }),
+  );
+  return { ...result, outputs };
+}
+
+test("the catalog move records the pin it replaced, and that pin is a working rollback target", () => {
+  const env = scratch();
+  try {
+    const { repo, commits } = sourceRepository(env.root, ["0.1.0", "0.2.0"]);
+    const bare = marketplaceRepository(env.root, catalogEntry("0.1.0", commits["0.1.0"]));
+    const seeded = git(bare, "rev-parse", "main");
+
+    const forward = runPublisher(env, repo, { commit: commits["0.2.0"], version: "0.2.0" });
+    assert.equal(forward.status, 0, `${forward.stdout}${forward.stderr}`);
+    assert.equal(readCatalog(bare).plugins[0].source.sha, commits["0.2.0"]);
+    assert.equal(readCatalog(bare).plugins[0].version, "0.2.0");
+    // The previous pin is the release the catalog was serving, not the one just published.
+    assert.deepEqual(
+      {
+        previous_marketplace_revision: forward.outputs.previous_marketplace_revision,
+        previous_plugin_sha: forward.outputs.previous_plugin_sha,
+        previous_plugin_version: forward.outputs.previous_plugin_version,
+      },
+      {
+        previous_marketplace_revision: seeded,
+        previous_plugin_sha: commits["0.1.0"],
+        previous_plugin_version: "0.1.0",
+      },
+    );
+    assert.equal(forward.outputs.marketplace_revision, git(bare, "rev-parse", "main"));
+    assert.notEqual(forward.outputs.marketplace_revision, seeded);
+
+    // Executable rollback: the recorded pin is enough to put the catalog back, with no new
+    // version and no hand-editing of the other repository.
+    const back = runPublisher(env, repo, {
+      commit: forward.outputs.previous_plugin_sha,
+      version: forward.outputs.previous_plugin_version,
+    });
+    assert.equal(back.status, 0, `${back.stdout}${back.stderr}`);
+    assert.equal(readCatalog(bare).plugins[0].source.sha, commits["0.1.0"]);
+    assert.equal(readCatalog(bare).plugins[0].version, "0.1.0");
+    assert.equal(back.outputs.previous_plugin_version, "0.2.0");
+  } finally {
+    fs.rmSync(env.root, { recursive: true, force: true });
+  }
+});
+
+test("an already-synced catalog reports the pin it is serving without pushing", () => {
+  const env = scratch();
+  try {
+    const { repo, commits } = sourceRepository(env.root, ["0.1.0"]);
+    const bare = marketplaceRepository(env.root, catalogEntry("0.1.0", commits["0.1.0"]));
+    const seeded = git(bare, "rev-parse", "main");
+    const result = runPublisher(env, repo, { commit: commits["0.1.0"], version: "0.1.0" });
+    assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+    assert.match(result.stdout, /nothing to push/u);
+    assert.equal(git(bare, "rev-parse", "main"), seeded);
+    assert.equal(result.outputs.marketplace_revision, seeded);
+    assert.equal(result.outputs.previous_marketplace_revision, seeded);
+    assert.equal(result.outputs.previous_plugin_sha, commits["0.1.0"]);
+  } finally {
+    fs.rmSync(env.root, { recursive: true, force: true });
+  }
+});
+
+// A move whose previous pin cannot be named is a move nobody can undo. Refusing leaves the catalog
+// serving the release it already served, which is the direction that never offers a plugin that
+// does not exist.
+test("a catalog whose current pin is not a rollback target is never moved", () => {
+  for (const [label, entry] of [
+    ["an abbreviated sha", catalogEntry("0.1.0", "abc1234")],
+    ["a missing sha", { name: "codestory", version: "0.1.0", source: { url: SOURCE_URL, path: "plugins/codestory" } }],
+    ["an unparsable version", catalogEntry("latest", "b".repeat(40))],
+  ]) {
+    const env = scratch();
+    try {
+      const { repo, commits } = sourceRepository(env.root, ["0.2.0"]);
+      const bare = marketplaceRepository(env.root, entry);
+      const seeded = git(bare, "rev-parse", "main");
+      const result = runPublisher(env, repo, { commit: commits["0.2.0"], version: "0.2.0" });
+      assert.equal(result.status, 1, `${label}: ${result.stdout}${result.stderr}`);
+      assert.match(result.stderr, /::error::.*is not a rollback target/u, label);
+      assert.equal(git(bare, "rev-parse", "main"), seeded, `${label} moved the catalog`);
+      assert.equal(result.outputs.marketplace_revision, undefined, label);
+    } finally {
+      fs.rmSync(env.root, { recursive: true, force: true });
+    }
+  }
+});

--- a/.github/workflows/marketplace-sync.yml
+++ b/.github/workflows/marketplace-sync.yml
@@ -97,6 +97,7 @@ jobs:
           repositories: AgentPluginMarketplace
 
       - name: Point the catalog at the published release
+        id: publish
         shell: bash
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -107,4 +108,28 @@ jobs:
           node .github/scripts/publish-marketplace-catalog.mjs \
             --source-repository "$GITHUB_WORKSPACE" \
             --commit "$INPUT_COMMIT" \
-            --version "$INPUT_VERSION"
+            --version "$INPUT_VERSION" \
+            --github-output "$GITHUB_OUTPUT"
+
+      # A catalog moved by this workflow is not a catalog moved by the release that published the
+      # plugin, and the two must stay distinguishable: the release lane's own runs record published
+      # or deferred, and this one records recovered. The pin it replaced travels with it, so the
+      # operator who ran a recovery can undo that recovery the same way.
+      - name: Record catalog recovery identity
+        shell: bash
+        env:
+          CATALOG_DELIVERY: recovered
+          INPUT_COMMIT: ${{ inputs.commit }}
+          INPUT_VERSION: ${{ inputs.version }}
+          MARKETPLACE_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+          PREVIOUS_PLUGIN_SHA: ${{ steps.publish.outputs.previous_plugin_sha }}
+          PREVIOUS_PLUGIN_VERSION: ${{ steps.publish.outputs.previous_plugin_version }}
+          PREVIOUS_REVISION: ${{ steps.publish.outputs.previous_marketplace_revision }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$MARKETPLACE_REVISION" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::Catalog recovery must resolve an immutable catalog revision."
+            exit 1
+          fi
+          echo "Catalog delivery state: $CATALOG_DELIVERY (codestory $INPUT_VERSION at $INPUT_COMMIT, catalog $MARKETPLACE_REVISION)." >> "$GITHUB_STEP_SUMMARY"
+          echo "Rollback target: codestory $PREVIOUS_PLUGIN_VERSION at $PREVIOUS_PLUGIN_SHA (catalog $PREVIOUS_REVISION)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -157,9 +157,11 @@ jobs:
       # The launcher provisions the pinned, already-published CLI over the real
       # github_release path, which is the one place the pin's content addressing
       # is enforced. A digest drift between the pin and the published archive
-      # fails here, before anything is tagged.
+      # fails here, before anything is tagged. The lane is stated rather than
+      # defaulted: this lane owns the source pin, and the native lane -- whose pin
+      # lawfully carries no archive digests -- must never run that assertion.
       - name: Provision the pinned CLI end to end
-        run: node scripts/prove-plugin-pinned-provision.mjs --timeout-ms 1200000
+        run: node scripts/prove-plugin-pinned-provision.mjs --lane plugin --timeout-ms 1200000
 
   publish:
     needs: [preflight, plugin-proof]
@@ -206,6 +208,11 @@ jobs:
     outputs:
       catalog_published: ${{ steps.delivery.outputs.catalog_published }}
       marketplace_revision: ${{ steps.delivery.outputs.marketplace_revision }}
+      # What the catalog served before this run moved it. A catalog move with no recorded
+      # predecessor is a move nobody can undo, so the rollback target travels with the state.
+      previous_marketplace_revision: ${{ steps.delivery.outputs.previous_marketplace_revision }}
+      previous_plugin_sha: ${{ steps.delivery.outputs.previous_plugin_sha }}
+      previous_plugin_version: ${{ steps.delivery.outputs.previous_plugin_version }}
     steps:
       - uses: actions/checkout@v5
 
@@ -245,6 +252,9 @@ jobs:
           TOKEN_OUTCOME: ${{ steps.token.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
           PUBLISHED_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+          PREVIOUS_REVISION: ${{ steps.publish.outputs.previous_marketplace_revision }}
+          PREVIOUS_PLUGIN_SHA: ${{ steps.publish.outputs.previous_plugin_sha }}
+          PREVIOUS_PLUGIN_VERSION: ${{ steps.publish.outputs.previous_plugin_version }}
           RECOVERY_WORKFLOW: marketplace-sync.yml
         run: |
           set -euo pipefail
@@ -256,10 +266,19 @@ jobs:
             catalog_published=true
             marketplace_revision="$PUBLISHED_REVISION"
           fi
-          echo "catalog_published=$catalog_published" >> "$GITHUB_OUTPUT"
-          echo "marketplace_revision=$marketplace_revision" >> "$GITHUB_OUTPUT"
+          # The rollback target is recorded whatever happened. On a published run it names the
+          # release a restore would return to; on a deferred run it names the release the catalog
+          # is still serving.
+          {
+            echo "catalog_published=$catalog_published"
+            echo "marketplace_revision=$marketplace_revision"
+            echo "previous_marketplace_revision=$PREVIOUS_REVISION"
+            echo "previous_plugin_sha=$PREVIOUS_PLUGIN_SHA"
+            echo "previous_plugin_version=$PREVIOUS_PLUGIN_VERSION"
+          } >> "$GITHUB_OUTPUT"
           if [ "$catalog_published" = "true" ]; then
             echo "Catalog delivery: published at $marketplace_revision." >> "$GITHUB_STEP_SUMMARY"
+            echo "Rollback target: codestory $PREVIOUS_PLUGIN_VERSION at $PREVIOUS_PLUGIN_SHA (catalog $PREVIOUS_REVISION), restorable with $RECOVERY_WORKFLOW." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           # $RECOVERY_WORKFLOW mints the SAME credential from the SAME environment, so it recovers a

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - plugins/codestory/**
       - .github/scripts/detect-codestory-release.py
+      - .github/scripts/publish-marketplace-catalog.mjs
+      - .github/scripts/publish-marketplace-catalog.test.mjs
       - .github/scripts/test-detect-codestory-release.py
       - .github/scripts/check-codestory-release.py
       - .github/scripts/check-packaged-agent-proof.py
@@ -68,7 +70,11 @@ on:
       - scripts/codex-worktree-setup.*
       - scripts/tests/codex-worktree-setup.test.mjs
       - scripts/prove-plugin-pinned-provision.mjs
+      - scripts/build-release-manifest.mjs
       - scripts/lib/wait-for-managed-runtime.mjs
+      - scripts/lib/pinned-archive-digests.mjs
+      - scripts/lib/provision-proof-lanes.mjs
+      - scripts/lib/release-manifest.mjs
       - scripts/tests/prove-plugin-pinned-provision.test.mjs
       - .codex/environments/environment.toml
   push:
@@ -78,6 +84,8 @@ on:
     paths:
       - plugins/codestory/**
       - .github/scripts/detect-codestory-release.py
+      - .github/scripts/publish-marketplace-catalog.mjs
+      - .github/scripts/publish-marketplace-catalog.test.mjs
       - .github/scripts/test-detect-codestory-release.py
       - .github/scripts/check-codestory-release.py
       - .github/scripts/check-packaged-agent-proof.py
@@ -141,7 +149,11 @@ on:
       - scripts/codex-worktree-setup.*
       - scripts/tests/codex-worktree-setup.test.mjs
       - scripts/prove-plugin-pinned-provision.mjs
+      - scripts/build-release-manifest.mjs
       - scripts/lib/wait-for-managed-runtime.mjs
+      - scripts/lib/pinned-archive-digests.mjs
+      - scripts/lib/provision-proof-lanes.mjs
+      - scripts/lib/release-manifest.mjs
       - scripts/tests/prove-plugin-pinned-provision.test.mjs
       - .codex/environments/environment.toml
   workflow_dispatch:
@@ -189,6 +201,7 @@ jobs:
       - name: Check release claim and evidence contracts
         run: >-
           node --test
+          .github/scripts/publish-marketplace-catalog.test.mjs
           scripts/tests/codestory-release-claims.test.mjs
           scripts/tests/codestory-release-closeout.test.mjs
           scripts/tests/codestory-release-evidence-gate.test.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,12 @@ jobs:
         run: >-
           node --test
           .github/scripts/build-marketplace-fixture.test.mjs
+          .github/scripts/publish-marketplace-catalog.test.mjs
           scripts/tests/codestory-release-claims.test.mjs
           scripts/tests/codestory-release-cell-manifest.test.mjs
           scripts/tests/codestory-release-closeout.test.mjs
           scripts/tests/codestory-release-evidence-gate.test.mjs
+          scripts/tests/prove-plugin-pinned-provision.test.mjs
 
       - name: Enforce workflow policy
         run: |
@@ -688,6 +690,25 @@ jobs:
           test -s target/release-assets/SHA256SUMS.txt
           (cd target/release-assets && sha256sum -c SHA256SUMS.txt)
 
+      # The native lane's archive digests. They cannot live in the frozen source tree -- these
+      # archives are built FROM that tree -- so they are generated here, from the bytes this
+      # release actually produced, and shipped as a release asset. Every digest is read off the
+      # archive file and cross-checked against SHA256SUMS.txt, so a checksum file that drifted
+      # from its archives stops the release instead of pinning the wrong bytes. Until the
+      # signature arms this is corruption detection over the release channel, not authentication.
+      - name: Generate the release manifest
+        env:
+          TAG: ${{ needs.preflight.outputs.tag }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          node scripts/build-release-manifest.mjs \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$GITHUB_SHA" \
+            --assets target/release-assets \
+            --output target/release-assets/codestory-release-manifest.json
+
       - name: Ship the accepted closeout summary with the release
         run: |
           set -euo pipefail
@@ -750,7 +771,8 @@ jobs:
           printf '%s\n' "${expected_names[@]}" | sort > "$expected_file"
           find target/release-assets -maxdepth 1 -type f \
             \( -name 'codestory-cli-v*.tar.gz' -o -name 'codestory-cli-v*.zip' \
-               -o -name 'SHA256SUMS.txt' -o -name 'release-closeout-summary.json' \) \
+               -o -name 'SHA256SUMS.txt' -o -name 'release-closeout-summary.json' \
+               -o -name 'codestory-release-manifest.json' \) \
             -exec basename {} \; | sort > "$actual_file"
           if ! diff -u "$expected_file" "$actual_file"; then
             echo "::error::Release assets differ from the release claim graph."
@@ -785,6 +807,11 @@ jobs:
     outputs:
       catalog_published: ${{ steps.delivery.outputs.catalog_published }}
       marketplace_revision: ${{ steps.delivery.outputs.marketplace_revision }}
+      # What the catalog served before this run moved it. A catalog move with no recorded
+      # predecessor is a move nobody can undo, so the rollback target travels with the state.
+      previous_marketplace_revision: ${{ steps.delivery.outputs.previous_marketplace_revision }}
+      previous_plugin_sha: ${{ steps.delivery.outputs.previous_plugin_sha }}
+      previous_plugin_version: ${{ steps.delivery.outputs.previous_plugin_version }}
     steps:
       - name: Checkout exact release source
         uses: actions/checkout@v5
@@ -829,6 +856,9 @@ jobs:
           TOKEN_OUTCOME: ${{ steps.token.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
           PUBLISHED_REVISION: ${{ steps.publish.outputs.marketplace_revision }}
+          PREVIOUS_REVISION: ${{ steps.publish.outputs.previous_marketplace_revision }}
+          PREVIOUS_PLUGIN_SHA: ${{ steps.publish.outputs.previous_plugin_sha }}
+          PREVIOUS_PLUGIN_VERSION: ${{ steps.publish.outputs.previous_plugin_version }}
           RECOVERY_WORKFLOW: marketplace-sync.yml
         run: |
           set -euo pipefail
@@ -840,10 +870,19 @@ jobs:
             catalog_published=true
             marketplace_revision="$PUBLISHED_REVISION"
           fi
-          echo "catalog_published=$catalog_published" >> "$GITHUB_OUTPUT"
-          echo "marketplace_revision=$marketplace_revision" >> "$GITHUB_OUTPUT"
+          # The rollback target is recorded whatever happened. On a published run it names the
+          # release a restore would return to; on a deferred run it names the release the catalog
+          # is still serving.
+          {
+            echo "catalog_published=$catalog_published"
+            echo "marketplace_revision=$marketplace_revision"
+            echo "previous_marketplace_revision=$PREVIOUS_REVISION"
+            echo "previous_plugin_sha=$PREVIOUS_PLUGIN_SHA"
+            echo "previous_plugin_version=$PREVIOUS_PLUGIN_VERSION"
+          } >> "$GITHUB_OUTPUT"
           if [ "$catalog_published" = "true" ]; then
             echo "Catalog delivery: published at $marketplace_revision." >> "$GITHUB_STEP_SUMMARY"
+            echo "Rollback target: codestory $PREVIOUS_PLUGIN_VERSION at $PREVIOUS_PLUGIN_SHA (catalog $PREVIOUS_REVISION), restorable with $RECOVERY_WORKFLOW." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           # $RECOVERY_WORKFLOW mints the SAME credential from the SAME environment, so it recovers a

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
+    "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
+        "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
+        "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "f0d2542d39094d6907be637c865f9a22cacc2c2b5073e3f99979282dd4c21e4c",
+  "candidate_sha256": "ec1af1a3fc4a484c93a5b33cf971d48a8fdca419ae705d64634c0dfa09c1ba08",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
+      "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
+      "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
+    "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/docs/architecture/host-integration.md
+++ b/docs/architecture/host-integration.md
@@ -18,8 +18,8 @@ sequenceDiagram
     Launcher->>CLI: use verified matching executable when present
     alt executable is missing or incompatible
         Launcher-->>Host: expose fail-open tool catalog and diagnostics
-        Launcher->>Release: fetch archive and SHA256SUMS
-        Launcher->>Launcher: bounded download, safe extraction, checksum and version checks
+        Launcher->>Release: fetch archive, SHA256SUMS, and release manifest
+        Launcher->>Launcher: bounded download, manifest binding, safe extraction, checksum and version checks
         Launcher->>CLI: validate stdio initialize
     end
     Launcher->>CLI: hand off requests without host restart
@@ -29,6 +29,30 @@ Provisioning is single-flight and bounded. A failed or incomplete download is
 not installed as current. The launcher may download the version-matched
 executable; the executable never downloads an embedding model, accelerator
 backend, helper executable, or retrieval service.
+
+### What the archive digests do and do not prove
+
+Two independent records name the archive the launcher installs, and neither is
+a signature.
+
+- The **source pin** in `plugins/codestory/cli-version.json` carries archive
+  digests only when the plugin fast lane pinned an already published CLI. That
+  pin ships inside the reviewed plugin package, so it is a record from a
+  different channel than the download. A native release cannot carry one: its
+  archives are built from the very tree that would hold the digests.
+- The **release manifest** (`codestory-release-manifest.json`) is generated
+  from the archives a release built, carries the release identity and each
+  target's filename, byte length, and SHA-256, and is attached to the release.
+  The launcher fetches it and holds the downloaded archive against it *before*
+  extracting. A release published before the manifest existed carries none;
+  the launcher records that absence rather than treating it as agreement.
+
+Because the manifest travels over the same channel as the archive it
+describes, it is corruption and drift detection, not authentication. Until the
+manifest is signed, the containment for a native release is: an exact
+repository commit pinned in the marketplace catalog over TLS, plus
+`SHA256SUMS.txt` and manifest digests. Signature verification is not shipped,
+and nothing in this repository claims it is.
 
 The fail-open catalog prevents installation work from looking like a missing
 plugin. It keeps diagnostics and the complete tool schema visible while the

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -169,6 +169,87 @@ function pinnedArchiveSha256(target) {
   return typeof digest === 'string' ? digest.toLowerCase() : null;
 }
 
+// The native lane's archive-digest owner, published beside the archives it describes.
+//
+// A native release's archive digests cannot be pinned in source: the archives are built FROM the
+// source tree that would carry them. The release generates this manifest from the archives it just
+// built, so the digests exist without the circularity. The schema below mirrors
+// scripts/lib/release-manifest.mjs; the plugin ships without that directory, and
+// plugin-static.test.mjs holds the two copies against each other.
+//
+// Containment, not authentication: until the manifest is signed it arrives over the same channel
+// as the archive, so it detects corruption and drift, not a channel that lies consistently.
+const RELEASE_MANIFEST_ASSET = 'codestory-release-manifest.json';
+const RELEASE_MANIFEST_DOMAIN = 'codestory.release-manifest';
+const RELEASE_MANIFEST_SCHEMA_VERSION = 1;
+
+function releaseManifestArchiveEntry(manifest, version, target) {
+  if (!isPlainObject(manifest)) throw new Error('release_manifest_invalid:not_an_object');
+  if (manifest.domain !== RELEASE_MANIFEST_DOMAIN) {
+    throw new Error('release_manifest_invalid:domain');
+  }
+  if (manifest.schema_version !== RELEASE_MANIFEST_SCHEMA_VERSION) {
+    throw new Error('release_manifest_invalid:schema_version');
+  }
+  // A manifest for a different release is a valid manifest for the wrong bytes, which is exactly
+  // the substitution a digest check is supposed to stop.
+  if (manifest.version !== version || manifest.tag !== `v${version}`) {
+    throw new Error('release_manifest_invalid:release_identity');
+  }
+  if (!/^[0-9a-f]{40}$/u.test(String(manifest.commit || ''))) {
+    throw new Error('release_manifest_invalid:commit');
+  }
+  if (!isPlainObject(manifest.archives)) throw new Error('release_manifest_invalid:archives');
+  const entry = manifest.archives[target];
+  if (!isPlainObject(entry)) throw new Error('release_manifest_invalid:target');
+  if (entry.filename !== archiveName(version, target)) {
+    throw new Error('release_manifest_invalid:filename');
+  }
+  if (!Number.isSafeInteger(entry.bytes) || entry.bytes <= 0) {
+    throw new Error('release_manifest_invalid:bytes');
+  }
+  if (!/^[0-9a-f]{64}$/u.test(String(entry.sha256 || ''))) {
+    throw new Error('release_manifest_invalid:sha256');
+  }
+  return entry;
+}
+
+// Fetched with the checksum file, before the archive transfer, so a manifest that is malformed or
+// describes another release stops the provision without paying for a multi-hundred-megabyte
+// download first. A release published before this manifest existed carries none: the absence is
+// recorded as a warning rather than treated as agreement, and the containment for those releases
+// stays what it was -- SHA256SUMS.txt plus the source pin when the pin carries digests.
+async function fetchReleaseManifestEntry(version, target, tempRoot, warnings) {
+  const manifestPath = path.join(tempRoot, RELEASE_MANIFEST_ASSET);
+  try {
+    await fetchReleaseFile(version, RELEASE_MANIFEST_ASSET, manifestPath);
+  } catch (error) {
+    warnings.push(`managed_cli_publication:release_manifest_absent:${managedCliFailureCode(error)}`);
+    return null;
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    throw new Error('release_manifest_invalid:json');
+  }
+  return releaseManifestArchiveEntry(manifest, version, target);
+}
+
+// Held against the downloaded bytes BEFORE extraction, because extraction is the first step that
+// acts on what the release channel supplied.
+function bindArchiveToReleaseManifest(entry, observed, warnings) {
+  if (!entry) return null;
+  if (entry.sha256 !== observed.sha256) {
+    throw new Error(`release_manifest_archive_mismatch:${entry.filename}:sha256`);
+  }
+  if (entry.bytes !== observed.bytes) {
+    throw new Error(`release_manifest_archive_mismatch:${entry.filename}:bytes`);
+  }
+  warnings.push('managed_cli_publication:release_manifest_bound');
+  return entry;
+}
+
 function pluginCacheVersion() {
   const parent = path.basename(path.dirname(pluginRoot)).toLowerCase();
   return parent === 'codestory' ? path.basename(pluginRoot) : null;
@@ -329,12 +410,18 @@ function expectedArchiveHash(sumsText, name) {
   throw new Error(`SHA256SUMS.txt did not contain ${name}`);
 }
 
+// The checksum file and the release manifest are both small metadata documents; only the archive
+// gets the archive-sized ceiling and the archive-sized clock.
+function releaseMetadataFile(name) {
+  return name === 'SHA256SUMS.txt' || name === RELEASE_MANIFEST_ASSET;
+}
+
 function releaseFileMaxBytes(name) {
-  return name === 'SHA256SUMS.txt' ? managedCliChecksumMaxBytes : managedCliArchiveMaxBytes;
+  return releaseMetadataFile(name) ? managedCliChecksumMaxBytes : managedCliArchiveMaxBytes;
 }
 
 function releaseFileTotalTimeoutMs(name) {
-  return name === 'SHA256SUMS.txt' ? releaseChecksumTotalTimeoutMs : releaseArchiveTotalTimeoutMs;
+  return releaseMetadataFile(name) ? releaseChecksumTotalTimeoutMs : releaseArchiveTotalTimeoutMs;
 }
 
 // A single mutable record of what provisioning is currently doing. Tool calls answered while the
@@ -2032,7 +2119,9 @@ function verifyPublishedManagedCli(
     manifest.archive !== expectedAsset ||
     manifest.target !== expectedTarget ||
     manifest.stdio_initialize_verified !== true ||
-    !/^[0-9a-f]{64}$/iu.test(String(manifest.archive_sha256 || ''))
+    !/^[0-9a-f]{64}$/iu.test(String(manifest.archive_sha256 || '')) ||
+    !Number.isSafeInteger(manifest.archive_bytes) ||
+    manifest.archive_bytes <= 0
   ) {
     return { verified: false, reason: 'manifest_release_metadata_invalid' };
   }
@@ -2339,6 +2428,9 @@ async function provisionManagedCli(dataDir, version, warnings = []) {
     const resumeBytes = partialDownloadBytes(archivePartialPath);
     if (resumeBytes > 0) warnings.push(`managed_cli_publication:resume_bytes:${resumeBytes}`);
     await fetchReleaseFile(version, 'SHA256SUMS.txt', sumsPath);
+    // Both metadata documents are read before the archive transfer starts, so a manifest that is
+    // malformed or belongs to another release costs one small request rather than a full download.
+    const releaseManifestEntry = await fetchReleaseManifestEntry(version, target, tempRoot, warnings);
     const archiveUrl = await fetchReleaseFile(version, asset, archivePath, {
       partialPath: archivePartialPath,
     });
@@ -2357,6 +2449,10 @@ async function provisionManagedCli(dataDir, version, warnings = []) {
         throw new Error(`archive_pin_mismatch:${asset}`);
       }
     }
+    // The native lane's digest authority, held against the downloaded bytes before extraction:
+    // extraction is the first step that acts on what the release channel supplied.
+    const archiveBytes = fs.statSync(archivePath).size;
+    bindArchiveToReleaseManifest(releaseManifestEntry, { sha256: actual, bytes: archiveBytes }, warnings);
     extractArchive(archivePath, extractDir);
 
     stagingDir = fs.mkdtempSync(path.join(root, `.provisioning-${version}-${process.pid}-`));
@@ -2374,6 +2470,10 @@ async function provisionManagedCli(dataDir, version, warnings = []) {
         ? archiveUrl
         : `explicit-package:${actual}`,
       archive_sha256: actual,
+      // Recorded so the pre-publish native provision proof can hold the provisioned archive
+      // against BOTH fields the release manifest carries. A length the manifest records and
+      // nothing reads is a field that cannot fail.
+      archive_bytes: archiveBytes,
       target,
       provisioned_at: new Date().toISOString(),
       stdio_initialize_verified: true,
@@ -4370,6 +4470,12 @@ if (require.main === module) {
       pinnedCliContract,
       pinnedCliVersion,
       pinnedArchiveSha256,
+      RELEASE_MANIFEST_ASSET,
+      RELEASE_MANIFEST_DOMAIN,
+      RELEASE_MANIFEST_SCHEMA_VERSION,
+      releaseManifestArchiveEntry,
+      fetchReleaseManifestEntry,
+      bindArchiveToReleaseManifest,
       publishDownloadedFile,
       managedCliDownloadCacheDir,
       removeManagedCliDownloadCache,

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -12,6 +12,12 @@ import { once } from "node:events";
 import { deflateRawSync, gunzipSync, gzipSync } from "node:zlib";
 import { PassThrough, Writable } from "node:stream";
 import { EventEmitter } from "node:events";
+import {
+  RELEASE_MANIFEST_ASSET,
+  RELEASE_MANIFEST_DOMAIN,
+  RELEASE_MANIFEST_SCHEMA_VERSION,
+  buildReleaseManifest,
+} from "../../../scripts/lib/release-manifest.mjs";
 
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
@@ -455,6 +461,7 @@ function managedReleaseManifest(version, executablePath, sha256) {
     archive: archiveName,
     archive_url: `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}/${archiveName}`,
     archive_sha256: "0".repeat(64),
+    archive_bytes: 4096,
     target,
     stdio_initialize_verified: true,
   };
@@ -4704,6 +4711,248 @@ test("managed cli quarantines corrupt installs, retains two, and fails closed on
       /managed_cli_quarantine_failed:EPERM/u,
     );
     await access(lockedDir);
+  } finally {
+    if (previousReleaseDir === undefined) delete process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+    else process.env.CODESTORY_PLUGIN_RELEASE_DIR = previousReleaseDir;
+    if (previousTestVersion === undefined) delete process.env.TEST_CODESTORY_VERSION;
+    else process.env.TEST_CODESTORY_VERSION = previousTestVersion;
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
+// The plugin ships without scripts/, so the launcher carries its own copy of the release-manifest
+// schema. Two copies of a contract drift, so the shipped one is held against the generator's.
+function releaseManifestFixture(version, target, archiveName, archiveBytes, archiveSha256) {
+  const filler = (filename) => ({ filename, bytes: 1024, sha256: "e".repeat(64) });
+  const archives = {
+    "macos-arm64": filler(`codestory-cli-v${version}-macos-arm64.tar.gz`),
+    "linux-x64": filler(`codestory-cli-v${version}-linux-x64.tar.gz`),
+    "windows-x64": filler(`codestory-cli-v${version}-windows-x64.zip`),
+  };
+  archives[target] = { filename: archiveName, bytes: archiveBytes, sha256: archiveSha256 };
+  return buildReleaseManifest({
+    version,
+    tag: `v${version}`,
+    commit: "a".repeat(40),
+    archives,
+  });
+}
+
+function releaseFixtureTarget(version) {
+  const { archiveName } = releaseAssetForPlatform(version);
+  return {
+    archiveName,
+    target: archiveName
+      .slice(`codestory-cli-v${version}-`.length)
+      .replace(/\.(?:zip|tar\.gz)$/u, ""),
+  };
+}
+
+async function writeReleaseManifestFile(releaseDir, manifest) {
+  await writeFile(
+    join(releaseDir, RELEASE_MANIFEST_ASSET),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+test("the launcher's release-manifest schema matches the generator's", async () => {
+  const version = await readPluginVersion();
+  const { archiveName, target } = releaseFixtureTarget(version);
+  assert.equal(launcherTest.RELEASE_MANIFEST_ASSET, RELEASE_MANIFEST_ASSET);
+  assert.equal(launcherTest.RELEASE_MANIFEST_DOMAIN, RELEASE_MANIFEST_DOMAIN);
+  assert.equal(launcherTest.RELEASE_MANIFEST_SCHEMA_VERSION, RELEASE_MANIFEST_SCHEMA_VERSION);
+  const manifest = releaseManifestFixture(version, target, archiveName, 2048, "b".repeat(64));
+  assert.deepEqual(launcherTest.releaseManifestArchiveEntry(manifest, version, target), {
+    filename: archiveName,
+    bytes: 2048,
+    sha256: "b".repeat(64),
+  });
+  // A manifest that is well formed for a DIFFERENT release describes intact bytes of the wrong
+  // release, which is the substitution the identity binding exists to refuse.
+  assert.throws(
+    () => launcherTest.releaseManifestArchiveEntry(manifest, "0.0.1", target),
+    /release_manifest_invalid:release_identity/u,
+  );
+  for (const [mutate, reason] of [
+    [(m) => ({ ...m, domain: "codestory.something-else" }), /domain/u],
+    [(m) => ({ ...m, schema_version: 2 }), /schema_version/u],
+    [(m) => ({ ...m, commit: "not-a-commit" }), /commit/u],
+    [(m) => ({ ...m, archives: { ...m.archives, [target]: undefined } }), /target/u],
+    [
+      (m) => ({ ...m, archives: { ...m.archives, [target]: { ...m.archives[target], bytes: 0 } } }),
+      /bytes/u,
+    ],
+    [
+      (m) => ({
+        ...m,
+        archives: { ...m.archives, [target]: { ...m.archives[target], sha256: "nope" } },
+      }),
+      /sha256/u,
+    ],
+  ]) {
+    assert.throws(
+      () => launcherTest.releaseManifestArchiveEntry(mutate(manifest), version, target),
+      reason,
+    );
+  }
+});
+
+test("managed provisioning binds the archive to the release manifest before extraction", { timeout: 30000 }, async () => {
+  const version = await readPluginVersion();
+  const previousReleaseDir = process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+  const previousTestVersion = process.env.TEST_CODESTORY_VERSION;
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-manifest-bind-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-manifest-release-"));
+  try {
+    const fixture = await writeReleaseFixture(releaseDir, version);
+    const { target } = releaseFixtureTarget(version);
+    const archiveBytes = (await stat(fixture.archivePath)).size;
+    process.env.CODESTORY_PLUGIN_RELEASE_DIR = releaseDir;
+    process.env.TEST_CODESTORY_VERSION = version;
+
+    await writeReleaseManifestFile(
+      releaseDir,
+      releaseManifestFixture(version, target, fixture.archiveName, archiveBytes, fixture.archiveSha256),
+    );
+    const warnings = [];
+    const resolved = await launcherTest.provisionManagedCli(dataDir, version, warnings);
+    assert.ok(resolved.path);
+    assert.equal(warnings.includes("managed_cli_publication:release_manifest_bound"), true, warnings.join(","));
+    const published = JSON.parse(
+      await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),
+    );
+    assert.equal(published.archive_sha256, fixture.archiveSha256);
+    assert.equal(published.archive_bytes, archiveBytes);
+  } finally {
+    if (previousReleaseDir === undefined) delete process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+    else process.env.CODESTORY_PLUGIN_RELEASE_DIR = previousReleaseDir;
+    if (previousTestVersion === undefined) delete process.env.TEST_CODESTORY_VERSION;
+    else process.env.TEST_CODESTORY_VERSION = previousTestVersion;
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
+// Ordering, not just refusal. The archive here is unextractable rubbish whose SHA256SUMS entry is
+// honest, so whichever check runs first names the failure: a manifest mismatch means the binding
+// ran BEFORE extraction, and the matching-manifest control proves the same bytes really do blow up
+// in the extractor, so the first assertion is not passing for some unrelated reason.
+test("a disagreeing release manifest stops provisioning before the archive is extracted", { timeout: 30000 }, async () => {
+  const version = await readPluginVersion();
+  const previousReleaseDir = process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+  const previousTestVersion = process.env.TEST_CODESTORY_VERSION;
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-manifest-order-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-manifest-order-release-"));
+  try {
+    const { archiveName, target } = releaseFixtureTarget(version);
+    const rubbish = Buffer.from("this is not an archive\n".repeat(64), "utf8");
+    const archivePath = join(releaseDir, archiveName);
+    await writeFile(archivePath, rubbish);
+    const archiveSha256 = createHash("sha256").update(rubbish).digest("hex");
+    await writeFile(join(releaseDir, "SHA256SUMS.txt"), `${archiveSha256}  ${archiveName}\n`, "utf8");
+    process.env.CODESTORY_PLUGIN_RELEASE_DIR = releaseDir;
+    process.env.TEST_CODESTORY_VERSION = version;
+
+    await writeReleaseManifestFile(
+      releaseDir,
+      releaseManifestFixture(version, target, archiveName, rubbish.length, "c".repeat(64)),
+    );
+    await assert.rejects(
+      () => launcherTest.provisionManagedCli(dataDir, version, []),
+      new RegExp(`release_manifest_archive_mismatch:${archiveName.replace(/\./gu, "\\.")}:sha256`, "u"),
+    );
+
+    await writeReleaseManifestFile(
+      releaseDir,
+      releaseManifestFixture(version, target, archiveName, rubbish.length + 1, archiveSha256),
+    );
+    await assert.rejects(
+      () => launcherTest.provisionManagedCli(dataDir, version, []),
+      new RegExp(`release_manifest_archive_mismatch:${archiveName.replace(/\./gu, "\\.")}:bytes`, "u"),
+    );
+
+    // Control: with a manifest that agrees, the same bytes reach the extractor and fail there.
+    await writeReleaseManifestFile(
+      releaseDir,
+      releaseManifestFixture(version, target, archiveName, rubbish.length, archiveSha256),
+    );
+    await assert.rejects(
+      () => launcherTest.provisionManagedCli(dataDir, version, []),
+      (error) => {
+        assert.equal(/release_manifest/u.test(error.message), false, error.message);
+        return true;
+      },
+    );
+    assert.equal(fs.existsSync(join(dataDir, "codestory-cli", version)), false);
+  } finally {
+    if (previousReleaseDir === undefined) delete process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+    else process.env.CODESTORY_PLUGIN_RELEASE_DIR = previousReleaseDir;
+    if (previousTestVersion === undefined) delete process.env.TEST_CODESTORY_VERSION;
+    else process.env.TEST_CODESTORY_VERSION = previousTestVersion;
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
+// The manifest is read with the checksum file, before the archive transfer. Proving that costs
+// nothing extra: the release directory here has no archive at all, so whichever fetch runs first
+// names the failure. A release-identity refusal means the manifest was read before the download
+// was attempted; an asset-fetch failure would mean it was not.
+test("a manifest for another release is refused before the archive is downloaded", { timeout: 30000 }, async () => {
+  const version = await readPluginVersion();
+  const previousReleaseDir = process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+  const previousTestVersion = process.env.TEST_CODESTORY_VERSION;
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-manifest-early-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-manifest-early-release-"));
+  try {
+    const { archiveName, target } = releaseFixtureTarget(version);
+    await writeFile(join(releaseDir, "SHA256SUMS.txt"), `${"d".repeat(64)}  ${archiveName}\n`, "utf8");
+    // A well-formed manifest, for the wrong release.
+    const other = "9.9.9";
+    const otherName = archiveName.replace(`v${version}`, `v${other}`);
+    await writeReleaseManifestFile(
+      releaseDir,
+      releaseManifestFixture(other, target, otherName, 1024, "d".repeat(64)),
+    );
+    process.env.CODESTORY_PLUGIN_RELEASE_DIR = releaseDir;
+    process.env.TEST_CODESTORY_VERSION = version;
+    await assert.rejects(
+      () => launcherTest.provisionManagedCli(dataDir, version, []),
+      /release_manifest_invalid:release_identity/u,
+    );
+  } finally {
+    if (previousReleaseDir === undefined) delete process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+    else process.env.CODESTORY_PLUGIN_RELEASE_DIR = previousReleaseDir;
+    if (previousTestVersion === undefined) delete process.env.TEST_CODESTORY_VERSION;
+    else process.env.TEST_CODESTORY_VERSION = previousTestVersion;
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
+// Releases published before the manifest existed carry none. That is a stated gap in the
+// containment -- recorded as a warning so status and doctor can see it -- and not an agreement.
+test("a release with no manifest provisions with the absence recorded, not assumed away", { timeout: 30000 }, async () => {
+  const version = await readPluginVersion();
+  const previousReleaseDir = process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+  const previousTestVersion = process.env.TEST_CODESTORY_VERSION;
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-manifest-absent-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-manifest-absent-release-"));
+  try {
+    await writeReleaseFixture(releaseDir, version);
+    process.env.CODESTORY_PLUGIN_RELEASE_DIR = releaseDir;
+    process.env.TEST_CODESTORY_VERSION = version;
+    const warnings = [];
+    const resolved = await launcherTest.provisionManagedCli(dataDir, version, warnings);
+    assert.ok(resolved.path);
+    assert.equal(
+      warnings.some((warning) => warning.startsWith("managed_cli_publication:release_manifest_absent:")),
+      true,
+      warnings.join(","),
+    );
+    assert.equal(warnings.includes("managed_cli_publication:release_manifest_bound"), false);
   } finally {
     if (previousReleaseDir === undefined) delete process.env.CODESTORY_PLUGIN_RELEASE_DIR;
     else process.env.CODESTORY_PLUGIN_RELEASE_DIR = previousReleaseDir;

--- a/release-claims.json
+++ b/release-claims.json
@@ -1518,7 +1518,16 @@
           "installer": "codex_marketplace_deferred_fixture",
           "live_catalog_revision": false
         }
-      ]
+      ],
+      "recovery": {
+        "id": "recovered",
+        "previous_pin_outputs": [
+          "previous_marketplace_revision",
+          "previous_plugin_sha",
+          "previous_plugin_version"
+        ],
+        "automatic_restore": false
+      }
     },
     "lost_runner_rerun": {
       "workflow": "lost-runner-rerun.yml",

--- a/scripts/build-release-manifest.mjs
+++ b/scripts/build-release-manifest.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Generate the release manifest from the archives a release actually built.
+//
+// The frozen source tree cannot carry native archive digests -- the archives are built from that
+// tree, so committing their digests into it is circular and would break the freeze and the
+// calibration lineage. This runs after the archives exist and before the release is created, so
+// the digests describe bytes that are already on disk.
+//
+//   node scripts/build-release-manifest.mjs --version X.Y.Z --tag vX.Y.Z --commit SHA \
+//     --assets DIR --output FILE
+//
+// Every digest is read off the archive file itself and then cross-checked against the release's
+// own SHA256SUMS.txt. Agreement between two independently produced records is the point: a
+// checksum file that drifted from the archives it names stops the release here rather than
+// shipping a manifest that pins the wrong bytes.
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { PINNED_ARCHIVE_TARGETS, parsePublishedArchiveDigests } from "./lib/pinned-archive-digests.mjs";
+import { buildReleaseManifest } from "./lib/release-manifest.mjs";
+
+export class ReleaseManifestBuildError extends Error {}
+
+function refuse(message) {
+  throw new ReleaseManifestBuildError(message);
+}
+
+export function parseBuildArguments(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (typeof flag !== "string" || !flag.startsWith("--")) {
+      refuse(`unexpected argument ${JSON.stringify(flag ?? null)}`);
+    }
+    if (!["--version", "--tag", "--commit", "--assets", "--output"].includes(flag)) {
+      refuse(`unknown argument ${flag}`);
+    }
+    if (values.has(flag)) refuse(`${flag} was given more than once`);
+    if (typeof value !== "string" || value.trim() === "") {
+      refuse(`${flag} needs a value`);
+    }
+    values.set(flag, value);
+  }
+  for (const flag of ["--version", "--tag", "--commit", "--assets", "--output"]) {
+    if (!values.has(flag)) refuse(`${flag} is required`);
+  }
+  return {
+    version: values.get("--version"),
+    tag: values.get("--tag"),
+    commit: values.get("--commit"),
+    assets: values.get("--assets"),
+    output: values.get("--output"),
+  };
+}
+
+/// Hash and measure one archive without holding it in memory. A release archive is hundreds of
+/// megabytes, and this runs on the same job that already has the whole asset set on disk.
+function measureArchive(archivePath) {
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(1 << 20);
+  const descriptor = fs.openSync(archivePath, "r");
+  let bytes = 0;
+  try {
+    for (;;) {
+      const read = fs.readSync(descriptor, buffer, 0, buffer.length, null);
+      if (read === 0) break;
+      hash.update(buffer.subarray(0, read));
+      bytes += read;
+    }
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return { bytes, sha256: hash.digest("hex") };
+}
+
+/// Measure the built archives and hold them against the release's own checksum file.
+export function buildReleaseManifestFromAssets({ version, tag, commit, assets }) {
+  const sumsPath = path.join(assets, "SHA256SUMS.txt");
+  let sumsText;
+  try {
+    sumsText = fs.readFileSync(sumsPath, "utf8");
+  } catch (error) {
+    refuse(`could not read ${sumsPath}: ${error.message}`);
+  }
+  let published;
+  try {
+    published = parsePublishedArchiveDigests(sumsText, version);
+  } catch (error) {
+    refuse(`${sumsPath} does not describe the ${version} archives: ${error.message}`);
+  }
+
+  const archives = {};
+  for (const [target, assetName] of Object.entries(PINNED_ARCHIVE_TARGETS)) {
+    const filename = assetName(version);
+    const archivePath = path.join(assets, filename);
+    let measured;
+    try {
+      measured = measureArchive(archivePath);
+    } catch (error) {
+      refuse(`could not read the built ${target} archive ${archivePath}: ${error.message}`);
+    }
+    if (measured.sha256 !== published[target]) {
+      refuse(
+        `${filename} hashes to ${measured.sha256} but SHA256SUMS.txt records ${published[target]}; ` +
+          `the built archives and the release checksum file disagree`,
+      );
+    }
+    archives[target] = { filename, bytes: measured.bytes, sha256: measured.sha256 };
+  }
+  return buildReleaseManifest({ version, tag, commit, archives });
+}
+
+export function main(argv) {
+  const options = parseBuildArguments(argv);
+  const manifest = buildReleaseManifestFromAssets(options);
+  fs.writeFileSync(options.output, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return manifest;
+}
+
+function invokedDirectly() {
+  if (!process.argv[1]) return false;
+  try {
+    return (
+      fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(process.argv[1])
+    );
+  } catch {
+    // Fall back to the URL comparison rather than assuming this is a library import: an entry
+    // point that decides it is not one exits 0 having proven nothing.
+    return import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+  }
+}
+
+if (invokedDirectly()) {
+  try {
+    const manifest = main(process.argv.slice(2));
+    const targets = Object.entries(manifest.archives)
+      .map(([target, entry]) => `${target} ${entry.sha256.slice(0, 12)}… (${entry.bytes} bytes)`)
+      .join(", ");
+    console.log(`Release manifest for ${manifest.tag} at ${manifest.commit}: ${targets}.`);
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -6,6 +6,8 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { RELEASE_MANIFEST_ASSET } from "./lib/release-manifest.mjs";
+
 const GRAPH_SCHEMA = "codestory.release-claims/v1";
 const GRAPH_VERSION = 11;
 const KNOWN_PACKAGE_TARGETS = new Set([
@@ -531,6 +533,37 @@ function validateCatalogDelivery(policy, dependencies, cellGroups) {
     if (!(group[key] ?? []).includes("installer")) {
       fail(`workflow_policy.catalog_delivery.installed_cell_group ${installedCellGroup} must carry installer in ${key}`);
     }
+  }
+  // Publication and recovery are different events and the ledger has to be able to tell them
+  // apart, so recovery gets its own declared identity rather than reusing the published one. The
+  // rollback it performs is only real if something records what to roll back TO, which is what
+  // `previous_pin_outputs` names: the publication job carries them out of the catalog move, and a
+  // catalog that cannot name its previous pin is never moved.
+  const recovery = object(delivery.recovery, "workflow_policy.catalog_delivery.recovery");
+  const recoveryId = nonEmptyText(recovery.id, "workflow_policy.catalog_delivery.recovery.id");
+  if (byId.has(recoveryId)) {
+    fail(`workflow_policy.catalog_delivery.recovery.id ${recoveryId} must be distinct from the delivery states`);
+  }
+  if (!identityMatchesFormat(recoveryId, "identifier")) {
+    fail("workflow_policy.catalog_delivery.recovery.id does not match identifier");
+  }
+  const pinOutputs = recovery.previous_pin_outputs;
+  if (!Array.isArray(pinOutputs) || pinOutputs.length === 0) {
+    fail("workflow_policy.catalog_delivery.recovery.previous_pin_outputs must name the recorded rollback target");
+  }
+  for (const [index, name] of pinOutputs.entries()) {
+    const output = nonEmptyText(
+      name,
+      `workflow_policy.catalog_delivery.recovery.previous_pin_outputs[${index}]`,
+    );
+    if (!identityMatchesFormat(output, "identifier")) {
+      fail(`workflow_policy.catalog_delivery.recovery.previous_pin_outputs[${index}] does not match identifier`);
+    }
+  }
+  // Stated, not implied. Restore is operator-initiated through `recovery_workflow` today; the
+  // graph says so rather than letting documentation claim an automatic rollback that no job runs.
+  if (recovery.automatic_restore !== false) {
+    fail("workflow_policy.catalog_delivery.recovery.automatic_restore must be false while restore is operator-initiated");
   }
   return delivery;
 }
@@ -1986,6 +2019,12 @@ export function releaseAssetNames(graph, version) {
         `codestory-cli-v${version}-${target}.${extension}`,
     ),
     "SHA256SUMS.txt",
+    // The native lane's archive digests. They cannot be pinned in source -- the archives are built
+    // from the tree that would carry them -- so the release generates them from the archives it
+    // just built and ships them here, where the launcher and the pre-publish provision proof can
+    // read them. Digest data over TLS until the signature arms: corruption detection, not
+    // authentication.
+    RELEASE_MANIFEST_ASSET,
     // The one machine-readable statement of what this release did and did not prove. It ships with
     // the release because the README tells readers to consult the ledger rather than the platform
     // table, and an Actions artifact with a 30-day retention is not something a release consumer

--- a/scripts/lib/pinned-archive-digests.mjs
+++ b/scripts/lib/pinned-archive-digests.mjs
@@ -34,7 +34,25 @@ export function parsePublishedArchiveDigests(source, version) {
   );
 }
 
-export function requirePinnedArchiveDigest(pin, target, observedDigest) {
+/// The only lane whose pin can lawfully carry archive digests.
+export const SOURCE_PIN_LANE = "plugin";
+
+/// Hold a provisioned archive against the digest the SOURCE PIN carries.
+///
+/// The plugin fast lane pins an ALREADY PUBLISHED CLI, so its `cli-version.json` names archives
+/// that exist and `bump-version.mjs` fills them in. The native lane's pin names the release that
+/// is about to be built from the very tree holding the pin, so `bump-version.mjs` deletes
+/// `archives` there by design. Running this assertion on a native pin is not a stricter check, it
+/// is a check that can only fail -- which is why `lane` is required with no default: a caller that
+/// forgets to say which lane it is cannot silently fall into the plugin one.
+export function requirePinnedArchiveDigest({ pin, target, observedDigest, lane }) {
+  if (lane !== SOURCE_PIN_LANE) {
+    throw new Error(
+      `only the ${SOURCE_PIN_LANE} lane may assert a source-pinned archive digest, not ` +
+        `${JSON.stringify(lane)}: a lawful native pin carries none, and the native lane's archive ` +
+        `digests are owned by the release manifest`,
+    );
+  }
   const pinnedDigest = pin?.archives?.[target];
   if (typeof pinnedDigest !== "string" || !SHA256.test(pinnedDigest)) {
     throw new Error(`CLI pin has no valid ${target} archive digest`);

--- a/scripts/lib/provision-proof-lanes.mjs
+++ b/scripts/lib/provision-proof-lanes.mjs
@@ -1,0 +1,192 @@
+// Which lane the pinned-provision proof is running in, and which archive-digest authority that
+// lane is allowed to consult.
+//
+// The two lanes own different things and the proof used to conflate them:
+//
+//   plugin  -- the fast lane pins an already-published CLI, so `plugins/codestory/cli-version.json`
+//              carries that release's archive digests and the proof must hold the provisioned
+//              archive against them.
+//   native  -- the pin names the release that is about to be built from the tree holding the pin,
+//              so it lawfully has no archive digests. The digests are generated with the archives
+//              and live in the release manifest. Running the source-pin assertion here is not a
+//              stricter check, it is a check that can only fail -- which is exactly what a frozen
+//              native head hit.
+//
+// This module is the single reader of the source-pin assertion. `prove-plugin-pinned-provision.mjs`
+// imports only from here, so no lane can reach `requirePinnedArchiveDigest` without declaring
+// itself, and neither lane can silently acquire the other's authority.
+
+import { requirePinnedArchiveDigest, SOURCE_PIN_LANE } from "./pinned-archive-digests.mjs";
+import { requireManifestArchiveDigest } from "./release-manifest.mjs";
+
+export const PROVISION_LANES = Object.freeze([SOURCE_PIN_LANE, "native"]);
+export const NATIVE_LANE = "native";
+// The plugin lane always provisions a published GitHub release. The native lane runs both before
+// publication -- against archives staged from the frozen head -- and after it, so it has to say
+// which one it means instead of accepting whichever it is handed.
+export const NATIVE_BUILD_SOURCES = Object.freeze(["github_release", "explicit_package"]);
+export const DEFAULT_TIMEOUT_MS = 600_000;
+
+const NATIVE_ONLY_FLAGS = Object.freeze([
+  "--expect-build-source",
+  "--release-manifest",
+  "--defer-archive-digest",
+]);
+
+export class ProvisionProofArgumentError extends Error {}
+
+function refuse(message) {
+  throw new ProvisionProofArgumentError(message);
+}
+
+/// Parse the proof's command line with no permissive defaults.
+///
+/// Unknown and repeated flags are refused rather than ignored: a misspelled `--lane natvie` that
+/// fell through to the plugin lane would run the source-pin assertion on a native pin, which is
+/// the failure this split exists to remove.
+export function parseProvisionProofArguments(argv) {
+  const seen = new Set();
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (typeof flag !== "string" || !flag.startsWith("--")) {
+      refuse(`unexpected argument ${JSON.stringify(flag ?? null)}`);
+    }
+    if (seen.has(flag)) refuse(`${flag} was given more than once`);
+    seen.add(flag);
+    if (flag === "--defer-archive-digest") {
+      values.set(flag, true);
+      continue;
+    }
+    if (!["--timeout-ms", "--lane", "--expect-build-source", "--release-manifest"].includes(flag)) {
+      refuse(`unknown argument ${flag}`);
+    }
+    // `argv[index + 1]` is undefined at the end of the line, which is how `--timeout-ms` with no
+    // value reaches the same refusal as `--timeout-ms garbage`.
+    values.set(flag, argv[index + 1]);
+    index += 1;
+  }
+
+  const rawTimeout = values.has("--timeout-ms") ? Number(values.get("--timeout-ms")) : DEFAULT_TIMEOUT_MS;
+  if (!Number.isFinite(rawTimeout) || rawTimeout <= 0) {
+    refuse(
+      `--timeout-ms needs a positive number of milliseconds, got ` +
+        `${JSON.stringify(values.get("--timeout-ms") ?? null)}.`,
+    );
+  }
+
+  const lane = values.has("--lane") ? values.get("--lane") : SOURCE_PIN_LANE;
+  if (!PROVISION_LANES.includes(lane)) {
+    refuse(`--lane must be one of ${PROVISION_LANES.join(", ")}, got ${JSON.stringify(lane ?? null)}.`);
+  }
+
+  if (lane === SOURCE_PIN_LANE) {
+    for (const flag of NATIVE_ONLY_FLAGS) {
+      if (values.has(flag)) {
+        refuse(
+          `${flag} belongs to the ${NATIVE_LANE} lane; the ${SOURCE_PIN_LANE} lane proves the ` +
+            `archive digest its own source pin carries.`,
+        );
+      }
+    }
+    return {
+      lane,
+      timeoutMs: rawTimeout,
+      expectBuildSource: "github_release",
+      releaseManifestPath: null,
+      deferArchiveDigest: false,
+    };
+  }
+
+  const expectBuildSource = values.get("--expect-build-source");
+  if (!NATIVE_BUILD_SOURCES.includes(expectBuildSource)) {
+    refuse(
+      `--lane ${NATIVE_LANE} needs --expect-build-source ${NATIVE_BUILD_SOURCES.join("|")}, got ` +
+        `${JSON.stringify(expectBuildSource ?? null)}.`,
+    );
+  }
+  const releaseManifestPath = values.get("--release-manifest");
+  const deferArchiveDigest = values.get("--defer-archive-digest") === true;
+  if (releaseManifestPath !== undefined && deferArchiveDigest) {
+    refuse("--release-manifest and --defer-archive-digest are mutually exclusive.");
+  }
+  if (releaseManifestPath === undefined && !deferArchiveDigest) {
+    // No fallback: the native lane has no source-pinned digest to drop back to, so an unstated
+    // intent must stop the proof rather than quietly prove less than the operator thinks.
+    refuse(
+      `--lane ${NATIVE_LANE} needs either --release-manifest PATH or an explicit ` +
+        `--defer-archive-digest; a native pin carries no archive digest to fall back on.`,
+    );
+  }
+  if (releaseManifestPath !== undefined && String(releaseManifestPath).trim() === "") {
+    refuse("--release-manifest needs a path to the staged release manifest.");
+  }
+  return {
+    lane,
+    timeoutMs: rawTimeout,
+    expectBuildSource,
+    releaseManifestPath: releaseManifestPath ?? null,
+    deferArchiveDigest,
+  };
+}
+
+/// Hold the provisioned archive against the authority this lane owns, and say which one that was.
+///
+/// The return value distinguishes a proven digest from a declared deferral so a caller cannot
+/// report "digest proven" for a run that proved no such thing.
+export function assertProvisionedArchiveDigest({
+  lane,
+  pin,
+  target,
+  provisioned,
+  releaseManifest = null,
+  deferArchiveDigest = false,
+}) {
+  if (lane === SOURCE_PIN_LANE) {
+    if (releaseManifest !== null || deferArchiveDigest) {
+      throw new Error(`the ${SOURCE_PIN_LANE} lane proves its source pin and nothing else`);
+    }
+    const pinnedDigest = requirePinnedArchiveDigest({
+      pin,
+      target,
+      observedDigest: provisioned?.sha256,
+      lane,
+    });
+    return {
+      asserted: true,
+      authority: "source_pin",
+      claim: `archive ${pinnedDigest.slice(0, 12)}… matches the ${target} digest in the source pin`,
+    };
+  }
+  if (lane !== NATIVE_LANE) {
+    throw new Error(`unknown provision lane ${JSON.stringify(lane ?? null)}`);
+  }
+  if (releaseManifest !== null && deferArchiveDigest) {
+    throw new Error("a deferred native digest assertion cannot also consume a release manifest");
+  }
+  if (releaseManifest !== null) {
+    const entry = requireManifestArchiveDigest(
+      releaseManifest,
+      { version: pin?.cli_version, tag: pin?.release_tag },
+      target,
+      provisioned,
+    );
+    return {
+      asserted: true,
+      authority: "release_manifest",
+      claim:
+        `archive ${entry.sha256.slice(0, 12)}… (${entry.bytes} bytes) matches the ${target} entry ` +
+        `in the ${releaseManifest.tag} release manifest`,
+    };
+  }
+  if (!deferArchiveDigest) {
+    throw new Error(`the ${NATIVE_LANE} lane needs a release manifest or a declared deferral`);
+  }
+  return {
+    asserted: false,
+    authority: "deferred",
+    claim:
+      `archive digest NOT proven here: the ${target} digest assertion is deferred to the ` +
+      `post-release manifest proof, because this native pin lawfully carries none`,
+  };
+}

--- a/scripts/lib/release-manifest.mjs
+++ b/scripts/lib/release-manifest.mjs
@@ -1,0 +1,168 @@
+// The native lane's archive-digest owner.
+//
+// A frozen source tree cannot carry native archive digests. The archives are built *from* the
+// frozen head, so a digest committed to that head would have to describe bytes that do not exist
+// yet, and a post-build source commit would invalidate the freeze and the calibration lineage.
+// bump-version.mjs therefore deletes `archives` on a native bump and the resulting pin is lawful
+// without them. The digests live here instead: a manifest generated from the archives the release
+// actually built, carrying the release identity those archives belong to.
+//
+// Containment, not closure. Until the Ed25519 signature arms, a manifest fetched over the same
+// channel as the archive is corruption detection, not authentication. Nothing in this module
+// claims otherwise, and the plugin lane's source pin -- which ships inside the reviewed plugin
+// package rather than beside the archive -- remains a separate, independently owned assertion.
+
+import { PINNED_ARCHIVE_TARGETS } from "./pinned-archive-digests.mjs";
+
+export const RELEASE_MANIFEST_DOMAIN = "codestory.release-manifest";
+export const RELEASE_MANIFEST_SCHEMA_VERSION = 1;
+export const RELEASE_MANIFEST_ASSET = "codestory-release-manifest.json";
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+const COMMIT = /^[0-9a-f]{40}$/u;
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
+const MANIFEST_TARGETS = Object.freeze(Object.keys(PINNED_ARCHIVE_TARGETS).sort());
+
+function refuse(message) {
+  throw new Error(`release manifest ${message}`);
+}
+
+function plainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/// Every check the manifest has to survive before any digest read is allowed. Callers never see a
+/// partially validated manifest: `validateReleaseManifest` either returns the manifest or throws.
+export function validateReleaseManifest(manifest) {
+  if (!plainObject(manifest)) refuse("must be a JSON object");
+  if (manifest.domain !== RELEASE_MANIFEST_DOMAIN) {
+    refuse(`domain must be ${RELEASE_MANIFEST_DOMAIN}, got ${JSON.stringify(manifest.domain)}`);
+  }
+  if (manifest.schema_version !== RELEASE_MANIFEST_SCHEMA_VERSION) {
+    refuse(
+      `schema_version must be ${RELEASE_MANIFEST_SCHEMA_VERSION}, ` +
+        `got ${JSON.stringify(manifest.schema_version)}`,
+    );
+  }
+  if (typeof manifest.version !== "string" || !SEMVER.test(manifest.version)) {
+    refuse(`version must be semver, got ${JSON.stringify(manifest.version)}`);
+  }
+  if (manifest.tag !== `v${manifest.version}`) {
+    refuse(`tag must be v${manifest.version}, got ${JSON.stringify(manifest.tag)}`);
+  }
+  if (typeof manifest.commit !== "string" || !COMMIT.test(manifest.commit)) {
+    refuse(`commit must be a 40-character lowercase hexadecimal id, got ${JSON.stringify(manifest.commit)}`);
+  }
+  if (!plainObject(manifest.archives)) refuse("archives must be a JSON object");
+  const present = Object.keys(manifest.archives).sort();
+  if (JSON.stringify(present) !== JSON.stringify(MANIFEST_TARGETS)) {
+    // A manifest missing a target is an incomplete release, and a manifest carrying an unknown one
+    // describes bytes no lane can name. Both are refused rather than partially trusted.
+    refuse(`archives must name exactly ${MANIFEST_TARGETS.join(", ")}, got ${present.join(", ") || "nothing"}`);
+  }
+  for (const target of MANIFEST_TARGETS) {
+    const entry = manifest.archives[target];
+    if (!plainObject(entry)) refuse(`${target} entry must be a JSON object`);
+    const expectedFilename = PINNED_ARCHIVE_TARGETS[target](manifest.version);
+    if (entry.filename !== expectedFilename) {
+      refuse(`${target} filename must be ${expectedFilename}, got ${JSON.stringify(entry.filename)}`);
+    }
+    if (!Number.isSafeInteger(entry.bytes) || entry.bytes <= 0) {
+      refuse(`${target} bytes must be a positive integer, got ${JSON.stringify(entry.bytes)}`);
+    }
+    if (typeof entry.sha256 !== "string" || !SHA256.test(entry.sha256)) {
+      refuse(`${target} sha256 must be 64 lowercase hexadecimal characters, got ${JSON.stringify(entry.sha256)}`);
+    }
+  }
+  return manifest;
+}
+
+/// Build the manifest from measured archive facts. The caller supplies bytes and digests it read
+/// off the built files; this function only decides the shape and refuses anything malformed.
+export function buildReleaseManifest({ version, tag, commit, archives }) {
+  if (!plainObject(archives)) refuse("archives must be a JSON object");
+  const built = {
+    domain: RELEASE_MANIFEST_DOMAIN,
+    schema_version: RELEASE_MANIFEST_SCHEMA_VERSION,
+    version,
+    tag,
+    commit,
+    // Sorted so two runs over the same archives produce byte-identical manifests, and so an
+    // unknown target survives into validation instead of being quietly dropped here.
+    archives: Object.fromEntries(
+      Object.keys(archives)
+        .sort()
+        .map((target) => {
+          const entry = archives[target];
+          if (!plainObject(entry)) return [target, entry];
+          return [
+            target,
+            {
+              filename: entry.filename,
+              bytes: entry.bytes,
+              sha256: typeof entry.sha256 === "string" ? entry.sha256.toLowerCase() : entry.sha256,
+            },
+          ];
+        }),
+    ),
+  };
+  return validateReleaseManifest(built);
+}
+
+export function parseReleaseManifest(source) {
+  let parsed;
+  try {
+    parsed = JSON.parse(source);
+  } catch (error) {
+    refuse(`is not valid JSON: ${error.message}`);
+  }
+  return validateReleaseManifest(parsed);
+}
+
+/// The native lane's only permitted archive-digest assertion.
+///
+/// `expected` is the release the caller believes it is provisioning. Binding it here is what stops
+/// a manifest from a *different* release -- an older one whose archives are genuinely intact --
+/// from satisfying the proof for this one. `observed` must carry both the digest and the byte
+/// length: length alone is not security, but a manifest that records it and a reader that ignores
+/// it is a field nothing checks.
+export function requireManifestArchiveDigest(manifest, expected, target, observed) {
+  validateReleaseManifest(manifest);
+  const expectedVersion = expected?.version;
+  const expectedTag = expected?.tag;
+  if (typeof expectedVersion !== "string" || !SEMVER.test(expectedVersion)) {
+    refuse(`assertion needs the semver release being provisioned, got ${JSON.stringify(expectedVersion)}`);
+  }
+  if (expectedTag !== `v${expectedVersion}`) {
+    refuse(`assertion needs tag v${expectedVersion}, got ${JSON.stringify(expectedTag)}`);
+  }
+  if (manifest.version !== expectedVersion || manifest.tag !== expectedTag) {
+    refuse(
+      `describes ${manifest.tag} (${manifest.version}), not the ${expectedTag} (${expectedVersion}) ` +
+        `being provisioned`,
+    );
+  }
+  if (!MANIFEST_TARGETS.includes(target)) {
+    refuse(`has no ${target} target; known targets are ${MANIFEST_TARGETS.join(", ")}`);
+  }
+  const entry = manifest.archives[target];
+  const observedDigest = observed?.sha256;
+  const observedBytes = observed?.bytes;
+  if (typeof observedDigest !== "string" || !SHA256.test(observedDigest)) {
+    refuse(`assertion needs the provisioned ${target} archive digest, got ${JSON.stringify(observedDigest)}`);
+  }
+  if (!Number.isSafeInteger(observedBytes) || observedBytes <= 0) {
+    refuse(`assertion needs the provisioned ${target} archive byte length, got ${JSON.stringify(observedBytes)}`);
+  }
+  if (observedDigest !== entry.sha256) {
+    refuse(
+      `${target} digest ${entry.sha256} does not match the provisioned archive digest ${observedDigest}`,
+    );
+  }
+  if (observedBytes !== entry.bytes) {
+    refuse(
+      `${target} length ${entry.bytes} does not match the provisioned archive length ${observedBytes}`,
+    );
+  }
+  return entry;
+}

--- a/scripts/prove-plugin-pinned-provision.mjs
+++ b/scripts/prove-plugin-pinned-provision.mjs
@@ -3,14 +3,24 @@
 //
 // Drives plugins/codestory/scripts/codestory-mcp.cjs the way a host does: spawn it, ask for
 // status, and wait for managed runtime metadata. Then verify what was actually provisioned:
-// the manifest must name the pinned version, a real github_release build source, and the pin's
-// own archive digest, and the provisioned binary must report the pinned version.
+// the manifest must name the pinned version and the build source this lane expects, the archive
+// digest must match the authority THIS LANE OWNS, and the provisioned binary must report the
+// pinned version.
 //
-//   node scripts/prove-plugin-pinned-provision.mjs [--timeout-ms 600000]
+//   plugin lane -- the fast lane pins an already-published CLI, so the source pin carries that
+//   release's archive digests and this proof holds the provision against them:
+//     node scripts/prove-plugin-pinned-provision.mjs [--timeout-ms 600000]
+//
+//   native lane -- the pin names the release about to be built from this very tree, so it lawfully
+//   carries no archive digests and the release manifest owns them instead:
+//     node scripts/prove-plugin-pinned-provision.mjs --lane native \
+//       --expect-build-source explicit_package --release-manifest PATH
+//     node scripts/prove-plugin-pinned-provision.mjs --lane native \
+//       --expect-build-source explicit_package --defer-archive-digest
 //
 // This file is an entry point and nothing else imports it, so its body runs unconditionally.
-// The bounded wait lives in scripts/lib/wait-for-managed-runtime.mjs, which the test imports
-// without running the proof.
+// The bounded wait lives in scripts/lib/wait-for-managed-runtime.mjs and the lane split lives in
+// scripts/lib/provision-proof-lanes.mjs, which the tests import without running the proof.
 
 import { spawn, execFileSync } from "node:child_process";
 import fs from "node:fs";
@@ -19,7 +29,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { waitForManagedRuntime } from "./lib/wait-for-managed-runtime.mjs";
-import { requirePinnedArchiveDigest } from "./lib/pinned-archive-digests.mjs";
+import {
+  assertProvisionedArchiveDigest,
+  parseProvisionProofArguments,
+} from "./lib/provision-proof-lanes.mjs";
+import { parseReleaseManifest } from "./lib/release-manifest.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const launcher = path.join(repositoryRoot, "plugins/codestory/scripts/codestory-mcp.cjs");
@@ -32,16 +46,26 @@ function fail(message) {
   process.exit(1);
 }
 
-// A missing or non-numeric value used to yield NaN, and every `Date.now() > NaN` comparison is
-// false, so the one flag that declares the bound silently removed it. Refuse the argument
-// instead: an unbounded gate is the failure this timeout exists to prevent.
-const timeoutIndex = process.argv.indexOf("--timeout-ms");
-const timeoutMs = timeoutIndex >= 0 ? Number(process.argv[timeoutIndex + 1]) : 600_000;
-if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-  fail(
-    `--timeout-ms needs a positive number of milliseconds, got ` +
-      `${JSON.stringify(process.argv[timeoutIndex + 1] ?? null)}.`,
-  );
+// A missing or non-numeric --timeout-ms used to yield NaN, and every `Date.now() > NaN` comparison
+// is false, so the one flag that declares the bound silently removed it. Every argument is refused
+// the same way now: an unbounded gate, a misspelled lane, or an unstated native digest authority
+// all stop the proof rather than quietly weakening it.
+let options;
+try {
+  options = parseProvisionProofArguments(process.argv.slice(2));
+} catch (error) {
+  fail(error.message);
+}
+
+let stagedReleaseManifest = null;
+if (options.releaseManifestPath) {
+  try {
+    stagedReleaseManifest = parseReleaseManifest(
+      fs.readFileSync(options.releaseManifestPath, "utf8"),
+    );
+  } catch (error) {
+    fail(`could not use ${options.releaseManifestPath}: ${error.message}`);
+  }
 }
 
 const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-pin-proof-"));
@@ -66,7 +90,7 @@ child.stdin.write(
 );
 
 try {
-  await waitForManagedRuntime({ child, runtimeMetadata, timeoutMs });
+  await waitForManagedRuntime({ child, runtimeMetadata, timeoutMs: options.timeoutMs });
 } catch (error) {
   fail(`${error.message}\n${stderr}`);
 }
@@ -83,11 +107,19 @@ const target =
 if (manifest.version !== pin.cli_version) {
   fail(`provisioned ${manifest.version}, pin names ${pin.cli_version}.`);
 }
-if (manifest.build_source !== "github_release") {
-  fail(`expected a github_release provision, observed ${manifest.build_source}.`);
+if (manifest.build_source !== options.expectBuildSource) {
+  fail(`expected a ${options.expectBuildSource} provision, observed ${manifest.build_source}.`);
 }
+let outcome;
 try {
-  requirePinnedArchiveDigest(pin, target, manifest.archive_sha256);
+  outcome = assertProvisionedArchiveDigest({
+    lane: options.lane,
+    pin,
+    target,
+    provisioned: { sha256: manifest.archive_sha256, bytes: manifest.archive_bytes },
+    releaseManifest: stagedReleaseManifest,
+    deferArchiveDigest: options.deferArchiveDigest,
+  });
 } catch (error) {
   fail(`${error.message}.`);
 }
@@ -96,9 +128,14 @@ const reported = execFileSync(binary, ["--version"], { encoding: "utf8" }).trim(
 if (!reported.includes(pin.cli_version)) {
   fail(`provisioned binary reports "${reported}", expected ${pin.cli_version}.`);
 }
+// A deferral is a real gap in what this run proved, so it is announced instead of being folded
+// into the success line. The post-release manifest proof is the step that closes it.
+if (!outcome.asserted) {
+  console.log(`::warning::${outcome.claim}.`);
+}
 console.log(
-  `Pinned provision proven: ${target} ${pin.cli_version} from github_release, ` +
-    `archive ${manifest.archive_sha256.slice(0, 12)}…, binary reports "${reported}".`,
+  `Pinned provision proven (${options.lane} lane): ${target} ${pin.cli_version} from ` +
+    `${manifest.build_source}, ${outcome.claim}, binary reports "${reported}".`,
 );
 fs.rmSync(dataDir, { recursive: true, force: true });
 process.exit(0);

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -701,6 +701,9 @@ test("public support, assets, and release notes derive from the package and clos
       "codestory-cli-v0.16.0-macos-arm64.tar.gz",
       "codestory-cli-v0.16.0-linux-x64.tar.gz",
       "SHA256SUMS.txt",
+      // A native release cannot pin its own archive digests in source, so the release generates
+      // them from the archives it built and ships them as an asset the launcher can fetch.
+      "codestory-release-manifest.json",
       // The README tells a reader to consult the ledger rather than the platform table, so the
       // machine-readable closeout summary has to ship with the release itself.
       "release-closeout-summary.json",
@@ -1059,6 +1062,54 @@ test("catalog delivery declares two distinguishable states and no release gate",
   assert.throws(
     () => validateReleaseClaimGraph(unrecoverable),
     /workflow_policy\.catalog_delivery\.recovery_workflow/u,
+  );
+});
+
+// Publication and recovery are different events. Folding recovery into the published identity is
+// how a catalog restored days later would read as the catalog the release itself delivered, and a
+// rollback with no recorded target is a rollback nobody can perform.
+test("catalog recovery is a distinguishable identity with a recorded rollback target", () => {
+  const recovery = graph.workflow_policy.catalog_delivery.recovery;
+  assert.equal(recovery.id, "recovered");
+  assert.equal(
+    graph.workflow_policy.catalog_delivery.states.some(({ id }) => id === recovery.id),
+    false,
+  );
+  assert.deepEqual(recovery.previous_pin_outputs, [
+    "previous_marketplace_revision",
+    "previous_plugin_sha",
+    "previous_plugin_version",
+  ]);
+  // Stated rather than implied: no job restores the catalog on its own yet, so the graph refuses
+  // to carry a `true` that documentation could quote as an automatic rollback.
+  assert.equal(recovery.automatic_restore, false);
+
+  const missing = structuredClone(graph);
+  delete missing.workflow_policy.catalog_delivery.recovery;
+  assert.throws(
+    () => validateReleaseClaimGraph(missing),
+    /workflow_policy\.catalog_delivery\.recovery must be an object/u,
+  );
+
+  const collided = structuredClone(graph);
+  collided.workflow_policy.catalog_delivery.recovery.id = "published";
+  assert.throws(
+    () => validateReleaseClaimGraph(collided),
+    /recovery\.id published must be distinct from the delivery states/u,
+  );
+
+  const untargeted = structuredClone(graph);
+  untargeted.workflow_policy.catalog_delivery.recovery.previous_pin_outputs = [];
+  assert.throws(
+    () => validateReleaseClaimGraph(untargeted),
+    /previous_pin_outputs must name the recorded rollback target/u,
+  );
+
+  const overclaimed = structuredClone(graph);
+  overclaimed.workflow_policy.catalog_delivery.recovery.automatic_restore = true;
+  assert.throws(
+    () => validateReleaseClaimGraph(overclaimed),
+    /automatic_restore must be false while restore is operator-initiated/u,
   );
 });
 

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "009a8564a0799107a60f22eb738a37ad299620981b5e4f051a7efbb3c08d4ce8",
+      "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {

--- a/scripts/tests/prove-plugin-pinned-provision.test.mjs
+++ b/scripts/tests/prove-plugin-pinned-provision.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,8 +8,20 @@ import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { requirePinnedArchiveDigest } from "../lib/pinned-archive-digests.mjs";
+import {
+  assertProvisionedArchiveDigest,
+  parseProvisionProofArguments,
+} from "../lib/provision-proof-lanes.mjs";
+import {
+  RELEASE_MANIFEST_ASSET,
+  buildReleaseManifest,
+  parseReleaseManifest,
+  requireManifestArchiveDigest,
+} from "../lib/release-manifest.mjs";
+import { buildReleaseManifestFromAssets, parseBuildArguments } from "../build-release-manifest.mjs";
 
 const scriptsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = path.resolve(scriptsDir, "..");
 const proofScript = path.join(scriptsDir, "prove-plugin-pinned-provision.mjs");
 const waitModuleUrl = pathToFileURL(path.join(scriptsDir, "lib/wait-for-managed-runtime.mjs")).href;
 
@@ -17,19 +30,61 @@ const waitModuleUrl = pathToFileURL(path.join(scriptsDir, "lib/wait-for-managed-
 // reported failure, not a wedged test run.
 const KILL_AFTER_MS = 5_000;
 const VALID_DIGEST = "a".repeat(64);
+const COMMIT = "9".repeat(40);
+
+function sourcePin(overrides = {}) {
+  return { schema_version: 1, cli_version: "1.2.3", release_tag: "v1.2.3", ...overrides };
+}
+
+function repositoryPin() {
+  return JSON.parse(
+    fs.readFileSync(path.join(repositoryRoot, "plugins/codestory/cli-version.json"), "utf8"),
+  );
+}
+
+function manifestFor(version, entries = {}) {
+  const archives = {
+    "macos-arm64": {
+      filename: `codestory-cli-v${version}-macos-arm64.tar.gz`,
+      bytes: 111,
+      sha256: "1".repeat(64),
+    },
+    "linux-x64": {
+      filename: `codestory-cli-v${version}-linux-x64.tar.gz`,
+      bytes: 222,
+      sha256: "2".repeat(64),
+    },
+    "windows-x64": {
+      filename: `codestory-cli-v${version}-windows-x64.zip`,
+      bytes: 333,
+      sha256: "3".repeat(64),
+    },
+  };
+  for (const [target, entry] of Object.entries(entries)) {
+    archives[target] = { ...archives[target], ...entry };
+  }
+  return buildReleaseManifest({ version, tag: `v${version}`, commit: COMMIT, archives });
+}
 
 test("the provision gate requires a source-pinned digest", () => {
   assert.throws(
-    () => requirePinnedArchiveDigest({ schema_version: 1 }, "macos-arm64", VALID_DIGEST),
+    () =>
+      requirePinnedArchiveDigest({
+        pin: sourcePin(),
+        target: "macos-arm64",
+        observedDigest: VALID_DIGEST,
+        lane: "plugin",
+      }),
     /no valid macos-arm64 archive digest/u,
   );
   assert.throws(
     () =>
-      requirePinnedArchiveDigest(
-        { archives: { "macos-arm64": "not-a-digest" } },
-        "macos-arm64",
-        VALID_DIGEST,
-      ),
+      requirePinnedArchiveDigest({
+        pin: sourcePin({ archives: { "macos-arm64": "not-a-digest" } }),
+        target: "macos-arm64",
+        observedDigest: VALID_DIGEST,
+        lane: "plugin",
+      }),
     /no valid macos-arm64 archive digest/u,
   );
 });
@@ -37,24 +92,414 @@ test("the provision gate requires a source-pinned digest", () => {
 test("the provision gate rejects a hostile archive digest", () => {
   assert.throws(
     () =>
-      requirePinnedArchiveDigest(
-        { archives: { "linux-x64": VALID_DIGEST } },
-        "linux-x64",
-        "b".repeat(64),
-      ),
+      requirePinnedArchiveDigest({
+        pin: sourcePin({ archives: { "linux-x64": VALID_DIGEST } }),
+        target: "linux-x64",
+        observedDigest: "b".repeat(64),
+        lane: "plugin",
+      }),
     /does not match the pin's linux-x64 digest/u,
   );
 });
 
 test("the provision gate accepts the exact source-pinned digest", () => {
   assert.equal(
-    requirePinnedArchiveDigest(
-      { archives: { "windows-x64": VALID_DIGEST } },
-      "windows-x64",
-      VALID_DIGEST,
-    ),
+    requirePinnedArchiveDigest({
+      pin: sourcePin({ archives: { "windows-x64": VALID_DIGEST } }),
+      target: "windows-x64",
+      observedDigest: VALID_DIGEST,
+      lane: "plugin",
+    }),
     VALID_DIGEST,
   );
+});
+
+// The lane is a required argument with no default, so a caller that omits it or misspells it is
+// refused rather than quietly granted the plugin lane's authority over a native pin.
+test("only the plugin lane may assert a source-pinned archive digest", () => {
+  const pin = sourcePin({ archives: { "linux-x64": VALID_DIGEST } });
+  for (const lane of ["native", undefined, "", "Plugin"]) {
+    assert.throws(
+      () => requirePinnedArchiveDigest({ pin, target: "linux-x64", observedDigest: VALID_DIGEST, lane }),
+      /only the plugin lane may assert a source-pinned archive digest/u,
+      `lane ${JSON.stringify(lane)} reached the source-pin assertion`,
+    );
+  }
+});
+
+// The freeze-critical case, held against the pin this repository actually carries rather than a
+// hand-made one. The frozen native head's pin is lawfully archive-less -- bump-version.mjs deletes
+// `archives` on a native bump because the archives are built FROM this tree -- and the proof used
+// to run the source-pin assertion on it unconditionally, which can only fail.
+test("the frozen source carries no circular native archive digest", () => {
+  const pin = repositoryPin();
+  assert.equal(
+    Object.hasOwn(pin, "archives"),
+    false,
+    "a native pin naming digests of archives built from its own tree is the circularity REL-MAN removes",
+  );
+});
+
+test("a lawful archive-less native pin fails the plugin lane and passes the native one", () => {
+  const pin = repositoryPin();
+  const target = "linux-x64";
+  const provisioned = { sha256: VALID_DIGEST, bytes: 4096 };
+
+  // What the frozen head hit before the split, reproduced on the real pin.
+  assert.throws(
+    () => requirePinnedArchiveDigest({ pin, target, observedDigest: provisioned.sha256, lane: "plugin" }),
+    /no valid linux-x64 archive digest/u,
+  );
+
+  // The native lane never reaches that assertion. Without a staged manifest it records an explicit
+  // deferral instead of claiming a digest it did not prove.
+  const deferred = assertProvisionedArchiveDigest({
+    lane: "native",
+    pin,
+    target,
+    provisioned,
+    deferArchiveDigest: true,
+  });
+  assert.equal(deferred.asserted, false);
+  assert.equal(deferred.authority, "deferred");
+  assert.match(deferred.claim, /NOT proven here/u);
+
+  // With the staged manifest it proves the digest the release itself owns.
+  const manifest = manifestFor(pin.cli_version, {
+    [target]: { bytes: provisioned.bytes, sha256: provisioned.sha256 },
+  });
+  const proven = assertProvisionedArchiveDigest({
+    lane: "native",
+    pin,
+    target,
+    provisioned,
+    releaseManifest: manifest,
+  });
+  assert.equal(proven.asserted, true);
+  assert.equal(proven.authority, "release_manifest");
+
+  // The dispatcher must be doing the assertion, not reporting that one happened. A native run
+  // whose provisioned archive disagrees with the staged manifest is refused here, in the same
+  // call that reported success a moment ago.
+  for (const hostile of [
+    { sha256: "f".repeat(64), bytes: provisioned.bytes },
+    { sha256: provisioned.sha256, bytes: provisioned.bytes + 1 },
+  ]) {
+    assert.throws(
+      () =>
+        assertProvisionedArchiveDigest({
+          lane: "native",
+          pin,
+          target,
+          provisioned: hostile,
+          releaseManifest: manifest,
+        }),
+      /release manifest linux-x64 (?:digest|length)/u,
+      JSON.stringify(hostile),
+    );
+  }
+  // And the plugin lane's own assertion is real: a pin that does carry a digest still refuses a
+  // provision that does not match it.
+  assert.throws(
+    () =>
+      assertProvisionedArchiveDigest({
+        lane: "plugin",
+        pin: { ...pin, archives: { [target]: VALID_DIGEST } },
+        target,
+        provisioned: { sha256: "f".repeat(64), bytes: 4096 },
+      }),
+    /does not match the pin's linux-x64 digest/u,
+  );
+});
+
+// The dispatcher is the single reader of the source-pin assertion. If the proof could import it
+// directly, a native branch could reacquire the plugin lane's authority without any lane check.
+test("the proof reaches the source-pin assertion only through the lane dispatcher", () => {
+  const source = fs.readFileSync(proofScript, "utf8");
+  assert.equal(
+    source.includes("pinned-archive-digests.mjs"),
+    false,
+    "prove-plugin-pinned-provision.mjs must not import the source-pin module directly",
+  );
+  assert.equal(source.includes("requirePinnedArchiveDigest"), false);
+  assert.equal(source.includes("provision-proof-lanes.mjs"), true);
+});
+
+test("the plugin lane refuses the native lane's digest authorities", () => {
+  const plugin = parseProvisionProofArguments([]);
+  assert.deepEqual(plugin, {
+    lane: "plugin",
+    timeoutMs: 600_000,
+    expectBuildSource: "github_release",
+    releaseManifestPath: null,
+    deferArchiveDigest: false,
+  });
+  for (const argv of [
+    ["--release-manifest", "manifest.json"],
+    ["--defer-archive-digest"],
+    ["--expect-build-source", "explicit_package"],
+  ]) {
+    assert.throws(
+      () => parseProvisionProofArguments(argv),
+      /belongs to the native lane/u,
+      argv.join(" "),
+    );
+  }
+  assert.throws(
+    () =>
+      assertProvisionedArchiveDigest({
+        lane: "plugin",
+        pin: sourcePin({ archives: { "linux-x64": VALID_DIGEST } }),
+        target: "linux-x64",
+        provisioned: { sha256: VALID_DIGEST, bytes: 10 },
+        deferArchiveDigest: true,
+      }),
+    /proves its source pin and nothing else/u,
+  );
+});
+
+test("the native lane refuses to run without a stated digest authority", () => {
+  assert.throws(
+    () => parseProvisionProofArguments(["--lane", "native", "--expect-build-source", "explicit_package"]),
+    /needs either --release-manifest PATH or an explicit --defer-archive-digest/u,
+  );
+  assert.throws(
+    () =>
+      parseProvisionProofArguments([
+        "--lane",
+        "native",
+        "--expect-build-source",
+        "explicit_package",
+        "--release-manifest",
+        "m.json",
+        "--defer-archive-digest",
+      ]),
+    /mutually exclusive/u,
+  );
+  assert.throws(
+    () => parseProvisionProofArguments(["--lane", "native", "--defer-archive-digest"]),
+    /needs --expect-build-source github_release\|explicit_package/u,
+  );
+  assert.throws(
+    () =>
+      parseProvisionProofArguments([
+        "--lane",
+        "native",
+        "--expect-build-source",
+        "candidate_archive",
+        "--defer-archive-digest",
+      ]),
+    /needs --expect-build-source github_release\|explicit_package/u,
+  );
+  assert.deepEqual(
+    parseProvisionProofArguments([
+      "--lane",
+      "native",
+      "--expect-build-source",
+      "explicit_package",
+      "--release-manifest",
+      "staged/manifest.json",
+    ]),
+    {
+      lane: "native",
+      timeoutMs: 600_000,
+      expectBuildSource: "explicit_package",
+      releaseManifestPath: "staged/manifest.json",
+      deferArchiveDigest: false,
+    },
+  );
+});
+
+// A misspelled or duplicated flag used to be ignored, which turns `--lane natvie` into a silent
+// plugin-lane run against a native pin -- the exact failure this package removes.
+test("the proof refuses unknown, repeated, and malformed arguments", () => {
+  assert.throws(() => parseProvisionProofArguments(["--lane", "natvie"]), /--lane must be one of/u);
+  assert.throws(() => parseProvisionProofArguments(["--wat", "1"]), /unknown argument --wat/u);
+  assert.throws(() => parseProvisionProofArguments(["positional"]), /unexpected argument/u);
+  assert.throws(
+    () => parseProvisionProofArguments(["--timeout-ms", "1", "--timeout-ms", "2"]),
+    /--timeout-ms was given more than once/u,
+  );
+  assert.throws(
+    () => parseProvisionProofArguments(["--timeout-ms"]),
+    /--timeout-ms needs a positive number/u,
+  );
+});
+
+test("the release manifest binds its digests to one release identity", () => {
+  const manifest = manifestFor("1.2.3");
+  const target = "linux-x64";
+  const provisioned = { sha256: "2".repeat(64), bytes: 222 };
+  assert.deepEqual(
+    requireManifestArchiveDigest(manifest, { version: "1.2.3", tag: "v1.2.3" }, target, provisioned),
+    { filename: "codestory-cli-v1.2.3-linux-x64.tar.gz", bytes: 222, sha256: "2".repeat(64) },
+  );
+  // A perfectly valid manifest for a DIFFERENT release describes intact bytes of the wrong
+  // release. Without the identity binding it would satisfy this assertion.
+  assert.throws(
+    () =>
+      requireManifestArchiveDigest(
+        manifestFor("1.2.4"),
+        { version: "1.2.3", tag: "v1.2.3" },
+        target,
+        provisioned,
+      ),
+    /describes v1\.2\.4 \(1\.2\.4\), not the v1\.2\.3 \(1\.2\.3\) being provisioned/u,
+  );
+  assert.throws(
+    () =>
+      requireManifestArchiveDigest(manifest, { version: "1.2.3", tag: "v1.2.3" }, target, {
+        sha256: "4".repeat(64),
+        bytes: 222,
+      }),
+    /linux-x64 digest .* does not match the provisioned archive digest/u,
+  );
+  // The length is recorded by the release and read here; a manifest field nothing checks cannot
+  // fail, so a byte-length drift is a refusal like any other.
+  assert.throws(
+    () =>
+      requireManifestArchiveDigest(manifest, { version: "1.2.3", tag: "v1.2.3" }, target, {
+        sha256: "2".repeat(64),
+        bytes: 223,
+      }),
+    /linux-x64 length 222 does not match the provisioned archive length 223/u,
+  );
+  assert.throws(
+    () =>
+      requireManifestArchiveDigest(manifest, { version: "1.2.3", tag: "v1.2.3" }, target, {
+        sha256: "2".repeat(64),
+      }),
+    /needs the provisioned linux-x64 archive byte length/u,
+  );
+  assert.throws(
+    () =>
+      requireManifestArchiveDigest(manifest, { version: "1.2.3", tag: "v1.2.3" }, "solaris-sparc", provisioned),
+    /has no solaris-sparc target/u,
+  );
+});
+
+test("the release manifest refuses every malformed shape", () => {
+  const good = manifestFor("1.2.3");
+  for (const [mutate, expected] of [
+    [(m) => ({ ...m, domain: "codestory.other" }), /domain must be codestory\.release-manifest/u],
+    [(m) => ({ ...m, schema_version: 2 }), /schema_version must be 1/u],
+    [(m) => ({ ...m, version: "not-semver" }), /version must be semver/u],
+    [(m) => ({ ...m, tag: "1.2.3" }), /tag must be v1\.2\.3/u],
+    [(m) => ({ ...m, commit: "ABC" }), /commit must be a 40-character lowercase hexadecimal id/u],
+    [
+      (m) => ({ ...m, archives: { "linux-x64": m.archives["linux-x64"] } }),
+      /archives must name exactly linux-x64, macos-arm64, windows-x64/u,
+    ],
+    [
+      (m) => ({ ...m, archives: { ...m.archives, extra: m.archives["linux-x64"] } }),
+      /archives must name exactly/u,
+    ],
+    [
+      (m) => ({
+        ...m,
+        archives: { ...m.archives, "linux-x64": { ...m.archives["linux-x64"], filename: "other.tar.gz" } },
+      }),
+      /linux-x64 filename must be codestory-cli-v1\.2\.3-linux-x64\.tar\.gz/u,
+    ],
+    [
+      (m) => ({
+        ...m,
+        archives: { ...m.archives, "linux-x64": { ...m.archives["linux-x64"], bytes: 0 } },
+      }),
+      /linux-x64 bytes must be a positive integer/u,
+    ],
+    [
+      (m) => ({
+        ...m,
+        archives: { ...m.archives, "linux-x64": { ...m.archives["linux-x64"], sha256: "AB" } },
+      }),
+      /linux-x64 sha256 must be 64 lowercase hexadecimal characters/u,
+    ],
+  ]) {
+    assert.throws(() => parseReleaseManifest(JSON.stringify(mutate(good))), expected);
+  }
+  assert.throws(() => parseReleaseManifest("{"), /is not valid JSON/u);
+});
+
+function stagedAssets(version, { corruptSums = false, omitTarget = null } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-release-assets-"));
+  const lines = [];
+  const expected = {};
+  for (const [target, filename] of [
+    ["macos-arm64", `codestory-cli-v${version}-macos-arm64.tar.gz`],
+    ["linux-x64", `codestory-cli-v${version}-linux-x64.tar.gz`],
+    ["windows-x64", `codestory-cli-v${version}-windows-x64.zip`],
+  ]) {
+    const body = Buffer.from(`${target} archive for ${version}\n`, "utf8");
+    if (target !== omitTarget) fs.writeFileSync(path.join(dir, filename), body);
+    const digest = createHash("sha256").update(body).digest("hex");
+    expected[target] = { filename, bytes: body.length, sha256: digest };
+    lines.push(`${corruptSums && target === "linux-x64" ? "0".repeat(64) : digest}  ${filename}`);
+  }
+  fs.writeFileSync(path.join(dir, "SHA256SUMS.txt"), `${lines.join("\n")}\n`, "utf8");
+  return { dir, expected };
+}
+
+test("the release manifest is generated from the archives the release built", () => {
+  const { dir, expected } = stagedAssets("1.2.3");
+  try {
+    const manifest = buildReleaseManifestFromAssets({
+      version: "1.2.3",
+      tag: "v1.2.3",
+      commit: COMMIT,
+      assets: dir,
+    });
+    assert.deepEqual(manifest.archives, expected);
+    assert.equal(manifest.commit, COMMIT);
+    // Round-trips through the reader the launcher and the native proof use.
+    assert.deepEqual(parseReleaseManifest(JSON.stringify(manifest)), manifest);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the generator refuses archives its own checksum file does not describe", () => {
+  const drifted = stagedAssets("1.2.3", { corruptSums: true });
+  try {
+    assert.throws(
+      () =>
+        buildReleaseManifestFromAssets({
+          version: "1.2.3",
+          tag: "v1.2.3",
+          commit: COMMIT,
+          assets: drifted.dir,
+        }),
+      /the built archives and the release checksum file disagree/u,
+    );
+  } finally {
+    fs.rmSync(drifted.dir, { recursive: true, force: true });
+  }
+  const incomplete = stagedAssets("1.2.3", { omitTarget: "windows-x64" });
+  try {
+    assert.throws(
+      () =>
+        buildReleaseManifestFromAssets({
+          version: "1.2.3",
+          tag: "v1.2.3",
+          commit: COMMIT,
+          assets: incomplete.dir,
+        }),
+      /could not read the built windows-x64 archive/u,
+    );
+  } finally {
+    fs.rmSync(incomplete.dir, { recursive: true, force: true });
+  }
+  assert.throws(() => parseBuildArguments(["--version", "1.2.3"]), /--tag is required/u);
+  assert.throws(() => parseBuildArguments(["--nope", "1"]), /unknown argument --nope/u);
+});
+
+test("the release manifest asset name is the one the launcher fetches", () => {
+  assert.equal(RELEASE_MANIFEST_ASSET, "codestory-release-manifest.json");
+  const launcher = fs.readFileSync(
+    path.join(repositoryRoot, "plugins/codestory/scripts/codestory-mcp.cjs"),
+    "utf8",
+  );
+  assert.equal(launcher.includes(`'${RELEASE_MANIFEST_ASSET}'`), true);
 });
 
 function runNode(args, options = {}) {
@@ -216,4 +661,49 @@ test("the gate refuses --timeout-ms with no value at all", async () => {
   const outcome = await runNode([proofScript, "--timeout-ms"]);
   assert.equal(outcome.code, 1, `the gate did not fail closed: ${JSON.stringify(outcome)}`);
   assert.match(outcome.stderr, /::error::--timeout-ms needs a positive number/u);
+});
+
+// The lane arguments have to be refused by the SCRIPT, not just by the parser the script imports:
+// the release lanes invoke this file, and an argument error that only the unit test sees would
+// still let a badly invoked native dispatch run the plugin lane's assertion.
+for (const [name, argv, expected] of [
+  [
+    "a native lane with no digest authority",
+    ["--lane", "native", "--expect-build-source", "explicit_package"],
+    /::error::--lane native needs either --release-manifest PATH or an explicit --defer-archive-digest/u,
+  ],
+  [
+    "a native lane with no build source",
+    ["--lane", "native", "--defer-archive-digest"],
+    /::error::--lane native needs --expect-build-source/u,
+  ],
+  [
+    "a plugin lane reaching for the manifest",
+    ["--release-manifest", "staged.json"],
+    /::error::--release-manifest belongs to the native lane/u,
+  ],
+  ["a misspelled lane", ["--lane", "natvie"], /::error::--lane must be one of/u],
+  ["an unknown argument", ["--nope", "1"], /::error::unknown argument --nope/u],
+]) {
+  test(`the gate refuses ${name} before it provisions anything`, async () => {
+    const outcome = await runNode([proofScript, ...argv]);
+    assert.equal(outcome.code, 1, `the gate did not fail closed: ${JSON.stringify(outcome)}`);
+    assert.match(outcome.stderr, expected);
+  });
+}
+
+test("the gate refuses a staged release manifest it cannot use", async () => {
+  const manifestPath = path.join(scratchDir(), "release-manifest.json");
+  fs.writeFileSync(manifestPath, JSON.stringify({ domain: "codestory.release-manifest" }), "utf8");
+  const outcome = await runNode([
+    proofScript,
+    "--lane",
+    "native",
+    "--expect-build-source",
+    "explicit_package",
+    "--release-manifest",
+    manifestPath,
+  ]);
+  assert.equal(outcome.code, 1, `the gate did not fail closed: ${JSON.stringify(outcome)}`);
+  assert.match(outcome.stderr, /::error::could not use .*release-manifest\.json: release manifest schema_version/u);
 });


### PR DESCRIPTION
Closes #1795. **#1671 stays open** — see Declared remainder.

## This removes the freeze blocker

Epic #1179 carries a standing constraint: REL-MAN must merge before release choreography step 6, because the native frozen-head provision proof hard-fails on a lawful pin. `prove-plugin-pinned-provision.mjs` called `requirePinnedArchiveDigest` unconditionally; `plugins/codestory/cli-version.json` has no `archives` key because `bump-version.mjs` deletes it on a native bump by design. A native dispatch could only ever fail.

**Lane split with no default to fall into.** `requirePinnedArchiveDigest` now takes a required `lane` and refuses anything but `plugin`. The proof takes `--lane plugin|native`; native requires an explicitly stated digest authority — either `--release-manifest PATH` or an explicit `--defer-archive-digest`, never an implicit fallback. Deferral prints a warning and the success line says the digest was **not** proven. Unknown, repeated, positional and lane-inappropriate arguments are refused rather than ignored. A test asserts the proof reaches the source-pin assertion only through the dispatcher.

**Release manifest** generated after checksum verification and before the release is created, with every digest cross-checked against `SHA256SUMS.txt`. The launcher fetches it alongside `SHA256SUMS.txt` before the archive transfer and holds the downloaded archive's digest and byte length against it **before extraction**. A release without a manifest still provisions, recording `release_manifest_absent`.

**Catalog recovery, bounded slice:** the replaced pin is recorded before pushing, and a catalog whose current entry is not a usable rollback target is refused.

## Declared remainder

Automatic prior-SHA restore on live-catalog smoke failure, the "release incomplete" declaration, and two further clauses. `release-claims.json` records `catalog_delivery.recovery` with `automatic_restore: false` — the gap is in the claim graph, not just the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
