### PR TITLE
[v0.17 S3-PHP] Extract PHP language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3942,7 +3942,7 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
         .or(match language {
             "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
             "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
-            | "cpp" | "dart" | "php" | "swift" => Some("//"),
+            | "cpp" | "dart" | "swift" => Some("//"),
             _ => None,
         });
     let Some(marker) = comment_marker else {

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "php",
+        line_comment: "//",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "php"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,6 +1265,7 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("php"), Some("//"));
         assert_eq!(line_comment_for_language("swift"), None);
     }
 

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -1,9 +1,9 @@
 use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
     GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
-    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY,
+    TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -39,7 +39,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("c", _) => Some(c()),
         ("go", _) => Some(go()),
         ("ruby", _) => Some(ruby()),
-        ("php", _) => Some(php()),
         ("csharp", _) => Some(csharp()),
         ("swift", _) => Some(swift()),
         ("dart", _) => Some(dart()),
@@ -145,16 +144,6 @@ fn ruby() -> LanguageConfig {
         RUBY_GRAPH_QUERY,
         None,
         LanguageRuleset::Ruby,
-    )
-}
-
-fn php() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_php::LANGUAGE_PHP.into(),
-        "php",
-        PHP_GRAPH_QUERY,
-        None,
-        LanguageRuleset::Php,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -17,6 +17,7 @@
 //! package to land deletes the residual arms entirely.
 
 pub(crate) mod kotlin;
