### PR TITLE
[v0.17 S3-GO] Extract Go language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3941,8 +3941,8 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
     let comment_marker = codestory_contracts::language_support::line_comment_for_language(language)
         .or(match language {
             "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
-            "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
-            | "cpp" | "dart" | "php" | "swift" => Some("//"),
+            "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "java" | "csharp" | "cpp"
+            | "dart" | "php" | "swift" => Some("//"),
             _ => None,
         });
     let Some(marker) = comment_marker else {
@@ -5572,8 +5572,8 @@ mod tests {
         assert!(bash.contains("\x1b[90m# comment\x1b[0m"), "{bash:?}");
     }
 
-    /// Kotlin's comment marker now comes from the language registry rather than
-    /// the local roster, and every other language must be unmoved.
+    /// Kotlin's and Go's comment markers now come from the language registry
+    /// rather than the local roster, and every other language must be unmoved.
     ///
     /// Asserting only "Kotlin still dims `//`" would pass with the registry
     /// lookup deleted, because the local roster used to answer for Kotlin too.
@@ -5631,14 +5631,20 @@ mod tests {
             }
         }
 
-        // The registry is the source for Kotlin: it must agree with the marker
-        // the roster used to hold.
+        // The registry is the source for Kotlin and Go: it must agree with the
+        // markers the roster used to hold.
         assert_eq!(
             codestory_contracts::language_support::line_comment_for_language("kotlin"),
             Some("//")
         );
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("go"),
+            Some("//")
+        );
         let kotlin = ansi_highlight_snippet("app/Main.kt", "val ok = true // comment");
         assert!(kotlin.contains("\x1b[90m// comment\x1b[0m"), "{kotlin:?}");
+        let go = ansi_highlight_snippet("cmd/main.go", "ok := true // comment");
+        assert!(go.contains("\x1b[90m// comment\x1b[0m"), "{go:?}");
     }
 
     /// Component dialects resolve through the companion-extension registry and

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "go",
+        line_comment: "//",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "go"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,6 +1265,7 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("go"), Some("//"));
         assert_eq!(line_comment_for_language("swift"), None);
     }
 

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -1,9 +1,9 @@
 use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
-    GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
-    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset, PHP_GRAPH_QUERY,
+    PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY,
+    TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -37,7 +37,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("typescript", _) => Some(typescript()),
         ("cpp", _) => Some(cpp()),
         ("c", _) => Some(c()),
-        ("go", _) => Some(go()),
         ("ruby", _) => Some(ruby()),
         ("php", _) => Some(php()),
         ("csharp", _) => Some(csharp()),
