### PR TITLE
[v0.17 S3-TYPESCRIPT] Extract TypeScript language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3941,8 +3941,8 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
     let comment_marker = codestory_contracts::language_support::line_comment_for_language(language)
         .or(match language {
             "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
-            "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
-            | "cpp" | "dart" | "php" | "swift" => Some("//"),
+            "rust" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp" | "cpp" | "dart"
+            | "php" | "swift" => Some("//"),
             _ => None,
         });
     let Some(marker) = comment_marker else {
@@ -5631,14 +5631,29 @@ mod tests {
             }
         }
 
-        // The registry is the source for Kotlin: it must agree with the marker
-        // the roster used to hold.
+        // The registry is the source for Kotlin and TypeScript: it must agree
+        // with the marker the roster used to hold. `tsx` deliberately still
+        // answers from the local roster — it has no public language profile,
+        // and #1682 owns that row.
         assert_eq!(
             codestory_contracts::language_support::line_comment_for_language("kotlin"),
             Some("//")
         );
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("typescript"),
+            Some("//")
+        );
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("tsx"),
+            None
+        );
         let kotlin = ansi_highlight_snippet("app/Main.kt", "val ok = true // comment");
         assert!(kotlin.contains("\x1b[90m// comment\x1b[0m"), "{kotlin:?}");
+        let typescript = ansi_highlight_snippet("src/app.ts", "const ok = true; // comment");
+        assert!(
+            typescript.contains("\x1b[90m// comment\x1b[0m"),
+            "{typescript:?}"
+        );
     }
 
     /// Component dialects resolve through the companion-extension registry and

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "typescript",
+        line_comment: "//",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "typescript"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,6 +1265,10 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("typescript"), Some("//"));
+        // `tsx` is an indexer-only dispatch name with no public profile, so it
+        // keeps answering from the CLI's own roster until #1682 lands.
+        assert_eq!(line_comment_for_language("tsx"), None);
         assert_eq!(line_comment_for_language("swift"), None);
     }
 

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -2,8 +2,7 @@ use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
     GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
     PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, languages, make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -33,8 +32,9 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("java", _) => Some(java()),
         ("rust", _) => Some(rust()),
         ("javascript", _) => Some(javascript()),
+        // `ts`/`mts`/`cts` are answered by the registry above; `tsx` keeps its
+        // own grammar and rule file until #1682 gives it a registry row.
         ("typescript", "tsx") => Some(tsx()),
-        ("typescript", _) => Some(typescript()),
         ("cpp", _) => Some(cpp()),
         ("c", _) => Some(c()),
         ("go", _) => Some(go()),
@@ -85,16 +85,6 @@ fn javascript() -> LanguageConfig {
         JAVASCRIPT_GRAPH_QUERY,
         None,
         LanguageRuleset::JavaScript,
-    )
-}
-
-fn typescript() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        "typescript",
-        TYPESCRIPT_GRAPH_QUERY,
-        Some(TYPESCRIPT_TAGS_QUERY),
-        LanguageRuleset::TypeScript,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -17,6 +17,7 @@
 //! package to land deletes the residual arms entirely.
 
 pub(crate) mod kotlin;
