### PR TITLE
[v0.17 READY-C2] Pin the reuse gates and state the Windows seal limit

### DIFF
--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -1990,3 +1990,74 @@ fn retrieval_annotations_are_classified_by_typed_kind_not_by_prose() {
         "the kind-less TraceRecorder::annotate entry point must stay retired"
     );
 }
+
+/// A sealed receipt must not claim more than the platform it runs on delivers.
+///
+/// READY-C (#1654) shipped `validation_receipts` documenting that "replacement,
+/// truncation, in-place rewriting ... all break the seal", and two tests
+/// asserting exactly that. Neither statement holds on Windows: `std::fs`
+/// reports no device/inode pair and no inode-change instant there, so a
+/// same-length rewrite that restores the modification time produces an
+/// identical observation and is answered from the receipt. Nothing contradicted
+/// the claim because `codestory-contracts` tests run only on Linux and macOS —
+/// the Windows lanes in `source-proof.yml` build `codestory-workspace` and
+/// `codestory-llama-sys` test targets only. The limit is therefore stated, in
+/// the contract and in the docs, and this is what keeps it stated.
+#[test]
+fn the_sealed_receipt_states_its_windows_limit_in_the_contract_and_the_docs() {
+    let receipts = read("crates/codestory-contracts/src/validation_receipts.rs");
+    let production = production_source(&receipts);
+    for required in [
+        "pub enum SealFidelity",
+        "    InodeChangeTracked,",
+        "    TimestampsOnly,",
+        "pub fn fidelity(&self) -> Option<SealFidelity>",
+    ] {
+        assert!(
+            production.contains(required),
+            "the receipt must report how much its observation can distinguish: missing `{required}`"
+        );
+    }
+
+    // The module contract and the enum variant that carries the weaker case
+    // both have to name the platform. "Some platforms report less" is the
+    // implying-away this replaced.
+    let module_contract = production
+        .split("\nuse std::collections::HashMap;")
+        .next()
+        .expect("module doc comment precedes the imports");
+    assert!(
+        module_contract.contains("Windows"),
+        "the receipt's module contract must name the platform whose seals are weaker"
+    );
+    let timestamps_only_doc = source_between(
+        &production,
+        "    /// The observation carries only",
+        "    TimestampsOnly,",
+    );
+    assert!(
+        timestamps_only_doc.contains("Windows"),
+        "the timestamps-only variant must name the platform it describes"
+    );
+
+    for (path, anchor) in [
+        (
+            "docs/architecture/subsystems/contracts.md",
+            "## Sealed validation receipts and their platform limit",
+        ),
+        (
+            "docs/architecture/subsystems/retrieval.md",
+            "#sealed-validation-receipts-and-their-platform-limit",
+        ),
+    ] {
+        let doc = read(path);
+        assert!(
+            doc.contains(anchor),
+            "{path} must carry the receipt platform limit: missing `{anchor}`"
+        );
+        assert!(
+            doc.contains("Windows"),
+            "{path} must name the platform the receipt is weaker on"
+        );
+    }
+}

--- a/crates/codestory-contracts/src/validation_receipts.rs
+++ b/crates/codestory-contracts/src/validation_receipts.rs
@@ -2,12 +2,35 @@
 //!
 //! A receipt records that one expensive validation of an *immutable* artifact
 //! succeeded. It is only reusable while the native identity of every file the
