### PR TITLE
[v0.17 S3-SWIFT] Extract Swift language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3942,7 +3942,7 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
         .or(match language {
             "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
             "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
-            | "cpp" | "dart" | "php" | "swift" => Some("//"),
+            | "cpp" | "dart" | "php" => Some("//"),
             _ => None,
         });
     let Some(marker) = comment_marker else {
@@ -5572,8 +5572,9 @@ mod tests {
         assert!(bash.contains("\x1b[90m# comment\x1b[0m"), "{bash:?}");
     }
 
-    /// Kotlin's comment marker now comes from the language registry rather than
-    /// the local roster, and every other language must be unmoved.
+    /// Kotlin's and Swift's comment markers now come from the language
+    /// registry rather than the local roster, and every other language must be
+    /// unmoved.
     ///
     /// Asserting only "Kotlin still dims `//`" would pass with the registry
     /// lookup deleted, because the local roster used to answer for Kotlin too.
@@ -5631,14 +5632,20 @@ mod tests {
             }
         }
 
-        // The registry is the source for Kotlin: it must agree with the marker
-        // the roster used to hold.
+        // The registry is the source for Kotlin and Swift: it must agree with
+        // the markers the roster used to hold.
         assert_eq!(
             codestory_contracts::language_support::line_comment_for_language("kotlin"),
             Some("//")
         );
         let kotlin = ansi_highlight_snippet("app/Main.kt", "val ok = true // comment");
         assert!(kotlin.contains("\x1b[90m// comment\x1b[0m"), "{kotlin:?}");
+        assert_eq!(
+            codestory_contracts::language_support::line_comment_for_language("swift"),
+            Some("//")
+        );
+        let swift = ansi_highlight_snippet("app/Main.swift", "let ok = true // comment");
+        assert!(swift.contains("\x1b[90m// comment\x1b[0m"), "{swift:?}");
     }
 
     /// Component dialects resolve through the companion-extension registry and

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "swift",
+        line_comment: "//",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "swift"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,7 +1265,8 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
-        assert_eq!(line_comment_for_language("swift"), None);
+        assert_eq!(line_comment_for_language("swift"), Some("//"));
+        assert_eq!(line_comment_for_language("dart"), None);
     }
 
     #[test]

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -2,8 +2,8 @@ use super::{
     BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
     GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
     PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -41,7 +41,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("ruby", _) => Some(ruby()),
         ("php", _) => Some(php()),
         ("csharp", _) => Some(csharp()),
-        ("swift", _) => Some(swift()),
         ("dart", _) => Some(dart()),
         ("bash", _) => Some(bash()),
         _ => None,
@@ -165,16 +164,6 @@ fn csharp() -> LanguageConfig {
         CSHARP_GRAPH_QUERY,
         None,
         LanguageRuleset::CSharp,
-    )
-}
-
-fn swift() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_swift::LANGUAGE.into(),
-        "swift",
-        SWIFT_GRAPH_QUERY,
-        None,
-        LanguageRuleset::Swift,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -17,6 +17,7 @@
 //! package to land deletes the residual arms entirely.
 
 pub(crate) mod kotlin;
