### PR TITLE
[v0.17 SRC-C2] Give unowned declaration rows position-independent identity

### DIFF
--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -44,6 +44,13 @@ mod framework_routes;
 pub mod intermediate_storage;
 mod language_configs;
 mod languages;
+
+/// SRC-C2 fence classification: lives in its own file because
+/// `codestory-indexer`'s own source is indexed by
+/// `tests/integration.rs`, which fails once a file crosses the 1 MB
+/// oversized-source cap this crate enforces.
+#[cfg(test)]
+mod projection_fence_tests;
 pub mod resolution;
 pub mod semantic;
 pub mod structural;
@@ -803,7 +810,19 @@ const FILE_STRUCTURAL_SYMBOL_KEY: &str = "__file_structural__";
 enum ProjectionUpdateMode {
     InsertFresh,
     NoChanges,
-    Delta { changed_callers: Vec<NodeId> },
+    Delta {
+        changed_callers: Vec<NodeId>,
+    },
+    /// The file-structural fence moved without changing what it contains.
+    ///
+    /// Every unowned row kept its identity and only its span shifted, so the
+    /// rows the fence owns are deleted and re-inserted at their new positions
+    /// while the node table — and everything anchored to it — is left alone.
+    /// `changed_callers` is still repaired caller-scoped, exactly as in
+    /// `Delta`.
+    RepositionUnowned {
+        changed_callers: Vec<NodeId>,
+    },
     FullReplace,
 }
 
