### PR TITLE
[v0.17 S2-3] Move process identity tri-state behind runtime

### DIFF
--- a/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker/gate.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result, bail};
 use codestory_retrieval::{
-    AwakeMonotonicClock, EmbeddingQualificationWorkerError as WorkerError, ProcessStartProbe,
-    SidecarRuntimeConfig, embedding_retry_state,
+    AwakeMonotonicClock, EmbeddingQualificationWorkerError as WorkerError, SidecarRuntimeConfig,
+    embedding_retry_state,
 };
+use codestory_runtime::ProcessStartProbe;
 use codestory_workspace::atomic_file::{PublishNewFileError, publish_new_private_file_atomic};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -207,7 +208,13 @@ pub(super) fn wait_for_gate(
 }
 
 pub(super) fn current_process_start_identity() -> Result<String> {
-    match codestory_retrieval::probe_process_start_identity(std::process::id()) {
+    current_process_start_identity_from_probe(codestory_runtime::process_start_identity(
+        std::process::id(),
+    ))
+}
+
+fn current_process_start_identity_from_probe(probe: ProcessStartProbe) -> Result<String> {
+    match probe {
         ProcessStartProbe::Running { start_identity } => Ok(start_identity),
         ProcessStartProbe::NotRunning => bail!("embedding_qualification_worker_not_running"),
         ProcessStartProbe::Unknown { reason } => {
@@ -268,8 +275,33 @@ pub(super) fn elapsed(clock: &dyn AwakeMonotonicClock, started_ns: u64) -> Durat
 
 #[cfg(test)]
 mod tests {
-    use super::write_atomic_json;
+    use super::{ProcessStartProbe, current_process_start_identity_from_probe, write_atomic_json};
     use serde_json::{Value, json};
+
+    #[test]
+    fn worker_process_start_identity_preserves_all_probe_outcomes() {
+        assert_eq!(
+            current_process_start_identity_from_probe(ProcessStartProbe::Running {
+                start_identity: "start-a".to_string(),
+            })
+            .expect("running worker identity"),
+            "start-a"
+        );
+        assert_eq!(
+            current_process_start_identity_from_probe(ProcessStartProbe::NotRunning)
+                .expect_err("missing worker must fail")
+                .to_string(),
+            "embedding_qualification_worker_not_running"
+        );
+        assert_eq!(
+            current_process_start_identity_from_probe(ProcessStartProbe::Unknown {
+                reason: "permission denied".to_string(),
+            })
+            .expect_err("unknown worker identity must fail")
+            .to_string(),
+            "embedding_qualification_worker_identity_unknown:permission denied"
+        );
+    }
 
     #[test]
     fn publishing_an_output_succeeds_and_leaves_only_the_complete_file() {

--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -12,7 +12,9 @@ use std::thread::{self, JoinHandle};
 use std::time::Instant;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use codestory_retrieval::{ProcessOwnerState, ProcessStartProbe};
+use codestory_runtime::{
+    ProcessOwnerState, ProcessStartProbe, process_owner_state, process_start_identity,
+};
 
 use codestory_contracts::owned_artifacts::{
     LOCAL_REFRESH_LOCK_FILE, LOCAL_REFRESH_STATE_GUARD_FILE, LOCAL_REFRESH_STATUS_FILE,
@@ -696,15 +698,10 @@ fn path_fingerprint(path: &Path) -> String {
 }
 
 fn recorded_process_start_identity(pid: u32) -> Option<String> {
-    match codestory_retrieval::probe_process_start_identity(pid) {
+    match process_start_identity(pid) {
         ProcessStartProbe::Running { start_identity } => Some(start_identity),
         ProcessStartProbe::NotRunning | ProcessStartProbe::Unknown { .. } => None,
     }
-}
-
-fn process_owner_state(pid: u32, expected_start_identity: Option<&str>) -> ProcessOwnerState {
-    let probe = codestory_retrieval::probe_process_start_identity(pid);
-    codestory_retrieval::process_owner_state(&probe, expected_start_identity)
 }
 
 #[cfg(test)]

--- a/crates/codestory-runtime/src/activation_status.rs
+++ b/crates/codestory-runtime/src/activation_status.rs
@@ -14,7 +14,34 @@ use std::fmt;
 use std::path::Path;
 
 use crate::services::ActivationService;
-use crate::{RetrievalStatusReport, RuntimeRetrievalProfile};
+use crate::{ProcessOwnerState, ProcessStartProbe, RetrievalStatusReport, RuntimeRetrievalProfile};
+
+/// Observe one PID's platform start identity without collapsing uncertainty.
+#[must_use]
+pub fn process_start_identity(pid: u32) -> ProcessStartProbe {
+    codestory_retrieval::probe_process_start_identity(pid)
+}
+
+/// Decide whether one PID still owns a persisted optional start identity.
+#[must_use]
+pub fn process_owner_state(pid: u32, expected_start_identity: Option<&str>) -> ProcessOwnerState {
+    let probe = process_start_identity(pid);
+    process_owner_state_for_probe(&probe, expected_start_identity)
+}
+
+fn process_owner_state_for_probe(
+    probe: &ProcessStartProbe,
+    expected_start_identity: Option<&str>,
+) -> ProcessOwnerState {
+    codestory_retrieval::process_owner_state(probe, expected_start_identity)
+}
+
+fn collapsed_process_start_identity(probe: ProcessStartProbe) -> Option<String> {
+    match probe {
+        ProcessStartProbe::Running { start_identity } => Some(start_identity),
+        ProcessStartProbe::NotRunning | ProcessStartProbe::Unknown { .. } => None,
+    }
+}
 
 /// Effective retrieval namespace selected for one status observation.
 ///
@@ -207,13 +234,7 @@ impl ActivationService {
     /// identity.
     #[must_use]
     pub fn host_process_start_identity() -> Option<String> {
-        match codestory_retrieval::probe_process_start_identity(std::process::id()) {
-            codestory_retrieval::ProcessStartProbe::Running { start_identity } => {
-                Some(start_identity)
-            }
-            codestory_retrieval::ProcessStartProbe::NotRunning
-            | codestory_retrieval::ProcessStartProbe::Unknown { .. } => None,
-        }
+        collapsed_process_start_identity(process_start_identity(std::process::id()))
     }
 
     /// Observe strict retrieval status using this service's pinned runtime
@@ -333,6 +354,90 @@ mod tests {
     use crate::Runtime;
     use std::fs;
     use std::path::PathBuf;
+
+    #[test]
+    fn process_owner_state_matches_retrieval_for_every_probe_and_expected_identity() {
+        let probes = [
+            (
+                "running",
+                ProcessStartProbe::Running {
+                    start_identity: "start-a".to_string(),
+                },
+                [
+                    ProcessOwnerState::Matching,
+                    ProcessOwnerState::GoneOrReused,
+                    ProcessOwnerState::Matching,
+                ],
+            ),
+            (
+                "unknown",
+                ProcessStartProbe::Unknown {
+                    reason: "probe failed".to_string(),
+                },
+                [
+                    ProcessOwnerState::Unknown,
+                    ProcessOwnerState::Unknown,
+                    ProcessOwnerState::Unknown,
+                ],
+            ),
+            (
+                "not_running",
+                ProcessStartProbe::NotRunning,
+                [
+                    ProcessOwnerState::GoneOrReused,
+                    ProcessOwnerState::GoneOrReused,
+                    ProcessOwnerState::GoneOrReused,
+                ],
+            ),
+        ];
+        let expected_identities = [
+            ("matching", Some("start-a")),
+            ("different", Some("start-b")),
+            ("absent", None),
+        ];
+        let mut compared_cells = 0;
+
+        for (probe_name, probe, expected_states) in &probes {
+            for ((identity_name, expected_identity), expected_state) in
+                expected_identities.iter().zip(expected_states)
+            {
+                let runtime_state = process_owner_state_for_probe(probe, *expected_identity);
+                let retrieval_state =
+                    codestory_retrieval::process_owner_state(probe, *expected_identity);
+                assert_eq!(
+                    runtime_state, retrieval_state,
+                    "probe={probe_name} expected={identity_name}"
+                );
+                assert_eq!(
+                    runtime_state, *expected_state,
+                    "probe={probe_name} expected={identity_name}"
+                );
+                compared_cells += 1;
+            }
+        }
+
+        assert_eq!(compared_cells, 9, "the differential table must stay 3x3");
+    }
+
+    #[test]
+    fn host_process_start_identity_keeps_collapsed_diagnostic_behavior() {
+        assert_eq!(
+            collapsed_process_start_identity(ProcessStartProbe::Running {
+                start_identity: "start-a".to_string(),
+            }),
+            Some("start-a".to_string())
+        );
+        assert_eq!(
+            collapsed_process_start_identity(ProcessStartProbe::NotRunning),
+            None
+        );
+        assert_eq!(
+            collapsed_process_start_identity(ProcessStartProbe::Unknown {
+                reason: "probe failed".to_string(),
+            }),
+            None
+        );
+    }
 
     struct DiagnosticsFixture {
         _project: tempfile::TempDir,

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -315,6 +315,7 @@ mod trail_story;
 pub use activation_status::{
     RetrievalEngineDiagnostics, RetrievalEngineDiagnosticsError, RetrievalEngineDiagnosticsStage,
     RetrievalStatusObservation, RetrievalStatusObservationError, RetrievalStatusSelection,
+    process_owner_state, process_start_identity,
 };
 pub use browser::{BrowserQueryItem, ReadOnlyBrowserService};
 pub use cache_rehydrate::{CacheRehydrateOutput, CacheRehydrateRequest, rehydrate_cache};
@@ -329,9 +330,9 @@ pub use repository_identity::{
     REPOSITORY_IDENTITY_SCHEMA_VERSION, RepositoryIdentityReport, inspect_repository_identity,
 };
 pub use retrieval_boundary::{
-    CacheCleanPlan, CacheCleanReport, ProcessStartProbe, RetrievalProcessDefaults,
-    RetrievalRuntimeDefaults, RetrievalRuntimeOverrides, RetrievalStatusReport,
-    RuntimeRetrievalConfig, RuntimeRetrievalProfile,
+    CacheCleanPlan, CacheCleanReport, ProcessOwnerState, ProcessStartProbe,
+    RetrievalProcessDefaults, RetrievalRuntimeDefaults, RetrievalRuntimeOverrides,
+    RetrievalStatusReport, RuntimeRetrievalConfig, RuntimeRetrievalProfile,
 };
 pub(crate) use search_runtime::SearchEngine;
 

--- a/crates/codestory-runtime/src/retrieval_boundary.rs
+++ b/crates/codestory-runtime/src/retrieval_boundary.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 pub use codestory_retrieval::{
-    CacheCleanPlan, CacheCleanReport, ProcessStartProbe, RetrievalStatusReport,
+    CacheCleanPlan, CacheCleanReport, ProcessOwnerState, ProcessStartProbe, RetrievalStatusReport,
     SidecarProcessDefaults as RetrievalProcessDefaults,
     SidecarRuntimeDefaults as RetrievalRuntimeDefaults,
     SidecarRuntimeOverrides as RetrievalRuntimeOverrides,


### PR DESCRIPTION
## Context

S2-1 and S2-2 moved retrieval configuration and strict status behind the runtime boundary. Local-refresh ownership and the embedding qualification worker still probed retrieval-owned process identity directly, and both need the full Running / NotRunning / Unknown distinction.

## What changed

- Added runtime-owned process-start observation and PID ownership functions without collapsing unknown evidence.
- Re-exported the process tri-state and ownership verdict through `codestory-runtime`.
- Retargeted local-refresh ownership and embedding-worker identity checks to runtime.
- Kept the existing self-PID stdio diagnostic behavior: NotRunning and Unknown still render as absent identity.

Provider-owned probes in `embedding_server_transport.rs` and benchmark code remain intentional and unchanged.

## Oracle

The runtime test executes all nine cells of Running / Unknown / NotRunning × matching / different / absent expected identity. Every cell is compared with retrieval's previous mapper and with an explicit expected verdict. Worker tests pin the exact running result and both error strings.

Adversarial review covered tri-state safety, local-refresh stale-owner decisions, worker error output, caller inventory, additive API compatibility, and oracle non-vacuity. It retained no finding on exact diff `8e419605...`.

## Verification

Exact head `f635bb7e` on `3c142b25`:

- exhaustive 3×3 runtime/retrieval differential (9 cells)
- collapsed host diagnostic behavior
- exact embedding-worker outcomes
- all 15 local-refresh ownership tests
- `cargo test --locked -p codestory-cli --test architecture_contracts` (38 passed)
- runtime/CLI all-target clippy with `-D warnings`
- `cargo fmt --all --check`
- `node scripts/lint-retrieval-generalization.mjs`
- `git diff --check`

No broad release proof was dispatched.

Closes #1836
Refs #1692
Refs #1179
