### PR TITLE
IDX-PERF-c: make indexing cost independent of statements-per-function

### DIFF
--- a/crates/codestory-indexer/examples/index_cost_probe.rs
+++ b/crates/codestory-indexer/examples/index_cost_probe.rs
@@ -24,10 +24,51 @@ fn dense_rust_source(target_bytes: usize) -> String {
     source
 }
 
+/// One function containing many statements — the shape that costs 110x at a
+/// fixed byte count, and the shape no fixture in the tree has.
+fn one_giant_rust_function(target_bytes: usize) -> String {
+    let mut source = String::with_capacity(target_bytes + 512);
+    source.push_str("pub struct Wide { pub field: i64 }\n");
+    source.push_str("impl Wide { pub fn get(&self) -> i64 { self.field } }\n\n");
+    source.push_str("pub fn giant() -> i64 {\n    let base: Wide = Wide { field: 0 };\n");
+    let mut index = 0usize;
+    while source.len() < target_bytes {
+        source.push_str(&format!(
+            "    let value_{index}: Wide = Wide {{ field: base.get() + {index} }};\n"
+        ));
+        index += 1;
+    }
+    source.push_str("    base.get()\n}\n");
+    source
+}
+
 fn main() {
+    println!("-- many small functions --");
     for target in [100_000usize, 250_000, 500_000, 1_000_000] {
         let source = dense_rust_source(target);
         let path = Path::new("probe.rs");
+        let config = codestory_indexer::get_language_for_ext("rs").expect("rust config");
+        let mut best = u128::MAX;
+        let mut nodes = 0usize;
+        for _ in 0..3 {
+            let started = Instant::now();
+            let result =
+                codestory_indexer::index_file(path, &source, &config, None, None).expect("index");
+            best = best.min(started.elapsed().as_millis());
+            nodes = result.nodes.len();
+        }
+        println!(
+            "{:>9} bytes  {:>7} ms  {:>6} nodes",
+            source.len(),
+            best,
+            nodes
+        );
+    }
+
+    println!("-- one giant function --");
+    for target in [25_000usize, 50_000, 100_000, 200_000] {
+        let source = one_giant_rust_function(target);
+        let path = Path::new("giant.rs");
         let config = codestory_indexer::get_language_for_ext("rs").expect("rust config");
         let mut best = u128::MAX;
         let mut nodes = 0usize;

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -5200,9 +5200,9 @@ fn split_top_level_type_arguments(raw: &str) -> Vec<String> {
     parts
 }
 
-fn walk_tree_nodes<F>(node: TsNode<'_>, visit: &mut F)
+fn walk_tree_nodes<'tree, F>(node: TsNode<'tree>, visit: &mut F)
 where
-    F: FnMut(TsNode<'_>),
+    F: FnMut(TsNode<'tree>),
 {
     visit(node);
     let mut cursor = node.walk();
@@ -5284,6 +5284,7 @@ fn collect_rust_receiver_call_hints(tree: &Tree, source: &str) -> Vec<RustReceiv
     let field_types = collect_rust_struct_field_types(tree, source, &aliases);
     let method_return_types = collect_rust_method_return_types(tree, source, &aliases);
     let mut hints = Vec::new();
+    let mut scopes: HashMap<usize, RustValueScope<'_>> = HashMap::new();
 
     walk_tree_nodes(tree.root_node(), &mut |node| {
         if node.kind() != "call_expression" {
@@ -5308,21 +5309,33 @@ fn collect_rust_receiver_call_hints(tree: &Tree, source: &str) -> Vec<RustReceiv
             return;
         };
         let impl_owner = rust_enclosing_impl_owner(node, source, &aliases);
-        let value_types = rust_enclosing_value_types(
-            node,
-            source,
-            &aliases,
-            &field_types,
-            &method_return_types,
-            impl_owner.as_deref(),
-        );
+        // One scope per enclosing function, advanced to this call rather than
+        // rebuilt for it. `no_scope` covers a call outside any function, which
+        // previously produced an empty map by finding no `function_item`.
+        let empty_value_types = HashMap::new();
+        let value_types = match rust_enclosing_function_item(node) {
+            Some(function_node) => {
+                let scope = scopes
+                    .entry(function_node.id())
+                    .or_insert_with(|| RustValueScope::new(function_node, impl_owner.clone()));
+                scope.advance_to(
+                    node.start_byte(),
+                    source,
+                    &aliases,
+                    &field_types,
+                    &method_return_types,
+                );
+                &scope.value_types
+            }
+            None => &empty_value_types,
+        };
         let Some(owner_name) = infer_rust_receiver_owner(
             receiver_node,
             source,
             impl_owner.as_deref(),
             &field_types,
             &method_return_types,
-            &value_types,
+            value_types,
             &aliases,
         )
         .filter(|value| is_rust_type_like_name(value)) else {
@@ -5547,69 +5560,106 @@ fn rust_enclosing_impl_owner(
     None
 }
 
-fn rust_enclosing_value_types(
-    call_node: TsNode<'_>,
-    source: &str,
-    aliases: &RustTypeAliases,
-    field_types: &RustStructFieldTypes,
-    method_return_types: &RustMethodReturnTypes,
-    impl_owner: Option<&str>,
-) -> HashMap<String, String> {
-    let mut function_node = None;
+/// One function's value bindings, resolved as call sites are reached.
+///
+/// The old shape rebuilt this map for *every* call by walking the enclosing
+/// function's whole subtree, so a function with K calls and N nodes cost
+/// O(K x N). That is the entire 110x blow-up in #1820: at a fixed ~500 KB,
+/// moving statements from many small functions into one giant one took
+/// `index_file` from ~1.2 s to ~134 s.
+///
+/// Two properties make a single pass equivalent rather than merely similar:
+///
+/// * a binding's inferred type depends only on the bindings *before* it, and
+/// * `walk_tree_nodes` is pre-order, so it visits nodes in non-decreasing
+///   `start_byte` — which makes the old `start_byte <= call_start_byte` filter
+///   a prefix of the walk, not an arbitrary subset of it.
+///
+/// So the insertion sequence is the same for every call in the function, and
+/// each call needs a prefix of it. Calls arrive in non-decreasing byte order
+/// too, so the cursor only ever moves forward and the whole function costs
+/// O(N) instead of O(K x N).
+struct RustValueScope<'tree> {
+    bindings: Vec<TsNode<'tree>>,
+    cursor: usize,
+    value_types: HashMap<String, String>,
+    impl_owner: Option<String>,
+}
+
+impl<'tree> RustValueScope<'tree> {
+    fn new(function_node: TsNode<'tree>, impl_owner: Option<String>) -> Self {
+        let mut bindings = Vec::new();
+        walk_tree_nodes(function_node, &mut |node| {
+            if matches!(node.kind(), "parameter" | "let_declaration") {
+                bindings.push(node);
+            }
+        });
+        Self {
+            bindings,
+            cursor: 0,
+            value_types: HashMap::new(),
+            impl_owner,
+        }
+    }
+
+    /// Fold in every binding that starts at or before `call_start_byte`.
+    fn advance_to(
+        &mut self,
+        call_start_byte: usize,
+        source: &str,
+        aliases: &RustTypeAliases,
+        field_types: &RustStructFieldTypes,
+        method_return_types: &RustMethodReturnTypes,
+    ) {
+        while let Some(binding) = self.bindings.get(self.cursor) {
+            if binding.start_byte() > call_start_byte {
+                break;
+            }
+            self.cursor += 1;
+            let binding = *binding;
+            let Some(pattern_node) = binding.child_by_field_name("pattern") else {
+                continue;
+            };
+            let Some(value_name) = rust_pattern_identifier(pattern_node, source) else {
+                continue;
+            };
+            let type_name = binding
+                .child_by_field_name("type")
+                .and_then(|ty| node_source_text(ty, source))
+                .and_then(|ty| normalize_rust_type_owner_name(&ty, aliases))
+                .or_else(|| {
+                    if binding.kind() != "let_declaration" {
+                        return None;
+                    }
+                    binding.child_by_field_name("value").and_then(|value| {
+                        infer_rust_value_owner_from_expression(
+                            value,
+                            source,
+                            self.impl_owner.as_deref(),
+                            field_types,
+                            method_return_types,
+                            &self.value_types,
+                            aliases,
+                        )
+                    })
+                });
+            let Some(type_name) = type_name else {
+                continue;
+            };
+            self.value_types.insert(value_name, type_name);
+        }
+    }
+}
+
+fn rust_enclosing_function_item(call_node: TsNode<'_>) -> Option<TsNode<'_>> {
     let mut cursor = call_node.parent();
     while let Some(current) = cursor {
         if current.kind() == "function_item" {
-            function_node = Some(current);
-            break;
+            return Some(current);
         }
         cursor = current.parent();
     }
-
-    let Some(function_node) = function_node else {
-        return HashMap::new();
-    };
-
-    let mut value_types = HashMap::new();
-    let call_start_byte = call_node.start_byte();
-    walk_tree_nodes(function_node, &mut |node| {
-        if node.start_byte() > call_start_byte {
-            return;
-        }
-        if !matches!(node.kind(), "parameter" | "let_declaration") {
-            return;
-        }
-        let Some(pattern_node) = node.child_by_field_name("pattern") else {
-            return;
-        };
-        let Some(value_name) = rust_pattern_identifier(pattern_node, source) else {
-            return;
-        };
-        let type_name = node
-            .child_by_field_name("type")
-            .and_then(|ty| node_source_text(ty, source))
-            .and_then(|ty| normalize_rust_type_owner_name(&ty, aliases))
-            .or_else(|| {
-                if node.kind() != "let_declaration" {
-                    return None;
-                }
-                node.child_by_field_name("value").and_then(|value| {
-                    infer_rust_value_owner_from_expression(
-                        value,
-                        source,
-                        impl_owner,
-                        field_types,
-                        method_return_types,
-                        &value_types,
-                        aliases,
-                    )
-                })
-            });
-        let Some(type_name) = type_name else {
-            return;
-        };
-        value_types.insert(value_name, type_name);
-    });
-    value_types
+    None
 }
 
 fn infer_rust_receiver_owner(

--- a/crates/codestory-indexer/tests/source_shape_cost.rs
+++ b/crates/codestory-indexer/tests/source_shape_cost.rs
@@ -7,16 +7,16 @@
 //! took `index_file` from 1,219 ms to 134,467 ms: 110x at constant byte count,
 //! with no fixture in the tree able to see it.
 //!
-//! This is a blow-up detector, not a benchmark. The budget is set roughly two
-//! orders of magnitude above the measured cost so ordinary CI noise, a loaded
-//! runner, or a slower machine cannot trip it — while the quadratic it guards
-//! against, which was ~30x worse than the budget, cannot pass.
+//! This is a blow-up detector, not a benchmark. The budget is ~28x the measured
+//! cost, so ordinary CI noise, a loaded runner, or a slower machine cannot trip
+//! it — while the quadratic it guards against, which ran to tens of seconds at
+//! this size, cannot pass.
 
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-/// Generous by construction: the shape below measures ~112 ms in a debug build
-/// and the quadratic it replaces measured in the tens of seconds.
+/// Generous by construction: the shape below measures ~177 ms in a debug build,
+/// and the quadratic it replaces measured in the tens of seconds at this size.
 const BUDGET: Duration = Duration::from_secs(5);
 
 /// One function whose body is a long run of typed `let` bindings, each
@@ -58,7 +58,7 @@ fn one_giant_function_costs_about_what_many_small_ones_do() {
         elapsed < BUDGET,
         "indexing {} bytes of one-giant-function Rust took {elapsed:?}, over the \
          {BUDGET:?} budget. Cost has become dependent on statements-per-function \
-         again — see #1820. This budget is ~45x the expected cost, so it does not \
+         again — see #1820. This budget is ~28x the expected cost, so it does not \
          fail for being slow; it fails for being quadratic.",
         source.len()
     );

--- a/crates/codestory-indexer/tests/source_shape_cost.rs
+++ b/crates/codestory-indexer/tests/source_shape_cost.rs
@@ -1,0 +1,65 @@
+//! IDX-PERF (#1820): indexing cost must not depend on a file's *shape*.
+//!
+//! Every fixture in this crate is written the way people write code — many
+//! small functions — and that is why a defect making cost quadratic in the
+//! number of statements *inside one function* went unnoticed. At a fixed
+//! ~500 KB, moving statements from many small functions into one giant one
+//! took `index_file` from 1,219 ms to 134,467 ms: 110x at constant byte count,
+//! with no fixture in the tree able to see it.
+//!
+//! This is a blow-up detector, not a benchmark. The budget is set roughly two
+//! orders of magnitude above the measured cost so ordinary CI noise, a loaded
+//! runner, or a slower machine cannot trip it — while the quadratic it guards
+//! against, which was ~30x worse than the budget, cannot pass.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Generous by construction: the shape below measures ~112 ms in a debug build
+/// and the quadratic it replaces measured in the tens of seconds.
+const BUDGET: Duration = Duration::from_secs(5);
+
+/// One function whose body is a long run of typed `let` bindings, each
+/// referring to an earlier one. That last part matters: receiver inference
+/// resolves each binding against the bindings before it, so this shape
+/// exercises the dependency chain rather than just the statement count.
+fn one_giant_function(target_bytes: usize) -> String {
+    let mut source = String::with_capacity(target_bytes + 256);
+    source.push_str("pub struct Wide {\n    pub field: i64,\n}\n\n");
+    source
+        .push_str("impl Wide {\n    pub fn get(&self) -> i64 {\n        self.field\n    }\n}\n\n");
+    source.push_str("pub fn giant() -> i64 {\n    let base: Wide = Wide { field: 0 };\n");
+    let mut index = 0usize;
+    while source.len() < target_bytes {
+        source.push_str(&format!(
+            "    let value_{index}: Wide = Wide {{ field: base.get() + {index} }};\n"
+        ));
+        index += 1;
+    }
+    source.push_str("    base.get()\n}\n");
+    source
+}
+
+#[test]
+fn one_giant_function_costs_about_what_many_small_ones_do() {
+    let source = one_giant_function(100_000);
+    let config = codestory_indexer::get_language_for_ext("rs").expect("rust language config");
+
+    let started = Instant::now();
+    let result = codestory_indexer::index_file(Path::new("giant.rs"), &source, &config, None, None)
+        .expect("index the giant function");
+    let elapsed = started.elapsed();
+
+    assert!(
+        !result.nodes.is_empty(),
+        "the fixture must actually project nodes, or this guard measures nothing"
+    );
+    assert!(
+        elapsed < BUDGET,
+        "indexing {} bytes of one-giant-function Rust took {elapsed:?}, over the \
+         {BUDGET:?} budget. Cost has become dependent on statements-per-function \
+         again — see #1820. This budget is ~45x the expected cost, so it does not \
+         fail for being slow; it fails for being quadratic.",
+        source.len()
+    );
+}


### PR DESCRIPTION
Closes #1820 — the last of its four loops, and the one that mattered.

At a fixed ~500 KB, moving statements from many small functions into one giant
one took `index_file` from 1,219 ms to 134,467 ms. **110× at constant byte
count.** `rust_enclosing_value_types` rebuilt a function's value bindings for
*every* call inside it, walking the whole enclosing subtree each time.

## Measured

| one giant fn | before | after | |
|---|---|---|---|
| 25 KB | 229 ms | 16 ms | 14× |
| 50 KB | 888 ms | 33 ms | 27× |
| 100 KB | 3,404 ms | 67 ms | 51× |
| 200 KB | 13,218 ms | 134 ms | **99×** |

16/33/67/134 is linear — 2× per doubling, against the 3.9× it was. The shape
penalty is gone: 200 KB of one giant function now costs 134 ms, where 250 KB of
many small functions costs 209 ms.

## The obvious fix is wrong

Computing one map per function and handing it to every call site would let a
call see bindings declared *after* it, changing inferred receivers with nothing
failing — a binding's type is resolved against the bindings before it
(`infer_rust_value_owner_from_expression` receives the map currently being
built).

Two properties make a single pass **equivalent**, not merely similar:

1. A binding depends only on bindings before it, never after.
2. `walk_tree_nodes` is pre-order, so it visits nodes in non-decreasing
   `start_byte` — which makes the old `start_byte <= call_start_byte` filter a
   *prefix* of the walk, not an arbitrary subset.

So the insertion sequence is identical for every call in the function, and each
call needs a prefix of it. Calls arrive in non-decreasing byte order too, so a
per-function cursor only moves forward: O(N) instead of O(calls × nodes).

`walk_tree_nodes` gains an explicit `'tree` lifetime so collected nodes can
outlive one callback. That is a relaxation of the previous higher-ranked bound,
so every existing caller is unaffected.

## The fixture this needed

`tests/source_shape_cost.rs`. Every other fixture in this crate is written the
way people write code — many small functions — which is precisely why a defect
quadratic in *statements-per-function* survived at 110×.

It is a blow-up detector, not a benchmark: the budget is ~28× the measured cost
(177 ms against a 5 s budget, measured rather than extrapolated), so a loaded CI
runner cannot trip it, while the quadratic — tens of seconds at this size —
cannot pass. The fixture chains each binding to an earlier one on
purpose, so it exercises the dependency chain rather than just statement count.

**Deviation worth stating:** #1820 asked for this fixture "in the bench set".
It is a test instead. The stated intent was that the 110× "cannot return
unnoticed", and the bench targets in `codestory-bench` are not CI gates — a
bench would measure the regression for anyone who chose to run it, and block
nobody. `examples/index_cost_probe.rs` (added in #1825) covers the measurement
role; the test covers the enforcement one.

## Verification

Byte-identical projections across all sixteen languages plus the fidelity
regression suite; `cargo test --workspace`, `cargo clippy --workspace
--all-targets`, `cargo fmt --check` clean.

## Cumulative across #1820

Measured with all four fixes composed, not by assuming they add up — the
earlier per-PR figures came from branches that each carried only three of them:

`index_file` on 1 MB of ordinary Rust: **7,059 ms → 1,774 ms (3.98×)**. On the
pathological shape: **13,218 ms → 134 ms (99×)**, and linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


