### PR TITLE
[v0.17 S2-4] Move process-wide cache operations behind runtime

### DIFF
--- a/crates/codestory-cli/src/app/lifecycle.rs
+++ b/crates/codestory-cli/src/app/lifecycle.rs
@@ -91,7 +91,8 @@ pub(super) fn open_agent_surface(
     let runtime = new_agent_surface_runtime(project, profile, run_id)?;
     let (before, opened) = runtime.ensure_open_with_before(refresh)?;
     ensure_index_ready(&opened, surface)?;
-    codestory_retrieval::ensure_product_embedding_backend_for_runtime(&runtime.sidecar)
+    let retrieval_config = codestory_runtime::RuntimeRetrievalConfig::from(runtime.sidecar.clone());
+    codestory_runtime::ensure_product_embedding_backend_for_runtime(&retrieval_config)
         .map_err(map_embedding_preflight_error)
         .with_context(|| format!("initialize retrieval for {surface}"))?;
     Ok(OpenedAgentSurface {
@@ -120,16 +121,16 @@ fn run_cache_clean(cmd: args::CacheCleanCommand) -> Result<()> {
     preflight_output_file(cmd.output_file.as_deref())?;
     crate::sidecar_runtime::prepare_cache_access();
     if cmd.apply {
-        let report = codestory_retrieval::apply_cache_clean().context("cache clean apply")?;
+        let report = codestory_runtime::apply_cache_clean().context("cache clean apply")?;
         let markdown = render_cache_clean_report_markdown(&report);
         return emit(cmd.format, &report, markdown, cmd.output_file.as_deref());
     }
-    let plan = codestory_retrieval::plan_cache_clean().context("cache clean plan")?;
+    let plan = codestory_runtime::plan_cache_clean().context("cache clean plan")?;
     let markdown = render_cache_clean_plan_markdown(&plan);
     emit(cmd.format, &plan, markdown, cmd.output_file.as_deref())
 }
 
-fn render_cache_clean_plan_markdown(plan: &codestory_retrieval::CacheCleanPlan) -> String {
+fn render_cache_clean_plan_markdown(plan: &codestory_runtime::CacheCleanPlan) -> String {
     let mut markdown = String::new();
     let _ = writeln!(markdown, "# Cache Clean");
     let _ = writeln!(markdown, "dry_run: `{}`", plan.dry_run);
@@ -167,7 +168,7 @@ fn render_cache_clean_plan_markdown(plan: &codestory_retrieval::CacheCleanPlan) 
     markdown
 }
 
-fn render_cache_clean_report_markdown(report: &codestory_retrieval::CacheCleanReport) -> String {
+fn render_cache_clean_report_markdown(report: &codestory_runtime::CacheCleanReport) -> String {
     let mut markdown = render_cache_clean_plan_markdown(&report.plan);
     let _ = writeln!(markdown, "\n## Removed");
     let _ = writeln!(markdown, "removed_bytes: {}", report.removed_bytes);

--- a/crates/codestory-cli/src/app/tests/lifecycle.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle.rs
@@ -1,4 +1,5 @@
 mod agent_surface;
+mod cache_clean;
 mod failures_http;
 mod files_affected;
 mod packet_diagnostics;

--- a/crates/codestory-cli/src/app/tests/lifecycle/agent_surface.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/agent_surface.rs
@@ -148,6 +148,37 @@ fn agent_surface_preflight_preserves_pending_promotion_without_recovery() {
     );
 }
 
+#[test]
+fn agent_surface_embedding_preflight_preserves_cli_error_text() {
+    let _env_lock = crate::config::config_env_test_lock();
+    let _env_snapshot = EnvVarSnapshot::clear(&[
+        "CODESTORY_RETRIEVAL_PROFILE",
+        "CODESTORY_RETRIEVAL_RUN_ID",
+        "CI",
+        "GITHUB_ACTIONS",
+    ]);
+    let (_temp, project_args, _storage_path, _current_schema) = agent_surface_refresh_fixture();
+    let runtime = RuntimeContext::new_inspect_only(&project_args).expect("create runtime");
+    let embedding_cache_root = runtime.sidecar.cache_root.clone();
+    fs::create_dir_all(&embedding_cache_root).expect("create embedding cache root");
+    let marker = embedding_cache_root.join(codestory_retrieval::TEST_EMBEDDING_UNAVAILABLE_MARKER);
+    fs::write(&marker, b"unavailable").expect("write embedding unavailable marker");
+
+    let error =
+        match open_agent_surface(&project_args, None, None, args::RefreshMode::None, "packet") {
+            Ok(_) => panic!("unavailable embedding backend must block packet activation"),
+            Err(error) => error,
+        };
+    assert_eq!(
+        format!("{error:#}"),
+        format!(
+            "initialize retrieval for packet: embedding backend unavailable by test marker in {}",
+            embedding_cache_root.display()
+        )
+    );
+    fs::remove_file(marker).expect("remove embedding unavailable marker");
+}
+
 pub(super) fn assert_order(markdown: &str, first: &str, second: &str) {
     let first_index = markdown
         .find(first)

--- a/crates/codestory-cli/src/app/tests/lifecycle/cache_clean.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/cache_clean.rs
@@ -1,0 +1,351 @@
+use crate::app::lifecycle::run_cache;
+use crate::args::{CacheAction, CacheCleanCommand, CacheCommand, OutputFormat};
+use codestory_retrieval::{CacheCleanPlan, CacheCleanReport};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::Path;
+use tempfile::tempdir;
+
+const OTHER_DIGEST: &str = codestory_retrieval::test_support::CACHE_CLEAN_OTHER_MODEL_DIGEST;
+const LIVE_WORKSPACE: &str = codestory_retrieval::test_support::CACHE_CLEAN_LIVE_WORKSPACE;
+const DEAD_WORKSPACE: &str = codestory_retrieval::test_support::CACHE_CLEAN_DEAD_WORKSPACE;
+const UNREGISTERED_WORKSPACE: &str =
+    codestory_retrieval::test_support::CACHE_CLEAN_UNREGISTERED_WORKSPACE;
+
+fn run_cache_clean(cache_root: &Path, apply: bool, format: OutputFormat, output: &Path) {
+    codestory_retrieval::with_test_cache_root(cache_root, || {
+        run_cache(CacheCommand {
+            action: CacheAction::Clean(CacheCleanCommand {
+                apply,
+                format,
+                output_file: Some(output.to_path_buf()),
+            }),
+        })
+        .expect("run cache clean fixture")
+    });
+}
+
+fn normalized_text(text: &str, cache_root: &Path, worktrees_root: &Path) -> String {
+    text.replace('\\', "/")
+        .replace(
+            &cache_root.to_string_lossy().replace('\\', "/"),
+            "<CACHE_ROOT>",
+        )
+        .replace(
+            &worktrees_root.to_string_lossy().replace('\\', "/"),
+            "<WORKTREES>",
+        )
+        .replace(codestory_llama_sys::MODEL_SHA256, "<CURRENT_MODEL_DIGEST>")
+}
+
+fn normalize_plan_value(value: &mut Value, cache_root: &Path, worktrees_root: &Path) {
+    value["cache_root"] = json!("<CACHE_ROOT>");
+    value["current_model_digest"] = json!("<CURRENT_MODEL_DIGEST>");
+    value["reclaimable_bytes"] = json!("<RECLAIMABLE_BYTES>");
+    for candidate in value["candidates"].as_array_mut().expect("plan candidates") {
+        candidate["bytes"] = match candidate["kind"].as_str() {
+            Some("abandoned_project_cache") => json!("<ABANDONED_BYTES>"),
+            Some("superseded_model_digest") => json!("<SUPERSEDED_BYTES>"),
+            other => panic!("unexpected candidate kind {other:?}"),
+        };
+        let proof = candidate["proof"].as_str().expect("candidate proof");
+        candidate["proof"] = json!(normalized_text(proof, cache_root, worktrees_root));
+    }
+    for retained in value["retained"].as_array_mut().expect("plan retained") {
+        let relative_path = retained["relative_path"]
+            .as_str()
+            .expect("retained relative path");
+        retained["relative_path"] =
+            json!(normalized_text(relative_path, cache_root, worktrees_root));
+        let detail = retained["detail"].as_str().expect("retained detail");
+        retained["detail"] = json!(normalized_text(detail, cache_root, worktrees_root));
+    }
+}
+
+fn normalize_report_value(value: &mut Value, cache_root: &Path, worktrees_root: &Path) {
+    normalize_plan_value(&mut value["plan"], cache_root, worktrees_root);
+    value["removed_bytes"] = json!("<REMOVED_BYTES>");
+    for removal in value["removals"].as_array_mut().expect("report removals") {
+        removal["bytes"] = match removal["kind"].as_str() {
+            Some("abandoned_project_cache") => json!("<ABANDONED_BYTES>"),
+            Some("superseded_model_digest") => json!("<SUPERSEDED_BYTES>"),
+            other => panic!("unexpected removal kind {other:?}"),
+        };
+    }
+}
+
+fn normalized_plan_markdown(
+    markdown: &str,
+    plan: &CacheCleanPlan,
+    cache_root: &Path,
+    worktrees_root: &Path,
+) -> String {
+    let mut markdown = normalized_text(markdown, cache_root, worktrees_root).replace(
+        &format!("reclaimable_bytes: {}", plan.reclaimable_bytes),
+        "reclaimable_bytes: <RECLAIMABLE_BYTES>",
+    );
+    for candidate in &plan.candidates {
+        let replacement = match candidate.kind {
+            codestory_retrieval::CacheCleanKind::AbandonedProjectCache => "<ABANDONED_BYTES>",
+            codestory_retrieval::CacheCleanKind::SupersededModelDigest => "<SUPERSEDED_BYTES>",
+        };
+        markdown = markdown.replace(
+            &format!("`{}` ({} bytes)", candidate.relative_path, candidate.bytes),
+            &format!("`{}` ({replacement} bytes)", candidate.relative_path),
+        );
+    }
+    markdown
+}
+
+fn byte_snapshot(root: &Path) -> BTreeMap<String, String> {
+    fn collect(root: &Path, current: &Path, entries: &mut BTreeMap<String, String>) {
+        let mut paths = std::fs::read_dir(current)
+            .expect("read snapshot directory")
+            .map(|entry| entry.expect("read snapshot entry").path())
+            .collect::<Vec<_>>();
+        paths.sort();
+        for path in paths {
+            let relative = path
+                .strip_prefix(root)
+                .expect("snapshot path below root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let metadata = std::fs::symlink_metadata(&path).expect("snapshot metadata");
+            if metadata.is_dir() {
+                entries.insert(format!("{relative}/"), "directory".into());
+                collect(root, &path, entries);
+            } else {
+                let bytes = std::fs::read(&path).expect("snapshot file bytes");
+                entries.insert(
+                    relative,
+                    format!("{}:{:x}", bytes.len(), Sha256::digest(&bytes)),
+                );
+            }
+        }
+    }
+
+    let mut entries = BTreeMap::new();
+    collect(root, root, &mut entries);
+    entries
+}
+
+fn directory_listing(root: &Path) -> BTreeMap<String, String> {
+    fn collect(root: &Path, current: &Path, entries: &mut BTreeMap<String, String>) {
+        let mut paths = std::fs::read_dir(current)
+            .expect("read listing directory")
+            .map(|entry| entry.expect("read listing entry").path())
+            .collect::<Vec<_>>();
+        paths.sort();
+        for path in paths {
+            let relative = path
+                .strip_prefix(root)
+                .expect("listing path below root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let metadata = std::fs::symlink_metadata(&path).expect("listing metadata");
+            if metadata.is_dir() {
+                entries.insert(format!("{relative}/"), "directory".into());
+                collect(root, &path, entries);
+            } else {
+                entries.insert(relative, format!("file: {} bytes", metadata.len()));
+            }
+        }
+    }
+
+    let mut entries = BTreeMap::new();
+    collect(root, root, &mut entries);
+    entries
+}
+
+fn expected_normalized_plan(dry_run: bool) -> Value {
+    json!({
+        "schema_version": 1,
+        "dry_run": dry_run,
+        "cache_root": "<CACHE_ROOT>",
+        "current_model_digest": "<CURRENT_MODEL_DIGEST>",
+        "reclaimable_bytes": "<RECLAIMABLE_BYTES>",
+        "candidates": [
+            {
+                "kind": "abandoned_project_cache",
+                "relative_path": DEAD_WORKSPACE,
+                "bytes": "<ABANDONED_BYTES>",
+                "proof": "registered project root <WORKTREES>/dead no longer exists"
+            },
+            {
+                "kind": "superseded_model_digest",
+                "relative_path": format!("embedded-models/sha256/{OTHER_DIGEST}"),
+                "bytes": "<SUPERSEDED_BYTES>",
+                "proof": "digest differs from the compiled model digest <CURRENT_MODEL_DIGEST> and no peer holds its materialization lock"
+            }
+        ],
+        "retained": [
+            {
+                "relative_path": LIVE_WORKSPACE,
+                "reason": "live_workspace",
+                "detail": "registered project root <WORKTREES>/live is live_workspace"
+            },
+            {
+                "relative_path": UNREGISTERED_WORKSPACE,
+                "reason": "unregistered_workspace",
+                "detail": "no schema 2 retention marker registers this workspace cache"
+            },
+            {
+                "relative_path": "embedded-models/sha256/<CURRENT_MODEL_DIGEST>",
+                "reason": "current_model_digest",
+                "detail": "digest matches the model compiled into this executable"
+            },
+            {
+                "relative_path": "embedded-models/sha256/not-a-digest",
+                "reason": "unrecognized_entry",
+                "detail": "directory name is not a SHA-256 digest"
+            }
+        ],
+        "errors": []
+    })
+}
+
+#[test]
+fn cache_clean_plan_cli_golden_is_observational_and_non_vacuous() {
+    let fixture = tempdir().expect("cache-clean plan fixture");
+    let cache_root = fixture.path().join("cache");
+    let worktrees_root = fixture.path().join("worktrees");
+    codestory_retrieval::test_support::populate_cache_clean_fixture(&cache_root, &worktrees_root)
+        .expect("populate cache-clean plan fixture");
+    let before = byte_snapshot(&cache_root);
+
+    let json_output = fixture.path().join("plan.json");
+    run_cache_clean(&cache_root, false, OutputFormat::Json, &json_output);
+    let plan: CacheCleanPlan =
+        serde_json::from_slice(&std::fs::read(&json_output).expect("read cache-clean JSON plan"))
+            .expect("parse cache-clean JSON plan");
+    assert_eq!(plan.candidates.len(), 2, "both cleanup proofs must fire");
+    assert_eq!(plan.retained.len(), 4, "all refusal classes must render");
+    assert!(
+        plan.reclaimable_bytes > 12,
+        "dead core bytes must be measured"
+    );
+    assert!(plan.errors.is_empty(), "fixture must be fully observable");
+    let mut normalized = serde_json::to_value(&plan).expect("serialize normalized plan");
+    normalize_plan_value(&mut normalized, &cache_root, &worktrees_root);
+    assert_eq!(normalized, expected_normalized_plan(true));
+
+    let markdown_output = fixture.path().join("plan.md");
+    run_cache_clean(&cache_root, false, OutputFormat::Markdown, &markdown_output);
+    let markdown = normalized_plan_markdown(
+        &std::fs::read_to_string(&markdown_output).expect("read cache-clean Markdown plan"),
+        &plan,
+        &cache_root,
+        &worktrees_root,
+    );
+    assert_eq!(
+        markdown,
+        format!(
+            "# Cache Clean\ndry_run: `true`\ncache_root: `<CACHE_ROOT>`\ncurrent_model_digest: `<CURRENT_MODEL_DIGEST>`\nreclaimable_bytes: <RECLAIMABLE_BYTES>\n\n## Candidates\n- `{DEAD_WORKSPACE}` (<ABANDONED_BYTES> bytes): registered project root <WORKTREES>/dead no longer exists\n- `embedded-models/sha256/{OTHER_DIGEST}` (<SUPERSEDED_BYTES> bytes): digest differs from the compiled model digest <CURRENT_MODEL_DIGEST> and no peer holds its materialization lock\n\n## Retained\n- `{LIVE_WORKSPACE}` [live_workspace]: registered project root <WORKTREES>/live is live_workspace\n- `{UNREGISTERED_WORKSPACE}` [unregistered_workspace]: no schema 2 retention marker registers this workspace cache\n- `embedded-models/sha256/<CURRENT_MODEL_DIGEST>` [current_model_digest]: digest matches the model compiled into this executable\n- `embedded-models/sha256/not-a-digest` [unrecognized_entry]: directory name is not a SHA-256 digest\n"
+        )
+    );
+    assert_eq!(
+        byte_snapshot(&cache_root),
+        before,
+        "cache-clean planning must leave every cache byte unchanged"
+    );
+}
+
+#[test]
+fn cache_clean_apply_cli_matches_owner_report_and_post_state() {
+    let fixture = tempdir().expect("cache-clean apply fixture");
+    let direct_cache = fixture.path().join("direct-cache");
+    let facade_cache = fixture.path().join("facade-cache");
+    let direct_worktrees = fixture.path().join("direct-worktrees");
+    let facade_worktrees = fixture.path().join("facade-worktrees");
+    codestory_retrieval::test_support::populate_cache_clean_fixture(
+        &direct_cache,
+        &direct_worktrees,
+    )
+    .expect("populate direct cleanup fixture");
+    codestory_retrieval::test_support::populate_cache_clean_fixture(
+        &facade_cache,
+        &facade_worktrees,
+    )
+    .expect("populate facade cleanup fixture");
+
+    let direct = codestory_retrieval::with_test_cache_root(&direct_cache, || {
+        codestory_retrieval::apply_cache_clean().expect("apply owner cleanup")
+    });
+    let facade_output = fixture.path().join("facade-report.json");
+    run_cache_clean(&facade_cache, true, OutputFormat::Json, &facade_output);
+    let facade: CacheCleanReport =
+        serde_json::from_slice(&std::fs::read(&facade_output).expect("read facade cleanup report"))
+            .expect("parse facade cleanup report");
+
+    assert_eq!(
+        direct.removals.len(),
+        2,
+        "owner fixture must remove both classes"
+    );
+    assert!(direct.removals.iter().all(|removal| removal.removed));
+    assert!(direct.errors.is_empty(), "owner cleanup must be error-free");
+    assert_eq!(facade.removals.len(), 2, "facade must remove both classes");
+    assert!(facade.removals.iter().all(|removal| removal.removed));
+    assert!(
+        facade.errors.is_empty(),
+        "facade cleanup must be error-free"
+    );
+
+    let mut direct_value = serde_json::to_value(&direct).expect("serialize owner report");
+    normalize_report_value(&mut direct_value, &direct_cache, &direct_worktrees);
+    let mut facade_value = serde_json::to_value(&facade).expect("serialize facade report");
+    normalize_report_value(&mut facade_value, &facade_cache, &facade_worktrees);
+    assert_eq!(facade_value, direct_value);
+    assert_eq!(
+        facade_value,
+        json!({
+            "schema_version": 1,
+            "dry_run": false,
+            "plan": expected_normalized_plan(false),
+            "removed_bytes": "<REMOVED_BYTES>",
+            "removals": [
+                {
+                    "kind": "abandoned_project_cache",
+                    "relative_path": DEAD_WORKSPACE,
+                    "bytes": "<ABANDONED_BYTES>",
+                    "removed": true
+                },
+                {
+                    "kind": "superseded_model_digest",
+                    "relative_path": format!("embedded-models/sha256/{OTHER_DIGEST}"),
+                    "bytes": "<SUPERSEDED_BYTES>",
+                    "removed": true
+                }
+            ],
+            "errors": []
+        })
+    );
+    assert_eq!(
+        directory_listing(&facade_cache),
+        directory_listing(&direct_cache),
+        "runtime-boundary cleanup must preserve the owner's exact post-state listing"
+    );
+    for cache_root in [&direct_cache, &facade_cache] {
+        assert!(!cache_root.join(DEAD_WORKSPACE).exists());
+        assert!(cache_root.join(LIVE_WORKSPACE).is_dir());
+        assert!(cache_root.join(UNREGISTERED_WORKSPACE).is_dir());
+        assert!(
+            cache_root
+                .join("embedded-models/sha256")
+                .join(codestory_llama_sys::MODEL_SHA256)
+                .is_dir()
+        );
+        assert!(
+            !cache_root
+                .join("embedded-models/sha256")
+                .join(OTHER_DIGEST)
+                .exists()
+        );
+        assert!(
+            cache_root
+                .join("retention/global_generation_gc.lock")
+                .is_file()
+        );
+    }
+}

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -239,6 +239,41 @@ fn ensure_retrieval_index_embedding_policy(sidecar: &SidecarRuntimeConfig) -> Re
         .context("retrieval index embedding device policy")
 }
 
+#[cfg(test)]
+mod embedding_preflight_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn retrieval_index_embedding_preflight_preserves_cli_error_text() {
+        let fixture = tempdir().expect("embedding preflight fixture");
+        let cache_root = fixture.path().join("unavailable");
+        std::fs::create_dir_all(&cache_root).expect("create embedding cache root");
+        std::fs::write(
+            cache_root.join(codestory_retrieval::TEST_EMBEDDING_UNAVAILABLE_MARKER),
+            b"unavailable",
+        )
+        .expect("write embedding unavailable marker");
+        let sidecar = codestory_retrieval::with_test_cache_root(&cache_root, || {
+            crate::sidecar_runtime::for_project_with_run_id(
+                fixture.path(),
+                codestory_retrieval::SidecarProfile::Agent,
+                Some("preflight-run"),
+            )
+        });
+
+        let error = ensure_retrieval_index_embedding_policy(&sidecar)
+            .expect_err("unavailable embedding backend must block retrieval index");
+        assert_eq!(
+            format!("{error:#}"),
+            format!(
+                "retrieval index embedding device policy: embedding backend unavailable by test marker in {}",
+                cache_root.display()
+            )
+        );
+    }
+}
+
 fn run_retrieval_index_refresh(
     runtime: &RuntimeContext,
     requested_refresh: RefreshMode,

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -235,7 +235,8 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
 }
 
 fn ensure_retrieval_index_embedding_policy(sidecar: &SidecarRuntimeConfig) -> Result<()> {
-    codestory_retrieval::ensure_product_embedding_backend_for_runtime(sidecar)
+    let retrieval_config = codestory_runtime::RuntimeRetrievalConfig::from(sidecar.clone());
+    codestory_runtime::ensure_product_embedding_backend_for_runtime(&retrieval_config)
         .context("retrieval index embedding device policy")
 }
 

--- a/crates/codestory-retrieval/src/test_support.rs
+++ b/crates/codestory-retrieval/src/test_support.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result, bail};
 use codestory_contracts::api::EmbeddingVectorPublicationIdentityDto;
+use codestory_contracts::owned_artifacts::embedded_model_digest_root;
 use codestory_store::{RetrievalIndexManifest, SourcePolicyExclusionPolicyIdentity, Store};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -77,6 +78,87 @@ pub fn retrieval_manifest_fixture(
         precise_semantic_import_revision: None,
         precise_semantic_import_producer: None,
     }
+}
+
+pub const CACHE_CLEAN_OTHER_MODEL_DIGEST: &str =
+    "1111111111111111111111111111111111111111111111111111111111111111";
+pub const CACHE_CLEAN_LIVE_WORKSPACE: &str = "aaaa000000000001";
+pub const CACHE_CLEAN_DEAD_WORKSPACE: &str = "bbbb000000000002";
+pub const CACHE_CLEAN_UNREGISTERED_WORKSPACE: &str = "cccc000000000003";
+
+/// Populate the complete process-cache cleanup matrix for boundary tests.
+///
+/// The fixture deliberately uses the retrieval owner's real Store and
+/// retention-marker writers. External crates cannot otherwise construct the
+/// positive evidence that distinguishes a retired cache from an unregistered
+/// one.
+pub fn populate_cache_clean_fixture(cache_root: &Path, worktrees_root: &Path) -> Result<()> {
+    std::fs::create_dir_all(cache_root).context("create cache-clean fixture root")?;
+    std::fs::create_dir_all(worktrees_root).context("create cache-clean worktrees root")?;
+    let live_root = worktrees_root.join("live");
+    let dead_root = worktrees_root.join("dead");
+    std::fs::create_dir_all(&live_root).context("create live fixture worktree")?;
+    std::fs::create_dir_all(&dead_root).context("create dead fixture worktree")?;
+
+    register_cache_clean_workspace(
+        cache_root,
+        CACHE_CLEAN_LIVE_WORKSPACE,
+        &live_root,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )?;
+    register_cache_clean_workspace(
+        cache_root,
+        CACHE_CLEAN_DEAD_WORKSPACE,
+        &dead_root,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    )?;
+
+    let unregistered = cache_root.join(CACHE_CLEAN_UNREGISTERED_WORKSPACE);
+    std::fs::create_dir_all(&unregistered).context("create unregistered fixture cache")?;
+    std::fs::write(unregistered.join("codestory.db"), b"unregistered")
+        .context("write unregistered fixture cache")?;
+
+    write_cache_clean_model(cache_root, codestory_llama_sys::MODEL_SHA256, 8)?;
+    write_cache_clean_model(cache_root, CACHE_CLEAN_OTHER_MODEL_DIGEST, 12)?;
+    let unrecognized = embedded_model_digest_root(cache_root).join("not-a-digest");
+    std::fs::create_dir_all(&unrecognized).context("create unrecognized model fixture")?;
+    std::fs::write(unrecognized.join("model.gguf"), b"unrecognized")
+        .context("write unrecognized model fixture")?;
+
+    std::fs::remove_dir_all(dead_root).context("retire dead fixture worktree")?;
+    Ok(())
+}
+
+fn register_cache_clean_workspace(
+    cache_root: &Path,
+    workspace_id: &str,
+    project_root: &Path,
+    input_hash: &str,
+) -> Result<()> {
+    let cache_dir = cache_root.join(workspace_id);
+    std::fs::create_dir_all(&cache_dir).context("create registered fixture cache")?;
+    drop(Store::open(cache_dir.join("codestory.db")).context("create fixture core store")?);
+
+    let mut manifest = retrieval_manifest_fixture("cache-clean-project", input_hash);
+    manifest.built_at_epoch_ms = 1;
+    let marker = crate::retention::GenerationRetentionMarker::next(
+        workspace_id,
+        project_root,
+        manifest,
+        None,
+        1,
+    )?;
+    let state_file = cache_root.join(crate::config::RETRIEVAL_STATE_FILE);
+    crate::retention::write_retention_marker(&state_file, &marker)?;
+    Ok(())
+}
+
+fn write_cache_clean_model(cache_root: &Path, digest: &str, bytes: usize) -> Result<PathBuf> {
+    let directory = embedded_model_digest_root(cache_root).join(digest);
+    std::fs::create_dir_all(&directory).context("create fixture model digest")?;
+    let path = directory.join("model.gguf");
+    std::fs::write(&path, vec![b'm'; bytes]).context("write fixture model bytes")?;
+    Ok(path)
 }
 
 /// Publish a strict, zero-dense query fixture with the same vector-generation evidence required

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -332,7 +332,8 @@ pub use repository_identity::{
 pub use retrieval_boundary::{
     CacheCleanPlan, CacheCleanReport, ProcessOwnerState, ProcessStartProbe,
     RetrievalProcessDefaults, RetrievalRuntimeDefaults, RetrievalRuntimeOverrides,
-    RetrievalStatusReport, RuntimeRetrievalConfig, RuntimeRetrievalProfile,
+    RetrievalStatusReport, RuntimeRetrievalConfig, RuntimeRetrievalProfile, apply_cache_clean,
+    ensure_product_embedding_backend_for_runtime, plan_cache_clean,
 };
 pub(crate) use search_runtime::SearchEngine;
 

--- a/crates/codestory-runtime/src/retrieval_boundary.rs
+++ b/crates/codestory-runtime/src/retrieval_boundary.rs
@@ -167,11 +167,29 @@ impl From<codestory_retrieval::SidecarRuntimeConfig> for RuntimeRetrievalConfig 
     }
 }
 
+/// Plan process-wide cache cleanup without mutating the cache tree.
+pub fn plan_cache_clean() -> anyhow::Result<CacheCleanPlan> {
+    codestory_retrieval::plan_cache_clean()
+}
+
+/// Apply process-wide cache cleanup under the retrieval owner's global lock.
+pub fn apply_cache_clean() -> anyhow::Result<CacheCleanReport> {
+    codestory_retrieval::apply_cache_clean()
+}
+
+/// Initialize and validate the embedding backend selected by this runtime.
+pub fn ensure_product_embedding_backend_for_runtime(
+    config: &RuntimeRetrievalConfig,
+) -> anyhow::Result<()> {
+    codestory_retrieval::ensure_product_embedding_backend_for_runtime(config.as_inner())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::RuntimeProcessConfig;
     use codestory_contracts::workspace::SourceIndexPolicy;
+    use std::collections::BTreeMap;
     use tempfile::tempdir;
 
     fn assert_structurally_equal(
@@ -401,5 +419,152 @@ mod tests {
             assert_eq!(RuntimeRetrievalProfile::from(direct), wrapped);
             assert_eq!(wrapped.as_str(), label);
         }
+    }
+
+    fn runtime_config_for_cache(
+        project_root: &Path,
+        cache_root: &Path,
+        profile: RuntimeRetrievalProfile,
+        run_id: Option<&str>,
+    ) -> RuntimeRetrievalConfig {
+        let defaults = RetrievalProcessDefaults::new(
+            cache_root.to_path_buf(),
+            RetrievalRuntimeDefaults::default(),
+        );
+        RuntimeRetrievalConfig::for_project_profile_with_process_defaults(
+            Some(project_root),
+            profile,
+            run_id,
+            &defaults,
+            &RetrievalRuntimeOverrides::default(),
+        )
+    }
+
+    fn error_chain(error: &anyhow::Error) -> Vec<String> {
+        error.chain().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn embedding_preflight_preserves_selected_configuration_and_error_chain() {
+        let fixture = tempdir().expect("runtime embedding preflight fixture");
+        let available_root = fixture.path().join("available");
+        let unavailable_root = fixture.path().join("unavailable");
+        std::fs::create_dir_all(&available_root).expect("create available embedding root");
+        std::fs::create_dir_all(&unavailable_root).expect("create unavailable embedding root");
+        std::fs::write(
+            unavailable_root.join(codestory_retrieval::TEST_EMBEDDING_UNAVAILABLE_MARKER),
+            b"unavailable",
+        )
+        .expect("write embedding unavailable marker");
+
+        for (profile, run_id) in [
+            (RuntimeRetrievalProfile::Local, None),
+            (RuntimeRetrievalProfile::Agent, Some("selected-agent-run")),
+        ] {
+            let available =
+                runtime_config_for_cache(fixture.path(), &available_root, profile, run_id);
+            codestory_retrieval::with_test_cache_root(&unavailable_root, || {
+                codestory_retrieval::ensure_product_embedding_backend_for_runtime(
+                    available.as_inner(),
+                )
+                .expect("owner preflight must use the selected available root");
+                ensure_product_embedding_backend_for_runtime(&available)
+                    .expect("runtime preflight must use the selected available root");
+            });
+
+            let unavailable =
+                runtime_config_for_cache(fixture.path(), &unavailable_root, profile, run_id);
+            codestory_retrieval::with_test_cache_root(&available_root, || {
+                let direct = codestory_retrieval::ensure_product_embedding_backend_for_runtime(
+                    unavailable.as_inner(),
+                )
+                .expect_err("owner preflight must use the selected unavailable root");
+                let facade = ensure_product_embedding_backend_for_runtime(&unavailable)
+                    .expect_err("runtime preflight must use the selected unavailable root");
+                assert_eq!(error_chain(&facade), error_chain(&direct));
+                assert_eq!(facade.to_string(), direct.to_string());
+                assert!(
+                    facade
+                        .to_string()
+                        .contains(&unavailable_root.display().to_string())
+                );
+            });
+        }
+    }
+
+    fn directory_listing(root: &Path) -> BTreeMap<String, String> {
+        fn collect(root: &Path, current: &Path, entries: &mut BTreeMap<String, String>) {
+            let mut paths = std::fs::read_dir(current)
+                .expect("read cleanup listing")
+                .map(|entry| entry.expect("read cleanup entry").path())
+                .collect::<Vec<_>>();
+            paths.sort();
+            for path in paths {
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("cleanup entry below root")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                let metadata = std::fs::symlink_metadata(&path).expect("cleanup metadata");
+                if metadata.is_dir() {
+                    entries.insert(format!("{relative}/"), "directory".into());
+                    collect(root, &path, entries);
+                } else {
+                    entries.insert(relative, format!("file: {} bytes", metadata.len()));
+                }
+            }
+        }
+
+        let mut entries = BTreeMap::new();
+        collect(root, root, &mut entries);
+        entries
+    }
+
+    #[test]
+    fn cache_clean_functions_preserve_owner_plan_report_and_post_state() {
+        let fixture = tempdir().expect("runtime cache-clean fixture");
+        let cache_root = fixture.path().join("cache");
+        let worktrees_root = fixture.path().join("worktrees");
+        codestory_retrieval::test_support::populate_cache_clean_fixture(
+            &cache_root,
+            &worktrees_root,
+        )
+        .expect("populate direct cache-clean fixture");
+
+        let (direct_plan, facade_plan, direct_report) =
+            codestory_retrieval::with_test_cache_root(&cache_root, || {
+                let direct_plan =
+                    codestory_retrieval::plan_cache_clean().expect("owner cleanup plan");
+                let facade_plan = plan_cache_clean().expect("runtime cleanup plan");
+                let direct_report =
+                    codestory_retrieval::apply_cache_clean().expect("owner cleanup apply");
+                (direct_plan, facade_plan, direct_report)
+            });
+        assert_eq!(facade_plan, direct_plan);
+        assert_eq!(
+            direct_plan.candidates.len(),
+            2,
+            "both proof classes must fire"
+        );
+        assert_eq!(
+            direct_report.removals.len(),
+            2,
+            "both proof classes must apply"
+        );
+        let direct_post_state = directory_listing(&cache_root);
+
+        std::fs::remove_dir_all(&cache_root).expect("reset cache-clean fixture root");
+        std::fs::remove_dir_all(&worktrees_root).expect("reset cache-clean worktrees root");
+        codestory_retrieval::test_support::populate_cache_clean_fixture(
+            &cache_root,
+            &worktrees_root,
+        )
+        .expect("repopulate runtime cache-clean fixture");
+        let facade_report = codestory_retrieval::with_test_cache_root(&cache_root, || {
+            apply_cache_clean().expect("runtime cleanup apply")
+        });
+
+        assert_eq!(facade_report, direct_report);
+        assert_eq!(directory_listing(&cache_root), direct_post_state);
     }
 }


### PR DESCRIPTION
## Context

The CLI still invoked three process-wide retrieval operations directly after the runtime configuration, status, and process-identity boundaries landed: cache-clean planning, cache-clean application, and embedding-backend preflight.

This PR is based on `7f45f1179659e1b552d82659b279c02ca79ddd3e`; reviewed head is `143605f9769bb3d120f1fc29b06d6599686e87e1`.

## What changed

- Added runtime-owned free-function facades for cache-clean planning, cache-clean application, and selected-configuration embedding preflight.
- Retargeted the four release CLI call sites in lifecycle and retrieval-index flows.
- Kept cache cleanup outside `ActivationService`; it is process-wide and has no project activation target.
- Added a fixed two-class cleanup fixture plus oracle-first CLI goldens and runtime differentials.

## How to review

1. Review oracle commit `e827060f` first. It contains no runtime API or production call move.
2. Check the fixed cleanup tree: live, dead, unregistered, current-model, superseded-model, and unrecognized entries all remain visible in the assertions.
3. Confirm dry-run preserves the cache tree byte-for-byte and apply compares both the complete report and recursive post-state.
4. Trace the Local and Agent selected-config embedding matrix and exact anyhow/CLI context chains.
5. Confirm the remaining direct retrieval references are the declared S2-5/S2-6 remainder.

## Verification

- runtime retrieval-boundary tests — 4 passed
- CLI cache-clean tests — 3 passed
- CLI embedding-preflight error-text tests — 2 passed
- retrieval cache-clean owner tests — 13 passed
- `cargo test --locked -p codestory-cli --test architecture_contracts` — 38 passed
- retrieval/runtime/CLI all-target clippy with `-D warnings`
- formatting, retrieval-generalization lint, diff, and scratch checks
- two independent exact-head reviews after rebase; full diff SHA-256 `c9d47bf2561d201e52da64f511be60d18f55ba7a232f3cc55715d7308415bb92`
- both rebased commits are patch-identical to the accepted pre-integration versions

No full-workspace or native-host gate was run for this support slice.

## Risk and follow-up

The runtime functions are literal facades and add no error context, so owner error chains remain unchanged. The CLI still constructs raw retrieval configuration and still owns rollback, inventory, query, and finalization references; those are the declared S2-5/S2-6 slices.

Closes #1838
Refs #1692
Refs #1179