-//! validation examined is byte-for-byte the same observation it was sealed to:
-//! same presence, same length, same modification and inode-change instants,
-//! same device/inode, same read-only bit. Replacement, truncation, in-place
-//! rewriting, and the appearance of a SQLite sidecar all break the seal, so a
-//! generation that was damaged after its first validation re-validates instead
-//! of hiding behind the earlier verdict.
+//! validation examined is the same observation it was sealed to: same presence,
+//! same length, same modification and inode-change instants, same device/inode,
+//! same read-only bit. Where the platform reports all of that — see the limit
+//! below — replacement, truncation, in-place rewriting, and the appearance of a
+//! SQLite sidecar all break the seal, so a generation damaged after its first
+//! validation re-validates instead of hiding behind the earlier verdict.
+//!
+//! **A seal is only as strong as the metadata the platform reports, and one
+//! shipped platform reports less.** The paragraph above holds in full on Unix,
+//! where `std::fs` exposes a device/inode pair and an inode-change instant.
+//! Windows exposes neither through `std::fs`, so a seal taken there compares
+//! presence, length, the creation and modification instants, and the read-only
+//! bit — nothing that records *that the bytes were rewritten*. A writer that
+//! rewrites an artifact in place without changing its length and then restores
+//! the modification time produces an observation identical to the sealed one,
+//! and the receipt answers for bytes it never read. The same is true of a
+//! replacement whose length, creation, and modification instants all match.
+//! [`SealFidelity`] names which of the two a given observation is, and
+//! [`ArtifactSeal::fidelity`] reports it. This is a stated limit of the
+//! receipt, not an accident of it: on a
+//! [`SealFidelity::TimestampsOnly`] platform a receipt proves the artifact was
+//! not casually touched; it does not prove the bytes are the ones the
+//! validation read. Nothing that must detect deliberate corruption may rest on
+//! a receipt alone there. Concretely, a consumer whose verdict is receipted
+//! carries the limit forward: on a timestamps-only platform an artifact
+//! rewritten in place at the same length, with its modification time restored,
+//! keeps answering with the verdict this process already sealed for it. What
+//! bounds that is the receipt's process-local lifetime, not the seal — the next
+//! process re-reads the bytes.
 //!
 //! Two rules are structural rather than conventional:
 //!
@@ -75,6 +98,33 @@ impl fmt::Display for ArtifactSealError {
 }
 
 impl std::error::Error for ArtifactSealError {}
+
+/// How much a present artifact's seal can distinguish.
+///
+/// This is a property of the observation, not of the caller: it is read off the
+/// native metadata the platform actually reported for that file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SealFidelity {
+    /// The observation carries a device/inode pair and an inode-change instant.
+    ///
+    /// A rewrite in place breaks the seal even when the writer keeps the length
+    /// and restores the modification time afterwards, and a replacement breaks
+    /// it even when the replacement's bytes and timestamps match. Unix reports
+    /// this.
+    InodeChangeTracked,
+    /// The observation carries only presence, length, the creation and
+    /// modification instants, and the read-only bit.
+    ///
+    /// Windows is this platform: `std::fs` reports no device/inode pair and no
+    /// inode-change instant there, so nothing in the seal records that an
+    /// artifact's bytes were rewritten. A same-length rewrite in place that
+    /// restores the modification time is indistinguishable from the sealed
+    /// observation, and so is a replacement that matches every field. The
+    /// residual guarantee is real but narrower: a change in presence, length,
+    /// creation instant, modification instant, or the read-only bit still
+    /// breaks the seal.
+    TimestampsOnly,
+}
 
 /// Native identity of one artifact at a single observation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -149,6 +199,28 @@ impl ArtifactSeal {
     /// Whether the artifact existed as a regular file when it was sealed.
     pub fn is_present(&self) -> bool {
         matches!(self.presence, SealPresence::Present { .. })
+    }
+
+    /// How much this observation can distinguish, or `None` when the artifact
+    /// was absent.
+    ///
+    /// Absence has no weaker form — an absent artifact that reappears always
+    /// breaks the seal — so the question only applies to a present one.
+    pub fn fidelity(&self) -> Option<SealFidelity> {
+        match self.presence {
+            SealPresence::Absent => None,
+            SealPresence::Present {
+                inode,
+                inode_change_nanos,
+                ..
+            } => Some(
+                if inode != 0 && inode_change_nanos != TIMESTAMP_UNAVAILABLE {
+                    SealFidelity::InodeChangeTracked
+                } else {
+                    SealFidelity::TimestampsOnly
+                },
+            ),
+        }
     }
 
     /// Observe every artifact in order, or report the first that cannot be
@@ -252,6 +324,12 @@ where
     /// describe a state the validation actually observed end to end.
     ///
     /// A failed validation removes any receipt for `key` and is never cached.
+    ///
+    /// "Still holds" means what [`SealFidelity`] says it means on this
+    /// platform. Where the observation is
+    /// [`SealFidelity::TimestampsOnly`] — Windows — a same-length in-place
+    /// rewrite that restores the modification time still satisfies the seal and
+    /// is answered from the receipt.
     pub fn validate_sealed<E>(
         &self,
         key: K,
@@ -376,6 +454,45 @@ mod tests {
         }
     }
 
