### PR TITLE
[v0.17 S3-BASH] Extract Bash language rules behind the indexer registry

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3940,7 +3940,7 @@ fn ansi_highlight_line(language: &str, line: &str) -> String {
     // extraction package has not landed yet (ARCH-012 roster burn-down).
     let comment_marker = codestory_contracts::language_support::line_comment_for_language(language)
         .or(match language {
-            "bash" | "python" | "ruby" | "toml" | "yaml" => Some("#"),
+            "python" | "ruby" | "toml" | "yaml" => Some("#"),
             "rust" | "typescript" | "tsx" | "javascript" | "jsx" | "go" | "java" | "csharp"
             | "cpp" | "dart" | "php" | "swift" => Some("//"),
             _ => None,

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -474,10 +474,16 @@ pub struct LanguageCommentProfile {
     pub line_comment: &'static str,
 }
 
-pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[LanguageCommentProfile {
-    language_name: "kotlin",
-    line_comment: "//",
-}];
+pub const LANGUAGE_COMMENT_PROFILES: &[LanguageCommentProfile] = &[
+    LanguageCommentProfile {
+        language_name: "kotlin",
+        line_comment: "//",
+    },
+    LanguageCommentProfile {
+        language_name: "bash",
+        line_comment: "#",
+    },
+];
 
 /// Line-comment marker for a registered language name.
 pub fn line_comment_for_language(language_name: &str) -> Option<&'static str> {
@@ -1245,7 +1251,7 @@ mod tests {
             .iter()
             .map(|profile| profile.language_name)
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["kotlin"]);
+        assert_eq!(names, vec!["kotlin", "bash"]);
         for profile in LANGUAGE_COMMENT_PROFILES {
             assert!(
                 language_support_profile_for_language_name(profile.language_name).is_some(),
@@ -1259,6 +1265,7 @@ mod tests {
             );
         }
         assert_eq!(line_comment_for_language("kotlin"), Some("//"));
+        assert_eq!(line_comment_for_language("bash"), Some("#"));
         assert_eq!(line_comment_for_language("swift"), None);
     }
 

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -1,9 +1,9 @@
 use super::{
-    BASH_GRAPH_QUERY, C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY,
-    GO_GRAPH_QUERY, JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset,
-    PHP_GRAPH_QUERY, PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY,
-    SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
-    TYPESCRIPT_TAGS_QUERY, languages, make_language_config,
+    C_GRAPH_QUERY, CPP_GRAPH_QUERY, CSHARP_GRAPH_QUERY, DART_GRAPH_QUERY, GO_GRAPH_QUERY,
+    JAVA_GRAPH_QUERY, JAVASCRIPT_GRAPH_QUERY, LanguageConfig, LanguageRuleset, PHP_GRAPH_QUERY,
+    PYTHON_GRAPH_QUERY, RUBY_GRAPH_QUERY, RUST_GRAPH_QUERY, RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY,
+    TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY, TYPESCRIPT_TAGS_QUERY, languages,
+    make_language_config,
 };
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
@@ -43,7 +43,6 @@ pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
         ("csharp", _) => Some(csharp()),
         ("swift", _) => Some(swift()),
         ("dart", _) => Some(dart()),
-        ("bash", _) => Some(bash()),
         _ => None,
     }
 }
@@ -185,15 +184,5 @@ fn dart() -> LanguageConfig {
         DART_GRAPH_QUERY,
         None,
         LanguageRuleset::Dart,
-    )
-}
-
-fn bash() -> LanguageConfig {
-    make_language_config(
-        tree_sitter_bash::LANGUAGE.into(),
-        "bash",
-        BASH_GRAPH_QUERY,
-        None,
-        LanguageRuleset::Bash,
     )
 }

