### PR TITLE
[v0.17 S3-DART] Extract Dart language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3942,7 +3942,7 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
         .or(match language {
             "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
             "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
-            | "cpp" | "dart" | "php" | "swift" => Some("//"),
+            | "cpp" | "php" | "swift" => Some("//"),
             _ => None,
         });
     let Some(marker) = comment_marker else {

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "dart",
+        line_comment: "//",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "dart"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,6 +1265,7 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("dart"), Some("//"));
         assert_eq!(line_comment_for_language("swift"), None);
     }
 

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -1,9 +1,9 @@
 use super::{
-    BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
-    GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
-    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, GO_GRAPH_QUERY,
+    JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset, PHP_GRAPH_QUERY,
+    PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY,
+    TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -42,7 +42,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("php", _) => Some(php()),
         ("csharp", _) => Some(csharp()),
         ("swift", _) => Some(swift()),
-        ("dart", _) => Some(dart()),
         ("bash", _) => Some(bash()),
         _ => None,
     }
@@ -175,16 +174,6 @@ fn swift() -> LanguageConfig {
         SWIFT_GRAPH_QUERY,
         None,
         LanguageRuleset::Swift,
-    )
-}
-
-fn dart() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_dart_orchard::LANGUAGE.into(),
-        "dart",
-        DART_GRAPH_QUERY,
-        None,
-        LanguageRuleset::Dart,
     )
 }
 

