### PR TITLE
[v0.17 S3-JAVASCRIPT] Extract JavaScript language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3941,8 +3941,8 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
     let comment_marker = codestory_contracts::language_support::line_comment_for_language(language)
         .or(match language {
             "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
-            "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
-            | "cpp" | "dart" | "php" | "swift" => Some("//"),
+            "rust" | "typescript" | "tsx" | "jsx" | "go" | "java" | "csharp" | "cpp" | "dart"
+            | "php" | "swift" => Some("//"),
             _ => None,
         });
     let Some(marker) = comment_marker else {
@@ -5572,8 +5572,9 @@ mod tests {
         assert!(bash.contains("\x1b[90m# comment\x1b[0m"), "{bash:?}");
     }
 
-    /// Kotlin's comment marker now comes from the language registry rather than
-    /// the local roster, and every other language must be unmoved.
+    /// Kotlin's and JavaScript's comment markers now come from the language
+    /// registry rather than the local roster, and every other language must be
+    /// unmoved.
     ///
     /// Asserting only "Kotlin still dims `//`" would pass with the registry
     /// lookup deleted, because the local roster used to answer for Kotlin too.
@@ -5639,6 +5640,25 @@ mod tests {
         );
         let kotlin = ansi_highlight_snippet("app/Main.kt", "val ok = true // comment");
         assert!(kotlin.contains("\x1b[90m// comment\x1b[0m"), "{kotlin:?}");
+
+        // Same for JavaScript. `jsx` is a highlighter dialect with no registry
+        // profile, so it must keep answering from the roster above; that split
+        // is what the `("javascript", ..)` / `("jsx", ..)` rows guard.
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("javascript"),
+            Some("//")
+        );
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("jsx"),
+            None
+        );
+        let javascript = ansi_highlight_snippet("app/main.js", "const ok = true // comment");
+        assert!(
+            javascript.contains("\x1b[90m// comment\x1b[0m"),
+            "{javascript:?}"
+        );
+        let jsx = ansi_highlight_snippet("app/View.jsx", "const ok = true // comment");
+        assert!(jsx.contains("\x1b[90m// comment\x1b[0m"), "{jsx:?}");
     }
 
     /// Component dialects resolve through the companion-extension registry and

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "javascript",
+        line_comment: "//",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "javascript"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,7 +1265,11 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("javascript"), Some("//"));
         assert_eq!(line_comment_for_language("swift"), None);
+        // `jsx` is a CLI highlighter dialect, not a registered language; it
+        // must keep answering from the CLI's own residual roster.
+        assert_eq!(line_comment_for_language("jsx"), None);
     }
 
     #[test]

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -1,9 +1,9 @@
 use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
-    GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
-    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, LanguageConfig, LanguageRuleset, PHP_GRAPH_QUERY,
+    PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY,
+    TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -32,7 +32,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("python", _) => Some(python()),
         ("java", _) => Some(java()),
         ("rust", _) => Some(rust()),
-        ("javascript", _) => Some(javascript()),
         ("typescript", "tsx") => Some(tsx()),
         ("typescript", _) => Some(typescript()),
         ("cpp", _) => Some(cpp()),
@@ -75,16 +74,6 @@ fn rust() -> LanguageConfig {
         RUST_GRAPH_QUERY,
         Some(RUST_TAGS_QUERY),
         LanguageRuleset::Rust,
-    )
-}
-
-fn javascript() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_javascript::LANGUAGE.into(),
-        "javascript",
-        JAVASCRIPT_GRAPH_QUERY,
-        None,
-        LanguageRuleset::JavaScript,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/javascript.rs
+++ b/crates/codestory-indexer/src/languages/javascript.rs
@@ -1,0 +1,457 @@
+//! JavaScript extraction rules.
+//!
+//! JavaScript's graph extraction lives here: the tree-sitter rule file, the
+//! compiled-rule cache, the member-call callsite marker, and the receiver-call
+//! resolution engine that turns `workflow.run(...)` into an edge aimed at
+//! `Workflow.run`. Every language-keyed dispatch in the crate reaches it
+//! through [`super::EXTRACTIONS`] rather than by spelling `"javascript"`.
+//!
+//! Three JavaScript-adjacent surfaces are deliberately *not* here, and none of
+//! them is JavaScript content:
+//!
+//! * the `js_*` / `js_ts_*` helpers in `lib.rs`
+//!   (`js_like_callable_source_name`, `js_ts_visible_local_type_name`,
+//!   `js_ts_local_binding_visible_at_call`,
+//!   `normalize_js_ts_private_receiver_surface`,
+//!   `normalized_receiver_variable`,
+//!   `collect_typescript_imported_type_bindings`,
+//!   `typescript_property_belongs_to_owner`), plus
+//!   `collect_javascript_static_call_edges` and
+//!   `collect_javascript_runtime_import_specs`. TypeScript and TSX call all of
+//!   them, so they are the shared JS-family seam and move — if ever — with the
+//!   last of the three dialects, not with this rollback unit.
+//! * the `"javascript" | "typescript"` arm of the framework-route scanner. The
+//!   per-language route collectors take non-uniform arguments and per-framework
+//!   `has_<framework>` preconditions, so routing them through the registry is
+//!   one change for all sixteen languages.
+//! * `LanguageRuleset::JavaScript`, which stays in `lib.rs` because the enum is
+//!   the compiled-rule cache key for every language at once.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both JavaScript fixtures so the move stays
+//! output-equal.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, ImportedTypeBinding, LanguageRuleset, ManualReceiverCallSpec,
+    ManualReceiverSource, OptionalReceiverOwnerBinding, ReceiverCallSiteKey, ReceiverOwnerBinding,
+    collect_receiver_call_specs_in_callable, collect_typescript_imported_type_bindings,
+    declaration_name, enclosing_node_with_kind, js_like_callable_source_name,
+    js_ts_local_binding_visible_at_call, js_ts_visible_local_type_name, member_call_method_col,
+    normalize_js_ts_private_receiver_surface, normalize_parameter_name,
+    normalized_receiver_variable, receiver_call_belongs_to_callable, receiver_callsite_key,
+    same_ts_span, trimmed_node_text, ts_node_graph_span, typescript_property_belongs_to_owner,
+    walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from JavaScript member-call
+/// syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:js-member-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/javascript.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for JavaScript.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["javascript"],
+    language_name: "javascript",
+    extensions: &["js", "jsx", "mjs", "cjs"],
+    ruleset: LanguageRuleset::JavaScript,
+    parser_language: javascript_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    receiver_call_specs: Some(receiver_call_specs),
+    member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
+    graph_call_syntax: Some("js_member"),
+    // `method_definition` already projects as METHOD straight out of the rule
+    // file, so JavaScript never asked for the FUNCTION -> METHOD promotion;
+    // `swift` and `dart` are the only languages that did.
+    promotes_type_member_functions_to_methods: false,
+    qualified_name_delimiter: ".",
+    route_comments_are_c_style: true,
+    // `JavaScriptSemanticResolver` is private to `semantic`, so the registry
+    // records the choice and `dedicated_semantic_resolver` still builds it.
+    uses_generic_semantic_resolver: false,
+    // Shared with typescript/vue/svelte/astro: candidates inside the JS family
+    // must stay reachable across those surfaces.
+    semantic_family: "webscript",
+};
+
+fn javascript_language() -> tree_sitter::Language {
+    tree_sitter_javascript::LANGUAGE.into()
+}
+
+/// Manual receiver-call edges for one parsed JavaScript file.
+///
+/// Was `lib.rs::collect_javascript_receiver_call_edges`.
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let imported_type_bindings =
+        collect_typescript_imported_type_bindings(tree.root_node(), source);
+    walk_tree_nodes(tree.root_node(), &mut |callable| {
+        if !matches!(
+            callable.kind(),
+            "method_definition" | "function_declaration" | "arrow_function"
+        ) {
+            return;
+        }
+        let Some(source_name) = js_like_callable_source_name(callable, source) else {
+            return;
+        };
+        let call_source = ManualReceiverSource {
+            name: &source_name,
+            span: ts_node_graph_span(callable),
+        };
+        let mut local_receiver_callsites = HashSet::new();
+        collect_javascript_constructor_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &imported_type_bindings,
+            &mut local_receiver_callsites,
+            &mut edges,
+        );
+        let mut receiver_types = HashMap::new();
+        if let Some(owner_name) = enclosing_node_with_kind(callable, &["class_declaration"])
+            .and_then(|owner| declaration_name(owner, source))
+            && callable.kind() == "method_definition"
+        {
+            receiver_types.insert("this".to_string(), owner_name);
+        }
+        let property_receiver_types = collect_javascript_class_property_receiver_types(
+            callable,
+            source,
+            &imported_type_bindings,
+        );
+        receiver_types.extend(
+            property_receiver_types
+                .iter()
+                .map(|(receiver_name, (owner_name, _))| {
+                    (receiver_name.clone(), owner_name.clone())
+                }),
+        );
+        if receiver_types.is_empty() {
+            return;
+        }
+        let mut receiver_modules = HashMap::new();
+        for (receiver_name, (_, owner_module)) in &property_receiver_types {
+            if let Some(module_name) = owner_module {
+                receiver_modules.insert(receiver_name.clone(), module_name.clone());
+            }
+        }
+        let start = edges.len();
+        collect_receiver_call_specs_in_callable(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &receiver_types,
+            member_call,
+            false,
+            &mut edges,
+        );
+        let mut fallback_specs = edges.split_off(start);
+        fallback_specs
+            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
+        for spec in &mut fallback_specs {
+            if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
+                spec.owner_module = Some(module_name.clone());
+            }
+        }
+        edges.extend(fallback_specs);
+    });
+    edges
+}
+
+fn collect_javascript_constructor_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let Some(owner) = javascript_visible_local_constructor_receiver_owner(
+            callable,
+            node,
+            &receiver_name,
+            source,
+            imported_type_bindings,
+        ) else {
+            return;
+        };
+        let method_col = member_call_method_col(node, source, &method_name);
+        local_receiver_callsites.insert(ReceiverCallSiteKey {
+            receiver_name: receiver_name.clone(),
+            method_name: method_name.clone(),
+            line: Some(node.start_position().row as u32 + 1),
+            method_col,
+        });
+        if let Some((owner_name, owner_module)) = owner {
+            edges.push(ManualReceiverCallSpec {
+                source_name: call_source.name.to_string(),
+                source_span: call_source.span,
+                receiver_name,
+                owner_name,
+                owner_module,
+                method_name,
+                method_col,
+                line: Some(node.start_position().row as u32 + 1),
+                allow_global_fallback: false,
+            });
+        }
+    });
+}
+
+fn javascript_visible_local_constructor_receiver_owner(
+    callable: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(callable, &mut |node| {
+        if node.kind() != "variable_declarator"
+            || !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > call_node.start_byte()
+            || !js_ts_local_binding_visible_at_call(node, call_node)
+        {
+            return;
+        }
+        let Some(binding_name) = node
+            .child_by_field_name("name")
+            .and_then(|name_node| trimmed_node_text(name_node, source))
+            .as_deref()
+            .and_then(normalize_parameter_name)
+        else {
+            return;
+        };
+        if binding_name != receiver_name {
+            return;
+        }
+        visible_bindings.push((
+            node.end_byte(),
+            javascript_constructor_receiver_owner(node, callable, source, imported_type_bindings),
+        ));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner)| owner)
+}
+
+fn javascript_constructor_receiver_owner(
+    node: TsNode<'_>,
+    callable: TsNode<'_>,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> OptionalReceiverOwnerBinding {
+    let value_node = node.child_by_field_name("value")?;
+    javascript_new_expression_receiver_owner(
+        value_node,
+        callable,
+        node,
+        source,
+        imported_type_bindings,
+    )
+}
+
+fn javascript_new_expression_receiver_owner(
+    value_node: TsNode<'_>,
+    scope_node: TsNode<'_>,
+    before_node: TsNode<'_>,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> OptionalReceiverOwnerBinding {
+    if value_node.kind() != "new_expression" {
+        return None;
+    }
+    let owner_name = value_node
+        .child_by_field_name("constructor")
+        .filter(|constructor| constructor.kind() == "identifier")
+        .and_then(|constructor| trimmed_node_text(constructor, source))
+        .as_deref()
+        .and_then(normalize_parameter_name)?;
+    if js_ts_visible_local_type_name(scope_node, before_node, &owner_name, source) {
+        return Some((owner_name, None));
+    }
+    imported_type_bindings
+        .get(&owner_name)
+        .map(|binding| {
+            (
+                binding.owner_name.clone(),
+                Some(binding.module_name.clone()),
+            )
+        })
+        .or(Some((owner_name, None)))
+}
+
+fn collect_javascript_class_property_receiver_types(
+    callable: TsNode<'_>,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> HashMap<String, ReceiverOwnerBinding> {
+    let mut receiver_types = HashMap::new();
+    if callable.kind() != "method_definition" || javascript_method_is_static(callable, source) {
+        return receiver_types;
+    }
+    let Some(class_node) = enclosing_node_with_kind(callable, &["class_declaration"]) else {
+        return receiver_types;
+    };
+    let mut candidates: HashMap<String, Vec<OptionalReceiverOwnerBinding>> = HashMap::new();
+    walk_tree_nodes(class_node, &mut |node| {
+        let Some((receiver_name, scope_node, value_node)) =
+            javascript_property_receiver_candidate(node, class_node, source)
+        else {
+            return;
+        };
+        let owner_name = javascript_new_expression_receiver_owner(
+            value_node,
+            scope_node,
+            node,
+            source,
+            imported_type_bindings,
+        );
+        candidates
+            .entry(receiver_name)
+            .or_default()
+            .push(owner_name);
+    });
+    for (receiver_name, owners) in candidates {
+        let Some(mut concrete_owners) = owners.into_iter().collect::<Option<Vec<_>>>() else {
+            continue;
+        };
+        concrete_owners.sort();
+        concrete_owners.dedup();
+        if concrete_owners.len() == 1 {
+            receiver_types.insert(receiver_name, concrete_owners.remove(0));
+        }
+    }
+    receiver_types
+}
+
+fn javascript_property_receiver_candidate<'tree>(
+    node: TsNode<'tree>,
+    class_node: TsNode<'tree>,
+    source: &str,
+) -> Option<(String, TsNode<'tree>, TsNode<'tree>)> {
+    if node.kind() == "assignment_expression"
+        && javascript_assignment_matches_instance_property_domain(node, class_node, source)
+    {
+        let receiver_name = node
+            .child_by_field_name("left")
+            .and_then(|left| javascript_this_property_receiver_name(left, source))?;
+        let scope_node =
+            enclosing_node_with_kind(node, &["method_definition"]).unwrap_or(class_node);
+        return Some((
+            receiver_name,
+            scope_node,
+            node.child_by_field_name("right")?,
+        ));
+    }
+    if matches!(node.kind(), "field_definition" | "public_field_definition")
+        && typescript_property_belongs_to_owner(node, class_node)
+        && !javascript_surface_starts_with_static(node, source)
+    {
+        let field_name = javascript_class_field_name(node, source)?;
+        return Some((
+            format!("this.{field_name}"),
+            class_node,
+            node.child_by_field_name("value")?,
+        ));
+    }
+    None
+}
+
+fn javascript_class_field_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    node.child_by_field_name("name")
+        .and_then(|name| trimmed_node_text(name, source))
+        .or_else(|| {
+            trimmed_node_text(node, source).map(|surface| {
+                surface
+                    .split('=')
+                    .next()
+                    .unwrap_or(surface.as_str())
+                    .trim()
+                    .to_string()
+            })
+        })
+        .as_deref()
+        .and_then(normalize_parameter_name)
+}
+
+fn javascript_assignment_matches_instance_property_domain(
+    assignment: TsNode<'_>,
+    class_node: TsNode<'_>,
+    source: &str,
+) -> bool {
+    if !enclosing_node_with_kind(assignment, &["class_declaration"])
+        .is_some_and(|owner| same_ts_span(owner, class_node))
+    {
+        return false;
+    }
+    let Some(method) = enclosing_node_with_kind(assignment, &["method_definition"]) else {
+        return false;
+    };
+    if javascript_method_is_static(method, source)
+        || !enclosing_node_with_kind(method, &["class_declaration"])
+            .is_some_and(|owner| same_ts_span(owner, class_node))
+    {
+        return false;
+    }
+    receiver_call_belongs_to_callable(assignment, method)
+}
+
+fn javascript_method_is_static(method: TsNode<'_>, source: &str) -> bool {
+    javascript_surface_starts_with_static(method, source)
+}
+
+fn javascript_surface_starts_with_static(node: TsNode<'_>, source: &str) -> bool {
+    trimmed_node_text(node, source).is_some_and(|surface| {
+        surface
+            .trim_start()
+            .strip_prefix("static")
+            .is_some_and(|rest| rest.chars().next().is_none_or(|ch| ch.is_whitespace()))
+    })
+}
+
+fn javascript_this_property_receiver_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    let receiver_name = normalized_receiver_variable(node, source)?;
+    let field_name = receiver_name.strip_prefix("this.")?;
+    Some(format!("this.{}", normalize_parameter_name(field_name)?))
+}
+
+fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let function = node.child_by_field_name("function")?;
+    if function.kind() != "member_expression" {
+        return None;
+    }
+    let receiver = function.child_by_field_name("object")?;
+    let method = function.child_by_field_name("property")?;
+    Some((
+        normalize_js_ts_private_receiver_surface(&normalized_receiver_variable(receiver, source)?),
+        trimmed_node_text(method, source)?,
+    ))
+}

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -16,6 +16,7 @@
 //! `registry_rows_do_not_shadow_unmigrated_languages` proves it — and the last
 //! package to land deletes the residual arms entirely.
 
