### PR TITLE
[v0.17 S3-RUBY] Extract Ruby language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3940,7 +3940,7 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
     // extraction package has not landed yet (ARCH-012 roster burn-down).
     let comment_marker = codestory_contracts::language_support::line_comment_for_language(language)
         .or(match language {
-            "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
+            "bash" | "python" | "toml" | "yaml" => Some("#"),
             "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
             | "cpp" | "dart" | "php" | "swift" => Some("//"),
             _ => None,

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "ruby",
+        line_comment: "#",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "ruby"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,6 +1265,7 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("ruby"), Some("#"));
         assert_eq!(line_comment_for_language("swift"), None);
     }
 

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -1,9 +1,9 @@
 use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
     GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
-    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY,
+    TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -38,7 +38,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("cpp", _) => Some(cpp()),
         ("c", _) => Some(c()),
         ("go", _) => Some(go()),
-        ("ruby", _) => Some(ruby()),
         ("php", _) => Some(php()),
         ("csharp", _) => Some(csharp()),
         ("swift", _) => Some(swift()),
@@ -135,16 +134,6 @@ fn go() -> LanguageConfig {
         GO_GRAPH_QUERY,
         None,
         LanguageRuleset::Go,
-    )
-}
-
-fn ruby() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_ruby::LANGUAGE.into(),
-        "ruby",
-        RUBY_GRAPH_QUERY,
-        None,
-        LanguageRuleset::Ruby,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -17,6 +17,7 @@
 //! package to land deletes the residual arms entirely.
 
 pub(crate) mod kotlin;