--- a/crates/codestory-indexer/src/languages/dart.rs
+++ b/crates/codestory-indexer/src/languages/dart.rs
@@ -1,0 +1,719 @@
+//! Dart extraction rules.
+//!
+//! Dart's graph extraction lives here: the tree-sitter rule file, the
+//! compiled-rule cache, the member-call callsite marker, the receiver-call
+//! resolution engine that turns `repo.save(...)` into an edge aimed at
+//! `Repository.save`, and the direct-call collector that recovers plain
+//! `helper()` callsites the rule file leaves as generic placeholders. Every
+//! language-keyed dispatch in the crate reaches them through
+//! [`super::EXTRACTIONS`] rather than by spelling `"dart"`.
+//!
+//! Three Dart surfaces are deliberately *not* here, and all three are shared
+//! seams rather than Dart content:
+//!
+//! * `lib.rs::language_precise_call_specs`, whose only row today is Dart's
+//!   [`direct_call_specs`]. [`super::LanguageExtraction`] has no field for a
+//!   precise-call collector because Dart is the only language with one; giving
+//!   the registry a sixteenth field is a change for all sixteen packages, not
+//!   part of Dart's rollback unit. The residual arm calls into this module.
+//! * `lib.rs::append_manual_receiver_call_edges`'s `language_name == "dart"`
+//!   branch, which *replaces* an annotated placeholder edge instead of
+//!   suppressing the manual one. That is edge-assembly policy shared by every
+//!   language's placeholder handling, not an extraction rule.
+//! * `resolution::mod`'s `Some("dart")` import-owner lookup, which is
+//!   resolution-side and still spells `"kotlin"` for the migrated language too.
+//!
+//! `LanguageRuleset::Dart` also stays in `lib.rs`, because the enum is the
+//! compiled-rule cache key for every language at once.
+//!
+//! This is a move, not a rewrite. The bodies below are the ones that used to
+//! sit in `lib.rs`, and `tests/language_extraction_snapshot.rs` pins the
+//! rendered projection of both Dart fixtures so the move stays output-equal.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use tree_sitter::{Node as TsNode, Tree};
+
+use super::LanguageExtraction;
+use crate::{
+    CompiledLanguageRules, LanguageRuleset, ManualPreciseCallSpec, ManualReceiverCallSpec,
+    ManualReceiverSource, OptionalReceiverOwnerBinding, ReceiverCallSiteKey,
+    collect_prefix_parameter_types, collect_receiver_call_specs_in_callable, declaration_name,
+    descendant_by_field_name, enclosing_node_with_kind, first_descendant_with_kind,
+    member_call_method_col, node_is_same_or_ancestor, normalize_parameter_name,
+    normalize_type_surface, previous_named_sibling_with_kind, receiver_call_belongs_to_callable,
+    receiver_callsite_key, same_ts_span, signature_parameter_surface, split_top_level_parameters,
+    trimmed_node_text, ts_node_graph_span, walk_tree_nodes,
+};
+
+/// Callsite marker written onto edges produced from Dart member-call syntax.
+pub(crate) const MEMBER_CALLSITE_MARKER: &str = "syntax:dart-member-call";
+
+const GRAPH_QUERY: &str = include_str!("../../rules/dart.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for Dart.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["dart"],
+    language_name: "dart",
+    extensions: &["dart"],
+    ruleset: LanguageRuleset::Dart,
+    parser_language: dart_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    receiver_call_specs: Some(receiver_call_specs),
+    member_callsite_marker: Some(MEMBER_CALLSITE_MARKER),
+    graph_call_syntax: Some("dart_member"),
+    // Carried over verbatim from `lib.rs`'s `matches!(language_name, "swift" |
+    // "dart")`. `rules/dart.scm` already labels class members METHOD, so the
+    // promotion is a no-op on both snapshot fixtures — mutating this field
+    // leaves them byte-identical. The value is preserved anyway because it is
+    // the one the god file had for every Dart file, not just these two.
+    promotes_type_member_functions_to_methods: true,
+    qualified_name_delimiter: ".",
+    route_comments_are_c_style: true,
+    uses_generic_semantic_resolver: true,
+    semantic_family: "dart",
+};
+
+fn dart_language() -> tree_sitter::Language {
+    tree_sitter_dart_orchard::LANGUAGE.into()
+}
+
+/// Manual receiver-call edges for one parsed Dart file.
+///
+/// Was `lib.rs::collect_dart_receiver_call_edges`.
+pub(crate) fn receiver_call_specs(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
+    let mut edges = Vec::new();
+    let import_alias_bindings = collect_dart_import_alias_bindings(source);
+    walk_tree_nodes(tree.root_node(), &mut |body| {
+        if body.kind() != "function_body" {
+            return;
+        }
+        let Some(signature) = dart_signature_for_body(body) else {
+            return;
+        };
+        let Some(source_name) = dart_callable_name(signature, source) else {
+            return;
+        };
+        let call_source = ManualReceiverSource {
+            name: &source_name,
+            span: ts_node_graph_span(signature),
+        };
+        let receiver_types = collect_prefix_parameter_types(signature, source);
+        let mut local_receiver_callsites = HashSet::new();
+        collect_dart_precise_receiver_call_specs(
+            body,
+            source,
+            ManualReceiverSource {
+                name: call_source.name,
+                span: call_source.span,
+            },
+            DartReceiverContext {
+                parameter_receiver_types: &receiver_types,
+                import_alias_bindings: &import_alias_bindings,
+            },
+            &mut local_receiver_callsites,
+            &mut edges,
+        );
+        if !receiver_types.is_empty() {
+            let receiver_modules =
+                collect_dart_parameter_type_modules(signature, source, &import_alias_bindings);
+            let start = edges.len();
+            collect_receiver_call_specs_in_callable(
+                body,
+                source,
+                ManualReceiverSource {
+                    name: call_source.name,
+                    span: call_source.span,
+                },
+                &receiver_types,
+                member_call,
+                false,
+                &mut edges,
+            );
+            let mut parameter_specs = edges.split_off(start);
+            parameter_specs
+                .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
+            for spec in &mut parameter_specs {
+                if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
+                    spec.owner_module = Some(module_name.clone());
+                }
+            }
+            edges.extend(parameter_specs);
+        }
+    });
+    edges
+}
+
+struct DartReceiverContext<'a> {
+    parameter_receiver_types: &'a HashMap<String, String>,
+    import_alias_bindings: &'a HashMap<String, String>,
+}
+
+fn collect_dart_precise_receiver_call_specs(
+    body: TsNode<'_>,
+    source: &str,
+    call_source: ManualReceiverSource<'_>,
+    context: DartReceiverContext<'_>,
+    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
+    edges: &mut Vec<ManualReceiverCallSpec>,
+) {
+    walk_tree_nodes(body, &mut |node| {
+        let Some((receiver_name, method_name)) = member_call(node, source) else {
+            return;
+        };
+        if !receiver_call_belongs_to_callable(node, body) {
+            return;
+        }
+        let method_col = member_call_method_col(node, source, &method_name);
+        let callsite_key = ReceiverCallSiteKey {
+            receiver_name: receiver_name.clone(),
+            method_name: method_name.clone(),
+            line: Some(node.start_position().row as u32 + 1),
+            method_col,
+        };
+
+        if let Some(owner) =
+            dart_visible_local_receiver_owner(body, node, &receiver_name, source, &context)
+        {
+            local_receiver_callsites.insert(callsite_key);
+            if let Some((owner_name, owner_module)) = owner {
+                edges.push(ManualReceiverCallSpec {
+                    source_name: call_source.name.to_string(),
+                    source_span: call_source.span,
+                    receiver_name,
+                    owner_name,
+                    owner_module,
+                    method_name,
+                    method_col,
+                    line: Some(node.start_position().row as u32 + 1),
+                    allow_global_fallback: false,
+                });
+            }
+            return;
+        }
+
+        let owner = if let Some(owner) = dart_self_receiver_owner(body, &receiver_name, source) {
+            Some(owner)
+        } else if !context
+            .parameter_receiver_types
+            .contains_key(&receiver_name)
+        {
+            dart_property_receiver_owner(body, &receiver_name, source, &context)
+        } else {
+            None
+        };
+        let Some((owner_name, owner_module)) = owner else {
+            return;
+        };
+        edges.push(ManualReceiverCallSpec {
+            source_name: call_source.name.to_string(),
+            source_span: call_source.span,
+            receiver_name,
+            owner_name,
+            owner_module,
+            method_name,
+            method_col,
+            line: Some(node.start_position().row as u32 + 1),
+            allow_global_fallback: false,
+        });
+    });
+}
+
+fn dart_self_receiver_owner(
+    body: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+) -> OptionalReceiverOwnerBinding {
+    if receiver_name != "this" {
+        return None;
+    }
+    let owner_node = enclosing_node_with_kind(body, &["class_definition"])?;
+    let owner_name = declaration_name(owner_node, source)?;
+    Some((owner_name, None))
+}
+
+fn dart_visible_local_receiver_owner(
+    body: TsNode<'_>,
+    call_node: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    context: &DartReceiverContext<'_>,
+) -> Option<OptionalReceiverOwnerBinding> {
+    let mut visible_bindings = Vec::new();
+    walk_tree_nodes(body, &mut |node| {
+        if node.kind() != "initialized_variable_definition" {
+            return;
+        }
+        if !receiver_call_belongs_to_callable(node, body)
+            || node.end_byte() > call_node.start_byte()
+        {
+            return;
+        }
+        let Some(binding_name) = dart_variable_binding_name(node, source) else {
+            return;
+        };
+        if binding_name != receiver_name || !dart_local_binding_visible_at_call(node, call_node) {
+            return;
+        }
+        visible_bindings.push((
+            node.end_byte(),
+            dart_initialized_constructor_owner(node, source, context),
+        ));
+    });
+    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
+    visible_bindings.pop().map(|(_, owner_name)| owner_name)
+}
+
+fn dart_property_receiver_owner(
+    body: TsNode<'_>,
+    receiver_name: &str,
+    source: &str,
+    context: &DartReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let field_name = receiver_name
+        .strip_prefix("this.")
+        .unwrap_or(receiver_name)
+        .trim();
+    if field_name == "this" || field_name.contains('.') {
+        return None;
+    }
+    let owner_node = enclosing_node_with_kind(body, &["class_definition"])?;
+    let mut property_bindings = Vec::new();
+    walk_tree_nodes(owner_node, &mut |node| {
+        if !matches!(
+            node.kind(),
+            "initialized_variable_definition" | "field_signature" | "declaration"
+        ) || !dart_property_belongs_to_owner(node, owner_node)
+        {
+            return;
+        }
+        let Some((binding_name, raw_type)) = dart_typed_variable_binding(node, source) else {
+            return;
+        };
+        if binding_name != field_name {
+            return;
+        }
+        if let Some(owner) = dart_receiver_owner_from_type(&raw_type, context) {
+            property_bindings.push(owner);
+        }
+    });
+    property_bindings.sort();
+    property_bindings.dedup();
+    if property_bindings.len() == 1 {
+        Some(property_bindings.remove(0))
+    } else {
+        None
+    }
+}
+
+fn dart_property_belongs_to_owner(property: TsNode<'_>, owner_node: TsNode<'_>) -> bool {
+    let mut current = property.parent();
+    while let Some(candidate) = current {
+        if same_ts_span(candidate, owner_node) {
+            return true;
+        }
+        if candidate.kind() == "function_body" || candidate.kind() == "class_definition" {
+            return false;
+        }
+        current = candidate.parent();
+    }
+    false
+}
+
+fn dart_variable_binding_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    if let Some(name) = node
+        .child_by_field_name("name")
+        .and_then(|name| trimmed_node_text(name, source))
+        .as_deref()
+        .and_then(normalize_parameter_name)
+    {
+        return Some(name);
+    }
+    let surface = trimmed_node_text(node, source)?;
+    let head = surface
+        .split('=')
+        .next()
+        .unwrap_or(surface.as_str())
+        .trim_end_matches(';')
+        .trim();
+    head.split_whitespace()
+        .last()
+        .and_then(normalize_parameter_name)
+}
+
+fn dart_typed_variable_binding(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    let binding_name = dart_variable_binding_name(node, source)?;
+    let surface = trimmed_node_text(node, source)?;
+    let head = surface
+        .split('=')
+        .next()
+        .unwrap_or(surface.as_str())
+        .trim_end_matches(';')
+        .trim();
+    let tokens = head
+        .split_whitespace()
+        .filter(|token| {
+            !matches!(
+                *token,
+                "abstract"
+                    | "covariant"
+                    | "external"
+                    | "final"
+                    | "late"
+                    | "static"
+                    | "const"
+                    | "var"
+                    | "required"
+            )
+        })
+        .collect::<Vec<_>>();
+    if tokens.len() < 2 {
+        return None;
+    }
+    let raw_type = tokens[..tokens.len() - 1].join(" ");
+    Some((binding_name, raw_type))
+}
+
+fn dart_receiver_owner_from_type(
+    raw_type: &str,
+    context: &DartReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let owner_name = normalize_type_surface(raw_type)?;
+    if let Some(qualifier) = dart_type_import_qualifier(raw_type) {
+        let module_name = context.import_alias_bindings.get(&qualifier)?;
+        return Some((owner_name, Some(module_name.clone())));
+    }
+    Some((owner_name, None))
+}
+
+fn dart_initialized_constructor_owner(
+    node: TsNode<'_>,
+    source: &str,
+    context: &DartReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    if let Some(owner_name) = node
+        .child_by_field_name("value")
+        .and_then(|value| dart_constructor_owner(value, source, context))
+    {
+        return Some(owner_name);
+    }
+    let surface = trimmed_node_text(node, source)?;
+    let (_, value_surface) = surface.split_once('=')?;
+    dart_constructor_owner_surface(value_surface, context)
+}
+
+fn dart_constructor_owner(
+    value: TsNode<'_>,
+    source: &str,
+    context: &DartReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    trimmed_node_text(value, source)
+        .as_deref()
+        .and_then(|surface| dart_constructor_owner_surface(surface, context))
+}
+
+fn dart_constructor_owner_surface(
+    surface: &str,
+    context: &DartReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let surface = surface.trim().trim_end_matches(';').trim();
+    let surface = surface
+        .strip_prefix("const ")
+        .or_else(|| surface.strip_prefix("new "))
+        .unwrap_or(surface)
+        .trim();
+    let (constructor_name, _) = surface.split_once('(')?;
+    dart_constructor_owner_from_type_surface(constructor_name, context)
+}
+
+fn dart_constructor_owner_from_type_surface(
+    type_surface: &str,
+    context: &DartReceiverContext<'_>,
+) -> OptionalReceiverOwnerBinding {
+    let type_surface = type_surface.trim();
+    if type_surface.contains("::") {
+        return None;
+    }
+    let owner_name = normalize_type_surface(type_surface)?;
+    if !owner_name
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_uppercase())
+    {
+        return None;
+    }
+    if let Some(qualifier) = dart_type_import_qualifier(type_surface) {
+        let module_name = context.import_alias_bindings.get(&qualifier)?;
+        return Some((owner_name, Some(module_name.clone())));
+    }
+    if type_surface.contains('.') {
+        return None;
+    }
+    Some((owner_name, None))
+}
+
+fn dart_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
+    let Some(binding_scope) = dart_lexical_scope(binding) else {
+        return false;
+    };
+    let Some(call_scope) = dart_lexical_scope(call_node) else {
+        return false;
+    };
+    node_is_same_or_ancestor(binding_scope, call_scope)
+}
+
+fn dart_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
+    enclosing_node_with_kind(node, &["block", "function_body"])
+}
+
+/// Manual direct-call edges for one parsed Dart file.
+///
+/// Was `lib.rs::collect_dart_direct_call_edges`.
+pub(crate) fn direct_call_specs(tree: &Tree, source: &str) -> Vec<ManualPreciseCallSpec> {
+    let mut edges = Vec::new();
+    walk_tree_nodes(tree.root_node(), &mut |body| {
+        if body.kind() != "function_body" {
+            return;
+        }
+        let Some(signature) = dart_signature_for_body(body) else {
+            return;
+        };
+        let Some(source_name) = dart_callable_name(signature, source) else {
+            return;
+        };
+        let source_span = ts_node_graph_span(signature);
+        walk_tree_nodes(body, &mut |node| {
+            let Some(target_name) = dart_direct_call(node, source) else {
+                return;
+            };
+            edges.push(ManualPreciseCallSpec {
+                source_name: source_name.clone(),
+                source_span,
+                target_name,
+                line: Some(node.start_position().row as u32 + 1),
+            });
+        });
+    });
+    edges
+}
+
+fn dart_signature_for_body<'tree>(body: TsNode<'tree>) -> Option<TsNode<'tree>> {
+    previous_named_sibling_with_kind(body, &["method_signature", "function_signature"])
+}
+
+fn collect_dart_parameter_type_modules(
+    callable: TsNode<'_>,
+    source: &str,
+    import_alias_bindings: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut receiver_modules = HashMap::new();
+    let Some(parameters) = signature_parameter_surface(callable, source) else {
+        return receiver_modules;
+    };
+    for parameter in split_top_level_parameters(&parameters) {
+        let parameter = parameter
+            .split('=')
+            .next()
+            .unwrap_or(parameter.as_str())
+            .trim();
+        let tokens = parameter
+            .split_whitespace()
+            .filter(|token| !matches!(*token, "final" | "const" | "var" | "required"))
+            .collect::<Vec<_>>();
+        if tokens.len() < 2 {
+            continue;
+        }
+        let Some(receiver_name) =
+            normalize_parameter_name(tokens.last().copied().unwrap_or_default())
+        else {
+            continue;
+        };
+        let raw_type = tokens[..tokens.len() - 1].join(" ");
+        let Some(qualifier) = dart_type_import_qualifier(&raw_type) else {
+            continue;
+        };
+        let Some(module_name) = import_alias_bindings.get(&qualifier) else {
+            continue;
+        };
+        receiver_modules.insert(receiver_name, module_name.clone());
+    }
+    receiver_modules
+}
+
+fn dart_type_import_qualifier(raw_type: &str) -> Option<String> {
+    if raw_type.contains('|') || raw_type.contains('&') {
+        return None;
+    }
+    let surface = raw_type.trim().trim_end_matches('?').trim();
+    let base = surface
+        .split(['<', '[', '('])
+        .next()
+        .unwrap_or(surface)
+        .trim();
+    let (qualifier, _) = base.rsplit_once('.')?;
+    normalize_parameter_name(qualifier)
+}
+
+fn collect_dart_import_alias_bindings(source: &str) -> HashMap<String, String> {
+    let mut bindings = HashMap::new();
+    let mut duplicates = HashSet::new();
+    for statement in dart_import_statements(source) {
+        let Some(module_name) = dart_import_module_name(&statement) else {
+            continue;
+        };
+        let Some(alias) = dart_import_alias_name(&statement) else {
+            continue;
+        };
+        if duplicates.contains(&alias) {
+            continue;
+        }
+        if bindings.contains_key(&alias) {
+            bindings.remove(&alias);
+            duplicates.insert(alias);
+            continue;
+        }
+        bindings.insert(alias, module_name);
+    }
+    bindings
+}
+
+fn dart_import_statements(source: &str) -> Vec<String> {
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut collecting = false;
+
+    for raw_line in source.lines() {
+        let line = raw_line.split("//").next().unwrap_or(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        if !collecting {
+            if !line.starts_with("import ") {
+                continue;
+            }
+            current.clear();
+            current.push_str(line);
+            if line.contains(';') {
+                statements.push(current.clone());
+            } else {
+                collecting = true;
+            }
+            continue;
+        }
+
+        current.push(' ');
+        current.push_str(line);
+        if line.contains(';') {
+            statements.push(current.clone());
+            current.clear();
+            collecting = false;
+        }
+    }
+
+    statements
+}
+
+fn dart_import_module_name(statement: &str) -> Option<String> {
+    let rest = statement.strip_prefix("import")?.trim();
+    let quote = rest.chars().find(|ch| matches!(*ch, '"' | '\''))?;
+    let start = rest.find(quote)? + quote.len_utf8();
+    let end = rest[start..].find(quote)? + start;
+    let module_name = rest[start..end].trim();
+    (!module_name.is_empty()).then(|| module_name.to_string())
+}
+
+fn dart_import_alias_name(statement: &str) -> Option<String> {
+    let mut tokens = statement
+        .trim_end_matches(';')
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    while let Some(token) = tokens.pop() {
+        if token == "as" {
+            return None;
+        }
+        if tokens.last().copied() == Some("as") {
+            return normalize_parameter_name(token);
+        }
+    }
+    None
+}
+
+fn member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
+    if !matches!(node.kind(), "expression_statement" | "return_statement") {
+        return None;
+    }
+    let text = trimmed_node_text(node, source)?;
+    let callable = text
+        .split('(')
+        .next()
+        .unwrap_or(text.as_str())
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    let separator = callable.rfind('.')?;
+    let receiver = callable[..separator].trim().trim_end_matches('?').trim();
+    let method = callable[separator + 1..]
+        .trim()
+        .trim_start_matches('?')
+        .trim();
+    Some((
+        normalized_dart_receiver_surface(receiver)?,
+        normalize_parameter_name(method)?,
+    ))
+}
+
+fn normalized_dart_receiver_surface(raw: &str) -> Option<String> {
+    let receiver = raw
+        .rsplit([' ', '\t', '\n', '\r', '(', '[', '{'])
+        .find(|part| !part.trim().is_empty())
+        .unwrap_or(raw)
+        .trim()
+        .trim_end_matches('?')
+        .trim();
+    if receiver.contains('.') {
+        let cleaned = receiver
+            .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '.')
+            .trim();
+        let valid = cleaned
+            .split('.')
+            .all(|part| normalize_parameter_name(part).is_some());
+        return (valid && !cleaned.is_empty()).then(|| cleaned.to_string());
+    }
+    normalize_parameter_name(receiver)
+}
+
+fn dart_direct_call(node: TsNode<'_>, source: &str) -> Option<String> {
+    if !matches!(node.kind(), "expression_statement" | "return_statement") {
+        return None;
+    }
+    let text = trimmed_node_text(node, source)?;
+    let callable = text
+        .split('(')
+        .next()
+        .unwrap_or(text.as_str())
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    if callable.contains('.') {
+        return None;
+    }
+    let callable = callable
+        .strip_prefix("return")
+        .map(str::trim)
+        .unwrap_or(callable);
+    callable
+        .split_whitespace()
+        .last()
+        .and_then(normalize_parameter_name)
+}
+
+fn dart_callable_name(node: TsNode<'_>, source: &str) -> Option<String> {
+    descendant_by_field_name(node, "name")
+        .or_else(|| first_descendant_with_kind(node, "identifier"))
+        .and_then(|name_node| trimmed_node_text(name_node, source))
+}

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -16,6 +16,7 @@
 //! `registry_rows_do_not_shadow_unmigrated_languages` proves it — and the last
 //! package to land deletes the residual arms entirely.
 
