### PR TITLE
IDX-PERF-b: range-search a callable's occurrences instead of scanning the file

### DIFF
--- a/crates/codestory-indexer/src/projection.rs
+++ b/crates/codestory-indexer/src/projection.rs
@@ -30,6 +30,12 @@ pub(crate) fn build_callable_projection_states(
             .or_default()
             .push(occurrence);
     }
+    // Sorted once per file so each callable can binary-search its own line
+    // window instead of scanning every occurrence in the file: that scan was
+    // 501M filter comparisons at 2 MB and 12.4B at 10 MB (#1820).
+    for file_occurrences in occurrences_by_file.values_mut() {
+        file_occurrences.sort_by_key(|occurrence| occurrence.location.start_line);
+    }
 
     let node_by_id = nodes
         .iter()
@@ -227,7 +233,17 @@ pub(crate) fn callable_relative_occurrence_parts(
     let Some(file_occurrences) = file_occurrences else {
         return Vec::new();
     };
-    let mut occurrence_parts = file_occurrences
+    // `file_occurrences` is sorted by start line, so everything this callable
+    // can own is one contiguous window. The lower bound is the first
+    // occurrence starting at or after the callable; the upper bound is the
+    // first starting past its end, which is sound because an occurrence never
+    // ends before it starts — anything starting past `end_line` must also end
+    // past it and so can never satisfy the predicate.
+    let first =
+        file_occurrences.partition_point(|occurrence| occurrence.location.start_line < start_line);
+    let past_last =
+        file_occurrences.partition_point(|occurrence| occurrence.location.start_line <= end_line);
+    let mut occurrence_parts = file_occurrences[first..past_last]
         .iter()
         .filter(|occurrence| {
             occurrence_belongs_to_callable_body(occurrence, node, start_line, end_line)


### PR DESCRIPTION
Closes #1826. **#1820 stays open** — `rust_enclosing_value_types` remains, and
it is the 110× shape blowup.

`callable_occurrence_projection_parts` re-scanned every occurrence in the file
for every FUNCTION/METHOD/MACRO node. The comparison count quadruples per
doubling: 1.28M at 100 KB, 501M at 2 MB, **12.4B at 10 MB**.

## Measured

Same fixture, min-of-three, release:

| source | before this | after | cumulative from `dev` |
|---|---|---|---|
| 100 KB | 60 ms | 57 ms | 112 ms → 1.96× |
| 250 KB | 212 ms | 192 ms | 529 ms → 2.76× |
| 500 KB | 646 ms | 549 ms | 1,863 ms → 3.39× |
| 1 MB | 2,267 ms | 1,764 ms | 7,059 ms → **4.00×** |

## The upper bound is the only subtle part

The predicate needs `end_line <= callable.end_line`, so it is not obvious that
you may stop scanning at the first occurrence whose *start* line exceeds it.
You may: an occurrence never ends before it starts, so anything starting past
the callable's end also ends past it and can never qualify. Without that
argument the early exit looks unsound and the scan has to run to the end of the
file anyway, which is most of the cost.

Output ordering is unaffected — the parts are sorted before return either way.

## Verification

Byte-identical projections across all sixteen languages plus the fidelity
regression suite; `cargo test --workspace`, `cargo clippy --workspace
--all-targets`, `cargo fmt --check` clean. These are optimisations, so a change
in output would be a bug, and the snapshot suite is what says there isn't one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)