+pub(crate) mod ruby;
 
 use std::sync::OnceLock;
 
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, ruby::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {

--- a/crates/codestory-indexer/src/languages/ruby.rs
+++ b/crates/codestory-indexer/src/languages/ruby.rs
@@ -1,0 +1,388 @@
+//! Ruby extraction rules.
+//!
+//! Ruby's graph extraction lives here: the tree-sitter rule file, the
+//! compiled-rule cache, the member-call callsite marker, and the receiver-call
+//! resolution engine that turns `@repo.save(...)` into an edge aimed at
+//! `Repository.save`. Every language-keyed dispatch in the crate reaches it
+//! through [`super::EXTRACTIONS`] rather than by spelling `"ruby"`.
+//!
+//! Four Ruby surfaces are deliberately *not* here, and each is a shared seam
+//! rather than Ruby content:
+//!
+//! * `lib.rs::collect_ruby_bare_call_edges` and `collect_ruby_runtime_import_specs`,
+//!   which hang off the manual-edge and runtime-import dispatches. Those take
+//!   non-uniform arguments across all sixteen languages, so routing them
+//!   through the registry is one change for the whole roster, not part of
+//!   Ruby's rollback unit.
+//! * `lib.rs::annotate_ruby_member_call_placeholders`, the pre-pass that stamps
+//!   [`MEMBER_CALLSITE_MARKER`] onto unresolved CALL placeholders before the
+//!   manual receiver-call edges are appended. It reaches into the edge buffer,
+//!   the dedup key set, and the index feature flags, none of which the registry
+//!   row describes; it calls [`member_call`] here for the syntax half.
+//! * `lib.rs::collect_rails_route` and its `"ruby"` arm in the framework-route
+//!   scanner, which is the same per-framework seam Kotlin's Ktor collector left
+//!   behind.
+//! * `LanguageRuleset::Ruby`, which stays in `lib.rs` because the enum is the
+//!   compiled-rule cache key for every language at once.
+//!
+//! Ruby's marker is *not* emitted by the rule file: `rules/ruby.scm` carries no
+//! `call_syntax` attribute, so the registry row pairs `member_callsite_marker`
+//! and `graph_call_syntax` as `None`/`None` and the marker is applied by the
+//! pre-pass above.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both Ruby fixtures so the move stays output-equal.
+
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, LanguageRuleset, ManualReceiverCallSpec, ManualReceiverSource,
+    code_before_hash_comment, declaration_name, enclosing_node_with_kind, member_call_method_col,
+    normalize_type_surface, normalized_receiver_variable, quoted_literal_surface,
+    receiver_call_belongs_to_callable, same_ts_span, trimmed_node_text, ts_node_graph_span,
+    walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from Ruby member-call syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:ruby-member-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/ruby.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for Ruby.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["ruby"],
+    language_name: "ruby",
+    extensions: &["rb"],
+    ruleset: LanguageRuleset::Ruby,
+    parser_language: ruby_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    receiver_call_specs: Some(receiver_call_specs),
+    // `rules/ruby.scm` emits no `call_syntax`, so there is no rule-file value
+    // for the registry to map; `annotate_ruby_member_call_placeholders` stamps
+    // `MEMBER_CALLSITE_MARKER` directly.
+    member_callsite_marker: None,
+    graph_call_syntax: None,
+    // A Ruby `method` inside a `class` is already projected as METHOD by the
+    // rule file, so the FUNCTION -> METHOD promotion does not apply.
+    promotes_type_member_functions_to_methods: false,
+    qualified_name_delimiter: ".",
+    route_comments_are_c_style: false,
+    // `semantic::RubySemanticResolver` is private to that module, so the
+    // registry records the choice and the residual match builds it.
+    uses_generic_semantic_resolver: false,
+    semantic_family: "ruby",
+};
+
+fn ruby_language() -> tree_sitter::Language {
+    tree_sitter_ruby::LANGUAGE.into()
+}
+
+/// Manual receiver-call edges for one parsed Ruby file.
+///
+/// Was `lib.rs::collect_ruby_receiver_call_edges`.
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let require_relative_module = ruby_single_require_relative_module(source);
+    let local_type_names = collect_ruby_file_type_names(tree.root_node(), source);
+    walk_tree_nodes(tree.root_node(), &mut |callable| {
+        if !matches!(callable.kind(), "method" | "singleton_method") {
+            return;
+        }
+        let Some(source_name) = declaration_name(callable, source) else {
+            return;
+        };
+        collect_ruby_precise_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: &source_name,
+                span: ts_node_graph_span(callable),
+            },
+            require_relative_module.as_deref(),
+            &local_type_names,
+            &mut edges,
+        );
+    });
+    edges
+}
+
+fn collect_ruby_precise_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    require_relative_module: Option<&str>,
+    local_type_names: &HashSet<String>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let owner_name = if let Some(owner_name) = ruby_constructor_owner_surface(&receiver_name) {
+            owner_name
+        } else if let Some(owner) =
+            ruby_visible_local_receiver_owner(callable, node, &receiver_name, source)
+        {
+            let Some(owner_name) = owner else {
+                return;
+            };
+            owner_name
+        } else if receiver_name.starts_with('@') {
+            let Some(owner_name) =
+                ruby_instance_variable_receiver_owner(callable, &receiver_name, source)
+            else {
+                return;
+            };
+            owner_name
+        } else {
+            return;
+        };
+        let owner_module =
+            ruby_receiver_owner_module(&owner_name, require_relative_module, local_type_names);
+        let method_col = member_call_method_col(node, source, &method_name);
+        edges.push(ManualReceiverCallSpec {
+            source_name: call_source.name.to_string(),
+            source_span: call_source.span,
+            receiver_name,
+            owner_name,
+            owner_module,
+            method_name,
+            method_col,
+            line: Some(node.start_position().row as u32 + 1),
+            allow_global_fallback: false,
+        });
+    });
+}
+
+fn ruby_receiver_owner_module(
+    owner_name: &str,
+    require_relative_module: Option<&str>,
+    local_type_names: &HashSet<String>,
+) -> Option<String> {
+    if local_type_names.contains(owner_name) {
+        return None;
+    }
+    require_relative_module.map(str::to_string)
+}
+
+fn collect_ruby_file_type_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
+    let mut names = HashSet::new();
+    walk_tree_nodes(root, &mut |node| match node.kind() {
+        "class" | "module" => {
+            if let Some(name) = declaration_name(node, source) {
+                names.insert(name);
+            }
+        }
+        "assignment" => {
+            if ruby_assignment_is_top_level(node)
+                && let Some(name) = node
+                    .child_by_field_name("left")
+                    .and_then(|left| trimmed_node_text(left, source))
+                    .and_then(|name| ruby_constant_name(&name))
+            {
+                names.insert(name);
+            }
+        }
+        _ => {}
+    });
+    names
+}
+
+fn ruby_assignment_is_top_level(node: TsNode<'_>) -> bool {
+    enclosing_node_with_kind(node, &["method", "singleton_method", "class", "module"]).is_none()
+}
+
+fn ruby_constant_name(raw: &str) -> Option<String> {
+    let name = raw.trim();
+    if name.contains("::") || name.contains('.') || name.starts_with('@') || name.starts_with('$') {
+        return None;
+    }
+    let first = name.chars().next()?;
+    first.is_uppercase().then(|| name.to_string())
+}
+
+fn ruby_single_require_relative_module(source: &str) -> Option<String> {
+    let mut modules = source
+        .lines()
+        .filter(|line| !line.starts_with(char::is_whitespace))
+        .filter_map(ruby_require_relative_module_from_line)
+        .collect::<Vec<_>>();
+    modules.sort();
+    modules.dedup();
+    if modules.len() == 1 {
+        modules.pop()
+    } else {
+        None
+    }
+}
+
+fn ruby_require_relative_module_from_line(line: &str) -> Option<String> {
+    let line = code_before_hash_comment(line).trim();
+    let rest = line
+        .strip_prefix("require_relative")
+        .filter(|rest| rest.is_empty() || rest.starts_with([' ', '\t', '(']))?
+        .trim()
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .trim();
+    let module_name = quoted_literal_surface(rest)?;
+    if module_name.starts_with("./") || module_name.starts_with("../") {
+        Some(module_name.to_string())
+    } else {
+        Some(format!("./{module_name}"))
+    }
+}
+
+fn ruby_instance_variable_receiver_owner(
+    callable: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+) -> Option<String> {
+    let class_node = enclosing_node_with_kind(callable, &["class"])?;
+    let mut owner_names: Vec<Option<String>> = Vec::new();
+    walk_tree_nodes(class_node, &mut |node| {
+        if !ruby_assignment_like_kind(node.kind()) {
+            return;
+        }
+        if !enclosing_node_with_kind(node, &["class"])
+            .is_some_and(|owner| same_ts_span(owner, class_node))
+        {
+            return;
+        }
+        if !ruby_assignment_matches_receiver_domain(node, callable, class_node) {
+            return;
+        }
+        let Some(left_node) = node.child_by_field_name("left") else {
+            return;
+        };
+        if normalized_receiver_variable(left_node, source).as_deref() != Some(receiver_name) {
+            return;
+        }
+        let owner_name = if node.kind() == "operator_assignment" {
+            None
+        } else {
+            node.child_by_field_name("right")
+                .and_then(|right_node| ruby_constructor_owner(right_node, source))
+        };
+        owner_names.push(owner_name);
+    });
+    let mut concrete_owners = owner_names.into_iter().collect::<Option<Vec<_>>>()?;
+    concrete_owners.sort();
+    concrete_owners.dedup();
+    if concrete_owners.len() == 1 {
+        concrete_owners.pop()
+    } else {
+        None
+    }
+}
+
+fn ruby_assignment_like_kind(kind: &str) -> bool {
+    matches!(kind, "assignment" | "operator_assignment")
+}
+
+fn ruby_assignment_matches_receiver_domain(
+    assignment: TsNode<'_>,
+    callable: TsNode<'_>,
+    class_node: TsNode<'_>,
+) -> bool {
+    let enclosing_method = enclosing_node_with_kind(assignment, &["method", "singleton_method"]);
+    match callable.kind() {
+        "method" => enclosing_method.is_some_and(|method| {
+            method.kind() == "method"
+                && enclosing_node_with_kind(method, &["class"])
+                    .is_some_and(|owner| same_ts_span(owner, class_node))
+        }),
+        "singleton_method" => enclosing_method.is_none_or(|method| {
+            method.kind() == "singleton_method"
+                && enclosing_node_with_kind(method, &["class"])
+                    .is_some_and(|owner| same_ts_span(owner, class_node))
+        }),
+        _ => false,
+    }
+}
+
+fn ruby_visible_local_receiver_owner(
+    callable: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+) -> Option<Option<String>> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(callable, &mut |node| {
+        if !ruby_assignment_like_kind(node.kind()) {
+            return;
+        }
+        if !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > call_node.start_byte()
+        {
+            return;
+        }
+        let Some(left_node) = node.child_by_field_name("left") else {
+            return;
+        };
+        if normalized_receiver_variable(left_node, source).as_deref() != Some(receiver_name) {
+            return;
+        }
+        let owner_name = if node.kind() == "operator_assignment" {
+            None
+        } else {
+            node.child_by_field_name("right")
+                .and_then(|right_node| ruby_constructor_owner(right_node, source))
+        };
+        visible_bindings.push((node.end_byte(), owner_name));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner)| owner)
+}
+
+/// Receiver and member of one Ruby member call, read from the grammar.
+///
+/// Was `lib.rs::ruby_receiver_call`. `lib.rs` still calls it from
+/// `annotate_ruby_member_call_placeholders`, which is why it is `pub(crate)`.
+pub(crate) fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if node.kind() != "call" {
+        return None;
+    }
+    let receiver = node.child_by_field_name("receiver")?;
+    let method = node.child_by_field_name("method")?;
+    let method_name = trimmed_node_text(method, source)?;
+    if method_name == "new" {
+        return None;
+    }
+    Some((normalized_receiver_variable(receiver, source)?, method_name))
+}
+
+fn ruby_constructor_owner(node: TsNode<'_>, source: &str) -> Option<String> {
+    if node.kind() != "call" {
+        return None;
+    }
+    let method = node.child_by_field_name("method")?;
+    if trimmed_node_text(method, source).as_deref() != Some("new") {
+        return None;
+    }
+    let receiver = node.child_by_field_name("receiver")?;
+    let raw_owner = trimmed_node_text(receiver, source)?;
+    normalize_type_surface(&raw_owner)
+}
+
+fn ruby_constructor_owner_surface(surface: &str) -> Option<String> {
+    let surface = surface.trim();
+    let (raw_owner, suffix) = surface.split_once(".new")?;
+    if !(suffix.is_empty() || suffix.starts_with('(') && suffix.ends_with(')')) {
+        return None;
+    }
+    let raw_owner = raw_owner.trim();
+    normalize_type_surface(raw_owner)
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -62,7 +62,6 @@ pub(crate) const CPP_MEMBER_CALLSITE_MARKER: &str = "syntax:cpp-member-call";
 pub(crate) const GO_SELECTOR_CALLSITE_MARKER: &str = "syntax:go-selector-call";
 pub(crate) const JAVA_MEMBER_CALLSITE_MARKER: &str = "syntax:java-member-call";
 pub(crate) const CSHARP_MEMBER_CALLSITE_MARKER: &str = "syntax:csharp-member-call";
-pub(crate) const RUBY_MEMBER_CALLSITE_MARKER: &str = "syntax:ruby-member-call";
 pub(crate) const PHP_MEMBER_CALLSITE_MARKER: &str = "syntax:php-member-call";
 pub(crate) const JS_MEMBER_CALLSITE_MARKER: &str = "syntax:js-member-call";
 pub(crate) const TS_MEMBER_CALLSITE_MARKER: &str = "syntax:ts-member-call";
@@ -139,7 +138,6 @@ const TSX_TAGS_QUERY: &str = TYPESCRIPT_TAGS_QUERY;
 const CPP_GRAPH_QUERY: &str = include_str!("../rules/cpp.scm");
 const C_GRAPH_QUERY: &str = include_str!("../rules/c.scm");
 const GO_GRAPH_QUERY: &str = include_str!("../rules/go.scm");
-const RUBY_GRAPH_QUERY: &str = include_str!("../rules/ruby.scm");
 const PHP_GRAPH_QUERY: &str = include_str!("../rules/php.scm");
 const CSHARP_GRAPH_QUERY: &str = include_str!("../rules/csharp.scm");
 const SWIFT_GRAPH_QUERY: &str = include_str!("../rules/swift.scm");
@@ -318,9 +316,10 @@ impl LanguageRuleset {
             }
             LanguageRuleset::C => compiled_rules_cache(language, C_GRAPH_QUERY, None, &C_RULES),
             LanguageRuleset::Go => compiled_rules_cache(language, GO_GRAPH_QUERY, None, &GO_RULES),
-            LanguageRuleset::Ruby => {
-                compiled_rules_cache(language, RUBY_GRAPH_QUERY, None, &RUBY_RULES)
-            }
+            // Answered by the registry above; see the Kotlin arm below.
+            LanguageRuleset::Ruby => Err(anyhow!(
+                "ruby compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::Php => {
                 compiled_rules_cache(language, PHP_GRAPH_QUERY, None, &PHP_RULES)
             }
@@ -381,7 +380,6 @@ static TSX_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::ne
 static CPP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static C_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static GO_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static RUBY_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static PHP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CSHARP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static SWIFT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
@@ -7597,7 +7595,6 @@ fn language_receiver_call_specs(
         "typescript" | "tsx" => collect_typescript_receiver_call_edges(tree, source),
         "java" => collect_java_receiver_call_edges(tree, source),
         "go" => collect_go_receiver_call_edges(tree, source),
-        "ruby" => collect_ruby_receiver_call_edges(tree, source),
         "php" => collect_php_receiver_call_edges(tree, source),
         "csharp" => collect_csharp_receiver_call_edges(tree, source),
         "cpp" => collect_cpp_receiver_call_edges(tree, source),
@@ -7757,7 +7754,7 @@ fn annotate_ruby_member_call_placeholders(
     flags: IndexFeatureFlags,
 ) {
     walk_tree_nodes(tree.root_node(), &mut |node| {
-        let Some((_, method_name)) = ruby_receiver_call(node, source) else {
+        let Some((_, method_name)) = languages::ruby::member_call(node, source) else {
             return;
         };
         annotate_call_placeholder_marker(
@@ -7769,7 +7766,7 @@ fn annotate_ruby_member_call_placeholders(
                 line: Some(node.start_position().row as u32 + 1),
                 method_col: member_call_method_col(node, source, &method_name),
                 method_name: &method_name,
-                marker: RUBY_MEMBER_CALLSITE_MARKER,
+                marker: languages::ruby::MEMBER_CALLSITE_MARKER,
             },
         );
     });
@@ -13454,162 +13451,6 @@ fn dart_signature_for_body<'tree>(body: TsNode<'tree>) -> Option<TsNode<'tree>> 
     previous_named_sibling_with_kind(body, &["method_signature", "function_signature"])
 }
 
-fn collect_ruby_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let require_relative_module = ruby_single_require_relative_module(source);
-    let local_type_names = collect_ruby_file_type_names(tree.root_node(), source);
-    walk_tree_nodes(tree.root_node(), &mut |callable| {
-        if !matches!(callable.kind(), "method" | "singleton_method") {
-            return;
-        }
-        let Some(source_name) = declaration_name(callable, source) else {
-            return;
-        };
-        collect_ruby_precise_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: &source_name,
-                span: ts_node_graph_span(callable),
-            },
-            require_relative_module.as_deref(),
-            &local_type_names,
-            &mut edges,
-        );
-    });
-    edges
-}
-
-fn collect_ruby_precise_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    require_relative_module: Option<&str>,
-    local_type_names: &HashSet<String>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = ruby_receiver_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let owner_name = if let Some(owner_name) = ruby_constructor_owner_surface(&receiver_name) {
-            owner_name
-        } else if let Some(owner) =
-            ruby_visible_local_receiver_owner(callable, node, &receiver_name, source)
-        {
-            let Some(owner_name) = owner else {
-                return;
-            };
-            owner_name
-        } else if receiver_name.starts_with('@') {
-            let Some(owner_name) =
-                ruby_instance_variable_receiver_owner(callable, &receiver_name, source)
-            else {
-                return;
-            };
-            owner_name
-        } else {
-            return;
-        };
-        let owner_module =
-            ruby_receiver_owner_module(&owner_name, require_relative_module, local_type_names);
-        let method_col = member_call_method_col(node, source, &method_name);
-        edges.push(ManualReceiverCallSpec {
-            source_name: call_source.name.to_string(),
-            source_span: call_source.span,
-            receiver_name,
-            owner_name,
-            owner_module,
-            method_name,
-            method_col,
-            line: Some(node.start_position().row as u32 + 1),
-            allow_global_fallback: false,
-        });
-    });
-}
-
-fn ruby_receiver_owner_module(
-    owner_name: &str,
-    require_relative_module: Option<&str>,
-    local_type_names: &HashSet<String>,
-) -> Option<String> {
-    if local_type_names.contains(owner_name) {
-        return None;
-    }
-    require_relative_module.map(str::to_string)
-}
-
-fn collect_ruby_file_type_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
-    let mut names = HashSet::new();
-    walk_tree_nodes(root, &mut |node| match node.kind() {
-        "class" | "module" => {
-            if let Some(name) = declaration_name(node, source) {
-                names.insert(name);
-            }
-        }
-        "assignment" => {
-            if ruby_assignment_is_top_level(node)
-                && let Some(name) = node
-                    .child_by_field_name("left")
-                    .and_then(|left| trimmed_node_text(left, source))
-                    .and_then(|name| ruby_constant_name(&name))
-            {
-                names.insert(name);
-            }
-        }
-        _ => {}
-    });
-    names
-}
-
-fn ruby_assignment_is_top_level(node: TsNode<'_>) -> bool {
-    enclosing_node_with_kind(node, &["method", "singleton_method", "class", "module"]).is_none()
-}
-
-fn ruby_constant_name(raw: &str) -> Option<String> {
-    let name = raw.trim();
-    if name.contains("::") || name.contains('.') || name.starts_with('@') || name.starts_with('$') {
-        return None;
-    }
-    let first = name.chars().next()?;
-    first.is_uppercase().then(|| name.to_string())
-}
-
-fn ruby_single_require_relative_module(source: &str) -> Option<String> {
-    let mut modules = source
-        .lines()
-        .filter(|line| !line.starts_with(char::is_whitespace))
-        .filter_map(ruby_require_relative_module_from_line)
-        .collect::<Vec<_>>();
-    modules.sort();
-    modules.dedup();
-    if modules.len() == 1 {
-        modules.pop()
-    } else {
-        None
-    }
-}
-
-fn ruby_require_relative_module_from_line(line: &str) -> Option<String> {
-    let line = code_before_hash_comment(line).trim();
-    let rest = line
-        .strip_prefix("require_relative")
-        .filter(|rest| rest.is_empty() || rest.starts_with([' ', '\t', '(']))?
-        .trim()
-        .trim_start_matches('(')
-        .trim_end_matches(')')
-        .trim();
-    let module_name = quoted_literal_surface(rest)?;
-    if module_name.starts_with("./") || module_name.starts_with("../") {
-        Some(module_name.to_string())
-    } else {
-        Some(format!("./{module_name}"))
-    }
-}
-
 fn quoted_literal_surface(surface: &str) -> Option<&str> {
     let mut chars = surface.chars();
     let quote = chars.next()?;
@@ -13618,74 +13459,6 @@ fn quoted_literal_surface(surface: &str) -> Option<&str> {
     }
     let end = surface[quote.len_utf8()..].find(quote)? + quote.len_utf8();
     Some(&surface[quote.len_utf8()..end])
-}
-
-fn ruby_instance_variable_receiver_owner(
-    callable: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-) -> Option<String> {
-    let class_node = enclosing_node_with_kind(callable, &["class"])?;
-    let mut owner_names: Vec<Option<String>> = Vec::new();
-    walk_tree_nodes(class_node, &mut |node| {
-        if !ruby_assignment_like_kind(node.kind()) {
-            return;
-        }
-        if !enclosing_node_with_kind(node, &["class"])
-            .is_some_and(|owner| same_ts_span(owner, class_node))
-        {
-            return;
-        }
-        if !ruby_assignment_matches_receiver_domain(node, callable, class_node) {
-            return;
-        }
-        let Some(left_node) = node.child_by_field_name("left") else {
-            return;
-        };
-        if normalized_receiver_variable(left_node, source).as_deref() != Some(receiver_name) {
-            return;
-        }
-        let owner_name = if node.kind() == "operator_assignment" {
-            None
-        } else {
-            node.child_by_field_name("right")
-                .and_then(|right_node| ruby_constructor_owner(right_node, source))
-        };
-        owner_names.push(owner_name);
-    });
-    let mut concrete_owners = owner_names.into_iter().collect::<Option<Vec<_>>>()?;
-    concrete_owners.sort();
-    concrete_owners.dedup();
-    if concrete_owners.len() == 1 {
-        concrete_owners.pop()
-    } else {
-        None
-    }
-}
-
-fn ruby_assignment_like_kind(kind: &str) -> bool {
-    matches!(kind, "assignment" | "operator_assignment")
-}
-
-fn ruby_assignment_matches_receiver_domain(
-    assignment: TsNode<'_>,
-    callable: TsNode<'_>,
-    class_node: TsNode<'_>,
-) -> bool {
-    let enclosing_method = enclosing_node_with_kind(assignment, &["method", "singleton_method"]);
-    match callable.kind() {
-        "method" => enclosing_method.is_some_and(|method| {
-            method.kind() == "method"
-                && enclosing_node_with_kind(method, &["class"])
-                    .is_some_and(|owner| same_ts_span(owner, class_node))
-        }),
-        "singleton_method" => enclosing_method.is_none_or(|method| {
-            method.kind() == "singleton_method"
-                && enclosing_node_with_kind(method, &["class"])
-                    .is_some_and(|owner| same_ts_span(owner, class_node))
-        }),
-        _ => false,
-    }
 }
 
 fn collect_receiver_call_specs_in_callable(
@@ -13910,40 +13683,6 @@ fn collect_csharp_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap
         }
     });
     receiver_types