+pub(crate) mod dart;
 pub(crate) mod kotlin;
 
 use std::sync::OnceLock;
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, dart::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {
@@ -235,6 +236,31 @@ mod tests {
         assert_eq!(
             extraction_for_ext("kts").map(|row| row.language_name),
             Some("kotlin")
+        );
+    }
+
+    /// The Dart row must keep the exact projection facts it had while it was
+    /// spread across `lib.rs`. Same reasoning as the Kotlin case above: these
+    /// values used to live in separate match statements, and a wrong value
+    /// here is a silent projection change that no threshold test would catch.
+    #[test]
+    fn dart_row_keeps_the_projection_facts_it_had_in_the_god_file() {
+        let dart = extraction_for_language("dart").expect("dart row");
+        assert!(dart.promotes_type_member_functions_to_methods);
+        assert_eq!(dart.qualified_name_delimiter, ".");
+        assert!(dart.route_comments_are_c_style);
+        assert_eq!(dart.semantic_family, "dart");
+        assert!(dart.uses_generic_semantic_resolver);
+        assert_eq!(dart.member_callsite_marker, Some("syntax:dart-member-call"));
+        assert_eq!(
+            member_callsite_marker_for_call_syntax("dart_member"),
+            Some("syntax:dart-member-call")
+        );
+        assert!(dart.receiver_call_specs.is_some());
+        assert!(dart.tags_query.is_none());
+        assert_eq!(
+            extraction_for_ext("dart").map(|row| row.language_name),
+            Some("dart")
         );
     }
 }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -66,7 +66,6 @@ pub(crate) const RUBY_MEMBER_CALLSITE_MARKER: &str = "syntax:ruby-member-call";
 pub(crate) const PHP_MEMBER_CALLSITE_MARKER: &str = "syntax:php-member-call";
 pub(crate) const JS_MEMBER_CALLSITE_MARKER: &str = "syntax:js-member-call";
 pub(crate) const TS_MEMBER_CALLSITE_MARKER: &str = "syntax:ts-member-call";
-pub(crate) const DART_MEMBER_CALLSITE_MARKER: &str = "syntax:dart-member-call";
 pub(crate) const SWIFT_MEMBER_CALLSITE_MARKER: &str = "syntax:swift-member-call";
 pub(crate) const RECEIVER_OWNER_CALLSITE_PREFIX: &str = "receiver-owner:";
 pub(crate) const RECEIVER_MODULE_CALLSITE_PREFIX: &str = "receiver-module:";
@@ -143,7 +142,6 @@ const RUBY_GRAPH_QUERY: &str = include_str!("../rules/ruby.scm");
 const PHP_GRAPH_QUERY: &str = include_str!("../rules/php.scm");
 const CSHARP_GRAPH_QUERY: &str = include_str!("../rules/csharp.scm");
 const SWIFT_GRAPH_QUERY: &str = include_str!("../rules/swift.scm");