--- a/crates/codestory-indexer/src/languages/bash.rs
+++ b/crates/codestory-indexer/src/languages/bash.rs
@@ -1,0 +1,68 @@
+//! Bash extraction rules.
+//!
+//! Bash's graph extraction lives here: the tree-sitter grammar, the rule file,
+//! the compiled-rule cache, and the projection facts (no method promotion, a
+//! `.` qualified-name delimiter, hash comments rather than C-style ones, the
+//! shared name-only semantic resolver, and its own family bucket). Every
+//! language-keyed dispatch in the crate reaches them through
+//! [`super::EXTRACTIONS`] rather than by spelling `"bash"`.
+//!
+//! Bash has no manual receiver-call engine and no member-call syntax, so
+//! `receiver_call_specs`, `member_callsite_marker` and `graph_call_syntax` are
+//! all `None`: shell has no receiver-qualified call form for the resolver to
+//! aim at, and the rule file emits no `call_syntax` attribute.
+//!
+//! Two Bash surfaces are deliberately *not* here, and both are shared seams
+//! rather than Bash content:
+//!
+//! * `lib.rs::collect_bash_source_import_specs` and its `"bash"` arm in
+//!   `collect_runtime_import_specs`. The per-language runtime-import
+//!   collectors have no [`super::LanguageExtraction`] field, so relocating one
+//!   would leave the `"bash"` spelling in the dispatch and only move code;
+//!   routing them through the registry is one change for all sixteen
+//!   languages, exactly as `collect_ktor_route` was left out of Kotlin's
+//!   rollback unit.
+//! * `LanguageRuleset::Bash`, which stays in `lib.rs` because the enum is the
+//!   compiled-rule cache key for every language at once.
+//!
+//! This is a move, not a rewrite. The parser config below is the one that used
+//! to sit in `language_configs.rs::bash`, and
+//! `tests/language_extraction_snapshot.rs` pins the rendered projection of
+//! both Bash fixtures so the move stays output-equal.
+
+use std::sync::OnceLock;
+
+use super::LanguageExtraction;
+use crate::{CompiledLanguageRules, LanguageRuleset};
+
+const GRAPH_QUERY: &str = include_str!("../../rules/bash.scm");
+
+static RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+
+/// The single registry row for Bash.
+pub(crate) const EXTRACTION: LanguageExtraction = LanguageExtraction {
+    dispatch_names: &["bash"],
+    language_name: "bash",
+    extensions: &["sh", "bash"],
+    ruleset: LanguageRuleset::Bash,
+    parser_language: bash_language,
+    graph_query: GRAPH_QUERY,
+    tags_query: None,
+    compiled_rules: &RULES,
+    receiver_call_specs: None,
+    member_callsite_marker: None,
+    graph_call_syntax: None,
+    // Shell has no type-like owners, so a `function_definition` never projects
+    // as METHOD; Bash was absent from the promotion roster in `lib.rs`.
+    promotes_type_member_functions_to_methods: false,
+    qualified_name_delimiter: ".",
+    // Shell comments start with `#`; Bash was absent from the C-style roster
+    // in `route_language_uses_c_style_comments`.
+    route_comments_are_c_style: false,
+    uses_generic_semantic_resolver: true,
+    semantic_family: "bash",
+};
+
+fn bash_language() -> tree_sitter::Language {
+    tree_sitter_bash::LANGUAGE.into()
+}

--- a/crates/codestory-indexer/src/languages/mod.rs
+++ b/crates/codestory-indexer/src/languages/mod.rs
@@ -16,6 +16,7 @@
 //! `registry_rows_do_not_shadow_unmigrated_languages` proves it — and the last
 //! package to land deletes the residual arms entirely.
 
+pub(crate) mod bash;
 pub(crate) mod kotlin;
 
 use std::sync::OnceLock;
@@ -69,7 +70,7 @@ pub(crate) struct LanguageExtraction {
 }
 
 /// Every language whose extraction rules have moved into this module tree.
-pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION];
+pub(crate) const EXTRACTIONS: &[LanguageExtraction] = &[kotlin::EXTRACTION, bash::EXTRACTION];
 
 /// Look a row up by any of its dispatch names.
 pub(crate) fn extraction_for_language(language_name: &str) -> Option<&'static LanguageExtraction> {
