### PR TITLE
IDX-PERF-a: remove two quadratic loops from per-file indexing

### DIFF
--- a/crates/codestory-indexer/examples/index_cost_probe.rs
+++ b/crates/codestory-indexer/examples/index_cost_probe.rs
@@ -1,0 +1,48 @@
+//! Time `index_file` on synthetic Rust sources of a fixed shape.
+//!
+//! #1820 asks for a before/after measurement on the same fixture, so this is
+//! deliberately reproducible rather than clever: one generator, one shape, the
+//! minimum of three runs. Run it on both revisions and compare.
+//!
+//! `cargo run --release -p codestory-indexer --example index_cost_probe`
+
+use std::path::Path;
+use std::time::Instant;
+
+fn dense_rust_source(target_bytes: usize) -> String {
+    let mut source = String::with_capacity(target_bytes + 512);
+    let mut index = 0usize;
+    while source.len() < target_bytes {
+        source.push_str(&format!(
+            "pub struct Holder{index} {{\n    pub field_{index}: i64,\n}}\n\n\
+             impl Holder{index} {{\n    pub fn read_{index}(&self) -> i64 {{\n\
+             \x20       let local = self.field_{index};\n        local + {index}\n    }}\n\
+             \x20   fn private_{index}(&self) -> i64 {{\n        self.read_{index}()\n    }}\n}}\n\n"
+        ));
+        index += 1;
+    }
+    source
+}
+
+fn main() {
+    for target in [100_000usize, 250_000, 500_000, 1_000_000] {
+        let source = dense_rust_source(target);
+        let path = Path::new("probe.rs");
+        let config = codestory_indexer::get_language_for_ext("rs").expect("rust config");
+        let mut best = u128::MAX;
+        let mut nodes = 0usize;
+        for _ in 0..3 {
+            let started = Instant::now();
+            let result =
+                codestory_indexer::index_file(path, &source, &config, None, None).expect("index");
+            best = best.min(started.elapsed().as_millis());
+            nodes = result.nodes.len();
+        }
+        println!(
+            "{:>9} bytes  {:>7} ms  {:>6} nodes",
+            source.len(),
+            best,
+            nodes
+        );
+    }
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -4260,11 +4260,48 @@ fn access_kind_from_graph_access(value: &str) -> Option<AccessKind> {
     }
 }
 