+pub(crate) mod javascript;
 pub(crate) mod kotlin;
 
 use std::sync::OnceLock;
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, javascript::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -64,7 +64,6 @@ pub(crate) const JAVA_MEMBER_CALLSITE_MARKER: &str = "syntax:java-member-call";
 pub(crate) const CSHARP_MEMBER_CALLSITE_MARKER: &str = "syntax:csharp-member-call";
 pub(crate) const RUBY_MEMBER_CALLSITE_MARKER: &str = "syntax:ruby-member-call";
 pub(crate) const PHP_MEMBER_CALLSITE_MARKER: &str = "syntax:php-member-call";
-pub(crate) const JS_MEMBER_CALLSITE_MARKER: &str = "syntax:js-member-call";
 pub(crate) const TS_MEMBER_CALLSITE_MARKER: &str = "syntax:ts-member-call";
 pub(crate) const DART_MEMBER_CALLSITE_MARKER: &str = "syntax:dart-member-call";
 pub(crate) const SWIFT_MEMBER_CALLSITE_MARKER: &str = "syntax:swift-member-call";
@@ -131,7 +130,6 @@ const PYTHON_GRAPH_QUERY: &str = include_str!("../rules/python.scm");
 const JAVA_GRAPH_QUERY: &str = include_str!("../rules/java.scm");
 const RUST_GRAPH_QUERY: &str = include_str!("../rules/rust.graph.scm");
 const RUST_TAGS_QUERY: &str = include_str!("../rules/rust.tags.scm");
-const JAVASCRIPT_GRAPH_QUERY: &str = include_str!("../rules/javascript.scm");
 const TYPESCRIPT_GRAPH_QUERY: &str = include_str!("../rules/typescript.graph.scm");
 const TYPESCRIPT_TAGS_QUERY: &str = include_str!("../rules/typescript.tags.scm");
 const TSX_GRAPH_QUERY: &str = include_str!("../rules/tsx.graph.scm");
@@ -301,9 +299,12 @@ impl LanguageRuleset {
                 Some(RUST_TAGS_QUERY),
                 &RUST_RULES,
             ),
