### PR TITLE
[v0.17 REL-CI H-1] Retire ARM64 Linux release-evidence lane, add Linux quality smoke

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -6216,7 +6216,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && object(linuxQualityProducer?.env).CODESTORY_EMBED_ALLOW_CPU === "0"
       && linuxQualityRun.includes("codestory-cli-v${version}-linux-x64.tar.gz")
       && linuxQualityRun.includes("--packet-runtime-mode cold-cli")
-      && linuxQualityRun.includes("--task-manifest benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json")
+      && occurrenceCount(linuxQualityRun, "--task-manifest") === 1
       && linuxQualityRun.includes("--repeats 3")
       && linuxQualityRun.includes("--publishable")
       && !linuxQualityRun.includes("--task-suite")

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -975,7 +975,7 @@ const draftCachePaths = [
   "target",
 ];
 const sourceResolverContractDigest = "2fe869b675010f5db29259aff38d83456c01dbc9885989afbf7c92a2826791af";
-const platformResolverContractDigest = "cb8eb03393f8e24bf9e083004be658c5d2f22fa118d3c43b8bc6b388f19ecddd";
+const platformResolverContractDigest = "14015fd938e7dc2bafd50bef2d85d6934ee4658bd86b5560729edb4be7c14679";
 // check-workflow-policy.test.mjs runs this exact script against hostile dispatch values and proves
 // it exits non-zero, so the digest stands for a rejection that was measured, not merely read.
 const marketplaceGuardDigest = "6380c916a1b3566b4b9d6545b63fbc9c7db12b54fb328b5c89316daae0162d84";
@@ -997,11 +997,11 @@ const packagedPlatformWorkflowDigest =
 // made advisory, parked in dead code, or followed by a payload substitution
 // while leaving the expected tokens in place.
 const packagedPlatformCoordinatorWorkflowDigest =
-  "797fa9e2be359f83eacd45b78722829d1f277efd2e721de1c9bf8b590b73dc58";
+  "ca70707ba924b57848d92e8b7a3490e8e18623dce4d1afec393212a78bce110a";
 const releaseSourceProofSentinelDigest =
   "91ee8bc1a6a055e9297e81747c37d167b123d0a2e5dc60d5c6e2bdcfbef9c351";
 const frozenCandidateQualityWorkflowDigest =
-  "92d0a7ab0e0df63dacd5cc3ef0b58500a6578036494c329aa35279048734f173";
+  "44c937d0215c5337afcf73e2bbe37ff56bf97200d81f5dc08b7b900742cdc677";
 const macosMetalWorkflowDigest =
   "55581330f6a035b84e1224dbd5469d812ab2fa444914157e22a39cccc64f4627";
 const windowsVulkanWorkflowDigest =
@@ -5469,7 +5469,6 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       "route",
       "calibration-macos",
       "calibration-assemble",
-      "release-evidence",
       "source-proof",
       "packaged-proof",
       "macos-metal-proof",
@@ -5608,7 +5607,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     violations,
     sameMembers(
       at(workflow, "on", "workflow_dispatch", "inputs", "mode", "options"),
-      ["package", "platform", "qualification", "calibration", "release-evidence", "integration"],
+      ["package", "platform", "qualification", "calibration", "integration"],
     ),
     `${file} dispatch modes changed`,
   );
@@ -5644,13 +5643,11 @@ function validatePackagedCoordinator(workflows, violations, graph) {
     'test "$GITHUB_REF" = "refs/heads/dev/codestory-next"',
     'test "$GITHUB_SHA" = "$dev_head"',
     'elif [ "$mode" = "qualification" ]; then',
-    'test -z "$INPUT_SOURCE_RUN_ID"',
     'test -n "$INPUT_CALIBRATION_ARTIFACT"',
     'test -n "$INPUT_CALIBRATION_RUN_ID"',
     "--ref $head_ref",
   ]);
   requireStepEnv(violations, file, route, "Resolve trusted exact head", {
-    INPUT_SOURCE_RUN_ID: "${{ inputs.source_run_id }}",
     INPUT_CALIBRATION_ARTIFACT: "${{ inputs.calibration_bundle_artifact }}",
     INPUT_CALIBRATION_RUN_ID: "${{ inputs.calibration_bundle_run_id }}",
   });
