### PR TITLE
[v0.17 EV-6c] Pin the Gap kind of every real annotation producer

### DIFF
--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -2211,3 +2211,214 @@ fn the_sealed_receipt_states_its_windows_limit_in_the_contract_and_the_docs() {
         );
     }
 }
+
+/// EV-6c (#1775). Every `Gap`-kind retrieval annotation a release build can emit, keyed by the
+/// file that produces it and the exact argument the producer passes, in source order.
+///
+/// EV-6b (#1746) pinned only the harmless direction: an observation carrying all ten retired
+/// prose markers no longer downgrades `agent_confidence`. The dangerous direction stayed open.
+/// Swapping `trace.annotate_gap(..)` for `trace.observe(..)`, or `RetrievalAnnotationDto::gap(..)`
+/// for `::observation(..)`, at any one site reclassifies a real evidence gap as routine
+/// telemetry: `agent_gap_notes` drops it, the packet keeps `high`/`ready`, and the operator is
+/// told an answer is grounded when the evidence behind it was never retrieved. That direction
+/// *inflates* stated confidence.
+///
+/// The behavioural half of this pin lives with the producers: `agent::trace::tests`,
+/// `agent::packet_batch::tests` and `agent::orchestrator::tests` drive the real code paths and
+/// read the kind back off the published `AgentRetrievalTraceDto`. This inventory covers the
+/// rest: the latency cut-offs and post-retrieval failures inside `execute_retrieval`,
+/// `investigate_query_expansion`, `maybe_read_source_context` and `build_mermaid_artifacts`,
+/// which no unit test can enter because reaching them needs a served retrieval and therefore a
+/// fully indexed sidecar. It is fail-closed in both directions: a producer whose kind flips, a
+/// producer that disappears, and a newly added gap producer all fail here.
+const PRODUCTION_GAP_ANNOTATION_PRODUCERS: &[(&str, &[&str])] = &[
+    (
+        "crates/codestory-runtime/src/agent/orchestrator.rs",
+        &[
+            "annotation",
+            "format!(\"Index freshness not checked: {}\", error.message)",
+            "format!(\"Graph artifact bundle truncated at {} bytes; narrow focus or reduce trail depth for complete graph exports.\", GRAPH_ARTIFACT_BUNDLE_BYTE_CAP)",
+            "format!(\"retrieval_primary rejected=true fail_closed=true reason={reason}\")",
+            "format!(\"retrieval_primary unavailable=true fail_closed=true reason={reason}\")",
+            "\"retrieval_primary skipped local nucleo investigation supplement on weak hits\"",
+            "format!(\"Investigation query expansion failed; continuing with initial hits: {}\", error.message)",
+            "\"Investigation discarded expansion-only hits for an unanchored natural-language query.\"",
+            "\"Investigation skipped repo-text diagnostics because packet evidence must come from sidecar-backed resolvable hits or direct source reads.\"",
+            "\"Investigation discarded low-confidence unanchored hits for a natural-language query.\"",
+            "\"Repo-text diagnostics are disabled for packet evidence; weak unanchored hits were not promoted.\"",
+            "\"Investigation low confidence gap after sidecar query expansion.\"",
+            "\"Grounding snapshot supplement skipped because sidecar-primary retrieval is mandatory.\"",
+            "\"Trail filter options unavailable; continuing with unsanitized filters.\"",
+            "\"Neighborhood retrieval failed; continuing with trail retrieval.\"",
+            "trail_truncated_annotation(idx + 1, plan.max_nodes)",
+            "format!(\"Trail {} failed and was skipped.\", idx + 1)",
+            "\"Latency-first cutoff skipped node occurrence lookups.\"",
+            "format!(\"Node occurrence lookup failed for {}: {}\", hit.display_name, error.message)",
+            "\"Latency-first cutoff skipped edge occurrence lookups.\"",
+            "\"Latency-first cutoff skipped investigation query expansion.\"",
+            "\"Latency-first cutoff skipped source reads.\"",
+            "\"Latency-first cutoff skipped mermaid synthesis.\"",
+        ],
+    ),
+    (
+        "crates/codestory-runtime/src/agent/packet_batch.rs",
+        &[
+            "\"packet_subqueries skipped budget=tiny\"",
+            "format!(\"packet_fused_subquery_batch_failed error={error:?}\")",
+            "format!(\"packet_fused_blocking_cancel_retry skipped reason=latency_budget_exhausted count={}\", retry_pending.len())",
+            "format!(\"packet_fused_blocking_cancel_retry_failed error={error:?}\")",
+            "format!(\"packet_fused_blocking_cancel_retry exhausted count={}\", retry_outcome.retryable_queries.len())",
+            "format!(\"packet_anchor_probes skipped reason={reason}\")",
+            "format!(\"packet_anchor_probe_failed query=`{}` error={}\", query.replace('`', \"'\"), message)",
+        ],
+    ),
+    ("crates/codestory-runtime/src/agent/trace.rs", &["message"]),
+];
+
+/// Collapse `source` onto one line so a producer's argument compares equal however rustfmt
+/// wrapped it.
+fn collapse_call_source(source: &str) -> String {
+    source
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace("( ", "(")
+        .replace(" )", ")")
+}
+
+/// The argument expression of every `Gap`-kind annotation producer in `source`, in source order.
+///
+/// `fn annotate_gap(..)` is `TraceRecorder`'s declaration, not a producer, so it is skipped; the
+/// one push inside its body is the producer that stands for it.
+fn gap_annotation_producer_arguments(source: &str) -> Vec<String> {
+    let dense = collapse_call_source(&production_source(source));
+    let mut arguments = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < dense.len() {
+        let Some((offset, token)) = ["annotate_gap(", "RetrievalAnnotationDto::gap("]
+            .into_iter()
+            .filter_map(|token| dense[cursor..].find(token).map(|at| (at, token)))
+            .min()
+        else {
+            break;
+        };
+        let start = cursor + offset;
+        cursor = start + token.len();
+        if dense[..start].ends_with("fn ") {
+            continue;
+        }
+        arguments.push(balanced_call_argument(&dense, cursor));
+    }
+    arguments
+}
+
+/// Text between a producer's opening parenthesis (already consumed) and its match. String and
+/// char literals are skipped so `query.replace('`', "'")` cannot unbalance the scan.
+fn balanced_call_argument(dense: &str, after_open: usize) -> String {
+    let bytes = dense.as_bytes();
+    let mut depth = 1usize;
+    let mut index = after_open;
+    let mut in_string = false;
+    let mut in_char = false;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if in_string || in_char {
+            match byte {
+                b'\\' => index += 1,
+                b'"' if in_string => in_string = false,
+                b'\'' if in_char => in_char = false,
+                _ => {}
+            }
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'\'' => in_char = true,
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return dense[after_open..index].trim_end_matches(',').to_string();
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    panic!("unbalanced annotation producer call at byte {after_open}");
+}
+
+#[test]
+fn every_production_gap_annotation_producer_is_pinned_to_the_gap_kind() {
+    for (path, expected) in PRODUCTION_GAP_ANNOTATION_PRODUCERS {
+        let expected = expected
+            .iter()
+            .map(|argument| (*argument).to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            gap_annotation_producer_arguments(&read(path)),
+            expected,
+            "{path}: the Gap-kind annotation producers changed. Reclassifying one as an \
+             observation inflates reported confidence, because `agent_gap_notes` then drops it \
+             and the packet keeps its high/ready verdict; adding one needs a behavioural test \
+             beside this inventory."
+        );
+    }
+
+    // Fail closed: no production file may classify an annotation as a gap without being pinned
+    // above, so a producer moved into a new module cannot escape the inventory.
+    let pinned = PRODUCTION_GAP_ANNOTATION_PRODUCERS
+        .iter()
+        .map(|(path, _)| (*path).to_string())
+        .collect::<BTreeSet<_>>();
+    let mut discovered = BTreeSet::new();
+    for member in workspace_members() {
+        let source_dir = repo_root().join(&member).join("src");
+        if !source_dir.is_dir() {
+            continue;
+        }
+        let mut files = Vec::new();
+        collect_rs_files(&source_dir, &mut files);
+        for file in files {
+            let relative = file
+                .strip_prefix(repo_root())
+                .expect("workspace-relative path")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let source = fs::read_to_string(&file).expect("read source");
+            let shipped = production_source(&source);
+
+            // The inventory scans two entry points. Keep them the *only* two: a struct literal
+            // or a bare `RetrievalAnnotationKindDto::Gap` outside the DTO would mint a gap the
+            // scan cannot see, and the pin above would quietly stop covering it.
+            assert!(
+                !shipped.contains("RetrievalAnnotationDto {")
+                    || relative == "crates/codestory-contracts/src/api/dto.rs",
+                "{relative} builds a RetrievalAnnotationDto by struct literal; annotations must \
+                 be minted through RetrievalAnnotationDto::gap / ::observation so the gap \
+                 inventory can see them"
+            );
+            assert!(
+                !shipped.contains("RetrievalAnnotationKindDto::Gap")
+                    || matches!(
+                        relative.as_str(),
+                        "crates/codestory-contracts/src/api/dto.rs"
+                            | "crates/codestory-cli/src/output.rs"
+                    ),
+                "{relative} names RetrievalAnnotationKindDto::Gap outside the DTO constructors \
+                 and the single confidence consumer"
+            );
+
+            if gap_annotation_producer_arguments(&source).is_empty() {
+                continue;
+            }
+            discovered.insert(relative);
+        }
+    }
+    assert_eq!(
+        discovered, pinned,
+        "a production file emits Gap-kind annotations without being pinned in \
+         PRODUCTION_GAP_ANNOTATION_PRODUCERS"
+    );
+}

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -13330,6 +13330,72 @@ mod tests {
     }
 
     #[test]
+    fn fail_closed_retrieval_records_its_annotation_as_an_evidence_gap() {
+        // EV-6c (#1775). The complement of the observation test above, driven through the real
+        // `execute_retrieval` rather than a hand-built annotation. Retrieval refusing to serve
+        // is the strongest possible evidence gap: the packet has no retrieval evidence at all.
+        // If this producer were reclassified as an observation, `agent_gap_notes` would drop it
+        // and a packet built on a refused retrieval would still report clean confidence.
+        let controller = AppController::new();
+        let req = AgentAskRequest {
+            prompt: "Trace how the router dispatches a request".to_string(),
+            retrieval_profile: AgentRetrievalProfileSelectionDto::Auto,
+            focus_node_id: None,
+            max_results: Some(5),
+            response_mode: AgentResponseModeDto::default(),
+            latency_budget_ms: Some(120_000),
+            include_evidence: false,
+            hybrid_weights: None,
+        };
+        let resolved_profile = resolve_profile(&req.prompt, &req.retrieval_profile);
+        let mut trace = TraceRecorder::new(Some(120_000));
+
+        let outcome = execute_retrieval(
+            &controller,
+            &req,
+            &req.prompt,
+            Instant::now(),
+            &resolved_profile,
+            &mut trace,
+        );
+        assert!(
+            outcome.is_err(),
+            "a controller with no open project must fail closed rather than serve"
+        );
+
+        let published = trace.finish(
+            "ev6c-fail-closed".to_string(),
+            AgentRetrievalPresetDto::Architecture,
+            AgentRetrievalPolicyModeDto::CompletenessFirst,
+        );
+        let fail_closed = published
+            .annotations
+            .iter()
+            .find(|annotation| {
+                annotation
+                    .text
+                    .starts_with("retrieval_primary unavailable=true")
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "fail-closed retrieval must annotate the trace: {:?}",
+                    published.annotations
+                )
+            });
+        assert_eq!(
+            fail_closed.kind,
+            RetrievalAnnotationKindDto::Gap,
+            "the fail-closed retrieval annotation must be an evidence gap: {}",
+            fail_closed.text
+        );
+        assert!(
+            fail_closed.is_gap(),
+            "the DTO predicate consumers read must agree: {}",
+            fail_closed.text
+        );
+    }
+
+    #[test]
     fn explicit_file_scoped_probe_citation_cannot_promote_sufficiency() {
         let root = packet_temp_root("explicit-source-probe-sufficiency");
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -746,7 +746,283 @@ pub(crate) fn packet_file_stem_matches_query(query: &str, path: Option<&str>) ->
 mod tests {
     use super::*;
     use crate::agent::packet_plan::build_packet_plan;
-    use codestory_contracts::api::{PacketPlanDto, PacketPlanQueryDto, PacketTaskClassDto};
+    use codestory_contracts::api::{
+        AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto,
+        PacketPlanDto, PacketPlanQueryDto, PacketTaskClassDto, RetrievalAnnotationKindDto,
+    };
+
+    /// EV-6c (#1775) helpers. Every gap producer in this module writes onto the answer's
+    /// retrieval trace, so the tests below drive the real production entry points
+    /// (`run_packet_planned_subqueries`, `run_packet_anchor_probes`) and read back the kind the
+    /// producer stamped. Nothing here hand-builds an annotation.
+    fn empty_answer() -> AgentAnswerDto {
+        AgentAnswerDto {
+            answer_id: "ev6c".to_string(),
+            prompt: "ev6c packet".to_string(),
+            summary: String::new(),
+            freshness: None,
+            sections: Vec::new(),
+            citations: Vec::new(),
+            subgraph_ids: Vec::new(),
+            retrieval_version: "test".to_string(),
+            graphs: Vec::new(),
+            retrieval_trace: AgentRetrievalTraceDto {
+                request_id: "ev6c".to_string(),
+                retrieval_publication: None,
+                resolved_profile: AgentRetrievalPresetDto::Architecture,
+                policy_mode: AgentRetrievalPolicyModeDto::LatencyFirst,
+                total_latency_ms: 0,
+                sla_target_ms: None,
+                sla_missed: false,
+                semantic_fallback_count: 0,
+                semantic_fallbacks: Vec::new(),
+                semantic_stage_timeout_zero_hits: 0,
+                semantic_abstained_count: 0,
+                annotations: Vec::new(),
+                packet_claim_profile_telemetry: None,
+                source_freshness_telemetry: None,
+                steps: Vec::new(),
+                packet_sidecar_diagnostics: Vec::new(),
+                retrieval_shadow: None,
+            },
+        }
+    }
+
+    fn ev6c_limits() -> PacketBudgetLimitsDto {
+        PacketBudgetLimitsDto {
+            max_anchors: 8,
+            max_files: 8,
+            max_snippets: 8,
+            max_trail_edges: 8,
+            max_output_bytes: 64_000,
+        }
+    }
+
+    fn ev6c_plan() -> PacketPlanDto {
+        PacketPlanDto {
+            task_class: PacketTaskClassDto::RouteTracing,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Trace how StringUtils normalizes request routes".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "StringUtils".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "CharSequenceUtils".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+            ],
+            probe_resolutions: Vec::new(),
+            obligations: Default::default(),
+            trace: Vec::new(),
+        }
+    }
+
+    /// Every annotation the run produced, as `(kind, text)`, in emission order.
+    fn classified(answer: &AgentAnswerDto) -> Vec<(RetrievalAnnotationKindDto, String)> {
+        answer
+            .retrieval_trace
+            .annotations
+            .iter()
+            .map(|annotation| (annotation.kind, annotation.text.clone()))
+            .collect()
+    }
+
+    fn kind_of(answer: &AgentAnswerDto, prefix: &str) -> RetrievalAnnotationKindDto {
+        let matches = answer
+            .retrieval_trace
+            .annotations
+            .iter()
+            .filter(|annotation| annotation.text.starts_with(prefix))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matches.len(),
+            1,
+            "expected exactly one annotation starting with `{prefix}`, got {:?}",
+            classified(answer)
+        );
+        matches[0].kind
+    }
+
+    #[test]
+    fn packet_subqueries_skipped_by_budget_is_published_as_an_evidence_gap() {
+        // EV-6c (#1775). A tiny budget means the planned subqueries never ran, so the evidence
+        // they would have produced is genuinely absent. Reclassifying this producer as an
+        // observation would leave `agent_confidence` at high for a packet that skipped its
+        // supplemental retrieval outright.
+        let mut answer = empty_answer();
+        run_packet_planned_subqueries(
+            &AppController::new(),
+            &ev6c_plan(),
+            PacketBudgetModeDto::Tiny,
+            &ev6c_limits(),
+            false,
+            PacketLatencyBudget::new(Some(120_000)),
+            &[],
+            &mut answer,
+        )
+        .expect("skipping subqueries on a tiny budget is not an error");
+
+        assert_eq!(
+            classified(&answer),
+            vec![(
+                RetrievalAnnotationKindDto::Gap,
+                "packet_subqueries skipped budget=tiny".to_string()
+            )],
+            "the skipped-subquery producer must publish an evidence gap"
+        );
+    }
+
+    #[test]
+    fn failed_fused_subquery_batch_is_published_as_an_evidence_gap() {
+        // EV-6c (#1775). The fused batch failing means none of the planned subqueries returned
+        // evidence. The sibling `packet_subqueries fused_batch=` note on the same path is
+        // routine telemetry, so this also pins that the two are not classified alike.
+        let mut answer = empty_answer();
+        let error = run_packet_planned_subqueries(
+            &AppController::new(),
+            &ev6c_plan(),
+            PacketBudgetModeDto::Compact,
+            &ev6c_limits(),
+            false,
+            PacketLatencyBudget::new(Some(120_000)),
+            &[],
+            &mut answer,
+        )
+        .expect_err("an unopened controller cannot serve a fused packet batch");
+        assert!(
+            !error.message.is_empty(),
+            "fail-closed batch error must carry a reason"
+        );
+
+        assert_eq!(
+            kind_of(&answer, "packet_fused_subquery_batch_failed error="),
+            RetrievalAnnotationKindDto::Gap,
+            "a failed subquery batch is missing evidence, not telemetry: {:?}",
+            classified(&answer)
+        );
+        assert_eq!(
+            kind_of(&answer, "packet_subqueries fused_batch="),
+            RetrievalAnnotationKindDto::Observation,
+            "batch sizing is routine telemetry: {:?}",
+            classified(&answer)
+        );
+    }
+
+    #[test]
+    fn anchor_probes_skipped_by_budget_are_published_as_an_evidence_gap() {
+        // EV-6c (#1775). Anchor probes never dispatched: the anchors they would have found are
+        // absent from the packet, so the reason string must ride a `Gap`.
+        let mut answer = empty_answer();
+        run_packet_anchor_expansion(
+            &AppController::new(),
+            &ev6c_plan(),
+            PacketBudgetModeDto::Tiny,
+            &ev6c_limits(),
+            false,
+            PacketLatencyBudget::new(Some(120_000)),
+            &[],
+            &mut answer,
+        )
+        .expect("skipping anchor probes on a tiny budget is not an error");
+
+        assert_eq!(
+            classified(&answer),
+            vec![(
+                RetrievalAnnotationKindDto::Gap,
+                "packet_anchor_probes skipped reason=budget=tiny".to_string()
+            )],
+            "the skipped-anchor-probe producer must publish an evidence gap"
+        );
+    }
+
+    #[test]
+    fn anchor_probes_dropped_for_latency_are_published_as_an_evidence_gap() {
+        // EV-6c (#1775). The other reason this producer fires: the latency budget was already
+        // spent. This is the reclassification that would hurt most — an answer that silently
+        // dropped its anchor expansion to hit an SLA must not also report clean confidence.
+        let mut answer = empty_answer();
+        answer.retrieval_trace.total_latency_ms = 5_000;
+        run_packet_anchor_expansion(
+            &AppController::new(),
+            &ev6c_plan(),
+            PacketBudgetModeDto::Compact,
+            &ev6c_limits(),
+            false,
+            PacketLatencyBudget::new(Some(1_000)),
+            &[],
+            &mut answer,
+        )
+        .expect("dropping anchor probes for latency is not an error");
+
+        assert_eq!(
+            classified(&answer),
+            vec![(
+                RetrievalAnnotationKindDto::Gap,
+                "packet_anchor_probes skipped reason=latency_budget_exhausted".to_string()
+            )],
+            "an SLA-driven anchor-probe drop must publish an evidence gap"
+        );
+        assert!(
+            answer.retrieval_trace.sla_missed,
+            "the latency-driven drop must also record the missed SLA"
+        );
+    }
+
+    #[test]
+    fn failed_anchor_probes_are_published_as_evidence_gaps_per_query() {
+        // EV-6c (#1775). One gap per unanswered probe query, so the packet cannot claim the
+        // anchors it asked for.
+        let plan = ev6c_plan();
+        let expected_queries = packet_anchor_probe_queries(&plan);
+        assert!(
+            !expected_queries.is_empty(),
+            "fixture plan must yield anchor probe queries"
+        );
+
+        let mut answer = empty_answer();
+        run_packet_anchor_expansion(
+            &AppController::new(),
+            &plan,
+            PacketBudgetModeDto::Compact,
+            &ev6c_limits(),
+            false,
+            PacketLatencyBudget::new(Some(120_000)),
+            &[],
+            &mut answer,
+        )
+        .expect_err("an unopened controller cannot serve anchor probes");
+
+        let failures = answer
+            .retrieval_trace
+            .annotations
+            .iter()
+            .filter(|annotation| {
+                annotation
+                    .text
+                    .starts_with("packet_anchor_probe_failed query=")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            failures.len(),
+            expected_queries.len(),
+            "every unanswered probe query must be reported: {:?}",
+            classified(&answer)
+        );
+        for failure in failures {
+            assert_eq!(
+                failure.kind,
+                RetrievalAnnotationKindDto::Gap,
+                "a probe query that returned no evidence is a gap: {}",
+                failure.text
+            );
+        }
+    }
 
     #[test]
     fn packet_latency_budget_preserves_advertised_range_and_default() {

--- a/crates/codestory-runtime/src/agent/trace.rs
+++ b/crates/codestory-runtime/src/agent/trace.rs
@@ -200,3 +200,71 @@ impl TraceRecorder {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::api::RetrievalAnnotationKindDto;
+
+    /// EV-6c (#1775). `TraceRecorder` is the single front door every orchestrator gap producer
+    /// goes through, so the body of [`TraceRecorder::annotate_gap`] is a one-line mutation that
+    /// reclassifies every genuine evidence gap the agent reports as routine telemetry. That
+    /// direction *inflates* reported confidence: `agent_gap_notes` drops the annotation, the
+    /// packet keeps `agent_confidence=high`, and the operator is told an answer is ready when
+    /// retrieval never produced the evidence behind it.
+    ///
+    /// EV-6b pinned only the opposite direction (prose must not downgrade). This pins the kind
+    /// on the DTO the recorder actually publishes — not on its private buffer — so swapping
+    /// `RetrievalAnnotationDto::gap` for `::observation` in either entry point fails here.
+    #[test]
+    fn trace_recorder_publishes_gaps_as_gap_kind_and_observations_as_observation_kind() {
+        let mut trace = TraceRecorder::new(Some(500));
+        trace.annotate_gap("Latency-first cutoff skipped source reads.");
+        trace.observe("index_freshness status=Fresh indexed_files=12");
+        trace.annotate_gap(String::from(
+            "Index freshness not checked: retrieval sidecar is down",
+        ));
+
+        let published = trace.finish(
+            "request-ev6c".to_string(),
+            AgentRetrievalPresetDto::Architecture,
+            AgentRetrievalPolicyModeDto::LatencyFirst,
+        );
+
+        let classified = published
+            .annotations
+            .iter()
+            .map(|annotation| (annotation.kind, annotation.text.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            classified,
+            vec![
+                (
+                    RetrievalAnnotationKindDto::Gap,
+                    "Latency-first cutoff skipped source reads."
+                ),
+                (
+                    RetrievalAnnotationKindDto::Observation,
+                    "index_freshness status=Fresh indexed_files=12"
+                ),
+                (
+                    RetrievalAnnotationKindDto::Gap,
+                    "Index freshness not checked: retrieval sidecar is down"
+                ),
+            ],
+            "annotate_gap must publish Gap and observe must publish Observation, in push order"
+        );
+        assert!(published.annotations[0].is_gap());
+        assert!(!published.annotations[1].is_gap());
+        assert!(published.annotations[2].is_gap());
+        assert_eq!(
+            published
+                .annotations
+                .iter()
+                .filter(|annotation| annotation.is_gap())
+                .count(),
+            2,
+            "two recorded evidence gaps must survive publication as gaps"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1775.

EV-6b pinned the safe direction (an observation carrying all ten legacy marker words no longer downgrades confidence). This pins the dangerous one: a mutation reclassifying a genuine evidence gap as an observation — which would **inflate** reported confidence — now fails a test, for all 31 producers.

Declared: the coverage is per-producer rather than structural, so a *new* producer added later is not automatically covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