-const DART_GRAPH_QUERY: &str = include_str!("../rules/dart.scm");
 const BASH_GRAPH_QUERY: &str = include_str!("../rules/bash.scm");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -336,9 +334,9 @@ impl LanguageRuleset {
             LanguageRuleset::Swift => {
                 compiled_rules_cache(language, SWIFT_GRAPH_QUERY, None, &SWIFT_RULES)
             }
-            LanguageRuleset::Dart => {
-                compiled_rules_cache(language, DART_GRAPH_QUERY, None, &DART_RULES)
-            }
+            LanguageRuleset::Dart => Err(anyhow!(
+                "dart compiled rules are owned by the language registry"
+            )),
             LanguageRuleset::Bash => {
                 compiled_rules_cache(language, BASH_GRAPH_QUERY, None, &BASH_RULES)
             }
@@ -385,7 +383,6 @@ static RUBY_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::n
 static PHP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CSHARP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static SWIFT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static DART_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static BASH_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 
 fn tag_definition_priority(definition: &TagDefinition) -> (u8, u8, u8) {
@@ -7398,8 +7395,11 @@ fn language_precise_call_specs(
     tree: &Tree,
     source: &str,
 ) -> Vec<ManualPreciseCallSpec> {
+    // Dart is the only language with a precise-call collector, so
+    // `LanguageExtraction` has no field for one; the arm calls into the
+    // migrated module rather than into a body still living here.
     match language_name {
-        "dart" => collect_dart_direct_call_edges(tree, source),
+        "dart" => languages::dart::direct_call_specs(tree, source),
         _ => Vec::new(),
     }
 }
@@ -7602,7 +7602,6 @@ fn language_receiver_call_specs(
         "csharp" => collect_csharp_receiver_call_edges(tree, source),
         "cpp" => collect_cpp_receiver_call_edges(tree, source),
         "swift" => collect_swift_receiver_call_edges(tree, source),
-        "dart" => collect_dart_receiver_call_edges(tree, source),
         _ => Vec::new(),
     }
 }
@@ -13028,74 +13027,6 @@ fn swift_type_import_qualifier(raw_type: &str) -> Option<String> {
     normalize_parameter_name(qualifier)
 }
 
-fn collect_dart_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
-    let mut edges = Vec::new();
-    let import_alias_bindings = collect_dart_import_alias_bindings(source);
-    walk_tree_nodes(tree.root_node(), &mut |body| {
-        if body.kind() != "function_body" {
-            return;
-        }
-        let Some(signature) = dart_signature_for_body(body) else {
-            return;
-        };
-        let Some(source_name) = dart_callable_name(signature, source) else {
-            return;
-        };
-        let call_source = ManualReceiverSource {
-            name: &source_name,
-            span: ts_node_graph_span(signature),
-        };
-        let receiver_types = collect_prefix_parameter_types(signature, source);
-        let mut local_receiver_callsites = HashSet::new();
-        collect_dart_precise_receiver_call_specs(
-            body,
-            source,
-            ManualReceiverSource {
-                name: call_source.name,
-                span: call_source.span,
-            },
-            DartReceiverContext {
-                parameter_receiver_types: &receiver_types,
-                import_alias_bindings: &import_alias_bindings,
-            },
-            &mut local_receiver_callsites,
-            &mut edges,
-        );
-        if !receiver_types.is_empty() {
-            let receiver_modules =
-                collect_dart_parameter_type_modules(signature, source, &import_alias_bindings);
-            let start = edges.len();
-            collect_receiver_call_specs_in_callable(
-                body,
-                source,
-                ManualReceiverSource {
-                    name: call_source.name,
-                    span: call_source.span,
-                },
-                &receiver_types,
-                dart_member_call,
-                false,
-                &mut edges,
-            );
-            let mut parameter_specs = edges.split_off(start);
-            parameter_specs
-                .retain(|spec| !local_receiver_callsites.contains(&receiver_callsite_key(spec)));
-            for spec in &mut parameter_specs {
-                if let Some(module_name) = receiver_modules.get(&spec.receiver_name) {
-                    spec.owner_module = Some(module_name.clone());
-                }
-            }
-            edges.extend(parameter_specs);
-        }
-    });
-    edges
-}
-
-struct DartReceiverContext<'a> {
-    parameter_receiver_types: &'a HashMap<String, String>,
-    import_alias_bindings: &'a HashMap<String, String>,
-}
-
 fn receiver_callsite_key(spec: &ManualReceiverCallSpec) -> ReceiverCallSiteKey {
     ReceiverCallSiteKey {
         receiver_name: spec.receiver_name.clone(),
@@ -13103,355 +13034,6 @@ fn receiver_callsite_key(spec: &ManualReceiverCallSpec) -> ReceiverCallSiteKey {
         line: spec.line,
         method_col: spec.method_col,
     }
-}
-
-fn collect_dart_precise_receiver_call_specs(
-    body: TsNode<'_>,
-    source: &str,
-    call_source: ManualReceiverSource<'_>,
-    context: DartReceiverContext<'_>,
-    local_receiver_callsites: &mut HashSet<ReceiverCallSiteKey>,
-    edges: &mut Vec<ManualReceiverCallSpec>,
-) {
-    walk_tree_nodes(body, &mut |node| {
-        let Some((receiver_name, method_name)) = dart_member_call(node, source) else {
-            return;
-        };
-        if !receiver_call_belongs_to_callable(node, body) {
-            return;
-        }
-        let method_col = member_call_method_col(node, source, &method_name);
-        let callsite_key = ReceiverCallSiteKey {
-            receiver_name: receiver_name.clone(),
-            method_name: method_name.clone(),
-            line: Some(node.start_position().row as u32 + 1),
-            method_col,
-        };
-
-        if let Some(owner) =
-            dart_visible_local_receiver_owner(body, node, &receiver_name, source, &context)
-        {
-            local_receiver_callsites.insert(callsite_key);
-            if let Some((owner_name, owner_module)) = owner {
-                edges.push(ManualReceiverCallSpec {
-                    source_name: call_source.name.to_string(),
-                    source_span: call_source.span,
-                    receiver_name,
-                    owner_name,
-                    owner_module,
-                    method_name,
-                    method_col,
-                    line: Some(node.start_position().row as u32 + 1),
-                    allow_global_fallback: false,
-                });
-            }
-            return;
-        }
-
-        let owner = if let Some(owner) = dart_self_receiver_owner(body, &receiver_name, source) {
-            Some(owner)
-        } else if !context
-            .parameter_receiver_types
-            .contains_key(&receiver_name)
-        {
-            dart_property_receiver_owner(body, &receiver_name, source, &context)
-        } else {
-            None
-        };
-        let Some((owner_name, owner_module)) = owner else {
-            return;
-        };
-        edges.push(ManualReceiverCallSpec {
-            source_name: call_source.name.to_string(),
-            source_span: call_source.span,
-            receiver_name,
-            owner_name,
-            owner_module,
-            method_name,
-            method_col,
-            line: Some(node.start_position().row as u32 + 1),
-            allow_global_fallback: false,
-        });
-    });
-}
-
-fn dart_self_receiver_owner(
-    body: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-) -> OptionalReceiverOwnerBinding {
-    if receiver_name != "this" {
-        return None;
-    }
-    let owner_node = enclosing_node_with_kind(body, &["class_definition"])?;
-    let owner_name = declaration_name(owner_node, source)?;
-    Some((owner_name, None))
-}
-
-fn dart_visible_local_receiver_owner(
-    body: TsNode<'_>,
-    call_node: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    context: &DartReceiverContext<'_>,
-) -> Option<OptionalReceiverOwnerBinding> {
-    let mut visible_bindings = Vec::new();
-    walk_tree_nodes(body, &mut |node| {
-        if node.kind() != "initialized_variable_definition" {
-            return;
-        }
-        if !receiver_call_belongs_to_callable(node, body)
-            || node.end_byte() > call_node.start_byte()
-        {
-            return;
-        }
-        let Some(binding_name) = dart_variable_binding_name(node, source) else {
-            return;
-        };
-        if binding_name != receiver_name || !dart_local_binding_visible_at_call(node, call_node) {
-            return;
-        }
-        visible_bindings.push((
-            node.end_byte(),
-            dart_initialized_constructor_owner(node, source, context),
-        ));
-    });
-    visible_bindings.sort_by_key(|(end_byte, _)| *end_byte);
-    visible_bindings.pop().map(|(_, owner_name)| owner_name)
-}
-
-fn dart_property_receiver_owner(
-    body: TsNode<'_>,
-    receiver_name: &str,
-    source: &str,
-    context: &DartReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let field_name = receiver_name
-        .strip_prefix("this.")
-        .unwrap_or(receiver_name)
-        .trim();
-    if field_name == "this" || field_name.contains('.') {
-        return None;
-    }
-    let owner_node = enclosing_node_with_kind(body, &["class_definition"])?;
-    let mut property_bindings = Vec::new();
-    walk_tree_nodes(owner_node, &mut |node| {
-        if !matches!(
-            node.kind(),
-            "initialized_variable_definition" | "field_signature" | "declaration"
-        ) || !dart_property_belongs_to_owner(node, owner_node)
-        {
-            return;
-        }
-        let Some((binding_name, raw_type)) = dart_typed_variable_binding(node, source) else {
-            return;
-        };
-        if binding_name != field_name {
-            return;
-        }
-        if let Some(owner) = dart_receiver_owner_from_type(&raw_type, context) {
-            property_bindings.push(owner);
-        }
-    });
-    property_bindings.sort();
-    property_bindings.dedup();
-    if property_bindings.len() == 1 {
-        Some(property_bindings.remove(0))
-    } else {
-        None
-    }
-}
-
-fn dart_property_belongs_to_owner(property: TsNode<'_>, owner_node: TsNode<'_>) -> bool {
-    let mut current = property.parent();
-    while let Some(candidate) = current {
-        if same_ts_span(candidate, owner_node) {
-            return true;
-        }
-        if candidate.kind() == "function_body" || candidate.kind() == "class_definition" {
-            return false;
-        }
-        current = candidate.parent();
-    }
-    false
-}
-
-fn dart_variable_binding_name(node: TsNode<'_>, source: &str) -> Option<String> {
-    if let Some(name) = node
-        .child_by_field_name("name")
-        .and_then(|name| trimmed_node_text(name, source))
-        .as_deref()
-        .and_then(normalize_parameter_name)
-    {
-        return Some(name);
-    }
-    let surface = trimmed_node_text(node, source)?;
-    let head = surface
-        .split('=')
-        .next()
-        .unwrap_or(surface.as_str())
-        .trim_end_matches(';')
-        .trim();
-    head.split_whitespace()
-        .last()
-        .and_then(normalize_parameter_name)
-}
-
-fn dart_typed_variable_binding(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    let binding_name = dart_variable_binding_name(node, source)?;
-    let surface = trimmed_node_text(node, source)?;
-    let head = surface
-        .split('=')
-        .next()
-        .unwrap_or(surface.as_str())
-        .trim_end_matches(';')
-        .trim();
-    let tokens = head
-        .split_whitespace()
-        .filter(|token| {
-            !matches!(
-                *token,
-                "abstract"
-                    | "covariant"
-                    | "external"
-                    | "final"
-                    | "late"
-                    | "static"
-                    | "const"
-                    | "var"
-                    | "required"
-            )
-        })
-        .collect::<Vec<_>>();
-    if tokens.len() < 2 {
-        return None;
-    }
-    let raw_type = tokens[..tokens.len() - 1].join(" ");
-    Some((binding_name, raw_type))
-}
-
-fn dart_receiver_owner_from_type(
-    raw_type: &str,
-    context: &DartReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let owner_name = normalize_type_surface(raw_type)?;
-    if let Some(qualifier) = dart_type_import_qualifier(raw_type) {
-        let module_name = context.import_alias_bindings.get(&qualifier)?;
-        return Some((owner_name, Some(module_name.clone())));
-    }
-    Some((owner_name, None))
-}
-
-fn dart_initialized_constructor_owner(
-    node: TsNode<'_>,
-    source: &str,
-    context: &DartReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    if let Some(owner_name) = node
-        .child_by_field_name("value")
-        .and_then(|value| dart_constructor_owner(value, source, context))
-    {
-        return Some(owner_name);
-    }
-    let surface = trimmed_node_text(node, source)?;
-    let (_, value_surface) = surface.split_once('=')?;
-    dart_constructor_owner_surface(value_surface, context)
-}
-
-fn dart_constructor_owner(
-    value: TsNode<'_>,
-    source: &str,
-    context: &DartReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    trimmed_node_text(value, source)
-        .as_deref()
-        .and_then(|surface| dart_constructor_owner_surface(surface, context))
-}
-
-fn dart_constructor_owner_surface(
-    surface: &str,
-    context: &DartReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let surface = surface.trim().trim_end_matches(';').trim();
-    let surface = surface
-        .strip_prefix("const ")
-        .or_else(|| surface.strip_prefix("new "))
-        .unwrap_or(surface)
-        .trim();
-    let (constructor_name, _) = surface.split_once('(')?;
-    dart_constructor_owner_from_type_surface(constructor_name, context)
-}
-
-fn dart_constructor_owner_from_type_surface(
-    type_surface: &str,
-    context: &DartReceiverContext<'_>,
-) -> OptionalReceiverOwnerBinding {
-    let type_surface = type_surface.trim();
-    if type_surface.contains("::") {
-        return None;
-    }
-    let owner_name = normalize_type_surface(type_surface)?;
-    if !owner_name
-        .chars()
-        .next()
-        .is_some_and(|first| first.is_ascii_uppercase())
-    {
-        return None;
-    }
-    if let Some(qualifier) = dart_type_import_qualifier(type_surface) {
-        let module_name = context.import_alias_bindings.get(&qualifier)?;
-        return Some((owner_name, Some(module_name.clone())));
-    }
-    if type_surface.contains('.') {
-        return None;
-    }
-    Some((owner_name, None))
-}
-
-fn dart_local_binding_visible_at_call(binding: TsNode<'_>, call_node: TsNode<'_>) -> bool {
-    let Some(binding_scope) = dart_lexical_scope(binding) else {
-        return false;
-    };
-    let Some(call_scope) = dart_lexical_scope(call_node) else {
-        return false;
-    };
-    node_is_same_or_ancestor(binding_scope, call_scope)
-}
-
-fn dart_lexical_scope(node: TsNode<'_>) -> Option<TsNode<'_>> {
-    enclosing_node_with_kind(node, &["block", "function_body"])
-}
-
-fn collect_dart_direct_call_edges(tree: &Tree, source: &str) -> Vec<ManualPreciseCallSpec> {
-    let mut edges = Vec::new();
-    walk_tree_nodes(tree.root_node(), &mut |body| {
-        if body.kind() != "function_body" {
-            return;
-        }
-        let Some(signature) = dart_signature_for_body(body) else {
-            return;
-        };
-        let Some(source_name) = dart_callable_name(signature, source) else {
-            return;
-        };
-        let source_span = ts_node_graph_span(signature);
-        walk_tree_nodes(body, &mut |node| {
-            let Some(target_name) = dart_direct_call(node, source) else {
-                return;
-            };
-            edges.push(ManualPreciseCallSpec {
-                source_name: source_name.clone(),
-                source_span,
-                target_name,
-                line: Some(node.start_position().row as u32 + 1),
-            });
-        });
-    });
-    edges
-}
-
-fn dart_signature_for_body<'tree>(body: TsNode<'tree>) -> Option<TsNode<'tree>> {
-    previous_named_sibling_with_kind(body, &["method_signature", "function_signature"])
 }
 
 fn collect_ruby_receiver_call_edges(tree: &Tree, source: &str) -> Vec<ManualReceiverCallSpec> {
@@ -14071,143 +13653,6 @@ fn collect_prefix_parameter_types(callable: TsNode<'_>, source: &str) -> HashMap
     receiver_types
 }
 
-fn collect_dart_parameter_type_modules(
-    callable: TsNode<'_>,
-    source: &str,
-    import_alias_bindings: &HashMap<String, String>,
-) -> HashMap<String, String> {
-    let mut receiver_modules = HashMap::new();
-    let Some(parameters) = signature_parameter_surface(callable, source) else {
-        return receiver_modules;
-    };
-    for parameter in split_top_level_parameters(&parameters) {
-        let parameter = parameter
-            .split('=')
-            .next()
-            .unwrap_or(parameter.as_str())
-            .trim();
-        let tokens = parameter
-            .split_whitespace()
-            .filter(|token| !matches!(*token, "final" | "const" | "var" | "required"))
-            .collect::<Vec<_>>();
-        if tokens.len() < 2 {
-            continue;
-        }
-        let Some(receiver_name) =
-            normalize_parameter_name(tokens.last().copied().unwrap_or_default())
-        else {
-            continue;
-        };
-        let raw_type = tokens[..tokens.len() - 1].join(" ");
-        let Some(qualifier) = dart_type_import_qualifier(&raw_type) else {
-            continue;
-        };
-        let Some(module_name) = import_alias_bindings.get(&qualifier) else {
-            continue;
-        };
-        receiver_modules.insert(receiver_name, module_name.clone());
-    }
-    receiver_modules
-}
-
-fn dart_type_import_qualifier(raw_type: &str) -> Option<String> {
-    if raw_type.contains('|') || raw_type.contains('&') {
-        return None;
-    }
-    let surface = raw_type.trim().trim_end_matches('?').trim();
-    let base = surface
-        .split(['<', '[', '('])
-        .next()
-        .unwrap_or(surface)
-        .trim();
-    let (qualifier, _) = base.rsplit_once('.')?;
-    normalize_parameter_name(qualifier)
-}
-
-fn collect_dart_import_alias_bindings(source: &str) -> HashMap<String, String> {
-    let mut bindings = HashMap::new();
-    let mut duplicates = HashSet::new();
-    for statement in dart_import_statements(source) {
-        let Some(module_name) = dart_import_module_name(&statement) else {
-            continue;
-        };
-        let Some(alias) = dart_import_alias_name(&statement) else {
-            continue;
-        };
-        if duplicates.contains(&alias) {
-            continue;
-        }
-        if bindings.contains_key(&alias) {
-            bindings.remove(&alias);
-            duplicates.insert(alias);
-            continue;
-        }
-        bindings.insert(alias, module_name);
-    }
-    bindings
-}
-
-fn dart_import_statements(source: &str) -> Vec<String> {
-    let mut statements = Vec::new();
-    let mut current = String::new();
-    let mut collecting = false;
-
-    for raw_line in source.lines() {
-        let line = raw_line.split("//").next().unwrap_or(raw_line).trim();
-        if line.is_empty() {
-            continue;
-        }
-        if !collecting {
-            if !line.starts_with("import ") {
-                continue;
-            }
-            current.clear();
-            current.push_str(line);
-            if line.contains(';') {
-                statements.push(current.clone());
-            } else {
-                collecting = true;
-            }
-            continue;
-        }
-
-        current.push(' ');
-        current.push_str(line);
-        if line.contains(';') {
-            statements.push(current.clone());
-            current.clear();
-            collecting = false;
-        }
-    }
-
-    statements
-}
-
-fn dart_import_module_name(statement: &str) -> Option<String> {
-    let rest = statement.strip_prefix("import")?.trim();
-    let quote = rest.chars().find(|ch| matches!(*ch, '"' | '\''))?;
-    let start = rest.find(quote)? + quote.len_utf8();
-    let end = rest[start..].find(quote)? + start;
-    let module_name = rest[start..end].trim();
-    (!module_name.is_empty()).then(|| module_name.to_string())
-}
-
-fn dart_import_alias_name(statement: &str) -> Option<String> {
-    let mut tokens = statement
-        .trim_end_matches(';')
-        .split_whitespace()
-        .collect::<Vec<_>>();
-    while let Some(token) = tokens.pop() {
-        if token == "as" {
-            return None;
-        }
-        if tokens.last().copied() == Some("as") {
-            return normalize_parameter_name(token);
-        }
-    }
-    None
-}
-
 /// The grammar's own parameter-list node for a callable, when it has one.
 ///
 /// Every vendored grammar that models parameters exposes the list either
@@ -14579,75 +14024,6 @@ fn normalized_swift_receiver_surface(raw: &str) -> Option<String> {
     normalize_parameter_name(receiver)
 }
 
-fn dart_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
-    if !matches!(node.kind(), "expression_statement" | "return_statement") {
-        return None;
-    }
-    let text = trimmed_node_text(node, source)?;
-    let callable = text
-        .split('(')
-        .next()
-        .unwrap_or(text.as_str())
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    let separator = callable.rfind('.')?;
-    let receiver = callable[..separator].trim().trim_end_matches('?').trim();
-    let method = callable[separator + 1..]
-        .trim()
-        .trim_start_matches('?')
-        .trim();
-    Some((
-        normalized_dart_receiver_surface(receiver)?,
-        normalize_parameter_name(method)?,
-    ))
-}
-
-fn normalized_dart_receiver_surface(raw: &str) -> Option<String> {
-    let receiver = raw
-        .rsplit([' ', '\t', '\n', '\r', '(', '[', '{'])
-        .find(|part| !part.trim().is_empty())
-        .unwrap_or(raw)
-        .trim()
-        .trim_end_matches('?')
-        .trim();
-    if receiver.contains('.') {
-        let cleaned = receiver
-            .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '.')
-            .trim();
-        let valid = cleaned
-            .split('.')
-            .all(|part| normalize_parameter_name(part).is_some());
-        return (valid && !cleaned.is_empty()).then(|| cleaned.to_string());
-    }
-    normalize_parameter_name(receiver)
-}
-
-fn dart_direct_call(node: TsNode<'_>, source: &str) -> Option<String> {
-    if !matches!(node.kind(), "expression_statement" | "return_statement") {
-        return None;
-    }
-    let text = trimmed_node_text(node, source)?;
-    let callable = text
-        .split('(')
-        .next()
-        .unwrap_or(text.as_str())
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    if callable.contains('.') {
-        return None;
-    }
-    let callable = callable
-        .strip_prefix("return")
-        .map(str::trim)
-        .unwrap_or(callable);
-    callable
-        .split_whitespace()
-        .last()
-        .and_then(normalize_parameter_name)
-}
-
 fn surface_member_call(node: TsNode<'_>, source: &str) -> Option<(String, String)> {
     let text = trimmed_node_text(node, source)?;
     let callable = text
@@ -14678,12 +14054,6 @@ fn normalized_receiver_surface(raw: &str) -> Option<String> {
         .trim_end_matches('?')
         .trim();
     normalize_parameter_name(terminal)
-}
-
-fn dart_callable_name(node: TsNode<'_>, source: &str) -> Option<String> {
-    descendant_by_field_name(node, "name")
-        .or_else(|| first_descendant_with_kind(node, "identifier"))
-        .and_then(|name_node| trimmed_node_text(name_node, source))
 }
 
 fn ruby_constructor_owner(node: TsNode<'_>, source: &str) -> Option<String> {
@@ -15201,11 +14571,11 @@ fn queue_qualified_child_names(
 }
 
 fn promotes_type_member_functions_to_methods(language_name: &str) -> bool {
-    // Registry first; `swift` and `dart` are the unmigrated residue.
+    // Registry first; `swift` is the unmigrated residue.
     if let Some(extraction) = languages::extraction_for_language(language_name) {
         return extraction.promotes_type_member_functions_to_methods;
     }
-    matches!(language_name, "swift" | "dart")
+    matches!(language_name, "swift")
 }
 
 fn qualified_name_delimiter(language_name: &str) -> &'static str {
@@ -17072,16 +16442,7 @@ fn route_language_uses_c_style_comments(language_name: &str) -> bool {
     }
     matches!(
         language_name,
-        "javascript"
-            | "typescript"
-            | "java"
-            | "rust"
-            | "go"
-            | "php"
-            | "csharp"
-            | "dart"
-            | "vue"
-            | "astro"
+        "javascript" | "typescript" | "java" | "rust" | "go" | "php" | "csharp" | "vue" | "astro"
     )
 }
 
@@ -20231,7 +19592,6 @@ pub fn index_file(
                                         "php_member" => Some(PHP_MEMBER_CALLSITE_MARKER),
                                         "js_member" => Some(JS_MEMBER_CALLSITE_MARKER),
                                         "ts_member" => Some(TS_MEMBER_CALLSITE_MARKER),
-                                        "dart_member" => Some(DART_MEMBER_CALLSITE_MARKER),
                                         "swift_member" => Some(SWIFT_MEMBER_CALLSITE_MARKER),
                                         _ => callsite_marker,
                                     },
@@ -25754,8 +25114,18 @@ class Test {
         let swift = get_language_for_ext("swift").expect("swift config");
         assert_eq!(swift.graph_query, SWIFT_GRAPH_QUERY);
 
+        // Dart's rule file moved into `languages::dart`; the config must still
+        // come back through the same extension lookup.
         let dart = get_language_for_ext("dart").expect("dart config");
-        assert_eq!(dart.graph_query, DART_GRAPH_QUERY);
+        assert_eq!(dart.language_name, "dart");
+        assert_eq!(
+            dart.graph_query,
+            languages::extraction_for_ext("dart")
+                .expect("dart registry row")
+                .graph_query
+        );
+        assert!(dart.graph_query.contains("dart_member"));
+        assert!(dart.tags_query.is_none());
 
         let bash = get_language_for_ext("sh").expect("bash config");
         assert_eq!(bash.graph_query, BASH_GRAPH_QUERY);

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1369,7 +1369,7 @@ fn is_dart_member_call_placeholder(edge_kind: EdgeKind, callsite_identity: Optio
     callsite_identity.is_some_and(|identity| {
         identity
             .split('|')
-            .any(|part| part == crate::DART_MEMBER_CALLSITE_MARKER)
+            .any(|part| part == crate::languages::dart::MEMBER_CALLSITE_MARKER)
     })
 }
 

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -413,9 +413,6 @@ fn dedicated_semantic_resolver(language: &str) -> Option<SemanticResolverKind> {
         "swift" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
             "swift",
         ))),
