### PR TITLE
[v0.17 S2-5] Move CLI retrieval operations behind runtime

### DIFF
--- a/crates/codestory-cli/src/app/diagnostics/doctor.rs
+++ b/crates/codestory-cli/src/app/diagnostics/doctor.rs
@@ -139,14 +139,12 @@ pub(in crate::app) fn build_doctor_output(
 /// point so inspecting a project can never migrate or recover it.
 fn observe_retained_rollback(
     runtime: &RuntimeContext,
-) -> Option<codestory_retrieval::RetainedRollbackObservation> {
-    codestory_retrieval::observe_retained_rollback_generation(
-        &runtime.project_root,
-        &runtime.storage_path,
-        &runtime.sidecar,
-    )
-    .ok()
-    .flatten()
+) -> Option<codestory_runtime::RetainedRollbackObservation> {
+    runtime
+        .activation
+        .observe_retained_rollback_generation(&runtime.project_root, &runtime.storage_path)
+        .ok()
+        .flatten()
 }
 
 /// Report the rollback lever, and recommend it only when it could help.
@@ -158,7 +156,7 @@ fn observe_retained_rollback(
 fn doctor_rollback_check(
     project: &str,
     sidecar_retrieval: &RetrievalStatusOutput,
-    retained: Option<&codestory_retrieval::RetainedRollbackObservation>,
+    retained: Option<&codestory_runtime::RetainedRollbackObservation>,
     next_commands: &mut Vec<String>,
 ) -> Option<crate::args::DoctorCheckOutput> {
     let retained = retained?;

--- a/crates/codestory-cli/src/app/diagnostics/readiness.rs
+++ b/crates/codestory-cli/src/app/diagnostics/readiness.rs
@@ -66,9 +66,11 @@ pub(in crate::app) fn agent_readiness_sidecar_runtime(
 ) -> codestory_retrieval::SidecarRuntimeConfig {
     crate::sidecar_runtime::for_project_with_run_id(
         project_root,
-        codestory_retrieval::SidecarProfile::Agent,
+        codestory_runtime::RuntimeRetrievalProfile::Agent,
         run_id,
     )
+    .as_raw_config_for_test()
+    .clone()
 }
 
 pub(in crate::app) fn readiness_lane_output(

--- a/crates/codestory-cli/src/app/lifecycle.rs
+++ b/crates/codestory-cli/src/app/lifecycle.rs
@@ -91,8 +91,7 @@ pub(super) fn open_agent_surface(
     let runtime = new_agent_surface_runtime(project, profile, run_id)?;
     let (before, opened) = runtime.ensure_open_with_before(refresh)?;
     ensure_index_ready(&opened, surface)?;
-    let retrieval_config = codestory_runtime::RuntimeRetrievalConfig::from(runtime.sidecar.clone());
-    codestory_runtime::ensure_product_embedding_backend_for_runtime(&retrieval_config)
+    codestory_runtime::ensure_product_embedding_backend_for_runtime(&runtime.sidecar)
         .map_err(map_embedding_preflight_error)
         .with_context(|| format!("initialize retrieval for {surface}"))?;
     Ok(OpenedAgentSurface {

--- a/crates/codestory-cli/src/app/tests/lifecycle/agent_surface.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/agent_surface.rs
@@ -159,7 +159,7 @@ fn agent_surface_embedding_preflight_preserves_cli_error_text() {
     ]);
     let (_temp, project_args, _storage_path, _current_schema) = agent_surface_refresh_fixture();
     let runtime = RuntimeContext::new_inspect_only(&project_args).expect("create runtime");
-    let embedding_cache_root = runtime.sidecar.cache_root.clone();
+    let embedding_cache_root = runtime.sidecar.as_raw_config_for_test().cache_root.clone();
     fs::create_dir_all(&embedding_cache_root).expect("create embedding cache root");
     let marker = embedding_cache_root.join(codestory_retrieval::TEST_EMBEDDING_UNAVAILABLE_MARKER);
     fs::write(&marker, b"unavailable").expect("write embedding unavailable marker");

--- a/crates/codestory-cli/src/app/tests/lifecycle/transport.rs
+++ b/crates/codestory-cli/src/app/tests/lifecycle/transport.rs
@@ -33,7 +33,8 @@ fn ground_and_retrieval_status_retain_the_native_live_probe() -> Result<()> {
         embedding_server_transport::ClientTransportMode::ObserveOnly,
     )?;
     let runtime = sidecar_runtime::local();
-    let client = codestory_retrieval::PerUserEmbeddingClient::for_runtime(&runtime)?;
+    let client =
+        codestory_retrieval::PerUserEmbeddingClient::for_runtime(runtime.as_raw_config_for_test())?;
     if let Err(error) = client.observe() {
         let message = format!("{error:#}");
         assert!(

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -903,7 +903,7 @@ pub(crate) struct RetrievalActivateRollbackCommand {
 /// JSON contract for `retrieval activate-rollback`.
 pub(crate) struct RetrievalActivateRollbackOutput {
     pub(crate) project: String,
-    pub(crate) outcome: codestory_retrieval::RollbackActivationOutcome,
+    pub(crate) outcome: codestory_runtime::RollbackActivationOutcome,
     pub(crate) next_commands: Vec<String>,
 }
 
@@ -911,15 +911,6 @@ pub(crate) struct RetrievalActivateRollbackOutput {
 pub(crate) enum CliSidecarProfile {
     Local,
     Agent,
-}
-
-impl From<CliSidecarProfile> for codestory_retrieval::SidecarProfile {
-    fn from(value: CliSidecarProfile) -> Self {
-        match value {
-            CliSidecarProfile::Local => Self::Local,
-            CliSidecarProfile::Agent => Self::Agent,
-        }
-    }
 }
 
 impl From<CliSidecarProfile> for codestory_runtime::RuntimeRetrievalProfile {

--- a/crates/codestory-cli/src/config.rs
+++ b/crates/codestory-cli/src/config.rs
@@ -47,7 +47,7 @@ pub(crate) struct CliStartupConfig {
     pub(crate) user_home: Option<PathBuf>,
     pub(crate) project_network_config_allowed: bool,
     pub(crate) stdio_cache_root: Option<PathBuf>,
-    pub(crate) sidecar_defaults: codestory_retrieval::SidecarProcessDefaults,
+    pub(crate) sidecar_defaults: codestory_runtime::RetrievalProcessDefaults,
     pub(crate) source_index_policy: SourceIndexPolicy,
 }
 
@@ -297,8 +297,8 @@ fn validate_config_trust_boundary(
 }
 
 impl CliConfig {
-    pub(crate) fn runtime_overrides(&self) -> codestory_retrieval::SidecarRuntimeOverrides {
-        codestory_retrieval::SidecarRuntimeOverrides {
+    pub(crate) fn runtime_overrides(&self) -> codestory_runtime::RetrievalRuntimeOverrides {
+        codestory_runtime::RetrievalRuntimeOverrides {
             hybrid_retrieval_enabled: self.hybrid_retrieval_enabled,
             semantic_doc_scope: self.semantic_doc_scope.clone(),
             semantic_doc_alias_mode: self.semantic_doc_alias_mode.clone(),

--- a/crates/codestory-cli/src/embedding_qualification/worker.rs
+++ b/crates/codestory-cli/src/embedding_qualification/worker.rs
@@ -85,7 +85,7 @@ pub(super) fn run(command: InternalEmbeddingQualificationCommand) -> Result<()> 
     let inclusive_started_ns = crate::embedding_server_transport::inclusive_now_ns()?;
     let started_ns = clock.now_ns();
     let defaults = crate::sidecar_runtime::process_defaults();
-    let runtime = crate::sidecar_runtime::for_project_auto_with_process_defaults(
+    let runtime = codestory_retrieval::SidecarRuntimeConfig::for_project_auto_with_process_defaults(
         &request.project,
         &defaults,
         &SidecarRuntimeOverrides::default(),

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -546,14 +546,572 @@ fn emit_retrieval_gc(
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(not(windows))]
     use crate::args::ProjectArgs;
     use crate::status_wire_test_support as wire;
     use anyhow::anyhow;
-    #[cfg(not(windows))]
     use std::fs;
-    #[cfg(not(windows))]
     use tempfile::tempdir;
+
+    struct LiveOperationFixture {
+        _project: tempfile::TempDir,
+        _core_cache: tempfile::TempDir,
+        args: ProjectArgs,
+        runtime: RuntimeContext,
+        project_id: String,
+        current_generation: String,
+        rollback_generation: String,
+    }
+
+    fn live_operation_fixture() -> LiveOperationFixture {
+        let project = tempdir().expect("operation project");
+        let core_cache = tempdir().expect("operation core cache");
+        fs::write(
+            project.path().join("lib.rs"),
+            "pub fn oracle_anchor_symbol() {}\n",
+        )
+        .expect("write operation source");
+        let args = ProjectArgs {
+            project: project.path().to_path_buf(),
+            cache_dir: Some(core_cache.path().to_path_buf()),
+        };
+        let runtime = RuntimeContext::new_inspect_only(&args).expect("operation runtime");
+        codestory_retrieval::test_support::publish_empty_complete_core_fixture(
+            &runtime.project_root,
+            &runtime.storage_path,
+        )
+        .expect("publish operation core");
+        let (current, rollback) =
+            codestory_retrieval::test_support::publish_retained_rollback_fixture(
+                &runtime.project_root,
+                &runtime.storage_path,
+                &runtime.sidecar,
+            )
+            .expect("publish retained rollback fixture");
+        let project_id = current.project_id.clone();
+        let current_generation = current
+            .sidecar_generation
+            .expect("current fixture generation");
+        let rollback_generation = rollback
+            .manifest
+            .sidecar_generation
+            .expect("rollback fixture generation");
+        LiveOperationFixture {
+            _project: project,
+            _core_cache: core_cache,
+            args,
+            runtime,
+            project_id,
+            current_generation,
+            rollback_generation,
+        }
+    }
+
+    fn read_rendered_operation(
+        emit_json: impl FnOnce(&std::path::Path),
+        emit_markdown: impl FnOnce(&std::path::Path),
+    ) -> (serde_json::Value, String) {
+        let output = tempfile::tempdir().expect("operation output");
+        let json_path = output.path().join("operation.json");
+        let markdown_path = output.path().join("operation.md");
+        emit_json(&json_path);
+        emit_markdown(&markdown_path);
+        let json =
+            serde_json::from_str(&std::fs::read_to_string(json_path).expect("read operation json"))
+                .expect("parse operation json");
+        let markdown = std::fs::read_to_string(markdown_path).expect("read operation markdown");
+        (json, markdown)
+    }
+
+    #[test]
+    fn pre_change_retrieval_inventory_and_apply_execute_real_cleanup() {
+        let retrieval_cache = tempdir().expect("operation retrieval cache");
+        codestory_retrieval::with_test_cache_root(retrieval_cache.path(), || {
+            let fixture = live_operation_fixture();
+            let stale_paths =
+                codestory_retrieval::test_support::write_reclaimable_generation_fixture(
+                    &fixture.runtime.sidecar,
+                    &fixture.project_id,
+                    "cccccccccccccccc",
+                )
+                .expect("write reclaimable generation");
+
+            let inventory_path = retrieval_cache.path().join("inventory.json");
+            run_retrieval_inventory(RetrievalInventoryCommand {
+                project: fixture.args.clone(),
+                apply: false,
+                format: OutputFormat::Json,
+                output_file: Some(inventory_path.clone()),
+            })
+            .expect("run retrieval inventory");
+            let inventory: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(inventory_path).expect("read inventory output"),
+            )
+            .expect("parse inventory output");
+            assert_eq!(inventory["dry_run"], true);
+            assert_eq!(inventory["generation_retention"]["reclaimable_bytes"], 24);
+            assert!(
+                stale_paths.iter().all(|path| path.is_dir()),
+                "dry-run inventory mutated the reclaimable generation"
+            );
+
+            let apply_path = retrieval_cache.path().join("inventory-apply.json");
+            run_retrieval_inventory(RetrievalInventoryCommand {
+                project: fixture.args,
+                apply: true,
+                format: OutputFormat::Json,
+                output_file: Some(apply_path.clone()),
+            })
+            .expect("apply retrieval inventory");
+            let applied: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(apply_path).expect("read inventory apply output"),
+            )
+            .expect("parse inventory apply output");
+            assert_eq!(applied["dry_run"], false);
+            assert_eq!(applied["generation_retention"]["removed_bytes"], 24);
+            assert_eq!(
+                applied["generation_retention"]["remaining_reclaimable_bytes"],
+                0
+            );
+            assert!(
+                stale_paths.iter().all(|path| !path.exists()),
+                "applied inventory left reclaimable generation bytes behind"
+            );
+        });
+    }
+
+    #[test]
+    fn pre_change_retrieval_query_executes_zero_dense_fixture_with_stable_hits() {
+        let retrieval_cache = tempdir().expect("operation retrieval cache");
+        codestory_retrieval::with_test_cache_root(retrieval_cache.path(), || {
+            let fixture = live_operation_fixture();
+            let query = "oracle_anchor_symbol";
+            let direct = codestory_retrieval::execute_retrieval_query_with_cache_for_runtime(
+                codestory_retrieval::QueryRequest {
+                    project_root: &fixture.runtime.project_root,
+                    storage_path: &fixture.runtime.storage_path,
+                    query,
+                    budget_ms: Some(500),
+                    cancelled: None,
+                },
+                &mut codestory_retrieval::RetrievalCache::new(),
+                &fixture.runtime.sidecar,
+            )
+            .expect("execute direct zero-dense query");
+            assert!(
+                direct.hits.iter().any(|hit| {
+                    hit.file_path == "lib.rs"
+                        && hit
+                            .source_excerpt
+                            .as_deref()
+                            .is_some_and(|excerpt| excerpt.contains("oracle_anchor_symbol"))
+                }),
+                "zero-dense fixture did not return the indexed source symbol: {:#?}",
+                direct.hits
+            );
+
+            let output_path = retrieval_cache.path().join("query.json");
+            run_retrieval_query(RetrievalQueryCommand {
+                query: query.into(),
+                project: fixture.args,
+                budget_ms: Some(500),
+                format: OutputFormat::Json,
+                output_file: Some(output_path.clone()),
+            })
+            .expect("run retrieval query");
+            let output: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(output_path).expect("read query output"))
+                    .expect("parse query output");
+            assert!(output["trace"]["elapsed_ms"].as_u64().is_some());
+            assert_eq!(output["trace"]["retrieval_mode"], "full");
+            let direct_hits: serde_json::Value = serde_json::from_str(
+                &serde_json::to_string(&direct.hits).expect("serialize direct hits"),
+            )
+            .expect("parse direct hits");
+            assert_eq!(
+                output["hits"], direct_hits,
+                "CLI query changed zero-dense hits or their order"
+            );
+        });
+    }
+
+    #[test]
+    fn pre_change_rollback_dry_run_and_apply_preserve_publication_semantics() {
+        let retrieval_cache = tempdir().expect("operation retrieval cache");
+        codestory_retrieval::with_test_cache_root(retrieval_cache.path(), || {
+            let fixture = live_operation_fixture();
+            let before = codestory_retrieval::observe_retained_rollback_generation(
+                &fixture.runtime.project_root,
+                &fixture.runtime.storage_path,
+                &fixture.runtime.sidecar,
+            )
+            .expect("observe retained rollback")
+            .expect("retained rollback exists");
+            assert_eq!(
+                before.current_generation.as_deref(),
+                Some(fixture.current_generation.as_str())
+            );
+            assert_eq!(
+                before.rollback_generation.as_deref(),
+                Some(fixture.rollback_generation.as_str())
+            );
+
+            let dry_run_path = retrieval_cache.path().join("rollback-dry-run.json");
+            run_retrieval_activate_rollback(RetrievalActivateRollbackCommand {
+                project: fixture.args.clone(),
+                dry_run: true,
+                format: OutputFormat::Json,
+                output_file: Some(dry_run_path.clone()),
+            })
+            .expect("validate retained rollback");
+            let dry_run: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(dry_run_path).expect("read rollback dry-run output"),
+            )
+            .expect("parse rollback dry-run output");
+            assert_eq!(dry_run["outcome"]["applied"], false);
+            assert_eq!(
+                dry_run["outcome"]["activated_generation"],
+                fixture.rollback_generation
+            );
+            assert_eq!(
+                codestory_retrieval::observe_retained_rollback_generation(
+                    &fixture.runtime.project_root,
+                    &fixture.runtime.storage_path,
+                    &fixture.runtime.sidecar,
+                )
+                .expect("re-observe retained rollback after dry-run"),
+                Some(before)
+            );
+
+            let apply_path = retrieval_cache.path().join("rollback-apply.json");
+            run_retrieval_activate_rollback(RetrievalActivateRollbackCommand {
+                project: fixture.args,
+                dry_run: false,
+                format: OutputFormat::Json,
+                output_file: Some(apply_path.clone()),
+            })
+            .expect("activate retained rollback");
+            let applied: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(apply_path).expect("read rollback apply output"),
+            )
+            .expect("parse rollback apply output");
+            assert_eq!(applied["outcome"]["applied"], true);
+            assert_eq!(
+                applied["outcome"]["activated_generation"],
+                fixture.rollback_generation
+            );
+            assert!(
+                codestory_retrieval::observe_retained_rollback_generation(
+                    &fixture.runtime.project_root,
+                    &fixture.runtime.storage_path,
+                    &fixture.runtime.sidecar,
+                )
+                .expect("observe after rollback activation")
+                .is_none(),
+                "applied rollback must consume the retained pointer"
+            );
+        });
+    }
+
+    #[test]
+    fn pre_change_retrieval_inventory_and_gc_wires_are_frozen() {
+        let inventory = codestory_retrieval::SidecarInventoryReport {
+            dry_run: true,
+            cache_root: "/cache-root".into(),
+            generation_retention: Some(
+                serde_json::from_value(serde_json::json!({
+                    "dry_run": true,
+                    "project_id": "project-fixed",
+                    "pruning_suppressed": false,
+                    "active_bytes": 11,
+                    "rollback_bytes": 13,
+                    "building_bytes": 17,
+                    "retained_bytes": 41,
+                    "reclaimable_bytes": 19,
+                    "bundles": [],
+                    "blocked": [],
+                    "errors": ["fixed inventory warning"]
+                }))
+                .expect("inventory retention plan"),
+            ),
+        };
+        let (inventory_json, inventory_markdown) = read_rendered_operation(
+            |path| {
+                emit_retrieval_inventory(OutputFormat::Json, &inventory, Some(path))
+                    .expect("emit inventory json")
+            },
+            |path| {
+                emit_retrieval_inventory(OutputFormat::Markdown, &inventory, Some(path))
+                    .expect("emit inventory markdown")
+            },
+        );
+        assert_eq!(
+            inventory_json,
+            serde_json::json!({
+                "dry_run": true,
+                "cache_root": "/cache-root",
+                "generation_retention": {
+                    "dry_run": true,
+                    "project_id": "project-fixed",
+                    "pruning_suppressed": false,
+                    "active_bytes": 11,
+                    "rollback_bytes": 13,
+                    "building_bytes": 17,
+                    "retained_bytes": 41,
+                    "reclaimable_bytes": 19,
+                    "bundles": [],
+                    "blocked": [],
+                    "errors": ["fixed inventory warning"]
+                }
+            })
+        );
+        assert_eq!(
+            inventory_markdown,
+            "# Retrieval runtime inventory\n\n- dry_run: true\n- cache_root: `/cache-root`\n- generation_retention_active_bytes: 11\n- generation_retention_rollback_bytes: 13\n- generation_retention_building_bytes: 17\n- generation_retention_retained_bytes: 41\n- generation_retention_reclaimable_bytes: 19\n- generation_retention_pruning_suppressed: false\n- generation_retention_errors: `fixed inventory warning`\n"
+        );
+
+        let gc = codestory_retrieval::SidecarGcReport {
+            dry_run: false,
+            cache_root: "/cache-root".into(),
+            generation_retention: Some(
+                serde_json::from_value(serde_json::json!({
+                    "dry_run": false,
+                    "project_id": "project-fixed",
+                    "pruning_suppressed": false,
+                    "active_bytes": 11,
+                    "rollback_bytes": 13,
+                    "building_bytes": 17,
+                    "retained_bytes": 41,
+                    "reclaimable_bytes": 19,
+                    "removed_bytes": 7,
+                    "remaining_reclaimable_bytes": 12,
+                    "removals": [{
+                        "generation": "old-generation",
+                        "semantic_generation": "old-semantic",
+                        "removed_paths": ["/cache-root/old-generation"],
+                        "semantic_generation_removed": true,
+                        "removed_bytes": 7,
+                        "remaining_reclaimable_bytes": 12,
+                        "errors": []
+                    }],
+                    "errors": ["fixed gc warning"]
+                }))
+                .expect("gc retention report"),
+            ),
+        };
+        let (gc_json, gc_markdown) = read_rendered_operation(
+            |path| emit_retrieval_gc(OutputFormat::Json, &gc, Some(path)).expect("emit gc json"),
+            |path| {
+                emit_retrieval_gc(OutputFormat::Markdown, &gc, Some(path))
+                    .expect("emit gc markdown")
+            },
+        );
+        assert_eq!(
+            gc_json,
+            serde_json::json!({
+                "dry_run": false,
+                "cache_root": "/cache-root",
+                "generation_retention": {
+                    "dry_run": false,
+                    "project_id": "project-fixed",
+                    "pruning_suppressed": false,
+                    "active_bytes": 11,
+                    "rollback_bytes": 13,
+                    "building_bytes": 17,
+                    "retained_bytes": 41,
+                    "reclaimable_bytes": 19,
+                    "removed_bytes": 7,
+                    "remaining_reclaimable_bytes": 12,
+                    "removals": [{
+                        "generation": "old-generation",
+                        "semantic_generation": "old-semantic",
+                        "removed_paths": ["/cache-root/old-generation"],
+                        "semantic_generation_removed": true,
+                        "removed_bytes": 7,
+                        "remaining_reclaimable_bytes": 12,
+                        "errors": []
+                    }],
+                    "errors": ["fixed gc warning"]
+                }
+            })
+        );
+        assert_eq!(
+            gc_markdown,
+            "# Retrieval runtime GC\n\n- dry_run: false\n- cache_root: `/cache-root`\n- generation_retention_active_bytes: 11\n- generation_retention_rollback_bytes: 13\n- generation_retention_building_bytes: 17\n- generation_retention_retained_bytes: 41\n- generation_retention_reclaimable_bytes: 19\n- generation_retention_removed_bytes: 7\n- generation_retention_remaining_reclaimable_bytes: 12\n- generation_retention_pruning_suppressed: false\n- generation_retention_errors: `fixed gc warning`\n"
+        );
+    }
+
+    #[test]
+    fn pre_change_retrieval_query_wire_preserves_hit_order_and_elapsed_type() {
+        let result = codestory_retrieval::QueryResult {
+            publication_identity: None,
+            query: "find fixed symbol".into(),
+            features: codestory_retrieval::classify_query("find fixed symbol"),
+            hits: vec![
+                codestory_retrieval::CandidateHit::lexical_stub("src/first.rs", 0.875),
+                codestory_retrieval::CandidateHit::with_source(
+                    "src/second.rs",
+                    Some("second_symbol".into()),
+                    0.625,
+                    codestory_retrieval::CandidateSource::Semantic,
+                ),
+            ],
+            trace: codestory_retrieval::QueryTrace {
+                retrieval_mode: "full".into(),
+                degraded_reason: None,
+                total_budget_ms: 500,
+                elapsed_ms: 37,
+                cancel_reason: None,
+                cache_hit: false,
+                stages: Vec::new(),
+            },
+        };
+        let (json, markdown) = read_rendered_operation(
+            |path| {
+                emit_retrieval_query(OutputFormat::Json, &result, Some(path))
+                    .expect("emit query json")
+            },
+            |path| {
+                emit_retrieval_query(OutputFormat::Markdown, &result, Some(path))
+                    .expect("emit query markdown")
+            },
+        );
+        assert_eq!(json["trace"]["elapsed_ms"].as_u64(), Some(37));
+        assert_eq!(json["hits"][0]["file_path"], "src/first.rs");
+        assert_eq!(json["hits"][1]["file_path"], "src/second.rs");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "query": "find fixed symbol",
+                "features": {
+                    "raw_query": "find fixed symbol",
+                    "shape": "natural_language",
+                    "token_count": 3,
+                    "has_path_separators": false,
+                    "has_camel_case_token": false,
+                    "has_snake_case_token": false,
+                    "looks_like_qualified_symbol": false
+                },
+                "hits": [{
+                    "file_path": "src/first.rs",
+                    "symbol_name": null,
+                    "start_line": null,
+                    "score": 0.875,
+                    "source": "lexical",
+                    "provenance": ["lexical_source"]
+                }, {
+                    "file_path": "src/second.rs",
+                    "symbol_name": "second_symbol",
+                    "start_line": null,
+                    "score": 0.625,
+                    "source": "semantic"
+                }],
+                "trace": {
+                    "retrieval_mode": "full",
+                    "total_budget_ms": 500,
+                    "elapsed_ms": 37,
+                    "cache_hit": false,
+                    "stages": []
+                }
+            })
+        );
+        assert_eq!(
+            markdown,
+            "# Retrieval query\n\n- query: `find fixed symbol`\n- shape: `NaturalLanguage`\n- retrieval_mode: `full`\n- hits: 2\n- top: src/first.rs (0.875)\n- elapsed_ms: 37\n"
+        );
+    }
+
+    #[test]
+    fn pre_change_rollback_wires_and_typed_refusal_chain_are_frozen() {
+        fn outcome(applied: bool) -> codestory_retrieval::RollbackActivationOutcome {
+            codestory_retrieval::RollbackActivationOutcome {
+                project_id: "project-fixed".into(),
+                applied,
+                previous_generation: Some("current-generation".into()),
+                previous_semantic_generation: "current-semantic".into(),
+                activated_generation: "rollback-generation".into(),
+                activated_semantic_generation: "rollback-semantic".into(),
+                activated_built_at_epoch_ms: 101,
+                rollback_verified_at_epoch_ms: 202,
+                rollback_pointer_retained: false,
+                activated_retrieval_mode: "full".into(),
+            }
+        }
+
+        for applied in [false, true] {
+            let outcome = outcome(applied);
+            let project = "/repo";
+            let next_commands = rollback_activation_next_commands(project, &outcome);
+            let markdown = render_rollback_activation_markdown(project, &outcome, &next_commands);
+            let payload = RetrievalActivateRollbackOutput {
+                project: project.into(),
+                outcome,
+                next_commands,
+            };
+            let (json, emitted_markdown) = read_rendered_operation(
+                |path| {
+                    emit(OutputFormat::Json, &payload, markdown.clone(), Some(path))
+                        .expect("emit rollback json")
+                },
+                |path| {
+                    emit(
+                        OutputFormat::Markdown,
+                        &payload,
+                        markdown.clone(),
+                        Some(path),
+                    )
+                    .expect("emit rollback markdown")
+                },
+            );
+            let expected_commands = if applied {
+                serde_json::json!([
+                    "codestory-cli doctor --project \"/repo\" --format markdown",
+                    "codestory-cli retrieval inventory --project \"/repo\" --apply"
+                ])
+            } else {
+                serde_json::json!(["codestory-cli retrieval activate-rollback --project \"/repo\""])
+            };
+            assert_eq!(
+                json,
+                serde_json::json!({
+                    "project": "/repo",
+                    "outcome": {
+                        "project_id": "project-fixed",
+                        "applied": applied,
+                        "previous_generation": "current-generation",
+                        "previous_semantic_generation": "current-semantic",
+                        "activated_generation": "rollback-generation",
+                        "activated_semantic_generation": "rollback-semantic",
+                        "activated_built_at_epoch_ms": 101,
+                        "rollback_verified_at_epoch_ms": 202,
+                        "rollback_pointer_retained": false,
+                        "activated_retrieval_mode": "full"
+                    },
+                    "next_commands": expected_commands
+                })
+            );
+            let expected_markdown = if applied {
+                "# Retrieval rollback activation\n\n- project: `/repo`\n- project_id: `project-fixed`\n- applied: true\n- previous_generation: `current-generation`\n- activated_generation: `rollback-generation`\n- activated_semantic_generation: `rollback-semantic`\n- activated_retrieval_mode: `full`\n- rollback_pointer_retained: false\n\n## Next\n\n- `codestory-cli doctor --project \"/repo\" --format markdown`\n- `codestory-cli retrieval inventory --project \"/repo\" --apply`\n"
+            } else {
+                "# Retrieval rollback activation\n\n- project: `/repo`\n- project_id: `project-fixed`\n- applied: false\n- previous_generation: `current-generation`\n- activated_generation: `rollback-generation`\n- activated_semantic_generation: `rollback-semantic`\n- activated_retrieval_mode: `full`\n- rollback_pointer_retained: false\n\nValidation only: the current retrieval generation was not changed. Rerun without `--dry-run` to activate.\n\n## Next\n\n- `codestory-cli retrieval activate-rollback --project \"/repo\"`\n"
+            };
+            assert_eq!(emitted_markdown, expected_markdown);
+        }
+
+        let error = annotate_rollback_activation_error(
+            codestory_retrieval::RollbackActivationError::Refused(
+                codestory_retrieval::RollbackActivationRefusal::RollbackEvidenceInvalid {
+                    reason: "fixed evidence mismatch".into(),
+                },
+            ),
+        );
+        assert_eq!(
+            error.chain().map(ToString::to_string).collect::<Vec<_>>(),
+            vec![
+                "retrieval activate-rollback refused: rollback_evidence_invalid",
+                "rollback_evidence_invalid: fixed evidence mismatch",
+            ]
+        );
+    }
 
     fn rendered_status_case(report: &RetrievalStatusReport) -> serde_json::Value {
         let output = tempfile::tempdir().expect("status output");

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -2,11 +2,10 @@ use anyhow::{Context, Result, bail};
 use codestory_contracts::api::IndexMode;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use codestory_retrieval::{
-    FinalizeIndexOutcome, QueryRequest, RetrievalIndexManifest,
-    SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, SidecarRuntimeConfig,
+use codestory_runtime::{
+    FinalizeIndexOutcome, RetrievalIndexManifest, RetrievalStatusReport, RuntimeRetrievalConfig,
+    SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
 };
-use codestory_runtime::RetrievalStatusReport;
 
 use crate::args::{
     CliSidecarProfile, OutputFormat, RefreshMode, RetrievalAction,
@@ -35,13 +34,14 @@ pub(crate) fn run_retrieval(cmd: RetrievalCommand) -> Result<()> {
 fn run_retrieval_activate_rollback(cmd: RetrievalActivateRollbackCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let outcome = codestory_retrieval::activate_retained_rollback_generation(
-        &runtime.project_root,
-        &runtime.storage_path,
-        &runtime.sidecar,
-        !cmd.dry_run,
-    )
-    .map_err(annotate_rollback_activation_error)?;
+    let outcome = runtime
+        .activation
+        .activate_retained_rollback_generation(
+            &runtime.project_root,
+            &runtime.storage_path,
+            !cmd.dry_run,
+        )
+        .map_err(annotate_rollback_activation_error)?;
     let project = crate::display::clean_path_string(&runtime.project_root.to_string_lossy());
     let next_commands = rollback_activation_next_commands(&project, &outcome);
     let markdown = render_rollback_activation_markdown(&project, &outcome, &next_commands);
@@ -58,7 +58,7 @@ fn run_retrieval_activate_rollback(cmd: RetrievalActivateRollbackCommand) -> Res
 /// The refusal is the product answer, not an internal failure, so the code has
 /// to survive into stderr and into any wrapping context a caller adds.
 fn annotate_rollback_activation_error(
-    error: codestory_retrieval::RollbackActivationError,
+    error: codestory_runtime::RollbackActivationError,
 ) -> anyhow::Error {
     let code = error.code();
     anyhow::anyhow!("{error}").context(format!("retrieval activate-rollback refused: {code}"))
@@ -66,7 +66,7 @@ fn annotate_rollback_activation_error(
 
 fn rollback_activation_next_commands(
     project: &str,
-    outcome: &codestory_retrieval::RollbackActivationOutcome,
+    outcome: &codestory_runtime::RollbackActivationOutcome,
 ) -> Vec<String> {
     if outcome.applied {
         return vec![
@@ -81,7 +81,7 @@ fn rollback_activation_next_commands(
 
 fn render_rollback_activation_markdown(
     project: &str,
-    outcome: &codestory_retrieval::RollbackActivationOutcome,
+    outcome: &codestory_runtime::RollbackActivationOutcome,
     next_commands: &[String],
 ) -> String {
     let mut markdown = format!(
@@ -173,36 +173,31 @@ pub(crate) fn run_retrieval_inventory(cmd: RetrievalInventoryCommand) -> Result<
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     if cmd.apply {
-        let report = codestory_retrieval::sidecar_gc_apply_with_storage(
-            &runtime.project_root,
-            &runtime.storage_path,
-        )
-        .context("retrieval inventory apply")?;
+        let report = runtime
+            .activation
+            .apply_retrieval_gc(&runtime.project_root, &runtime.storage_path)
+            .context("retrieval inventory apply")?;
         return emit_retrieval_gc(cmd.format, &report, cmd.output_file.as_deref());
     }
-    let report = codestory_retrieval::sidecar_inventory_with_storage(
-        &runtime.project_root,
-        &runtime.storage_path,
-    )
-    .context("retrieval inventory")?;
+    let report = runtime
+        .activation
+        .retrieval_inventory(&runtime.project_root, &runtime.storage_path)
+        .context("retrieval inventory")?;
     emit_retrieval_inventory(cmd.format, &report, cmd.output_file.as_deref())
 }
 
 fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let result = codestory_retrieval::execute_retrieval_query_with_cache_for_runtime(
-        QueryRequest {
-            project_root: &runtime.project_root,
-            storage_path: &runtime.storage_path,
-            query: &cmd.query,
-            budget_ms: cmd.budget_ms,
-            cancelled: None,
-        },
-        &mut codestory_retrieval::RetrievalCache::new(),
-        &runtime.sidecar,
-    )
-    .context("retrieval query")?;
+    let result = runtime
+        .activation
+        .execute_retrieval_query(
+            &runtime.project_root,
+            &runtime.storage_path,
+            &cmd.query,
+            cmd.budget_ms,
+        )
+        .context("retrieval query")?;
     emit_retrieval_query(cmd.format, &result, cmd.output_file.as_deref())
 }
 
@@ -234,9 +229,8 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
     emit_retrieval_index(cmd.format, &outcome, cmd.output_file.as_deref())
 }
 
-fn ensure_retrieval_index_embedding_policy(sidecar: &SidecarRuntimeConfig) -> Result<()> {
-    let retrieval_config = codestory_runtime::RuntimeRetrievalConfig::from(sidecar.clone());
-    codestory_runtime::ensure_product_embedding_backend_for_runtime(&retrieval_config)
+fn ensure_retrieval_index_embedding_policy(sidecar: &RuntimeRetrievalConfig) -> Result<()> {
+    codestory_runtime::ensure_product_embedding_backend_for_runtime(sidecar)
         .context("retrieval index embedding device policy")
 }
 
@@ -258,7 +252,7 @@ mod embedding_preflight_tests {
         let sidecar = codestory_retrieval::with_test_cache_root(&cache_root, || {
             crate::sidecar_runtime::for_project_with_run_id(
                 fixture.path(),
-                codestory_retrieval::SidecarProfile::Agent,
+                codestory_runtime::RuntimeRetrievalProfile::Agent,
                 Some("preflight-run"),
             )
         });
@@ -316,7 +310,7 @@ pub(crate) fn finalize_retrieval_index_for_runtime(
 
 pub(crate) fn finalize_retrieval_index_for_sidecar_runtime(
     runtime: &RuntimeContext,
-    sidecar: &SidecarRuntimeConfig,
+    sidecar: &RuntimeRetrievalConfig,
 ) -> Result<FinalizeIndexOutcome> {
     let cancelled = AtomicBool::new(false);
     finalize_retrieval_index_for_sidecar_runtime_with_cancel(runtime, sidecar, &cancelled)
@@ -324,7 +318,7 @@ pub(crate) fn finalize_retrieval_index_for_sidecar_runtime(
 
 pub(crate) fn finalize_retrieval_index_for_sidecar_runtime_with_cancel(
     runtime: &RuntimeContext,
-    sidecar: &SidecarRuntimeConfig,
+    sidecar: &RuntimeRetrievalConfig,
     cancelled: &AtomicBool,
 ) -> Result<FinalizeIndexOutcome> {
     if cancelled.load(Ordering::Acquire) {
@@ -332,13 +326,15 @@ pub(crate) fn finalize_retrieval_index_for_sidecar_runtime_with_cancel(
     }
     let opened = runtime.ensure_open(crate::args::RefreshMode::None)?;
     ensure_index_ready(&opened, "retrieval index")?;
-    codestory_retrieval::finalize_index_for_runtime_with_cancel(
-        &runtime.project_root,
-        &runtime.storage_path,
-        sidecar,
-        cancelled,
-    )
-    .context("retrieval index finalize")
+    runtime
+        .activation
+        .finalize_retrieval_index_with_cancel(
+            &runtime.project_root,
+            &runtime.storage_path,
+            sidecar,
+            cancelled,
+        )
+        .context("retrieval index finalize")
 }
 
 fn retrieval_index_should_retry_full_refresh(
@@ -367,8 +363,8 @@ struct RetrievalIndexOutput<'a> {
     manifest: &'a RetrievalIndexManifest,
     degraded_modes: &'a [String],
     scip_stubbed: bool,
-    generation_retention_plan: &'a codestory_retrieval::GenerationRetentionPlan,
-    generation_retention: &'a codestory_retrieval::GenerationRetentionApplyReport,
+    generation_retention_plan: &'a codestory_runtime::GenerationRetentionPlan,
+    generation_retention: &'a codestory_runtime::GenerationRetentionApplyReport,
 }
 
 fn emit_retrieval_index(
@@ -401,7 +397,7 @@ fn emit_retrieval_index(
 
 fn emit_retrieval_query(
     format: OutputFormat,
-    result: &codestory_retrieval::QueryResult,
+    result: &codestory_runtime::QueryResult,
     output_file: Option<&std::path::Path>,
 ) -> Result<()> {
     let top_hit = result
@@ -485,7 +481,7 @@ fn emit_retrieval_status(
 
 fn emit_retrieval_inventory(
     format: OutputFormat,
-    report: &codestory_retrieval::SidecarInventoryReport,
+    report: &codestory_runtime::SidecarInventoryReport,
     output_file: Option<&std::path::Path>,
 ) -> Result<()> {
     let mut markdown = format!(
@@ -514,7 +510,7 @@ fn emit_retrieval_inventory(
 
 fn emit_retrieval_gc(
     format: OutputFormat,
-    report: &codestory_retrieval::SidecarGcReport,
+    report: &codestory_runtime::SidecarGcReport,
     output_file: Option<&std::path::Path>,
 ) -> Result<()> {
     let mut markdown = format!(
@@ -584,7 +580,7 @@ mod tests {
             codestory_retrieval::test_support::publish_retained_rollback_fixture(
                 &runtime.project_root,
                 &runtime.storage_path,
-                &runtime.sidecar,
+                runtime.sidecar.as_raw_config_for_test(),
             )
             .expect("publish retained rollback fixture");
         let project_id = current.project_id.clone();
@@ -629,7 +625,7 @@ mod tests {
             let fixture = live_operation_fixture();
             let stale_paths =
                 codestory_retrieval::test_support::write_reclaimable_generation_fixture(
-                    &fixture.runtime.sidecar,
+                    fixture.runtime.sidecar.as_raw_config_for_test(),
                     &fixture.project_id,
                     "cccccccccccccccc",
                 )
@@ -694,7 +690,7 @@ mod tests {
                     cancelled: None,
                 },
                 &mut codestory_retrieval::RetrievalCache::new(),
-                &fixture.runtime.sidecar,
+                fixture.runtime.sidecar.as_raw_config_for_test(),
             )
             .expect("execute direct zero-dense query");
             assert!(
@@ -742,7 +738,7 @@ mod tests {
             let before = codestory_retrieval::observe_retained_rollback_generation(
                 &fixture.runtime.project_root,
                 &fixture.runtime.storage_path,
-                &fixture.runtime.sidecar,
+                fixture.runtime.sidecar.as_raw_config_for_test(),
             )
             .expect("observe retained rollback")
             .expect("retained rollback exists");
@@ -776,7 +772,7 @@ mod tests {
                 codestory_retrieval::observe_retained_rollback_generation(
                     &fixture.runtime.project_root,
                     &fixture.runtime.storage_path,
-                    &fixture.runtime.sidecar,
+                    fixture.runtime.sidecar.as_raw_config_for_test(),
                 )
                 .expect("re-observe retained rollback after dry-run"),
                 Some(before)
@@ -803,7 +799,7 @@ mod tests {
                 codestory_retrieval::observe_retained_rollback_generation(
                     &fixture.runtime.project_root,
                     &fixture.runtime.storage_path,
-                    &fixture.runtime.sidecar,
+                    fixture.runtime.sidecar.as_raw_config_for_test(),
                 )
                 .expect("observe after rollback activation")
                 .is_none(),

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -13,7 +13,7 @@ use codestory_contracts::config_registry;
 use codestory_runtime::{
     ActivationService, BookmarkService, GroundingService, IndexService, ProjectService,
     PublicOperation, PublicOperationService, ReadOnlyBrowserService, Runtime, RuntimeProcessConfig,
-    TargetResolution,
+    RuntimeRetrievalConfig, RuntimeRetrievalProfile, TargetResolution,
 };
 use serde::Serialize;
 use std::path::{Component, Path, PathBuf};
@@ -76,7 +76,7 @@ pub(crate) struct RuntimeContext {
     pub(crate) context_key: ProjectContextKey,
     pub(crate) cache_root: PathBuf,
     pub(crate) storage_path: PathBuf,
-    pub(crate) sidecar: codestory_retrieval::SidecarRuntimeConfig,
+    pub(crate) sidecar: RuntimeRetrievalConfig,
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) source_index_policy: codestory_contracts::workspace::SourceIndexPolicy,
 }
@@ -95,7 +95,7 @@ struct RuntimeContextConfiguration {
     context_key: ProjectContextKey,
     cache_root: PathBuf,
     storage_path: PathBuf,
-    sidecar: codestory_retrieval::SidecarRuntimeConfig,
+    sidecar: RuntimeRetrievalConfig,
     source_index_policy: codestory_contracts::workspace::SourceIndexPolicy,
 }
 
@@ -159,7 +159,7 @@ impl RuntimeContextConfiguration {
 
     fn with_profile_and_run_id(
         mut self,
-        profile: codestory_retrieval::SidecarProfile,
+        profile: RuntimeRetrievalProfile,
         run_id: Option<&str>,
     ) -> Self {
         self.sidecar =
@@ -171,10 +171,11 @@ impl RuntimeContextConfiguration {
     }
 
     fn build(self) -> RuntimeContext {
-        let runtime = Runtime::new_with_process_config(RuntimeProcessConfig::new(
-            self.sidecar.clone(),
-            self.source_index_policy.clone(),
-        ));
+        let runtime =
+            Runtime::new_with_process_config(RuntimeProcessConfig::new_with_retrieval_config(
+                self.sidecar.clone(),
+                self.source_index_policy.clone(),
+            ));
         let events = runtime.events();
         RuntimeContext {
             activation: runtime.activation_service(),
@@ -299,7 +300,7 @@ impl RuntimeContext {
     ) -> Result<Self> {
         let selected = profile
             .map(Into::into)
-            .unwrap_or(codestory_retrieval::SidecarProfile::Agent);
+            .unwrap_or(RuntimeRetrievalProfile::Agent);
         Ok(
             RuntimeContextConfiguration::resolve(args, startup, None, None)?
                 .with_profile_and_run_id(selected, run_id)
@@ -327,7 +328,7 @@ impl RuntimeContext {
                 Some(&retained.project_identity),
                 Some(&logical),
             )?
-            .with_profile_and_run_id(codestory_retrieval::SidecarProfile::Agent, None)
+            .with_profile_and_run_id(RuntimeRetrievalProfile::Agent, None)
             .context_key,
         ))
     }
@@ -678,10 +679,10 @@ pub(crate) fn map_public_operation<T, U>(
 
 fn runtime_configuration_id(
     cache_root: &Path,
-    sidecar: &codestory_retrieval::SidecarRuntimeConfig,
+    sidecar: &RuntimeRetrievalConfig,
     source_index_policy: &codestory_contracts::workspace::SourceIndexPolicy,
 ) -> String {
-    RuntimeProcessConfig::new(sidecar.clone(), source_index_policy.clone())
+    RuntimeProcessConfig::new_with_retrieval_config(sidecar.clone(), source_index_policy.clone())
         .configuration_id(cache_root)
 }
 
@@ -1525,7 +1526,8 @@ mod tests {
 
         let assert_isolated_paths =
             |runtime: &RuntimeContext, expected_root: &Path, other_root: &Path| {
-                assert_eq!(runtime.sidecar.cache_root.as_path(), expected_root);
+                let sidecar = runtime.sidecar.as_raw_config_for_test();
+                assert_eq!(sidecar.cache_root.as_path(), expected_root);
                 assert_eq!(
                     runtime.storage_path,
                     runtime.cache_root.join("codestory.db")
@@ -1533,11 +1535,11 @@ mod tests {
                 for path in [
                     runtime.cache_root.as_path(),
                     runtime.storage_path.as_path(),
-                    runtime.sidecar.cache_root.as_path(),
-                    runtime.sidecar.layout.lexical_data_dir.as_path(),
-                    runtime.sidecar.layout.semantic_data_dir.as_path(),
-                    runtime.sidecar.layout.scip_artifacts_root.as_path(),
-                    runtime.sidecar.layout.state_file.as_path(),
+                    sidecar.cache_root.as_path(),
+                    sidecar.layout.lexical_data_dir.as_path(),
+                    sidecar.layout.semantic_data_dir.as_path(),
+                    sidecar.layout.scip_artifacts_root.as_path(),
+                    sidecar.layout.state_file.as_path(),
                 ] {
                     assert!(
                         path.starts_with(expected_root),
@@ -1592,6 +1594,7 @@ mod tests {
 
         let retained = runtime
             .sidecar
+            .as_raw_config_for_test()
             .project_identity
             .as_ref()
             .expect("sidecar retains observed project identity");
@@ -1940,13 +1943,13 @@ mod tests {
         codestory_retrieval::test_support::publish_zero_dense_pinned_query_fixture(
             &project,
             &reader.storage_path,
-            &reader.sidecar,
+            reader.sidecar.as_raw_config_for_test(),
         )
         .expect("publish retrieval generation A");
         let retrieval_a = codestory_retrieval::strict_sidecar_status_for_runtime(
             &project,
             Some(&reader.storage_path),
-            reader.sidecar.clone(),
+            reader.sidecar.as_raw_config_for_test().clone(),
         )
         .expect("inspect retrieval generation A");
         assert!(retrieval_a.is_live_ready(), "{retrieval_a:?}");
@@ -1965,7 +1968,7 @@ mod tests {
         let replacement_run_id = "between-pins-run-b".to_string();
         let publisher_project = project.clone();
         let publisher_storage = reader.storage_path.clone();
-        let publisher_runtime = reader.sidecar.clone();
+        let publisher_runtime = reader.sidecar.as_raw_config_for_test().clone();
         let publisher_generation_id = replacement_generation_id.clone();
         let publisher_run_id = replacement_run_id.clone();
         codestory_runtime::set_before_retrieval_pin_test_hook(move || {
@@ -2004,7 +2007,7 @@ mod tests {
         let retrieval_b = codestory_retrieval::strict_sidecar_status_for_runtime(
             &project,
             Some(&reader.storage_path),
-            reader.sidecar.clone(),
+            reader.sidecar.as_raw_config_for_test().clone(),
         )
         .expect("inspect retrieval generation B");
         assert!(retrieval_b.is_live_ready(), "{retrieval_b:?}");

--- a/crates/codestory-cli/src/sidecar_runtime.rs
+++ b/crates/codestory-cli/src/sidecar_runtime.rs
@@ -5,11 +5,12 @@
 //! isolation before the constructor (or startup configuration) can fall back
 //! to the platform `ProjectDirs` cache.
 
+use codestory_runtime::{
+    RetrievalProcessDefaults, RetrievalRuntimeOverrides, RuntimeRetrievalConfig,
+};
 #[cfg(test)]
-use codestory_retrieval::SidecarProfile;
+use codestory_runtime::{RetrievalRuntimeDefaults, RuntimeRetrievalProfile};
 #[cfg(test)]
-use codestory_retrieval::SidecarRuntimeDefaults;
-use codestory_retrieval::{SidecarProcessDefaults, SidecarRuntimeConfig, SidecarRuntimeOverrides};
 use std::path::Path;
 #[cfg(test)]
 use std::path::PathBuf;
@@ -19,6 +20,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Prepare process cache access before any CLI startup or sidecar lookup.
 pub(crate) fn prepare_cache_access() {
     #[cfg(test)]
+    prepare_test_cache_access();
+}
+
+#[cfg(test)]
+fn prepare_test_cache_access() {
     codestory_retrieval::enable_automatic_test_cache_root_for_process();
 }
 
@@ -45,17 +51,17 @@ fn with_default_test_cache_root<T>(task: impl FnOnce() -> T) -> T {
     codestory_retrieval::with_test_cache_root(&root, task)
 }
 
-pub(crate) fn process_defaults() -> SidecarProcessDefaults {
+pub(crate) fn process_defaults() -> RetrievalProcessDefaults {
     prepare_cache_access();
     #[cfg(test)]
     return with_default_test_cache_root(|| {
-        SidecarProcessDefaults::new(
+        RetrievalProcessDefaults::new(
             codestory_retrieval::user_cache_root(),
-            SidecarRuntimeDefaults::from_process_env(),
+            RetrievalRuntimeDefaults::from_process_env(),
         )
     });
     #[cfg(not(test))]
-    codestory_retrieval::sidecar_process_defaults()
+    codestory_runtime::retrieval_process_defaults()
 }
 
 #[cfg(test)]
@@ -64,49 +70,40 @@ pub(crate) fn user_cache_root() -> PathBuf {
 }
 
 #[cfg(test)]
-pub(crate) fn local() -> SidecarRuntimeConfig {
+pub(crate) fn local() -> RuntimeRetrievalConfig {
     let defaults = process_defaults();
-    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+    RuntimeRetrievalConfig::for_project_profile_with_process_defaults(
         None,
-        SidecarProfile::Local,
+        RuntimeRetrievalProfile::Local,
         None,
         &defaults,
-        &SidecarRuntimeOverrides::default(),
+        &RetrievalRuntimeOverrides::default(),
     )
 }
 
 #[cfg(test)]
 pub(crate) fn for_project_with_run_id(
     project_root: &Path,
-    profile: SidecarProfile,
+    profile: RuntimeRetrievalProfile,
     run_id: Option<&str>,
-) -> SidecarRuntimeConfig {
+) -> RuntimeRetrievalConfig {
     let defaults = process_defaults();
-    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+    RuntimeRetrievalConfig::for_project_profile_with_process_defaults(
         Some(project_root),
         profile,
         run_id,
         &defaults,
-        &SidecarRuntimeOverrides::default(),
+        &RetrievalRuntimeOverrides::default(),
     )
-}
-
-pub(crate) fn for_project_auto_with_process_defaults(
-    project_root: &Path,
-    defaults: &SidecarProcessDefaults,
-    overrides: &SidecarRuntimeOverrides,
-) -> SidecarRuntimeConfig {
-    prepare_cache_access();
-    SidecarRuntimeConfig::for_project_auto_with_process_defaults(project_root, defaults, overrides)
 }
 
 pub(crate) fn for_project_auto_with_process_defaults_and_identity(
     project_identity: &codestory_workspace::ProjectIdentityV3,
-    defaults: &SidecarProcessDefaults,
-    overrides: &SidecarRuntimeOverrides,
-) -> SidecarRuntimeConfig {
+    defaults: &RetrievalProcessDefaults,
+    overrides: &RetrievalRuntimeOverrides,
+) -> RuntimeRetrievalConfig {
     prepare_cache_access();
-    SidecarRuntimeConfig::for_project_auto_with_process_defaults_and_identity(
+    RuntimeRetrievalConfig::for_project_auto_with_process_defaults_and_identity(
         project_identity,
         defaults,
         overrides,
@@ -132,7 +129,7 @@ mod tests {
             .expect("gateway should activate a process-unique test cache root");
 
         assert_eq!(cache_root, active_root);
-        assert!(local().layout.state_file.starts_with(&cache_root));
+        assert!(local().status_cache_state_path().starts_with(&cache_root));
     }
 
     #[test]
@@ -147,7 +144,7 @@ mod tests {
                     let first = user_cache_root();
                     let second = user_cache_root();
                     assert_eq!(first, second);
-                    assert!(local().layout.state_file.starts_with(&first));
+                    assert!(local().status_cache_state_path().starts_with(&first));
                     first
                 })
                 .expect("spawn named cache test thread")
@@ -164,7 +161,7 @@ mod tests {
         }
         let (root, state_file) = std::thread::spawn(|| {
             let root = user_cache_root();
-            let state_file = local().layout.state_file;
+            let state_file = local().status_cache_state_path().to_path_buf();
             (root, state_file)
         })
         .join()

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -4713,7 +4713,7 @@ fn stdio_status_cache_key_with_publication(runtime: &RuntimeContext, publication
         ),
         format!(
             "sidecar_state:{}",
-            stdio_path_fingerprint(&runtime.sidecar.layout.state_file)
+            stdio_path_fingerprint(runtime.sidecar.status_cache_state_path())
         ),
         format!(
             "local_refresh_state:{}",
@@ -8770,7 +8770,9 @@ version = "0.11.20"
         // The transport is an adapter: it must publish exactly the backend
         // identity the retrieval layer reports for this context's runtime
         // configuration, reached through the runtime rather than probed here.
-        let expected = codestory_retrieval::embedding_runtime_id_for_runtime(&runtime.sidecar);
+        let expected = codestory_retrieval::embedding_runtime_id_for_runtime(
+            runtime.sidecar.as_raw_config_for_test(),
+        );
         assert!(
             !expected.is_empty(),
             "the product embedding backend identity must be a real value for this assertion to bite"
@@ -8812,14 +8814,15 @@ version = "0.11.20"
         // Equivalence: the adapter must publish the same observation the
         // retrieval layer produces for this context's own sidecar runtime
         // configuration and storage, byte for byte.
-        let expected_engine = serde_json::to_value(
-            codestory_retrieval::probe_infrastructure_health(&runtime.sidecar),
-        )
-        .expect("serialize infrastructure health");
+        let expected_engine =
+            serde_json::to_value(codestory_retrieval::probe_infrastructure_health(
+                runtime.sidecar.as_raw_config_for_test(),
+            ))
+            .expect("serialize infrastructure health");
         let expected_status = codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,
             Some(&runtime.storage_path),
-            runtime.sidecar.clone(),
+            runtime.sidecar.as_raw_config_for_test().clone(),
         )
         .expect("strict sidecar status");
         assert_eq!(observed["engine"], expected_engine);
@@ -8838,8 +8841,10 @@ version = "0.11.20"
         // unavailable-object shape is pinned in
         // `codestory_runtime::activation_status`.
         let expected_embedding_server =
-            match codestory_retrieval::PerUserEmbeddingClient::for_runtime(&runtime.sidecar)
-                .and_then(|client| client.observe())
+            match codestory_retrieval::PerUserEmbeddingClient::for_runtime(
+                runtime.sidecar.as_raw_config_for_test(),
+            )
+            .and_then(|client| client.observe())
             {
                 Ok(Some(snapshot)) => {
                     serde_json::to_value(snapshot).expect("serialize embedding server snapshot")
@@ -10030,7 +10035,7 @@ version = "0.11.20"
         codestory_retrieval::test_support::publish_zero_dense_pinned_query_fixture(
             &active.runtime.project_root,
             &active.runtime.storage_path,
-            &active.runtime.sidecar,
+            active.runtime.sidecar.as_raw_config_for_test(),
         )
         .expect("publish strict zero-dense retrieval fixture");
         active

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -144,6 +144,7 @@ fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
 fn cli_sidecar_construction_stays_behind_test_safe_gateway() {
     let source_root = repo_root().join("crates/codestory-cli/src");
     let gateway_path = source_root.join("sidecar_runtime.rs");
+    let qualification_provider = source_root.join("embedding_qualification/worker.rs");
     let gateway = fs::read_to_string(&gateway_path).expect("read sidecar runtime gateway");
     let activation = gateway
         .find("enable_automatic_test_cache_root_for_process")
@@ -186,6 +187,9 @@ fn cli_sidecar_construction_stays_behind_test_safe_gateway() {
         }
         let source = fs::read_to_string(&path).expect("read CLI source");
         for needle in forbidden {
+            if path == qualification_provider && needle == "SidecarRuntimeConfig::for_project_" {
+                continue;
+            }
             if source.contains(needle) {
                 violations.push(format!("{}: {needle}", path.display()));
             }
@@ -195,6 +199,42 @@ fn cli_sidecar_construction_stays_behind_test_safe_gateway() {
         violations.is_empty(),
         "CLI sidecar constructors must remain behind sidecar_runtime.rs:\n{}",
         violations.join("\n")
+    );
+}
+
+#[test]
+fn ordinary_cli_retrieval_operations_route_through_runtime() {
+    let source_root = repo_root().join("crates/codestory-cli/src");
+    let mut files = Vec::new();
+    collect_rs_files(&source_root, &mut files);
+    let forbidden = [
+        "codestory_retrieval::activate_retained_rollback_generation(",
+        "codestory_retrieval::observe_retained_rollback_generation(",
+        "codestory_retrieval::sidecar_inventory_with_storage(",
+        "codestory_retrieval::sidecar_gc_apply_with_storage(",
+        "codestory_retrieval::execute_retrieval_query_with_cache_for_runtime(",
+        "codestory_retrieval::finalize_index_for_runtime_with_cancel(",
+    ];
+    let mut violations = Vec::new();
+    let mut scanned = 0_usize;
+    for path in files {
+        let source = fs::read_to_string(&path).expect("read CLI source");
+        let source = production_source(&source);
+        scanned += 1;
+        for needle in forbidden {
+            if source.contains(needle) {
+                violations.push(format!("{}: {needle}", path.display()));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "ordinary CLI retrieval operations must route through codestory_runtime:\n{}",
+        violations.join("\n")
+    );
+    assert!(
+        scanned > 20,
+        "CLI retrieval-operation gate scanned only {scanned} files"
     );
 }
 

--- a/crates/codestory-retrieval/src/test_support.rs
+++ b/crates/codestory-retrieval/src/test_support.rs
@@ -1,7 +1,10 @@
 use anyhow::{Context, Result, bail};
 use codestory_contracts::api::EmbeddingVectorPublicationIdentityDto;
 use codestory_contracts::owned_artifacts::embedded_model_digest_root;
-use codestory_store::{RetrievalIndexManifest, SourcePolicyExclusionPolicyIdentity, Store};
+use codestory_store::{
+    RetrievalIndexManifest, RetrievalIndexRollbackRecord, SourcePolicyExclusionPolicyIdentity,
+    Store,
+};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 
@@ -42,6 +45,19 @@ pub fn publish_complete_core_fixture(
         .put_index_publication(publication)
         .context("publish complete core fixture")?;
     Ok(())
+}
+
+/// Create the empty complete core used by cross-crate retrieval fixtures.
+pub fn publish_empty_complete_core_fixture(project_root: &Path, storage_path: &Path) -> Result<()> {
+    let mut storage = Store::open(storage_path).context("open empty complete core fixture")?;
+    let publication = codestory_store::IndexPublicationRecord {
+        generation: 1,
+        generation_id: "11111111-1111-4111-8111-111111111111".into(),
+        run_id: "operation-oracle-run".into(),
+        mode: codestory_store::IndexPublicationMode::Full,
+        published_at_epoch_ms: 1,
+    };
+    publish_complete_core_fixture(&mut storage, project_root, &publication)
 }
 
 pub fn retrieval_manifest_fixture(
@@ -270,6 +286,73 @@ pub fn publish_zero_dense_pinned_query_fixture(
 
     publish_zero_dense_vector_evidence(runtime, &manifest, &publication)?;
     Ok(manifest)
+}
+
+/// Publish two live-ready generations and retain the older one for rollback.
+///
+/// Cross-crate boundary tests use this to exercise the public observation and
+/// activation operations without recreating private vector-evidence details.
+pub fn publish_retained_rollback_fixture(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &crate::SidecarRuntimeConfig,
+) -> Result<(RetrievalIndexManifest, RetrievalIndexRollbackRecord)> {
+    std::fs::write(
+        project_root.join("rollback_old.rs"),
+        "pub fn rollback_old() {}\n",
+    )
+    .context("write retained rollback source")?;
+    let older = publish_zero_dense_pinned_query_fixture(project_root, storage_path, runtime)
+        .context("publish retained rollback generation")?;
+    std::fs::write(
+        project_root.join("rollback_current.rs"),
+        "pub fn rollback_current() {}\n",
+    )
+    .context("write current rollback source")?;
+    let current = publish_zero_dense_pinned_query_fixture(project_root, storage_path, runtime)
+        .context("publish current rollback generation")?;
+    if older.sidecar_generation == current.sidecar_generation {
+        bail!("retained rollback fixture requires distinct generations");
+    }
+    let rollback = RetrievalIndexRollbackRecord {
+        manifest: older,
+        verified_at_epoch_ms: 4_242,
+    };
+    let mut storage =
+        Store::open(storage_path).context("open retained rollback fixture storage")?;
+    storage
+        .publish_retrieval_index_publication(&current, Some(&rollback))
+        .context("arm retained rollback fixture")?;
+    Ok((current, rollback))
+}
+
+/// Add one unprotected generation bundle to an otherwise valid fixture.
+pub fn write_reclaimable_generation_fixture(
+    runtime: &crate::SidecarRuntimeConfig,
+    project_id: &str,
+    suffix: &str,
+) -> Result<Vec<PathBuf>> {
+    let generation = format!("{project_id}-{suffix}");
+    let paths = vec![
+        runtime
+            .layout
+            .lexical_data_dir
+            .join("shards")
+            .join(&generation),
+        runtime.layout.scip_artifacts_root.join(&generation),
+        runtime
+            .layout
+            .semantic_data_dir
+            .join("collections")
+            .join(format!("codestory_{project_id}_{suffix}")),
+    ];
+    for (path, bytes) in paths.iter().zip([7_usize, 8, 9]) {
+        std::fs::create_dir_all(path)
+            .with_context(|| format!("create reclaimable fixture {}", path.display()))?;
+        std::fs::write(path.join("data"), vec![b'x'; bytes])
+            .with_context(|| format!("write reclaimable fixture {}", path.display()))?;
+    }
+    Ok(paths)
 }
 
 /// Publish a replacement core identity and its strict zero-dense retrieval

--- a/crates/codestory-runtime/src/activation_retrieval.rs
+++ b/crates/codestory-runtime/src/activation_retrieval.rs
@@ -1,0 +1,218 @@
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+
+use crate::{
+    ActivationService, FinalizeIndexOutcome, QueryResult, RetainedRollbackObservation,
+    RollbackActivationError, RollbackActivationOutcome, RuntimeRetrievalConfig, SidecarGcReport,
+    SidecarInventoryReport,
+};
+
+impl ActivationService {
+    /// Observe the retained rollback pointer without validating or mutating it.
+    pub fn observe_retained_rollback_generation(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+    ) -> anyhow::Result<Option<RetainedRollbackObservation>> {
+        codestory_retrieval::observe_retained_rollback_generation(
+            project_root,
+            storage_path,
+            self.controller.runtime_config.as_ref(),
+        )
+    }
+
+    /// Validate and optionally activate the retained rollback generation.
+    pub fn activate_retained_rollback_generation(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+        apply: bool,
+    ) -> Result<RollbackActivationOutcome, RollbackActivationError> {
+        codestory_retrieval::activate_retained_rollback_generation(
+            project_root,
+            storage_path,
+            self.controller.runtime_config.as_ref(),
+            apply,
+        )
+    }
+
+    /// Observe immutable retrieval generations and the current retention plan.
+    pub fn retrieval_inventory(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+    ) -> anyhow::Result<SidecarInventoryReport> {
+        codestory_retrieval::sidecar_inventory_with_storage(project_root, storage_path)
+    }
+
+    /// Apply the retrieval owner's bounded generation-retention plan.
+    pub fn apply_retrieval_gc(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+    ) -> anyhow::Result<SidecarGcReport> {
+        codestory_retrieval::sidecar_gc_apply_with_storage(project_root, storage_path)
+    }
+
+    /// Execute one query with a fresh caller-isolated retrieval cache.
+    pub fn execute_retrieval_query(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+        query: &str,
+        budget_ms: Option<u64>,
+    ) -> anyhow::Result<QueryResult> {
+        codestory_retrieval::execute_retrieval_query_with_cache_for_runtime(
+            codestory_retrieval::QueryRequest {
+                project_root,
+                storage_path,
+                query,
+                budget_ms,
+                cancelled: None,
+            },
+            &mut codestory_retrieval::RetrievalCache::new(),
+            self.controller.runtime_config.as_ref(),
+        )
+    }
+
+    /// Finalize retrieval artifacts for the adapter-selected runtime profile.
+    pub fn finalize_retrieval_index_with_cancel(
+        &self,
+        project_root: &Path,
+        storage_path: &Path,
+        config: &RuntimeRetrievalConfig,
+        cancelled: &AtomicBool,
+    ) -> anyhow::Result<FinalizeIndexOutcome> {
+        codestory_retrieval::finalize_index_for_runtime_with_cancel(
+            project_root,
+            storage_path,
+            config.as_inner(),
+            cancelled,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Runtime, RuntimeProcessConfig};
+    use codestory_contracts::workspace::SourceIndexPolicy;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tempfile::tempdir;
+
+    fn error_chain(error: &anyhow::Error) -> Vec<String> {
+        error.chain().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn facade_preserves_observation_query_and_finalize_error_contracts() {
+        let project = tempdir().expect("operation project");
+        let storage = tempdir().expect("operation storage");
+        let storage_path = storage.path().join("codestory.db");
+        let raw = codestory_retrieval::SidecarRuntimeConfig::for_project_profile(
+            Some(project.path()),
+            codestory_retrieval::SidecarProfile::Local,
+        );
+        let runtime = Runtime::new_with_process_config(RuntimeProcessConfig::new(
+            raw.clone(),
+            SourceIndexPolicy::default(),
+        ));
+        let facade = runtime.activation_service();
+
+        let direct_observation = codestory_retrieval::observe_retained_rollback_generation(
+            project.path(),
+            &storage_path,
+            &raw,
+        )
+        .expect("direct observation");
+        let facade_observation = facade
+            .observe_retained_rollback_generation(project.path(), &storage_path)
+            .expect("facade observation");
+        assert_eq!(facade_observation, direct_observation);
+
+        let direct_query = codestory_retrieval::execute_retrieval_query_with_cache_for_runtime(
+            codestory_retrieval::QueryRequest {
+                project_root: project.path(),
+                storage_path: &storage_path,
+                query: "missing",
+                budget_ms: Some(37),
+                cancelled: None,
+            },
+            &mut codestory_retrieval::RetrievalCache::new(),
+            &raw,
+        )
+        .expect_err("missing storage must fail direct query");
+        let facade_query = facade
+            .execute_retrieval_query(project.path(), &storage_path, "missing", Some(37))
+            .expect_err("missing storage must fail facade query");
+        assert_eq!(error_chain(&facade_query), error_chain(&direct_query));
+
+        let selected: RuntimeRetrievalConfig = raw.clone().into();
+        let cancelled = AtomicBool::new(true);
+        let direct_finalize = codestory_retrieval::finalize_index_for_runtime_with_cancel(
+            project.path(),
+            &storage_path,
+            &raw,
+            &cancelled,
+        )
+        .expect_err("cancelled direct finalize must fail");
+        let facade_finalize = facade
+            .finalize_retrieval_index_with_cancel(
+                project.path(),
+                &storage_path,
+                &selected,
+                &cancelled,
+            )
+            .expect_err("cancelled facade finalize must fail");
+        assert_eq!(error_chain(&facade_finalize), error_chain(&direct_finalize));
+        assert!(cancelled.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn facade_preserves_rollback_refusal_and_inventory_results() {
+        let cache = tempdir().expect("operation cache");
+        codestory_retrieval::with_test_cache_root(cache.path(), || {
+            let project = tempdir().expect("operation project");
+            let storage = tempdir().expect("operation storage");
+            let storage_path = storage.path().join("codestory.db");
+            let raw = codestory_retrieval::SidecarRuntimeConfig::for_project_profile(
+                Some(project.path()),
+                codestory_retrieval::SidecarProfile::Local,
+            );
+            let runtime = Runtime::new_with_process_config(RuntimeProcessConfig::new(
+                raw.clone(),
+                SourceIndexPolicy::default(),
+            ));
+            let facade = runtime.activation_service();
+
+            let direct_refusal = codestory_retrieval::activate_retained_rollback_generation(
+                project.path(),
+                &storage_path,
+                &raw,
+                false,
+            )
+            .expect_err("missing publication must refuse direct activation");
+            let facade_refusal = facade
+                .activate_retained_rollback_generation(project.path(), &storage_path, false)
+                .expect_err("missing publication must refuse facade activation");
+            assert_eq!(facade_refusal.code(), direct_refusal.code());
+            assert_eq!(facade_refusal.to_string(), direct_refusal.to_string());
+
+            let direct_inventory =
+                codestory_retrieval::sidecar_inventory_with_storage(project.path(), &storage_path)
+                    .expect("direct inventory");
+            let facade_inventory = facade
+                .retrieval_inventory(project.path(), &storage_path)
+                .expect("facade inventory");
+            assert_eq!(facade_inventory, direct_inventory);
+
+            let direct_gc =
+                codestory_retrieval::sidecar_gc_apply_with_storage(project.path(), &storage_path)
+                    .expect("direct gc");
+            let facade_gc = facade
+                .apply_retrieval_gc(project.path(), &storage_path)
+                .expect("facade gc");
+            assert_eq!(facade_gc, direct_gc);
+        });
+    }
+}

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -38,8 +38,6 @@ use codestory_contracts::language_support::{
     language_support_profile_for_language_name,
 };
 use codestory_indexer::CancellationToken;
-#[cfg(test)]
-use codestory_store::RetrievalIndexManifest;
 use codestory_store::{
     BUILD_EDGE_SEED_BATCH_SIZE, CURRENT_SCHEMA_VERSION, DenseAnchorInput,
     DenseAnchorInputReuseMetadata, FileInfo, FileRole as StoreFileRole, GroundingEdgeKindCount,
@@ -289,6 +287,7 @@ mod path_resolution;
 pub use path_resolution::resolve_project_file_path_from_root;
 mod process_config;
 pub use process_config::RuntimeProcessConfig;
+mod activation_retrieval;
 mod query_language;
 mod repository_identity;
 mod retrieval_boundary;
@@ -330,10 +329,14 @@ pub use repository_identity::{
     REPOSITORY_IDENTITY_SCHEMA_VERSION, RepositoryIdentityReport, inspect_repository_identity,
 };
 pub use retrieval_boundary::{
-    CacheCleanPlan, CacheCleanReport, ProcessOwnerState, ProcessStartProbe,
-    RetrievalProcessDefaults, RetrievalRuntimeDefaults, RetrievalRuntimeOverrides,
-    RetrievalStatusReport, RuntimeRetrievalConfig, RuntimeRetrievalProfile, apply_cache_clean,
-    ensure_product_embedding_backend_for_runtime, plan_cache_clean,
+    CacheCleanPlan, CacheCleanReport, FinalizeIndexOutcome, GenerationRetentionApplyReport,
+    GenerationRetentionPlan, ProcessOwnerState, ProcessStartProbe, QueryResult,
+    RetainedRollbackObservation, RetrievalIndexManifest, RetrievalProcessDefaults,
+    RetrievalRuntimeDefaults, RetrievalRuntimeOverrides, RetrievalStatusReport,
+    RollbackActivationError, RollbackActivationOutcome, RollbackActivationRefusal,
+    RuntimeRetrievalConfig, RuntimeRetrievalProfile, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
+    SidecarGcReport, SidecarInventoryReport, apply_cache_clean,
+    ensure_product_embedding_backend_for_runtime, plan_cache_clean, retrieval_process_defaults,
 };
 pub(crate) use search_runtime::SearchEngine;
 

--- a/crates/codestory-runtime/src/retrieval_boundary.rs
+++ b/crates/codestory-runtime/src/retrieval_boundary.rs
@@ -1,7 +1,11 @@
 use std::path::Path;
 
 pub use codestory_retrieval::{
-    CacheCleanPlan, CacheCleanReport, ProcessOwnerState, ProcessStartProbe, RetrievalStatusReport,
+    CacheCleanPlan, CacheCleanReport, FinalizeIndexOutcome, GenerationRetentionApplyReport,
+    GenerationRetentionPlan, ProcessOwnerState, ProcessStartProbe, QueryResult,
+    RetainedRollbackObservation, RetrievalIndexManifest, RetrievalStatusReport,
+    RollbackActivationError, RollbackActivationOutcome, RollbackActivationRefusal,
+    SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, SidecarGcReport, SidecarInventoryReport,
     SidecarProcessDefaults as RetrievalProcessDefaults,
     SidecarRuntimeDefaults as RetrievalRuntimeDefaults,
     SidecarRuntimeOverrides as RetrievalRuntimeOverrides,
@@ -159,6 +163,12 @@ impl RuntimeRetrievalConfig {
     pub(crate) fn into_inner(self) -> codestory_retrieval::SidecarRuntimeConfig {
         self.0
     }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn as_raw_config_for_test(&self) -> &codestory_retrieval::SidecarRuntimeConfig {
+        &self.0
+    }
 }
 
 impl From<codestory_retrieval::SidecarRuntimeConfig> for RuntimeRetrievalConfig {
@@ -175,6 +185,11 @@ pub fn plan_cache_clean() -> anyhow::Result<CacheCleanPlan> {
 /// Apply process-wide cache cleanup under the retrieval owner's global lock.
 pub fn apply_cache_clean() -> anyhow::Result<CacheCleanReport> {
     codestory_retrieval::apply_cache_clean()
+}
+
+/// Capture retrieval-owned process defaults for an adapter process.
+pub fn retrieval_process_defaults() -> RetrievalProcessDefaults {
+    codestory_retrieval::sidecar_process_defaults()
 }
 
 /// Initialize and validate the embedding backend selected by this runtime.


### PR DESCRIPTION
## Context

This is S2-5 of #1692. It moves the remaining ordinary CLI retrieval operations and raw runtime configuration behind the runtime boundary while preserving the declared embedding-provider exception for S2-6.

Closes #1841
Refs #1692
Refs #1179

## What changed

- froze pre-change JSON/Markdown and live-operation oracles for inventory/GC, zero-dense query, and rollback observation/dry-run/apply
- added ActivationService facades for rollback, inventory/GC, query, and finalize
- made RuntimeRetrievalConfig the retained CLI configuration and moved the qualification providers raw constructor into its provider module
- retargeted ordinary CLI consumers and added an executable direct-operation architecture gate

## Review

Commit order is intentional:

1. 57b52e71 freezes the pre-change behavior
2. 07d37350 adds the runtime facade
3. a6c9bed1 retargets CLI consumers

Focus on selected configuration identity, error-chain equality, dry-run/apply inversion, fresh query-cache behavior, and the exact S2-6 provider remainder.

## Verification

Passed on a6c9bed1:

- CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-cli --lib pre_change_
- CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-runtime --lib activation_retrieval::tests
- cargo test --locked -p codestory-cli --test architecture_contracts
- cargo check --locked -p codestory-cli --all-targets
- cargo check --locked -p codestory-cli --lib
- cargo clippy --locked -p codestory-runtime --all-targets -- -D warnings
- cargo clippy --locked -p codestory-cli --all-targets -- -D warnings
- cargo fmt --all -- --check
- node scripts/lint-retrieval-generalization.mjs
- git diff --check

Not run: the broad workspace proof. Exact-head adversarial review accepted a6c9bed1. This remains a draft until CI finishes; do not merge a later SHA without fresh acceptance.