@@ -235,6 +236,48 @@ mod tests {
         assert_eq!(
             extraction_for_ext("kts").map(|row| row.language_name),
             Some("kotlin")
+        );
+    }
+
+    /// The Bash row must keep the exact projection facts it had while it was
+    /// spread across `lib.rs`, `language_configs.rs` and `semantic/mod.rs`.
+    ///
+    /// This row is load-bearing in a way Kotlin's was not. Mutation testing on
+    /// the two Bash fixtures shows `language_extraction_snapshot` catches the
+    /// routing and rule-file fields (`extensions`, `graph_query`,
+    /// `language_name`) but is *blind* to six others, because shell has no
+    /// type-like owners, no owner-qualified names, no framework routes and no
+    /// receiver-qualified call form for the fixtures to exercise. Flipping
+    /// `promotes_type_member_functions_to_methods`, `qualified_name_delimiter`,
+    /// `route_comments_are_c_style`, `semantic_family`,
+    /// `uses_generic_semantic_resolver`, or wiring a foreign engine into
+    /// `receiver_call_specs` each leaves both goldens byte-identical. The
+    /// assertions below are the pre-move roster restated, so a registry row
+    /// that contradicted the god file fails here instead of shipping.
+    #[test]
+    fn bash_row_keeps_the_projection_facts_it_had_in_the_god_file() {
+        let bash = extraction_for_language("bash").expect("bash row");
+        // `lib.rs::promotes_type_member_functions_to_methods` listed only
+        // `swift` and `dart`; Bash fell through to `false`.
+        assert!(!bash.promotes_type_member_functions_to_methods);
+        // `lib.rs::qualified_name_delimiter` gave `::` to rust/cpp/c only.
+        assert_eq!(bash.qualified_name_delimiter, ".");
+        // Bash was absent from `route_language_uses_c_style_comments`.
+        assert!(!bash.route_comments_are_c_style);
+        assert_eq!(bash.semantic_family, "bash");
+        assert!(bash.uses_generic_semantic_resolver);
+        // Shell has no member-call syntax and no manual receiver-call engine.
+        assert!(bash.receiver_call_specs.is_none());
+        assert!(bash.member_callsite_marker.is_none());
+        assert!(bash.graph_call_syntax.is_none());
+        assert!(bash.tags_query.is_none());
+        assert_eq!(
+            extraction_for_ext("sh").map(|row| row.language_name),
+            Some("bash")
+        );
+        assert_eq!(
+            extraction_for_ext("bash").map(|row| row.language_name),
+            Some("bash")
         );
     }
 }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -144,7 +144,6 @@ const PHP_GRAPH_QUERY: &str = include_str!("../rules/php.scm");
 const CSHARP_GRAPH_QUERY: &str = include_str!("../rules/csharp.scm");
 const SWIFT_GRAPH_QUERY: &str = include_str!("../rules/swift.scm");
 const DART_GRAPH_QUERY: &str = include_str!("../rules/dart.scm");
-const BASH_GRAPH_QUERY: &str = include_str!("../rules/bash.scm");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LanguageRuleset {
@@ -339,9 +338,12 @@ impl LanguageRuleset {
             LanguageRuleset::Dart => {
                 compiled_rules_cache(language, DART_GRAPH_QUERY, None, &DART_RULES)
             }
-            LanguageRuleset::Bash => {
-                compiled_rules_cache(language, BASH_GRAPH_QUERY, None, &BASH_RULES)
-            }
+            // Answered by the registry above; the arm only exists because the
+            // match must stay exhaustive. Failing closed here rather than
+            // panicking keeps a future registry mistake a typed indexing error.
+            LanguageRuleset::Bash => Err(anyhow!(
+                "bash compiled rules are owned by the language registry"
+            )),
         }
     }
 }
@@ -386,7 +388,6 @@ static PHP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::ne
 static CSHARP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static SWIFT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static DART_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
-static BASH_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 
 fn tag_definition_priority(definition: &TagDefinition) -> (u8, u8, u8) {
     let role_priority = canonical_role_priority(definition.canonical_role);
@@ -25757,8 +25758,19 @@ class Test {
         let dart = get_language_for_ext("dart").expect("dart config");
         assert_eq!(dart.graph_query, DART_GRAPH_QUERY);
 
+        // Bash moved into `languages::bash`; the config it hands back must
+        // still come back through the same extension lookup.
         let bash = get_language_for_ext("sh").expect("bash config");
-        assert_eq!(bash.graph_query, BASH_GRAPH_QUERY);
+        assert_eq!(bash.language_name, "bash");
+        assert_eq!(
+            bash.graph_query,
+            languages::extraction_for_ext("sh")
+                .expect("bash registry row")
+                .graph_query
+        );
+        assert!(bash.tags_query.is_none());
+        let bash_extension = get_language_for_ext("bash").expect("bash extension config");
+        assert_eq!(bash_extension.graph_query, bash.graph_query);
     }
 
     #[test]

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -416,9 +416,6 @@ fn dedicated_semantic_resolver(language: &str) -> Option<SemanticResolverKind> {
         "dart" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
             "dart",
         ))),
-        "bash" => Some(SemanticResolverKind::Generic(GenericSemanticResolver::new(
-            "bash",
-        ))),
         _ => None,
     }
 }