-        "dart" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
-            "dart",
-        ))),
         "bash" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
             "bash",
         ))),
@@ -601,7 +598,6 @@ fn language_family_bucket(language: &'static str) -> &'static str {
         "php" => "php",
         "csharp" => "csharp",
         "swift" => "swift",
-        "dart" => "dart",
         "bash" => "bash",
         language if is_structural_language_name(language) => "structural",
         _ => language,

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/dart_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/dart_fidelity.txt
@@ -1,0 +1,35 @@
+node CLASS name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.dart:ConsoleNotifier line=7 col=1 end=11:2 file=FILE:<ROOT>/fidelity.dart@1
+node CLASS name=Event qn=Event canonical=<ROOT>/fidelity.dart:Event line=19 col=1 end=23:2 file=FILE:<ROOT>/fidelity.dart@1
+node CLASS name=Repository qn=Repository canonical=<ROOT>/fidelity.dart:Repository line=13 col=1 end=17:2 file=FILE:<ROOT>/fidelity.dart@1
+node CLASS name=Workflow qn=Workflow canonical=<ROOT>/fidelity.dart:Workflow line=25 col=1 end=35:2 file=FILE:<ROOT>/fidelity.dart@1
+node FILE name=<ROOT>/fidelity.dart qn=<ROOT>/fidelity.dart canonical=<ROOT>/fidelity.dart:<ROOT>/fidelity.dart:1 line=1 col=1 end=41:0 file=FILE:<ROOT>/fidelity.dart@1
+node FUNCTION name=orchestrateDart qn=orchestrateDart canonical=<ROOT>/fidelity.dart:orchestrateDart#0 line=37 col=1 end=37:23 file=FILE:<ROOT>/fidelity.dart@1
+node INTERFACE name=Notifier qn=Notifier canonical=<ROOT>/fidelity.dart:Notifier line=7 col=34 end=7:42 file=FILE:<ROOT>/fidelity.dart@1
+node METHOD name=ConsoleNotifier.notify qn=ConsoleNotifier.notify canonical=<ROOT>/fidelity.dart:ConsoleNotifier.notify#0 line=8 col=3 end=8:27 file=FILE:<ROOT>/fidelity.dart@1
+node METHOD name=Notifier.notify qn=Notifier.notify canonical=<ROOT>/fidelity.dart:Notifier.notify#0 line=4 col=3 end=4:28 file=FILE:<ROOT>/fidelity.dart@1
+node METHOD name=Repository.save qn=Repository.save canonical=<ROOT>/fidelity.dart:Repository.save#0 line=14 col=3 end=14:25 file=FILE:<ROOT>/fidelity.dart@1
+node METHOD name=Workflow.decorate qn=Workflow.decorate canonical=<ROOT>/fidelity.dart:Workflow.decorate#0 line=32 col=3 end=32:31 file=FILE:<ROOT>/fidelity.dart@1
+node METHOD name=Workflow.run qn=Workflow.run canonical=<ROOT>/fidelity.dart:Workflow.run#0 line=26 col=3 end=26:66 file=FILE:<ROOT>/fidelity.dart@1
+node MODULE name='dart:math' qn='dart:math' canonical=<ROOT>/fidelity.dart:'dart:math'#0 line=1 col=8 end=1:19 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=ConsoleNotifier qn=ConsoleNotifier canonical=<ROOT>/fidelity.dart:ConsoleNotifier#0 line=39 col=32 end=39:47 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=Event qn=Event canonical=<ROOT>/fidelity.dart:Event#0 line=39 col=16 end=39:21 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=Repository qn=Repository canonical=<ROOT>/fidelity.dart:Repository#0 line=39 col=51 end=39:61 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=Workflow qn=Workflow canonical=<ROOT>/fidelity.dart:Workflow#0 line=38 col=20 end=38:28 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.dart:decorate#0 line=29 col=5 end=29:13 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=max qn=max canonical=<ROOT>/fidelity.dart:max#0 line=40 col=3 end=40:6 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.dart:notify#0 line=27 col=14 end=27:20 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=print qn=print canonical=<ROOT>/fidelity.dart:print#0 line=9 col=5 end=9:10 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=print qn=print canonical=<ROOT>/fidelity.dart:print#1 line=15 col=5 end=15:10 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.dart:run#0 line=39 col=12 end=39:15 file=FILE:<ROOT>/fidelity.dart@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.dart:save#0 line=28 col=16 end=28:20 file=FILE:<ROOT>/fidelity.dart@1
+edge CALL src=FUNCTION:orchestrateDart@37 dst=METHOD:Workflow.run@26 resolved_src=FUNCTION:orchestrateDart@37 resolved_dst=METHOD:Workflow.run@26 line=39 confidence=1.0000 certainty=Certain callsite=h0:39:1:h1 candidates=[]
+edge CALL src=METHOD:Workflow.run@26 dst=METHOD:Notifier.notify@4 resolved_src=METHOD:Workflow.run@26 resolved_dst=METHOD:Notifier.notify@4 line=27 confidence=1.0000 certainty=Certain callsite=h0:27:1:h2 candidates=[]
+edge CALL src=METHOD:Workflow.run@26 dst=METHOD:Repository.save@14 resolved_src=METHOD:Workflow.run@26 resolved_dst=METHOD:Repository.save@14 line=28 confidence=1.0000 certainty=Certain callsite=h0:28:1:h3 candidates=[]
+edge CALL src=METHOD:Workflow.run@26 dst=METHOD:Workflow.decorate@32 resolved_src=METHOD:Workflow.run@26 resolved_dst=METHOD:Workflow.decorate@32 line=29 confidence=1.0000 certainty=Certain callsite=h0:29:1:h4 candidates=[]
+edge IMPORT src=MODULE:'dart:math'@1 dst=MODULE:'dart:math'@1 resolved_src=MODULE:'dart:math'@1 resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ConsoleNotifier@7 dst=INTERFACE:Notifier@7 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ConsoleNotifier@7 dst=METHOD:ConsoleNotifier.notify@8 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Repository@13 dst=METHOD:Repository.save@14 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@25 dst=METHOD:Workflow.decorate@32 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Workflow@25 dst=METHOD:Workflow.run@26 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Notifier@7 dst=METHOD:Notifier.notify@4 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/dart_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/dart_tictactoe.txt
@@ -1,0 +1,106 @@
+node CLASS name=ArtificialPlayer qn=ArtificialPlayer canonical=game.dart:ArtificialPlayer line=46 col=1 end=58:2 file=FILE:game.dart@1
+node CLASS name=Field qn=Field canonical=game.dart:Field line=19 col=1 end=34:2 file=FILE:game.dart@1
+node CLASS name=GameObject qn=GameObject canonical=game.dart:GameObject line=15 col=1 end=17:2 file=FILE:game.dart@1
+node CLASS name=HumanPlayer qn=HumanPlayer canonical=game.dart:HumanPlayer line=40 col=1 end=44:2 file=FILE:game.dart@1
+node CLASS name=TicTacToe qn=TicTacToe canonical=game.dart:TicTacToe line=60 col=1 end=68:2 file=FILE:game.dart@1
+node FILE name=game.dart qn=game.dart canonical=game.dart:game.dart:1 line=1 col=1 end=73:0 file=FILE:game.dart@1
+node FUNCTION name=main qn=main canonical=game.dart:main#0 line=70 col=1 end=70:12 file=FILE:game.dart@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.dart:numberIn#0 line=3 col=1 end=3:15 file=FILE:game.dart@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.dart:numberOut#0 line=7 col=1 end=7:24 file=FILE:game.dart@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.dart:stringOut#0 line=11 col=1 end=11:29 file=FILE:game.dart@1
+node INTERFACE name=Player qn=Player canonical=game.dart:Player line=40 col=30 end=40:36 file=FILE:game.dart@1
+node METHOD name=ArtificialPlayer.minMax qn=ArtificialPlayer.minMax canonical=game.dart:ArtificialPlayer.minMax#0 line=47 col=3 end=47:48 file=FILE:game.dart@1
+node METHOD name=ArtificialPlayer.turn qn=ArtificialPlayer.turn canonical=game.dart:ArtificialPlayer.turn#0 line=54 col=3 end=54:36 file=FILE:game.dart@1
+node METHOD name=Field.makeMove qn=Field.makeMove canonical=game.dart:Field.makeMove#0 line=26 col=3 end=26:45 file=FILE:game.dart@1
+node METHOD name=Field.sameInRow qn=Field.sameInRow canonical=game.dart:Field.sameInRow#0 line=22 col=3 end=22:39 file=FILE:game.dart@1
+node METHOD name=GameObject.announce qn=GameObject.announce canonical=game.dart:GameObject.announce#0 line=16 col=3 end=16:18 file=FILE:game.dart@1
+node METHOD name=HumanPlayer.turn qn=HumanPlayer.turn canonical=game.dart:HumanPlayer.turn#0 line=41 col=3 end=41:36 file=FILE:game.dart@1
+node METHOD name=Player.turn qn=Player.turn canonical=game.dart:Player.turn#0 line=37 col=3 end=37:37 file=FILE:game.dart@1
+node METHOD name=TicTacToe.run qn=TicTacToe.run canonical=game.dart:TicTacToe.run#0 line=63 col=3 end=63:13 file=FILE:game.dart@1
+node MODULE name='dart:math' qn='dart:math' canonical=game.dart:'dart:math'#0 line=1 col=8 end=1:19 file=FILE:game.dart@1
+node UNKNOWN name=Field qn=Field canonical=game.dart:Field#0 line=61 col=17 end=61:22 file=FILE:game.dart@1
+node UNKNOWN name=Random qn=Random canonical=game.dart:Random#0 line=66 col=5 end=66:11 file=FILE:game.dart@1
+node UNKNOWN name=TicTacToe qn=TicTacToe canonical=game.dart:TicTacToe#0 line=71 col=16 end=71:25 file=FILE:game.dart@1
+node UNKNOWN name=minMax qn=minMax canonical=game.dart:minMax#0 line=51 col=12 end=51:18 file=FILE:game.dart@1
+node UNKNOWN name=minMax qn=minMax canonical=game.dart:minMax#1 line=55 col=5 end=55:11 file=FILE:game.dart@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.dart:numberIn#1 line=64 col=5 end=64:13 file=FILE:game.dart@1
+node UNKNOWN name=print qn=print canonical=game.dart:print#0 line=8 col=3 end=8:8 file=FILE:game.dart@1
+node UNKNOWN name=print qn=print canonical=game.dart:print#1 line=12 col=3 end=12:8 file=FILE:game.dart@1
+node UNKNOWN name=run qn=run canonical=game.dart:run#0 line=72 col=8 end=72:11 file=FILE:game.dart@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.dart:sameInRow#0 line=31 col=5 end=31:14 file=FILE:game.dart@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.dart:stringOut#1 line=65 col=5 end=65:14 file=FILE:game.dart@1
+edge CALL src=FUNCTION:main@70 dst=METHOD:TicTacToe.run@63 resolved_src=- resolved_dst=METHOD:TicTacToe.run@63 line=72 confidence=1.0000 certainty=Certain callsite=h0:72:1:h1 candidates=[]
+edge CALL src=METHOD:ArtificialPlayer.turn@54 dst=METHOD:ArtificialPlayer.minMax@47 resolved_src=- resolved_dst=METHOD:ArtificialPlayer.minMax@47 line=55 confidence=1.0000 certainty=Certain callsite=h0:55:1:h2 candidates=[]
+edge CALL src=METHOD:Field.makeMove@26 dst=METHOD:Field.sameInRow@22 resolved_src=- resolved_dst=METHOD:Field.sameInRow@22 line=31 confidence=1.0000 certainty=Certain callsite=h0:31:1:h3 candidates=[]
+edge CALL src=METHOD:HumanPlayer.turn@41 dst=METHOD:Field.makeMove@26 resolved_src=- resolved_dst=METHOD:Field.makeMove@26 line=42 confidence=1.0000 certainty=Certain callsite=h0:42:1:h4 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@63 dst=FUNCTION:numberIn@3 resolved_src=- resolved_dst=FUNCTION:numberIn@3 line=64 confidence=1.0000 certainty=Certain callsite=h0:64:1:h5 candidates=[]
+edge CALL src=METHOD:TicTacToe.run@63 dst=FUNCTION:stringOut@11 resolved_src=- resolved_dst=FUNCTION:stringOut@11 line=65 confidence=1.0000 certainty=Certain callsite=h0:65:1:h6 candidates=[]
+edge IMPORT src=MODULE:'dart:math'@1 dst=MODULE:'dart:math'@1 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:ArtificialPlayer@46 dst=INTERFACE:Player@40 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:Field@19 dst=CLASS:GameObject@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:HumanPlayer@40 dst=INTERFACE:Player@40 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge INHERITANCE src=CLASS:TicTacToe@60 dst=CLASS:GameObject@15 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@46 dst=METHOD:ArtificialPlayer.minMax@47 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:ArtificialPlayer@46 dst=METHOD:ArtificialPlayer.turn@54 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@19 dst=METHOD:Field.makeMove@26 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:Field@19 dst=METHOD:Field.sameInRow@22 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:GameObject@15 dst=METHOD:GameObject.announce@16 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:HumanPlayer@40 dst=METHOD:HumanPlayer.turn@41 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=CLASS:TicTacToe@60 dst=METHOD:TicTacToe.run@63 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+edge MEMBER src=INTERFACE:Player@40 dst=METHOD:Player.turn@37 resolved_src=- resolved_dst=- line=0 confidence=- certainty=Certain callsite=- candidates=[]
+file path=game.dart language=dart lines=73 complete=true role=Source
+occurrence element=CLASS:ArtificialPlayer@46 kind=DEFINITION span=46:1-58:2
+occurrence element=CLASS:Field@19 kind=DEFINITION span=19:1-34:2
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=15:1-17:2
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=19:21-19:31
+occurrence element=CLASS:GameObject@15 kind=DEFINITION span=60:25-60:35
+occurrence element=CLASS:HumanPlayer@40 kind=DEFINITION span=40:1-44:2
+occurrence element=CLASS:TicTacToe@60 kind=DEFINITION span=60:1-68:2
+occurrence element=FUNCTION:main@70 kind=DEFINITION span=70:1-70:12
+occurrence element=FUNCTION:numberIn@3 kind=DEFINITION span=3:1-3:15
+occurrence element=FUNCTION:numberOut@7 kind=DEFINITION span=7:1-7:24
+occurrence element=FUNCTION:stringOut@11 kind=DEFINITION span=11:1-11:29
+occurrence element=INTERFACE:Player@40 kind=DEFINITION span=36:1-38:2
+occurrence element=INTERFACE:Player@40 kind=DEFINITION span=40:30-40:36
+occurrence element=INTERFACE:Player@40 kind=DEFINITION span=46:35-46:41
+occurrence element=METHOD:ArtificialPlayer.minMax@47 kind=DEFINITION span=47:3-47:48
+occurrence element=METHOD:ArtificialPlayer.turn@54 kind=DEFINITION span=54:3-54:36
+occurrence element=METHOD:Field.makeMove@26 kind=DEFINITION span=26:3-26:45
+occurrence element=METHOD:Field.sameInRow@22 kind=DEFINITION span=22:3-22:39
+occurrence element=METHOD:GameObject.announce@16 kind=DEFINITION span=16:3-16:18
+occurrence element=METHOD:HumanPlayer.turn@41 kind=DEFINITION span=41:3-41:36
+occurrence element=METHOD:Player.turn@37 kind=DEFINITION span=37:3-37:37
+occurrence element=METHOD:TicTacToe.run@63 kind=DEFINITION span=63:3-63:13
+occurrence element=MODULE:'dart:math'@1 kind=DEFINITION span=1:8-1:19
+occurrence element=UNKNOWN:Field@61 kind=DEFINITION span=61:17-61:22
+occurrence element=UNKNOWN:Random@66 kind=DEFINITION span=66:5-66:11
+occurrence element=UNKNOWN:TicTacToe@71 kind=DEFINITION span=71:16-71:25
+occurrence element=UNKNOWN:minMax@51 kind=DEFINITION span=51:12-51:18
+occurrence element=UNKNOWN:minMax@55 kind=DEFINITION span=55:5-55:11
+occurrence element=UNKNOWN:numberIn@64 kind=DEFINITION span=64:5-64:13
+occurrence element=UNKNOWN:print@12 kind=DEFINITION span=12:3-12:8
+occurrence element=UNKNOWN:print@8 kind=DEFINITION span=8:3-8:8
+occurrence element=UNKNOWN:run@72 kind=DEFINITION span=72:8-72:11
+occurrence element=UNKNOWN:sameInRow@31 kind=DEFINITION span=31:5-31:14
+occurrence element=UNKNOWN:stringOut@65 kind=DEFINITION span=65:5-65:14
+access node=METHOD:ArtificialPlayer.minMax@47 kind=Public
+access node=METHOD:ArtificialPlayer.turn@54 kind=Public
+access node=METHOD:Field.makeMove@26 kind=Public
+access node=METHOD:Field.sameInRow@22 kind=Public
+access node=METHOD:GameObject.announce@16 kind=Public
+access node=METHOD:HumanPlayer.turn@41 kind=Public
+access node=METHOD:Player.turn@37 kind=Public
+access node=METHOD:TicTacToe.run@63 kind=Public
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "13:main", node_id: NodeId(-5857072483582358186), signature_hash: -4671339478033693080, normalized_signature: Some("shape:8984960628363654967"), body_hash: 5340298209655279445, start_line: 70, end_line: 70 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "13:numberIn", node_id: NodeId(1789088172167782369), signature_hash: 2477812878330356949, normalized_signature: Some("outline:-1793518511152586733"), body_hash: 2591909000467289069, start_line: 3, end_line: 3 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "13:numberOut", node_id: NodeId(1087646804274541104), signature_hash: -1579019679195996938, normalized_signature: Some("outline:-1793518511152586733"), body_hash: -3390307132350075639, start_line: 7, end_line: 7 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "13:stringOut", node_id: NodeId(-5891819783022959128), signature_hash: -5818630870471287222, normalized_signature: Some("outline:-1793518511152586733"), body_hash: 6208400749090755015, start_line: 11, end_line: 11 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "14:ArtificialPlayer.minMax", node_id: NodeId(-1431279924960269748), signature_hash: 2816889471617643129, normalized_signature: Some("outline:-5083272169020481154"), body_hash: 512118297661447575, start_line: 47, end_line: 47 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "14:ArtificialPlayer.turn", node_id: NodeId(1501899458215180529), signature_hash: 5754064973517794814, normalized_signature: Some("shape:6124763378763744556"), body_hash: 3390548165151957644, start_line: 54, end_line: 54 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "14:Field.makeMove", node_id: NodeId(-183387836363658654), signature_hash: -7686617887134063555, normalized_signature: Some("shape:8458474035177833593"), body_hash: -949950107874055423, start_line: 26, end_line: 26 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "14:Field.sameInRow", node_id: NodeId(701280348454705766), signature_hash: 8317776364922746511, normalized_signature: Some("outline:-5083272169020481154"), body_hash: 5237164820150251760, start_line: 22, end_line: 22 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "14:GameObject.announce", node_id: NodeId(-4479523467783061319), signature_hash: 6265382829821424686, normalized_signature: Some("outline:-5083272169020481154"), body_hash: 2281276605351895009, start_line: 16, end_line: 16 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "14:HumanPlayer.turn", node_id: NodeId(-1216559423763927890), signature_hash: -1551097434895889655, normalized_signature: Some("shape:7164779443168732580"), body_hash: 1703219438516552849, start_line: 41, end_line: 41 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "14:Player.turn", node_id: NodeId(3983705973672247437), signature_hash: -1091959065548758310, normalized_signature: Some("outline:-5083272169020481154"), body_hash: -1041864639719970143, start_line: 37, end_line: 37 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "14:TicTacToe.run", node_id: NodeId(1973322840329670188), signature_hash: 5136661510898306809, normalized_signature: Some("shape:255436906924033835"), body_hash: -3295100025934209292, start_line: 63, end_line: 63 }
+callable_state CallableProjectionState { file_id: 8885278408206200492, symbol_key: "__file_structural__", node_id: NodeId(8885278408206200492), signature_hash: 553768115714561381, normalized_signature: None, body_hash: 2224578709090503675, start_line: 1, end_line: 73 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "dart",
+        extension: "dart",
+        fidelity_filename: "fidelity.dart",
+        fidelity_source: include_str!("fixtures/fidelity_lab/dart_fidelity_lab.dart"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/dart_fidelity.txt"),
+        tictactoe_filename: "game.dart",
+        tictactoe_source: include_str!("fixtures/tictactoe/dart_tictactoe.dart"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/dart_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1690.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