@@ -125,16 +124,6 @@ fn c() -> LanguageConfig {
         C_GRAPH_QUERY,
         None,
         LanguageRuleset::C,
-    )
-}
-
-fn go() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_go::LANGUAGE.into(),
-        "go",
-        GO_GRAPH_QUERY,
-        None,
-        LanguageRuleset::Go,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/go.rs
+++ b/crates/codestory-indexer/src/languages/go.rs
@@ -1,0 +1,805 @@
+//! Go extraction rules.
+//!
+//! Go's graph extraction lives here: the tree-sitter rule file, the
+//! compiled-rule cache, the selector-call callsite marker, the manual MEMBER
+//! collector that ties `func (r *Repository) Save()` back to the `Repository`
+//! declaration, and the receiver-call resolution engine that turns
+//! `w.repo.Save(...)` into an edge aimed at `Repository.Save`. Every
+//! language-keyed dispatch in the crate reaches them through
+//! [`super::EXTRACTIONS`] rather than by spelling `"go"`.
+//!
+//! Three Go surfaces are deliberately *not* here, and all three are shared
+//! seams rather than per-language registry rows:
+//!
+//! * `lib.rs::collect_go_route` / `go_route_framework` and their `"go"` arm in
+//!   the framework-route scanner. The per-language route collectors take
+//!   non-uniform arguments and a per-framework precondition, so routing them
+//!   through the registry is one change for all sixteen languages, not part of
+//!   Go's rollback unit.
+//! * `lib.rs::append_text_only_go_symbols` and its text-symbol helpers, which
+//!   belong to the parser-less fallback path (`index_text_only_file`) rather
+//!   than to parser-backed extraction.
+//! * `LanguageRuleset::Go`, which stays in `lib.rs` because the enum is the
+//!   compiled-rule cache key for every language at once.
+//!
+//! `SemanticResolverKind::Go` also stays in
+//! `semantic::dedicated_semantic_resolver`: Go has a dedicated resolver type
+//! and those types are private to that module, so the registry records the
+//! choice (`uses_generic_semantic_resolver: false`) and the residual match
+//! constructs it. Kotlin, being generic, could delete its arm; Go cannot.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both Go fixtures so the move stays output-equal.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, LanguageRuleset, ManualMemberEdgeSpec, ManualReceiverCallSpec,
+    ManualReceiverSource, OptionalReceiverOwnerBinding, ReceiverCallSiteKey, ReceiverOwnerBinding,
+    collect_receiver_call_specs_in_callable, declaration_name, descendant_by_field_name,
+    enclosing_node_with_kind, member_call_method_col, node_is_same_or_ancestor,
+    normalize_parameter_name, normalized_receiver_variable, receiver_call_belongs_to_callable,
+    receiver_callsite_key, trimmed_node_text, ts_node_graph_span, walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from Go selector-call syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:go-selector-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/go.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for Go.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["go"],
+    language_name: "go",
+    extensions: &["go"],
+    ruleset: LanguageRuleset::Go,
+    parser_language: go_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    member_edge_specs: Some(member_edge_specs),
+    receiver_call_specs: Some(receiver_call_specs),
+    member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
+    graph_call_syntax: Some("go_selector"),
+    // A Go method is already a `method_declaration` with an explicit receiver,
+    // so the rule file emits METHOD directly and the projection must not
+    // re-promote a plain `func` that happens to sit under a type-like owner.
+    // `false` is the value the god file's roster gave Go.
+    promotes_type_member_functions_to_methods: false,
+    qualified_name_delimiter: ".",
+    route_comments_are_c_style: true,
+    // Go has a dedicated `GoSemanticResolver`; the residual match in
+    // `semantic::dedicated_semantic_resolver` still constructs it.
+    uses_generic_semantic_resolver: false,
+    semantic_family: "go",
+};
+
+fn go_language() -> tree_sitter::Language {
+    tree_sitter_go::LANGUAGE.into()
+}
+
+pub(crate) fn member_edge_specs(tree: &Tree, source: &str) -> Vec<ManualMemberEdgeSpec> {
+    let mut edges = Vec::new();
+    walk_tree_nodes(tree.root_node(), &mut |node| match node.kind() {
+        "method_declaration" => {
+            let Some(method_name_node) = node.child_by_field_name("name") else {
+                return;
+            };
+            let Some(receiver_node) = node.child_by_field_name("receiver") else {
+                return;
+            };
+            let Some(source_name) = go_receiver_owner_name(receiver_node, source) else {
+                return;
+            };
+            let Some(target_name) = trimmed_node_text(method_name_node, source) else {
+                return;
+            };
+
+            edges.push(ManualMemberEdgeSpec {
+                source_name,
+                target_name,
+                source_span: ts_node_graph_span(
+                    receiver_owner_declaration_node(tree.root_node(), source, receiver_node)
+                        .unwrap_or(receiver_node),
+                ),
+                target_span: ts_node_graph_span(node),
+                line: Some(node.start_position().row as u32 + 1),
+            });
+        }
+        "method_elem" => {
+            let Some(owner_node) = enclosing_node_with_kind(node, &["type_declaration"]) else {
+                return;
+            };
+            let Some(owner_name_node) = descendant_by_field_name(owner_node, "name") else {
+                return;
+            };
+            let Some(source_name) = trimmed_node_text(owner_name_node, source) else {
+                return;
+            };
+            let Some(method_name_node) = node.child_by_field_name("name") else {
+                return;
+            };
+            let Some(target_name) = trimmed_node_text(method_name_node, source) else {
+                return;
+            };
+
+            edges.push(ManualMemberEdgeSpec {
+                source_name,
+                target_name,
+                source_span: ts_node_graph_span(owner_node),
+                target_span: ts_node_graph_span(node),
+                line: Some(node.start_position().row as u32 + 1),
+            });
+        }
+        _ => {}
+    });
+    edges
+}
+
+fn receiver_owner_declaration_node<'tree>(
+    root: TsNode<'tree>,
+    source: &str,
+    receiver_node: TsNode<'tree>,
+) -> Option<TsNode<'tree>> {
+    let owner_name = go_receiver_owner_name(receiver_node, source)?;
+    find_go_type_declaration_by_name(root, source, &owner_name)
+}
+
+fn find_go_type_declaration_by_name<'tree>(
+    node: TsNode<'tree>,
+    source: &str,
+    owner_name: &str,
+) -> Option<TsNode<'tree>> {
+    if node.kind() == "type_declaration"
+        && let Some(name_node) = descendant_by_field_name(node, "name")
+        && trimmed_node_text(name_node, source).as_deref() == Some(owner_name)
+    {
+        return Some(node);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if let Some(found) = find_go_type_declaration_by_name(child, source, owner_name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn go_receiver_owner_name(receiver_node: TsNode<'_>, source: &str) -> Option<String> {
+    let text = trimmed_node_text(receiver_node, source)?;
+    let inner = text
+        .trim()
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .trim();
+    let raw_owner = inner.split_whitespace().last()?.trim();
+    normalize_go_type_surface(raw_owner)
+}
+
+fn normalize_go_type_surface(raw: &str) -> Option<String> {
+    let mut surface = raw.trim();
+    while let Some(stripped) = surface.strip_prefix('*') {
+        surface = stripped.trim_start();
+    }
+    if let Some(stripped) = surface.strip_prefix("[]") {
+        surface = stripped.trim_start();
+    }
+    let base = surface.split('[').next().unwrap_or(surface).trim();
+    let terminal = base.rsplit('.').next().unwrap_or(base).trim();
+    (!terminal.is_empty()).then(|| terminal.to_string())
+}
+
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let import_bindings = collect_go_import_bindings(source);
+    walk_tree_nodes(tree.root_node(), &mut |callable| {
+        if !matches!(
+            callable.kind(),
+            "function_declaration" | "method_declaration"
+        ) {
+            return;
+        }
+        let Some(source_name) = declaration_name(callable, source) else {
+            return;
+        };
+        let call_source = ManualReceiverSource {
+            name: &source_name,
+            span: ts_node_graph_span(callable),
+        };
+        let mut local_binding_callsites = HashSet::new();
+        collect_go_local_composite_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &import_bindings,
+            &mut local_binding_callsites,
+            &mut edges,
+        );
+        let method_receiver_bindings = collect_go_method_receiver_bindings(
+            callable,
+            tree.root_node(),
+            source,
+            &import_bindings,
+        );
+        let mut receiver_types = method_receiver_bindings
+            .iter()
+            .map(|(receiver_name, (owner_name, _))| (receiver_name.clone(), owner_name.clone()))
+            .collect::<HashMap<_, _>>();
+        receiver_types.extend(collect_go_parameter_types(callable, source));
+        if receiver_types.is_empty() {
+            return;
+        }
+        let mut receiver_modules =
+            collect_go_parameter_type_modules(callable, source, &import_bindings);
+        for (receiver_name, (_, owner_module)) in &method_receiver_bindings {
+            if let Some(module_name) = owner_module {
+                receiver_modules.insert(receiver_name.clone(), module_name.clone());
+            }
+        }
+        let start = edges.len();
+        collect_receiver_call_specs_in_callable(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &receiver_types,
+            selector_call,
+            false,
+            &mut edges,
+        );
+        let mut parameter_specs = edges.split_off(start);
+        parameter_specs
+            .retain(|spec| !local_binding_callsites.contains(&receiver_callsite_key(spec)));
+        for spec in &mut parameter_specs {
+            if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
+                spec.owner_module = Some(module_name.clone());
+            }
+        }
+        edges.extend(parameter_specs);
+    });
+    edges
+}
+
+fn collect_go_local_composite_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    import_bindings: &HashMap<String, String>,
+    local_binding_callsites: &mut HashSet<ReceiverCallSiteKey>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = selector_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let Some(owner_name) = go_visible_local_composite_owner(
+            callable,
+            node,
+            &receiver_name,
+            source,
+            import_bindings,
+        ) else {
+            return;
+        };
+        let method_col = member_call_method_col(node, source, &method_name);
+        local_binding_callsites.insert(ReceiverCallSiteKey {
+            receiver_name: receiver_name.clone(),
+            method_name: method_name.clone(),
+            line: Some(node.start_position().row as u32 + 1),
+            method_col,
+        });
+        if let Some((owner_name, owner_module)) = owner_name {
+            edges.push(ManualReceiverCallSpec {
+                source_name: call_source.name.to_string(),
+                source_span: call_source.span,
+                receiver_name,
+                owner_name,
+                owner_module,
+                method_name,
+                method_col,
+                line: Some(node.start_position().row as u32 + 1),
+                allow_global_fallback: false,
+            });
+        }
+    });
+}
+
+fn go_visible_local_composite_owner(
+    callable: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    import_bindings: &HashMap<String, String>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(callable, &mut |node| {
+        if !matches!(
+            node.kind(),
+            "short_var_declaration" | "assignment_statement"
+        ) {
+            return;
+        }
+        if !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > call_node.start_byte()
+        {
+            return;
+        }
+        if !go_local_binding_visible_at_call(node, call_node) {
+            return;
+        }
+        let Some(owner_name) =
+            go_receiver_write_owner(node, receiver_name, source, import_bindings)
+        else {
+            return;
+        };
+        visible_bindings.push((node.end_byte(), owner_name));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner_name)| owner_name)
+}
+
+fn go_receiver_write_owner(
+    node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    import_bindings: &HashMap<String, String>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    if !matches!(
+        node.kind(),
+        "short_var_declaration" | "assignment_statement"
+    ) {
+        return None;
+    }
+    let left_items = node
+        .child_by_field_name("left")
+        .map(go_expression_list_items)
+        .unwrap_or_default();
+    let receiver_index = left_items.iter().position(|left| {
+        normalized_receiver_variable(*left, source).as_deref() == Some(receiver_name)
+    })?;
+    let owner_name = node
+        .child_by_field_name("right")
+        .map(go_expression_list_items)
+        .and_then(|right_items| {
+            right_items.get(receiver_index).and_then(|right| {
+                go_direct_composite_literal_owner(*right, source, import_bindings)
+            })
+        });
+    Some(owner_name)
+}
+
+fn go_expression_list_items(node: TsNode<'_>) -> Vec<TsNode<'_>> {
+    if node.kind() != "expression_list" {
+        return vec![node];
+    }
+    let mut items = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        items.push(child);
+    }
+    items
+}
+
+fn go_direct_composite_literal_owner(
+    node: TsNode<'_>,
+    source: &str,
+    import_bindings: &HashMap<String, String>,
+) -> OptionalReceiverOwnerBinding {
+    if node.kind() == "composite_literal" {
+        return node
+            .child_by_field_name("type")
+            .and_then(|type_node| trimmed_node_text(type_node, source))
+            .as_deref()
+            .and_then(|type_surface| {
+                go_composite_literal_owner_binding_from_type(type_surface, import_bindings)
+            });
+    }
+    trimmed_node_text(node, source)
+        .as_deref()
+        .and_then(|surface| go_direct_composite_literal_owner_surface(surface, import_bindings))
+}
+
+fn go_direct_composite_literal_owner_surface(
+    surface: &str,
+    import_bindings: &HashMap<String, String>,
+) -> OptionalReceiverOwnerBinding {
+    let surface = surface.trim().trim_start_matches('&').trim();
+    if !surface.contains('{') {
+        return None;
+    }
+    let type_surface = surface
+        .split_once('{')
+        .map(|(type_surface, _)| type_surface)
+        .unwrap_or(surface)
+        .trim();
+    go_composite_literal_owner_binding_from_type(type_surface, import_bindings)
+}
+
+fn go_composite_literal_owner_binding_from_type(
+    type_surface: &str,
+    import_bindings: &HashMap<String, String>,
+) -> OptionalReceiverOwnerBinding {
+    let type_surface = type_surface.trim().trim_start_matches('&').trim();
+    if type_surface.contains('(')
+        || type_surface.contains(')')
+        || type_surface.starts_with("[]")
+        || type_surface.starts_with("map[")
+    {
+        return None;
+    }
+    let owner_name = normalize_go_type_surface(type_surface)?;
+    if !owner_name
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+    {
+        return None;
+    }
+    if let Some(qualifier) = go_type_import_qualifier(type_surface) {
+        let module_name = import_bindings.get(&qualifier)?;
+        return Some((owner_name, Some(module_name.clone())));
+    }
+    if type_surface.contains('.') {
+        return None;
+    }
+    Some((owner_name, None))
+}
+
+fn go_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
+    let Some(binding_scope) = go_lexical_scope(binding) else {
+        return false;
+    };
+    let Some(call_scope) = go_lexical_scope(call_node) else {
+        return false;
+    };
+    node_is_same_or_ancestor(binding_scope, call_scope)
+}
+
+fn go_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
+    enclosing_node_with_kind(node, &["block"])
+}
+
+fn collect_go_method_receiver_bindings(
+    callable: TsNode<'_>,
+    root: TsNode<'_>,
+    source: &str,
+    import_bindings: &HashMap<String, String>,
+) -> HashMap<String, ReceiverOwnerBinding> {
+    let mut receiver_types = HashMap::new();
+    if callable.kind() != "method_declaration" {
+        return receiver_types;
+    }
+    let Some(receiver_node) = callable.child_by_field_name("receiver") else {
+        return receiver_types;
+    };
+    let Some(receiver_name) = go_receiver_variable_name(receiver_node, source) else {
+        return receiver_types;
+    };
+    let Some(owner_name) = go_receiver_owner_name(receiver_node, source) else {
+        return receiver_types;
+    };
+    receiver_types.insert(receiver_name.clone(), (owner_name.clone(), None));
+    let Some(owner_node) = find_go_type_declaration_by_name(root, source, &owner_name) else {
+        return receiver_types;
+    };
+    for (field_name, field_owner) in
+        collect_go_struct_field_types(owner_node, source, import_bindings)
+    {
+        receiver_types.insert(format!("{receiver_name}.{field_name}"), field_owner);
+    }
+    receiver_types
+}
+
+fn go_receiver_variable_name(receiver_node: TsNode<'_>, source: &str) -> Option<String> {
+    let text = trimmed_node_text(receiver_node, source)?;
+    let inner = text
+        .trim()
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .trim();
+    let tokens = inner.split_whitespace().collect::<Vec<_>>();
+    if tokens.len() < 2 {
+        return None;
+    }
+    normalize_parameter_name(tokens[0])
+}
+
+fn collect_go_struct_field_types(
+    owner_node: TsNode<'_>,
+    source: &str,
+    import_bindings: &HashMap<String, String>,
+) -> HashMap<String, ReceiverOwnerBinding> {
+    let mut field_types = HashMap::new();
+    walk_tree_nodes(owner_node, &mut |node| {
+        if node.kind() != "field_declaration" {
+            return;
+        }
+        for (field_name, owner_name) in go_field_declaration_bindings(node, source, import_bindings)
+        {
+            field_types.insert(field_name, owner_name);
+        }
+    });
+    field_types
+}
+
+fn go_field_declaration_bindings(
+    node: TsNode<'_>,
+    source: &str,
+    import_bindings: &HashMap<String, String>,
+) -> Vec<(String, ReceiverOwnerBinding)> {
+    if let Some(type_node) = node.child_by_field_name("type")
+        && let Some(raw_type) = trimmed_node_text(type_node, source)
+        && let Some(owner_binding) = go_receiver_owner_from_type(&raw_type, import_bindings)
+    {
+        let mut names = Vec::new();
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.end_byte() > type_node.start_byte() {
+                continue;
+            }
+            if matches!(child.kind(), "field_identifier" | "identifier")
+                && let Some(name) = normalized_receiver_variable(child, source)
+            {
+                names.push(name);
+            }
+        }
+        if !names.is_empty() {
+            return names
+                .into_iter()
+                .map(|name| (name, owner_binding.clone()))
+                .collect();
+        }
+    }
+
+    trimmed_node_text(node, source)
+        .as_deref()
+        .map(|surface| go_field_declaration_bindings_surface(surface, import_bindings))
+        .unwrap_or_default()
+}
+
+fn go_field_declaration_bindings_surface(
+    surface: &str,
+    import_bindings: &HashMap<String, String>,
+) -> Vec<(String, ReceiverOwnerBinding)> {
+    let surface = surface.split('`').next().unwrap_or(surface).trim();
+    let tokens = surface.split_whitespace().collect::<Vec<_>>();
+    let Some(raw_type) = tokens.last() else {
+        return Vec::new();
+    };
+    if tokens.len() < 2 {
+        return Vec::new();
+    }
+    let Some(owner_binding) = go_receiver_owner_from_type(raw_type, import_bindings) else {
+        return Vec::new();
+    };
+    let names_surface = tokens[..tokens.len() - 1].join(" ");
+    names_surface
+        .split(',')
+        .filter_map(normalize_parameter_name)
+        .map(|name| (name, owner_binding.clone()))
+        .collect()
+}
+
+fn go_receiver_owner_from_type(
+    raw_type: &str,
+    import_bindings: &HashMap<String, String>,
+) -> OptionalReceiverOwnerBinding {
+    let owner_name = normalize_go_type_surface(raw_type)?;
+    if let Some(qualifier) = go_type_import_qualifier(raw_type) {
+        let module_name = import_bindings.get(&qualifier)?;
+        return Some((owner_name, Some(module_name.clone())));
+    }
+    Some((owner_name, None))
+}
+
+fn collect_go_import_bindings(source: &str) -> HashMap<String, String> {
+    let mut bindings = HashMap::new();
+    let mut duplicates = HashSet::new();
+    let mut in_import_list = false;
+    for raw_line in source.lines() {
+        let line = go_strip_line_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        if in_import_list {
+            if line.starts_with(')') {
+                in_import_list = false;
+                continue;
+            }
+            if let Some((local_name, module_name)) = go_import_binding_from_spec(line) {
+                insert_unique_import_binding(
+                    &mut bindings,
+                    &mut duplicates,
+                    local_name,
+                    module_name,
+                );
+            }
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("import") else {
+            continue;
+        };
+        let rest = rest.trim();
+        if rest.starts_with('(') {
+            in_import_list = true;
+            continue;
+        }
+        if let Some((local_name, module_name)) = go_import_binding_from_spec(rest) {
+            insert_unique_import_binding(&mut bindings, &mut duplicates, local_name, module_name);
+        }
+    }
+    bindings
+}
+
+fn insert_unique_import_binding(
+    bindings: &mut HashMap<String, String>,
+    duplicates: &mut HashSet<String>,
+    local_name: String,
+    module_name: String,
+) {
+    if duplicates.contains(&local_name) {
+        return;
+    }
+    if bindings.contains_key(&local_name) {
+        bindings.remove(&local_name);
+        duplicates.insert(local_name);
+        return;
+    }
+    bindings.insert(local_name, module_name);
+}
+
+fn go_strip_line_comment(line: &str) -> &str {
+    line.split("//").next().unwrap_or(line)
+}
+
+fn go_import_binding_from_spec(spec: &str) -> Option<(String, String)> {
+    let spec = spec.trim().trim_end_matches(';').trim();
+    if spec.is_empty() {
+        return None;
+    }
+    let tokens = spec.split_whitespace().collect::<Vec<_>>();
+    let (local_name, module_name) = match tokens.as_slice() {
+        [module] => {
+            let module_name = go_import_module_name(module)?;
+            (go_default_import_local_name(&module_name)?, module_name)
+        }
+        [alias, module] if *alias != "." && *alias != "_" => {
+            let module_name = go_import_module_name(module)?;
+            (normalize_parameter_name(alias)?, module_name)
+        }
+        _ => return None,
+    };
+    Some((local_name, module_name))
+}
+
+fn go_import_module_name(raw: &str) -> Option<String> {
+    let module = raw.trim().trim_matches(|ch| matches!(ch, '"' | '\'' | '`'));
+    (!module.is_empty()).then(|| module.to_string())
+}
+
+fn go_default_import_local_name(module_name: &str) -> Option<String> {
+    module_name
+        .rsplit('/')
+        .next()
+        .and_then(normalize_parameter_name)
+}
+
+fn collect_go_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
+    let mut receiver_types = HashMap::new();
+    let Some(parameters) = callable.child_by_field_name("parameters") else {
+        return receiver_types;
+    };
+    walk_tree_nodes(parameters, &mut |node| {
+        if !matches!(
+            node.kind(),
+            "parameter_declaration" | "variadic_parameter_declaration"
+        ) {
+            return;
+        }
+        let Some(type_node) = node.child_by_field_name("type") else {
+            return;
+        };
+        let Some(raw_type) = trimmed_node_text(type_node, source) else {
+            return;
+        };
+        let Some(owner_name) = normalize_go_type_surface(&raw_type) else {
+            return;
+        };
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() == "identifier"
+                && child.end_byte() <= type_node.start_byte()
+                && let Some(name) = normalized_receiver_variable(child, source)
+            {
+                receiver_types.insert(name, owner_name.clone());
+            }
+        }
+    });
+    receiver_types
+}
+
+fn collect_go_parameter_type_modules(
+    callable: TsNode<'_>,
+    source: &str,
+    import_bindings: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut receiver_modules = HashMap::new();
+    let Some(parameters) = callable.child_by_field_name("parameters") else {
+        return receiver_modules;
+    };
+    walk_tree_nodes(parameters, &mut |node| {
+        if !matches!(
+            node.kind(),
+            "parameter_declaration" | "variadic_parameter_declaration"
+        ) {
+            return;
+        }
+        let Some(type_node) = node.child_by_field_name("type") else {
+            return;
+        };
+        let Some(raw_type) = trimmed_node_text(type_node, source) else {
+            return;
+        };
+        let Some(qualifier) = go_type_import_qualifier(&raw_type) else {
+            return;
+        };
+        let Some(module_name) = import_bindings.get(&qualifier) else {
+            return;
+        };
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() == "identifier"
+                && child.end_byte() <= type_node.start_byte()
+                && let Some(name) = normalized_receiver_variable(child, source)
+            {
+                receiver_modules.insert(name, module_name.clone());
+            }
+        }
+    });
+    receiver_modules
+}
+
+fn go_type_import_qualifier(raw_type: &str) -> Option<String> {
+    let mut surface = raw_type.trim();
+    while let Some(stripped) = surface.strip_prefix('*') {
+        surface = stripped.trim_start();
+    }
+    while let Some(stripped) = surface.strip_prefix("[]") {
+        surface = stripped.trim_start();
+    }
+    let base = surface.split('[').next().unwrap_or(surface).trim();
+    let (qualifier, _) = base.rsplit_once('.')?;
+    normalize_parameter_name(qualifier)
+}
+
+fn selector_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let function = node.child_by_field_name("function")?;
+    if function.kind() != "selector_expression" {
+        return None;
+    }
+    let receiver = function.child_by_field_name("operand")?;
+    let method = function.child_by_field_name("field")?;
+    Some((
+        normalized_receiver_variable(receiver, source)?,
+        trimmed_node_text(method, source)?,
+    ))
+}