@@ -602,7 +599,6 @@ fn language_family_bucket(language: &'static str) -> &'static str {
         "csharp" => "csharp",
         "swift" => "swift",
         "dart" => "dart",
-        "bash" => "bash",
         language if is_structural_language_name(language) => "structural",
         _ => language,
     }

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/bash_fidelity.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/bash_fidelity.txt
@@ -1,0 +1,28 @@
+node FILE name=<ROOT>/fidelity.sh qn=<ROOT>/fidelity.sh canonical=<ROOT>/fidelity.sh:<ROOT>/fidelity.sh:1 line=1 col=1 end=29:0 file=FILE:<ROOT>/fidelity.sh@1
+node FUNCTION name=decorate qn=decorate canonical=<ROOT>/fidelity.sh:decorate#0 line=13 col=1 end=16:2 file=FILE:<ROOT>/fidelity.sh@1
+node FUNCTION name=notify qn=notify canonical=<ROOT>/fidelity.sh:notify#0 line=3 col=1 end=6:2 file=FILE:<ROOT>/fidelity.sh@1
+node FUNCTION name=orchestrate_bash qn=orchestrate_bash canonical=<ROOT>/fidelity.sh:orchestrate_bash#0 line=25 col=1 end=27:2 file=FILE:<ROOT>/fidelity.sh@1
+node FUNCTION name=run qn=run canonical=<ROOT>/fidelity.sh:run#0 line=18 col=1 end=23:2 file=FILE:<ROOT>/fidelity.sh@1
+node FUNCTION name=save qn=save canonical=<ROOT>/fidelity.sh:save#0 line=8 col=1 end=11:2 file=FILE:<ROOT>/fidelity.sh@1
+node MODULE name=./logger.sh qn=./logger.sh canonical=<ROOT>/fidelity.sh:./logger.sh#0 line=1 col=8 end=1:19 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=decorate qn=decorate canonical=<ROOT>/fidelity.sh:decorate#1 line=22 col=3 end=22:11 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=notify qn=notify canonical=<ROOT>/fidelity.sh:notify#1 line=20 col=3 end=20:9 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=orchestrate_bash qn=orchestrate_bash canonical=<ROOT>/fidelity.sh:orchestrate_bash#1 line=29 col=1 end=29:17 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=printf qn=printf canonical=<ROOT>/fidelity.sh:printf#0 line=5 col=3 end=5:9 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=printf qn=printf canonical=<ROOT>/fidelity.sh:printf#1 line=10 col=3 end=10:9 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=printf qn=printf canonical=<ROOT>/fidelity.sh:printf#2 line=15 col=3 end=15:9 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=run qn=run canonical=<ROOT>/fidelity.sh:run#1 line=26 col=3 end=26:6 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=save qn=save canonical=<ROOT>/fidelity.sh:save#1 line=21 col=3 end=21:7 file=FILE:<ROOT>/fidelity.sh@1
+node UNKNOWN name=source qn=source canonical=<ROOT>/fidelity.sh:source#0 line=1 col=1 end=1:7 file=FILE:<ROOT>/fidelity.sh@1
+node VARIABLE name=event qn=event canonical=<ROOT>/fidelity.sh:event#0 line=4 col=3 end=4:13 file=FILE:<ROOT>/fidelity.sh@1
+node VARIABLE name=event qn=event canonical=<ROOT>/fidelity.sh:event#1 line=9 col=3 end=9:13 file=FILE:<ROOT>/fidelity.sh@1
+node VARIABLE name=event qn=event canonical=<ROOT>/fidelity.sh:event#2 line=14 col=3 end=14:13 file=FILE:<ROOT>/fidelity.sh@1
+node VARIABLE name=event qn=event canonical=<ROOT>/fidelity.sh:event#3 line=19 col=3 end=19:13 file=FILE:<ROOT>/fidelity.sh@1
+edge CALL src=FUNCTION:decorate@13 dst=UNKNOWN:printf@15 resolved_src=FUNCTION:decorate@13 resolved_dst=- line=15 confidence=- certainty=- callsite=h0:15:1:h1 candidates=[]
+edge CALL src=FUNCTION:notify@3 dst=UNKNOWN:printf@5 resolved_src=FUNCTION:notify@3 resolved_dst=- line=5 confidence=- certainty=- callsite=h0:5:1:h2 candidates=[]
+edge CALL src=FUNCTION:orchestrate_bash@25 dst=UNKNOWN:run@26 resolved_src=FUNCTION:orchestrate_bash@25 resolved_dst=FUNCTION:run@18 line=26 confidence=0.9500 certainty=Certain callsite=h0:26:1:h3 candidates=[]
+edge CALL src=FUNCTION:run@18 dst=UNKNOWN:decorate@22 resolved_src=FUNCTION:run@18 resolved_dst=FUNCTION:decorate@13 line=22 confidence=0.9500 certainty=Certain callsite=h0:22:1:h4 candidates=[]
+edge CALL src=FUNCTION:run@18 dst=UNKNOWN:notify@20 resolved_src=FUNCTION:run@18 resolved_dst=FUNCTION:notify@3 line=20 confidence=0.9500 certainty=Certain callsite=h0:20:1:h5 candidates=[]
+edge CALL src=FUNCTION:run@18 dst=UNKNOWN:save@21 resolved_src=FUNCTION:run@18 resolved_dst=FUNCTION:save@8 line=21 confidence=0.9500 certainty=Certain callsite=h0:21:1:h6 candidates=[]
+edge CALL src=FUNCTION:save@8 dst=UNKNOWN:printf@10 resolved_src=FUNCTION:save@8 resolved_dst=- line=10 confidence=- certainty=- callsite=h0:10:1:h7 candidates=[]
+edge IMPORT src=MODULE:./logger.sh@1 dst=MODULE:./logger.sh@1 resolved_src=MODULE:./logger.sh@1 resolved_dst=- line=1 confidence=- certainty=- callsite=- candidates=[]

--- a/crates/codestory-indexer/tests/fixtures/language_snapshots/bash_tictactoe.txt
+++ b/crates/codestory-indexer/tests/fixtures/language_snapshots/bash_tictactoe.txt
@@ -1,0 +1,100 @@
+node FILE name=game.sh qn=game.sh canonical=game.sh:game.sh:1 line=1 col=1 end=55:0 file=FILE:game.sh@1
+node FUNCTION name=main qn=main canonical=game.sh:main#0 line=51 col=1 end=53:2 file=FILE:game.sh@1
+node FUNCTION name=makeMove qn=makeMove canonical=game.sh:makeMove#0 line=21 col=1 end=30:2 file=FILE:game.sh@1
+node FUNCTION name=minMax qn=minMax canonical=game.sh:minMax#0 line=36 col=1 end=43:2 file=FILE:game.sh@1
+node FUNCTION name=numberIn qn=numberIn canonical=game.sh:numberIn#0 line=3 col=1 end=5:2 file=FILE:game.sh@1
+node FUNCTION name=numberOut qn=numberOut canonical=game.sh:numberOut#0 line=7 col=1 end=9:2 file=FILE:game.sh@1
+node FUNCTION name=run qn=run canonical=game.sh:run#0 line=45 col=1 end=49:2 file=FILE:game.sh@1
+node FUNCTION name=sameInRow qn=sameInRow canonical=game.sh:sameInRow#0 line=15 col=1 end=19:2 file=FILE:game.sh@1
+node FUNCTION name=stringOut qn=stringOut canonical=game.sh:stringOut#0 line=11 col=1 end=13:2 file=FILE:game.sh@1
+node FUNCTION name=turn qn=turn canonical=game.sh:turn#0 line=32 col=1 end=34:2 file=FILE:game.sh@1
+node MODULE name=./random.sh qn=./random.sh canonical=game.sh:./random.sh#0 line=1 col=8 end=1:19 file=FILE:game.sh@1
+node UNKNOWN name=echo qn=echo canonical=game.sh:echo#0 line=4 col=3 end=4:7 file=FILE:game.sh@1
+node UNKNOWN name=echo qn=echo canonical=game.sh:echo#1 line=18 col=3 end=18:7 file=FILE:game.sh@1
+node UNKNOWN name=echo qn=echo canonical=game.sh:echo#2 line=29 col=3 end=29:7 file=FILE:game.sh@1
+node UNKNOWN name=echo qn=echo canonical=game.sh:echo#3 line=39 col=5 end=39:9 file=FILE:game.sh@1
+node UNKNOWN name=main qn=main canonical=game.sh:main#1 line=55 col=1 end=55:5 file=FILE:game.sh@1
+node UNKNOWN name=makeMove qn=makeMove canonical=game.sh:makeMove#1 line=33 col=3 end=33:11 file=FILE:game.sh@1
+node UNKNOWN name=minMax qn=minMax canonical=game.sh:minMax#1 line=42 col=3 end=42:9 file=FILE:game.sh@1
+node UNKNOWN name=minMax qn=minMax canonical=game.sh:minMax#2 line=48 col=3 end=48:9 file=FILE:game.sh@1
+node UNKNOWN name=numberIn qn=numberIn canonical=game.sh:numberIn#1 line=46 col=3 end=46:11 file=FILE:game.sh@1
+node UNKNOWN name=printf qn=printf canonical=game.sh:printf#0 line=8 col=3 end=8:9 file=FILE:game.sh@1
+node UNKNOWN name=printf qn=printf canonical=game.sh:printf#1 line=12 col=3 end=12:9 file=FILE:game.sh@1
+node UNKNOWN name=return qn=return canonical=game.sh:return#0 line=26 col=5 end=26:11 file=FILE:game.sh@1
+node UNKNOWN name=return qn=return canonical=game.sh:return#1 line=40 col=5 end=40:11 file=FILE:game.sh@1
+node UNKNOWN name=run qn=run canonical=game.sh:run#1 line=52 col=3 end=52:6 file=FILE:game.sh@1
+node UNKNOWN name=sameInRow qn=sameInRow canonical=game.sh:sameInRow#1 line=28 col=3 end=28:12 file=FILE:game.sh@1
+node UNKNOWN name=source qn=source canonical=game.sh:source#0 line=1 col=1 end=1:7 file=FILE:game.sh@1
+node UNKNOWN name=stringOut qn=stringOut canonical=game.sh:stringOut#1 line=47 col=3 end=47:12 file=FILE:game.sh@1
+node VARIABLE name=amount qn=amount canonical=game.sh:amount#0 line=17 col=3 end=17:14 file=FILE:game.sh@1
+node VARIABLE name=col qn=col canonical=game.sh:col#0 line=23 col=3 end=23:11 file=FILE:game.sh@1
+node VARIABLE name=depth qn=depth canonical=game.sh:depth#0 line=37 col=3 end=37:13 file=FILE:game.sh@1
+node VARIABLE name=row qn=row canonical=game.sh:row#0 line=22 col=3 end=22:11 file=FILE:game.sh@1
+node VARIABLE name=token qn=token canonical=game.sh:token#0 line=16 col=3 end=16:13 file=FILE:game.sh@1
+node VARIABLE name=token qn=token canonical=game.sh:token#1 line=24 col=3 end=24:13 file=FILE:game.sh@1
+edge CALL src=FUNCTION:main@51 dst=UNKNOWN:run@52 resolved_src=- resolved_dst=- line=52 confidence=- certainty=- callsite=h0:52:1:h1 candidates=[]
+edge CALL src=FUNCTION:makeMove@21 dst=UNKNOWN:echo@29 resolved_src=- resolved_dst=- line=29 confidence=- certainty=- callsite=h0:29:1:h2 candidates=[]
+edge CALL src=FUNCTION:makeMove@21 dst=UNKNOWN:return@26 resolved_src=- resolved_dst=- line=26 confidence=- certainty=- callsite=h0:26:1:h3 candidates=[]
+edge CALL src=FUNCTION:makeMove@21 dst=UNKNOWN:sameInRow@28 resolved_src=- resolved_dst=- line=28 confidence=- certainty=- callsite=h0:28:1:h4 candidates=[]
+edge CALL src=FUNCTION:minMax@36 dst=UNKNOWN:echo@39 resolved_src=- resolved_dst=- line=39 confidence=- certainty=- callsite=h0:39:1:h5 candidates=[]
+edge CALL src=FUNCTION:minMax@36 dst=UNKNOWN:minMax@42 resolved_src=- resolved_dst=- line=42 confidence=- certainty=- callsite=h0:42:1:h6 candidates=[]
+edge CALL src=FUNCTION:minMax@36 dst=UNKNOWN:return@40 resolved_src=- resolved_dst=- line=40 confidence=- certainty=- callsite=h0:40:1:h7 candidates=[]
+edge CALL src=FUNCTION:numberIn@3 dst=UNKNOWN:echo@4 resolved_src=- resolved_dst=- line=4 confidence=- certainty=- callsite=h0:4:1:h8 candidates=[]
+edge CALL src=FUNCTION:numberOut@7 dst=UNKNOWN:printf@8 resolved_src=- resolved_dst=- line=8 confidence=- certainty=- callsite=h0:8:1:h9 candidates=[]
+edge CALL src=FUNCTION:run@45 dst=UNKNOWN:minMax@48 resolved_src=- resolved_dst=- line=48 confidence=- certainty=- callsite=h0:48:1:h10 candidates=[]
+edge CALL src=FUNCTION:run@45 dst=UNKNOWN:numberIn@46 resolved_src=- resolved_dst=- line=46 confidence=- certainty=- callsite=h0:46:1:h11 candidates=[]
+edge CALL src=FUNCTION:run@45 dst=UNKNOWN:stringOut@47 resolved_src=- resolved_dst=- line=47 confidence=- certainty=- callsite=h0:47:1:h12 candidates=[]
+edge CALL src=FUNCTION:sameInRow@15 dst=UNKNOWN:echo@18 resolved_src=- resolved_dst=- line=18 confidence=- certainty=- callsite=h0:18:1:h13 candidates=[]
+edge CALL src=FUNCTION:stringOut@11 dst=UNKNOWN:printf@12 resolved_src=- resolved_dst=- line=12 confidence=- certainty=- callsite=h0:12:1:h14 candidates=[]
+edge CALL src=FUNCTION:turn@32 dst=UNKNOWN:makeMove@33 resolved_src=- resolved_dst=- line=33 confidence=- certainty=- callsite=h0:33:1:h15 candidates=[]
+edge IMPORT src=MODULE:./random.sh@1 dst=MODULE:./random.sh@1 resolved_src=- resolved_dst=- line=1 confidence=- certainty=- callsite=- candidates=[]
+file path=game.sh language=bash lines=55 complete=true role=Source
+occurrence element=FUNCTION:main@51 kind=DEFINITION span=51:1-53:2
+occurrence element=FUNCTION:makeMove@21 kind=DEFINITION span=21:1-30:2
+occurrence element=FUNCTION:minMax@36 kind=DEFINITION span=36:1-43:2
+occurrence element=FUNCTION:numberIn@3 kind=DEFINITION span=3:1-5:2
+occurrence element=FUNCTION:numberOut@7 kind=DEFINITION span=7:1-9:2
+occurrence element=FUNCTION:run@45 kind=DEFINITION span=45:1-49:2
+occurrence element=FUNCTION:sameInRow@15 kind=DEFINITION span=15:1-19:2
+occurrence element=FUNCTION:stringOut@11 kind=DEFINITION span=11:1-13:2
+occurrence element=FUNCTION:turn@32 kind=DEFINITION span=32:1-34:2
+occurrence element=MODULE:./random.sh@1 kind=DEFINITION span=1:8-1:19
+occurrence element=UNKNOWN:echo@18 kind=DEFINITION span=18:3-18:7
+occurrence element=UNKNOWN:echo@29 kind=DEFINITION span=29:3-29:7
+occurrence element=UNKNOWN:echo@39 kind=DEFINITION span=39:5-39:9
+occurrence element=UNKNOWN:echo@4 kind=DEFINITION span=4:3-4:7
+occurrence element=UNKNOWN:main@55 kind=DEFINITION span=55:1-55:5
+occurrence element=UNKNOWN:makeMove@33 kind=DEFINITION span=33:3-33:11
+occurrence element=UNKNOWN:minMax@42 kind=DEFINITION span=42:3-42:9
+occurrence element=UNKNOWN:minMax@48 kind=DEFINITION span=48:3-48:9
+occurrence element=UNKNOWN:numberIn@46 kind=DEFINITION span=46:3-46:11
+occurrence element=UNKNOWN:printf@12 kind=DEFINITION span=12:3-12:9
+occurrence element=UNKNOWN:printf@8 kind=DEFINITION span=8:3-8:9
+occurrence element=UNKNOWN:return@26 kind=DEFINITION span=26:5-26:11
+occurrence element=UNKNOWN:return@40 kind=DEFINITION span=40:5-40:11
+occurrence element=UNKNOWN:run@52 kind=DEFINITION span=52:3-52:6
+occurrence element=UNKNOWN:sameInRow@28 kind=DEFINITION span=28:3-28:12
+occurrence element=UNKNOWN:source@1 kind=DEFINITION span=1:1-1:7
+occurrence element=UNKNOWN:stringOut@47 kind=DEFINITION span=47:3-47:12
+occurrence element=VARIABLE:amount@17 kind=DEFINITION span=17:3-17:14
+occurrence element=VARIABLE:col@23 kind=DEFINITION span=23:3-23:11
+occurrence element=VARIABLE:depth@37 kind=DEFINITION span=37:3-37:13
+occurrence element=VARIABLE:row@22 kind=DEFINITION span=22:3-22:11
+occurrence element=VARIABLE:token@16 kind=DEFINITION span=16:3-16:13
+occurrence element=VARIABLE:token@24 kind=DEFINITION span=24:3-24:13
+access node=VARIABLE:amount@17 kind=Public
+access node=VARIABLE:col@23 kind=Public
+access node=VARIABLE:depth@37 kind=Public
+access node=VARIABLE:row@22 kind=Public
+access node=VARIABLE:token@16 kind=Public
+access node=VARIABLE:token@24 kind=Public
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:main", node_id: NodeId(-3635321003423131788), signature_hash: -4671339478033693080, normalized_signature: Some("shape:6083604196958491942"), body_hash: 760610733551956591, start_line: 51, end_line: 53 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:makeMove", node_id: NodeId(-2515598397687256798), signature_hash: 5173406897340347930, normalized_signature: Some("shape:-1235026875210414673"), body_hash: 9149177360853350432, start_line: 21, end_line: 30 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:minMax", node_id: NodeId(7081801660925780151), signature_hash: -8051465974728078519, normalized_signature: Some("shape:-9198897625861577702"), body_hash: 6006497835269164092, start_line: 36, end_line: 43 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:numberIn", node_id: NodeId(-5905922039771045421), signature_hash: 2477812878330356949, normalized_signature: Some("shape:-7083630050789299289"), body_hash: 5561877708812231360, start_line: 3, end_line: 5 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:numberOut", node_id: NodeId(-7934113418855399154), signature_hash: -1579019679195996938, normalized_signature: Some("shape:4534084180875376373"), body_hash: -5825159797702543837, start_line: 7, end_line: 9 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:run", node_id: NodeId(690218248480803604), signature_hash: 5222842858713591688, normalized_signature: Some("shape:8445692896744983391"), body_hash: -8886277489832578549, start_line: 45, end_line: 49 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:sameInRow", node_id: NodeId(5861375836366715686), signature_hash: 954397003606297678, normalized_signature: Some("shape:-8036842316825594099"), body_hash: 1566588196809705519, start_line: 15, end_line: 19 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:stringOut", node_id: NodeId(-4261065684697691790), signature_hash: -5818630870471287222, normalized_signature: Some("shape:8953728298715117053"), body_hash: -1270341848088446665, start_line: 11, end_line: 13 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "13:turn", node_id: NodeId(-8531347618660569562), signature_hash: -3321651350975386290, normalized_signature: Some("shape:-4838422319707821228"), body_hash: -2554722678388236973, start_line: 32, end_line: 34 }
+callable_state CallableProjectionState { file_id: 3699121416828224428, symbol_key: "__file_structural__", node_id: NodeId(3699121416828224428), signature_hash: 553768115714561381, normalized_signature: None, body_hash: 2836811500587000585, start_line: 1, end_line: 55 }