-            LanguageRuleset::JavaScript => {
-                compiled_rules_cache(language, JAVASCRIPT_GRAPH_QUERY, None, &JAVASCRIPT_RULES)
-            }
+            // Answered by the registry above; the arm only exists because the
+            // match must stay exhaustive. Failing closed here rather than
+            // panicking keeps a future registry mistake a typed indexing error.
+            LanguageRuleset::JavaScript => Err(anyhow!(
+                "javascript compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::TypeScript => compiled_rules_cache(
                 language,
                 TYPESCRIPT_GRAPH_QUERY,
@@ -375,7 +376,6 @@ fn compiled_rules_cache(
 static PYTHON_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static JAVA_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static RUST_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static JAVASCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static TYPESCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static TSX_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CPP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
@@ -6154,93 +6154,6 @@ fn collect_javascript_static_call_edges(tree: &Tree, source: &str) -> Vec<Manual
     edges
 }
 
-fn collect_javascript_receiver_call_edges(
-    tree: &Tree,
-    source: &str,
-) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let imported_type_bindings =
-        collect_typescript_imported_type_bindings(tree.root_node(), source);
-    walk_tree_nodes(tree.root_node(), &mut |callable| {
-        if !matches!(
-            callable.kind(),
-            "method_definition" | "function_declaration" | "arrow_function"
-        ) {
-            return;
-        }
-        let Some(source_name) = js_like_callable_source_name(callable, source) else {
-            return;
-        };
-        let call_source = ManualReceiverSource {
-            name: &source_name,
-            span: ts_node_graph_span(callable),
-        };
-        let mut local_receiver_callsites = HashSet::new();
-        collect_javascript_constructor_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &imported_type_bindings,
-            &mut local_receiver_callsites,
-            &mut edges,
-        );
-        let mut receiver_types = HashMap::new();
-        if let Some(owner_name) = enclosing_node_with_kind(callable, &["class_declaration"])
-            .and_then(|owner| declaration_name(owner, source))
-            && callable.kind() == "method_definition"
-        {
-            receiver_types.insert("this".to_string(), owner_name);
-        }
-        let property_receiver_types = collect_javascript_class_property_receiver_types(
-            callable,
-            source,
-            &imported_type_bindings,
-        );
-        receiver_types.extend(
-            property_receiver_types
-                .iter()
-                .map(|(receiver_name, (owner_name, _))| {
-                    (receiver_name.clone(), owner_name.clone())
-                }),
-        );
-        if receiver_types.is_empty() {
-            return;
-        }
-        let mut receiver_modules = HashMap::new();
-        for (receiver_name, (_, owner_module)) in &property_receiver_types {
-            if let Some(module_name) = owner_module {
-                receiver_modules.insert(receiver_name.clone(), module_name.clone());
-            }
-        }
-        let start = edges.len();
-        collect_receiver_call_specs_in_callable(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &receiver_types,
-            javascript_member_call,
-            false,
-            &mut edges,
-        );
-        let mut fallback_specs = edges.split_off(start);
-        fallback_specs
-            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
-        for spec in &mut fallback_specs {
-            if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
-                spec.owner_module = Some(module_name.clone());
-            }
-        }
-        edges.extend(fallback_specs);
-    });
-    edges
-}
-
 fn js_like_callable_source_name(node: TsNode<'_>, source: &str) -> Option<String> {
     match node.kind() {
         "function_declaration" | "method_definition" => declaration_name(node, source),
@@ -6249,135 +6162,6 @@ fn js_like_callable_source_name(node: TsNode<'_>, source: &str) -> Option<String
             .and_then(|parent| tsx_callable_binding_name(parent, source)),
         _ => None,
     }
-}
-
-fn collect_javascript_constructor_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = javascript_member_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let Some(owner) = javascript_visible_local_constructor_receiver_owner(
-            callable,
-            node,
-            &receiver_name,
-            source,
-            imported_type_bindings,
-        ) else {
-            return;
-        };
-        let method_col = member_call_method_col(node, source, &method_name);
-        local_receiver_callsites.insert(ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
-            method_col,
-        });
-        if let Some((owner_name, owner_module)) = owner {
-            edges.push(ManualReceiverCallSpec {
-                source_name: call_source.name.to_string(),
-                source_span: call_source.span,
-                receiver_name,
-                owner_name,
-                owner_module,
-                method_name,
-                method_col,
-                line: Some(node.start_position().row as u32 + 1),
-                allow_global_fallback: false,
-            });
-        }
-    });
-}
-
-fn javascript_visible_local_constructor_receiver_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if node.kind() != "variable_declarator"
-            || !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
-            || !js_ts_local_binding_visible_at_call(node, call_node)
-        {
-            return;
-        }
-        let Some(binding_name) = node
-            .child_by_field_name("name")
-            .and_then(|name_node| trimmed_node_text(name_node, source))
-            .as_deref()
-            .and_then(normalize_parameter_name)
-        else {
-            return;
-        };
-        if binding_name != receiver_name {
-            return;
-        }
-        visible_bindings.push((
-            node.end_byte(),
-            javascript_constructor_receiver_owner(node, callable, source, imported_type_bindings),
-        ));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner)| owner)
-}
-
-fn javascript_constructor_receiver_owner(
-    node: TsNode<'_>,
-    callable: TsNode<'_>,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> OptionalReceiverOwnerBinding {
-    let value_node = node.child_by_field_name("value")?;
-    javascript_new_expression_receiver_owner(
-        value_node,
-        callable,
-        node,
-        source,
-        imported_type_bindings,
-    )
-}
-
-fn javascript_new_expression_receiver_owner(
-    value_node: TsNode<'_>,
-    scope_node: TsNode<'_>,
-    before_node: TsNode<'_>,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> OptionalReceiverOwnerBinding {
-    if value_node.kind() != "new_expression" {
-        return None;
-    }
-    let owner_name = value_node
-        .child_by_field_name("constructor")
-        .filter(|constructor| constructor.kind() == "identifier")
-        .and_then(|constructor| trimmed_node_text(constructor, source))
-        .as_deref()
-        .and_then(normalize_parameter_name)?;
-    if js_ts_visible_local_type_name(scope_node, before_node, &owner_name, source) {
-        return Some((owner_name, None));
-    }
-    imported_type_bindings
-        .get(&owner_name)
-        .map(|binding| {
-            (
-                binding.owner_name.clone(),
-                Some(binding.module_name.clone()),
-            )
-        })
-        .or(Some((owner_name, None)))
 }
 
 fn js_ts_visible_local_type_name(
@@ -6421,141 +6205,6 @@ fn js_ts_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_
 
 fn js_ts_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
     enclosing_node_with_kind(node, &["statement_block", "block", "program"])
-}
-
-fn collect_javascript_class_property_receiver_types(
-    callable: TsNode<'_>,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> HashMap<String, ReceiverOwnerBinding> {
-    let mut receiver_types = HashMap::new();
-    if callable.kind() != "method_definition" || javascript_method_is_static(callable, source) {
-        return receiver_types;
-    }
-    let Some(class_node) = enclosing_node_with_kind(callable, &["class_declaration"]) else {
-        return receiver_types;
-    };
-    let mut candidates: HashMap<String, Vec<OptionalReceiverOwnerBinding>> = HashMap::new();
-    walk_tree_nodes(class_node, &mut |node| {
-        let Some((receiver_name, scope_node, value_node)) =
-            javascript_property_receiver_candidate(node, class_node, source)
-        else {
-            return;
-        };
-        let owner_name = javascript_new_expression_receiver_owner(
-            value_node,
-            scope_node,
-            node,
-            source,
-            imported_type_bindings,
-        );
-        candidates
-            .entry(receiver_name)
-            .or_default()
-            .push(owner_name);
-    });
-    for (receiver_name, owners) in candidates {
-        let Some(mut concrete_owners) = owners.into_iter().collect::<Option<Vec<_>>>() else {
-            continue;
-        };
-        concrete_owners.sort();
-        concrete_owners.dedup();
-        if concrete_owners.len() == 1 {
-            receiver_types.insert(receiver_name, concrete_owners.remove(0));
-        }
-    }
-    receiver_types
-}
-
-fn javascript_property_receiver_candidate<'tree>(
-    node: TsNode<'tree>,
-    class_node: TsNode<'tree>,
-    source: &str,
-) -> Option<(String, TsNode<'tree>, TsNode<'tree>)> {
-    if node.kind() == "assignment_expression"
-        && javascript_assignment_matches_instance_property_domain(node, class_node, source)
-    {
-        let receiver_name = node
-            .child_by_field_name("left")
-            .and_then(|left| javascript_this_property_receiver_name(left, source))?;
-        let scope_node =
-            enclosing_node_with_kind(node, &["method_definition"]).unwrap_or(class_node);
-        return Some((
-            receiver_name,
-            scope_node,
-            node.child_by_field_name("right")?,
-        ));
-    }
-    if matches!(node.kind(), "field_definition" | "public_field_definition")
-        && typescript_property_belongs_to_owner(node, class_node)
-        && !javascript_surface_starts_with_static(node, source)
-    {
-        let field_name = javascript_class_field_name(node, source)?;
-        return Some((
-            format!("this.{field_name}"),
-            class_node,
-            node.child_by_field_name("value")?,
-        ));
-    }
-    None
-}
-
-fn javascript_class_field_name(node: TsNode<'_>, source: &str) -> Option<String> {
-    node.child_by_field_name("name")
-        .and_then(|name| trimmed_node_text(name, source))
-        .or_else(|| {
-            trimmed_node_text(node, source).map(|surface| {
-                surface
-                    .split('=')
-                    .next()
-                    .unwrap_or(surface.as_str())
-                    .trim()
-                    .to_string()
-            })
-        })
-        .as_deref()
-        .and_then(normalize_parameter_name)
-}
-
-fn javascript_assignment_matches_instance_property_domain(
-    assignment: TsNode<'_>,
-    class_node: TsNode<'_>,
-    source: &str,
-) -> bool {
-    if !enclosing_node_with_kind(assignment, &["class_declaration"])
-        .is_some_and(|owner| same_ts_span(owner, class_node))
-    {
-        return false;
-    }
-    let Some(method) = enclosing_node_with_kind(assignment, &["method_definition"]) else {
-        return false;
-    };
-    if javascript_method_is_static(method, source)
-        || !enclosing_node_with_kind(method, &["class_declaration"])
-            .is_some_and(|owner| same_ts_span(owner, class_node))
-    {
-        return false;
-    }
-    receiver_call_belongs_to_callable(assignment, method)
-}
-
-fn javascript_method_is_static(method: TsNode<'_>, source: &str) -> bool {
-    javascript_surface_starts_with_static(method, source)
-}
-
-fn javascript_surface_starts_with_static(node: TsNode<'_>, source: &str) -> bool {
-    trimmed_node_text(node, source).is_some_and(|surface| {
-        surface
-            .trim_start()
-            .strip_prefix("static")
-            .is_some_and(|rest| rest.chars().next().is_none_or(|ch| ch.is_whitespace()))
-    })
-}
-
-fn javascript_this_property_receiver_name(node: TsNode<'_>, source: &str) -> Option<String> {
-    let receiver_name = normalized_receiver_variable(node, source)?;
-    let field_name = receiver_name.strip_prefix("this.")?;
-    Some(format!("this.{}", normalize_parameter_name(field_name)?))
 }
 
 fn rust_macro_owner_name(mut node: TsNode<'_>, source: &str) -> Option<String> {
@@ -7592,7 +7241,6 @@ fn language_receiver_call_specs(
         };
     }
     match language_name {
-        "javascript" => collect_javascript_receiver_call_edges(tree, source),
         "python" => collect_python_receiver_call_edges(tree, source),
         "typescript" | "tsx" => collect_typescript_receiver_call_edges(tree, source),
         "java" => collect_java_receiver_call_edges(tree, source),
@@ -14483,22 +14131,6 @@ fn typescript_member_call(node: TsNode<'_>, source: &str) -> Option<(String, Str
     ))
 }
 
-fn javascript_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if node.kind() != "call_expression" {
-        return None;
-    }
-    let function = node.child_by_field_name("function")?;
-    if function.kind() != "member_expression" {
-        return None;
-    }
-    let receiver = function.child_by_field_name("object")?;
-    let method = function.child_by_field_name("property")?;
-    Some((
-        normalize_js_ts_private_receiver_surface(&normalized_receiver_variable(receiver, source)?),
-        trimmed_node_text(method, source)?,
-    ))
-}
-
 fn normalize_js_ts_private_receiver_surface(receiver: &str) -> String {
     receiver
         .split('.')
@@ -17072,16 +16704,7 @@ fn route_language_uses_c_style_comments(language_name: &str) -> bool {
     }
     matches!(
         language_name,
-        "javascript"
-            | "typescript"
-            | "java"
-            | "rust"
-            | "go"
-            | "php"
-            | "csharp"
-            | "dart"
-            | "vue"
-            | "astro"
+        "typescript" | "java" | "rust" | "go" | "php" | "csharp" | "dart" | "vue" | "astro"
     )
 }
 