+pub(crate) mod swift;
 
 use std::sync::OnceLock;
 
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, swift::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {

--- a/crates/codestory-indexer/src/languages/swift.rs
+++ b/crates/codestory-indexer/src/languages/swift.rs
@@ -1,0 +1,655 @@
+//! Swift extraction rules.
+//!
+//! Swift's graph extraction lives here: the tree-sitter rule file, the
+//! compiled-rule cache, the member-call callsite marker, and the receiver-call
+//! resolution engine that turns `repository.save(...)` into an edge aimed at
+//! `Repository.save`. Every language-keyed dispatch in the crate reaches it
+//! through [`super::EXTRACTIONS`] rather than by spelling `"swift"`.
+//!
+//! Three Swift surfaces are deliberately *not* here, and all three are shared
+//! seams rather than Swift content:
+//!
+//! * `lib.rs::collect_vapor_route` and its `"swift"` arm in the
+//!   framework-route scanner. The per-language route collectors take
+//!   non-uniform arguments and a per-framework `has_<framework>` precondition,
+//!   so routing them through the registry is one change for all sixteen
+//!   languages, not part of Swift's rollback unit.
+//! * `LanguageRuleset::Swift`, which stays in `lib.rs` because the enum is the
+//!   compiled-rule cache key for every language at once.
+//! * `resolution::find_swift_imported_owner_member_readonly` and the
+//!   `Sources/<Module>` path matching it uses. That is import resolution over
+//!   an already-built graph, owned by the resolver, not extraction.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both Swift fixtures so the move stays output-equal.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, LanguageRuleset, ManualReceiverCallSpec, ManualReceiverSource,
+    OptionalReceiverOwnerBinding, ReceiverCallSiteKey, collect_colon_parameter_types,
+    collect_receiver_call_specs_in_callable, declaration_name, enclosing_node_with_kind,
+    member_call_method_col, node_is_same_or_ancestor, normalize_parameter_name,
+    normalize_type_surface, parameter_name_before_colon, parameter_type_after_colon,
+    receiver_call_belongs_to_callable, receiver_callsite_key, same_ts_span,
+    signature_parameter_surface, split_top_level_parameters, trimmed_node_text, ts_node_graph_span,
+    walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from Swift member-call syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:swift-member-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/swift.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for Swift.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["swift"],
+    language_name: "swift",
+    extensions: &["swift"],
+    ruleset: LanguageRuleset::Swift,
+    parser_language: swift_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    receiver_call_specs: Some(receiver_call_specs),
+    member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
+    graph_call_syntax: Some("swift_member"),
+    // A `function_declaration` whose owner is type-like is a method in Swift;
+    // the projection promotes FUNCTION to METHOD for exactly these languages.
+    promotes_type_member_functions_to_methods: true,
+    qualified_name_delimiter: ".",
+    // Swift *does* use `//` and `/* */`, but the framework-route scanner has
+    // never stripped them for Swift: its roster is a separate fact with its own
+    // owner, and turning this on would change which Vapor route lines the
+    // scanner claims. The CLI comment roster and this one disagree on purpose.
+    route_comments_are_c_style: false,
+    uses_generic_semantic_resolver: true,
+    semantic_family: "swift",
+};
+
+fn swift_language() -> tree_sitter::Language {
+    tree_sitter_swift::LANGUAGE.into()
+}
+
+/// Manual receiver-call edges for one parsed Swift file.
+///
+/// Was `lib.rs::collect_swift_receiver_call_edges`.
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let imports = collect_swift_imports(source);
+    let local_type_names = collect_swift_type_binding_names(tree.root_node(), source);
+    walk_tree_nodes(tree.root_node(), &mut |callable| {
+        if callable.kind() != "function_declaration" {
+            return;
+        }
+        let Some(source_name) = declaration_name(callable, source) else {
+            return;
+        };
+        let call_source = ManualReceiverSource {
+            name: &source_name,
+            span: ts_node_graph_span(callable),
+        };
+        let receiver_types = collect_colon_parameter_types(callable, source);
+        let mut local_receiver_callsites = HashSet::new();
+        collect_swift_precise_receiver_call_specs(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            SwiftReceiverContext {
+                parameter_receiver_types: &receiver_types,
+                imports: &imports,
+                local_type_names: &local_type_names,
+            },
+            &mut local_receiver_callsites,
+            &mut edges,
+        );
+        if receiver_types.is_empty() {
+            return;
+        }
+        let receiver_modules =
+            collect_swift_parameter_type_modules(callable, source, &imports, &local_type_names);
+        let start = edges.len();
+        collect_receiver_call_specs_in_callable(
+            callable,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            &receiver_types,
+            member_call,
+            false,
+            &mut edges,
+        );
+        let mut parameter_specs = edges.split_off(start);
+        parameter_specs
+            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
+        for spec in &mut parameter_specs {
+            if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
+                spec.owner_module = Some(module_name.clone());
+            }
+        }
+        edges.extend(parameter_specs);
+    });
+    edges
+}
+
+struct SwiftReceiverContext<'a> {
+    parameter_receiver_types: &'a HashMap<String, String>,
+    imports: &'a SwiftImportContext,
+    local_type_names: &'a HashSet<String>,
+}
+
+#[derive(Debug, Default)]
+struct SwiftImportContext {
+    whole_modules: HashSet<String>,
+    scoped_types: HashSet<(String, String)>,
+}
+
+impl SwiftImportContext {
+    fn type_is_imported(&self, module_name: &str, owner_name: &str) -> bool {
+        self.whole_modules.contains(module_name)
+            || self
+                .scoped_types
+                .iter()
+                .any(|(module, owner)| module == module_name && owner == owner_name)
+    }
+
+    fn unqualified_owner_module(&self, owner_name: &str) -> Option<String> {
+        let mut candidates = self
+            .scoped_types
+            .iter()
+            .filter_map(|(module_name, imported_owner)| {
+                (imported_owner == owner_name).then_some(module_name.clone())
+            })
+            .collect::<HashSet<_>>();
+        if self.whole_modules.len() == 1
+            && let Some(module_name) = self.whole_modules.iter().next()
+        {
+            candidates.insert(module_name.clone());
+        }
+        (candidates.len() == 1)
+            .then(|| candidates.into_iter().next())
+            .flatten()
+    }
+}
+
+fn collect_swift_precise_receiver_call_specs(
+    callable: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    context: SwiftReceiverContext<'_>,
+    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(callable, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, callable) {
+            return;
+        }
+        let method_col = member_call_method_col(node, source, &method_name);
+        let callsite_key = ReceiverCallSiteKey {
+            receiver_name: receiver_name.clone(),
+            method_name: method_name.clone(),
+            line: Some(node.start_position().row as u32 + 1),
+            method_col,
+        };
+
+        if let Some(owner) =
+            swift_visible_local_receiver_owner(callable, node, &receiver_name, source, &context)
+        {
+            local_receiver_callsites.insert(callsite_key);
+            if let Some((owner_name, owner_module)) = owner {
+                edges.push(ManualReceiverCallSpec {
+                    source_name: call_source.name.to_string(),
+                    source_span: call_source.span,
+                    receiver_name,
+                    owner_name,
+                    owner_module,
+                    method_name,
+                    method_col,
+                    line: Some(node.start_position().row as u32 + 1),
+                    allow_global_fallback: false,
+                });
+            }
+            return;
+        }
+
+        let owner = if let Some(owner) = swift_self_receiver_owner(callable, &receiver_name, source)
+        {
+            Some(owner)
+        } else if !context
+            .parameter_receiver_types
+            .contains_key(&receiver_name)
+        {
+            swift_property_receiver_owner(callable, &receiver_name, source, &context)
+        } else {
+            None
+        };
+        let Some((owner_name, owner_module)) = owner else {
+            return;
+        };
+        edges.push(ManualReceiverCallSpec {
+            source_name: call_source.name.to_string(),
+            source_span: call_source.span,
+            receiver_name,
+            owner_name,
+            owner_module,
+            method_name,
+            method_col,
+            line: Some(node.start_position().row as u32 + 1),
+            allow_global_fallback: false,
+        });
+    });
+}
+
+fn swift_self_receiver_owner(
+    callable: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+) -> OptionalReceiverOwnerBinding {
+    if receiver_name != "self" {
+        return None;
+    }
+    let owner_node = enclosing_node_with_kind(callable, &["class_declaration"])?;
+    let owner_name = declaration_name(owner_node, source)?;
+    Some((owner_name, None))
+}
+
+fn swift_visible_local_receiver_owner(
+    callable: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    context: &SwiftReceiverContext<'_>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(callable, &mut |node| {
+        if node.kind() != "property_declaration" {
+            return;
+        }
+        if !receiver_call_belongs_to_callable(node, callable)
+            || node.end_byte() > call_node.start_byte()
+        {
+            return;
+        }
+        let Some(binding_name) = swift_property_binding_name(node, source) else {
+            return;
+        };
+        if binding_name != receiver_name || !swift_local_binding_visible_at_call(node, call_node) {
+            return;
+        }
+        visible_bindings.push((
+            node.end_byte(),
+            swift_initialized_constructor_owner(node, source, context),
+        ));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner_name)| owner_name)
+}
+
+fn swift_property_receiver_owner(
+    callable: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    context: &SwiftReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let field_name = receiver_name
+        .strip_prefix("self.")
+        .unwrap_or(receiver_name)
+        .trim();
+    if field_name == "self" || field_name.contains('.') {
+        return None;
+    }
+    let owner_node = enclosing_node_with_kind(callable, &["class_declaration"])?;
+    let mut property_bindings = Vec::new();
+    walk_tree_nodes(owner_node, &mut |node| {
+        if node.kind() != "property_declaration"
+            || !swift_property_belongs_to_owner(node, owner_node)
+        {
+            return;
+        }
+        let Some(binding_name) = swift_property_binding_name(node, source) else {
+            return;
+        };
+        if binding_name != field_name {
+            return;
+        }
+        if let Some(owner) = swift_typed_property_owner(node, source, context) {
+            property_bindings.push(owner);
+        }
+    });
+    property_bindings.sort();
+    property_bindings.dedup();
+    if property_bindings.len() == 1 {
+        Some(property_bindings.remove(0))
+    } else {
+        None
+    }
+}
+
+fn swift_property_belongs_to_owner(property: TsNode<'_>, owner_node: TsNode<'_>) -> bool {
+    let mut current = property.parent();
+    while let Some(candidate) = current {
+        if same_ts_span(candidate, owner_node) {
+            return true;
+        }
+        if candidate.kind() == "function_declaration" || candidate.kind() == "class_declaration" {
+            return false;
+        }
+        current = candidate.parent();
+    }
+    false
+}
+
+fn swift_property_binding_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    node.child_by_field_name("name")
+        .and_then(|name| trimmed_node_text(name, source))
+        .as_deref()
+        .and_then(|surface| {
+            surface
+                .split_whitespace()
+                .filter(|token| !matches!(*token, "let" | "var"))
+                .filter_map(normalize_parameter_name)
+                .next_back()
+        })
+}
+
+fn swift_initialized_constructor_owner(
+    node: TsNode<'_>,
+    source: &str,
+    context: &SwiftReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    if let Some(owner_name) = node
+        .child_by_field_name("value")
+        .and_then(|value| swift_constructor_owner(value, source, context))
+    {
+        return Some(owner_name);
+    }
+    let surface = trimmed_node_text(node, source)?;
+    let (_, value_surface) = surface.split_once('=')?;
+    swift_constructor_owner_surface(value_surface, context)
+}
+
+fn swift_typed_property_owner(
+    node: TsNode<'_>,
+    source: &str,
+    context: &SwiftReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let surface = trimmed_node_text(node, source)?;
+    let head = surface.split('=').next().unwrap_or(surface.as_str()).trim();
+    let rest = head
+        .rsplit_once(" let ")
+        .map(|(_, rest)| rest)
+        .or_else(|| head.rsplit_once(" var ").map(|(_, rest)| rest))
+        .or_else(|| head.strip_prefix("let "))
+        .or_else(|| head.strip_prefix("var "))?
+        .trim();
+    let (_, type_side) = rest.split_once(':')?;
+    swift_receiver_owner_from_type(&parameter_type_after_colon(type_side), context)
+}
+
+fn swift_receiver_owner_from_type(
+    raw_type: &str,
+    context: &SwiftReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let owner_name = normalize_type_surface(raw_type)?;
+    if let Some(module_name) = swift_type_import_qualifier(raw_type) {
+        if context.imports.type_is_imported(&module_name, &owner_name) {
+            return Some((owner_name, Some(module_name)));
+        }
+        return None;
+    }
+    if context.local_type_names.contains(&owner_name) {
+        return Some((owner_name, None));
+    }
+    if let Some(module_name) = context.imports.unqualified_owner_module(&owner_name) {
+        return Some((owner_name, Some(module_name)));
+    }
+    Some((owner_name, None))
+}
+
+fn swift_constructor_owner(
+    value: TsNode<'_>,
+    source: &str,
+    context: &SwiftReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    trimmed_node_text(value, source)
+        .as_deref()
+        .and_then(|surface| swift_constructor_owner_surface(surface, context))
+}
+
+fn swift_constructor_owner_surface(
+    surface: &str,
+    context: &SwiftReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let surface = surface.trim().trim_end_matches(';').trim();
+    let (constructor_name, _) = surface.split_once('(')?;
+    swift_constructor_owner_from_type_surface(constructor_name, context)
+}
+
+fn swift_constructor_owner_from_type_surface(
+    type_surface: &str,
+    context: &SwiftReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let type_surface = type_surface.trim();
+    if type_surface.contains("::") {
+        return None;
+    }
+    let owner_name = normalize_type_surface(type_surface)?;
+    if !owner_name
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_uppercase())
+    {
+        return None;
+    }
+    swift_receiver_owner_from_type(type_surface, context)
+}
+
+fn swift_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
+    let Some(binding_scope) = swift_lexical_scope(binding) else {
+        return false;
+    };
+    let Some(call_scope) = swift_lexical_scope(call_node) else {
+        return false;
+    };
+    node_is_same_or_ancestor(binding_scope, call_scope)
+}
+
+fn swift_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
+    enclosing_node_with_kind(node, &["statements", "function_body"])
+}
+
+fn collect_swift_parameter_type_modules(
+    callable: TsNode<'_>,
+    source: &str,
+    imports: &SwiftImportContext,
+    local_type_names: &HashSet<String>,
+) -> HashMap<String, String> {
+    let mut receiver_modules = HashMap::new();
+    let Some(parameters) = signature_parameter_surface(callable, source) else {
+        return receiver_modules;
+    };
+    for parameter in split_top_level_parameters(&parameters) {
+        let Some((name_side, type_side)) = parameter.split_once(':') else {
+            continue;
+        };
+        let Some(receiver_name) = parameter_name_before_colon(name_side) else {
+            continue;
+        };
+        let raw_type = parameter_type_after_colon(type_side);
+        let Some(owner_name) = normalize_type_surface(&raw_type) else {
+            continue;
+        };
+        if let Some(module_name) = swift_type_import_qualifier(&raw_type) {
+            if imports.type_is_imported(&module_name, &owner_name) {
+                receiver_modules.insert(receiver_name, module_name);
+            }
+            continue;
+        }
+        if local_type_names.contains(&owner_name) {
+            continue;
+        }
+        if let Some(module_name) = imports.unqualified_owner_module(&owner_name) {
+            receiver_modules.insert(receiver_name, module_name);
+        }
+    }
+    receiver_modules
+}
+
+fn collect_swift_imports(source: &str) -> SwiftImportContext {
+    let mut imports = SwiftImportContext::default();
+    for swift_import in source.lines().filter_map(swift_import_from_line) {
+        match swift_import {
+            SwiftImport::WholeModule(module_name) => {
+                imports.whole_modules.insert(module_name);
+            }
+            SwiftImport::ScopedType {
+                module_name,
+                owner_name,
+            } => {
+                imports.scoped_types.insert((module_name, owner_name));
+            }
+        }
+    }
+    imports
+}
+
+enum SwiftImport {
+    WholeModule(String),
+    ScopedType {
+        module_name: String,
+        owner_name: String,
+    },
+}
+
+fn swift_import_from_line(raw_line: &str) -> Option<SwiftImport> {
+    let line = raw_line
+        .split("//")
+        .next()
+        .unwrap_or(raw_line)
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    if line.is_empty() {
+        return None;
+    }
+    let tokens = line.split_whitespace().collect::<Vec<_>>();
+    let import_index = tokens.iter().position(|token| *token == "import")?;
+    let first_import_token = tokens.get(import_index + 1)?;
+    if matches!(
+        *first_import_token,
+        "class" | "struct" | "enum" | "protocol" | "typealias"
+    ) {
+        let scoped_surface = tokens.get(import_index + 2)?.trim();
+        let module_name = swift_import_module_name(scoped_surface)?;
+        let owner_name = swift_import_scoped_owner_name(scoped_surface)?;
+        return Some(SwiftImport::ScopedType {
+            module_name,
+            owner_name,
+        });
+    }
+    if matches!(*first_import_token, "func" | "var") {
+        return None;
+    }
+    let module_surface = first_import_token.trim();
+    swift_import_module_name(module_surface).map(SwiftImport::WholeModule)
+}
+
+fn swift_import_module_name(module_surface: &str) -> Option<String> {
+    let module_name = module_surface
+        .split('.')
+        .next()
+        .unwrap_or(module_surface)
+        .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_');
+    (!module_name.is_empty()).then(|| module_name.to_string())
+}
+
+fn swift_import_scoped_owner_name(module_surface: &str) -> Option<String> {
+    let (_, owner_surface) = module_surface.rsplit_once('.')?;
+    normalize_parameter_name(owner_surface)
+}
+
+fn collect_swift_type_binding_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
+    let mut names = HashSet::new();
+    walk_tree_nodes(root, &mut |node| {
+        if matches!(
+            node.kind(),
+            "class_declaration"
+                | "protocol_declaration"
+                | "struct_declaration"
+                | "enum_declaration"
+                | "typealias_declaration"
+        ) && let Some(name) =
+            declaration_name(node, source).and_then(|name| normalize_parameter_name(&name))
+        {
+            names.insert(name);
+        }
+    });
+    names
+}
+
+fn swift_type_import_qualifier(raw_type: &str) -> Option<String> {
+    if raw_type.contains('|') || raw_type.contains('&') {
+        return None;
+    }
+    let surface = raw_type.trim().trim_end_matches('?').trim();
+    let base = surface
+        .split(['<', '[', '('])
+        .next()
+        .unwrap_or(surface)
+        .trim();
+    let (qualifier, _) = base.rsplit_once('.')?;
+    normalize_parameter_name(qualifier)
+}
+
+fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let text = trimmed_node_text(node, source)?;
+    let callable = text
+        .split('(')
+        .next()
+        .unwrap_or(text.as_str())
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    let separator = callable.rfind('.')?;
+    let receiver = callable[..separator].trim().trim_end_matches('?').trim();
+    let method = callable[separator + 1..]
+        .trim()
+        .trim_start_matches('?')
+        .trim();
+    Some((
+        normalized_swift_receiver_surface(receiver)?,
+        normalize_parameter_name(method)?,
+    ))
+}
+
+fn normalized_swift_receiver_surface(raw: &str) -> Option<String> {
+    let receiver = raw.trim().trim_end_matches('?').trim();
+    if receiver.contains('.') {
+        let cleaned = receiver
+            .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '.')
+            .trim();
+        let valid = cleaned
+            .split('.')
+            .all(|part| normalize_parameter_name(part).is_some());
+        return (valid && !cleaned.is_empty()).then(|| cleaned.to_string());
+    }
+    normalize_parameter_name(receiver)
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -67,7 +67,6 @@ pub(crate) const PHP_MEMBER_CALLSITE_MARKER: &str = "syntax:php-member-call";
 pub(crate) const JS_MEMBER_CALLSITE_MARKER: &str = "syntax:js-member-call";
 pub(crate) const TS_MEMBER_CALLSITE_MARKER: &str = "syntax:ts-member-call";
 pub(crate) const DART_MEMBER_CALLSITE_MARKER: &str = "syntax:dart-member-call";