+    /// The declared fidelity has to match the platform the build is for.
+    ///
+    /// This is the statement the two detection tests below branch on. Pinning
+    /// it separately keeps the pair honest: over-claiming
+    /// [`SealFidelity::InodeChangeTracked`] on a platform that cannot deliver
+    /// it would otherwise only surface as a silent receipt reuse of corrupted
+    /// bytes.
+    #[test]
+    fn a_present_artifact_reports_the_fidelity_its_platform_actually_provides() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let artifact = dir.path().join("shard.sqlite3");
+        write(&artifact, "generation-a");
+        let fidelity = ArtifactSeal::observe(&artifact)
+            .expect("seal the artifact")
+            .fidelity();
+
+        #[cfg(unix)]
+        assert_eq!(
+            fidelity,
+            Some(SealFidelity::InodeChangeTracked),
+            "Unix reports a device/inode pair and an inode-change instant"
+        );
+        #[cfg(not(unix))]
+        assert_eq!(
+            fidelity,
+            Some(SealFidelity::TimestampsOnly),
+            "Windows `std::fs` reports no device/inode pair and no inode-change instant; \
+             claiming otherwise would let a corrupted generation answer from its receipt"
+        );
+
+        assert_eq!(
+            ArtifactSeal::observe(&dir.path().join("absent.sqlite3"))
+                .expect("seal an absent artifact")
+                .fidelity(),
+            None,
+            "absence has no weaker form"
+        );
+    }
+
     #[test]
     fn an_unchanged_artifact_is_validated_once_and_reused() {
         let dir = tempfile::TempDir::new().expect("temp dir");
@@ -408,13 +525,26 @@ mod tests {
         );
     }
 
+    /// The seal's strength against a deliberate in-place rewrite, stated
+    /// exactly as far as the platform can carry it.
+    ///
+    /// This test used to assert detection unconditionally. It runs only where
+    /// `codestory-contracts` tests run — Linux and macOS — so the assertion was
+    /// never contradicted, while the same code on Windows answers the rewritten
+    /// artifact from the earlier receipt. Both outcomes are pinned here against
+    /// the fidelity the observation itself reports, so neither platform's
+    /// behaviour can drift and neither can be claimed for the other.
     #[test]