--- a/crates/codestory-indexer/src/languages/kotlin.rs
+++ b/crates/codestory-indexer/src/languages/kotlin.rs
@@ -55,6 +55,9 @@ pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
     graph_query: GRAPH_QUERY,
     tags_query: None,
     compiled_rules: &RULES,
+    // Kotlin's MEMBER edges come from `rules/kotlin.scm`; it never had an arm
+    // in `lib.rs::language_member_specs`.
+    member_edge_specs: None,
     receiver_call_specs: Some(receiver_call_specs),
     member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
     graph_call_syntax: Some("kotlin_member"),

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -16,13 +16,14 @@
 //! `registry_rows_do_not_shadow_unmigrated_languages` proves it — and the last
 //! package to land deletes the residual arms entirely.
 
+pub(crate) mod go;
 pub(crate) mod kotlin;
 
 use std::sync::OnceLock;
 
 use tree_sitter::{Language, Tree};
 
-use crate::{CompiledLanguageRules, LanguageRuleset, ManualReceiverCallSpec};
+use crate::{CompiledLanguageRules, LanguageRuleset, ManualMemberEdgeSpec, ManualReceiverCallSpec};
 
 /// Everything the indexer knows about one migrated language.
 ///
@@ -48,6 +49,11 @@ pub(crate) struct LanguageExtraction {
     pub(crate) tags_query: Option<&'static str>,
     /// Process-wide cache for the compiled graph/tags rules.
     pub(crate) compiled_rules: &'static OnceLock<Result<CompiledLanguageRules, String>>,
+    /// Manual MEMBER-edge collector, when the language has one. Added by the
+    /// first migrated language that owns one (Go); Kotlin's rules produce
+    /// MEMBER edges from the rule file alone and its row is `None`, which is
+    /// exactly what the residual `_ => Vec::new()` arm gave it.
+    pub(crate) member_edge_specs: Option<fn(&Tree, &str) -> Vec<ManualMemberEdgeSpec>>,
     /// Manual receiver-call collector, when the language has one.
     pub(crate) receiver_call_specs: Option<fn(&Tree, &str) -> Vec<ManualReceiverCallSpec>>,
     /// Callsite marker for edges produced from member-call syntax.
@@ -69,7 +75,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, go::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {
@@ -235,6 +241,34 @@ mod tests {
         assert_eq!(
             extraction_for_ext("kts").map(|row| row.language_name),
             Some("kotlin")
+        );
+    }
+
+    /// The Go row must keep the exact projection facts it had while it was
+    /// spread across `lib.rs`. Go differs from Kotlin on three of them —
+    /// it does *not* promote type-member functions to methods, it does *not*
+    /// use the generic semantic resolver, and it owns a manual MEMBER-edge
+    /// collector — and each wrong value is a silent projection change that no
+    /// threshold test would catch.
+    #[test]
+    fn go_row_keeps_the_projection_facts_it_had_in_the_god_file() {
+        let go = extraction_for_language("go").expect("go row");
+        assert!(!go.promotes_type_member_functions_to_methods);
+        assert_eq!(go.qualified_name_delimiter, ".");
+        assert!(go.route_comments_are_c_style);
+        assert_eq!(go.semantic_family, "go");
+        assert!(!go.uses_generic_semantic_resolver);
+        assert_eq!(go.member_callsite_marker, Some("syntax:go-selector-call"));
+        assert_eq!(
+            member_callsite_marker_for_call_syntax("go_selector"),
+            Some("syntax:go-selector-call")
+        );
+        assert!(go.receiver_call_specs.is_some());
+        assert!(go.member_edge_specs.is_some());
+        assert!(go.tags_query.is_none());
+        assert_eq!(
+            extraction_for_ext("go").map(|row| row.language_name),
+            Some("go")
         );
     }
 }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -59,7 +59,6 @@ use symbol_table::SymbolTable;
 
 pub(crate) const PYTHON_ATTRIBUTE_CALLSITE_MARKER: &str = "syntax:python-attribute-call";
 pub(crate) const CPP_MEMBER_CALLSITE_MARKER: &str = "syntax:cpp-member-call";
-pub(crate) const GO_SELECTOR_CALLSITE_MARKER: &str = "syntax:go-selector-call";
 pub(crate) const JAVA_MEMBER_CALLSITE_MARKER: &str = "syntax:java-member-call";
 pub(crate) const CSHARP_MEMBER_CALLSITE_MARKER: &str = "syntax:csharp-member-call";
 pub(crate) const RUBY_MEMBER_CALLSITE_MARKER: &str = "syntax:ruby-member-call";
@@ -138,7 +137,6 @@ const TSX_GRAPH_QUERY: &str = include_str!("../rules/tsx.graph.scm");
 const TSX_TAGS_QUERY: &str = TYPESCRIPT_TAGS_QUERY;
 const CPP_GRAPH_QUERY: &str = include_str!("../rules/cpp.scm");
 const C_GRAPH_QUERY: &str = include_str!("../rules/c.scm");
-const GO_GRAPH_QUERY: &str = include_str!("../rules/go.scm");
 const RUBY_GRAPH_QUERY: &str = include_str!("../rules/ruby.scm");
 const PHP_GRAPH_QUERY: &str = include_str!("../rules/php.scm");
 const CSHARP_GRAPH_QUERY: &str = include_str!("../rules/csharp.scm");
@@ -317,7 +315,9 @@ impl LanguageRuleset {
                 compiled_rules_cache(language, CPP_GRAPH_QUERY, None, &CPP_RULES)
             }
             LanguageRuleset::C => compiled_rules_cache(language, C_GRAPH_QUERY, None, &C_RULES),
-            LanguageRuleset::Go => compiled_rules_cache(language, GO_GRAPH_QUERY, None, &GO_RULES),
+            LanguageRuleset::Go => Err(anyhow!(
+                "go compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::Ruby => {
                 compiled_rules_cache(language, RUBY_GRAPH_QUERY, None, &RUBY_RULES)
             }
@@ -380,7 +380,6 @@ static TYPESCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceL
 static TSX_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CPP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static C_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static GO_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static RUBY_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static PHP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CSHARP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
@@ -7498,8 +7497,14 @@ fn language_member_specs(
     tree: &Tree,
     source: &str,
 ) -> Vec<ManualMemberEdgeSpec> {
+    // Registry first; the arms below are the languages that have not moved yet.
+    if let Some(extraction) = languages::extraction_for_language(language_name) {
+        return match extraction.member_edge_specs {
+            Some(collect) => collect(tree, source),
+            None => Vec::new(),
+        };
+    }
     match language_name {
-        "go" => collect_go_member_edges(tree, source),
         "ruby" => collect_enclosing_type_member_edges(
             tree,
             source,
@@ -7596,7 +7601,6 @@ fn language_receiver_call_specs(
         "python" => collect_python_receiver_call_edges(tree, source),
         "typescript" | "tsx" => collect_typescript_receiver_call_edges(tree, source),
         "java" => collect_java_receiver_call_edges(tree, source),
-        "go" => collect_go_receiver_call_edges(tree, source),
         "ruby" => collect_ruby_receiver_call_edges(tree, source),
         "php" => collect_php_receiver_call_edges(tree, source),
         "csharp" => collect_csharp_receiver_call_edges(tree, source),
@@ -8115,94 +8119,6 @@ fn edge_callsite_col(edge: &Edge) -> Option<u32> {
         .ok()
 }
 
-fn collect_go_member_edges(tree: &Tree, source: &str) -> Vec<ManualMemberEdgeSpec> {
-    let mut edges = Vec::new();
-    walk_tree_nodes(tree.root_node(), &mut |node| match node.kind() {
-        "method_declaration" => {
-            let Some(method_name_node) = node.child_by_field_name("name") else {
-                return;
-            };
-            let Some(receiver_node) = node.child_by_field_name("receiver") else {
-                return;
-            };
-            let Some(source_name) = go_receiver_owner_name(receiver_node, source) else {
-                return;
-            };
-            let Some(target_name) = trimmed_node_text(method_name_node, source) else {
-                return;
-            };
-
-            edges.push(ManualMemberEdgeSpec {
-                source_name,
-                target_name,
-                source_span: ts_node_graph_span(
-                    receiver_owner_declaration_node(tree.root_node(), source, receiver_node)
-                        .unwrap_or(receiver_node),
-                ),
-                target_span: ts_node_graph_span(node),
-                line: Some(node.start_position().row as u32 + 1),
-            });
-        }
-        "method_elem" => {
-            let Some(owner_node) = enclosing_node_with_kind(node, &["type_declaration"]) else {
-                return;
-            };
-            let Some(owner_name_node) = descendant_by_field_name(owner_node, "name") else {
-                return;
-            };
-            let Some(source_name) = trimmed_node_text(owner_name_node, source) else {
-                return;
-            };
-            let Some(method_name_node) = node.child_by_field_name("name") else {
-                return;
-            };
-            let Some(target_name) = trimmed_node_text(method_name_node, source) else {
-                return;
-            };
-
-            edges.push(ManualMemberEdgeSpec {
-                source_name,
-                target_name,
-                source_span: ts_node_graph_span(owner_node),
-                target_span: ts_node_graph_span(node),
-                line: Some(node.start_position().row as u32 + 1),
-            });
-        }
-        _ => {}
-    });
-    edges
-}
-
-fn receiver_owner_declaration_node<'tree>(
-    root: TsNode<'tree>,
-    source: &str,
-    receiver_node: TsNode<'tree>,
-) -> Option<TsNode<'tree>> {
-    let owner_name = go_receiver_owner_name(receiver_node, source)?;
-    find_go_type_declaration_by_name(root, source, &owner_name)
-}
-
-fn find_go_type_declaration_by_name<'tree>(
-    node: TsNode<'tree>,
-    source: &str,
-    owner_name: &str,
-) -> Option<TsNode<'tree>> {
-    if node.kind() == "type_declaration"
-        && let Some(name_node) = descendant_by_field_name(node, "name")
-        && trimmed_node_text(name_node, source).as_deref() == Some(owner_name)
-    {
-        return Some(node);
-    }
-
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if let Some(found) = find_go_type_declaration_by_name(child, source, owner_name) {
-            return Some(found);
-        }
-    }
-    None
-}
-
 fn descendant_by_field_name<'tree>(node: TsNode<'tree>, field_name: &str) -> Option<TsNode<'tree>> {
     if let Some(child) = node.child_by_field_name(field_name) {
         return Some(child);
@@ -8227,30 +8143,6 @@ fn first_descendant_with_kind<'tree>(node: TsNode<'tree>, kind: &str) -> Option<
         }
     }
     None