-fn source_line(source: &str, line: u32) -> Option<&str> {
-    if line == 0 {
-        return None;
+/// Byte offsets of each line start, built once per file.
+///
+/// `source.lines().nth(n)` walks from byte zero on every call, and
+/// `infer_access_from_source` calls it up to twice for every graph node — so
+/// the cost was O(nodes x bytes) and measured at 66% of a 2 MB Rust index and
+/// 36% of TypeScript (#1820). The offsets make each lookup O(line length).
+///
+/// The boundaries must match `str::lines()` exactly, because these lines feed
+/// visibility classification and therefore the projected access of every
+/// member. `lines()` splits on `\n`, strips one trailing `\r`, and does not
+/// yield a final empty line for a source that ends in a newline.
+struct LineOffsets {
+    starts: Vec<usize>,
+}
+
+impl LineOffsets {
+    fn new(source: &str) -> Self {
+        let bytes = source.as_bytes();
+        let mut starts =
+            Vec::with_capacity(bytes.iter().filter(|byte| **byte == b'\n').count() + 1);
+        starts.push(0);
+        for (index, byte) in bytes.iter().enumerate() {
+            if *byte == b'\n' {
+                starts.push(index + 1);
+            }
+        }
+        // A trailing newline opens no line: `"a\n".lines()` yields just `"a"`.
+        if starts.last() == Some(&bytes.len()) {
+            starts.pop();
+        }
+        Self { starts }
     }
-    source.lines().nth((line - 1) as usize)
+
+    /// The 1-based `line`, with its terminator stripped, or `None` past the end.
+    fn line<'a>(&self, source: &'a str, line: u32) -> Option<&'a str> {
+        let start = *self.starts.get(line.checked_sub(1)? as usize)?;
+        let end = source[start..]
+            .find('\n')
+            .map_or(source.len(), |offset| start + offset);
+        let text = &source[start..end];
+        Some(text.strip_suffix('\r').unwrap_or(text))
+    }
 }
 
 fn classify_keyword_access(text: &str) -> Option<AccessKind> {
@@ -5316,15 +5353,38 @@ fn apply_rust_receiver_call_hints(
         return;
     }
 
-    for hint in hints {
-        for node in unique_nodes.values_mut() {
-            if node.kind == NodeKind::UNKNOWN
-                && node.serialized_name == hint.method_name
-                && node.start_line == Some(hint.start_line)
-                && node.start_col == Some(hint.start_col)
-            {
-                node.serialized_name = hint.qualified_method_name.clone();
-                node.qualified_name = Some(hint.qualified_method_name.clone());
+    // Both operands grow with file size, so the original nested scan was
+    // O(hints x nodes) and measured at 20% of a 2 MB Rust index (#1820).
+    // Indexing the unresolved nodes by call site makes it O(hints + nodes).
+    let mut unresolved_by_site: HashMap<(&str, u32, u32), Vec<NodeId>> = HashMap::new();
+    for (id, node) in unique_nodes.iter() {
+        if node.kind != NodeKind::UNKNOWN {
+            continue;
+        }
+        let (Some(start_line), Some(start_col)) = (node.start_line, node.start_col) else {
+            continue;
+        };
+        unresolved_by_site
+            .entry((node.serialized_name.as_str(), start_line, start_col))
+            .or_default()
+            .push(*id);
+    }
+    let matched = hints
+        .iter()
+        .filter_map(|hint| {
+            let key = (hint.method_name.as_str(), hint.start_line, hint.start_col);
+            // Taken, not read: once a site is rewritten its nodes carry the
+            // qualified name and can no longer match this key, which is what
+            // the sequential scan did by re-reading `serialized_name`.
+            unresolved_by_site.remove(&key).map(|ids| (hint, ids))
+        })
+        .map(|(hint, ids)| (hint.qualified_method_name.clone(), ids))
+        .collect::<Vec<_>>();
+    for (qualified_method_name, ids) in matched {
+        for id in ids {
+            if let Some(node) = unique_nodes.get_mut(&id) {
+                node.serialized_name = qualified_method_name.clone();
+                node.qualified_name = Some(qualified_method_name.clone());
             }
         }
     }
@@ -8443,6 +8503,7 @@ fn infer_access_from_source(
     language_name: &str,
     tree: &Tree,
     source: &str,
+    lines: &LineOffsets,
     start_line: u32,
     kind: NodeKind,
 ) -> Option<AccessKind> {
@@ -8457,7 +8518,7 @@ fn infer_access_from_source(
         return None;
     }
 
-    if let Some(line_text) = source_line(source, start_line) {
+    if let Some(line_text) = lines.line(source, start_line) {
         let access = match language_name {
             "rust" => classify_rust_visibility(line_text),
             _ => classify_keyword_access(line_text),
@@ -8468,7 +8529,7 @@ fn infer_access_from_source(
     }
     if let Some(prev_line) = start_line
         .checked_sub(1)
-        .and_then(|line| source_line(source, line))
+        .and_then(|line| lines.line(source, line))
     {
         let access = match language_name {
             "rust" => classify_rust_visibility(prev_line),
@@ -13376,6 +13437,7 @@ pub fn index_file(
 
     // 1. First pass: Create nodes and a temporary mapping from GraphNodeId -> OurNodeId
     let mut graph_to_node_id = HashMap::new();
+    let line_offsets = LineOffsets::new(source);
     let mut unique_nodes: HashMap<NodeId, Node> = HashMap::new();
     let mut component_access_by_node_id: HashMap<NodeId, AccessKind> = HashMap::new();
     let mut canonical_role_by_node_id = HashMap::<NodeId, CanonicalNodeRole>::new();
@@ -13534,6 +13596,7 @@ pub fn index_file(
                     language_config.language_name,
                     &tree,
                     source,
+                    &line_offsets,
                     start_line,
                     kind,
                 )

--- a/crates/codestory-indexer/src/tests/mod.rs
+++ b/crates/codestory-indexer/src/tests/mod.rs
@@ -1246,6 +1246,52 @@ fn incremental_incomplete_result_preserves_previous_projection() -> Result<()> {
     Ok(())
 }
 
+/// `LineOffsets` replaced `source.lines().nth()` in the visibility classifier,
+/// so any disagreement with `str::lines()` silently changes the projected
+/// access of a member — no panic, no error row, just a different graph. This
+/// pins every boundary case rather than trusting the two to agree.
+#[test]
+fn line_offsets_agree_with_str_lines_on_every_boundary_shape() {
+    for source in [
+        "",
+        "\n",
+        "\n\n",
+        "a",
+        "a\n",
+        "a\nb",
+        "a\nb\n",
+        "a\r\nb\r\n",
+        "a\r\nb",
+        "\r\n",
+        "pub fn a() {}\n\nprivate:\n  int x;\n",
+        "trailing spaces   \nand a tab\t\n",
+        "unicode: héllo wörld\nsecond ünicode line\n",
+        "no trailing newline at all",
+    ] {
+        let offsets = super::LineOffsets::new(source);
+        let expected: Vec<&str> = source.lines().collect();
+        for (index, want) in expected.iter().enumerate() {
+            let line = u32::try_from(index + 1).expect("line number");
+            assert_eq!(
+                offsets.line(source, line),
+                Some(*want),
+                "line {line} of {source:?}"
+            );
+        }
+        assert_eq!(
+            offsets.line(source, 0),
+            None,
+            "line numbers are 1-based; 0 must not resolve for {source:?}"
+        );
+        let past_end = u32::try_from(expected.len() + 1).expect("line number");
+        assert_eq!(
+            offsets.line(source, past_end),
+            None,
+            "reading past the last line of {source:?} must be None, not empty"
+        );
+    }
+}
+
 #[test]
 fn a_structural_source_over_the_structural_bound_is_refused_below_the_parser_headroom() -> Result<()>
 {


### PR DESCRIPTION
Closes #1824. **#1820 stays open** — two of its four loops remain, including
the 110x shape blowup.

Both changes are pure internal-representation work. Every one of the sixteen
byte-identical language projections is unchanged, as is the fidelity regression
suite, and the node counts match exactly at every probe size.

## Measured

Same fixture at both revisions, `examples/index_cost_probe.rs`, min-of-three,
release build:

| source | before | after | |
|---|---|---|---|
| 100 KB | 112 ms | 60 ms | 1.9× |
| 250 KB | 529 ms | 212 ms | 2.5× |
| 500 KB | 1,863 ms | 646 ms | 2.9× |
| 1 MB | 7,059 ms | 2,267 ms | **3.1×** |

The speedup grows with size because what is removed is quadratic, not constant.

## `source_line` walked the file on every call

It was `source.lines().nth(n)` — a scan from byte zero — and
`infer_access_from_source` calls it up to twice for *every* graph node. So
visibility inference alone cost O(nodes × bytes): **66% of a 2 MB Rust index,
36% of TypeScript**. `LineOffsets` records each line start once per file.

The boundaries must match `str::lines()` exactly. These lines feed visibility
classification and therefore the projected access of every member, so a
disagreement changes the graph with no panic and no error row. A test pins them
across fourteen shapes — empty input, bare newlines, CRLF, no trailing newline,
multi-byte characters — because `lines()` has three separate behaviours worth
getting wrong (strips one `\r`, yields no final empty line after a trailing
newline, and is 1-based here while `nth` is 0-based).

## `apply_rust_receiver_call_hints` was a literal nested loop

`for hint { for node }`, both operands growing with file size: **20% of a 2 MB
Rust index**. The unresolved nodes are now indexed by call site.

The rewrite preserves the sequential scan's ordering semantics rather than
approximating them. Each site is **taken** from the index when it matches, so a
node already rewritten to its qualified name cannot match a later hint for the
same site — which is exactly what re-reading `serialized_name` achieved before.
An index that merely *read* entries would apply both hints and produce a
different graph.

## Verification

`cargo test --workspace`, `cargo clippy --workspace --all-targets`, and
`cargo fmt --check` are clean. The load-bearing check is the byte-identical
projection suite: these are optimisations, so any change in output is a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)