-    fn in_place_corruption_that_restores_the_modification_time_still_breaks_the_seal() {
+    fn an_in_place_rewrite_that_restores_the_modification_time_is_detected_only_at_full_fidelity() {
         let dir = tempfile::TempDir::new().expect("temp dir");
         let artifact = dir.path().join("shard.sqlite3");
         write(&artifact, "generation-a");
         let pinned_modified = 1_700_000_000_000_000_000;
         set_modified(&artifact, pinned_modified);
+        let fidelity = ArtifactSeal::observe(&artifact)
+            .expect("seal the artifact")
+            .fidelity()
+            .expect("a present artifact reports its fidelity");
         let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
         let validator = CountingValidator::new();
         let artifacts = vec![artifact.clone()];
@@ -433,29 +563,73 @@ mod tests {
             .validate_sealed(artifact.clone(), &artifacts, || validator.ok("damaged"))
             .expect("re-validate after in-place corruption");
 
-        assert_eq!(
-            after, "damaged",
-            "corrupted bytes must not be answered from the earlier receipt"
-        );
-        assert_eq!(validator.runs.get(), 2);
-        assert_eq!(
-            cache.stats(&artifact),
-            Some(ReceiptStats {
-                validations: 2,
-                reuses: 0,
-                invalidations: 1,
-            })
-        );
+        match fidelity {
+            SealFidelity::InodeChangeTracked => {
+                assert_eq!(
+                    after, "damaged",
+                    "corrupted bytes must not be answered from the earlier receipt"
+                );
+                assert_eq!(validator.runs.get(), 2);
+                assert_eq!(
+                    cache.stats(&artifact),
+                    Some(ReceiptStats {
+                        validations: 2,
+                        reuses: 0,
+                        invalidations: 1,
+                    })
+                );
+            }
+            SealFidelity::TimestampsOnly => {
+                // The stated limit, asserted rather than assumed: nothing in
+                // the observation changed, so the receipt answers for bytes it
+                // never read.
+                assert_eq!(
+                    after, "healthy",
+                    "a timestamps-only seal cannot see a same-length rewrite"
+                );
+                assert_eq!(validator.runs.get(), 1);
+                assert_eq!(
+                    cache.stats(&artifact),
+                    Some(ReceiptStats {
+                        validations: 1,
+                        reuses: 1,
+                        invalidations: 0,
+                    })
+                );
+
+                // What the platform does still guarantee: a rewrite that
+                // changes the length breaks the seal.
+                write(&artifact, "generation-X-longer");
+                set_modified(&artifact, pinned_modified);
+                cache
+                    .validate_sealed(artifact.clone(), &artifacts, || validator.ok("resized"))
+                    .expect("re-validate after a length change");
+                assert_eq!(validator.runs.get(), 2);
+            }
+        }
     }
 
+    /// Replacement detection, stated exactly as far as the platform can carry
+    /// it.
+    ///
+    /// A timestamps-only observation carries no file identity, so whether a
+    /// byte-identical replacement is noticed there depends on whether the new
+    /// file happens to inherit the old creation instant — which on NTFS it
+    /// sometimes does. The contract therefore claims nothing about that case
+    /// on such a platform, and this test claims nothing either; it pins the
+    /// residual guarantee instead.
     #[test]
-    fn replacing_the_artifact_with_identical_bytes_breaks_the_seal() {
+    fn replacing_the_artifact_with_identical_bytes_is_detected_only_at_full_fidelity() {
         let dir = tempfile::TempDir::new().expect("temp dir");
         let artifact = dir.path().join("shard.sqlite3");
         let replacement = dir.path().join("shard.sqlite3.new");
         write(&artifact, "generation-a");
         let pinned_modified = 1_700_000_000_000_000_000;
         set_modified(&artifact, pinned_modified);
+        let fidelity = ArtifactSeal::observe(&artifact)
+            .expect("seal the artifact")
+            .fidelity()
+            .expect("a present artifact reports its fidelity");
         let cache: SealedReceiptCache<PathBuf, String> = SealedReceiptCache::new(4);
         let validator = CountingValidator::new();
         let artifacts = vec![artifact.clone()];
@@ -472,11 +646,29 @@ mod tests {
             .validate_sealed(artifact.clone(), &artifacts, || validator.ok("rebuilt"))
             .expect("re-validate after replacement");
 
-        assert_eq!(
-            validator.runs.get(),
-            2,
-            "a replaced file is a different artifact even when its bytes match"
-        );
+        match fidelity {
+            SealFidelity::InodeChangeTracked => assert_eq!(
+                validator.runs.get(),
+                2,
+                "a replaced file is a different artifact even when its bytes match"
+            ),
+            SealFidelity::TimestampsOnly => {
+                // The residual guarantee: a replacement that does not restore
+                // the modification time is still refused.
+                let runs_after_identical_replacement = validator.runs.get();
+                write(&replacement, "generation-a");
+                set_modified(&replacement, pinned_modified + 1);
+                std::fs::rename(&replacement, &artifact).expect("replace artifact again");
+                cache
+                    .validate_sealed(artifact.clone(), &artifacts, || validator.ok("rebuilt"))
+                    .expect("re-validate after a retimed replacement");
+                assert_eq!(
+                    validator.runs.get(),
+                    runs_after_identical_replacement + 1,
+                    "a timestamps-only seal must still refuse a replacement it can see"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -4070,4 +4070,256 @@ mod tests {
             "a damaged lexical shard must fall through to the rebuild"
         );
     }
+
+    /// One published, live-healthy generation plus everything needed to drive
+    /// finalize and retention against it.
+    #[cfg(feature = "test-support")]
+    struct PublishedGeneration {
+        project: TempDir,
+        _cache: TempDir,
+        _storage_dir: TempDir,
+        storage_path: PathBuf,
+        runtime: SidecarRuntimeConfig,
+        manifest: RetrievalIndexManifest,
+        scip_dir: PathBuf,
+    }
+
+    /// Publish a complete zero-dense generation through the same fixture the
+    /// rollback contracts use, in a live store carrying a complete core
+    /// publication.
+    #[cfg(feature = "test-support")]
+    fn publish_live_generation() -> PublishedGeneration {
+        use codestory_store::{IndexPublicationMode, IndexPublicationRecord};
+
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "pub fn handler() {}").expect("source");
+        let storage_dir = TempDir::new().expect("storage");
+        let cache = TempDir::new().expect("cache");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let store = Store::open(&storage_path).expect("open storage");
+        store
+            .put_index_publication(&IndexPublicationRecord {
+                generation: 1,
+                generation_id: "11111111-1111-4111-8111-111111111111".into(),
+                run_id: "run-one".into(),
+                mode: IndexPublicationMode::Full,
+                published_at_epoch_ms: 1,
+            })
+            .expect("publish core identity");
+        drop(store);
+        let runtime = crate::config::with_test_cache_root(cache.path(), || {
+            SidecarRuntimeConfig::for_project_profile(
+                Some(project.path()),
+                crate::SidecarProfile::Local,
+            )
+        });
+        let manifest = crate::test_support::publish_zero_dense_pinned_query_fixture(
+            project.path(),
+            &storage_path,
+            &runtime,
+        )
+        .expect("publish live generation");
+        let generation = manifest
+            .sidecar_generation
+            .clone()
+            .expect("fixture generation");
+        let scip_dir = runtime.layout.scip_project_dir(&generation);
+        PublishedGeneration {
+            project,
+            _cache: cache,
+            _storage_dir: storage_dir,
+            storage_path,
+            runtime,
+            manifest,
+            scip_dir,
+        }
+    }
+
+    /// The finalize phases a whole pass emitted.
+    ///
+    /// The reuse branch returns before the first phase, so an empty phase list
+    /// *is* the reuse decision as the product renders it: no lexical, semantic,
+    /// or graph work was scheduled. Every rebuild announces `lexical sidecar`
+    /// first. Both passes stop at the publication fence in this environment —
+    /// there is no per-user embedding server — which is downstream of the
+    /// decision under test and identical for both legs.
+    #[cfg(feature = "test-support")]
+    fn finalize_phases(fixture: &PublishedGeneration) -> (Vec<&'static str>, String) {
+        let phases = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let collect = std::rc::Rc::clone(&phases);
+        let outcome = finalize_index_for_runtime_with_progress(
+            fixture.project.path(),
+            &fixture.storage_path,
+            &fixture.runtime,
+            move |phase| collect.borrow_mut().push(phase),
+        );
+        let rendered = match outcome {
+            Ok(outcome) => format!("{outcome:?}"),
+            Err(error) => format!("{error:#}"),
+        };
+        let emitted = phases.borrow().clone();
+        (emitted, rendered)
+    }
+
+    /// Everything upstream of the reuse gate still admits this generation.
+    ///
+    /// Without this the rebuild leg below could pass for the wrong reason: a
+    /// staleness verdict or a failed evidence validation reaches the same
+    /// rebuild through a different door. Damaging `index.scip` must leave both
+    /// of those admitting, so the fall-through is attributable to the live
+    /// probe and to nothing else.
+    #[cfg(feature = "test-support")]
+    fn assert_reuse_gate_is_the_only_refusal(fixture: &PublishedGeneration) {
+        let storage = Store::open(&fixture.storage_path).expect("open storage");
+        assert_eq!(
+            crate::generation::manifest_unavailable_reason_for_runtime(
+                &fixture.manifest.project_id,
+                &storage,
+                &fixture.manifest,
+                &fixture.runtime,
+            ),
+            None,
+            "the stored manifest must still be current, or the rebuild proves nothing"
+        );
+        let publication = storage
+            .get_complete_index_publication()
+            .expect("load core publication")
+            .expect("complete core publication");
+        let residency =
+            crate::embeddings::acquire_product_embedding_residency_for_runtime(&fixture.runtime)
+                .expect("acquire test residency");
+        let device = crate::embeddings::embedding_device_readiness_for_runtime(&fixture.runtime);
+        crate::embedded_vector::validate_generation_evidence_for_publication(
+            &fixture.runtime.layout,
+            &storage,
+            &fixture.manifest,
+            &publication,
+            &fixture.runtime,
+            &device,
+            residency.identity(),
+        )
+        .expect("deep generation evidence must still validate");
+        let status = probe_sidecar_health_for_runtime(
+            &fixture.runtime.layout,
+            &fixture.manifest.project_id,
+            Some(fixture.manifest.clone()),
+            &device,
+            &fixture.runtime,
+        );
+        assert_eq!(
+            status.retrieval_mode, "full",
+            "the manifest still classifies full, which is why `retrieval_mode` could never refuse"
+        );
+        assert!(
+            status.degraded_reason.is_some(),
+            "the live probe must be the one thing that refuses"
+        );
+    }
+
+    /// Reverting the finalize reuse gate to the manifest-class comparison has
+    /// to fail here.
+    ///
+    /// The earlier assertions in this module pin
+    /// `unchanged_generation_is_reusable` itself; nothing pinned that the
+    /// finalize pass consults it, so restoring the manifest-class comparison at
+    /// the call site left the whole suite green. This drives the real entry
+    /// point and reads the decision off the phases the product emits.
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn finalize_rebuilds_an_unchanged_generation_whose_graph_artifact_was_damaged() {
+        let _env = crate::test_support::env_lock();
+        let fixture = publish_live_generation();
+
+        let (healthy_phases, healthy_outcome) = finalize_phases(&fixture);
+        assert!(
+            healthy_phases.is_empty(),
+            "an intact unchanged generation must still be reused without rebuilding: \
+             {healthy_phases:?} ({healthy_outcome})"
+        );
+
+        std::fs::write(
+            fixture.scip_dir.join(crate::scip_index::SCIP_INDEX_FILE),
+            b"\0\0\0\0",
+        )
+        .expect("damage the graph marker in place");
+        assert_reuse_gate_is_the_only_refusal(&fixture);
+
+        let (damaged_phases, damaged_outcome) = finalize_phases(&fixture);
+        assert!(
+            damaged_phases.starts_with(&["lexical sidecar"]),
+            "a generation damaged after publication must fall through to the rebuild: \
+             {damaged_phases:?} ({damaged_outcome})"
+        );
+        assert!(
+            damaged_phases.contains(&"graph artifact"),
+            "the rebuild must reach the graph lane that was damaged: \
+             {damaged_phases:?} ({damaged_outcome})"
+        );
+    }
+
+    /// Reverting the rollback verification gate to `retrieval_mode != "full"`
+    /// has to fail here.
+    ///
+    /// `prepare_generation_retention` is the only writer of the rollback
+    /// pointer. Its fence deep-validates vector bytes, producer evidence, and
+    /// anchor coverage — none of which read the graph lane — so a generation
+    /// whose graph artifact was damaged after publication passes every other
+    /// check and is refused only by the live probe.
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn rollback_selection_refuses_a_candidate_whose_live_graph_lane_is_damaged() {
+        let _env = crate::test_support::env_lock();
+        let fixture = publish_live_generation();
+        let active_hash = "b".repeat(64);
+        let active = crate::test_support::retrieval_manifest_fixture(
+            &fixture.manifest.project_id,
+            &active_hash,
+        );
+        let select = |storage: &Store| {
+            let residency = crate::embeddings::acquire_product_embedding_residency_for_runtime(
+                &fixture.runtime,
+            )
+            .expect("acquire test residency");
+            let device =
+                crate::embeddings::embedding_device_readiness_for_runtime(&fixture.runtime);
+            let producer_compatibility_identity = vector_producer_compatibility_identity(
+                &device,
+                residency.identity(),
+                crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            )
+            .expect("producer compatibility identity");
+            let context = GenerationRetentionContext {
+                runtime: &fixture.runtime,
+                layout: &fixture.runtime.layout,
+                workspace_id: "workspace",
+                previous_manifest: Some(&fixture.manifest),
+                embedding_device: &device,
+                embedding_residency: residency,
+                producer_compatibility_identity,
+            };
+            prepare_generation_retention(&context, &fixture.manifest.project_id, &active, storage)
+                .expect("prepare retention")
+                .verified_previous
+        };
+
+        let storage = Store::open(&fixture.storage_path).expect("open candidate storage");
+        assert!(
+            select(&storage).is_some(),
+            "a live-healthy generation must still be recorded as a verified rollback target"
+        );
+        drop(storage);
+
+        std::fs::write(
+            fixture.scip_dir.join(crate::scip_index::SCIP_INDEX_FILE),
+            b"\0\0\0\0",
+        )
+        .expect("damage the graph marker in place");
+        assert_reuse_gate_is_the_only_refusal(&fixture);
+
+        let storage = Store::open(&fixture.storage_path).expect("open damaged storage");
+        assert!(
+            select(&storage).is_none(),
+            "a damaged generation must not be recorded as a verified rollback target"
+        );
+    }
 }

--- a/docs/architecture/subsystems/contracts.md
+++ b/docs/architecture/subsystems/contracts.md
@@ -11,7 +11,8 @@ runtime, and adapters. It contains contracts, not orchestration or rendering.
 - grounding, readiness, status, publication, and symbol-workflow DTOs;
 - tagged packet probes plus normalized resolution, ambiguity, and rejection
   metadata;
-- language-support profiles and evidence tiers.
+- language-support profiles and evidence tiers;
+- sealed validation receipts for immutable artifacts.
 
 ## Entry points
 
@@ -20,6 +21,29 @@ runtime, and adapters. It contains contracts, not orchestration or rendering.
 - `src/grounding.rs` and `src/trail.rs`: evidence groupings
 - `src/workspace.rs`: shared workspace contracts
 - `src/language_support.rs`: source-of-truth support labels
+- `src/validation_receipts.rs`: sealed, process-local validation receipts
+
+## Sealed validation receipts and their platform limit
+
+A receipt caches one successful validation of an immutable artifact and is
+reusable only while the artifact's native identity matches the observation the
+receipt was sealed to. A failing validation is never cached and removes any
+receipt the key already held.
+
+The seal is only as strong as the metadata the platform reports, and Windows
+reports less than Unix does. On Unix a seal carries the device/inode pair and
+the inode-change instant, so an in-place rewrite breaks it even when the writer
+restores the modification time, and a replacement breaks it even when the new
+bytes and timestamps match. `std::fs` exposes neither field on Windows, so a
+seal there compares presence, length, the creation and modification instants,
+and the read-only bit. **On Windows a same-length in-place rewrite that restores
+the modification time satisfies the seal, and the receipt answers for bytes it
+never read.** A receipt proves the artifact was not casually touched on that
+platform; it does not prove the bytes are the ones the validation read, and
+nothing that must detect deliberate corruption may rest on a receipt alone
+there. `SealFidelity` names which of the two an observation is, and
+`ArtifactSeal::fidelity` reports it, so callers and tests read the limit off the
+observation instead of assuming the stronger case.
 
 ## Extension rules
 
@@ -34,4 +58,6 @@ runtime, and adapters. It contains contracts, not orchestration or rendering.
 - runtime or CLI imports another crate's private type instead of a contract;
 - DTOs perform I/O or choose product behavior;
 - adapter-only formatting types become shared domain concepts;
-- a support or readiness label exists without one source-of-truth definition.
+- a support or readiness label exists without one source-of-truth definition;
+- a sealed receipt is treated as corruption detection on a platform whose
+  observations are timestamps-only.

--- a/docs/architecture/subsystems/retrieval.md
+++ b/docs/architecture/subsystems/retrieval.md
@@ -54,6 +54,22 @@ server drains before replacement; active work or leases return typed retry
 state. Clients never choose another endpoint, kill a remembered PID, or fall
 back to an in-process engine.
 
+Two promotions can put a previously published generation back into service:
+finalize reusing an unchanged generation, and retention recording a verified
+rollback pointer. Both require the live probe verdict
+(`RetrievalStatusReport::is_live_ready`), never the stored manifest's
+`retrieval_mode`, which is overridden to `full` for every published manifest and
+so can never refuse. A generation damaged after publication is rebuilt in place
+rather than republished, and is not recorded as a rollback target.
+
+Health probes cache the immutable half of lexical deep verification as a sealed
+validation receipt, and inherit its platform limit, stated in
+[the contracts subsystem](contracts.md#sealed-validation-receipts-and-their-platform-limit):
+on Windows a same-length in-place rewrite that restores the modification time
+still satisfies the seal, so within one process the probe keeps answering with
+the lexical verdict it already sealed. Receipts are process-local, so the next
+process re-reads the bytes; nothing persists a stale verdict across a restart.
+
 Retrieval finalization holds an embedding residency lease across candidate
 build, validation, and publication. Manifest compatibility uses the stable
 producer contract assembled from retrieval-owned model, pooling, normalization,
@@ -76,7 +92,9 @@ a live publication fence and is not persisted as vector compatibility.
 ## Failure signatures
 
 - a query resolves numeric IDs against a different core publication;
-- `retrieval_mode=full` is treated as live engine proof;
+- `retrieval_mode=full` is treated as live engine proof, or gates reuse or
+  rollback verification;
+- a sealed receipt is treated as proof that an artifact's bytes are intact;
 - deep row validation runs on every query;
 - cleanup recurses from a previously validated pathname;
 - a project silently reconfigures or bypasses the per-user server.


### PR DESCRIPTION
Closes #1774.

Both of READY-C's reuse gates could previously be reverted with the whole suite green — correct behavior, unpinned guarantee. They are now pinned.

The Windows seal limit takes the issue's explicit alternative: sealed receipts cannot detect in-place corruption or replacement on Windows, so that limit is now **stated in the receipt contract and the docs** rather than implied away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