+pub(crate) mod php;
 
 use std::sync::OnceLock;
 
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, php::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {

--- a/crates/codestory-indexer/src/languages/php.rs
+++ b/crates/codestory-indexer/src/languages/php.rs
@@ -1,0 +1,812 @@
+//! PHP extraction rules.
+//!
+//! PHP's graph extraction lives here: the tree-sitter rule file, the
+//! compiled-rule cache, the member-call callsite marker, the namespace/type
+//! MEMBER collector, and the receiver-call resolution engine that turns
+//! `$this->repo->save(...)` into an edge aimed at `Repository.save`. Every
+//! language-keyed dispatch in the crate reaches those through
+//! [`super::EXTRACTIONS`] rather than by spelling `"php"`.
+//!
+//! Three PHP-adjacent surfaces are deliberately *not* here, and all three are
+//! shared seams rather than PHP content:
+//!
+//! * `lib.rs::collect_laravel_route` and its `"php"` arm in the framework-route
+//!   scanner. The per-language route collectors take non-uniform arguments and
+//!   a per-framework `has_<framework>` precondition, so routing them through
+//!   the registry is one change for all sixteen languages, not part of PHP's
+//!   rollback unit.
+//! * `LanguageRuleset::Php`, which stays in `lib.rs` because the enum is the
+//!   compiled-rule cache key for every language at once.
+//! * `lib.rs::language_member_specs`, which is still a plain `match` because
+//!   [`super::LanguageExtraction`] has no manual-MEMBER field yet; adding one
+//!   would touch every sibling package's row. Its `"php"` arm therefore stays
+//!   in `lib.rs` and calls [`member_edge_specs`] here, so the rule body moved
+//!   even though the dispatch has not.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both PHP fixtures so the move stays output-equal.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, ImportedTypeBinding, LanguageRuleset, ManualMemberEdgeSpec,
+    ManualReceiverCallSpec, ManualReceiverSource, OptionalReceiverOwnerBinding,
+    ReceiverCallSiteKey, ReceiverOwnerBinding, collect_enclosing_type_member_edges,
+    collect_receiver_call_specs_in_callable, declaration_name, enclosing_node_with_kind,
+    member_call_method_col, normalize_parameter_name, normalize_type_surface,
+    normalized_receiver_variable, receiver_call_belongs_to_callable, receiver_callsite_key,
+    same_ts_span, split_top_level_parameters, trimmed_node_text, ts_node_graph_span,
+    walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from PHP member-call syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:php-member-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/php.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for PHP.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["php"],
+    language_name: "php",
+    extensions: &["php"],
+    ruleset: LanguageRuleset::Php,
+    parser_language: php_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    receiver_call_specs: Some(receiver_call_specs),
+    member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
+    graph_call_syntax: Some("php_member"),
+    // PHP methods are already `method_declaration` nodes, so the projection
+    // never had to promote FUNCTION to METHOD for an owned member; `php` was
+    // absent from the promotion roster before the move.
+    promotes_type_member_functions_to_methods: false,
+    qualified_name_delimiter: ".",
+    route_comments_are_c_style: true,
+    // `semantic::PhpSemanticResolver` is a dedicated resolver type private to
+    // that module, so the registry records the choice and `semantic::mod`
+    // still constructs it.
+    uses_generic_semantic_resolver: false,
+    semantic_family: "php",
+};
+
+fn php_language() -> tree_sitter::Language {
+    tree_sitter_php::LANGUAGE_PHP.into()
+}
+
+/// Manual MEMBER edges for one parsed PHP file.
+///
+/// Was `lib.rs::collect_php_member_edges`.
+pub(crate) fn member_edge_specs(tree: &Tree, source: &str) -> Vec<ManualMemberEdgeSpec> {
+    let mut edges = collect_enclosing_type_member_edges(
+        tree,
+        source,
+        &[
+            "class_declaration",
+            "interface_declaration",
+            "trait_declaration",
+        ],
+        &["method_declaration"],
+    );
+    edges.extend(collect_php_namespace_member_edges(tree, source));
+    edges
+}
+
+fn collect_php_namespace_member_edges(tree: &Tree, source: &str) -> Vec<ManualMemberEdgeSpec> {
+    let mut edges = Vec::new();
+    let root = tree.root_node();
+    walk_tree_nodes(root, &mut |namespace| {
+        if namespace.kind() != "namespace_definition" {
+            return;
+        }
+        let Some(body) = namespace.child_by_field_name("body") else {
+            return;
+        };
+        collect_php_namespace_member_edges_in_scope(namespace, body, source, &mut edges);
+    });
+
+    let mut current_namespace = None;
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if child.kind() == "namespace_definition" {
+            current_namespace = child.child_by_field_name("body").is_none().then_some(child);
+            continue;
+        }
+        let Some(namespace) = current_namespace else {
+            continue;
+        };
+        collect_php_namespace_member_edge(namespace, child, source, &mut edges);
+    }
+
+    edges
+}
+
+fn collect_php_namespace_member_edges_in_scope(
+    namespace: TsNode<'_>,
+    scope: TsNode<'_>,
+    source: &str,
+    edges: &mut Vec<ManualMemberEdgeSpec>,
+) {
+    let mut cursor = scope.walk();
+    for child in scope.named_children(&mut cursor) {
+        collect_php_namespace_member_edge(namespace, child, source, edges);
+    }
+}
+
+fn collect_php_namespace_member_edge(
+    namespace: TsNode<'_>,
+    child: TsNode<'_>,
+    source: &str,
+    edges: &mut Vec<ManualMemberEdgeSpec>,
+) {
+    if !matches!(child.kind(), "class_declaration" | "interface_declaration") {
+        return;
+    }
+    let Some(source_name) = declaration_name(namespace, source) else {
+        return;
+    };
+    let Some(target_name) = declaration_name(child, source) else {
+        return;
+    };
+    edges.push(ManualMemberEdgeSpec {
+        source_name,
+        target_name,
+        source_span: ts_node_graph_span(namespace),
+        target_span: ts_node_graph_span(child),
+        line: Some(child.start_position().row as u32 + 1),
+    });
+}
+
+/// Manual receiver-call edges for one parsed PHP file.
+///
+/// Was `lib.rs::collect_php_receiver_call_edges`.
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let root = tree.root_node();
+    walk_tree_nodes(tree.root_node(), &mut |callable| {
+        if !matches!(
+            callable.kind(),
+            "function_definition" | "method_declaration"
+        ) {
+            return;
+        }
+        let Some(source_name) = declaration_name(callable, source) else {
+            return;
+        };
+        let visible_type_names = collect_php_visible_type_binding_names(root, callable, source);
+        let imported_type_bindings =
+            collect_php_visible_imported_type_bindings(root, callable, source, &visible_type_names);
+        let call_source = ManualReceiverSource {
+            name: &source_name,
+            span: ts_node_graph_span(callable),
+        };
+        let mut local_receiver_callsites = HashSet::new();
+        collect_php_local_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &visible_type_names,
+            &imported_type_bindings,
+            &mut local_receiver_callsites,
+            &mut edges,
+        );
+        let receiver_types = collect_php_parameter_types(callable, source);
+        if receiver_types.is_empty() {
+            return;
+        }
+        let start = edges.len();
+        collect_receiver_call_specs_in_callable(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &receiver_types,
+            member_call,
+            false,
+            &mut edges,
+        );
+        let mut parameter_specs = edges.split_off(start);
+        parameter_specs
+            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
+        for spec in &mut parameter_specs {
+            if let Some(binding) = imported_type_bindings.get(&spec.owner_name) {
+                spec.owner_name = binding.owner_name.clone();
+                spec.owner_module = Some(binding.module_name.clone());
+            }
+        }
+        edges.extend(parameter_specs);
+    });
+    edges
+}
+
+fn collect_php_local_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    visible_type_names: &HashSet<String>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let owner = php_self_receiver_owner(callable, &receiver_name, source)
+            .map(Some)
+            .or_else(|| {
+                php_field_receiver_owner(
+                    callable,
+                    &receiver_name,
+                    source,
+                    visible_type_names,
+                    imported_type_bindings,
+                )
+                .map(Some)
+            })
+            .or_else(|| {
+                php_direct_new_owner_surface(
+                    &receiver_name,
+                    visible_type_names,
+                    imported_type_bindings,
+                )
+                .map(Some)
+            })
+            .or_else(|| {
+                php_visible_local_receiver_owner(
+                    callable,
+                    node,
+                    &receiver_name,
+                    source,
+                    visible_type_names,
+                    imported_type_bindings,
+                )
+            });
+        let Some(owner) = owner else {
+            return;
+        };
+        let method_col = member_call_method_col(node, source, &method_name);
+        local_receiver_callsites.insert(ReceiverCallSiteKey {
+            receiver_name: receiver_name.clone(),
+            method_name: method_name.clone(),
+            line: Some(node.start_position().row as u32 + 1),
+            method_col,
+        });
+        if let Some((owner_name, owner_module)) = owner {
+            edges.push(ManualReceiverCallSpec {
+                source_name: call_source.name.to_string(),
+                source_span: call_source.span,
+                receiver_name,
+                owner_name,
+                owner_module,
+                method_name,
+                method_col,
+                line: Some(node.start_position().row as u32 + 1),
+                allow_global_fallback: false,
+            });
+        }
+    });
+}
+
+fn php_self_receiver_owner(
+    callable: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+) -> OptionalReceiverOwnerBinding {
+    if receiver_name != "this" {
+        return None;
+    }
+    let owner_node = enclosing_node_with_kind(
+        callable,
+        &[
+            "class_declaration",
+            "interface_declaration",
+            "trait_declaration",
+        ],
+    )?;
+    let owner_name = declaration_name(owner_node, source)?;
+    Some((owner_name, None))
+}
+
+fn php_field_receiver_owner(
+    callable: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    visible_type_names: &HashSet<String>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> OptionalReceiverOwnerBinding {
+    let field_name = receiver_name.strip_prefix("this->")?.trim();
+    let class_node = enclosing_node_with_kind(callable, &["class_declaration"])?;
+    let mut field_bindings = Vec::new();
+    walk_tree_nodes(class_node, &mut |node| {
+        if !matches!(
+            node.kind(),
+            "property_declaration" | "property_promotion_parameter"
+        ) {
+            return;
+        }
+        if !enclosing_node_with_kind(node, &["class_declaration"])
+            .is_some_and(|owner| same_ts_span(owner, class_node))
+        {
+            return;
+        }
+        let Some(surface) = trimmed_node_text(node, source) else {
+            return;
+        };
+        for (binding_name, owner) in
+            php_typed_member_bindings_surface(&surface, visible_type_names, imported_type_bindings)
+        {
+            if binding_name == field_name {
+                field_bindings.push(owner);
+            }
+        }
+    });
+    field_bindings.sort();
+    field_bindings.dedup();
+    if field_bindings.len() == 1 {
+        Some(field_bindings.remove(0))
+    } else {
+        None
+    }
+}
+
+fn php_typed_member_bindings_surface(
+    surface: &str,
+    visible_type_names: &HashSet<String>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> Vec<(String, ReceiverOwnerBinding)> {
+    let surface = surface
+        .split('=')
+        .next()
+        .unwrap_or(surface)
+        .trim()
+        .trim_end_matches([';', ','])
+        .trim();
+    let Some((type_side, _)) = surface.split_once('$') else {
+        return Vec::new();
+    };
+    let Some(raw_type) = type_side
+        .split_whitespace()
+        .last()
+        .filter(|token| !php_member_modifier_token(token))
+    else {
+        return Vec::new();
+    };
+    let Some(owner) =
+        php_receiver_owner_from_type(raw_type, visible_type_names, imported_type_bindings)
+    else {
+        return Vec::new();
+    };
+
+    surface
+        .split('$')
+        .skip(1)
+        .filter_map(|part| {
+            let name = part
+                .chars()
+                .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+                .collect::<String>();
+            normalize_parameter_name(&name).map(|name| (name, owner.clone()))
+        })
+        .collect()
+}
+
+fn php_member_modifier_token(token: &str) -> bool {
+    matches!(
+        token,
+        "public" | "protected" | "private" | "readonly" | "static" | "var" | "final" | "abstract"
+    )
+}
+
+fn php_visible_local_receiver_owner(
+    callable: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    visible_type_names: &HashSet<String>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(callable, &mut |node| {
+        if node.kind() != "assignment_expression" {
+            return;
+        }
+        if !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > call_node.start_byte()
+        {
+            return;
+        }
+        let Some(left_node) = node.child_by_field_name("left") else {
+            return;
+        };
+        if normalized_receiver_variable(left_node, source).as_deref() != Some(receiver_name) {
+            return;
+        }
+        let owner = node.child_by_field_name("right").and_then(|right_node| {
+            php_direct_new_owner(
+                right_node,
+                source,
+                visible_type_names,
+                imported_type_bindings,
+            )
+        });
+        visible_bindings.push((node.end_byte(), owner));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner)| owner)
+}
+
+fn php_direct_new_owner(
+    node: TsNode<'_>,
+    source: &str,
+    visible_type_names: &HashSet<String>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> OptionalReceiverOwnerBinding {
+    trimmed_node_text(node, source)
+        .as_deref()
+        .and_then(|surface| {
+            php_direct_new_owner_surface(surface, visible_type_names, imported_type_bindings)
+        })
+}
+
+fn php_direct_new_owner_surface(
+    surface: &str,
+    visible_type_names: &HashSet<String>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> OptionalReceiverOwnerBinding {
+    let surface = surface
+        .trim()
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .trim();
+    let rest = surface.strip_prefix("new ")?;
+    let type_surface = rest.split(['(', '{']).next().unwrap_or(rest).trim();
+    if type_surface.contains('\\') {
+        return None;
+    }
+    php_receiver_owner_from_type(type_surface, visible_type_names, imported_type_bindings)
+}
+
+fn php_receiver_owner_from_type(
+    raw_type: &str,
+    visible_type_names: &HashSet<String>,
+    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
+) -> OptionalReceiverOwnerBinding {
+    let raw_type = raw_type.trim().trim_start_matches('?').trim();
+    if raw_type.contains('\\') || raw_type.contains('|') || raw_type.contains('&') {
+        return None;
+    }
+    let owner_name = normalize_type_surface(raw_type)?;
+    if visible_type_names.contains(&owner_name) {
+        return Some((owner_name, None));
+    }
+    if let Some(binding) = imported_type_bindings.get(&owner_name) {
+        return Some((
+            binding.owner_name.clone(),
+            Some(binding.module_name.clone()),
+        ));
+    }
+    None
+}
+
+fn collect_php_visible_imported_type_bindings(
+    root: TsNode<'_>,
+    callable: TsNode<'_>,
+    source: &str,
+    visible_type_names: &HashSet<String>,
+) -> HashMap<String, ImportedTypeBinding> {
+    let mut bindings = HashMap::new();
+    let mut duplicates = HashSet::new();
+
+    if let Some(namespace) = enclosing_node_with_kind(callable, &["namespace_definition"])
+        && let Some(body) = namespace.child_by_field_name("body")
+    {
+        collect_php_imported_type_bindings_in_scope(
+            body,
+            source,
+            visible_type_names,
+            &mut bindings,
+            &mut duplicates,
+        );
+    } else {
+        let (start_byte, end_byte) = php_unbracketed_namespace_segment(root, callable);
+        collect_php_imported_type_bindings_in_root_segment(
+            root,
+            source,
+            visible_type_names,
+            &mut bindings,
+            &mut duplicates,
+            start_byte,
+            end_byte,
+        );
+    }
+
+    bindings
+}
+
+fn collect_php_imported_type_bindings_in_scope(
+    scope: TsNode<'_>,
+    source: &str,
+    visible_type_names: &HashSet<String>,
+    bindings: &mut HashMap<String, ImportedTypeBinding>,
+    duplicates: &mut HashSet<String>,
+) {
+    let mut cursor = scope.walk();
+    for statement in scope.named_children(&mut cursor) {
+        if statement.kind() != "namespace_use_declaration" {
+            continue;
+        }
+        let Some(statement_surface) = trimmed_node_text(statement, source) else {
+            continue;
+        };
+        for (owner_name, local_name, module_name) in
+            php_import_type_binding_names(&statement_surface)
+        {
+            if visible_type_names.contains(&local_name) || duplicates.contains(&local_name) {
+                continue;
+            }
+            if bindings.contains_key(&local_name) {
+                bindings.remove(&local_name);
+                duplicates.insert(local_name);
+                continue;
+            }
+            bindings.insert(
+                local_name,
+                ImportedTypeBinding {
+                    module_name,
+                    owner_name,
+                },
+            );
+        }
+    }
+}
+
+fn collect_php_imported_type_bindings_in_root_segment(
+    root: TsNode<'_>,
+    source: &str,
+    visible_type_names: &HashSet<String>,
+    bindings: &mut HashMap<String, ImportedTypeBinding>,
+    duplicates: &mut HashSet<String>,
+    start_byte: usize,
+    end_byte: usize,
+) {
+    let mut cursor = root.walk();
+    for statement in root.named_children(&mut cursor) {
+        if statement.start_byte() < start_byte || statement.start_byte() >= end_byte {
+            continue;
+        }
+        if statement.kind() != "namespace_use_declaration" {
+            continue;
+        }
+        let Some(statement_surface) = trimmed_node_text(statement, source) else {
+            continue;
+        };
+        for (owner_name, local_name, module_name) in
+            php_import_type_binding_names(&statement_surface)
+        {
+            if visible_type_names.contains(&local_name) || duplicates.contains(&local_name) {
+                continue;
+            }
+            if bindings.contains_key(&local_name) {
+                bindings.remove(&local_name);
+                duplicates.insert(local_name);
+                continue;
+            }
+            bindings.insert(
+                local_name,
+                ImportedTypeBinding {
+                    module_name,
+                    owner_name,
+                },
+            );
+        }
+    }
+}
+
+fn collect_php_visible_type_binding_names(
+    root: TsNode<'_>,
+    callable: TsNode<'_>,
+    source: &str,
+) -> HashSet<String> {
+    let mut names = HashSet::new();
+    if let Some(namespace) = enclosing_node_with_kind(callable, &["namespace_definition"])
+        && let Some(body) = namespace.child_by_field_name("body")
+    {
+        collect_php_type_binding_names_in_scope(body, source, &mut names);
+    } else {
+        let (start_byte, end_byte) = php_unbracketed_namespace_segment(root, callable);
+        collect_php_type_binding_names_in_root_segment(
+            root, source, &mut names, start_byte, end_byte,
+        );
+    }
+    names
+}
+
+fn collect_php_type_binding_names_in_scope(
+    scope: TsNode<'_>,
+    source: &str,
+    names: &mut HashSet<String>,
+) {
+    let mut cursor = scope.walk();
+    for child in scope.named_children(&mut cursor) {
+        if matches!(child.kind(), "class_declaration" | "interface_declaration")
+            && let Some(name) = declaration_name(child, source)
+        {
+            names.insert(name);
+        }
+    }
+}
+
+fn collect_php_type_binding_names_in_root_segment(
+    root: TsNode<'_>,
+    source: &str,
+    names: &mut HashSet<String>,
+    start_byte: usize,
+    end_byte: usize,
+) {
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if child.start_byte() < start_byte || child.start_byte() >= end_byte {
+            continue;
+        }
+        if matches!(child.kind(), "class_declaration" | "interface_declaration")
+            && let Some(name) = declaration_name(child, source)
+        {
+            names.insert(name);
+        }
+    }
+}
+
+fn php_unbracketed_namespace_segment(root: TsNode<'_>, node: TsNode<'_>) -> (usize, usize) {
+    let mut start_byte = root.start_byte();
+    let mut end_byte = root.end_byte();
+    let node_start = node.start_byte();
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if child.kind() != "namespace_definition" || child.child_by_field_name("body").is_some() {
+            continue;
+        }
+        if node_start < child.start_byte() {
+            end_byte = child.start_byte();
+            break;
+        }
+        start_byte = child.end_byte();
+        end_byte = root.end_byte();
+    }
+    (start_byte, end_byte)
+}
+
+fn php_import_type_binding_names(statement: &str) -> Vec<(String, String, String)> {
+    let Some(rest) = statement.strip_prefix("use") else {
+        return Vec::new();
+    };
+    let rest = rest.trim().trim_end_matches(';').trim();
+    if starts_with_case_insensitive_keyword(rest, "function")
+        || starts_with_case_insensitive_keyword(rest, "const")
+        || rest.contains('{')
+    {
+        return Vec::new();
+    }
+
+    split_top_level_parameters(rest)
+        .into_iter()
+        .filter_map(|part| php_import_type_binding_name(&part))
+        .collect()
+}
+
+fn php_import_type_binding_name(import_surface: &str) -> Option<(String, String, String)> {
+    let import_surface = import_surface.trim();
+    if starts_with_case_insensitive_keyword(import_surface, "function")
+        || starts_with_case_insensitive_keyword(import_surface, "const")
+    {
+        return None;
+    }
+    let (module_surface, alias_surface) =
+        split_case_insensitive_alias(import_surface, "as").unwrap_or((import_surface, ""));
+    let (owner_name, module_name) = php_imported_owner_module_name(module_surface)?;
+    let local_name = if alias_surface.trim().is_empty() {
+        owner_name.clone()
+    } else {
+        normalize_parameter_name(alias_surface)?
+    };
+    Some((owner_name, local_name, module_name))
+}
+
+fn split_case_insensitive_alias<'a>(surface: &'a str, keyword: &str) -> Option<(&'a str, &'a str)> {
+    let mut tokens = surface.split_whitespace();
+    let module_surface = tokens.next()?;
+    let separator = tokens.next()?;
+    let alias_surface = tokens.next()?;
+    if tokens.next().is_some() || !separator.eq_ignore_ascii_case(keyword) {
+        return None;
+    }
+    Some((module_surface, alias_surface))
+}
+
+fn starts_with_case_insensitive_keyword(surface: &str, keyword: &str) -> bool {
+    let mut parts = surface.split_whitespace();
+    parts
+        .next()
+        .is_some_and(|token| token.eq_ignore_ascii_case(keyword))
+}
+
+fn php_imported_owner_module_name(raw_module: &str) -> Option<(String, String)> {
+    let module = raw_module.trim().trim_start_matches('\\').trim();
+    if module.is_empty()
+        || module.contains('*')
+        || module.contains('|')
+        || module.split_whitespace().count() != 1
+    {
+        return None;
+    }
+    let (namespace, owner_name) = module.rsplit_once('\\')?;
+    let owner_name = normalize_parameter_name(owner_name)?;
+    if namespace.trim().is_empty() {
+        return None;
+    }
+    Some((owner_name.clone(), format!("{namespace}.{owner_name}")))
+}
+
+fn collect_php_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
+    let mut receiver_types = HashMap::new();
+    let Some(parameters) = callable.child_by_field_name("parameters") else {
+        return receiver_types;
+    };
+    walk_tree_nodes(parameters, &mut |node| {
+        if !matches!(
+            node.kind(),
+            "simple_parameter" | "variadic_parameter" | "property_promotion_parameter"
+        ) {
+            return;
+        }
+        let Some(type_node) = node.child_by_field_name("type") else {
+            return;
+        };
+        let Some(raw_type) = trimmed_node_text(type_node, source) else {
+            return;
+        };
+        let Some(owner_name) = normalize_type_surface(&raw_type) else {
+            return;
+        };
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return;
+        };
+        if let Some(name) = normalized_receiver_variable(name_node, source) {
+            receiver_types.insert(name, owner_name);
+        }
+    });
+    receiver_types
+}
+
+/// Receiver and member of one PHP member call, read from the grammar.
+///
+/// Was `lib.rs::php_member_call`.
+fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if !matches!(
+        node.kind(),
+        "member_call_expression" | "nullsafe_member_call_expression"
+    ) {
+        return None;
+    }
+    let receiver = node.child_by_field_name("object")?;
+    let method = node.child_by_field_name("name")?;
+    Some((
+        normalized_receiver_variable(receiver, source)?,
+        trimmed_node_text(method, source)?,
+    ))
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -63,7 +63,6 @@ pub(crate) const GO_SELECTOR_CALLSITE_MARKER: &str = "syntax:go-selector-call";
 pub(crate) const JAVA_MEMBER_CALLSITE_MARKER: &str = "syntax:java-member-call";
 pub(crate) const CSHARP_MEMBER_CALLSITE_MARKER: &str = "syntax:csharp-member-call";
 pub(crate) const RUBY_MEMBER_CALLSITE_MARKER: &str = "syntax:ruby-member-call";
