### PR TITLE
[v0.17 S3-TSX] Extract TSX language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3941,8 +3941,8 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
     let comment_marker = codestory_contracts::language_support::line_comment_for_language(language)
         .or(match language {
             "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
-            "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
-            | "cpp" | "dart" | "php" | "swift" => Some("//"),
+            "rust" | "typescript" | "javascript" | "jsx" | "go" | "java" | "csharp" | "cpp"
+            | "dart" | "php" | "swift" => Some("//"),
             _ => None,
         });
     let Some(marker) = comment_marker else {
@@ -5572,8 +5572,8 @@ mod tests {
         assert!(bash.contains("\x1b[90m# comment\x1b[0m"), "{bash:?}");
     }
 
-    /// Kotlin's comment marker now comes from the language registry rather than
-    /// the local roster, and every other language must be unmoved.
+    /// Kotlin's and TSX's comment markers now come from the language registry
+    /// rather than the local roster, and every other language must be unmoved.
     ///
     /// Asserting only "Kotlin still dims `//`" would pass with the registry
     /// lookup deleted, because the local roster used to answer for Kotlin too.
@@ -5639,6 +5639,24 @@ mod tests {
         );
         let kotlin = ansi_highlight_snippet("app/Main.kt", "val ok = true // comment");
         assert!(kotlin.contains("\x1b[90m// comment\x1b[0m"), "{kotlin:?}");
+
+        // Same for the `tsx` dialect. `typescript` and `jsx` must still come
+        // from the local roster, because their packages have not landed: a row
+        // that answered for them here would move rendering ownership early.
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("tsx"),
+            Some("//")
+        );
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("typescript"),
+            None
+        );
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("jsx"),
+            None
+        );
+        let tsx = ansi_highlight_snippet("app/View.tsx", "const ok = true; // comment");
+        assert!(tsx.contains("\x1b[90m// comment\x1b[0m"), "{tsx:?}");
     }
 
     /// Component dialects resolve through the companion-extension registry and

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -470,14 +470,29 @@ pub fn companion_surface_language(ext: &str) -> Option<&'static str> {
 /// languages whose consumer roster deliberately differs from their real syntax.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LanguageCommentProfile {
+    /// The name consumers actually spell. Usually a registry language name,
+    /// but a dialect that only the indexer and the highlighter distinguish
+    /// (`tsx`) is keyed by that dialect, because that is the string the
+    /// consumer roster held.
     pub language_name: &'static str,
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    // `tsx` is not a registry language — the registry routes `.tsx` to
+    // `typescript` — but it is the indexer's dispatch name for the JSX-aware
+    // TypeScript config and the CLI highlighter's own dialect string. The row
+    // covers that dialect only; `typescript` itself stays with the consumer
+    // roster until #1681.
+    LanguageCommentProfile {
+        language_name: "tsx",
+        line_comment: "//",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,10 +1260,16 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "tsx"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
-                language_support_profile_for_language_name(profile.language_name).is_some(),
+                language_support_profile_for_language_name(profile.language_name).is_some()
+                    // `tsx` is a dialect, not a registered surface: the registry
+                    // routes `.tsx` to `typescript`. It is keyed here under its
+                    // own name because that is the string the indexer dispatches
+                    // on and the CLI highlighter renders, and because
+                    // `typescript` itself has not migrated.
+                    || profile.language_name == "tsx",
                 "`{}` has no public language profile",
                 profile.language_name
             );
@@ -1259,6 +1280,14 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("tsx"), Some("//"));
+        // The dialect row must not answer for the language it routes to: the
+        // `typescript` roster entry is #1681's to move.
+        assert_eq!(
+            language_support_profile_for_ext("tsx").map(|profile| profile.language_name),
+            Some("typescript")
+        );
+        assert_eq!(line_comment_for_language("typescript"), None);
         assert_eq!(line_comment_for_language("swift"), None);
     }
 

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -2,8 +2,8 @@ use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
     GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
     PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    SWIFT_GRAPH_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -33,7 +33,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("java", _) => Some(java()),
         ("rust", _) => Some(rust()),
         ("javascript", _) => Some(javascript()),
-        ("typescript", "tsx") => Some(tsx()),
         ("typescript", _) => Some(typescript()),
         ("cpp", _) => Some(cpp()),
         ("c", _) => Some(c()),
@@ -95,16 +94,6 @@ fn typescript() -> LanguageConfig {
         TYPESCRIPT_GRAPH_QUERY,
         Some(TYPESCRIPT_TAGS_QUERY),
         LanguageRuleset::TypeScript,
-    )
-}
-
-fn tsx() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_typescript::LANGUAGE_TSX.into(),
-        "typescript",
-        TSX_GRAPH_QUERY,
-        Some(TSX_TAGS_QUERY),
-        LanguageRuleset::Tsx,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -17,6 +17,7 @@
 //! package to land deletes the residual arms entirely.
 
 pub(crate) mod kotlin;
+pub(crate) mod tsx;
 
 use std::sync::OnceLock;
 
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, tsx::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {
@@ -236,5 +237,54 @@ mod tests {
             extraction_for_ext("kts").map(|row| row.language_name),
             Some("kotlin")
         );
+    }
+
+    /// The TSX row must keep the exact facts the god file gave the dispatch
+    /// name `tsx`, including the three that are `false`/`None` on purpose.
+    ///
+    /// Every value below was read off a `match` arm — or off the *absence* of
+    /// one — before the move. The absences are the dangerous half: nothing
+    /// else in the suite notices if a row silently starts promoting member
+    /// functions to methods, claims a call syntax that belongs to TypeScript,
+    /// or joins the framework-route comment roster.
+    #[test]
+    fn tsx_row_keeps_the_projection_facts_it_had_in_the_god_file() {
+        let tsx = extraction_for_language("tsx").expect("tsx row");
+
+        // `.tsx` is `typescript` to the outside world and `tsx` inside the
+        // indexer; that split is the reason `dispatch_names` exists.
+        assert_eq!(tsx.language_name, "typescript");
+        assert_eq!(tsx.dispatch_names, &["tsx"]);
+        assert!(extraction_for_language("typescript").is_none());
+        assert_eq!(
+            extraction_for_ext("tsx").map(|row| row.language_name),
+            Some("typescript")
+        );
+        assert!(extraction_for_ext("ts").is_none());
+
+        // `promotes_type_member_functions_to_methods` was `matches!(name,
+        // "swift" | "dart")` and `qualified_name_delimiter` was `"::"` only for
+        // `rust`/`cpp`/`c`; neither ever matched `tsx`.
+        assert!(!tsx.promotes_type_member_functions_to_methods);
+        assert_eq!(tsx.qualified_name_delimiter, ".");
+        // The framework-route comment roster reaches languages by their public
+        // registry name, so `tsx` was never in it. This deliberately disagrees
+        // with the CLI highlighter, which does render `tsx` comments; they are
+        // separate facts with separate owners.
+        assert!(!tsx.route_comments_are_c_style);
+
+        // `rules/tsx.graph.scm` emits TypeScript's `ts_member` call syntax and
+        // shares its marker constant, so the marker is #1681's to move and the
+        // residual `lib.rs` arm must still be the one that answers.
+        assert_eq!(tsx.member_callsite_marker, None);
+        assert_eq!(tsx.graph_call_syntax, None);
+        assert_eq!(member_callsite_marker_for_call_syntax("ts_member"), None);
+
+        // TypeScript's receiver-call engine is shared, not copied.
+        assert!(tsx.receiver_call_specs.is_some());
+        assert!(tsx.tags_query.is_some());
+        assert!(tsx.graph_query.contains("ts_member"));
+        assert!(!tsx.uses_generic_semantic_resolver);
+        assert_eq!(tsx.semantic_family, "webscript");
     }
 }