--- a/crates/codestory-indexer/tests/language_extraction_snapshot.rs
+++ b/crates/codestory-indexer/tests/language_extraction_snapshot.rs
@@ -47,16 +47,28 @@ struct SnapshotCase {
     tictactoe_golden: &'static str,
 }
 
-const CASES: &[SnapshotCase] = &[SnapshotCase {
-    language: "kotlin",
-    extension: "kt",
-    fidelity_filename: "fidelity.kt",
-    fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
-    fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
-    tictactoe_filename: "game.kt",
-    tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
-    tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
-}];
+const CASES: &[SnapshotCase] = &[
+    SnapshotCase {
+        language: "kotlin",
+        extension: "kt",
+        fidelity_filename: "fidelity.kt",
+        fidelity_source: include_str!("fixtures/fidelity_lab/kotlin_fidelity_lab.kt"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/kotlin_fidelity.txt"),
+        tictactoe_filename: "game.kt",
+        tictactoe_source: include_str!("fixtures/tictactoe/kotlin_tictactoe.kt"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/kotlin_tictactoe.txt"),
+    },
+    SnapshotCase {
+        language: "bash",
+        extension: "sh",
+        fidelity_filename: "fidelity.sh",
+        fidelity_source: include_str!("fixtures/fidelity_lab/bash_fidelity_lab.sh"),
+        fidelity_golden: include_str!("fixtures/language_snapshots/bash_fidelity.txt"),
+        tictactoe_filename: "game.sh",
+        tictactoe_source: include_str!("fixtures/tictactoe/bash_tictactoe.sh"),
+        tictactoe_golden: include_str!("fixtures/language_snapshots/bash_tictactoe.txt"),
+    },
+];
 
 #[test]
 fn moved_language_rules_keep_the_fidelity_lab_projection_byte_identical() -> Result<()> {


### PR DESCRIPTION
Closes #1691.

One rollback unit in the S3 series, following the pattern S3-KOTLIN (#1676) established.

## Proof

**Equality**: the two projection snapshots (fidelity lab, tictactoe) are byte-identical before and after the move. Goldens were captured from the pre-move tree, the move applied, then re-rendered and diffed — the committed goldens are literally the pre-move bytes.

**Mechanical**: every deleted line from `lib.rs` (and `language_configs.rs`) was matched against the moved bodies after undoing the declared renames — zero unmatched lines. Function accounting is stated in the commit body.

**Falsification**: registry fields were reverted and the snapshots observed failing, with the exact text recorded. Kotlin established why this matters — flipping `promotes_type_member_functions_to_methods` or changing `qualified_name_delimiter` fails these snapshots while `fidelity_regression` stays green, and for the delimiter no pre-existing test catches it at all.

No crate-root helper gained `pub(crate)` (private items are already visible to descendant modules), and the deliberate CLI-vs-route-scanner comment-roster disagreement was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
