### PR TITLE
[v0.17 CAP-1c] Bind text retrieval to the active source policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Raising the source-file size limit no longer leaves newly admitted files
+  missing from lexical, repository-text, or semantic search. Unsupported binary
+  images are now classified by file type instead of being reported as oversized
+  source.
 - A packet no longer reports a step of a flow as covered because a different
   step was. Coverage was decided by the kind of position a step occupies —
   entrypoint, dispatch, terminal boundary — so when a question asked about two

--- a/crates/codestory-cli/tests/runtime_backed_flows.rs
+++ b/crates/codestory-cli/tests/runtime_backed_flows.rs
@@ -209,6 +209,77 @@ fn assert_publication_metadata(json: &Value, surface: &str, retrieval_expected: 
 }
 
 #[test]
+fn raised_source_file_cap_preserves_lexical_recall() {
+    let workspace = tempdir().expect("create widened source workspace");
+    let core_cache = tempdir().expect("create widened source core cache");
+    let retrieval_cache = tempdir().expect("create widened source retrieval cache");
+    let needle = "active_policy_lexical_recall_needle";
+    let default_cap = codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP;
+    let file_bytes = default_cap + 1_024;
+    let widened_cap = file_bytes + 1_024;
+    let prefix = format!("// {needle}\n// ");
+    let mut contents = prefix.clone();
+    contents.push_str(&"x".repeat(file_bytes as usize - prefix.len()));
+    assert_eq!(contents.len() as u64, file_bytes);
+    fs::write(workspace.path().join("large.rs"), contents).expect("write widened source");
+
+    let mut command = test_support::cli_command();
+    let index = command
+        .args(["index", "--refresh", "full", "--format", "json"])
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--cache-dir")
+        .arg(core_cache.path())
+        .env(
+            "CODESTORY_INDEX_SOURCE_FILE_BYTE_CAP",
+            widened_cap.to_string(),
+        )
+        .output()
+        .expect("index widened source");
+    assert!(
+        index.status.success(),
+        "widened source index failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&index.stderr),
+        String::from_utf8_lossy(&index.stdout)
+    );
+
+    let project = fs::canonicalize(workspace.path()).expect("canonical widened workspace");
+    let storage_path = core_cache.path().join("codestory.db");
+    let runtime = codestory_retrieval::with_test_cache_root(retrieval_cache.path(), || {
+        codestory_retrieval::SidecarRuntimeConfig::for_project_profile(
+            Some(&project),
+            codestory_retrieval::SidecarProfile::Local,
+        )
+    });
+    let manifest = codestory_retrieval::test_support::publish_zero_dense_pinned_query_fixture(
+        &project,
+        &storage_path,
+        &runtime,
+    )
+    .expect("publish widened source lexical fixture");
+    let generation = manifest
+        .sidecar_generation
+        .as_deref()
+        .expect("widened source sidecar generation");
+    let input_hash = manifest
+        .sidecar_input_hash
+        .as_deref()
+        .expect("widened source sidecar input hash");
+    let hits = codestory_retrieval::LexicalClient::new(&runtime.layout)
+        .search(&runtime.layout, generation, input_hash, needle, 10)
+        .expect("search widened source lexical shard");
+
+    assert!(
+        hits.iter().any(|hit| {
+            hit.file_path == "large.rs"
+                && hit.source == codestory_retrieval::CandidateSource::Lexical
+                && hit.provenance.iter().any(|value| value == "lexical_source")
+        }),
+        "over-default policy-admitted source was absent from lexical recall: {hits:#?}"
+    );
+}
+
+#[test]
 #[ignore = "builds indexed runtime fixtures; run explicitly when touching CLI/runtime read-command flows"]
 fn read_commands_support_explicit_auto_refresh_after_indexing() {
     let workspace = copy_tictactoe_workspace();

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -2446,7 +2446,7 @@ mod tests {
         }
         let error = finalize_index(project.path(), &storage_path)
             .expect_err("empty stores cannot satisfy mandatory sidecar indexing");
-        let message = error.to_string();
+        let message = format!("{error:#}");
         assert!(
             message.contains("mandatory")
                 || message.contains("embedding_device_unverified")
@@ -2957,9 +2957,22 @@ mod tests {
         let project = TempDir::new().expect("project");
         std::fs::write(project.path().join("lib.rs"), "pub fn do_work() {}\n")
             .expect("write source");
-        let mut storage = Store::new_in_memory().expect("storage");
         let storage_path = project.path().join("codestory.db");
+        let mut storage = Store::open(&storage_path).expect("storage");
         insert_matching_semantic_doc(&mut storage, project.path());
+        let publication = codestory_store::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "core-generation".into(),
+            run_id: "core-run".into(),
+            mode: codestory_store::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut storage,
+            project.path(),
+            &publication,
+        )
+        .expect("complete core fixture");
 
         assert_eq!(
             storage
@@ -3014,6 +3027,25 @@ mod tests {
         let mut second_storage = Store::open(&second_storage_path).expect("second store");
         insert_matching_semantic_doc(&mut first_storage, first_project.path());
         insert_matching_semantic_doc(&mut second_storage, second_project.path());
+        let publication = codestory_store::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "core-generation".into(),
+            run_id: "core-run".into(),
+            mode: codestory_store::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut first_storage,
+            first_project.path(),
+            &publication,
+        )
+        .expect("first complete core fixture");
+        crate::test_support::publish_complete_core_fixture(
+            &mut second_storage,
+            second_project.path(),
+            &publication,
+        )
+        .expect("second complete core fixture");
 
         let first_project_id = sidecar_project_id_for_root(first_project.path());
         let second_project_id = sidecar_project_id_for_root(second_project.path());
@@ -3055,17 +3087,21 @@ mod tests {
     fn producer_compatibility_change_selects_a_distinct_immutable_generation() {
         let project = TempDir::new().expect("project");
         std::fs::write(project.path().join("lib.rs"), "pub fn stable() {}\n").expect("source");
-        let storage = Store::new_in_memory().expect("storage");
         let storage_path = project.path().join("codestory.db");
-        storage
-            .put_index_publication(&codestory_store::IndexPublicationRecord {
-                generation: 1,
-                generation_id: "core-generation".into(),
-                run_id: "core-run".into(),
-                mode: codestory_store::IndexPublicationMode::Full,
-                published_at_epoch_ms: 1,
-            })
-            .expect("core publication");
+        let mut storage = Store::open(&storage_path).expect("storage");
+        let publication = codestory_store::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "core-generation".into(),
+            run_id: "core-run".into(),
+            mode: codestory_store::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut storage,
+            project.path(),
+            &publication,
+        )
+        .expect("complete core fixture");
         let project_id = "project";
         let package_a = compute_sidecar_input_fingerprint(
             &storage,
@@ -3157,15 +3193,19 @@ mod tests {
         storage
             .upsert_dense_anchor_inputs_batch(&[doc.clone()])
             .expect("first doc");
-        storage
-            .put_index_publication(&codestory_store::IndexPublicationRecord {
-                generation: 1,
-                generation_id: "g1".into(),
-                run_id: "r1".into(),
-                mode: codestory_store::IndexPublicationMode::Full,
-                published_at_epoch_ms: 1,
-            })
-            .expect("first core publication");
+        let first_publication = codestory_store::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "g1".into(),
+            run_id: "r1".into(),
+            mode: codestory_store::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut storage,
+            project.path(),
+            &first_publication,
+        )
+        .expect("first complete core fixture");
         let first = compute_sidecar_input_fingerprint(
             &storage,
             project.path(),
@@ -3180,15 +3220,19 @@ mod tests {
         storage
             .upsert_dense_anchor_inputs_batch(&[doc.clone()])
             .expect("rebind unchanged doc");
-        storage
-            .put_index_publication(&codestory_store::IndexPublicationRecord {
-                generation: 2,
-                generation_id: "g2".into(),
-                run_id: "r2".into(),
-                mode: codestory_store::IndexPublicationMode::Full,
-                published_at_epoch_ms: 2,
-            })
-            .expect("second core publication");
+        let second_publication = codestory_store::IndexPublicationRecord {
+            generation: 2,
+            generation_id: "g2".into(),
+            run_id: "r2".into(),
+            mode: codestory_store::IndexPublicationMode::Full,
+            published_at_epoch_ms: 2,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut storage,
+            project.path(),
+            &second_publication,
+        )
+        .expect("second complete core fixture");
         let rebound = compute_sidecar_input_fingerprint(
             &storage,
             project.path(),
@@ -3695,16 +3739,20 @@ mod tests {
         let storage_dir = TempDir::new().expect("storage");
         let cache = TempDir::new().expect("cache");
         let storage_path = storage_dir.path().join("codestory.db");
-        let store = Store::open(&storage_path).expect("open storage");
-        store
-            .put_index_publication(&IndexPublicationRecord {
-                generation: 1,
-                generation_id: "11111111-1111-4111-8111-111111111111".into(),
-                run_id: "run-one".into(),
-                mode: IndexPublicationMode::Full,
-                published_at_epoch_ms: 1,
-            })
-            .expect("publish core identity");
+        let mut store = Store::open(&storage_path).expect("open storage");
+        let publication = IndexPublicationRecord {
+            generation: 1,
+            generation_id: "11111111-1111-4111-8111-111111111111".into(),
+            run_id: "run-one".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut store,
+            project.path(),
+            &publication,
+        )
+        .expect("publish complete core fixture");
         drop(store);
         let runtime = crate::config::with_test_cache_root(cache.path(), || {
             SidecarRuntimeConfig::for_project_profile(
@@ -4096,16 +4144,20 @@ mod tests {
         let storage_dir = TempDir::new().expect("storage");
         let cache = TempDir::new().expect("cache");
         let storage_path = storage_dir.path().join("codestory.db");
-        let store = Store::open(&storage_path).expect("open storage");
-        store
-            .put_index_publication(&IndexPublicationRecord {
-                generation: 1,
-                generation_id: "11111111-1111-4111-8111-111111111111".into(),
-                run_id: "run-one".into(),
-                mode: IndexPublicationMode::Full,
-                published_at_epoch_ms: 1,
-            })
-            .expect("publish core identity");
+        let mut store = Store::open(&storage_path).expect("open storage");
+        let publication = IndexPublicationRecord {
+            generation: 1,
+            generation_id: "11111111-1111-4111-8111-111111111111".into(),
+            run_id: "run-one".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut store,
+            project.path(),
+            &publication,
+        )
+        .expect("publish complete core fixture");
         drop(store);
         let runtime = crate::config::with_test_cache_root(cache.path(), || {
             SidecarRuntimeConfig::for_project_profile(

--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -4,11 +4,13 @@ use anyhow::{Context, Result, bail};
 use codestory_contracts::api::SearchTargetDto;
 use codestory_contracts::owned_artifacts::sqlite_file_with_sidecars;
 use codestory_contracts::validation_receipts::SealedReceiptCache;
-use codestory_store::{FileRole, Store, SymbolSearchDoc};
+use codestory_store::{FileRole, SourcePolicyExclusionPolicyIdentity, Store, SymbolSearchDoc};
 use codestory_workspace::paths::sqlite_open_path;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -17,9 +19,8 @@ pub const LEXICAL_INDEX_FILE: &str = "lexical-index.sqlite3";
 const LEGACY_INDEX_FILE: &str = "lexical-index.jsonl";
 const LEGACY_META_FILE: &str = "shard-meta.json";
 const LEGACY_STUB_MARKER: &str = ".zoekt-stub";
-/// Derived from the source cap. A file the indexer admits but this lane drops
-/// is indexed-but-unfindable: no error row, no `retry_required`, and strict
-/// readiness still reports Full.
+/// Default lexical source-file cap for scans without a pinned core publication.
+/// Product scans use the active cap recorded with that publication.
 pub(crate) const MAX_FILE_BYTES: u64 = codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP;
 const MAX_CANDIDATES: usize = 4_096;
 const COVERAGE_PATH_SAMPLE: usize = 32;
@@ -940,6 +941,7 @@ fn scan_lexical_documents(
     symbol_storage_path: Option<&Path>,
     visit: &mut dyn FnMut(&LexicalDocument) -> Result<()>,
 ) -> Result<LexicalCoverage> {
+    let source_policy = lexical_source_policy(project_root, source_storage_path)?;
     let workspace = match source_storage_path {
         Some(storage_path) => {
             codestory_workspace::WorkspaceManifest::open_with_storage_owned_exclusions(
@@ -953,12 +955,13 @@ fn scan_lexical_documents(
     let discovered = workspace
         .source_files()
         .context("discover canonical workspace files for lexical index")?;
-    let mut coverage = LexicalCoverage {
-        discovered_files: discovered.len().min(u32::MAX as usize) as u32,
-        ..Default::default()
-    };
+    let mut coverage = LexicalCoverage::default();
     for path in discovered {
         let relative = lexical_relative_path(project_root, &path);
+        if source_policy.excluded_paths.contains(&relative) {
+            continue;
+        }
+        coverage.discovered_files = coverage.discovered_files.saturating_add(1);
         let metadata = match std::fs::metadata(&path) {
             Ok(metadata) => metadata,
             Err(_) => {
@@ -967,13 +970,18 @@ fn scan_lexical_documents(
                 continue;
             }
         };
-        if metadata.len() > MAX_FILE_BYTES {
+        if metadata.len() > source_policy.max_file_bytes {
             coverage.omitted_oversized = coverage.omitted_oversized.saturating_add(1);
             push_coverage_sample(&mut coverage.omitted_path_sample, relative);
             continue;
         }
-        let content = match std::fs::read_to_string(&path) {
-            Ok(content) => content,
+        let content = match read_lexical_file_text_limited(&path, source_policy.max_file_bytes) {
+            Ok(Some(content)) => content,
+            Ok(None) => {
+                coverage.omitted_oversized = coverage.omitted_oversized.saturating_add(1);
+                push_coverage_sample(&mut coverage.omitted_path_sample, relative);
+                continue;
+            }
             Err(_) => {
                 coverage.unreadable_files = coverage.unreadable_files.saturating_add(1);
                 push_coverage_sample(&mut coverage.unreadable_path_sample, relative);
@@ -992,6 +1000,96 @@ fn scan_lexical_documents(
     }
     scan_symbol_documents(project_root, symbol_storage_path, visit)?;
     Ok(coverage)
+}
+
+fn read_lexical_file_text_limited(path: &Path, max_bytes: u64) -> std::io::Result<Option<String>> {
+    let file = std::fs::File::open(path)?;
+    read_lexical_text_limited(file, max_bytes)
+}
+
+fn read_lexical_text_limited(reader: impl Read, max_bytes: u64) -> std::io::Result<Option<String>> {
+    let mut bytes = Vec::new();
+    let mut reader = reader.take(max_bytes.saturating_add(1));
+    reader.read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > max_bytes {
+        return Ok(None);
+    }
+    String::from_utf8(bytes)
+        .map(Some)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+struct LexicalSourcePolicy {
+    max_file_bytes: u64,
+    excluded_paths: HashSet<String>,
+}
+
+fn lexical_source_policy(
+    project_root: &Path,
+    source_storage_path: Option<&Path>,
+) -> Result<LexicalSourcePolicy> {
+    let Some(storage_path) = source_storage_path else {
+        return Ok(LexicalSourcePolicy {
+            max_file_bytes: MAX_FILE_BYTES,
+            excluded_paths: HashSet::new(),
+        });
+    };
+    if !storage_path.is_file() {
+        bail!(
+            "pinned core storage for lexical source policy is missing: {}",
+            storage_path.display()
+        );
+    }
+    let storage =
+        Store::open_read_only(storage_path).context("open storage for lexical source policy")?;
+    let publication = storage
+        .get_complete_index_publication()
+        .context("load complete core publication for lexical source policy")?
+        .context("complete core publication for lexical source policy is missing")?;
+    let manifest = storage
+        .get_source_policy_exclusion_manifest()
+        .context("load lexical source policy manifest")?
+        .context("lexical source policy manifest is missing")?;
+    let records = storage
+        .get_source_policy_exclusions()
+        .context("load lexical source policy exclusions")?;
+    let project_identity = codestory_workspace::project_identity_v3(project_root);
+    let validated = storage
+        .validate_source_policy_exclusion_publication(
+            &publication,
+            &project_identity.project_id,
+            &project_identity.workspace_id,
+            SourcePolicyExclusionPolicyIdentity::new(
+                &manifest.policy_version,
+                manifest.byte_cap,
+                manifest.structural_unit_cap,
+            ),
+        )
+        .context("validate lexical source policy publication")?;
+    let confirmed_publication = storage
+        .get_complete_index_publication()
+        .context("confirm complete core publication for lexical source policy")?;
+    let confirmed_manifest = storage
+        .get_source_policy_exclusion_manifest()
+        .context("confirm lexical source policy manifest")?;
+    let confirmed_records = storage
+        .get_source_policy_exclusions()
+        .context("confirm lexical source policy exclusions")?;
+    if validated != manifest
+        || confirmed_publication.as_ref() != Some(&publication)
+        || confirmed_manifest.as_ref() != Some(&manifest)
+        || confirmed_records != records
+    {
+        bail!("lexical source policy publication changed while it was being pinned");
+    }
+
+    Ok(LexicalSourcePolicy {
+        max_file_bytes: validated.byte_cap,
+        excluded_paths: records
+            .into_iter()
+            .map(|record| record.normalized_path)
+            .collect(),
+    })
 }
 
 fn scan_symbol_documents(
@@ -1448,15 +1546,8 @@ pub(crate) fn make_test_file_writable(path: &Path) {
     std::fs::set_permissions(path, permissions).expect("make test file writable");
 }
 
-/// A file the indexer admits but this lane drops is indexed-but-unfindable: it
-/// lands in the graph with symbols, is absent from the FTS shard, and nothing
-/// reports an error — strict readiness still says Full.
-///
-/// The assertion below compares two compile-time constants, so it catches a
-/// future *default* bump that forgets this lane. It cannot see the runtime
-/// override: the indexer gates on `SourceIndexPolicy.byte_cap`, which
-/// `CODESTORY_INDEX_SOURCE_FILE_BYTE_CAP` raises without an upper clamp, and
-/// closing that needs the policy plumbed here (#1823).
+/// Keep the fallback aligned if the default source policy changes. Product
+/// scans resolve the active cap from the pinned core publication instead.
 const _: () = assert!(
     MAX_FILE_BYTES >= codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP,
     "the lexical lane must admit every file the indexer does"
@@ -1465,14 +1556,76 @@ const _: () = assert!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Read;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
+
+    struct CountingReader {
+        remaining: usize,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let count = buffer.len().min(self.remaining);
+            buffer[..count].fill(b'x');
+            self.remaining -= count;
+            self.bytes_read.fetch_add(count, Ordering::SeqCst);
+            Ok(count)
+        }
+    }
 
     fn build(project: &Path, data: &Path, generation: &str, input: &str) -> PathBuf {
         let fingerprint = lexical_input_fingerprint(project, None).expect("fingerprint");
         build_lexical_shard(project, None, data, generation, &fingerprint, input)
             .expect("build lexical shard");
         shard_dir_for(data, generation)
+    }
+
+    fn publish_test_source_policy(
+        storage: &mut Store,
+        project_root: &Path,
+        byte_cap: u64,
+        candidates: &[codestory_workspace::OversizedSourceExclusionCandidate],
+    ) {
+        let publication = codestory_store::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "test-generation".to_string(),
+            run_id: "test-run".to_string(),
+            mode: codestory_store::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        storage
+            .put_index_publication(&publication)
+            .expect("publish test core identity");
+        let identity = codestory_workspace::project_identity_v3(project_root);
+        storage
+            .publish_source_policy_exclusion_generation(
+                &publication,
+                &identity.project_id,
+                &identity.workspace_id,
+                SourcePolicyExclusionPolicyIdentity::new(
+                    codestory_contracts::workspace::OVERSIZED_SOURCE_POLICY_VERSION,
+                    byte_cap,
+                    codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
+                ),
+                candidates,
+            )
+            .expect("publish test source policy");
+    }
+
+    #[test]
+    fn lexical_text_reader_stops_after_cap_overflow_sentinel() {
+        let bytes_read = Arc::new(AtomicUsize::new(0));
+        let reader = CountingReader {
+            remaining: 4_096,
+            bytes_read: Arc::clone(&bytes_read),
+        };
+
+        let contents = read_lexical_text_limited(reader, 64).expect("bounded read");
+
+        assert!(contents.is_none());
+        assert_eq!(bytes_read.load(Ordering::SeqCst), 65);
     }
 
     #[test]
@@ -1896,7 +2049,9 @@ mod tests {
         let storage_path = project.path().join("cache").join("custom-core.db");
         std::fs::create_dir_all(storage_path.parent().expect("storage parent"))
             .expect("storage parent");
-        let _storage = Store::open(&storage_path).expect("custom in-worktree store");
+        let mut storage = Store::open(&storage_path).expect("custom in-worktree store");
+        publish_test_source_policy(&mut storage, project.path(), MAX_FILE_BYTES, &[]);
+        drop(storage);
         let sibling = project
             .path()
             .join("cache")
@@ -1956,6 +2111,136 @@ mod tests {
                 .map(|hit| hit.path.as_str()),
             Some("cache/custom-core.search-generations-user/user-config.json")
         );
+    }
+
+    #[test]
+    fn pinned_policy_exclusions_filter_structural_files_without_narrowing_parser_recall() {
+        let project = TempDir::new().expect("project");
+        let src = project.path().join("src");
+        let data = project.path().join("data");
+        std::fs::create_dir_all(&src).expect("src");
+        std::fs::create_dir_all(&data).expect("data");
+
+        let widened_cap = MAX_FILE_BYTES + 1_024;
+        let parser_path = src.join("widened.rs");
+        let mut parser_source = b"fn widened_parser_token() {}\n".to_vec();
+        parser_source.resize(MAX_FILE_BYTES as usize + 1, b' ');
+        std::fs::write(&parser_path, &parser_source).expect("widened parser source");
+
+        let json_path = data.join("config.json");
+        let mut json_source = br#"{"excluded_structural_token":"x"}"#.to_vec();
+        json_source.resize(
+            codestory_contracts::workspace::DEFAULT_STRUCTURAL_SOURCE_BYTE_CAP as usize + 1,
+            b' ',
+        );
+        std::fs::write(&json_path, &json_source).expect("excluded structural source");
+
+        let storage_root = TempDir::new().expect("storage root");
+        let storage_path = storage_root.path().join("core.db");
+        let mut storage = Store::open(&storage_path).expect("core storage");
+        publish_test_source_policy(
+            &mut storage,
+            project.path(),
+            widened_cap,
+            &[codestory_workspace::OversizedSourceExclusionCandidate {
+                normalized_path: "data/config.json".to_string(),
+                content_hash: format!("{:x}", Sha256::digest(&json_source)),
+                observed_size: json_source.len() as u64,
+                observed_unit_count: 0,
+                policy_version: codestory_contracts::workspace::OVERSIZED_SOURCE_POLICY_VERSION
+                    .to_string(),
+                byte_cap: codestory_contracts::workspace::DEFAULT_STRUCTURAL_SOURCE_BYTE_CAP,
+                structural_unit_cap: codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
+            }],
+        );
+        drop(storage);
+
+        let mut source_paths = std::collections::BTreeSet::new();
+        let coverage =
+            scan_lexical_documents(project.path(), Some(&storage_path), None, &mut |document| {
+                if document.source == LexicalDocumentSource::LexicalSource {
+                    source_paths.insert(document.path.clone());
+                }
+                Ok(())
+            })
+            .expect("scan pinned lexical sources");
+
+        assert_eq!(
+            source_paths,
+            std::collections::BTreeSet::from(["src/widened.rs".to_string()])
+        );
+        assert_eq!(coverage.discovered_files, 1);
+        assert_eq!(coverage.indexed_files, 1);
+        assert!(coverage.complete());
+    }
+
+    #[test]
+    fn pinned_lexical_scan_fails_closed_without_source_policy_publication() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "fn source() {}\n").expect("source");
+        let storage_root = TempDir::new().expect("storage root");
+        let storage_path = storage_root.path().join("core.db");
+        drop(Store::open(&storage_path).expect("bare core storage"));
+
+        let error = lexical_input_fingerprint(project.path(), Some(&storage_path))
+            .expect_err("missing publication must fail closed");
+
+        assert!(
+            format!("{error:#}")
+                .contains("complete core publication for lexical source policy is missing")
+        );
+    }
+
+    #[test]
+    fn pinned_lexical_scan_rejects_a_foreign_project_policy() {
+        let project_a = TempDir::new().expect("project a");
+        let project_b = TempDir::new().expect("project b");
+        std::fs::create_dir_all(project_a.path().join("data")).expect("project a data");
+        std::fs::create_dir_all(project_b.path().join("data")).expect("project b data");
+        std::fs::write(
+            project_a.path().join("data/config.json"),
+            br#"{"selected_project_token":"a"}"#,
+        )
+        .expect("project a source");
+
+        let mut excluded_source = br#"{"foreign_project_token":"b"}"#.to_vec();
+        excluded_source.resize(
+            codestory_contracts::workspace::DEFAULT_STRUCTURAL_SOURCE_BYTE_CAP as usize + 1,
+            b' ',
+        );
+        std::fs::write(project_b.path().join("data/config.json"), &excluded_source)
+            .expect("project b source");
+
+        let identity_a = codestory_workspace::project_identity_v3(project_a.path());
+        let identity_b = codestory_workspace::project_identity_v3(project_b.path());
+        assert_ne!(identity_a.workspace_id, identity_b.workspace_id);
+
+        let storage_root = TempDir::new().expect("foreign storage root");
+        let storage_path = storage_root.path().join("core.db");
+        let mut storage = Store::open(&storage_path).expect("foreign core storage");
+        publish_test_source_policy(
+            &mut storage,
+            project_b.path(),
+            MAX_FILE_BYTES,
+            &[codestory_workspace::OversizedSourceExclusionCandidate {
+                normalized_path: "data/config.json".to_string(),
+                content_hash: format!("{:x}", Sha256::digest(&excluded_source)),
+                observed_size: excluded_source.len() as u64,
+                observed_unit_count: 0,
+                policy_version: codestory_contracts::workspace::OVERSIZED_SOURCE_POLICY_VERSION
+                    .to_string(),
+                byte_cap: codestory_contracts::workspace::DEFAULT_STRUCTURAL_SOURCE_BYTE_CAP,
+                structural_unit_cap: codestory_contracts::workspace::DEFAULT_STRUCTURAL_UNIT_CAP,
+            }],
+        );
+        drop(storage);
+
+        let error = lexical_input_fingerprint(project_a.path(), Some(&storage_path))
+            .expect_err("foreign core policy must fail closed");
+
+        assert!(format!("{error:#}").contains(
+            "source policy exclusion manifest does not match the complete core publication"
+        ));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -732,10 +732,9 @@ mod tests {
             mode: IndexPublicationMode::Full,
             published_at_epoch_ms: 2,
         };
-        let store = Store::open(&storage_path).expect("open storage");
-        store
-            .put_index_publication(&first_core)
-            .expect("publish first core identity");
+        let mut store = Store::open(&storage_path).expect("open storage");
+        crate::test_support::publish_complete_core_fixture(&mut store, project.path(), &first_core)
+            .expect("publish first complete core fixture");
         drop(store);
         let runtime = crate::config::with_test_cache_root(cache.path(), || {
             SidecarRuntimeConfig::for_project_profile(
@@ -756,9 +755,12 @@ mod tests {
         drop(first_session);
 
         let mut store = Store::open(&storage_path).expect("open identity-only writer");
-        store
-            .put_index_publication(&second_core)
-            .expect("publish second core identity");
+        crate::test_support::publish_complete_core_fixture(
+            &mut store,
+            project.path(),
+            &second_core,
+        )
+        .expect("publish second complete core fixture");
         store
             .publish_dense_anchor_generation(
                 &second_core,

--- a/crates/codestory-retrieval/src/rollback.rs
+++ b/crates/codestory-retrieval/src/rollback.rs
@@ -463,16 +463,20 @@ mod tests {
         let cache = TempDir::new().expect("cache");
         let storage_path = storage_dir.path().join("codestory.db");
         std::fs::write(project.path().join("lib.rs"), "pub fn alpha() {}\n").expect("seed source");
-        let store = Store::open(&storage_path).expect("open storage");
-        store
-            .put_index_publication(&IndexPublicationRecord {
-                generation: 1,
-                generation_id: "11111111-1111-4111-8111-111111111111".into(),
-                run_id: "run-one".into(),
-                mode: IndexPublicationMode::Full,
-                published_at_epoch_ms: 1,
-            })
-            .expect("publish core identity");
+        let mut store = Store::open(&storage_path).expect("open storage");
+        let publication = IndexPublicationRecord {
+            generation: 1,
+            generation_id: "11111111-1111-4111-8111-111111111111".into(),
+            run_id: "run-one".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut store,
+            project.path(),
+            &publication,
+        )
+        .expect("publish complete core fixture");
         drop(store);
         let runtime = crate::config::with_test_cache_root(cache.path(), || {
             SidecarRuntimeConfig::for_project_profile(

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -523,7 +523,20 @@ mod tests {
         let storage_path = project.path().join("cache").join("custom-core.db");
         std::fs::create_dir_all(storage_path.parent().expect("storage parent"))
             .expect("storage parent");
-        let storage = Store::open(&storage_path).expect("store");
+        let mut storage = Store::open(&storage_path).expect("store");
+        let publication = codestory_store::IndexPublicationRecord {
+            generation: 1,
+            generation_id: "core-generation".into(),
+            run_id: "core-run".into(),
+            mode: codestory_store::IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        crate::test_support::publish_complete_core_fixture(
+            &mut storage,
+            project.path(),
+            &publication,
+        )
+        .expect("complete core fixture");
         let runtime = SidecarRuntimeConfig::local();
         let project_id =
             sidecar_project_id_for_runtime(project.path(), &runtime).expect("project id");

--- a/crates/codestory-retrieval/src/test_support.rs
+++ b/crates/codestory-retrieval/src/test_support.rs
@@ -15,6 +15,34 @@ pub fn env_lock() -> MutexGuard<'static, ()> {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
+/// Publish the minimum complete core identity required by retrieval fixtures
+/// that hash lexical source input from a pinned store.
+pub fn publish_complete_core_fixture(
+    storage: &mut Store,
+    project_root: &Path,
+    publication: &codestory_store::IndexPublicationRecord,
+) -> Result<()> {
+    let identity = codestory_workspace::project_identity_v3(project_root);
+    let source_policy = codestory_contracts::workspace::SourceIndexPolicy::default();
+    storage
+        .publish_source_policy_exclusion_generation(
+            publication,
+            &identity.project_id,
+            &identity.workspace_id,
+            SourcePolicyExclusionPolicyIdentity::new(
+                &source_policy.policy_version,
+                source_policy.byte_cap,
+                source_policy.structural_unit_cap,
+            ),
+            &[],
+        )
+        .context("publish empty source policy exclusion fixture")?;
+    storage
+        .put_index_publication(publication)
+        .context("publish complete core fixture")?;
+    Ok(())
+}
+
 pub fn retrieval_manifest_fixture(
     project_id: &str,
     sidecar_input_hash: &str,

--- a/crates/codestory-retrieval/tests/full_stack_integration.rs
+++ b/crates/codestory-retrieval/tests/full_stack_integration.rs
@@ -4,7 +4,9 @@
 //! generation is published.
 
 use codestory_contracts::graph::{Node, NodeId, NodeKind};
-use codestory_retrieval::test_support::publish_zero_dense_pinned_query_fixture;
+use codestory_retrieval::test_support::{
+    publish_complete_core_fixture, publish_zero_dense_pinned_query_fixture,
+};
 use codestory_retrieval::{
     QueryRequest, RetrievalCache, RetrievalStageKind, SidecarProcessDefaults, SidecarProfile,
     SidecarRuntimeConfig, SidecarRuntimeDefaults, SidecarRuntimeOverrides, StageCompletionStatus,
@@ -94,15 +96,15 @@ fn seed_fixture_graph(storage: &mut Store, project_root: &Path) -> NodeId {
             updated_at_epoch_ms: 1,
         }])
         .expect("symbol search doc");
-    storage
-        .put_index_publication(&IndexPublicationRecord {
-            generation: 1,
-            generation_id: "11111111-1111-4111-8111-111111111111".into(),
-            run_id: "core-run-1".into(),
-            mode: IndexPublicationMode::Full,
-            published_at_epoch_ms: 1,
-        })
-        .expect("core publication");
+    let publication = IndexPublicationRecord {
+        generation: 1,
+        generation_id: "11111111-1111-4111-8111-111111111111".into(),
+        run_id: "core-run-1".into(),
+        mode: IndexPublicationMode::Full,
+        published_at_epoch_ms: 1,
+    };
+    publish_complete_core_fixture(storage, project_root, &publication)
+        .expect("complete core fixture");
     function.id
 }
 

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -2125,6 +2125,33 @@ mod tests {
         controller: AppController,
     }
 
+    fn publish_test_complete_core(
+        store: &mut Store,
+        project_root: &Path,
+        publication: &codestory_store::IndexPublicationRecord,
+    ) {
+        use codestory_store::SourcePolicyExclusionPolicyIdentity;
+
+        let identity = codestory_workspace::project_identity_v3(project_root);
+        let source_policy = codestory_contracts::workspace::SourceIndexPolicy::default();
+        store
+            .publish_source_policy_exclusion_generation(
+                publication,
+                &identity.project_id,
+                &identity.workspace_id,
+                SourcePolicyExclusionPolicyIdentity::new(
+                    &source_policy.policy_version,
+                    source_policy.byte_cap,
+                    source_policy.structural_unit_cap,
+                ),
+                &[],
+            )
+            .expect("publish empty source policy exclusion generation");
+        store
+            .put_index_publication(publication)
+            .expect("publish complete core generation");
+    }
+
     fn pinned_operation_fixture() -> PinnedOperationFixture {
         use codestory_store::{IndexPublicationMode, IndexPublicationRecord};
 
@@ -2132,16 +2159,15 @@ mod tests {
         let storage = tempfile::tempdir().expect("storage");
         let retrieval_cache = tempfile::tempdir().expect("retrieval cache");
         let storage_path = storage.path().join("codestory.db");
-        let store = Store::open(&storage_path).expect("open storage");
-        store
-            .put_index_publication(&IndexPublicationRecord {
-                generation: 1,
-                generation_id: "11111111-1111-4111-8111-111111111111".into(),
-                run_id: "run-one".into(),
-                mode: IndexPublicationMode::Full,
-                published_at_epoch_ms: 1,
-            })
-            .expect("publish initial core generation");
+        let mut store = Store::open(&storage_path).expect("open storage");
+        let publication = IndexPublicationRecord {
+            generation: 1,
+            generation_id: "11111111-1111-4111-8111-111111111111".into(),
+            run_id: "run-one".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        publish_test_complete_core(&mut store, project.path(), &publication);
         drop(store);
         let runtime = codestory_retrieval::with_test_cache_root(retrieval_cache.path(), || {
             SidecarRuntimeConfig::for_project_profile(
@@ -2243,16 +2269,23 @@ mod tests {
                     "response assembly must retain the operation pin"
                 );
                 if build_calls == 1 {
-                    let writer = Store::open(&fixture.storage_path).expect("open drift writer");
-                    writer
-                        .put_index_publication(&IndexPublicationRecord {
-                            generation: 2,
-                            generation_id: "22222222-2222-4222-8222-222222222222".into(),
-                            run_id: "run-two".into(),
-                            mode: IndexPublicationMode::Full,
-                            published_at_epoch_ms: 2,
-                        })
-                        .expect("publish concurrent core generation");
+                    let mut writer = Store::open(&fixture.storage_path).expect("open drift writer");
+                    let publication = IndexPublicationRecord {
+                        generation: 2,
+                        generation_id: "22222222-2222-4222-8222-222222222222".into(),
+                        run_id: "run-two".into(),
+                        mode: IndexPublicationMode::Full,
+                        published_at_epoch_ms: 2,
+                    };
+                    publish_test_complete_core(
+                        &mut writer,
+                        fixture
+                            .controller
+                            .require_project_root()
+                            .expect("project root")
+                            .as_path(),
+                        &publication,
+                    );
                 }
                 Ok(TestPublicationResponse::default())
             },
@@ -2325,16 +2358,23 @@ mod tests {
         PinnedRetrievalRead::begin(&fixture.controller).expect("first pin");
         assert_eq!(canonical_stream_count(&fixture.controller), 1);
 
-        let writer = Store::open(&fixture.storage_path).expect("open publication writer");
-        writer
-            .put_index_publication(&IndexPublicationRecord {
-                generation: 2,
-                generation_id: "22222222-2222-4222-8222-222222222222".into(),
-                run_id: "run-two".into(),
-                mode: IndexPublicationMode::Full,
-                published_at_epoch_ms: 2,
-            })
-            .expect("publish a second core generation");
+        let mut writer = Store::open(&fixture.storage_path).expect("open publication writer");
+        let publication = IndexPublicationRecord {
+            generation: 2,
+            generation_id: "22222222-2222-4222-8222-222222222222".into(),
+            run_id: "run-two".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 2,
+        };
+        publish_test_complete_core(
+            &mut writer,
+            fixture
+                .controller
+                .require_project_root()
+                .expect("project root")
+                .as_path(),
+            &publication,
+        );
         drop(writer);
         publish_zero_dense_pinned_query_fixture(
             fixture
@@ -4013,15 +4053,14 @@ mod tests {
                 original_node,
             ])
             .expect("insert nodes");
-        storage
-            .put_index_publication(&IndexPublicationRecord {
-                generation: 1,
-                generation_id: "11111111-1111-4111-8111-111111111111".into(),
-                run_id: "run-one".into(),
-                mode: IndexPublicationMode::Full,
-                published_at_epoch_ms: 1,
-            })
-            .expect("publish first identity");
+        let first_publication = IndexPublicationRecord {
+            generation: 1,
+            generation_id: "11111111-1111-4111-8111-111111111111".into(),
+            run_id: "run-one".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        };
+        publish_test_complete_core(&mut storage, project.path(), &first_publication);
         drop(storage);
 
         let runtime = codestory_retrieval::with_test_cache_root(retrieval_cache.path(), || {
@@ -4052,15 +4091,14 @@ mod tests {
                 ..Default::default()
             }])
             .expect("reuse numeric id in replacement generation");
-        writer
-            .put_index_publication(&IndexPublicationRecord {
-                generation: 2,
-                generation_id: "22222222-2222-4222-8222-222222222222".into(),
-                run_id: "run-two".into(),
-                mode: IndexPublicationMode::Full,
-                published_at_epoch_ms: 2,
-            })
-            .expect("publish replacement identity");
+        let replacement_publication = IndexPublicationRecord {
+            generation: 2,
+            generation_id: "22222222-2222-4222-8222-222222222222".into(),
+            run_id: "run-two".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 2,
+        };
+        publish_test_complete_core(&mut writer, project.path(), &replacement_publication);
         let replacement_manifest = retrieval_manifest_fixture(&project_id, "second");
         writer
             .upsert_retrieval_index_manifest(&replacement_manifest)

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -2130,26 +2130,12 @@ mod tests {
         project_root: &Path,
         publication: &codestory_store::IndexPublicationRecord,
     ) {
-        use codestory_store::SourcePolicyExclusionPolicyIdentity;
-
-        let identity = codestory_workspace::project_identity_v3(project_root);
-        let source_policy = codestory_contracts::workspace::SourceIndexPolicy::default();
-        store
-            .publish_source_policy_exclusion_generation(
-                publication,
-                &identity.project_id,
-                &identity.workspace_id,
-                SourcePolicyExclusionPolicyIdentity::new(
-                    &source_policy.policy_version,
-                    source_policy.byte_cap,
-                    source_policy.structural_unit_cap,
-                ),
-                &[],
-            )
-            .expect("publish empty source policy exclusion generation");
-        store
-            .put_index_publication(publication)
-            .expect("publish complete core generation");
+        codestory_retrieval::test_support::publish_complete_core_fixture(
+            store,
+            project_root,
+            publication,
+        )
+        .expect("publish complete core generation");
     }
 
     fn pinned_operation_fixture() -> PinnedOperationFixture {

--- a/crates/codestory-runtime/src/controller_indexing.rs
+++ b/crates/codestory-runtime/src/controller_indexing.rs
@@ -23,8 +23,8 @@ use crate::search_state_cache::{
     rebuild_search_state_from_storage_for_runtime, refresh_caches, workspace_refresh_inputs,
 };
 use crate::semantic_projection::{
-    CacheRefreshStats, SEMANTIC_POLICY_VERSION, SemanticProjectionRepublishOutcome,
-    apply_cache_refresh_stats, summarize_symbol_doc,
+    CacheRefreshStats, LLM_SYMBOL_DOC_SCHEMA_VERSION, SEMANTIC_POLICY_VERSION,
+    SemanticProjectionRepublishOutcome, apply_cache_refresh_stats, summarize_symbol_doc,
 };
 use crate::semantic_republish::semantic_projection_republish_for_runtime;
 use crate::support::{clamp_i64_to_u32, clamp_u128_to_u32};
@@ -731,12 +731,12 @@ impl AppController {
         }
         let storage = Store::open_read_only(storage_path).map_err(|error| {
             ApiError::internal(format!(
-                "Failed to inspect dense-anchor publication readiness: {error}"
+                "Failed to inspect core publication readiness: {error}"
             ))
         })?;
         let Some(publication) = storage.get_complete_index_publication().map_err(|error| {
             ApiError::internal(format!(
-                "Failed to inspect dense-anchor core publication: {error}"
+                "Failed to inspect complete core publication: {error}"
             ))
         })?
         else {
@@ -748,6 +748,19 @@ impl AppController {
             || storage
                 .validate_structural_text_unit_publication(&publication)
                 .is_err()
+        {
+            return Ok(true);
+        }
+        if storage
+            .has_symbol_search_doc_contract_mismatch(
+                LLM_SYMBOL_DOC_SCHEMA_VERSION,
+                SEMANTIC_POLICY_VERSION,
+            )
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to inspect semantic document publication readiness: {error}"
+                ))
+            })?
         {
             return Ok(true);
         }

--- a/crates/codestory-runtime/src/index_full.rs
+++ b/crates/codestory-runtime/src/index_full.rs
@@ -251,6 +251,7 @@ fn prepare_full_refresh_snapshots(
     source_identity: &str,
     cancel_token: Option<&CancellationToken>,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    source_index_policy: &SourceIndexPolicy,
 ) -> Result<PreparedFullRefreshSnapshots, ApiError> {
     let semantic_started = Instant::now();
     let semantic_stats = finalize_staged_semantic_docs_for_runtime(
@@ -260,7 +261,9 @@ fn prepare_full_refresh_snapshots(
         source_identity,
         cancel_token,
         runtime,
-        SemanticProjectionDocumentSource::SourceFiles,
+        SemanticProjectionDocumentSource::SourceFiles {
+            max_file_bytes: source_index_policy.byte_cap,
+        },
     )?;
     ensure_indexing_active(cancel_token)?;
     let semantic_duration = semantic_started.elapsed();
@@ -451,6 +454,7 @@ fn prepare_full_refresh(
         &live_state.dense_anchor_source_identity,
         cancel_token,
         runtime,
+        source_index_policy,
     )?;
     wall_durations.semantic_stage = snapshots.semantic_duration;
     wall_durations.snapshot_stage = snapshots.snapshot_duration;

--- a/crates/codestory-runtime/src/index_incremental.rs
+++ b/crates/codestory-runtime/src/index_incremental.rs
@@ -806,7 +806,9 @@ fn prepare_incremental_refresh(
         &source_identity,
         cancel_token,
         runtime,
-        SemanticProjectionDocumentSource::SourceFiles,
+        SemanticProjectionDocumentSource::SourceFiles {
+            max_file_bytes: source_index_policy.byte_cap,
+        },
     )?;
     ensure_indexing_active(cancel_token)?;
     let finalize_stats = preparation

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -388,12 +388,14 @@ pub use target_resolution::{
 
 pub(crate) use services::active_public_operation_cancellation;
 pub(crate) use support::{
-    FocusedSourceContext, HYBRID_RETRIEVAL_ENABLED_ENV, SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES,
-    SEMANTIC_FILE_TEXT_MAX_BYTES, aggregate_symbol_matches, clamp_i64_to_u32, clamp_u64_to_u32,
-    clamp_u128_to_u32, clamp_usize_to_u32, extract_symbol_search_terms, file_text_match_line,
-    hybrid_retrieval_enabled, looks_like_repo_text_query, node_display_name, preferred_occurrence,
-    query_has_symbol_or_literal_signal, read_file_text_limited, read_searchable_file_contents,
-    should_expand_symbol_query, source_freshness_telemetry_for_operation,
+    BoundedTextRead, FocusedSourceContext, HYBRID_RETRIEVAL_ENABLED_ENV,
+    SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES, SEMANTIC_FILE_TEXT_MAX_BYTES, aggregate_symbol_matches,
+    clamp_i64_to_u32, clamp_u64_to_u32, clamp_u128_to_u32, clamp_usize_to_u32,
+    extract_symbol_search_terms, file_text_match_line, hybrid_retrieval_enabled,
+    looks_like_repo_text_query, node_display_name, preferred_occurrence,
+    query_has_symbol_or_literal_signal, read_file_text_limited,
+    read_searchable_file_contents_limited, should_expand_symbol_query,
+    source_freshness_telemetry_for_operation,
 };
 #[cfg(test)]
 pub(crate) use support::{apply_hybrid_limits, normalized_hybrid_weights};

--- a/crates/codestory-runtime/src/repo_text.rs
+++ b/crates/codestory-runtime/src/repo_text.rs
@@ -1,20 +1,20 @@
 use super::{
-    ApiError, AppController, HashSet, Instant, NodeId, Path, RepoTextScanStatsDto, SearchHit,
-    SearchMatchQualityDto, Storage, clamp_u128_to_u32, clamp_usize_to_u32,
+    ApiError, AppController, BoundedTextRead, HashSet, Instant, NodeId, Path, RepoTextScanStatsDto,
+    SearchHit, SearchMatchQualityDto, Storage, clamp_u128_to_u32, clamp_usize_to_u32,
     compare_search_hits_with_project_root, extract_symbol_search_terms, file_text_match_line,
-    read_searchable_file_contents,
+    read_searchable_file_contents_limited,
 };
 #[cfg(test)]
 use super::{SearchRepoTextMode, looks_like_repo_text_query};
 #[cfg(test)]
 use crate::search_intent::repo_text_auto_fallback_reason;
 use crate::search_intent::text_contains_query_term;
+use codestory_workspace::SourceIndexPolicy;
 
 pub(super) const REPO_TEXT_SCAN_FILE_CAP: usize = 2_000;
 pub(super) const REPO_TEXT_SCAN_BYTE_CAP: usize = 32 * 1024 * 1024;
 pub(super) const REPO_TEXT_SCAN_TIME_CAP_MS: u128 = 500;
-/// Derived from the source cap, for the same reason as the lexical and
-/// semantic lanes: an admitted file must stay searchable.
+/// Default repo-text cap. Product scans use the active source-index policy.
 pub(super) const REPO_TEXT_MAX_FILE_BYTES: u64 =
     codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP;
 #[derive(Debug, Clone)]
@@ -22,6 +22,44 @@ pub(super) struct RepoTextScan {
     pub(super) hits: Vec<SearchHit>,
     #[cfg(test)]
     pub(super) stats: RepoTextScanStatsDto,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum RepoTextFileReadOutcome {
+    Contents(String),
+    FileTooLarge,
+    ByteBudgetExceeded,
+    Unreadable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RepoTextFileRead {
+    pub(super) outcome: RepoTextFileReadOutcome,
+    pub(super) bytes_read: u64,
+}
+
+pub(super) fn read_repo_text_file(
+    path: &str,
+    max_file_bytes: u64,
+    remaining_total_bytes: u64,
+) -> RepoTextFileRead {
+    let read_limit = max_file_bytes.min(remaining_total_bytes);
+    let read = read_searchable_file_contents_limited(path, read_limit);
+    let bytes_read = read.bytes_read();
+    let outcome = match read {
+        BoundedTextRead::Contents { contents, .. } => RepoTextFileReadOutcome::Contents(contents),
+        BoundedTextRead::LimitExceeded { .. }
+            if bytes_read > remaining_total_bytes || remaining_total_bytes < max_file_bytes =>
+        {
+            RepoTextFileReadOutcome::ByteBudgetExceeded
+        }
+        BoundedTextRead::LimitExceeded { .. } => RepoTextFileReadOutcome::FileTooLarge,
+        BoundedTextRead::Unreadable { .. } => RepoTextFileReadOutcome::Unreadable,
+    };
+    RepoTextFileRead {
+        outcome,
+        bytes_read,
+    }
 }
 
 impl AppController {
@@ -45,10 +83,12 @@ impl AppController {
     pub(super) fn collect_repo_text_hits(
         storage: &Storage,
         project_root: Option<&Path>,
+        source_index_policy: &SourceIndexPolicy,
         query: &str,
         limit: usize,
         indexed_hit_ids: &HashSet<NodeId>,
     ) -> Result<RepoTextScan, ApiError> {
+        let max_file_bytes = source_index_policy.byte_cap;
         let started_at = Instant::now();
         let mut stats = RepoTextScanStatsDto {
             scanned_file_count: 0,
@@ -72,6 +112,7 @@ impl AppController {
 
         let mut hits = Vec::new();
         let mut seen = indexed_hit_ids.clone();
+        let mut read_byte_count = 0_u64;
         let terms = extract_symbol_search_terms(query);
         let normalized_query = query.trim().to_ascii_lowercase();
         for file in storage
@@ -87,13 +128,13 @@ impl AppController {
             let Ok(metadata) = std::fs::metadata(&file.path) else {
                 continue;
             };
-            if metadata.len() > REPO_TEXT_MAX_FILE_BYTES {
+            if metadata.len() > max_file_bytes {
                 stats.skipped_large_file_count = stats.skipped_large_file_count.saturating_add(1);
                 continue;
             }
-            let projected_bytes =
-                u64::from(stats.scanned_byte_count).saturating_add(metadata.len());
-            if projected_bytes > REPO_TEXT_SCAN_BYTE_CAP as u64 {
+            let remaining_total_bytes = (REPO_TEXT_SCAN_BYTE_CAP as u64)
+                .saturating_sub(read_byte_count.min(REPO_TEXT_SCAN_BYTE_CAP as u64));
+            if metadata.len() > remaining_total_bytes {
                 Self::mark_repo_text_scan_truncated(
                     &mut stats,
                     format!(
@@ -103,13 +144,27 @@ impl AppController {
                 );
                 break;
             }
-            let Some(contents) = read_searchable_file_contents(&path_string) else {
-                continue;
+            let read = read_repo_text_file(&path_string, max_file_bytes, remaining_total_bytes);
+            read_byte_count = read_byte_count.saturating_add(read.bytes_read);
+            let contents = match read.outcome {
+                RepoTextFileReadOutcome::Contents(contents) => contents,
+                RepoTextFileReadOutcome::FileTooLarge => {
+                    stats.skipped_large_file_count =
+                        stats.skipped_large_file_count.saturating_add(1);
+                    continue;
+                }
+                RepoTextFileReadOutcome::ByteBudgetExceeded => {
+                    Self::mark_repo_text_scan_truncated(
+                        &mut stats,
+                        format!(
+                            "repo-text scan stopped before reading more than {} bytes",
+                            REPO_TEXT_SCAN_BYTE_CAP
+                        ),
+                    );
+                    break;
+                }
+                RepoTextFileReadOutcome::Unreadable => continue,
             };
-            if contents.len() as u64 > REPO_TEXT_MAX_FILE_BYTES {
-                stats.skipped_large_file_count = stats.skipped_large_file_count.saturating_add(1);
-                continue;
-            }
             stats.scanned_byte_count = stats
                 .scanned_byte_count
                 .saturating_add(clamp_usize_to_u32(contents.len()));
@@ -331,8 +386,7 @@ impl AppController {
     }
 }
 
-/// Same parity the lexical lane asserts. These constants are what make an
-/// admitted file readable; any of them lagging the source cap is silent.
+/// Keep the default fallback aligned if the default source policy changes.
 const _: () = assert!(
     REPO_TEXT_MAX_FILE_BYTES >= codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP,
     "repo-text scanning must admit every file the indexer does"

--- a/crates/codestory-runtime/src/search_plan.rs
+++ b/crates/codestory-runtime/src/search_plan.rs
@@ -1286,6 +1286,7 @@ impl AppController {
                 let scan = Self::collect_repo_text_hits(
                     storage,
                     project_root.as_deref(),
+                    &self.source_index_policy,
                     &subquery.query,
                     repo_text_limit,
                     &seen_repo_text_ids,

--- a/crates/codestory-runtime/src/semantic_projection.rs
+++ b/crates/codestory-runtime/src/semantic_projection.rs
@@ -1,10 +1,10 @@
 use super::{
-    AccessKind, ApiError, BTreeMap, BTreeSet, BUILD_EDGE_SEED_BATCH_SIZE, CancellationToken,
-    DenseAnchorInput, DenseAnchorInputReuseMetadata, EmbeddingProfileContractDto, FileInfo,
-    GraphEdge, GraphNode, GraphNodeId, HashMap, HashSet, IndexPublicationRecord,
-    IndexingPhaseTimings, Instant, LlmSymbolDoc, LlmSymbolDocStats, Path, RetrievalFileRole,
-    SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES, SEMANTIC_FILE_TEXT_MAX_BYTES, SearchEngine,
-    SourceIndexPolicy, SourcePolicyExclusionPolicyIdentity, Storage, StoreFileRole,
+    AccessKind, ApiError, BTreeMap, BTreeSet, BUILD_EDGE_SEED_BATCH_SIZE, BoundedTextRead,
+    CancellationToken, DenseAnchorInput, DenseAnchorInputReuseMetadata,
+    EmbeddingProfileContractDto, FileInfo, GraphEdge, GraphNode, GraphNodeId, HashMap, HashSet,
+    IndexPublicationRecord, IndexingPhaseTimings, Instant, LlmSymbolDoc, LlmSymbolDocStats, Path,
+    RetrievalFileRole, SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES, SEMANTIC_FILE_TEXT_MAX_BYTES,
+    SearchEngine, SourceIndexPolicy, SourcePolicyExclusionPolicyIdentity, Storage, StoreFileRole,
     SymbolSearchDoc, clamp_u128_to_u32, clamp_usize_to_u32, current_epoch_ms,
     indexing_cancelled_error, is_indexing_cancelled, node_display_name, read_file_text_limited,
     retrieval_file_role_from_path, semantic_doc_language_from_path, semantic_path_aliases,
@@ -360,7 +360,11 @@ pub(super) fn local_symbol_summary(doc: &LlmSymbolDoc) -> String {
     )
 }
 
-pub(super) const LLM_SYMBOL_DOC_SCHEMA_VERSION: u32 = 6;
+/// Version 7 binds source-backed semantic documents to the active source-file
+/// admission cap. A version-6 document cannot prove an over-default file body
+/// was available when it was built, so retained cores must repair it from
+/// source instead of restamping it through `StoredCore` republish.
+pub(super) const LLM_SYMBOL_DOC_SCHEMA_VERSION: u32 = 7;
 pub(super) const LLM_SYMBOL_DOC_VERSION_PREFIX: &str = "semantic_doc_version:";
 #[cfg(test)]
 pub(super) const SEARCH_NODE_BATCH_SIZE: usize = 8_192;
@@ -1320,11 +1324,12 @@ pub(super) fn semantic_graph_dependent_file_ids_by_seed(
 pub(super) fn build_semantic_file_text_cache(
     graph_context: &SemanticDocGraphContext,
     semantic_nodes: &[&GraphNode],
+    max_file_bytes: u64,
 ) -> HashMap<String, Option<String>> {
     build_semantic_file_text_cache_with_limits(
         graph_context,
         semantic_nodes,
-        SEMANTIC_FILE_TEXT_MAX_BYTES,
+        max_file_bytes,
         SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES,
     )
 }
@@ -1355,10 +1360,11 @@ pub(super) fn build_semantic_file_text_cache_with_limits(
 
 pub(super) fn build_semantic_file_text_cache_from_paths(
     file_paths: &HashMap<String, String>,
+    max_file_bytes: u64,
 ) -> HashMap<String, Option<String>> {
     build_semantic_file_text_cache_from_paths_with_limits(
         file_paths,
-        SEMANTIC_FILE_TEXT_MAX_BYTES,
+        max_file_bytes,
         SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES,
     )
 }
@@ -1368,12 +1374,29 @@ pub(super) fn build_semantic_file_text_cache_from_paths_with_limits(
     max_file_bytes: u64,
     max_cache_bytes: usize,
 ) -> HashMap<String, Option<String>> {
+    build_semantic_file_text_cache_from_paths_with_limits_and_reader(
+        file_paths,
+        max_file_bytes,
+        max_cache_bytes,
+        |read_path, read_limit| read_file_text_limited(Path::new(read_path), read_limit),
+    )
+    .0
+}
+
+fn build_semantic_file_text_cache_from_paths_with_limits_and_reader(
+    file_paths: &HashMap<String, String>,
+    max_file_bytes: u64,
+    max_cache_bytes: usize,
+    mut read_file: impl FnMut(&str, u64) -> BoundedTextRead,
+) -> (HashMap<String, Option<String>>, u64) {
     let mut file_paths = file_paths
         .iter()
         .map(|(display_path, read_path)| (display_path.clone(), read_path.clone()))
         .collect::<Vec<_>>();
     file_paths.sort_by(|left, right| left.0.cmp(&right.0));
 
+    let aggregate_byte_cap = u64::try_from(max_cache_bytes).unwrap_or(u64::MAX);
+    let mut bytes_read = 0_u64;
     let mut cached_bytes = 0usize;
     let mut cache_exhausted = false;
     let mut cache = HashMap::with_capacity(file_paths.len());
@@ -1383,12 +1406,32 @@ pub(super) fn build_semantic_file_text_cache_from_paths_with_limits(
             continue;
         }
 
-        let contents = read_file_text_limited(Path::new(&read_path), max_file_bytes)
-            .ok()
-            .flatten();
-        let Some(contents) = contents else {
+        let remaining_bytes = aggregate_byte_cap.saturating_sub(bytes_read.min(aggregate_byte_cap));
+        if remaining_bytes == 0 {
+            cache_exhausted = true;
             cache.insert(display_path, None);
             continue;
+        }
+        let read_limit = max_file_bytes.min(remaining_bytes);
+        let read = read_file(&read_path, read_limit);
+        bytes_read = bytes_read.saturating_add(read.bytes_read());
+        if bytes_read >= aggregate_byte_cap {
+            cache_exhausted = true;
+        }
+
+        let contents = match read {
+            BoundedTextRead::Contents { contents, .. } => contents,
+            BoundedTextRead::LimitExceeded { .. } => {
+                if read_limit < max_file_bytes {
+                    cache_exhausted = true;
+                }
+                cache.insert(display_path, None);
+                continue;
+            }
+            BoundedTextRead::Unreadable { .. } => {
+                cache.insert(display_path, None);
+                continue;
+            }
         };
 
         let body_bytes = contents.len();
@@ -1401,7 +1444,75 @@ pub(super) fn build_semantic_file_text_cache_from_paths_with_limits(
         cached_bytes = cached_bytes.saturating_add(body_bytes);
         cache.insert(display_path, Some(contents));
     }
-    cache
+    // A bounded read uses one byte past its limit to distinguish an exact fit
+    // from growth. Every such byte is charged here, so only the read that
+    // exhausts the aggregate allowance can cross it, and then by one byte.
+    (cache, bytes_read)
+}
+
+#[cfg(test)]
+mod bounded_file_text_cache_tests {
+    use super::*;
+    use std::io::Read;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    struct CountingReader {
+        remaining: usize,
+        byte: u8,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let count = buffer.len().min(self.remaining);
+            buffer[..count].fill(self.byte);
+            self.remaining -= count;
+            self.bytes_read.fetch_add(count, Ordering::SeqCst);
+            Ok(count)
+        }
+    }
+
+    #[test]
+    fn semantic_cache_charges_invalid_text_before_aggregate_overflow() {
+        let file_paths = HashMap::from([
+            ("a.rs".to_string(), "invalid".to_string()),
+            ("b.rs".to_string(), "oversized".to_string()),
+            ("c.rs".to_string(), "unreached".to_string()),
+        ]);
+        let aggregate_cap = 7usize;
+        let actual_bytes_read = Arc::new(AtomicUsize::new(0));
+        let observed_bytes_read = Arc::clone(&actual_bytes_read);
+
+        let (cache, charged_bytes) =
+            build_semantic_file_text_cache_from_paths_with_limits_and_reader(
+                &file_paths,
+                64,
+                aggregate_cap,
+                |read_path, read_limit| {
+                    let (remaining, byte) = match read_path {
+                        "invalid" => (4, 0xff),
+                        "oversized" => (64, b'x'),
+                        "unreached" => panic!("aggregate exhaustion must stop later reads"),
+                        _ => panic!("unexpected read path: {read_path}"),
+                    };
+                    crate::support::read_text_limited(
+                        CountingReader {
+                            remaining,
+                            byte,
+                            bytes_read: Arc::clone(&observed_bytes_read),
+                        },
+                        read_limit,
+                    )
+                },
+            );
+
+        assert_eq!(actual_bytes_read.load(Ordering::SeqCst), aggregate_cap + 1);
+        assert_eq!(charged_bytes, (aggregate_cap + 1) as u64);
+        assert!(cache.values().all(Option::is_none));
+    }
 }
 
 pub(super) fn edge_digest_for_edges(edges: &[GraphEdge], limit: usize) -> Vec<String> {
@@ -2674,10 +2785,14 @@ struct SemanticRuntimePolicy {
     max_tokens: usize,
     stream_sort_window_size: usize,
     scope: SemanticDocScope,
+    max_file_bytes: u64,
 }
 
 impl SemanticRuntimePolicy {
-    fn from_runtime(runtime: &codestory_retrieval::SidecarRuntimeConfig) -> Self {
+    fn from_runtime(
+        runtime: &codestory_retrieval::SidecarRuntimeConfig,
+        max_file_bytes: u64,
+    ) -> Self {
         let anchor_batch_size = runtime.retrieval.llm_doc_embed_batch_size;
         Self {
             updated_at_epoch_ms: current_epoch_ms(),
@@ -2690,6 +2805,7 @@ impl SemanticRuntimePolicy {
                 .saturating_mul(runtime.retrieval.stream_sort_window_batches)
                 .max(1),
             scope: semantic_doc_scope_from_value(&runtime.retrieval.semantic_doc_scope),
+            max_file_bytes,
         }
     }
 }
@@ -2888,7 +3004,11 @@ fn prepare_incremental_semantic_context(
     );
     stats.node_lookup_entries = clamp_usize_to_u32(nodes.len());
     let file_cache_started = Instant::now();
-    let file_text_cache = build_semantic_file_text_cache(&graph_context, &inputs.semantic_nodes);
+    let file_text_cache = build_semantic_file_text_cache(
+        &graph_context,
+        &inputs.semantic_nodes,
+        policy.max_file_bytes,
+    );
     Ok(PreparedIncrementalSemanticContext {
         graph: graph_context,
         file_text_cache,
@@ -3070,11 +3190,12 @@ pub(super) fn sync_llm_symbol_projection_for_runtime(
     source_identity: &str,
     cancel_token: Option<&CancellationToken>,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    max_file_bytes: u64,
 ) -> Result<SemanticProjectionStats, ApiError> {
     if is_indexing_cancelled(cancel_token) {
         return Err(indexing_cancelled_error());
     }
-    let policy = SemanticRuntimePolicy::from_runtime(runtime);
+    let policy = SemanticRuntimePolicy::from_runtime(runtime, max_file_bytes);
     tracing::debug!(
         anchor_batch_size = policy.anchor_batch_size,
         "Using dense anchor input publication batch size"
@@ -3151,8 +3272,17 @@ pub(super) fn sync_llm_symbol_projection_for_runtime(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum SemanticProjectionDocumentSource {
-    SourceFiles,
+    SourceFiles { max_file_bytes: u64 },
     StoredCore,
+}
+
+impl SemanticProjectionDocumentSource {
+    fn max_file_bytes(self) -> u64 {
+        match self {
+            Self::SourceFiles { max_file_bytes } => max_file_bytes,
+            Self::StoredCore => SEMANTIC_FILE_TEXT_MAX_BYTES,
+        }
+    }
 }
 
 struct PreparedFullSemanticStream {
@@ -3227,22 +3357,25 @@ fn prepare_full_semantic_stream(
             .map(String::len)
             .sum(),
     );
-    let (file_text_cache, file_cache_build_ns) =
-        if document_source == SemanticProjectionDocumentSource::SourceFiles {
-            let mut file_text_paths = HashMap::new();
-            for file_id in &semantic_file_ids {
-                let Some(display_path) = file_paths.get(file_id) else {
-                    continue;
-                };
-                let read_path = file_read_paths.get(file_id).unwrap_or(display_path).clone();
-                file_text_paths.insert(display_path.clone(), read_path);
-            }
-            let file_cache_started = Instant::now();
-            let cache = build_semantic_file_text_cache_from_paths(&file_text_paths);
-            (cache, file_cache_started.elapsed().as_nanos())
-        } else {
-            (HashMap::new(), 0)
-        };
+    let (file_text_cache, file_cache_build_ns) = if matches!(
+        document_source,
+        SemanticProjectionDocumentSource::SourceFiles { .. }
+    ) {
+        let mut file_text_paths = HashMap::new();
+        for file_id in &semantic_file_ids {
+            let Some(display_path) = file_paths.get(file_id) else {
+                continue;
+            };
+            let read_path = file_read_paths.get(file_id).unwrap_or(display_path).clone();
+            file_text_paths.insert(display_path.clone(), read_path);
+        }
+        let file_cache_started = Instant::now();
+        let cache =
+            build_semantic_file_text_cache_from_paths(&file_text_paths, policy.max_file_bytes);
+        (cache, file_cache_started.elapsed().as_nanos())
+    } else {
+        (HashMap::new(), 0)
+    };
     Ok((
         PreparedFullSemanticStream {
             semantic_kinds,
@@ -3473,7 +3606,7 @@ pub(super) fn sync_full_llm_symbol_projection_streaming_for_runtime(
     if is_indexing_cancelled(cancel_token) {
         return Err(indexing_cancelled_error());
     }
-    let policy = SemanticRuntimePolicy::from_runtime(runtime);
+    let policy = SemanticRuntimePolicy::from_runtime(runtime, document_source.max_file_bytes());
     let existing_docs = storage
         .get_dense_anchor_input_reuse_metadata()
         .map_err(|e| ApiError::internal(format!("Failed to load dense anchor metadata: {e}")))?
@@ -3529,7 +3662,9 @@ pub(super) fn finalize_staged_semantic_docs(
         "core:test-publication",
         cancel_token,
         &test_sidecar_runtime_from_env(),
-        SemanticProjectionDocumentSource::SourceFiles,
+        SemanticProjectionDocumentSource::SourceFiles {
+            max_file_bytes: SourceIndexPolicy::default().byte_cap,
+        },
     )
 }
 
@@ -3596,6 +3731,7 @@ pub(super) fn finalize_staged_semantic_docs_for_runtime(
             source_identity,
             cancel_token,
             runtime,
+            document_source.max_file_bytes(),
         )?;
         stats.node_load_ms = node_load_ms;
         stats.node_load_rows = node_load_rows;

--- a/crates/codestory-runtime/src/support.rs
+++ b/crates/codestory-runtime/src/support.rs
@@ -9,9 +9,8 @@ use std::io::Read;
 use std::path::Path;
 
 pub(crate) use codestory_contracts::config_registry::HYBRID_RETRIEVAL_ENABLED_ENV;
-/// Derived from the source cap: a file the indexer admits must also be
-/// readable as semantic document text, or it lands in the graph with symbols
-/// and is silently absent from every body-backed answer.
+/// Default semantic file-text cap. Product projections use the active
+/// source-index policy retained by the runtime.
 pub(crate) const SEMANTIC_FILE_TEXT_MAX_BYTES: u64 =
     codestory_contracts::workspace::DEFAULT_SOURCE_FILE_BYTE_CAP;
 pub(crate) const SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES: usize = 64 * 1_024 * 1_024;
@@ -364,40 +363,101 @@ fn is_high_signal_literal_token(token: &str) -> bool {
         && token.chars().any(|ch| ch.is_ascii_alphabetic())
 }
 
-pub(crate) fn read_searchable_file_contents(path: &str) -> Option<String> {
-    if let Ok(contents) = std::fs::read_to_string(path) {
-        return Some(contents);
-    }
-
-    #[cfg(windows)]
-    {
-        if let Some(stripped) = path.strip_prefix(r"\\?\")
-            && let Ok(contents) = std::fs::read_to_string(stripped)
-        {
-            return Some(contents);
-        }
-    }
-
-    None
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BoundedTextRead {
+    Contents { contents: String, bytes_read: u64 },
+    LimitExceeded { bytes_read: u64 },
+    Unreadable { bytes_read: u64 },
 }
 
-pub(crate) fn read_file_text_limited(
-    path: &Path,
+impl BoundedTextRead {
+    pub(crate) fn bytes_read(&self) -> u64 {
+        match self {
+            Self::Contents { bytes_read, .. }
+            | Self::LimitExceeded { bytes_read }
+            | Self::Unreadable { bytes_read } => *bytes_read,
+        }
+    }
+}
+
+pub(crate) fn read_searchable_file_contents_limited(path: &str, max_bytes: u64) -> BoundedTextRead {
+    #[cfg(windows)]
+    let fallback_path = path.strip_prefix(r"\\?\");
+    #[cfg(not(windows))]
+    let fallback_path = None;
+
+    read_searchable_file_contents_limited_with(
+        path,
+        fallback_path,
+        max_bytes,
+        |read_path, read_limit| read_file_text_limited(Path::new(read_path), read_limit),
+    )
+}
+
+fn read_searchable_file_contents_limited_with(
+    path: &str,
+    fallback_path: Option<&str>,
     max_bytes: u64,
-) -> std::io::Result<Option<String>> {
-    let metadata = std::fs::metadata(path)?;
+    mut read: impl FnMut(&str, u64) -> BoundedTextRead,
+) -> BoundedTextRead {
+    let primary = read(path, max_bytes);
+    if matches!(primary, BoundedTextRead::Unreadable { bytes_read: 0 })
+        && let Some(fallback_path) = fallback_path
+    {
+        return read(fallback_path, max_bytes);
+    }
+    primary
+}
+
+pub(crate) fn read_file_text_limited(path: &Path, max_bytes: u64) -> BoundedTextRead {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return BoundedTextRead::Unreadable { bytes_read: 0 };
+    };
     if metadata.len() > max_bytes {
-        return Ok(None);
+        return BoundedTextRead::LimitExceeded { bytes_read: 0 };
     }
 
-    let file = std::fs::File::open(path)?;
-    let mut reader = file.take(max_bytes.saturating_add(1));
-    let mut contents = String::new();
-    reader.read_to_string(&mut contents)?;
-    if contents.len() as u64 > max_bytes {
-        return Ok(None);
+    let Ok(file) = std::fs::File::open(path) else {
+        return BoundedTextRead::Unreadable { bytes_read: 0 };
+    };
+    read_text_limited(file, max_bytes)
+}
+
+pub(crate) fn read_text_limited(mut reader: impl Read, max_bytes: u64) -> BoundedTextRead {
+    let mut bytes = Vec::new();
+    let mut bytes_read = 0_u64;
+    let read_limit = max_bytes.saturating_add(1);
+    let mut buffer = [0_u8; 8 * 1_024];
+    while (bytes.len() as u64) < read_limit {
+        let remaining = read_limit.saturating_sub(bytes.len() as u64);
+        let chunk_len = buffer
+            .len()
+            .min(usize::try_from(remaining).unwrap_or(buffer.len()));
+        match reader.read(&mut buffer[..chunk_len]) {
+            Ok(0) => break,
+            Ok(count) => {
+                bytes_read = bytes_read.saturating_add(count as u64);
+                if bytes.try_reserve_exact(count).is_err() {
+                    return BoundedTextRead::Unreadable { bytes_read };
+                }
+                bytes.extend_from_slice(&buffer[..count]);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => {
+                return BoundedTextRead::Unreadable { bytes_read };
+            }
+        }
     }
-    Ok(Some(contents))
+    if bytes_read > max_bytes {
+        return BoundedTextRead::LimitExceeded { bytes_read };
+    }
+    match String::from_utf8(bytes) {
+        Ok(contents) => BoundedTextRead::Contents {
+            contents,
+            bytes_read,
+        },
+        Err(_) => BoundedTextRead::Unreadable { bytes_read },
+    }
 }
 
 pub(crate) fn aggregate_symbol_matches(
@@ -459,6 +519,74 @@ mod tests {
     use codestory_contracts::graph::{
         NodeId as CoreNodeId, Occurrence, OccurrenceKind, SourceLocation,
     };
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    struct CountingReader {
+        remaining: usize,
+        byte: u8,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let count = buffer.len().min(self.remaining);
+            buffer[..count].fill(self.byte);
+            self.remaining -= count;
+            self.bytes_read.fetch_add(count, Ordering::SeqCst);
+            Ok(count)
+        }
+    }
+
+    struct FailingReader {
+        remaining_before_error: usize,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    struct InterruptingReader {
+        contents: &'static [u8],
+        position: usize,
+        interrupt_at: usize,
+        interrupted: bool,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    impl Read for InterruptingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            if !self.interrupted && self.position == self.interrupt_at {
+                self.interrupted = true;
+                return Err(std::io::Error::from(std::io::ErrorKind::Interrupted));
+            }
+            let phase_end = if self.interrupted {
+                self.contents.len()
+            } else {
+                self.interrupt_at
+            };
+            let count = buffer.len().min(phase_end.saturating_sub(self.position));
+            if count == 0 {
+                return Ok(0);
+            }
+            buffer[..count].copy_from_slice(&self.contents[self.position..self.position + count]);
+            self.position += count;
+            self.bytes_read.fetch_add(count, Ordering::SeqCst);
+            Ok(count)
+        }
+    }
+
+    impl Read for FailingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            if self.remaining_before_error == 0 {
+                return Err(std::io::Error::other("hostile read failure"));
+            }
+            let count = buffer.len().min(self.remaining_before_error);
+            buffer[..count].fill(b'x');
+            self.remaining_before_error -= count;
+            self.bytes_read.fetch_add(count, Ordering::SeqCst);
+            Ok(count)
+        }
+    }
 
     fn occurrence(kind: OccurrenceKind, line: u32) -> Occurrence {
         Occurrence {
@@ -486,5 +614,116 @@ mod tests {
 
         assert_eq!(preferred.kind, OccurrenceKind::DEFINITION);
         assert_eq!(preferred.location.start_line, 20);
+    }
+
+    #[test]
+    fn limited_text_reader_stops_after_cap_overflow_sentinel() {
+        let bytes_read = Arc::new(AtomicUsize::new(0));
+        let reader = CountingReader {
+            remaining: 4_096,
+            byte: b'x',
+            bytes_read: Arc::clone(&bytes_read),
+        };
+
+        let outcome = read_text_limited(reader, 32);
+
+        assert_eq!(outcome, BoundedTextRead::LimitExceeded { bytes_read: 33 });
+        assert_eq!(bytes_read.load(Ordering::SeqCst), 33);
+    }
+
+    #[test]
+    fn limited_text_reader_charges_invalid_utf8_and_partial_errors() {
+        let invalid_bytes_read = Arc::new(AtomicUsize::new(0));
+        let invalid = read_text_limited(
+            CountingReader {
+                remaining: 31,
+                byte: 0xff,
+                bytes_read: Arc::clone(&invalid_bytes_read),
+            },
+            64,
+        );
+        assert_eq!(invalid, BoundedTextRead::Unreadable { bytes_read: 31 });
+        assert_eq!(invalid_bytes_read.load(Ordering::SeqCst), 31);
+
+        let failed_bytes_read = Arc::new(AtomicUsize::new(0));
+        let failed = read_text_limited(
+            FailingReader {
+                remaining_before_error: 19,
+                bytes_read: Arc::clone(&failed_bytes_read),
+            },
+            64,
+        );
+        assert_eq!(failed, BoundedTextRead::Unreadable { bytes_read: 19 });
+        assert_eq!(failed_bytes_read.load(Ordering::SeqCst), 19);
+    }
+
+    #[test]
+    fn limited_text_reader_retries_interrupted_reads_without_double_charging() {
+        for interrupt_at in [0, 3] {
+            let bytes_read = Arc::new(AtomicUsize::new(0));
+            let outcome = read_text_limited(
+                InterruptingReader {
+                    contents: b"valid text",
+                    position: 0,
+                    interrupt_at,
+                    interrupted: false,
+                    bytes_read: Arc::clone(&bytes_read),
+                },
+                64,
+            );
+
+            assert_eq!(
+                outcome,
+                BoundedTextRead::Contents {
+                    contents: "valid text".to_string(),
+                    bytes_read: 10,
+                }
+            );
+            assert_eq!(bytes_read.load(Ordering::SeqCst), 10);
+        }
+    }
+
+    #[test]
+    fn searchable_file_fallback_never_retries_after_consuming_bytes() {
+        let mut calls = Vec::new();
+        let outcome = read_searchable_file_contents_limited_with(
+            r"\\?\C:\source.rs",
+            Some(r"C:\source.rs"),
+            64,
+            |path, _| {
+                calls.push(path.to_string());
+                BoundedTextRead::Unreadable { bytes_read: 19 }
+            },
+        );
+
+        assert_eq!(outcome, BoundedTextRead::Unreadable { bytes_read: 19 });
+        assert_eq!(calls, vec![r"\\?\C:\source.rs"]);
+
+        let mut calls = Vec::new();
+        let outcome = read_searchable_file_contents_limited_with(
+            r"\\?\C:\source.rs",
+            Some(r"C:\source.rs"),
+            64,
+            |path, _| {
+                calls.push(path.to_string());
+                if calls.len() == 1 {
+                    BoundedTextRead::Unreadable { bytes_read: 0 }
+                } else {
+                    BoundedTextRead::Contents {
+                        contents: "fallback".to_string(),
+                        bytes_read: 8,
+                    }
+                }
+            },
+        );
+
+        assert_eq!(
+            outcome,
+            BoundedTextRead::Contents {
+                contents: "fallback".to_string(),
+                bytes_read: 8,
+            }
+        );
+        assert_eq!(calls, vec![r"\\?\C:\source.rs", r"C:\source.rs"]);
     }
 }

--- a/crates/codestory-runtime/src/tests.rs
+++ b/crates/codestory-runtime/src/tests.rs
@@ -833,7 +833,7 @@ fn dense_policy_keeps_low_degree_local_functions_and_variables_sparse() {
                 node,
                 &node.serialized_name,
                 Some("src/internal/local.rs"),
-                "semantic_doc_version: 6\nkind: local\n",
+                "semantic_doc_version: 7\nkind: local\n",
                 Some(AccessKind::Private),
             ),
             None
@@ -4068,6 +4068,95 @@ fn semantic_projection_republish_fails_closed_when_stored_document_is_missing() 
         Some(before)
     );
     assert_no_staged_publication_artifacts(&storage_path);
+}
+
+#[test]
+fn previous_semantic_body_contract_requires_source_refresh_before_republish() {
+    const UNPROVEN_SOURCE_BODY_DOC_VERSION: u32 = 6;
+
+    let _env = hybrid_test_env();
+    let workspace = copy_tictactoe_workspace();
+    let storage_path = workspace.path().join(".cache").join("codestory.db");
+    let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
+    controller
+        .open_project_summary_with_storage_path(
+            workspace.path().to_path_buf(),
+            storage_path.clone(),
+        )
+        .expect("open project");
+    controller
+        .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+        .expect("publish current semantic core");
+
+    let mut storage = Storage::open(&storage_path).expect("open current semantic core");
+    let before = storage
+        .get_complete_index_publication()
+        .expect("read current publication")
+        .expect("complete current publication");
+    let mut retained_docs = storage
+        .get_symbol_search_docs_batch_after(None, 10_000)
+        .expect("read current semantic documents");
+    assert!(
+        !retained_docs.is_empty(),
+        "fixture must contain semantic documents"
+    );
+    for doc in &mut retained_docs {
+        assert_eq!(doc.doc_hash, llm_symbol_doc_hash(&doc.doc_text));
+        assert_eq!(doc.policy_version, SEMANTIC_POLICY_VERSION);
+        doc.doc_version = UNPROVEN_SOURCE_BODY_DOC_VERSION;
+    }
+    let retained_count = retained_docs.len();
+    storage
+        .upsert_symbol_search_docs_batch(&retained_docs)
+        .expect("persist retained pre-cap-provenance semantic documents");
+    drop(storage);
+
+    assert!(
+        controller
+            .complete_core_requires_publication_repair(&storage_path)
+            .expect("inspect retained semantic contract"),
+        "a core whose semantic documents cannot prove the active source cap must require repair"
+    );
+    let error = controller
+        .republish_semantic_projections_blocking()
+        .expect_err("StoredCore republish must not restamp the unproven document contract");
+    assert_eq!(error.code, "semantic_projection_migration_required");
+    assert_eq!(
+        Storage::database_complete_index_publication(&storage_path)
+            .expect("read publication after rejected republish"),
+        Some(before)
+    );
+    assert_no_staged_publication_artifacts(&storage_path);
+
+    let repair = controller
+        .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+        .expect("repair retained semantic documents from source");
+    let probe = repair
+        .incremental_plan_probe
+        .as_ref()
+        .expect("source-backed repair must report its plan decision");
+    assert_eq!(
+        probe.outcome,
+        IncrementalPlanProbeOutcomeDto::SemanticDocContractDrift
+    );
+    assert!(
+        repair.symbol_search_docs_written.unwrap_or(0) >= clamp_usize_to_u32(retained_count),
+        "contract drift must rebuild every semantic document from source"
+    );
+    let repaired = Storage::open(&storage_path).expect("open repaired semantic core");
+    assert!(
+        repaired
+            .get_symbol_search_docs_batch_after(None, 10_000)
+            .expect("read repaired semantic documents")
+            .iter()
+            .all(|doc| doc.doc_version == LLM_SYMBOL_DOC_SCHEMA_VERSION)
+    );
+    drop(repaired);
+    assert!(
+        !controller
+            .complete_core_requires_publication_repair(&storage_path)
+            .expect("inspect repaired semantic contract")
+    );
 }
 
 #[test]

--- a/crates/codestory-runtime/src/tests/repo_text.rs
+++ b/crates/codestory-runtime/src/tests/repo_text.rs
@@ -2,10 +2,11 @@ use super::{
     AppController, CoreNodeId, FileInfo, HashMap, HashSet, Instant, Node, NodeKind,
     REPO_TEXT_MAX_FILE_BYTES, REPO_TEXT_SCAN_BYTE_CAP, REPO_TEXT_SCAN_FILE_CAP,
     REPO_TEXT_SCAN_TIME_CAP_MS, RepoTextScanStatsDto, SearchHitOrigin,
-    SearchPlanPromotionStatusDto, SearchRepoTextMode, SearchRequest, Storage,
+    SearchPlanPromotionStatusDto, SearchRepoTextMode, SearchRequest, SourceIndexPolicy, Storage,
     assert_mandatory_retrieval_unavailable, fs, search_plan_anchor_groups,
     search_plan_next_actions, search_plan_terms, search_plan_test_hit, tempdir,
 };
+use crate::repo_text::{RepoTextFileReadOutcome, read_repo_text_file};
 
 #[test]
 fn search_plan_repo_text_owner_identifier_does_not_promote_member_symbol() {
@@ -303,6 +304,7 @@ fn repo_text_ranking_uses_path_and_query_tokens_for_svelte_surfaces() {
     let scan = AppController::collect_repo_text_hits(
         &storage,
         Some(temp.path()),
+        &SourceIndexPolicy::default(),
         "readSnapshot get_snapshot App.svelte invoke",
         5,
         &HashSet::new(),
@@ -368,6 +370,7 @@ fn repo_text_partial_matches_surface_public_page_wiring() {
     let scan = AppController::collect_repo_text_hits(
         &storage,
         Some(temp.path()),
+        &SourceIndexPolicy::default(),
         "how posts comments auth and elsewhere feed connect to public pages",
         10,
         &HashSet::new(),
@@ -412,6 +415,7 @@ fn repo_text_partial_match_requires_distinct_query_terms() {
     let scan = AppController::collect_repo_text_hits(
         &storage,
         Some(temp.path()),
+        &SourceIndexPolicy::default(),
         "posts comments auth",
         10,
         &HashSet::new(),
@@ -458,6 +462,7 @@ fn repo_text_scan_reports_file_cap_on_large_low_match_fixture() {
     let scan = AppController::collect_repo_text_hits(
         &storage,
         Some(temp.path()),
+        &SourceIndexPolicy::default(),
         "needle that is not present",
         10,
         &HashSet::new(),
@@ -541,6 +546,7 @@ fn repo_text_scan_skips_large_files_before_reading_contents() {
     let scan = AppController::collect_repo_text_hits(
         &storage,
         Some(temp.path()),
+        &SourceIndexPolicy::default(),
         "needle",
         10,
         &HashSet::new(),
@@ -552,4 +558,46 @@ fn repo_text_scan_skips_large_files_before_reading_contents() {
     assert_eq!(scan.stats.scanned_byte_count, 0);
     assert_eq!(scan.stats.skipped_large_file_count, 1);
     assert!(!scan.stats.truncated);
+
+    let widened_policy = SourceIndexPolicy::oversized(REPO_TEXT_MAX_FILE_BYTES + 1_024);
+    let scan = AppController::collect_repo_text_hits(
+        &storage,
+        Some(temp.path()),
+        &widened_policy,
+        "needle",
+        10,
+        &HashSet::new(),
+    )
+    .expect("repo text scan with widened source policy");
+
+    assert_eq!(
+        scan.hits.len(),
+        1,
+        "widened admitted source must be searchable"
+    );
+    assert_eq!(scan.stats.skipped_large_file_count, 0);
+}
+
+#[test]
+fn repo_text_file_read_is_bounded_by_remaining_aggregate_budget() {
+    let temp = tempdir().expect("temp dir");
+    let source_path = temp.path().join("grew-after-metadata.rs");
+    fs::write(&source_path, "x".repeat(4_096)).expect("write source");
+
+    let result = read_repo_text_file(source_path.to_string_lossy().as_ref(), 8_192, 31);
+
+    assert_eq!(result.outcome, RepoTextFileReadOutcome::ByteBudgetExceeded);
+    assert_eq!(result.bytes_read, 0);
+}
+
+#[test]
+fn repo_text_file_read_charges_invalid_utf8() {
+    let temp = tempdir().expect("temp dir");
+    let source_path = temp.path().join("invalid.rs");
+    fs::write(&source_path, vec![0xff; 19]).expect("write invalid source");
+
+    let result = read_repo_text_file(source_path.to_string_lossy().as_ref(), 64, 31);
+
+    assert_eq!(result.outcome, RepoTextFileReadOutcome::Unreadable);
+    assert_eq!(result.bytes_read, 19);
 }


### PR DESCRIPTION
## Context

A runtime source-file cap above the 2 MB default admitted files into the core graph while lexical FTS, repository-text scanning, and semantic document bodies still stopped at compile-time constants. The publication could report full readiness even though the admitted file was absent from body-backed retrieval.

This PR is based on `5bb01067e2d44a4ecdefbca37f37620707633aa2`; reviewed head is `3f2d3b686672d99241515a185b6a05998245e07f`.

## What changed

- Lexical shard construction reads the active cap from the pinned complete core/source-policy publication, validates that publication against the selected project identity, and skips its exact policy-excluded paths before scanning.
- Repository-text scanning uses the controller's immutable active `SourceIndexPolicy`.
- Full and incremental semantic projections carry the active cap into bounded source reads.
- Semantic document schema version 7 marks source-backed documents built under this contract. Retained v6 cores require source-backed incremental repair; StoredCore republish rejects them instead of restamping incomplete bodies.
- Per-file and aggregate reads charge bytes consumed on invalid UTF-8 and partial errors, stop at the remaining aggregate allowance plus one overflow sentinel, retry `Interrupted`, and avoid a second Windows path attempt after any bytes were consumed.
- Synthetic strict-retrieval fixtures share one test-only complete-core publisher that stamps the exact project, workspace, publication, and default source-policy identity before lexical hashing. Product fail-closed behavior remains unchanged.

## How to review

1. Start at `lexical_source_policy` and its structural/foreign-core regressions.
2. Trace `SourceIndexPolicy.byte_cap` through repository-text and the two semantic source-backed projection paths.
3. Review the v6-to-v7 readiness/repair test and confirm StoredCore remains source-free.
4. Review the bounded-reader outcomes and aggregate budget tests.
5. Treat `raised_source_file_cap_preserves_lexical_recall` as the end-to-end oracle: the unique token exists only in an over-default source body and must return with `lexical_source` provenance.
6. Confirm `publish_complete_core_fixture` is test-gated and every synthetic replacement publication restamps its policy identity.

## Verification

Product head:

- exact over-default lexical-recall CLI regression
- focused lexical pinned-policy, foreign-core, structural-exclusion, storage-owned, and bounded-reader tests
- focused repository-text aggregate, semantic aggregate, retained-core migration, and nine semantic-republish tests
- runtime, retrieval, and CLI all-target clippy with `-D warnings`
- formatting, retrieval-generalization lint, and diff checks
- repeated independent adversarial full-diff review, including fresh exact-head review after every retained fix and after rebase

Final fixture head:

- `CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-retrieval` — 292 passed, 3 ignored; integration tests green
- `CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-retrieval --features test-support --lib` — 302 passed, 3 ignored
- `CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-retrieval --features test-support --test full_stack_integration` — 3 passed
- exact feature-gated rollback lane — 6 passed
- `CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-runtime --lib agent::retrieval_primary::tests` — 58 passed
- retrieval all-target clippy with `test-support`, plus runtime/CLI all-target clippy with `-D warnings`
- formatting, retrieval-generalization lint, diff, and scratch checks
- two independent exact-diff reviews; final reviewed test-only diff SHA-256 `7bf24ada346df78889bb5bdcba3075b836e5c39560c5c24c5f26630a1b15f75a`

No full-workspace or native Windows gate was run for this support PR. The Windows fallback was covered through the platform-neutral injected seam.

## Risk and migration

The semantic document contract moves from 6 to 7, forcing a source-backed incremental repair before an older core can be republished. The database schema, dense selection policy, release version, and embedding revision do not move. Lexical construction now fails closed when the pinned core/source-policy publication is absent, inconsistent, foreign to the selected workspace, or changes while being read.

Closes #1823
Refs #1179