-pub(crate) const PHP_MEMBER_CALLSITE_MARKER: &str = "syntax:php-member-call";
 pub(crate) const JS_MEMBER_CALLSITE_MARKER: &str = "syntax:js-member-call";
 pub(crate) const TS_MEMBER_CALLSITE_MARKER: &str = "syntax:ts-member-call";
 pub(crate) const DART_MEMBER_CALLSITE_MARKER: &str = "syntax:dart-member-call";
@@ -140,7 +139,6 @@ const CPP_GRAPH_QUERY: &str = include_str!("../rules/cpp.scm");
 const C_GRAPH_QUERY: &str = include_str!("../rules/c.scm");
 const GO_GRAPH_QUERY: &str = include_str!("../rules/go.scm");
 const RUBY_GRAPH_QUERY: &str = include_str!("../rules/ruby.scm");
-const PHP_GRAPH_QUERY: &str = include_str!("../rules/php.scm");
 const CSHARP_GRAPH_QUERY: &str = include_str!("../rules/csharp.scm");
 const SWIFT_GRAPH_QUERY: &str = include_str!("../rules/swift.scm");
 const DART_GRAPH_QUERY: &str = include_str!("../rules/dart.scm");
@@ -321,9 +319,12 @@ impl LanguageRuleset {
             LanguageRuleset::Ruby => {
                 compiled_rules_cache(language, RUBY_GRAPH_QUERY, None, &RUBY_RULES)
             }
-            LanguageRuleset::Php => {
-                compiled_rules_cache(language, PHP_GRAPH_QUERY, None, &PHP_RULES)
-            }
+            // Answered by the registry above; the arm only exists because the
+            // match must stay exhaustive. Failing closed here rather than
+            // panicking keeps a future registry mistake a typed indexing error.
+            LanguageRuleset::Php => Err(anyhow!(
+                "php compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::CSharp => {
                 compiled_rules_cache(language, CSHARP_GRAPH_QUERY, None, &CSHARP_RULES)
             }
@@ -382,7 +383,6 @@ static CPP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::ne
 static C_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static GO_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static RUBY_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static PHP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CSHARP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static SWIFT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static DART_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
@@ -4371,7 +4371,7 @@ struct CallPlaceholderMarkerAnnotation<'a> {
 fn receiver_annotation_required_callsite_marker(language_name: &str) -> Option<&'static str> {
     match language_name {
         "python" => Some(PYTHON_ATTRIBUTE_CALLSITE_MARKER),
-        "php" => Some(PHP_MEMBER_CALLSITE_MARKER),
+        "php" => Some(languages::php::MEMBER_CALLSITE_MARKER),
         _ => None,
     }
 }
@@ -7506,7 +7506,7 @@ fn language_member_specs(
             &["class", "module"],
             &["method", "singleton_method"],
         ),
-        "php" => collect_php_member_edges(tree, source),
+        "php" => languages::php::member_edge_specs(tree, source),
         "csharp" => collect_enclosing_type_member_edges(
             tree,
             source,
@@ -7598,7 +7598,6 @@ fn language_receiver_call_specs(
         "java" => collect_java_receiver_call_edges(tree, source),
         "go" => collect_go_receiver_call_edges(tree, source),
         "ruby" => collect_ruby_receiver_call_edges(tree, source),
-        "php" => collect_php_receiver_call_edges(tree, source),
         "csharp" => collect_csharp_receiver_call_edges(tree, source),
         "cpp" => collect_cpp_receiver_call_edges(tree, source),
         "swift" => collect_swift_receiver_call_edges(tree, source),
@@ -10705,681 +10704,6 @@ fn go_default_import_local_name(module_name: &str) -> Option<String> {
         .and_then(normalize_parameter_name)
 }
 
-fn collect_php_member_edges(tree: &Tree, source: &str) -> Vec<ManualMemberEdgeSpec> {
-    let mut edges = collect_enclosing_type_member_edges(
-        tree,
-        source,
-        &[
-            "class_declaration",
-            "interface_declaration",
-            "trait_declaration",
-        ],
-        &["method_declaration"],
-    );
-    edges.extend(collect_php_namespace_member_edges(tree, source));
-    edges
-}
-
-fn collect_php_namespace_member_edges(tree: &Tree, source: &str) -> Vec<ManualMemberEdgeSpec> {
-    let mut edges = Vec::new();
-    let root = tree.root_node();
-    walk_tree_nodes(root, &mut |namespace| {
-        if namespace.kind() != "namespace_definition" {
-            return;
-        }
-        let Some(body) = namespace.child_by_field_name("body") else {
-            return;
-        };
-        collect_php_namespace_member_edges_in_scope(namespace, body, source, &mut edges);
-    });
-
-    let mut current_namespace = None;
-    let mut cursor = root.walk();
-    for child in root.named_children(&mut cursor) {
-        if child.kind() == "namespace_definition" {
-            current_namespace = child.child_by_field_name("body").is_none().then_some(child);
-            continue;
-        }
-        let Some(namespace) = current_namespace else {
-            continue;
-        };
-        collect_php_namespace_member_edge(namespace, child, source, &mut edges);
-    }
-
-    edges
-}
-
-fn collect_php_namespace_member_edges_in_scope(
-    namespace: TsNode<'_>,
-    scope: TsNode<'_>,
-    source: &str,
-    edges: &mut Vec<ManualMemberEdgeSpec>,
-) {
-    let mut cursor = scope.walk();
-    for child in scope.named_children(&mut cursor) {
-        collect_php_namespace_member_edge(namespace, child, source, edges);
-    }
-}
-
-fn collect_php_namespace_member_edge(
-    namespace: TsNode<'_>,
-    child: TsNode<'_>,
-    source: &str,
-    edges: &mut Vec<ManualMemberEdgeSpec>,
-) {
-    if !matches!(child.kind(), "class_declaration" | "interface_declaration") {
-        return;
-    }
-    let Some(source_name) = declaration_name(namespace, source) else {
-        return;
-    };
-    let Some(target_name) = declaration_name(child, source) else {
-        return;
-    };
-    edges.push(ManualMemberEdgeSpec {
-        source_name,
-        target_name,
-        source_span: ts_node_graph_span(namespace),
-        target_span: ts_node_graph_span(child),
-        line: Some(child.start_position().row as u32 + 1),
-    });
-}
-
-fn collect_php_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let root = tree.root_node();
-    walk_tree_nodes(tree.root_node(), &mut |callable| {
-        if !matches!(
-            callable.kind(),
-            "function_definition" | "method_declaration"
-        ) {
-            return;
-        }
-        let Some(source_name) = declaration_name(callable, source) else {
-            return;
-        };
-        let visible_type_names = collect_php_visible_type_binding_names(root, callable, source);
-        let imported_type_bindings =
-            collect_php_visible_imported_type_bindings(root, callable, source, &visible_type_names);
-        let call_source = ManualReceiverSource {
-            name: &source_name,
-            span: ts_node_graph_span(callable),
-        };
-        let mut local_receiver_callsites = HashSet::new();
-        collect_php_local_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &visible_type_names,
-            &imported_type_bindings,
-            &mut local_receiver_callsites,
-            &mut edges,
-        );
-        let receiver_types = collect_php_parameter_types(callable, source);
-        if receiver_types.is_empty() {
-            return;
-        }
-        let start = edges.len();
-        collect_receiver_call_specs_in_callable(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &receiver_types,
-            php_member_call,
-            false,
-            &mut edges,
-        );
-        let mut parameter_specs = edges.split_off(start);
-        parameter_specs
-            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
-        for spec in &mut parameter_specs {
-            if let Some(binding) = imported_type_bindings.get(&spec.owner_name) {
-                spec.owner_name = binding.owner_name.clone();
-                spec.owner_module = Some(binding.module_name.clone());
-            }
-        }
-        edges.extend(parameter_specs);
-    });
-    edges
-}
-
-fn collect_php_local_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    visible_type_names: &HashSet<String>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = php_member_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let owner = php_self_receiver_owner(callable, &receiver_name, source)
-            .map(Some)
-            .or_else(|| {
-                php_field_receiver_owner(
-                    callable,
-                    &receiver_name,
-                    source,
-                    visible_type_names,
-                    imported_type_bindings,
-                )
-                .map(Some)
-            })
-            .or_else(|| {
-                php_direct_new_owner_surface(
-                    &receiver_name,
-                    visible_type_names,
-                    imported_type_bindings,
-                )
-                .map(Some)
-            })
-            .or_else(|| {
-                php_visible_local_receiver_owner(
-                    callable,
-                    node,
-                    &receiver_name,
-                    source,
-                    visible_type_names,
-                    imported_type_bindings,
-                )
-            });
-        let Some(owner) = owner else {
-            return;
-        };
-        let method_col = member_call_method_col(node, source, &method_name);
-        local_receiver_callsites.insert(ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
-            method_col,
-        });
-        if let Some((owner_name, owner_module)) = owner {
-            edges.push(ManualReceiverCallSpec {
-                source_name: call_source.name.to_string(),
-                source_span: call_source.span,
-                receiver_name,
-                owner_name,
-                owner_module,
-                method_name,
-                method_col,
-                line: Some(node.start_position().row as u32 + 1),
-                allow_global_fallback: false,
-            });
-        }
-    });
-}
-
-fn php_self_receiver_owner(
-    callable: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-) -> OptionalReceiverOwnerBinding {
-    if receiver_name != "this" {
-        return None;
-    }
-    let owner_node = enclosing_node_with_kind(
-        callable,
-        &[
-            "class_declaration",
-            "interface_declaration",
-            "trait_declaration",
-        ],
-    )?;
-    let owner_name = declaration_name(owner_node, source)?;
-    Some((owner_name, None))
-}
-
-fn php_field_receiver_owner(
-    callable: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    visible_type_names: &HashSet<String>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> OptionalReceiverOwnerBinding {
-    let field_name = receiver_name.strip_prefix("this->")?.trim();
-    let class_node = enclosing_node_with_kind(callable, &["class_declaration"])?;
-    let mut field_bindings = Vec::new();
-    walk_tree_nodes(class_node, &mut |node| {
-        if !matches!(
-            node.kind(),
-            "property_declaration" | "property_promotion_parameter"
-        ) {
-            return;
-        }
-        if !enclosing_node_with_kind(node, &["class_declaration"])
-            .is_some_and(|owner| same_ts_span(owner, class_node))
-        {
-            return;
-        }
-        let Some(surface) = trimmed_node_text(node, source) else {
-            return;
-        };
-        for (binding_name, owner) in
-            php_typed_member_bindings_surface(&surface, visible_type_names, imported_type_bindings)
-        {
-            if binding_name == field_name {
-                field_bindings.push(owner);
-            }
-        }
-    });
-    field_bindings.sort();
-    field_bindings.dedup();
-    if field_bindings.len() == 1 {
-        Some(field_bindings.remove(0))
-    } else {
-        None
-    }
-}
-
-fn php_typed_member_bindings_surface(
-    surface: &str,
-    visible_type_names: &HashSet<String>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> Vec<(String, ReceiverOwnerBinding)> {
-    let surface = surface
-        .split('=')
-        .next()
-        .unwrap_or(surface)
-        .trim()
-        .trim_end_matches([';', ','])
-        .trim();
-    let Some((type_side, _)) = surface.split_once('$') else {
-        return Vec::new();
-    };
-    let Some(raw_type) = type_side
-        .split_whitespace()
-        .last()
-        .filter(|token| !php_member_modifier_token(token))
-    else {
-        return Vec::new();
-    };
-    let Some(owner) =
-        php_receiver_owner_from_type(raw_type, visible_type_names, imported_type_bindings)
-    else {
-        return Vec::new();
-    };
-
-    surface
-        .split('$')
-        .skip(1)
-        .filter_map(|part| {
-            let name = part
-                .chars()
-                .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
-                .collect::<String>();
-            normalize_parameter_name(&name).map(|name| (name, owner.clone()))
-        })
-        .collect()
-}
-
-fn php_member_modifier_token(token: &str) -> bool {
-    matches!(
-        token,
-        "public" | "protected" | "private" | "readonly" | "static" | "var" | "final" | "abstract"
-    )
-}
-
-fn php_visible_local_receiver_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    visible_type_names: &HashSet<String>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if node.kind() != "assignment_expression" {
-            return;
-        }
-        if !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
-        {
-            return;
-        }
-        let Some(left_node) = node.child_by_field_name("left") else {
-            return;
-        };
-        if normalized_receiver_variable(left_node, source).as_deref() != Some(receiver_name) {
-            return;
-        }
-        let owner = node.child_by_field_name("right").and_then(|right_node| {
-            php_direct_new_owner(
-                right_node,
-                source,
-                visible_type_names,
-                imported_type_bindings,
-            )
-        });
-        visible_bindings.push((node.end_byte(), owner));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner)| owner)
-}
-
-fn php_direct_new_owner(
-    node: TsNode<'_>,
-    source: &str,
-    visible_type_names: &HashSet<String>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> OptionalReceiverOwnerBinding {
-    trimmed_node_text(node, source)
-        .as_deref()
-        .and_then(|surface| {
-            php_direct_new_owner_surface(surface, visible_type_names, imported_type_bindings)
-        })
-}
-
-fn php_direct_new_owner_surface(
-    surface: &str,
-    visible_type_names: &HashSet<String>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> OptionalReceiverOwnerBinding {
-    let surface = surface
-        .trim()
-        .trim_start_matches('(')
-        .trim_end_matches(')')
-        .trim();
-    let rest = surface.strip_prefix("new ")?;
-    let type_surface = rest.split(['(', '{']).next().unwrap_or(rest).trim();
-    if type_surface.contains('\\') {
-        return None;
-    }
-    php_receiver_owner_from_type(type_surface, visible_type_names, imported_type_bindings)
-}
-
-fn php_receiver_owner_from_type(
-    raw_type: &str,
-    visible_type_names: &HashSet<String>,
-    imported_type_bindings: &HashMap<String, ImportedTypeBinding>,
-) -> OptionalReceiverOwnerBinding {
-    let raw_type = raw_type.trim().trim_start_matches('?').trim();
-    if raw_type.contains('\\') || raw_type.contains('|') || raw_type.contains('&') {
-        return None;
-    }
-    let owner_name = normalize_type_surface(raw_type)?;
-    if visible_type_names.contains(&owner_name) {
-        return Some((owner_name, None));
-    }
-    if let Some(binding) = imported_type_bindings.get(&owner_name) {
-        return Some((
-            binding.owner_name.clone(),
-            Some(binding.module_name.clone()),
-        ));
-    }
-    None
-}
-
-fn collect_php_visible_imported_type_bindings(
-    root: TsNode<'_>,
-    callable: TsNode<'_>,
-    source: &str,
-    visible_type_names: &HashSet<String>,
-) -> HashMap<String, ImportedTypeBinding> {
-    let mut bindings = HashMap::new();
-    let mut duplicates = HashSet::new();
-
-    if let Some(namespace) = enclosing_node_with_kind(callable, &["namespace_definition"])
-        && let Some(body) = namespace.child_by_field_name("body")
-    {
-        collect_php_imported_type_bindings_in_scope(
-            body,
-            source,
-            visible_type_names,
-            &mut bindings,
-            &mut duplicates,
-        );
-    } else {
-        let (start_byte, end_byte) = php_unbracketed_namespace_segment(root, callable);
-        collect_php_imported_type_bindings_in_root_segment(
-            root,
-            source,
-            visible_type_names,
-            &mut bindings,
-            &mut duplicates,
-            start_byte,
-            end_byte,
-        );
-    }
-
-    bindings
-}
-
-fn collect_php_imported_type_bindings_in_scope(
-    scope: TsNode<'_>,
-    source: &str,
-    visible_type_names: &HashSet<String>,
-    bindings: &mut HashMap<String, ImportedTypeBinding>,
-    duplicates: &mut HashSet<String>,
-) {
-    let mut cursor = scope.walk();
-    for statement in scope.named_children(&mut cursor) {
-        if statement.kind() != "namespace_use_declaration" {
-            continue;
-        }
-        let Some(statement_surface) = trimmed_node_text(statement, source) else {
-            continue;
-        };
-        for (owner_name, local_name, module_name) in
-            php_import_type_binding_names(&statement_surface)
-        {
-            if visible_type_names.contains(&local_name) || duplicates.contains(&local_name) {
-                continue;
-            }
-            if bindings.contains_key(&local_name) {
-                bindings.remove(&local_name);
-                duplicates.insert(local_name);
-                continue;
-            }
-            bindings.insert(
-                local_name,
-                ImportedTypeBinding {
-                    module_name,
-                    owner_name,
-                },
-            );
-        }
-    }
-}
-
-fn collect_php_imported_type_bindings_in_root_segment(
-    root: TsNode<'_>,
-    source: &str,
-    visible_type_names: &HashSet<String>,
-    bindings: &mut HashMap<String, ImportedTypeBinding>,
-    duplicates: &mut HashSet<String>,
-    start_byte: usize,
-    end_byte: usize,
-) {
-    let mut cursor = root.walk();
-    for statement in root.named_children(&mut cursor) {
-        if statement.start_byte() < start_byte || statement.start_byte() >= end_byte {
-            continue;
-        }
-        if statement.kind() != "namespace_use_declaration" {
-            continue;
-        }
-        let Some(statement_surface) = trimmed_node_text(statement, source) else {
-            continue;
-        };
-        for (owner_name, local_name, module_name) in
-            php_import_type_binding_names(&statement_surface)
-        {
-            if visible_type_names.contains(&local_name) || duplicates.contains(&local_name) {
-                continue;
-            }
-            if bindings.contains_key(&local_name) {
-                bindings.remove(&local_name);
-                duplicates.insert(local_name);
-                continue;
-            }
-            bindings.insert(
-                local_name,
-                ImportedTypeBinding {
-                    module_name,
-                    owner_name,
-                },
-            );
-        }
-    }
-}
-
-fn collect_php_visible_type_binding_names(
-    root: TsNode<'_>,
-    callable: TsNode<'_>,
-    source: &str,
-) -> HashSet<String> {
-    let mut names = HashSet::new();
-    if let Some(namespace) = enclosing_node_with_kind(callable, &["namespace_definition"])
-        && let Some(body) = namespace.child_by_field_name("body")
-    {
-        collect_php_type_binding_names_in_scope(body, source, &mut names);
-    } else {
-        let (start_byte, end_byte) = php_unbracketed_namespace_segment(root, callable);
-        collect_php_type_binding_names_in_root_segment(
-            root, source, &mut names, start_byte, end_byte,
-        );
-    }
-    names
-}
-
-fn collect_php_type_binding_names_in_scope(
-    scope: TsNode<'_>,
-    source: &str,
-    names: &mut HashSet<String>,
-) {
-    let mut cursor = scope.walk();
-    for child in scope.named_children(&mut cursor) {
-        if matches!(child.kind(), "class_declaration" | "interface_declaration")
-            && let Some(name) = declaration_name(child, source)
-        {
-            names.insert(name);
-        }
-    }
-}
-
-fn collect_php_type_binding_names_in_root_segment(
-    root: TsNode<'_>,
-    source: &str,
-    names: &mut HashSet<String>,
-    start_byte: usize,
-    end_byte: usize,
-) {
-    let mut cursor = root.walk();
-    for child in root.named_children(&mut cursor) {
-        if child.start_byte() < start_byte || child.start_byte() >= end_byte {
-            continue;
-        }
-        if matches!(child.kind(), "class_declaration" | "interface_declaration")
-            && let Some(name) = declaration_name(child, source)
-        {
-            names.insert(name);
-        }
-    }
-}
-
-fn php_unbracketed_namespace_segment(root: TsNode<'_>, node: TsNode<'_>) -> (usize, usize) {
-    let mut start_byte = root.start_byte();
-    let mut end_byte = root.end_byte();
-    let node_start = node.start_byte();
-    let mut cursor = root.walk();
-    for child in root.named_children(&mut cursor) {
-        if child.kind() != "namespace_definition" || child.child_by_field_name("body").is_some() {
-            continue;
-        }
-        if node_start < child.start_byte() {
-            end_byte = child.start_byte();
-            break;
-        }
-        start_byte = child.end_byte();
-        end_byte = root.end_byte();
-    }
-    (start_byte, end_byte)
-}
-
-fn php_import_type_binding_names(statement: &str) -> Vec<(String, String, String)> {
-    let Some(rest) = statement.strip_prefix("use") else {
-        return Vec::new();
-    };
-    let rest = rest.trim().trim_end_matches(';').trim();
-    if starts_with_case_insensitive_keyword(rest, "function")
-        || starts_with_case_insensitive_keyword(rest, "const")
-        || rest.contains('{')
-    {
-        return Vec::new();
-    }
-
-    split_top_level_parameters(rest)
-        .into_iter()
-        .filter_map(|part| php_import_type_binding_name(&part))
-        .collect()
-}
-
-fn php_import_type_binding_name(import_surface: &str) -> Option<(String, String, String)> {
-    let import_surface = import_surface.trim();
-    if starts_with_case_insensitive_keyword(import_surface, "function")
-        || starts_with_case_insensitive_keyword(import_surface, "const")
-    {
-        return None;
-    }
-    let (module_surface, alias_surface) =
-        split_case_insensitive_alias(import_surface, "as").unwrap_or((import_surface, ""));
-    let (owner_name, module_name) = php_imported_owner_module_name(module_surface)?;
-    let local_name = if alias_surface.trim().is_empty() {
-        owner_name.clone()
-    } else {
-        normalize_parameter_name(alias_surface)?
-    };
-    Some((owner_name, local_name, module_name))
-}
-
-fn split_case_insensitive_alias<'a>(surface: &'a str, keyword: &str) -> Option<(&'a str, &'a str)> {
-    let mut tokens = surface.split_whitespace();
-    let module_surface = tokens.next()?;
-    let separator = tokens.next()?;
-    let alias_surface = tokens.next()?;
-    if tokens.next().is_some() || !separator.eq_ignore_ascii_case(keyword) {
-        return None;
-    }
-    Some((module_surface, alias_surface))
-}
-
-fn starts_with_case_insensitive_keyword(surface: &str, keyword: &str) -> bool {
-    let mut parts = surface.split_whitespace();
-    parts
-        .next()
-        .is_some_and(|token| token.eq_ignore_ascii_case(keyword))
-}
-
-fn php_imported_owner_module_name(raw_module: &str) -> Option<(String, String)> {
-    let module = raw_module.trim().trim_start_matches('\\').trim();
-    if module.is_empty()
-        || module.contains('*')
-        || module.contains('|')
-        || module.split_whitespace().count() != 1
-    {
-        return None;
-    }
-    let (namespace, owner_name) = module.rsplit_once('\\')?;
-    let owner_name = normalize_parameter_name(owner_name)?;
-    if namespace.trim().is_empty() {
-        return None;
-    }
-    Some((owner_name.clone(), format!("{namespace}.{owner_name}")))
-}
-
 fn collect_csharp_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
     let mut edges = Vec::new();
     let root = tree.root_node();
@@ -13853,37 +13177,6 @@ fn go_type_import_qualifier(raw_type: &str) -> Option<String> {
     normalize_parameter_name(qualifier)
 }
 
-fn collect_php_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
-    let mut receiver_types = HashMap::new();
-    let Some(parameters) = callable.child_by_field_name("parameters") else {
-        return receiver_types;
-    };
-    walk_tree_nodes(parameters, &mut |node| {
-        if !matches!(
-            node.kind(),
-            "simple_parameter" | "variadic_parameter" | "property_promotion_parameter"
-        ) {
-            return;
-        }
-        let Some(type_node) = node.child_by_field_name("type") else {
-            return;
-        };
-        let Some(raw_type) = trimmed_node_text(type_node, source) else {
-            return;
-        };
-        let Some(owner_name) = normalize_type_surface(&raw_type) else {
-            return;
-        };
-        let Some(name_node) = node.child_by_field_name("name") else {
-            return;
-        };
-        if let Some(name) = normalized_receiver_variable(name_node, source) {
-            receiver_types.insert(name, owner_name);
-        }
-    });
-    receiver_types
-}
-
 fn collect_csharp_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap<String, String> {
     let mut receiver_types = HashMap::new();
     let Some(parameters) = callable.child_by_field_name("parameters") else {
@@ -14409,21 +13702,6 @@ fn python_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)
         ));
     }
     surface_member_call(node, source)
