### PR TITLE
[v0.17 S3-PYTHON] Extract Python language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3940,7 +3940,7 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
     // extraction package has not landed yet (ARCH-012 roster burn-down).
     let comment_marker = codestory_contracts::language_support::line_comment_for_language(language)
         .or(match language {
-            "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
+            "bash" | "ruby" | "toml" | "yaml" => Some("#"),
             "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
             | "cpp" | "dart" | "php" | "swift" => Some("//"),
             _ => None,
@@ -5572,8 +5572,8 @@ mod tests {
         assert!(bash.contains("\x1b[90m# comment\x1b[0m"), "{bash:?}");
     }
 
-    /// Kotlin's comment marker now comes from the language registry rather than
-    /// the local roster, and every other language must be unmoved.
+    /// Migrated languages take their comment marker from the language registry
+    /// rather than the local roster, and every other language must be unmoved.
     ///
     /// Asserting only "Kotlin still dims `//`" would pass with the registry
     /// lookup deleted, because the local roster used to answer for Kotlin too.
@@ -5631,14 +5631,20 @@ mod tests {
             }
         }
 
-        // The registry is the source for Kotlin: it must agree with the marker
-        // the roster used to hold.
+        // The registry is the source for the migrated languages: it must agree
+        // with the marker the roster used to hold.
         assert_eq!(
             codestory_contracts::language_support::line_comment_for_language("kotlin"),
             Some("//")
         );
         let kotlin = ansi_highlight_snippet("app/Main.kt", "val ok = true // comment");
         assert!(kotlin.contains("\x1b[90m// comment\x1b[0m"), "{kotlin:?}");
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("python"),
+            Some("#")
+        );
+        let python = ansi_highlight_snippet("app/main.py", "ok = True  # comment");
+        assert!(python.contains("\x1b[90m# comment\x1b[0m"), "{python:?}");
     }
 
     /// Component dialects resolve through the companion-extension registry and

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "python",
+        line_comment: "#",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "python"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,6 +1265,7 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("python"), Some("#"));
         assert_eq!(line_comment_for_language("swift"), None);
     }
 

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -1,9 +1,9 @@
 use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
     GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
-    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    PHP_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY,
+    TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -29,7 +29,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
     }
 
     match (profile.language_name, ext.as_str()) {
-        ("python", _) => Some(python()),
         ("java", _) => Some(java()),
         ("rust", _) => Some(rust()),
         ("javascript", _) => Some(javascript()),
@@ -46,16 +45,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("bash", _) => Some(bash()),
         _ => None,
     }