-}
-
-fn ruby_visible_local_receiver_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-) -> Option<Option<String>> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if !ruby_assignment_like_kind(node.kind()) {
-            return;
-        }
-        if !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
-        {
-            return;
-        }
-        let Some(left_node) = node.child_by_field_name("left") else {
-            return;
-        };
-        if normalized_receiver_variable(left_node, source).as_deref() != Some(receiver_name) {
-            return;
-        }
-        let owner_name = if node.kind() == "operator_assignment" {
-            None
-        } else {
-            node.child_by_field_name("right")
-                .and_then(|right_node| ruby_constructor_owner(right_node, source))
-        };
-        visible_bindings.push((node.end_byte(), owner_name));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner)| owner)
 }
 
 fn collect_python_receiver_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
@@ -14454,19 +14193,6 @@ fn java_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> 
     ))
 }
 
-fn ruby_receiver_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if node.kind() != "call" {
-        return None;
-    }
-    let receiver = node.child_by_field_name("receiver")?;
-    let method = node.child_by_field_name("method")?;
-    let method_name = trimmed_node_text(method, source)?;
-    if method_name == "new" {
-        return None;
-    }
-    Some((normalized_receiver_variable(receiver, source)?, method_name))
-}
-
 fn typescript_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
     if node.kind() != "call_expression" {
         return None;
@@ -14684,29 +14410,6 @@ fn dart_callable_name(node: TsNode<'_>, source: &str) -> Option<String> {
     descendant_by_field_name(node, "name")
         .or_else(|| first_descendant_with_kind(node, "identifier"))
         .and_then(|name_node| trimmed_node_text(name_node, source))
-}
-
-fn ruby_constructor_owner(node: TsNode<'_>, source: &str) -> Option<String> {
-    if node.kind() != "call" {
-        return None;
-    }
-    let method = node.child_by_field_name("method")?;
-    if trimmed_node_text(method, source).as_deref() != Some("new") {
-        return None;
-    }
-    let receiver = node.child_by_field_name("receiver")?;
-    let raw_owner = trimmed_node_text(receiver, source)?;
-    normalize_type_surface(&raw_owner)
-}
-
-fn ruby_constructor_owner_surface(surface: &str) -> Option<String> {
-    let surface = surface.trim();
-    let (raw_owner, suffix) = surface.split_once(".new")?;
-    if !(suffix.is_empty() || suffix.starts_with('(') && suffix.ends_with(')')) {
-        return None;
-    }
-    let raw_owner = raw_owner.trim();
-    normalize_type_surface(raw_owner)
 }
 
 fn normalized_receiver_variable(node: TsNode<'_>, source: &str) -> Option<String> {

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1429,7 +1429,7 @@ fn is_ruby_member_call_placeholder(edge_kind: EdgeKind, callsite_identity: Optio
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::RUBY_MEMBER_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::ruby::MEMBER_CALLSITE_MARKER)
     })
 }
 

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -597,7 +597,6 @@ fn language_family_bucket(language: &'static str) -> &'static str {
         "rust" => "rust",
         "java" => "java",
         "go" => "go",
-        "ruby" => "ruby",
         "php" => "php",
         "csharp" => "csharp",
         "swift" => "swift",

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/ruby_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/ruby_fidelity.txt
@@ -1,0 +1,46 @@
+node CLASS name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.rb:ConsoleNotifier line=9 col=1 end=13:4 file=FILE:<ROOT>/fidelity.rb@1
+node CLASS name=Notifier qn=Notifier canonical=<ROOT>/fidelity.rb:Notifier line=3 col=1 end=7:4 file=FILE:<ROOT>/fidelity.rb@1
+node CLASS name=Repository qn=Repository canonical=<ROOT>/fidelity.rb:Repository line=15 col=1 end=19:4 file=FILE:<ROOT>/fidelity.rb@1
+node CLASS name=Workflow qn=Workflow canonical=<ROOT>/fidelity.rb:Workflow line=23 col=1 end=38:4 file=FILE:<ROOT>/fidelity.rb@1
+node FILE name=<ROOT>/fidelity.rb qn=<ROOT>/fidelity.rb canonical=<ROOT>/fidelity.rb:<ROOT>/fidelity.rb:1 line=1 col=1 end=42:0 file=FILE:<ROOT>/fidelity.rb@1
+node METHOD name=ConsoleNotifier.notify qn=ConsoleNotifier.notify canonical=<ROOT>/fidelity.rb:ConsoleNotifier.notify#0 line=10 col=3 end=12:6 file=FILE:<ROOT>/fidelity.rb@1
+node METHOD name=Notifier.notify qn=Notifier.notify canonical=<ROOT>/fidelity.rb:Notifier.notify#0 line=4 col=3 end=6:6 file=FILE:<ROOT>/fidelity.rb@1
+node METHOD name=Repository.save qn=Repository.save canonical=<ROOT>/fidelity.rb:Repository.save#0 line=16 col=3 end=18:6 file=FILE:<ROOT>/fidelity.rb@1
+node METHOD name=Workflow.decorate qn=Workflow.decorate canonical=<ROOT>/fidelity.rb:Workflow.decorate#0 line=35 col=3 end=37:6 file=FILE:<ROOT>/fidelity.rb@1
+node METHOD name=Workflow.initialize qn=Workflow.initialize canonical=<ROOT>/fidelity.rb:Workflow.initialize#0 line=24 col=3 end=27:6 file=FILE:<ROOT>/fidelity.rb@1
+node METHOD name=Workflow.run qn=Workflow.run canonical=<ROOT>/fidelity.rb:Workflow.run#0 line=29 col=3 end=33:6 file=FILE:<ROOT>/fidelity.rb@1
+node METHOD name=orchestrate_ruby qn=orchestrate_ruby canonical=<ROOT>/fidelity.rb:orchestrate_ruby#0 line=40 col=1 end=42:4 file=FILE:<ROOT>/fidelity.rb@1
+node MODULE name="logger" qn="logger" canonical=<ROOT>/fidelity.rb:"logger"#0 line=1 col=9 end=1:17 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.rb:decorate#0 line=32 col=5 end=32:13 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=name qn=name canonical=<ROOT>/fidelity.rb:name#0 line=5 col=11 end=5:15 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=name qn=name canonical=<ROOT>/fidelity.rb:name#1 line=11 col=16 end=11:20 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=name qn=name canonical=<ROOT>/fidelity.rb:name#2 line=17 col=11 end=17:15 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=name qn=name canonical=<ROOT>/fidelity.rb:name#3 line=36 col=11 end=36:15 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=new qn=new canonical=<ROOT>/fidelity.rb:new#0 line=21 col=16 end=21:19 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=new qn=new canonical=<ROOT>/fidelity.rb:new#1 line=41 col=63 end=41:66 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.rb:notify#0 line=30 col=15 end=30:21 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=puts qn=puts canonical=<ROOT>/fidelity.rb:puts#0 line=11 col=5 end=11:9 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=require qn=require canonical=<ROOT>/fidelity.rb:require#0 line=1 col=1 end=1:8 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.rb:run#0 line=41 col=53 end=41:56 file=FILE:<ROOT>/fidelity.rb@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.rb:save#0 line=31 col=17 end=31:21 file=FILE:<ROOT>/fidelity.rb@1
+edge CALL src=METHOD:ConsoleNotifier.notify@10 dst=UNKNOWN:name@11 resolved_src=METHOD:ConsoleNotifier.notify@10 resolved_dst=- line=11 confidence=- certainty=- callsite=h0:11:16:h1|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:ConsoleNotifier.notify@10 dst=UNKNOWN:puts@11 resolved_src=METHOD:ConsoleNotifier.notify@10 resolved_dst=- line=11 confidence=- certainty=- callsite=h0:11:5:h2 candidates=[]
+edge CALL src=METHOD:Notifier.notify@4 dst=UNKNOWN:name@5 resolved_src=METHOD:Notifier.notify@4 resolved_dst=- line=5 confidence=- certainty=- callsite=h0:5:11:h3|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:Repository.save@16 dst=UNKNOWN:name@17 resolved_src=METHOD:Repository.save@16 resolved_dst=- line=17 confidence=- certainty=- callsite=h0:17:11:h4|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:Workflow.decorate@35 dst=UNKNOWN:name@36 resolved_src=METHOD:Workflow.decorate@35 resolved_dst=- line=36 confidence=- certainty=- callsite=h0:36:11:h5|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:Workflow.run@29 dst=UNKNOWN:decorate@32 resolved_src=METHOD:Workflow.run@29 resolved_dst=METHOD:Workflow.decorate@35 line=32 confidence=0.9500 certainty=Certain callsite=h0:32:5:h6 candidates=[]
+edge CALL src=METHOD:Workflow.run@29 dst=UNKNOWN:notify@30 resolved_src=METHOD:Workflow.run@29 resolved_dst=- line=30 confidence=- certainty=- callsite=h0:30:15:h7|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:Workflow.run@29 dst=UNKNOWN:save@31 resolved_src=METHOD:Workflow.run@29 resolved_dst=- line=31 confidence=- certainty=- callsite=h0:31:17:h8|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:orchestrate_ruby@40 dst=METHOD:Workflow.run@29 resolved_src=METHOD:orchestrate_ruby@40 resolved_dst=METHOD:Workflow.run@29 line=41 confidence=1.0000 certainty=Certain callsite=h0:41:1:h9 candidates=[]
+edge CALL src=METHOD:orchestrate_ruby@40 dst=UNKNOWN:new@41 resolved_src=METHOD:orchestrate_ruby@40 resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:12:h10 candidates=[]
+edge CALL src=METHOD:orchestrate_ruby@40 dst=UNKNOWN:new@41 resolved_src=METHOD:orchestrate_ruby@40 resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:32:h10 candidates=[]
+edge CALL src=METHOD:orchestrate_ruby@40 dst=UNKNOWN:new@41 resolved_src=METHOD:orchestrate_ruby@40 resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:48:h10 candidates=[]
+edge CALL src=METHOD:orchestrate_ruby@40 dst=UNKNOWN:new@41 resolved_src=METHOD:orchestrate_ruby@40 resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:63:h10 candidates=[]
+edge IMPORT src=MODULE:"logger"@1 dst=MODULE:"logger"@1 resolved_src=MODULE:"logger"@1 resolved_dst=- line=1 confidence=- certainty=- callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ConsoleNotifier@9 dst=CLASS:Notifier@3 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@9 dst=METHOD:ConsoleNotifier.notify@10 resolved_src=- resolved_dst=- line=10 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Notifier@3 dst=METHOD:Notifier.notify@4 resolved_src=- resolved_dst=- line=4 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@15 dst=METHOD:Repository.save@16 resolved_src=- resolved_dst=- line=16 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@23 dst=METHOD:Workflow.decorate@35 resolved_src=- resolved_dst=- line=35 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@23 dst=METHOD:Workflow.initialize@24 resolved_src=- resolved_dst=- line=24 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@23 dst=METHOD:Workflow.run@29 resolved_src=- resolved_dst=- line=29 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/ruby_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/ruby_tictactoe.txt
@@ -1,0 +1,131 @@
+node CLASS name=ArtificialPlayer qn=ArtificialPlayer canonical=game.rb:ArtificialPlayer line=62 col=1 end=72:4 file=FILE:game.rb@1
+node CLASS name=Field qn=Field canonical=game.rb:Field line=20 col=1 end=48:4 file=FILE:game.rb@1
+node CLASS name=GameObject qn=GameObject canonical=game.rb:GameObject line=15 col=1 end=18:4 file=FILE:game.rb@1
+node CLASS name=HumanPlayer qn=HumanPlayer canonical=game.rb:HumanPlayer line=56 col=1 end=60:4 file=FILE:game.rb@1
+node CLASS name=Player qn=Player canonical=game.rb:Player line=50 col=1 end=54:4 file=FILE:game.rb@1
+node CLASS name=TicTacToe qn=TicTacToe canonical=game.rb:TicTacToe line=74 col=1 end=81:4 file=FILE:game.rb@1
+node FILE name=game.rb qn=game.rb canonical=game.rb:game.rb:1 line=1 col=1 end=85:0 file=FILE:game.rb@1
+node METHOD name=ArtificialPlayer.minMax qn=ArtificialPlayer.minMax canonical=game.rb:ArtificialPlayer.minMax#0 line=63 col=3 end=66:6 file=FILE:game.rb@1
+node METHOD name=ArtificialPlayer.turn qn=ArtificialPlayer.turn canonical=game.rb:ArtificialPlayer.turn#0 line=68 col=3 end=71:6 file=FILE:game.rb@1
+node METHOD name=Field.initialize qn=Field.initialize canonical=game.rb:Field.initialize#0 line=21 col=3 end=24:6 file=FILE:game.rb@1
+node METHOD name=Field.makeMove qn=Field.makeMove canonical=game.rb:Field.makeMove#0 line=41 col=3 end=47:6 file=FILE:game.rb@1
+node METHOD name=Field.opponent qn=Field.opponent canonical=game.rb:Field.opponent#0 line=26 col=3 end=30:6 file=FILE:game.rb@1
+node METHOD name=Field.sameInRow qn=Field.sameInRow canonical=game.rb:Field.sameInRow#0 line=32 col=3 end=39:6 file=FILE:game.rb@1
+node METHOD name=GameObject.announce qn=GameObject.announce canonical=game.rb:GameObject.announce#0 line=16 col=3 end=17:6 file=FILE:game.rb@1
+node METHOD name=HumanPlayer.turn qn=HumanPlayer.turn canonical=game.rb:HumanPlayer.turn#0 line=57 col=3 end=59:6 file=FILE:game.rb@1
+node METHOD name=Player.turn qn=Player.turn canonical=game.rb:Player.turn#0 line=51 col=3 end=53:6 file=FILE:game.rb@1
+node METHOD name=TicTacToe.run qn=TicTacToe.run canonical=game.rb:TicTacToe.run#0 line=75 col=3 end=80:6 file=FILE:game.rb@1
+node METHOD name=numberIn qn=numberIn canonical=game.rb:numberIn#0 line=3 col=1 end=5:4 file=FILE:game.rb@1
+node METHOD name=numberOut qn=numberOut canonical=game.rb:numberOut#0 line=7 col=1 end=9:4 file=FILE:game.rb@1
+node METHOD name=stringOut qn=stringOut canonical=game.rb:stringOut#0 line=11 col=1 end=13:4 file=FILE:game.rb@1
+node MODULE name="random" qn="random" canonical=game.rb:"random"#0 line=1 col=9 end=1:17 file=FILE:game.rb@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.rb:makeMove#0 line=58 col=11 end=58:19 file=FILE:game.rb@1
+node UNKNOWN name=minMax qn=minMax canonical=game.rb:minMax#0 line=65 col=5 end=65:11 file=FILE:game.rb@1
+node UNKNOWN name=minMax qn=minMax canonical=game.rb:minMax#1 line=69 col=5 end=69:11 file=FILE:game.rb@1
+node UNKNOWN name=new qn=new canonical=game.rb:new#0 line=22 col=34 end=22:37 file=FILE:game.rb@1
+node UNKNOWN name=new qn=new canonical=game.rb:new#1 line=76 col=20 end=76:23 file=FILE:game.rb@1
+node UNKNOWN name=new qn=new canonical=game.rb:new#2 line=84 col=13 end=84:16 file=FILE:game.rb@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.rb:numberIn#1 line=77 col=5 end=77:13 file=FILE:game.rb@1
+node UNKNOWN name=print qn=print canonical=game.rb:print#0 line=8 col=3 end=8:8 file=FILE:game.rb@1
+node UNKNOWN name=print qn=print canonical=game.rb:print#1 line=12 col=3 end=12:8 file=FILE:game.rb@1
+node UNKNOWN name=rand qn=rand canonical=game.rb:rand#0 line=79 col=12 end=79:16 file=FILE:game.rb@1
+node UNKNOWN name=require qn=require canonical=game.rb:require#0 line=1 col=1 end=1:8 file=FILE:game.rb@1
+node UNKNOWN name=run qn=run canonical=game.rb:run#0 line=84 col=17 end=84:20 file=FILE:game.rb@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.rb:sameInRow#0 line=45 col=5 end=45:14 file=FILE:game.rb@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.rb:stringOut#1 line=78 col=5 end=78:14 file=FILE:game.rb@1
+node UNKNOWN name=times qn=times canonical=game.rb:times#0 line=35 col=7 end=35:12 file=FILE:game.rb@1
+edge CALL src=METHOD:ArtificialPlayer.minMax@63 dst=UNKNOWN:minMax@65 resolved_src=- resolved_dst=- line=65 confidence=- certainty=- callsite=h0:65:5:h1 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@68 dst=UNKNOWN:minMax@69 resolved_src=- resolved_dst=- line=69 confidence=- certainty=- callsite=h0:69:5:h2 candidates=[]
+edge CALL src=METHOD:Field.initialize@21 dst=UNKNOWN:new@22 resolved_src=- resolved_dst=- line=22 confidence=- certainty=- callsite=h0:22:19:h3 candidates=[]
+edge CALL src=METHOD:Field.initialize@21 dst=UNKNOWN:new@22 resolved_src=- resolved_dst=- line=22 confidence=- certainty=- callsite=h0:22:34:h3 candidates=[]
+edge CALL src=METHOD:Field.makeMove@41 dst=UNKNOWN:sameInRow@45 resolved_src=- resolved_dst=- line=45 confidence=- certainty=- callsite=h0:45:5:h4 candidates=[]
+edge CALL src=METHOD:Field.sameInRow@32 dst=UNKNOWN:times@35 resolved_src=- resolved_dst=- line=35 confidence=- certainty=- callsite=h0:35:7:h5|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@57 dst=UNKNOWN:makeMove@58 resolved_src=- resolved_dst=- line=58 confidence=- certainty=- callsite=h0:58:11:h6|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@75 dst=UNKNOWN:new@76 resolved_src=- resolved_dst=- line=76 confidence=- certainty=- callsite=h0:76:20:h7 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@75 dst=UNKNOWN:numberIn@77 resolved_src=- resolved_dst=- line=77 confidence=- certainty=- callsite=h0:77:5:h8 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@75 dst=UNKNOWN:rand@79 resolved_src=- resolved_dst=- line=79 confidence=- certainty=- callsite=h0:79:12:h9|syntax:ruby-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@75 dst=UNKNOWN:stringOut@78 resolved_src=- resolved_dst=- line=78 confidence=- certainty=- callsite=h0:78:5:h10 candidates=[]
+edge CALL src=METHOD:numberOut@7 dst=UNKNOWN:print@8 resolved_src=- resolved_dst=- line=8 confidence=- certainty=- callsite=h0:8:3:h11 candidates=[]
+edge CALL src=METHOD:stringOut@11 dst=UNKNOWN:print@12 resolved_src=- resolved_dst=- line=12 confidence=- certainty=- callsite=h0:12:3:h12 candidates=[]
+edge IMPORT src=MODULE:"random"@1 dst=MODULE:"random"@1 resolved_src=- resolved_dst=- line=1 confidence=- certainty=- callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ArtificialPlayer@62 dst=CLASS:Player@50 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@20 dst=CLASS:GameObject@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:HumanPlayer@56 dst=CLASS:Player@50 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:TicTacToe@74 dst=CLASS:GameObject@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@62 dst=METHOD:ArtificialPlayer.minMax@63 resolved_src=- resolved_dst=- line=63 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@62 dst=METHOD:ArtificialPlayer.turn@68 resolved_src=- resolved_dst=- line=68 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@20 dst=METHOD:Field.initialize@21 resolved_src=- resolved_dst=- line=21 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@20 dst=METHOD:Field.makeMove@41 resolved_src=- resolved_dst=- line=41 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@20 dst=METHOD:Field.opponent@26 resolved_src=- resolved_dst=- line=26 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@20 dst=METHOD:Field.sameInRow@32 resolved_src=- resolved_dst=- line=32 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:GameObject@15 dst=METHOD:GameObject.announce@16 resolved_src=- resolved_dst=- line=16 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@56 dst=METHOD:HumanPlayer.turn@57 resolved_src=- resolved_dst=- line=57 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Player@50 dst=METHOD:Player.turn@51 resolved_src=- resolved_dst=- line=51 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@74 dst=METHOD:TicTacToe.run@75 resolved_src=- resolved_dst=- line=75 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.rb language=ruby lines=85 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@62 kind=DEFINITION span=62:1-72:4
+occurrence element=CLASS:Field@20 kind=DEFINITION span=20:1-48:4
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=15:1-18:4
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=20:15-20:25
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=74:19-74:29
+occurrence element=CLASS:HumanPlayer@56 kind=DEFINITION span=56:1-60:4
+occurrence element=CLASS:Player@50 kind=DEFINITION span=50:1-54:4
+occurrence element=CLASS:Player@50 kind=DEFINITION span=56:21-56:27
+occurrence element=CLASS:Player@50 kind=DEFINITION span=62:26-62:32
+occurrence element=CLASS:TicTacToe@74 kind=DEFINITION span=74:1-81:4
+occurrence element=METHOD:ArtificialPlayer.minMax@63 kind=DEFINITION span=63:3-66:6
+occurrence element=METHOD:ArtificialPlayer.turn@68 kind=DEFINITION span=68:3-71:6
+occurrence element=METHOD:Field.initialize@21 kind=DEFINITION span=21:3-24:6
+occurrence element=METHOD:Field.makeMove@41 kind=DEFINITION span=41:3-47:6
+occurrence element=METHOD:Field.opponent@26 kind=DEFINITION span=26:3-30:6
+occurrence element=METHOD:Field.sameInRow@32 kind=DEFINITION span=32:3-39:6
+occurrence element=METHOD:GameObject.announce@16 kind=DEFINITION span=16:3-17:6
+occurrence element=METHOD:HumanPlayer.turn@57 kind=DEFINITION span=57:3-59:6
+occurrence element=METHOD:Player.turn@51 kind=DEFINITION span=51:3-53:6
+occurrence element=METHOD:TicTacToe.run@75 kind=DEFINITION span=75:3-80:6
+occurrence element=METHOD:numberIn@3 kind=DEFINITION span=3:1-5:4
+occurrence element=METHOD:numberOut@7 kind=DEFINITION span=7:1-9:4
+occurrence element=METHOD:stringOut@11 kind=DEFINITION span=11:1-13:4
+occurrence element=MODULE:"random"@1 kind=DEFINITION span=1:9-1:17
+occurrence element=UNKNOWN:makeMove@58 kind=DEFINITION span=58:11-58:19
+occurrence element=UNKNOWN:minMax@65 kind=DEFINITION span=65:5-65:11
+occurrence element=UNKNOWN:minMax@69 kind=DEFINITION span=69:5-69:11
+occurrence element=UNKNOWN:new@22 kind=DEFINITION span=22:34-22:37
+occurrence element=UNKNOWN:new@76 kind=DEFINITION span=76:20-76:23
+occurrence element=UNKNOWN:new@84 kind=DEFINITION span=84:13-84:16
+occurrence element=UNKNOWN:numberIn@77 kind=DEFINITION span=77:5-77:13
+occurrence element=UNKNOWN:print@12 kind=DEFINITION span=12:3-12:8
+occurrence element=UNKNOWN:print@8 kind=DEFINITION span=8:3-8:8
+occurrence element=UNKNOWN:rand@79 kind=DEFINITION span=79:12-79:16
+occurrence element=UNKNOWN:require@1 kind=DEFINITION span=1:1-1:8
+occurrence element=UNKNOWN:run@84 kind=DEFINITION span=84:17-84:20
+occurrence element=UNKNOWN:sameInRow@45 kind=DEFINITION span=45:5-45:14
+occurrence element=UNKNOWN:stringOut@78 kind=DEFINITION span=78:5-78:14
+occurrence element=UNKNOWN:times@35 kind=DEFINITION span=35:7-35:12
+access node=METHOD:ArtificialPlayer.minMax@63 kind=Public
+access node=METHOD:ArtificialPlayer.turn@68 kind=Public
+access node=METHOD:Field.initialize@21 kind=Public
+access node=METHOD:Field.makeMove@41 kind=Public
+access node=METHOD:Field.opponent@26 kind=Public
+access node=METHOD:Field.sameInRow@32 kind=Public
+access node=METHOD:GameObject.announce@16 kind=Public
+access node=METHOD:HumanPlayer.turn@57 kind=Public
+access node=METHOD:Player.turn@51 kind=Public
+access node=METHOD:TicTacToe.run@75 kind=Public
+access node=METHOD:numberIn@3 kind=Public
+access node=METHOD:numberOut@7 kind=Public
+access node=METHOD:stringOut@11 kind=Public
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:ArtificialPlayer.minMax", node_id: NodeId(-2305454530479827731), signature_hash: 2816889471617643129, normalized_signature: Some("shape:3892327511108441983"), body_hash: -672599015500449883, start_line: 63, end_line: 66 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:ArtificialPlayer.turn", node_id: NodeId(-2216272334490518232), signature_hash: 5754064973517794814, normalized_signature: Some("shape:783417546980888174"), body_hash: 5681829404713968296, start_line: 68, end_line: 71 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:Field.initialize", node_id: NodeId(-1270925165430776420), signature_hash: -9120393158106245982, normalized_signature: Some("shape:6360098408552140898"), body_hash: -4137518291482918327, start_line: 21, end_line: 24 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:Field.makeMove", node_id: NodeId(7658723807322863601), signature_hash: -7686617887134063555, normalized_signature: Some("shape:4191619700394149013"), body_hash: 5685978943429425826, start_line: 41, end_line: 47 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:Field.opponent", node_id: NodeId(-5247767992258324109), signature_hash: 5718448952121283431, normalized_signature: Some("outline:-5087212818695232478"), body_hash: -2851369941469327825, start_line: 26, end_line: 30 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:Field.sameInRow", node_id: NodeId(-1596154395995987253), signature_hash: 8317776364922746511, normalized_signature: Some("shape:6173194982228443029"), body_hash: 3075336871449158430, start_line: 32, end_line: 39 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:GameObject.announce", node_id: NodeId(2566414094649540464), signature_hash: 6265382829821424686, normalized_signature: Some("outline:-5084398068927579993"), body_hash: -1904460546639563293, start_line: 16, end_line: 17 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:HumanPlayer.turn", node_id: NodeId(-5309813005216789555), signature_hash: -1551097434895889655, normalized_signature: Some("shape:4546493373888983564"), body_hash: 6582402943341370509, start_line: 57, end_line: 59 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:Player.turn", node_id: NodeId(-3476264032076398104), signature_hash: -1091959065548758310, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -7593047486753193641, start_line: 51, end_line: 53 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:TicTacToe.run", node_id: NodeId(6558845360998134269), signature_hash: 5136661510898306809, normalized_signature: Some("shape:-7720857568580268095"), body_hash: -3744663677110146298, start_line: 75, end_line: 80 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:numberIn", node_id: NodeId(-5001430822321770114), signature_hash: 378904191093197768, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -6870881889205310903, start_line: 3, end_line: 5 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:numberOut", node_id: NodeId(4135351678322494333), signature_hash: 7734359841249861705, normalized_signature: Some("shape:-761404221283775011"), body_hash: -6350574982772305127, start_line: 7, end_line: 9 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "14:stringOut", node_id: NodeId(5151016081776191281), signature_hash: 4766693839703088001, normalized_signature: Some("shape:-2085153621185569755"), body_hash: -7393721029465409886, start_line: 11, end_line: 13 }
+callable_state CallableProjectionState { file_id: 8159992984445929388, symbol_key: "__file_structural__", node_id: NodeId(8159992984445929388), signature_hash: 553768115714561381, normalized_signature: None, body_hash: 7018471151357077143, start_line: 1, end_line: 85 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "ruby",
+        extension: "rb",
+        fidelity_filename: "fidelity.rb",
+        fidelity_source: include_str!("fixtures/fidelity_lab/ruby_fidelity_lab.rb"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/ruby_fidelity.txt"),
+        tictactoe_filename: "game.rb",
+        tictactoe_source: include_str!("fixtures/tictactoe/ruby_tictactoe.rb"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/ruby_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1686.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
