### PR TITLE
[v0.17 S2-6] Ban direct CLI retrieval consumers outside enumerated providers

### DIFF
--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -316,6 +316,117 @@ fn cli_transport_adapters_do_not_probe_retrieval_directly() {
     }
 }
 
+/// The CLI routes retrieval work through `codestory_runtime`; only these
+/// providers implement retrieval-owned traits or supply qualification-proof
+/// operations. Routing providers through `ActivationService` would invert that
+/// dependency.
+///
+/// The fixture list is temporary: S2-7 deletes it by teaching classification
+/// to honor module-level `#[cfg(test)]` gates.
+#[test]
+fn cli_owns_no_direct_retrieval_consumers_outside_providers() {
+    let source_root = repo_root().join("crates/codestory-cli/src");
+    let provider_allowlist = BTreeSet::from([
+        "embedding_server_transport.rs",
+        "embedding_qualification/worker.rs",
+        "embedding_qualification/worker/gate.rs",
+        "embedding_qualification/worker/protocol.rs",
+        "embedding_qualification/worker/operations/absence.rs",
+        "embedding_qualification/worker/operations/activation.rs",
+        "embedding_qualification/worker/operations/dead_client.rs",
+        "embedding_qualification/worker/operations/measure.rs",
+        "embedding_qualification/worker/operations/owner_exit.rs",
+        "embedding_qualification/worker/operations/queue.rs",
+        "sidecar_runtime.rs",
+    ]);
+    let module_gated_fixture_exemptions = BTreeSet::from(["status_wire_test_support.rs"]);
+
+    let transport = production_source(&read(
+        "crates/codestory-cli/src/embedding_server_transport.rs",
+    ));
+    for provider_trait in [
+        "impl codestory_retrieval::AwakeMonotonicClock for",
+        "impl codestory_retrieval::EmbeddingServerStream for",
+        "impl codestory_retrieval::EmbeddingClientTransport for",
+        "impl codestory_retrieval::EmbeddingServerTransport for",
+        "impl codestory_retrieval::EmbeddingServerListener for",
+    ] {
+        assert!(
+            transport.contains(provider_trait),
+            "embedding_server_transport.rs must retain its retrieval provider trait impl: {provider_trait}"
+        );
+    }
+    let qualification_worker = production_source(&read(
+        "crates/codestory-cli/src/embedding_qualification/worker.rs",
+    ));
+    assert!(
+        qualification_worker.contains("codestory_retrieval::run_per_user_embedding_qualification("),
+        "embedding qualification provider must retain run_per_user_embedding_qualification"
+    );
+
+    let app = read("crates/codestory-cli/src/app.rs");
+    assert!(
+        app.contains("#[cfg(test)]\nmod tests;"),
+        "app/tests/ is exempt only while app.rs keeps its module-level #[cfg(test)] gate"
+    );
+    let lib = read("crates/codestory-cli/src/lib.rs");
+    assert!(
+        lib.contains("#[cfg(test)]\nmod status_wire_test_support;"),
+        "status_wire_test_support.rs is exempt only while lib.rs keeps its module-level #[cfg(test)] gate"
+    );
+
+    let mut files = Vec::new();
+    collect_rs_files(&source_root, &mut files);
+    files.sort();
+    let mut scanned = 0_usize;
+    let mut violations = Vec::new();
+    let mut provider_references = BTreeSet::new();
+    for path in files {
+        let relative = path
+            .strip_prefix(&source_root)
+            .expect("CLI source lives below source root")
+            .to_string_lossy()
+            .replace('\\', "/");
+        if relative.starts_with("app/tests/")
+            || module_gated_fixture_exemptions.contains(relative.as_str())
+        {
+            continue;
+        }
+
+        scanned += 1;
+        let source = production_source(&fs::read_to_string(&path).expect("read CLI source"));
+        let has_retrieval_reference = source.contains("codestory_retrieval");
+        if provider_allowlist.contains(relative.as_str()) {
+            if has_retrieval_reference {
+                provider_references.insert(relative);
+            }
+            continue;
+        }
+        for line in source
+            .lines()
+            .filter(|line| line.contains("codestory_retrieval"))
+        {
+            violations.push(format!("{}: {}", path.display(), line.trim()));
+        }
+    }
+
+    assert!(
+        scanned > 20,
+        "CLI retrieval-consumer scan must cover more than 20 release-compiled files; scanned {scanned}"
+    );
+    assert!(
+        violations.is_empty(),
+        "CLI retrieval consumers must route through codestory_runtime outside enumerated providers:\n{}",
+        violations.join("\n")
+    );
+    for provider in &provider_allowlist {
+        assert!(
+            provider_references.contains(*provider),
+            "provider allowlist entry {provider} has no release-compiled codestory_retrieval reference; remove the stale allowlist entry"
+        );
+    }
+}
+
 #[test]
 fn workspace_crate_stays_decoupled_from_store_and_runtime() {
     let dependencies = dependency_names("crates/codestory-workspace/Cargo.toml");


### PR DESCRIPTION
## Context

This is S2-6 of #1692. S2-5 left the enumerated provider set as the only release-compiled direct retrieval consumers in the CLI; this slice installs the CLI-wide executable ban that keeps it that way. It changes zero product source lines.

Closes #1843
Refs #1692
Refs #1179

## What changed

One new architecture-contract test, `cli_owns_no_direct_retrieval_consumers_outside_providers`:

- scans every release-compiled source under `crates/codestory-cli/src` (same `production_source` semantics as the existing gates, crate-name match) and bans `codestory_retrieval` references outside an enumerated allowlist;
- the allowlist is exactly the audited remainder: `embedding_server_transport.rs`, the nine `embedding_qualification` driver files, and the `sidecar_runtime.rs` gateway;
- anti-vacuity in both directions: the five provider trait impls and the qualification proof call must remain by name, every allowlisted file must still carry a release-compiled reference, the module-gate text for the two fixture exemptions must still exist, and the scan must cover more than 20 files;
- the fixture exemption (`app/tests/**`, `status_wire_test_support.rs`) is an explicitly commented temporary list that S2-7 deletes by teaching classification to honor module-level `#[cfg(test)]` gates.

## Review

Single commit `d4eed422`, +111 lines, one file. Focus on: exact-path allowlist matching (no suffix tricks), `production_source` applied before matching, the both-directions allowlist check, and the gate-text assertions backing the temporary fixture exemption.

## Verification

Passed on `d4eed422` (implementer, re-run independently by supervisor):

- `CODESTORY_TEST_EMBED_ALLOW_CPU=1 cargo test --locked -p codestory-cli --test architecture_contracts` — 40 passed
- `cargo clippy --locked -p codestory-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Hostile mutations demonstrated and reverted during implementation: non-allowlisted consumer in `output.rs` → ban fires; deleted `AwakeMonotonicClock` impl → trait anti-vacuity fires; stale `args.rs` allowlist entry → both-directions check fires; removed `#[cfg(test)]` gate in `app.rs` → gate assertion fires.

Independent fresh-context adversarial review on the exact head is running; this PR stays draft until it accepts and CI is green. The broad workspace proof deliberately does not run on this support slice.