-pub(crate) const SWIFT_MEMBER_CALLSITE_MARKER: &str = "syntax:swift-member-call";
 pub(crate) const RECEIVER_OWNER_CALLSITE_PREFIX: &str = "receiver-owner:";
 pub(crate) const RECEIVER_MODULE_CALLSITE_PREFIX: &str = "receiver-module:";
 
@@ -142,7 +141,6 @@ const GO_GRAPH_QUERY: &str = include_str!("../rules/go.scm");
 const RUBY_GRAPH_QUERY: &str = include_str!("../rules/ruby.scm");
 const PHP_GRAPH_QUERY: &str = include_str!("../rules/php.scm");
 const CSHARP_GRAPH_QUERY: &str = include_str!("../rules/csharp.scm");
-const SWIFT_GRAPH_QUERY: &str = include_str!("../rules/swift.scm");
 const DART_GRAPH_QUERY: &str = include_str!("../rules/dart.scm");
 const BASH_GRAPH_QUERY: &str = include_str!("../rules/bash.scm");
 
@@ -327,15 +325,15 @@ impl LanguageRuleset {
             LanguageRuleset::CSharp => {
                 compiled_rules_cache(language, CSHARP_GRAPH_QUERY, None, &CSHARP_RULES)
             }
-            // Answered by the registry above; the arm only exists because the
-            // match must stay exhaustive. Failing closed here rather than
+            // Answered by the registry above; these arms only exist because
+            // the match must stay exhaustive. Failing closed here rather than
             // panicking keeps a future registry mistake a typed indexing error.
             LanguageRuleset::Kotlin => Err(anyhow!(
                 "kotlin compiled rules are owned by the language registry"
             )),
-            LanguageRuleset::Swift => {
-                compiled_rules_cache(language, SWIFT_GRAPH_QUERY, None, &SWIFT_RULES)
-            }
+            LanguageRuleset::Swift => Err(anyhow!(
+                "swift compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::Dart => {
                 compiled_rules_cache(language, DART_GRAPH_QUERY, None, &DART_RULES)
             }
@@ -384,7 +382,6 @@ static GO_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new
 static RUBY_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static PHP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CSHARP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static SWIFT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static DART_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static BASH_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 
@@ -7601,7 +7598,6 @@ fn language_receiver_call_specs(
         "php" => collect_php_receiver_call_edges(tree, source),
         "csharp" => collect_csharp_receiver_call_edges(tree, source),
         "cpp" => collect_cpp_receiver_call_edges(tree, source),
-        "swift" => collect_swift_receiver_call_edges(tree, source),
         "dart" => collect_dart_receiver_call_edges(tree, source),
         _ => Vec::new(),
     }
@@ -12493,541 +12489,6 @@ fn normalize_cpp_type_surface(raw_type: &str) -> Option<String> {
     normalize_type_surface(owner)
 }
 
-fn collect_swift_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let imports = collect_swift_imports(source);
-    let local_type_names = collect_swift_type_binding_names(tree.root_node(), source);
-    walk_tree_nodes(tree.root_node(), &mut |callable| {
-        if callable.kind() != "function_declaration" {
-            return;
-        }
-        let Some(source_name) = declaration_name(callable, source) else {
-            return;
-        };
-        let call_source = ManualReceiverSource {
-            name: &source_name,
-            span: ts_node_graph_span(callable),
-        };
-        let receiver_types = collect_colon_parameter_types(callable, source);
-        let mut local_receiver_callsites = HashSet::new();
-        collect_swift_precise_receiver_call_specs(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            SwiftReceiverContext {
-                parameter_receiver_types: &receiver_types,
-                imports: &imports,
-                local_type_names: &local_type_names,
-            },
-            &mut local_receiver_callsites,
-            &mut edges,
-        );
-        if receiver_types.is_empty() {
-            return;
-        }
-        let receiver_modules =
-            collect_swift_parameter_type_modules(callable, source, &imports, &local_type_names);
-        let start = edges.len();
-        collect_receiver_call_specs_in_callable(
-            callable,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            &receiver_types,
-            swift_member_call,
-            false,
-            &mut edges,
-        );
-        let mut parameter_specs = edges.split_off(start);
-        parameter_specs
-            .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
-        for spec in &mut parameter_specs {
-            if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
-                spec.owner_module = Some(module_name.clone());
-            }
-        }
-        edges.extend(parameter_specs);
-    });
-    edges
-}
-
-struct SwiftReceiverContext<'a> {
-    parameter_receiver_types: &'a HashMap<String, String>,
-    imports: &'a SwiftImportContext,
-    local_type_names: &'a HashSet<String>,
-}
-
-#[derive(Debug, Default)]
-struct SwiftImportContext {
-    whole_modules: HashSet<String>,
-    scoped_types: HashSet<(String, String)>,
-}
-
-impl SwiftImportContext {
-    fn type_is_imported(&self, module_name: &str, owner_name: &str) -> bool {
-        self.whole_modules.contains(module_name)
-            || self
-                .scoped_types
-                .iter()
-                .any(|(module, owner)| module == module_name && owner == owner_name)
-    }
-
-    fn unqualified_owner_module(&self, owner_name: &str) -> Option<String> {
-        let mut candidates = self
-            .scoped_types
-            .iter()
-            .filter_map(|(module_name, imported_owner)| {
-                (imported_owner == owner_name).then_some(module_name.clone())
-            })
-            .collect::<HashSet<_>>();
-        if self.whole_modules.len() == 1
-            && let Some(module_name) = self.whole_modules.iter().next()
-        {
-            candidates.insert(module_name.clone());
-        }
-        (candidates.len() == 1)
-            .then(|| candidates.into_iter().next())
-            .flatten()
-    }
-}
-
-fn collect_swift_precise_receiver_call_specs(
-    callable: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    context: SwiftReceiverContext<'_>,
-    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(callable, &mut |node| {
-        let Some((receiver_name, method_name)) = swift_member_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, callable) {
-            return;
-        }
-        let method_col = member_call_method_col(node, source, &method_name);
-        let callsite_key = ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
-            method_col,
-        };
-
-        if let Some(owner) =
-            swift_visible_local_receiver_owner(callable, node, &receiver_name, source, &context)
-        {
-            local_receiver_callsites.insert(callsite_key);
-            if let Some((owner_name, owner_module)) = owner {
-                edges.push(ManualReceiverCallSpec {
-                    source_name: call_source.name.to_string(),
-                    source_span: call_source.span,
-                    receiver_name,
-                    owner_name,
-                    owner_module,
-                    method_name,
-                    method_col,
-                    line: Some(node.start_position().row as u32 + 1),
-                    allow_global_fallback: false,
-                });
-            }
-            return;
-        }
-
-        let owner = if let Some(owner) = swift_self_receiver_owner(callable, &receiver_name, source)
-        {
-            Some(owner)
-        } else if !context
-            .parameter_receiver_types
-            .contains_key(&receiver_name)
-        {
-            swift_property_receiver_owner(callable, &receiver_name, source, &context)
-        } else {
-            None
-        };
-        let Some((owner_name, owner_module)) = owner else {
-            return;
-        };
-        edges.push(ManualReceiverCallSpec {
-            source_name: call_source.name.to_string(),
-            source_span: call_source.span,
-            receiver_name,
-            owner_name,
-            owner_module,
-            method_name,
-            method_col,
-            line: Some(node.start_position().row as u32 + 1),
-            allow_global_fallback: false,
-        });
-    });
-}
-
-fn swift_self_receiver_owner(
-    callable: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-) -> OptionalReceiverOwnerBinding {
-    if receiver_name != "self" {
-        return None;
-    }
-    let owner_node = enclosing_node_with_kind(callable, &["class_declaration"])?;
-    let owner_name = declaration_name(owner_node, source)?;
-    Some((owner_name, None))
-}
-
-fn swift_visible_local_receiver_owner(
-    callable: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    context: &SwiftReceiverContext<'_>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(callable, &mut |node| {
-        if node.kind() != "property_declaration" {
-            return;
-        }
-        if !receiver_call_belongs_to_callable(node, callable)
-            || node.end_byte() > call_node.start_byte()
-        {
-            return;
-        }
-        let Some(binding_name) = swift_property_binding_name(node, source) else {
-            return;
-        };
-        if binding_name != receiver_name || !swift_local_binding_visible_at_call(node, call_node) {
-            return;
-        }
-        visible_bindings.push((
-            node.end_byte(),
-            swift_initialized_constructor_owner(node, source, context),
-        ));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner_name)| owner_name)
-}
-
-fn swift_property_receiver_owner(
-    callable: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    context: &SwiftReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let field_name = receiver_name
-        .strip_prefix("self.")
-        .unwrap_or(receiver_name)
-        .trim();
-    if field_name == "self" || field_name.contains('.') {
-        return None;
-    }
-    let owner_node = enclosing_node_with_kind(callable, &["class_declaration"])?;
-    let mut property_bindings = Vec::new();
-    walk_tree_nodes(owner_node, &mut |node| {
-        if node.kind() != "property_declaration"
-            || !swift_property_belongs_to_owner(node, owner_node)
-        {
-            return;
-        }
-        let Some(binding_name) = swift_property_binding_name(node, source) else {
-            return;
-        };
-        if binding_name != field_name {
-            return;
-        }
-        if let Some(owner) = swift_typed_property_owner(node, source, context) {
-            property_bindings.push(owner);
-        }
-    });
-    property_bindings.sort();
-    property_bindings.dedup();
-    if property_bindings.len() == 1 {
-        Some(property_bindings.remove(0))
-    } else {
-        None
-    }
-}
-
-fn swift_property_belongs_to_owner(property: TsNode<'_>, owner_node: TsNode<'_>) -> bool {
-    let mut current = property.parent();
-    while let Some(candidate) = current {
-        if same_ts_span(candidate, owner_node) {
-            return true;
-        }
-        if candidate.kind() == "function_declaration" || candidate.kind() == "class_declaration" {
-            return false;
-        }
-        current = candidate.parent();
-    }
-    false
-}
-
-fn swift_property_binding_name(node: TsNode<'_>, source: &str) -> Option<String> {
-    node.child_by_field_name("name")
-        .and_then(|name| trimmed_node_text(name, source))
-        .as_deref()
-        .and_then(|surface| {
-            surface
-                .split_whitespace()
-                .filter(|token| !matches!(*token, "let" | "var"))
-                .filter_map(normalize_parameter_name)
-                .next_back()
-        })
-}
-
-fn swift_initialized_constructor_owner(
-    node: TsNode<'_>,
-    source: &str,
-    context: &SwiftReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    if let Some(owner_name) = node
-        .child_by_field_name("value")
-        .and_then(|value| swift_constructor_owner(value, source, context))
-    {
-        return Some(owner_name);
-    }
-    let surface = trimmed_node_text(node, source)?;
-    let (_, value_surface) = surface.split_once('=')?;
-    swift_constructor_owner_surface(value_surface, context)
-}
-
-fn swift_typed_property_owner(
-    node: TsNode<'_>,
-    source: &str,
-    context: &SwiftReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let surface = trimmed_node_text(node, source)?;
-    let head = surface.split('=').next().unwrap_or(surface.as_str()).trim();
-    let rest = head
-        .rsplit_once(" let ")
-        .map(|(_, rest)| rest)
-        .or_else(|| head.rsplit_once(" var ").map(|(_, rest)| rest))
-        .or_else(|| head.strip_prefix("let "))
-        .or_else(|| head.strip_prefix("var "))?
-        .trim();
-    let (_, type_side) = rest.split_once(':')?;
-    swift_receiver_owner_from_type(&parameter_type_after_colon(type_side), context)
-}
-
-fn swift_receiver_owner_from_type(
-    raw_type: &str,
-    context: &SwiftReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let owner_name = normalize_type_surface(raw_type)?;
-    if let Some(module_name) = swift_type_import_qualifier(raw_type) {
-        if context.imports.type_is_imported(&module_name, &owner_name) {
-            return Some((owner_name, Some(module_name)));
-        }
-        return None;
-    }
-    if context.local_type_names.contains(&owner_name) {
-        return Some((owner_name, None));
-    }
-    if let Some(module_name) = context.imports.unqualified_owner_module(&owner_name) {
-        return Some((owner_name, Some(module_name)));
-    }
-    Some((owner_name, None))
-}
-
-fn swift_constructor_owner(
-    value: TsNode<'_>,
-    source: &str,
-    context: &SwiftReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    trimmed_node_text(value, source)
-        .as_deref()
-        .and_then(|surface| swift_constructor_owner_surface(surface, context))
-}
-
-fn swift_constructor_owner_surface(
-    surface: &str,
-    context: &SwiftReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let surface = surface.trim().trim_end_matches(';').trim();
-    let (constructor_name, _) = surface.split_once('(')?;
-    swift_constructor_owner_from_type_surface(constructor_name, context)
-}
-
-fn swift_constructor_owner_from_type_surface(
-    type_surface: &str,
-    context: &SwiftReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let type_surface = type_surface.trim();
-    if type_surface.contains("::") {
-        return None;
-    }
-    let owner_name = normalize_type_surface(type_surface)?;
-    if !owner_name
-        .chars()
-        .next()
-        .is_some_and(|first| first.is_ascii_uppercase())
-    {
-        return None;
-    }
-    swift_receiver_owner_from_type(type_surface, context)
-}
-
-fn swift_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
-    let Some(binding_scope) = swift_lexical_scope(binding) else {
-        return false;
-    };
-    let Some(call_scope) = swift_lexical_scope(call_node) else {
-        return false;
-    };
-    node_is_same_or_ancestor(binding_scope, call_scope)
-}
-
-fn swift_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
-    enclosing_node_with_kind(node, &["statements", "function_body"])
-}
-
-fn collect_swift_parameter_type_modules(
-    callable: TsNode<'_>,
-    source: &str,
-    imports: &SwiftImportContext,
-    local_type_names: &HashSet<String>,
-) -> HashMap<String, String> {
-    let mut receiver_modules = HashMap::new();
-    let Some(parameters) = signature_parameter_surface(callable, source) else {
-        return receiver_modules;
-    };
-    for parameter in split_top_level_parameters(&parameters) {
-        let Some((name_side, type_side)) = parameter.split_once(':') else {
-            continue;
-        };
-        let Some(receiver_name) = parameter_name_before_colon(name_side) else {
-            continue;
-        };
-        let raw_type = parameter_type_after_colon(type_side);
-        let Some(owner_name) = normalize_type_surface(&raw_type) else {
-            continue;
-        };
-        if let Some(module_name) = swift_type_import_qualifier(&raw_type) {
-            if imports.type_is_imported(&module_name, &owner_name) {
-                receiver_modules.insert(receiver_name, module_name);
-            }
-            continue;
-        }
-        if local_type_names.contains(&owner_name) {
-            continue;
-        }
-        if let Some(module_name) = imports.unqualified_owner_module(&owner_name) {
-            receiver_modules.insert(receiver_name, module_name);
-        }
-    }
-    receiver_modules
-}
-
-fn collect_swift_imports(source: &str) -> SwiftImportContext {
-    let mut imports = SwiftImportContext::default();
-    for swift_import in source.lines().filter_map(swift_import_from_line) {
-        match swift_import {
-            SwiftImport::WholeModule(module_name) => {
-                imports.whole_modules.insert(module_name);
-            }
-            SwiftImport::ScopedType {
-                module_name,
-                owner_name,
-            } => {
-                imports.scoped_types.insert((module_name, owner_name));
-            }
-        }
-    }
-    imports
-}
-
-enum SwiftImport {
-    WholeModule(String),
-    ScopedType {
-        module_name: String,
-        owner_name: String,
-    },
-}
-
-fn swift_import_from_line(raw_line: &str) -> Option<SwiftImport> {
-    let line = raw_line
-        .split("//")
-        .next()
-        .unwrap_or(raw_line)
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    if line.is_empty() {
-        return None;
-    }
-    let tokens = line.split_whitespace().collect::<Vec<_>>();
-    let import_index = tokens.iter().position(|token| *token == "import")?;
-    let first_import_token = tokens.get(import_index + 1)?;
-    if matches!(
-        *first_import_token,
-        "class" | "struct" | "enum" | "protocol" | "typealias"
-    ) {
-        let scoped_surface = tokens.get(import_index + 2)?.trim();
-        let module_name = swift_import_module_name(scoped_surface)?;
-        let owner_name = swift_import_scoped_owner_name(scoped_surface)?;
-        return Some(SwiftImport::ScopedType {
-            module_name,
-            owner_name,
-        });
-    }
-    if matches!(*first_import_token, "func" | "var") {
-        return None;
-    }
-    let module_surface = first_import_token.trim();
-    swift_import_module_name(module_surface).map(SwiftImport::WholeModule)
-}
-
-fn swift_import_module_name(module_surface: &str) -> Option<String> {
-    let module_name = module_surface
-        .split('.')
-        .next()
-        .unwrap_or(module_surface)
-        .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_');
-    (!module_name.is_empty()).then(|| module_name.to_string())
-}
-
-fn swift_import_scoped_owner_name(module_surface: &str) -> Option<String> {
-    let (_, owner_surface) = module_surface.rsplit_once('.')?;
-    normalize_parameter_name(owner_surface)
-}
-
-fn collect_swift_type_binding_names(root: TsNode<'_>, source: &str) -> HashSet<String> {
-    let mut names = HashSet::new();
-    walk_tree_nodes(root, &mut |node| {
-        if matches!(
-            node.kind(),
-            "class_declaration"
-                | "protocol_declaration"
-                | "struct_declaration"
-                | "enum_declaration"
-                | "typealias_declaration"
-        ) && let Some(name) =
-            declaration_name(node, source).and_then(|name| normalize_parameter_name(&name))
-        {
-            names.insert(name);
-        }
-    });
-    names
-}
-
-fn swift_type_import_qualifier(raw_type: &str) -> Option<String> {
-    if raw_type.contains('|') || raw_type.contains('&') {
-        return None;
-    }
-    let surface = raw_type.trim().trim_end_matches('?').trim();
-    let base = surface
-        .split(['<', '[', '('])
-        .next()
-        .unwrap_or(surface)
-        .trim();
-    let (qualifier, _) = base.rsplit_once('.')?;
-    normalize_parameter_name(qualifier)
-}
-
 fn collect_dart_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
     let mut edges = Vec::new();
     let import_alias_bindings = collect_dart_import_alias_bindings(source);