+pub(crate) mod typescript;
 
 use std::sync::OnceLock;
 
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, typescript::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {

--- a/crates/codestory-indexer/src/languages/typescript.rs
+++ b/crates/codestory-indexer/src/languages/typescript.rs
@@ -1,0 +1,709 @@
+//! TypeScript extraction rules.
+//!
+//! TypeScript's graph extraction lives here: the tree-sitter graph and tags
+//! rule files, the compiled-rule cache, the member-call callsite marker, and
+//! the receiver-call resolution engine that turns `repository.save(...)` into
+//! an edge aimed at `Repository.save`. Every language-keyed dispatch in the
+//! crate reaches it through [`super::EXTRACTIONS`] rather than by spelling
+//! `"typescript"`.
+//!
+//! Three TypeScript-adjacent surfaces are deliberately *not* here, and none of
+//! them is TypeScript content this package owns:
+//!
+//! * TSX. It is its own rollback unit (#1682) with its own grammar, graph rule
+//!   file, compiled-rule cache and dispatch name. Until it lands, the residual
+//!   `"tsx"` arms in `lib.rs` and `language_configs.rs` keep answering for it,
+//!   and the one arm that shared TypeScript's receiver-call engine now calls
+//!   into this module instead of a `lib.rs` local. Absorbing TSX here would
+//!   merge two rollback units and silently hand `.tsx` files TypeScript's
+//!   grammar.
+//! * `TypeScriptSemanticResolver`, which stays in `semantic::typescript`
+//!   because the resolver types are private to that module. The registry row
+//!   records the choice (`uses_generic_semantic_resolver: false`) and
+//!   `semantic::dedicated_semantic_resolver` still constructs it.
+//! * `lib.rs`'s Express/React/SvelteKit route collectors and the
+//!   `JavaScriptDialect::TypeScript` selector. The per-language route
+//!   collectors take non-uniform arguments and per-framework preconditions, so
+//!   routing them through the registry is one change for all sixteen
+//!   languages, not part of TypeScript's rollback unit.
+//!
+//! Two functions below are `pub(crate)` because JavaScript's still-unmigrated
+//! receiver-call engine in `lib.rs` calls them
+//! (`collect_typescript_imported_type_bindings` and
+//! `typescript_property_belongs_to_owner`). They are TypeScript rules that
+//! JavaScript borrows rather than shared crate-root helpers, so they move with
+//! the rest and JavaScript reaches them by path until #1680 lands.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both TypeScript fixtures so the move stays
+//! output-equal.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, ImportedTypeBinding, LanguageRuleset, ManualReceiverCallSpec,
+    ManualReceiverSource, OptionalReceiverOwnerBinding, ReceiverCallSiteKey, ReceiverOwnerBinding,
+    collect_colon_parameter_types, collect_receiver_call_specs_in_callable, declaration_name,
+    enclosing_node_with_kind, js_like_callable_source_name, js_ts_local_binding_visible_at_call,
+    js_ts_visible_local_type_name, member_call_method_col,
+    normalize_js_ts_private_receiver_surface, normalize_parameter_name, normalize_type_surface,
+    normalized_receiver_variable, parameter_name_before_colon, parameter_type_after_colon,
+    receiver_call_belongs_to_callable, receiver_callsite_key, same_ts_span,
+    signature_parameter_surface, split_top_level_parameters, trimmed_node_text, ts_node_graph_span,
+    walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from TypeScript member-call
+/// syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:ts-member-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/typescript.graph.scm");
+
+/// TSX reuses TypeScript's tags query verbatim, exactly as `lib.rs` did with
+/// `TSX_TAGS_QUERY = TYPESCRIPT_TAGS_QUERY`; #1682 takes ownership of that
+/// reference when TSX moves.
+pub(crate) const TAGS_QUERY: &str = include_str!("../../rules/typescript.tags.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for TypeScript.
+///
+/// `tsx` is deliberately absent from both `dispatch_names` and `extensions`:
+/// the contracts registry routes `.tsx` to the `typescript` language name, but
+/// the indexer parses it with a different grammar and a different rule file,
+/// and that row belongs to #1682.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["typescript"],
+    language_name: "typescript",
+    extensions: &["ts", "mts", "cts"],
+    ruleset: LanguageRuleset::TypeScript,
+    parser_language: typescript_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: Some(TAGS_QUERY),
+    compiled_rules: &RULES,
+    receiver_call_specs: Some(receiver_call_specs),
+    member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
+    graph_call_syntax: Some("ts_member"),
+    // TypeScript's rule file already projects class members as METHOD, so the
+    // qualified-name traversal must not promote FUNCTION children on top of
+    // it. `false` is the value the god file's match had.
+    promotes_type_member_functions_to_methods: false,
+    qualified_name_delimiter: ".",
+    route_comments_are_c_style: true,
+    // `semantic::TypeScriptSemanticResolver` is a dedicated resolver whose type
+    // is private to that module; the registry records the choice and the
+    // residual match there constructs it.
+    uses_generic_semantic_resolver: false,
+    semantic_family: "webscript",
+};
+
+fn typescript_language() -> tree_sitter::Language {
+    tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+}
+
+/// Manual receiver-call edges for one parsed TypeScript file.
+///
+/// Was `lib.rs::collect_typescript_receiver_call_edges`.
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let imported_type_bindings =
+        collect_typescript_imported_type_bindings(tree.root_node(), source);
+    let namespace_import_bindings =
+        collect_typescript_namespace_import_bindings(tree.root_node(), source);
+    walk_tree_nodes(tree.root_node(), &mut |callable| {
+        if !matches!(
+            callable.kind(),
+            "function_declaration" | "method_definition" | "arrow_function"
+        ) {
+            return;
+        }
+        let Some(source_name) = js_like_callable_source_name(callable, source) else {
+            return;
+        };
+        let call_source = ManualReceiverSource {
+            name: &source_name,
+            span: ts_node_graph_span(callable),
+        };
+        let mut local_receiver_callsites = HashSet::new();
+        collect_typescript_constructor_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &imported_type_bindings,
+            &namespace_import_bindings,
+            &mut local_receiver_callsites,
+            &mut edges,
+        );
+        let parameter_receiver_types = collect_colon_parameter_types(callable, source);
+        let mut receiver_types = parameter_receiver_types.clone();
+        if let Some(owner_name) = enclosing_node_with_kind(callable, &["class_declaration"])
+            .and_then(|owner| declaration_name(owner, source))
+            && callable.kind() == "method_definition"
+        {
+            receiver_types.insert("this".to_string(), owner_name);
+        }
+        let property_receiver_types = collect_typescript_class_property_receiver_bindings(
+            callable,
+            source,
+            &imported_type_bindings,
+            &namespace_import_bindings,
+        );
+        receiver_types.extend(
+            property_receiver_types
+                .iter()
+                .map(|(receiver_name, (owner_name, _))| {
+                    (receiver_name.clone(), owner_name.clone())
+                }),
+        );
+        if receiver_types.is_empty() {
+            return;
+        }
+        let mut receiver_modules =
+            collect_typescript_parameter_type_modules(callable, source, &namespace_import_bindings);
+        for (receiver_name, (_, owner_module)) in &property_receiver_types {
+            if let Some(module_name) = owner_module {
+                receiver_modules.insert(receiver_name.clone(), module_name.clone());
+            }
+        }
+        let start = edges.len();
+        collect_receiver_call_specs_in_callable(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &receiver_types,
+            member_call,
+            false,
+            &mut edges,
+        );
+        let mut fallback_specs = edges.split_off(start);
+        fallback_specs
+            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
+        for spec in &mut fallback_specs {
+            if parameter_receiver_types.contains_key(&spec.receiver_name)
+                && let Some(binding) = imported_type_bindings.get(&spec.owner_name)
+            {
+                spec.owner_name = binding.owner_name.clone();
+                spec.owner_module = Some(binding.module_name.clone());
+            } else if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
+                spec.owner_module = Some(module_name.clone());
+            }
+        }
+        edges.extend(fallback_specs);
+    });
+    edges
+}
+
+fn collect_typescript_constructor_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    namespace_import_bindings: &HashMap<String, String>,
+    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let Some(owner) = typescript_visible_local_constructor_receiver_owner(
+            callable,
+            node,
+            &receiver_name,
+            source,
+            imported_type_bindings,
+            namespace_import_bindings,
+        ) else {
+            return;
+        };
+        let method_col = member_call_method_col(node, source, &method_name);
+        local_receiver_callsites.insert(ReceiverCallSiteKey {
+            receiver_name: receiver_name.clone(),
+            method_name: method_name.clone(),
+            line: Some(node.start_position().row as u32 + 1),
+            method_col,
+        });
+        if let Some((owner_name, owner_module)) = owner {
+            edges.push(ManualReceiverCallSpec {
+                source_name: call_source.name.to_string(),
+                source_span: call_source.span,
+                receiver_name,
+                owner_name,
+                owner_module,
+                method_name,
+                method_col,
+                line: Some(node.start_position().row as u32 + 1),
+                allow_global_fallback: false,
+            });
+        }
+    });
+}
+
+fn typescript_visible_local_constructor_receiver_owner(
+    callable: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    namespace_import_bindings: &HashMap<String, String>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(callable, &mut |node| {
+        if node.kind() != "variable_declarator"
+            || !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > call_node.start_byte()
+            || !js_ts_local_binding_visible_at_call(node, call_node)
+        {
+            return;
+        }
+        let Some(binding_name) = node
+            .child_by_field_name("name")
+            .and_then(|name_node| trimmed_node_text(name_node, source))
+            .as_deref()
+            .and_then(normalize_parameter_name)
+        else {
+            return;
+        };
+        if binding_name != receiver_name {
+            return;
+        }
+        visible_bindings.push((
+            node.end_byte(),
+            typescript_constructor_receiver_owner(
+                node,
+                callable,
+                source,
+                imported_type_bindings,
+                namespace_import_bindings,
+            ),
+        ));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner)| owner)
+}
+
+fn typescript_constructor_receiver_owner(
+    node: TsNode<'_>,
+    callable: TsNode<'_>,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    namespace_import_bindings: &HashMap<String, String>,
+) -> OptionalReceiverOwnerBinding {
+    let constructor_type = node
+        .child_by_field_name("value")
+        .and_then(|value_node| typescript_new_expression_constructor_type(value_node, source))?;
+    let owner_name = normalize_type_surface(&constructor_type)?;
+    if typescript_type_import_qualifier(&constructor_type).is_none()
+        && js_ts_visible_local_type_name(callable, node, &owner_name, source)
+    {
+        return Some((owner_name, None));
+    }
+    typescript_receiver_owner_from_type(
+        &constructor_type,
+        imported_type_bindings,
+        namespace_import_bindings,
+    )
+}
+
+fn typescript_new_expression_constructor_type(node: TsNode<'_>, source: &str) -> Option<String> {
+    if node.kind() != "new_expression" {
+        return None;
+    }
+    node.child_by_field_name("constructor")
+        .and_then(|constructor| trimmed_node_text(constructor, source))
+        .map(|constructor| constructor.trim().to_string())
+        .filter(|constructor| !constructor.is_empty())
+}
+
+fn collect_typescript_class_property_receiver_bindings(
+    callable: TsNode<'_>,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    namespace_import_bindings: &HashMap<String, String>,
+) -> HashMap<String, ReceiverOwnerBinding> {
+    let mut receiver_bindings = HashMap::new();
+    if callable.kind() != "method_definition" {
+        return receiver_bindings;
+    }
+    let Some(class_node) = enclosing_node_with_kind(callable, &["class_declaration"]) else {
+        return receiver_bindings;
+    };
+    let mut candidates: HashMap<String, Vec<ReceiverOwnerBinding>> = HashMap::new();
+    walk_tree_nodes(class_node, &mut |node| {
+        if node.kind() != "public_field_definition"
+            || !typescript_property_belongs_to_owner(node, class_node)
+        {
+            return;
+        }
+        let Some((field_name, raw_type)) = typescript_property_receiver_binding(node, source)
+        else {
+            return;
+        };
+        let Some(owner) = typescript_receiver_owner_from_type(
+            &raw_type,
+            imported_type_bindings,
+            namespace_import_bindings,
+        ) else {
+            return;
+        };
+        candidates
+            .entry(format!("this.{field_name}"))
+            .or_default()
+            .push(owner);
+    });
+    for (receiver_name, mut owners) in candidates {
+        owners.sort();
+        owners.dedup();
+        if owners.len() == 1 {
+            receiver_bindings.insert(receiver_name, owners.remove(0));
+        }
+    }
+    receiver_bindings
+}
+
+pub(crate) fn typescript_property_belongs_to_owner(
+    property: TsNode<'_>,
+    class_node: TsNode<'_>,
+) -> bool {
+    let mut current = property.parent();
+    while let Some(candidate) = current {
+        if same_ts_span(candidate, class_node) {
+            return true;
+        }
+        if matches!(candidate.kind(), "method_definition" | "class_declaration") {
+            return false;
+        }
+        current = candidate.parent();
+    }
+    false
+}
+
+fn typescript_property_receiver_binding(
+    node: TsNode<'_>,
+    source: &str,
+) -> Option<(String, String)> {
+    let field_name = node
+        .child_by_field_name("name")
+        .and_then(|name| trimmed_node_text(name, source))
+        .as_deref()
+        .and_then(normalize_parameter_name)?;
+    let surface = trimmed_node_text(node, source)?;
+    let head = surface
+        .split('=')
+        .next()
+        .unwrap_or(surface.as_str())
+        .trim_end_matches(';')
+        .trim();
+    let (_, type_side) = head.split_once(':')?;
+    Some((field_name, parameter_type_after_colon(type_side)))
+}
+
+fn typescript_receiver_owner_from_type(
+    raw_type: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    namespace_import_bindings: &HashMap<String, String>,
+) -> OptionalReceiverOwnerBinding {
+    let owner_name = normalize_type_surface(raw_type)?;
+    if let Some(qualifier) = typescript_type_import_qualifier(raw_type) {
+        let module_name = namespace_import_bindings.get(&qualifier)?;
+        return Some((owner_name, Some(module_name.clone())));
+    }
+    if let Some(binding) = imported_type_bindings.get(&owner_name) {
+        return Some((
+            binding.owner_name.clone(),
+            Some(binding.module_name.clone()),
+        ));
+    }
+    Some((owner_name, None))
+}
+
+pub(crate) fn collect_typescript_imported_type_bindings(
+    root: TsNode<'_>,
+    source: &str,
+) -> HashMap<String, ImportedTypeBinding> {
+    let top_level_bindings = collect_typescript_top_level_type_binding_names(root, source);
+    let mut bindings = HashMap::new();
+    let mut duplicates = HashSet::new();
+    let mut cursor = root.walk();
+    for statement in root.named_children(&mut cursor) {
+        if statement.kind() != "import_statement" {
+            continue;
+        }
+        let Some(module_name) = statement
+            .child_by_field_name("source")
+            .and_then(|module| trimmed_node_text(module, source))
+        else {
+            continue;
+        };
+        for (owner_name, local_name) in typescript_import_binding_names(statement, source) {
+            if top_level_bindings.contains(&local_name) {
+                continue;
+            }
+            if duplicates.contains(&local_name) {
+                continue;
+            }
+            if bindings.contains_key(&local_name) {
+                bindings.remove(&local_name);
+                duplicates.insert(local_name);
+                continue;
+            }
+            bindings.insert(
+                local_name,
+                ImportedTypeBinding {
+                    module_name: module_name.clone(),
+                    owner_name,
+                },
+            );
+        }
+    }
+    bindings
+}
+
+fn typescript_import_binding_names(statement: TsNode<'_>, source: &str) -> Vec<(String, String)> {
+    let mut bindings = Vec::new();
+    let mut cursor = statement.walk();
+    for child in statement.named_children(&mut cursor) {
+        if child.kind() != "import_clause" {
+            continue;
+        }
+        let mut import_clause_cursor = child.walk();
+        for clause_child in child.named_children(&mut import_clause_cursor) {
+            match clause_child.kind() {
+                "identifier" => {
+                    if let Some(local_name) = trimmed_node_text(clause_child, source)
+                        .and_then(|name| normalize_parameter_name(&name))
+                    {
+                        bindings.push((local_name.clone(), local_name));
+                    }
+                }
+                "named_imports" => {
+                    let mut named_cursor = clause_child.walk();
+                    for import_specifier in clause_child.named_children(&mut named_cursor) {
+                        if import_specifier.kind() == "import_specifier"
+                            && let Some(binding) =
+                                typescript_import_specifier_binding_names(import_specifier, source)
+                        {
+                            bindings.push(binding);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    bindings
+}
+
+fn collect_typescript_namespace_import_bindings(
+    root: TsNode<'_>,
+    source: &str,
+) -> HashMap<String, String> {
+    let top_level_bindings = collect_typescript_top_level_type_binding_names(root, source);
+    let import_local_bindings = collect_typescript_import_local_binding_names(root, source);
+    let mut bindings = HashMap::new();
+    let mut duplicates = HashSet::new();
+    let mut cursor = root.walk();
+    for statement in root.named_children(&mut cursor) {
+        if statement.kind() != "import_statement" {
+            continue;
+        }
+        let Some(module_name) = statement
+            .child_by_field_name("source")
+            .and_then(|module| trimmed_node_text(module, source))
+        else {
+            continue;
+        };
+        for local_name in typescript_namespace_import_names(statement, source) {
+            if top_level_bindings.contains(&local_name)
+                || import_local_bindings.contains(&local_name)
+            {
+                continue;
+            }
+            if duplicates.contains(&local_name) {
+                continue;
+            }
+            if bindings.contains_key(&local_name) {
+                bindings.remove(&local_name);
+                duplicates.insert(local_name);
+                continue;
+            }
+            bindings.insert(local_name, module_name.clone());
+        }
+    }
+    bindings
+}
+
+fn collect_typescript_import_local_binding_names(
+    root: TsNode<'_>,
+    source: &str,
+) -> HashSet<String> {
+    let mut bindings = HashSet::new();
+    let mut cursor = root.walk();
+    for statement in root.named_children(&mut cursor) {
+        if statement.kind() != "import_statement" {
+            continue;
+        }
+        for (_, local_name) in typescript_import_binding_names(statement, source) {
+            bindings.insert(local_name);
+        }
+    }
+    bindings
+}
+
+fn typescript_namespace_import_names(statement: TsNode<'_>, source: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut cursor = statement.walk();
+    for child in statement.named_children(&mut cursor) {
+        if child.kind() != "import_clause" {
+            continue;
+        }
+        let mut import_clause_cursor = child.walk();
+        for clause_child in child.named_children(&mut import_clause_cursor) {
+            if clause_child.kind() != "namespace_import" {
+                continue;
+            }
+            let mut namespace_cursor = clause_child.walk();
+            for namespace_child in clause_child.named_children(&mut namespace_cursor) {
+                if namespace_child.kind() == "identifier"
+                    && let Some(local_name) = trimmed_node_text(namespace_child, source)
+                        .and_then(|name| normalize_parameter_name(&name))
+                {
+                    names.push(local_name);
+                }
+            }
+        }
+    }
+    names
+}
+
+fn typescript_import_specifier_binding_names(
+    import_specifier: TsNode<'_>,
+    source: &str,
+) -> Option<(String, String)> {
+    let name_node = import_specifier.child_by_field_name("name")?;
+    let owner_name =
+        trimmed_node_text(name_node, source).and_then(|name| normalize_parameter_name(&name))?;
+    let local_node = import_specifier
+        .child_by_field_name("alias")
+        .unwrap_or(name_node);
+    let local_name =
+        trimmed_node_text(local_node, source).and_then(|name| normalize_parameter_name(&name))?;
+    Some((owner_name, local_name))
+}
+
+fn collect_typescript_top_level_type_binding_names(
+    root: TsNode<'_>,
+    source: &str,
+) -> HashSet<String> {
+    let mut bindings = HashSet::new();
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        collect_typescript_top_level_type_binding_name(child, source, &mut bindings);
+    }
+    bindings
+}
+
+fn collect_typescript_top_level_type_binding_name(
+    node: TsNode<'_>,
+    source: &str,
+    bindings: &mut HashSet<String>,
+) {
+    match node.kind() {
+        "class_declaration"
+        | "interface_declaration"
+        | "type_alias_declaration"
+        | "enum_declaration" => {
+            if let Some(name) =
+                declaration_name(node, source).and_then(|name| normalize_parameter_name(&name))
+            {
+                bindings.insert(name);
+            }
+        }
+        "export_statement" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                collect_typescript_top_level_type_binding_name(child, source, bindings);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_typescript_parameter_type_modules(
+    callable: TsNode<'_>,
+    source: &str,
+    namespace_import_bindings: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut receiver_modules = HashMap::new();
+    let Some(parameters) = signature_parameter_surface(callable, source) else {
+        return receiver_modules;
+    };
+    for parameter in split_top_level_parameters(&parameters) {
+        let Some((name_side, type_side)) = parameter.split_once(':') else {
+            continue;
+        };
+        let Some(receiver_name) = parameter_name_before_colon(name_side) else {
+            continue;
+        };
+        let Some(qualifier) =
+            typescript_type_import_qualifier(&parameter_type_after_colon(type_side))
+        else {
+            continue;
+        };
+        let Some(module_name) = namespace_import_bindings.get(&qualifier) else {
+            continue;
+        };
+        receiver_modules.insert(receiver_name, module_name.clone());
+    }
+    receiver_modules
+}
+
+fn typescript_type_import_qualifier(raw_type: &str) -> Option<String> {
+    if raw_type.contains('|') || raw_type.contains('&') {
+        return None;
+    }
+    let mut surface = raw_type.trim().trim_end_matches('?').trim();
+    while let Some(stripped) = surface.strip_prefix("readonly") {
+        surface = stripped.trim_start();
+    }
+    let base = surface
+        .split(['<', '[', '('])
+        .next()
+        .unwrap_or(surface)
+        .trim();
+    let (qualifier, _) = base.rsplit_once('.')?;
+    normalize_parameter_name(qualifier)
+}
+
+/// Receiver and member of one TypeScript member call, read from the grammar.
+///
+/// Was `lib.rs::typescript_member_call`.
+fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let function = node.child_by_field_name("function")?;
+    if function.kind() != "member_expression" {
+        return None;
+    }
+    let receiver = function.child_by_field_name("object")?;
+    let method = function.child_by_field_name("property")?;
+    Some((
+        normalize_js_ts_private_receiver_surface(&normalized_receiver_variable(receiver, source)?),
+        trimmed_node_text(method, source)?,
+    ))
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -65,7 +65,6 @@ pub(crate) const CSHARP_MEMBER_CALLSITE_MARKER: &str = "syntax:csharp-member-cal
 pub(crate) const RUBY_MEMBER_CALLSITE_MARKER: &str = "syntax:ruby-member-call";
 pub(crate) const PHP_MEMBER_CALLSITE_MARKER: &str = "syntax:php-member-call";
 pub(crate) const JS_MEMBER_CALLSITE_MARKER: &str = "syntax:js-member-call";
-pub(crate) const TS_MEMBER_CALLSITE_MARKER: &str = "syntax:ts-member-call";
 pub(crate) const DART_MEMBER_CALLSITE_MARKER: &str = "syntax:dart-member-call";
 pub(crate) const SWIFT_MEMBER_CALLSITE_MARKER: &str = "syntax:swift-member-call";
 pub(crate) const RECEIVER_OWNER_CALLSITE_PREFIX: &str = "receiver-owner:";
@@ -132,10 +131,10 @@ const JAVA_GRAPH_QUERY: &str = include_str!("../rules/java.scm");
 const RUST_GRAPH_QUERY: &str = include_str!("../rules/rust.graph.scm");
 const RUST_TAGS_QUERY: &str = include_str!("../rules/rust.tags.scm");
 const JAVASCRIPT_GRAPH_QUERY: &str = include_str!("../rules/javascript.scm");
-const TYPESCRIPT_GRAPH_QUERY: &str = include_str!("../rules/typescript.graph.scm");
-const TYPESCRIPT_TAGS_QUERY: &str = include_str!("../rules/typescript.tags.scm");
 const TSX_GRAPH_QUERY: &str = include_str!("../rules/tsx.graph.scm");
-const TSX_TAGS_QUERY: &str = TYPESCRIPT_TAGS_QUERY;
+// TSX still reuses TypeScript's tags query verbatim; the asset moved into the
+// TypeScript registry row and #1682 takes ownership of this reference.
+const TSX_TAGS_QUERY: &str = languages::typescript::TAGS_QUERY;
 const CPP_GRAPH_QUERY: &str = include_str!("../rules/cpp.scm");
 const C_GRAPH_QUERY: &str = include_str!("../rules/c.scm");
 const GO_GRAPH_QUERY: &str = include_str!("../rules/go.scm");
@@ -304,12 +303,10 @@ impl LanguageRuleset {
             LanguageRuleset::JavaScript => {
                 compiled_rules_cache(language, JAVASCRIPT_GRAPH_QUERY, None, &JAVASCRIPT_RULES)
             }
-            LanguageRuleset::TypeScript => compiled_rules_cache(
-                language,
-                TYPESCRIPT_GRAPH_QUERY,
-                Some(TYPESCRIPT_TAGS_QUERY),
-                &TYPESCRIPT_RULES,
-            ),
+            // Answered by the registry above; see the Kotlin arm below.
+            LanguageRuleset::TypeScript => Err(anyhow!(
+                "typescript compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::Tsx => {
                 compiled_rules_cache(language, TSX_GRAPH_QUERY, Some(TSX_TAGS_QUERY), &TSX_RULES)
             }
@@ -376,7 +373,6 @@ static PYTHON_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock:
 static JAVA_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static RUST_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static JAVASCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static TYPESCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static TSX_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CPP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static C_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
@@ -6160,7 +6156,7 @@ fn collect_javascript_receiver_call_edges(
 ) -> Vec<ManualReceiverCallSpec> {
     let mut edges = Vec::new();
     let imported_type_bindings =
-        collect_typescript_imported_type_bindings(tree.root_node(), source);
+        languages::typescript::collect_typescript_imported_type_bindings(tree.root_node(), source);
     walk_tree_nodes(tree.root_node(), &mut |callable| {
         if !matches!(
             callable.kind(),
@@ -6487,7 +6483,7 @@ fn javascript_property_receiver_candidate<'tree>(
         ));
     }
     if matches!(node.kind(), "field_definition" | "public_field_definition")
-        && typescript_property_belongs_to_owner(node, class_node)
+        && languages::typescript::typescript_property_belongs_to_owner(node, class_node)
         && !javascript_surface_starts_with_static(node, source)
     {
         let field_name = javascript_class_field_name(node, source)?;
@@ -7594,7 +7590,9 @@ fn language_receiver_call_specs(
     match language_name {
         "javascript" => collect_javascript_receiver_call_edges(tree, source),
         "python" => collect_python_receiver_call_edges(tree, source),
-        "typescript" | "tsx" => collect_typescript_receiver_call_edges(tree, source),
+        // TSX has always run TypeScript's receiver-call engine; the engine
+        // moved into the registry row and #1682 takes over this arm.
+        "tsx" => languages::typescript::receiver_call_specs(tree, source),
         "java" => collect_java_receiver_call_edges(tree, source),
         "go" => collect_go_receiver_call_edges(tree, source),
         "ruby" => collect_ruby_receiver_call_edges(tree, source),
@@ -8848,586 +8846,6 @@ fn collect_python_imported_type_bindings(
         }
     }
     bindings
-}
-
-fn collect_typescript_receiver_call_edges(
-    tree: &Tree,
-    source: &str,
-) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let imported_type_bindings =
-        collect_typescript_imported_type_bindings(tree.root_node(), source);
-    let namespace_import_bindings =
-        collect_typescript_namespace_import_bindings(tree.root_node(), source);
-    walk_tree_nodes(tree.root_node(), &mut |callable| {
-        if !matches!(
-            callable.kind(),
-            "function_declaration" | "method_definition" | "arrow_function"
-        ) {
-            return;
-        }
-        let Some(source_name) = js_like_callable_source_name(callable, source) else {
-            return;
-        };
-        let call_source = ManualReceiverSource {
-            name: &source_name,
-            span: ts_node_graph_span(callable),
-        };
-        let mut local_receiver_callsites = HashSet::new();
-        collect_typescript_constructor_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &imported_type_bindings,
-            &namespace_import_bindings,
-            &mut local_receiver_callsites,
-            &mut edges,
-        );
-        let parameter_receiver_types = collect_colon_parameter_types(callable, source);
-        let mut receiver_types = parameter_receiver_types.clone();
-        if let Some(owner_name) = enclosing_node_with_kind(callable, &["class_declaration"])
-            .and_then(|owner| declaration_name(owner, source))
-            && callable.kind() == "method_definition"
-        {
-            receiver_types.insert("this".to_string(), owner_name);
-        }
-        let property_receiver_types = collect_typescript_class_property_receiver_bindings(
-            callable,
-            source,
-            &imported_type_bindings,
-            &namespace_import_bindings,
-        );
-        receiver_types.extend(
-            property_receiver_types
-                .iter()
-                .map(|(receiver_name, (owner_name, _))| {
-                    (receiver_name.clone(), owner_name.clone())
-                }),
-        );
-        if receiver_types.is_empty() {
-            return;
-        }
-        let mut receiver_modules =
-            collect_typescript_parameter_type_modules(callable, source, &namespace_import_bindings);
-        for (receiver_name, (_, owner_module)) in &property_receiver_types {
-            if let Some(module_name) = owner_module {
-                receiver_modules.insert(receiver_name.clone(), module_name.clone());
-            }
-        }
-        let start = edges.len();
-        collect_receiver_call_specs_in_callable(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &receiver_types,
-            typescript_member_call,
-            false,
-            &mut edges,
-        );
-        let mut fallback_specs = edges.split_off(start);
-        fallback_specs
-            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
-        for spec in &mut fallback_specs {
-            if parameter_receiver_types.contains_key(&spec.receiver_name)
-                && let Some(binding) = imported_type_bindings.get(&spec.owner_name)
-            {
-                spec.owner_name = binding.owner_name.clone();
-                spec.owner_module = Some(binding.module_name.clone());
-            } else if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
-                spec.owner_module = Some(module_name.clone());
-            }
-        }
-        edges.extend(fallback_specs);
-    });
-    edges
-}
-
-fn collect_typescript_constructor_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    namespace_import_bindings: &HashMap<String, String>,
-    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = typescript_member_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let Some(owner) = typescript_visible_local_constructor_receiver_owner(
-            callable,
-            node,
-            &receiver_name,
-            source,
-            imported_type_bindings,
-            namespace_import_bindings,
-        ) else {
-            return;
-        };
-        let method_col = member_call_method_col(node, source, &method_name);
-        local_receiver_callsites.insert(ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
-            method_col,
-        });
-        if let Some((owner_name, owner_module)) = owner {
-            edges.push(ManualReceiverCallSpec {
-                source_name: call_source.name.to_string(),
-                source_span: call_source.span,
-                receiver_name,
-                owner_name,
-                owner_module,
-                method_name,
-                method_col,
-                line: Some(node.start_position().row as u32 + 1),
-                allow_global_fallback: false,
-            });
-        }
-    });
-}
-
-fn typescript_visible_local_constructor_receiver_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    namespace_import_bindings: &HashMap<String, String>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if node.kind() != "variable_declarator"
-            || !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
-            || !js_ts_local_binding_visible_at_call(node, call_node)
-        {
-            return;
-        }
-        let Some(binding_name) = node
-            .child_by_field_name("name")
-            .and_then(|name_node| trimmed_node_text(name_node, source))
-            .as_deref()
-            .and_then(normalize_parameter_name)
-        else {
-            return;
-        };
-        if binding_name != receiver_name {
-            return;
-        }
-        visible_bindings.push((
-            node.end_byte(),
-            typescript_constructor_receiver_owner(
-                node,
-                callable,
-                source,
-                imported_type_bindings,
-                namespace_import_bindings,
-            ),
-        ));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner)| owner)
-}
-
-fn typescript_constructor_receiver_owner(
-    node: TsNode<'_>,
-    callable: TsNode<'_>,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    namespace_import_bindings: &HashMap<String, String>,
-) -> OptionalReceiverOwnerBinding {
-    let constructor_type = node
-        .child_by_field_name("value")
-        .and_then(|value_node| typescript_new_expression_constructor_type(value_node, source))?;
-    let owner_name = normalize_type_surface(&constructor_type)?;
-    if typescript_type_import_qualifier(&constructor_type).is_none()
-        && js_ts_visible_local_type_name(callable, node, &owner_name, source)
-    {
-        return Some((owner_name, None));
-    }
-    typescript_receiver_owner_from_type(
-        &constructor_type,
-        imported_type_bindings,
-        namespace_import_bindings,
-    )
-}
-
-fn typescript_new_expression_constructor_type(node: TsNode<'_>, source: &str) -> Option<String> {
-    if node.kind() != "new_expression" {
-        return None;
-    }
-    node.child_by_field_name("constructor")
-        .and_then(|constructor| trimmed_node_text(constructor, source))
-        .map(|constructor| constructor.trim().to_string())
-        .filter(|constructor| !constructor.is_empty())
-}
-
-fn collect_typescript_class_property_receiver_bindings(
-    callable: TsNode<'_>,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    namespace_import_bindings: &HashMap<String, String>,
-) -> HashMap<String, ReceiverOwnerBinding> {
-    let mut receiver_bindings = HashMap::new();
-    if callable.kind() != "method_definition" {
-        return receiver_bindings;
-    }
-    let Some(class_node) = enclosing_node_with_kind(callable, &["class_declaration"]) else {
-        return receiver_bindings;
-    };
-    let mut candidates: HashMap<String, Vec<ReceiverOwnerBinding>> = HashMap::new();
-    walk_tree_nodes(class_node, &mut |node| {
-        if node.kind() != "public_field_definition"
-            || !typescript_property_belongs_to_owner(node, class_node)
-        {
-            return;
-        }
-        let Some((field_name, raw_type)) = typescript_property_receiver_binding(node, source)
-        else {
-            return;
-        };
-        let Some(owner) = typescript_receiver_owner_from_type(
-            &raw_type,
-            imported_type_bindings,
-            namespace_import_bindings,
-        ) else {
-            return;
-        };
-        candidates
-            .entry(format!("this.{field_name}"))
-            .or_default()
-            .push(owner);
-    });
-    for (receiver_name, mut owners) in candidates {
-        owners.sort();
-        owners.dedup();
-        if owners.len() == 1 {
-            receiver_bindings.insert(receiver_name, owners.remove(0));
-        }
-    }
-    receiver_bindings
-}
-
-fn typescript_property_belongs_to_owner(property: TsNode<'_>, class_node: TsNode<'_>) -> bool {
-    let mut current = property.parent();
-    while let Some(candidate) = current {
-        if same_ts_span(candidate, class_node) {
-            return true;
-        }
-        if matches!(candidate.kind(), "method_definition" | "class_declaration") {
-            return false;
-        }
-        current = candidate.parent();
-    }
-    false
-}
-
-fn typescript_property_receiver_binding(
-    node: TsNode<'_>,
-    source: &str,
-) -> Option<(String, String)> {
-    let field_name = node
-        .child_by_field_name("name")
-        .and_then(|name| trimmed_node_text(name, source))
-        .as_deref()
-        .and_then(normalize_parameter_name)?;
-    let surface = trimmed_node_text(node, source)?;
-    let head = surface
-        .split('=')
-        .next()
-        .unwrap_or(surface.as_str())
-        .trim_end_matches(';')
-        .trim();
-    let (_, type_side) = head.split_once(':')?;
-    Some((field_name, parameter_type_after_colon(type_side)))
-}
-
-fn typescript_receiver_owner_from_type(
-    raw_type: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    namespace_import_bindings: &HashMap<String, String>,
-) -> OptionalReceiverOwnerBinding {
-    let owner_name = normalize_type_surface(raw_type)?;
-    if let Some(qualifier) = typescript_type_import_qualifier(raw_type) {
-        let module_name = namespace_import_bindings.get(&qualifier)?;
-        return Some((owner_name, Some(module_name.clone())));
-    }
-    if let Some(binding) = imported_type_bindings.get(&owner_name) {
-        return Some((
-            binding.owner_name.clone(),
-            Some(binding.module_name.clone()),
-        ));
-    }
-    Some((owner_name, None))
-}
-
-fn collect_typescript_imported_type_bindings(
-    root: TsNode<'_>,
-    source: &str,
-) -> HashMap<String, ImportedTypeBinding> {
-    let top_level_bindings = collect_typescript_top_level_type_binding_names(root, source);
-    let mut bindings = HashMap::new();
-    let mut duplicates = HashSet::new();
-    let mut cursor = root.walk();
-    for statement in root.named_children(&mut cursor) {
-        if statement.kind() != "import_statement" {
-            continue;
-        }
-        let Some(module_name) = statement
-            .child_by_field_name("source")
-            .and_then(|module| trimmed_node_text(module, source))
-        else {
-            continue;
-        };
-        for (owner_name, local_name) in typescript_import_binding_names(statement, source) {
-            if top_level_bindings.contains(&local_name) {
-                continue;
-            }
-            if duplicates.contains(&local_name) {
-                continue;
-            }
-            if bindings.contains_key(&local_name) {
-                bindings.remove(&local_name);
-                duplicates.insert(local_name);
-                continue;
-            }
-            bindings.insert(
-                local_name,
-                ImportedTypeBinding {
-                    module_name: module_name.clone(),
-                    owner_name,
-                },
-            );
-        }
-    }
-    bindings
-}
-
-fn typescript_import_binding_names(statement: TsNode<'_>, source: &str) -> Vec<(String, String)> {
-    let mut bindings = Vec::new();
-    let mut cursor = statement.walk();
-    for child in statement.named_children(&mut cursor) {
-        if child.kind() != "import_clause" {
-            continue;
-        }
-        let mut import_clause_cursor = child.walk();
-        for clause_child in child.named_children(&mut import_clause_cursor) {
-            match clause_child.kind() {
-                "identifier" => {
-                    if let Some(local_name) = trimmed_node_text(clause_child, source)
-                        .and_then(|name| normalize_parameter_name(&name))
-                    {
-                        bindings.push((local_name.clone(), local_name));
-                    }
-                }
-                "named_imports" => {
-                    let mut named_cursor = clause_child.walk();
-                    for import_specifier in clause_child.named_children(&mut named_cursor) {
-                        if import_specifier.kind() == "import_specifier"
-                            && let Some(binding) =
-                                typescript_import_specifier_binding_names(import_specifier, source)
-                        {
-                            bindings.push(binding);
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-    bindings
-}
-
-fn collect_typescript_namespace_import_bindings(
-    root: TsNode<'_>,
-    source: &str,
-) -> HashMap<String, String> {
-    let top_level_bindings = collect_typescript_top_level_type_binding_names(root, source);
-    let import_local_bindings = collect_typescript_import_local_binding_names(root, source);
-    let mut bindings = HashMap::new();
-    let mut duplicates = HashSet::new();
-    let mut cursor = root.walk();
-    for statement in root.named_children(&mut cursor) {
-        if statement.kind() != "import_statement" {
-            continue;
-        }
-        let Some(module_name) = statement
-            .child_by_field_name("source")
-            .and_then(|module| trimmed_node_text(module, source))
-        else {
-            continue;
-        };
-        for local_name in typescript_namespace_import_names(statement, source) {
-            if top_level_bindings.contains(&local_name)
-                || import_local_bindings.contains(&local_name)
-            {
-                continue;
-            }
-            if duplicates.contains(&local_name) {
-                continue;
-            }
-            if bindings.contains_key(&local_name) {
-                bindings.remove(&local_name);
-                duplicates.insert(local_name);
-                continue;
-            }
-            bindings.insert(local_name, module_name.clone());
-        }
-    }
-    bindings
-}
-
-fn collect_typescript_import_local_binding_names(
-    root: TsNode<'_>,
-    source: &str,
-) -> HashSet<String> {
-    let mut bindings = HashSet::new();
-    let mut cursor = root.walk();
-    for statement in root.named_children(&mut cursor) {
-        if statement.kind() != "import_statement" {
-            continue;
-        }
-        for (_, local_name) in typescript_import_binding_names(statement, source) {
-            bindings.insert(local_name);
-        }
-    }
-    bindings
-}
-
-fn typescript_namespace_import_names(statement: TsNode<'_>, source: &str) -> Vec<String> {
-    let mut names = Vec::new();
-    let mut cursor = statement.walk();
-    for child in statement.named_children(&mut cursor) {
-        if child.kind() != "import_clause" {
-            continue;
-        }
-        let mut import_clause_cursor = child.walk();
-        for clause_child in child.named_children(&mut import_clause_cursor) {
-            if clause_child.kind() != "namespace_import" {
-                continue;
-            }
-            let mut namespace_cursor = clause_child.walk();
-            for namespace_child in clause_child.named_children(&mut namespace_cursor) {
-                if namespace_child.kind() == "identifier"
-                    && let Some(local_name) = trimmed_node_text(namespace_child, source)
-                        .and_then(|name| normalize_parameter_name(&name))
-                {
-                    names.push(local_name);
-                }
-            }
-        }
-    }
-    names
-}
-
-fn typescript_import_specifier_binding_names(
-    import_specifier: TsNode<'_>,
-    source: &str,
-) -> Option<(String, String)> {
-    let name_node = import_specifier.child_by_field_name("name")?;
-    let owner_name =
-        trimmed_node_text(name_node, source).and_then(|name| normalize_parameter_name(&name))?;
-    let local_node = import_specifier
-        .child_by_field_name("alias")
-        .unwrap_or(name_node);
-    let local_name =
-        trimmed_node_text(local_node, source).and_then(|name| normalize_parameter_name(&name))?;
-    Some((owner_name, local_name))
-}
-
-fn collect_typescript_top_level_type_binding_names(
-    root: TsNode<'_>,
-    source: &str,
-) -> HashSet<String> {
-    let mut bindings = HashSet::new();
-    let mut cursor = root.walk();
-    for child in root.named_children(&mut cursor) {
-        collect_typescript_top_level_type_binding_name(child, source, &mut bindings);
-    }
-    bindings
-}
-
-fn collect_typescript_top_level_type_binding_name(
-    node: TsNode<'_>,
-    source: &str,
-    bindings: &mut HashSet<String>,
-) {
-    match node.kind() {
-        "class_declaration"
-        | "interface_declaration"
-        | "type_alias_declaration"
-        | "enum_declaration" => {
-            if let Some(name) =
-                declaration_name(node, source).and_then(|name| normalize_parameter_name(&name))
-            {
-                bindings.insert(name);
-            }
-        }
-        "export_statement" => {
-            let mut cursor = node.walk();
-            for child in node.named_children(&mut cursor) {
-                collect_typescript_top_level_type_binding_name(child, source, bindings);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn collect_typescript_parameter_type_modules(
-    callable: TsNode<'_>,
-    source: &str,
-    namespace_import_bindings: &HashMap<String, String>,
-) -> HashMap<String, String> {
-    let mut receiver_modules = HashMap::new();
-    let Some(parameters) = signature_parameter_surface(callable, source) else {
-        return receiver_modules;
-    };
-    for parameter in split_top_level_parameters(&parameters) {
-        let Some((name_side, type_side)) = parameter.split_once(':') else {
-            continue;
-        };
-        let Some(receiver_name) = parameter_name_before_colon(name_side) else {
-            continue;
-        };
-        let Some(qualifier) =
-            typescript_type_import_qualifier(&parameter_type_after_colon(type_side))
-        else {
-            continue;
-        };
-        let Some(module_name) = namespace_import_bindings.get(&qualifier) else {
-            continue;
-        };
-        receiver_modules.insert(receiver_name, module_name.clone());
-    }
-    receiver_modules
-}
-
-fn typescript_type_import_qualifier(raw_type: &str) -> Option<String> {
-    if raw_type.contains('|') || raw_type.contains('&') {
-        return None;
-    }
-    let mut surface = raw_type.trim().trim_end_matches('?').trim();
-    while let Some(stripped) = surface.strip_prefix("readonly") {
-        surface = stripped.trim_start();
-    }
-    let base = surface
-        .split(['<', '[', '('])
-        .next()
-        .unwrap_or(surface)
-        .trim();
-    let (qualifier, _) = base.rsplit_once('.')?;
-    normalize_parameter_name(qualifier)
 }
 
 fn collect_python_top_level_binding_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
@@ -14467,22 +13885,6 @@ fn ruby_receiver_call(node: TsNode<'_>, source: &str) -> Option<(String, String)
     Some((normalized_receiver_variable(receiver, source)?, method_name))
 }
 
-fn typescript_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if node.kind() != "call_expression" {
-        return None;
-    }
-    let function = node.child_by_field_name("function")?;
-    if function.kind() != "member_expression" {
-        return None;
-    }
-    let receiver = function.child_by_field_name("object")?;
-    let method = function.child_by_field_name("property")?;
-    Some((
-        normalize_js_ts_private_receiver_surface(&normalized_receiver_variable(receiver, source)?),
-        trimmed_node_text(method, source)?,
-    ))
-}
-
 fn javascript_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
     if node.kind() != "call_expression" {
         return None;
@@ -17072,16 +16474,7 @@ fn route_language_uses_c_style_comments(language_name: &str) -> bool {
     }
     matches!(
         language_name,
-        "javascript"
-            | "typescript"
-            | "java"
-            | "rust"
-            | "go"
-            | "php"
-            | "csharp"
-            | "dart"
-            | "vue"
-            | "astro"
+        "javascript" | "java" | "rust" | "go" | "php" | "csharp" | "dart" | "vue" | "astro"
     )
 }
 
@@ -20230,7 +19623,6 @@ pub fn index_file(
                                         "csharp_member" => Some(CSHARP_MEMBER_CALLSITE_MARKER),
                                         "php_member" => Some(PHP_MEMBER_CALLSITE_MARKER),
                                         "js_member" => Some(JS_MEMBER_CALLSITE_MARKER),
-                                        "ts_member" => Some(TS_MEMBER_CALLSITE_MARKER),
                                         "dart_member" => Some(DART_MEMBER_CALLSITE_MARKER),
                                         "swift_member" => Some(SWIFT_MEMBER_CALLSITE_MARKER),
                                         _ => callsite_marker,
@@ -25728,13 +25120,22 @@ class Test {
         assert_eq!(rust.graph_query, RUST_GRAPH_QUERY);
         assert_eq!(rust.tags_query, Some(RUST_TAGS_QUERY));
 
+        // TypeScript's rule files moved into `languages::typescript`; the
+        // config must still come back through the same extension lookup, and
+        // TSX must still reuse the tags query it always shared.
         let ts = get_language_for_ext("ts").expect("ts config");
-        assert_eq!(ts.graph_query, TYPESCRIPT_GRAPH_QUERY);
-        assert_eq!(ts.tags_query, Some(TYPESCRIPT_TAGS_QUERY));
+        let ts_row = languages::extraction_for_ext("ts").expect("typescript registry row");
+        assert_eq!(ts.language_name, "typescript");
+        assert_eq!(ts.graph_query, ts_row.graph_query);
+        assert_eq!(ts.tags_query, ts_row.tags_query);
+        assert!(ts.graph_query.contains("ts_member"));
+        assert!(ts.tags_query.is_some());
 
         let tsx = get_language_for_ext("tsx").expect("tsx config");
         assert_eq!(tsx.graph_query, TSX_GRAPH_QUERY);
         assert_eq!(tsx.tags_query, Some(TSX_TAGS_QUERY));
+        assert_eq!(tsx.tags_query, ts.tags_query);
+        assert_ne!(tsx.graph_query, ts.graph_query);
 
         // Kotlin's rule file moved into `languages::kotlin`; the config must
         // still come back through the same extension lookup.

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1345,7 +1345,7 @@ fn is_ts_member_call_placeholder(edge_kind: EdgeKind, callsite_identity: Option<
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::TS_MEMBER_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::typescript::MEMBER_CALLSITE_MARKER)
     })
 }
 

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -592,7 +592,7 @@ fn language_family_bucket(language: &'static str) -> &'static str {
     }
     match language {
         "c" | "cpp" => "native",
-        "javascript" | "typescript" | "vue" | "svelte" | "astro" => "webscript",
+        "javascript" | "vue" | "svelte" | "astro" => "webscript",
         "python" => "python",
         "rust" => "rust",
         "java" => "java",

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/typescript_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/typescript_fidelity.txt
@@ -1,0 +1,69 @@
+node CLASS name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.ts:ConsoleNotifier line=14 col=7 end=14:22 file=FILE:<ROOT>/fidelity.ts@1
+node CLASS name=Repository qn=Repository canonical=<ROOT>/fidelity.ts:Repository line=24 col=7 end=24:17 file=FILE:<ROOT>/fidelity.ts@1
+node CLASS name=Workflow qn=Workflow canonical=<ROOT>/fidelity.ts:Workflow line=34 col=7 end=34:15 file=FILE:<ROOT>/fidelity.ts@1
+node ENUM name=WorkflowMode qn=WorkflowMode canonical=<ROOT>/fidelity.ts:WorkflowMode line=6 col=1 end=8:2 file=FILE:<ROOT>/fidelity.ts@1
+node FIELD name=name qn=name canonical=<ROOT>/fidelity.ts:name#0 line=34 col=28 end=34:32 file=FILE:<ROOT>/fidelity.ts@1
+node FIELD name=name qn=name canonical=<ROOT>/fidelity.ts:name#1 line=57 col=37 end=57:41 file=FILE:<ROOT>/fidelity.ts@1
+node FIELD name=name qn=name canonical=<ROOT>/fidelity.ts:name#2 line=58 col=58 end=58:62 file=FILE:<ROOT>/fidelity.ts@1
+node FILE name=<ROOT>/fidelity.ts qn=<ROOT>/fidelity.ts canonical=<ROOT>/fidelity.ts:<ROOT>/fidelity.ts:1 line=1 col=1 end=59:0 file=FILE:<ROOT>/fidelity.ts@1
+node FUNCTION name=orchestrateTs qn=orchestrateTs canonical=<ROOT>/fidelity.ts:orchestrateTs#0 line=56 col=8 end=59:2 file=FILE:<ROOT>/fidelity.ts@1
+node INTERFACE name=Notifier qn=Notifier canonical=<ROOT>/fidelity.ts:Notifier line=10 col=11 end=10:19 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=ConsoleNotifier.notify qn=ConsoleNotifier.notify canonical=<ROOT>/fidelity.ts:ConsoleNotifier.notify#0 line=15 col=5 end=17:6 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=ConsoleNotifier.writeLog qn=ConsoleNotifier.writeLog canonical=<ROOT>/fidelity.ts:ConsoleNotifier.writeLog#0 line=19 col=5 end=21:6 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=Notifier.notify qn=Notifier.notify canonical=<ROOT>/fidelity.ts:Notifier.notify#0 line=11 col=5 end=11:32 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=Repository.save qn=Repository.save canonical=<ROOT>/fidelity.ts:Repository.save#0 line=25 col=5 end=27:6 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=Repository.track qn=Repository.track canonical=<ROOT>/fidelity.ts:Repository.track#0 line=29 col=5 end=31:6 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=Workflow.decorate qn=Workflow.decorate canonical=<ROOT>/fidelity.ts:Workflow.decorate#0 line=51 col=5 end=53:6 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=Workflow.identity qn=Workflow.identity canonical=<ROOT>/fidelity.ts:Workflow.identity#0 line=35 col=5 end=37:6 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=Workflow.run qn=Workflow.run canonical=<ROOT>/fidelity.ts:Workflow.run#0 line=39 col=5 end=44:6 file=FILE:<ROOT>/fidelity.ts@1
+node METHOD name=Workflow.runAsync qn=Workflow.runAsync canonical=<ROOT>/fidelity.ts:Workflow.runAsync#0 line=46 col=5 end=49:6 file=FILE:<ROOT>/fidelity.ts@1
+node MODULE name="fs" qn="fs" canonical=<ROOT>/fidelity.ts:"fs"#0 line=1 col=42 end=1:46 file=FILE:<ROOT>/fidelity.ts@1
+node MODULE name="path" qn="path" canonical=<ROOT>/fidelity.ts:"path"#0 line=2 col=34 end=2:40 file=FILE:<ROOT>/fidelity.ts@1
+node TYPEDEF name=Mapper qn=Mapper canonical=<ROOT>/fidelity.ts:Mapper line=4 col=1 end=4:34 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.ts:decorate#0 line=43 col=14 end=43:22 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=identity qn=identity canonical=<ROOT>/fidelity.ts:identity#0 line=40 col=29 end=40:37 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=join qn=join canonical=<ROOT>/fidelity.ts:join#0 line=2 col=10 end=2:14 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=mapper qn=mapper canonical=<ROOT>/fidelity.ts:mapper#0 line=36 col=16 end=36:22 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.ts:notify#0 line=41 col=18 end=41:24 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=pathJoin qn=pathJoin canonical=<ROOT>/fidelity.ts:pathJoin#0 line=2 col=18 end=2:26 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=pathJoin qn=pathJoin canonical=<ROOT>/fidelity.ts:pathJoin#1 line=52 col=16 end=52:24 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=readFile qn=readFile canonical=<ROOT>/fidelity.ts:readFile#0 line=1 col=26 end=1:34 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=readFileSync qn=readFileSync canonical=<ROOT>/fidelity.ts:readFileSync#0 line=1 col=10 end=1:22 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=resolve qn=resolve canonical=<ROOT>/fidelity.ts:resolve#0 line=48 col=23 end=48:30 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.ts:run#0 line=47 col=14 end=47:17 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.ts:run#1 line=58 col=14 end=58:17 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.ts:save#0 line=42 col=20 end=42:24 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=toString qn=toString canonical=<ROOT>/fidelity.ts:toString#0 line=52 col=71 end=52:79 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=track qn=track canonical=<ROOT>/fidelity.ts:track#0 line=26 col=14 end=26:19 file=FILE:<ROOT>/fidelity.ts@1
+node UNKNOWN name=writeLog qn=writeLog canonical=<ROOT>/fidelity.ts:writeLog#0 line=16 col=14 end=16:22 file=FILE:<ROOT>/fidelity.ts@1
+edge CALL src=FUNCTION:orchestrateTs@56 dst=CLASS:ConsoleNotifier@14 resolved_src=FUNCTION:orchestrateTs@56 resolved_dst=- line=58 confidence=- certainty=- callsite=h0:58:1:h1 candidates=[]
+edge CALL src=FUNCTION:orchestrateTs@56 dst=CLASS:Repository@24 resolved_src=FUNCTION:orchestrateTs@56 resolved_dst=- line=58 confidence=- certainty=- callsite=h0:58:1:h2 candidates=[]
+edge CALL src=FUNCTION:orchestrateTs@56 dst=CLASS:Workflow@34 resolved_src=FUNCTION:orchestrateTs@56 resolved_dst=- line=57 confidence=- certainty=- callsite=h0:57:1:h3 candidates=[]
+edge CALL src=FUNCTION:orchestrateTs@56 dst=METHOD:Workflow.run@39 resolved_src=FUNCTION:orchestrateTs@56 resolved_dst=METHOD:Workflow.run@39 line=58 confidence=1.0000 certainty=Certain callsite=h0:58:1:h4 candidates=[]
+edge CALL src=METHOD:ConsoleNotifier.notify@15 dst=METHOD:ConsoleNotifier.writeLog@19 resolved_src=METHOD:ConsoleNotifier.notify@15 resolved_dst=METHOD:ConsoleNotifier.writeLog@19 line=16 confidence=1.0000 certainty=Certain callsite=h0:16:1:h5 candidates=[]
+edge CALL src=METHOD:Repository.save@25 dst=METHOD:Repository.track@29 resolved_src=METHOD:Repository.save@25 resolved_dst=METHOD:Repository.track@29 line=26 confidence=1.0000 certainty=Certain callsite=h0:26:1:h6 candidates=[]
+edge CALL src=METHOD:Workflow.decorate@51 dst=UNKNOWN:pathJoin@52 resolved_src=METHOD:Workflow.decorate@51 resolved_dst=- line=52 confidence=- certainty=- callsite=h0:52:1:h7 candidates=[]
+edge CALL src=METHOD:Workflow.decorate@51 dst=UNKNOWN:toString@52 resolved_src=METHOD:Workflow.decorate@51 resolved_dst=- line=52 confidence=- certainty=- callsite=h0:52:1:h8|syntax:ts-member-call candidates=[]
+edge CALL src=METHOD:Workflow.identity@35 dst=UNKNOWN:mapper@36 resolved_src=METHOD:Workflow.identity@35 resolved_dst=- line=36 confidence=- certainty=- callsite=h0:36:1:h9 candidates=[]
+edge CALL src=METHOD:Workflow.run@39 dst=METHOD:Notifier.notify@11 resolved_src=METHOD:Workflow.run@39 resolved_dst=METHOD:Notifier.notify@11 line=41 confidence=1.0000 certainty=Certain callsite=h0:41:1:h10 candidates=[]
+edge CALL src=METHOD:Workflow.run@39 dst=METHOD:Repository.save@25 resolved_src=METHOD:Workflow.run@39 resolved_dst=METHOD:Repository.save@25 line=42 confidence=1.0000 certainty=Certain callsite=h0:42:1:h11 candidates=[]
+edge CALL src=METHOD:Workflow.run@39 dst=METHOD:Workflow.decorate@51 resolved_src=METHOD:Workflow.run@39 resolved_dst=METHOD:Workflow.decorate@51 line=43 confidence=1.0000 certainty=Certain callsite=h0:43:1:h12 candidates=[]
+edge CALL src=METHOD:Workflow.run@39 dst=METHOD:Workflow.identity@35 resolved_src=METHOD:Workflow.run@39 resolved_dst=METHOD:Workflow.identity@35 line=40 confidence=1.0000 certainty=Certain callsite=h0:40:1:h13 candidates=[]
+edge CALL src=METHOD:Workflow.runAsync@46 dst=METHOD:Workflow.run@39 resolved_src=METHOD:Workflow.runAsync@46 resolved_dst=METHOD:Workflow.run@39 line=47 confidence=1.0000 certainty=Certain callsite=h0:47:1:h4 candidates=[]
+edge CALL src=METHOD:Workflow.runAsync@46 dst=UNKNOWN:resolve@48 resolved_src=METHOD:Workflow.runAsync@46 resolved_dst=- line=48 confidence=- certainty=- callsite=h0:48:1:h14|syntax:ts-member-call candidates=[]
+edge IMPORT src=MODULE:"fs"@1 dst=MODULE:"fs"@1 resolved_src=MODULE:"fs"@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=MODULE:"path"@2 dst=MODULE:"path"@2 resolved_src=MODULE:"path"@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:join@2 dst=MODULE:"path"@2 resolved_src=UNKNOWN:join@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:pathJoin@2 dst=MODULE:"path"@2 resolved_src=UNKNOWN:pathJoin@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:readFile@1 dst=MODULE:"fs"@1 resolved_src=UNKNOWN:readFile@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:readFileSync@1 dst=MODULE:"fs"@1 resolved_src=UNKNOWN:readFileSync@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ConsoleNotifier@14 dst=INTERFACE:Notifier@10 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@14 dst=METHOD:ConsoleNotifier.notify@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@14 dst=METHOD:ConsoleNotifier.writeLog@19 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@24 dst=METHOD:Repository.save@25 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@24 dst=METHOD:Repository.track@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@34 dst=METHOD:Workflow.decorate@51 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@34 dst=METHOD:Workflow.identity@35 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@34 dst=METHOD:Workflow.run@39 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@34 dst=METHOD:Workflow.runAsync@46 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Notifier@10 dst=METHOD:Notifier.notify@11 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/typescript_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/typescript_tictactoe.txt
@@ -1,0 +1,403 @@
+node CLASS name=ArtificialPlayer qn=ArtificialPlayer canonical=game.ts:ArtificialPlayer line=184 col=7 end=184:23 file=FILE:game.ts@1
+node CLASS name=Field qn=Field canonical=game.ts:Field line=29 col=7 end=29:12 file=FILE:game.ts@1
+node CLASS name=GameObject qn=GameObject canonical=game.ts:GameObject line=23 col=7 end=23:17 file=FILE:game.ts@1
+node CLASS name=HumanPlayer qn=HumanPlayer canonical=game.ts:HumanPlayer line=154 col=7 end=154:18 file=FILE:game.ts@1
+node CLASS name=Player qn=Player canonical=game.ts:Player line=154 col=27 end=154:33 file=FILE:game.ts@1
+node CLASS name=TicTacToe qn=TicTacToe canonical=game.ts:TicTacToe line=238 col=14 end=238:23 file=FILE:game.ts@1
+node FIELD name=Token qn=Token canonical=game.ts:Token#0 line=30 col=10 end=30:15 file=FILE:game.ts@1
+node FIELD name=col qn=col canonical=game.ts:col#0 line=8 col=3 end=8:6 file=FILE:game.ts@1
+node FIELD name=field qn=field canonical=game.ts:field#0 line=239 col=11 end=239:16 file=FILE:game.ts@1
+node FIELD name=grid qn=grid canonical=game.ts:grid#0 line=36 col=11 end=36:15 file=FILE:game.ts@1
+node FIELD name=left qn=left canonical=game.ts:left#0 line=37 col=11 end=37:15 file=FILE:game.ts@1
+node FIELD name=move qn=move canonical=game.ts:move#0 line=198 col=41 end=198:45 file=FILE:game.ts@1
+node FIELD name=name qn=name canonical=game.ts:name#0 line=143 col=3 end=143:7 file=FILE:game.ts@1
+node FIELD name=players qn=players canonical=game.ts:players#0 line=240 col=11 end=240:18 file=FILE:game.ts@1
+node FIELD name=row qn=row canonical=game.ts:row#0 line=7 col=3 end=7:6 file=FILE:game.ts@1
+node FIELD name=token qn=token canonical=game.ts:token#0 line=142 col=3 end=142:8 file=FILE:game.ts@1
+node FIELD name=value qn=value canonical=game.ts:value#0 line=198 col=53 end=198:58 file=FILE:game.ts@1
+node FILE name=game.ts qn=game.ts canonical=game.ts:game.ts:1 line=1 col=1 end=309:0 file=FILE:game.ts@1
+node FUNCTION name=main qn=main canonical=game.ts:main#0 line=304 col=8 end=309:2 file=FILE:game.ts@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.ts:numberIn#0 line=11 col=1 end=13:2 file=FILE:game.ts@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.ts:numberOut#0 line=15 col=1 end=17:2 file=FILE:game.ts@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.ts:stringOut#0 line=19 col=1 end=21:2 file=FILE:game.ts@1
+node METHOD name=ArtificialPlayer.evaluate qn=ArtificialPlayer.evaluate canonical=game.ts:ArtificialPlayer.evaluate#0 line=185 col=3 end=196:4 file=FILE:game.ts@1
+node METHOD name=ArtificialPlayer.minMax qn=ArtificialPlayer.minMax canonical=game.ts:ArtificialPlayer.minMax#0 line=198 col=3 end=229:4 file=FILE:game.ts@1
+node METHOD name=ArtificialPlayer.turn qn=ArtificialPlayer.turn canonical=game.ts:ArtificialPlayer.turn#0 line=231 col=3 end=235:4 file=FILE:game.ts@1
+node METHOD name=Field.clearMove qn=Field.clearMove canonical=game.ts:Field.clearMove#0 line=109 col=3 end=115:4 file=FILE:game.ts@1
+node METHOD name=Field.cloneField qn=Field.cloneField canonical=game.ts:Field.cloneField#0 line=45 col=3 end=54:4 file=FILE:game.ts@1
+node METHOD name=Field.constructor qn=Field.constructor canonical=game.ts:Field.constructor#0 line=39 col=3 end=43:4 file=FILE:game.ts@1
+node METHOD name=Field.inRange qn=Field.inRange canonical=game.ts:Field.inRange#0 line=66 col=3 end=68:4 file=FILE:game.ts@1
+node METHOD name=Field.isDraw qn=Field.isDraw canonical=game.ts:Field.isDraw#0 line=74 col=3 end=76:4 file=FILE:game.ts@1
+node METHOD name=Field.isEmpty qn=Field.isEmpty canonical=game.ts:Field.isEmpty#0 line=70 col=3 end=72:4 file=FILE:game.ts@1
+node METHOD name=Field.makeMove qn=Field.makeMove canonical=game.ts:Field.makeMove#0 line=98 col=3 end=107:4 file=FILE:game.ts@1
+node METHOD name=Field.opponent qn=Field.opponent canonical=game.ts:Field.opponent#0 line=56 col=3 end=64:4 file=FILE:game.ts@1
+node METHOD name=Field.sameInRow qn=Field.sameInRow canonical=game.ts:Field.sameInRow#0 line=78 col=3 end=96:4 file=FILE:game.ts@1
+node METHOD name=Field.show qn=Field.show canonical=game.ts:Field.show#0 line=117 col=3 end=138:4 file=FILE:game.ts@1
+node METHOD name=GameObject.announce qn=GameObject.announce canonical=game.ts:GameObject.announce#0 line=24 col=3 end=26:4 file=FILE:game.ts@1
+node METHOD name=HumanPlayer.check qn=HumanPlayer.check canonical=game.ts:HumanPlayer.check#0 line=159 col=3 end=169:4 file=FILE:game.ts@1
+node METHOD name=HumanPlayer.input qn=HumanPlayer.input canonical=game.ts:HumanPlayer.input#0 line=155 col=3 end=157:4 file=FILE:game.ts@1
+node METHOD name=HumanPlayer.turn qn=HumanPlayer.turn canonical=game.ts:HumanPlayer.turn#0 line=171 col=3 end=181:4 file=FILE:game.ts@1
+node METHOD name=TicTacToe.checkWinner qn=TicTacToe.checkWinner canonical=game.ts:TicTacToe.checkWinner#0 line=248 col=3 end=250:4 file=FILE:game.ts@1
+node METHOD name=TicTacToe.constructor qn=TicTacToe.constructor canonical=game.ts:TicTacToe.constructor#0 line=242 col=3 end=246:4 file=FILE:game.ts@1
+node METHOD name=TicTacToe.isDraw qn=TicTacToe.isDraw canonical=game.ts:TicTacToe.isDraw#0 line=252 col=3 end=254:4 file=FILE:game.ts@1
+node METHOD name=TicTacToe.probeCalls qn=TicTacToe.probeCalls canonical=game.ts:TicTacToe.probeCalls#0 line=273 col=3 end=275:4 file=FILE:game.ts@1
+node METHOD name=TicTacToe.run qn=TicTacToe.run canonical=game.ts:TicTacToe.run#0 line=277 col=3 end=301:4 file=FILE:game.ts@1
+node METHOD name=TicTacToe.selectPlayer qn=TicTacToe.selectPlayer canonical=game.ts:TicTacToe.selectPlayer#0 line=256 col=3 end=265:4 file=FILE:game.ts@1
+node METHOD name=TicTacToe.start qn=TicTacToe.start canonical=game.ts:TicTacToe.start#0 line=267 col=3 end=271:4 file=FILE:game.ts@1
+node METHOD name=constructor qn=constructor canonical=game.ts:constructor#0 line=145 col=3 end=149:4 file=FILE:game.ts@1
+node MODULE name="./helper" qn="./helper" canonical=game.ts:"./helper"#0 line=2 col=24 end=2:34 file=FILE:game.ts@1
+node MODULE name="./random" qn="./random" canonical=game.ts:"./random"#0 line=1 col=27 end=1:37 file=FILE:game.ts@1
+node TYPEDEF name=Move qn=Move canonical=game.ts:Move line=6 col=1 end=9:3 file=FILE:game.ts@1
+node TYPEDEF name=Token qn=Token canonical=game.ts:Token line=4 col=1 end=4:24 file=FILE:game.ts@1
+node UNKNOWN name=Array qn=Array canonical=game.ts:Array#0 line=41 col=49 end=41:54 file=FILE:game.ts@1
+node UNKNOWN name=Boolean qn=Boolean canonical=game.ts:Boolean#0 line=270 col=12 end=270:19 file=FILE:game.ts@1
+node UNKNOWN name=String qn=String canonical=game.ts:String#0 line=16 col=24 end=16:30 file=FILE:game.ts@1
+node UNKNOWN name=announce qn=announce canonical=game.ts:announce#0 line=290 col=14 end=290:22 file=FILE:game.ts@1
+node UNKNOWN name=announce qn=announce canonical=game.ts:announce#1 line=295 col=14 end=295:22 file=FILE:game.ts@1
+node UNKNOWN name=check qn=check canonical=game.ts:check#0 line=176 col=12 end=176:17 file=FILE:game.ts@1
+node UNKNOWN name=check qn=check canonical=game.ts:check#1 line=177 col=16 end=177:21 file=FILE:game.ts@1
+node UNKNOWN name=checkWinner qn=checkWinner canonical=game.ts:checkWinner#0 line=274 col=10 end=274:21 file=FILE:game.ts@1
+node UNKNOWN name=checkWinner qn=checkWinner canonical=game.ts:checkWinner#1 line=287 col=12 end=287:23 file=FILE:game.ts@1
+node UNKNOWN name=checkWinner qn=checkWinner canonical=game.ts:checkWinner#2 line=289 col=16 end=289:27 file=FILE:game.ts@1
+node UNKNOWN name=clearMove qn=clearMove canonical=game.ts:clearMove#0 line=214 col=15 end=214:24 file=FILE:game.ts@1
+node UNKNOWN name=cloneField qn=cloneField canonical=game.ts:cloneField#0 line=232 col=24 end=232:34 file=FILE:game.ts@1
+node UNKNOWN name=evaluate qn=evaluate canonical=game.ts:evaluate#0 line=210 col=30 end=210:38 file=FILE:game.ts@1
+node UNKNOWN name=fill qn=fill canonical=game.ts:fill#0 line=41 col=65 end=41:69 file=FILE:game.ts@1
+node UNKNOWN name=from qn=from canonical=game.ts:from#0 line=41 col=23 end=41:27 file=FILE:game.ts@1
+node UNKNOWN name=helper qn=helper canonical=game.ts:helper#0 line=2 col=10 end=2:16 file=FILE:game.ts@1
+node UNKNOWN name=helper qn=helper canonical=game.ts:helper#1 line=25 col=5 end=25:11 file=FILE:game.ts@1
+node UNKNOWN name=inRange qn=inRange canonical=game.ts:inRange#0 line=99 col=15 end=99:22 file=FILE:game.ts@1
+node UNKNOWN name=inRange qn=inRange canonical=game.ts:inRange#1 line=110 col=15 end=110:22 file=FILE:game.ts@1
+node UNKNOWN name=inRange qn=inRange canonical=game.ts:inRange#2 line=160 col=16 end=160:23 file=FILE:game.ts@1
+node UNKNOWN name=input qn=input canonical=game.ts:input#0 line=175 col=25 end=175:30 file=FILE:game.ts@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.ts:isDraw#0 line=105 col=10 end=105:16 file=FILE:game.ts@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.ts:isDraw#1 line=211 col=39 end=211:45 file=FILE:game.ts@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.ts:isDraw#2 line=253 col=23 end=253:29 file=FILE:game.ts@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.ts:isDraw#3 line=288 col=12 end=288:18 file=FILE:game.ts@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.ts:isDraw#4 line=294 col=16 end=294:22 file=FILE:game.ts@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.ts:isEmpty#0 line=99 col=38 end=99:45 file=FILE:game.ts@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.ts:isEmpty#1 line=110 col=37 end=110:44 file=FILE:game.ts@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.ts:isEmpty#2 line=164 col=16 end=164:23 file=FILE:game.ts@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.ts:isEmpty#3 line=205 col=20 end=205:27 file=FILE:game.ts@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.ts:makeMove#0 line=209 col=15 end=209:23 file=FILE:game.ts@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.ts:makeMove#1 line=286 col=18 end=286:26 file=FILE:game.ts@1
+node UNKNOWN name=minMax qn=minMax canonical=game.ts:minMax#0 line=212 col=29 end=212:35 file=FILE:game.ts@1
+node UNKNOWN name=minMax qn=minMax canonical=game.ts:minMax#1 line=233 col=23 end=233:29 file=FILE:game.ts@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.ts:numberIn#1 line=156 col=40 end=156:48 file=FILE:game.ts@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.ts:numberIn#2 line=257 col=23 end=257:31 file=FILE:game.ts@1
+node UNKNOWN name=numberOut qn=numberOut canonical=game.ts:numberOut#1 line=120 col=7 end=120:16 file=FILE:game.ts@1
+node UNKNOWN name=opponent qn=opponent canonical=game.ts:opponent#0 line=189 col=31 end=189:39 file=FILE:game.ts@1
+node UNKNOWN name=opponent qn=opponent canonical=game.ts:opponent#1 line=212 col=49 end=212:57 file=FILE:game.ts@1
+node UNKNOWN name=randomInt qn=randomInt canonical=game.ts:randomInt#0 line=1 col=10 end=1:19 file=FILE:game.ts@1
+node UNKNOWN name=randomInt qn=randomInt canonical=game.ts:randomInt#1 line=221 col=15 end=221:24 file=FILE:game.ts@1
+node UNKNOWN name=run qn=run canonical=game.ts:run#0 line=307 col=10 end=307:13 file=FILE:game.ts@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.ts:sameInRow#0 line=104 col=10 end=104:19 file=FILE:game.ts@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.ts:sameInRow#1 line=186 col=15 end=186:24 file=FILE:game.ts@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.ts:sameInRow#2 line=189 col=15 end=189:24 file=FILE:game.ts@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.ts:sameInRow#3 line=192 col=15 end=192:24 file=FILE:game.ts@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.ts:sameInRow#4 line=249 col=23 end=249:32 file=FILE:game.ts@1
+node UNKNOWN name=selectPlayer qn=selectPlayer canonical=game.ts:selectPlayer#0 line=268 col=28 end=268:40 file=FILE:game.ts@1
+node UNKNOWN name=selectPlayer qn=selectPlayer canonical=game.ts:selectPlayer#1 line=269 col=28 end=269:40 file=FILE:game.ts@1
+node UNKNOWN name=show qn=show canonical=game.ts:show#0 line=278 col=16 end=278:20 file=FILE:game.ts@1
+node UNKNOWN name=start qn=start canonical=game.ts:start#0 line=306 col=12 end=306:17 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#1 line=118 col=5 end=118:14 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#10 line=165 col=7 end=165:16 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#11 line=172 col=5 end=172:14 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#12 line=173 col=5 end=173:14 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#13 line=291 col=9 end=291:18 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#14 line=296 col=9 end=296:18 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#2 line=121 col=7 end=121:16 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#3 line=125 col=11 end=125:20 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#4 line=127 col=11 end=127:20 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#5 line=129 col=11 end=129:20 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#6 line=132 col=11 end=132:20 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#7 line=135 col=7 end=135:16 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#8 line=137 col=5 end=137:14 file=FILE:game.ts@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.ts:stringOut#9 line=161 col=7 end=161:16 file=FILE:game.ts@1
+node UNKNOWN name=turn qn=turn canonical=game.ts:turn#0 line=285 col=27 end=285:31 file=FILE:game.ts@1
+node UNKNOWN name=write qn=write canonical=game.ts:write#0 line=16 col=18 end=16:23 file=FILE:game.ts@1
+node UNKNOWN name=write qn=write canonical=game.ts:write#1 line=20 col=18 end=20:23 file=FILE:game.ts@1
+edge CALL src=FUNCTION:main@304 dst=CLASS:TicTacToe@238 resolved_src=- resolved_dst=- line=305 confidence=- certainty=- callsite=h0:305:1:h1 candidates=[]
+edge CALL src=FUNCTION:main@304 dst=METHOD:TicTacToe.run@277 resolved_src=- resolved_dst=METHOD:TicTacToe.run@277 line=307 confidence=1.0000 certainty=Certain callsite=h0:307:1:h2 candidates=[]
+edge CALL src=FUNCTION:main@304 dst=METHOD:TicTacToe.start@267 resolved_src=- resolved_dst=METHOD:TicTacToe.start@267 line=306 confidence=1.0000 certainty=Certain callsite=h0:306:1:h3 candidates=[]
+edge CALL src=FUNCTION:numberOut@15 dst=UNKNOWN:String@16 resolved_src=- resolved_dst=- line=16 confidence=- certainty=- callsite=h0:16:1:h4 candidates=[]
+edge CALL src=FUNCTION:numberOut@15 dst=UNKNOWN:write@16 resolved_src=- resolved_dst=- line=16 confidence=- certainty=- callsite=h0:16:1:h5|syntax:ts-member-call candidates=[]
+edge CALL src=FUNCTION:stringOut@19 dst=UNKNOWN:write@20 resolved_src=- resolved_dst=- line=20 confidence=- certainty=- callsite=h0:20:1:h6|syntax:ts-member-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@185 dst=METHOD:Field.opponent@56 resolved_src=- resolved_dst=METHOD:Field.opponent@56 line=189 confidence=1.0000 certainty=Certain callsite=h0:189:1:h7 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@185 dst=METHOD:Field.sameInRow@78 resolved_src=- resolved_dst=METHOD:Field.sameInRow@78 line=186 confidence=1.0000 certainty=Certain callsite=h0:186:1:h8 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@185 dst=METHOD:Field.sameInRow@78 resolved_src=- resolved_dst=METHOD:Field.sameInRow@78 line=189 confidence=1.0000 certainty=Certain callsite=h0:189:1:h8 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@185 dst=METHOD:Field.sameInRow@78 resolved_src=- resolved_dst=METHOD:Field.sameInRow@78 line=192 confidence=1.0000 certainty=Certain callsite=h0:192:1:h8 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@198 dst=METHOD:ArtificialPlayer.evaluate@185 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.evaluate@185 line=210 confidence=1.0000 certainty=Certain callsite=h0:210:1:h9 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@198 dst=METHOD:Field.clearMove@109 resolved_src=- resolved_dst=METHOD:Field.clearMove@109 line=214 confidence=1.0000 certainty=Certain callsite=h0:214:1:h10 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@198 dst=METHOD:Field.isDraw@74 resolved_src=- resolved_dst=METHOD:Field.isDraw@74 line=211 confidence=1.0000 certainty=Certain callsite=h0:211:1:h11 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@198 dst=METHOD:Field.isEmpty@70 resolved_src=- resolved_dst=METHOD:Field.isEmpty@70 line=205 confidence=1.0000 certainty=Certain callsite=h0:205:1:h12 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@198 dst=METHOD:Field.makeMove@98 resolved_src=- resolved_dst=METHOD:Field.makeMove@98 line=209 confidence=1.0000 certainty=Certain callsite=h0:209:1:h13 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@198 dst=METHOD:Field.opponent@56 resolved_src=- resolved_dst=METHOD:Field.opponent@56 line=212 confidence=1.0000 certainty=Certain callsite=h0:212:1:h7 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@198 dst=UNKNOWN:randomInt@221 resolved_src=- resolved_dst=- line=221 confidence=- certainty=- callsite=h0:221:1:h14 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@231 dst=METHOD:ArtificialPlayer.minMax@198 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.minMax@198 line=233 confidence=1.0000 certainty=Certain callsite=h0:233:1:h15 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@231 dst=METHOD:Field.cloneField@45 resolved_src=- resolved_dst=METHOD:Field.cloneField@45 line=232 confidence=1.0000 certainty=Certain callsite=h0:232:1:h16 candidates=[]
+edge CALL src=METHOD:Field.clearMove@109 dst=METHOD:Field.inRange@66 resolved_src=- resolved_dst=METHOD:Field.inRange@66 line=110 confidence=1.0000 certainty=Certain callsite=h0:110:1:h17 candidates=[]
+edge CALL src=METHOD:Field.clearMove@109 dst=METHOD:Field.isEmpty@70 resolved_src=- resolved_dst=METHOD:Field.isEmpty@70 line=110 confidence=1.0000 certainty=Certain callsite=h0:110:1:h12 candidates=[]
+edge CALL src=METHOD:Field.cloneField@45 dst=CLASS:Field@29 resolved_src=- resolved_dst=- line=46 confidence=- certainty=- callsite=h0:46:1:h18 candidates=[]
+edge CALL src=METHOD:Field.constructor@39 dst=CLASS:Field@29 resolved_src=- resolved_dst=- line=244 confidence=- certainty=- callsite=h0:244:1:h18 candidates=[]
+edge CALL src=METHOD:Field.constructor@39 dst=UNKNOWN:Array@41 resolved_src=- resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:1:h19 candidates=[]
+edge CALL src=METHOD:Field.constructor@39 dst=UNKNOWN:fill@41 resolved_src=- resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:1:h20|syntax:ts-member-call candidates=[]
+edge CALL src=METHOD:Field.constructor@39 dst=UNKNOWN:from@41 resolved_src=- resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:1:h21|syntax:ts-member-call candidates=[]
+edge CALL src=METHOD:Field.makeMove@98 dst=METHOD:Field.inRange@66 resolved_src=- resolved_dst=METHOD:Field.inRange@66 line=99 confidence=1.0000 certainty=Certain callsite=h0:99:1:h17 candidates=[]
+edge CALL src=METHOD:Field.makeMove@98 dst=METHOD:Field.isDraw@74 resolved_src=- resolved_dst=METHOD:Field.isDraw@74 line=105 confidence=1.0000 certainty=Certain callsite=h0:105:1:h11 candidates=[]
+edge CALL src=METHOD:Field.makeMove@98 dst=METHOD:Field.isEmpty@70 resolved_src=- resolved_dst=METHOD:Field.isEmpty@70 line=99 confidence=1.0000 certainty=Certain callsite=h0:99:1:h12 candidates=[]
+edge CALL src=METHOD:Field.makeMove@98 dst=METHOD:Field.sameInRow@78 resolved_src=- resolved_dst=METHOD:Field.sameInRow@78 line=104 confidence=1.0000 certainty=Certain callsite=h0:104:1:h8 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:numberOut@120 resolved_src=- resolved_dst=- line=120 confidence=- certainty=- callsite=h0:120:1:h22 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:stringOut@118 resolved_src=- resolved_dst=- line=118 confidence=- certainty=- callsite=h0:118:1:h23 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:stringOut@121 resolved_src=- resolved_dst=- line=121 confidence=- certainty=- callsite=h0:121:1:h24 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:stringOut@125 resolved_src=- resolved_dst=- line=125 confidence=- certainty=- callsite=h0:125:1:h25 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:stringOut@127 resolved_src=- resolved_dst=- line=127 confidence=- certainty=- callsite=h0:127:1:h26 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:stringOut@129 resolved_src=- resolved_dst=- line=129 confidence=- certainty=- callsite=h0:129:1:h27 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:stringOut@132 resolved_src=- resolved_dst=- line=132 confidence=- certainty=- callsite=h0:132:1:h28 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:stringOut@135 resolved_src=- resolved_dst=- line=135 confidence=- certainty=- callsite=h0:135:1:h29 candidates=[]
+edge CALL src=METHOD:Field.show@117 dst=UNKNOWN:stringOut@137 resolved_src=- resolved_dst=- line=137 confidence=- certainty=- callsite=h0:137:1:h30 candidates=[]
+edge CALL src=METHOD:GameObject.announce@24 dst=UNKNOWN:helper@25 resolved_src=- resolved_dst=- line=25 confidence=- certainty=- callsite=h0:25:1:h31 candidates=[]
+edge CALL src=METHOD:HumanPlayer.check@159 dst=METHOD:Field.inRange@66 resolved_src=- resolved_dst=METHOD:Field.inRange@66 line=160 confidence=1.0000 certainty=Certain callsite=h0:160:1:h17 candidates=[]
+edge CALL src=METHOD:HumanPlayer.check@159 dst=METHOD:Field.isEmpty@70 resolved_src=- resolved_dst=METHOD:Field.isEmpty@70 line=164 confidence=1.0000 certainty=Certain callsite=h0:164:1:h12 candidates=[]
+edge CALL src=METHOD:HumanPlayer.check@159 dst=UNKNOWN:stringOut@161 resolved_src=- resolved_dst=- line=161 confidence=- certainty=- callsite=h0:161:1:h32 candidates=[]
+edge CALL src=METHOD:HumanPlayer.check@159 dst=UNKNOWN:stringOut@165 resolved_src=- resolved_dst=- line=165 confidence=- certainty=- callsite=h0:165:1:h33 candidates=[]
+edge CALL src=METHOD:HumanPlayer.input@155 dst=UNKNOWN:numberIn@156 resolved_src=- resolved_dst=- line=156 confidence=- certainty=- callsite=h0:156:1:h34 candidates=[]
+edge CALL src=METHOD:HumanPlayer.input@155 dst=UNKNOWN:numberIn@156 resolved_src=- resolved_dst=- line=156 confidence=- certainty=- callsite=h0:156:2:h34 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@171 dst=METHOD:HumanPlayer.check@159 resolved_src=- resolved_dst=METHOD:HumanPlayer.check@159 line=176 confidence=1.0000 certainty=Certain callsite=h0:176:1:h35 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@171 dst=METHOD:HumanPlayer.check@159 resolved_src=- resolved_dst=METHOD:HumanPlayer.check@159 line=177 confidence=1.0000 certainty=Certain callsite=h0:177:1:h35 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@171 dst=METHOD:HumanPlayer.input@155 resolved_src=- resolved_dst=METHOD:HumanPlayer.input@155 line=175 confidence=1.0000 certainty=Certain callsite=h0:175:1:h36 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@171 dst=UNKNOWN:stringOut@172 resolved_src=- resolved_dst=- line=172 confidence=- certainty=- callsite=h0:172:1:h37 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@171 dst=UNKNOWN:stringOut@173 resolved_src=- resolved_dst=- line=173 confidence=- certainty=- callsite=h0:173:1:h38 candidates=[]
+edge CALL src=METHOD:TicTacToe.checkWinner@248 dst=METHOD:Field.sameInRow@78 resolved_src=- resolved_dst=METHOD:Field.sameInRow@78 line=249 confidence=1.0000 certainty=Certain callsite=h0:249:1:h8 candidates=[]
+edge CALL src=METHOD:TicTacToe.isDraw@252 dst=METHOD:Field.isDraw@74 resolved_src=- resolved_dst=METHOD:Field.isDraw@74 line=253 confidence=1.0000 certainty=Certain callsite=h0:253:1:h11 candidates=[]
+edge CALL src=METHOD:TicTacToe.probeCalls@273 dst=METHOD:TicTacToe.checkWinner@248 resolved_src=- resolved_dst=METHOD:TicTacToe.checkWinner@248 line=274 confidence=1.0000 certainty=Certain callsite=h0:274:1:h39 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=METHOD:Field.makeMove@98 resolved_src=- resolved_dst=METHOD:Field.makeMove@98 line=286 confidence=1.0000 certainty=Certain callsite=h0:286:1:h13 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=METHOD:Field.show@117 resolved_src=- resolved_dst=METHOD:Field.show@117 line=278 confidence=1.0000 certainty=Certain callsite=h0:278:1:h40 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=METHOD:TicTacToe.checkWinner@248 resolved_src=- resolved_dst=METHOD:TicTacToe.checkWinner@248 line=287 confidence=1.0000 certainty=Certain callsite=h0:287:1:h39 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=METHOD:TicTacToe.checkWinner@248 resolved_src=- resolved_dst=METHOD:TicTacToe.checkWinner@248 line=289 confidence=1.0000 certainty=Certain callsite=h0:289:1:h39 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=METHOD:TicTacToe.isDraw@252 resolved_src=- resolved_dst=METHOD:TicTacToe.isDraw@252 line=288 confidence=1.0000 certainty=Certain callsite=h0:288:1:h41 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=METHOD:TicTacToe.isDraw@252 resolved_src=- resolved_dst=METHOD:TicTacToe.isDraw@252 line=294 confidence=1.0000 certainty=Certain callsite=h0:294:1:h41 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=UNKNOWN:announce@290 resolved_src=- resolved_dst=- line=290 confidence=- certainty=- callsite=h0:290:1:h42|syntax:ts-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=UNKNOWN:announce@295 resolved_src=- resolved_dst=- line=295 confidence=- certainty=- callsite=h0:295:1:h43|syntax:ts-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=UNKNOWN:stringOut@291 resolved_src=- resolved_dst=- line=291 confidence=- certainty=- callsite=h0:291:1:h44 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=UNKNOWN:stringOut@296 resolved_src=- resolved_dst=- line=296 confidence=- certainty=- callsite=h0:296:1:h45 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@277 dst=UNKNOWN:turn@285 resolved_src=- resolved_dst=- line=285 confidence=- certainty=- callsite=h0:285:1:h46|syntax:ts-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.selectPlayer@256 dst=CLASS:ArtificialPlayer@184 resolved_src=- resolved_dst=- line=262 confidence=- certainty=- callsite=h0:262:1:h47 candidates=[]
+edge CALL src=METHOD:TicTacToe.selectPlayer@256 dst=CLASS:HumanPlayer@154 resolved_src=- resolved_dst=- line=259 confidence=- certainty=- callsite=h0:259:1:h48 candidates=[]
+edge CALL src=METHOD:TicTacToe.selectPlayer@256 dst=UNKNOWN:numberIn@257 resolved_src=- resolved_dst=- line=257 confidence=- certainty=- callsite=h0:257:1:h49 candidates=[]
+edge CALL src=METHOD:TicTacToe.start@267 dst=METHOD:TicTacToe.selectPlayer@256 resolved_src=- resolved_dst=METHOD:TicTacToe.selectPlayer@256 line=268 confidence=1.0000 certainty=Certain callsite=h0:268:1:h50 candidates=[]
+edge CALL src=METHOD:TicTacToe.start@267 dst=METHOD:TicTacToe.selectPlayer@256 resolved_src=- resolved_dst=METHOD:TicTacToe.selectPlayer@256 line=269 confidence=1.0000 certainty=Certain callsite=h0:269:1:h50 candidates=[]
+edge CALL src=METHOD:TicTacToe.start@267 dst=UNKNOWN:Boolean@270 resolved_src=- resolved_dst=- line=270 confidence=- certainty=- callsite=h0:270:1:h51 candidates=[]
+edge IMPORT src=MODULE:"./helper"@2 dst=MODULE:"./helper"@2 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=MODULE:"./random"@1 dst=MODULE:"./random"@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:helper@2 dst=MODULE:"./helper"@2 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:randomInt@1 dst=MODULE:"./random"@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ArtificialPlayer@184 dst=CLASS:Player@154 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@29 dst=CLASS:GameObject@23 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:HumanPlayer@154 dst=CLASS:Player@154 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:TicTacToe@238 dst=CLASS:GameObject@23 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@184 dst=METHOD:ArtificialPlayer.evaluate@185 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@184 dst=METHOD:ArtificialPlayer.minMax@198 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@184 dst=METHOD:ArtificialPlayer.turn@231 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.clearMove@109 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.cloneField@45 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.constructor@39 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.inRange@66 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.isDraw@74 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.isEmpty@70 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.makeMove@98 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.opponent@56 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.sameInRow@78 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.show@117 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:GameObject@23 dst=METHOD:GameObject.announce@24 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@154 dst=METHOD:HumanPlayer.check@159 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@154 dst=METHOD:HumanPlayer.input@155 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@154 dst=METHOD:HumanPlayer.turn@171 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@238 dst=METHOD:TicTacToe.checkWinner@248 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@238 dst=METHOD:TicTacToe.constructor@242 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@238 dst=METHOD:TicTacToe.isDraw@252 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@238 dst=METHOD:TicTacToe.probeCalls@273 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@238 dst=METHOD:TicTacToe.run@277 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@238 dst=METHOD:TicTacToe.selectPlayer@256 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@238 dst=METHOD:TicTacToe.start@267 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.ts language=typescript lines=309 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@184 kind=DEFINITION span=184:7-184:23
+occurrence element=CLASS:Field@29 kind=DEFINITION span=29:7-29:12
+occurrence element=CLASS:GameObject@23 kind=DEFINITION span=238:32-238:42
+occurrence element=CLASS:GameObject@23 kind=DEFINITION span=23:7-23:17
+occurrence element=CLASS:GameObject@23 kind=DEFINITION span=29:21-29:31
+occurrence element=CLASS:HumanPlayer@154 kind=DEFINITION span=154:7-154:18
+occurrence element=CLASS:Player@154 kind=DEFINITION span=154:27-154:33
+occurrence element=CLASS:Player@154 kind=DEFINITION span=184:32-184:38
+occurrence element=CLASS:TicTacToe@238 kind=DEFINITION span=238:14-238:23
+occurrence element=FIELD:Token@30 kind=DEFINITION span=30:10-30:15
+occurrence element=FIELD:col@8 kind=DEFINITION span=8:3-8:6
+occurrence element=FIELD:field@239 kind=DEFINITION span=239:11-239:16
+occurrence element=FIELD:grid@36 kind=DEFINITION span=36:11-36:15
+occurrence element=FIELD:left@37 kind=DEFINITION span=37:11-37:15
+occurrence element=FIELD:move@198 kind=DEFINITION span=198:41-198:45
+occurrence element=FIELD:name@143 kind=DEFINITION span=143:3-143:7
+occurrence element=FIELD:players@240 kind=DEFINITION span=240:11-240:18
+occurrence element=FIELD:row@7 kind=DEFINITION span=7:3-7:6
+occurrence element=FIELD:token@142 kind=DEFINITION span=142:3-142:8
+occurrence element=FIELD:value@198 kind=DEFINITION span=198:53-198:58
+occurrence element=FUNCTION:main@304 kind=DEFINITION span=304:8-309:2
+occurrence element=FUNCTION:numberIn@11 kind=DEFINITION span=11:1-13:2
+occurrence element=FUNCTION:numberOut@15 kind=DEFINITION span=15:1-17:2
+occurrence element=FUNCTION:stringOut@19 kind=DEFINITION span=19:1-21:2
+occurrence element=METHOD:ArtificialPlayer.evaluate@185 kind=DEFINITION span=185:3-196:4
+occurrence element=METHOD:ArtificialPlayer.minMax@198 kind=DEFINITION span=198:3-229:4
+occurrence element=METHOD:ArtificialPlayer.turn@231 kind=DEFINITION span=231:3-235:4
+occurrence element=METHOD:Field.clearMove@109 kind=DEFINITION span=109:3-115:4
+occurrence element=METHOD:Field.cloneField@45 kind=DEFINITION span=45:3-54:4
+occurrence element=METHOD:Field.constructor@39 kind=DEFINITION span=39:3-43:4
+occurrence element=METHOD:Field.inRange@66 kind=DEFINITION span=66:3-68:4
+occurrence element=METHOD:Field.isDraw@74 kind=DEFINITION span=74:3-76:4
+occurrence element=METHOD:Field.isEmpty@70 kind=DEFINITION span=70:3-72:4
+occurrence element=METHOD:Field.makeMove@98 kind=DEFINITION span=98:3-107:4
+occurrence element=METHOD:Field.opponent@56 kind=DEFINITION span=56:3-64:4
+occurrence element=METHOD:Field.sameInRow@78 kind=DEFINITION span=78:3-96:4
+occurrence element=METHOD:Field.show@117 kind=DEFINITION span=117:3-138:4
+occurrence element=METHOD:GameObject.announce@24 kind=DEFINITION span=24:3-26:4
+occurrence element=METHOD:HumanPlayer.check@159 kind=DEFINITION span=159:3-169:4
+occurrence element=METHOD:HumanPlayer.input@155 kind=DEFINITION span=155:3-157:4
+occurrence element=METHOD:HumanPlayer.turn@171 kind=DEFINITION span=171:3-181:4
+occurrence element=METHOD:TicTacToe.checkWinner@248 kind=DEFINITION span=248:3-250:4
+occurrence element=METHOD:TicTacToe.constructor@242 kind=DEFINITION span=242:3-246:4
+occurrence element=METHOD:TicTacToe.isDraw@252 kind=DEFINITION span=252:3-254:4
+occurrence element=METHOD:TicTacToe.probeCalls@273 kind=DEFINITION span=273:3-275:4
+occurrence element=METHOD:TicTacToe.run@277 kind=DEFINITION span=277:3-301:4
+occurrence element=METHOD:TicTacToe.selectPlayer@256 kind=DEFINITION span=256:3-265:4
+occurrence element=METHOD:TicTacToe.start@267 kind=DEFINITION span=267:3-271:4
+occurrence element=METHOD:constructor@145 kind=DEFINITION span=145:3-149:4
+occurrence element=MODULE:"./helper"@2 kind=DEFINITION span=2:24-2:34
+occurrence element=MODULE:"./random"@1 kind=DEFINITION span=1:27-1:37
+occurrence element=TYPEDEF:Move@6 kind=DEFINITION span=6:1-9:3
+occurrence element=TYPEDEF:Token@4 kind=DEFINITION span=4:1-4:24
+occurrence element=UNKNOWN:Array@41 kind=DEFINITION span=41:49-41:54
+occurrence element=UNKNOWN:Boolean@270 kind=DEFINITION span=270:12-270:19
+occurrence element=UNKNOWN:String@16 kind=DEFINITION span=16:24-16:30
+occurrence element=UNKNOWN:announce@290 kind=DEFINITION span=290:14-290:22
+occurrence element=UNKNOWN:announce@295 kind=DEFINITION span=295:14-295:22
+occurrence element=UNKNOWN:check@176 kind=DEFINITION span=176:12-176:17
+occurrence element=UNKNOWN:check@177 kind=DEFINITION span=177:16-177:21
+occurrence element=UNKNOWN:checkWinner@274 kind=DEFINITION span=274:10-274:21
+occurrence element=UNKNOWN:checkWinner@287 kind=DEFINITION span=287:12-287:23
+occurrence element=UNKNOWN:checkWinner@289 kind=DEFINITION span=289:16-289:27
+occurrence element=UNKNOWN:clearMove@214 kind=DEFINITION span=214:15-214:24
+occurrence element=UNKNOWN:cloneField@232 kind=DEFINITION span=232:24-232:34
+occurrence element=UNKNOWN:evaluate@210 kind=DEFINITION span=210:30-210:38
+occurrence element=UNKNOWN:fill@41 kind=DEFINITION span=41:65-41:69
+occurrence element=UNKNOWN:from@41 kind=DEFINITION span=41:23-41:27
+occurrence element=UNKNOWN:helper@2 kind=DEFINITION span=2:10-2:16
+occurrence element=UNKNOWN:helper@25 kind=DEFINITION span=25:5-25:11
+occurrence element=UNKNOWN:inRange@110 kind=DEFINITION span=110:15-110:22
+occurrence element=UNKNOWN:inRange@160 kind=DEFINITION span=160:16-160:23
+occurrence element=UNKNOWN:inRange@99 kind=DEFINITION span=99:15-99:22
+occurrence element=UNKNOWN:input@175 kind=DEFINITION span=175:25-175:30
+occurrence element=UNKNOWN:isDraw@105 kind=DEFINITION span=105:10-105:16
+occurrence element=UNKNOWN:isDraw@211 kind=DEFINITION span=211:39-211:45
+occurrence element=UNKNOWN:isDraw@253 kind=DEFINITION span=253:23-253:29
+occurrence element=UNKNOWN:isDraw@288 kind=DEFINITION span=288:12-288:18
+occurrence element=UNKNOWN:isDraw@294 kind=DEFINITION span=294:16-294:22
+occurrence element=UNKNOWN:isEmpty@110 kind=DEFINITION span=110:37-110:44
+occurrence element=UNKNOWN:isEmpty@164 kind=DEFINITION span=164:16-164:23
+occurrence element=UNKNOWN:isEmpty@205 kind=DEFINITION span=205:20-205:27
+occurrence element=UNKNOWN:isEmpty@99 kind=DEFINITION span=99:38-99:45
+occurrence element=UNKNOWN:makeMove@209 kind=DEFINITION span=209:15-209:23
+occurrence element=UNKNOWN:makeMove@286 kind=DEFINITION span=286:18-286:26
+occurrence element=UNKNOWN:minMax@212 kind=DEFINITION span=212:29-212:35
+occurrence element=UNKNOWN:minMax@233 kind=DEFINITION span=233:23-233:29
+occurrence element=UNKNOWN:numberIn@156 kind=DEFINITION span=156:40-156:48
+occurrence element=UNKNOWN:numberIn@257 kind=DEFINITION span=257:23-257:31
+occurrence element=UNKNOWN:numberOut@120 kind=DEFINITION span=120:7-120:16
+occurrence element=UNKNOWN:opponent@189 kind=DEFINITION span=189:31-189:39
+occurrence element=UNKNOWN:opponent@212 kind=DEFINITION span=212:49-212:57
+occurrence element=UNKNOWN:randomInt@1 kind=DEFINITION span=1:10-1:19
+occurrence element=UNKNOWN:randomInt@221 kind=DEFINITION span=221:15-221:24
+occurrence element=UNKNOWN:run@307 kind=DEFINITION span=307:10-307:13
+occurrence element=UNKNOWN:sameInRow@104 kind=DEFINITION span=104:10-104:19
+occurrence element=UNKNOWN:sameInRow@186 kind=DEFINITION span=186:15-186:24
+occurrence element=UNKNOWN:sameInRow@189 kind=DEFINITION span=189:15-189:24
+occurrence element=UNKNOWN:sameInRow@192 kind=DEFINITION span=192:15-192:24
+occurrence element=UNKNOWN:sameInRow@249 kind=DEFINITION span=249:23-249:32
+occurrence element=UNKNOWN:selectPlayer@268 kind=DEFINITION span=268:28-268:40
+occurrence element=UNKNOWN:selectPlayer@269 kind=DEFINITION span=269:28-269:40
+occurrence element=UNKNOWN:show@278 kind=DEFINITION span=278:16-278:20
+occurrence element=UNKNOWN:start@306 kind=DEFINITION span=306:12-306:17
+occurrence element=UNKNOWN:stringOut@118 kind=DEFINITION span=118:5-118:14
+occurrence element=UNKNOWN:stringOut@121 kind=DEFINITION span=121:7-121:16
+occurrence element=UNKNOWN:stringOut@125 kind=DEFINITION span=125:11-125:20
+occurrence element=UNKNOWN:stringOut@127 kind=DEFINITION span=127:11-127:20
+occurrence element=UNKNOWN:stringOut@129 kind=DEFINITION span=129:11-129:20
+occurrence element=UNKNOWN:stringOut@132 kind=DEFINITION span=132:11-132:20
+occurrence element=UNKNOWN:stringOut@135 kind=DEFINITION span=135:7-135:16
+occurrence element=UNKNOWN:stringOut@137 kind=DEFINITION span=137:5-137:14
+occurrence element=UNKNOWN:stringOut@161 kind=DEFINITION span=161:7-161:16
+occurrence element=UNKNOWN:stringOut@165 kind=DEFINITION span=165:7-165:16
+occurrence element=UNKNOWN:stringOut@172 kind=DEFINITION span=172:5-172:14
+occurrence element=UNKNOWN:stringOut@173 kind=DEFINITION span=173:5-173:14
+occurrence element=UNKNOWN:stringOut@291 kind=DEFINITION span=291:9-291:18
+occurrence element=UNKNOWN:stringOut@296 kind=DEFINITION span=296:9-296:18
+occurrence element=UNKNOWN:turn@285 kind=DEFINITION span=285:27-285:31
+occurrence element=UNKNOWN:write@16 kind=DEFINITION span=16:18-16:23
+occurrence element=UNKNOWN:write@20 kind=DEFINITION span=20:18-20:23
+access node=FIELD:field@239 kind=Private
+access node=FIELD:grid@36 kind=Private
+access node=FIELD:left@37 kind=Private
+access node=FIELD:players@240 kind=Private
+access node=METHOD:ArtificialPlayer.evaluate@185 kind=Public
+access node=METHOD:ArtificialPlayer.minMax@198 kind=Public
+access node=METHOD:ArtificialPlayer.turn@231 kind=Public
+access node=METHOD:Field.clearMove@109 kind=Public
+access node=METHOD:Field.cloneField@45 kind=Public
+access node=METHOD:Field.constructor@39 kind=Public
+access node=METHOD:Field.inRange@66 kind=Public
+access node=METHOD:Field.isDraw@74 kind=Public
+access node=METHOD:Field.isEmpty@70 kind=Public
+access node=METHOD:Field.makeMove@98 kind=Public
+access node=METHOD:Field.opponent@56 kind=Public
+access node=METHOD:Field.sameInRow@78 kind=Public
+access node=METHOD:Field.show@117 kind=Public
+access node=METHOD:GameObject.announce@24 kind=Public
+access node=METHOD:HumanPlayer.check@159 kind=Public
+access node=METHOD:HumanPlayer.input@155 kind=Public
+access node=METHOD:HumanPlayer.turn@171 kind=Public
+access node=METHOD:TicTacToe.checkWinner@248 kind=Public
+access node=METHOD:TicTacToe.constructor@242 kind=Public
+access node=METHOD:TicTacToe.isDraw@252 kind=Public
+access node=METHOD:TicTacToe.probeCalls@273 kind=Public
+access node=METHOD:TicTacToe.run@277 kind=Public
+access node=METHOD:TicTacToe.selectPlayer@256 kind=Public
+access node=METHOD:TicTacToe.start@267 kind=Public
+access node=METHOD:constructor@145 kind=Public
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "13:main", node_id: NodeId(6727796206157739310), signature_hash: -4671339478033693080, normalized_signature: Some("shape:984563778702004951"), body_hash: -1339483200538649359, start_line: 304, end_line: 309 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "13:numberIn", node_id: NodeId(3473737834801802537), signature_hash: 2477812878330356949, normalized_signature: Some("outline:-1795207361013140379"), body_hash: -5799076556058130842, start_line: 11, end_line: 13 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "13:numberOut", node_id: NodeId(2691679804232393048), signature_hash: -1579019679195996938, normalized_signature: Some("shape:-7518921926393888768"), body_hash: -2763114819604303204, start_line: 15, end_line: 17 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "13:stringOut", node_id: NodeId(4167814038827373872), signature_hash: -5818630870471287222, normalized_signature: Some("shape:3196082884056502991"), body_hash: -2469159291278026123, start_line: 19, end_line: 21 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:ArtificialPlayer.evaluate", node_id: NodeId(1906316733576003705), signature_hash: -3339369090062122330, normalized_signature: Some("shape:-1550214276137000799"), body_hash: 4865134386501077365, start_line: 185, end_line: 196 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:ArtificialPlayer.minMax", node_id: NodeId(-9215380114239242716), signature_hash: 2816889471617643129, normalized_signature: Some("shape:-8096502567202063894"), body_hash: -480795846500759211, start_line: 198, end_line: 229 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:ArtificialPlayer.turn", node_id: NodeId(-6003445242777965111), signature_hash: 5754064973517794814, normalized_signature: Some("shape:4612479691636639645"), body_hash: -2652296153239786616, start_line: 231, end_line: 235 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.clearMove", node_id: NodeId(4704277302161329637), signature_hash: -3022140259302478, normalized_signature: Some("shape:-5609033441938793590"), body_hash: -3657826705311905325, start_line: 109, end_line: 115 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.cloneField", node_id: NodeId(1650801215023779134), signature_hash: 7778963861333372529, normalized_signature: Some("shape:-3975393857557175234"), body_hash: 1514400683417181067, start_line: 45, end_line: 54 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.constructor", node_id: NodeId(6082613119388305725), signature_hash: 6795144599545714474, normalized_signature: Some("shape:5630094355285618832"), body_hash: 8623972378444928730, start_line: 39, end_line: 43 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.inRange", node_id: NodeId(4472881972003103213), signature_hash: -8452809604799432690, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -5167291170261496876, start_line: 66, end_line: 68 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.isDraw", node_id: NodeId(886495427333575839), signature_hash: 7260325517996505566, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -8570124094816548714, start_line: 74, end_line: 76 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.isEmpty", node_id: NodeId(-671469649200364532), signature_hash: -7303087957103600159, normalized_signature: Some("outline:-5084961018881034800"), body_hash: 4841627472070151509, start_line: 70, end_line: 72 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.makeMove", node_id: NodeId(-5785535772821068934), signature_hash: -7686617887134063555, normalized_signature: Some("shape:7170642633197633617"), body_hash: -2264748847672571460, start_line: 98, end_line: 107 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.opponent", node_id: NodeId(-5320923615143741384), signature_hash: 5718448952121283431, normalized_signature: Some("outline:-5075390869670978506"), body_hash: 3150201255156974284, start_line: 56, end_line: 64 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.sameInRow", node_id: NodeId(-6464330170131321362), signature_hash: 8317776364922746511, normalized_signature: Some("outline:39053722370928195"), body_hash: -3121208784735839042, start_line: 78, end_line: 96 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:Field.show", node_id: NodeId(188395735819345816), signature_hash: -3470856697129697909, normalized_signature: Some("shape:-6393741377204873923"), body_hash: -3508803830167809508, start_line: 117, end_line: 138 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:GameObject.announce", node_id: NodeId(-5496480953283077615), signature_hash: 6265382829821424686, normalized_signature: Some("shape:-6937714838043631087"), body_hash: -6274213749022641390, start_line: 24, end_line: 26 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:HumanPlayer.check", node_id: NodeId(-6905842643888710123), signature_hash: 1939816138975990522, normalized_signature: Some("shape:-2041748163681691964"), body_hash: -2531058636950950386, start_line: 159, end_line: 169 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:HumanPlayer.input", node_id: NodeId(183754848538877801), signature_hash: -3809286021505677146, normalized_signature: Some("shape:6789306045084434438"), body_hash: -1218019279812378746, start_line: 155, end_line: 157 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:HumanPlayer.turn", node_id: NodeId(-8324596310372862362), signature_hash: -1551097434895889655, normalized_signature: Some("shape:-2090442267130361162"), body_hash: -6380288778795099129, start_line: 171, end_line: 181 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:TicTacToe.checkWinner", node_id: NodeId(-7937628806665507258), signature_hash: -7287660358945405677, normalized_signature: Some("shape:4326649433580919058"), body_hash: -2443578222395850134, start_line: 248, end_line: 250 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:TicTacToe.constructor", node_id: NodeId(-8175768614593770731), signature_hash: -9167033954688097950, normalized_signature: Some("outline:-5087212818695232478"), body_hash: -2050067086679050707, start_line: 242, end_line: 246 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:TicTacToe.isDraw", node_id: NodeId(-8135066250664865561), signature_hash: -160070021693570394, normalized_signature: Some("shape:-6509214657003215474"), body_hash: -8276095482876337186, start_line: 252, end_line: 254 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:TicTacToe.probeCalls", node_id: NodeId(-7539491653391818166), signature_hash: -1793306237384058767, normalized_signature: Some("shape:-108337260977001481"), body_hash: 1528036088194583991, start_line: 273, end_line: 275 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:TicTacToe.run", node_id: NodeId(-3944937904098589468), signature_hash: 5136661510898306809, normalized_signature: Some("shape:5464110797373327035"), body_hash: 5362941817952931317, start_line: 277, end_line: 301 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:TicTacToe.selectPlayer", node_id: NodeId(8835952981887312508), signature_hash: -6255132847551752433, normalized_signature: Some("shape:-2914839126246499349"), body_hash: 3620782857542223294, start_line: 256, end_line: 265 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:TicTacToe.start", node_id: NodeId(2562878172647700229), signature_hash: -2053738397397415406, normalized_signature: Some("shape:8996267714814229957"), body_hash: 2295220445070072843, start_line: 267, end_line: 271 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "14:constructor", node_id: NodeId(4164354656018189599), signature_hash: 8020987290552271096, normalized_signature: Some("outline:-5087212818695232478"), body_hash: -1094593521566738173, start_line: 145, end_line: 149 }
+callable_state CallableProjectionState { file_id: 3342959304880589176, symbol_key: "__file_structural__", node_id: NodeId(3342959304880589176), signature_hash: 553768115714561381, normalized_signature: None, body_hash: 5312641816907042554, start_line: 1, end_line: 309 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "typescript",
+        extension: "ts",
+        fidelity_filename: "fidelity.ts",
+        fidelity_source: include_str!("fixtures/fidelity_lab/typescript_fidelity_lab.ts"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/typescript_fidelity.txt"),
+        tictactoe_filename: "game.ts",
+        tictactoe_source: include_str!("fixtures/tictactoe/typescript_tictactoe.ts"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/typescript_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1681.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