-}
-
-fn go_receiver_owner_name(receiver_node: TsNode<'_>, source: &str) -> Option<String> {
-    let text = trimmed_node_text(receiver_node, source)?;
-    let inner = text
-        .trim()
-        .trim_start_matches('(')
-        .trim_end_matches(')')
-        .trim();
-    let raw_owner = inner.split_whitespace().last()?.trim();
-    normalize_go_type_surface(raw_owner)
-}
-
-fn normalize_go_type_surface(raw: &str) -> Option<String> {
-    let mut surface = raw.trim();
-    while let Some(stripped) = surface.strip_prefix('*') {
-        surface = stripped.trim_start();
-    }
-    if let Some(stripped) = surface.strip_prefix("[]") {
-        surface = stripped.trim_start();
-    }
-    let base = surface.split('[').next().unwrap_or(surface).trim();
-    let terminal = base.rsplit('.').next().unwrap_or(base).trim();
-    (!terminal.is_empty()).then(|| terminal.to_string())
 }
 
 fn collect_python_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
@@ -9602,417 +9494,6 @@ fn python_import_binding_names(imported: &str) -> Option<(String, String)> {
     ))
 }
 
-fn collect_go_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let import_bindings = collect_go_import_bindings(source);
-    walk_tree_nodes(tree.root_node(), &mut |callable| {
-        if !matches!(
-            callable.kind(),
-            "function_declaration" | "method_declaration"
-        ) {
-            return;
-        }
-        let Some(source_name) = declaration_name(callable, source) else {
-            return;
-        };
-        let call_source = ManualReceiverSource {
-            name: &source_name,
-            span: ts_node_graph_span(callable),
-        };
-        let mut local_binding_callsites = HashSet::new();
-        collect_go_local_composite_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &import_bindings,
-            &mut local_binding_callsites,
-            &mut edges,
-        );
-        let method_receiver_bindings = collect_go_method_receiver_bindings(
-            callable,
-            tree.root_node(),
-            source,
-            &import_bindings,
-        );
-        let mut receiver_types = method_receiver_bindings
-            .iter()
-            .map(|(receiver_name, (owner_name, _))| (receiver_name.clone(), owner_name.clone()))
-            .collect::<HashMap<_, _>>();
-        receiver_types.extend(collect_go_parameter_types(callable, source));
-        if receiver_types.is_empty() {
-            return;
-        }
-        let mut receiver_modules =
-            collect_go_parameter_type_modules(callable, source, &import_bindings);
-        for (receiver_name, (_, owner_module)) in &method_receiver_bindings {
-            if let Some(module_name) = owner_module {
-                receiver_modules.insert(receiver_name.clone(), module_name.clone());
-            }
-        }
-        let start = edges.len();
-        collect_receiver_call_specs_in_callable(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &receiver_types,
-            go_selector_call,
-            false,
-            &mut edges,
-        );
-        let mut parameter_specs = edges.split_off(start);
-        parameter_specs
-            .retain(|spec| !local_binding_callsites.contains(&receiver_callsite_key(spec)));
-        for spec in &mut parameter_specs {
-            if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
-                spec.owner_module = Some(module_name.clone());
-            }
-        }
-        edges.extend(parameter_specs);
-    });
-    edges
-}
-
-fn collect_go_local_composite_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    import_bindings: &HashMap<String, String>,
-    local_binding_callsites: &mut HashSet<ReceiverCallSiteKey>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = go_selector_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let Some(owner_name) = go_visible_local_composite_owner(
-            callable,
-            node,
-            &receiver_name,
-            source,
-            import_bindings,
-        ) else {
-            return;
-        };
-        let method_col = member_call_method_col(node, source, &method_name);
-        local_binding_callsites.insert(ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
-            method_col,
-        });
-        if let Some((owner_name, owner_module)) = owner_name {
-            edges.push(ManualReceiverCallSpec {
-                source_name: call_source.name.to_string(),
-                source_span: call_source.span,
-                receiver_name,
-                owner_name,
-                owner_module,
-                method_name,
-                method_col,
-                line: Some(node.start_position().row as u32 + 1),
-                allow_global_fallback: false,
-            });
-        }
-    });
-}
-
-fn go_visible_local_composite_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if !matches!(
-            node.kind(),
-            "short_var_declaration" | "assignment_statement"
-        ) {
-            return;
-        }
-        if !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
-        {
-            return;
-        }
-        if !go_local_binding_visible_at_call(node, call_node) {
-            return;
-        }
-        let Some(owner_name) =
-            go_receiver_write_owner(node, receiver_name, source, import_bindings)
-        else {
-            return;
-        };
-        visible_bindings.push((node.end_byte(), owner_name));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner_name)| owner_name)
-}
-
-fn go_receiver_write_owner(
-    node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    if !matches!(
-        node.kind(),
-        "short_var_declaration" | "assignment_statement"
-    ) {
-        return None;
-    }
-    let left_items = node
-        .child_by_field_name("left")
-        .map(go_expression_list_items)
-        .unwrap_or_default();
-    let receiver_index = left_items.iter().position(|left| {
-        normalized_receiver_variable(*left, source).as_deref() == Some(receiver_name)
-    })?;
-    let owner_name = node
-        .child_by_field_name("right")
-        .map(go_expression_list_items)
-        .and_then(|right_items| {
-            right_items.get(receiver_index).and_then(|right| {
-                go_direct_composite_literal_owner(*right, source, import_bindings)
-            })
-        });
-    Some(owner_name)
-}
-
-fn go_expression_list_items(node: TsNode<'_>) -> Vec<TsNode<'_>> {
-    if node.kind() != "expression_list" {
-        return vec![node];
-    }
-    let mut items = Vec::new();
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        items.push(child);
-    }
-    items
-}
-
-fn go_direct_composite_literal_owner(
-    node: TsNode<'_>,
-    source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> OptionalReceiverOwnerBinding {
-    if node.kind() == "composite_literal" {
-        return node
-            .child_by_field_name("type")
-            .and_then(|type_node| trimmed_node_text(type_node, source))
-            .as_deref()
-            .and_then(|type_surface| {
-                go_composite_literal_owner_binding_from_type(type_surface, import_bindings)
-            });
-    }
-    trimmed_node_text(node, source)
-        .as_deref()
-        .and_then(|surface| go_direct_composite_literal_owner_surface(surface, import_bindings))
-}
-
-fn go_direct_composite_literal_owner_surface(
-    surface: &str,
-    import_bindings: &HashMap<String, String>,
-) -> OptionalReceiverOwnerBinding {
-    let surface = surface.trim().trim_start_matches('&').trim();
-    if !surface.contains('{') {
-        return None;
-    }
-    let type_surface = surface
-        .split_once('{')
-        .map(|(type_surface, _)| type_surface)
-        .unwrap_or(surface)
-        .trim();
-    go_composite_literal_owner_binding_from_type(type_surface, import_bindings)
-}
-
-fn go_composite_literal_owner_binding_from_type(
-    type_surface: &str,
-    import_bindings: &HashMap<String, String>,
-) -> OptionalReceiverOwnerBinding {
-    let type_surface = type_surface.trim().trim_start_matches('&').trim();
-    if type_surface.contains('(')
-        || type_surface.contains(')')
-        || type_surface.starts_with("[]")
-        || type_surface.starts_with("map[")
-    {
-        return None;
-    }
-    let owner_name = normalize_go_type_surface(type_surface)?;
-    if !owner_name
-        .chars()
-        .next()
-        .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
-    {
-        return None;
-    }
-    if let Some(qualifier) = go_type_import_qualifier(type_surface) {
-        let module_name = import_bindings.get(&qualifier)?;
-        return Some((owner_name, Some(module_name.clone())));
-    }
-    if type_surface.contains('.') {
-        return None;
-    }
-    Some((owner_name, None))
-}
-
-fn go_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
-    let Some(binding_scope) = go_lexical_scope(binding) else {
-        return false;
-    };
-    let Some(call_scope) = go_lexical_scope(call_node) else {
-        return false;
-    };
-    node_is_same_or_ancestor(binding_scope, call_scope)
-}
-
-fn go_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
-    enclosing_node_with_kind(node, &["block"])
-}
-
-fn collect_go_method_receiver_bindings(
-    callable: TsNode<'_>,
-    root: TsNode<'_>,
-    source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> HashMap<String, ReceiverOwnerBinding> {
-    let mut receiver_types = HashMap::new();
-    if callable.kind() != "method_declaration" {
-        return receiver_types;
-    }
-    let Some(receiver_node) = callable.child_by_field_name("receiver") else {
-        return receiver_types;
-    };
-    let Some(receiver_name) = go_receiver_variable_name(receiver_node, source) else {
-        return receiver_types;
-    };
-    let Some(owner_name) = go_receiver_owner_name(receiver_node, source) else {
-        return receiver_types;
-    };
-    receiver_types.insert(receiver_name.clone(), (owner_name.clone(), None));
-    let Some(owner_node) = find_go_type_declaration_by_name(root, source, &owner_name) else {
-        return receiver_types;
-    };
-    for (field_name, field_owner) in
-        collect_go_struct_field_types(owner_node, source, import_bindings)
-    {
-        receiver_types.insert(format!("{receiver_name}.{field_name}"), field_owner);
-    }
-    receiver_types
-}
-
-fn go_receiver_variable_name(receiver_node: TsNode<'_>, source: &str) -> Option<String> {
-    let text = trimmed_node_text(receiver_node, source)?;
-    let inner = text
-        .trim()
-        .trim_start_matches('(')
-        .trim_end_matches(')')
-        .trim();
-    let tokens = inner.split_whitespace().collect::<Vec<_>>();
-    if tokens.len() < 2 {
-        return None;
-    }
-    normalize_parameter_name(tokens[0])
-}
-
-fn collect_go_struct_field_types(
-    owner_node: TsNode<'_>,
-    source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> HashMap<String, ReceiverOwnerBinding> {
-    let mut field_types = HashMap::new();
-    walk_tree_nodes(owner_node, &mut |node| {
-        if node.kind() != "field_declaration" {
-            return;
-        }
-        for (field_name, owner_name) in go_field_declaration_bindings(node, source, import_bindings)
-        {
-            field_types.insert(field_name, owner_name);
-        }
-    });
-    field_types
-}
-
-fn go_field_declaration_bindings(
-    node: TsNode<'_>,
-    source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> Vec<(String, ReceiverOwnerBinding)> {
-    if let Some(type_node) = node.child_by_field_name("type")
-        && let Some(raw_type) = trimmed_node_text(type_node, source)
-        && let Some(owner_binding) = go_receiver_owner_from_type(&raw_type, import_bindings)
-    {
-        let mut names = Vec::new();
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            if child.end_byte() > type_node.start_byte() {
-                continue;
-            }
-            if matches!(child.kind(), "field_identifier" | "identifier")
-                && let Some(name) = normalized_receiver_variable(child, source)
-            {
-                names.push(name);
-            }
-        }
-        if !names.is_empty() {
-            return names
-                .into_iter()
-                .map(|name| (name, owner_binding.clone()))
-                .collect();
-        }
-    }
-
-    trimmed_node_text(node, source)
-        .as_deref()
-        .map(|surface| go_field_declaration_bindings_surface(surface, import_bindings))
-        .unwrap_or_default()
-}
-
-fn go_field_declaration_bindings_surface(
-    surface: &str,
-    import_bindings: &HashMap<String, String>,
-) -> Vec<(String, ReceiverOwnerBinding)> {
-    let surface = surface.split('`').next().unwrap_or(surface).trim();
-    let tokens = surface.split_whitespace().collect::<Vec<_>>();
-    let Some(raw_type) = tokens.last() else {
-        return Vec::new();
-    };
-    if tokens.len() < 2 {
-        return Vec::new();
-    }
-    let Some(owner_binding) = go_receiver_owner_from_type(raw_type, import_bindings) else {
-        return Vec::new();
-    };
-    let names_surface = tokens[..tokens.len() - 1].join(" ");
-    names_surface
-        .split(',')
-        .filter_map(normalize_parameter_name)
-        .map(|name| (name, owner_binding.clone()))
-        .collect()
-}
-
-fn go_receiver_owner_from_type(
-    raw_type: &str,
-    import_bindings: &HashMap<String, String>,
-) -> OptionalReceiverOwnerBinding {
-    let owner_name = normalize_go_type_surface(raw_type)?;
-    if let Some(qualifier) = go_type_import_qualifier(raw_type) {
-        let module_name = import_bindings.get(&qualifier)?;
-        return Some((owner_name, Some(module_name.clone())));
-    }
-    Some((owner_name, None))
-}
-
 fn collect_java_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
     let mut edges = Vec::new();
     let import_bindings = collect_java_import_type_bindings(tree.root_node(), source);
@@ -10611,98 +10092,6 @@ fn java_import_type_module_name(import_node: TsNode<'_>, source: &str) -> Option
         return None;
     }
     Some(module_name.to_string())
-}
-
-fn collect_go_import_bindings(source: &str) -> HashMap<String, String> {
-    let mut bindings = HashMap::new();
-    let mut duplicates = HashSet::new();
-    let mut in_import_list = false;
-    for raw_line in source.lines() {
-        let line = go_strip_line_comment(raw_line).trim();
-        if line.is_empty() {
-            continue;
-        }
-        if in_import_list {
-            if line.starts_with(')') {
-                in_import_list = false;
-                continue;
-            }
-            if let Some((local_name, module_name)) = go_import_binding_from_spec(line) {
-                insert_unique_import_binding(
-                    &mut bindings,
-                    &mut duplicates,
-                    local_name,
-                    module_name,
-                );
-            }
-            continue;
-        }
-        let Some(rest) = line.strip_prefix("import") else {
-            continue;
-        };
-        let rest = rest.trim();
-        if rest.starts_with('(') {
-            in_import_list = true;
-            continue;
-        }
-        if let Some((local_name, module_name)) = go_import_binding_from_spec(rest) {
-            insert_unique_import_binding(&mut bindings, &mut duplicates, local_name, module_name);
-        }
-    }
-    bindings
-}
-
-fn insert_unique_import_binding(
-    bindings: &mut HashMap<String, String>,
-    duplicates: &mut HashSet<String>,
-    local_name: String,
-    module_name: String,
-) {
-    if duplicates.contains(&local_name) {
-        return;
-    }
-    if bindings.contains_key(&local_name) {
-        bindings.remove(&local_name);
-        duplicates.insert(local_name);
-        return;
-    }
-    bindings.insert(local_name, module_name);
-}
-
-fn go_strip_line_comment(line: &str) -> &str {
-    line.split("//").next().unwrap_or(line)
-}
-
-fn go_import_binding_from_spec(spec: &str) -> Option<(String, String)> {
-    let spec = spec.trim().trim_end_matches(';').trim();
-    if spec.is_empty() {
-        return None;
-    }
-    let tokens = spec.split_whitespace().collect::<Vec<_>>();
-    let (local_name, module_name) = match tokens.as_slice() {
-        [module] => {
-            let module_name = go_import_module_name(module)?;
-            (go_default_import_local_name(&module_name)?, module_name)
-        }
-        [alias, module] if *alias != "." && *alias != "_" => {
-            let module_name = go_import_module_name(module)?;
-            (normalize_parameter_name(alias)?, module_name)
-        }
-        _ => return None,
-    };
-    Some((local_name, module_name))
-}
-
-fn go_import_module_name(raw: &str) -> Option<String> {
-    let module = raw.trim().trim_matches(|ch| matches!(ch, '"' | '\'' | '`'));
-    (!module.is_empty()).then(|| module.to_string())
-}
-
-fn go_default_import_local_name(module_name: &str) -> Option<String> {
-    module_name
-        .rsplit('/')
-        .next()
-        .and_then(normalize_parameter_name)
 }
 
 fn collect_php_member_edges(tree: &Tree, source: &str) -> Vec<ManualMemberEdgeSpec> {
@@ -13765,94 +13154,6 @@ fn receiver_call_belongs_to_callable(node: TsNode<'_>, callable: TsNode<'_>) -> 
         .is_some_and(|nearest| nearest.kind() == callable.kind() && same_ts_span(nearest, callable))
 }
 
-fn collect_go_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
-    let mut receiver_types = HashMap::new();
-    let Some(parameters) = callable.child_by_field_name("parameters") else {
-        return receiver_types;
-    };
-    walk_tree_nodes(parameters, &mut |node| {
-        if !matches!(
-            node.kind(),
-            "parameter_declaration" | "variadic_parameter_declaration"
-        ) {
-            return;
-        }
-        let Some(type_node) = node.child_by_field_name("type") else {
-            return;
-        };
-        let Some(raw_type) = trimmed_node_text(type_node, source) else {
-            return;
-        };
-        let Some(owner_name) = normalize_go_type_surface(&raw_type) else {
-            return;
-        };
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            if child.kind() == "identifier"
-                && child.end_byte() <= type_node.start_byte()
-                && let Some(name) = normalized_receiver_variable(child, source)
-            {
-                receiver_types.insert(name, owner_name.clone());
-            }
-        }
-    });
-    receiver_types
-}
-
-fn collect_go_parameter_type_modules(
-    callable: TsNode<'_>,
-    source: &str,
-    import_bindings: &HashMap<String, String>,
-) -> HashMap<String, String> {
-    let mut receiver_modules = HashMap::new();
-    let Some(parameters) = callable.child_by_field_name("parameters") else {
-        return receiver_modules;
-    };
-    walk_tree_nodes(parameters, &mut |node| {
-        if !matches!(
-            node.kind(),
-            "parameter_declaration" | "variadic_parameter_declaration"
-        ) {
-            return;
-        }
-        let Some(type_node) = node.child_by_field_name("type") else {
-            return;
-        };
-        let Some(raw_type) = trimmed_node_text(type_node, source) else {
-            return;
-        };
-        let Some(qualifier) = go_type_import_qualifier(&raw_type) else {
-            return;
-        };
-        let Some(module_name) = import_bindings.get(&qualifier) else {
-            return;
-        };
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            if child.kind() == "identifier"
-                && child.end_byte() <= type_node.start_byte()
-                && let Some(name) = normalized_receiver_variable(child, source)
-            {
-                receiver_modules.insert(name, module_name.clone());
-            }
-        }
-    });
-    receiver_modules
-}
-
-fn go_type_import_qualifier(raw_type: &str) -> Option<String> {
-    let mut surface = raw_type.trim();
-    while let Some(stripped) = surface.strip_prefix('*') {
-        surface = stripped.trim_start();
-    }
-    while let Some(stripped) = surface.strip_prefix("[]") {
-        surface = stripped.trim_start();
-    }
-    let base = surface.split('[').next().unwrap_or(surface).trim();
-    let (qualifier, _) = base.rsplit_once('.')?;
-    normalize_parameter_name(qualifier)
-}
-
 fn collect_php_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
     let mut receiver_types = HashMap::new();
     let Some(parameters) = callable.child_by_field_name("parameters") else {
@@ -14354,22 +13655,6 @@ fn normalize_parameter_name(raw: &str) -> Option<String> {
         .trim_start_matches('$')
         .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_');
     (!cleaned.is_empty()).then(|| cleaned.to_string())
-}
-
-fn go_selector_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if node.kind() != "call_expression" {
-        return None;
-    }
-    let function = node.child_by_field_name("function")?;
-    if function.kind() != "selector_expression" {
-        return None;
-    }
-    let receiver = function.child_by_field_name("operand")?;
-    let method = function.child_by_field_name("field")?;
-    Some((
-        normalized_receiver_variable(receiver, source)?,
-        trimmed_node_text(method, source)?,
-    ))
 }
 
 fn python_attribute_call_nodes<'tree>(