--- a/crates/codestory-indexer/src/languages/tsx.rs
+++ b/crates/codestory-indexer/src/languages/tsx.rs
@@ -1,0 +1,85 @@
+//! TSX extraction rules.
+//!
+//! TSX is the row the [`super::LanguageExtraction::dispatch_names`] field
+//! exists for. `.tsx` is not a language in the public registry — the contracts
+//! registry routes it to `typescript` alongside `.ts`, `.mts` and `.cts` — but
+//! the indexer has always kept it as a *separate parser configuration*, because
+//! it needs the JSX-aware grammar (`LANGUAGE_TSX`) and its own rule file. So
+//! this row answers to the indexer-only dispatch name `tsx` while reporting
+//! `typescript` as its public `language_name`, and `extraction_for_ext` keys on
+//! the extension so `tsx` and `ts` stay two configs for one public language.
+//!
+//! Three TSX-adjacent surfaces are deliberately *not* here, and all three are
+//! shared with a language whose own S3 package has not landed:
+//!
+//! * `lib.rs::collect_typescript_receiver_call_edges`. TSX and TypeScript run
+//!   the same receiver-call engine; the body belongs to TypeScript (#1681) and
+//!   this row only points at it. Copying it here would fork one engine into
+//!   two.
+//! * `TS_MEMBER_CALLSITE_MARKER` and the `ts_member` `call_syntax` arm.
+//!   `rules/tsx.graph.scm` and `rules/typescript.graph.scm` emit the *same*
+//!   `call_syntax = "ts_member"` and share one marker constant, so the marker
+//!   is TypeScript's to move, not TSX's. Claiming it here would make the
+//!   registry's `call_syntax` uniqueness check fail the day #1681 lands, and
+//!   would park a TypeScript constant inside the TSX module. Both marker
+//!   fields are therefore `None` and the residual `ts_member` arm in `lib.rs`
+//!   keeps answering — identically — for `.tsx` and `.ts` alike.
+//! * `lib.rs::collect_tsx_jsx_usage_edges` and the `reconcile_tsx_usage_targets`
+//!   / `prune_tsx_duplicate_reference_nodes` pair. Their name says `tsx` but
+//!   their gate is `is_jsx_like_file`, which is true for `.jsx` as well, and
+//!   `.jsx` is JavaScript (#1680). They are a JSX-dialect seam across two
+//!   languages, not TSX content.
+//!
+//! `LanguageRuleset::Tsx` also stays in `lib.rs`, for the same reason Kotlin's
+//! does: the enum is the compiled-rule cache key for every language at once.
+//!
+//! This is a move, not a rewrite. `tests/language_extraction_snapshot.rs` pins
+//! the rendered projection of both TSX fixtures so the move stays output-equal.
+
+use super::LanguageExtraction;
+use crate::{CompiledLanguageRules, LanguageRuleset, TYPESCRIPT_TAGS_QUERY};
+use std::sync::OnceLock;
+
+const GRAPH_QUERY: &str = include_str!("../../rules/tsx.graph.scm");
+
+/// TSX reuses TypeScript's tags query verbatim; it always has.
+const TAGS_QUERY: &str = TYPESCRIPT_TAGS_QUERY;
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for TSX.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["tsx"],
+    language_name: "typescript",
+    extensions: &["tsx"],
+    ruleset: LanguageRuleset::Tsx,
+    parser_language: tsx_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: Some(TAGS_QUERY),
+    compiled_rules: &RULES,
+    // Shared with TypeScript; see the module doc.
+    receiver_call_specs: Some(crate::collect_typescript_receiver_call_edges),
+    // `ts_member` is TypeScript's marker, not TSX's; see the module doc.
+    member_callsite_marker: None,
+    graph_call_syntax: None,
+    // A `method_definition` is already a METHOD in the TSX grammar, so the
+    // FUNCTION-to-METHOD promotion never applied to TSX and must not start.
+    promotes_type_member_functions_to_methods: false,
+    qualified_name_delimiter: ".",
+    // Deliberately `false`, and deliberately different from the CLI's comment
+    // roster. The framework-route scanner reaches languages by their *public*
+    // registry name, so a `.tsx` file is scanned as `typescript` and the
+    // dispatch name `tsx` has never been in that roster. Flipping this to
+    // `true` would not fix anything — it would add a route-claim surface that
+    // no `.tsx` file has today.
+    route_comments_are_c_style: false,
+    // TypeScript has a dedicated resolver, and `.tsx` files reach it as
+    // `typescript` because `detect_resolver_language` returns the public
+    // registry name.
+    uses_generic_semantic_resolver: false,
+    semantic_family: "webscript",
+};
+
+fn tsx_language() -> tree_sitter::Language {
+    tree_sitter_typescript::LANGUAGE_TSX.into()
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -134,8 +134,6 @@ const RUST_TAGS_QUERY: &str = include_str!("../rules/rust.tags.scm");
 const JAVASCRIPT_GRAPH_QUERY: &str = include_str!("../rules/javascript.scm");
 const TYPESCRIPT_GRAPH_QUERY: &str = include_str!("../rules/typescript.graph.scm");
 const TYPESCRIPT_TAGS_QUERY: &str = include_str!("../rules/typescript.tags.scm");
-const TSX_GRAPH_QUERY: &str = include_str!("../rules/tsx.graph.scm");
-const TSX_TAGS_QUERY: &str = TYPESCRIPT_TAGS_QUERY;
 const CPP_GRAPH_QUERY: &str = include_str!("../rules/cpp.scm");
 const C_GRAPH_QUERY: &str = include_str!("../rules/c.scm");
 const GO_GRAPH_QUERY: &str = include_str!("../rules/go.scm");
@@ -310,9 +308,10 @@ impl LanguageRuleset {
                 Some(TYPESCRIPT_TAGS_QUERY),
                 &TYPESCRIPT_RULES,
             ),
-            LanguageRuleset::Tsx => {
-                compiled_rules_cache(language, TSX_GRAPH_QUERY, Some(TSX_TAGS_QUERY), &TSX_RULES)
-            }
+            // Answered by the registry above; see the `Kotlin` arm below.
+            LanguageRuleset::Tsx => Err(anyhow!(
+                "tsx compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::Cpp => {
                 compiled_rules_cache(language, CPP_GRAPH_QUERY, None, &CPP_RULES)
             }
@@ -377,7 +376,6 @@ static JAVA_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::n
 static RUST_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static JAVASCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static TYPESCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static TSX_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CPP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static C_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static GO_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
@@ -7594,7 +7592,7 @@ fn language_receiver_call_specs(
     match language_name {
         "javascript" => collect_javascript_receiver_call_edges(tree, source),
         "python" => collect_python_receiver_call_edges(tree, source),
-        "typescript" | "tsx" => collect_typescript_receiver_call_edges(tree, source),
+        "typescript" => collect_typescript_receiver_call_edges(tree, source),
         "java" => collect_java_receiver_call_edges(tree, source),
         "go" => collect_go_receiver_call_edges(tree, source),
         "ruby" => collect_ruby_receiver_call_edges(tree, source),
@@ -25732,9 +25730,19 @@ class Test {
         assert_eq!(ts.graph_query, TYPESCRIPT_GRAPH_QUERY);
         assert_eq!(ts.tags_query, Some(TYPESCRIPT_TAGS_QUERY));
 
+        // TSX's rule files moved into `languages::tsx`; the config must still
+        // come back through the same extension lookup, still on the TSX
+        // grammar, and still sharing TypeScript's tags query.
         let tsx = get_language_for_ext("tsx").expect("tsx config");
-        assert_eq!(tsx.graph_query, TSX_GRAPH_QUERY);
-        assert_eq!(tsx.tags_query, Some(TSX_TAGS_QUERY));
+        assert_eq!(tsx.language_name, "typescript");
+        assert_eq!(
+            tsx.graph_query,
+            languages::extraction_for_ext("tsx")
+                .expect("tsx registry row")
+                .graph_query
+        );
+        assert_ne!(tsx.graph_query, ts.graph_query);
+        assert_eq!(tsx.tags_query, Some(TYPESCRIPT_TAGS_QUERY));
 
         // Kotlin's rule file moved into `languages::kotlin`; the config must
         // still come back through the same extension lookup.

--- a/crates/codestory-indexer/tests/fixtures/fidelity_lab/tsx_fidelity_lab.tsx
+++ b/crates/codestory-indexer/tests/fixtures/fidelity_lab/tsx_fidelity_lab.tsx
@@ -1,0 +1,73 @@
+import { readFileSync as readFile } from "fs";
+import { join as pathJoin } from "path";
+
+type Mapper<T> = (value: T) => T;
+
+enum WorkflowMode {
+    Sync = "sync",
+}
+
+interface Notifier {
+    notify(value: string): void;
+}
+
+class ConsoleNotifier implements Notifier {
+    notify(value: string): void {
+        this.writeLog(value);
+    }
+
+    writeLog(value: string): void {
+        void value;
+    }
+}
+
+class Repository<T> {
+    save(item: T): void {
+        this.track(item);
+    }
+
+    track(item: T): void {
+        void item;
+    }
+}
+
+class Workflow<T extends { name: string }> {
+    identity(value: T, mapper: Mapper<T>): T {
+        return mapper(value);
+    }
+
+    run(notifier: Notifier, repository: Repository<T>, item: T): void {
+        const mapped = this.identity(item, (value) => value);
+        notifier.notify(mapped.name);
+        repository.save(mapped);
+        this.decorate(mapped);
+    }
+
+    async runAsync(notifier: Notifier, repository: Repository<T>, item: T): Promise<void> {
+        this.run(notifier, repository, item);
+        await Promise.resolve();
+    }
+
+    decorate(item: T): string {
+        return pathJoin(item.name, WorkflowMode.Sync, readFile.length.toString());
+    }
+}
+
+function StatusBadge(props: { label: string }) {
+    return <span className="badge">{props.label}</span>;
+}
+
+export function WorkflowPanel(props: { label: string }) {
+    const workflow = new Workflow<{ name: string }>();
+    workflow.run(new ConsoleNotifier(), new Repository<{ name: string }>(), { name: "checkout" });
+    return (
+        <section className="panel">
+            <StatusBadge label={props.label} />
+        </section>
+    );
+}
+
+export function orchestrateTsx(): void {
+    const workflow = new Workflow<{ name: string }>();
+    workflow.run(new ConsoleNotifier(), new Repository<{ name: string }>(), { name: "checkout" });
+}

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/tsx_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/tsx_fidelity.txt
@@ -1,0 +1,81 @@
+node CLASS name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.tsx:ConsoleNotifier line=14 col=7 end=14:22 file=FILE:<ROOT>/fidelity.tsx@1
+node CLASS name=Repository qn=Repository canonical=<ROOT>/fidelity.tsx:Repository line=24 col=7 end=24:17 file=FILE:<ROOT>/fidelity.tsx@1
+node CLASS name=Workflow qn=Workflow canonical=<ROOT>/fidelity.tsx:Workflow line=34 col=7 end=34:15 file=FILE:<ROOT>/fidelity.tsx@1
+node ENUM name=WorkflowMode qn=WorkflowMode canonical=<ROOT>/fidelity.tsx:WorkflowMode line=6 col=1 end=8:2 file=FILE:<ROOT>/fidelity.tsx@1
+node FIELD name=className qn=className canonical=<ROOT>/fidelity.tsx:className#0 line=64 col=18 end=64:27 file=FILE:<ROOT>/fidelity.tsx@1
+node FIELD name=label qn=label canonical=<ROOT>/fidelity.tsx:label#0 line=56 col=31 end=56:36 file=FILE:<ROOT>/fidelity.tsx@1
+node FIELD name=name qn=name canonical=<ROOT>/fidelity.tsx:name#0 line=34 col=28 end=34:32 file=FILE:<ROOT>/fidelity.tsx@1
+node FILE name=<ROOT>/fidelity.tsx qn=<ROOT>/fidelity.tsx canonical=<ROOT>/fidelity.tsx:<ROOT>/fidelity.tsx:1 line=1 col=1 end=73:0 file=FILE:<ROOT>/fidelity.tsx@1
+node FUNCTION name=StatusBadge qn=StatusBadge canonical=<ROOT>/fidelity.tsx:StatusBadge#0 line=56 col=1 end=58:2 file=FILE:<ROOT>/fidelity.tsx@1
+node FUNCTION name=WorkflowPanel qn=WorkflowPanel canonical=<ROOT>/fidelity.tsx:WorkflowPanel#0 line=60 col=8 end=68:2 file=FILE:<ROOT>/fidelity.tsx@1
+node FUNCTION name=orchestrateTsx qn=orchestrateTsx canonical=<ROOT>/fidelity.tsx:orchestrateTsx#0 line=70 col=8 end=73:2 file=FILE:<ROOT>/fidelity.tsx@1
+node FUNCTION name=section qn=section canonical=<ROOT>/fidelity.tsx:section#0 line=64 col=10 end=64:17 file=FILE:<ROOT>/fidelity.tsx@1
+node INTERFACE name=Notifier qn=Notifier canonical=<ROOT>/fidelity.tsx:Notifier line=10 col=11 end=10:19 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=ConsoleNotifier.notify qn=ConsoleNotifier.notify canonical=<ROOT>/fidelity.tsx:ConsoleNotifier.notify#0 line=15 col=5 end=17:6 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=ConsoleNotifier.writeLog qn=ConsoleNotifier.writeLog canonical=<ROOT>/fidelity.tsx:ConsoleNotifier.writeLog#0 line=19 col=5 end=21:6 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=Notifier.notify qn=Notifier.notify canonical=<ROOT>/fidelity.tsx:Notifier.notify#0 line=11 col=5 end=11:32 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=Repository.save qn=Repository.save canonical=<ROOT>/fidelity.tsx:Repository.save#0 line=25 col=5 end=27:6 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=Repository.track qn=Repository.track canonical=<ROOT>/fidelity.tsx:Repository.track#0 line=29 col=5 end=31:6 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=Workflow.decorate qn=Workflow.decorate canonical=<ROOT>/fidelity.tsx:Workflow.decorate#0 line=51 col=5 end=53:6 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=Workflow.identity qn=Workflow.identity canonical=<ROOT>/fidelity.tsx:Workflow.identity#0 line=35 col=5 end=37:6 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=Workflow.run qn=Workflow.run canonical=<ROOT>/fidelity.tsx:Workflow.run#0 line=39 col=5 end=44:6 file=FILE:<ROOT>/fidelity.tsx@1
+node METHOD name=Workflow.runAsync qn=Workflow.runAsync canonical=<ROOT>/fidelity.tsx:Workflow.runAsync#0 line=46 col=5 end=49:6 file=FILE:<ROOT>/fidelity.tsx@1
+node MODULE name="fs" qn="fs" canonical=<ROOT>/fidelity.tsx:"fs"#0 line=1 col=42 end=1:46 file=FILE:<ROOT>/fidelity.tsx@1
+node MODULE name="path" qn="path" canonical=<ROOT>/fidelity.tsx:"path"#0 line=2 col=34 end=2:40 file=FILE:<ROOT>/fidelity.tsx@1
+node TYPEDEF name=Mapper qn=Mapper canonical=<ROOT>/fidelity.tsx:Mapper line=4 col=1 end=4:34 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.tsx:decorate#0 line=43 col=14 end=43:22 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=identity qn=identity canonical=<ROOT>/fidelity.tsx:identity#0 line=40 col=29 end=40:37 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=join qn=join canonical=<ROOT>/fidelity.tsx:join#0 line=2 col=10 end=2:14 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=mapper qn=mapper canonical=<ROOT>/fidelity.tsx:mapper#0 line=36 col=16 end=36:22 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.tsx:notify#0 line=41 col=18 end=41:24 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=pathJoin qn=pathJoin canonical=<ROOT>/fidelity.tsx:pathJoin#0 line=2 col=18 end=2:26 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=pathJoin qn=pathJoin canonical=<ROOT>/fidelity.tsx:pathJoin#1 line=52 col=16 end=52:24 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=readFile qn=readFile canonical=<ROOT>/fidelity.tsx:readFile#0 line=1 col=26 end=1:34 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=readFileSync qn=readFileSync canonical=<ROOT>/fidelity.tsx:readFileSync#0 line=1 col=10 end=1:22 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=resolve qn=resolve canonical=<ROOT>/fidelity.tsx:resolve#0 line=48 col=23 end=48:30 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.tsx:run#0 line=47 col=14 end=47:17 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.tsx:run#1 line=62 col=14 end=62:17 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.tsx:run#2 line=72 col=14 end=72:17 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.tsx:save#0 line=42 col=20 end=42:24 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=toString qn=toString canonical=<ROOT>/fidelity.tsx:toString#0 line=52 col=71 end=52:79 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=track qn=track canonical=<ROOT>/fidelity.tsx:track#0 line=26 col=14 end=26:19 file=FILE:<ROOT>/fidelity.tsx@1
+node UNKNOWN name=writeLog qn=writeLog canonical=<ROOT>/fidelity.tsx:writeLog#0 line=16 col=14 end=16:22 file=FILE:<ROOT>/fidelity.tsx@1
+edge CALL src=FUNCTION:WorkflowPanel@60 dst=CLASS:ConsoleNotifier@14 resolved_src=FUNCTION:WorkflowPanel@60 resolved_dst=- line=62 confidence=- certainty=- callsite=h0:62:1:h1 candidates=[]
+edge CALL src=FUNCTION:WorkflowPanel@60 dst=CLASS:Repository@24 resolved_src=FUNCTION:WorkflowPanel@60 resolved_dst=- line=62 confidence=- certainty=- callsite=h0:62:1:h2 candidates=[]
+edge CALL src=FUNCTION:WorkflowPanel@60 dst=CLASS:Workflow@34 resolved_src=FUNCTION:WorkflowPanel@60 resolved_dst=- line=61 confidence=- certainty=- callsite=h0:61:1:h3 candidates=[]
+edge CALL src=FUNCTION:WorkflowPanel@60 dst=FUNCTION:StatusBadge@56 resolved_src=FUNCTION:WorkflowPanel@60 resolved_dst=FUNCTION:StatusBadge@56 line=65 confidence=0.9500 certainty=Certain callsite=h0:65:1:h4 candidates=[]
+edge CALL src=FUNCTION:WorkflowPanel@60 dst=FUNCTION:section@64 resolved_src=FUNCTION:WorkflowPanel@60 resolved_dst=FUNCTION:section@64 line=0 confidence=0.9500 certainty=Certain callsite=h0:0:1:h5 candidates=[]
+edge CALL src=FUNCTION:WorkflowPanel@60 dst=METHOD:Workflow.run@39 resolved_src=FUNCTION:WorkflowPanel@60 resolved_dst=METHOD:Workflow.run@39 line=62 confidence=1.0000 certainty=Certain callsite=h0:62:1:h6 candidates=[]
+edge CALL src=FUNCTION:orchestrateTsx@70 dst=CLASS:ConsoleNotifier@14 resolved_src=FUNCTION:orchestrateTsx@70 resolved_dst=- line=72 confidence=- certainty=- callsite=h0:72:1:h1 candidates=[]
+edge CALL src=FUNCTION:orchestrateTsx@70 dst=CLASS:Repository@24 resolved_src=FUNCTION:orchestrateTsx@70 resolved_dst=- line=72 confidence=- certainty=- callsite=h0:72:1:h2 candidates=[]
+edge CALL src=FUNCTION:orchestrateTsx@70 dst=CLASS:Workflow@34 resolved_src=FUNCTION:orchestrateTsx@70 resolved_dst=- line=71 confidence=- certainty=- callsite=h0:71:1:h3 candidates=[]
+edge CALL src=FUNCTION:orchestrateTsx@70 dst=METHOD:Workflow.run@39 resolved_src=FUNCTION:orchestrateTsx@70 resolved_dst=METHOD:Workflow.run@39 line=72 confidence=1.0000 certainty=Certain callsite=h0:72:1:h6 candidates=[]
+edge CALL src=METHOD:ConsoleNotifier.notify@15 dst=METHOD:ConsoleNotifier.writeLog@19 resolved_src=METHOD:ConsoleNotifier.notify@15 resolved_dst=METHOD:ConsoleNotifier.writeLog@19 line=16 confidence=1.0000 certainty=Certain callsite=h0:16:1:h7 candidates=[]
+edge CALL src=METHOD:Repository.save@25 dst=METHOD:Repository.track@29 resolved_src=METHOD:Repository.save@25 resolved_dst=METHOD:Repository.track@29 line=26 confidence=1.0000 certainty=Certain callsite=h0:26:1:h8 candidates=[]
+edge CALL src=METHOD:Workflow.decorate@51 dst=UNKNOWN:toString@52 resolved_src=METHOD:Workflow.decorate@51 resolved_dst=- line=52 confidence=- certainty=- callsite=h0:52:1:h9|syntax:ts-member-call candidates=[]
+edge CALL src=METHOD:Workflow.identity@35 dst=UNKNOWN:mapper@36 resolved_src=METHOD:Workflow.identity@35 resolved_dst=- line=36 confidence=- certainty=- callsite=h0:36:1:h10 candidates=[]
+edge CALL src=METHOD:Workflow.run@39 dst=METHOD:Notifier.notify@11 resolved_src=METHOD:Workflow.run@39 resolved_dst=METHOD:Notifier.notify@11 line=41 confidence=1.0000 certainty=Certain callsite=h0:41:1:h11 candidates=[]
+edge CALL src=METHOD:Workflow.run@39 dst=METHOD:Repository.save@25 resolved_src=METHOD:Workflow.run@39 resolved_dst=METHOD:Repository.save@25 line=42 confidence=1.0000 certainty=Certain callsite=h0:42:1:h12 candidates=[]
+edge CALL src=METHOD:Workflow.run@39 dst=METHOD:Workflow.decorate@51 resolved_src=METHOD:Workflow.run@39 resolved_dst=METHOD:Workflow.decorate@51 line=43 confidence=1.0000 certainty=Certain callsite=h0:43:1:h13 candidates=[]
+edge CALL src=METHOD:Workflow.run@39 dst=METHOD:Workflow.identity@35 resolved_src=METHOD:Workflow.run@39 resolved_dst=METHOD:Workflow.identity@35 line=40 confidence=1.0000 certainty=Certain callsite=h0:40:1:h14 candidates=[]
+edge CALL src=METHOD:Workflow.runAsync@46 dst=METHOD:Workflow.run@39 resolved_src=METHOD:Workflow.runAsync@46 resolved_dst=METHOD:Workflow.run@39 line=47 confidence=1.0000 certainty=Certain callsite=h0:47:1:h6 candidates=[]
+edge CALL src=METHOD:Workflow.runAsync@46 dst=UNKNOWN:resolve@48 resolved_src=METHOD:Workflow.runAsync@46 resolved_dst=- line=48 confidence=- certainty=- callsite=h0:48:1:h15|syntax:ts-member-call candidates=[]
+edge CALL src=UNKNOWN:pathJoin@52 dst=UNKNOWN:pathJoin@2 resolved_src=UNKNOWN:pathJoin@52 resolved_dst=UNKNOWN:pathJoin@2 line=52 confidence=0.9500 certainty=Certain callsite=h0:52:1:h16 candidates=[]
+edge IMPORT src=MODULE:"fs"@1 dst=MODULE:"fs"@1 resolved_src=MODULE:"fs"@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=MODULE:"path"@2 dst=MODULE:"path"@2 resolved_src=MODULE:"path"@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:join@2 dst=MODULE:"path"@2 resolved_src=UNKNOWN:join@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:pathJoin@2 dst=MODULE:"path"@2 resolved_src=UNKNOWN:pathJoin@2 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:readFile@1 dst=MODULE:"fs"@1 resolved_src=UNKNOWN:readFile@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:readFileSync@1 dst=MODULE:"fs"@1 resolved_src=UNKNOWN:readFileSync@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ConsoleNotifier@14 dst=INTERFACE:Notifier@10 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@14 dst=METHOD:ConsoleNotifier.notify@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@14 dst=METHOD:ConsoleNotifier.writeLog@19 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@24 dst=METHOD:Repository.save@25 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@24 dst=METHOD:Repository.track@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@34 dst=METHOD:Workflow.decorate@51 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@34 dst=METHOD:Workflow.identity@35 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@34 dst=METHOD:Workflow.run@39 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@34 dst=METHOD:Workflow.runAsync@46 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Notifier@10 dst=METHOD:Notifier.notify@11 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge USAGE src=FUNCTION:WorkflowPanel@60 dst=FIELD:className@64 resolved_src=- resolved_dst=- line=0 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:WorkflowPanel@60 dst=FIELD:label@56 resolved_src=- resolved_dst=- line=65 confidence=- certainty=- callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/tsx_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/tsx_tictactoe.txt
@@ -1,0 +1,244 @@
+node CLASS name=ArtificialPlayer qn=ArtificialPlayer canonical=game.tsx:ArtificialPlayer line=100 col=7 end=100:23 file=FILE:game.tsx@1
+node CLASS name=Field qn=Field canonical=game.tsx:Field line=51 col=7 end=51:12 file=FILE:game.tsx@1
+node CLASS name=GameObject qn=GameObject canonical=game.tsx:GameObject line=45 col=7 end=45:17 file=FILE:game.tsx@1
+node CLASS name=TicTacToe qn=TicTacToe canonical=game.tsx:TicTacToe line=125 col=14 end=125:23 file=FILE:game.tsx@1
+node FIELD name=cells qn=cells canonical=game.tsx:cells#0 line=35 col=23 end=35:28 file=FILE:game.tsx@1
+node FIELD name=className qn=className canonical=game.tsx:className#0 line=29 col=13 end=29:22 file=FILE:game.tsx@1
+node FIELD name=col qn=col canonical=game.tsx:col#0 line=8 col=3 end=8:6 file=FILE:game.tsx@1
+node FIELD name=field qn=field canonical=game.tsx:field#0 line=126 col=11 end=126:16 file=FILE:game.tsx@1
+node FIELD name=game qn=game canonical=game.tsx:game#0 line=150 col=32 end=150:36 file=FILE:game.tsx@1
+node FIELD name=grid qn=grid canonical=game.tsx:grid#0 line=52 col=11 end=52:15 file=FILE:game.tsx@1
+node FIELD name=left qn=left canonical=game.tsx:left#0 line=53 col=11 end=53:15 file=FILE:game.tsx@1
+node FIELD name=move qn=move canonical=game.tsx:move#0 line=13 col=3 end=13:7 file=FILE:game.tsx@1
+node FIELD name=onClick qn=onClick canonical=game.tsx:onClick#0 line=29 col=30 end=29:37 file=FILE:game.tsx@1
+node FIELD name=onPick qn=onPick canonical=game.tsx:onPick#0 line=14 col=3 end=14:9 file=FILE:game.tsx@1
+node FIELD name=opponent qn=opponent canonical=game.tsx:opponent#0 line=127 col=11 end=127:19 file=FILE:game.tsx@1
+node FIELD name=row qn=row canonical=game.tsx:row#0 line=7 col=3 end=7:6 file=FILE:game.tsx@1
+node FIELD name=value qn=value canonical=game.tsx:value#0 line=12 col=3 end=12:8 file=FILE:game.tsx@1
+node FILE name=game.tsx qn=game.tsx canonical=game.tsx:game.tsx:1 line=1 col=1 end=164:0 file=FILE:game.tsx@1
+node FUNCTION name=Board qn=Board canonical=game.tsx:Board#0 line=150 col=8 end=159:2 file=FILE:game.tsx@1
+node FUNCTION name=Cell qn=Cell canonical=game.tsx:Cell#0 line=27 col=1 end=33:2 file=FILE:game.tsx@1
+node FUNCTION name=Row qn=Row canonical=game.tsx:Row#0 line=35 col=1 end=43:2 file=FILE:game.tsx@1
+node FUNCTION name=button qn=button canonical=game.tsx:button#0 line=29 col=6 end=29:12 file=FILE:game.tsx@1
+node FUNCTION name=div qn=div canonical=game.tsx:div#0 line=37 col=6 end=37:9 file=FILE:game.tsx@1
+node FUNCTION name=main qn=main canonical=game.tsx:main#0 line=153 col=6 end=153:10 file=FILE:game.tsx@1
+node FUNCTION name=main qn=main canonical=game.tsx:main#1 line=161 col=8 end=164:2 file=FILE:game.tsx@1
+node FUNCTION name=tokenLabel qn=tokenLabel canonical=game.tsx:tokenLabel#0 line=17 col=1 end=25:2 file=FILE:game.tsx@1
+node INTERFACE name=CellProps qn=CellProps canonical=game.tsx:CellProps line=11 col=11 end=11:20 file=FILE:game.tsx@1
+node METHOD name=ArtificialPlayer.evaluate qn=ArtificialPlayer.evaluate canonical=game.tsx:ArtificialPlayer.evaluate#0 line=101 col=3 end=106:4 file=FILE:game.tsx@1
+node METHOD name=ArtificialPlayer.turn qn=ArtificialPlayer.turn canonical=game.tsx:ArtificialPlayer.turn#0 line=108 col=3 end=122:4 file=FILE:game.tsx@1
+node METHOD name=Field.clearMove qn=Field.clearMove canonical=game.tsx:Field.clearMove#0 line=91 col=3 end=97:4 file=FILE:game.tsx@1
+node METHOD name=Field.constructor qn=Field.constructor canonical=game.tsx:Field.constructor#0 line=55 col=3 end=63:4 file=FILE:game.tsx@1
+node METHOD name=Field.inRange qn=Field.inRange canonical=game.tsx:Field.inRange#0 line=65 col=3 end=67:4 file=FILE:game.tsx@1
+node METHOD name=Field.isDraw qn=Field.isDraw canonical=game.tsx:Field.isDraw#0 line=73 col=3 end=75:4 file=FILE:game.tsx@1
+node METHOD name=Field.isEmpty qn=Field.isEmpty canonical=game.tsx:Field.isEmpty#0 line=69 col=3 end=71:4 file=FILE:game.tsx@1
+node METHOD name=Field.makeMove qn=Field.makeMove canonical=game.tsx:Field.makeMove#0 line=81 col=3 end=89:4 file=FILE:game.tsx@1
+node METHOD name=Field.rows qn=Field.rows canonical=game.tsx:Field.rows#0 line=77 col=3 end=79:4 file=FILE:game.tsx@1
+node METHOD name=GameObject.announce qn=GameObject.announce canonical=game.tsx:GameObject.announce#0 line=46 col=3 end=48:4 file=FILE:game.tsx@1
+node METHOD name=TicTacToe.board qn=TicTacToe.board canonical=game.tsx:TicTacToe.board#0 line=145 col=3 end=147:4 file=FILE:game.tsx@1
+node METHOD name=TicTacToe.constructor qn=TicTacToe.constructor canonical=game.tsx:TicTacToe.constructor#0 line=129 col=3 end=133:4 file=FILE:game.tsx@1
+node METHOD name=TicTacToe.pick qn=TicTacToe.pick canonical=game.tsx:TicTacToe.pick#0 line=135 col=3 end=143:4 file=FILE:game.tsx@1
+node MODULE name="./helper" qn="./helper" canonical=game.tsx:"./helper"#0 line=2 col=24 end=2:34 file=FILE:game.tsx@1
+node MODULE name="./random" qn="./random" canonical=game.tsx:"./random"#0 line=1 col=27 end=1:37 file=FILE:game.tsx@1
+node TYPEDEF name=Move qn=Move canonical=game.tsx:Move line=6 col=1 end=9:3 file=FILE:game.tsx@1
+node TYPEDEF name=Token qn=Token canonical=game.tsx:Token line=4 col=1 end=4:24 file=FILE:game.tsx@1
+node UNKNOWN name=announce qn=announce canonical=game.tsx:announce#0 line=142 col=10 end=142:18 file=FILE:game.tsx@1
+node UNKNOWN name=board qn=board canonical=game.tsx:board#0 line=151 col=27 end=151:32 file=FILE:game.tsx@1
+node UNKNOWN name=clearMove qn=clearMove canonical=game.tsx:clearMove#0 line=141 col=16 end=141:25 file=FILE:game.tsx@1
+node UNKNOWN name=evaluate qn=evaluate canonical=game.tsx:evaluate#0 line=114 col=28 end=114:36 file=FILE:game.tsx@1
+node UNKNOWN name=helper qn=helper canonical=game.tsx:helper#0 line=2 col=10 end=2:16 file=FILE:game.tsx@1
+node UNKNOWN name=helper qn=helper canonical=game.tsx:helper#1 line=47 col=5 end=47:11 file=FILE:game.tsx@1
+node UNKNOWN name=inRange qn=inRange canonical=game.tsx:inRange#0 line=82 col=15 end=82:22 file=FILE:game.tsx@1
+node UNKNOWN name=inRange qn=inRange canonical=game.tsx:inRange#1 line=92 col=15 end=92:22 file=FILE:game.tsx@1
+node UNKNOWN name=isDraw qn=isDraw canonical=game.tsx:isDraw#0 line=87 col=10 end=87:16 file=FILE:game.tsx@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.tsx:isEmpty#0 line=82 col=38 end=82:45 file=FILE:game.tsx@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.tsx:isEmpty#1 line=92 col=37 end=92:44 file=FILE:game.tsx@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.tsx:isEmpty#2 line=102 col=16 end=102:23 file=FILE:game.tsx@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.tsx:makeMove#0 line=136 col=21 end=136:29 file=FILE:game.tsx@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.tsx:makeMove#1 line=140 col=16 end=140:24 file=FILE:game.tsx@1
+node UNKNOWN name=onPick qn=onPick canonical=game.tsx:onPick#1 line=29 col=51 end=29:57 file=FILE:game.tsx@1
+node UNKNOWN name=pick qn=pick canonical=game.tsx:pick#0 line=154 col=65 end=154:69 file=FILE:game.tsx@1
+node UNKNOWN name=pick qn=pick canonical=game.tsx:pick#1 line=155 col=65 end=155:69 file=FILE:game.tsx@1
+node UNKNOWN name=pick qn=pick canonical=game.tsx:pick#2 line=156 col=65 end=156:69 file=FILE:game.tsx@1
+node UNKNOWN name=pick qn=pick canonical=game.tsx:pick#3 line=163 col=8 end=163:12 file=FILE:game.tsx@1
+node UNKNOWN name=randomInt qn=randomInt canonical=game.tsx:randomInt#0 line=1 col=10 end=1:19 file=FILE:game.tsx@1
+node UNKNOWN name=randomInt qn=randomInt canonical=game.tsx:randomInt#1 line=105 col=12 end=105:21 file=FILE:game.tsx@1
+node UNKNOWN name=rows qn=rows canonical=game.tsx:rows#0 line=146 col=23 end=146:27 file=FILE:game.tsx@1
+node UNKNOWN name=tokenLabel qn=tokenLabel canonical=game.tsx:tokenLabel#1 line=30 col=8 end=30:18 file=FILE:game.tsx@1
+node UNKNOWN name=turn qn=turn canonical=game.tsx:turn#0 line=139 col=33 end=139:37 file=FILE:game.tsx@1
+edge CALL src=FUNCTION:Board@150 dst=FUNCTION:Row@35 resolved_src=- resolved_dst=- line=154 confidence=- certainty=- callsite=h0:154:1:h1 candidates=[]
+edge CALL src=FUNCTION:Board@150 dst=FUNCTION:Row@35 resolved_src=- resolved_dst=- line=155 confidence=- certainty=- callsite=h0:155:1:h1 candidates=[]
+edge CALL src=FUNCTION:Board@150 dst=FUNCTION:Row@35 resolved_src=- resolved_dst=- line=156 confidence=- certainty=- callsite=h0:156:1:h1 candidates=[]
+edge CALL src=FUNCTION:Board@150 dst=FUNCTION:main@153 resolved_src=- resolved_dst=- line=0 confidence=- certainty=- callsite=h0:0:1:h2 candidates=[]
+edge CALL src=FUNCTION:Board@150 dst=UNKNOWN:board@151 resolved_src=- resolved_dst=- line=151 confidence=- certainty=- callsite=h0:151:1:h3|syntax:ts-member-call candidates=[]
+edge CALL src=FUNCTION:Board@150 dst=UNKNOWN:pick@154 resolved_src=- resolved_dst=- line=154 confidence=- certainty=- callsite=h0:154:1:h4|syntax:ts-member-call candidates=[]
+edge CALL src=FUNCTION:Cell@27 dst=FUNCTION:button@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=- callsite=h0:0:1:h5 candidates=[]
+edge CALL src=FUNCTION:Cell@27 dst=UNKNOWN:tokenLabel@30 resolved_src=- resolved_dst=- line=30 confidence=- certainty=- callsite=h0:30:1:h6 candidates=[]
+edge CALL src=FUNCTION:Row@35 dst=FUNCTION:Cell@27 resolved_src=- resolved_dst=- line=38 confidence=- certainty=- callsite=h0:38:1:h7 candidates=[]
+edge CALL src=FUNCTION:Row@35 dst=FUNCTION:Cell@27 resolved_src=- resolved_dst=- line=39 confidence=- certainty=- callsite=h0:39:1:h7 candidates=[]
+edge CALL src=FUNCTION:Row@35 dst=FUNCTION:Cell@27 resolved_src=- resolved_dst=- line=40 confidence=- certainty=- callsite=h0:40:1:h7 candidates=[]
+edge CALL src=FUNCTION:Row@35 dst=FUNCTION:div@37 resolved_src=- resolved_dst=- line=0 confidence=- certainty=- callsite=h0:0:1:h8 candidates=[]
+edge CALL src=FUNCTION:button@29 dst=UNKNOWN:onPick@29 resolved_src=- resolved_dst=- line=29 confidence=- certainty=- callsite=h0:29:1:h9|syntax:ts-member-call candidates=[]
+edge CALL src=FUNCTION:main@153 dst=CLASS:TicTacToe@125 resolved_src=- resolved_dst=- line=162 confidence=- certainty=- callsite=h0:162:1:h10 candidates=[]
+edge CALL src=FUNCTION:main@161 dst=METHOD:TicTacToe.pick@135 resolved_src=- resolved_dst=METHOD:TicTacToe.pick@135 line=163 confidence=1.0000 certainty=Certain callsite=h0:163:1:h11 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.evaluate@101 dst=METHOD:Field.isEmpty@69 resolved_src=- resolved_dst=METHOD:Field.isEmpty@69 line=102 confidence=1.0000 certainty=Certain callsite=h0:102:1:h12 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@108 dst=METHOD:ArtificialPlayer.evaluate@101 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.evaluate@101 line=114 confidence=1.0000 certainty=Certain callsite=h0:114:1:h13 candidates=[]
+edge CALL src=METHOD:Field.clearMove@91 dst=METHOD:Field.inRange@65 resolved_src=- resolved_dst=METHOD:Field.inRange@65 line=92 confidence=1.0000 certainty=Certain callsite=h0:92:1:h14 candidates=[]
+edge CALL src=METHOD:Field.clearMove@91 dst=METHOD:Field.isEmpty@69 resolved_src=- resolved_dst=METHOD:Field.isEmpty@69 line=92 confidence=1.0000 certainty=Certain callsite=h0:92:1:h12 candidates=[]
+edge CALL src=METHOD:Field.constructor@55 dst=CLASS:ArtificialPlayer@100 resolved_src=- resolved_dst=- line=132 confidence=- certainty=- callsite=h0:132:1:h15 candidates=[]
+edge CALL src=METHOD:Field.constructor@55 dst=CLASS:Field@51 resolved_src=- resolved_dst=- line=131 confidence=- certainty=- callsite=h0:131:1:h16 candidates=[]
+edge CALL src=METHOD:Field.makeMove@81 dst=METHOD:Field.inRange@65 resolved_src=- resolved_dst=METHOD:Field.inRange@65 line=82 confidence=1.0000 certainty=Certain callsite=h0:82:1:h14 candidates=[]
+edge CALL src=METHOD:Field.makeMove@81 dst=METHOD:Field.isDraw@73 resolved_src=- resolved_dst=METHOD:Field.isDraw@73 line=87 confidence=1.0000 certainty=Certain callsite=h0:87:1:h17 candidates=[]
+edge CALL src=METHOD:Field.makeMove@81 dst=METHOD:Field.isEmpty@69 resolved_src=- resolved_dst=METHOD:Field.isEmpty@69 line=82 confidence=1.0000 certainty=Certain callsite=h0:82:1:h12 candidates=[]
+edge CALL src=METHOD:TicTacToe.board@145 dst=METHOD:Field.rows@77 resolved_src=- resolved_dst=METHOD:Field.rows@77 line=146 confidence=1.0000 certainty=Certain callsite=h0:146:1:h18 candidates=[]
+edge CALL src=METHOD:TicTacToe.pick@135 dst=METHOD:ArtificialPlayer.turn@108 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.turn@108 line=139 confidence=1.0000 certainty=Certain callsite=h0:139:1:h19 candidates=[]
+edge CALL src=METHOD:TicTacToe.pick@135 dst=METHOD:Field.clearMove@91 resolved_src=- resolved_dst=METHOD:Field.clearMove@91 line=141 confidence=1.0000 certainty=Certain callsite=h0:141:1:h20 candidates=[]
+edge CALL src=METHOD:TicTacToe.pick@135 dst=METHOD:Field.makeMove@81 resolved_src=- resolved_dst=METHOD:Field.makeMove@81 line=136 confidence=1.0000 certainty=Certain callsite=h0:136:1:h21 candidates=[]
+edge CALL src=METHOD:TicTacToe.pick@135 dst=METHOD:Field.makeMove@81 resolved_src=- resolved_dst=METHOD:Field.makeMove@81 line=140 confidence=1.0000 certainty=Certain callsite=h0:140:1:h21 candidates=[]
+edge CALL src=METHOD:TicTacToe.pick@135 dst=UNKNOWN:announce@142 resolved_src=- resolved_dst=- line=142 confidence=- certainty=- callsite=h0:142:1:h22|syntax:ts-member-call candidates=[]
+edge CALL src=UNKNOWN:helper@47 dst=UNKNOWN:helper@2 resolved_src=- resolved_dst=- line=47 confidence=- certainty=- callsite=h0:47:1:h23 candidates=[]
+edge CALL src=UNKNOWN:pick@155 dst=UNKNOWN:pick@154 resolved_src=- resolved_dst=- line=155 confidence=- certainty=- callsite=h0:155:1:h24|syntax:ts-member-call candidates=[]
+edge CALL src=UNKNOWN:pick@156 dst=UNKNOWN:pick@154 resolved_src=- resolved_dst=- line=156 confidence=- certainty=- callsite=h0:156:1:h25|syntax:ts-member-call candidates=[]
+edge CALL src=UNKNOWN:randomInt@105 dst=UNKNOWN:randomInt@1 resolved_src=- resolved_dst=- line=105 confidence=- certainty=- callsite=h0:105:1:h26 candidates=[]
+edge IMPORT src=MODULE:"./helper"@2 dst=MODULE:"./helper"@2 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=MODULE:"./random"@1 dst=MODULE:"./random"@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:helper@2 dst=MODULE:"./helper"@2 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:randomInt@1 dst=MODULE:"./random"@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ArtificialPlayer@100 dst=CLASS:GameObject@45 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@51 dst=CLASS:GameObject@45 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:TicTacToe@125 dst=CLASS:GameObject@45 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@100 dst=METHOD:ArtificialPlayer.evaluate@101 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@100 dst=METHOD:ArtificialPlayer.turn@108 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@51 dst=METHOD:Field.clearMove@91 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@51 dst=METHOD:Field.constructor@55 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@51 dst=METHOD:Field.inRange@65 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@51 dst=METHOD:Field.isDraw@73 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@51 dst=METHOD:Field.isEmpty@69 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@51 dst=METHOD:Field.makeMove@81 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@51 dst=METHOD:Field.rows@77 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:GameObject@45 dst=METHOD:GameObject.announce@46 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@125 dst=METHOD:TicTacToe.board@145 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@125 dst=METHOD:TicTacToe.constructor@129 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@125 dst=METHOD:TicTacToe.pick@135 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge USAGE src=FUNCTION:Board@150 dst=FIELD:cells@35 resolved_src=- resolved_dst=- line=154 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Board@150 dst=FIELD:className@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Board@150 dst=FIELD:onPick@14 resolved_src=- resolved_dst=- line=154 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Board@150 dst=FIELD:row@7 resolved_src=- resolved_dst=- line=154 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Cell@27 dst=FIELD:className@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Cell@27 dst=FIELD:onClick@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Row@35 dst=FIELD:className@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Row@35 dst=FIELD:move@13 resolved_src=- resolved_dst=- line=38 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Row@35 dst=FIELD:onPick@14 resolved_src=- resolved_dst=- line=38 confidence=- certainty=- callsite=- candidates=[]
+edge USAGE src=FUNCTION:Row@35 dst=FIELD:value@12 resolved_src=- resolved_dst=- line=38 confidence=- certainty=- callsite=- candidates=[]
+file path=game.tsx language=typescript lines=164 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@100 kind=DEFINITION span=100:7-100:23
+occurrence element=CLASS:Field@51 kind=DEFINITION span=51:7-51:12
+occurrence element=CLASS:GameObject@45 kind=DEFINITION span=100:32-100:42
+occurrence element=CLASS:GameObject@45 kind=DEFINITION span=125:32-125:42
+occurrence element=CLASS:GameObject@45 kind=DEFINITION span=45:7-45:17
+occurrence element=CLASS:GameObject@45 kind=DEFINITION span=51:21-51:31
+occurrence element=CLASS:TicTacToe@125 kind=DEFINITION span=125:14-125:23
+occurrence element=FIELD:cells@35 kind=DEFINITION span=35:23-35:28
+occurrence element=FIELD:className@29 kind=DEFINITION span=29:13-29:22
+occurrence element=FIELD:col@8 kind=DEFINITION span=8:3-8:6
+occurrence element=FIELD:field@126 kind=DEFINITION span=126:11-126:16
+occurrence element=FIELD:game@150 kind=DEFINITION span=150:32-150:36
+occurrence element=FIELD:grid@52 kind=DEFINITION span=52:11-52:15
+occurrence element=FIELD:left@53 kind=DEFINITION span=53:11-53:15
+occurrence element=FIELD:move@13 kind=DEFINITION span=13:3-13:7
+occurrence element=FIELD:onClick@29 kind=DEFINITION span=29:30-29:37
+occurrence element=FIELD:onPick@14 kind=DEFINITION span=14:3-14:9
+occurrence element=FIELD:opponent@127 kind=DEFINITION span=127:11-127:19
+occurrence element=FIELD:row@7 kind=DEFINITION span=7:3-7:6
+occurrence element=FIELD:value@12 kind=DEFINITION span=12:3-12:8
+occurrence element=FUNCTION:Board@150 kind=DEFINITION span=150:8-159:2
+occurrence element=FUNCTION:Cell@27 kind=DEFINITION span=27:1-33:2
+occurrence element=FUNCTION:Row@35 kind=DEFINITION span=35:1-43:2
+occurrence element=FUNCTION:button@29 kind=DEFINITION span=29:6-29:12
+occurrence element=FUNCTION:div@37 kind=DEFINITION span=37:6-37:9
+occurrence element=FUNCTION:main@153 kind=DEFINITION span=153:6-153:10
+occurrence element=FUNCTION:main@161 kind=DEFINITION span=161:8-164:2
+occurrence element=FUNCTION:tokenLabel@17 kind=DEFINITION span=17:1-25:2
+occurrence element=INTERFACE:CellProps@11 kind=DEFINITION span=11:11-11:20
+occurrence element=METHOD:ArtificialPlayer.evaluate@101 kind=DEFINITION span=101:3-106:4
+occurrence element=METHOD:ArtificialPlayer.turn@108 kind=DEFINITION span=108:3-122:4
+occurrence element=METHOD:Field.clearMove@91 kind=DEFINITION span=91:3-97:4
+occurrence element=METHOD:Field.constructor@55 kind=DEFINITION span=55:3-63:4
+occurrence element=METHOD:Field.inRange@65 kind=DEFINITION span=65:3-67:4
+occurrence element=METHOD:Field.isDraw@73 kind=DEFINITION span=73:3-75:4
+occurrence element=METHOD:Field.isEmpty@69 kind=DEFINITION span=69:3-71:4
+occurrence element=METHOD:Field.makeMove@81 kind=DEFINITION span=81:3-89:4
+occurrence element=METHOD:Field.rows@77 kind=DEFINITION span=77:3-79:4
+occurrence element=METHOD:GameObject.announce@46 kind=DEFINITION span=46:3-48:4
+occurrence element=METHOD:TicTacToe.board@145 kind=DEFINITION span=145:3-147:4
+occurrence element=METHOD:TicTacToe.constructor@129 kind=DEFINITION span=129:3-133:4
+occurrence element=METHOD:TicTacToe.pick@135 kind=DEFINITION span=135:3-143:4
+occurrence element=MODULE:"./helper"@2 kind=DEFINITION span=2:24-2:34
+occurrence element=MODULE:"./random"@1 kind=DEFINITION span=1:27-1:37
+occurrence element=TYPEDEF:Move@6 kind=DEFINITION span=6:1-9:3
+occurrence element=TYPEDEF:Token@4 kind=DEFINITION span=4:1-4:24
+occurrence element=UNKNOWN:announce@142 kind=DEFINITION span=142:10-142:18
+occurrence element=UNKNOWN:board@151 kind=DEFINITION span=151:27-151:32
+occurrence element=UNKNOWN:clearMove@141 kind=DEFINITION span=141:16-141:25
+occurrence element=UNKNOWN:evaluate@114 kind=DEFINITION span=114:28-114:36
+occurrence element=UNKNOWN:helper@2 kind=DEFINITION span=2:10-2:16
+occurrence element=UNKNOWN:helper@47 kind=DEFINITION span=47:5-47:11
+occurrence element=UNKNOWN:inRange@82 kind=DEFINITION span=82:15-82:22
+occurrence element=UNKNOWN:inRange@92 kind=DEFINITION span=92:15-92:22
+occurrence element=UNKNOWN:isDraw@87 kind=DEFINITION span=87:10-87:16
+occurrence element=UNKNOWN:isEmpty@102 kind=DEFINITION span=102:16-102:23
+occurrence element=UNKNOWN:isEmpty@82 kind=DEFINITION span=82:38-82:45
+occurrence element=UNKNOWN:isEmpty@92 kind=DEFINITION span=92:37-92:44
+occurrence element=UNKNOWN:makeMove@136 kind=DEFINITION span=136:21-136:29
+occurrence element=UNKNOWN:makeMove@140 kind=DEFINITION span=140:16-140:24
+occurrence element=UNKNOWN:onPick@29 kind=DEFINITION span=29:51-29:57
+occurrence element=UNKNOWN:pick@154 kind=DEFINITION span=154:65-154:69
+occurrence element=UNKNOWN:pick@155 kind=DEFINITION span=155:65-155:69
+occurrence element=UNKNOWN:pick@156 kind=DEFINITION span=156:65-156:69
+occurrence element=UNKNOWN:pick@163 kind=DEFINITION span=163:8-163:12
+occurrence element=UNKNOWN:randomInt@1 kind=DEFINITION span=1:10-1:19
+occurrence element=UNKNOWN:randomInt@105 kind=DEFINITION span=105:12-105:21
+occurrence element=UNKNOWN:rows@146 kind=DEFINITION span=146:23-146:27
+occurrence element=UNKNOWN:tokenLabel@30 kind=DEFINITION span=30:8-30:18
+occurrence element=UNKNOWN:turn@139 kind=DEFINITION span=139:33-139:37
+access node=FIELD:className@29 kind=Public
+access node=FIELD:field@126 kind=Private
+access node=FIELD:grid@52 kind=Private
+access node=FIELD:left@53 kind=Private
+access node=FIELD:onClick@29 kind=Public
+access node=FIELD:opponent@127 kind=Private
+access node=METHOD:ArtificialPlayer.evaluate@101 kind=Public
+access node=METHOD:ArtificialPlayer.turn@108 kind=Public
+access node=METHOD:Field.clearMove@91 kind=Public
+access node=METHOD:Field.constructor@55 kind=Public
+access node=METHOD:Field.inRange@65 kind=Public
+access node=METHOD:Field.isDraw@73 kind=Public
+access node=METHOD:Field.isEmpty@69 kind=Public
+access node=METHOD:Field.makeMove@81 kind=Public
+access node=METHOD:Field.rows@77 kind=Public
+access node=METHOD:GameObject.announce@46 kind=Public
+access node=METHOD:TicTacToe.board@145 kind=Public
+access node=METHOD:TicTacToe.constructor@129 kind=Public
+access node=METHOD:TicTacToe.pick@135 kind=Public
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "13:Board", node_id: NodeId(-58527397445540665), signature_hash: -9010421034474908197, normalized_signature: Some("shape:4935451048788435828"), body_hash: 5703596668956645134, start_line: 150, end_line: 159 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "13:Cell", node_id: NodeId(-8438377986514056141), signature_hash: 3832958115132467035, normalized_signature: Some("shape:4535241117014538077"), body_hash: 5159021474496144376, start_line: 27, end_line: 33 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "13:Row", node_id: NodeId(-6889767165843046629), signature_hash: -6253407580123594297, normalized_signature: Some("shape:6504831437327793549"), body_hash: 8949892768696320399, start_line: 35, end_line: 43 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "13:button", node_id: NodeId(-4348506163033861125), signature_hash: -9120599125457830493, normalized_signature: Some("shape:5796145517636365347"), body_hash: -5783418087970544966, start_line: 29, end_line: 29 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "13:div", node_id: NodeId(-2809348445563293116), signature_hash: -935513631673984014, normalized_signature: Some("outline:-1793518511152586733"), body_hash: -8888091842825138237, start_line: 37, end_line: 37 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "13:main", node_id: NodeId(4616488697868602066), signature_hash: -4671339478033693080, normalized_signature: Some("shape:5983920156585348712"), body_hash: -2045356737158685207, start_line: 153, end_line: 153 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "13:main", node_id: NodeId(4616489797380230277), signature_hash: -4671339478033693080, normalized_signature: Some("shape:-1550258063606445053"), body_hash: 8990146851857213756, start_line: 161, end_line: 164 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "13:tokenLabel", node_id: NodeId(2951362405926791418), signature_hash: 2453353863296413412, normalized_signature: Some("outline:-1800836860548445349"), body_hash: -4156896032434162540, start_line: 17, end_line: 25 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:ArtificialPlayer.evaluate", node_id: NodeId(881930982258325029), signature_hash: -3339369090062122330, normalized_signature: Some("shape:-554031375901977189"), body_hash: -164477342352592581, start_line: 101, end_line: 106 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:ArtificialPlayer.turn", node_id: NodeId(3095714670153480157), signature_hash: 5754064973517794814, normalized_signature: Some("shape:-6793771729218438093"), body_hash: -4793678948938790680, start_line: 108, end_line: 122 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:Field.clearMove", node_id: NodeId(6587492490135750297), signature_hash: -3022140259302478, normalized_signature: Some("shape:-319005352343789277"), body_hash: 6512185859257839242, start_line: 91, end_line: 97 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:Field.constructor", node_id: NodeId(5206607837022258193), signature_hash: 6795144599545714474, normalized_signature: Some("shape:-7984952471233951053"), body_hash: -6877708281523338280, start_line: 55, end_line: 63 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:Field.inRange", node_id: NodeId(-7650018926874321663), signature_hash: -8452809604799432690, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -3074377517147720922, start_line: 65, end_line: 67 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:Field.isDraw", node_id: NodeId(-8681875340098141653), signature_hash: 7260325517996505566, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -3587177011067932241, start_line: 73, end_line: 75 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:Field.isEmpty", node_id: NodeId(-5151356892953044696), signature_hash: -7303087957103600159, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -1616556938663478118, start_line: 69, end_line: 71 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:Field.makeMove", node_id: NodeId(-3544969137293475530), signature_hash: -7686617887134063555, normalized_signature: Some("shape:1877073300841969243"), body_hash: -5475615297966182806, start_line: 81, end_line: 89 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:Field.rows", node_id: NodeId(3578150512697395940), signature_hash: -8575155791985719677, normalized_signature: Some("outline:-5084961018881034800"), body_hash: 3196776792474126508, start_line: 77, end_line: 79 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:GameObject.announce", node_id: NodeId(-4910525915264931675), signature_hash: 6265382829821424686, normalized_signature: Some("shape:1053352375547529618"), body_hash: -2140526456050809445, start_line: 46, end_line: 48 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:TicTacToe.board", node_id: NodeId(-2538822715498621591), signature_hash: 809848471190349994, normalized_signature: Some("shape:1723644308566149600"), body_hash: -7107333460881112177, start_line: 145, end_line: 147 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:TicTacToe.constructor", node_id: NodeId(4582267099969079345), signature_hash: -9167033954688097950, normalized_signature: Some("outline:-5087212818695232478"), body_hash: -2657224169385267888, start_line: 129, end_line: 133 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "14:TicTacToe.pick", node_id: NodeId(2718943774471667888), signature_hash: -2396742236410006141, normalized_signature: Some("shape:3656790944212650451"), body_hash: -9086931632419372472, start_line: 135, end_line: 143 }
+callable_state CallableProjectionState { file_id: 4615304419513614810, symbol_key: "__file_structural__", node_id: NodeId(4615304419513614810), signature_hash: 553768115714561381, normalized_signature: None, body_hash: -4496094463774549978, start_line: 1, end_line: 164 }

--- a/crates/codestory-indexer/tests/fixtures/tictactoe/tsx_tictactoe.tsx
+++ b/crates/codestory-indexer/tests/fixtures/tictactoe/tsx_tictactoe.tsx
@@ -1,0 +1,164 @@
+import { randomInt } from "./random";
+import { helper } from "./helper";
+
+type Token = 0 | 1 | 4;
+
+type Move = {
+  row: number;
+  col: number;
+};
+
+interface CellProps {
+  value: Token;
+  move: Move;
+  onPick: (move: Move) => void;
+}
+
+function tokenLabel(value: Token): string {
+  if (value === 1) {
+    return "X";
+  }
+  if (value === 4) {
+    return "O";
+  }
+  return " ";
+}
+
+function Cell(props: CellProps) {
+  return (
+    <button className="cell" onClick={() => props.onPick(props.move)}>
+      {tokenLabel(props.value)}
+    </button>
+  );
+}
+
+function Row(props: { cells: Token[]; row: number; onPick: (move: Move) => void }) {
+  return (
+    <div className="row">
+      <Cell value={props.cells[0]} move={{ row: props.row, col: 0 }} onPick={props.onPick} />
+      <Cell value={props.cells[1]} move={{ row: props.row, col: 1 }} onPick={props.onPick} />
+      <Cell value={props.cells[2]} move={{ row: props.row, col: 2 }} onPick={props.onPick} />
+    </div>
+  );
+}
+
+class GameObject {
+  announce(): void {
+    helper();
+  }
+}
+
+class Field extends GameObject {
+  private grid: Token[][];
+  private left: number;
+
+  constructor() {
+    super();
+    this.grid = [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ];
+    this.left = 9;
+  }
+
+  inRange(move: Move): boolean {
+    return move.row >= 0 && move.row < 3 && move.col >= 0 && move.col < 3;
+  }
+
+  isEmpty(move: Move): boolean {
+    return this.grid[move.row][move.col] === 0;
+  }
+
+  isDraw(): boolean {
+    return this.left === 0;
+  }
+
+  rows(): Token[][] {
+    return this.grid;
+  }
+
+  makeMove(move: Move, token: Token): boolean {
+    if (!this.inRange(move) || !this.isEmpty(move)) {
+      return false;
+    }
+    this.grid[move.row][move.col] = token;
+    this.left -= 1;
+    this.isDraw();
+    return true;
+  }
+
+  clearMove(move: Move): void {
+    if (!this.inRange(move) || this.isEmpty(move)) {
+      return;
+    }
+    this.grid[move.row][move.col] = 0;
+    this.left += 1;
+  }
+}
+
+class ArtificialPlayer extends GameObject {
+  evaluate(field: Field, move: Move): number {
+    if (!field.isEmpty(move)) {
+      return -1;
+    }
+    return randomInt(0, 2);
+  }
+
+  turn(field: Field): Move {
+    let best: Move = { row: 0, col: 0 };
+    let bestValue = -1;
+    for (let row = 0; row < 3; row += 1) {
+      for (let col = 0; col < 3; col += 1) {
+        const move = { row, col };
+        const value = this.evaluate(field, move);
+        if (value > bestValue) {
+          bestValue = value;
+          best = move;
+        }
+      }
+    }
+    return best;
+  }
+}
+
+export class TicTacToe extends GameObject {
+  private field: Field;
+  private opponent: ArtificialPlayer;
+
+  constructor() {
+    super();
+    this.field = new Field();
+    this.opponent = new ArtificialPlayer();
+  }
+
+  pick(move: Move): void {
+    if (!this.field.makeMove(move, 1)) {
+      return;
+    }
+    const reply = this.opponent.turn(this.field);
+    this.field.makeMove(reply, 4);
+    this.field.clearMove(reply);
+    this.announce();
+  }
+
+  board(): Token[][] {
+    return this.field.rows();
+  }
+}
+
+export function Board(props: { game: TicTacToe }) {
+  const rows = props.game.board();
+  return (
+    <main className="board">
+      <Row cells={rows[0]} row={0} onPick={(move) => props.game.pick(move)} />
+      <Row cells={rows[1]} row={1} onPick={(move) => props.game.pick(move)} />
+      <Row cells={rows[2]} row={2} onPick={(move) => props.game.pick(move)} />
+    </main>
+  );
+}
+
+export function main(): void {
+  const game = new TicTacToe();
+  game.pick({ row: 1, col: 1 });
+}

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,32 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    // TSX is the one row whose fixtures are new rather than reused: the
+    // `fidelity_lab` and `tictactoe` corpora only carried a `.ts` file, and a
+    // `.ts` fixture proves nothing about the TSX grammar, the `tsx.graph.scm`
+    // rule file, or the JSX usage edges that only a `.tsx` extension turns on.
+    SnapshotCase {
+        language: "tsx",
+        extension: "tsx",
+        fidelity_filename: "fidelity.tsx",
+        fidelity_source: include_str!("fixtures/fidelity_lab/tsx_fidelity_lab.tsx"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/tsx_fidelity.txt"),
+        tictactoe_filename: "game.tsx",
+        tictactoe_source: include_str!("fixtures/tictactoe/tsx_tictactoe.tsx"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/tsx_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1682.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