@@ -14541,44 +14002,6 @@ fn cpp_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
     ))
 }
 
-fn swift_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if node.kind() != "call_expression" {
-        return None;
-    }
-    let text = trimmed_node_text(node, source)?;
-    let callable = text
-        .split('(')
-        .next()
-        .unwrap_or(text.as_str())
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    let separator = callable.rfind('.')?;
-    let receiver = callable[..separator].trim().trim_end_matches('?').trim();
-    let method = callable[separator + 1..]
-        .trim()
-        .trim_start_matches('?')
-        .trim();
-    Some((
-        normalized_swift_receiver_surface(receiver)?,
-        normalize_parameter_name(method)?,
-    ))
-}
-
-fn normalized_swift_receiver_surface(raw: &str) -> Option<String> {
-    let receiver = raw.trim().trim_end_matches('?').trim();
-    if receiver.contains('.') {
-        let cleaned = receiver
-            .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '.')
-            .trim();
-        let valid = cleaned
-            .split('.')
-            .all(|part| normalize_parameter_name(part).is_some());
-        return (valid && !cleaned.is_empty()).then(|| cleaned.to_string());
-    }
-    normalize_parameter_name(receiver)
-}
-
 fn dart_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
     if !matches!(node.kind(), "expression_statement" | "return_statement") {
         return None;
@@ -15201,11 +14624,11 @@ fn queue_qualified_child_names(
 }
 
 fn promotes_type_member_functions_to_methods(language_name: &str) -> bool {
-    // Registry first; `swift` and `dart` are the unmigrated residue.
+    // Registry first; `dart` is the unmigrated residue.
     if let Some(extraction) = languages::extraction_for_language(language_name) {
         return extraction.promotes_type_member_functions_to_methods;
     }
-    matches!(language_name, "swift" | "dart")
+    matches!(language_name, "dart")
 }
 
 fn qualified_name_delimiter(language_name: &str) -> &'static str {
@@ -20232,7 +19655,6 @@ pub fn index_file(
                                         "js_member" => Some(JS_MEMBER_CALLSITE_MARKER),
                                         "ts_member" => Some(TS_MEMBER_CALLSITE_MARKER),
                                         "dart_member" => Some(DART_MEMBER_CALLSITE_MARKER),
-                                        "swift_member" => Some(SWIFT_MEMBER_CALLSITE_MARKER),
                                         _ => callsite_marker,
                                     },
                                 };