@@ -17072,16 +16357,7 @@ fn route_language_uses_c_style_comments(language_name: &str) -> bool {
     }
     matches!(
         language_name,
-        "javascript"
-            | "typescript"
-            | "java"
-            | "rust"
-            | "go"
-            | "php"
-            | "csharp"
-            | "dart"
-            | "vue"
-            | "astro"
+        "javascript" | "typescript" | "java" | "rust" | "php" | "csharp" | "dart" | "vue" | "astro"
     )
 }
 
@@ -20225,7 +19501,6 @@ pub fn index_file(
                                             Some(PYTHON_ATTRIBUTE_CALLSITE_MARKER)
                                         }
                                         "cpp_member" => Some(CPP_MEMBER_CALLSITE_MARKER),
-                                        "go_selector" => Some(GO_SELECTOR_CALLSITE_MARKER),
                                         "java_member" => Some(JAVA_MEMBER_CALLSITE_MARKER),
                                         "csharp_member" => Some(CSHARP_MEMBER_CALLSITE_MARKER),
                                         "php_member" => Some(PHP_MEMBER_CALLSITE_MARKER),

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1393,7 +1393,7 @@ fn is_go_selector_call_placeholder(edge_kind: EdgeKind, callsite_identity: Optio
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::GO_SELECTOR_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::go::MEMBER_CALLSITE_MARKER)
     })
 }
 

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -596,7 +596,6 @@ fn language_family_bucket(language: &'static str) -> &'static str {
         "python" => "python",
         "rust" => "rust",
         "java" => "java",
-        "go" => "go",
         "ruby" => "ruby",
         "php" => "php",
         "csharp" => "csharp",

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/go_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/go_fidelity.txt
@@ -1,0 +1,31 @@
+node FILE name=<ROOT>/fidelity.go qn=<ROOT>/fidelity.go canonical=<ROOT>/fidelity.go:<ROOT>/fidelity.go:1 line=1 col=1 end=43:0 file=FILE:<ROOT>/fidelity.go@1
+node FUNCTION name=decorate qn=decorate canonical=<ROOT>/fidelity.go:decorate#1 line=36 col=1 end=38:2 file=FILE:<ROOT>/fidelity.go@1
+node FUNCTION name=orchestrateGo qn=orchestrateGo canonical=<ROOT>/fidelity.go:orchestrateGo#0 line=40 col=1 end=43:2 file=FILE:<ROOT>/fidelity.go@1
+node METHOD name=ConsoleNotifier.Notify qn=ConsoleNotifier.Notify canonical=<ROOT>/fidelity.go:ConsoleNotifier.Notify#0 line=11 col=1 end=13:2 file=FILE:<ROOT>/fidelity.go@1
+node METHOD name=Notifier.Notify qn=Notifier.Notify canonical=<ROOT>/fidelity.go:Notifier.Notify#0 line=6 col=2 end=6:15 file=FILE:<ROOT>/fidelity.go@1
+node METHOD name=Repository.Save qn=Repository.Save canonical=<ROOT>/fidelity.go:Repository.Save#0 line=17 col=1 end=19:2 file=FILE:<ROOT>/fidelity.go@1
+node METHOD name=Workflow.Run qn=Workflow.Run canonical=<ROOT>/fidelity.go:Workflow.Run#0 line=30 col=1 end=34:2 file=FILE:<ROOT>/fidelity.go@1
+node MODULE name="fmt" qn="fmt" canonical=<ROOT>/fidelity.go:"fmt"#0 line=3 col=8 end=3:13 file=FILE:<ROOT>/fidelity.go@1
+node MODULE name=main qn=main canonical=<ROOT>/fidelity.go:main#0 line=1 col=1 end=1:13 file=FILE:<ROOT>/fidelity.go@1
+node STRUCT name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.go:ConsoleNotifier line=9 col=1 end=9:30 file=FILE:<ROOT>/fidelity.go@1
+node STRUCT name=Event qn=Event canonical=<ROOT>/fidelity.go:Event line=21 col=1 end=23:2 file=FILE:<ROOT>/fidelity.go@1
+node STRUCT name=Notifier qn=Notifier canonical=<ROOT>/fidelity.go:Notifier line=5 col=1 end=7:2 file=FILE:<ROOT>/fidelity.go@1
+node STRUCT name=Repository qn=Repository canonical=<ROOT>/fidelity.go:Repository line=15 col=1 end=15:25 file=FILE:<ROOT>/fidelity.go@1
+node STRUCT name=Workflow qn=Workflow canonical=<ROOT>/fidelity.go:Workflow line=25 col=1 end=28:2 file=FILE:<ROOT>/fidelity.go@1
+node UNKNOWN name=Notify qn=Notify canonical=<ROOT>/fidelity.go:Notify#0 line=31 col=13 end=31:19 file=FILE:<ROOT>/fidelity.go@1
+node UNKNOWN name=Println qn=Println canonical=<ROOT>/fidelity.go:Println#0 line=12 col=6 end=12:13 file=FILE:<ROOT>/fidelity.go@1
+node UNKNOWN name=Println qn=Println canonical=<ROOT>/fidelity.go:Println#1 line=18 col=6 end=18:13 file=FILE:<ROOT>/fidelity.go@1
+node UNKNOWN name=Run qn=Run canonical=<ROOT>/fidelity.go:Run#0 line=42 col=11 end=42:14 file=FILE:<ROOT>/fidelity.go@1
+node UNKNOWN name=Save qn=Save canonical=<ROOT>/fidelity.go:Save#0 line=32 col=9 end=32:13 file=FILE:<ROOT>/fidelity.go@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.go:decorate#0 line=33 col=2 end=33:10 file=FILE:<ROOT>/fidelity.go@1
+edge CALL src=FUNCTION:orchestrateGo@40 dst=METHOD:Workflow.Run@30 resolved_src=FUNCTION:orchestrateGo@40 resolved_dst=METHOD:Workflow.Run@30 line=42 confidence=1.0000 certainty=Certain callsite=h0:42:1:h1 candidates=[]
+edge CALL src=METHOD:ConsoleNotifier.Notify@11 dst=UNKNOWN:Println@12 resolved_src=METHOD:ConsoleNotifier.Notify@11 resolved_dst=- line=12 confidence=- certainty=- callsite=h0:12:1:h2|syntax:go-selector-call candidates=[]
+edge CALL src=METHOD:Repository.Save@17 dst=UNKNOWN:Println@18 resolved_src=METHOD:Repository.Save@17 resolved_dst=- line=18 confidence=- certainty=- callsite=h0:18:1:h3|syntax:go-selector-call candidates=[]
+edge CALL src=METHOD:Workflow.Run@30 dst=METHOD:Notifier.Notify@6 resolved_src=METHOD:Workflow.Run@30 resolved_dst=METHOD:Notifier.Notify@6 line=31 confidence=1.0000 certainty=Certain callsite=h0:31:1:h4 candidates=[]
+edge CALL src=METHOD:Workflow.Run@30 dst=METHOD:Repository.Save@17 resolved_src=METHOD:Workflow.Run@30 resolved_dst=METHOD:Repository.Save@17 line=32 confidence=1.0000 certainty=Certain callsite=h0:32:1:h5 candidates=[]
+edge CALL src=METHOD:Workflow.Run@30 dst=UNKNOWN:decorate@33 resolved_src=METHOD:Workflow.Run@30 resolved_dst=FUNCTION:decorate@36 line=33 confidence=0.9500 certainty=Certain callsite=h0:33:1:h6 candidates=[]
+edge IMPORT src=MODULE:"fmt"@3 dst=MODULE:"fmt"@3 resolved_src=MODULE:"fmt"@3 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:ConsoleNotifier@9 dst=METHOD:ConsoleNotifier.Notify@11 resolved_src=- resolved_dst=- line=11 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:Notifier@5 dst=METHOD:Notifier.Notify@6 resolved_src=- resolved_dst=- line=6 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:Repository@15 dst=METHOD:Repository.Save@17 resolved_src=- resolved_dst=- line=17 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:Workflow@25 dst=METHOD:Workflow.Run@30 resolved_src=- resolved_dst=- line=30 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/go_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/go_tictactoe.txt
@@ -1,0 +1,112 @@
+node FILE name=game.go qn=game.go canonical=game.go:game.go:1 line=1 col=1 end=98:0 file=FILE:game.go@1
+node FUNCTION name=main qn=main canonical=game.go:main#1 line=95 col=1 end=98:2 file=FILE:game.go@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.go:numberIn#0 line=8 col=1 end=10:2 file=FILE:game.go@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.go:numberOut#0 line=12 col=1 end=14:2 file=FILE:game.go@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.go:stringOut#0 line=16 col=1 end=18:2 file=FILE:game.go@1
+node METHOD name=ArtificialPlayer.minMax qn=ArtificialPlayer.minMax canonical=game.go:ArtificialPlayer.minMax#0 line=72 col=1 end=77:2 file=FILE:game.go@1
+node METHOD name=ArtificialPlayer.turn qn=ArtificialPlayer.turn canonical=game.go:ArtificialPlayer.turn#0 line=79 col=1 end=82:2 file=FILE:game.go@1
+node METHOD name=Field.makeMove qn=Field.makeMove canonical=game.go:Field.makeMove#0 line=50 col=1 end=58:2 file=FILE:game.go@1
+node METHOD name=Field.opponent qn=Field.opponent canonical=game.go:Field.opponent#0 line=29 col=1 end=37:2 file=FILE:game.go@1
+node METHOD name=Field.sameInRow qn=Field.sameInRow canonical=game.go:Field.sameInRow#0 line=39 col=1 end=48:2 file=FILE:game.go@1
+node METHOD name=GameObject.announce qn=GameObject.announce canonical=game.go:GameObject.announce#0 line=22 col=1 end=22:32 file=FILE:game.go@1
+node METHOD name=HumanPlayer.turn qn=HumanPlayer.turn canonical=game.go:HumanPlayer.turn#0 line=66 col=1 end=68:2 file=FILE:game.go@1
+node METHOD name=Player.turn qn=Player.turn canonical=game.go:Player.turn#0 line=61 col=2 end=61:36 file=FILE:game.go@1
+node METHOD name=TicTacToe.run qn=TicTacToe.run canonical=game.go:TicTacToe.run#0 line=88 col=1 end=93:2 file=FILE:game.go@1
+node MODULE name="fmt" qn="fmt" canonical=game.go:"fmt"#0 line=4 col=2 end=4:7 file=FILE:game.go@1
+node MODULE name="math/rand" qn="math/rand" canonical=game.go:"math/rand"#0 line=5 col=2 end=5:13 file=FILE:game.go@1
+node MODULE name=main qn=main canonical=game.go:main#0 line=1 col=1 end=1:13 file=FILE:game.go@1
+node STRUCT name=ArtificialPlayer qn=ArtificialPlayer canonical=game.go:ArtificialPlayer line=70 col=1 end=70:31 file=FILE:game.go@1
+node STRUCT name=Field qn=Field canonical=game.go:Field line=24 col=1 end=27:2 file=FILE:game.go@1
+node STRUCT name=GameObject qn=GameObject canonical=game.go:GameObject line=20 col=1 end=20:25 file=FILE:game.go@1
+node STRUCT name=HumanPlayer qn=HumanPlayer canonical=game.go:HumanPlayer line=64 col=1 end=64:26 file=FILE:game.go@1
+node STRUCT name=Player qn=Player canonical=game.go:Player line=60 col=1 end=62:2 file=FILE:game.go@1
+node STRUCT name=TicTacToe qn=TicTacToe canonical=game.go:TicTacToe line=84 col=1 end=86:2 file=FILE:game.go@1
+node UNKNOWN name=Intn qn=Intn canonical=game.go:Intn#0 line=92 col=7 end=92:11 file=FILE:game.go@1
+node UNKNOWN name=Print qn=Print canonical=game.go:Print#0 line=13 col=6 end=13:11 file=FILE:game.go@1
+node UNKNOWN name=Print qn=Print canonical=game.go:Print#1 line=17 col=6 end=17:11 file=FILE:game.go@1
+node UNKNOWN name=make qn=make canonical=game.go:make#0 line=89 col=25 end=89:29 file=FILE:game.go@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.go:makeMove#0 line=67 col=15 end=67:23 file=FILE:game.go@1
+node UNKNOWN name=minMax qn=minMax canonical=game.go:minMax#0 line=76 col=11 end=76:17 file=FILE:game.go@1
+node UNKNOWN name=minMax qn=minMax canonical=game.go:minMax#1 line=80 col=4 end=80:10 file=FILE:game.go@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.go:numberIn#1 line=90 col=2 end=90:10 file=FILE:game.go@1
+node UNKNOWN name=run qn=run canonical=game.go:run#0 line=97 col=7 end=97:10 file=FILE:game.go@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.go:sameInRow#0 line=56 col=4 end=56:13 file=FILE:game.go@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.go:stringOut#1 line=91 col=2 end=91:11 file=FILE:game.go@1
+edge CALL src=FUNCTION:main@95 dst=METHOD:TicTacToe.run@88 resolved_src=- resolved_dst=METHOD:TicTacToe.run@88 line=97 confidence=1.0000 certainty=Certain callsite=h0:97:1:h1 candidates=[]
+edge CALL src=FUNCTION:numberOut@12 dst=UNKNOWN:Print@13 resolved_src=- resolved_dst=- line=13 confidence=- certainty=- callsite=h0:13:1:h2|syntax:go-selector-call candidates=[]
+edge CALL src=FUNCTION:stringOut@16 dst=UNKNOWN:Print@17 resolved_src=- resolved_dst=- line=17 confidence=- certainty=- callsite=h0:17:1:h3|syntax:go-selector-call candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@79 dst=METHOD:ArtificialPlayer.minMax@72 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.minMax@72 line=80 confidence=1.0000 certainty=Certain callsite=h0:80:1:h4 candidates=[]
+edge CALL src=METHOD:Field.makeMove@50 dst=METHOD:Field.sameInRow@39 resolved_src=- resolved_dst=METHOD:Field.sameInRow@39 line=56 confidence=1.0000 certainty=Certain callsite=h0:56:1:h5 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@66 dst=METHOD:Field.makeMove@50 resolved_src=- resolved_dst=METHOD:Field.makeMove@50 line=67 confidence=1.0000 certainty=Certain callsite=h0:67:1:h6 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@88 dst=UNKNOWN:Intn@92 resolved_src=- resolved_dst=- line=92 confidence=- certainty=- callsite=h0:92:1:h7|syntax:go-selector-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@88 dst=UNKNOWN:make@89 resolved_src=- resolved_dst=- line=89 confidence=- certainty=- callsite=h0:89:1:h8 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@88 dst=UNKNOWN:numberIn@90 resolved_src=- resolved_dst=- line=90 confidence=- certainty=- callsite=h0:90:1:h9 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@88 dst=UNKNOWN:stringOut@91 resolved_src=- resolved_dst=- line=91 confidence=- certainty=- callsite=h0:91:1:h10 candidates=[]
+edge IMPORT src=MODULE:"fmt"@4 dst=MODULE:"fmt"@4 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge IMPORT src=MODULE:"math/rand"@5 dst=MODULE:"math/rand"@5 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:ArtificialPlayer@70 dst=METHOD:ArtificialPlayer.minMax@72 resolved_src=- resolved_dst=- line=72 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:ArtificialPlayer@70 dst=METHOD:ArtificialPlayer.turn@79 resolved_src=- resolved_dst=- line=79 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:Field@24 dst=METHOD:Field.makeMove@50 resolved_src=- resolved_dst=- line=50 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:Field@24 dst=METHOD:Field.opponent@29 resolved_src=- resolved_dst=- line=29 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:Field@24 dst=METHOD:Field.sameInRow@39 resolved_src=- resolved_dst=- line=39 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:GameObject@20 dst=METHOD:GameObject.announce@22 resolved_src=- resolved_dst=- line=22 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:HumanPlayer@64 dst=METHOD:HumanPlayer.turn@66 resolved_src=- resolved_dst=- line=66 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:Player@60 dst=METHOD:Player.turn@61 resolved_src=- resolved_dst=- line=61 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=STRUCT:TicTacToe@84 dst=METHOD:TicTacToe.run@88 resolved_src=- resolved_dst=- line=88 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.go language=go lines=98 complete=true role=Source
+occurrence element=FUNCTION:main@95 kind=DEFINITION span=95:1-98:2
+occurrence element=FUNCTION:numberIn@8 kind=DEFINITION span=8:1-10:2
+occurrence element=FUNCTION:numberOut@12 kind=DEFINITION span=12:1-14:2
+occurrence element=FUNCTION:stringOut@16 kind=DEFINITION span=16:1-18:2
+occurrence element=METHOD:ArtificialPlayer.minMax@72 kind=DEFINITION span=72:1-77:2
+occurrence element=METHOD:ArtificialPlayer.turn@79 kind=DEFINITION span=79:1-82:2
+occurrence element=METHOD:Field.makeMove@50 kind=DEFINITION span=50:1-58:2
+occurrence element=METHOD:Field.opponent@29 kind=DEFINITION span=29:1-37:2
+occurrence element=METHOD:Field.sameInRow@39 kind=DEFINITION span=39:1-48:2
+occurrence element=METHOD:GameObject.announce@22 kind=DEFINITION span=22:1-22:32
+occurrence element=METHOD:HumanPlayer.turn@66 kind=DEFINITION span=66:1-68:2
+occurrence element=METHOD:Player.turn@61 kind=DEFINITION span=61:2-61:36
+occurrence element=METHOD:TicTacToe.run@88 kind=DEFINITION span=88:1-93:2
+occurrence element=MODULE:"fmt"@4 kind=DEFINITION span=4:2-4:7
+occurrence element=MODULE:"math/rand"@5 kind=DEFINITION span=5:2-5:13
+occurrence element=MODULE:main@1 kind=DEFINITION span=1:1-1:13
+occurrence element=STRUCT:ArtificialPlayer@70 kind=DEFINITION span=70:1-70:31
+occurrence element=STRUCT:Field@24 kind=DEFINITION span=24:1-27:2
+occurrence element=STRUCT:GameObject@20 kind=DEFINITION span=20:1-20:25
+occurrence element=STRUCT:HumanPlayer@64 kind=DEFINITION span=64:1-64:26
+occurrence element=STRUCT:Player@60 kind=DEFINITION span=60:1-62:2
+occurrence element=STRUCT:TicTacToe@84 kind=DEFINITION span=84:1-86:2
+occurrence element=UNKNOWN:Intn@92 kind=DEFINITION span=92:7-92:11
+occurrence element=UNKNOWN:Print@13 kind=DEFINITION span=13:6-13:11
+occurrence element=UNKNOWN:Print@17 kind=DEFINITION span=17:6-17:11
+occurrence element=UNKNOWN:make@89 kind=DEFINITION span=89:25-89:29
+occurrence element=UNKNOWN:makeMove@67 kind=DEFINITION span=67:15-67:23
+occurrence element=UNKNOWN:minMax@76 kind=DEFINITION span=76:11-76:17
+occurrence element=UNKNOWN:minMax@80 kind=DEFINITION span=80:4-80:10
+occurrence element=UNKNOWN:numberIn@90 kind=DEFINITION span=90:2-90:10
+occurrence element=UNKNOWN:run@97 kind=DEFINITION span=97:7-97:10
+occurrence element=UNKNOWN:sameInRow@56 kind=DEFINITION span=56:4-56:13
+occurrence element=UNKNOWN:stringOut@91 kind=DEFINITION span=91:2-91:11
+access node=METHOD:ArtificialPlayer.minMax@72 kind=Public
+access node=METHOD:ArtificialPlayer.turn@79 kind=Public
+access node=METHOD:Field.makeMove@50 kind=Public
+access node=METHOD:Field.opponent@29 kind=Public
+access node=METHOD:Field.sameInRow@39 kind=Public
+access node=METHOD:GameObject.announce@22 kind=Public
+access node=METHOD:HumanPlayer.turn@66 kind=Public
+access node=METHOD:Player.turn@61 kind=Public
+access node=METHOD:TicTacToe.run@88 kind=Public
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "13:main", node_id: NodeId(-7701807741696418100), signature_hash: -4671339478033693080, normalized_signature: Some("shape:-8097269470219391812"), body_hash: 7649160330512063217, start_line: 95, end_line: 98 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "13:numberIn", node_id: NodeId(-5458843576889243136), signature_hash: 2477812878330356949, normalized_signature: Some("outline:-1795207361013140379"), body_hash: 7819804390695130296, start_line: 8, end_line: 10 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "13:numberOut", node_id: NodeId(8650796649741548235), signature_hash: -1579019679195996938, normalized_signature: Some("shape:6494744104446376511"), body_hash: -3664118331073172199, start_line: 12, end_line: 14 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "13:stringOut", node_id: NodeId(2890021218222218907), signature_hash: -5818630870471287222, normalized_signature: Some("shape:-4171357402576902801"), body_hash: 6563995274820913865, start_line: 16, end_line: 18 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:ArtificialPlayer.minMax", node_id: NodeId(-4752009928134637621), signature_hash: 2816889471617643129, normalized_signature: Some("shape:7252598355569294271"), body_hash: -3893025900751997511, start_line: 72, end_line: 77 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:ArtificialPlayer.turn", node_id: NodeId(-3059775494361641910), signature_hash: 5754064973517794814, normalized_signature: Some("shape:6536110741441658288"), body_hash: 512579226939742730, start_line: 79, end_line: 82 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:Field.makeMove", node_id: NodeId(-3427862867751260553), signature_hash: -7686617887134063555, normalized_signature: Some("shape:8226940670190187613"), body_hash: -4053878199630013218, start_line: 50, end_line: 58 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:Field.opponent", node_id: NodeId(-8366382801925705643), signature_hash: 5718448952121283431, normalized_signature: Some("outline:-5075390869670978506"), body_hash: 6370433801870713149, start_line: 29, end_line: 37 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:Field.sameInRow", node_id: NodeId(-2266150577301757827), signature_hash: 8317776364922746511, normalized_signature: Some("outline:-5076516769578077345"), body_hash: 5488410606900878281, start_line: 39, end_line: 48 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:GameObject.announce", node_id: NodeId(-7584130302283939542), signature_hash: 6265382829821424686, normalized_signature: Some("outline:-5083272169020481154"), body_hash: -9184305782704489594, start_line: 22, end_line: 22 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:HumanPlayer.turn", node_id: NodeId(3997570138104193539), signature_hash: -1551097434895889655, normalized_signature: Some("shape:-5975803393761620842"), body_hash: 3887084545519181443, start_line: 66, end_line: 68 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:Player.turn", node_id: NodeId(7007379194437988318), signature_hash: -1091959065548758310, normalized_signature: Some("outline:-5083272169020481154"), body_hash: 3722172886773608007, start_line: 61, end_line: 61 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "14:TicTacToe.run", node_id: NodeId(-2351823062342898013), signature_hash: 5136661510898306809, normalized_signature: Some("shape:6988561129212029927"), body_hash: -7082128133548912827, start_line: 88, end_line: 93 }
+callable_state CallableProjectionState { file_id: 7318852721560449636, symbol_key: "__file_structural__", node_id: NodeId(7318852721560449636), signature_hash: 553768115714561381, normalized_signature: None, body_hash: -6401511314156261294, start_line: 1, end_line: 98 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "go",
+        extension: "go",
+        fidelity_filename: "fidelity.go",
+        fidelity_source: include_str!("fixtures/fidelity_lab/go_fidelity_lab.go"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/go_fidelity.txt"),
+        tictactoe_filename: "game.go",
+        tictactoe_source: include_str!("fixtures/tictactoe/go_tictactoe.go"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/go_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1685.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