-}
-
-fn python() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_python::LANGUAGE.into(),
-        "python",
-        PYTHON_GRAPH_QUERY,
-        None,
-        LanguageRuleset::Python,
-    )
 }
 
 fn java() -> LanguageConfig {

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -17,6 +17,7 @@
 //! package to land deletes the residual arms entirely.
 
 pub(crate) mod kotlin;
+pub(crate) mod python;
 
 use std::sync::OnceLock;
 
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, python::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {
@@ -235,6 +236,40 @@ mod tests {
         assert_eq!(
             extraction_for_ext("kts").map(|row| row.language_name),
             Some("kotlin")
+        );
+    }
+
+    /// The Python row must keep the exact projection facts it had while it was
+    /// spread across `lib.rs`. Python's values differ from Kotlin's on two of
+    /// them, which is precisely why they have to be pinned: `promotes_type_...`
+    /// was false because the rule file already projects a class body's
+    /// `function_definition` as a METHOD, and `route_comments_are_c_style` was
+    /// false because Python comments are `#`.
+    #[test]
+    fn python_row_keeps_the_projection_facts_it_had_in_the_god_file() {
+        let python = extraction_for_language("python").expect("python row");
+        assert!(!python.promotes_type_member_functions_to_methods);
+        assert_eq!(python.qualified_name_delimiter, ".");
+        assert!(!python.route_comments_are_c_style);
+        assert_eq!(python.semantic_family, "python");
+        assert!(!python.uses_generic_semantic_resolver);
+        assert_eq!(
+            python.member_callsite_marker,
+            Some("syntax:python-attribute-call")
+        );
+        assert_eq!(
+            member_callsite_marker_for_call_syntax("python_attribute"),
+            Some("syntax:python-attribute-call")
+        );
+        assert!(python.receiver_call_specs.is_some());
+        assert!(python.tags_query.is_none());
+        assert_eq!(
+            extraction_for_ext("py").map(|row| row.language_name),
+            Some("python")
+        );
+        assert_eq!(
+            extraction_for_ext("pyi").map(|row| row.language_name),
+            Some("python")
         );
     }
 }

--- a/crates/codestory-indexer/src/languages/python.rs
+++ b/crates/codestory-indexer/src/languages/python.rs
@@ -1,0 +1,998 @@
+//! Python extraction rules.
+//!
+//! Python's graph extraction lives here: the tree-sitter rule file, the
+//! compiled-rule cache, the attribute-call callsite marker, and the
+//! receiver-call resolution engine that turns `repo.save(...)`,
+//! `self.store.load(...)` and `@decorator`-shaped calls into edges aimed at the
+//! owner they were declared against. Every language-keyed dispatch in the crate
+//! reaches it through [`super::EXTRACTIONS`] rather than by spelling
+//! `"python"`.
+//!
+//! Five Python entry points stay `pub(crate)` because their *call sites* are
+//! shared seams that no registry field describes yet — the seam keeps its
+//! `language_name == "python"` guard in `lib.rs` and calls in here for the
+//! content:
+//!
+//! * [`decorator_call_specs`], invoked from the manual-edge collector next to
+//!   the Rust macro and Ruby bare-call collectors;
+//! * [`is_implicit_receiver`] and [`attribute_method_col`], read by
+//!   `lib.rs::append_manual_receiver_call_edges` and
+//!   `lib.rs::member_call_method_col`, which every language's receiver engine
+//!   shares;
+//! * [`is_constant_name`], read by the graph-node projection that promotes a
+//!   SCREAMING_CASE Python `VARIABLE` to `CONSTANT`;
+//! * [`MEMBER_CALLSITE_MARKER`], read by `resolution` and by the two `lib.rs`
+//!   placeholder-annotation rosters.
+//!
+//! Two further Python surfaces are deliberately *not* here, and both are shared
+//! seams rather than Python content:
+//!
+//! * `lib.rs::collect_python_route` and its `"python"` arm in the
+//!   framework-route scanner. The per-language route collectors take
+//!   non-uniform arguments, so routing them through the registry is one change
+//!   for all sixteen languages, not part of Python's rollback unit.
+//! * `LanguageRuleset::Python`, which stays in `lib.rs` because the enum is the
+//!   compiled-rule cache key for every language at once.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both Python fixtures so the move stays output-equal.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use codestory_contracts::graph::EdgeKind;
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, ImportedTypeBinding, LanguageRuleset, ManualEdgeSpec,
+    ManualReceiverCallSpec, ManualReceiverSource, OptionalReceiverOwnerBinding,
+    ReceiverCallSiteKey, collect_colon_parameter_types, collect_receiver_call_specs_in_callable,
+    declaration_name, enclosing_node_with_kind, first_descendant_with_kind, member_call_method_col,
+    node_source_text, normalize_parameter_name, normalized_receiver_variable,
+    parameter_name_before_colon, receiver_call_belongs_to_callable, receiver_callsite_key,
+    same_ts_span, signature_parameter_surface, split_top_level_parameters, surface_member_call,
+    trimmed_node_text, ts_node_graph_span, walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from Python attribute-call
+/// syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:python-attribute-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/python.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for Python.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["python"],
+    language_name: "python",
+    extensions: &["py", "pyi"],
+    ruleset: LanguageRuleset::Python,
+    parser_language: python_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    receiver_call_specs: Some(receiver_call_specs),
+    member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
+    graph_call_syntax: Some("python_attribute"),
+    // A Python `function_definition` under a `class_definition` is already
+    // projected as a METHOD by the rule file, so the projection must not
+    // promote it a second time.
+    promotes_type_member_functions_to_methods: false,
+    qualified_name_delimiter: ".",
+    // Python comments are `#`, so the route scanner takes the hash-stripping
+    // branch rather than the C-style one.
+    route_comments_are_c_style: false,
+    // `semantic::PythonSemanticResolver` is a dedicated resolver, private to
+    // that module; the registry records the choice and the residual match in
+    // `semantic::dedicated_semantic_resolver` constructs it.
+    uses_generic_semantic_resolver: false,
+    semantic_family: "python",
+};
+
+fn python_language() -> tree_sitter::Language {
+    tree_sitter_python::LANGUAGE.into()
+}
+
+pub(crate) fn is_constant_name(name: &str) -> bool {
+    let trimmed = name.trim();
+    !trimmed.is_empty()
+        && trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_')
+        && trimmed.chars().any(|ch| ch.is_ascii_uppercase())
+}
+
+fn python_decorator_target_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    match node.kind() {
+        "decorator" => {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor)
+                .find_map(|child| python_decorator_target_name(child, source))
+        }
+        "call" => node
+            .child_by_field_name("function")
+            .and_then(|function| python_decorator_target_name(function, source)),
+        "attribute" => node
+            .child_by_field_name("attribute")
+            .and_then(|attribute| node_source_text(attribute, source))
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty()),
+        "identifier" => node_source_text(node, source)
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty()),
+        _ => None,
+    }
+}
+
+pub(crate) fn decorator_call_specs(tree: &Tree, source: &str) -> Vec<ManualEdgeSpec> {
+    let mut edges = Vec::new();
+    walk_tree_nodes(tree.root_node(), &mut |node| {
+        if node.kind() != "decorated_definition" {
+            return;
+        }
+        let Some(definition) = node.child_by_field_name("definition") else {
+            return;
+        };
+        let Some(source_name) = definition
+            .child_by_field_name("name")
+            .and_then(|name| node_source_text(name, source))
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty())
+        else {
+            return;
+        };
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() != "decorator" {
+                continue;
+            }
+            let Some(target_name) = python_decorator_target_name(child, source) else {
+                continue;
+            };
+            edges.push(ManualEdgeSpec {
+                source_name: source_name.clone(),
+                target_name,
+                kind: EdgeKind::CALL,
+                line: Some(child.start_position().row as u32 + 1),
+            });
+        }
+    });
+    edges
+}
+
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let imported_type_bindings = collect_python_imported_type_bindings(tree.root_node(), source);
+    walk_tree_nodes(tree.root_node(), &mut |callable| {
+        if callable.kind() != "function_definition" {
+            return;
+        }
+        let Some(source_name) = declaration_name(callable, source) else {
+            return;
+        };
+        let call_source = ManualReceiverSource {
+            name: &source_name,
+            span: ts_node_graph_span(callable),
+        };
+        let mut local_receiver_callsites = HashSet::new();
+        collect_python_constructor_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &imported_type_bindings,
+            &mut local_receiver_callsites,
+            &mut edges,
+        );
+        collect_python_instance_property_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &imported_type_bindings,
+            &mut edges,
+        );
+        let receiver_types = collect_python_receiver_types(callable, source);
+        if receiver_types.is_empty() {
+            return;
+        }
+        let start = edges.len();
+        collect_receiver_call_specs_in_callable(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &receiver_types,
+            member_call,
+            true,
+            &mut edges,
+        );
+        let mut fallback_specs = edges.split_off(start);
+        fallback_specs
+            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
+        for spec in &mut fallback_specs {
+            if !is_implicit_receiver(&spec.receiver_name)
+                && let Some(binding) = imported_type_bindings.get(&spec.owner_name)
+            {
+                spec.owner_name = binding.owner_name.clone();
+                spec.owner_module = Some(binding.module_name.clone());
+            }
+        }
+        edges.extend(fallback_specs);
+    });
+    edges
+}
+
+pub(crate) fn is_implicit_receiver(receiver_name: &str) -> bool {
+    matches!(receiver_name, "self" | "cls")
+}
+
+fn collect_python_instance_property_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    let Some(class_node) = enclosing_node_with_kind(callable, &["class_definition"]) else {
+        return;
+    };
+    let Some(self_name) = python_instance_self_parameter(callable, source) else {
+        return;
+    };
+    if python_function_has_static_or_classmethod_decorator(callable, source) {
+        return;
+    }
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable)
+            || !python_receiver_is_self_property(&receiver_name, &self_name)
+        {
+            return;
+        }
+        let Some(owner) = python_visible_instance_property_receiver_owner(
+            class_node,
+            callable,
+            node,
+            &receiver_name,
+            source,
+            imported_type_bindings,
+        ) else {
+            return;
+        };
+        if let Some((owner_name, owner_module)) = owner {
+            edges.push(ManualReceiverCallSpec {
+                source_name: call_source.name.to_string(),
+                source_span: call_source.span,
+                receiver_name,
+                owner_name,
+                owner_module,
+                method_name: method_name.clone(),
+                method_col: member_call_method_col(node, source, &method_name),
+                line: Some(node.start_position().row as u32 + 1),
+                allow_global_fallback: false,
+            });
+        }
+    });
+}
+
+fn python_visible_instance_property_receiver_owner(
+    class_node: TsNode<'_>,
+    call_method: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut candidates = Vec::new();
+    walk_tree_nodes(class_node, &mut |node| {
+        let Some((assignment_receiver, assignment_method, owner)) =
+            python_instance_property_assignment_owner(
+                node,
+                class_node,
+                source,
+                imported_type_bindings,
+            )
+        else {
+            return;
+        };
+        if assignment_receiver != receiver_name
+            || !python_property_assignment_visible_at_call(
+                node,
+                assignment_method,
+                call_method,
+                call_node,
+            )
+        {
+            return;
+        }
+        candidates.push(owner);
+    });
+    if candidates.is_empty() {
+        return None;
+    }
+    let Some(mut concrete_owners) = candidates.into_iter().collect::<Option<Vec<_>>>() else {
+        return Some(None);
+    };
+    concrete_owners.sort();
+    concrete_owners.dedup();
+    if concrete_owners.len() == 1 {
+        Some(Some(concrete_owners.remove(0)))
+    } else {
+        Some(None)
+    }
+}
+
+fn python_instance_property_assignment_owner<'tree>(
+    node: TsNode<'tree>,
+    class_node: TsNode<'tree>,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> Option<(String, TsNode<'tree>, OptionalReceiverOwnerBinding)> {
+    if node.kind() != "assignment" {
+        return None;
+    }
+    let method = enclosing_node_with_kind(node, &["function_definition"])?;
+    if !python_method_belongs_to_class(method, class_node)
+        || !receiver_call_belongs_to_callable(node, method)
+        || python_function_has_static_or_classmethod_decorator(method, source)
+    {
+        return None;
+    }
+    let self_name = python_instance_self_parameter(method, source)?;
+    let receiver_name = node
+        .child_by_field_name("left")
+        .and_then(|left| python_self_property_receiver_name(left, source, &self_name))?;
+    let owner =
+        python_property_constructor_receiver_owner(node, method, source, imported_type_bindings);
+    Some((receiver_name, method, owner))
+}
+
+fn python_property_assignment_visible_at_call(
+    assignment: TsNode<'_>,
+    assignment_method: TsNode<'_>,
+    call_method: TsNode<'_>,
+    call_node: TsNode<'_>,
+) -> bool {
+    !same_ts_span(assignment_method, call_method) || assignment.end_byte() <= call_node.start_byte()
+}
+
+fn python_instance_self_parameter(method: TsNode<'_>, source: &str) -> Option<String> {
+    let self_name = first_python_self_parameter(method, source)?;
+    (self_name == "self").then_some(self_name)
+}
+
+fn python_method_belongs_to_class(method: TsNode<'_>, class_node: TsNode<'_>) -> bool {
+    let mut current = method.parent();
+    while let Some(candidate) = current {
+        if same_ts_span(candidate, class_node) {
+            return true;
+        }
+        if matches!(candidate.kind(), "function_definition" | "class_definition") {
+            return false;
+        }
+        current = candidate.parent();
+    }
+    false
+}
+
+fn python_receiver_is_self_property(receiver_name: &str, self_name: &str) -> bool {
+    receiver_name
+        .strip_prefix(self_name)
+        .is_some_and(|suffix| suffix.starts_with('.') && suffix.len() > 1)
+}
+
+fn python_function_has_static_or_classmethod_decorator(function: TsNode<'_>, source: &str) -> bool {
+    let Some(parent) = function.parent() else {
+        return false;
+    };
+    if parent.kind() != "decorated_definition" {
+        return false;
+    }
+    let mut cursor = parent.walk();
+    parent.named_children(&mut cursor).any(|child| {
+        child.kind() == "decorator"
+            && trimmed_node_text(child, source)
+                .as_deref()
+                .and_then(python_decorator_terminal_name)
+                .is_some_and(|name| matches!(name.as_str(), "staticmethod" | "classmethod"))
+    })
+}
+
+fn python_decorator_terminal_name(surface: &str) -> Option<String> {
+    let head = surface
+        .trim()
+        .trim_start_matches('@')
+        .split('(')
+        .next()
+        .unwrap_or(surface)
+        .trim();
+    let terminal = head.rsplit('.').next().unwrap_or(head);
+    normalize_parameter_name(terminal)
+}
+
+fn python_self_property_receiver_name(
+    node: TsNode<'_>,
+    source: &str,
+    self_name: &str,
+) -> Option<String> {
+    if node.kind() != "attribute" {
+        return None;
+    }
+    let object = node.child_by_field_name("object")?;
+    if trimmed_node_text(object, source).as_deref() != Some(self_name) {
+        return None;
+    }
+    let field_name = node
+        .child_by_field_name("attribute")
+        .and_then(|field| trimmed_node_text(field, source))
+        .and_then(|name| normalize_parameter_name(&name))?;
+    Some(format!("{self_name}.{field_name}"))
+}
+
+fn python_property_constructor_receiver_owner(
+    node: TsNode<'_>,
+    method: TsNode<'_>,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> OptionalReceiverOwnerBinding {
+    let owner_name = node
+        .child_by_field_name("right")
+        .and_then(|right_node| python_direct_constructor_call_type(right_node, source))?;
+    if python_visible_local_type_name(method, node, &owner_name, source) {
+        return Some((owner_name, None));
+    }
+    if python_callable_has_local_binding_name(method, &owner_name, source) {
+        return None;
+    }
+    if let Some(binding) = imported_type_bindings.get(&owner_name) {
+        return Some((
+            binding.owner_name.clone(),
+            Some(binding.module_name.clone()),
+        ));
+    }
+    if python_constructor_name_looks_like_type(&owner_name) {
+        Some((owner_name, None))
+    } else {
+        None
+    }
+}
+
+fn collect_python_constructor_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let Some(owner) = python_visible_local_constructor_receiver_owner(
+            callable,
+            node,
+            &receiver_name,
+            source,
+            imported_type_bindings,
+        ) else {
+            return;
+        };
+        let method_col = member_call_method_col(node, source, &method_name);
+        local_receiver_callsites.insert(ReceiverCallSiteKey {
+            receiver_name: receiver_name.clone(),
+            method_name: method_name.clone(),
+            line: Some(node.start_position().row as u32 + 1),
+            method_col,
+        });
+        if let Some((owner_name, owner_module)) = owner {
+            edges.push(ManualReceiverCallSpec {
+                source_name: call_source.name.to_string(),
+                source_span: call_source.span,
+                receiver_name,
+                owner_name,
+                owner_module,
+                method_name,
+                method_col,
+                line: Some(node.start_position().row as u32 + 1),
+                allow_global_fallback: false,
+            });
+        }
+    });
+}
+
+fn python_visible_local_constructor_receiver_owner(
+    callable: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(callable, &mut |node| {
+        if node.kind() != "assignment"
+            || !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > call_node.start_byte()
+        {
+            return;
+        }
+        let Some(left) = node.child_by_field_name("left") else {
+            return;
+        };
+        if !python_assignment_target_binds_name(left, receiver_name, source) {
+            return;
+        }
+        let owner = if python_plain_identifier_name(left, source).as_deref() == Some(receiver_name)
+        {
+            python_constructor_receiver_owner(node, callable, source, imported_type_bindings)
+        } else {
+            None
+        };
+        visible_bindings.push((node.end_byte(), owner));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner)| owner)
+}
+
+fn python_assignment_target_binds_name(
+    node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+) -> bool {
+    let mut bindings = HashSet::new();
+    collect_python_assignment_target_bindings(node, source, &mut bindings);
+    bindings.contains(receiver_name)
+}
+
+fn python_constructor_receiver_owner(
+    node: TsNode<'_>,
+    callable: TsNode<'_>,
+    source: &str,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> OptionalReceiverOwnerBinding {
+    let owner_name = node
+        .child_by_field_name("right")
+        .and_then(|right_node| python_direct_constructor_call_type(right_node, source))?;
+    if python_visible_local_type_name(callable, node, &owner_name, source) {
+        return Some((owner_name, None));
+    }
+    if python_callable_has_local_binding_name(callable, &owner_name, source) {
+        return None;
+    }
+    if let Some(binding) = imported_type_bindings.get(&owner_name) {
+        return Some((
+            binding.owner_name.clone(),
+            Some(binding.module_name.clone()),
+        ));
+    }
+    if python_constructor_name_looks_like_type(&owner_name) {
+        Some((owner_name, None))
+    } else {
+        None
+    }
+}
+
+fn python_direct_constructor_call_type(node: TsNode<'_>, source: &str) -> Option<String> {
+    if node.kind() != "call" {
+        return None;
+    }
+    let function = node.child_by_field_name("function")?;
+    if function.kind() != "identifier" {
+        return None;
+    }
+    trimmed_node_text(function, source).and_then(|name| normalize_parameter_name(&name))
+}
+
+fn python_visible_local_type_name(
+    callable: TsNode<'_>,
+    before_node: TsNode<'_>,
+    owner_name: &str,
+    source: &str,
+) -> bool {
+    let mut found = false;
+    walk_tree_nodes(callable, &mut |node| {
+        if found
+            || node.kind() != "class_definition"
+            || !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > before_node.start_byte()
+        {
+            return;
+        }
+        if declaration_name(node, source).as_deref() == Some(owner_name) {
+            found = true;
+        }
+    });
+    found
+}
+
+fn python_callable_has_local_binding_name(
+    callable: TsNode<'_>,
+    binding_name: &str,
+    source: &str,
+) -> bool {
+    let mut found = false;
+    walk_tree_nodes(callable, &mut |node| {
+        if found || !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let candidate_names = python_local_binding_names(node, source);
+        if candidate_names.iter().any(|name| name == binding_name) {
+            found = true;
+        }
+    });
+    found
+}
+
+fn python_local_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
+    match node.kind() {
+        "class_definition" | "function_definition" => declaration_name(node, source)
+            .and_then(|name| normalize_parameter_name(&name))
+            .into_iter()
+            .collect(),
+        "assignment" => {
+            let mut bindings = HashSet::new();
+            if let Some(left) = node.child_by_field_name("left") {
+                collect_python_assignment_target_bindings(left, source, &mut bindings);
+            }
+            bindings.into_iter().collect()
+        }
+        "import_from_statement" => python_from_import_local_binding_names(node, source),
+        "import_statement" => python_import_local_binding_names(node, source),
+        _ => Vec::new(),
+    }
+}
+
+fn python_from_import_local_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
+    let Some(surface) = trimmed_node_text(node, source) else {
+        return Vec::new();
+    };
+    let Some(rest) = surface.strip_prefix("from ") else {
+        return Vec::new();
+    };
+    let Some((_, imports)) = rest.split_once(" import ") else {
+        return Vec::new();
+    };
+    let imports = python_import_list_surface(imports);
+    split_top_level_parameters(imports)
+        .into_iter()
+        .filter_map(|imported| python_import_binding_names(&imported).map(|(_, local)| local))
+        .collect()
+}
+
+fn python_import_local_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
+    let Some(surface) = trimmed_node_text(node, source) else {
+        return Vec::new();
+    };
+    let Some(imports) = surface.strip_prefix("import ") else {
+        return Vec::new();
+    };
+    split_top_level_parameters(imports)
+        .into_iter()
+        .filter_map(|imported| python_import_local_binding_name(&imported))
+        .collect()
+}
+
+fn python_import_local_binding_name(imported: &str) -> Option<String> {
+    let imported = imported.trim();
+    if imported.is_empty() {
+        return None;
+    }
+    let tokens = imported.split_whitespace().collect::<Vec<_>>();
+    let local_name = match tokens.as_slice() {
+        [module] => module.split('.').next()?,
+        [_, "as", local] => local,
+        _ => return None,
+    };
+    normalize_parameter_name(local_name)
+}
+
+fn python_plain_identifier_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    if node.kind() != "identifier" {
+        return None;
+    }
+    trimmed_node_text(node, source).and_then(|name| normalize_parameter_name(&name))
+}
+
+fn python_constructor_name_looks_like_type(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_uppercase())
+}
+
+fn collect_python_imported_type_bindings(
+    root: TsNode<'_>,
+    source: &str,
+) -> HashMap<String, ImportedTypeBinding> {
+    let top_level_bindings = collect_python_top_level_binding_names(root, source);
+    let mut bindings = HashMap::new();
+    let mut duplicates = HashSet::new();
+    for statement in python_top_level_from_import_statements(source) {
+        let Some(rest) = statement.strip_prefix("from ") else {
+            continue;
+        };
+        let Some((module_name, imports)) = rest.split_once(" import ") else {
+            continue;
+        };
+        let module_name = module_name.trim();
+        if module_name.is_empty() {
+            continue;
+        }
+        let imports = python_import_list_surface(imports);
+        for imported in split_top_level_parameters(imports) {
+            let Some((owner_name, local_name)) = python_import_binding_names(&imported) else {
+                continue;
+            };
+            if top_level_bindings.contains(&local_name) {
+                continue;
+            }
+            if duplicates.contains(&local_name) {
+                continue;
+            }
+            if bindings.contains_key(&local_name) {
+                bindings.remove(&local_name);
+                duplicates.insert(local_name);
+                continue;
+            }
+            bindings.insert(
+                local_name,
+                ImportedTypeBinding {
+                    module_name: module_name.to_string(),
+                    owner_name,
+                },
+            );
+        }
+    }
+    bindings
+}
+
+fn collect_python_top_level_binding_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
+    let mut bindings = HashSet::new();
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        collect_python_top_level_binding_name(child, source, &mut bindings);
+    }
+    bindings
+}
+
+fn collect_python_top_level_binding_name(
+    node: TsNode<'_>,
+    source: &str,
+    bindings: &mut HashSet<String>,
+) {
+    match node.kind() {
+        "class_definition" | "function_definition" => {
+            if let Some(name) =
+                declaration_name(node, source).and_then(|name| normalize_parameter_name(&name))
+            {
+                bindings.insert(name);
+            }
+        }
+        "decorated_definition" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if matches!(child.kind(), "class_definition" | "function_definition") {
+                    collect_python_top_level_binding_name(child, source, bindings);
+                    break;
+                }
+            }
+        }
+        "assignment" | "type_alias_statement" => {
+            collect_python_top_level_assignment_bindings(node, source, bindings);
+        }
+        "expression_statement" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if matches!(child.kind(), "assignment" | "type_alias_statement") {
+                    collect_python_top_level_assignment_bindings(child, source, bindings);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_python_top_level_assignment_bindings(
+    node: TsNode<'_>,
+    source: &str,
+    bindings: &mut HashSet<String>,
+) {
+    let Some(target) = node
+        .child_by_field_name("left")
+        .or_else(|| node.child_by_field_name("name"))
+    else {
+        return;
+    };
+    collect_python_assignment_target_bindings(target, source, bindings);
+}
+
+fn collect_python_assignment_target_bindings(
+    node: TsNode<'_>,
+    source: &str,
+    bindings: &mut HashSet<String>,
+) {
+    match node.kind() {
+        "identifier" => {
+            if let Some(name) =
+                trimmed_node_text(node, source).and_then(|name| normalize_parameter_name(&name))
+            {
+                bindings.insert(name);
+            }
+        }
+        "list"
+        | "list_pattern"
+        | "parenthesized_expression"
+        | "pattern_list"
+        | "tuple"
+        | "tuple_pattern" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                collect_python_assignment_target_bindings(child, source, bindings);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn python_top_level_from_import_statements(source: &str) -> Vec<String> {
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut paren_depth = 0usize;
+    let mut collecting = false;
+
+    for raw_line in source.lines() {
+        if !collecting {
+            if raw_line.starts_with(char::is_whitespace) {
+                continue;
+            }
+            let line = python_strip_comment(raw_line).trim();
+            if !line.starts_with("from ") {
+                continue;
+            }
+            current.clear();
+            current.push_str(line);
+            paren_depth = python_paren_depth_delta(0, line);
+            if paren_depth == 0 {
+                statements.push(current.clone());
+            } else {
+                collecting = true;
+            }
+            continue;
+        }
+
+        let line = python_strip_comment(raw_line).trim();
+        if !line.is_empty() {
+            current.push('\n');
+            current.push_str(line);
+            paren_depth = python_paren_depth_delta(paren_depth, line);
+        }
+        if paren_depth == 0 {
+            statements.push(current.clone());
+            current.clear();
+            collecting = false;
+        }
+    }
+
+    statements
+}
+
+fn python_strip_comment(line: &str) -> &str {
+    line.split('#').next().unwrap_or(line)
+}
+
+fn python_paren_depth_delta(mut depth: usize, line: &str) -> usize {
+    for ch in line.chars() {
+        match ch {
+            '(' => depth = depth.saturating_add(1),
+            ')' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    depth
+}
+
+fn python_import_list_surface(imports: &str) -> &str {
+    let imports = imports.trim();
+    imports
+        .strip_prefix('(')
+        .and_then(|inner| inner.strip_suffix(')'))
+        .map(str::trim)
+        .unwrap_or(imports)
+}
+
+fn python_import_binding_names(imported: &str) -> Option<(String, String)> {
+    let imported = imported.trim();
+    if imported.is_empty() || imported == "*" {
+        return None;
+    }
+
+    let tokens = imported.split_whitespace().collect::<Vec<_>>();
+    let (owner_name, local_name) = match tokens.as_slice() {
+        [owner] => (*owner, *owner),
+        [owner, "as", local] => (*owner, *local),
+        _ => return None,
+    };
+    Some((
+        normalize_parameter_name(owner_name)?,
+        normalize_parameter_name(local_name)?,
+    ))
+}
+
+fn collect_python_receiver_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
+    let mut receiver_types = collect_colon_parameter_types(callable, source);
+    if let Some(owner_name) = enclosing_node_with_kind(callable, &["class_definition"])
+        .and_then(|owner| declaration_name(owner, source))
+        && let Some(self_name) = first_python_self_parameter(callable, source)
+    {
+        receiver_types.insert(self_name, owner_name);
+    }
+    receiver_types
+}
+
+fn first_python_self_parameter(callable: TsNode<'_>, source: &str) -> Option<String> {
+    let parameters = signature_parameter_surface(callable, source)?;
+    let first = split_top_level_parameters(&parameters).into_iter().next()?;
+    let name_side = first
+        .split_once(':')
+        .map(|(name_side, _)| name_side)
+        .unwrap_or(first.as_str());
+    let name = parameter_name_before_colon(name_side)?;
+    matches!(name.as_str(), "self" | "cls").then_some(name)
+}
+
+fn python_attribute_call_nodes<'tree>(
+    node: TsNode<'tree>,
+) -> Option<(TsNode<'tree>, TsNode<'tree>)> {
+    if node.kind() != "call" {
+        return None;
+    }
+    let function = node.child_by_field_name("function")?;
+    let attribute = if function.kind() == "attribute" {
+        function
+    } else {
+        first_descendant_with_kind(function, "attribute")?
+    };
+    Some((
+        attribute.child_by_field_name("object")?,
+        attribute.child_by_field_name("attribute")?,
+    ))
+}
+
+pub(crate) fn attribute_method_col(
+    node: TsNode<'_>,
+    source: &str,
+    method_name: &str,
+) -> Option<u32> {
+    let (_, method) = python_attribute_call_nodes(node)?;
+    if trimmed_node_text(method, source).as_deref() != Some(method_name) {
+        return None;
+    }
+    Some(method.start_position().column as u32 + 1)
+}
+
+fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if node.kind() != "call" {
+        return None;
+    }
+    if let Some((receiver, method)) = python_attribute_call_nodes(node) {
+        return Some((
+            normalized_receiver_variable(receiver, source)?,
+            trimmed_node_text(method, source)?,
+        ));
+    }
+    surface_member_call(node, source)
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -57,7 +57,6 @@ pub use cancellation::CancellationToken;
 use intermediate_storage::IntermediateStorage;
 use symbol_table::SymbolTable;
 
-pub(crate) const PYTHON_ATTRIBUTE_CALLSITE_MARKER: &str = "syntax:python-attribute-call";
 pub(crate) const CPP_MEMBER_CALLSITE_MARKER: &str = "syntax:cpp-member-call";
 pub(crate) const GO_SELECTOR_CALLSITE_MARKER: &str = "syntax:go-selector-call";
 pub(crate) const JAVA_MEMBER_CALLSITE_MARKER: &str = "syntax:java-member-call";
@@ -127,7 +126,6 @@ fn parser_direct_structural_certainty(kind: EdgeKind) -> Option<ResolutionCertai
 
 // Source of truth for live rule assets. Keep this registry aligned with
 // `get_language_for_ext` so dead rule files do not silently linger.
-const PYTHON_GRAPH_QUERY: &str = include_str!("../rules/python.scm");
 const JAVA_GRAPH_QUERY: &str = include_str!("../rules/java.scm");
 const RUST_GRAPH_QUERY: &str = include_str!("../rules/rust.graph.scm");
 const RUST_TAGS_QUERY: &str = include_str!("../rules/rust.tags.scm");
@@ -289,9 +287,12 @@ impl LanguageRuleset {
             );
         }
         match self {
-            LanguageRuleset::Python => {
-                compiled_rules_cache(language, PYTHON_GRAPH_QUERY, None, &PYTHON_RULES)
-            }
+            // Answered by the registry above; the arm only exists because the
+            // match must stay exhaustive. Failing closed here rather than
+            // panicking keeps a future registry mistake a typed indexing error.
+            LanguageRuleset::Python => Err(anyhow!(
+                "python compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::Java => {
                 compiled_rules_cache(language, JAVA_GRAPH_QUERY, None, &JAVA_RULES)
             }
@@ -372,7 +373,6 @@ fn compiled_rules_cache(
         .map_err(|message| anyhow!(message.clone()))
 }
 
-static PYTHON_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static JAVA_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static RUST_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static JAVASCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
@@ -4201,15 +4201,6 @@ fn access_kind_from_graph_access(value: &str) -> Option<AccessKind> {
     }
 }
 
-fn is_python_constant_name(name: &str) -> bool {
-    let trimmed = name.trim();
-    !trimmed.is_empty()
-        && trimmed
-            .chars()
-            .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_')
-        && trimmed.chars().any(|ch| ch.is_ascii_uppercase())
-}
-
 fn source_line(source: &str, line: u32) -> Option<&str> {
     if line == 0 {
         return None;
@@ -4368,9 +4359,15 @@ struct CallPlaceholderMarkerAnnotation<'a> {
     marker: &'static str,
 }
 
+/// Languages whose receiver-call placeholders must carry a syntax marker.
+///
+/// This is a narrower roster than `member_callsite_marker`: Kotlin owns a
+/// marker in the registry and is deliberately absent here. There is no registry
+/// field for it, so a migrated language keeps its arm and only repoints the
+/// constant.
 fn receiver_annotation_required_callsite_marker(language_name: &str) -> Option<&'static str> {
     match language_name {
-        "python" => Some(PYTHON_ATTRIBUTE_CALLSITE_MARKER),
+        "python" => Some(languages::python::MEMBER_CALLSITE_MARKER),
         "php" => Some(PHP_MEMBER_CALLSITE_MARKER),
         _ => None,
     }
@@ -6600,64 +6597,6 @@ fn collect_rust_macro_call_edges(tree: &Tree, source: &str) -> Vec<ManualEdgeSpe
     edges
 }
 
-fn python_decorator_target_name(node: TsNode<'_>, source: &str) -> Option<String> {
-    match node.kind() {
-        "decorator" => {
-            let mut cursor = node.walk();
-            node.named_children(&mut cursor)
-                .find_map(|child| python_decorator_target_name(child, source))
-        }
-        "call" => node
-            .child_by_field_name("function")
-            .and_then(|function| python_decorator_target_name(function, source)),
-        "attribute" => node
-            .child_by_field_name("attribute")
-            .and_then(|attribute| node_source_text(attribute, source))
-            .map(|name| name.trim().to_string())
-            .filter(|name| !name.is_empty()),
-        "identifier" => node_source_text(node, source)
-            .map(|name| name.trim().to_string())
-            .filter(|name| !name.is_empty()),
-        _ => None,
-    }
-}
-
-fn collect_python_decorator_call_edges(tree: &Tree, source: &str) -> Vec<ManualEdgeSpec> {
-    let mut edges = Vec::new();
-    walk_tree_nodes(tree.root_node(), &mut |node| {
-        if node.kind() != "decorated_definition" {
-            return;
-        }
-        let Some(definition) = node.child_by_field_name("definition") else {
-            return;
-        };
-        let Some(source_name) = definition
-            .child_by_field_name("name")
-            .and_then(|name| node_source_text(name, source))
-            .map(|name| name.trim().to_string())
-            .filter(|name| !name.is_empty())
-        else {
-            return;
-        };
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            if child.kind() != "decorator" {
-                continue;
-            }
-            let Some(target_name) = python_decorator_target_name(child, source) else {
-                continue;
-            };
-            edges.push(ManualEdgeSpec {
-                source_name: source_name.clone(),
-                target_name,
-                kind: EdgeKind::CALL,
-                line: Some(child.start_position().row as u32 + 1),
-            });
-        }
-    });
-    edges
-}
-
 fn collect_ruby_bare_call_edges(tree: &Tree, source: &str) -> Vec<ManualEdgeSpec> {
     let mut edges = Vec::new();
     walk_tree_nodes(tree.root_node(), &mut |callable| {
@@ -7306,7 +7245,7 @@ fn append_manual_usage_edges(
         specs.extend(collect_rust_macro_call_edges(tree, source));
     }
     if language_name == "python" {
-        specs.extend(collect_python_decorator_call_edges(tree, source));
+        specs.extend(languages::python::decorator_call_specs(tree, source));
     }
     if language_name == "ruby" {
         specs.extend(collect_ruby_bare_call_edges(tree, source));
@@ -7593,7 +7532,6 @@ fn language_receiver_call_specs(
     }
     match language_name {
         "javascript" => collect_javascript_receiver_call_edges(tree, source),
-        "python" => collect_python_receiver_call_edges(tree, source),
         "typescript" | "tsx" => collect_typescript_receiver_call_edges(tree, source),
         "java" => collect_java_receiver_call_edges(tree, source),
         "go" => collect_go_receiver_call_edges(tree, source),
@@ -7693,7 +7631,9 @@ fn append_manual_receiver_call_edges(
             file_id,
             spec.allow_global_fallback,
         ) else {
-            if language_name == "python" && !is_python_implicit_receiver(&spec.receiver_name) {
+            if language_name == "python"
+                && !languages::python::is_implicit_receiver(&spec.receiver_name)
+            {
                 annotate_receiver_call_placeholder_owner(
                     unique_nodes,
                     result_edges,
@@ -7706,7 +7646,7 @@ fn append_manual_receiver_call_edges(
                         owner_name: &spec.owner_name,
                         owner_module: spec.owner_module.as_deref(),
                     },
-                    Some(PYTHON_ATTRIBUTE_CALLSITE_MARKER),
+                    Some(languages::python::MEMBER_CALLSITE_MARKER),
                 );
             }
             continue;
@@ -8251,603 +8191,6 @@ fn normalize_go_type_surface(raw: &str) -> Option<String> {
     let base = surface.split('[').next().unwrap_or(surface).trim();
     let terminal = base.rsplit('.').next().unwrap_or(base).trim();
     (!terminal.is_empty()).then(|| terminal.to_string())
-}
-
-fn collect_python_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let imported_type_bindings = collect_python_imported_type_bindings(tree.root_node(), source);
-    walk_tree_nodes(tree.root_node(), &mut |callable| {
-        if callable.kind() != "function_definition" {
-            return;
-        }
-        let Some(source_name) = declaration_name(callable, source) else {
-            return;
-        };
-        let call_source = ManualReceiverSource {
-            name: &source_name,
-            span: ts_node_graph_span(callable),
-        };
-        let mut local_receiver_callsites = HashSet::new();
-        collect_python_constructor_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &imported_type_bindings,
-            &mut local_receiver_callsites,
-            &mut edges,
-        );
-        collect_python_instance_property_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &imported_type_bindings,
-            &mut edges,
-        );
-        let receiver_types = collect_python_receiver_types(callable, source);
-        if receiver_types.is_empty() {
-            return;
-        }
-        let start = edges.len();
-        collect_receiver_call_specs_in_callable(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &receiver_types,
-            python_member_call,
-            true,
-            &mut edges,
-        );
-        let mut fallback_specs = edges.split_off(start);
-        fallback_specs
-            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
-        for spec in &mut fallback_specs {
-            if !is_python_implicit_receiver(&spec.receiver_name)
-                && let Some(binding) = imported_type_bindings.get(&spec.owner_name)
-            {
-                spec.owner_name = binding.owner_name.clone();
-                spec.owner_module = Some(binding.module_name.clone());
-            }
-        }
-        edges.extend(fallback_specs);
-    });
-    edges
-}
-
-fn is_python_implicit_receiver(receiver_name: &str) -> bool {
-    matches!(receiver_name, "self" | "cls")
-}
-
-fn collect_python_instance_property_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    let Some(class_node) = enclosing_node_with_kind(callable, &["class_definition"]) else {
-        return;
-    };
-    let Some(self_name) = python_instance_self_parameter(callable, source) else {
-        return;
-    };
-    if python_function_has_static_or_classmethod_decorator(callable, source) {
-        return;
-    }
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = python_member_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable)
-            || !python_receiver_is_self_property(&receiver_name, &self_name)
-        {
-            return;
-        }
-        let Some(owner) = python_visible_instance_property_receiver_owner(
-            class_node,
-            callable,
-            node,
-            &receiver_name,
-            source,
-            imported_type_bindings,
-        ) else {
-            return;
-        };
-        if let Some((owner_name, owner_module)) = owner {
-            edges.push(ManualReceiverCallSpec {
-                source_name: call_source.name.to_string(),
-                source_span: call_source.span,
-                receiver_name,
-                owner_name,
-                owner_module,
-                method_name: method_name.clone(),
-                method_col: member_call_method_col(node, source, &method_name),
-                line: Some(node.start_position().row as u32 + 1),
-                allow_global_fallback: false,
-            });
-        }
-    });
-}
-
-fn python_visible_instance_property_receiver_owner(
-    class_node: TsNode<'_>,
-    call_method: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut candidates = Vec::new();
-    walk_tree_nodes(class_node, &mut |node| {
-        let Some((assignment_receiver, assignment_method, owner)) =
-            python_instance_property_assignment_owner(
-                node,
-                class_node,
-                source,
-                imported_type_bindings,
-            )
-        else {
-            return;
-        };
-        if assignment_receiver != receiver_name
-            || !python_property_assignment_visible_at_call(
-                node,
-                assignment_method,
-                call_method,
-                call_node,
-            )
-        {
-            return;
-        }
-        candidates.push(owner);
-    });
-    if candidates.is_empty() {
-        return None;
-    }
-    let Some(mut concrete_owners) = candidates.into_iter().collect::<Option<Vec<_>>>() else {
-        return Some(None);
-    };
-    concrete_owners.sort();
-    concrete_owners.dedup();
-    if concrete_owners.len() == 1 {
-        Some(Some(concrete_owners.remove(0)))
-    } else {
-        Some(None)
-    }
-}
-
-fn python_instance_property_assignment_owner<'tree>(
-    node: TsNode<'tree>,
-    class_node: TsNode<'tree>,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> Option<(String, TsNode<'tree>, OptionalReceiverOwnerBinding)> {
-    if node.kind() != "assignment" {
-        return None;
-    }
-    let method = enclosing_node_with_kind(node, &["function_definition"])?;
-    if !python_method_belongs_to_class(method, class_node)
-        || !receiver_call_belongs_to_callable(node, method)
-        || python_function_has_static_or_classmethod_decorator(method, source)
-    {
-        return None;
-    }
-    let self_name = python_instance_self_parameter(method, source)?;
-    let receiver_name = node
-        .child_by_field_name("left")
-        .and_then(|left| python_self_property_receiver_name(left, source, &self_name))?;
-    let owner =
-        python_property_constructor_receiver_owner(node, method, source, imported_type_bindings);
-    Some((receiver_name, method, owner))
-}
-
-fn python_property_assignment_visible_at_call(
-    assignment: TsNode<'_>,
-    assignment_method: TsNode<'_>,
-    call_method: TsNode<'_>,
-    call_node: TsNode<'_>,
-) -> bool {
-    !same_ts_span(assignment_method, call_method) || assignment.end_byte() <= call_node.start_byte()
-}
-
-fn python_instance_self_parameter(method: TsNode<'_>, source: &str) -> Option<String> {
-    let self_name = first_python_self_parameter(method, source)?;
-    (self_name == "self").then_some(self_name)
-}
-
-fn python_method_belongs_to_class(method: TsNode<'_>, class_node: TsNode<'_>) -> bool {
-    let mut current = method.parent();
-    while let Some(candidate) = current {
-        if same_ts_span(candidate, class_node) {
-            return true;
-        }
-        if matches!(candidate.kind(), "function_definition" | "class_definition") {
-            return false;
-        }
-        current = candidate.parent();
-    }
-    false
-}
-
-fn python_receiver_is_self_property(receiver_name: &str, self_name: &str) -> bool {
-    receiver_name
-        .strip_prefix(self_name)
-        .is_some_and(|suffix| suffix.starts_with('.') && suffix.len() > 1)
-}
-
-fn python_function_has_static_or_classmethod_decorator(function: TsNode<'_>, source: &str) -> bool {
-    let Some(parent) = function.parent() else {
-        return false;
-    };
-    if parent.kind() != "decorated_definition" {
-        return false;
-    }
-    let mut cursor = parent.walk();
-    parent.named_children(&mut cursor).any(|child| {
-        child.kind() == "decorator"
-            && trimmed_node_text(child, source)
-                .as_deref()
-                .and_then(python_decorator_terminal_name)
-                .is_some_and(|name| matches!(name.as_str(), "staticmethod" | "classmethod"))
-    })
-}
-
-fn python_decorator_terminal_name(surface: &str) -> Option<String> {
-    let head = surface
-        .trim()
-        .trim_start_matches('@')
-        .split('(')
-        .next()
-        .unwrap_or(surface)
-        .trim();
-    let terminal = head.rsplit('.').next().unwrap_or(head);
-    normalize_parameter_name(terminal)
-}
-
-fn python_self_property_receiver_name(
-    node: TsNode<'_>,
-    source: &str,
-    self_name: &str,
-) -> Option<String> {
-    if node.kind() != "attribute" {
-        return None;
-    }
-    let object = node.child_by_field_name("object")?;
-    if trimmed_node_text(object, source).as_deref() != Some(self_name) {
-        return None;
-    }
-    let field_name = node
-        .child_by_field_name("attribute")
-        .and_then(|field| trimmed_node_text(field, source))
-        .and_then(|name| normalize_parameter_name(&name))?;
-    Some(format!("{self_name}.{field_name}"))
-}
-
-fn python_property_constructor_receiver_owner(
-    node: TsNode<'_>,
-    method: TsNode<'_>,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> OptionalReceiverOwnerBinding {
-    let owner_name = node
-        .child_by_field_name("right")
-        .and_then(|right_node| python_direct_constructor_call_type(right_node, source))?;
-    if python_visible_local_type_name(method, node, &owner_name, source) {
-        return Some((owner_name, None));
-    }
-    if python_callable_has_local_binding_name(method, &owner_name, source) {
-        return None;
-    }
-    if let Some(binding) = imported_type_bindings.get(&owner_name) {
-        return Some((
-            binding.owner_name.clone(),
-            Some(binding.module_name.clone()),
-        ));
-    }
-    if python_constructor_name_looks_like_type(&owner_name) {
-        Some((owner_name, None))
-    } else {
-        None
-    }
-}
-
-fn collect_python_constructor_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = python_member_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let Some(owner) = python_visible_local_constructor_receiver_owner(
-            callable,
-            node,
-            &receiver_name,
-            source,
-            imported_type_bindings,
-        ) else {
-            return;
-        };
-        let method_col = member_call_method_col(node, source, &method_name);
-        local_receiver_callsites.insert(ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
-            method_col,
-        });
-        if let Some((owner_name, owner_module)) = owner {
-            edges.push(ManualReceiverCallSpec {
-                source_name: call_source.name.to_string(),
-                source_span: call_source.span,
-                receiver_name,
-                owner_name,
-                owner_module,
-                method_name,
-                method_col,
-                line: Some(node.start_position().row as u32 + 1),
-                allow_global_fallback: false,
-            });
-        }
-    });
-}
-
-fn python_visible_local_constructor_receiver_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if node.kind() != "assignment"
-            || !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
-        {
-            return;
-        }
-        let Some(left) = node.child_by_field_name("left") else {
-            return;
-        };
-        if !python_assignment_target_binds_name(left, receiver_name, source) {
-            return;
-        }
-        let owner = if python_plain_identifier_name(left, source).as_deref() == Some(receiver_name)
-        {
-            python_constructor_receiver_owner(node, callable, source, imported_type_bindings)
-        } else {
-            None
-        };
-        visible_bindings.push((node.end_byte(), owner));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner)| owner)
-}
-
-fn python_assignment_target_binds_name(
-    node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-) -> bool {
-    let mut bindings = HashSet::new();
-    collect_python_assignment_target_bindings(node, source, &mut bindings);
-    bindings.contains(receiver_name)
-}
-
-fn python_constructor_receiver_owner(
-    node: TsNode<'_>,
-    callable: TsNode<'_>,
-    source: &str,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> OptionalReceiverOwnerBinding {
-    let owner_name = node
-        .child_by_field_name("right")
-        .and_then(|right_node| python_direct_constructor_call_type(right_node, source))?;
-    if python_visible_local_type_name(callable, node, &owner_name, source) {
-        return Some((owner_name, None));
-    }
-    if python_callable_has_local_binding_name(callable, &owner_name, source) {
-        return None;
-    }
-    if let Some(binding) = imported_type_bindings.get(&owner_name) {
-        return Some((
-            binding.owner_name.clone(),
-            Some(binding.module_name.clone()),
-        ));
-    }
-    if python_constructor_name_looks_like_type(&owner_name) {
-        Some((owner_name, None))
-    } else {
-        None
-    }
-}
-
-fn python_direct_constructor_call_type(node: TsNode<'_>, source: &str) -> Option<String> {
-    if node.kind() != "call" {
-        return None;
-    }
-    let function = node.child_by_field_name("function")?;
-    if function.kind() != "identifier" {
-        return None;
-    }
-    trimmed_node_text(function, source).and_then(|name| normalize_parameter_name(&name))
-}
-
-fn python_visible_local_type_name(
-    callable: TsNode<'_>,
-    before_node: TsNode<'_>,
-    owner_name: &str,
-    source: &str,
-) -> bool {
-    let mut found = false;
-    walk_tree_nodes(callable, &mut |node| {
-        if found
-            || node.kind() != "class_definition"
-            || !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > before_node.start_byte()
-        {
-            return;
-        }
-        if declaration_name(node, source).as_deref() == Some(owner_name) {
-            found = true;
-        }
-    });
-    found
-}
-
-fn python_callable_has_local_binding_name(
-    callable: TsNode<'_>,
-    binding_name: &str,
-    source: &str,
-) -> bool {
-    let mut found = false;
-    walk_tree_nodes(callable, &mut |node| {
-        if found || !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let candidate_names = python_local_binding_names(node, source);
-        if candidate_names.iter().any(|name| name == binding_name) {
-            found = true;
-        }
-    });
-    found
-}
-
-fn python_local_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
-    match node.kind() {
-        "class_definition" | "function_definition" => declaration_name(node, source)
-            .and_then(|name| normalize_parameter_name(&name))
-            .into_iter()
-            .collect(),
-        "assignment" => {
-            let mut bindings = HashSet::new();
-            if let Some(left) = node.child_by_field_name("left") {
-                collect_python_assignment_target_bindings(left, source, &mut bindings);
-            }
-            bindings.into_iter().collect()
-        }
-        "import_from_statement" => python_from_import_local_binding_names(node, source),
-        "import_statement" => python_import_local_binding_names(node, source),
-        _ => Vec::new(),
-    }
-}
-
-fn python_from_import_local_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
-    let Some(surface) = trimmed_node_text(node, source) else {
-        return Vec::new();
-    };
-    let Some(rest) = surface.strip_prefix("from ") else {
-        return Vec::new();
-    };
-    let Some((_, imports)) = rest.split_once(" import ") else {
-        return Vec::new();
-    };
-    let imports = python_import_list_surface(imports);
-    split_top_level_parameters(imports)
-        .into_iter()
-        .filter_map(|imported| python_import_binding_names(&imported).map(|(_, local)| local))
-        .collect()
-}
-
-fn python_import_local_binding_names(node: TsNode<'_>, source: &str) -> Vec<String> {
-    let Some(surface) = trimmed_node_text(node, source) else {
-        return Vec::new();
-    };
-    let Some(imports) = surface.strip_prefix("import ") else {
-        return Vec::new();
-    };
-    split_top_level_parameters(imports)
-        .into_iter()
-        .filter_map(|imported| python_import_local_binding_name(&imported))
-        .collect()
-}
-
-fn python_import_local_binding_name(imported: &str) -> Option<String> {
-    let imported = imported.trim();
-    if imported.is_empty() {
-        return None;
-    }
-    let tokens = imported.split_whitespace().collect::<Vec<_>>();
-    let local_name = match tokens.as_slice() {
-        [module] => module.split('.').next()?,
-        [_, "as", local] => local,
-        _ => return None,
-    };
-    normalize_parameter_name(local_name)
-}
-
-fn python_plain_identifier_name(node: TsNode<'_>, source: &str) -> Option<String> {
-    if node.kind() != "identifier" {
-        return None;
-    }
-    trimmed_node_text(node, source).and_then(|name| normalize_parameter_name(&name))
-}
-
-fn python_constructor_name_looks_like_type(name: &str) -> bool {
-    name.chars()
-        .next()
-        .is_some_and(|ch| ch == '_' || ch.is_uppercase())
-}
-
-fn collect_python_imported_type_bindings(
-    root: TsNode<'_>,
-    source: &str,
-) -> HashMap<String, ImportedTypeBinding> {
-    let top_level_bindings = collect_python_top_level_binding_names(root, source);
-    let mut bindings = HashMap::new();
-    let mut duplicates = HashSet::new();
-    for statement in python_top_level_from_import_statements(source) {
-        let Some(rest) = statement.strip_prefix("from ") else {
-            continue;
-        };
-        let Some((module_name, imports)) = rest.split_once(" import ") else {
-            continue;
-        };
-        let module_name = module_name.trim();
-        if module_name.is_empty() {
-            continue;
-        }
-        let imports = python_import_list_surface(imports);
-        for imported in split_top_level_parameters(imports) {
-            let Some((owner_name, local_name)) = python_import_binding_names(&imported) else {
-                continue;
-            };
-            if top_level_bindings.contains(&local_name) {
-                continue;
-            }
-            if duplicates.contains(&local_name) {
-                continue;
-            }
-            if bindings.contains_key(&local_name) {
-                bindings.remove(&local_name);
-                duplicates.insert(local_name);
-                continue;
-            }
-            bindings.insert(
-                local_name,
-                ImportedTypeBinding {
-                    module_name: module_name.to_string(),
-                    owner_name,
-                },
-            );
-        }
-    }
-    bindings
 }
 
 fn collect_typescript_receiver_call_edges(
@@ -9428,178 +8771,6 @@ fn typescript_type_import_qualifier(raw_type: &str) -> Option<String> {
         .trim();
     let (qualifier, _) = base.rsplit_once('.')?;
     normalize_parameter_name(qualifier)
-}
-
-fn collect_python_top_level_binding_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
-    let mut bindings = HashSet::new();
-    let mut cursor = root.walk();
-    for child in root.named_children(&mut cursor) {
-        collect_python_top_level_binding_name(child, source, &mut bindings);
-    }
-    bindings
-}
-
-fn collect_python_top_level_binding_name(
-    node: TsNode<'_>,
-    source: &str,
-    bindings: &mut HashSet<String>,
-) {
-    match node.kind() {
-        "class_definition" | "function_definition" => {
-            if let Some(name) =
-                declaration_name(node, source).and_then(|name| normalize_parameter_name(&name))
-            {
-                bindings.insert(name);
-            }
-        }
-        "decorated_definition" => {
-            let mut cursor = node.walk();
-            for child in node.named_children(&mut cursor) {
-                if matches!(child.kind(), "class_definition" | "function_definition") {
-                    collect_python_top_level_binding_name(child, source, bindings);
-                    break;
-                }
-            }
-        }
-        "assignment" | "type_alias_statement" => {
-            collect_python_top_level_assignment_bindings(node, source, bindings);
-        }
-        "expression_statement" => {
-            let mut cursor = node.walk();
-            for child in node.named_children(&mut cursor) {
-                if matches!(child.kind(), "assignment" | "type_alias_statement") {
-                    collect_python_top_level_assignment_bindings(child, source, bindings);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-fn collect_python_top_level_assignment_bindings(
-    node: TsNode<'_>,
-    source: &str,
-    bindings: &mut HashSet<String>,
-) {
-    let Some(target) = node
-        .child_by_field_name("left")
-        .or_else(|| node.child_by_field_name("name"))
-    else {
-        return;
-    };
-    collect_python_assignment_target_bindings(target, source, bindings);
-}
-
-fn collect_python_assignment_target_bindings(
-    node: TsNode<'_>,
-    source: &str,
-    bindings: &mut HashSet<String>,
-) {
-    match node.kind() {
-        "identifier" => {
-            if let Some(name) =
-                trimmed_node_text(node, source).and_then(|name| normalize_parameter_name(&name))
-            {
-                bindings.insert(name);
-            }
-        }
-        "list"
-        | "list_pattern"
-        | "parenthesized_expression"
-        | "pattern_list"
-        | "tuple"
-        | "tuple_pattern" => {
-            let mut cursor = node.walk();
-            for child in node.named_children(&mut cursor) {
-                collect_python_assignment_target_bindings(child, source, bindings);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn python_top_level_from_import_statements(source: &str) -> Vec<String> {
-    let mut statements = Vec::new();
-    let mut current = String::new();
-    let mut paren_depth = 0usize;
-    let mut collecting = false;
-
-    for raw_line in source.lines() {
-        if !collecting {
-            if raw_line.starts_with(char::is_whitespace) {
-                continue;
-            }
-            let line = python_strip_comment(raw_line).trim();
-            if !line.starts_with("from ") {
-                continue;
-            }
-            current.clear();
-            current.push_str(line);
-            paren_depth = python_paren_depth_delta(0, line);
-            if paren_depth == 0 {
-                statements.push(current.clone());
-            } else {
-                collecting = true;
-            }
-            continue;
-        }
-
-        let line = python_strip_comment(raw_line).trim();
-        if !line.is_empty() {
-            current.push('\n');
-            current.push_str(line);
-            paren_depth = python_paren_depth_delta(paren_depth, line);
-        }
-        if paren_depth == 0 {
-            statements.push(current.clone());
-            current.clear();
-            collecting = false;
-        }
-    }
-
-    statements
-}
-
-fn python_strip_comment(line: &str) -> &str {
-    line.split('#').next().unwrap_or(line)
-}
-
-fn python_paren_depth_delta(mut depth: usize, line: &str) -> usize {
-    for ch in line.chars() {
-        match ch {
-            '(' => depth = depth.saturating_add(1),
-            ')' => depth = depth.saturating_sub(1),
-            _ => {}
-        }
-    }
-    depth
-}
-
-fn python_import_list_surface(imports: &str) -> &str {
-    let imports = imports.trim();
-    imports
-        .strip_prefix('(')
-        .and_then(|inner| inner.strip_suffix(')'))
-        .map(str::trim)
-        .unwrap_or(imports)
-}
-
-fn python_import_binding_names(imported: &str) -> Option<(String, String)> {
-    let imported = imported.trim();
-    if imported.is_empty() || imported == "*" {
-        return None;
-    }
-
-    let tokens = imported.split_whitespace().collect::<Vec<_>>();
-    let (owner_name, local_name) = match tokens.as_slice() {
-        [owner] => (*owner, *owner),
-        [owner, "as", local] => (*owner, *local),
-        _ => return None,
-    };
-    Some((
-        normalize_parameter_name(owner_name)?,
-        normalize_parameter_name(local_name)?,
-    ))
 }
 
 fn collect_go_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
@@ -13723,7 +12894,7 @@ fn collect_receiver_call_specs_in_callable(
 }
 
 fn member_call_method_col(node: TsNode<'_>, source: &str, method_name: &str) -> Option<u32> {
-    if let Some(col) = python_attribute_method_col(node, source, method_name) {
+    if let Some(col) = languages::python::attribute_method_col(node, source, method_name) {
         return Some(col);
     }
 
@@ -13944,28 +13115,6 @@ fn ruby_visible_local_receiver_owner(
     });
     visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
     visible_bindings.pop().map(|(_, owner)| owner)
-}
-
-fn collect_python_receiver_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
-    let mut receiver_types = collect_colon_parameter_types(callable, source);
-    if let Some(owner_name) = enclosing_node_with_kind(callable, &["class_definition"])
-        .and_then(|owner| declaration_name(owner, source))
-        && let Some(self_name) = first_python_self_parameter(callable, source)
-    {
-        receiver_types.insert(self_name, owner_name);
-    }
-    receiver_types
-}
-
-fn first_python_self_parameter(callable: TsNode<'_>, source: &str) -> Option<String> {
-    let parameters = signature_parameter_surface(callable, source)?;
-    let first = split_top_level_parameters(&parameters).into_iter().next()?;
-    let name_side = first
-        .split_once(':')
-        .map(|(name_side, _)| name_side)
-        .unwrap_or(first.as_str());
-    let name = parameter_name_before_colon(name_side)?;
-    matches!(name.as_str(), "self" | "cls").then_some(name)
 }
 
 fn collect_colon_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
@@ -14370,45 +13519,6 @@ fn go_selector_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> 
         normalized_receiver_variable(receiver, source)?,
         trimmed_node_text(method, source)?,
     ))
-}
-
-fn python_attribute_call_nodes<'tree>(
-    node: TsNode<'tree>,
-) -> Option<(TsNode<'tree>, TsNode<'tree>)> {
-    if node.kind() != "call" {
-        return None;
-    }
-    let function = node.child_by_field_name("function")?;
-    let attribute = if function.kind() == "attribute" {
-        function
-    } else {
-        first_descendant_with_kind(function, "attribute")?
-    };
-    Some((
-        attribute.child_by_field_name("object")?,
-        attribute.child_by_field_name("attribute")?,
-    ))
-}
-
-fn python_attribute_method_col(node: TsNode<'_>, source: &str, method_name: &str) -> Option<u32> {
-    let (_, method) = python_attribute_call_nodes(node)?;
-    if trimmed_node_text(method, source).as_deref() != Some(method_name) {
-        return None;
-    }
-    Some(method.start_position().column as u32 + 1)
-}
-
-fn python_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if node.kind() != "call" {
-        return None;
-    }
-    if let Some((receiver, method)) = python_attribute_call_nodes(node) {
-        return Some((
-            normalized_receiver_variable(receiver, source)?,
-            trimmed_node_text(method, source)?,
-        ));
-    }
-    surface_member_call(node, source)
 }
 
 fn php_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
@@ -20005,7 +19115,7 @@ pub fn index_file(
             let mut kind = node_kind_from_graph_kind(kind_str.as_str());
             if language_config.language_name == "python"
                 && kind == NodeKind::VARIABLE
-                && is_python_constant_name(&name_str)
+                && languages::python::is_constant_name(&name_str)
             {
                 kind = NodeKind::CONSTANT;
             }
@@ -20221,9 +19331,6 @@ pub fn index_file(
                                 match languages::member_callsite_marker_for_call_syntax(raw) {
                                     Some(marker) => Some(marker),
                                     None => match raw {
-                                        "python_attribute" => {
-                                            Some(PYTHON_ATTRIBUTE_CALLSITE_MARKER)
-                                        }
                                         "cpp_member" => Some(CPP_MEMBER_CALLSITE_MARKER),
                                         "go_selector" => Some(GO_SELECTOR_CALLSITE_MARKER),
                                         "java_member" => Some(JAVA_MEMBER_CALLSITE_MARKER),

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1309,7 +1309,7 @@ fn is_python_dotted_call_placeholder(edge_kind: EdgeKind, callsite_identity: Opt
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::PYTHON_ATTRIBUTE_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::python::MEMBER_CALLSITE_MARKER)
     })
 }
 
@@ -3939,7 +3939,10 @@ mod tests {
 
     #[test]
     fn test_python_dotted_placeholders_do_not_create_semantic_request_keys() {
-        let dotted_identity = format!("2:10:2:14|{}", crate::PYTHON_ATTRIBUTE_CALLSITE_MARKER);
+        let dotted_identity = format!(
+            "2:10:2:14|{}",
+            crate::languages::python::MEMBER_CALLSITE_MARKER
+        );
         let dotted_lookup = SemanticEdgeLookup {
             edge_kind: EdgeKind::CALL,
             file_id: Some(1),

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -593,7 +593,6 @@ fn language_family_bucket(language: &'static str) -> &'static str {
     match language {
         "c" | "cpp" => "native",
         "javascript" | "typescript" | "vue" | "svelte" | "astro" => "webscript",
-        "python" => "python",
         "rust" => "rust",
         "java" => "java",
         "go" => "go",

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/python_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/python_fidelity.txt
@@ -1,0 +1,94 @@
+node CLASS name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.py:ConsoleNotifier line=24 col=7 end=24:22 file=FILE:<ROOT>/fidelity.py@1
+node CLASS name=Event qn=Event canonical=<ROOT>/fidelity.py:Event line=40 col=7 end=40:12 file=FILE:<ROOT>/fidelity.py@1
+node CLASS name=Notifier qn=Notifier canonical=<ROOT>/fidelity.py:Notifier line=19 col=7 end=19:15 file=FILE:<ROOT>/fidelity.py@1
+node CLASS name=Repository qn=Repository canonical=<ROOT>/fidelity.py:Repository line=32 col=7 end=32:17 file=FILE:<ROOT>/fidelity.py@1
+node CLASS name=Workflow qn=Workflow canonical=<ROOT>/fidelity.py:Workflow line=45 col=7 end=45:15 file=FILE:<ROOT>/fidelity.py@1
+node CONSTANT name=MAX_RETRIES qn=MAX_RETRIES canonical=<ROOT>/fidelity.py:MAX_RETRIES#0 line=9 col=1 end=9:12 file=FILE:<ROOT>/fidelity.py@1
+node CONSTANT name=T qn=T canonical=<ROOT>/fidelity.py:T#0 line=8 col=1 end=8:2 file=FILE:<ROOT>/fidelity.py@1
+node FILE name=<ROOT>/fidelity.py qn=<ROOT>/fidelity.py canonical=<ROOT>/fidelity.py:<ROOT>/fidelity.py:1 line=1 col=1 end=68:0 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=ConsoleNotifier.notify qn=ConsoleNotifier.notify canonical=<ROOT>/fidelity.py:ConsoleNotifier.notify#0 line=25 col=5 end=26:30 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=ConsoleNotifier.write_log qn=ConsoleNotifier.write_log canonical=<ROOT>/fidelity.py:ConsoleNotifier.write_log#0 line=28 col=5 end=29:18 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=Event.__init__ qn=Event.__init__ canonical=<ROOT>/fidelity.py:Event.__init__#0 line=41 col=5 end=42:25 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=Notifier.notify qn=Notifier.notify canonical=<ROOT>/fidelity.py:Notifier.notify#0 line=20 col=5 end=21:34 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=Repository.save qn=Repository.save canonical=<ROOT>/fidelity.py:Repository.save#0 line=33 col=5 end=34:25 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=Repository.track qn=Repository.track canonical=<ROOT>/fidelity.py:Repository.track#0 line=36 col=5 end=37:17 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=Workflow.decorate qn=Workflow.decorate canonical=<ROOT>/fidelity.py:Workflow.decorate#0 line=58 col=5 end=59:53 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=Workflow.run qn=Workflow.run canonical=<ROOT>/fidelity.py:Workflow.run#0 line=47 col=5 end=50:29 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=Workflow.run_async qn=Workflow.run_async canonical=<ROOT>/fidelity.py:Workflow.run_async#0 line=52 col=5 end=56:46 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=orchestrate qn=orchestrate canonical=<ROOT>/fidelity.py:orchestrate#0 line=62 col=1 end=68:60 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=trace qn=trace canonical=<ROOT>/fidelity.py:trace#0 line=12 col=1 end=16:19 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=trace qn=trace canonical=<ROOT>/fidelity.py:trace#1 line=46 col=6 end=46:11 file=FILE:<ROOT>/fidelity.py@1
+node FUNCTION name=wrapped qn=wrapped canonical=<ROOT>/fidelity.py:wrapped#0 line=13 col=5 end=14:35 file=FILE:<ROOT>/fidelity.py@1
+node MODULE name=asyncio qn=asyncio canonical=<ROOT>/fidelity.py:asyncio#0 line=3 col=8 end=3:15 file=FILE:<ROOT>/fidelity.py@1
+node MODULE name=collections qn=collections canonical=<ROOT>/fidelity.py:collections#0 line=4 col=8 end=4:19 file=FILE:<ROOT>/fidelity.py@1
+node MODULE name=math qn=math canonical=<ROOT>/fidelity.py:math#0 line=5 col=8 end=5:12 file=FILE:<ROOT>/fidelity.py@1
+node MODULE name=typing qn=typing canonical=<ROOT>/fidelity.py:typing#0 line=6 col=8 end=6:14 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.py:ConsoleNotifier#0 line=65 col=16 end=65:31 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=Event qn=Event canonical=<ROOT>/fidelity.py:Event#0 line=63 col=24 end=63:29 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=Repository qn=Repository canonical=<ROOT>/fidelity.py:Repository#0 line=66 col=37 end=66:47 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=TypeVar qn=TypeVar canonical=<ROOT>/fidelity.py:TypeVar#0 line=8 col=7 end=8:14 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=Workflow qn=Workflow canonical=<ROOT>/fidelity.py:Workflow#0 line=64 col=16 end=64:24 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=col qn=col canonical=<ROOT>/fidelity.py:col#0 line=4 col=23 end=4:26 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.py:decorate#0 line=50 col=14 end=50:22 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=deque qn=deque canonical=<ROOT>/fidelity.py:deque#0 line=63 col=17 end=63:22 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=float qn=float canonical=<ROOT>/fidelity.py:float#0 line=59 col=30 end=59:35 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=fn qn=fn canonical=<ROOT>/fidelity.py:fn#0 line=14 col=16 end=14:18 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=len qn=len canonical=<ROOT>/fidelity.py:len#0 line=59 col=36 end=59:39 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=math_mod qn=math_mod canonical=<ROOT>/fidelity.py:math_mod#0 line=5 col=16 end=5:24 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.py:notify#0 line=48 col=18 end=48:24 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.py:notify#1 line=54 col=18 end=54:24 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=picker qn=picker canonical=<ROOT>/fidelity.py:picker#1 line=54 col=25 end=54:31 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=popleft qn=popleft canonical=<ROOT>/fidelity.py:popleft#0 line=68 col=50 end=68:57 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.py:run#0 line=56 col=14 end=56:17 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.py:run#1 line=68 col=18 end=68:21 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.py:save#0 line=49 col=20 end=49:24 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=sleep qn=sleep canonical=<ROOT>/fidelity.py:sleep#0 line=55 col=23 end=55:28 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=sqrt qn=sqrt canonical=<ROOT>/fidelity.py:sqrt#0 line=59 col=25 end=59:29 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=t qn=t canonical=<ROOT>/fidelity.py:t#0 line=6 col=18 end=6:19 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=track qn=track canonical=<ROOT>/fidelity.py:track#0 line=34 col=14 end=34:19 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=upper qn=upper canonical=<ROOT>/fidelity.py:upper#0 line=53 col=62 end=53:67 file=FILE:<ROOT>/fidelity.py@1
+node UNKNOWN name=write_log qn=write_log canonical=<ROOT>/fidelity.py:write_log#0 line=26 col=14 end=26:23 file=FILE:<ROOT>/fidelity.py@1
+node VARIABLE name=_ qn=_ canonical=<ROOT>/fidelity.py:_#0 line=29 col=9 end=29:10 file=FILE:<ROOT>/fidelity.py@1
+node VARIABLE name=_ qn=_ canonical=<ROOT>/fidelity.py:_#1 line=37 col=9 end=37:10 file=FILE:<ROOT>/fidelity.py@1
+node VARIABLE name=notifier qn=notifier canonical=<ROOT>/fidelity.py:notifier#0 line=65 col=5 end=65:13 file=FILE:<ROOT>/fidelity.py@1
+node VARIABLE name=picker qn=picker canonical=<ROOT>/fidelity.py:picker#0 line=53 col=9 end=53:15 file=FILE:<ROOT>/fidelity.py@1
+node VARIABLE name=queue qn=queue canonical=<ROOT>/fidelity.py:queue#0 line=63 col=5 end=63:10 file=FILE:<ROOT>/fidelity.py@1
+node VARIABLE name=repository qn=repository canonical=<ROOT>/fidelity.py:repository#0 line=66 col=5 end=66:15 file=FILE:<ROOT>/fidelity.py@1
+node VARIABLE name=workflow qn=workflow canonical=<ROOT>/fidelity.py:workflow#0 line=64 col=5 end=64:13 file=FILE:<ROOT>/fidelity.py@1
+edge CALL src=FUNCTION:ConsoleNotifier.notify@25 dst=FUNCTION:ConsoleNotifier.write_log@28 resolved_src=FUNCTION:ConsoleNotifier.notify@25 resolved_dst=FUNCTION:ConsoleNotifier.write_log@28 line=26 confidence=1.0000 certainty=Certain callsite=h0:26:1:h1 candidates=[]
+edge CALL src=FUNCTION:Repository.save@33 dst=FUNCTION:Repository.track@36 resolved_src=FUNCTION:Repository.save@33 resolved_dst=FUNCTION:Repository.track@36 line=34 confidence=1.0000 certainty=Certain callsite=h0:34:1:h2 candidates=[]
+edge CALL src=FUNCTION:Workflow.decorate@58 dst=UNKNOWN:float@59 resolved_src=FUNCTION:Workflow.decorate@58 resolved_dst=- line=59 confidence=- certainty=- callsite=h0:59:30:h3 candidates=[]
+edge CALL src=FUNCTION:Workflow.decorate@58 dst=UNKNOWN:len@59 resolved_src=FUNCTION:Workflow.decorate@58 resolved_dst=- line=59 confidence=- certainty=- callsite=h0:59:36:h4 candidates=[]
+edge CALL src=FUNCTION:Workflow.decorate@58 dst=UNKNOWN:sqrt@59 resolved_src=FUNCTION:Workflow.decorate@58 resolved_dst=- line=59 confidence=- certainty=- callsite=h0:59:25:h5|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:Workflow.run@47 dst=FUNCTION:Notifier.notify@20 resolved_src=FUNCTION:Workflow.run@47 resolved_dst=FUNCTION:Notifier.notify@20 line=48 confidence=1.0000 certainty=Certain callsite=h0:48:1:h6 candidates=[]
+edge CALL src=FUNCTION:Workflow.run@47 dst=FUNCTION:Repository.save@33 resolved_src=FUNCTION:Workflow.run@47 resolved_dst=FUNCTION:Repository.save@33 line=49 confidence=1.0000 certainty=Certain callsite=h0:49:1:h7 candidates=[]
+edge CALL src=FUNCTION:Workflow.run@47 dst=FUNCTION:Workflow.decorate@58 resolved_src=FUNCTION:Workflow.run@47 resolved_dst=FUNCTION:Workflow.decorate@58 line=50 confidence=1.0000 certainty=Certain callsite=h0:50:1:h8 candidates=[]
+edge CALL src=FUNCTION:Workflow.run@47 dst=FUNCTION:trace@12 resolved_src=FUNCTION:Workflow.run@47 resolved_dst=FUNCTION:trace@12 line=46 confidence=0.9500 certainty=Certain callsite=h0:46:1:h9 candidates=[]
+edge CALL src=FUNCTION:Workflow.run@47 dst=FUNCTION:trace@46 resolved_src=FUNCTION:Workflow.run@47 resolved_dst=FUNCTION:trace@12 line=0 confidence=0.9500 certainty=Certain callsite=h0:0:1:h10 candidates=[]
+edge CALL src=FUNCTION:Workflow.run_async@52 dst=FUNCTION:Notifier.notify@20 resolved_src=FUNCTION:Workflow.run_async@52 resolved_dst=FUNCTION:Notifier.notify@20 line=54 confidence=1.0000 certainty=Certain callsite=h0:54:1:h6 candidates=[]
+edge CALL src=FUNCTION:Workflow.run_async@52 dst=FUNCTION:Workflow.run@47 resolved_src=FUNCTION:Workflow.run_async@52 resolved_dst=FUNCTION:Workflow.run@47 line=56 confidence=1.0000 certainty=Certain callsite=h0:56:1:h11 candidates=[]
+edge CALL src=FUNCTION:Workflow.run_async@52 dst=UNKNOWN:picker@54 resolved_src=FUNCTION:Workflow.run_async@52 resolved_dst=- line=54 confidence=- certainty=- callsite=h0:54:25:h12 candidates=[]
+edge CALL src=FUNCTION:Workflow.run_async@52 dst=UNKNOWN:sleep@55 resolved_src=FUNCTION:Workflow.run_async@52 resolved_dst=- line=55 confidence=- certainty=- callsite=h0:55:23:h13|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:Workflow.run_async@52 dst=UNKNOWN:upper@53 resolved_src=FUNCTION:Workflow.run_async@52 resolved_dst=- line=53 confidence=- certainty=- callsite=h0:53:62:h14|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:orchestrate@62 dst=FUNCTION:Workflow.run@47 resolved_src=FUNCTION:orchestrate@62 resolved_dst=FUNCTION:Workflow.run@47 line=68 confidence=1.0000 certainty=Certain callsite=h0:68:1:h11 candidates=[]
+edge CALL src=FUNCTION:orchestrate@62 dst=UNKNOWN:ConsoleNotifier@65 resolved_src=FUNCTION:orchestrate@62 resolved_dst=- line=65 confidence=- certainty=- callsite=h0:65:16:h15 candidates=[]
+edge CALL src=FUNCTION:orchestrate@62 dst=UNKNOWN:Event@63 resolved_src=FUNCTION:orchestrate@62 resolved_dst=- line=63 confidence=- certainty=- callsite=h0:63:24:h16 candidates=[]
+edge CALL src=FUNCTION:orchestrate@62 dst=UNKNOWN:Repository@66 resolved_src=FUNCTION:orchestrate@62 resolved_dst=- line=66 confidence=- certainty=- callsite=h0:66:37:h17 candidates=[]
+edge CALL src=FUNCTION:orchestrate@62 dst=UNKNOWN:Workflow@64 resolved_src=FUNCTION:orchestrate@62 resolved_dst=- line=64 confidence=- certainty=- callsite=h0:64:16:h18 candidates=[]
+edge CALL src=FUNCTION:orchestrate@62 dst=UNKNOWN:deque@63 resolved_src=FUNCTION:orchestrate@62 resolved_dst=- line=63 confidence=- certainty=- callsite=h0:63:17:h19|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:orchestrate@62 dst=UNKNOWN:popleft@68 resolved_src=FUNCTION:orchestrate@62 resolved_dst=- line=68 confidence=- certainty=- callsite=h0:68:50:h20|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:wrapped@13 dst=UNKNOWN:fn@14 resolved_src=FUNCTION:wrapped@13 resolved_dst=- line=14 confidence=- certainty=- callsite=h0:14:16:h21 candidates=[]
+edge IMPORT src=MODULE:asyncio@3 dst=MODULE:asyncio@3 resolved_src=MODULE:asyncio@3 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:col@4 dst=MODULE:collections@4 resolved_src=UNKNOWN:col@4 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:math_mod@5 dst=MODULE:math@5 resolved_src=UNKNOWN:math_mod@5 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:t@6 dst=MODULE:typing@6 resolved_src=UNKNOWN:t@6 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ConsoleNotifier@24 dst=CLASS:Notifier@19 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@24 dst=FUNCTION:ConsoleNotifier.notify@25 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@24 dst=FUNCTION:ConsoleNotifier.write_log@28 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Event@40 dst=FUNCTION:Event.__init__@41 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Notifier@19 dst=FUNCTION:Notifier.notify@20 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@32 dst=FUNCTION:Repository.save@33 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@32 dst=FUNCTION:Repository.track@36 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@45 dst=FUNCTION:Workflow.decorate@58 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@45 dst=FUNCTION:Workflow.run@47 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@45 dst=FUNCTION:Workflow.run_async@52 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/python_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/python_tictactoe.txt
@@ -1,0 +1,506 @@
+node CLASS name=ArtificialPlayer qn=ArtificialPlayer canonical=game.py:ArtificialPlayer line=182 col=7 end=182:23 file=FILE:game.py@1
+node CLASS name=Enum qn=Enum canonical=game.py:Enum line=22 col=14 end=22:18 file=FILE:game.py@1
+node CLASS name=Field qn=Field canonical=game.py:Field line=21 col=7 end=21:12 file=FILE:game.py@1
+node CLASS name=GameObject qn=GameObject canonical=game.py:GameObject line=17 col=7 end=17:17 file=FILE:game.py@1
+node CLASS name=HumanPlayer qn=HumanPlayer canonical=game.py:HumanPlayer line=147 col=7 end=147:18 file=FILE:game.py@1
+node CLASS name=Move qn=Move canonical=game.py:Move line=36 col=8 end=36:12 file=FILE:game.py@1
+node CLASS name=Node qn=Node canonical=game.py:Node line=183 col=8 end=183:12 file=FILE:game.py@1
+node CLASS name=Player qn=Player canonical=game.py:Player line=137 col=7 end=137:13 file=FILE:game.py@1
+node CLASS name=TicTacToe qn=TicTacToe canonical=game.py:TicTacToe line=243 col=7 end=243:16 file=FILE:game.py@1
+node CLASS name=Token qn=Token canonical=game.py:Token line=22 col=8 end=22:13 file=FILE:game.py@1
+node CONSTANT name=TOKEN_NONE qn=TOKEN_NONE canonical=game.py:TOKEN_NONE#0 line=23 col=3 end=23:13 file=FILE:game.py@1
+node CONSTANT name=TOKEN_PLAYER_A qn=TOKEN_PLAYER_A canonical=game.py:TOKEN_PLAYER_A#0 line=24 col=3 end=24:17 file=FILE:game.py@1
+node CONSTANT name=TOKEN_PLAYER_B qn=TOKEN_PLAYER_B canonical=game.py:TOKEN_PLAYER_B#0 line=25 col=3 end=25:17 file=FILE:game.py@1
+node FILE name=game.py qn=game.py canonical=game.py:game.py:1 line=1 col=1 end=308:0 file=FILE:game.py@1
+node FUNCTION name=ArtificialPlayer.__init__ qn=ArtificialPlayer.__init__ canonical=game.py:ArtificialPlayer.__init__#0 line=189 col=2 end=190:37 file=FILE:game.py@1
+node FUNCTION name=ArtificialPlayer._evaluate qn=ArtificialPlayer._evaluate canonical=game.py:ArtificialPlayer._evaluate#0 line=233 col=2 end=240:11 file=FILE:game.py@1
+node FUNCTION name=ArtificialPlayer._minMax qn=ArtificialPlayer._minMax canonical=game.py:ArtificialPlayer._minMax#0 line=199 col=2 end=230:14 file=FILE:game.py@1
+node FUNCTION name=ArtificialPlayer.turn qn=ArtificialPlayer.turn canonical=game.py:ArtificialPlayer.turn#0 line=193 col=2 end=196:19 file=FILE:game.py@1
+node FUNCTION name=Field.__init__ qn=Field.__init__ canonical=game.py:Field.__init__#0 line=42 col=2 end=49:17 file=FILE:game.py@1
+node FUNCTION name=Field.clear qn=Field.clear canonical=game.py:Field.clear#0 line=61 col=2 end=65:17 file=FILE:game.py@1
+node FUNCTION name=Field.clearMove qn=Field.clearMove canonical=game.py:Field.clearMove#0 line=126 col=2 end=134:18 file=FILE:game.py@1
+node FUNCTION name=Field.clone qn=Field.clone canonical=game.py:Field.clone#0 line=52 col=2 end=58:15 file=FILE:game.py@1
+node FUNCTION name=Field.inRange qn=Field.inRange canonical=game.py:Field.inRange#0 line=101 col=2 end=102:75 file=FILE:game.py@1
+node FUNCTION name=Field.isEmpty qn=Field.isEmpty canonical=game.py:Field.isEmpty#0 line=105 col=2 end=106:66 file=FILE:game.py@1
+node FUNCTION name=Field.isFull qn=Field.isFull canonical=game.py:Field.isFull#0 line=109 col=2 end=110:25 file=FILE:game.py@1
+node FUNCTION name=Field.makeMove qn=Field.makeMove canonical=game.py:Field.makeMove#0 line=113 col=2 end=123:18 file=FILE:game.py@1
+node FUNCTION name=Field.opponent qn=Field.opponent canonical=game.py:Field.opponent#0 line=28 col=2 end=33:32 file=FILE:game.py@1
+node FUNCTION name=Field.sameInRow qn=Field.sameInRow canonical=game.py:Field.sameInRow#0 line=87 col=2 end=98:15 file=FILE:game.py@1
+node FUNCTION name=Field.show qn=Field.show canonical=game.py:Field.show#0 line=68 col=2 end=84:20 file=FILE:game.py@1
+node FUNCTION name=HumanPlayer.__init__ qn=HumanPlayer.__init__ canonical=game.py:HumanPlayer.__init__#0 line=148 col=2 end=149:37 file=FILE:game.py@1
+node FUNCTION name=HumanPlayer._check qn=HumanPlayer._check canonical=game.py:HumanPlayer._check#0 line=172 col=2 end=179:14 file=FILE:game.py@1
+node FUNCTION name=HumanPlayer._input qn=HumanPlayer._input canonical=game.py:HumanPlayer._input#0 line=162 col=2 end=169:14 file=FILE:game.py@1
+node FUNCTION name=HumanPlayer.turn qn=HumanPlayer.turn canonical=game.py:HumanPlayer.turn#0 line=152 col=2 end=159:14 file=FILE:game.py@1
+node FUNCTION name=Move.__init__ qn=Move.__init__ canonical=game.py:Move.__init__#0 line=37 col=3 end=39:19 file=FILE:game.py@1
+node FUNCTION name=Node.__init__ qn=Node.__init__ canonical=game.py:Node.__init__#0 line=184 col=3 end=186:18 file=FILE:game.py@1
+node FUNCTION name=Player.__init__ qn=Player.__init__ canonical=game.py:Player.__init__#0 line=138 col=2 end=140:19 file=FILE:game.py@1
+node FUNCTION name=Player.turn qn=Player.turn canonical=game.py:Player.turn#0 line=143 col=2 end=144:28 file=FILE:game.py@1
+node FUNCTION name=TicTacToe.__init__ qn=TicTacToe.__init__ canonical=game.py:TicTacToe.__init__#0 line=244 col=2 end=246:31 file=FILE:game.py@1
+node FUNCTION name=TicTacToe._reset qn=TicTacToe._reset canonical=game.py:TicTacToe._reset#0 line=280 col=2 end=283:22 file=FILE:game.py@1
+node FUNCTION name=TicTacToe._selectPlayer qn=TicTacToe._selectPlayer canonical=game.py:TicTacToe._selectPlayer#0 line=286 col=2 end=298:31 file=FILE:game.py@1
+node FUNCTION name=TicTacToe.run qn=TicTacToe.run canonical=game.py:TicTacToe.run#0 line=265 col=2 end=277:38 file=FILE:game.py@1
+node FUNCTION name=TicTacToe.start qn=TicTacToe.start canonical=game.py:TicTacToe.start#0 line=249 col=2 end=262:14 file=FILE:game.py@1
+node FUNCTION name=main qn=main canonical=game.py:main#0 line=301 col=1 end=304:18 file=FILE:game.py@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.py:numberIn#0 line=5 col=1 end=6:21 file=FILE:game.py@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.py:numberOut#0 line=9 col=1 end=10:25 file=FILE:game.py@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.py:stringOut#0 line=13 col=1 end=14:20 file=FILE:game.py@1
+node MODULE name=enum qn=enum canonical=game.py:enum#0 line=1 col=6 end=1:10 file=FILE:game.py@1
+node MODULE name=random qn=random canonical=game.py:random#0 line=2 col=6 end=2:12 file=FILE:game.py@1
+node UNKNOWN name=ArtificialPlayer qn=ArtificialPlayer canonical=game.py:ArtificialPlayer#0 line=295 col=12 end=295:28 file=FILE:game.py@1
+node UNKNOWN name=Enum qn=Enum canonical=game.py:Enum#0 line=1 col=18 end=1:22 file=FILE:game.py@1
+node UNKNOWN name=Field qn=Field canonical=game.py:Field#0 line=53 col=11 end=53:16 file=FILE:game.py@1
+node UNKNOWN name=Field qn=Field canonical=game.py:Field#1 line=245 col=17 end=245:22 file=FILE:game.py@1
+node UNKNOWN name=HumanPlayer qn=HumanPlayer canonical=game.py:HumanPlayer#0 line=293 col=12 end=293:23 file=FILE:game.py@1
+node UNKNOWN name=Move qn=Move canonical=game.py:Move#0 line=163 col=16 end=163:20 file=FILE:game.py@1
+node UNKNOWN name=Move qn=Move canonical=game.py:Move#1 line=203 col=16 end=203:20 file=FILE:game.py@1
+node UNKNOWN name=Node qn=Node canonical=game.py:Node#0 line=200 col=27 end=200:31 file=FILE:game.py@1
+node UNKNOWN name=TicTacToe qn=TicTacToe canonical=game.py:TicTacToe#0 line=302 col=14 end=302:23 file=FILE:game.py@1
+node UNKNOWN name=__init__ qn=__init__ canonical=game.py:__init__#0 line=149 col=10 end=149:18 file=FILE:game.py@1
+node UNKNOWN name=__init__ qn=__init__ canonical=game.py:__init__#1 line=190 col=10 end=190:18 file=FILE:game.py@1
+node UNKNOWN name=_check qn=_check canonical=game.py:_check#0 line=157 col=12 end=157:18 file=FILE:game.py@1
+node UNKNOWN name=_evaluate qn=_evaluate canonical=game.py:_evaluate#0 line=216 col=22 end=216:31 file=FILE:game.py@1
+node UNKNOWN name=_input qn=_input canonical=game.py:_input#0 line=156 col=16 end=156:22 file=FILE:game.py@1
+node UNKNOWN name=_minMax qn=_minMax canonical=game.py:_minMax#0 line=195 col=15 end=195:22 file=FILE:game.py@1
+node UNKNOWN name=_minMax qn=_minMax canonical=game.py:_minMax#1 line=218 col=24 end=218:31 file=FILE:game.py@1
+node UNKNOWN name=_reset qn=_reset canonical=game.py:_reset#0 line=250 col=8 end=250:14 file=FILE:game.py@1
+node UNKNOWN name=_selectPlayer qn=_selectPlayer canonical=game.py:_selectPlayer#0 line=253 col=27 end=253:40 file=FILE:game.py@1
+node UNKNOWN name=_selectPlayer qn=_selectPlayer canonical=game.py:_selectPlayer#1 line=257 col=27 end=257:40 file=FILE:game.py@1
+node UNKNOWN name=append qn=append canonical=game.py:append#0 line=47 col=9 end=47:15 file=FILE:game.py@1
+node UNKNOWN name=append qn=append canonical=game.py:append#1 line=48 col=15 end=48:21 file=FILE:game.py@1
+node UNKNOWN name=clear qn=clear canonical=game.py:clear#0 line=283 col=15 end=283:20 file=FILE:game.py@1
+node UNKNOWN name=clearMove qn=clearMove canonical=game.py:clearMove#0 line=220 col=11 end=220:20 file=FILE:game.py@1
+node UNKNOWN name=clone qn=clone canonical=game.py:clone#0 line=194 col=21 end=194:26 file=FILE:game.py@1
+node UNKNOWN name=inRange qn=inRange canonical=game.py:inRange#0 line=114 col=15 end=114:22 file=FILE:game.py@1
+node UNKNOWN name=inRange qn=inRange canonical=game.py:inRange#1 line=127 col=15 end=127:22 file=FILE:game.py@1
+node UNKNOWN name=inRange qn=inRange canonical=game.py:inRange#2 line=173 col=16 end=173:23 file=FILE:game.py@1
+node UNKNOWN name=input qn=input canonical=game.py:input#0 line=6 col=13 end=6:18 file=FILE:game.py@1
+node UNKNOWN name=int qn=int canonical=game.py:int#0 line=6 col=9 end=6:12 file=FILE:game.py@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.py:isEmpty#0 line=116 col=15 end=116:22 file=FILE:game.py@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.py:isEmpty#1 line=129 col=11 end=129:18 file=FILE:game.py@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.py:isEmpty#2 line=176 col=18 end=176:25 file=FILE:game.py@1
+node UNKNOWN name=isEmpty qn=isEmpty canonical=game.py:isEmpty#3 line=211 col=18 end=211:25 file=FILE:game.py@1
+node UNKNOWN name=isFull qn=isFull canonical=game.py:isFull#0 line=120 col=11 end=120:17 file=FILE:game.py@1
+node UNKNOWN name=isFull qn=isFull canonical=game.py:isFull#1 line=217 col=37 end=217:43 file=FILE:game.py@1
+node UNKNOWN name=main qn=main canonical=game.py:main#1 line=308 col=2 end=308:6 file=FILE:game.py@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.py:makeMove#0 line=214 col=11 end=214:19 file=FILE:game.py@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.py:makeMove#1 line=270 col=16 end=270:24 file=FILE:game.py@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.py:numberIn#1 line=165 col=14 end=165:22 file=FILE:game.py@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.py:numberIn#2 line=167 col=14 end=167:22 file=FILE:game.py@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.py:numberIn#3 line=291 col=16 end=291:24 file=FILE:game.py@1
+node UNKNOWN name=numberOut qn=numberOut canonical=game.py:numberOut#1 line=71 col=4 end=71:13 file=FILE:game.py@1
+node UNKNOWN name=opponent qn=opponent canonical=game.py:opponent#0 line=218 col=45 end=218:53 file=FILE:game.py@1
+node UNKNOWN name=opponent qn=opponent canonical=game.py:opponent#1 line=236 col=30 end=236:38 file=FILE:game.py@1
+node UNKNOWN name=print qn=print canonical=game.py:print#0 line=10 col=2 end=10:7 file=FILE:game.py@1
+node UNKNOWN name=print qn=print canonical=game.py:print#1 line=14 col=2 end=14:7 file=FILE:game.py@1
+node UNKNOWN name=randint qn=randint canonical=game.py:randint#0 line=2 col=20 end=2:27 file=FILE:game.py@1
+node UNKNOWN name=randint qn=randint canonical=game.py:randint#1 line=228 col=9 end=228:16 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#0 line=44 col=12 end=44:17 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#1 line=46 col=13 end=46:18 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#10 line=268 col=12 end=268:17 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#11 line=281 col=12 end=281:17 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#2 line=54 col=12 end=54:17 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#3 line=55 col=13 end=55:18 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#4 line=62 col=12 end=62:17 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#5 line=63 col=13 end=63:18 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#6 line=70 col=14 end=70:19 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#7 line=73 col=15 end=73:20 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#8 line=206 col=12 end=206:17 file=FILE:game.py@1
+node UNKNOWN name=range qn=range canonical=game.py:range#9 line=208 col=13 end=208:18 file=FILE:game.py@1
+node UNKNOWN name=run qn=run canonical=game.py:run#0 line=304 col=13 end=304:16 file=FILE:game.py@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.py:sameInRow#0 line=234 col=12 end=234:21 file=FILE:game.py@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.py:sameInRow#1 line=236 col=14 end=236:23 file=FILE:game.py@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.py:sameInRow#2 line=238 col=14 end=238:23 file=FILE:game.py@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.py:sameInRow#3 line=272 col=19 end=272:28 file=FILE:game.py@1
+node UNKNOWN name=show qn=show canonical=game.py:show#0 line=266 col=15 end=266:19 file=FILE:game.py@1
+node UNKNOWN name=show qn=show canonical=game.py:show#1 line=271 col=16 end=271:20 file=FILE:game.py@1
+node UNKNOWN name=start qn=start canonical=game.py:start#0 line=303 col=18 end=303:23 file=FILE:game.py@1
+node UNKNOWN name=str qn=str canonical=game.py:str#0 line=10 col=8 end=10:11 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#1 line=69 col=3 end=69:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#10 line=154 col=3 end=154:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#11 line=164 col=3 end=164:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#12 line=166 col=3 end=166:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#13 line=168 col=3 end=168:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#14 line=174 col=4 end=174:13 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#15 line=177 col=4 end=177:13 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#16 line=251 col=3 end=251:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#17 line=261 col=3 end=261:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#18 line=273 col=5 end=273:14 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#19 line=274 col=5 end=274:14 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#2 line=72 col=4 end=72:13 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#20 line=277 col=3 end=277:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#21 line=288 col=4 end=288:13 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#22 line=289 col=4 end=289:13 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#23 line=290 col=4 end=290:13 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#24 line=298 col=4 end=298:13 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#3 line=75 col=6 end=75:15 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#4 line=77 col=6 end=77:15 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#5 line=79 col=6 end=79:15 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#6 line=81 col=6 end=81:15 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#7 line=83 col=5 end=83:14 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#8 line=84 col=3 end=84:12 file=FILE:game.py@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.py:stringOut#9 line=153 col=3 end=153:12 file=FILE:game.py@1
+node UNKNOWN name=turn qn=turn canonical=game.py:turn#0 line=270 col=32 end=270:36 file=FILE:game.py@1
+node VARIABLE name=count qn=count canonical=game.py:count#0 line=89 col=3 end=89:8 file=FILE:game.py@1
+node VARIABLE name=field qn=field canonical=game.py:field#0 line=53 col=3 end=53:8 file=FILE:game.py@1
+node VARIABLE name=move qn=move canonical=game.py:move#0 line=156 col=4 end=156:8 file=FILE:game.py@1
+node VARIABLE name=move qn=move canonical=game.py:move#1 line=163 col=3 end=163:7 file=FILE:game.py@1
+node VARIABLE name=move qn=move canonical=game.py:move#2 line=203 col=3 end=203:7 file=FILE:game.py@1
+node VARIABLE name=node qn=node canonical=game.py:node#0 line=195 col=3 end=195:7 file=FILE:game.py@1
+node VARIABLE name=node qn=node canonical=game.py:node#1 line=200 col=3 end=200:7 file=FILE:game.py@1
+node VARIABLE name=player qn=player canonical=game.py:player#0 line=269 col=4 end=269:10 file=FILE:game.py@1
+node VARIABLE name=playerIndex qn=playerIndex canonical=game.py:playerIndex#0 line=267 col=3 end=267:14 file=FILE:game.py@1
+node VARIABLE name=playerIndex qn=playerIndex canonical=game.py:playerIndex#1 line=276 col=4 end=276:15 file=FILE:game.py@1
+node VARIABLE name=row qn=row canonical=game.py:row#0 line=45 col=4 end=45:7 file=FILE:game.py@1
+node VARIABLE name=sameMove qn=sameMove canonical=game.py:sameMove#0 line=204 col=3 end=204:11 file=FILE:game.py@1
+node VARIABLE name=sameMove qn=sameMove canonical=game.py:sameMove#1 line=225 col=6 end=225:14 file=FILE:game.py@1
+node VARIABLE name=selection qn=selection canonical=game.py:selection#0 line=291 col=4 end=291:13 file=FILE:game.py@1
+node VARIABLE name=tempField qn=tempField canonical=game.py:tempField#0 line=194 col=3 end=194:12 file=FILE:game.py@1
+node VARIABLE name=tictactoe qn=tictactoe canonical=game.py:tictactoe#0 line=302 col=2 end=302:11 file=FILE:game.py@1
+node VARIABLE name=total qn=total canonical=game.py:total#0 line=88 col=3 end=88:8 file=FILE:game.py@1
+node VARIABLE name=turnValue qn=turnValue canonical=game.py:turnValue#0 line=216 col=5 end=216:14 file=FILE:game.py@1
+node VARIABLE name=turnValue qn=turnValue canonical=game.py:turnValue#1 line=218 col=6 end=218:15 file=FILE:game.py@1
+edge CALL src=FUNCTION:ArtificialPlayer.__init__@189 dst=UNKNOWN:__init__@190 resolved_src=- resolved_dst=- line=190 confidence=- certainty=- callsite=h0:190:10:h1|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._evaluate@233 dst=UNKNOWN:opponent@236 resolved_src=- resolved_dst=- line=236 confidence=- certainty=- callsite=h0:236:30:h2|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._evaluate@233 dst=UNKNOWN:sameInRow@234 resolved_src=- resolved_dst=- line=234 confidence=- certainty=- callsite=h0:234:12:h3|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._evaluate@233 dst=UNKNOWN:sameInRow@236 resolved_src=- resolved_dst=- line=236 confidence=- certainty=- callsite=h0:236:14:h4|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._evaluate@233 dst=UNKNOWN:sameInRow@238 resolved_src=- resolved_dst=- line=238 confidence=- certainty=- callsite=h0:238:14:h5|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=FUNCTION:ArtificialPlayer._evaluate@233 resolved_src=- resolved_dst=FUNCTION:ArtificialPlayer._evaluate@233 line=216 confidence=1.0000 certainty=Certain callsite=h0:216:1:h6 candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:Move@203 resolved_src=- resolved_dst=- line=203 confidence=- certainty=- callsite=h0:203:16:h7|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:Node@200 resolved_src=- resolved_dst=- line=200 confidence=- certainty=- callsite=h0:200:27:h8|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:clearMove@220 resolved_src=- resolved_dst=- line=220 confidence=- certainty=- callsite=h0:220:11:h9|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:isEmpty@211 resolved_src=- resolved_dst=- line=211 confidence=- certainty=- callsite=h0:211:18:h10|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:isFull@217 resolved_src=- resolved_dst=- line=217 confidence=- certainty=- callsite=h0:217:37:h11|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:makeMove@214 resolved_src=- resolved_dst=- line=214 confidence=- certainty=- callsite=h0:214:11:h12|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:opponent@218 resolved_src=- resolved_dst=- line=218 confidence=- certainty=- callsite=h0:218:45:h13|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:randint@228 resolved_src=- resolved_dst=- line=228 confidence=- certainty=- callsite=h0:228:9:h14 candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:range@206 resolved_src=- resolved_dst=- line=206 confidence=- certainty=- callsite=h0:206:12:h15 candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer._minMax@199 dst=UNKNOWN:range@208 resolved_src=- resolved_dst=- line=208 confidence=- certainty=- callsite=h0:208:13:h16 candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer.turn@193 dst=FUNCTION:ArtificialPlayer._minMax@199 resolved_src=- resolved_dst=FUNCTION:ArtificialPlayer._minMax@199 line=195 confidence=1.0000 certainty=Certain callsite=h0:195:1:h17 candidates=[]
+edge CALL src=FUNCTION:ArtificialPlayer.turn@193 dst=UNKNOWN:clone@194 resolved_src=- resolved_dst=- line=194 confidence=- certainty=- callsite=h0:194:21:h18|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:Field.__init__@42 dst=UNKNOWN:append@47 resolved_src=- resolved_dst=- line=47 confidence=- certainty=- callsite=h0:47:9:h19|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:Field.__init__@42 dst=UNKNOWN:append@48 resolved_src=- resolved_dst=- line=48 confidence=- certainty=- callsite=h0:48:15:h20|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:Field.__init__@42 dst=UNKNOWN:range@44 resolved_src=- resolved_dst=- line=44 confidence=- certainty=- callsite=h0:44:12:h21 candidates=[]
+edge CALL src=FUNCTION:Field.__init__@42 dst=UNKNOWN:range@46 resolved_src=- resolved_dst=- line=46 confidence=- certainty=- callsite=h0:46:13:h22 candidates=[]
+edge CALL src=FUNCTION:Field.clear@61 dst=UNKNOWN:range@62 resolved_src=- resolved_dst=- line=62 confidence=- certainty=- callsite=h0:62:12:h23 candidates=[]
+edge CALL src=FUNCTION:Field.clear@61 dst=UNKNOWN:range@63 resolved_src=- resolved_dst=- line=63 confidence=- certainty=- callsite=h0:63:13:h24 candidates=[]
+edge CALL src=FUNCTION:Field.clearMove@126 dst=FUNCTION:Field.inRange@101 resolved_src=- resolved_dst=FUNCTION:Field.inRange@101 line=127 confidence=1.0000 certainty=Certain callsite=h0:127:1:h25 candidates=[]
+edge CALL src=FUNCTION:Field.clearMove@126 dst=FUNCTION:Field.isEmpty@105 resolved_src=- resolved_dst=FUNCTION:Field.isEmpty@105 line=129 confidence=1.0000 certainty=Certain callsite=h0:129:1:h26 candidates=[]
+edge CALL src=FUNCTION:Field.clone@52 dst=UNKNOWN:Field@53 resolved_src=- resolved_dst=- line=53 confidence=- certainty=- callsite=h0:53:11:h27 candidates=[]
+edge CALL src=FUNCTION:Field.clone@52 dst=UNKNOWN:range@54 resolved_src=- resolved_dst=- line=54 confidence=- certainty=- callsite=h0:54:12:h28 candidates=[]
+edge CALL src=FUNCTION:Field.clone@52 dst=UNKNOWN:range@55 resolved_src=- resolved_dst=- line=55 confidence=- certainty=- callsite=h0:55:13:h29 candidates=[]
+edge CALL src=FUNCTION:Field.makeMove@113 dst=FUNCTION:Field.inRange@101 resolved_src=- resolved_dst=FUNCTION:Field.inRange@101 line=114 confidence=1.0000 certainty=Certain callsite=h0:114:1:h25 candidates=[]
+edge CALL src=FUNCTION:Field.makeMove@113 dst=FUNCTION:Field.isEmpty@105 resolved_src=- resolved_dst=FUNCTION:Field.isEmpty@105 line=116 confidence=1.0000 certainty=Certain callsite=h0:116:1:h26 candidates=[]
+edge CALL src=FUNCTION:Field.makeMove@113 dst=FUNCTION:Field.isFull@109 resolved_src=- resolved_dst=FUNCTION:Field.isFull@109 line=120 confidence=1.0000 certainty=Certain callsite=h0:120:1:h30 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:numberOut@71 resolved_src=- resolved_dst=- line=71 confidence=- certainty=- callsite=h0:71:4:h31 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:range@70 resolved_src=- resolved_dst=- line=70 confidence=- certainty=- callsite=h0:70:14:h32 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:range@73 resolved_src=- resolved_dst=- line=73 confidence=- certainty=- callsite=h0:73:15:h33 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:stringOut@69 resolved_src=- resolved_dst=- line=69 confidence=- certainty=- callsite=h0:69:3:h34 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:stringOut@72 resolved_src=- resolved_dst=- line=72 confidence=- certainty=- callsite=h0:72:4:h35 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:stringOut@75 resolved_src=- resolved_dst=- line=75 confidence=- certainty=- callsite=h0:75:6:h36 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:stringOut@77 resolved_src=- resolved_dst=- line=77 confidence=- certainty=- callsite=h0:77:6:h37 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:stringOut@79 resolved_src=- resolved_dst=- line=79 confidence=- certainty=- callsite=h0:79:6:h38 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:stringOut@81 resolved_src=- resolved_dst=- line=81 confidence=- certainty=- callsite=h0:81:6:h39 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:stringOut@83 resolved_src=- resolved_dst=- line=83 confidence=- certainty=- callsite=h0:83:5:h40 candidates=[]
+edge CALL src=FUNCTION:Field.show@68 dst=UNKNOWN:stringOut@84 resolved_src=- resolved_dst=- line=84 confidence=- certainty=- callsite=h0:84:3:h41 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer.__init__@148 dst=UNKNOWN:__init__@149 resolved_src=- resolved_dst=- line=149 confidence=- certainty=- callsite=h0:149:10:h42|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._check@172 dst=UNKNOWN:inRange@173 resolved_src=- resolved_dst=- line=173 confidence=- certainty=- callsite=h0:173:16:h43|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._check@172 dst=UNKNOWN:isEmpty@176 resolved_src=- resolved_dst=- line=176 confidence=- certainty=- callsite=h0:176:18:h44|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._check@172 dst=UNKNOWN:stringOut@174 resolved_src=- resolved_dst=- line=174 confidence=- certainty=- callsite=h0:174:4:h45 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._check@172 dst=UNKNOWN:stringOut@177 resolved_src=- resolved_dst=- line=177 confidence=- certainty=- callsite=h0:177:4:h46 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._input@162 dst=UNKNOWN:Move@163 resolved_src=- resolved_dst=- line=163 confidence=- certainty=- callsite=h0:163:16:h47|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._input@162 dst=UNKNOWN:numberIn@165 resolved_src=- resolved_dst=- line=165 confidence=- certainty=- callsite=h0:165:14:h48 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._input@162 dst=UNKNOWN:numberIn@167 resolved_src=- resolved_dst=- line=167 confidence=- certainty=- callsite=h0:167:14:h49 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._input@162 dst=UNKNOWN:stringOut@164 resolved_src=- resolved_dst=- line=164 confidence=- certainty=- callsite=h0:164:3:h50 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._input@162 dst=UNKNOWN:stringOut@166 resolved_src=- resolved_dst=- line=166 confidence=- certainty=- callsite=h0:166:3:h51 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer._input@162 dst=UNKNOWN:stringOut@168 resolved_src=- resolved_dst=- line=168 confidence=- certainty=- callsite=h0:168:3:h52 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer.turn@152 dst=FUNCTION:HumanPlayer._check@172 resolved_src=- resolved_dst=FUNCTION:HumanPlayer._check@172 line=157 confidence=1.0000 certainty=Certain callsite=h0:157:1:h53 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer.turn@152 dst=FUNCTION:HumanPlayer._input@162 resolved_src=- resolved_dst=FUNCTION:HumanPlayer._input@162 line=156 confidence=1.0000 certainty=Certain callsite=h0:156:1:h54 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer.turn@152 dst=UNKNOWN:stringOut@153 resolved_src=- resolved_dst=- line=153 confidence=- certainty=- callsite=h0:153:3:h55 candidates=[]
+edge CALL src=FUNCTION:HumanPlayer.turn@152 dst=UNKNOWN:stringOut@154 resolved_src=- resolved_dst=- line=154 confidence=- certainty=- callsite=h0:154:3:h56 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.__init__@244 dst=UNKNOWN:Field@245 resolved_src=- resolved_dst=- line=245 confidence=- certainty=- callsite=h0:245:17:h57 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._reset@280 dst=FUNCTION:Field.clear@61 resolved_src=- resolved_dst=FUNCTION:Field.clear@61 line=283 confidence=1.0000 certainty=Certain callsite=h0:283:1:h58 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._reset@280 dst=UNKNOWN:range@281 resolved_src=- resolved_dst=- line=281 confidence=- certainty=- callsite=h0:281:12:h59 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._selectPlayer@286 dst=UNKNOWN:ArtificialPlayer@295 resolved_src=- resolved_dst=- line=295 confidence=- certainty=- callsite=h0:295:12:h60 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._selectPlayer@286 dst=UNKNOWN:HumanPlayer@293 resolved_src=- resolved_dst=- line=293 confidence=- certainty=- callsite=h0:293:12:h61 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._selectPlayer@286 dst=UNKNOWN:numberIn@291 resolved_src=- resolved_dst=- line=291 confidence=- certainty=- callsite=h0:291:16:h62 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._selectPlayer@286 dst=UNKNOWN:stringOut@288 resolved_src=- resolved_dst=- line=288 confidence=- certainty=- callsite=h0:288:4:h63 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._selectPlayer@286 dst=UNKNOWN:stringOut@289 resolved_src=- resolved_dst=- line=289 confidence=- certainty=- callsite=h0:289:4:h64 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._selectPlayer@286 dst=UNKNOWN:stringOut@290 resolved_src=- resolved_dst=- line=290 confidence=- certainty=- callsite=h0:290:4:h65 candidates=[]
+edge CALL src=FUNCTION:TicTacToe._selectPlayer@286 dst=UNKNOWN:stringOut@298 resolved_src=- resolved_dst=- line=298 confidence=- certainty=- callsite=h0:298:4:h66 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=FUNCTION:Field.makeMove@113 resolved_src=- resolved_dst=FUNCTION:Field.makeMove@113 line=270 confidence=1.0000 certainty=Certain callsite=h0:270:1:h67 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=FUNCTION:Field.sameInRow@87 resolved_src=- resolved_dst=FUNCTION:Field.sameInRow@87 line=272 confidence=1.0000 certainty=Certain callsite=h0:272:1:h68 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=FUNCTION:Field.show@68 resolved_src=- resolved_dst=FUNCTION:Field.show@68 line=266 confidence=1.0000 certainty=Certain callsite=h0:266:1:h69 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=FUNCTION:Field.show@68 resolved_src=- resolved_dst=FUNCTION:Field.show@68 line=271 confidence=1.0000 certainty=Certain callsite=h0:271:1:h69 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=UNKNOWN:range@268 resolved_src=- resolved_dst=- line=268 confidence=- certainty=- callsite=h0:268:12:h70 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=UNKNOWN:stringOut@273 resolved_src=- resolved_dst=- line=273 confidence=- certainty=- callsite=h0:273:5:h71 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=UNKNOWN:stringOut@274 resolved_src=- resolved_dst=- line=274 confidence=- certainty=- callsite=h0:274:5:h72 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=UNKNOWN:stringOut@277 resolved_src=- resolved_dst=- line=277 confidence=- certainty=- callsite=h0:277:3:h73 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.run@265 dst=UNKNOWN:turn@270 resolved_src=- resolved_dst=- line=270 confidence=- certainty=- callsite=h0:270:32:h74|syntax:python-attribute-call candidates=[]
+edge CALL src=FUNCTION:TicTacToe.start@249 dst=FUNCTION:TicTacToe._reset@280 resolved_src=- resolved_dst=FUNCTION:TicTacToe._reset@280 line=250 confidence=1.0000 certainty=Certain callsite=h0:250:1:h75 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.start@249 dst=FUNCTION:TicTacToe._selectPlayer@286 resolved_src=- resolved_dst=FUNCTION:TicTacToe._selectPlayer@286 line=253 confidence=1.0000 certainty=Certain callsite=h0:253:1:h76 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.start@249 dst=FUNCTION:TicTacToe._selectPlayer@286 resolved_src=- resolved_dst=FUNCTION:TicTacToe._selectPlayer@286 line=257 confidence=1.0000 certainty=Certain callsite=h0:257:1:h76 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.start@249 dst=UNKNOWN:stringOut@251 resolved_src=- resolved_dst=- line=251 confidence=- certainty=- callsite=h0:251:3:h77 candidates=[]
+edge CALL src=FUNCTION:TicTacToe.start@249 dst=UNKNOWN:stringOut@261 resolved_src=- resolved_dst=- line=261 confidence=- certainty=- callsite=h0:261:3:h78 candidates=[]
+edge CALL src=FUNCTION:main@301 dst=FUNCTION:TicTacToe.run@265 resolved_src=- resolved_dst=FUNCTION:TicTacToe.run@265 line=304 confidence=1.0000 certainty=Certain callsite=h0:304:1:h79 candidates=[]
+edge CALL src=FUNCTION:main@301 dst=FUNCTION:TicTacToe.start@249 resolved_src=- resolved_dst=FUNCTION:TicTacToe.start@249 line=303 confidence=1.0000 certainty=Certain callsite=h0:303:1:h80 candidates=[]
+edge CALL src=FUNCTION:main@301 dst=UNKNOWN:TicTacToe@302 resolved_src=- resolved_dst=- line=302 confidence=- certainty=- callsite=h0:302:14:h81 candidates=[]
+edge CALL src=FUNCTION:numberIn@5 dst=UNKNOWN:input@6 resolved_src=- resolved_dst=- line=6 confidence=- certainty=- callsite=h0:6:13:h82 candidates=[]
+edge CALL src=FUNCTION:numberIn@5 dst=UNKNOWN:int@6 resolved_src=- resolved_dst=- line=6 confidence=- certainty=- callsite=h0:6:9:h83 candidates=[]
+edge CALL src=FUNCTION:numberOut@9 dst=UNKNOWN:print@10 resolved_src=- resolved_dst=- line=10 confidence=- certainty=- callsite=h0:10:2:h84 candidates=[]
+edge CALL src=FUNCTION:numberOut@9 dst=UNKNOWN:str@10 resolved_src=- resolved_dst=- line=10 confidence=- certainty=- callsite=h0:10:8:h85 candidates=[]
+edge CALL src=FUNCTION:stringOut@13 dst=UNKNOWN:print@14 resolved_src=- resolved_dst=- line=14 confidence=- certainty=- callsite=h0:14:2:h86 candidates=[]
+edge IMPORT src=UNKNOWN:Enum@1 dst=MODULE:enum@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=UNKNOWN:randint@2 dst=MODULE:random@2 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ArtificialPlayer@182 dst=CLASS:Player@137 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@21 dst=CLASS:GameObject@17 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:HumanPlayer@147 dst=CLASS:Player@137 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Player@137 dst=CLASS:GameObject@17 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Token@22 dst=CLASS:Enum@22 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@182 dst=FUNCTION:ArtificialPlayer.__init__@189 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@182 dst=FUNCTION:ArtificialPlayer._evaluate@233 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@182 dst=FUNCTION:ArtificialPlayer._minMax@199 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@182 dst=FUNCTION:ArtificialPlayer.turn@193 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.__init__@42 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.clear@61 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.clearMove@126 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.clone@52 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.inRange@101 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.isEmpty@105 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.isFull@109 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.makeMove@113 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.opponent@28 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.sameInRow@87 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@21 dst=FUNCTION:Field.show@68 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@147 dst=FUNCTION:HumanPlayer.__init__@148 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@147 dst=FUNCTION:HumanPlayer._check@172 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@147 dst=FUNCTION:HumanPlayer._input@162 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@147 dst=FUNCTION:HumanPlayer.turn@152 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Move@36 dst=FUNCTION:Move.__init__@37 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Node@183 dst=FUNCTION:Node.__init__@184 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Player@137 dst=FUNCTION:Player.__init__@138 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Player@137 dst=FUNCTION:Player.turn@143 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@243 dst=FUNCTION:TicTacToe.__init__@244 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@243 dst=FUNCTION:TicTacToe._reset@280 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@243 dst=FUNCTION:TicTacToe._selectPlayer@286 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@243 dst=FUNCTION:TicTacToe.run@265 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@243 dst=FUNCTION:TicTacToe.start@249 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.py language=python lines=308 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@182 kind=DEFINITION span=182:7-182:23
+occurrence element=CLASS:Enum@22 kind=DEFINITION span=22:14-22:18
+occurrence element=CLASS:Field@21 kind=DEFINITION span=21:7-21:12
+occurrence element=CLASS:GameObject@17 kind=DEFINITION span=137:14-137:24
+occurrence element=CLASS:GameObject@17 kind=DEFINITION span=17:7-17:17
+occurrence element=CLASS:GameObject@17 kind=DEFINITION span=21:13-21:23
+occurrence element=CLASS:HumanPlayer@147 kind=DEFINITION span=147:7-147:18
+occurrence element=CLASS:Move@36 kind=DEFINITION span=36:8-36:12
+occurrence element=CLASS:Node@183 kind=DEFINITION span=183:8-183:12
+occurrence element=CLASS:Player@137 kind=DEFINITION span=137:7-137:13
+occurrence element=CLASS:Player@137 kind=DEFINITION span=147:19-147:25
+occurrence element=CLASS:Player@137 kind=DEFINITION span=182:24-182:30
+occurrence element=CLASS:TicTacToe@243 kind=DEFINITION span=243:7-243:16
+occurrence element=CLASS:Token@22 kind=DEFINITION span=22:8-22:13
+occurrence element=CONSTANT:TOKEN_NONE@23 kind=DEFINITION span=23:3-23:13
+occurrence element=CONSTANT:TOKEN_PLAYER_A@24 kind=DEFINITION span=24:3-24:17
+occurrence element=CONSTANT:TOKEN_PLAYER_B@25 kind=DEFINITION span=25:3-25:17
+occurrence element=FUNCTION:ArtificialPlayer.__init__@189 kind=DEFINITION span=189:2-190:37
+occurrence element=FUNCTION:ArtificialPlayer._evaluate@233 kind=DEFINITION span=233:2-240:11
+occurrence element=FUNCTION:ArtificialPlayer._minMax@199 kind=DEFINITION span=199:2-230:14
+occurrence element=FUNCTION:ArtificialPlayer.turn@193 kind=DEFINITION span=193:2-196:19
+occurrence element=FUNCTION:Field.__init__@42 kind=DEFINITION span=42:2-49:17
+occurrence element=FUNCTION:Field.clear@61 kind=DEFINITION span=61:2-65:17
+occurrence element=FUNCTION:Field.clearMove@126 kind=DEFINITION span=126:2-134:18
+occurrence element=FUNCTION:Field.clone@52 kind=DEFINITION span=52:2-58:15
+occurrence element=FUNCTION:Field.inRange@101 kind=DEFINITION span=101:2-102:75
+occurrence element=FUNCTION:Field.isEmpty@105 kind=DEFINITION span=105:2-106:66
+occurrence element=FUNCTION:Field.isFull@109 kind=DEFINITION span=109:2-110:25
+occurrence element=FUNCTION:Field.makeMove@113 kind=DEFINITION span=113:2-123:18
+occurrence element=FUNCTION:Field.opponent@28 kind=DEFINITION span=28:2-33:32
+occurrence element=FUNCTION:Field.sameInRow@87 kind=DEFINITION span=87:2-98:15
+occurrence element=FUNCTION:Field.show@68 kind=DEFINITION span=68:2-84:20
+occurrence element=FUNCTION:HumanPlayer.__init__@148 kind=DEFINITION span=148:2-149:37
+occurrence element=FUNCTION:HumanPlayer._check@172 kind=DEFINITION span=172:2-179:14
+occurrence element=FUNCTION:HumanPlayer._input@162 kind=DEFINITION span=162:2-169:14
+occurrence element=FUNCTION:HumanPlayer.turn@152 kind=DEFINITION span=152:2-159:14
+occurrence element=FUNCTION:Move.__init__@37 kind=DEFINITION span=37:3-39:19
+occurrence element=FUNCTION:Node.__init__@184 kind=DEFINITION span=184:3-186:18
+occurrence element=FUNCTION:Player.__init__@138 kind=DEFINITION span=138:2-140:19
+occurrence element=FUNCTION:Player.turn@143 kind=DEFINITION span=143:2-144:28
+occurrence element=FUNCTION:TicTacToe.__init__@244 kind=DEFINITION span=244:2-246:31
+occurrence element=FUNCTION:TicTacToe._reset@280 kind=DEFINITION span=280:2-283:22
+occurrence element=FUNCTION:TicTacToe._selectPlayer@286 kind=DEFINITION span=286:2-298:31
+occurrence element=FUNCTION:TicTacToe.run@265 kind=DEFINITION span=265:2-277:38
+occurrence element=FUNCTION:TicTacToe.start@249 kind=DEFINITION span=249:2-262:14
+occurrence element=FUNCTION:main@301 kind=DEFINITION span=301:1-304:18
+occurrence element=FUNCTION:numberIn@5 kind=DEFINITION span=5:1-6:21
+occurrence element=FUNCTION:numberOut@9 kind=DEFINITION span=9:1-10:25
+occurrence element=FUNCTION:stringOut@13 kind=DEFINITION span=13:1-14:20
+occurrence element=MODULE:enum@1 kind=DEFINITION span=1:6-1:10
+occurrence element=MODULE:random@2 kind=DEFINITION span=2:6-2:12
+occurrence element=UNKNOWN:ArtificialPlayer@295 kind=DEFINITION span=295:12-295:28
+occurrence element=UNKNOWN:Enum@1 kind=DEFINITION span=1:18-1:22
+occurrence element=UNKNOWN:Field@245 kind=DEFINITION span=245:17-245:22
+occurrence element=UNKNOWN:Field@53 kind=DEFINITION span=53:11-53:16
+occurrence element=UNKNOWN:HumanPlayer@293 kind=DEFINITION span=293:12-293:23
+occurrence element=UNKNOWN:Move@163 kind=DEFINITION span=163:16-163:20
+occurrence element=UNKNOWN:Move@203 kind=DEFINITION span=203:16-203:20
+occurrence element=UNKNOWN:Node@200 kind=DEFINITION span=200:27-200:31
+occurrence element=UNKNOWN:TicTacToe@302 kind=DEFINITION span=302:14-302:23
+occurrence element=UNKNOWN:__init__@149 kind=DEFINITION span=149:10-149:18
+occurrence element=UNKNOWN:__init__@190 kind=DEFINITION span=190:10-190:18
+occurrence element=UNKNOWN:_check@157 kind=DEFINITION span=157:12-157:18
+occurrence element=UNKNOWN:_evaluate@216 kind=DEFINITION span=216:22-216:31
+occurrence element=UNKNOWN:_input@156 kind=DEFINITION span=156:16-156:22
+occurrence element=UNKNOWN:_minMax@195 kind=DEFINITION span=195:15-195:22
+occurrence element=UNKNOWN:_minMax@218 kind=DEFINITION span=218:24-218:31
+occurrence element=UNKNOWN:_reset@250 kind=DEFINITION span=250:8-250:14
+occurrence element=UNKNOWN:_selectPlayer@253 kind=DEFINITION span=253:27-253:40
+occurrence element=UNKNOWN:_selectPlayer@257 kind=DEFINITION span=257:27-257:40
+occurrence element=UNKNOWN:append@47 kind=DEFINITION span=47:9-47:15
+occurrence element=UNKNOWN:append@48 kind=DEFINITION span=48:15-48:21
+occurrence element=UNKNOWN:clear@283 kind=DEFINITION span=283:15-283:20
+occurrence element=UNKNOWN:clearMove@220 kind=DEFINITION span=220:11-220:20
+occurrence element=UNKNOWN:clone@194 kind=DEFINITION span=194:21-194:26
+occurrence element=UNKNOWN:inRange@114 kind=DEFINITION span=114:15-114:22
+occurrence element=UNKNOWN:inRange@127 kind=DEFINITION span=127:15-127:22
+occurrence element=UNKNOWN:inRange@173 kind=DEFINITION span=173:16-173:23
+occurrence element=UNKNOWN:input@6 kind=DEFINITION span=6:13-6:18
+occurrence element=UNKNOWN:int@6 kind=DEFINITION span=6:9-6:12
+occurrence element=UNKNOWN:isEmpty@116 kind=DEFINITION span=116:15-116:22
+occurrence element=UNKNOWN:isEmpty@129 kind=DEFINITION span=129:11-129:18
+occurrence element=UNKNOWN:isEmpty@176 kind=DEFINITION span=176:18-176:25
+occurrence element=UNKNOWN:isEmpty@211 kind=DEFINITION span=211:18-211:25
+occurrence element=UNKNOWN:isFull@120 kind=DEFINITION span=120:11-120:17
+occurrence element=UNKNOWN:isFull@217 kind=DEFINITION span=217:37-217:43
+occurrence element=UNKNOWN:main@308 kind=DEFINITION span=308:2-308:6
+occurrence element=UNKNOWN:makeMove@214 kind=DEFINITION span=214:11-214:19
+occurrence element=UNKNOWN:makeMove@270 kind=DEFINITION span=270:16-270:24
+occurrence element=UNKNOWN:numberIn@165 kind=DEFINITION span=165:14-165:22
+occurrence element=UNKNOWN:numberIn@167 kind=DEFINITION span=167:14-167:22
+occurrence element=UNKNOWN:numberIn@291 kind=DEFINITION span=291:16-291:24
+occurrence element=UNKNOWN:numberOut@71 kind=DEFINITION span=71:4-71:13
+occurrence element=UNKNOWN:opponent@218 kind=DEFINITION span=218:45-218:53
+occurrence element=UNKNOWN:opponent@236 kind=DEFINITION span=236:30-236:38
+occurrence element=UNKNOWN:print@10 kind=DEFINITION span=10:2-10:7
+occurrence element=UNKNOWN:print@14 kind=DEFINITION span=14:2-14:7
+occurrence element=UNKNOWN:randint@2 kind=DEFINITION span=2:20-2:27
+occurrence element=UNKNOWN:randint@228 kind=DEFINITION span=228:9-228:16
+occurrence element=UNKNOWN:range@206 kind=DEFINITION span=206:12-206:17
+occurrence element=UNKNOWN:range@208 kind=DEFINITION span=208:13-208:18
+occurrence element=UNKNOWN:range@268 kind=DEFINITION span=268:12-268:17
+occurrence element=UNKNOWN:range@281 kind=DEFINITION span=281:12-281:17
+occurrence element=UNKNOWN:range@44 kind=DEFINITION span=44:12-44:17
+occurrence element=UNKNOWN:range@46 kind=DEFINITION span=46:13-46:18
+occurrence element=UNKNOWN:range@54 kind=DEFINITION span=54:12-54:17
+occurrence element=UNKNOWN:range@55 kind=DEFINITION span=55:13-55:18
+occurrence element=UNKNOWN:range@62 kind=DEFINITION span=62:12-62:17
+occurrence element=UNKNOWN:range@63 kind=DEFINITION span=63:13-63:18
+occurrence element=UNKNOWN:range@70 kind=DEFINITION span=70:14-70:19
+occurrence element=UNKNOWN:range@73 kind=DEFINITION span=73:15-73:20
+occurrence element=UNKNOWN:run@304 kind=DEFINITION span=304:13-304:16
+occurrence element=UNKNOWN:sameInRow@234 kind=DEFINITION span=234:12-234:21
+occurrence element=UNKNOWN:sameInRow@236 kind=DEFINITION span=236:14-236:23
+occurrence element=UNKNOWN:sameInRow@238 kind=DEFINITION span=238:14-238:23
+occurrence element=UNKNOWN:sameInRow@272 kind=DEFINITION span=272:19-272:28
+occurrence element=UNKNOWN:show@266 kind=DEFINITION span=266:15-266:19
+occurrence element=UNKNOWN:show@271 kind=DEFINITION span=271:16-271:20
+occurrence element=UNKNOWN:start@303 kind=DEFINITION span=303:18-303:23
+occurrence element=UNKNOWN:str@10 kind=DEFINITION span=10:8-10:11
+occurrence element=UNKNOWN:stringOut@153 kind=DEFINITION span=153:3-153:12
+occurrence element=UNKNOWN:stringOut@154 kind=DEFINITION span=154:3-154:12
+occurrence element=UNKNOWN:stringOut@164 kind=DEFINITION span=164:3-164:12
+occurrence element=UNKNOWN:stringOut@166 kind=DEFINITION span=166:3-166:12
+occurrence element=UNKNOWN:stringOut@168 kind=DEFINITION span=168:3-168:12
+occurrence element=UNKNOWN:stringOut@174 kind=DEFINITION span=174:4-174:13
+occurrence element=UNKNOWN:stringOut@177 kind=DEFINITION span=177:4-177:13
+occurrence element=UNKNOWN:stringOut@251 kind=DEFINITION span=251:3-251:12
+occurrence element=UNKNOWN:stringOut@261 kind=DEFINITION span=261:3-261:12
+occurrence element=UNKNOWN:stringOut@273 kind=DEFINITION span=273:5-273:14
+occurrence element=UNKNOWN:stringOut@274 kind=DEFINITION span=274:5-274:14
+occurrence element=UNKNOWN:stringOut@277 kind=DEFINITION span=277:3-277:12
+occurrence element=UNKNOWN:stringOut@288 kind=DEFINITION span=288:4-288:13
+occurrence element=UNKNOWN:stringOut@289 kind=DEFINITION span=289:4-289:13
+occurrence element=UNKNOWN:stringOut@290 kind=DEFINITION span=290:4-290:13
+occurrence element=UNKNOWN:stringOut@298 kind=DEFINITION span=298:4-298:13
+occurrence element=UNKNOWN:stringOut@69 kind=DEFINITION span=69:3-69:12
+occurrence element=UNKNOWN:stringOut@72 kind=DEFINITION span=72:4-72:13
+occurrence element=UNKNOWN:stringOut@75 kind=DEFINITION span=75:6-75:15
+occurrence element=UNKNOWN:stringOut@77 kind=DEFINITION span=77:6-77:15
+occurrence element=UNKNOWN:stringOut@79 kind=DEFINITION span=79:6-79:15
+occurrence element=UNKNOWN:stringOut@81 kind=DEFINITION span=81:6-81:15
+occurrence element=UNKNOWN:stringOut@83 kind=DEFINITION span=83:5-83:14
+occurrence element=UNKNOWN:stringOut@84 kind=DEFINITION span=84:3-84:12
+occurrence element=UNKNOWN:turn@270 kind=DEFINITION span=270:32-270:36
+occurrence element=VARIABLE:count@89 kind=DEFINITION span=89:3-89:8
+occurrence element=VARIABLE:field@53 kind=DEFINITION span=53:3-53:8
+occurrence element=VARIABLE:move@156 kind=DEFINITION span=156:4-156:8
+occurrence element=VARIABLE:move@163 kind=DEFINITION span=163:3-163:7
+occurrence element=VARIABLE:move@203 kind=DEFINITION span=203:3-203:7
+occurrence element=VARIABLE:node@195 kind=DEFINITION span=195:3-195:7
+occurrence element=VARIABLE:node@200 kind=DEFINITION span=200:3-200:7
+occurrence element=VARIABLE:player@269 kind=DEFINITION span=269:4-269:10
+occurrence element=VARIABLE:playerIndex@267 kind=DEFINITION span=267:3-267:14
+occurrence element=VARIABLE:playerIndex@276 kind=DEFINITION span=276:4-276:15
+occurrence element=VARIABLE:row@45 kind=DEFINITION span=45:4-45:7
+occurrence element=VARIABLE:sameMove@204 kind=DEFINITION span=204:3-204:11
+occurrence element=VARIABLE:sameMove@225 kind=DEFINITION span=225:6-225:14
+occurrence element=VARIABLE:selection@291 kind=DEFINITION span=291:4-291:13
+occurrence element=VARIABLE:tempField@194 kind=DEFINITION span=194:3-194:12
+occurrence element=VARIABLE:tictactoe@302 kind=DEFINITION span=302:2-302:11
+occurrence element=VARIABLE:total@88 kind=DEFINITION span=88:3-88:8
+occurrence element=VARIABLE:turnValue@216 kind=DEFINITION span=216:5-216:14
+occurrence element=VARIABLE:turnValue@218 kind=DEFINITION span=218:6-218:15
+access node=CONSTANT:TOKEN_NONE@23 kind=Public
+access node=CONSTANT:TOKEN_PLAYER_A@24 kind=Public
+access node=CONSTANT:TOKEN_PLAYER_B@25 kind=Public
+access node=VARIABLE:count@89 kind=Public
+access node=VARIABLE:field@53 kind=Public
+access node=VARIABLE:move@156 kind=Public
+access node=VARIABLE:move@163 kind=Public
+access node=VARIABLE:move@203 kind=Public
+access node=VARIABLE:node@195 kind=Public
+access node=VARIABLE:node@200 kind=Public
+access node=VARIABLE:player@269 kind=Public
+access node=VARIABLE:playerIndex@267 kind=Public
+access node=VARIABLE:playerIndex@276 kind=Public
+access node=VARIABLE:row@45 kind=Public
+access node=VARIABLE:sameMove@204 kind=Public
+access node=VARIABLE:sameMove@225 kind=Public
+access node=VARIABLE:selection@291 kind=Public
+access node=VARIABLE:tempField@194 kind=Public
+access node=VARIABLE:tictactoe@302 kind=Public
+access node=VARIABLE:total@88 kind=Public
+access node=VARIABLE:turnValue@216 kind=Public
+access node=VARIABLE:turnValue@218 kind=Public
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:ArtificialPlayer.__init__", node_id: NodeId(5989378751334661710), signature_hash: 1755476741879730270, normalized_signature: Some("shape:3866101950015543316"), body_hash: 6386031208097564258, start_line: 189, end_line: 190 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:ArtificialPlayer._evaluate", node_id: NodeId(-2961465523989852172), signature_hash: -8349635676682364848, normalized_signature: Some("shape:-5808747585328297118"), body_hash: -8398272015669385772, start_line: 233, end_line: 240 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:ArtificialPlayer._minMax", node_id: NodeId(4277291887458799085), signature_hash: 2418964870271381011, normalized_signature: Some("shape:-35501155718880390"), body_hash: -7032342299762495036, start_line: 199, end_line: 230 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:ArtificialPlayer.turn", node_id: NodeId(4165849448595149059), signature_hash: -1169764551011815891, normalized_signature: Some("shape:-7355955248722865667"), body_hash: -7032459764732231503, start_line: 193, end_line: 196 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.__init__", node_id: NodeId(2608793095535553549), signature_hash: -5575150427984782109, normalized_signature: Some("shape:-5472095419973164130"), body_hash: -1876883133129826800, start_line: 42, end_line: 49 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.clear", node_id: NodeId(7003162059303496426), signature_hash: -6169274095310701782, normalized_signature: Some("shape:-2624939224003736862"), body_hash: 908476727114895809, start_line: 61, end_line: 65 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.clearMove", node_id: NodeId(2608317473481884691), signature_hash: -9048124430405793411, normalized_signature: Some("shape:-8858423963534275558"), body_hash: 6123819446525943392, start_line: 126, end_line: 134 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.clone", node_id: NodeId(2411219944413668106), signature_hash: 1378355590425012202, normalized_signature: Some("shape:-1444109967516730316"), body_hash: 4081137360906492718, start_line: 52, end_line: 58 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.inRange", node_id: NodeId(3929423940423021163), signature_hash: 6370111462321436821, normalized_signature: Some("outline:-1792392611245487894"), body_hash: -3881089500508782279, start_line: 101, end_line: 102 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.isEmpty", node_id: NodeId(8085543292579253070), signature_hash: 1497344284946948862, normalized_signature: Some("outline:-1792392611245487894"), body_hash: 474654353539328972, start_line: 105, end_line: 106 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.isFull", node_id: NodeId(-9122721243812861278), signature_hash: 6260677086336585810, normalized_signature: Some("outline:-1792392611245487894"), body_hash: 4724751421930111428, start_line: 109, end_line: 110 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.makeMove", node_id: NodeId(2036697598788759048), signature_hash: 4333676292522098868, normalized_signature: Some("shape:5636139822989682067"), body_hash: 8790910928787061859, start_line: 113, end_line: 123 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.opponent", node_id: NodeId(-7374923262064213286), signature_hash: 396845555584238298, normalized_signature: Some("outline:-1788451961570736570"), body_hash: -8317798079304444793, start_line: 28, end_line: 33 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.sameInRow", node_id: NodeId(-503403200566016048), signature_hash: 5931070487030413932, normalized_signature: Some("shape:-7212304814644848492"), body_hash: -1726395781560375072, start_line: 87, end_line: 98 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Field.show", node_id: NodeId(-4691435348074014098), signature_hash: 6545884105094088190, normalized_signature: Some("shape:-4913784757335701208"), body_hash: 6913586263552348062, start_line: 68, end_line: 84 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:HumanPlayer.__init__", node_id: NodeId(-2929626825153398959), signature_hash: 6565865036368802503, normalized_signature: Some("shape:7351140673194461088"), body_hash: -2834321968593391181, start_line: 148, end_line: 149 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:HumanPlayer._check", node_id: NodeId(987095681779573124), signature_hash: 5194962015948308960, normalized_signature: Some("shape:-8445830967205959128"), body_hash: 2839570124550177389, start_line: 172, end_line: 179 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:HumanPlayer._input", node_id: NodeId(4648841601402798328), signature_hash: -6907293988443763388, normalized_signature: Some("shape:8763965824551667739"), body_hash: 7553101411172641673, start_line: 162, end_line: 169 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:HumanPlayer.turn", node_id: NodeId(5581724472880576372), signature_hash: -7215589493974656048, normalized_signature: Some("shape:9163240756385270039"), body_hash: 1870951159174135186, start_line: 152, end_line: 159 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Move.__init__", node_id: NodeId(832642991965325378), signature_hash: 1015947852990068354, normalized_signature: Some("outline:-1795207361013140379"), body_hash: 8243943182077432973, start_line: 37, end_line: 39 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Node.__init__", node_id: NodeId(-1598687336164433347), signature_hash: -2849779087175510493, normalized_signature: Some("outline:-1795207361013140379"), body_hash: -8427981612631534571, start_line: 184, end_line: 186 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Player.__init__", node_id: NodeId(-4727475047681808898), signature_hash: 2323012146506699470, normalized_signature: Some("outline:-1795207361013140379"), body_hash: 7415511865380373646, start_line: 138, end_line: 140 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:Player.turn", node_id: NodeId(1168914400897689075), signature_hash: -6236141171673811747, normalized_signature: Some("outline:-1792392611245487894"), body_hash: 980230644416580105, start_line: 143, end_line: 144 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:TicTacToe.__init__", node_id: NodeId(-6549864785023178987), signature_hash: 8118541719181814827, normalized_signature: Some("shape:959675877598862817"), body_hash: -8282644452411426388, start_line: 244, end_line: 246 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:TicTacToe._reset", node_id: NodeId(-3486612097034760113), signature_hash: 3655216159136547257, normalized_signature: Some("shape:125358581695886382"), body_hash: 1062078011439877800, start_line: 280, end_line: 283 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:TicTacToe._selectPlayer", node_id: NodeId(-2265567783195135033), signature_hash: 8095590326225479217, normalized_signature: Some("shape:8400806291373403838"), body_hash: -498213367202910865, start_line: 286, end_line: 298 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:TicTacToe.run", node_id: NodeId(-7637538619124929910), signature_hash: 415849543742481066, normalized_signature: Some("shape:8105026971534037408"), body_hash: -1236957507326693843, start_line: 265, end_line: 277 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:TicTacToe.start", node_id: NodeId(7393767884582127243), signature_hash: -2173138682723514523, normalized_signature: Some("shape:-163612864639532168"), body_hash: 6687092593975261804, start_line: 249, end_line: 262 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:main", node_id: NodeId(-1437938411531175156), signature_hash: -4671339478033693080, normalized_signature: Some("shape:-1515120247180913178"), body_hash: -3211263890253540770, start_line: 301, end_line: 304 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:numberIn", node_id: NodeId(7935436492154356219), signature_hash: 2477812878330356949, normalized_signature: Some("shape:-3459214452230704719"), body_hash: -7092376848787408438, start_line: 5, end_line: 6 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:numberOut", node_id: NodeId(770247654827272598), signature_hash: -1579019679195996938, normalized_signature: Some("shape:-8785239976009734509"), body_hash: -4913445228260769170, start_line: 9, end_line: 10 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "13:stringOut", node_id: NodeId(-7519405162588533286), signature_hash: -5818630870471287222, normalized_signature: Some("shape:7342203676796833973"), body_hash: 3475513809850346643, start_line: 13, end_line: 14 }
+callable_state CallableProjectionState { file_id: 4297592266589437056, symbol_key: "__file_structural__", node_id: NodeId(4297592266589437056), signature_hash: 553768115714561381, normalized_signature: None, body_hash: -1540130469466338248, start_line: 1, end_line: 308 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "python",
+        extension: "py",
+        fidelity_filename: "fidelity.py",
+        fidelity_source: include_str!("fixtures/fidelity_lab/python_fidelity_lab.py"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/python_fidelity.txt"),
+        tictactoe_filename: "game.py",
+        tictactoe_source: include_str!("fixtures/tictactoe/python_tictactoe.py"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/python_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1683.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