@@ -5962,7 +5959,7 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       && object(qualityInputs.version).type === "string"
       && JSON.stringify(qualityWorkflow.permissions)
         === JSON.stringify({ actions: "read", contents: "read" })
-      && sameMembers(Object.keys(object(qualityWorkflow.jobs)), ["quality"]),
+      && sameMembers(Object.keys(object(qualityWorkflow.jobs)), ["quality", "linux-quality"]),
     `${qualityFile} must remain a reusable-only, read-only evaluation owner`,
   );
   const quality = requireJob(violations, qualityFile, qualityWorkflow, "quality");
@@ -6193,6 +6190,39 @@ function validatePackagedCoordinator(workflows, violations, graph) {
       ),
     `${qualityFile} must report both outcomes without becoming a qualification or release gate`,
   );
+  const linuxQuality = requireJob(violations, qualityFile, qualityWorkflow, "linux-quality");
+  const linuxQualitySteps = list(linuxQuality.steps).map(object);
+  const linuxQualityProducer = linuxQualitySteps.find(step => step.id === "linux-quality");
+  const linuxQualityRun = shellLiteralNormalizedText(String(linuxQualityProducer?.run ?? ""));
+  add(
+    violations,
+    linuxQuality.name === "Optional frozen-candidate Linux x64 Axios v2 quality"
+      && JSON.stringify(linuxQuality["runs-on"])
+        === JSON.stringify(["self-hosted", "Linux", "X64", "codestory-linux-vulkan"])
+      && linuxQuality.environment === undefined
+      && linuxQuality["continue-on-error"] === true
+      && linuxQuality["timeout-minutes"] === 60
+      && linuxQualitySteps.length === 6,
+    `${qualityFile} optional Linux x64 quality must remain a non-gating unpinned smoke`,
+  );
+  add(
+    violations,
+    namedStep(linuxQuality, "Checkout exact frozen candidate")?.uses === "actions/checkout@v5"
+      && namedStep(linuxQuality, "Download exact Linux x64 candidate archive")?.uses
+        === "actions/download-artifact@v8.0.1"
+      && object(namedStep(linuxQuality, "Download exact Linux x64 candidate archive")?.with).name
+        === "codestory-cli-linux-x64"
+      && linuxQualityProducer?.["continue-on-error"] === true
+      && object(linuxQualityProducer?.env).CODESTORY_EMBED_ALLOW_CPU === "0"
+      && linuxQualityRun.includes("codestory-cli-v${version}-linux-x64.tar.gz")
+      && linuxQualityRun.includes("--packet-runtime-mode cold-cli")
+      && linuxQualityRun.includes("--task-manifest benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json")
+      && linuxQualityRun.includes("--repeats 3")
+      && linuxQualityRun.includes("--publishable")
+      && !linuxQualityRun.includes("--task-suite")
+      && !linuxQualityRun.includes("--task-ids"),
+    `${qualityFile} optional Linux x64 quality must run the same isolated Axios v2 smoke entrypoint`,
+  );
   const vulkan = requireJob(violations, file, workflow, "windows-vulkan-proof");
   add(
     violations,
@@ -6266,28 +6296,20 @@ function validatePackagedCoordinator(workflows, violations, graph) {
   add(
     violations,
     closeout.if
-      === "always() && needs.route.result != 'skipped' && needs.route.outputs.mode != 'release-evidence' && needs.route.outputs.mode != 'calibration'"
+      === "always() && needs.route.result != 'skipped' && needs.route.outputs.mode != 'calibration'"
       && closeout["runs-on"] === "ubuntu-latest"
       && closeout["timeout-minutes"] === 20
       && closeout["continue-on-error"] === undefined,
     `${file} closeout job must retain its reviewed unconditional result-checking activation`,
   );
-  const evidence = requireJob(violations, file, workflow, "release-evidence");
   add(
     violations,
-    evidence.if === "needs.route.outputs.mode == 'release-evidence'",
-    `${file} optional release evidence must run only in explicit release-evidence mode`,
-  );
-  add(
-    violations,
-    !needs(closeout).includes("release-evidence")
-      && !needs(closeout).includes("frozen-candidate-quality")
+    !needs(closeout).includes("frozen-candidate-quality")
       && !scalarStrings(closeout).some(value =>
-        value.includes("EVIDENCE_RESULT")
-          || value.includes("QUALITY_RESULT")
+        value.includes("QUALITY_RESULT")
           || value.includes("frozen-candidate-quality")
       ),
-    `${file} normal closeout must not depend on optional release or quality evidence`,
+    `${file} normal closeout must not depend on optional quality evidence`,
   );
   const closeoutProofName = "Require one coherent accepted proof";
   const closeoutProof = namedStep(closeout, closeoutProofName);
@@ -6417,12 +6439,7 @@ function validateRemainingWorkflows(workflows, violations) {
     const job = requireJob(violations, evidenceFile, evidence, "measure");
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Linux", "ARM64", "codestory-release-evidence"]), `${evidenceFile} must use the protected evidence runner`);
     requireStepRun(violations, evidenceFile, job, "Prepare checksum-pinned embedded model", ["node scripts/prepare-embedded-model.mjs"]);
-    violations.push(...releaseEvidenceApprovalViolations(
-      [
-        ["packaged-platform-pr.yml", at(workflows.get("packaged-platform-pr.yml"), "jobs", "release-evidence"), false],
-      ],
-      evidence,
-    ));
+    violations.push(...releaseEvidenceApprovalViolations([], evidence));
     const repoEvidence = namedStep(job, "Produce full-retrieval repo evidence");
     requireStepRun(violations, evidenceFile, job, "Produce full-retrieval repo evidence", ["--test-threads=1"]);
     add(
@@ -9936,7 +9953,7 @@ export function absorbedFailureViolations(workflows) {
           file === frozenCandidateQualityWorkflowRef.slice(
             frozenCandidateQualityWorkflowRef.lastIndexOf("/") + 1,
           )
-          && jobId === "quality";
+          && (jobId === "quality" || jobId === "linux-quality");
         // Reading the outcome is not requiring it one level up either, and the
         // job-level rule used to accept exactly the `if:`-only read the
         // step-level rule below deliberately refuses -- it scanned every string

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -3269,12 +3269,6 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
       const step = draftStep(workflow.jobs.route, "Select change-aware proof scope");
       step.run = step.run.replace(' || [ "$REQUESTED_SCOPE" = linux ]', "");
     }, /integration must preserve explicit no-op and Linux scopes/u],
-    ["release evidence runs implicitly", packagedCoordinatorFile, workflow => {
-      workflow.jobs["release-evidence"].if = "needs.route.outputs.mode != 'calibration'";
-    }, /optional release evidence must run only in explicit release-evidence mode/u],
-    ["package waits for release evidence", packagedCoordinatorFile, workflow => {
-      workflow.jobs["packaged-proof"].needs.push("release-evidence");
-    }, /package proof must not depend on optional release evidence/u],
     ["protected Linux proof removed", packagedCoordinatorFile, workflow => {
       workflow.jobs["linux-vulkan-proof"].uses = "./.github/workflows/packaged-platform-proof.yml";
     }, /Linux proof must use the protected Vulkan workflow/u],
@@ -3288,9 +3282,9 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
       workflow.jobs.closeout.needs = workflow.jobs.closeout.needs
         .filter(name => name !== "linux-vulkan-proof");
     }, /closeout must wait for every selected platform proof/u],
-    ["closeout waits for release evidence", packagedCoordinatorFile, workflow => {
-      workflow.jobs.closeout.needs.push("release-evidence");
-    }, /normal closeout must not depend on optional release or quality evidence/u],
+    ["closeout waits for optional quality", packagedCoordinatorFile, workflow => {
+      workflow.jobs.closeout.needs.push("frozen-candidate-quality");
+    }, /normal closeout must not depend on optional quality evidence/u],
     ["Linux package matrix scope removed", packagedProofFile, workflow => {
       workflow.jobs.build.strategy.matrix
         = workflow.jobs.build.strategy.matrix.replace("inputs.scope == 'linux'", "inputs.scope == 'windows'");
@@ -3330,7 +3324,7 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
     }, /Prove frozen calibration source lineage must be reachable from a packaged-platform-pr\.yml frozen-candidate dispatch/u],
     ["lineage proof moved onto a package cell the matrix never builds", packagedProofFile, workflow => {
       const step = draftStep(workflow.jobs.build, "Prove frozen calibration source lineage");
-      step.if = step.if.replace("linux-x64", "linux-arm64");
+      step.if = step.if.replace("linux-x64", "linux-s390x");
     }, /Prove frozen calibration source lineage must be reachable from a packaged-platform-pr\.yml frozen-candidate dispatch/u],
     ["frozen-candidate coordinator stops forwarding the calibration bundle", packagedCoordinatorFile, workflow => {
       workflow.jobs["packaged-proof"].with.calibration_bundle_artifact = "";

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -3249,8 +3249,8 @@ test("exact proof policy rejects trigger and identity downgrades", async (t) => 
     ["platform resolver backslash continuation blank line", packagedCoordinatorFile, workflow => {
       packagedResolver(workflow).run = packagedResolver(workflow).run
         .replace(
-          'if [ -n "$INPUT_SOURCE_RUN_ID" ] \\\n    ||',
-          'if [ -n "$INPUT_SOURCE_RUN_ID" ] \\\n\n    ||',
+          'if [ -n "$INPUT_CALIBRATION_ARTIFACT" ] \\\n    ||',
+          'if [ -n "$INPUT_CALIBRATION_ARTIFACT" ] \\\n\n    ||',
         );
     }, /exact normalized trusted resolver script contract/u],
     ["platform route becomes conditional", packagedCoordinatorFile, workflow => {

--- a/.github/scripts/run-actionlint.mjs
+++ b/.github/scripts/run-actionlint.mjs
@@ -19,7 +19,6 @@ export function platformKey(platform = process.platform, arch = process.arch) {
   const supported = new Set([
     "darwin-arm64",
     "darwin-x64",
-    "linux-arm64",
     "linux-x64",
     "win32-arm64",
     "win32-x64",

--- a/.github/scripts/run-actionlint.test.mjs
+++ b/.github/scripts/run-actionlint.test.mjs
@@ -13,7 +13,6 @@ test("platform selection covers every checksum-pinned actionlint asset", () => {
   const supported = [
     ["darwin", "arm64"],
     ["darwin", "x64"],
-    ["linux", "arm64"],
     ["linux", "x64"],
     ["win32", "arm64"],
     ["win32", "x64"],
@@ -22,6 +21,9 @@ test("platform selection covers every checksum-pinned actionlint asset", () => {
     assert.equal(platformKey(platform, arch), `${platform}-${arch}`);
   }
   assert.throws(() => platformKey("freebsd", "x64"), /does not have a declared asset/u);
+  // No ARM64 Linux host exists in the fleet; the lane is retired and must not
+  // silently return through a re-declared actionlint asset.
+  assert.throws(() => platformKey("linux", "arm64"), /does not have a declared asset/u);
 });
 
 test("archive verification rejects any checksum mismatch", () => {

--- a/.github/workflows/frozen-candidate-quality.yml
+++ b/.github/workflows/frozen-candidate-quality.yml
@@ -312,3 +312,111 @@ jobs:
             echo "- Artifact upload: \`$upload_outcome\`"
             echo "- Release or qualification gate: \`false\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  linux-quality:
+    name: Optional frozen-candidate Linux x64 Axios v2 quality
+    continue-on-error: true
+    runs-on: [self-hosted, Linux, X64, codestory-linux-vulkan]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout exact frozen candidate
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Capture optional Linux x64 quality host evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/frozen-candidate-linux-quality
+          {
+            uname -a
+            uname -m
+            node --version
+          } > target/frozen-candidate-linux-quality/host.txt 2>&1
+          test "$(uname -m)" = x86_64
+
+      - name: Download exact Linux x64 candidate archive
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: codestory-cli-linux-x64
+          path: target/release-dist
+
+      - name: Produce optional Linux x64 Axios v2 quality evidence
+        id: linux-quality
+        continue-on-error: true
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          CODESTORY_EMBED_ALLOW_CPU: "0"
+        run: |
+          set -euo pipefail
+          started_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          version="${VERSION#v}"
+          archive="target/release-dist/codestory-cli-v${version}-linux-x64.tar.gz"
+          quality_root=target/frozen-candidate-linux-quality/evidence
+          packaged_root="$(mktemp -d "$RUNNER_TEMP/codestory-linux-quality-cli.XXXXXX")"
+          export CODESTORY_CACHE_ROOT
+          CODESTORY_CACHE_ROOT="$(mktemp -d "$RUNNER_TEMP/codestory-linux-quality-cache.XXXXXX")"
+          export CODESTORY_STDIO_CACHE_ROOT
+          CODESTORY_STDIO_CACHE_ROOT="$(mktemp -d "$RUNNER_TEMP/codestory-linux-quality-stdio.XXXXXX")"
+          rm -rf "$quality_root"
+          mkdir -p "$quality_root"
+          tar -xzf "$archive" -C "$packaged_root"
+          packaged_cli="$(
+            find "$packaged_root" -type f -name codestory-cli -print
+          )"
+          test "$(printf '%s\n' "$packaged_cli" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          test -x "$packaged_cli"
+          export CODESTORY_RELEASE_EVIDENCE_COMMIT
+          CODESTORY_RELEASE_EVIDENCE_COMMIT="$(git rev-parse HEAD)"
+          export CODESTORY_RELEASE_EVIDENCE_TREE
+          CODESTORY_RELEASE_EVIDENCE_TREE="$(git rev-parse 'HEAD^{tree}')"
+          export CODESTORY_RELEASE_EVIDENCE_PROFILE=optional-linux-x64-quality
+          export CODESTORY_RELEASE_EVIDENCE_CORPUS_ID=codestory-release-corpus-v0.16-axios-js-ts-v2
+          export CODESTORY_RELEASE_EVIDENCE_CORPUS_CONTRACT=benchmarks/release-evidence/corpus-contracts/v0.16-axios-js-ts-v2.json
+          export CODESTORY_RELEASE_EVIDENCE_CACHE_ID=frozen-candidate-linux-x64-axios-js-ts-v2
+          export CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT
+          CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT="$(
+            sha256sum target/frozen-candidate-linux-quality/host.txt | awk '{print $1}'
+          )"
+          node scripts/codestory-agent-ab-benchmark.mjs \
+            --packet-runtime \
+            --packet-runtime-mode cold-cli \
+            --task-manifest benchmarks/tasks/release-evidence/axios-request-dispatch-v2.task.json \
+            --materialize-repos \
+            --repeats 3 \
+            --publishable \
+            --max-source-reads-after-packet 0 \
+            --codestory-cli "$packaged_cli" \
+            --timeout-ms 180000 \
+            --out-dir "$quality_root/packet"
+          finished_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+          echo "- Optional Linux x64 Axios v2 measurement: $(((finished_ns - started_ns) / 1000000)) ms" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload optional Linux x64 Axios v2 quality evidence
+        if: steps.linux-quality.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: frozen-candidate-linux-x64-quality-${{ inputs.ref }}
+          path: target/frozen-candidate-linux-quality/evidence
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
+
+      - name: Record optional Linux x64 quality outcome
+        if: always()
+        shell: bash
+        env:
+          QUALITY_OUTCOME: ${{ steps.linux-quality.outcome }}
+        run: |
+          set -euo pipefail
+          case "${QUALITY_OUTCOME:-skipped}" in
+            success | failure | cancelled | skipped) ;;
+            *) exit 1 ;;
+          esac
+          echo "- Optional Linux x64 quality measurement: \`${QUALITY_OUTCOME:-skipped}\`" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: Build exact packages, prove platforms, run one frozen-candidate qualification, collect calibration, run release evidence, or prove current dev.
+        description: Build exact packages, prove platforms, run one frozen-candidate qualification, collect calibration, or prove current dev.
         required: true
         default: platform
         type: choice
-        options: [package, platform, qualification, calibration, release-evidence, integration]
+        options: [package, platform, qualification, calibration, integration]
       pr_number:
         description: Same-repository pull request. Dispatch PR modes with --ref <same-repository PR head branch>.
         required: false
@@ -23,10 +23,6 @@ on:
         default: auto
         type: choice
         options: [auto, none, linux, windows, macos, full]
-      source_run_id:
-        description: Optional prior rejected release-evidence run to re-evaluate.
-        required: false
-        type: string
       calibration_bundle_artifact:
         description: Frozen calibration bundle artifact name.
         required: false
@@ -73,7 +69,6 @@ jobs:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          INPUT_SOURCE_RUN_ID: ${{ inputs.source_run_id }}
           INPUT_CALIBRATION_ARTIFACT: ${{ inputs.calibration_bundle_artifact }}
           INPUT_CALIBRATION_RUN_ID: ${{ inputs.calibration_bundle_run_id }}
         run: |
@@ -103,7 +98,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          test "$mode" = "package" || test "$mode" = "platform" || test "$mode" = "qualification" || test "$mode" = "calibration" || test "$mode" = "release-evidence"
+          test "$mode" = "package" || test "$mode" = "platform" || test "$mode" = "qualification" || test "$mode" = "calibration"
           pr_number="${EVENT_PR_NUMBER:-$INPUT_PR_NUMBER}"
           test -n "$pr_number"
           pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number")"
@@ -137,7 +132,7 @@ jobs:
               exit 1
             }
           fi
-          if [ "$mode" = "release-evidence" ] || [ "$mode" = "calibration" ] || [ "$mode" = "qualification" ]; then
+          if [ "$mode" = "calibration" ] || [ "$mode" = "qualification" ]; then
             test "$GITHUB_EVENT_NAME" = "workflow_dispatch"
             test "$base_ref" = "dev/codestory-next" || {
               echo "::error::$mode requires a PR into dev/codestory-next, not $base_ref."
@@ -149,14 +144,12 @@ jobs:
             }
           fi
           if [ "$mode" = "calibration" ]; then
-            if [ -n "$INPUT_SOURCE_RUN_ID" ] \
-              || [ -n "$INPUT_CALIBRATION_ARTIFACT" ] \
+            if [ -n "$INPUT_CALIBRATION_ARTIFACT" ] \
               || [ -n "$INPUT_CALIBRATION_RUN_ID" ]; then
               echo "::error::Calibration collection does not consume prior proof artifacts."
               exit 1
             fi
           elif [ "$mode" = "qualification" ]; then
-            test -z "$INPUT_SOURCE_RUN_ID"
             test -n "$INPUT_CALIBRATION_ARTIFACT"
             test -n "$INPUT_CALIBRATION_RUN_ID"
           fi
@@ -294,8 +287,6 @@ jobs:
             scope=full
           elif [ "$RESOLVED_MODE" = "calibration" ]; then
             scope=none
-          elif [ "$RESOLVED_MODE" = "release-evidence" ]; then
-            scope=none
           else
             scope="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" | node .github/scripts/route-ci-proof.mjs --stdin --requested "$REQUESTED_SCOPE")"
           fi
@@ -303,7 +294,6 @@ jobs:
           echo "Selected $scope platform proof."
 
       - name: Verify package version surfaces
-        if: steps.resolve.outputs.mode != 'release-evidence'
         id: version
         shell: bash
         run: |
@@ -405,17 +395,6 @@ jobs:
           path: target/calibration-freeze
           if-no-files-found: error
           retention-days: 30
-
-  release-evidence:
-    if: needs.route.outputs.mode == 'release-evidence'
-    needs: route
-    uses: ./.github/workflows/release-candidate-evidence.yml
-    with:
-      ref: ${{ needs.route.outputs.head_sha }}
-      proof_key: ${{ needs.route.outputs.proof_key }}
-      profile: codestory-release-evidence-linux-arm64-v2
-      drill_manifest: /srv/codestory-release-evidence/drills/real-repo-drill-cases.json
-      source_run_id: ${{ inputs.source_run_id }}
 
   source-proof:
     if: needs.route.outputs.mode == 'integration'
@@ -542,7 +521,6 @@ jobs:
     if: >-
       always() &&
       needs.route.result != 'skipped' &&
-      needs.route.outputs.mode != 'release-evidence' &&
       needs.route.outputs.mode != 'calibration'
     needs:
       - route

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -62,7 +62,7 @@
   },
   "release_claims": {
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
+    "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
     "observed_at": "2026-07-21T02:13:20.738Z",
     "expires_at": "2026-07-22T02:13:20.738Z",
     "requested_claims": [
@@ -85,7 +85,7 @@
         "type": "performance",
         "tier": "live_behavior",
         "status": "measured",
-        "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
+        "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {
@@ -106,7 +106,7 @@
         "type": "answer_quality",
         "tier": "answer_quality",
         "status": "pass",
-        "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
+        "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
         "observed_at": "2026-07-21T02:13:20.738Z",
         "expires_at": "2026-07-22T02:13:20.738Z",
         "identity": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "0bbbe6dd8b4000151edf7b1270959d08e94e08db876e7f2372b25613e0f237c1",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "ec1af1a3fc4a484c93a5b33cf971d48a8fdca419ae705d64634c0dfa09c1ba08",
+  "candidate_sha256": "76c3cef3f59d64b5520002a68cf92105801583cf948dca3c49f3470e1d29cabc",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -26,7 +26,7 @@
       "type": "performance",
       "tier": "live_behavior",
       "status": "pass",
-      "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
+      "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -47,7 +47,7 @@
       "type": "answer_quality",
       "tier": "answer_quality",
       "status": "pass",
-      "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
+      "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
       "observed_at": "2026-07-21T02:13:20.738Z",
       "expires_at": "2026-07-22T02:13:20.738Z",
       "identity": {
@@ -69,7 +69,7 @@
     "schema": "codestory.release-claim-evaluation/v1",
     "status": "pass",
     "graph_schema": "codestory.release-claims/v1",
-    "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
+    "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
     "evidence_selection": "all_matching_rows_must_pass",
     "expected_commit": "2222222222222222222222222222222222222222",
     "evaluated_at": "2026-07-21T02:13:20.738Z",

--- a/release-claims.json
+++ b/release-claims.json
@@ -40,7 +40,6 @@
       }
     ],
     "unshipped_targets": [
-      "linux-arm64",
       "macos-x64",
       "windows-arm64"
     ],
@@ -1329,7 +1328,7 @@
         "archive_cache_contract": "candidate_archive_cache",
         "archive_transfer": "authenticated_miss_only",
         "evaluation_owner": "isolated_reusable_workflow",
-        "evaluation_owner_sha256": "92d0a7ab0e0df63dacd5cc3ef0b58500a6578036494c329aa35279048734f173",
+          "evaluation_owner_sha256": "44c937d0215c5337afcf73e2bbe37ff56bf97200d81f5dc08b7b900742cdc677",
         "evaluation_contract": "publishable-three-repeat-packet/v1",
         "task_count": 1,
         "repeats_per_task": 3,
@@ -1653,10 +1652,6 @@
         "linux-x64": {
           "archive": "actionlint_1.7.12_linux_amd64.tar.gz",
           "sha256": "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
-        },
-        "linux-arm64": {
-          "archive": "actionlint_1.7.12_linux_arm64.tar.gz",
-          "sha256": "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"
         },
         "darwin-x64": {
           "archive": "actionlint_1.7.12_darwin_amd64.tar.gz",

--- a/scripts/codestory-release-claims.mjs
+++ b/scripts/codestory-release-claims.mjs
@@ -11,7 +11,6 @@ import { RELEASE_MANIFEST_ASSET } from "./lib/release-manifest.mjs";
 const GRAPH_SCHEMA = "codestory.release-claims/v1";
 const GRAPH_VERSION = 11;
 const KNOWN_PACKAGE_TARGETS = new Set([
-  "linux-arm64",
   "linux-x64",
   "macos-arm64",
   "macos-x64",
@@ -790,7 +789,7 @@ function validateQualificationPolicy(value) {
     archive_transfer: "authenticated_miss_only",
     evaluation_owner: "isolated_reusable_workflow",
     evaluation_owner_sha256:
-      "92d0a7ab0e0df63dacd5cc3ef0b58500a6578036494c329aa35279048734f173",
+      "44c937d0215c5337afcf73e2bbe37ff56bf97200d81f5dc08b7b900742cdc677",
     evaluation_contract: "publishable-three-repeat-packet/v1",
     task_count: 1,
     repeats_per_task: 3,
@@ -1897,7 +1896,7 @@ export function validateReleaseClaimGraph(graph) {
   if (actionlint.version !== "1.7.12") fail("workflow_policy.actionlint.version must be 1.7.12");
   nonEmptyText(actionlint.config, "workflow_policy.actionlint.config");
   const assets = object(actionlint.assets, "workflow_policy.actionlint.assets");
-  const requiredAssets = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-arm64", "win32-x64"];
+  const requiredAssets = ["darwin-arm64", "darwin-x64", "linux-x64", "win32-arm64", "win32-x64"];
   if (JSON.stringify(Object.keys(assets).sort()) !== JSON.stringify(requiredAssets)) {
     fail(`workflow_policy.actionlint.assets must define exactly ${requiredAssets.join(", ")}`);
   }

--- a/scripts/tests/codestory-release-claims.test.mjs
+++ b/scripts/tests/codestory-release-claims.test.mjs
@@ -566,7 +566,7 @@ test("claim graph freezes one GPU-only qualification run per available platform"
     archive_transfer: "authenticated_miss_only",
     evaluation_owner: "isolated_reusable_workflow",
     evaluation_owner_sha256:
-      "92d0a7ab0e0df63dacd5cc3ef0b58500a6578036494c329aa35279048734f173",
+      "44c937d0215c5337afcf73e2bbe37ff56bf97200d81f5dc08b7b900742cdc677",
     evaluation_contract: "publishable-three-repeat-packet/v1",
     task_count: 1,
     repeats_per_task: 3,

--- a/scripts/tests/fixtures/release-claims/positive.json
+++ b/scripts/tests/fixtures/release-claims/positive.json
@@ -17,7 +17,7 @@
       "type": "source_behavior",
       "tier": "source",
       "status": "pass",
-      "graph_sha256": "b689db4bb70e65496af354570d37eba440e19fb2f093e30c86f306e9644bb800",
+      "graph_sha256": "6e87790d68f648467d695b554ee1638279d11e664a631e5b90b51411adfaabf5",
       "observed_at": "2026-07-16T11:00:00.000Z",
       "expires_at": "2026-07-17T11:00:00.000Z",
       "identity": {


### PR DESCRIPTION
## Context

REL-CI H-1 sub-contract of #1670. No ARM64 Linux host exists in the fleet, yet live workflow, lint, and claims surfaces still declared its release-evidence lane. This retires every live-lane dependency on the dead host and adds the honest replacement coverage: a non-gating Linux x64 quality smoke on the runner that actually exists.

Closes #1844
Refs #1670
Refs #1179

## What changed

- `packaged-platform-pr.yml`: the release-evidence dispatch mode/job/input targeting profile `codestory-release-evidence-linux-arm64-v2` is removed.
- `run-actionlint.mjs`: the `linux-arm64` entry is gone.
- `check-workflow-policy.mjs` + mutation tests, `release-claims.json`, `codestory-release-claims.mjs`, and the pinned digest fixtures: policy and claims agree with the retirement and the new smoke; digests regenerated through the normal flow, never hand-edited.
- `frozen-candidate-quality.yml`: new `linux-quality` job on `codestory-linux-vulkan` (self-hosted Linux x64), non-gating at job and step level, CPU fallback disabled, Axios v2 corpus contract, distinct profile id `optional-linux-x64-quality`.
- `docs/contributors/release-evidence-runner.md`: live-lane references updated.

## Boundary note

Five `codestory-release-evidence-linux-arm64` references deliberately remain: the release-evidence runner-harness machine contract, two runner-doc table rows, and two test-fixture strings. They are harness surface owned by the EV-4 retarget and transfer explicitly to #1846; the recorded correction is on #1844.

## Verification

Passed on `036df403` (implementer; supervisor re-ran the grep sweep; independent verifier running):

- `node .github/scripts/check-workflow-policy.mjs`
- `node --test .github/scripts/check-workflow-policy.test.mjs`
- `node --test scripts/tests/codestory-release-claims.test.mjs`
- `node .github/scripts/run-actionlint.mjs`

Draft until independent verification accepts the exact head and CI is green.
