### PR TITLE
[v0.17 S2-1] Add the runtime retrieval-type boundary

### DIFF
--- a/crates/codestory-runtime/src/controller_core.rs
+++ b/crates/codestory-runtime/src/controller_core.rs
@@ -45,7 +45,7 @@ impl AppController {
     }
 
     pub(crate) fn new_with_process_config(config: RuntimeProcessConfig) -> Self {
-        Self::new_with_source_index_policy(config.sidecar, config.source_index_policy)
+        Self::new_with_source_index_policy(config.sidecar.into_inner(), config.source_index_policy)
     }
 
     pub(crate) fn new_with_source_index_policy(

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -291,6 +291,7 @@ mod process_config;
 pub use process_config::RuntimeProcessConfig;
 mod query_language;
 mod repository_identity;
+mod retrieval_boundary;
 mod search;
 mod search_runtime;
 #[cfg(feature = "benchmark-support")]
@@ -325,6 +326,11 @@ use path_identity::{OperationPathIdentityResolver, PathIdentityUnavailable};
 pub use query_language::{GraphQueryParseError, parse_graph_query};
 pub use repository_identity::{
     REPOSITORY_IDENTITY_SCHEMA_VERSION, RepositoryIdentityReport, inspect_repository_identity,
+};
+pub use retrieval_boundary::{
+    CacheCleanPlan, CacheCleanReport, ProcessStartProbe, RetrievalProcessDefaults,
+    RetrievalRuntimeDefaults, RetrievalRuntimeOverrides, RetrievalStatusReport,
+    RuntimeRetrievalConfig, RuntimeRetrievalProfile,
 };
 pub(crate) use search_runtime::SearchEngine;
 

--- a/crates/codestory-runtime/src/process_config.rs
+++ b/crates/codestory-runtime/src/process_config.rs
@@ -1,5 +1,5 @@
+use crate::RuntimeRetrievalConfig;
 use codestory_contracts::workspace::SourceIndexPolicy;
-use codestory_retrieval::SidecarRuntimeConfig;
 use std::path::Path;
 
 /// Immutable process-owned defaults injected into one runtime.
@@ -9,12 +9,24 @@ use std::path::Path;
 /// evaluation controls remain owned by their respective subsystems.
 #[derive(Debug, Clone)]
 pub struct RuntimeProcessConfig {
-    pub sidecar: SidecarRuntimeConfig,
+    pub sidecar: RuntimeRetrievalConfig,
     pub source_index_policy: SourceIndexPolicy,
 }
 
 impl RuntimeProcessConfig {
-    pub fn new(sidecar: SidecarRuntimeConfig, source_index_policy: SourceIndexPolicy) -> Self {
+    /// Preserve the existing retrieval-config constructor while adapters move
+    /// to the runtime-owned wrapper in staged S2 slices.
+    pub fn new(
+        sidecar: codestory_retrieval::SidecarRuntimeConfig,
+        source_index_policy: SourceIndexPolicy,
+    ) -> Self {
+        Self::new_with_retrieval_config(sidecar.into(), source_index_policy)
+    }
+
+    pub fn new_with_retrieval_config(
+        sidecar: RuntimeRetrievalConfig,
+        source_index_policy: SourceIndexPolicy,
+    ) -> Self {
         Self {
             sidecar,
             source_index_policy,
@@ -22,7 +34,10 @@ impl RuntimeProcessConfig {
     }
 
     pub fn local() -> Self {
-        Self::new(SidecarRuntimeConfig::local(), SourceIndexPolicy::default())
+        Self::new_with_retrieval_config(
+            RuntimeRetrievalConfig::local(),
+            SourceIndexPolicy::default(),
+        )
     }
 
     /// Return the non-secret identity of the immutable project runtime
@@ -36,7 +51,7 @@ impl RuntimeProcessConfig {
         // Credentials never enter the digest. Their presence participates in
         // the immutable boundary, while secret material remains outside logs
         // and diagnostic identifiers.
-        let sidecar = &self.sidecar;
+        let sidecar = self.sidecar.as_inner();
         let source_index_policy = &self.source_index_policy;
         let mut identity = format!(
             "{}\0{:?}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}",

--- a/crates/codestory-runtime/src/retrieval_boundary.rs
+++ b/crates/codestory-runtime/src/retrieval_boundary.rs
@@ -1,0 +1,391 @@
+use std::path::Path;
+
+pub use codestory_retrieval::{
+    CacheCleanPlan, CacheCleanReport, ProcessStartProbe, RetrievalStatusReport,
+    SidecarProcessDefaults as RetrievalProcessDefaults,
+    SidecarRuntimeDefaults as RetrievalRuntimeDefaults,
+    SidecarRuntimeOverrides as RetrievalRuntimeOverrides,
+};
+
+/// Retrieval profile selected by an adapter when it constructs a runtime.
+///
+/// The retrieval crate owns how profiles map to artifact namespaces. Runtime
+/// owns the public construction boundary so adapters do not import that
+/// implementation type directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeRetrievalProfile {
+    Local,
+    Agent,
+}
+
+impl From<RuntimeRetrievalProfile> for codestory_retrieval::SidecarProfile {
+    fn from(profile: RuntimeRetrievalProfile) -> Self {
+        match profile {
+            RuntimeRetrievalProfile::Local => Self::Local,
+            RuntimeRetrievalProfile::Agent => Self::Agent,
+        }
+    }
+}
+
+impl From<codestory_retrieval::SidecarProfile> for RuntimeRetrievalProfile {
+    fn from(profile: codestory_retrieval::SidecarProfile) -> Self {
+        match profile {
+            codestory_retrieval::SidecarProfile::Local => Self::Local,
+            codestory_retrieval::SidecarProfile::Agent => Self::Agent,
+        }
+    }
+}
+
+/// Immutable retrieval configuration supplied to one runtime.
+///
+/// Construction is intentionally mirrored here rather than re-exported. That
+/// gives CLI consumers a runtime-owned type while retrieval retains artifact,
+/// namespace, and engine-policy ownership.
+#[derive(Debug, Clone)]
+pub struct RuntimeRetrievalConfig(codestory_retrieval::SidecarRuntimeConfig);
+
+impl RuntimeRetrievalConfig {
+    pub fn local() -> Self {
+        codestory_retrieval::SidecarRuntimeConfig::local().into()
+    }
+
+    pub fn for_project_auto(project_root: &Path) -> Self {
+        codestory_retrieval::SidecarRuntimeConfig::for_project_auto(project_root).into()
+    }
+
+    pub fn for_project_auto_with_process_defaults(
+        project_root: &Path,
+        process_defaults: &RetrievalProcessDefaults,
+        overrides: &RetrievalRuntimeOverrides,
+    ) -> Self {
+        codestory_retrieval::SidecarRuntimeConfig::for_project_auto_with_process_defaults(
+            project_root,
+            process_defaults,
+            overrides,
+        )
+        .into()
+    }
+
+    pub fn for_project_auto_with_process_defaults_and_identity(
+        project_identity: &codestory_workspace::ProjectIdentityV3,
+        process_defaults: &RetrievalProcessDefaults,
+        overrides: &RetrievalRuntimeOverrides,
+    ) -> Self {
+        codestory_retrieval::SidecarRuntimeConfig::for_project_auto_with_process_defaults_and_identity(
+            project_identity,
+            process_defaults,
+            overrides,
+        )
+        .into()
+    }
+
+    pub fn for_project_profile(
+        project_root: Option<&Path>,
+        profile: RuntimeRetrievalProfile,
+    ) -> Self {
+        codestory_retrieval::SidecarRuntimeConfig::for_project_profile(project_root, profile.into())
+            .into()
+    }
+
+    pub fn for_project_profile_with_run_id(
+        project_root: Option<&Path>,
+        profile: RuntimeRetrievalProfile,
+        run_id: Option<&str>,
+    ) -> Self {
+        codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id(
+            project_root,
+            profile.into(),
+            run_id,
+        )
+        .into()
+    }
+
+    pub fn for_project_profile_with_process_defaults(
+        project_root: Option<&Path>,
+        profile: RuntimeRetrievalProfile,
+        run_id: Option<&str>,
+        process_defaults: &RetrievalProcessDefaults,
+        overrides: &RetrievalRuntimeOverrides,
+    ) -> Self {
+        codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+            project_root,
+            profile.into(),
+            run_id,
+            process_defaults,
+            overrides,
+        )
+        .into()
+    }
+
+    pub fn with_profile_and_run_id(
+        &self,
+        project_root: Option<&Path>,
+        profile: RuntimeRetrievalProfile,
+        run_id: Option<&str>,
+    ) -> Self {
+        self.0
+            .with_profile_and_run_id(project_root, profile.into(), run_id)
+            .into()
+    }
+
+    pub fn profile(&self) -> RuntimeRetrievalProfile {
+        self.0.profile.into()
+    }
+
+    /// Retrieval-owned publication state observed by adapter status caches.
+    ///
+    /// The path is read-only at this boundary. Status adapters may fingerprint
+    /// it, but cannot construct layouts or mutate retrieval state through the
+    /// opaque runtime configuration.
+    pub fn status_cache_state_path(&self) -> &Path {
+        &self.0.layout.state_file
+    }
+
+    pub(crate) fn as_inner(&self) -> &codestory_retrieval::SidecarRuntimeConfig {
+        &self.0
+    }
+
+    pub(crate) fn into_inner(self) -> codestory_retrieval::SidecarRuntimeConfig {
+        self.0
+    }
+}
+
+impl From<codestory_retrieval::SidecarRuntimeConfig> for RuntimeRetrievalConfig {
+    fn from(config: codestory_retrieval::SidecarRuntimeConfig) -> Self {
+        Self(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RuntimeProcessConfig;
+    use codestory_contracts::workspace::SourceIndexPolicy;
+    use tempfile::tempdir;
+
+    fn assert_structurally_equal(
+        wrapped: &codestory_retrieval::SidecarRuntimeConfig,
+        direct: &codestory_retrieval::SidecarRuntimeConfig,
+    ) {
+        assert_eq!(wrapped.project_identity, direct.project_identity);
+        assert_eq!(wrapped.cache_root, direct.cache_root);
+        assert_eq!(
+            wrapped.layout.lexical_data_dir,
+            direct.layout.lexical_data_dir
+        );
+        assert_eq!(
+            wrapped.layout.semantic_data_dir,
+            direct.layout.semantic_data_dir
+        );
+        assert_eq!(
+            wrapped.layout.scip_artifacts_root,
+            direct.layout.scip_artifacts_root
+        );
+        assert_eq!(wrapped.layout.state_file, direct.layout.state_file);
+        assert_eq!(wrapped.profile, direct.profile);
+        assert_eq!(wrapped.run_id, direct.run_id);
+        assert_eq!(wrapped.namespace, direct.namespace);
+        assert_eq!(wrapped.embedding, direct.embedding);
+        assert_eq!(wrapped.retrieval, direct.retrieval);
+        assert_eq!(wrapped.summary, direct.summary);
+    }
+
+    fn assert_constructor_pair(
+        label: &str,
+        wrapped: RuntimeRetrievalConfig,
+        direct: codestory_retrieval::SidecarRuntimeConfig,
+        configuration_root: &Path,
+    ) {
+        let policy = SourceIndexPolicy::default();
+        let wrapped_id =
+            RuntimeProcessConfig::new_with_retrieval_config(wrapped.clone(), policy.clone())
+                .configuration_id(configuration_root);
+        let direct_id =
+            RuntimeProcessConfig::new(direct.clone(), policy).configuration_id(configuration_root);
+        assert_eq!(
+            wrapped_id, direct_id,
+            "{label} changed configuration identity"
+        );
+        assert_eq!(
+            wrapped.status_cache_state_path(),
+            direct.layout.state_file,
+            "{label} changed the observational retrieval state path"
+        );
+        assert_structurally_equal(wrapped.as_inner(), &direct);
+        assert_structurally_equal(&wrapped.into_inner(), &direct);
+    }
+
+    #[test]
+    fn constructors_preserve_retrieval_configuration_identity_and_structure() {
+        let fixture = tempdir().expect("runtime retrieval fixture");
+        let project_root = fixture.path().join("project");
+        let cache_root = fixture.path().join("cache");
+        std::fs::create_dir_all(&project_root).expect("create project fixture");
+        let process_defaults =
+            RetrievalProcessDefaults::new(cache_root, RetrievalRuntimeDefaults::default());
+        let overrides = RetrievalRuntimeOverrides {
+            hybrid_retrieval_enabled: Some(false),
+            semantic_doc_scope: Some("all".to_string()),
+            semantic_doc_alias_mode: Some("canonical".to_string()),
+            summary_endpoint: Some("http://127.0.0.1:1".to_string()),
+            summary_model: Some("identity-fixture".to_string()),
+        };
+        let configuration_root = fixture.path().join("project-cache");
+
+        assert_constructor_pair(
+            "local",
+            RuntimeRetrievalConfig::local(),
+            codestory_retrieval::SidecarRuntimeConfig::local(),
+            &configuration_root,
+        );
+        assert_constructor_pair(
+            "project auto",
+            RuntimeRetrievalConfig::for_project_auto(&project_root),
+            codestory_retrieval::SidecarRuntimeConfig::for_project_auto(&project_root),
+            &configuration_root,
+        );
+        assert_constructor_pair(
+            "project auto with process defaults",
+            RuntimeRetrievalConfig::for_project_auto_with_process_defaults(
+                &project_root,
+                &process_defaults,
+                &overrides,
+            ),
+            codestory_retrieval::SidecarRuntimeConfig::for_project_auto_with_process_defaults(
+                &project_root,
+                &process_defaults,
+                &overrides,
+            ),
+            &configuration_root,
+        );
+
+        let project_identity = codestory_workspace::project_identity_v3(&project_root);
+        assert_constructor_pair(
+            "project auto with retained identity",
+            RuntimeRetrievalConfig::for_project_auto_with_process_defaults_and_identity(
+                &project_identity,
+                &process_defaults,
+                &overrides,
+            ),
+            codestory_retrieval::SidecarRuntimeConfig::for_project_auto_with_process_defaults_and_identity(
+                &project_identity,
+                &process_defaults,
+                &overrides,
+            ),
+            &configuration_root,
+        );
+
+        for (label, profile, direct_profile) in [
+            (
+                "local profile",
+                RuntimeRetrievalProfile::Local,
+                codestory_retrieval::SidecarProfile::Local,
+            ),
+            (
+                "agent profile",
+                RuntimeRetrievalProfile::Agent,
+                codestory_retrieval::SidecarProfile::Agent,
+            ),
+        ] {
+            assert_constructor_pair(
+                label,
+                RuntimeRetrievalConfig::for_project_profile(Some(&project_root), profile),
+                codestory_retrieval::SidecarRuntimeConfig::for_project_profile(
+                    Some(&project_root),
+                    direct_profile,
+                ),
+                &configuration_root,
+            );
+            for run_id in [None, Some("identity-run")] {
+                assert_constructor_pair(
+                    &format!("{label} with run id {run_id:?}"),
+                    RuntimeRetrievalConfig::for_project_profile_with_run_id(
+                        Some(&project_root),
+                        profile,
+                        run_id,
+                    ),
+                    codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id(
+                        Some(&project_root),
+                        direct_profile,
+                        run_id,
+                    ),
+                    &configuration_root,
+                );
+                assert_constructor_pair(
+                    &format!("{label} with process defaults and run id {run_id:?}"),
+                    RuntimeRetrievalConfig::for_project_profile_with_process_defaults(
+                        Some(&project_root),
+                        profile,
+                        run_id,
+                        &process_defaults,
+                        &overrides,
+                    ),
+                    codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+                        Some(&project_root),
+                        direct_profile,
+                        run_id,
+                        &process_defaults,
+                        &overrides,
+                    ),
+                    &configuration_root,
+                );
+            }
+        }
+
+        let wrapped_base = RuntimeRetrievalConfig::for_project_profile_with_process_defaults(
+            Some(&project_root),
+            RuntimeRetrievalProfile::Local,
+            None,
+            &process_defaults,
+            &overrides,
+        );
+        let direct_base =
+            codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+                Some(&project_root),
+                codestory_retrieval::SidecarProfile::Local,
+                None,
+                &process_defaults,
+                &overrides,
+            );
+        for (profile, direct_profile) in [
+            (
+                RuntimeRetrievalProfile::Local,
+                codestory_retrieval::SidecarProfile::Local,
+            ),
+            (
+                RuntimeRetrievalProfile::Agent,
+                codestory_retrieval::SidecarProfile::Agent,
+            ),
+        ] {
+            for run_id in [None, Some("reselected")] {
+                assert_constructor_pair(
+                    &format!("profile reselection {profile:?} with run id {run_id:?}"),
+                    wrapped_base.with_profile_and_run_id(Some(&project_root), profile, run_id),
+                    direct_base.with_profile_and_run_id(
+                        Some(&project_root),
+                        direct_profile,
+                        run_id,
+                    ),
+                    &configuration_root,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn profile_wrapper_preserves_both_profile_variants() {
+        for (wrapped, direct) in [
+            (
+                RuntimeRetrievalProfile::Local,
+                codestory_retrieval::SidecarProfile::Local,
+            ),
+            (
+                RuntimeRetrievalProfile::Agent,
+                codestory_retrieval::SidecarProfile::Agent,
+            ),
+        ] {
+            assert_eq!(codestory_retrieval::SidecarProfile::from(wrapped), direct);
+            assert_eq!(RuntimeRetrievalProfile::from(direct), wrapped);
+        }
+    }
+}


### PR DESCRIPTION
## Context

S2 removes ordinary CLI ownership of retrieval transport configuration in staged, reviewable slices. This first slice creates the runtime-owned boundary that later adapter retargets use; it deliberately moves no consumers yet.

Base: `8e2e55e47599811805debbd2bd0a699171ebc16e`
Head: `a353d185`

## What changed

- adds opaque runtime-owned retrieval profile and configuration types
- mirrors every retrieval configuration constructor without exposing a wrapper-to-retrieval escape hatch
- preserves the existing `RuntimeProcessConfig::new(SidecarRuntimeConfig, ...)` API during the staged migration and adds an unambiguous wrapper constructor
- exposes the one read-only state path required by the stdio status cache
- re-exports retrieval-owned rendered data surfaces through runtime
- stores the wrapper in `RuntimeProcessConfig` and unwraps it only inside runtime orchestration

## How to review

Start with `retrieval_boundary.rs`. Check that each wrapper constructor delegates argument-for-argument, that only `as_inner` and `into_inner` can recover the retrieval type and both stay crate-private, and that the public state-path accessor grants no mutation authority. Then verify the two `RuntimeProcessConfig` constructor signatures and the controller extraction point.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-runtime --lib` — 1,073 passed
- `CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-cli --test architecture_contracts` — 38 passed
- `cargo check --locked -p codestory-cli`
- differential constructor oracle covers `configuration_id`, every `SidecarRuntimeConfig` field, the read-only status-cache path, both profiles, both run-id states, all constructors, and reselection

Independent review found and drove two fixes before commit: exhaustive constructor coverage, and preservation of the production status-cache/API compatibility seams. Exact-head re-review retained no finding.

## Risk and follow-up

The risk is boundary drift while later slices retarget consumers. This slice keeps behavior anchored to direct retrieval construction and preserves the old public constructor. S2-2 owns the status data surface; later S2 slices own adapter retargeting and the executable dependency fence.

Closes #1831
Refs #1692
Refs #1179