-}
-
-fn php_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if !matches!(
-        node.kind(),
-        "member_call_expression" | "nullsafe_member_call_expression"
-    ) {
-        return None;
-    }
-    let receiver = node.child_by_field_name("object")?;
-    let method = node.child_by_field_name("name")?;
-    Some((
-        normalized_receiver_variable(receiver, source)?,
-        trimmed_node_text(method, source)?,
-    ))
 }
 
 fn csharp_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
@@ -17072,16 +16350,7 @@ fn route_language_uses_c_style_comments(language_name: &str) -> bool {
     }
     matches!(
         language_name,
-        "javascript"
-            | "typescript"
-            | "java"
-            | "rust"
-            | "go"
-            | "php"
-            | "csharp"
-            | "dart"
-            | "vue"
-            | "astro"
+        "javascript" | "typescript" | "java" | "rust" | "go" | "csharp" | "dart" | "vue" | "astro"
     )
 }
 
@@ -20228,7 +19497,6 @@ pub fn index_file(
                                         "go_selector" => Some(GO_SELECTOR_CALLSITE_MARKER),
                                         "java_member" => Some(JAVA_MEMBER_CALLSITE_MARKER),
                                         "csharp_member" => Some(CSHARP_MEMBER_CALLSITE_MARKER),
-                                        "php_member" => Some(PHP_MEMBER_CALLSITE_MARKER),
                                         "js_member" => Some(JS_MEMBER_CALLSITE_MARKER),
                                         "ts_member" => Some(TS_MEMBER_CALLSITE_MARKER),
                                         "dart_member" => Some(DART_MEMBER_CALLSITE_MARKER),

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1441,7 +1441,7 @@ fn is_php_member_call_placeholder(edge_kind: EdgeKind, callsite_identity: Option
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::PHP_MEMBER_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::php::MEMBER_CALLSITE_MARKER)
     })
 }
 

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -598,7 +598,6 @@ fn language_family_bucket(language: &'static str) -> &'static str {
         "java" => "java",
         "go" => "go",
         "ruby" => "ruby",
-        "php" => "php",
         "csharp" => "csharp",
         "swift" => "swift",
         "dart" => "dart",

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/php_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/php_fidelity.txt
@@ -1,0 +1,39 @@
+node CLASS name=ConsoleNotifier qn=App.ConsoleNotifier canonical=<ROOT>/fidelity.php:App.ConsoleNotifier line=12 col=1 end=18:2 file=FILE:<ROOT>/fidelity.php@1
+node CLASS name=Event qn=App.Event canonical=<ROOT>/fidelity.php:App.Event line=28 col=1 end=33:2 file=FILE:<ROOT>/fidelity.php@1
+node CLASS name=Repository qn=App.Repository canonical=<ROOT>/fidelity.php:App.Repository line=20 col=1 end=26:2 file=FILE:<ROOT>/fidelity.php@1
+node CLASS name=Workflow qn=App.Workflow canonical=<ROOT>/fidelity.php:App.Workflow line=35 col=1 end=54:2 file=FILE:<ROOT>/fidelity.php@1
+node FILE name=<ROOT>/fidelity.php qn=<ROOT>/fidelity.php canonical=<ROOT>/fidelity.php:<ROOT>/fidelity.php:1 line=1 col=1 end=60:0 file=FILE:<ROOT>/fidelity.php@1
+node FUNCTION name=orchestrate_php qn=orchestrate_php canonical=<ROOT>/fidelity.php:orchestrate_php#0 line=56 col=1 end=60:2 file=FILE:<ROOT>/fidelity.php@1
+node INTERFACE name=Notifier qn=App.Notifier canonical=<ROOT>/fidelity.php:App.Notifier line=7 col=1 end=10:2 file=FILE:<ROOT>/fidelity.php@1
+node METHOD name=ConsoleNotifier.notify qn=App.ConsoleNotifier.notify canonical=<ROOT>/fidelity.php:App.ConsoleNotifier.notify#0 line=14 col=5 end=17:6 file=FILE:<ROOT>/fidelity.php@1
+node METHOD name=Event.__construct qn=App.Event.__construct canonical=<ROOT>/fidelity.php:App.Event.__construct#0 line=30 col=5 end=32:6 file=FILE:<ROOT>/fidelity.php@1
+node METHOD name=Notifier.notify qn=App.Notifier.notify canonical=<ROOT>/fidelity.php:App.Notifier.notify#0 line=9 col=5 end=9:48 file=FILE:<ROOT>/fidelity.php@1
+node METHOD name=Repository.save qn=App.Repository.save canonical=<ROOT>/fidelity.php:App.Repository.save#0 line=22 col=5 end=25:6 file=FILE:<ROOT>/fidelity.php@1
+node METHOD name=Workflow.__construct qn=App.Workflow.__construct canonical=<ROOT>/fidelity.php:App.Workflow.__construct#0 line=37 col=5 end=41:6 file=FILE:<ROOT>/fidelity.php@1
+node METHOD name=Workflow.decorate qn=App.Workflow.decorate canonical=<ROOT>/fidelity.php:App.Workflow.decorate#0 line=50 col=5 end=53:6 file=FILE:<ROOT>/fidelity.php@1
+node METHOD name=Workflow.run qn=App.Workflow.run canonical=<ROOT>/fidelity.php:App.Workflow.run#0 line=43 col=5 end=48:6 file=FILE:<ROOT>/fidelity.php@1
+node MODULE name=Random/Randomizer qn=Random/Randomizer canonical=<ROOT>/fidelity.php:Random/Randomizer#0 line=5 col=5 end=5:22 file=FILE:<ROOT>/fidelity.php@1
+node NAMESPACE name=App qn=App canonical=<ROOT>/fidelity.php:App#0 line=3 col=1 end=3:15 file=FILE:<ROOT>/fidelity.php@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.php:decorate#0 line=47 col=16 end=47:24 file=FILE:<ROOT>/fidelity.php@1
+node UNKNOWN name=getBytes qn=getBytes canonical=<ROOT>/fidelity.php:getBytes#0 line=59 col=50 end=59:58 file=FILE:<ROOT>/fidelity.php@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.php:notify#0 line=45 col=26 end=45:32 file=FILE:<ROOT>/fidelity.php@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.php:run#0 line=59 col=16 end=59:19 file=FILE:<ROOT>/fidelity.php@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.php:save#0 line=46 col=28 end=46:32 file=FILE:<ROOT>/fidelity.php@1
+edge CALL src=FUNCTION:orchestrate_php@56 dst=METHOD:Workflow.run@43 resolved_src=FUNCTION:orchestrate_php@56 resolved_dst=METHOD:Workflow.run@43 line=59 confidence=1.0000 certainty=Certain callsite=h0:59:1:h1 candidates=[]
+edge CALL src=FUNCTION:orchestrate_php@56 dst=UNKNOWN:getBytes@59 resolved_src=FUNCTION:orchestrate_php@56 resolved_dst=- line=59 confidence=- certainty=- callsite=h0:59:1:h2|syntax:php-member-call|receiver-owner:Randomizer|receiver-module:Random.Randomizer candidates=[]
+edge CALL src=METHOD:Workflow.run@43 dst=METHOD:Notifier.notify@9 resolved_src=METHOD:Workflow.run@43 resolved_dst=METHOD:Notifier.notify@9 line=45 confidence=1.0000 certainty=Certain callsite=h0:45:1:h3 candidates=[]
+edge CALL src=METHOD:Workflow.run@43 dst=METHOD:Repository.save@22 resolved_src=METHOD:Workflow.run@43 resolved_dst=METHOD:Repository.save@22 line=46 confidence=1.0000 certainty=Certain callsite=h0:46:1:h4 candidates=[]
+edge CALL src=METHOD:Workflow.run@43 dst=METHOD:Workflow.decorate@50 resolved_src=METHOD:Workflow.run@43 resolved_dst=METHOD:Workflow.decorate@50 line=47 confidence=1.0000 certainty=Certain callsite=h0:47:1:h5 candidates=[]
+edge IMPORT src=MODULE:Random/Randomizer@5 dst=MODULE:Random/Randomizer@5 resolved_src=MODULE:Random/Randomizer@5 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@12 dst=METHOD:ConsoleNotifier.notify@14 resolved_src=- resolved_dst=- line=14 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Event@28 dst=METHOD:Event.__construct@30 resolved_src=- resolved_dst=- line=30 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@20 dst=METHOD:Repository.save@22 resolved_src=- resolved_dst=- line=22 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@35 dst=METHOD:Workflow.__construct@37 resolved_src=- resolved_dst=- line=37 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@35 dst=METHOD:Workflow.decorate@50 resolved_src=- resolved_dst=- line=50 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@35 dst=METHOD:Workflow.run@43 resolved_src=- resolved_dst=- line=43 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Notifier@7 dst=METHOD:Notifier.notify@9 resolved_src=- resolved_dst=- line=9 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:App@3 dst=CLASS:ConsoleNotifier@12 resolved_src=- resolved_dst=- line=12 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:App@3 dst=CLASS:Event@28 resolved_src=- resolved_dst=- line=28 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:App@3 dst=CLASS:Repository@20 resolved_src=- resolved_dst=- line=20 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:App@3 dst=CLASS:Workflow@35 resolved_src=- resolved_dst=- line=35 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:App@3 dst=INTERFACE:Notifier@7 resolved_src=- resolved_dst=- line=7 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/php_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/php_tictactoe.txt
@@ -1,0 +1,116 @@
+node CLASS name=ArtificialPlayer qn=TicTacToe.ArtificialPlayer canonical=game.php:TicTacToe.ArtificialPlayer line=88 col=1 end=103:2 file=FILE:game.php@1
+node CLASS name=Field qn=TicTacToe.Field canonical=game.php:TicTacToe.Field line=29 col=1 end=73:2 file=FILE:game.php@1
+node CLASS name=GameObject qn=GameObject canonical=game.php:GameObject line=29 col=21 end=29:31 file=FILE:game.php@1
+node CLASS name=GameObject qn=TicTacToe.GameObject canonical=game.php:TicTacToe.GameObject line=22 col=1 end=27:2 file=FILE:game.php@1
+node CLASS name=HumanPlayer qn=TicTacToe.HumanPlayer canonical=game.php:TicTacToe.HumanPlayer line=80 col=1 end=86:2 file=FILE:game.php@1
+node CLASS name=TicTacToe qn=TicTacToe.TicTacToe canonical=game.php:TicTacToe.TicTacToe line=105 col=1 end=116:2 file=FILE:game.php@1
+node FILE name=game.php qn=game.php canonical=game.php:game.php:1 line=1 col=1 end=118:0 file=FILE:game.php@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.php:numberIn#0 line=7 col=1 end=10:2 file=FILE:game.php@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.php:numberOut#0 line=12 col=1 end=15:2 file=FILE:game.php@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.php:stringOut#0 line=17 col=1 end=20:2 file=FILE:game.php@1
+node INTERFACE name=Player qn=TicTacToe.Player canonical=game.php:TicTacToe.Player line=75 col=1 end=78:2 file=FILE:game.php@1
+node METHOD name=ArtificialPlayer.minMax qn=TicTacToe.ArtificialPlayer.minMax canonical=game.php:TicTacToe.ArtificialPlayer.minMax#0 line=90 col=5 end=96:6 file=FILE:game.php@1
+node METHOD name=ArtificialPlayer.turn qn=TicTacToe.ArtificialPlayer.turn canonical=game.php:TicTacToe.ArtificialPlayer.turn#0 line=98 col=5 end=102:6 file=FILE:game.php@1
+node METHOD name=Field.__construct qn=TicTacToe.Field.__construct canonical=game.php:TicTacToe.Field.__construct#0 line=35 col=5 end=38:6 file=FILE:game.php@1
+node METHOD name=Field.makeMove qn=TicTacToe.Field.makeMove canonical=game.php:TicTacToe.Field.makeMove#0 line=63 col=5 end=72:6 file=FILE:game.php@1
+node METHOD name=Field.opponent qn=TicTacToe.Field.opponent canonical=game.php:TicTacToe.Field.opponent#0 line=40 col=5 end=49:6 file=FILE:game.php@1
+node METHOD name=Field.sameInRow qn=TicTacToe.Field.sameInRow canonical=game.php:TicTacToe.Field.sameInRow#0 line=51 col=5 end=61:6 file=FILE:game.php@1
+node METHOD name=GameObject.announce qn=TicTacToe.GameObject.announce canonical=game.php:TicTacToe.GameObject.announce#0 line=24 col=5 end=26:6 file=FILE:game.php@1
+node METHOD name=HumanPlayer.turn qn=TicTacToe.HumanPlayer.turn canonical=game.php:TicTacToe.HumanPlayer.turn#0 line=82 col=5 end=85:6 file=FILE:game.php@1
+node METHOD name=Player.turn qn=TicTacToe.Player.turn canonical=game.php:TicTacToe.Player.turn#0 line=77 col=5 end=77:58 file=FILE:game.php@1
+node METHOD name=TicTacToe.run qn=TicTacToe.TicTacToe.run canonical=game.php:TicTacToe.TicTacToe.run#0 line=109 col=5 end=115:6 file=FILE:game.php@1
+node MODULE name=Random/Randomizer qn=Random/Randomizer canonical=game.php:Random/Randomizer#0 line=5 col=5 end=5:22 file=FILE:game.php@1
+node NAMESPACE name=TicTacToe qn=TicTacToe canonical=game.php:TicTacToe#0 line=3 col=1 end=3:21 file=FILE:game.php@1
+node UNKNOWN name=array_fill qn=array_fill canonical=game.php:array_fill#0 line=37 col=40 end=37:50 file=FILE:game.php@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.php:makeMove#0 line=84 col=24 end=84:32 file=FILE:game.php@1
+node UNKNOWN name=minMax qn=minMax canonical=game.php:minMax#0 line=95 col=23 end=95:29 file=FILE:game.php@1
+node UNKNOWN name=minMax qn=minMax canonical=game.php:minMax#1 line=100 col=16 end=100:22 file=FILE:game.php@1
+node UNKNOWN name=nextInt qn=nextInt canonical=game.php:nextInt#0 line=114 col=29 end=114:36 file=FILE:game.php@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.php:numberIn#1 line=112 col=9 end=112:17 file=FILE:game.php@1
+node UNKNOWN name=run qn=run canonical=game.php:run#0 line=118 col=20 end=118:23 file=FILE:game.php@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.php:sameInRow#0 line=70 col=16 end=70:25 file=FILE:game.php@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.php:stringOut#1 line=113 col=9 end=113:18 file=FILE:game.php@1
+edge CALL src=METHOD:ArtificialPlayer.turn@98 dst=METHOD:ArtificialPlayer.minMax@90 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.minMax@90 line=100 confidence=1.0000 certainty=Certain callsite=h0:100:1:h1 candidates=[]
+edge CALL src=METHOD:Field.__construct@35 dst=UNKNOWN:array_fill@37 resolved_src=- resolved_dst=- line=37 confidence=- certainty=- callsite=h0:37:1:h2 candidates=[]
+edge CALL src=METHOD:Field.__construct@35 dst=UNKNOWN:array_fill@37 resolved_src=- resolved_dst=- line=37 confidence=- certainty=- callsite=h0:37:2:h2 candidates=[]
+edge CALL src=METHOD:Field.makeMove@63 dst=METHOD:Field.sameInRow@51 resolved_src=- resolved_dst=METHOD:Field.sameInRow@51 line=70 confidence=1.0000 certainty=Certain callsite=h0:70:1:h3 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@82 dst=METHOD:Field.makeMove@63 resolved_src=- resolved_dst=METHOD:Field.makeMove@63 line=84 confidence=1.0000 certainty=Certain callsite=h0:84:1:h4 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@109 dst=UNKNOWN:nextInt@114 resolved_src=- resolved_dst=- line=114 confidence=- certainty=- callsite=h0:114:1:h5|syntax:php-member-call|receiver-owner:Randomizer|receiver-module:Random.Randomizer candidates=[]
+edge CALL src=METHOD:TicTacToe.run@109 dst=UNKNOWN:numberIn@112 resolved_src=- resolved_dst=- line=112 confidence=- certainty=- callsite=h0:112:1:h6 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@109 dst=UNKNOWN:stringOut@113 resolved_src=- resolved_dst=- line=113 confidence=- certainty=- callsite=h0:113:1:h7 candidates=[]
+edge IMPORT src=MODULE:Random/Randomizer@5 dst=MODULE:Random/Randomizer@5 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@29 dst=CLASS:GameObject@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:TicTacToe@105 dst=CLASS:GameObject@29 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@88 dst=METHOD:ArtificialPlayer.minMax@90 resolved_src=- resolved_dst=- line=90 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@88 dst=METHOD:ArtificialPlayer.turn@98 resolved_src=- resolved_dst=- line=98 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.__construct@35 resolved_src=- resolved_dst=- line=35 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.makeMove@63 resolved_src=- resolved_dst=- line=63 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.opponent@40 resolved_src=- resolved_dst=- line=40 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@29 dst=METHOD:Field.sameInRow@51 resolved_src=- resolved_dst=- line=51 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:GameObject@22 dst=METHOD:GameObject.announce@24 resolved_src=- resolved_dst=- line=24 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@80 dst=METHOD:HumanPlayer.turn@82 resolved_src=- resolved_dst=- line=82 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@105 dst=METHOD:TicTacToe.run@109 resolved_src=- resolved_dst=- line=109 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Player@75 dst=METHOD:Player.turn@77 resolved_src=- resolved_dst=- line=77 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:TicTacToe@3 dst=CLASS:ArtificialPlayer@88 resolved_src=- resolved_dst=- line=88 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:TicTacToe@3 dst=CLASS:Field@29 resolved_src=- resolved_dst=- line=29 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:TicTacToe@3 dst=CLASS:GameObject@22 resolved_src=- resolved_dst=- line=22 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:TicTacToe@3 dst=CLASS:HumanPlayer@80 resolved_src=- resolved_dst=- line=80 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:TicTacToe@3 dst=CLASS:TicTacToe@105 resolved_src=- resolved_dst=- line=105 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=NAMESPACE:TicTacToe@3 dst=INTERFACE:Player@75 resolved_src=- resolved_dst=- line=75 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.php language=php lines=118 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@88 kind=DEFINITION span=88:1-103:2
+occurrence element=CLASS:Field@29 kind=DEFINITION span=29:1-73:2
+occurrence element=CLASS:GameObject@22 kind=DEFINITION span=22:1-27:2
+occurrence element=CLASS:GameObject@29 kind=DEFINITION span=105:25-105:35
+occurrence element=CLASS:GameObject@29 kind=DEFINITION span=29:21-29:31
+occurrence element=CLASS:HumanPlayer@80 kind=DEFINITION span=80:1-86:2
+occurrence element=CLASS:TicTacToe@105 kind=DEFINITION span=105:1-116:2
+occurrence element=FUNCTION:numberIn@7 kind=DEFINITION span=7:1-10:2
+occurrence element=FUNCTION:numberOut@12 kind=DEFINITION span=12:1-15:2
+occurrence element=FUNCTION:stringOut@17 kind=DEFINITION span=17:1-20:2
+occurrence element=INTERFACE:Player@75 kind=DEFINITION span=75:1-78:2
+occurrence element=METHOD:ArtificialPlayer.minMax@90 kind=DEFINITION span=90:5-96:6
+occurrence element=METHOD:ArtificialPlayer.turn@98 kind=DEFINITION span=98:5-102:6
+occurrence element=METHOD:Field.__construct@35 kind=DEFINITION span=35:5-38:6
+occurrence element=METHOD:Field.makeMove@63 kind=DEFINITION span=63:5-72:6
+occurrence element=METHOD:Field.opponent@40 kind=DEFINITION span=40:5-49:6
+occurrence element=METHOD:Field.sameInRow@51 kind=DEFINITION span=51:5-61:6
+occurrence element=METHOD:GameObject.announce@24 kind=DEFINITION span=24:5-26:6
+occurrence element=METHOD:HumanPlayer.turn@82 kind=DEFINITION span=82:5-85:6
+occurrence element=METHOD:Player.turn@77 kind=DEFINITION span=77:5-77:58
+occurrence element=METHOD:TicTacToe.run@109 kind=DEFINITION span=109:5-115:6
+occurrence element=MODULE:Random/Randomizer@5 kind=DEFINITION span=5:5-5:22
+occurrence element=NAMESPACE:TicTacToe@3 kind=DEFINITION span=3:1-3:21
+occurrence element=UNKNOWN:array_fill@37 kind=DEFINITION span=37:40-37:50
+occurrence element=UNKNOWN:makeMove@84 kind=DEFINITION span=84:24-84:32
+occurrence element=UNKNOWN:minMax@100 kind=DEFINITION span=100:16-100:22
+occurrence element=UNKNOWN:minMax@95 kind=DEFINITION span=95:23-95:29
+occurrence element=UNKNOWN:nextInt@114 kind=DEFINITION span=114:29-114:36
+occurrence element=UNKNOWN:numberIn@112 kind=DEFINITION span=112:9-112:17
+occurrence element=UNKNOWN:run@118 kind=DEFINITION span=118:20-118:23
+occurrence element=UNKNOWN:sameInRow@70 kind=DEFINITION span=70:16-70:25
+occurrence element=UNKNOWN:stringOut@113 kind=DEFINITION span=113:9-113:18
+access node=METHOD:ArtificialPlayer.minMax@90 kind=Public
+access node=METHOD:ArtificialPlayer.turn@98 kind=Public
+access node=METHOD:Field.__construct@35 kind=Public
+access node=METHOD:Field.makeMove@63 kind=Public
+access node=METHOD:Field.opponent@40 kind=Public
+access node=METHOD:Field.sameInRow@51 kind=Public
+access node=METHOD:GameObject.announce@24 kind=Public
+access node=METHOD:HumanPlayer.turn@82 kind=Public
+access node=METHOD:Player.turn@77 kind=Public
+access node=METHOD:TicTacToe.run@109 kind=Public
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "13:numberIn", node_id: NodeId(-7850779125888789456), signature_hash: 2477812878330356949, normalized_signature: Some("outline:-1794081461106041540"), body_hash: -8762726624460636624, start_line: 7, end_line: 10 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "13:numberOut", node_id: NodeId(-1447436687754153957), signature_hash: -1579019679195996938, normalized_signature: Some("outline:-1794081461106041540"), body_hash: -4867661882905395713, start_line: 12, end_line: 15 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "13:stringOut", node_id: NodeId(1599438850392661835), signature_hash: -5818630870471287222, normalized_signature: Some("outline:-1794081461106041540"), body_hash: 4644188999977821824, start_line: 17, end_line: 20 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.ArtificialPlayer.minMax", node_id: NodeId(8029435488395149577), signature_hash: -6859643847646628701, normalized_signature: Some("shape:-2608313845711318915"), body_hash: 7744519947621391062, start_line: 90, end_line: 96 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.ArtificialPlayer.turn", node_id: NodeId(1968078213223845940), signature_hash: -8495276445739008764, normalized_signature: Some("shape:-5078934614221895033"), body_hash: 1706019074395249724, start_line: 98, end_line: 102 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.Field.__construct", node_id: NodeId(-2208003403216265041), signature_hash: 4585338508208773749, normalized_signature: Some("shape:-3509333274106978022"), body_hash: -5782736763390821939, start_line: 35, end_line: 38 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.Field.makeMove", node_id: NodeId(-3292118031427156763), signature_hash: -7015829758109473257, normalized_signature: Some("shape:-824984375727768651"), body_hash: -4825275194622422185, start_line: 63, end_line: 72 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.Field.opponent", node_id: NodeId(-4140556791429577481), signature_hash: 6548377796614971309, normalized_signature: Some("outline:-5076516769578077345"), body_hash: 1162480070770046686, start_line: 40, end_line: 49 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.Field.sameInRow", node_id: NodeId(-789613575146425969), signature_hash: 577240268869951381, normalized_signature: Some("outline:31735372975069579"), body_hash: -5640719502248168146, start_line: 51, end_line: 61 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.GameObject.announce", node_id: NodeId(4993151564124375788), signature_hash: 8159730552014832428, normalized_signature: Some("outline:-5084961018881034800"), body_hash: -3094451936880305499, start_line: 24, end_line: 26 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.HumanPlayer.turn", node_id: NodeId(5735421101707362641), signature_hash: -4935815070297363741, normalized_signature: Some("shape:-1117341136637250039"), body_hash: 9161846392741600280, start_line: 82, end_line: 85 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.Player.turn", node_id: NodeId(4153867858318907420), signature_hash: -918494154596152668, normalized_signature: Some("outline:-5083272169020481154"), body_hash: -4216802774850148624, start_line: 77, end_line: 77 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "14:TicTacToe.TicTacToe.run", node_id: NodeId(2419740236747960625), signature_hash: 2105959521563754291, normalized_signature: Some("shape:-6959750541430875846"), body_hash: -1084349564929774830, start_line: 109, end_line: 115 }
+callable_state CallableProjectionState { file_id: -6460368281953754356, symbol_key: "__file_structural__", node_id: NodeId(-6460368281953754356), signature_hash: 553768115714561381, normalized_signature: None, body_hash: -4167641783090616645, start_line: 1, end_line: 118 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "php",
+        extension: "php",
+        fidelity_filename: "fidelity.php",
+        fidelity_source: include_str!("fixtures/fidelity_lab/php_fidelity_lab.php"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/php_fidelity.txt"),
+        tictactoe_filename: "game.php",
+        tictactoe_source: include_str!("fixtures/tictactoe/php_tictactoe.php"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/php_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1687.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