@@ -20229,7 +19852,6 @@ pub fn index_file(
                                         "java_member" => Some(JAVA_MEMBER_CALLSITE_MARKER),
                                         "csharp_member" => Some(CSHARP_MEMBER_CALLSITE_MARKER),
                                         "php_member" => Some(PHP_MEMBER_CALLSITE_MARKER),
-                                        "js_member" => Some(JS_MEMBER_CALLSITE_MARKER),
                                         "ts_member" => Some(TS_MEMBER_CALLSITE_MARKER),
                                         "dart_member" => Some(DART_MEMBER_CALLSITE_MARKER),
                                         "swift_member" => Some(SWIFT_MEMBER_CALLSITE_MARKER),

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1333,7 +1333,7 @@ fn is_js_member_call_placeholder(edge_kind: EdgeKind, callsite_identity: Option<
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::JS_MEMBER_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::javascript::MEMBER_CALLSITE_MARKER)
     })
 }
 

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -592,7 +592,7 @@ fn language_family_bucket(language: &'static str) -> &'static str {
     }
     match language {
         "c" | "cpp" => "native",
-        "javascript" | "typescript" | "vue" | "svelte" | "astro" => "webscript",
+        "typescript" | "vue" | "svelte" | "astro" => "webscript",
         "python" => "python",
         "rust" => "rust",
         "java" => "java",
@@ -866,6 +866,57 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(ids, vec![21_i64], "kotlin caller candidates: {out:?}");
         assert_eq!(language_family_bucket("kotlin"), "kotlin");
+        Ok(())
+    }
+
+    /// JavaScript keeps sharing the `webscript` family after the bucket moved
+    /// into the extraction registry.
+    ///
+    /// The single-file projection snapshots cannot see this field at all, and
+    /// asserting the registry value would be a tautology, so this drives the
+    /// filter instead: a JavaScript caller must still reach a same-named
+    /// TypeScript declaration (they share `webscript`) while a Kotlin
+    /// declaration stays out of reach. Giving JavaScript its own bucket would
+    /// silently drop the TypeScript candidate and no other test would notice.
+    #[test]
+    fn javascript_keeps_sharing_the_webscript_family_after_the_registry_move() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        create_node_table(&conn)?;
+        insert_file_node(&conn, 1, "caller.js")?;
+        insert_file_node(&conn, 2, "helper.ts")?;
+        insert_file_node(&conn, 3, "Helper.kt")?;
+        for (id, file_id) in [(30_i64, 2_i64), (31_i64, 3_i64)] {
+            conn.execute(
+                "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    id,
+                    NodeKind::FUNCTION as i32,
+                    "persistRecord",
+                    "persistRecord",
+                    file_id,
+                    5_i64
+                ],
+            )?;
+        }
+
+        let index = SemanticCandidateIndex::load(&conn, &[NodeKind::FUNCTION as i32])?;
+        let out = resolve_call_candidates(
+            &index,
+            &[NodeKind::FUNCTION as i32],
+            "persistRecord",
+            Some(1),
+            detect_language(Some("caller.js")),
+            0.82,
+            0.70,
+        )?;
+
+        let ids = out
+            .iter()
+            .map(|candidate| candidate.target_node_id)
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![30_i64], "javascript caller candidates: {out:?}");
+        assert_eq!(language_family_bucket("javascript"), "webscript");
         Ok(())
     }
 

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/javascript_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/javascript_fidelity.txt
@@ -1,0 +1,64 @@
+node CLASS name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.js:ConsoleNotifier line=10 col=7 end=10:22 file=FILE:<ROOT>/fidelity.js@1
+node CLASS name=Notifier qn=Notifier canonical=<ROOT>/fidelity.js:Notifier line=4 col=7 end=4:15 file=FILE:<ROOT>/fidelity.js@1
+node CLASS name=Repository qn=Repository canonical=<ROOT>/fidelity.js:Repository line=20 col=7 end=20:17 file=FILE:<ROOT>/fidelity.js@1
+node CLASS name=Workflow qn=Workflow canonical=<ROOT>/fidelity.js:Workflow line=30 col=7 end=30:15 file=FILE:<ROOT>/fidelity.js@1
+node FILE name=<ROOT>/fidelity.js qn=<ROOT>/fidelity.js canonical=<ROOT>/fidelity.js:<ROOT>/fidelity.js:1 line=1 col=1 end=55:0 file=FILE:<ROOT>/fidelity.js@1
+node FUNCTION name=orchestrateJs qn=orchestrateJs canonical=<ROOT>/fidelity.js:orchestrateJs#0 line=52 col=8 end=55:2 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=ConsoleNotifier.notify qn=ConsoleNotifier.notify canonical=<ROOT>/fidelity.js:ConsoleNotifier.notify#0 line=11 col=5 end=13:6 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=ConsoleNotifier.writeLog qn=ConsoleNotifier.writeLog canonical=<ROOT>/fidelity.js:ConsoleNotifier.writeLog#0 line=15 col=5 end=17:6 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=Notifier.notify qn=Notifier.notify canonical=<ROOT>/fidelity.js:Notifier.notify#0 line=5 col=5 end=7:6 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=Repository.save qn=Repository.save canonical=<ROOT>/fidelity.js:Repository.save#0 line=21 col=5 end=23:6 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=Repository.track qn=Repository.track canonical=<ROOT>/fidelity.js:Repository.track#0 line=25 col=5 end=27:6 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=Workflow.decorate qn=Workflow.decorate canonical=<ROOT>/fidelity.js:Workflow.decorate#0 line=47 col=5 end=49:6 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=Workflow.identity qn=Workflow.identity canonical=<ROOT>/fidelity.js:Workflow.identity#0 line=31 col=5 end=33:6 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=Workflow.run qn=Workflow.run canonical=<ROOT>/fidelity.js:Workflow.run#0 line=35 col=5 end=40:6 file=FILE:<ROOT>/fidelity.js@1
+node METHOD name=Workflow.runAsync qn=Workflow.runAsync canonical=<ROOT>/fidelity.js:Workflow.runAsync#0 line=42 col=5 end=45:6 file=FILE:<ROOT>/fidelity.js@1
+node MODULE name="fs" qn="fs" canonical=<ROOT>/fidelity.js:"fs"#0 line=1 col=42 end=1:46 file=FILE:<ROOT>/fidelity.js@1
+node MODULE name="path" qn="path" canonical=<ROOT>/fidelity.js:"path"#0 line=2 col=34 end=2:40 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=String qn=String canonical=<ROOT>/fidelity.js:String#0 line=48 col=36 end=48:42 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.js:decorate#0 line=39 col=14 end=39:22 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=identity qn=identity canonical=<ROOT>/fidelity.js:identity#0 line=36 col=29 end=36:37 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=join qn=join canonical=<ROOT>/fidelity.js:join#0 line=2 col=10 end=2:14 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=mapper qn=mapper canonical=<ROOT>/fidelity.js:mapper#0 line=32 col=16 end=32:22 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.js:notify#0 line=37 col=18 end=37:24 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=pathJoin qn=pathJoin canonical=<ROOT>/fidelity.js:pathJoin#0 line=2 col=18 end=2:26 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=pathJoin qn=pathJoin canonical=<ROOT>/fidelity.js:pathJoin#1 line=48 col=16 end=48:24 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=readFile qn=readFile canonical=<ROOT>/fidelity.js:readFile#0 line=1 col=26 end=1:34 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=readFileSync qn=readFileSync canonical=<ROOT>/fidelity.js:readFileSync#0 line=1 col=10 end=1:22 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=resolve qn=resolve canonical=<ROOT>/fidelity.js:resolve#0 line=44 col=23 end=44:30 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.js:run#0 line=43 col=14 end=43:17 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.js:run#1 line=54 col=14 end=54:17 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.js:save#0 line=38 col=20 end=38:24 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=track qn=track canonical=<ROOT>/fidelity.js:track#0 line=22 col=14 end=22:19 file=FILE:<ROOT>/fidelity.js@1
+node UNKNOWN name=writeLog qn=writeLog canonical=<ROOT>/fidelity.js:writeLog#0 line=12 col=14 end=12:22 file=FILE:<ROOT>/fidelity.js@1
+edge CALL src=FUNCTION:orchestrateJs@52 dst=CLASS:ConsoleNotifier@10 resolved_src=FUNCTION:orchestrateJs@52 resolved_dst=- line=54 confidence=- certainty=- callsite=h0:54:1:h1 candidates=[]
+edge CALL src=FUNCTION:orchestrateJs@52 dst=CLASS:Repository@20 resolved_src=FUNCTION:orchestrateJs@52 resolved_dst=- line=54 confidence=- certainty=- callsite=h0:54:1:h2 candidates=[]
+edge CALL src=FUNCTION:orchestrateJs@52 dst=CLASS:Workflow@30 resolved_src=FUNCTION:orchestrateJs@52 resolved_dst=- line=53 confidence=- certainty=- callsite=h0:53:1:h3 candidates=[]
+edge CALL src=FUNCTION:orchestrateJs@52 dst=METHOD:Workflow.run@35 resolved_src=FUNCTION:orchestrateJs@52 resolved_dst=METHOD:Workflow.run@35 line=54 confidence=1.0000 certainty=Certain callsite=h0:54:1:h4 candidates=[]
+edge CALL src=METHOD:ConsoleNotifier.notify@11 dst=METHOD:ConsoleNotifier.writeLog@15 resolved_src=METHOD:ConsoleNotifier.notify@11 resolved_dst=METHOD:ConsoleNotifier.writeLog@15 line=12 confidence=1.0000 certainty=Certain callsite=h0:12:1:h5 candidates=[]
+edge CALL src=METHOD:Repository.save@21 dst=METHOD:Repository.track@25 resolved_src=METHOD:Repository.save@21 resolved_dst=METHOD:Repository.track@25 line=22 confidence=1.0000 certainty=Certain callsite=h0:22:1:h6 candidates=[]
+edge CALL src=METHOD:Workflow.decorate@47 dst=UNKNOWN:String@48 resolved_src=METHOD:Workflow.decorate@47 resolved_dst=- line=48 confidence=- certainty=- callsite=h0:48:1:h7 candidates=[]
+edge CALL src=METHOD:Workflow.decorate@47 dst=UNKNOWN:pathJoin@48 resolved_src=METHOD:Workflow.decorate@47 resolved_dst=- line=48 confidence=- certainty=- callsite=h0:48:1:h8 candidates=[]
+edge CALL src=METHOD:Workflow.identity@31 dst=UNKNOWN:mapper@32 resolved_src=METHOD:Workflow.identity@31 resolved_dst=- line=32 confidence=- certainty=- callsite=h0:32:1:h9 candidates=[]
+edge CALL src=METHOD:Workflow.run@35 dst=METHOD:Workflow.decorate@47 resolved_src=METHOD:Workflow.run@35 resolved_dst=METHOD:Workflow.decorate@47 line=39 confidence=1.0000 certainty=Certain callsite=h0:39:1:h10 candidates=[]
+edge CALL src=METHOD:Workflow.run@35 dst=METHOD:Workflow.identity@31 resolved_src=METHOD:Workflow.run@35 resolved_dst=METHOD:Workflow.identity@31 line=36 confidence=1.0000 certainty=Certain callsite=h0:36:1:h11 candidates=[]
+edge CALL src=METHOD:Workflow.run@35 dst=UNKNOWN:notify@37 resolved_src=METHOD:Workflow.run@35 resolved_dst=- line=37 confidence=- certainty=- callsite=h0:37:1:h12|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:Workflow.run@35 dst=UNKNOWN:save@38 resolved_src=METHOD:Workflow.run@35 resolved_dst=- line=38 confidence=- certainty=- callsite=h0:38:1:h13|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:Workflow.runAsync@42 dst=METHOD:Workflow.run@35 resolved_src=METHOD:Workflow.runAsync@42 resolved_dst=METHOD:Workflow.run@35 line=43 confidence=1.0000 certainty=Certain callsite=h0:43:1:h4 candidates=[]
+edge CALL src=METHOD:Workflow.runAsync@42 dst=UNKNOWN:resolve@44 resolved_src=METHOD:Workflow.runAsync@42 resolved_dst=- line=44 confidence=- certainty=- callsite=h0:44:1:h14|syntax:js-member-call candidates=[]
+edge IMPORT src=MODULE:"fs"@1 dst=MODULE:"fs"@1 resolved_src=MODULE:"fs"@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=MODULE:"path"@2 dst=MODULE:"path"@2 resolved_src=MODULE:"path"@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:join@2 dst=MODULE:"path"@2 resolved_src=UNKNOWN:join@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:pathJoin@2 dst=MODULE:"path"@2 resolved_src=UNKNOWN:pathJoin@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:readFile@1 dst=MODULE:"fs"@1 resolved_src=UNKNOWN:readFile@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:readFileSync@1 dst=MODULE:"fs"@1 resolved_src=UNKNOWN:readFileSync@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ConsoleNotifier@10 dst=CLASS:Notifier@4 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@10 dst=METHOD:ConsoleNotifier.notify@11 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@10 dst=METHOD:ConsoleNotifier.writeLog@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Notifier@4 dst=METHOD:Notifier.notify@5 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@20 dst=METHOD:Repository.save@21 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@20 dst=METHOD:Repository.track@25 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@30 dst=METHOD:Workflow.decorate@47 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@30 dst=METHOD:Workflow.identity@31 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@30 dst=METHOD:Workflow.run@35 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@30 dst=METHOD:Workflow.runAsync@42 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/javascript_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/javascript_tictactoe.txt
@@ -1,0 +1,384 @@
+node CLASS name=ArtificialPlayer qn=ArtificialPlayer canonical=game.js:ArtificialPlayer line=175 col=7 end=175:23 file=FILE:game.js@1
+node CLASS name=Field qn=Field canonical=game.js:Field line=22 col=7 end=22:12 file=FILE:game.js@1
+node CLASS name=GameObject qn=GameObject canonical=game.js:GameObject line=16 col=7 end=16:17 file=FILE:game.js@1
+node CLASS name=HumanPlayer qn=HumanPlayer canonical=game.js:HumanPlayer line=143 col=7 end=143:18 file=FILE:game.js@1
+node CLASS name=Player qn=Player canonical=game.js:Player line=131 col=7 end=131:13 file=FILE:game.js@1
+node CLASS name=TicTacToe qn=TicTacToe canonical=game.js:TicTacToe line=229 col=14 end=229:23 file=FILE:game.js@1
+node FILE name=game.js qn=game.js canonical=game.js:game.js:1 line=1 col=1 end=294:0 file=FILE:game.js@1
+node FUNCTION name=main qn=main canonical=game.js:main#0 line=289 col=8 end=294:2 file=FILE:game.js@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.js:numberIn#0 line=4 col=1 end=6:2 file=FILE:game.js@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.js:numberOut#0 line=8 col=1 end=10:2 file=FILE:game.js@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.js:stringOut#0 line=12 col=1 end=14:2 file=FILE:game.js@1
+node METHOD name=ArtificialPlayer.evaluate qn=ArtificialPlayer.evaluate canonical=game.js:ArtificialPlayer.evaluate#0 line=176 col=3 end=187:4 file=FILE:game.js@1
+node METHOD name=ArtificialPlayer.minMax qn=ArtificialPlayer.minMax canonical=game.js:ArtificialPlayer.minMax#0 line=189 col=3 end=220:4 file=FILE:game.js@1
+node METHOD name=ArtificialPlayer.turn qn=ArtificialPlayer.turn canonical=game.js:ArtificialPlayer.turn#0 line=222 col=3 end=226:4 file=FILE:game.js@1
+node METHOD name=Field.clearMove qn=Field.clearMove canonical=game.js:Field.clearMove#0 line=99 col=3 end=105:4 file=FILE:game.js@1
+node METHOD name=Field.cloneField qn=Field.cloneField canonical=game.js:Field.cloneField#0 line=35 col=3 end=44:4 file=FILE:game.js@1
+node METHOD name=Field.constructor qn=Field.constructor canonical=game.js:Field.constructor#0 line=29 col=3 end=33:4 file=FILE:game.js@1
+node METHOD name=Field.inRange qn=Field.inRange canonical=game.js:Field.inRange#0 line=56 col=3 end=58:4 file=FILE:game.js@1
+node METHOD name=Field.isDraw qn=Field.isDraw canonical=game.js:Field.isDraw#0 line=64 col=3 end=66:4 file=FILE:game.js@1
+node METHOD name=Field.isEmpty qn=Field.isEmpty canonical=game.js:Field.isEmpty#0 line=60 col=3 end=62:4 file=FILE:game.js@1
+node METHOD name=Field.makeMove qn=Field.makeMove canonical=game.js:Field.makeMove#0 line=88 col=3 end=97:4 file=FILE:game.js@1
+node METHOD name=Field.opponent qn=Field.opponent canonical=game.js:Field.opponent#0 line=46 col=3 end=54:4 file=FILE:game.js@1
+node METHOD name=Field.sameInRow qn=Field.sameInRow canonical=game.js:Field.sameInRow#0 line=68 col=3 end=86:4 file=FILE:game.js@1
+node METHOD name=Field.show qn=Field.show canonical=game.js:Field.show#0 line=107 col=3 end=128:4 file=FILE:game.js@1
+node METHOD name=GameObject.announce qn=GameObject.announce canonical=game.js:GameObject.announce#0 line=17 col=3 end=19:4 file=FILE:game.js@1
+node METHOD name=HumanPlayer.check qn=HumanPlayer.check canonical=game.js:HumanPlayer.check#0 line=150 col=3 end=160:4 file=FILE:game.js@1
+node METHOD name=HumanPlayer.input qn=HumanPlayer.input canonical=game.js:HumanPlayer.input#0 line=144 col=3 end=148:4 file=FILE:game.js@1
+node METHOD name=HumanPlayer.turn qn=HumanPlayer.turn canonical=game.js:HumanPlayer.turn#0 line=162 col=3 end=172:4 file=FILE:game.js@1
+node METHOD name=Player.constructor qn=Player.constructor canonical=game.js:Player.constructor#0 line=132 col=3 end=136:4 file=FILE:game.js@1
+node METHOD name=Player.turn qn=Player.turn canonical=game.js:Player.turn#0 line=138 col=3 end=140:4 file=FILE:game.js@1
+node METHOD name=TicTacToe.checkWinner qn=TicTacToe.checkWinner canonical=game.js:TicTacToe.checkWinner#0 line=236 col=3 end=238:4 file=FILE:game.js@1
+node METHOD name=TicTacToe.constructor qn=TicTacToe.constructor canonical=game.js:TicTacToe.constructor#0 line=230 col=3 end=234:4 file=FILE:game.js@1
+node METHOD name=TicTacToe.isDraw qn=TicTacToe.isDraw canonical=game.js:TicTacToe.isDraw#0 line=240 col=3 end=242:4 file=FILE:game.js@1
+node METHOD name=TicTacToe.probeCalls qn=TicTacToe.probeCalls canonical=game.js:TicTacToe.probeCalls#0 line=261 col=3 end=263:4 file=FILE:game.js@1
+node METHOD name=TicTacToe.run qn=TicTacToe.run canonical=game.js:TicTacToe.run#0 line=265 col=3 end=286:4 file=FILE:game.js@1
+node METHOD name=TicTacToe.selectPlayer qn=TicTacToe.selectPlayer canonical=game.js:TicTacToe.selectPlayer#0 line=244 col=3 end=253:4 file=FILE:game.js@1
+node METHOD name=TicTacToe.start qn=TicTacToe.start canonical=game.js:TicTacToe.start#0 line=255 col=3 end=259:4 file=FILE:game.js@1
+node MODULE name="./helper.js" qn="./helper.js" canonical=game.js:"./helper.js"#0 line=2 col=24 end=2:37 file=FILE:game.js@1
+node MODULE name="./random.js" qn="./random.js" canonical=game.js:"./random.js"#0 line=1 col=27 end=1:40 file=FILE:game.js@1
+node UNKNOWN name=Array qn=Array canonical=game.js:Array#0 line=31 col=49 end=31:54 file=FILE:game.js@1
+node UNKNOWN name=Boolean qn=Boolean canonical=game.js:Boolean#0 line=258 col=12 end=258:19 file=FILE:game.js@1
+node UNKNOWN name=String qn=String canonical=game.js:String#0 line=9 col=24 end=9:30 file=FILE:game.js@1
+node UNKNOWN name=announce qn=announce canonical=game.js:announce#0 line=275 col=14 end=275:22 file=FILE:game.js@1
+node UNKNOWN name=announce qn=announce canonical=game.js:announce#1 line=280 col=14 end=280:22 file=FILE:game.js@1
+node UNKNOWN name=check qn=check canonical=game.js:check#0 line=167 col=12 end=167:17 file=FILE:game.js@1
+node UNKNOWN name=check qn=check canonical=game.js:check#1 line=168 col=16 end=168:21 file=FILE:game.js@1
+node UNKNOWN name=checkWinner qn=checkWinner canonical=game.js:checkWinner#0 line=262 col=10 end=262:21 file=FILE:game.js@1
+node UNKNOWN name=checkWinner qn=checkWinner canonical=game.js:checkWinner#1 line=272 col=12 end=272:23 file=FILE:game.js@1
+node UNKNOWN name=checkWinner qn=checkWinner canonical=game.js:checkWinner#2 line=274 col=16 end=274:27 file=FILE:game.js@1
+node UNKNOWN name=clearMove qn=clearMove canonical=game.js:clearMove#0 line=205 col=15 end=205:24 file=FILE:game.js@1
+node UNKNOWN name=cloneField qn=cloneField canonical=game.js:cloneField#0 line=223 col=24 end=223:34 file=FILE:game.js@1
+node UNKNOWN name=evaluate qn=evaluate canonical=game.js:evaluate#0 line=201 col=30 end=201:38 file=FILE:game.js@1
+node UNKNOWN name=fill qn=fill canonical=game.js:fill#0 line=31 col=58 end=31:62 file=FILE:game.js@1
+node UNKNOWN name=from qn=from canonical=game.js:from#0 line=31 col=23 end=31:27 file=FILE:game.js@1
+node UNKNOWN name=helper qn=helper canonical=game.js:helper#0 line=2 col=10 end=2:16 file=FILE:game.js@1
+node UNKNOWN name=helper qn=helper canonical=game.js:helper#1 line=18 col=5 end=18:11 file=FILE:game.js@1
+node UNKNOWN name=inRange qn=inRange canonical=game.js:inRange#0 line=89 col=15 end=89:22 file=FILE:game.js@1
+node UNKNOWN name=inRange qn=inRange canonical=game.js:inRange#1 line=100 col=15 end=100:22 file=FILE:game.js@1
+node UNKNOWN name=inRange qn=inRange canonical=game.js:inRange#2 line=151 col=16 end=151:23 file=FILE:game.js@1
+node UNKNOWN name=input qn=input canonical=game.js:input#0 line=166 col=25 end=166:30 file=FILE:game.js@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.js:isDraw#0 line=95 col=10 end=95:16 file=FILE:game.js@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.js:isDraw#1 line=202 col=39 end=202:45 file=FILE:game.js@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.js:isDraw#2 line=241 col=23 end=241:29 file=FILE:game.js@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.js:isDraw#3 line=273 col=12 end=273:18 file=FILE:game.js@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.js:isDraw#4 line=279 col=16 end=279:22 file=FILE:game.js@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.js:isEmpty#0 line=89 col=38 end=89:45 file=FILE:game.js@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.js:isEmpty#1 line=100 col=37 end=100:44 file=FILE:game.js@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.js:isEmpty#2 line=155 col=16 end=155:23 file=FILE:game.js@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.js:isEmpty#3 line=196 col=20 end=196:27 file=FILE:game.js@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.js:makeMove#0 line=200 col=15 end=200:23 file=FILE:game.js@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.js:makeMove#1 line=271 col=18 end=271:26 file=FILE:game.js@1
+node UNKNOWN name=minMax qn=minMax canonical=game.js:minMax#0 line=203 col=29 end=203:35 file=FILE:game.js@1
+node UNKNOWN name=minMax qn=minMax canonical=game.js:minMax#1 line=224 col=23 end=224:29 file=FILE:game.js@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.js:numberIn#1 line=145 col=17 end=145:25 file=FILE:game.js@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.js:numberIn#2 line=146 col=17 end=146:25 file=FILE:game.js@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.js:numberIn#3 line=245 col=23 end=245:31 file=FILE:game.js@1
+node UNKNOWN name=numberOut qn=numberOut canonical=game.js:numberOut#1 line=110 col=7 end=110:16 file=FILE:game.js@1
+node UNKNOWN name=opponent qn=opponent canonical=game.js:opponent#0 line=180 col=31 end=180:39 file=FILE:game.js@1
+node UNKNOWN name=opponent qn=opponent canonical=game.js:opponent#1 line=203 col=49 end=203:57 file=FILE:game.js@1
+node UNKNOWN name=randomInt qn=randomInt canonical=game.js:randomInt#0 line=1 col=10 end=1:19 file=FILE:game.js@1
+node UNKNOWN name=randomInt qn=randomInt canonical=game.js:randomInt#1 line=212 col=15 end=212:24 file=FILE:game.js@1
+node UNKNOWN name=run qn=run canonical=game.js:run#0 line=292 col=10 end=292:13 file=FILE:game.js@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.js:sameInRow#0 line=94 col=10 end=94:19 file=FILE:game.js@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.js:sameInRow#1 line=177 col=15 end=177:24 file=FILE:game.js@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.js:sameInRow#2 line=180 col=15 end=180:24 file=FILE:game.js@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.js:sameInRow#3 line=183 col=15 end=183:24 file=FILE:game.js@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.js:sameInRow#4 line=237 col=23 end=237:32 file=FILE:game.js@1
+node UNKNOWN name=selectPlayer qn=selectPlayer canonical=game.js:selectPlayer#0 line=256 col=28 end=256:40 file=FILE:game.js@1
+node UNKNOWN name=selectPlayer qn=selectPlayer canonical=game.js:selectPlayer#1 line=257 col=28 end=257:40 file=FILE:game.js@1
+node UNKNOWN name=show qn=show canonical=game.js:show#0 line=266 col=16 end=266:20 file=FILE:game.js@1
+node UNKNOWN name=start qn=start canonical=game.js:start#0 line=291 col=12 end=291:17 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#1 line=108 col=5 end=108:14 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#10 line=156 col=7 end=156:16 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#11 line=163 col=5 end=163:14 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#12 line=164 col=5 end=164:14 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#13 line=276 col=9 end=276:18 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#14 line=281 col=9 end=281:18 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#2 line=111 col=7 end=111:16 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#3 line=115 col=11 end=115:20 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#4 line=117 col=11 end=117:20 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#5 line=119 col=11 end=119:20 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#6 line=122 col=11 end=122:20 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#7 line=125 col=7 end=125:16 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#8 line=127 col=5 end=127:14 file=FILE:game.js@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.js:stringOut#9 line=152 col=7 end=152:16 file=FILE:game.js@1
+node UNKNOWN name=turn qn=turn canonical=game.js:turn#0 line=270 col=27 end=270:31 file=FILE:game.js@1
+node UNKNOWN name=write qn=write canonical=game.js:write#0 line=9 col=18 end=9:23 file=FILE:game.js@1
+node UNKNOWN name=write qn=write canonical=game.js:write#1 line=13 col=18 end=13:23 file=FILE:game.js@1
+edge CALL src=FUNCTION:main@289 dst=CLASS:TicTacToe@229 resolved_src=- resolved_dst=- line=290 confidence=- certainty=- callsite=h0:290:1:h1 candidates=[]
+edge CALL src=FUNCTION:main@289 dst=METHOD:TicTacToe.run@265 resolved_src=- resolved_dst=METHOD:TicTacToe.run@265 line=292 confidence=1.0000 certainty=Certain callsite=h0:292:1:h2 candidates=[]
+edge CALL src=FUNCTION:main@289 dst=METHOD:TicTacToe.start@255 resolved_src=- resolved_dst=METHOD:TicTacToe.start@255 line=291 confidence=1.0000 certainty=Certain callsite=h0:291:1:h3 candidates=[]
+edge CALL src=FUNCTION:numberOut@8 dst=UNKNOWN:String@9 resolved_src=- resolved_dst=- line=9 confidence=- certainty=- callsite=h0:9:1:h4 candidates=[]
+edge CALL src=FUNCTION:numberOut@8 dst=UNKNOWN:write@9 resolved_src=- resolved_dst=- line=9 confidence=- certainty=- callsite=h0:9:1:h5|syntax:js-member-call candidates=[]
+edge CALL src=FUNCTION:stringOut@12 dst=UNKNOWN:write@13 resolved_src=- resolved_dst=- line=13 confidence=- certainty=- callsite=h0:13:1:h6|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@176 dst=UNKNOWN:opponent@180 resolved_src=- resolved_dst=- line=180 confidence=- certainty=- callsite=h0:180:1:h7|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@176 dst=UNKNOWN:sameInRow@177 resolved_src=- resolved_dst=- line=177 confidence=- certainty=- callsite=h0:177:1:h8|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@176 dst=UNKNOWN:sameInRow@180 resolved_src=- resolved_dst=- line=180 confidence=- certainty=- callsite=h0:180:1:h9|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@176 dst=UNKNOWN:sameInRow@183 resolved_src=- resolved_dst=- line=183 confidence=- certainty=- callsite=h0:183:1:h10|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@189 dst=METHOD:ArtificialPlayer.evaluate@176 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.evaluate@176 line=201 confidence=1.0000 certainty=Certain callsite=h0:201:1:h11 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@189 dst=UNKNOWN:clearMove@205 resolved_src=- resolved_dst=- line=205 confidence=- certainty=- callsite=h0:205:1:h12|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@189 dst=UNKNOWN:isDraw@202 resolved_src=- resolved_dst=- line=202 confidence=- certainty=- callsite=h0:202:1:h13|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@189 dst=UNKNOWN:isEmpty@196 resolved_src=- resolved_dst=- line=196 confidence=- certainty=- callsite=h0:196:1:h14|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@189 dst=UNKNOWN:makeMove@200 resolved_src=- resolved_dst=- line=200 confidence=- certainty=- callsite=h0:200:1:h15|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@189 dst=UNKNOWN:opponent@203 resolved_src=- resolved_dst=- line=203 confidence=- certainty=- callsite=h0:203:1:h16|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@189 dst=UNKNOWN:randomInt@212 resolved_src=- resolved_dst=- line=212 confidence=- certainty=- callsite=h0:212:1:h17 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@222 dst=METHOD:ArtificialPlayer.minMax@189 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.minMax@189 line=224 confidence=1.0000 certainty=Certain callsite=h0:224:1:h18 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@222 dst=UNKNOWN:cloneField@223 resolved_src=- resolved_dst=- line=223 confidence=- certainty=- callsite=h0:223:1:h19|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:Field.clearMove@99 dst=METHOD:Field.inRange@56 resolved_src=- resolved_dst=METHOD:Field.inRange@56 line=100 confidence=1.0000 certainty=Certain callsite=h0:100:1:h20 candidates=[]
+edge CALL src=METHOD:Field.clearMove@99 dst=METHOD:Field.isEmpty@60 resolved_src=- resolved_dst=METHOD:Field.isEmpty@60 line=100 confidence=1.0000 certainty=Certain callsite=h0:100:1:h21 candidates=[]
+edge CALL src=METHOD:Field.cloneField@35 dst=CLASS:Field@22 resolved_src=- resolved_dst=- line=36 confidence=- certainty=- callsite=h0:36:1:h22 candidates=[]
+edge CALL src=METHOD:Field.constructor@29 dst=CLASS:Field@22 resolved_src=- resolved_dst=- line=232 confidence=- certainty=- callsite=h0:232:1:h22 candidates=[]
+edge CALL src=METHOD:Field.constructor@29 dst=UNKNOWN:Array@31 resolved_src=- resolved_dst=- line=31 confidence=- certainty=- callsite=h0:31:1:h23 candidates=[]
+edge CALL src=METHOD:Field.constructor@29 dst=UNKNOWN:fill@31 resolved_src=- resolved_dst=- line=31 confidence=- certainty=- callsite=h0:31:1:h24|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:Field.constructor@29 dst=UNKNOWN:from@31 resolved_src=- resolved_dst=- line=31 confidence=- certainty=- callsite=h0:31:1:h25|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:Field.makeMove@88 dst=METHOD:Field.inRange@56 resolved_src=- resolved_dst=METHOD:Field.inRange@56 line=89 confidence=1.0000 certainty=Certain callsite=h0:89:1:h20 candidates=[]
+edge CALL src=METHOD:Field.makeMove@88 dst=METHOD:Field.isDraw@64 resolved_src=- resolved_dst=METHOD:Field.isDraw@64 line=95 confidence=1.0000 certainty=Certain callsite=h0:95:1:h26 candidates=[]
+edge CALL src=METHOD:Field.makeMove@88 dst=METHOD:Field.isEmpty@60 resolved_src=- resolved_dst=METHOD:Field.isEmpty@60 line=89 confidence=1.0000 certainty=Certain callsite=h0:89:1:h21 candidates=[]
+edge CALL src=METHOD:Field.makeMove@88 dst=METHOD:Field.sameInRow@68 resolved_src=- resolved_dst=METHOD:Field.sameInRow@68 line=94 confidence=1.0000 certainty=Certain callsite=h0:94:1:h27 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:numberOut@110 resolved_src=- resolved_dst=- line=110 confidence=- certainty=- callsite=h0:110:1:h28 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:stringOut@108 resolved_src=- resolved_dst=- line=108 confidence=- certainty=- callsite=h0:108:1:h29 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:stringOut@111 resolved_src=- resolved_dst=- line=111 confidence=- certainty=- callsite=h0:111:1:h30 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:stringOut@115 resolved_src=- resolved_dst=- line=115 confidence=- certainty=- callsite=h0:115:1:h31 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:stringOut@117 resolved_src=- resolved_dst=- line=117 confidence=- certainty=- callsite=h0:117:1:h32 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:stringOut@119 resolved_src=- resolved_dst=- line=119 confidence=- certainty=- callsite=h0:119:1:h33 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:stringOut@122 resolved_src=- resolved_dst=- line=122 confidence=- certainty=- callsite=h0:122:1:h34 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:stringOut@125 resolved_src=- resolved_dst=- line=125 confidence=- certainty=- callsite=h0:125:1:h35 candidates=[]
+edge CALL src=METHOD:Field.show@107 dst=UNKNOWN:stringOut@127 resolved_src=- resolved_dst=- line=127 confidence=- certainty=- callsite=h0:127:1:h36 candidates=[]
+edge CALL src=METHOD:GameObject.announce@17 dst=UNKNOWN:helper@18 resolved_src=- resolved_dst=- line=18 confidence=- certainty=- callsite=h0:18:1:h37 candidates=[]
+edge CALL src=METHOD:HumanPlayer.check@150 dst=UNKNOWN:inRange@151 resolved_src=- resolved_dst=- line=151 confidence=- certainty=- callsite=h0:151:1:h38|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:HumanPlayer.check@150 dst=UNKNOWN:isEmpty@155 resolved_src=- resolved_dst=- line=155 confidence=- certainty=- callsite=h0:155:1:h39|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:HumanPlayer.check@150 dst=UNKNOWN:stringOut@152 resolved_src=- resolved_dst=- line=152 confidence=- certainty=- callsite=h0:152:1:h40 candidates=[]
+edge CALL src=METHOD:HumanPlayer.check@150 dst=UNKNOWN:stringOut@156 resolved_src=- resolved_dst=- line=156 confidence=- certainty=- callsite=h0:156:1:h41 candidates=[]
+edge CALL src=METHOD:HumanPlayer.input@144 dst=UNKNOWN:numberIn@145 resolved_src=- resolved_dst=- line=145 confidence=- certainty=- callsite=h0:145:1:h42 candidates=[]
+edge CALL src=METHOD:HumanPlayer.input@144 dst=UNKNOWN:numberIn@146 resolved_src=- resolved_dst=- line=146 confidence=- certainty=- callsite=h0:146:1:h43 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@162 dst=METHOD:HumanPlayer.check@150 resolved_src=- resolved_dst=METHOD:HumanPlayer.check@150 line=167 confidence=1.0000 certainty=Certain callsite=h0:167:1:h44 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@162 dst=METHOD:HumanPlayer.check@150 resolved_src=- resolved_dst=METHOD:HumanPlayer.check@150 line=168 confidence=1.0000 certainty=Certain callsite=h0:168:1:h44 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@162 dst=METHOD:HumanPlayer.input@144 resolved_src=- resolved_dst=METHOD:HumanPlayer.input@144 line=166 confidence=1.0000 certainty=Certain callsite=h0:166:1:h45 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@162 dst=UNKNOWN:stringOut@163 resolved_src=- resolved_dst=- line=163 confidence=- certainty=- callsite=h0:163:1:h46 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@162 dst=UNKNOWN:stringOut@164 resolved_src=- resolved_dst=- line=164 confidence=- certainty=- callsite=h0:164:1:h47 candidates=[]
+edge CALL src=METHOD:TicTacToe.checkWinner@236 dst=METHOD:Field.sameInRow@68 resolved_src=- resolved_dst=METHOD:Field.sameInRow@68 line=237 confidence=1.0000 certainty=Certain callsite=h0:237:1:h27 candidates=[]
+edge CALL src=METHOD:TicTacToe.isDraw@240 dst=METHOD:Field.isDraw@64 resolved_src=- resolved_dst=METHOD:Field.isDraw@64 line=241 confidence=1.0000 certainty=Certain callsite=h0:241:1:h26 candidates=[]
+edge CALL src=METHOD:TicTacToe.probeCalls@261 dst=METHOD:TicTacToe.checkWinner@236 resolved_src=- resolved_dst=METHOD:TicTacToe.checkWinner@236 line=262 confidence=1.0000 certainty=Certain callsite=h0:262:1:h48 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=METHOD:Field.makeMove@88 resolved_src=- resolved_dst=METHOD:Field.makeMove@88 line=271 confidence=1.0000 certainty=Certain callsite=h0:271:1:h49 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=METHOD:Field.show@107 resolved_src=- resolved_dst=METHOD:Field.show@107 line=266 confidence=1.0000 certainty=Certain callsite=h0:266:1:h50 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=METHOD:TicTacToe.checkWinner@236 resolved_src=- resolved_dst=METHOD:TicTacToe.checkWinner@236 line=272 confidence=1.0000 certainty=Certain callsite=h0:272:1:h48 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=METHOD:TicTacToe.checkWinner@236 resolved_src=- resolved_dst=METHOD:TicTacToe.checkWinner@236 line=274 confidence=1.0000 certainty=Certain callsite=h0:274:1:h48 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=METHOD:TicTacToe.isDraw@240 resolved_src=- resolved_dst=METHOD:TicTacToe.isDraw@240 line=273 confidence=1.0000 certainty=Certain callsite=h0:273:1:h51 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=METHOD:TicTacToe.isDraw@240 resolved_src=- resolved_dst=METHOD:TicTacToe.isDraw@240 line=279 confidence=1.0000 certainty=Certain callsite=h0:279:1:h51 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=UNKNOWN:announce@275 resolved_src=- resolved_dst=- line=275 confidence=- certainty=- callsite=h0:275:1:h52|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=UNKNOWN:announce@280 resolved_src=- resolved_dst=- line=280 confidence=- certainty=- callsite=h0:280:1:h53|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=UNKNOWN:stringOut@276 resolved_src=- resolved_dst=- line=276 confidence=- certainty=- callsite=h0:276:1:h54 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=UNKNOWN:stringOut@281 resolved_src=- resolved_dst=- line=281 confidence=- certainty=- callsite=h0:281:1:h55 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@265 dst=UNKNOWN:turn@270 resolved_src=- resolved_dst=- line=270 confidence=- certainty=- callsite=h0:270:1:h56|syntax:js-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.selectPlayer@244 dst=CLASS:ArtificialPlayer@175 resolved_src=- resolved_dst=- line=250 confidence=- certainty=- callsite=h0:250:1:h57 candidates=[]
+edge CALL src=METHOD:TicTacToe.selectPlayer@244 dst=CLASS:HumanPlayer@143 resolved_src=- resolved_dst=- line=247 confidence=- certainty=- callsite=h0:247:1:h58 candidates=[]
+edge CALL src=METHOD:TicTacToe.selectPlayer@244 dst=UNKNOWN:numberIn@245 resolved_src=- resolved_dst=- line=245 confidence=- certainty=- callsite=h0:245:1:h59 candidates=[]
+edge CALL src=METHOD:TicTacToe.start@255 dst=METHOD:TicTacToe.selectPlayer@244 resolved_src=- resolved_dst=METHOD:TicTacToe.selectPlayer@244 line=256 confidence=1.0000 certainty=Certain callsite=h0:256:1:h60 candidates=[]
+edge CALL src=METHOD:TicTacToe.start@255 dst=METHOD:TicTacToe.selectPlayer@244 resolved_src=- resolved_dst=METHOD:TicTacToe.selectPlayer@244 line=257 confidence=1.0000 certainty=Certain callsite=h0:257:1:h60 candidates=[]
+edge CALL src=METHOD:TicTacToe.start@255 dst=UNKNOWN:Boolean@258 resolved_src=- resolved_dst=- line=258 confidence=- certainty=- callsite=h0:258:1:h61 candidates=[]
+edge IMPORT src=MODULE:"./helper.js"@2 dst=MODULE:"./helper.js"@2 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=MODULE:"./random.js"@1 dst=MODULE:"./random.js"@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:helper@2 dst=MODULE:"./helper.js"@2 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:randomInt@1 dst=MODULE:"./random.js"@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ArtificialPlayer@175 dst=CLASS:Player@131 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@22 dst=CLASS:GameObject@16 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:HumanPlayer@143 dst=CLASS:Player@131 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Player@131 dst=CLASS:GameObject@16 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:TicTacToe@229 dst=CLASS:GameObject@16 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@175 dst=METHOD:ArtificialPlayer.evaluate@176 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@175 dst=METHOD:ArtificialPlayer.minMax@189 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@175 dst=METHOD:ArtificialPlayer.turn@222 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.clearMove@99 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.cloneField@35 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.constructor@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.inRange@56 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.isDraw@64 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.isEmpty@60 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.makeMove@88 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.opponent@46 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.sameInRow@68 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@22 dst=METHOD:Field.show@107 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:GameObject@16 dst=METHOD:GameObject.announce@17 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@143 dst=METHOD:HumanPlayer.check@150 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@143 dst=METHOD:HumanPlayer.input@144 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@143 dst=METHOD:HumanPlayer.turn@162 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Player@131 dst=METHOD:Player.constructor@132 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Player@131 dst=METHOD:Player.turn@138 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@229 dst=METHOD:TicTacToe.checkWinner@236 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@229 dst=METHOD:TicTacToe.constructor@230 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@229 dst=METHOD:TicTacToe.isDraw@240 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@229 dst=METHOD:TicTacToe.probeCalls@261 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@229 dst=METHOD:TicTacToe.run@265 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@229 dst=METHOD:TicTacToe.selectPlayer@244 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@229 dst=METHOD:TicTacToe.start@255 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.js language=javascript lines=294 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@175 kind=DEFINITION span=175:7-175:23
+occurrence element=CLASS:Field@22 kind=DEFINITION span=22:7-22:12
+occurrence element=CLASS:GameObject@16 kind=DEFINITION span=131:22-131:32
+occurrence element=CLASS:GameObject@16 kind=DEFINITION span=16:7-16:17
+occurrence element=CLASS:GameObject@16 kind=DEFINITION span=229:32-229:42
+occurrence element=CLASS:GameObject@16 kind=DEFINITION span=22:21-22:31
+occurrence element=CLASS:HumanPlayer@143 kind=DEFINITION span=143:7-143:18
+occurrence element=CLASS:Player@131 kind=DEFINITION span=131:7-131:13
+occurrence element=CLASS:Player@131 kind=DEFINITION span=143:27-143:33
+occurrence element=CLASS:Player@131 kind=DEFINITION span=175:32-175:38
+occurrence element=CLASS:TicTacToe@229 kind=DEFINITION span=229:14-229:23
+occurrence element=FUNCTION:main@289 kind=DEFINITION span=289:8-294:2
+occurrence element=FUNCTION:numberIn@4 kind=DEFINITION span=4:1-6:2
+occurrence element=FUNCTION:numberOut@8 kind=DEFINITION span=8:1-10:2
+occurrence element=FUNCTION:stringOut@12 kind=DEFINITION span=12:1-14:2
+occurrence element=METHOD:ArtificialPlayer.evaluate@176 kind=DEFINITION span=176:3-187:4
+occurrence element=METHOD:ArtificialPlayer.minMax@189 kind=DEFINITION span=189:3-220:4
+occurrence element=METHOD:ArtificialPlayer.turn@222 kind=DEFINITION span=222:3-226:4
+occurrence element=METHOD:Field.clearMove@99 kind=DEFINITION span=99:3-105:4
+occurrence element=METHOD:Field.cloneField@35 kind=DEFINITION span=35:3-44:4
+occurrence element=METHOD:Field.constructor@29 kind=DEFINITION span=29:3-33:4
+occurrence element=METHOD:Field.inRange@56 kind=DEFINITION span=56:3-58:4
+occurrence element=METHOD:Field.isDraw@64 kind=DEFINITION span=64:3-66:4
+occurrence element=METHOD:Field.isEmpty@60 kind=DEFINITION span=60:3-62:4
+occurrence element=METHOD:Field.makeMove@88 kind=DEFINITION span=88:3-97:4
+occurrence element=METHOD:Field.opponent@46 kind=DEFINITION span=46:3-54:4
+occurrence element=METHOD:Field.sameInRow@68 kind=DEFINITION span=68:3-86:4
+occurrence element=METHOD:Field.show@107 kind=DEFINITION span=107:3-128:4
+occurrence element=METHOD:GameObject.announce@17 kind=DEFINITION span=17:3-19:4
+occurrence element=METHOD:HumanPlayer.check@150 kind=DEFINITION span=150:3-160:4
+occurrence element=METHOD:HumanPlayer.input@144 kind=DEFINITION span=144:3-148:4
+occurrence element=METHOD:HumanPlayer.turn@162 kind=DEFINITION span=162:3-172:4
+occurrence element=METHOD:Player.constructor@132 kind=DEFINITION span=132:3-136:4
+occurrence element=METHOD:Player.turn@138 kind=DEFINITION span=138:3-140:4
+occurrence element=METHOD:TicTacToe.checkWinner@236 kind=DEFINITION span=236:3-238:4
+occurrence element=METHOD:TicTacToe.constructor@230 kind=DEFINITION span=230:3-234:4
+occurrence element=METHOD:TicTacToe.isDraw@240 kind=DEFINITION span=240:3-242:4
+occurrence element=METHOD:TicTacToe.probeCalls@261 kind=DEFINITION span=261:3-263:4
+occurrence element=METHOD:TicTacToe.run@265 kind=DEFINITION span=265:3-286:4
+occurrence element=METHOD:TicTacToe.selectPlayer@244 kind=DEFINITION span=244:3-253:4
+occurrence element=METHOD:TicTacToe.start@255 kind=DEFINITION span=255:3-259:4
+occurrence element=MODULE:"./helper.js"@2 kind=DEFINITION span=2:24-2:37
+occurrence element=MODULE:"./random.js"@1 kind=DEFINITION span=1:27-1:40
+occurrence element=UNKNOWN:Array@31 kind=DEFINITION span=31:49-31:54
+occurrence element=UNKNOWN:Boolean@258 kind=DEFINITION span=258:12-258:19
+occurrence element=UNKNOWN:String@9 kind=DEFINITION span=9:24-9:30
+occurrence element=UNKNOWN:announce@275 kind=DEFINITION span=275:14-275:22
+occurrence element=UNKNOWN:announce@280 kind=DEFINITION span=280:14-280:22
+occurrence element=UNKNOWN:check@167 kind=DEFINITION span=167:12-167:17
+occurrence element=UNKNOWN:check@168 kind=DEFINITION span=168:16-168:21
+occurrence element=UNKNOWN:checkWinner@262 kind=DEFINITION span=262:10-262:21
+occurrence element=UNKNOWN:checkWinner@272 kind=DEFINITION span=272:12-272:23
+occurrence element=UNKNOWN:checkWinner@274 kind=DEFINITION span=274:16-274:27
+occurrence element=UNKNOWN:clearMove@205 kind=DEFINITION span=205:15-205:24
+occurrence element=UNKNOWN:cloneField@223 kind=DEFINITION span=223:24-223:34
+occurrence element=UNKNOWN:evaluate@201 kind=DEFINITION span=201:30-201:38
+occurrence element=UNKNOWN:fill@31 kind=DEFINITION span=31:58-31:62
+occurrence element=UNKNOWN:from@31 kind=DEFINITION span=31:23-31:27
+occurrence element=UNKNOWN:helper@18 kind=DEFINITION span=18:5-18:11
+occurrence element=UNKNOWN:helper@2 kind=DEFINITION span=2:10-2:16
+occurrence element=UNKNOWN:inRange@100 kind=DEFINITION span=100:15-100:22
+occurrence element=UNKNOWN:inRange@151 kind=DEFINITION span=151:16-151:23
+occurrence element=UNKNOWN:inRange@89 kind=DEFINITION span=89:15-89:22
+occurrence element=UNKNOWN:input@166 kind=DEFINITION span=166:25-166:30
+occurrence element=UNKNOWN:isDraw@202 kind=DEFINITION span=202:39-202:45
+occurrence element=UNKNOWN:isDraw@241 kind=DEFINITION span=241:23-241:29
+occurrence element=UNKNOWN:isDraw@273 kind=DEFINITION span=273:12-273:18
+occurrence element=UNKNOWN:isDraw@279 kind=DEFINITION span=279:16-279:22
+occurrence element=UNKNOWN:isDraw@95 kind=DEFINITION span=95:10-95:16
+occurrence element=UNKNOWN:isEmpty@100 kind=DEFINITION span=100:37-100:44
+occurrence element=UNKNOWN:isEmpty@155 kind=DEFINITION span=155:16-155:23
+occurrence element=UNKNOWN:isEmpty@196 kind=DEFINITION span=196:20-196:27
+occurrence element=UNKNOWN:isEmpty@89 kind=DEFINITION span=89:38-89:45
+occurrence element=UNKNOWN:makeMove@200 kind=DEFINITION span=200:15-200:23
+occurrence element=UNKNOWN:makeMove@271 kind=DEFINITION span=271:18-271:26
+occurrence element=UNKNOWN:minMax@203 kind=DEFINITION span=203:29-203:35
+occurrence element=UNKNOWN:minMax@224 kind=DEFINITION span=224:23-224:29
+occurrence element=UNKNOWN:numberIn@145 kind=DEFINITION span=145:17-145:25
+occurrence element=UNKNOWN:numberIn@146 kind=DEFINITION span=146:17-146:25
+occurrence element=UNKNOWN:numberIn@245 kind=DEFINITION span=245:23-245:31
+occurrence element=UNKNOWN:numberOut@110 kind=DEFINITION span=110:7-110:16
+occurrence element=UNKNOWN:opponent@180 kind=DEFINITION span=180:31-180:39
+occurrence element=UNKNOWN:opponent@203 kind=DEFINITION span=203:49-203:57
+occurrence element=UNKNOWN:randomInt@1 kind=DEFINITION span=1:10-1:19
+occurrence element=UNKNOWN:randomInt@212 kind=DEFINITION span=212:15-212:24
+occurrence element=UNKNOWN:run@292 kind=DEFINITION span=292:10-292:13
+occurrence element=UNKNOWN:sameInRow@177 kind=DEFINITION span=177:15-177:24
+occurrence element=UNKNOWN:sameInRow@180 kind=DEFINITION span=180:15-180:24
+occurrence element=UNKNOWN:sameInRow@183 kind=DEFINITION span=183:15-183:24
+occurrence element=UNKNOWN:sameInRow@237 kind=DEFINITION span=237:23-237:32
+occurrence element=UNKNOWN:sameInRow@94 kind=DEFINITION span=94:10-94:19
+occurrence element=UNKNOWN:selectPlayer@256 kind=DEFINITION span=256:28-256:40
+occurrence element=UNKNOWN:selectPlayer@257 kind=DEFINITION span=257:28-257:40
+occurrence element=UNKNOWN:show@266 kind=DEFINITION span=266:16-266:20
+occurrence element=UNKNOWN:start@291 kind=DEFINITION span=291:12-291:17
+occurrence element=UNKNOWN:stringOut@108 kind=DEFINITION span=108:5-108:14
+occurrence element=UNKNOWN:stringOut@111 kind=DEFINITION span=111:7-111:16
+occurrence element=UNKNOWN:stringOut@115 kind=DEFINITION span=115:11-115:20
+occurrence element=UNKNOWN:stringOut@117 kind=DEFINITION span=117:11-117:20
+occurrence element=UNKNOWN:stringOut@119 kind=DEFINITION span=119:11-119:20
+occurrence element=UNKNOWN:stringOut@122 kind=DEFINITION span=122:11-122:20
+occurrence element=UNKNOWN:stringOut@125 kind=DEFINITION span=125:7-125:16
+occurrence element=UNKNOWN:stringOut@127 kind=DEFINITION span=127:5-127:14
+occurrence element=UNKNOWN:stringOut@152 kind=DEFINITION span=152:7-152:16
+occurrence element=UNKNOWN:stringOut@156 kind=DEFINITION span=156:7-156:16
+occurrence element=UNKNOWN:stringOut@163 kind=DEFINITION span=163:5-163:14
+occurrence element=UNKNOWN:stringOut@164 kind=DEFINITION span=164:5-164:14
+occurrence element=UNKNOWN:stringOut@276 kind=DEFINITION span=276:9-276:18
+occurrence element=UNKNOWN:stringOut@281 kind=DEFINITION span=281:9-281:18
+occurrence element=UNKNOWN:turn@270 kind=DEFINITION span=270:27-270:31
+occurrence element=UNKNOWN:write@13 kind=DEFINITION span=13:18-13:23
+occurrence element=UNKNOWN:write@9 kind=DEFINITION span=9:18-9:23
+access node=METHOD:ArtificialPlayer.evaluate@176 kind=Public
+access node=METHOD:ArtificialPlayer.minMax@189 kind=Public
+access node=METHOD:ArtificialPlayer.turn@222 kind=Public
+access node=METHOD:Field.clearMove@99 kind=Public
+access node=METHOD:Field.cloneField@35 kind=Public
+access node=METHOD:Field.constructor@29 kind=Public
+access node=METHOD:Field.inRange@56 kind=Public
+access node=METHOD:Field.isDraw@64 kind=Public
+access node=METHOD:Field.isEmpty@60 kind=Public
+access node=METHOD:Field.makeMove@88 kind=Public
+access node=METHOD:Field.opponent@46 kind=Public
+access node=METHOD:Field.sameInRow@68 kind=Public
+access node=METHOD:Field.show@107 kind=Public
+access node=METHOD:GameObject.announce@17 kind=Public
+access node=METHOD:HumanPlayer.check@150 kind=Public
+access node=METHOD:HumanPlayer.input@144 kind=Public
+access node=METHOD:HumanPlayer.turn@162 kind=Public
+access node=METHOD:Player.constructor@132 kind=Public
+access node=METHOD:Player.turn@138 kind=Public
+access node=METHOD:TicTacToe.checkWinner@236 kind=Public
+access node=METHOD:TicTacToe.constructor@230 kind=Public
+access node=METHOD:TicTacToe.isDraw@240 kind=Public
+access node=METHOD:TicTacToe.probeCalls@261 kind=Public
+access node=METHOD:TicTacToe.run@265 kind=Public
+access node=METHOD:TicTacToe.selectPlayer@244 kind=Public
+access node=METHOD:TicTacToe.start@255 kind=Public
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "13:main", node_id: NodeId(8504272869567546964), signature_hash: -4671339478033693080, normalized_signature: Some("shape:-6917225099115343732"), body_hash: -8566065645855868065, start_line: 289, end_line: 294 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "13:numberIn", node_id: NodeId(-6315465127160673421), signature_hash: 2477812878330356949, normalized_signature: Some("outline:-1795207361013140379"), body_hash: 1109794254765209168, start_line: 4, end_line: 6 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "13:numberOut", node_id: NodeId(-2505028436061351250), signature_hash: -1579019679195996938, normalized_signature: Some("shape:-5069313506102143158"), body_hash: 6301304741144006283, start_line: 8, end_line: 10 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "13:stringOut", node_id: NodeId(-296596494596208878), signature_hash: -5818630870471287222, normalized_signature: Some("shape:8879003180601431523"), body_hash: 3465881721452299410, start_line: 12, end_line: 14 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:ArtificialPlayer.evaluate", node_id: NodeId(-6791584937985889817), signature_hash: -3339369090062122330, normalized_signature: Some("shape:5439266098851876780"), body_hash: -2378544905958982745, start_line: 176, end_line: 187 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:ArtificialPlayer.minMax", node_id: NodeId(-203669973802134782), signature_hash: 2816889471617643129, normalized_signature: Some("shape:5387134704222747116"), body_hash: -5482980978411667592, start_line: 189, end_line: 220 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:ArtificialPlayer.turn", node_id: NodeId(1379102487328840235), signature_hash: 5754064973517794814, normalized_signature: Some("shape:2750423606995422394"), body_hash: -7117114173641015066, start_line: 222, end_line: 226 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.clearMove", node_id: NodeId(1787487001293607579), signature_hash: -3022140259302478, normalized_signature: Some("shape:-5472466539703934341"), body_hash: 7640899031357747029, start_line: 99, end_line: 105 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.cloneField", node_id: NodeId(-8162469106728687640), signature_hash: 7778963861333372529, normalized_signature: Some("shape:5169560048621515286"), body_hash: 5254848855897858613, start_line: 35, end_line: 44 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.constructor", node_id: NodeId(-1866023019235821373), signature_hash: 6795144599545714474, normalized_signature: Some("shape:608948685383722915"), body_hash: 4754061427103159828, start_line: 29, end_line: 33 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.inRange", node_id: NodeId(9092234337167987635), signature_hash: -8452809604799432690, normalized_signature: Some("outline:-5084961018881034800"), body_hash: 6338931391262355245, start_line: 56, end_line: 58 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.isDraw", node_id: NodeId(-4624925475263322867), signature_hash: 7260325517996505566, normalized_signature: Some("outline:-5084961018881034800"), body_hash: 7248444521995393359, start_line: 64, end_line: 66 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.isEmpty", node_id: NodeId(-1029130240061024682), signature_hash: -7303087957103600159, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -3600068050732004567, start_line: 60, end_line: 62 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.makeMove", node_id: NodeId(7703648105307394992), signature_hash: -7686617887134063555, normalized_signature: Some("shape:-1347379432609828763"), body_hash: 1066089104257548789, start_line: 88, end_line: 97 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.opponent", node_id: NodeId(4378940972652702850), signature_hash: 5718448952121283431, normalized_signature: Some("outline:-5075390869670978506"), body_hash: -6589262295358775754, start_line: 46, end_line: 54 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.sameInRow", node_id: NodeId(1324306169995292168), signature_hash: 8317776364922746511, normalized_signature: Some("outline:39053722370928195"), body_hash: 6541909732307076455, start_line: 68, end_line: 86 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Field.show", node_id: NodeId(3738654107149538390), signature_hash: -3470856697129697909, normalized_signature: Some("shape:-2852872954604689271"), body_hash: 234898907249596001, start_line: 107, end_line: 128 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:GameObject.announce", node_id: NodeId(-4111446346771741861), signature_hash: 6265382829821424686, normalized_signature: Some("shape:4653416267105996665"), body_hash: -7939336403439250166, start_line: 17, end_line: 19 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:HumanPlayer.check", node_id: NodeId(-7548860230969506781), signature_hash: 1939816138975990522, normalized_signature: Some("shape:8692847248478310953"), body_hash: -3637898637486742110, start_line: 150, end_line: 160 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:HumanPlayer.input", node_id: NodeId(7263237642810088175), signature_hash: -3809286021505677146, normalized_signature: Some("shape:2825381502579953551"), body_hash: -3979924102330769501, start_line: 144, end_line: 148 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:HumanPlayer.turn", node_id: NodeId(-4860501950400080676), signature_hash: -1551097434895889655, normalized_signature: Some("shape:6290630185053673190"), body_hash: -6394215579831791467, start_line: 162, end_line: 172 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Player.constructor", node_id: NodeId(-7896812941834749686), signature_hash: 1459491240378128671, normalized_signature: Some("outline:-5087212818695232478"), body_hash: -4024523951762479406, start_line: 132, end_line: 136 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:Player.turn", node_id: NodeId(3268905490135043067), signature_hash: -1091959065548758310, normalized_signature: Some("outline:-5084961018881034800"), body_hash: 7374371606352428595, start_line: 138, end_line: 140 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:TicTacToe.checkWinner", node_id: NodeId(-1123973907201426288), signature_hash: -7287660358945405677, normalized_signature: Some("shape:-3974907770350565706"), body_hash: -8661474692284074530, start_line: 236, end_line: 238 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:TicTacToe.constructor", node_id: NodeId(4788484689354589371), signature_hash: -9167033954688097950, normalized_signature: Some("outline:-5087212818695232478"), body_hash: -4300041013264973592, start_line: 230, end_line: 234 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:TicTacToe.isDraw", node_id: NodeId(7589834313831188085), signature_hash: -160070021693570394, normalized_signature: Some("shape:7207692003922788594"), body_hash: -4998066279668690059, start_line: 240, end_line: 242 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:TicTacToe.probeCalls", node_id: NodeId(2600619131175994584), signature_hash: -1793306237384058767, normalized_signature: Some("shape:8258667085465016562"), body_hash: -4374928601735356655, start_line: 261, end_line: 263 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:TicTacToe.run", node_id: NodeId(6341370554137479666), signature_hash: 5136661510898306809, normalized_signature: Some("shape:3510680989701995652"), body_hash: 1494157563737541023, start_line: 265, end_line: 286 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:TicTacToe.selectPlayer", node_id: NodeId(-1146549163583479934), signature_hash: -6255132847551752433, normalized_signature: Some("shape:-2867347793455673562"), body_hash: -7480889940579491112, start_line: 244, end_line: 253 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "14:TicTacToe.start", node_id: NodeId(-6961802906960531293), signature_hash: -2053738397397415406, normalized_signature: Some("shape:-3368728074198172228"), body_hash: -7485950044447383571, start_line: 255, end_line: 259 }
+callable_state CallableProjectionState { file_id: 7327191833755101244, symbol_key: "__file_structural__", node_id: NodeId(7327191833755101244), signature_hash: 553768115714561381, normalized_signature: None, body_hash: -4728348350088183401, start_line: 1, end_line: 294 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "javascript",
+        extension: "js",
+        fidelity_filename: "fidelity.js",
+        fidelity_source: include_str!("fixtures/fidelity_lab/javascript_fidelity_lab.js"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/javascript_fidelity.txt"),
+        tictactoe_filename: "game.js",
+        tictactoe_source: include_str!("fixtures/tictactoe/javascript_tictactoe.js"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/javascript_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1680.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