@@ -25751,8 +25173,18 @@ class Test {
         let kotlin_script = get_language_for_ext("kts").expect("kotlin script config");
         assert_eq!(kotlin_script.graph_query, kotlin.graph_query);
 
+        // Swift's rule file moved into `languages::swift`; the config must
+        // still come back through the same extension lookup.
         let swift = get_language_for_ext("swift").expect("swift config");
-        assert_eq!(swift.graph_query, SWIFT_GRAPH_QUERY);
+        assert_eq!(swift.language_name, "swift");
+        assert_eq!(
+            swift.graph_query,
+            languages::extraction_for_ext("swift")
+                .expect("swift registry row")
+                .graph_query
+        );
+        assert!(swift.graph_query.contains("swift_member"));
+        assert!(swift.tags_query.is_none());
 
         let dart = get_language_for_ext("dart").expect("dart config");
         assert_eq!(dart.graph_query, DART_GRAPH_QUERY);

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1381,7 +1381,7 @@ fn is_swift_member_call_placeholder(edge_kind: EdgeKind, callsite_identity: Opti
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::SWIFT_MEMBER_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::swift::MEMBER_CALLSITE_MARKER)
     })
 }
 

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -410,9 +410,6 @@ fn dedicated_semantic_resolver(language: &str) -> Option<SemanticResolverKind> {
         "ruby" => Some(SemanticResolverKind::Ruby(RubySemanticResolver)),
         "php" => Some(SemanticResolverKind::Php(PhpSemanticResolver)),
         "csharp" => Some(SemanticResolverKind::CSharp(CSharpSemanticResolver)),
-        "swift" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
-            "swift",
-        ))),
         "dart" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
             "dart",
         ))),