@@ -1349,6 +1368,17 @@ impl<'a> ProjectionWriter<'a> {
                 match update_mode {
                     ProjectionUpdateMode::InsertFresh | ProjectionUpdateMode::NoChanges => {}
                     ProjectionUpdateMode::Delta { changed_callers } => {
+                        self.storage
+                            .delete_projection_for_callers(file_id, &changed_callers)
+                            .map_err(|e| anyhow!("Storage delta cleanup error: {:?}", e))?;
+                    }
+                    ProjectionUpdateMode::RepositionUnowned { changed_callers } => {
+                        // Order matters: the unowned cleanup reads ownership off
+                        // the stored callable rows, and the caller cleanup
+                        // deletes them.
+                        self.storage
+                            .delete_unowned_projection_for_file(file_id)
+                            .map_err(|e| anyhow!("Storage reposition cleanup error: {:?}", e))?;
                         self.storage
                             .delete_projection_for_callers(file_id, &changed_callers)
                             .map_err(|e| anyhow!("Storage delta cleanup error: {:?}", e))?;
@@ -20784,22 +20814,29 @@ pub(crate) fn build_callable_projection_states(
 
     if let Some(file_node) = nodes.iter().find(|node| node.kind == NodeKind::FILE) {
         let repaired_callables = CallableProjectionExtents::from_states(&states);
+        let fence = structural_projection_fence(
+            file_node.id,
+            nodes,
+            edges,
+            occurrences,
+            &node_by_id,
+            &repaired_callables,
+        );
         states.push(CallableProjectionState {
             file_id: file_node.id.0,
             symbol_key: FILE_STRUCTURAL_SYMBOL_KEY.to_string(),
             node_id: file_node.id,
-            signature_hash: callable_signature_hash(FILE_STRUCTURAL_SYMBOL_KEY),
+            // On a callable row this column is the identity the delta path
+            // cannot repair; on the file row it means the same thing for the
+            // unowned population, which is why the identity lives here rather
+            // than in a second row: a second row keyed to the same `node_id`
+            // would double every `callable_projection_state` join an annotation
+            // lookup makes against the FILE node.
+            signature_hash: fence.identity,
             // The file structural row is not a callable, so it carries no
             // normalized signature and can never satisfy a rebind probe.
             normalized_signature: None,
-            body_hash: structural_projection_hash(
-                file_node.id,
-                nodes,
-                edges,
-                occurrences,
-                &node_by_id,
-                &repaired_callables,
-            ),
+            body_hash: fence.detector,
             start_line: 1,
             end_line: file_node.end_line.unwrap_or(1),
         });
@@ -21120,15 +21157,48 @@ impl CallableProjectionExtents {
     }
 }
 
-fn structural_projection_hash(
+/// The two numbers the file-structural row carries.
+struct StructuralProjectionFence {
+    /// `body_hash`: the fence's change detector, and a **frozen wire format**.
+    /// A store written by an earlier release compares against this value
+    /// directly, so altering one part string would re-replace — and so strip
+    /// the annotations from — every file in every existing database.
+    detector: i64,
+    /// `signature_hash`: the same population with the repairable positions
+    /// taken out, which is what lets a pure shift be repaired in place instead
+    /// of read as churn.
+    identity: i64,
+}
+
+/// Stamp distinguishing one file-structural *identity* format from the next.
+///
+/// Embeds `CALLABLE_PROJECTION_FORMAT_STAMP`, so a callable-format bump
+/// invalidates this one too.
+const FILE_STRUCTURAL_IDENTITY_FORMAT_STAMP: &str = "file-structural-identity-format:1";
+
+/// The one unowned row class the reposition repair cannot fix.
+///
+/// `Store::delete_unowned_projection_for_file` removes the file's unowned edge
+/// rows by `file_node_id`, because that is the only column tying an edge row to
+/// the parse that will re-emit it. An unowned edge recorded against a
+/// *different* file — or against no file at all — is therefore never reached by
+/// that repair, and edge rows are insert-or-ignore, so a moved one would keep
+/// its old line forever. Those edges keep their line inside the identity hash,
+/// which routes them to `FullReplace`: the only cleanup that does reach them.
+fn edge_position_is_repairable_by_file(edge: &Edge, file_id: NodeId) -> bool {
+    edge.file_node_id == Some(file_id)
+}
+
+fn structural_projection_fence(
     file_id: NodeId,
     nodes: &[Node],
     edges: &[Edge],
     occurrences: &[Occurrence],
     node_by_id: &HashMap<NodeId, &Node>,
     repaired_callables: &CallableProjectionExtents,
-) -> i64 {
+) -> StructuralProjectionFence {
     let mut parts = Vec::new();
+    let mut identity_parts = Vec::new();
 
     for node in nodes {
         if node.id == file_id {
@@ -21143,10 +21213,9 @@ fn structural_projection_hash(
         } else {
             "node"
         };
-        parts.push(format!(
-            "{role}:{}:{qualified_name}:{}",
-            node.kind as i32, node.id.0
-        ));
+        let part = format!("{role}:{}:{qualified_name}:{}", node.kind as i32, node.id.0);
+        identity_parts.push(part.clone());
+        parts.push(part);
     }
 
     for edge in edges {
@@ -21154,27 +21223,26 @@ fn structural_projection_hash(
         {
             continue;
         }
-        let source_name = node_by_id
-            .get(&edge.source)
-            .map(|node| {
-                node.qualified_name
-                    .as_deref()
-                    .unwrap_or(node.serialized_name.as_str())
-            })
-            .unwrap_or_default();
-        let target_name = node_by_id
-            .get(&edge.target)
-            .map(|node| {
-                node.qualified_name
-                    .as_deref()
-                    .unwrap_or(node.serialized_name.as_str())
-            })
-            .unwrap_or_default();
-        parts.push(format!(
-            "edge:{}:{source_name}:{target_name}:{}",
-            edge.kind as i32,
-            edge.line.unwrap_or(0)
-        ));
+        let endpoint_name = |id: &NodeId| {
+            node_by_id
+                .get(id)
+                .map(|node| {
+                    node.qualified_name
+                        .as_deref()
+                        .unwrap_or(node.serialized_name.as_str())
+                })
+                .unwrap_or_default()
+        };
+        let source_name = endpoint_name(&edge.source);
+        let target_name = endpoint_name(&edge.target);
+        let kind = edge.kind as i32;
+        let line = edge.line.unwrap_or(0);
+        parts.push(format!("edge:{kind}:{source_name}:{target_name}:{line}"));
+        identity_parts.push(if edge_position_is_repairable_by_file(edge, file_id) {
+            format!("edge:{kind}:{source_name}:{target_name}")
+        } else {
+            format!("unrepairable-edge:{kind}:{source_name}:{target_name}:{line}")
+        });
     }
 
     for occurrence in occurrences {
@@ -21184,19 +21252,65 @@ fn structural_projection_hash(
         if repaired_callables.owns_occurrence(occurrence) {
             continue;
         }
+        let element = occurrence.element_id;
+        let kind = occurrence.kind as i32;
         parts.push(format!(
-            "occurrence:{}:{}:{}:{}:{}:{}",
-            occurrence.element_id,
-            occurrence.kind as i32,
+            "occurrence:{element}:{kind}:{}:{}:{}:{}",
             occurrence.location.start_line,
             occurrence.location.start_col,
             occurrence.location.end_line,
             occurrence.location.end_col
         ));
+        identity_parts.push(format!("occurrence:{element}:{kind}"));
     }
 
     parts.sort();
-    hash_parts(parts.iter().map(String::as_str))
+    identity_parts.sort();
+    StructuralProjectionFence {
+        detector: hash_parts(parts.iter().map(String::as_str)),
+        identity: hash_parts(
+            [
+                FILE_STRUCTURAL_IDENTITY_FORMAT_STAMP,
+                CALLABLE_PROJECTION_FORMAT_STAMP,
+            ]
+            .into_iter()
+            .chain(identity_parts.iter().map(String::as_str)),
+        ),
+    }
+}
+
+/// How the file-structural fence classifies one refresh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileStructuralVerdict {
+    /// The fence saw nothing move and nothing change.
+    Unchanged,
+    /// Only repairable positions moved.
+    Repositioned,
+    /// The unowned population itself changed, or there is no identity evidence.
+    Replaced,
+}
+
+/// Read the stored file-structural row against the one just projected.
+///
+/// The upgrade from a store that predates the identity hash needs no migration
+/// and triggers no re-projection wave. Those rows hold
+/// `callable_signature_hash(FILE_STRUCTURAL_SYMBOL_KEY)` — one constant, the
+/// same for every file — which is not equal to any identity this function is
+/// handed, so a legacy row is read as churn and behaves exactly as it did
+/// before: `NoChanges` while the change detector agrees, `FullReplace` the
+/// moment it does not. The first edit to a file re-stamps it with a real
+/// identity, and only from then on can it be repositioned.
+fn classify_file_structural_fence(
+    existing: &CallableProjectionState,
+    current: &CallableProjectionState,
+) -> FileStructuralVerdict {
+    if current.body_hash == existing.body_hash {
+        return FileStructuralVerdict::Unchanged;
+    }
+    if existing.signature_hash != current.signature_hash {
+        return FileStructuralVerdict::Replaced;
+    }
+    FileStructuralVerdict::Repositioned
 }
 
 fn classify_projection_update(
@@ -21230,12 +21344,14 @@ fn classify_projection_update(
     }
 
     let mut changed_callers = Vec::new();
+    let mut fence = FileStructuralVerdict::Unchanged;
     for current_state in current {
         let Some(existing_state) = existing_by_key.get(current_state.symbol_key.as_str()) else {
             return ProjectionUpdateMode::FullReplace;
         };
         if current_state.symbol_key == FILE_STRUCTURAL_SYMBOL_KEY {
-            if current_state.body_hash != existing_state.body_hash {
+            fence = classify_file_structural_fence(existing_state, current_state);
+            if fence == FileStructuralVerdict::Replaced {
                 return ProjectionUpdateMode::FullReplace;
             }
             continue;
@@ -21248,10 +21364,15 @@ fn classify_projection_update(
         }
     }
 
-    if changed_callers.is_empty() {
-        ProjectionUpdateMode::NoChanges
-    } else {
-        ProjectionUpdateMode::Delta { changed_callers }
+    match fence {
+        FileStructuralVerdict::Replaced => ProjectionUpdateMode::FullReplace,
+        FileStructuralVerdict::Repositioned => {
+            ProjectionUpdateMode::RepositionUnowned { changed_callers }
+        }
+        FileStructuralVerdict::Unchanged if changed_callers.is_empty() => {
+            ProjectionUpdateMode::NoChanges
+        }
+        FileStructuralVerdict::Unchanged => ProjectionUpdateMode::Delta { changed_callers },
     }
 }
 

--- a/crates/codestory-indexer/src/projection_fence_tests.rs
+++ b/crates/codestory-indexer/src/projection_fence_tests.rs
@@ -1,0 +1,248 @@
+//! How the file-structural fence classifies one refresh (SRC-C2).
+//!
+//! These read `classify_projection_update` directly, so they can pin the two
+//! things an end-to-end probe cannot reach: the one unowned row class that
+//! genuinely still needs `FullReplace`, and the wire format a store written by
+//! the previous release compares against.
+
+use crate::*;
+
+/// A file whose declarations are almost all unowned: a module node and its
+/// import edge, a class header and its definition occurrence, and one
+/// method. Nothing but the method has a projection row, so everything else
+/// is fenced by the file-structural row.
+///
+/// `import_edge_file` is the `file_node_id` the import edge is recorded
+/// against — `Some(file)` for the ordinary case, anything else for the one
+/// class `Store::delete_unowned_projection_for_file` cannot reach.
+fn projection_for_unowned_declarations(
+    shift: u32,
+    import_edge_file: Option<NodeId>,
+    keep_module_node: bool,
+) -> Vec<CallableProjectionState> {
+    let file_id = NodeId(1);
+    let module_id = NodeId(20);
+    let class_id = NodeId(30);
+    let callable_id = NodeId(2);
+    let mut nodes = vec![
+        Node {
+            id: file_id,
+            kind: NodeKind::FILE,
+            serialized_name: "Widget.java".to_string(),
+            qualified_name: Some("Widget.java".to_string()),
+            start_line: Some(1),
+            start_col: Some(1),
+            end_line: Some(40),
+            end_col: Some(1),
+            ..Default::default()
+        },
+        Node {
+            id: class_id,
+            kind: NodeKind::CLASS,
+            serialized_name: "Widget".to_string(),
+            qualified_name: Some("Widget".to_string()),
+            file_node_id: Some(file_id),
+            start_line: Some(3 + shift),
+            start_col: Some(1),
+            end_line: Some(12 + shift),
+            end_col: Some(1),
+            ..Default::default()
+        },
+        Node {
+            id: callable_id,
+            kind: NodeKind::METHOD,
+            serialized_name: "Widget.total".to_string(),
+            qualified_name: Some("Widget.total".to_string()),
+            file_node_id: Some(file_id),
+            start_line: Some(6 + shift),
+            start_col: Some(5),
+            end_line: Some(8 + shift),
+            end_col: Some(5),
+            ..Default::default()
+        },
+    ];
+    if keep_module_node {
+        nodes.push(Node {
+            id: module_id,
+            kind: NodeKind::MODULE,
+            serialized_name: "java.util.List".to_string(),
+            qualified_name: Some("java.util.List".to_string()),
+            file_node_id: Some(file_id),
+            start_line: Some(1 + shift),
+            start_col: Some(1),
+            end_line: Some(1 + shift),
+            end_col: Some(23),
+            ..Default::default()
+        });
+    }
+    let edges = vec![Edge {
+        id: EdgeId(7),
+        source: file_id,
+        target: module_id,
+        kind: EdgeKind::IMPORT,
+        file_node_id: import_edge_file,
+        line: Some(1 + shift),
+        ..Default::default()
+    }];
+    let occurrences = vec![
+        Occurrence {
+            element_id: module_id.0,
+            kind: OccurrenceKind::DEFINITION,
+            location: SourceLocation {
+                file_node_id: file_id,
+                start_line: 1 + shift,
+                start_col: 1,
+                end_line: 1 + shift,
+                end_col: 23,
+            },
+        },
+        Occurrence {
+            element_id: class_id.0,
+            kind: OccurrenceKind::DEFINITION,
+            location: SourceLocation {
+                file_node_id: file_id,
+                start_line: 3 + shift,
+                start_col: 1,
+                end_line: 3 + shift,
+                end_col: 21,
+            },
+        },
+    ];
+    build_callable_projection_states(&nodes, &edges, &occurrences)
+}
+
+#[test]
+fn unowned_declarations_that_only_moved_are_repositioned() {
+    let before = projection_for_unowned_declarations(0, Some(NodeId(1)), true);
+    assert_eq!(
+        classify_projection_update(
+            &before,
+            &projection_for_unowned_declarations(0, Some(NodeId(1)), true)
+        ),
+        ProjectionUpdateMode::NoChanges,
+        "an unchanged file must not be reprojected"
+    );
+
+    let shifted = projection_for_unowned_declarations(1, Some(NodeId(1)), true);
+    assert_eq!(
+        classify_projection_update(&before, &shifted),
+        ProjectionUpdateMode::RepositionUnowned {
+            changed_callers: vec![NodeId(2)]
+        },
+        "an import, a class header and their rows moving one line must be \
+         repaired in place, and the callable that moved with them must still \
+         be repaired caller-scoped"
+    );
+}
+
+#[test]
+fn a_removed_unowned_declaration_still_forces_a_full_replacement() {
+    // The reposition repair never deletes a node row, so it is only sound
+    // while the unowned population is unchanged.
+    let before = projection_for_unowned_declarations(0, Some(NodeId(1)), true);
+    let without_module = projection_for_unowned_declarations(1, Some(NodeId(1)), false);
+    assert_eq!(
+        classify_projection_update(&before, &without_module),
+        ProjectionUpdateMode::FullReplace,
+        "a declaration that disappeared must not be repaired in place"
+    );
+}
+
+#[test]
+fn an_unowned_edge_outside_the_file_scope_still_forces_a_full_replacement() {
+    // `delete_unowned_projection_for_file` deletes edge rows by
+    // `file_node_id`, so an unowned edge recorded against another file is
+    // never reached by it; non-call edge ids do not include the line, so
+    // the re-insert is ignored and the stale line survives. This is the one
+    // unowned class that still has to take the whole-file replacement, and
+    // it is the only reason the identity hash keeps any line at all.
+    let before = projection_for_unowned_declarations(0, Some(NodeId(999)), true);
+    assert_eq!(
+        classify_projection_update(
+            &before,
+            &projection_for_unowned_declarations(0, Some(NodeId(999)), true)
+        ),
+        ProjectionUpdateMode::NoChanges,
+        "an unchanged file must not be reprojected"
+    );
+    assert_eq!(
+        classify_projection_update(
+            &before,
+            &projection_for_unowned_declarations(1, Some(NodeId(999)), true)
+        ),
+        ProjectionUpdateMode::FullReplace,
+        "an unowned edge the file-scoped cleanup cannot reach must keep \
+         forcing a full replacement when it moves"
+    );
+
+    // Control: the identical shift is repairable once the same edge is
+    // recorded against the file the cleanup deletes by.
+    let file_scoped = projection_for_unowned_declarations(0, Some(NodeId(1)), true);
+    assert_eq!(
+        classify_projection_update(
+            &file_scoped,
+            &projection_for_unowned_declarations(1, Some(NodeId(1)), true)
+        ),
+        ProjectionUpdateMode::RepositionUnowned {
+            changed_callers: vec![NodeId(2)]
+        },
+    );
+}
+
+/// The change detector for
+/// `projection_for_unowned_declarations(0, Some(NodeId(1)), true)`, as produced
+/// by the release that wrote the databases this one has to read.
+///
+/// This constant is a compatibility pin, not a golden output. Every store
+/// in the field holds this number for its own files; changing any part
+/// string the change detector hashes would make every one of them compare
+/// unequal on the next refresh, and `FullReplace` deletes annotations.
+/// Moving it is a deliberate, declared re-projection wave.
+const FROZEN_FILE_STRUCTURAL_BODY_HASH: i64 = -3_900_083_451_554_756_332;
+
+fn file_structural_row(states: &[CallableProjectionState]) -> &CallableProjectionState {
+    states
+        .iter()
+        .find(|state| state.symbol_key == FILE_STRUCTURAL_SYMBOL_KEY)
+        .expect("file structural row")
+}
+
+#[test]
+fn a_store_from_the_previous_release_upgrades_without_a_reprojection_wave() {
+    let before = projection_for_unowned_declarations(0, Some(NodeId(1)), true);
+    assert_eq!(
+        file_structural_row(&before).body_hash,
+        FROZEN_FILE_STRUCTURAL_BODY_HASH,
+        "the change detector's wire format is frozen: a different value here \
+         re-replaces every file in every existing database"
+    );
+
+    // What such a database actually holds: the identity column carries the
+    // one constant the previous release wrote there for every file.
+    let legacy = before
+        .iter()
+        .cloned()
+        .map(|mut state| {
+            if state.symbol_key == FILE_STRUCTURAL_SYMBOL_KEY {
+                state.signature_hash = callable_signature_hash(FILE_STRUCTURAL_SYMBOL_KEY);
+            }
+            state
+        })
+        .collect::<Vec<_>>();
+    assert_ne!(
+        file_structural_row(&legacy).signature_hash,
+        file_structural_row(&before).signature_hash,
+        "the fixture must actually differ from a real identity"
+    );
+    assert_eq!(
+        classify_projection_update(&legacy, &before),
+        ProjectionUpdateMode::NoChanges,
+        "an untouched file in an upgraded store must not be reprojected"
+    );
+    let shifted = projection_for_unowned_declarations(1, Some(NodeId(1)), true);
+    assert_eq!(
+        classify_projection_update(&legacy, &shifted),
+        ProjectionUpdateMode::FullReplace,
+        "a legacy row carries no identity, so its fence moving is still churn"
+    );
+}

--- a/crates/codestory-indexer/tests/projection_identity.rs
+++ b/crates/codestory-indexer/tests/projection_identity.rs
@@ -221,11 +221,12 @@ fn a_moved_call_edge_carries_its_new_line() -> anyhow::Result<()> {
 }
 
 #[test]
-fn a_shifted_occurrence_no_callable_owns_forces_a_full_replacement() -> anyhow::Result<()> {
+fn a_shifted_occurrence_no_callable_owns_is_repaired_in_place() -> anyhow::Result<()> {
     // Occurrence rows carry no id, so an occurrence the caller-scoped cleanup
     // does not delete becomes a duplicate rather than an updated row. The
     // struct field's occurrence sits outside every callable, so nothing but the
-    // file fence can see it move.
+    // file fence can see it move — and until SRC-C2 the fence answered by
+    // replacing the file, which is what destroyed the bookmark asserted below.
     let dir = tempdir()?;
     let root = dir.path();
     let path = root.join("lib.rs");
@@ -237,6 +238,8 @@ fn a_shifted_occurrence_no_callable_owns_forces_a_full_replacement() -> anyhow::
         .into_iter()
         .find(|node| node.serialized_name == "Thing::value")
         .expect("field node");
+    let category = storage.create_bookmark_category("review")?;
+    let bookmark = storage.add_bookmark(category, field.id, Some("the field"))?;
 
     // Insert above everything, so the field itself moves.
     fs::write(&path, format!("// header\n{RUST_BEFORE}"))?;
@@ -251,6 +254,15 @@ fn a_shifted_occurrence_no_callable_owns_forces_a_full_replacement() -> anyhow::
         field_spans,
         vec![(field.id.0, 5, 5)],
         "the field's occurrence must move once, not be duplicated"
+    );
+    let bookmarks = storage.get_bookmarks(Some(category))?;
+    assert_eq!(
+        bookmarks
+            .iter()
+            .map(|entry| (entry.id, entry.node_id))
+            .collect::<Vec<_>>(),
+        vec![(bookmark, field.id)],
+        "repairing the fence in place is what keeps the field's annotation alive"
     );
     Ok(())
 }

--- a/crates/codestory-indexer/tests/unowned_declaration_identity.rs
+++ b/crates/codestory-indexer/tests/unowned_declaration_identity.rs
@@ -1,0 +1,482 @@
+//! Unowned declaration identity across position-shifting edits (SRC-C2).
+//!
+//! SRC-C gave *callables* a position-independent identity. Everything else a
+//! file declares — its imports, its top-level constants, its fields, its class
+//! and namespace headers — is "unowned": no callable projection row repairs it,
+//! so the file-structural fence used to hash every one of those rows together
+//! with its span. Inserting a single header comment moved all of them, the
+//! fence read that as churn, and `FullReplace` deleted every `bookmark_node`
+//! row in the file.
+//!
+//! Every assertion here reads rows the production incremental path actually
+//! wrote, through `WorkspaceIndexer::run_incremental` against a real store. The
+//! central oracle is stronger than "the bookmark is still there": the store an
+//! incremental refresh leaves behind must be **byte-identical** to the store a
+//! from-scratch index of the same post-edit source produces. That is what rules
+//! out the failure modes a bookmark count cannot see — a stale occurrence at
+//! the pre-shift span, an edge still carrying its old line, an abandoned node
+//! row.
+
+use codestory_contracts::events::EventBus;
+use codestory_contracts::graph::{NodeId, NodeKind};
+use codestory_indexer::WorkspaceIndexer;
+use codestory_store::Store as Storage;
+use rusqlite::types::Value;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn reindex(root: &Path, storage: &mut Storage, path: &Path) -> anyhow::Result<()> {
+    let indexer = WorkspaceIndexer::new(root.to_path_buf());
+    let event_bus = EventBus::new();
+    let refresh_info = codestory_workspace::RefreshInfo {
+        mode: codestory_workspace::BuildMode::Incremental,
+        files_to_index: vec![path.to_path_buf()],
+        files_to_remove: vec![],
+        existing_file_ids: HashMap::new(),
+    };
+    indexer.run_incremental(storage, &refresh_info, &event_bus, None)?;
+    Ok(())
+}
+
+/// Every projection table whose rows the reposition repair is responsible for,
+/// plus the node table it must leave alone.
+///
+/// `file` is excluded on purpose: it carries the source mtime, which two runs
+/// separated by a write cannot agree on and which no consumer of this contract
+/// reads.
+const PROJECTION_QUERIES: [(&str, &str); 5] = [
+    (
+        "node",
+        "SELECT id, kind, serialized_name, qualified_name, canonical_id, file_node_id,
+                start_line, start_col, end_line, end_col
+         FROM node ORDER BY id",
+    ),
+    (
+        "edge",
+        "SELECT id, source_node_id, target_node_id, kind, file_node_id, line,
+                resolved_source_node_id, resolved_target_node_id, callsite_identity
+         FROM edge ORDER BY id, source_node_id, target_node_id, kind",
+    ),
+    (
+        "occurrence",
+        "SELECT element_id, kind, file_node_id, start_line, start_col, end_line, end_col
+         FROM occurrence
+         ORDER BY element_id, kind, file_node_id, start_line, start_col, end_line, end_col",
+    ),
+    (
+        "callable_projection_state",
+        "SELECT file_id, symbol_key, node_id, signature_hash, normalized_signature,
+                body_hash, start_line, end_line
+         FROM callable_projection_state ORDER BY file_id, symbol_key",
+    ),
+    (
+        "component_access",
+        "SELECT node_id, type FROM component_access ORDER BY node_id, type",
+    ),
+];
+
+/// One named table's rows, each row a list of column values.
+type TableRows = (&'static str, Vec<Vec<Value>>);
+
+fn projection_snapshot(storage: &Storage) -> anyhow::Result<Vec<TableRows>> {
+    let mut snapshot = Vec::with_capacity(PROJECTION_QUERIES.len());
+    for (name, query) in PROJECTION_QUERIES {
+        let mut statement = storage.get_connection().prepare(query)?;
+        let column_count = statement.column_count();
+        let rows = statement
+            .query_map([], |row| {
+                (0..column_count)
+                    .map(|column| row.get::<_, Value>(column))
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        snapshot.push((name, rows));
+    }
+    Ok(snapshot)
+}
+
+fn assert_repaired_like_a_fresh_index(
+    repaired: &Storage,
+    fresh: &Storage,
+    label: &str,
+) -> anyhow::Result<()> {
+    for ((table, repaired_rows), (_, fresh_rows)) in projection_snapshot(repaired)?
+        .into_iter()
+        .zip(projection_snapshot(fresh)?)
+    {
+        assert_eq!(
+            repaired_rows, fresh_rows,
+            "[{label}] the incrementally repaired `{table}` projection differs from a \
+             from-scratch index of the same source"
+        );
+    }
+    Ok(())
+}
+
+fn node_named(storage: &Storage, name: &str) -> anyhow::Result<Option<(NodeId, Option<u32>)>> {
+    let matches = storage
+        .get_nodes()?
+        .into_iter()
+        .filter(|node| node.serialized_name == name)
+        .collect::<Vec<_>>();
+    assert!(
+        matches.len() <= 1,
+        "expected at most one `{name}`, got {:?}",
+        matches
+            .iter()
+            .map(|node| (node.id.0, node.start_line))
+            .collect::<Vec<_>>()
+    );
+    Ok(matches.first().map(|node| (node.id, node.start_line)))
+}
+
+fn file_node_id(storage: &Storage) -> anyhow::Result<NodeId> {
+    Ok(storage
+        .get_nodes()?
+        .into_iter()
+        .find(|node| node.kind == NodeKind::FILE)
+        .expect("file node")
+        .id)
+}
+
+/// One language family's fixture.
+struct LanguageCase {
+    label: &'static str,
+    file_name: &'static str,
+    /// Source declaring an import, a top-level (or class-level) constant, a
+    /// type header, and one callable.
+    source: &'static str,
+    /// The callable whose bookmark must survive.
+    callable: &'static str,
+    /// The type header that only moves.
+    header: &'static str,
+    /// An unowned declaration node that disappears in `without_import`.
+    import_node: &'static str,
+    /// The same source with the import removed: a genuine population change
+    /// that must still take the whole-file replacement.
+    without_import: &'static str,
+    /// Comment syntax for the inserted header line.
+    line_comment: &'static str,
+    /// Line the comment is inserted *before* (1-based), for languages whose
+    /// first line must stay first.
+    insert_before_line: usize,
+}
+
+const CASES: &[LanguageCase] = &[
+    LanguageCase {
+        label: "java",
+        file_name: "Widget.java",
+        source: "import java.util.List;\n\npublic class Widget {\n    public static final int LIMIT = 10;\n\n    public int total(int base) {\n        return base + LIMIT;\n    }\n}\n",
+        callable: "Widget.total",
+        header: "Widget",
+        import_node: "java.util.List",
+        without_import: "public class Widget {\n    public static final int LIMIT = 10;\n\n    public int total(int base) {\n        return base + LIMIT;\n    }\n}\n",
+        line_comment: "//",
+        insert_before_line: 1,
+    },
+    LanguageCase {
+        label: "csharp",
+        file_name: "Widget.cs",
+        source: "using System;\n\nnamespace Demo\n{\n    public class Widget\n    {\n        public const int Limit = 10;\n\n        public int Total(int baseValue)\n        {\n            return baseValue + Limit;\n        }\n    }\n}\n",
+        callable: "Widget.Total",
+        header: "Widget",
+        import_node: "System",
+        without_import: "namespace Demo\n{\n    public class Widget\n    {\n        public const int Limit = 10;\n\n        public int Total(int baseValue)\n        {\n            return baseValue + Limit;\n        }\n    }\n}\n",
+        line_comment: "//",
+        insert_before_line: 1,
+    },
+    LanguageCase {
+        label: "kotlin",
+        file_name: "Widget.kt",
+        source: "import kotlin.math.max\n\nconst val LIMIT = 10\n\nclass Widget {\n    fun total(base: Int): Int {\n        return max(base, LIMIT)\n    }\n}\n",
+        callable: "Widget.total",
+        header: "Widget",
+        import_node: "kotlin.math.max",
+        without_import: "const val LIMIT = 10\n\nclass Widget {\n    fun total(base: Int): Int {\n        return base + LIMIT\n    }\n}\n",
+        line_comment: "//",
+        insert_before_line: 1,
+    },
+    LanguageCase {
+        label: "python",
+        file_name: "widget.py",
+        source: "import os\n\nLIMIT = 10\n\n\nclass Widget:\n    def total(self, base):\n        return base + LIMIT\n",
+        callable: "Widget.total",
+        header: "Widget",
+        import_node: "os",
+        without_import: "LIMIT = 10\n\n\nclass Widget:\n    def total(self, base):\n        return base + LIMIT\n",
+        line_comment: "#",
+        insert_before_line: 1,
+    },
+    LanguageCase {
+        label: "typescript",
+        file_name: "widget.ts",
+        source: "import { readFileSync } from \"fs\";\n\nexport const LIMIT = 10;\n\nexport class Widget {\n    total(base: number): number {\n        return base + LIMIT;\n    }\n}\n",
+        callable: "Widget.total",
+        header: "Widget",
+        import_node: "\"fs\"",
+        without_import: "export const LIMIT = 10;\n\nexport class Widget {\n    total(base: number): number {\n        return base + LIMIT;\n    }\n}\n",
+        line_comment: "//",
+        insert_before_line: 1,
+    },
+    LanguageCase {
+        label: "ruby",
+        file_name: "widget.rb",
+        source: "require 'set'\n\nLIMIT = 10\n\nclass Widget\n  def total(base)\n    base + LIMIT\n  end\nend\n",
+        callable: "Widget.total",
+        header: "Widget",
+        import_node: "'set'",
+        without_import: "LIMIT = 10\n\nclass Widget\n  def total(base)\n    base + LIMIT\n  end\nend\n",
+        line_comment: "#",
+        insert_before_line: 1,
+    },
+    LanguageCase {
+        label: "php",
+        file_name: "widget.php",
+        // `<?php` must stay on line 1, so the comment lands under it.
+        source: "<?php\nnamespace Demo;\n\nconst LIMIT = 10;\n\nclass Widget\n{\n    public function total(int $base): int\n    {\n        return $base + LIMIT;\n    }\n}\n",
+        callable: "Widget.total",
+        header: "Widget",
+        import_node: "Demo",
+        without_import: "<?php\nconst LIMIT = 10;\n\nclass Widget\n{\n    public function total(int $base): int\n    {\n        return $base + LIMIT;\n    }\n}\n",
+        line_comment: "//",
+        insert_before_line: 2,
+    },
+    LanguageCase {
+        label: "cpp",
+        file_name: "widget.cpp",
+        source: "#include <vector>\n\nconst int kLimit = 10;\n\nclass Widget {\npublic:\n    int total(int base) {\n        return base + kLimit;\n    }\n};\n",
+        callable: "Widget::total",
+        header: "Widget",
+        import_node: "<vector>",
+        without_import: "const int kLimit = 10;\n\nclass Widget {\npublic:\n    int total(int base) {\n        return base + kLimit;\n    }\n};\n",
+        line_comment: "//",
+        insert_before_line: 1,
+    },
+    LanguageCase {
+        label: "go",
+        file_name: "widget.go",
+        source: "package demo\n\nimport \"fmt\"\n\nconst Limit = 10\n\nfunc Total(base int) string {\n\treturn fmt.Sprint(base + Limit)\n}\n",
+        callable: "Total",
+        header: "demo",
+        import_node: "\"fmt\"",
+        without_import: "package demo\n\nconst Limit = 10\n\nfunc Total(base int) int {\n\treturn base + Limit\n}\n",
+        line_comment: "//",
+        insert_before_line: 1,
+    },
+    LanguageCase {
+        label: "rust",
+        file_name: "widget.rs",
+        source: "use std::fmt::Debug;\n\npub const LIMIT: i32 = 10;\n\npub struct Widget {\n    pub value: i32,\n}\n\npub fn total(base: i32) -> i32 {\n    base + LIMIT\n}\n",
+        callable: "total",
+        header: "Widget",
+        import_node: "std::fmt::Debug",
+        without_import: "pub const LIMIT: i32 = 10;\n\npub struct Widget {\n    pub value: i32,\n}\n\npub fn total(base: i32) -> i32 {\n    base + LIMIT\n}\n",
+        line_comment: "//",
+        insert_before_line: 1,
+    },
+];
+
+impl LanguageCase {
+    /// The same source with one comment line inserted, so every declaration
+    /// below it — import, constant, type header, callable — moves down by one
+    /// and nothing else changes.
+    fn shifted(&self) -> String {
+        let mut lines = self.source.lines().collect::<Vec<_>>();
+        let comment = format!("{} shifted by SRC-C2", self.line_comment);
+        lines.insert(self.insert_before_line - 1, comment.as_str());
+        let mut out = lines.join("\n");
+        out.push('\n');
+        out
+    }
+}
+
+#[test]
+fn a_header_comment_preserves_bookmarks_in_every_language_family() -> anyhow::Result<()> {
+    for case in CASES {
+        let dir = tempdir()?;
+        let root = dir.path();
+        let path = root.join(case.file_name);
+        fs::write(&path, case.source)?;
+        let mut storage = Storage::new_in_memory()?;
+        reindex(root, &mut storage, &path)?;
+
+        let (callable_id, callable_line) = node_named(&storage, case.callable)?
+            .unwrap_or_else(|| panic!("[{}] no `{}` node", case.label, case.callable));
+        let (header_id, header_line) = node_named(&storage, case.header)?
+            .unwrap_or_else(|| panic!("[{}] no `{}` node", case.label, case.header));
+        let (import_id, import_line) = node_named(&storage, case.import_node)?
+            .unwrap_or_else(|| panic!("[{}] no `{}` node", case.label, case.import_node));
+        let node_ids_before = {
+            let mut ids = storage
+                .get_nodes()?
+                .into_iter()
+                .map(|node| node.id.0)
+                .collect::<Vec<_>>();
+            ids.sort_unstable();
+            ids
+        };
+
+        let category = storage.create_bookmark_category("review")?;
+        let on_callable = storage.add_bookmark(category, callable_id, Some("the callable"))?;
+        let on_header = storage.add_bookmark(category, header_id, Some("the type header"))?;
+        let on_import = storage.add_bookmark(category, import_id, Some("the import"))?;
+
+        fs::write(&path, case.shifted())?;
+        reindex(root, &mut storage, &path)?;
+
+        let mut bookmarks = storage.get_bookmarks(Some(category))?;
+        bookmarks.sort_by_key(|bookmark| bookmark.id);
+        assert_eq!(
+            bookmarks
+                .iter()
+                .map(|bookmark| (bookmark.id, bookmark.node_id))
+                .collect::<Vec<_>>(),
+            vec![
+                (on_callable, callable_id),
+                (on_header, header_id),
+                (on_import, import_id),
+            ],
+            "[{}] inserting a header comment must not delete annotations anchored to \
+             a callable, a type header, or an import",
+            case.label
+        );
+
+        // Preserved is not enough: the rows have to have been *repaired*.
+        assert_eq!(
+            node_named(&storage, case.callable)?,
+            Some((callable_id, callable_line.map(|line| line + 1))),
+            "[{}] the callable must keep its id and follow the shift",
+            case.label
+        );
+        assert_eq!(
+            node_named(&storage, case.header)?,
+            Some((header_id, header_line.map(|line| line + 1))),
+            "[{}] the type header must keep its id and follow the shift",
+            case.label
+        );
+        assert_eq!(
+            node_named(&storage, case.import_node)?,
+            Some((import_id, import_line.map(|line| line + 1))),
+            "[{}] the import must keep its id and follow the shift",
+            case.label
+        );
+        let node_ids_after = {
+            let mut ids = storage
+                .get_nodes()?
+                .into_iter()
+                .map(|node| node.id.0)
+                .collect::<Vec<_>>();
+            ids.sort_unstable();
+            ids
+        };
+        assert_eq!(
+            node_ids_before, node_ids_after,
+            "[{}] a pure shift must neither mint nor abandon a node",
+            case.label
+        );
+
+        // The whole projection, not just the rows this test happens to name.
+        let mut fresh = Storage::new_in_memory()?;
+        reindex(root, &mut fresh, &path)?;
+        assert_repaired_like_a_fresh_index(&storage, &fresh, case.label)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn removing_an_unowned_declaration_still_replaces_the_file() -> anyhow::Result<()> {
+    // Fail-closed control. The reposition repair deletes edges and occurrences
+    // but never a node row, so it is only sound while the unowned population is
+    // unchanged. An edit that *removes* an unowned declaration — and shifts
+    // everything below it, so it looks like a shift to any position-blind
+    // check — must still take the whole-file replacement, or the removed node
+    // survives as an orphan that nothing will ever delete.
+    for case in CASES {
+        let dir = tempdir()?;
+        let root = dir.path();
+        let path = root.join(case.file_name);
+        fs::write(&path, case.source)?;
+        let mut storage = Storage::new_in_memory()?;
+        reindex(root, &mut storage, &path)?;
+        assert!(
+            node_named(&storage, case.import_node)?.is_some(),
+            "[{}] fixture must declare `{}`",
+            case.label,
+            case.import_node
+        );
+
+        fs::write(&path, case.without_import)?;
+        reindex(root, &mut storage, &path)?;
+
+        assert_eq!(
+            node_named(&storage, case.import_node)?,
+            None,
+            "[{}] a removed unowned declaration must not survive an incremental refresh",
+            case.label
+        );
+
+        let mut fresh = Storage::new_in_memory()?;
+        reindex(root, &mut fresh, &path)?;
+        assert_repaired_like_a_fresh_index(&storage, &fresh, case.label)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn a_shifted_import_leaves_no_stale_occurrence_or_edge_line() -> anyhow::Result<()> {
+    // The two row shapes the fence exists for, read directly: occurrence rows
+    // carry no id (a moved one becomes a second row rather than an updated
+    // one), and non-call edge rows are insert-or-ignore on an id that does not
+    // include the line (a moved one keeps its old line forever).
+    let case = &CASES[0];
+    let dir = tempdir()?;
+    let root = dir.path();
+    let path = root.join(case.file_name);
+    fs::write(&path, case.source)?;
+    let mut storage = Storage::new_in_memory()?;
+    reindex(root, &mut storage, &path)?;
+
+    let file_id = file_node_id(&storage)?;
+    let before = storage.get_occurrences_for_file(file_id)?.len();
+    let import_edge_lines_before = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == codestory_contracts::graph::EdgeKind::IMPORT)
+        .map(|edge| edge.line)
+        .collect::<Vec<_>>();
+    assert!(
+        !import_edge_lines_before.is_empty(),
+        "fixture must record an import edge"
+    );
+
+    fs::write(&path, case.shifted())?;
+    reindex(root, &mut storage, &path)?;
+
+    let after = storage.get_occurrences_for_file(file_node_id(&storage)?)?;
+    assert_eq!(
+        after.len(),
+        before,
+        "a pure shift must not add an occurrence row: {:?}",
+        after
+            .iter()
+            .map(|occ| (occ.element_id, occ.location.start_line))
+            .collect::<Vec<_>>()
+    );
+    let import_edge_lines_after = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == codestory_contracts::graph::EdgeKind::IMPORT)
+        .map(|edge| edge.line)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        import_edge_lines_after,
+        import_edge_lines_before
+            .iter()
+            .map(|line| line.map(|line| line + 1))
+            .collect::<Vec<_>>(),
+        "the import edge must carry its new line, not its old one"
+    );
+    Ok(())
+}

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -47,7 +47,7 @@ pub use storage_impl::{
     StructuralTextArtifactCacheWrite, StructuralTextProjection,
     StructuralTextPublicationCompatibility, StructuralTextUnit,
     StructuralTextUnitPublicationManifest, SymbolSearchDoc, SymbolSummaryRecord,
-    stored_vector_encoding, structural_text_unit_digest,
+    UnownedProjectionRemovalSummary, stored_vector_encoding, structural_text_unit_digest,
 };
 
 impl Store {

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -3741,6 +3741,17 @@ pub struct CallerProjectionRemovalSummary {
     pub removed_callable_projection_state_count: usize,
 }
 
+/// What a file-structural reposition repair removed.
+///
+/// Deliberately has no node, bookmark, or file-row counter: the repair exists
+/// precisely because it must not touch any of them.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnownedProjectionRemovalSummary {
+    pub file_id: i64,
+    pub removed_edge_count: usize,
+    pub removed_occurrence_count: usize,
+}
+
 /// Lightweight symbol projection used by lexical search sidecars.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchSymbolProjection {
@@ -7930,6 +7941,85 @@ impl Storage {
             removed_edge_count: removed_edges,
             removed_occurrence_count: removed_occurrences,
             removed_callable_projection_state_count,
+        })
+    }
+
+    /// Remove exactly the rows the file-structural fence owns.
+    ///
+    /// This is the third cleanup, between `delete_projection_for_callers` (the
+    /// rows of one changed callable) and `delete_file_projection` (the file and
+    /// every node in it, which is what destroys annotations). It exists so a
+    /// file whose unowned declarations only *moved* — a shifted import, a
+    /// shifted top-level constant, a shifted class header — can be repaired by
+    /// re-inserting those rows at their new positions instead of by deleting
+    /// the file.
+    ///
+    /// It deletes nothing keyed to a node: no `node`, no `bookmark_node`, no
+    /// `component_access`, no `file` row. The node table is upserted by id, so
+    /// positions self-heal there, and the caller is responsible for having
+    /// established that no node identity changed.
+    ///
+    /// Ownership is read off the stored `callable_projection_state` rows, which
+    /// still hold the *pre-edit* extents at this point — the same rows, and the
+    /// same containment test, `delete_projection_for_callers` uses. The
+    /// file-structural row is excluded by `node_id <> file_node_id`: it is not a
+    /// callable, and its extent is the whole file, so treating it as an owner
+    /// would protect every row in the file from the cleanup.
+    pub fn delete_unowned_projection_for_file(
+        &mut self,
+        file_node_id: i64,
+    ) -> Result<UnownedProjectionRemovalSummary, StorageError> {
+        let tx = self.conn.transaction()?;
+
+        // Mirror of `structural_projection_fence`'s occurrence arm: an
+        // occurrence is unowned when it is neither a projected callable's own
+        // definition nor inside a projected callable's recorded extent.
+        let removed_occurrences = tx.execute(
+            "DELETE FROM occurrence
+             WHERE file_node_id = ?1
+             AND element_id NOT IN (
+                SELECT node_id FROM callable_projection_state
+                WHERE file_id = ?1 AND node_id <> ?1
+             )
+             AND NOT EXISTS (
+                SELECT 1
+                FROM callable_projection_state cps
+                WHERE cps.file_id = ?1
+                AND cps.node_id <> ?1
+                AND occurrence.start_line >= cps.start_line
+                AND occurrence.end_line <= cps.end_line
+             )",
+            params![file_node_id],
+        )?;
+
+        // Mirror of the edge arm: an edge is unowned unless it is one of the
+        // two kinds the caller-scoped cleanup rewrites *and* a projected
+        // callable of this file sources it. Scoped to `file_node_id` because
+        // that is the set this file's parse re-emits.
+        let removed_edges = tx.execute(
+            &format!(
+                "DELETE FROM edge
+                 WHERE file_node_id = ?1
+                 AND NOT (
+                    kind IN ({}, {})
+                    AND source_node_id IN (
+                        SELECT node_id FROM callable_projection_state
+                        WHERE file_id = ?1 AND node_id <> ?1
+                    )
+                 )",
+                EdgeKind::CALL as i32,
+                EdgeKind::USAGE as i32
+            ),
+            params![file_node_id],
+        )?;
+
+        tx.commit()?;
+        self.invalidate_grounding_snapshots()?;
+
+        Ok(UnownedProjectionRemovalSummary {
+            file_id: file_node_id,
+            removed_edge_count: removed_edges,
+            removed_occurrence_count: removed_occurrences,
         })
     }
 

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -4962,6 +4962,260 @@ fn test_delete_projection_for_callers_removes_callable_scoped_data() -> Result<(
 }
 
 #[test]
+fn test_delete_unowned_projection_for_file_spares_nodes_and_annotations() -> Result<(), StorageError>
+{
+    // The reposition repair's whole reason to exist is that it removes the
+    // rows a re-parse re-emits and nothing else. Over-deleting here is exactly
+    // as damaging as the `FullReplace` it replaces, and the incremental
+    // integration probes cannot see it: they re-insert everything afterwards.
+    let mut storage = Storage::new_in_memory()?;
+    let file_id = 9_i64;
+    let file_node = Node {
+        id: NodeId(file_id),
+        kind: NodeKind::FILE,
+        serialized_name: "src/lib.rs".to_string(),
+        ..Default::default()
+    };
+    let callable = Node {
+        id: NodeId(901),
+        kind: NodeKind::FUNCTION,
+        serialized_name: "run".to_string(),
+        file_node_id: Some(file_node.id),
+        ..Default::default()
+    };
+    let header = Node {
+        id: NodeId(902),
+        kind: NodeKind::STRUCT,
+        serialized_name: "Thing".to_string(),
+        file_node_id: Some(file_node.id),
+        ..Default::default()
+    };
+    let imported = Node {
+        id: NodeId(903),
+        kind: NodeKind::MODULE,
+        serialized_name: "std::fmt".to_string(),
+        file_node_id: Some(file_node.id),
+        ..Default::default()
+    };
+
+    storage.insert_file(&FileInfo {
+        id: file_id,
+        path: PathBuf::from("src/lib.rs"),
+        language: "rust".to_string(),
+        modification_time: 1,
+        indexed: true,
+        complete: true,
+        line_count: 50,
+        file_role: FileRole::Source,
+    })?;
+    storage.insert_nodes_batch(&[
+        file_node.clone(),
+        callable.clone(),
+        header.clone(),
+        imported.clone(),
+        Node {
+            id: NodeId(951),
+            kind: NodeKind::FILE,
+            serialized_name: "src/other.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(950),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "other".to_string(),
+            file_node_id: Some(NodeId(951)),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_edges_batch(&[
+        // Owned: a call the caller-scoped cleanup rewrites.
+        Edge {
+            id: EdgeId(1),
+            source: callable.id,
+            target: imported.id,
+            kind: EdgeKind::CALL,
+            file_node_id: Some(file_node.id),
+            line: Some(11),
+            ..Default::default()
+        },
+        // Unowned: an import edge the file sources.
+        Edge {
+            id: EdgeId(2),
+            source: file_node.id,
+            target: imported.id,
+            kind: EdgeKind::IMPORT,
+            file_node_id: Some(file_node.id),
+            line: Some(1),
+            ..Default::default()
+        },
+        // Unowned by kind even though a projected callable sources it.
+        Edge {
+            id: EdgeId(3),
+            source: callable.id,
+            target: header.id,
+            kind: EdgeKind::TYPE_USAGE,
+            file_node_id: Some(file_node.id),
+            line: Some(11),
+            ..Default::default()
+        },
+        // Another file's row, incidentally pointing into this one.
+        Edge {
+            id: EdgeId(4),
+            source: NodeId(950),
+            target: callable.id,
+            kind: EdgeKind::CALL,
+            file_node_id: Some(NodeId(951)),
+            line: Some(4),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_occurrences_batch(&[
+        // Owned: the callable's own definition.
+        Occurrence {
+            element_id: callable.id.0,
+            kind: OccurrenceKind::DEFINITION,
+            location: SourceLocation {
+                file_node_id: file_node.id,
+                start_line: 10,
+                start_col: 0,
+                end_line: 12,
+                end_col: 1,
+            },
+        },
+        // Owned: inside the callable's recorded extent.
+        Occurrence {
+            element_id: imported.id.0,
+            kind: OccurrenceKind::REFERENCE,
+            location: SourceLocation {
+                file_node_id: file_node.id,
+                start_line: 11,
+                start_col: 4,
+                end_line: 11,
+                end_col: 10,
+            },
+        },
+        // Unowned: the import, above every callable.
+        Occurrence {
+            element_id: imported.id.0,
+            kind: OccurrenceKind::DEFINITION,
+            location: SourceLocation {
+                file_node_id: file_node.id,
+                start_line: 1,
+                start_col: 0,
+                end_line: 1,
+                end_col: 14,
+            },
+        },
+        // Unowned: the struct header, between the import and the callable.
+        Occurrence {
+            element_id: header.id.0,
+            kind: OccurrenceKind::DEFINITION,
+            location: SourceLocation {
+                file_node_id: file_node.id,
+                start_line: 3,
+                start_col: 0,
+                end_line: 3,
+                end_col: 12,
+            },
+        },
+    ])?;
+    storage.upsert_callable_projection_states(&[
+        CallableProjectionState {
+            file_id,
+            symbol_key: "src/lib.rs::run:FUNCTION".to_string(),
+            node_id: callable.id,
+            signature_hash: 111,
+            normalized_signature: None,
+            body_hash: 211,
+            start_line: 10,
+            end_line: 12,
+        },
+        // The file-structural row: same `node_id` as the file, extent covering
+        // the whole file. Treated as an owner it would protect every row here.
+        CallableProjectionState {
+            file_id,
+            symbol_key: "__file_structural__".to_string(),
+            node_id: file_node.id,
+            signature_hash: 311,
+            normalized_signature: None,
+            body_hash: 411,
+            start_line: 1,
+            end_line: 50,
+        },
+    ])?;
+
+    let category = storage.create_bookmark_category("review")?;
+    let on_header = storage.add_bookmark(category, header.id, Some("the header"))?;
+    let on_import = storage.add_bookmark(category, imported.id, Some("the import"))?;
+
+    let summary = storage.delete_unowned_projection_for_file(file_id)?;
+    assert_eq!(
+        summary.removed_edge_count, 2,
+        "the import and the type usage"
+    );
+    assert_eq!(
+        summary.removed_occurrence_count, 2,
+        "the import definition and the struct header"
+    );
+
+    let mut remaining_edges = storage
+        .get_edges()?
+        .into_iter()
+        .map(|edge| edge.id.0)
+        .collect::<Vec<_>>();
+    remaining_edges.sort_unstable();
+    assert_eq!(
+        remaining_edges,
+        vec![1, 4],
+        "the caller-scoped call survives for the caller cleanup, and another \
+         file's row is not this file's to delete"
+    );
+
+    let mut remaining_occurrences = storage
+        .get_occurrences()?
+        .into_iter()
+        .map(|occurrence| (occurrence.element_id, occurrence.location.start_line))
+        .collect::<Vec<_>>();
+    remaining_occurrences.sort_unstable();
+    assert_eq!(
+        remaining_occurrences,
+        vec![(callable.id.0, 10), (imported.id.0, 11)],
+        "everything a projected callable owns survives"
+    );
+
+    let mut remaining_nodes = storage
+        .get_nodes()?
+        .into_iter()
+        .map(|node| node.id.0)
+        .collect::<Vec<_>>();
+    remaining_nodes.sort_unstable();
+    assert_eq!(
+        remaining_nodes,
+        vec![file_id, 901, 902, 903, 950, 951],
+        "the repair must not delete a single node row"
+    );
+    assert_eq!(
+        storage
+            .get_callable_projection_states_for_file(file_id)?
+            .len(),
+        2,
+        "projection state is rewritten by the flush, not by this cleanup"
+    );
+
+    let mut bookmarks = storage.get_bookmarks(Some(category))?;
+    bookmarks.sort_by_key(|bookmark| bookmark.id);
+    assert_eq!(
+        bookmarks
+            .iter()
+            .map(|bookmark| (bookmark.id, bookmark.node_id))
+            .collect::<Vec<_>>(),
+        vec![(on_header, header.id), (on_import, imported.id)],
+        "no annotation may be destroyed by the reposition repair"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_opening_v3_db_resets_projection_state() -> Result<(), StorageError> {
     let db_path = std::env::temp_dir().join(format!(
         "codestory-store-v3-migration-{}.db",


### PR DESCRIPTION
Closes #1773.

SRC-C made *callables* position-independent, but the file-structural fence still hashed every unowned occurrence with its span — so a shifted import, top-level constant, field or class header still forced `FullReplace`, which deletes every `bookmark_node` row for the file. Measured before this change: inserting one header comment destroyed every bookmark in Java, C#, Kotlin, Python, TypeScript, Ruby, PHP and C++ files. Go free functions were the exception, not the rule.

Unowned declaration rows now carry a position-independent identity, proven per language family with integration probes against a real store rather than unit fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