@@ -600,7 +597,6 @@ fn language_family_bucket(language: &'static str) -> &'static str {
         "ruby" => "ruby",
         "php" => "php",
         "csharp" => "csharp",
-        "swift" => "swift",
         "dart" => "dart",
         "bash" => "bash",
         language if is_structural_language_name(language) => "structural",

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/swift_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/swift_fidelity.txt
@@ -1,0 +1,40 @@
+node CLASS name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.swift:ConsoleNotifier line=7 col=1 end=11:2 file=FILE:<ROOT>/fidelity.swift@1
+node CLASS name=Event qn=Event canonical=<ROOT>/fidelity.swift:Event line=19 col=1 end=25:2 file=FILE:<ROOT>/fidelity.swift@1
+node CLASS name=Repository qn=Repository canonical=<ROOT>/fidelity.swift:Repository line=13 col=1 end=17:2 file=FILE:<ROOT>/fidelity.swift@1
+node CLASS name=Workflow qn=Workflow canonical=<ROOT>/fidelity.swift:Workflow line=27 col=1 end=37:2 file=FILE:<ROOT>/fidelity.swift@1
+node FILE name=<ROOT>/fidelity.swift qn=<ROOT>/fidelity.swift canonical=<ROOT>/fidelity.swift:<ROOT>/fidelity.swift:1 line=1 col=1 end=42:0 file=FILE:<ROOT>/fidelity.swift@1
+node FUNCTION name=orchestrateSwift qn=orchestrateSwift canonical=<ROOT>/fidelity.swift:orchestrateSwift#0 line=39 col=1 end=42:2 file=FILE:<ROOT>/fidelity.swift@1
+node INTERFACE name=Notifier qn=Notifier canonical=<ROOT>/fidelity.swift:Notifier line=3 col=1 end=5:2 file=FILE:<ROOT>/fidelity.swift@1
+node METHOD name=ConsoleNotifier.notify qn=ConsoleNotifier.notify canonical=<ROOT>/fidelity.swift:ConsoleNotifier.notify#0 line=8 col=5 end=10:6 file=FILE:<ROOT>/fidelity.swift@1
+node METHOD name=Notifier.notify qn=Notifier.notify canonical=<ROOT>/fidelity.swift:Notifier.notify#0 line=4 col=5 end=4:30 file=FILE:<ROOT>/fidelity.swift@1
+node METHOD name=Repository.save qn=Repository.save canonical=<ROOT>/fidelity.swift:Repository.save#0 line=14 col=5 end=16:6 file=FILE:<ROOT>/fidelity.swift@1
+node METHOD name=Workflow.decorate qn=Workflow.decorate canonical=<ROOT>/fidelity.swift:Workflow.decorate#0 line=34 col=5 end=36:6 file=FILE:<ROOT>/fidelity.swift@1
+node METHOD name=Workflow.run qn=Workflow.run canonical=<ROOT>/fidelity.swift:Workflow.run#0 line=28 col=5 end=32:6 file=FILE:<ROOT>/fidelity.swift@1
+node MODULE name=Foundation qn=Foundation canonical=<ROOT>/fidelity.swift:Foundation#0 line=1 col=8 end=1:18 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.swift:ConsoleNotifier#0 line=41 col=57 end=41:72 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=Event qn=Event canonical=<ROOT>/fidelity.swift:Event#0 line=41 col=25 end=41:30 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=Repository qn=Repository canonical=<ROOT>/fidelity.swift:Repository#0 line=41 col=88 end=41:98 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=Workflow qn=Workflow canonical=<ROOT>/fidelity.swift:Workflow#0 line=40 col=20 end=40:28 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.swift:decorate#0 line=31 col=9 end=31:17 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.swift:notify#0 line=29 col=18 end=29:24 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=print qn=print canonical=<ROOT>/fidelity.swift:print#0 line=9 col=9 end=9:14 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=print qn=print canonical=<ROOT>/fidelity.swift:print#1 line=15 col=9 end=15:14 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.swift:run#0 line=41 col=14 end=41:17 file=FILE:<ROOT>/fidelity.swift@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.swift:save#0 line=30 col=20 end=30:24 file=FILE:<ROOT>/fidelity.swift@1
+edge CALL src=FUNCTION:orchestrateSwift@39 dst=METHOD:Workflow.run@28 resolved_src=FUNCTION:orchestrateSwift@39 resolved_dst=METHOD:Workflow.run@28 line=41 confidence=1.0000 certainty=Certain callsite=h0:41:1:h1 candidates=[]
+edge CALL src=FUNCTION:orchestrateSwift@39 dst=UNKNOWN:ConsoleNotifier@41 resolved_src=FUNCTION:orchestrateSwift@39 resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:1:h2 candidates=[]
+edge CALL src=FUNCTION:orchestrateSwift@39 dst=UNKNOWN:Event@41 resolved_src=FUNCTION:orchestrateSwift@39 resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:1:h3 candidates=[]
+edge CALL src=FUNCTION:orchestrateSwift@39 dst=UNKNOWN:Repository@41 resolved_src=FUNCTION:orchestrateSwift@39 resolved_dst=- line=41 confidence=- certainty=- callsite=h0:41:1:h4 candidates=[]
+edge CALL src=FUNCTION:orchestrateSwift@39 dst=UNKNOWN:Workflow@40 resolved_src=FUNCTION:orchestrateSwift@39 resolved_dst=- line=40 confidence=- certainty=- callsite=h0:40:1:h5 candidates=[]
+edge CALL src=METHOD:ConsoleNotifier.notify@8 dst=UNKNOWN:print@9 resolved_src=METHOD:ConsoleNotifier.notify@8 resolved_dst=- line=9 confidence=- certainty=- callsite=h0:9:1:h6 candidates=[]
+edge CALL src=METHOD:Repository.save@14 dst=UNKNOWN:print@15 resolved_src=METHOD:Repository.save@14 resolved_dst=- line=15 confidence=- certainty=- callsite=h0:15:1:h7 candidates=[]
+edge CALL src=METHOD:Workflow.run@28 dst=METHOD:Notifier.notify@4 resolved_src=METHOD:Workflow.run@28 resolved_dst=METHOD:Notifier.notify@4 line=29 confidence=1.0000 certainty=Certain callsite=h0:29:1:h8 candidates=[]
+edge CALL src=METHOD:Workflow.run@28 dst=METHOD:Repository.save@14 resolved_src=METHOD:Workflow.run@28 resolved_dst=METHOD:Repository.save@14 line=30 confidence=1.0000 certainty=Certain callsite=h0:30:1:h9 candidates=[]
+edge CALL src=METHOD:Workflow.run@28 dst=UNKNOWN:decorate@31 resolved_src=METHOD:Workflow.run@28 resolved_dst=METHOD:Workflow.decorate@34 line=31 confidence=0.9500 certainty=Certain callsite=h0:31:1:h10 candidates=[]
+edge IMPORT src=MODULE:Foundation@1 dst=MODULE:Foundation@1 resolved_src=MODULE:Foundation@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ConsoleNotifier@7 dst=INTERFACE:Notifier@3 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@7 dst=METHOD:ConsoleNotifier.notify@8 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@13 dst=METHOD:Repository.save@14 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@27 dst=METHOD:Workflow.decorate@34 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@27 dst=METHOD:Workflow.run@28 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Notifier@3 dst=METHOD:Notifier.notify@4 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/swift_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/swift_tictactoe.txt
@@ -1,0 +1,106 @@
+node CLASS name=ArtificialPlayer qn=ArtificialPlayer canonical=game.swift:ArtificialPlayer line=46 col=1 end=58:2 file=FILE:game.swift@1
+node CLASS name=Field qn=Field canonical=game.swift:Field line=19 col=1 end=34:2 file=FILE:game.swift@1
+node CLASS name=GameObject qn=GameObject canonical=game.swift:GameObject line=15 col=1 end=17:2 file=FILE:game.swift@1
+node CLASS name=HumanPlayer qn=HumanPlayer canonical=game.swift:HumanPlayer line=40 col=1 end=44:2 file=FILE:game.swift@1
+node CLASS name=TicTacToe qn=TicTacToe canonical=game.swift:TicTacToe line=60 col=1 end=68:2 file=FILE:game.swift@1
+node FILE name=game.swift qn=game.swift canonical=game.swift:game.swift:1 line=1 col=1 end=73:0 file=FILE:game.swift@1
+node FUNCTION name=main qn=main canonical=game.swift:main#0 line=70 col=1 end=73:2 file=FILE:game.swift@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.swift:numberIn#0 line=3 col=1 end=5:2 file=FILE:game.swift@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.swift:numberOut#0 line=7 col=1 end=9:2 file=FILE:game.swift@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.swift:stringOut#0 line=11 col=1 end=13:2 file=FILE:game.swift@1
+node INTERFACE name=Player qn=Player canonical=game.swift:Player line=36 col=1 end=38:2 file=FILE:game.swift@1
+node METHOD name=ArtificialPlayer.minMax qn=ArtificialPlayer.minMax canonical=game.swift:ArtificialPlayer.minMax#0 line=47 col=5 end=52:6 file=FILE:game.swift@1
+node METHOD name=ArtificialPlayer.turn qn=ArtificialPlayer.turn canonical=game.swift:ArtificialPlayer.turn#0 line=54 col=5 end=57:6 file=FILE:game.swift@1
+node METHOD name=Field.makeMove qn=Field.makeMove canonical=game.swift:Field.makeMove#0 line=26 col=5 end=33:6 file=FILE:game.swift@1
+node METHOD name=Field.sameInRow qn=Field.sameInRow canonical=game.swift:Field.sameInRow#0 line=22 col=5 end=24:6 file=FILE:game.swift@1
+node METHOD name=GameObject.announce qn=GameObject.announce canonical=game.swift:GameObject.announce#0 line=16 col=5 end=16:23 file=FILE:game.swift@1
+node METHOD name=HumanPlayer.turn qn=HumanPlayer.turn canonical=game.swift:HumanPlayer.turn#0 line=41 col=5 end=43:6 file=FILE:game.swift@1
+node METHOD name=Player.turn qn=Player.turn canonical=game.swift:Player.turn#0 line=37 col=5 end=37:48 file=FILE:game.swift@1
+node METHOD name=TicTacToe.run qn=TicTacToe.run canonical=game.swift:TicTacToe.run#0 line=63 col=5 end=67:6 file=FILE:game.swift@1
+node MODULE name=Foundation qn=Foundation canonical=game.swift:Foundation#0 line=1 col=8 end=1:18 file=FILE:game.swift@1
+node UNKNOWN name=Field qn=Field canonical=game.swift:Field#0 line=61 col=17 end=61:22 file=FILE:game.swift@1
+node UNKNOWN name=TicTacToe qn=TicTacToe canonical=game.swift:TicTacToe#0 line=71 col=16 end=71:25 file=FILE:game.swift@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.swift:makeMove#0 line=42 col=22 end=42:30 file=FILE:game.swift@1
+node UNKNOWN name=minMax qn=minMax canonical=game.swift:minMax#0 line=51 col=16 end=51:22 file=FILE:game.swift@1
+node UNKNOWN name=minMax qn=minMax canonical=game.swift:minMax#1 line=55 col=9 end=55:15 file=FILE:game.swift@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.swift:numberIn#1 line=64 col=9 end=64:17 file=FILE:game.swift@1
+node UNKNOWN name=print qn=print canonical=game.swift:print#0 line=8 col=5 end=8:10 file=FILE:game.swift@1
+node UNKNOWN name=print qn=print canonical=game.swift:print#1 line=12 col=5 end=12:10 file=FILE:game.swift@1
+node UNKNOWN name=random qn=random canonical=game.swift:random#0 line=66 col=13 end=66:19 file=FILE:game.swift@1
+node UNKNOWN name=run qn=run canonical=game.swift:run#0 line=72 col=10 end=72:13 file=FILE:game.swift@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.swift:sameInRow#0 line=31 col=9 end=31:18 file=FILE:game.swift@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.swift:stringOut#1 line=65 col=9 end=65:18 file=FILE:game.swift@1
+edge CALL src=FUNCTION:main@70 dst=METHOD:TicTacToe.run@63 resolved_src=- resolved_dst=METHOD:TicTacToe.run@63 line=72 confidence=1.0000 certainty=Certain callsite=h0:72:1:h1 candidates=[]
+edge CALL src=FUNCTION:main@70 dst=UNKNOWN:TicTacToe@71 resolved_src=- resolved_dst=- line=71 confidence=- certainty=- callsite=h0:71:1:h2 candidates=[]
+edge CALL src=FUNCTION:numberOut@7 dst=UNKNOWN:print@8 resolved_src=- resolved_dst=- line=8 confidence=- certainty=- callsite=h0:8:1:h3 candidates=[]
+edge CALL src=FUNCTION:stringOut@11 dst=UNKNOWN:print@12 resolved_src=- resolved_dst=- line=12 confidence=- certainty=- callsite=h0:12:1:h4 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.minMax@47 dst=UNKNOWN:minMax@51 resolved_src=- resolved_dst=- line=51 confidence=- certainty=- callsite=h0:51:1:h5 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@54 dst=UNKNOWN:minMax@55 resolved_src=- resolved_dst=- line=55 confidence=- certainty=- callsite=h0:55:1:h6 candidates=[]
+edge CALL src=METHOD:Field.makeMove@26 dst=UNKNOWN:sameInRow@31 resolved_src=- resolved_dst=- line=31 confidence=- certainty=- callsite=h0:31:1:h7 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@41 dst=METHOD:Field.makeMove@26 resolved_src=- resolved_dst=METHOD:Field.makeMove@26 line=42 confidence=1.0000 certainty=Certain callsite=h0:42:1:h8 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@63 dst=UNKNOWN:numberIn@64 resolved_src=- resolved_dst=- line=64 confidence=- certainty=- callsite=h0:64:1:h9 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@63 dst=UNKNOWN:random@66 resolved_src=- resolved_dst=- line=66 confidence=- certainty=- callsite=h0:66:1:h10|syntax:swift-member-call candidates=[]
+edge CALL src=METHOD:TicTacToe.run@63 dst=UNKNOWN:stringOut@65 resolved_src=- resolved_dst=- line=65 confidence=- certainty=- callsite=h0:65:1:h11 candidates=[]
+edge IMPORT src=MODULE:Foundation@1 dst=MODULE:Foundation@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ArtificialPlayer@46 dst=INTERFACE:Player@36 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@19 dst=CLASS:GameObject@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:HumanPlayer@40 dst=INTERFACE:Player@36 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:TicTacToe@60 dst=CLASS:GameObject@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@46 dst=METHOD:ArtificialPlayer.minMax@47 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@46 dst=METHOD:ArtificialPlayer.turn@54 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@19 dst=METHOD:Field.makeMove@26 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@19 dst=METHOD:Field.sameInRow@22 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:GameObject@15 dst=METHOD:GameObject.announce@16 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@40 dst=METHOD:HumanPlayer.turn@41 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@60 dst=METHOD:TicTacToe.run@63 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Player@36 dst=METHOD:Player.turn@37 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.swift language=swift lines=73 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@46 kind=DEFINITION span=46:1-58:2
+occurrence element=CLASS:Field@19 kind=DEFINITION span=19:1-34:2
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=15:1-17:2
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=19:14-19:24
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=60:18-60:28
+occurrence element=CLASS:HumanPlayer@40 kind=DEFINITION span=40:1-44:2
+occurrence element=CLASS:TicTacToe@60 kind=DEFINITION span=60:1-68:2
+occurrence element=FUNCTION:main@70 kind=DEFINITION span=70:1-73:2
+occurrence element=FUNCTION:numberIn@3 kind=DEFINITION span=3:1-5:2
+occurrence element=FUNCTION:numberOut@7 kind=DEFINITION span=7:1-9:2
+occurrence element=FUNCTION:stringOut@11 kind=DEFINITION span=11:1-13:2
+occurrence element=INTERFACE:Player@36 kind=DEFINITION span=36:1-38:2
+occurrence element=INTERFACE:Player@36 kind=DEFINITION span=40:20-40:26
+occurrence element=INTERFACE:Player@36 kind=DEFINITION span=46:25-46:31
+occurrence element=METHOD:ArtificialPlayer.minMax@47 kind=DEFINITION span=47:5-52:6
+occurrence element=METHOD:ArtificialPlayer.turn@54 kind=DEFINITION span=54:5-57:6
+occurrence element=METHOD:Field.makeMove@26 kind=DEFINITION span=26:5-33:6
+occurrence element=METHOD:Field.sameInRow@22 kind=DEFINITION span=22:5-24:6
+occurrence element=METHOD:GameObject.announce@16 kind=DEFINITION span=16:5-16:23
+occurrence element=METHOD:HumanPlayer.turn@41 kind=DEFINITION span=41:5-43:6
+occurrence element=METHOD:Player.turn@37 kind=DEFINITION span=37:5-37:48
+occurrence element=METHOD:TicTacToe.run@63 kind=DEFINITION span=63:5-67:6
+occurrence element=MODULE:Foundation@1 kind=DEFINITION span=1:8-1:18
+occurrence element=UNKNOWN:Field@61 kind=DEFINITION span=61:17-61:22
+occurrence element=UNKNOWN:TicTacToe@71 kind=DEFINITION span=71:16-71:25
+occurrence element=UNKNOWN:makeMove@42 kind=DEFINITION span=42:22-42:30
+occurrence element=UNKNOWN:minMax@51 kind=DEFINITION span=51:16-51:22
+occurrence element=UNKNOWN:minMax@55 kind=DEFINITION span=55:9-55:15
+occurrence element=UNKNOWN:numberIn@64 kind=DEFINITION span=64:9-64:17
+occurrence element=UNKNOWN:print@12 kind=DEFINITION span=12:5-12:10
+occurrence element=UNKNOWN:print@8 kind=DEFINITION span=8:5-8:10
+occurrence element=UNKNOWN:random@66 kind=DEFINITION span=66:13-66:19
+occurrence element=UNKNOWN:run@72 kind=DEFINITION span=72:10-72:13
+occurrence element=UNKNOWN:sameInRow@31 kind=DEFINITION span=31:9-31:18
+occurrence element=UNKNOWN:stringOut@65 kind=DEFINITION span=65:9-65:18
+access node=METHOD:Player.turn@37 kind=Public
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "13:main", node_id: NodeId(-3423996949260316550), signature_hash: -4671339478033693080, normalized_signature: Some("shape:5773979336569973888"), body_hash: 5859124419576403463, start_line: 70, end_line: 73 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "13:numberIn", node_id: NodeId(-1267727796621147827), signature_hash: 2477812878330356949, normalized_signature: Some("outline:-1795207361013140379"), body_hash: -2651324468227230200, start_line: 3, end_line: 5 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "13:numberOut", node_id: NodeId(3517603286906082308), signature_hash: -1579019679195996938, normalized_signature: Some("shape:-3637818959780900931"), body_hash: 6116599310178205983, start_line: 7, end_line: 9 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "13:stringOut", node_id: NodeId(7812934521386828052), signature_hash: -5818630870471287222, normalized_signature: Some("shape:7551547839370387787"), body_hash: -458709331684409505, start_line: 11, end_line: 13 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "14:ArtificialPlayer.minMax", node_id: NodeId(-4419904789916822560), signature_hash: 2816889471617643129, normalized_signature: Some("shape:7805834156005369755"), body_hash: 5901752386896665932, start_line: 47, end_line: 52 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "14:ArtificialPlayer.turn", node_id: NodeId(6522613382430633829), signature_hash: 5754064973517794814, normalized_signature: Some("shape:8701663052778439718"), body_hash: -5106232253613748363, start_line: 54, end_line: 57 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "14:Field.makeMove", node_id: NodeId(-2837882578834380066), signature_hash: -7686617887134063555, normalized_signature: Some("shape:-7999689338462430793"), body_hash: -6287651087895490112, start_line: 26, end_line: 33 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "14:Field.sameInRow", node_id: NodeId(-2478902800719635038), signature_hash: 8317776364922746511, normalized_signature: Some("outline:-5084961018881034800"), body_hash: 3504302695715122618, start_line: 22, end_line: 24 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "14:GameObject.announce", node_id: NodeId(-5016737099158972531), signature_hash: 6265382829821424686, normalized_signature: Some("outline:-5083272169020481154"), body_hash: -3890044506291050462, start_line: 16, end_line: 16 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "14:HumanPlayer.turn", node_id: NodeId(4663529929033117402), signature_hash: -1551097434895889655, normalized_signature: Some("shape:4258290717924085500"), body_hash: -4130765882017361125, start_line: 41, end_line: 43 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "14:Player.turn", node_id: NodeId(1346664393590581465), signature_hash: -1091959065548758310, normalized_signature: Some("outline:-5083272169020481154"), body_hash: 8520942317656981369, start_line: 37, end_line: 37 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "14:TicTacToe.run", node_id: NodeId(6068130392145726696), signature_hash: 5136661510898306809, normalized_signature: Some("shape:4198545024297928906"), body_hash: -8190002634728956043, start_line: 63, end_line: 67 }
+callable_state CallableProjectionState { file_id: -9078361163529215938, symbol_key: "__file_structural__", node_id: NodeId(-9078361163529215938), signature_hash: 553768115714561381, normalized_signature: None, body_hash: -135304642893323884, start_line: 1, end_line: 73 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "swift",
+        extension: "swift",
+        fidelity_filename: "fidelity.swift",
+        fidelity_source: include_str!("fixtures/fidelity_lab/swift_fidelity_lab.swift"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/swift_fidelity.txt"),
+        tictactoe_filename: "game.swift",
+        tictactoe_source: include_str!("fixtures/tictactoe/swift_tictactoe.swift"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/swift_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1689.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
